### PR TITLE
gh-135878: Fix crash in `types.SimpleNamespace.__repr__`

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-06-24-14-43-24.gh-issue-135878.Db4roX.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-24-14-43-24.gh-issue-135878.Db4roX.rst
@@ -1,3 +1,3 @@
-Fixes a crash of :class:`types.SimpleNamespace` on free-threading builds,
+Fixes a crash of :class:`types.SimpleNamespace` on :term:`free threading` builds,
 when several threads were calling its :meth:`~object.__repr__` method at the
 same time.

--- a/Misc/NEWS.d/next/Library/2025-06-24-14-43-24.gh-issue-135878.Db4roX.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-24-14-43-24.gh-issue-135878.Db4roX.rst
@@ -1,0 +1,3 @@
+Fixes a crash of :class:`types.SimpleNamespace` on free-threading builds,
+when several threads were calling its :meth:`~object.__repr__` method at the
+same time.

--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -126,6 +126,7 @@ namespace_repr(PyObject *ns)
 
             if (PyDict_GetItemRef(d, key, &value) == 1) {
                 item = PyUnicode_FromFormat("%U=%R", key, value);
+                Py_DECREF(value);
                 if (item == NULL) {
                     loop_error = 1;
                 }

--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -124,8 +124,7 @@ namespace_repr(PyObject *ns)
         if (PyUnicode_Check(key) && PyUnicode_GET_LENGTH(key) > 0) {
             PyObject *value, *item;
 
-            value = PyDict_GetItemWithError(d, key);
-            if (value != NULL) {
+            if (PyDict_GetItemRef(d, key, &value) == 1) {
                 item = PyUnicode_FromFormat("%U=%R", key, value);
                 if (item == NULL) {
                     loop_error = 1;
@@ -135,7 +134,7 @@ namespace_repr(PyObject *ns)
                     Py_DECREF(item);
                 }
             }
-            else if (PyErr_Occurred()) {
+            else {
                 loop_error = 1;
             }
         }

--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -124,7 +124,8 @@ namespace_repr(PyObject *ns)
         if (PyUnicode_Check(key) && PyUnicode_GET_LENGTH(key) > 0) {
             PyObject *value, *item;
 
-            if (PyDict_GetItemRef(d, key, &value) == 1) {
+            int has_key = PyDict_GetItemRef(d, key, &value);
+            if (has_key == 1) {
                 item = PyUnicode_FromFormat("%U=%R", key, value);
                 Py_DECREF(value);
                 if (item == NULL) {
@@ -135,7 +136,7 @@ namespace_repr(PyObject *ns)
                     Py_DECREF(item);
                 }
             }
-            else {
+            else if (has_key < 0) {
                 loop_error = 1;
             }
         }


### PR DESCRIPTION
Note, that there's a small behavior change. We now treat missing keys as errors, because it is the correct thing to do. When `->ns_dict` does not have keys from its `PyObject_GetIter(keys)` - this is strange.

Any suggestions about the test case here are welcome!

<!-- gh-issue-number: gh-135878 -->
* Issue: gh-135878
<!-- /gh-issue-number -->
