### PR TITLE
GH-135904: Optimize the JIT's assembly control flow

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-24-16-46-34.gh-issue-135904.78xfon.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-24-16-46-34.gh-issue-135904.78xfon.rst
@@ -1,0 +1,2 @@
+Perform more aggressive control-flow optimizations on the machine code
+templates emitted by the experimental JIT compiler.

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -287,6 +287,7 @@ class OptimizerAArch64(Optimizer):  # pylint: disable = too-few-public-methods
 
     # TODO: @diegorusso
     _alignment = 8
+    # https://developer.arm.com/documentation/ddi0602/2025-03/Base-Instructions/B--Branch-
     _re_jump = re.compile(r"\s*b\s+(?P<target>[\w.]+)")
 
 
@@ -297,7 +298,9 @@ class OptimizerX86(Optimizer):  # pylint: disable = too-few-public-methods
     _re_branch = re.compile(
         rf"\s*(?P<instruction>{'|'.join(_X86_BRANCHES)})\s+(?P<target>[\w.]+)"
     )
+    # https://www.felixcloutier.com/x86/jmp
     _re_jump = re.compile(r"\s*jmp\s+(?P<target>[\w.]+)")
+    # https://www.felixcloutier.com/x86/ret
     _re_return = re.compile(r"\s*ret\b")
 
 

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -4,7 +4,6 @@ import re
 import typing
 
 _RE_NEVER_MATCH = re.compile(r"(?!)")  # Same as saying "not string.startswith('')".
-
 _X86_BRANCHES = {
     "ja": "jna",
     "jae": "jnae",
@@ -51,7 +50,6 @@ class _Block:
 
 @dataclasses.dataclass
 class Optimizer:
-
     path: pathlib.Path
     _: dataclasses.KW_ONLY
     prefix: str = ""

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -7,7 +7,7 @@ import typing
 
 # Same as saying "not string.startswith('')":
 _RE_NEVER_MATCH = re.compile(r"(?!)")
-# Dictionary mapping x86 branching instructions to their inverted counterparts.
+# Dictionary mapping branch instructions to their inverted branch instructions.
 # If a branch cannot be inverted, the value is None:
 _X86_BRANCHES = {
     "ja": "jna",

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -67,7 +67,7 @@ class Optimizer:
         r'\s*(?P<label>[\w."$?@]+):'  # One group: label.
     )
     _re_noise: typing.ClassVar[re.Pattern[str]] = re.compile(
-        r"\s*(?:[#.]|$)"  # No groups.
+        r"\s*(?:\.|#|//|$)"  # No groups.
     )
     _re_return: typing.ClassVar[re.Pattern[str]] = _RE_NEVER_MATCH  # No groups.
 
@@ -223,6 +223,7 @@ class Optimizer:
 class OptimizerAArch64(Optimizer):
     # TODO: @diegorusso
     _alignment = 8
+    _re_jump = re.compile(r"\s*b\s+(?P<target>[\w.]+)")
 
 
 class OptimizerX86(Optimizer):

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -4,69 +4,34 @@ import pathlib
 import re
 import typing
 
-branches = {}
-for op, nop in [
-    ("ja", "jna"),
-    ("jae", "jnae"),
-    ("jb", "jnb"),
-    ("jbe", "jnbe"),
-    ("jc", "jnc"),
-    ("jcxz", None),
-    ("je", "jne"),
-    ("jecxz", None),
-    ("jg", "jng"),
-    ("jge", "jnge"),
-    ("jl", "jnl"),
-    ("jle", "jnle"),
-    ("jo", "jno"),
-    ("jp", "jnp"),
-    ("jpe", "jpo"),
-    ("jrxz", None),
-    ("js", "jns"),
-    ("jz", "jnz"),
-    ("loop", None),
-    ("loope", None),
-    ("loopne", None),
-    ("loopnz", None),
-    ("loopz", None),
-]:
-    branches[op] = nop
-    if nop:
-        branches[nop] = op
+_RE_NEVER_MATCH = re.compile(r"(?!)")
 
-
-def _get_branch(line: str) -> str | None:
-    branch = re.match(rf"\s*({'|'.join(branches)})\s+([\w\.]+)", line)
-    return branch and branch[2]
-
-
-def _invert_branch(line: str, label: str) -> str | None:
-    branch = re.match(rf"\s*({'|'.join(branches)})\s+([\w\.]+)", line)
-    assert branch
-    inverted = branches.get(branch[1])
-    if not inverted:
-        return None
-    line = line.replace(branch[1], inverted, 1)  # XXX
-    line = line.replace(branch[2], label, 1)  # XXX
-    return line
-
-
-def _get_jump(line: str) -> str | None:
-    jump = re.match(r"\s*(?:rex64\s+)?jmpq?\s+\*?([\w\.]+)", line)
-    return jump and jump[1]
-
-
-def _get_label(line: str) -> str | None:
-    label = re.match(r"\s*([\w\.]+):", line)
-    return label and label[1]
-
-
-def _is_return(line: str) -> bool:
-    return re.match(r"\s*ret\s+", line) is not None
-
-
-def _is_noise(line: str) -> bool:
-    return re.match(r"\s*([#\.]|$)", line) is not None
+_X86_BRANCHES = {
+    "ja": "jna",
+    "jae": "jnae",
+    "jb": "jnb",
+    "jbe": "jnbe",
+    "jc": "jnc",
+    "jcxz": None,
+    "je": "jne",
+    "jecxz": None,
+    "jg": "jng",
+    "jge": "jnge",
+    "jl": "jnl",
+    "jle": "jnle",
+    "jo": "jno",
+    "jp": "jnp",
+    "jpe": "jpo",
+    "jrxz": None,
+    "js": "jns",
+    "jz": "jnz",
+    "loop": None,
+    "loope": None,
+    "loopne": None,
+    "loopnz": None,
+    "loopz": None,
+}
+_X86_BRANCHES |= {v: k for k, v in _X86_BRANCHES.items() if v}
 
 
 @dataclasses.dataclass
@@ -91,12 +56,6 @@ class _Block:
         return self
 
 
-class _Labels(dict):
-    def __missing__(self, key: str) -> _Block:
-        self[key] = _Block(key)
-        return self[key]
-
-
 @dataclasses.dataclass
 class Optimizer:
 
@@ -104,44 +63,104 @@ class Optimizer:
     _: dataclasses.KW_ONLY
     prefix: str = ""
     _graph: _Block = dataclasses.field(init=False)
-    _labels: _Labels = dataclasses.field(init=False, default_factory=_Labels)
-
-    _re_branch: typing.ClassVar[re.Pattern[str]]  # Two groups: instruction and target.
-    _re_jump: typing.ClassVar[re.Pattern[str]]  # One group: target.
-    _re_return: typing.ClassVar[re.Pattern[str]]  # No groups.
+    _labels: dict = dataclasses.field(init=False, default_factory=dict)
+    _alignment: typing.ClassVar[int] = 1
+    _branches: typing.ClassVar[dict[str, str | None]] = {}
+    _re_branch: typing.ClassVar[re.Pattern[str]] = (
+        _RE_NEVER_MATCH  # Two groups: instruction and target.
+    )
+    _re_jump: typing.ClassVar[re.Pattern[str]] = _RE_NEVER_MATCH  # One group: target.
+    _re_label: typing.ClassVar[re.Pattern[str]] = re.compile(
+        r"\s*(?P<label>[\w\.]+):"
+    )  # One group: label.
+    _re_noise: typing.ClassVar[re.Pattern[str]] = re.compile(
+        r"\s*(?:[#\.]|$)"
+    )  # No groups.
+    _re_return: typing.ClassVar[re.Pattern[str]] = _RE_NEVER_MATCH  # No groups.
 
     def __post_init__(self) -> None:
         text = self._preprocess(self.path.read_text())
         self._graph = block = self._new_block()
         for line in text.splitlines():
-            if label := _get_label(line):
-                block.link = block = self._labels[label]
+            if label := self._parse_label(line):
+                block.link = block = self._lookup_label(label)
+                block.noise.append(line)
+                continue
             elif block.target or not block.fallthrough:
                 block.link = block = self._new_block()
-            if _is_noise(line) or _get_label(line):
+            if self._parse_noise(line):
                 if block.instructions:
                     block.link = block = self._new_block()
                 block.noise.append(line)
                 continue
             block.instructions.append(line)
-            if target := _get_branch(line):
-                block.target = self._labels[target]
+            if target := self._parse_branch(line):
+                block.target = self._lookup_label(target)
                 assert block.fallthrough
-            elif target := _get_jump(line):
-                block.target = self._labels[target]
+            elif target := self._parse_jump(line):
+                block.target = self._lookup_label(target)
                 block.fallthrough = False
-            elif _is_return(line):
+            elif self._parse_return(line):
                 assert not block.target
                 block.fallthrough = False
 
-    def _new_block(self, label: str | None = None) -> _Block:
-        if not label:
-            label = f"{self.prefix}_JIT_LABEL_{len(self._labels)}"
-        assert label not in self._labels, label
-        block = self._labels[label] = _Block(label, [f"{label}:"])
+    @classmethod
+    def _parse_branch(cls, line: str) -> str | None:
+        branch = cls._re_branch.match(line)
+        return branch and branch["target"]
+
+    @classmethod
+    def _parse_jump(cls, line: str) -> str | None:
+        jump = cls._re_jump.match(line)
+        return jump and jump["target"]
+
+    @classmethod
+    def _parse_label(cls, line: str) -> str | None:
+        label = cls._re_label.match(line)
+        return label and label["label"]
+
+    @classmethod
+    def _parse_noise(cls, line: str) -> bool:
+        return cls._re_noise.match(line) is not None
+
+    @classmethod
+    def _parse_return(cls, line: str) -> bool:
+        return cls._re_return.match(line) is not None
+
+    @classmethod
+    def _invert_branch(cls, line: str, target: str) -> str | None:
+        branch = cls._re_branch.match(line)
+        assert branch
+        inverted = cls._branches.get(branch["instruction"])
+        if not inverted:
+            return None
+        (a, b), (c, d) = branch.span("instruction"), branch.span("target")
+        return "".join([line[:a], inverted, line[b:c], target, line[d:]])
+
+    @classmethod
+    def _thread_jump(cls, line: str, target: str) -> str:
+        jump = cls._re_jump.match(line) or cls._re_branch.match(line)
+        assert jump
+        a, b = jump.span("target")
+        return "".join([line[:a], target, line[b:]])
+
+    @staticmethod
+    def _create_jump(target: str) -> str | None:
+        return None
+
+    def _lookup_label(self, label: str) -> _Block:
+        if label not in self._labels:
+            self._labels[label] = _Block(label)
+        return self._labels[label]
+
+    def _new_block(self) -> _Block:
+        label = f"{self.prefix}_JIT_LABEL_{len(self._labels)}"
+        block = self._lookup_label(label)
+        block.noise.append(f"{label}:")
         return block
 
-    def _preprocess(self, text: str) -> str:
+    @staticmethod
+    def _preprocess(text: str) -> str:
         return text
 
     def _blocks(self) -> typing.Generator[_Block, None, None]:
@@ -159,9 +178,11 @@ class Optimizer:
         for end in reversed(list(self._blocks())):
             if end.instructions:
                 break
-        continuation = self._labels[f"{self.prefix}_JIT_CONTINUE"]
+        align = self._new_block()
+        align.noise.append(f"\t.balign\t{self._alignment}")
+        continuation = self._lookup_label(f"{self.prefix}_JIT_CONTINUE")
         continuation.noise.append(f"{continuation.label}:")
-        end.link, continuation.link = continuation, end.link
+        end.link, align.link, continuation.link = align, continuation, end.link
 
     def _mark_hot_blocks(self) -> None:
         predecessors = collections.defaultdict(set)
@@ -170,7 +191,7 @@ class Optimizer:
                 predecessors[block.target].add(block)
             if block.fallthrough and block.link:
                 predecessors[block.link].add(block)
-        todo = [self._labels[f"{self.prefix}_JIT_CONTINUE"]]
+        todo = [self._lookup_label(f"{self.prefix}_JIT_CONTINUE")]
         while todo:
             block = todo.pop()
             block.hot = True
@@ -185,43 +206,41 @@ class Optimizer:
             if (
                 block.fallthrough
                 and block.target
-                and block.link
                 and block.target.hot
+                and block.link
                 and not block.link.hot
             ):
-                # Turn...
-                #         branch hot
-                # ...into..
-                #         opposite-branch ._JIT_LABEL_N
-                #         jmp hot
-                #     ._JIT_LABEL_N:
                 label_block = self._new_block()
-                inverted = _invert_branch(block.instructions[-1], label_block.label)
-                if inverted is None:
+                branch = block.instructions[-1]
+                inverted = self._invert_branch(branch, label_block.label)
+                jump = self._create_jump(block.target.label)
+                if inverted is None or jump is None:
                     continue
                 jump_block = self._new_block()
-                jump_block.instructions.append(f"\tjmp\t{block.target.label}")
+                jump_block.instructions.append(jump)
                 jump_block.target = block.target
                 jump_block.fallthrough = False
                 block.instructions[-1] = inverted
                 block.target = label_block
-                label_block.link = block.link
-                jump_block.link = label_block
-                block.link = jump_block
+                block.link, jump_block.link, label_block.link = (
+                    jump_block,
+                    label_block,
+                    block.link,
+                )
 
     def _thread_jumps(self) -> None:
         for block in self._blocks():
             while block.target:
-                label = block.target.label
                 target = block.target.resolve()
                 if (
                     not target.fallthrough
                     and target.target
                     and len(target.instructions) == 1
                 ):
-                    block.instructions[-1] = block.instructions[-1].replace(
-                        label, target.target.label
-                    )  # XXX
+                    jump = block.instructions[-1]
+                    block.instructions[-1] = self._thread_jump(
+                        jump, target.target.label
+                    )
                     block.target = target.target
                 else:
                     break
@@ -273,13 +292,23 @@ class Optimizer:
         self.path.write_text("\n".join(self._lines()))
 
 
+class OptimizerAArch64(Optimizer):
+    # TODO: @diegorusso
+    _alignment = 8
+
+
 class OptimizerX86(Optimizer):
 
+    _branches = _X86_BRANCHES
     _re_branch = re.compile(
-        rf"\s*(?P<instruction>{'|'.join(branches)})\s+(?P<target>[\w\.]+)"
+        rf"\s*(?P<instruction>{'|'.join(_X86_BRANCHES)})\s+(?P<target>[\w\.]+)"
     )
     _re_jump = re.compile(r"\s*jmp\s+(?P<target>[\w\.]+)")
     _re_return = re.compile(r"\s*ret\b")
+
+    @staticmethod
+    def _create_jump(target: str) -> str:
+        return f"\tjmp\t{target}"
 
 
 class OptimizerX86Windows(OptimizerX86):

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -1,0 +1,292 @@
+import collections
+import dataclasses
+import pathlib
+import re
+import typing
+
+branches = {}
+for op, nop in [
+    ("ja", "jna"),
+    ("jae", "jnae"),
+    ("jb", "jnb"),
+    ("jbe", "jnbe"),
+    ("jc", "jnc"),
+    ("jcxz", None),
+    ("je", "jne"),
+    ("jecxz", None),
+    ("jg", "jng"),
+    ("jge", "jnge"),
+    ("jl", "jnl"),
+    ("jle", "jnle"),
+    ("jo", "jno"),
+    ("jp", "jnp"),
+    ("jpe", "jpo"),
+    ("jrxz", None),
+    ("js", "jns"),
+    ("jz", "jnz"),
+    ("loop", None),
+    ("loope", None),
+    ("loopne", None),
+    ("loopnz", None),
+    ("loopz", None),
+]:
+    branches[op] = nop
+    if nop:
+        branches[nop] = op
+
+
+def _get_branch(line: str) -> str | None:
+    branch = re.match(rf"\s*({'|'.join(branches)})\s+([\w\.]+)", line)
+    return branch and branch[2]
+
+
+def _invert_branch(line: str, label: str) -> str | None:
+    branch = re.match(rf"\s*({'|'.join(branches)})\s+([\w\.]+)", line)
+    assert branch
+    inverted = branches.get(branch[1])
+    if not inverted:
+        return None
+    line = line.replace(branch[1], inverted, 1)  # XXX
+    line = line.replace(branch[2], label, 1)  # XXX
+    return line
+
+
+def _get_jump(line: str) -> str | None:
+    jump = re.match(r"\s*(?:rex64\s+)?jmpq?\s+\*?([\w\.]+)", line)
+    return jump and jump[1]
+
+
+def _get_label(line: str) -> str | None:
+    label = re.match(r"\s*([\w\.]+):", line)
+    return label and label[1]
+
+
+def _is_return(line: str) -> bool:
+    return re.match(r"\s*ret\s+", line) is not None
+
+
+def _is_noise(line: str) -> bool:
+    return re.match(r"\s*([#\.]|$)", line) is not None
+
+
+@dataclasses.dataclass
+class _Block:
+    label: str
+    noise: list[str] = dataclasses.field(default_factory=list)
+    instructions: list[str] = dataclasses.field(default_factory=list)
+    target: typing.Self | None = None
+    link: typing.Self | None = None
+    fallthrough: bool = True
+    hot: bool = False
+
+    def __eq__(self, other: object) -> bool:
+        return self is other
+
+    def __hash__(self) -> int:
+        return super().__hash__()
+
+    def resolve(self) -> typing.Self:
+        while self.link and not self.instructions:
+            self = self.link
+        return self
+
+
+class _Labels(dict):
+    def __missing__(self, key: str) -> _Block:
+        self[key] = _Block(key)
+        return self[key]
+
+
+@dataclasses.dataclass
+class Optimizer:
+
+    path: pathlib.Path
+    _: dataclasses.KW_ONLY
+    prefix: str = ""
+    _graph: _Block = dataclasses.field(init=False)
+    _labels: _Labels = dataclasses.field(init=False, default_factory=_Labels)
+
+    _re_branch: typing.ClassVar[re.Pattern[str]]  # Two groups: instruction and target.
+    _re_jump: typing.ClassVar[re.Pattern[str]]  # One group: target.
+    _re_return: typing.ClassVar[re.Pattern[str]]  # No groups.
+
+    def __post_init__(self) -> None:
+        text = self._preprocess(self.path.read_text())
+        self._graph = block = self._new_block()
+        for line in text.splitlines():
+            if label := _get_label(line):
+                block.link = block = self._labels[label]
+            elif block.target or not block.fallthrough:
+                block.link = block = self._new_block()
+            if _is_noise(line) or _get_label(line):
+                if block.instructions:
+                    block.link = block = self._new_block()
+                block.noise.append(line)
+                continue
+            block.instructions.append(line)
+            if target := _get_branch(line):
+                block.target = self._labels[target]
+                assert block.fallthrough
+            elif target := _get_jump(line):
+                block.target = self._labels[target]
+                block.fallthrough = False
+            elif _is_return(line):
+                assert not block.target
+                block.fallthrough = False
+
+    def _new_block(self, label: str | None = None) -> _Block:
+        if not label:
+            label = f"{self.prefix}_JIT_LABEL_{len(self._labels)}"
+        assert label not in self._labels, label
+        block = self._labels[label] = _Block(label, [f"{label}:"])
+        return block
+
+    def _preprocess(self, text: str) -> str:
+        return text
+
+    def _blocks(self) -> typing.Generator[_Block, None, None]:
+        block = self._graph
+        while block:
+            yield block
+            block = block.link
+
+    def _lines(self) -> typing.Generator[str, None, None]:
+        for block in self._blocks():
+            yield from block.noise
+            yield from block.instructions
+
+    def _insert_continue_label(self) -> None:
+        for end in reversed(list(self._blocks())):
+            if end.instructions:
+                break
+        continuation = self._labels[f"{self.prefix}_JIT_CONTINUE"]
+        continuation.noise.append(f"{continuation.label}:")
+        end.link, continuation.link = continuation, end.link
+
+    def _mark_hot_blocks(self) -> None:
+        predecessors = collections.defaultdict(set)
+        for block in self._blocks():
+            if block.target:
+                predecessors[block.target].add(block)
+            if block.fallthrough and block.link:
+                predecessors[block.link].add(block)
+        todo = [self._labels[f"{self.prefix}_JIT_CONTINUE"]]
+        while todo:
+            block = todo.pop()
+            block.hot = True
+            todo.extend(
+                predecessor
+                for predecessor in predecessors[block]
+                if not predecessor.hot
+            )
+
+    def _invert_hot_branches(self) -> None:
+        for block in self._blocks():
+            if (
+                block.fallthrough
+                and block.target
+                and block.link
+                and block.target.hot
+                and not block.link.hot
+            ):
+                # Turn...
+                #         branch hot
+                # ...into..
+                #         opposite-branch ._JIT_LABEL_N
+                #         jmp hot
+                #     ._JIT_LABEL_N:
+                label_block = self._new_block()
+                inverted = _invert_branch(block.instructions[-1], label_block.label)
+                if inverted is None:
+                    continue
+                jump_block = self._new_block()
+                jump_block.instructions.append(f"\tjmp\t{block.target.label}")
+                jump_block.target = block.target
+                jump_block.fallthrough = False
+                block.instructions[-1] = inverted
+                block.target = label_block
+                label_block.link = block.link
+                jump_block.link = label_block
+                block.link = jump_block
+
+    def _thread_jumps(self) -> None:
+        for block in self._blocks():
+            while block.target:
+                label = block.target.label
+                target = block.target.resolve()
+                if (
+                    not target.fallthrough
+                    and target.target
+                    and len(target.instructions) == 1
+                ):
+                    block.instructions[-1] = block.instructions[-1].replace(
+                        label, target.target.label
+                    )  # XXX
+                    block.target = target.target
+                else:
+                    break
+
+    def _remove_dead_code(self) -> None:
+        reachable = set()
+        todo = [self._graph]
+        while todo:
+            block = todo.pop()
+            reachable.add(block)
+            if block.target and block.target not in reachable:
+                todo.append(block.target)
+            if block.fallthrough and block.link and block.link not in reachable:
+                todo.append(block.link)
+        for block in self._blocks():
+            if block not in reachable:
+                block.instructions.clear()
+
+    def _remove_redundant_jumps(self) -> None:
+        for block in self._blocks():
+            if (
+                block.target
+                and block.link
+                and block.target.resolve() is block.link.resolve()
+            ):
+                block.target = None
+                block.fallthrough = True
+                block.instructions.pop()
+
+    def _remove_unused_labels(self) -> None:
+        used = set()
+        for block in self._blocks():
+            if block.target:
+                used.add(block.target)
+        for block in self._blocks():
+            if block not in used and block.label.startswith(
+                f"{self.prefix}_JIT_LABEL_"
+            ):
+                del block.noise[0]
+
+    def run(self) -> None:
+        self._insert_continue_label()
+        self._mark_hot_blocks()
+        self._invert_hot_branches()
+        self._thread_jumps()
+        self._remove_dead_code()
+        self._remove_redundant_jumps()
+        self._remove_unused_labels()
+        self.path.write_text("\n".join(self._lines()))
+
+
+class OptimizerX86(Optimizer):
+
+    _re_branch = re.compile(
+        rf"\s*(?P<instruction>{'|'.join(branches)})\s+(?P<target>[\w\.]+)"
+    )
+    _re_jump = re.compile(r"\s*jmp\s+(?P<target>[\w\.]+)")
+    _re_return = re.compile(r"\s*ret\b")
+
+
+class OptimizerX86Windows(OptimizerX86):
+
+    def _preprocess(self, text: str) -> str:
+        text = super()._preprocess(text)
+        far_indirect_jump = (
+            rf"rex64\s+jmpq\s+\*__imp_(?P<target>{self.prefix}_JIT_\w+)\(%rip\)"
+        )
+        return re.sub(far_indirect_jump, r"jmp\t\g<target>", text)

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -71,10 +71,10 @@ class Optimizer:
     )
     _re_jump: typing.ClassVar[re.Pattern[str]] = _RE_NEVER_MATCH  # One group: target.
     _re_label: typing.ClassVar[re.Pattern[str]] = re.compile(
-        r"\s*(?P<label>[\w\.]+):"
+        r'\s*(?P<label>[\w"$.?@]+):'
     )  # One group: label.
     _re_noise: typing.ClassVar[re.Pattern[str]] = re.compile(
-        r"\s*(?:[#\.]|$)"
+        r"\s*(?:[#.]|$)"
     )  # No groups.
     _re_return: typing.ClassVar[re.Pattern[str]] = _RE_NEVER_MATCH  # No groups.
 
@@ -257,6 +257,8 @@ class Optimizer:
                 todo.append(block.link)
         for block in self._blocks():
             if block not in reachable:
+                block.target = None
+                block.fallthrough = True
                 block.instructions.clear()
 
     def _remove_redundant_jumps(self) -> None:
@@ -301,9 +303,9 @@ class OptimizerX86(Optimizer):
 
     _branches = _X86_BRANCHES
     _re_branch = re.compile(
-        rf"\s*(?P<instruction>{'|'.join(_X86_BRANCHES)})\s+(?P<target>[\w\.]+)"
+        rf"\s*(?P<instruction>{'|'.join(_X86_BRANCHES)})\s+(?P<target>[\w.]+)"
     )
-    _re_jump = re.compile(r"\s*jmp\s+(?P<target>[\w\.]+)")
+    _re_jump = re.compile(r"\s*jmp\s+(?P<target>[\w.]+)")
     _re_return = re.compile(r"\s*ret\b")
 
     @staticmethod

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -288,7 +288,7 @@ class Optimizer:
         self._mark_hot_blocks()
         self._invert_hot_branches()
         self._thread_jumps()
-        self._remove_dead_code()
+        # self._remove_dead_code()  # XXX: Need calls to reason about this!
         self._remove_redundant_jumps()
         self._remove_unused_labels()
         self.path.write_text("\n".join(self._lines()))

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -206,23 +206,6 @@ class Stencil:
             self.disassembly.append(f"{offset:x}: {' '.join(['00'] * padding)}")
         self.body.extend([0] * padding)
 
-    # def add_nops(self, nop: bytes, alignment: int) -> None:
-    #     """Add NOPs until there is alignment. Fail if it is not possible."""
-    #     offset = len(self.body)
-    #     nop_size = len(nop)
-
-    #     # Calculate the gap to the next multiple of alignment.
-    #     gap = -offset % alignment
-    #     if gap:
-    #         if gap % nop_size == 0:
-    #             count = gap // nop_size
-    #             self.body.extend(nop * count)
-    #         else:
-    #             raise ValueError(
-    #                 f"Cannot add nops of size '{nop_size}' to a body with "
-    #                 f"offset '{offset}' to align with '{alignment}'"
-    #             )
-
 
 @dataclasses.dataclass
 class StencilGroup:
@@ -240,9 +223,7 @@ class StencilGroup:
     _got: dict[str, int] = dataclasses.field(default_factory=dict, init=False)
     _trampolines: set[int] = dataclasses.field(default_factory=set, init=False)
 
-    def process_relocations(
-        self, known_symbols: dict[str, int], *, alignment: int = 1, nop: bytes = b""
-    ) -> None:
+    def process_relocations(self, known_symbols: dict[str, int]) -> None:
         """Fix up all GOT and internal relocations for this stencil group."""
         for hole in self.code.holes.copy():
             if (
@@ -262,7 +243,6 @@ class StencilGroup:
                 self._trampolines.add(ordinal)
                 hole.addend = ordinal
                 hole.symbol = None
-        # self.code.add_nops(nop=nop, alignment=alignment)
         self.data.pad(8)
         for stencil in [self.code, self.data]:
             for hole in stencil.holes:

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -17,8 +17,6 @@ class HoleValue(enum.Enum):
 
     # The base address of the machine code for the current uop (exposed as _JIT_ENTRY):
     CODE = enum.auto()
-    # The base address of the machine code for the next uop (exposed as _JIT_CONTINUE):
-    CONTINUE = enum.auto()
     # The base address of the read-only data for this uop:
     DATA = enum.auto()
     # The address of the current executor (exposed as _JIT_EXECUTOR):
@@ -97,7 +95,6 @@ _PATCH_FUNCS = {
 # Translate HoleValues to C expressions:
 _HOLE_EXPRS = {
     HoleValue.CODE: "(uintptr_t)code",
-    HoleValue.CONTINUE: "(uintptr_t)code + sizeof(code_body)",
     HoleValue.DATA: "(uintptr_t)data",
     HoleValue.EXECUTOR: "(uintptr_t)executor",
     # These should all have been turned into DATA values by process_relocations:
@@ -209,63 +206,22 @@ class Stencil:
             self.disassembly.append(f"{offset:x}: {' '.join(['00'] * padding)}")
         self.body.extend([0] * padding)
 
-    def add_nops(self, nop: bytes, alignment: int) -> None:
-        """Add NOPs until there is alignment. Fail if it is not possible."""
-        offset = len(self.body)
-        nop_size = len(nop)
+    # def add_nops(self, nop: bytes, alignment: int) -> None:
+    #     """Add NOPs until there is alignment. Fail if it is not possible."""
+    #     offset = len(self.body)
+    #     nop_size = len(nop)
 
-        # Calculate the gap to the next multiple of alignment.
-        gap = -offset % alignment
-        if gap:
-            if gap % nop_size == 0:
-                count = gap // nop_size
-                self.body.extend(nop * count)
-            else:
-                raise ValueError(
-                    f"Cannot add nops of size '{nop_size}' to a body with "
-                    f"offset '{offset}' to align with '{alignment}'"
-                )
-
-    def remove_jump(self) -> None:
-        """Remove a zero-length continuation jump, if it exists."""
-        hole = max(self.holes, key=lambda hole: hole.offset)
-        match hole:
-            case Hole(
-                offset=offset,
-                kind="IMAGE_REL_AMD64_REL32",
-                value=HoleValue.GOT,
-                symbol="_JIT_CONTINUE",
-                addend=-4,
-            ) as hole:
-                # jmp qword ptr [rip]
-                jump = b"\x48\xff\x25\x00\x00\x00\x00"
-                offset -= 3
-            case Hole(
-                offset=offset,
-                kind="IMAGE_REL_I386_REL32" | "R_X86_64_PLT32" | "X86_64_RELOC_BRANCH",
-                value=HoleValue.CONTINUE,
-                symbol=None,
-                addend=addend,
-            ) as hole if (
-                _signed(addend) == -4
-            ):
-                # jmp 5
-                jump = b"\xe9\x00\x00\x00\x00"
-                offset -= 1
-            case Hole(
-                offset=offset,
-                kind="R_AARCH64_JUMP26",
-                value=HoleValue.CONTINUE,
-                symbol=None,
-                addend=0,
-            ) as hole:
-                # b #4
-                jump = b"\x00\x00\x00\x14"
-            case _:
-                return
-        if self.body[offset:] == jump:
-            self.body = self.body[:offset]
-            self.holes.remove(hole)
+    #     # Calculate the gap to the next multiple of alignment.
+    #     gap = -offset % alignment
+    #     if gap:
+    #         if gap % nop_size == 0:
+    #             count = gap // nop_size
+    #             self.body.extend(nop * count)
+    #         else:
+    #             raise ValueError(
+    #                 f"Cannot add nops of size '{nop_size}' to a body with "
+    #                 f"offset '{offset}' to align with '{alignment}'"
+    #             )
 
 
 @dataclasses.dataclass
@@ -306,8 +262,7 @@ class StencilGroup:
                 self._trampolines.add(ordinal)
                 hole.addend = ordinal
                 hole.symbol = None
-        self.code.remove_jump()
-        self.code.add_nops(nop=nop, alignment=alignment)
+        # self.code.add_nops(nop=nop, alignment=alignment)
         self.data.pad(8)
         for stencil in [self.code, self.data]:
             for hole in stencil.holes:

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -531,53 +531,39 @@ def get_target(host: str) -> _COFF | _ELF | _MachO:
     target: _COFF | _ELF | _MachO
     if re.fullmatch(r"aarch64-apple-darwin.*", host):
         condition = "defined(__aarch64__) && defined(__APPLE__)"
-        target = _MachO(
-            host, condition, optimizer=_optimizers.OptimizerAArch64, prefix="_"
-        )
+        optimizer = _optimizers.OptimizerAArch64
+        target = _MachO(host, condition, optimizer=optimizer, prefix="_")
     elif re.fullmatch(r"aarch64-pc-windows-msvc", host):
         args = ["-fms-runtime-lib=dll", "-fplt"]
         condition = "defined(_M_ARM64)"
-        target = _COFF(
-            host, condition, args=args, optimizer=_optimizers.OptimizerAArch64
-        )
+        optimizer = _optimizers.OptimizerAArch64
+        target = _COFF(host, condition, args=args, optimizer=optimizer)
     elif re.fullmatch(r"aarch64-.*-linux-gnu", host):
-        args = [
-            "-fpic",
-            # On aarch64 Linux, intrinsics were being emitted and this flag
-            # was required to disable them.
-            "-mno-outline-atomics",
-        ]
+        # -mno-outline-atomics: Keep intrinsics from being emitted.
+        args = ["-fpic", "-mno-outline-atomics"]
         condition = "defined(__aarch64__) && defined(__linux__)"
-        target = _ELF(
-            host, condition, args=args, optimizer=_optimizers.OptimizerAArch64
-        )
+        optimizer = _optimizers.OptimizerAArch64
+        target = _ELF(host, condition, args=args, optimizer=optimizer)
     elif re.fullmatch(r"i686-pc-windows-msvc", host):
-        args = [
-            "-DPy_NO_ENABLE_SHARED",
-            # __attribute__((preserve_none)) is not supported
-            "-Wno-ignored-attributes",
-        ]
+        # -Wno-ignored-attributes: __attribute__((preserve_none)) is not supported here.
+        args = ["-DPy_NO_ENABLE_SHARED", "-Wno-ignored-attributes"]
+        optimizer = _optimizers.OptimizerX86Windows
         condition = "defined(_M_IX86)"
-        target = _COFF(
-            host,
-            condition,
-            args=args,
-            optimizer=_optimizers.OptimizerX86Windows,
-            prefix="_",
-        )
+        target = _COFF(host, condition, args=args, optimizer=optimizer, prefix="_")
     elif re.fullmatch(r"x86_64-apple-darwin.*", host):
         condition = "defined(__x86_64__) && defined(__APPLE__)"
-        target = _MachO(host, condition, optimizer=_optimizers.OptimizerX86, prefix="_")
+        optimizer = _optimizers.OptimizerX86
+        target = _MachO(host, condition, optimizer=optimizer, prefix="_")
     elif re.fullmatch(r"x86_64-pc-windows-msvc", host):
         args = ["-fms-runtime-lib=dll"]
         condition = "defined(_M_X64)"
-        target = _COFF(
-            host, condition, args=args, optimizer=_optimizers.OptimizerX86Windows
-        )
+        optimizer = _optimizers.OptimizerX86Windows
+        target = _COFF(host, condition, args=args, optimizer=optimizer)
     elif re.fullmatch(r"x86_64-.*-linux-gnu", host):
         args = ["-fno-pic", "-mcmodel=medium", "-mlarge-data-threshold=0"]
         condition = "defined(__x86_64__) && defined(__linux__)"
-        target = _ELF(host, condition, args=args, optimizer=_optimizers.OptimizerX86)
+        optimizer = _optimizers.OptimizerX86
+        target = _ELF(host, condition, args=args, optimizer=optimizer)
     else:
         raise ValueError(host)
     return target

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -42,7 +42,7 @@ class _Target(typing.Generic[_S, _R]):
     condition: str
     _: dataclasses.KW_ONLY
     args: typing.Sequence[str] = ()
-    optimizer: type[_optimizers.Optimizer]
+    optimizer: type[_optimizers.Optimizer] = _optimizers.Optimizer
     prefix: str = ""
     stable: bool = False
     debug: bool = False
@@ -520,6 +520,7 @@ class _MachO(
 
 def get_target(host: str) -> _COFF | _ELF | _MachO:
     """Build a _Target for the given host "triple" and options."""
+    optimizer: type[_optimizers.Optimizer]
     target: _COFF | _ELF | _MachO
     if re.fullmatch(r"aarch64-apple-darwin.*", host):
         condition = "defined(__aarch64__) && defined(__APPLE__)"
@@ -539,7 +540,7 @@ def get_target(host: str) -> _COFF | _ELF | _MachO:
     elif re.fullmatch(r"i686-pc-windows-msvc", host):
         # -Wno-ignored-attributes: __attribute__((preserve_none)) is not supported here.
         args = ["-DPy_NO_ENABLE_SHARED", "-Wno-ignored-attributes"]
-        optimizer = _optimizers.OptimizerX86Windows
+        optimizer = _optimizers.OptimizerX86
         condition = "defined(_M_IX86)"
         target = _COFF(host, condition, args=args, optimizer=optimizer, prefix="_")
     elif re.fullmatch(r"x86_64-apple-darwin.*", host):
@@ -549,7 +550,7 @@ def get_target(host: str) -> _COFF | _ELF | _MachO:
     elif re.fullmatch(r"x86_64-pc-windows-msvc", host):
         args = ["-fms-runtime-lib=dll"]
         condition = "defined(_M_X64)"
-        optimizer = _optimizers.OptimizerX86Windows
+        optimizer = _optimizers.OptimizerX8664Windows
         target = _COFF(host, condition, args=args, optimizer=optimizer)
     elif re.fullmatch(r"x86_64-.*-linux-gnu", host):
         args = ["-fno-pic", "-mcmodel=medium", "-mlarge-data-threshold=0"]

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -38,7 +38,6 @@ _R = typing.TypeVar(
 
 @dataclasses.dataclass
 class _Target(typing.Generic[_S, _R]):
-
     triple: str
     condition: str
     _: dataclasses.KW_ONLY

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -136,7 +136,6 @@ class _Target(typing.Generic[_S, _R]):
             f"-I{CPYTHON / 'Tools' / 'jit'}",
             "-O3",
             "-S",
-            # "-c",
             # Shorten full absolute file paths in the generated code (like the
             # __FILE__ macro and assert failure messages) for reproducibility:
             f"-ffile-prefix-map={CPYTHON}=.",
@@ -161,13 +160,7 @@ class _Target(typing.Generic[_S, _R]):
         ]
         await _llvm.run("clang", args_s, echo=self.verbose)
         self.optimizer(s, prefix=self.prefix).run()
-        args_o = [
-            f"--target={self.triple}",
-            "-c",
-            "-o",
-            f"{o}",
-            f"{s}",
-        ]
+        args_o = [f"--target={self.triple}", "-c", "-o", f"{o}", f"{s}"]
         await _llvm.run("clang", args_o, echo=self.verbose)
         return await self._parse(o)
 


### PR DESCRIPTION
This adds a pass to the JIT build step that optimizes the control flow of the assembly for each template before compiling it to machine code. It replaces our current zero-length jump removal, and does a bit more:

- It allows the assembler to resolve and efficiently encode jumps to `_JIT_CONTINUE` by just sticking a label in the assembly itself.
- It inverts certain branches where branching is the common case and falling through is the uncommon case, increasing our ability to maintain a straight-line sequence of hot code.

Another benefit of this approach is that the machine code in the comments of `jit_stencils-*.h` *actually* represents the real code emitted at runtime (currently our jump-removal and nop padding change the code, but not the comment).

The resulting code is over [1% faster](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20250623-3.15.0a0-a987be7-JIT/bm-20250623-linux-x86_64-brandtbucher-justin_hot-3.15.0a0-a987be7-vs-base.svg). For an idea of how it impacts the stencils themselves, here's a [diff](https://gist.github.com/brandtbucher/d2b4511802e4739bb4c3f257301f112a).

Note that this mostly punts on AArch64 support... all I've done is implement the same zero-length jump removal that we already had (but @diegorusso is going to take care of the rest).

Later, we'll do proper hot-cold splitting, but that's for another PR.

<!-- gh-issue-number: gh-135904 -->
* Issue: gh-135904
<!-- /gh-issue-number -->
