### PR TITLE
[3.13] gh-135839: Fix `module_traverse` and `module_clear` in `_interpchannelsmodule` (GH-135840)

### DIFF
--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -3556,8 +3556,7 @@ module_traverse(PyObject *mod, visitproc visit, void *arg)
 {
     module_state *state = get_module_state(mod);
     assert(state != NULL);
-    traverse_module_state(state, visit, arg);
-    return 0;
+    return traverse_module_state(state, visit, arg);
 }
 
 static int
@@ -3567,8 +3566,7 @@ module_clear(PyObject *mod)
     assert(state != NULL);
 
     // Now we clear the module state.
-    clear_module_state(state);
-    return 0;
+    return clear_module_state(state);
 }
 
 static void


### PR DESCRIPTION
(cherry picked from commit dd59c786cfb1018eb5abe877bfa7265ea9a3c2b9)


<!-- gh-issue-number: gh-135839 -->
* Issue: gh-135839
<!-- /gh-issue-number -->
