### PR TITLE
gh-82575: Adjust `time.get_clock_info` *adjustable* attribute doc

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -238,8 +238,8 @@ Functions
 
    The result has the following attributes:
 
-   - *adjustable*: ``True`` if the clock can be changed automatically (e.g. by
-     a NTP daemon) or manually by the system administrator, ``False`` otherwise
+   - *adjustable*: ``True`` if the clock can be set to jump forward or backward
+     in time, ``False`` otherwise. Does not refer to gradual NTP rate adjustments.
    - *implementation*: The name of the underlying C function used to get
      the clock value.  Refer to :ref:`time-clock-id-constants` for possible values.
    - *monotonic*: ``True`` if the clock cannot go backward,


### PR DESCRIPTION
@vstinner Is this along the lines of the enhancement you were thinking about?


<!-- gh-issue-number: gh-82575 -->
* Issue: gh-82575
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135920.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->