### PR TITLE
[3.14] gh-135755: Move SPECIAL_ constants to a private header (GH-135922)

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -133,13 +133,6 @@ PyAPI_FUNC(void) PyEval_ReleaseThread(PyThreadState *tstate);
 #define FVS_MASK      0x4
 #define FVS_HAVE_SPEC 0x4
 
-/* Special methods used by LOAD_SPECIAL */
-#define SPECIAL___ENTER__   0
-#define SPECIAL___EXIT__    1
-#define SPECIAL___AENTER__  2
-#define SPECIAL___AEXIT__   3
-#define SPECIAL_MAX   3
-
 #ifndef Py_LIMITED_API
 #  define Py_CPYTHON_CEVAL_H
 #  include "cpython/ceval.h"

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -363,6 +363,13 @@ PyAPI_FUNC(_PyStackRef) _PyFloat_FromDouble_ConsumeInputs(_PyStackRef left, _PyS
 extern int _PyRunRemoteDebugger(PyThreadState *tstate);
 #endif
 
+/* Special methods used by LOAD_SPECIAL */
+#define SPECIAL___ENTER__   0
+#define SPECIAL___EXIT__    1
+#define SPECIAL___AENTER__  2
+#define SPECIAL___AEXIT__   3
+#define SPECIAL_MAX   3
+
 #ifdef __cplusplus
 }
 #endif

--- a/Modules/_opcode.c
+++ b/Modules/_opcode.c
@@ -5,7 +5,7 @@
 #include "Python.h"
 #include "compile.h"
 #include "opcode.h"
-#include "pycore_ceval.h"
+#include "pycore_ceval.h"           // SPECIAL_MAX
 #include "pycore_code.h"
 #include "pycore_compile.h"
 #include "pycore_intrinsics.h"

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -8,7 +8,7 @@
 #include "pycore_backoff.h"
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_cell.h"          // PyCell_GetRef()
-#include "pycore_ceval.h"
+#include "pycore_ceval.h"         // SPECIAL___ENTER__
 #include "pycore_code.h"
 #include "pycore_dict.h"
 #include "pycore_emscripten_signal.h"  // _Py_CHECK_EMSCRIPTEN_SIGNALS

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -28,6 +28,7 @@
 #include "pycore_pystate.h"       // _Py_GetConfig()
 #include "pycore_symtable.h"      // PySTEntryObject
 #include "pycore_unicodeobject.h" // _PyUnicode_EqualToASCIIString
+#include "pycore_ceval.h"         // SPECIAL___ENTER__
 
 #define NEED_OPCODE_METADATA
 #include "pycore_opcode_metadata.h" // _PyOpcode_opcode_metadata, _PyOpcode_num_popped/pushed


### PR DESCRIPTION
Macros without a `Py`/`_Py` prefix should not be defined in public headers.

(cherry picked from commit 1b1ae82fab0093924b8b89eb1c7eea11d7be7b18)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135755 -->
* Issue: gh-135755
<!-- /gh-issue-number -->
