### PR TITLE
gh-131591: Document Py_REMOTE_DEBUG

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -683,6 +683,13 @@ also be used to improve performance.
    not compiled. This includes both the functionality to schedule code to be executed
    and the functionality to receive code to be executed.
 
+   .. c:macro:: Py_REMOTE_DEBUG
+
+      This macro is defined by default, unless Python is configured with
+      :option:`--without-remote-debug`.
+
+      Note that even if the macro is defined, remote debugging may not be
+      available (for example, on an incompatible platform).
 
    .. versionadded:: 3.14
 


### PR DESCRIPTION
The docs for macros defined by configure are spotty. Let's start fixing that with ones that that are new in 3.14.

Should `Py_REMOTE_DEBUG` be private? I can add a `_Py` prefix instead of docs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131591 -->
* Issue: gh-131591
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135929.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->