### PR TITLE
gh-135927: Fix MSVC Clatest C builds

### DIFF
--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -73,14 +73,14 @@
 #        else
 #            define _Py_ALIGNED_DEF(N, T) alignas(N) alignas(T) T
 #        endif
+#    elif defined(_MSC_VER)
+#        define _Py_ALIGNED_DEF(N, T) __declspec(align(N)) T
 #    elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 #        define _Py_ALIGNED_DEF(N, T) alignas(N) alignas(T) T
 #    elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #        define _Py_ALIGNED_DEF(N, T)  _Alignas(N) _Alignas(T) T
 #    elif (defined(__GNUC__) || defined(__clang__))
 #        define _Py_ALIGNED_DEF(N, T) __attribute__((aligned(N))) T
-#    elif defined(_MSC_VER)
-#        define _Py_ALIGNED_DEF(N, T) __declspec(align(N)) T
 #    else
 #        define _Py_ALIGNED_DEF(N, T) _Alignas(N) _Alignas(T) T
 #    endif

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -49,7 +49,8 @@
 // Static inline functions should use _Py_NULL rather than using directly NULL
 // to prevent C++ compiler warnings. On C23 and newer and on C++11 and newer,
 // _Py_NULL is defined as nullptr.
-#if (defined (__STDC_VERSION__) && __STDC_VERSION__ > 201710L) \
+#if (defined(__GNUC__) || defined(__clang__)) && \
+    (defined (__STDC_VERSION__) && __STDC_VERSION__ > 201710L) \
         || (defined(__cplusplus) && __cplusplus >= 201103)
 #  define _Py_NULL nullptr
 #else

--- a/Misc/NEWS.d/next/Build/2025-06-25-13-27-14.gh-issue-135927.iCNPQc.rst
+++ b/Misc/NEWS.d/next/Build/2025-06-25-13-27-14.gh-issue-135927.iCNPQc.rst
@@ -1,0 +1,1 @@
+Fix building with MSVC when passing option ``/std:clatest``.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3148,7 +3148,7 @@ static PyObject *
 math_issubnormal_impl(PyObject *module, double x)
 /*[clinic end generated code: output=4e76ac98ddcae761 input=9a20aba7107d0d95]*/
 {
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#if !defined(_MSC_VER) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
     return PyBool_FromLong(issubnormal(x));
 #else
     return PyBool_FromLong(isfinite(x) && x && !isnormal(x));


### PR DESCRIPTION
The problem is that we are checking for the latest C assuming only GCC and Clang supports it, but in reality MSVC supports it (on some configurations) too.

The fix is to account for MSVC.


<!-- gh-issue-number: gh-135927 -->
* Issue: gh-135927
<!-- /gh-issue-number -->
