### PR TITLE
[3.13] gh-135839: Fix `module_traverse` and `module_clear` in subinterp modules (GH-135937)

### DIFF
--- a/Modules/_interpqueuesmodule.c
+++ b/Modules/_interpqueuesmodule.c
@@ -1937,8 +1937,7 @@ static int
 module_traverse(PyObject *mod, visitproc visit, void *arg)
 {
     module_state *state = get_module_state(mod);
-    traverse_module_state(state, visit, arg);
-    return 0;
+    return traverse_module_state(state, visit, arg);
 }
 
 static int
@@ -1947,8 +1946,7 @@ module_clear(PyObject *mod)
     module_state *state = get_module_state(mod);
 
     // Now we clear the module state.
-    clear_module_state(state);
-    return 0;
+    return clear_module_state(state);
 }
 
 static void

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -1540,8 +1540,7 @@ module_traverse(PyObject *mod, visitproc visit, void *arg)
 {
     module_state *state = get_module_state(mod);
     assert(state != NULL);
-    traverse_module_state(state, visit, arg);
-    return 0;
+    return traverse_module_state(state, visit, arg);
 }
 
 static int
@@ -1549,8 +1548,7 @@ module_clear(PyObject *mod)
 {
     module_state *state = get_module_state(mod);
     assert(state != NULL);
-    clear_module_state(state);
-    return 0;
+    return clear_module_state(state);
 }
 
 static void


### PR DESCRIPTION
(cherry picked from commit bcc2cbaa7f112323939e853ed69fd82f19568ccf)


<!-- gh-issue-number: gh-135839 -->
* Issue: gh-135839
<!-- /gh-issue-number -->
