### PR TITLE
[3.13] gh-135871: Fix needless spinning in `_PyMutex_LockTimed` with zero timeout (gh-135872)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2025-06-23-18-08-32.gh-issue-135871.50C528.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-06-23-18-08-32.gh-issue-135871.50C528.rst
@@ -1,0 +1,2 @@
+Non-blocking mutex lock attempts now return immediately when the lock is busy
+instead of briefly spinning in the :term:`free threading` build.

--- a/Python/lock.c
+++ b/Python/lock.c
@@ -58,7 +58,7 @@ _PyMutex_LockTimed(PyMutex *m, PyTime_t timeout, _PyLockFlags flags)
             return PY_LOCK_ACQUIRED;
         }
     }
-    else if (timeout == 0) {
+    if (timeout == 0) {
         return PY_LOCK_FAILURE;
     }
 


### PR DESCRIPTION
The free threading build could spin unnecessarily on `_Py_yield()` if the initial compare and swap failed.
(cherry picked from commit cbfaf41caf135b8598a560854cd59e992a2ccfed)


<!-- gh-issue-number: gh-135871 -->
* Issue: gh-135871
<!-- /gh-issue-number -->
