### PR TITLE
gh-91555: add warning to docs about possibility of deadlock/infinite recursion

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -1065,7 +1065,8 @@ possible, while any potentially slow operations (such as sending an email via
       accessed via :meth:`~multiprocessing.get_logger`.
       :class:`multiprocessing.Queue` will log ``DEBUG`` level messages upon
       items being queued. If those log messages are processed by a
-      :class:`QueueHandler` using the same :class:`multiprocessing.Queue` instance, it will cause a deadlock or infinite recursion.
+      :class:`QueueHandler` using the same :class:`multiprocessing.Queue` instance,
+      it will cause a deadlock or infinite recursion.
 
    .. method:: emit(record)
 

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -1064,8 +1064,8 @@ possible, while any potentially slow operations (such as sending an email via
       The :mod:`multiprocessing` module uses an internal logger created and
       accessed via :meth:`~multiprocessing.get_logger`.
       :class:`multiprocessing.Queue` will log ``DEBUG`` level messages upon
-      items being queued. If those log messages are processed by the same
-      :class:`QueueHandler` it will cause a deadlock or infinite recursion.
+      items being queued. If those log messages are processed by a
+      :class:`QueueHandler` using the same :class:`multiprocessing.Queue` instance, it will cause a deadlock or infinite recursion.
 
    .. method:: emit(record)
 

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -1059,6 +1059,14 @@ possible, while any potentially slow operations (such as sending an email via
    .. note:: If you are using :mod:`multiprocessing`, you should avoid using
       :class:`~queue.SimpleQueue` and instead use :class:`multiprocessing.Queue`.
 
+   .. warning::
+
+      The :mod:`multiprocessing` module uses an internal logger created and
+      accessed via :meth:`~multiprocessing.get_logger`.
+      :class:`multiprocessing.Queue` will log ``DEBUG`` level messages upon
+      items being queued. If those log messages are processed by the same
+      :class:`QueueHandler` it will cause a deadlock or infinite recursion.
+
    .. method:: emit(record)
 
       Enqueues the result of preparing the LogRecord. Should an exception


### PR DESCRIPTION
Attempt to clarify in the documentation that care must be taken when using multiprocessing classes to implement logging since they have builtin internal logging, and hence may cause deadlock/infinite recursion.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-91555 -->
* Issue: gh-91555
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135954.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->