### PR TITLE
Docs: Fix duplicate word typos

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1250,7 +1250,7 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
 .. c:function:: void PyInterpreterState_Clear(PyInterpreterState *interp)
 
    Reset all information in an interpreter state object.  There must be
-   an :term:`attached thread state` for the the interpreter.
+   an :term:`attached thread state` for the interpreter.
 
    .. audit-event:: cpython.PyInterpreterState_Clear "" c.PyInterpreterState_Clear
 

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -439,7 +439,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    All *n_bytes* of the buffer are written: large buffers are padded with
    zeroes.
 
-   If the returned value is greater than than *n_bytes*, the value was
+   If the returned value is greater than *n_bytes*, the value was
    truncated: as many of the lowest bits of the value as could fit are written,
    and the higher bits are ignored. This matches the typical behavior
    of a C-style downcast.

--- a/Doc/extending/newtypes_tutorial.rst
+++ b/Doc/extending/newtypes_tutorial.rst
@@ -277,7 +277,7 @@ be an instance of a subclass.
    The explicit cast to ``CustomObject *`` above is needed because we defined
    ``Custom_dealloc`` to take a ``PyObject *`` argument, as the ``tp_dealloc``
    function pointer expects to receive a ``PyObject *`` argument.
-   By assigning to the the ``tp_dealloc`` slot of a type, we declare
+   By assigning to the ``tp_dealloc`` slot of a type, we declare
    that it can only be called with instances of our ``CustomObject``
    class, so the cast to ``(CustomObject *)`` is safe.
    This is object-oriented polymorphism, in C!

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -2965,7 +2965,7 @@ fields, or any other data types containing pointer type fields.
    .. attribute:: is_anonymous
 
       True if this field is anonymous, that is, it contains nested sub-fields
-      that should be be merged into a containing structure or union.
+      that should be merged into a containing structure or union.
 
 
 .. _ctypes-arrays-pointers:

--- a/Doc/library/email.header.rst
+++ b/Doc/library/email.header.rst
@@ -206,7 +206,7 @@ The :mod:`email.header` module also provides the following convenient functions.
 
    .. note::
 
-       This function exists for for backwards compatibility only. For
+       This function exists for backwards compatibility only. For
        new code, we recommend using :class:`email.headerregistry.HeaderRegistry`.
 
 
@@ -225,5 +225,5 @@ The :mod:`email.header` module also provides the following convenient functions.
 
    .. note::
 
-       This function exists for for backwards compatibility only, and is
+       This function exists for backwards compatibility only, and is
        not recommended for use in new code.

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -1048,7 +1048,7 @@ their subgroups based on the types of the contained exceptions.
    subclasses that need a different constructor signature need to
    override that rather than :meth:`~object.__init__`. For example, the following
    defines an exception group subclass which accepts an exit_code and
-   and constructs the group's message from it. ::
+   constructs the group's message from it. ::
 
       class Errors(ExceptionGroup):
          def __new__(cls, errors, exit_code):

--- a/Doc/library/faulthandler.rst
+++ b/Doc/library/faulthandler.rst
@@ -90,7 +90,7 @@ An error will be printed instead of the stack.
 
 Additionally, some compilers do not support :term:`CPython's <CPython>`
 implementation of C stack dumps. As a result, a different error may be printed
-instead of the stack, even if the the operating system supports dumping stacks.
+instead of the stack, even if the operating system supports dumping stacks.
 
 .. note::
 

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -269,7 +269,7 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
 
       Resizing a map created with *access* of :const:`ACCESS_READ` or
       :const:`ACCESS_COPY`, will raise a :exc:`TypeError` exception.
-      Resizing a map created with with *trackfd* set to ``False``,
+      Resizing a map created with *trackfd* set to ``False``,
       will raise a :exc:`ValueError` exception.
 
       **On Windows**: Resizing the map will raise an :exc:`OSError` if there are other

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1985,7 +1985,7 @@ The :mod:`pathlib.types` module provides types for static type checking.
 
       If *follow_symlinks* is ``False``, return ``True`` only if the path
       is a file (without following symlinks); return ``False`` if the path
-      is a directory or other other non-file, or if it doesn't exist.
+      is a directory or other non-file, or if it doesn't exist.
 
    .. method:: is_symlink()
 

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -543,7 +543,7 @@ objects that simplify communication by providing the standard file interface)::
 
 The difference is that the ``readline()`` call in the second handler will call
 ``recv()`` multiple times until it encounters a newline character, while the
-the first handler had to use a ``recv()`` loop to accumulate data until a
+first handler had to use a ``recv()`` loop to accumulate data until a
 newline itself.  If it had just used a single ``recv()`` without the loop it
 would just have returned what has been received so far from the client.
 TCP is stream based: data arrives in the order it was sent, but there no

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -621,7 +621,7 @@ since it is impossible to detect the termination of alien threads.
       an error to :meth:`~Thread.join` a thread before it has been started
       and attempts to do so raise the same exception.
 
-      If an attempt is made to join a running daemonic thread in in late stages
+      If an attempt is made to join a running daemonic thread in late stages
       of :term:`Python finalization <interpreter shutdown>` :meth:`!join`
       raises a :exc:`PythonFinalizationError`.
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -653,7 +653,7 @@ Miscellaneous options
      .. versionadded:: 3.13
 
    * :samp:`-X thread_inherit_context={0,1}` causes :class:`~threading.Thread`
-     to, by default, use a copy of context of of the caller of
+     to, by default, use a copy of context of the caller of
      ``Thread.start()`` when starting.  Otherwise, threads will start
      with an empty context.  If unset, the value of this option defaults
      to ``1`` on free-threaded builds and to ``0`` otherwise.  See also
@@ -1284,7 +1284,7 @@ conflict.
 .. envvar:: PYTHON_THREAD_INHERIT_CONTEXT
 
    If this variable is set to ``1`` then :class:`~threading.Thread` will,
-   by default, use a copy of context of of the caller of ``Thread.start()``
+   by default, use a copy of context of the caller of ``Thread.start()``
    when starting.  Otherwise, new threads will start with an empty context.
    If unset, this variable defaults to ``1`` on free-threaded builds and to
    ``0`` otherwise.  See also :option:`-X thread_inherit_context<-X>`.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1996,7 +1996,7 @@ New Deprecations
     (Contributed by Alex Waygood in :gh:`105566` and :gh:`105570`.)
 
   * Deprecate the :func:`typing.no_type_check_decorator` decorator function,
-    to be removed in in Python 3.15.
+    to be removed in Python 3.15.
     After eight years in the :mod:`typing` module,
     it has yet to be supported by any major type checker.
     (Contributed by Alex Waygood in :gh:`106309`.)


### PR DESCRIPTION
"and and", "the the", etc.

Found via regex search for the patterns `\b(\w+)\b +\1\b` and `\b(\w+)\b *\n *\1\b`.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135958.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->