### PR TITLE
gh-135966: Modify iOS testbed to make app_packages a site directory

### DIFF
--- a/Doc/using/ios.rst
+++ b/Doc/using/ios.rst
@@ -298,9 +298,9 @@ To add Python to an iOS Xcode project:
    * Signal handlers (:c:member:`PyConfig.install_signal_handlers`) are *enabled*;
    * System logging (:c:member:`PyConfig.use_system_logger`) is *enabled*
      (optional, but strongly recommended; this is enabled by default);
-   * ``PYTHONHOME`` for the interpreter is configured to point at the
+   * :envvar:`PYTHONHOME` for the interpreter is configured to point at the
      ``python`` subfolder of your app's bundle; and
-   * The ``PYTHONPATH`` for the interpreter includes:
+   * The :envvar:`PYTHONPATH` for the interpreter includes:
 
      - the ``python/lib/python3.X`` subfolder of your app's bundle,
      - the ``python/lib/python3.X/lib-dynload`` subfolder of your app's bundle, and
@@ -324,7 +324,12 @@ modules in your app, some additional steps will be required:
   the ``lib-dynload`` folder can be copied and adapted for this purpose.
 
 * If you're using a separate folder for third-party packages, ensure that folder
-  is included as part of the ``PYTHONPATH`` configuration in step 10.
+  is included as part of the :envvar:`PYTHONPATH` configuration in step 10.
+
+* If any of the folders that contain third-party packages will contain ``.pth``
+  files, you should add that folder as a *site directory* (using
+  :meth:`site.addsitedir`), rather than adding to :envvar:`PYTHONPATH` or
+  :attr:`sys.path` directly.
 
 Testing a Python package
 ------------------------

--- a/Misc/NEWS.d/next/Tests/2025-06-26-15-15-35.gh-issue-135966.EBpF8Y.rst
+++ b/Misc/NEWS.d/next/Tests/2025-06-26-15-15-35.gh-issue-135966.EBpF8Y.rst
@@ -1,0 +1,1 @@
+The iOS testbed now handles the ``app_packages`` folder as a site directory.


### PR DESCRIPTION
Modifies the startup of the iOS testbed so that the `app_packages` folder is treated as a site directory.

This ensures that ``.pth`` files that are installed by packaged (such as the setuptools "distutils_hack") will not be processed.

This surfaced during testing of an iOS patch for Pillow, which uses pyroma; pyroma depends on distutils; but because the .pth file installed by setuptools isn't processed, distutils can't be imported, and so neither can pyroma.

Also documents this as a likely integration requirement for anyone embedding CPython on iOS.

<!-- gh-issue-number: gh-135966 -->
* Issue: gh-135966
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135967.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->