### PR TITLE
gh-135968: Add iOS binary stubs for strip

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2025-06-26-15-58-13.gh-issue-135968.C4v_-W.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-06-26-15-58-13.gh-issue-135968.C4v_-W.rst
@@ -1,0 +1,1 @@
+Stubs for ``strip`` are now provided as part of an iOS install.

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-strip
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-strip
@@ -1,0 +1,2 @@
+#!/bin/sh
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} strip -arch arm64 "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-strip
+++ b/iOS/Resources/bin/arm64-apple-ios-strip
@@ -1,0 +1,2 @@
+#!/bin/sh
+xcrun --sdk iphoneos${IOS_SDK_VERSION} strip -arch arm64 "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-strip
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-strip
@@ -1,0 +1,2 @@
+#!/bin/sh
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} strip -arch x86_64 "$@"


### PR DESCRIPTION
Adds iOS binary stubs for strip.

This is something that came up in the development of a port of `numpy`; Meson looks for `strip` by default, and raises a warning if it can't be found. It's easy enough to provide the stub to avoid the warning.

<!-- gh-issue-number: gh-135968 -->
* Issue: gh-135968
<!-- /gh-issue-number -->
