### PR TITLE
gh-135862: fix asyncio socket partial writes of non-1d-binary arrays

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -1077,7 +1077,11 @@ class _SelectorSocketTransport(_SelectorTransport):
                 self._fatal_error(exc, 'Fatal write error on socket transport')
                 return
             else:
-                data = memoryview(data)[n:]
+                if isinstance(data, memoryview):
+                    data = data.cast('c')[n:]
+                else:
+                    data = memoryview(data)[n:]
+                assert(data.itemsize == 1)
                 if not data:
                     return
             # Not all was written; register write handler.

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -780,7 +780,7 @@ class SelectorSocketTransportTests(test_utils.TestCase):
         arr = array.array('l', [-1, 1])
         data = memoryview(arr)
 
-        self.sock.send.return_value = len(data) * data.itemsize // 2
+        self.sock.send.return_value = len(arr) * data.itemsize // 2
 
         transport = self.socket_transport()
         transport.write(data)
@@ -795,7 +795,7 @@ class SelectorSocketTransportTests(test_utils.TestCase):
         arr = ndarray(items, format='l', shape=(1, 2, 2))
         data = memoryview(arr)
 
-        self.sock.send.return_value = len(data) * data.itemsize // 2
+        self.sock.send.return_value = arr.nbytes // 2
 
         transport = self.socket_transport()
         transport.write(data)

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -780,7 +780,7 @@ class SelectorSocketTransportTests(test_utils.TestCase):
         arr = array.array('l', [-1, 1])
         data = memoryview(arr)
 
-        self.sock.send.return_value = 8
+        self.sock.send.return_value = len(data) * data.itemsize // 2
 
         transport = self.socket_transport()
         transport.write(data)
@@ -795,7 +795,7 @@ class SelectorSocketTransportTests(test_utils.TestCase):
         arr = ndarray(items, format='l', shape=(1, 2, 2))
         data = memoryview(arr)
 
-        self.sock.send.return_value = 16
+        self.sock.send.return_value = len(data) * data.itemsize // 2
 
         transport = self.socket_transport()
         transport.write(data)

--- a/Misc/NEWS.d/next/Library/2025-06-26-22-12-13.gh-issue-135862.wYKSKx.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-26-22-12-13.gh-issue-135862.wYKSKx.rst
@@ -1,0 +1,2 @@
+Fix bug where partial writes of :class:`memoryview` s of non-byte or 2+
+dimensional arrays would write remaining binary data incorrectly.


### PR DESCRIPTION
The `asyncio` code is writing binary data to a `socket.socket`, and advancing through the buffer after a partial write by doing `memoryview(data)[n:]`, where `n` is the number of bytes written.

This assumes the `memoryview` is a one dimensional buffer of bytes, which is not the case e.g. for a `memoryview` of an `array.array` of non-bytes, or an `ndarray` with more than one dimension. Partial writes of such `memoryview`s will corrupt the stream, repeating or omitting some data.

When creating a `memoryview` from a `memoryview`, first convert it to a one-dimensional array of bytes before taking the remaining slice, thus avoiding these issues.

Add an assertion that the remaining data is bytes, to guard against possible regressions if additional types of data are allowed in the future.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135862 -->
* Issue: gh-135862
<!-- /gh-issue-number -->
