### PR TITLE
gh-135755: Document __future__.* and CO_* as proper Sphinx objects

### DIFF
--- a/Doc/c-api/code.rst
+++ b/Doc/c-api/code.rst
@@ -211,6 +211,71 @@ bound into a function.
    .. versionadded:: 3.12
 
 
+.. _c_codeobject_flags:
+
+Code Object Flags
+-----------------
+
+Code objects contain a bit-field of flags, which can be retrieved as the
+:attr:`~codeobject.co_flags` Python attribute (for example using
+:c:func:`PyObject_GetAttrString`), and set using a *flags* argument to
+:c:func:`PyUnstable_Code_New` and similar functions.
+
+Flags whose names start with ``CO_FUTURE_`` correspond to features normally
+selectable by :ref:`future statements <future>`. These flags can be used in
+:c:member:`PyCompilerFlags.cf_flags`.
+Note that many ``CO_FUTURE_`` flags are mandatory in current versions of
+Python, and setting them has no effect.
+
+The following flags are available.
+For their meaning, see the linked documentation of their Python equivalents.
+
+
+.. list-table::
+   :widths: auto
+   :header-rows: 1
+
+   * * Flag
+     * Meaning
+   * * .. c:macro:: CO_OPTIMIZED
+     * :py:data:`inspect.CO_OPTIMIZED`
+   * * .. c:macro:: CO_NEWLOCALS
+     * :py:data:`inspect.CO_NEWLOCALS`
+   * * .. c:macro:: CO_VARARGS
+     * :py:data:`inspect.CO_VARARGS`
+   * * .. c:macro:: CO_VARKEYWORDS
+     * :py:data:`inspect.CO_VARKEYWORDS`
+   * * .. c:macro:: CO_NESTED
+     * :py:data:`inspect.CO_NESTED`
+   * * .. c:macro:: CO_GENERATOR
+     * :py:data:`inspect.CO_GENERATOR`
+   * * .. c:macro:: CO_COROUTINE
+     * :py:data:`inspect.CO_COROUTINE`
+   * * .. c:macro:: CO_ITERABLE_COROUTINE
+     * :py:data:`inspect.CO_ITERABLE_COROUTINE`
+   * * .. c:macro:: CO_ASYNC_GENERATOR
+     * :py:data:`inspect.CO_ASYNC_GENERATOR`
+   * * .. c:macro:: CO_HAS_DOCSTRING
+     * :py:data:`inspect.CO_HAS_DOCSTRING`
+   * * .. c:macro:: CO_METHOD
+     * :py:data:`inspect.CO_METHOD`
+
+   * * .. c:macro:: CO_FUTURE_DIVISION
+     * no effect (:py:data:`__future__.division`)
+   * * .. c:macro:: CO_FUTURE_ABSOLUTE_IMPORT
+     * no effect (:py:data:`__future__.absolute_import`)
+   * * .. c:macro:: CO_FUTURE_WITH_STATEMENT
+     * no effect (:py:data:`__future__.with_statement`)
+   * * .. c:macro:: CO_FUTURE_PRINT_FUNCTION
+     * no effect (:py:data:`__future__.print_function`)
+   * * .. c:macro:: CO_FUTURE_UNICODE_LITERALS
+     * no effect (:py:data:`__future__.unicode_literals`)
+   * * .. c:macro:: CO_FUTURE_GENERATOR_STOP
+     * no effect (:py:data:`__future__.generator_stop`)
+   * * .. c:macro:: CO_FUTURE_ANNOTATIONS
+     * :py:data:`__future__.annotations`
+
+
 Extra information
 -----------------
 

--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -361,7 +361,7 @@ the same library that the Python runtime is using.
       :py:mod:`!ast` Python module, which exports these constants under
       the same names.
 
-   The "``Py_CF``" flags above can be combined with "``CO_FUTURE``" flags such
+   The "``PyCF``" flags above can be combined with "``CO_FUTURE``" flags such
    as :c:macro:`CO_FUTURE_ANNOTATIONS` to enable features normally
    selectable using :ref:`future statements <future>`.
    See :ref:`c_codeobject_flags` for a complete list.

--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -361,7 +361,7 @@ the same library that the Python runtime is using.
       :py:mod:`!ast` Python module, which exports these constants under
       the same names.
 
-   .. c:var:: int CO_FUTURE_DIVISION
-
-      This bit can be set in *flags* to cause division operator ``/`` to be
-      interpreted as "true division" according to :pep:`238`.
+   The "``Py_CF``" flags above can be combined with "``CO_FUTURE``" flags such
+   as :c:macro:`CO_FUTURE_ANNOTATIONS` to enable features normally
+   selectable using :ref:`future statements <future>`.
+   See :ref:`c_codeobject_flags` for a complete list.

--- a/Doc/library/__future__.rst
+++ b/Doc/library/__future__.rst
@@ -46,39 +46,39 @@ language using this mechanism:
      * optional in
      * mandatory in
      * effect
-   * * nested_scopes
+   * * .. data:: nested_scopes
      * 2.1.0b1
      * 2.2
      * :pep:`227`: *Statically Nested Scopes*
-   * * generators
+   * * .. data:: generators
      * 2.2.0a1
      * 2.3
      * :pep:`255`: *Simple Generators*
-   * * division
+   * * .. data:: division
      * 2.2.0a2
      * 3.0
      * :pep:`238`: *Changing the Division Operator*
-   * * absolute_import
+   * * .. data:: absolute_import
      * 2.5.0a1
      * 3.0
      * :pep:`328`: *Imports: Multi-Line and Absolute/Relative*
-   * * with_statement
+   * * .. data:: with_statement
      * 2.5.0a1
      * 2.6
      * :pep:`343`: *The “with” Statement*
-   * * print_function
+   * * .. data:: print_function
      * 2.6.0a2
      * 3.0
      * :pep:`3105`: *Make print a function*
-   * * unicode_literals
+   * * .. data:: unicode_literals
      * 2.6.0a2
      * 3.0
      * :pep:`3112`: *Bytes literals in Python 3000*
-   * * generator_stop
+   * * .. data:: generator_stop
      * 3.5.0b1
      * 3.7
      * :pep:`479`: *StopIteration handling inside generators*
-   * * annotations
+   * * .. data:: annotations
      * 3.7.0b1
      * Never [1]_
      * :pep:`563`: *Postponed evaluation of annotations*,

--- a/Doc/library/__future__.rst
+++ b/Doc/library/__future__.rst
@@ -37,38 +37,52 @@ No feature description will ever be deleted from :mod:`__future__`. Since its
 introduction in Python 2.1 the following features have found their way into the
 language using this mechanism:
 
-+------------------+-------------+--------------+---------------------------------------------+
-| feature          | optional in | mandatory in | effect                                      |
-+==================+=============+==============+=============================================+
-| nested_scopes    | 2.1.0b1     | 2.2          | :pep:`227`:                                 |
-|                  |             |              | *Statically Nested Scopes*                  |
-+------------------+-------------+--------------+---------------------------------------------+
-| generators       | 2.2.0a1     | 2.3          | :pep:`255`:                                 |
-|                  |             |              | *Simple Generators*                         |
-+------------------+-------------+--------------+---------------------------------------------+
-| division         | 2.2.0a2     | 3.0          | :pep:`238`:                                 |
-|                  |             |              | *Changing the Division Operator*            |
-+------------------+-------------+--------------+---------------------------------------------+
-| absolute_import  | 2.5.0a1     | 3.0          | :pep:`328`:                                 |
-|                  |             |              | *Imports: Multi-Line and Absolute/Relative* |
-+------------------+-------------+--------------+---------------------------------------------+
-| with_statement   | 2.5.0a1     | 2.6          | :pep:`343`:                                 |
-|                  |             |              | *The "with" Statement*                      |
-+------------------+-------------+--------------+---------------------------------------------+
-| print_function   | 2.6.0a2     | 3.0          | :pep:`3105`:                                |
-|                  |             |              | *Make print a function*                     |
-+------------------+-------------+--------------+---------------------------------------------+
-| unicode_literals | 2.6.0a2     | 3.0          | :pep:`3112`:                                |
-|                  |             |              | *Bytes literals in Python 3000*             |
-+------------------+-------------+--------------+---------------------------------------------+
-| generator_stop   | 3.5.0b1     | 3.7          | :pep:`479`:                                 |
-|                  |             |              | *StopIteration handling inside generators*  |
-+------------------+-------------+--------------+---------------------------------------------+
-| annotations      | 3.7.0b1     | Never [1]_   | :pep:`563`:                                 |
-|                  |             |              | *Postponed evaluation of annotations*,      |
-|                  |             |              | :pep:`649`: *Deferred evaluation of         |
-|                  |             |              | annotations using descriptors*              |
-+------------------+-------------+--------------+---------------------------------------------+
+
+.. list-table::
+   :widths: auto
+   :header-rows: 1
+
+   * * feature
+     * optional in
+     * mandatory in
+     * effect
+   * * nested_scopes
+     * 2.1.0b1
+     * 2.2
+     * :pep:`227`: *Statically Nested Scopes*
+   * * generators
+     * 2.2.0a1
+     * 2.3
+     * :pep:`255`: *Simple Generators*
+   * * division
+     * 2.2.0a2
+     * 3.0
+     * :pep:`238`: *Changing the Division Operator*
+   * * absolute_import
+     * 2.5.0a1
+     * 3.0
+     * :pep:`328`: *Imports: Multi-Line and Absolute/Relative*
+   * * with_statement
+     * 2.5.0a1
+     * 2.6
+     * :pep:`343`: *The “with” Statement*
+   * * print_function
+     * 2.6.0a2
+     * 3.0
+     * :pep:`3105`: *Make print a function*
+   * * unicode_literals
+     * 2.6.0a2
+     * 3.0
+     * :pep:`3112`: *Bytes literals in Python 3000*
+   * * generator_stop
+     * 3.5.0b1
+     * 3.7
+     * :pep:`479`: *StopIteration handling inside generators*
+   * * annotations
+     * 3.7.0b1
+     * Never [1]_
+     * :pep:`563`: *Postponed evaluation of annotations*,
+       :pep:`649`: *Deferred evaluation of annotations using descriptors*
 
 .. XXX Adding a new entry?  Remember to update simple_stmts.rst, too.
 


### PR DESCRIPTION
`__future__` feature descriptions and `CO_` C macros were documented in prose, but lacked Sphinx markup that marked them as Python attributes and C macros. For example:

- Searching for “[nested scopes](https://docs.python.org/3/search.html?q=nested_scopes)” yields full-text results only
- Searching for “[CO_GENERATOR](https://docs.python.org/3/search.html?q=CO_GENERATOR)” yields “`inspect.CO_GENERATOR` (Python data, in inspect — Inspect live objects)”, but no C API.

This affects users of the Intersphinx inventory as well.

This patch adds the Sphinx definintions, and puts them in `list-table`s to make the ReST more maintainabile.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135755 -->
* Issue: gh-135755
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135980.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->