### PR TITLE
gh-135995: Fix missing char in palmos encoding

### DIFF
--- a/Lib/encodings/palmos.py
+++ b/Lib/encodings/palmos.py
@@ -201,7 +201,7 @@ decoding_table = (
     '\u02dc'   #  0x98 -> SMALL TILDE
     '\u2122'   #  0x99 -> TRADE MARK SIGN
     '\u0161'   #  0x9A -> LATIN SMALL LETTER S WITH CARON
-    '\x9b'     #  0x9B -> <control>
+    '\u203a'   #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
     '\u0153'   #  0x9C -> LATIN SMALL LIGATURE OE
     '\x9d'     #  0x9D -> <control>
     '\x9e'     #  0x9E -> <control>

--- a/Misc/NEWS.d/next/Library/2025-06-26-17-28-49.gh-issue-135995.pPrDCt.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-26-17-28-49.gh-issue-135995.pPrDCt.rst
@@ -1,2 +1,1 @@
-:mod:`codecs`: The byte ``0x9b`` now correctly decodes to ``›`` (U+203A - SINGLE
-RIGHT-POINTING ANGLE QUOTATION MARK) when using the palmos encoding.
+In the palmos encoding, make byte ``0x9b`` decode to ``›`` (U+203A - SINGLE RIGHT-POINTING ANGLE QUOTATION MARK).

--- a/Misc/NEWS.d/next/Library/2025-06-26-17-28-49.gh-issue-135995.pPrDCt.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-26-17-28-49.gh-issue-135995.pPrDCt.rst
@@ -1,0 +1,1 @@
+Fix missing `›` char in palmos encoding.

--- a/Misc/NEWS.d/next/Library/2025-06-26-17-28-49.gh-issue-135995.pPrDCt.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-26-17-28-49.gh-issue-135995.pPrDCt.rst
@@ -1,1 +1,2 @@
-Fix missing ``›`` char in palmos encoding.
+:mod:`codecs`: The byte `0x9b` now correctly decodes to `›` (U+203A - SINGLE
+RIGHT-POINTING ANGLE QUOTATION MARK) when using the palmos encoding.

--- a/Misc/NEWS.d/next/Library/2025-06-26-17-28-49.gh-issue-135995.pPrDCt.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-26-17-28-49.gh-issue-135995.pPrDCt.rst
@@ -1,2 +1,2 @@
-:mod:`codecs`: The byte `0x9b` now correctly decodes to `›` (U+203A - SINGLE
+:mod:`codecs`: The byte ``0x9b`` now correctly decodes to ``›`` (U+203A - SINGLE
 RIGHT-POINTING ANGLE QUOTATION MARK) when using the palmos encoding.

--- a/Misc/NEWS.d/next/Library/2025-06-26-17-28-49.gh-issue-135995.pPrDCt.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-26-17-28-49.gh-issue-135995.pPrDCt.rst
@@ -1,1 +1,1 @@
-Fix missing `›` char in palmos encoding.
+Fix missing ``›`` char in palmos encoding.


### PR DESCRIPTION
0x8b correctly encodes to ‹, but 0x9b was mistakenly marked as a control character instead of ›. You can see the correct glyphs in this screenshot of Palm OS 3.5, or on [this page](https://web.archive.org/web/20250429234603/https://www.sealiesoftware.com/palmfonts/):

![cloudpilot-emu github io_app_ (8)](https://github.com/user-attachments/assets/725e7dcc-441b-4448-8a40-9c6669f1c065)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

-->


<!-- gh-issue-number: gh-135995 -->
* Issue: gh-135995
<!-- /gh-issue-number -->
