### PR TITLE
gh-48181: Document `codecs.charmap_build`

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -57,8 +57,8 @@ any codec:
 
    Return a mapping suitable for decoding a custom single-byte encoding.
    Given a :class:`str` *string* of up to 256 characters representing an
-   encoding table, returns either a compact internal mapping object or a
-   dictionary mapping character ordinals to byte values.
+   encoding table, returns either a compact internal mapping object
+   ``EncodingMap`` or a :class:`dictionary <dict>` mapping character ordinals to byte values.
    Raises a :exc:`TypeError` on invalid input.
 
 The full details for each codec can also be looked up directly:

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -53,6 +53,14 @@ any codec:
    :exc:`UnicodeDecodeError`). Refer to :ref:`codec-base-classes` for more
    information on codec error handling.
 
+.. function:: charmap_build(string)
+
+   Return a mapping suitable for decoding a custom single-byte encoding.
+   Given a string *string* of up to 256 characters representing an encoding
+   table, returns either a compact internal mapping object or a dictionary
+   mapping character ordinals to byte values. Raises a :exc:`TypeError`
+   on invalid input.
+
 The full details for each codec can also be looked up directly:
 
 .. function:: lookup(encoding, /)

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -58,8 +58,8 @@ any codec:
    Return a mapping suitable for decoding a custom single-byte encoding.
    Given a :class:`str` *string* of up to 256 characters representing an
    encoding table, returns either a compact internal mapping object
-   ``EncodingMap`` or a :class:`dictionary <dict>` mapping character ordinals to byte values.
-   Raises a :exc:`TypeError` on invalid input.
+   ``EncodingMap`` or a :class:`dictionary <dict>` mapping character ordinals
+   to byte values. Raises a :exc:`TypeError` on invalid input.
 
 The full details for each codec can also be looked up directly:
 

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -55,9 +55,9 @@ any codec:
 
 .. function:: charmap_build(string)
 
-   Return a mapping suitable for decoding a custom single-byte encoding.
-   Given a :class:`str` *string* of up to 256 characters representing an
-   encoding table, returns either a compact internal mapping object
+   Return a mapping suitable for encoding with a custom single-byte encoding.
+   Given a :class:`str` *string* of up to 256 characters representing a
+   decoding table, returns either a compact internal mapping object
    ``EncodingMap`` or a :class:`dictionary <dict>` mapping character ordinals
    to byte values. Raises a :exc:`TypeError` on invalid input.
 

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -57,9 +57,8 @@ any codec:
 
    Return a mapping suitable for decoding a custom single-byte encoding.
    Given a string *string* of up to 256 characters representing an encoding
-   table, returns either a compact internal mapping object or a dictionary
-   mapping character ordinals to byte values. Raises a :exc:`TypeError`
-   on invalid input.
+   table, returns a dictionary mapping character ordinals to byte values.
+   Raises a :exc:`TypeError` on invalid input.
 
 The full details for each codec can also be looked up directly:
 

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -56,8 +56,9 @@ any codec:
 .. function:: charmap_build(string)
 
    Return a mapping suitable for decoding a custom single-byte encoding.
-   Given a string *string* of up to 256 characters representing an encoding
-   table, returns a dictionary mapping character ordinals to byte values.
+   Given a :class:`str` *string* of up to 256 characters representing an
+   encoding table, returns either a compact internal mapping object or a
+   dictionary mapping character ordinals to byte values.
    Raises a :exc:`TypeError` on invalid input.
 
 The full details for each codec can also be looked up directly:


### PR DESCRIPTION
That is one old issue:-)

I used my docs from when I [documented the underlying C API](https://docs.python.org/dev/c-api/unicode.html#c.PyUnicode_BuildEncodingMap).

Per @malemburg 's comment, this does not need more testing, since the C API is already well tested. This raises the question, should we note what this function is in the documentation (i.e. link to to C API it exports)? I am also not sure about the best place to put it, I am happy to move it.


<!-- gh-issue-number: gh-48181 -->
* Issue: gh-48181
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135997.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->