### PR TITLE
[3.13] Docs: Fix duplicate word typos (GH-135958)

### DIFF
--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -382,7 +382,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    All *n_bytes* of the buffer are written: large buffers are padded with
    zeroes.
 
-   If the returned value is greater than than *n_bytes*, the value was
+   If the returned value is greater than *n_bytes*, the value was
    truncated: as many of the lowest bits of the value as could fit are written,
    and the higher bits are ignored. This matches the typical behavior
    of a C-style downcast.

--- a/Doc/library/email.header.rst
+++ b/Doc/library/email.header.rst
@@ -206,7 +206,7 @@ The :mod:`email.header` module also provides the following convenient functions.
 
    .. note::
 
-       This function exists for for backwards compatibility only. For
+       This function exists for backwards compatibility only. For
        new code, we recommend using :class:`email.headerregistry.HeaderRegistry`.
 
 
@@ -225,5 +225,5 @@ The :mod:`email.header` module also provides the following convenient functions.
 
    .. note::
 
-       This function exists for for backwards compatibility only, and is
+       This function exists for backwards compatibility only, and is
        not recommended for use in new code.

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -1038,7 +1038,7 @@ their subgroups based on the types of the contained exceptions.
    subclasses that need a different constructor signature need to
    override that rather than :meth:`~object.__init__`. For example, the following
    defines an exception group subclass which accepts an exit_code and
-   and constructs the group's message from it. ::
+   constructs the group's message from it. ::
 
       class Errors(ExceptionGroup):
          def __new__(cls, errors, exit_code):

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -269,7 +269,7 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
 
       Resizing a map created with *access* of :const:`ACCESS_READ` or
       :const:`ACCESS_COPY`, will raise a :exc:`TypeError` exception.
-      Resizing a map created with with *trackfd* set to ``False``,
+      Resizing a map created with *trackfd* set to ``False``,
       will raise a :exc:`ValueError` exception.
 
       **On Windows**: Resizing the map will raise an :exc:`OSError` if there are other

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -535,7 +535,7 @@ objects that simplify communication by providing the standard file interface)::
 
 The difference is that the ``readline()`` call in the second handler will call
 ``recv()`` multiple times until it encounters a newline character, while the
-the first handler had to use a ``recv()`` loop to accumulate data until a
+first handler had to use a ``recv()`` loop to accumulate data until a
 newline itself.  If it had just used a single ``recv()`` without the loop it
 would just have returned what has been received so far from the client.
 TCP is stream based: data arrives in the order it was sent, but there no

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2005,7 +2005,7 @@ New Deprecations
     (Contributed by Alex Waygood in :gh:`105566` and :gh:`105570`.)
 
   * Deprecate the :func:`typing.no_type_check_decorator` decorator function,
-    to be removed in in Python 3.15.
+    to be removed in Python 3.15.
     After eight years in the :mod:`typing` module,
     it has yet to be supported by any major type checker.
     (Contributed by Alex Waygood in :gh:`106309`.)


### PR DESCRIPTION
(cherry picked from commit 34ce1920ca33c11ca2c379ed0ef30a91010bef4f)



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136008.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->