### PR TITLE
gh-108765: fix comment about macro definitions in `_stat.c` post GH-108854

### DIFF
--- a/Modules/_stat.c
+++ b/Modules/_stat.c
@@ -57,7 +57,7 @@ typedef unsigned short mode_t;
  * Only the names are defined by POSIX but not their value. All common file
  * types seems to have the same numeric value on all platforms, though.
  *
- * pyport.h guarantees S_IFMT, S_IFDIR, S_IFCHR, S_IFREG and S_IFLNK
+ * fileutils.h guarantees S_IFMT, S_IFDIR, S_IFCHR, S_IFREG and S_IFLNK
  */
 
 #ifndef S_IFBLK
@@ -86,7 +86,7 @@ typedef unsigned short mode_t;
 
 
 /* S_ISXXX()
- * pyport.h defines S_ISDIR(), S_ISREG() and S_ISCHR()
+ * fileutils.h defines S_ISDIR(), S_ISREG() and S_ISCHR()
  */
 
 #ifndef S_ISBLK


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This pull request only fixes a typo in the `_stat.c` file.

Since https://github.com/python/cpython/pull/108854, the definitions of `S_ISDIR()`, `S_ISREG()` and `S_ISCHR()`, as well as the part that includes `sys/stat.h`, have moved from `Include/pyport.h` to `Include/fileutils.h`. However the comment in `Modules/_stat.c` still refers to `Include/pyport.h` so this pull request fixes it.

---

As note, I didn't create and add an issue number because I think it is a trivial change. In the same context, I didn't think it was necessary to add NEWS as well.

<!-- gh-issue-number: gh-108765 -->
* Issue: gh-108765
<!-- /gh-issue-number -->
