### PR TITLE
gh-132732: Treat `bytes` as constants in `_Py_uop_sym_is_safe_const`

### DIFF
--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -209,6 +209,7 @@ _Py_uop_sym_is_safe_const(JitOptContext *ctx, JitOptRef sym)
     PyTypeObject *typ = Py_TYPE(const_val);
     return (typ == &PyLong_Type) ||
            (typ == &PyUnicode_Type) ||
+           (typ == &PyBytes_Type) ||
            (typ == &PyFloat_Type) ||
            (typ == &PyTuple_Type) ||
            (typ == &PyBool_Type);


### PR DESCRIPTION

```python
b'a' + b'b'  # is a constant evaluation
```

<!-- gh-issue-number: gh-132732 -->
* Issue: gh-132732
<!-- /gh-issue-number -->
