### PR TITLE
gh-132908: check the return type of isnormal() and issubnormal()

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1974,6 +1974,11 @@ class MathTests(unittest.TestCase):
         self.assertFalse(math.isfinite(float("-inf")))
 
     def testIsnormal(self):
+        # C11, §7.12.3.5 requires isnormal() to return
+        # a nonzero value if and only its argument has
+        # a normal value.
+        self.assertIsInstance(math.isnormal(1.0), bool)
+
         self.assertTrue(math.isnormal(1.25))
         self.assertTrue(math.isnormal(-1.0))
         self.assertFalse(math.isnormal(0.0))
@@ -1985,6 +1990,11 @@ class MathTests(unittest.TestCase):
         self.assertFalse(math.isnormal(-FLOAT_MIN/2))
 
     def testIssubnormal(self):
+        # issubnormal() is a C extension (ISO/IEC TS 18661-1:2014)
+        # and part of the C23 standard. In particular, it follows
+        # the same convention as isnormal() for its return value.
+        self.assertIsInstance(math.issubnormal(FLOAT_MIN/2), bool)
+
         self.assertFalse(math.issubnormal(1.25))
         self.assertFalse(math.issubnormal(-1.0))
         self.assertFalse(math.issubnormal(0.0))


### PR DESCRIPTION
I've actually stumbled upon the isnormal() C11 requirements (which I assume are the same as issubnormal() ones but I don't have a C23 copy) and I think we can add those checks (I first thought about returning the integer value given by `signbit` but in C++, it returns a bool instead of just an integer [on some implementations it gives the power of 2 representing the sign bit].

<!-- gh-issue-number: gh-132908 -->
* Issue: gh-132908
<!-- /gh-issue-number -->
