### PR TITLE
gh-81520:  Add documentatoion about unexpected os.path.ismount() behaviour

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -298,9 +298,10 @@ the :mod:`glob` module.)
    device than *path*, or whether :file:`{path}/..` and *path* point to the same
    i-node on the same device --- this should detect mount points for all Unix
    and POSIX variants.  It is not able to reliably detect bind mounts on the
-   same filesystem.  On Windows, a drive letter root and a share UNC are
-   always mount points, and for any other path ``GetVolumePathName`` is called
-   to see if it is different from the input path.
+   same filesystem. On Linux systems, it will always return ``True`` for btrfs
+   subvolumes, even if they aren't mount points. On Windows, a drive letter root
+   and a share UNC are always mount points, and for any other path
+   ``GetVolumePathName`` is called to see if it is different from the input path.
 
    .. versionchanged:: 3.4
       Added support for detecting non-root mount points on Windows.


### PR DESCRIPTION
2 PRs, one adds documentation about the false positives with btrfs subvolumes & the 2nd about adding the unexpected behaviour to the docstring, so that it also shows up in `pydoc`

<!-- gh-issue-number: gh-81520 -->
* Issue: gh-81520
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136058.org.readthedocs.build/en/136058/library/os.path.html#os.path.ismount

<!-- readthedocs-preview cpython-previews end -->