### PR TITLE
gh-136059: docs: pathlib: Mention that iterdir() is surprisingly not streaming

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1328,6 +1328,12 @@ Reading directories
    If the path is not a directory or otherwise inaccessible, :exc:`OSError` is
    raised.
 
+   .. warning::
+      Despite its name and being a generator, this function currently
+      does not stream directory entries: It reads all directory
+      entries into memory before yielding the first entry.
+      If you need constant-memory iteration across a large number of
+      directory entries, use :func:`os.scandir` instead.
 
 .. method:: Path.glob(pattern, *, case_sensitive=None, recurse_symlinks=False)
 


### PR DESCRIPTION
This undocumented gotcha can cause excessive memory usage when "iterating" over very large directories.

This is because iterdir() does

    entries = list(scandir_it)

Fixing (if at all desired) will likel need least significant amounts of discussion and testing, so first document the behaviour.

See:

* #136059

<!-- gh-issue-number: gh-136059 -->
* Issue: gh-136059
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136060.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->