### PR TITLE
gh-136062: Buffer Overflow Vulnerability in _Py_wreadlink Function

### DIFF
--- a/Misc/NEWS.d/next/Security/2025-06-28-08-24-06.gh-issue-136062.fXKonh.rst
+++ b/Misc/NEWS.d/next/Security/2025-06-28-08-24-06.gh-issue-136062.fXKonh.rst
@@ -1,0 +1,1 @@
+Fix buffer overflow vulnerability in `_Py_wreadlink` function by ensuring proper null-termination when using `wcsncpy`.

--- a/Misc/NEWS.d/next/Security/2025-06-28-08-24-06.gh-issue-136062.fXKonh.rst
+++ b/Misc/NEWS.d/next/Security/2025-06-28-08-24-06.gh-issue-136062.fXKonh.rst
@@ -1,1 +1,1 @@
-Fix buffer overflow vulnerability in `_Py_wreadlink` function by ensuring proper null-termination when using `wcsncpy`.
+Fix buffer overflow vulnerability in :func:`_Py_wreadlink` function by ensuring proper null-termination when using :c:func:`wcsncpy`.

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2102,7 +2102,8 @@ _Py_wreadlink(const wchar_t *path, wchar_t *buf, size_t buflen)
         errno = EINVAL;
         return -1;
     }
-    wcsncpy(buf, wbuf, buflen);
+    wcsncpy(buf, wbuf, buflen - 1);
+    buf[buflen - 1] = L'\0';  /* Ensure null termination */
     PyMem_RawFree(wbuf);
     return (int)r1;
 }


### PR DESCRIPTION


<!-- gh-issue-number: gh-136062 -->
* Issue: gh-136062
<!-- /gh-issue-number -->
