### PR TITLE
gh-134759: `UnboundLocalError` in `email.message.Message.get_payload`

### DIFF
--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -313,6 +313,8 @@ class Message:
                 # If it does happen, turn the string into bytes in a way
                 # guaranteed not to fail.
                 bpayload = payload.encode('raw-unicode-escape')
+        elif isinstance(payload, bytes):
+            bpayload = payload
         if cte == 'quoted-printable':
             return quopri.decodestring(bpayload)
         elif cte == 'base64':

--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -313,7 +313,7 @@ class Message:
                 # If it does happen, turn the string into bytes in a way
                 # guaranteed not to fail.
                 bpayload = payload.encode('raw-unicode-escape')
-        elif isinstance(payload, bytes):
+        else:
             bpayload = payload
         if cte == 'quoted-printable':
             return quopri.decodestring(bpayload)

--- a/Lib/test/test_email/test_message.py
+++ b/Lib/test/test_email/test_message.py
@@ -1056,10 +1056,10 @@ class TestEmailMessage(TestEmailMessageBase, TestEmailBase):
         m.get_body()
 
     def test_get_bytes_payload_with_quoted_printable_encoding(self):
-        payload = b'Some payload'
+        payload = memoryview(b'Some payload')
         m = self._make_message()
         m.add_header('Content-Transfer-Encoding', 'quoted-printable')
-        m._payload = payload
+        m.set_payload(payload)
         self.assertEqual(m.get_payload(decode=True), payload)
 
 

--- a/Lib/test/test_email/test_message.py
+++ b/Lib/test/test_email/test_message.py
@@ -1056,6 +1056,8 @@ class TestEmailMessage(TestEmailMessageBase, TestEmailBase):
         m.get_body()
 
     def test_get_bytes_payload_with_quoted_printable_encoding(self):
+        # We use a memoryview to avoid directly changing the private payload
+        # and to prevent using the dedicated paths for string or bytes objects.
         payload = memoryview(b'Some payload')
         m = self._make_message()
         m.add_header('Content-Transfer-Encoding', 'quoted-printable')

--- a/Lib/test/test_email/test_message.py
+++ b/Lib/test/test_email/test_message.py
@@ -1055,6 +1055,13 @@ class TestEmailMessage(TestEmailMessageBase, TestEmailBase):
         # AttributeError: 'str' object has no attribute 'is_attachment'
         m.get_body()
 
+    def test_get_bytes_payload_with_quoted_printable_encoding(self):
+        payload = b'Some payload'
+        m = self._make_message()
+        m.add_header('Content-Transfer-Encoding', 'quoted-printable')
+        m._payload = payload
+        self.assertEqual(m.get_payload(decode=True), payload)
+
 
 class TestMIMEPart(TestEmailMessageBase, TestEmailBase):
     # Doing the full test run here may seem a bit redundant, since the two

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1054,6 +1054,7 @@ Alexander Lakeev
 David Lam
 Thomas Lamb
 Valerie Lambert
+Kliment Lamonov
 Peter Lamut
 Jean-Baptiste "Jiba" Lamy
 Ronan Lamy

--- a/Misc/NEWS.d/next/Library/2025-06-28-11-32-57.gh-issue-134759.AjjKcG.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-28-11-32-57.gh-issue-134759.AjjKcG.rst
@@ -1,1 +1,2 @@
-Fix ``UnboundLocalError`` in ``email.message.Message.get_payload``. Patch by Kliment Lamonov.
+Fix :exc:`UnboundLocalError` in :func:`email.message.Message.get_payload` when
+the payload to decode is a :class:`bytes` object. Patch by Kliment Lamonov.

--- a/Misc/NEWS.d/next/Library/2025-06-28-11-32-57.gh-issue-134759.AjjKcG.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-28-11-32-57.gh-issue-134759.AjjKcG.rst
@@ -1,0 +1,1 @@
+Fix ``UnboundLocalError`` in ``email.message.Message.get_payload``. Patch by Kliment Lamonov.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Hello!

I worked on #134759 and was able to reproduce the `UnboundLocalError` by passing bytes payload directly to `_payload`. I'm not sure can we do it in a "public" way, like throw `.set_payload()` but if payload some how become bytes (and content-transfer-encoding is equal quoted-printable) it is now not falling :)

I'm also add myself to ACKS list, but not sure is my changes enough for it. If you say I'll remove myself with no questions.


<!-- gh-issue-number: gh-134759 -->
* Issue: gh-134759
<!-- /gh-issue-number -->
