### PR TITLE
gh-136063: fix quadratic-complexity parsing in `email.message._parseparam`

### DIFF
--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -74,19 +74,23 @@ def _parseparam(s):
     # RDM This might be a Header, so for now stringify it.
     s = ';' + str(s)
     plist = []
-    while s[:1] == ';':
-        s = s[1:]
-        end = s.find(';')
-        while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
+    start = 0
+    while s.find(';', start) == start:
+        start += 1
+        end = s.find(';', start)
+        while end > 0 and (
+            s.count('"', start, end) - s.count('\\"', start, end)
+        ) % 2:
             end = s.find(';', end + 1)
         if end < 0:
             end = len(s)
-        f = s[:end]
-        if '=' in f:
-            i = f.index('=')
-            f = f[:i].strip().lower() + '=' + f[i+1:].strip()
+        i = s.find('=', start, end)
+        if i == -1:
+            f = s[start:end]
+        else:
+            f = s[start:i].rstrip().lower() + '=' + s[i+1:end].lstrip()
         plist.append(f.strip())
-        s = s[end:]
+        start = end
     return plist
 
 

--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -78,10 +78,19 @@ def _parseparam(s):
     while s.find(';', start) == start:
         start += 1
         end = s.find(';', start)
-        while end > 0 and (
-            s.count('"', start, end) - s.count('\\"', start, end)
-        ) % 2:
-            end = s.find(';', end + 1)
+        # The following while block is equivalent to:
+        #
+        #   while end > 0 and (
+        #       s.count('"', start, end) - s.count('\\"', start, end)
+        #   ) % 2:
+        #       end = s.find(';', end + 1)
+        #
+        ind, diff = start, 0
+        while end > 0:
+            diff += s.count('"', ind, end) - s.count('\\"', ind, end)
+            if diff % 2 == 0:
+                break
+            end, ind = ind, s.find(';', end + 1)
         if end < 0:
             end = len(s)
         i = s.find('=', start, end)

--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -78,13 +78,6 @@ def _parseparam(s):
     while s.find(';', start) == start:
         start += 1
         end = s.find(';', start)
-        # The following while block is equivalent to:
-        #
-        #   while end > 0 and (
-        #       s.count('"', start, end) - s.count('\\"', start, end)
-        #   ) % 2:
-        #       end = s.find(';', end + 1)
-        #
         ind, diff = start, 0
         while end > 0:
             diff += s.count('"', ind, end) - s.count('\\"', ind, end)

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -497,6 +497,11 @@ class TestMessageAPI(TestEmailBase):
                 self.assertEqual(len(set(res)), 1)
                 self.assertEqual(res[0], r)
 
+        # This will be considered as a single parameter.
+        malformed = 's="' + ';' * (N - 1)
+        res = email.message._parseparam(malformed)
+        self.assertEqual(res, [malformed])
+
     def test_field_containment(self):
         msg = email.message_from_string('Header: exists')
         self.assertIn('header', msg)

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -485,12 +485,17 @@ class TestMessageAPI(TestEmailBase):
         # Ensure that email.message._parseparam() is fast.
         # See https://github.com/python/cpython/issues/136063.
         N = 100_000
-        res = email.message._parseparam(';' * N)
-        self.assertEqual(res, [''] * N)
-        res = email.message._parseparam('foo=bar;' * N)
-        self.assertEqual(res, ['foo=bar'] * N)
-        res = email.message._parseparam(' FOO = bar ;' * N)
-        self.assertEqual(res, ['foo=bar'] * N)
+        for s, r in [
+            ("", ""),
+            ("foo=bar", "foo=bar"),
+            (" FOO = bar    ", "foo=bar"),
+        ]:
+            with self.subTest(s=s, r=r, N=N):
+                src = f'{s};' * (N - 1) + s
+                res = email.message._parseparam(src)
+                self.assertEqual(len(res), N)
+                self.assertEqual(len(set(res)), 1)
+                self.assertEqual(res[0], r)
 
     def test_field_containment(self):
         msg = email.message_from_string('Header: exists')

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -481,6 +481,17 @@ class TestMessageAPI(TestEmailBase):
             "Content-Type: foo; bar*0=\"baz\\\"foobar\"; bar*1=\"\\\"baz\"")
         self.assertEqual(msg.get_param('bar'), 'baz"foobar"baz')
 
+    def test_get_param_linear_complexity(self):
+        # Ensure that email.message._parseparam() is fast.
+        # See https://github.com/python/cpython/issues/136063.
+        N = 100_000
+        res = email.message._parseparam(';' * N)
+        self.assertEqual(res, [''] * N)
+        res = email.message._parseparam('foo=bar;' * N)
+        self.assertEqual(res, ['foo=bar'] * N)
+        res = email.message._parseparam(' FOO = bar ;' * N)
+        self.assertEqual(res, ['foo=bar'] * N)
+
     def test_field_containment(self):
         msg = email.message_from_string('Header: exists')
         self.assertIn('header', msg)

--- a/Misc/NEWS.d/next/Security/2025-06-28-13-23-53.gh-issue-136063.aGk0Jv.rst
+++ b/Misc/NEWS.d/next/Security/2025-06-28-13-23-53.gh-issue-136063.aGk0Jv.rst
@@ -1,0 +1,2 @@
+:mod:`email.message`: ensure linear complexity for legacy HTTP parameters
+parsing. Patch by Bénédikt Tran.


### PR DESCRIPTION
@serhiy-storchaka I think this one can be done without changing the interface. Just to be sure, but `count()` and `find()` have all linear complexities right (linear in the window they are using, not in the entire string).

<!-- gh-issue-number: gh-136063 -->
* Issue: gh-136063
<!-- /gh-issue-number -->
