### PR TITLE
Re-export `._replace` as `.replace` in `urllib.parse` result types

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1675,5 +1675,23 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(request.get_method(), 'HEAD')
 
 
+class TestReplaceMethod:
+    """Testcase to test the '.replace' method"""
+
+    def test_defrag(self):
+        result = urllib.parse.defrag("http://www.python.org")
+        result = result.replace(frament="something")
+        self.assertEqual(result.fragment, "something")
+
+    def test_urlsplit(self):
+        result = urllib.parse.urlsplit("http://www.python.org")
+        result = result.replace(frament="something")
+        self.assertEqual(result.fragment, "something")
+
+    def test_urlparse(self):
+        result = urllib.parse.urlparse("http://www.python.org")
+        result = result.replace(frament="something")
+        self.assertEqual(result.fragment, "something")
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -313,6 +313,11 @@ access to perform some operation on the resource.
 _ParseResultBase.query.__doc__ = _SplitResultBase.query.__doc__
 _ParseResultBase.fragment.__doc__ = _SplitResultBase.fragment.__doc__
 
+# Re-export these, since we don't have a 'replace' field
+# and making the user call '._replace' feels yucky
+_DefragResultBase.replace = _DefragResultBase._replace
+_SplitResultBase.replace = _SplitResultBase._replace
+_ParseResultBase.replace = _ParseResultBase._replace
 
 # For backwards compatibility, alias _NetlocResultMixinStr
 # ResultBase is no longer part of the documented API, but it is


### PR DESCRIPTION
I do Python interviewing, and part of one of our interviews has folks parsing URLs.

I've noticed people gloss over the `._replace` at the end of the examples in https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse and I'm somewhat convinced that's due to the fact that subconsciously PEP 8 (and beyond) has trained folks to assume leading underscore is not "public" ( a good convention).

This isn't a debate about `namedtuple`. I assume it uses `._replace` so that _it_ doesn't preclude folks from using `namedtuple` with a field named `replace`.

But for concrete `namedtuple` subclasses which are known not to have a `replace` field, it'd be nice if the callers could just use `.replace` like all the other "normal" classes.

(Then there's the issue with linters complaining about usage of using a method that starts with an underscore, but that's not my motivation so I'll just point it out and move on)

(I also don't want this to devolve into a conversation about "ok but what about <other namedtuple subclass>". Perfect is the enemy og good)