### PR TITLE
gh-131885: update documented signatures for `csv.{writer,reader}`

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -53,7 +53,7 @@ The :mod:`csv` module defines the following functions:
 .. index::
    single: universal newlines; csv.reader function
 
-.. function:: reader(csvfile, dialect='excel', **fmtparams)
+.. function:: reader(csvfile, /, dialect='excel', **fmtparams)
 
    Return a :ref:`reader object <reader-objects>` that will process
    lines from the given *csvfile*.  A csvfile must be an iterable of
@@ -84,7 +84,7 @@ The :mod:`csv` module defines the following functions:
       Spam, Lovely Spam, Wonderful Spam
 
 
-.. function:: writer(csvfile, dialect='excel', **fmtparams)
+.. function:: writer(csvfile, /, dialect='excel', **fmtparams)
 
    Return a writer object responsible for converting the user's data into delimited
    strings on the given file-like object.  *csvfile* can be any object with a


### PR DESCRIPTION
…ter` have some positional-only arguments


```python
import csv

with open("example.csv", "w", newline='') as csvfile:
    csv.writer(csvfile=csvfile)  # TypeError:  expected at least 1 argument, got 0
```

```python
import csv

csv.reader(csvfile="a")  # TypeError:  expected at least 1 argument, got 0
```

<!-- gh-issue-number: gh-131885 -->
* Issue: gh-131885
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136085.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->