### PR TITLE
gh-136052: Do not generate empty encoded-words

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -3011,7 +3011,10 @@ def _fold_as_ew(to_encode, lines, maxlen, last_ew, ew_combine_allowed, charset, 
             to_encode_word = to_encode_word[:-1]
             encoded_word = _ew.encode(to_encode_word, charset=encode_as)
             excess = len(encoded_word) - remaining_space
-        lines[-1] += encoded_word
+        # If encoding a single character pushes this line over the limit,
+        # give up on it and go to the next line.
+        if to_encode_word != "":
+            lines[-1] += encoded_word
         to_encode = to_encode[len(to_encode_word):]
         leading_whitespace = ''
 

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -3084,6 +3084,14 @@ class TestFolding(TestEmailBase):
                         "mich.  And that's\n"
                    " all I'm sayin.\n")
 
+    def test_unicode_near_end_of_line(self):
+        self._test(parser.get_unstructured("Mein Kaktus ist sehr attraktiv. Er "
+                                           "hat viele Stacheln und liebt "
+                                           "übriggebliebenes Eigelb."),
+                   "Mein Kaktus ist sehr attraktiv. Er hat viele "
+                       "Stacheln und liebt \n"
+                   " =?utf-8?q?=C3=BCbriggebliebenes?= Eigelb.\n")
+
     def test_unicode_after_unknown_not_combined(self):
         self._test(parser.get_unstructured("=?unknown-8bit?q?=A4?=\xa4"),
                    "=?unknown-8bit?q?=A4?==?utf-8?q?=C2=A4?=\n")

--- a/Misc/NEWS.d/next/Library/2025-06-29-15-25-56.gh-issue-136052.P1HgAD.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-29-15-25-56.gh-issue-136052.P1HgAD.rst
@@ -1,0 +1,1 @@
+Do not create empty MIME encoded-words when preparing e-mail headers.


### PR DESCRIPTION
Fixes #136052.

The code assumes that it will always be able to encode a single character. This is not always true, such as when the CTE is quoted-printable and the line has space remaining for less than three characters.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136052 -->
* Issue: gh-136052
<!-- /gh-issue-number -->
