### PR TITLE
gh-86845: Improve `datetime.timestamp` example

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1535,7 +1535,7 @@ Instance methods:
 
       or by calculating the timestamp directly::
 
-         timestamp = (dt - datetime(1970, 1, 1)) / timedelta(seconds=1)
+         timestamp = (dt - datetime(1970, 1, 1)).total_seconds()
 
 .. method:: datetime.weekday()
 


### PR DESCRIPTION
I agree this is a marginal improvement, see my [comment](https://github.com/python/cpython/issues/86845#issuecomment-3016878362) on the linked issue for my thoughts on this.


<!-- gh-issue-number: gh-86845 -->
* Issue: gh-86845
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136105.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->