### PR TITLE
gh-136047: Allow typing._allow_reckless_class_checks to check `_py_abc`

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1843,15 +1843,11 @@ def _no_init_or_replace_init(self, *args, **kwargs):
     cls.__init__(self, *args, **kwargs)
 
 
-_RECKLESS_CLASS_CHECK_ALLOWED = {'abc', 'functools', None}
-_SYS_HAS_GETFRAMEMODULENAME = hasattr(sys, '_getframemodulename')
-if not _SYS_HAS_GETFRAMEMODULENAME:
-    _RECKLESS_CLASS_CHECK_ALLOWED.add('_py_abc')
-
-
 def _caller(depth=1, default='__main__'):
-    if _SYS_HAS_GETFRAMEMODULENAME:
+    try:
         return sys._getframemodulename(depth + 1) or default
+    except AttributeError:  # For platforms without _getframemodulename()
+        pass
     try:
         return sys._getframe(depth + 1).f_globals.get('__name__', default)
     except (AttributeError, ValueError):  # For platforms without _getframe()
@@ -1864,7 +1860,7 @@ def _allow_reckless_class_checks(depth=2):
     The abc and functools modules indiscriminately call isinstance() and
     issubclass() on the whole MRO of a user class, which may contain protocols.
     """
-    return _caller(depth) in _RECKLESS_CLASS_CHECK_ALLOWED
+    return _caller(depth) in {'abc', 'functools', None}
 
 
 _PROTO_ALLOWLIST = {

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1860,7 +1860,9 @@ def _allow_reckless_class_checks(depth=2):
     The abc and functools modules indiscriminately call isinstance() and
     issubclass() on the whole MRO of a user class, which may contain protocols.
     """
-    return _caller(depth) in {'abc', 'functools', None}
+    # gh-136047: When `_abc` module is not available, `_py_abc` is required to
+    # allow `_py_abc.ABCMeta` fallback.
+    return _caller(depth) in {'abc', '_py_abc', 'functools', None}
 
 
 _PROTO_ALLOWLIST = {

--- a/Misc/NEWS.d/next/Library/2025-07-05-06-59-46.gh-issue-136047.qWvycf.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-05-06-59-46.gh-issue-136047.qWvycf.rst
@@ -1,0 +1,2 @@
+Fix issues with :mod:`typing` when the C implementation of :mod:`abc` is not
+available.


### PR DESCRIPTION
When `abc.py` fails to import `_abc` and instead imports `_py_abc.ABCMeta`, `_py_abc.ABCMeta.__module__` is set to `abc` to allow `typing._allow_reckless_class_checks` to work with it.

Unfortunately, when `typing._caller` falls back to using `sys._getframe`, its `globals()` contains the real module name instead of the module name of the frame's function.

This patch allows checking for `_py_abc` in that scenario.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136047 -->
* Issue: gh-136047
<!-- /gh-issue-number -->
