### PR TITLE
gh-136122: Fix video link for math.tau documentation

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -804,7 +804,7 @@ Constants
    The mathematical constant *τ* = 6.283185..., to available precision.
    Tau is a circle constant equal to 2\ *π*, the ratio of a circle's circumference to
    its radius. To learn more about Tau, check out Vi Hart's video `Pi is (still)
-   Wrong <https://www.youtube.com/watch?v=jG7vhMMXagQ>`_, and start celebrating
+   Wrong <https://vimeo.com/147792667>`_, and start celebrating
    `Tau day <https://tauday.com/>`_ by eating twice as much pie!
 
    .. versionadded:: 3.6


### PR DESCRIPTION
"Pi is (still) Wrong" by Vi Hart was removed from YouTube, and so the link has been replaced with a Vimeo link. See https://github.com/python/cpython/issues/136122

<!-- gh-issue-number: gh-136122 -->
* Issue: gh-136122
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136129.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->