### PR TITLE
gh-136140: Add update(**kwargs) method to types.SimpleNamespace

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -21,6 +21,8 @@ import types
 import unittest.mock
 import weakref
 import typing
+from types import SimpleNamespace 
+
 
 c_types = import_fresh_module('types', fresh=['_types'])
 py_types = import_fresh_module('types', blocked=['_types'])
@@ -2128,6 +2130,23 @@ class SimpleNamespaceTests(unittest.TestCase):
             types.SimpleNamespace() > FakeSimpleNamespace()
         with self.assertRaises(TypeError):
             types.SimpleNamespace() >= FakeSimpleNamespace()
+    
+    def test_update_method(self):
+        ns = SimpleNamespace(a=1)
+        self.assertEqual(ns.a, 1)
+
+        ns.update(b=2, c=3)
+        self.assertEqual(ns.b, 2)
+        self.assertEqual(ns.c, 3)
+
+        # Overwriting existing key
+        ns.update(a=42)
+        self.assertEqual(ns.a, 42)
+
+        # No update with no kwargs
+        ns.update()
+        self.assertEqual(vars(ns), {'a': 42, 'b': 2, 'c': 3})
+
 
 
 class CoroutineTests(unittest.TestCase):

--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -245,6 +245,7 @@ namespace_replace(PyObject *self, PyObject *args, PyObject *kwargs)
     return result;
 }
 
+static PyObject *namespace_update(PyObject *self, PyObject *args, PyObject *kwds);
 
 static PyMethodDef namespace_methods[] = {
     {"__reduce__", namespace_reduce, METH_NOARGS,
@@ -252,7 +253,11 @@ static PyMethodDef namespace_methods[] = {
     {"__replace__", _PyCFunction_CAST(namespace_replace), METH_VARARGS|METH_KEYWORDS,
      PyDoc_STR("__replace__($self, /, **changes)\n--\n\n"
         "Return a copy of the namespace object with new values for the specified attributes.")},
-    {NULL,         NULL}  // sentinel
+    {"update", (PyCFunction)(void(*)(void))namespace_update,
+     METH_VARARGS | METH_KEYWORDS,
+     PyDoc_STR("update(**kwargs)\n--\n\nUpdate namespace attributes from keyword arguments.")
+    },
+
 };
 
 
@@ -321,3 +326,28 @@ _PyNamespace_New(PyObject *kwds)
 
     return (PyObject *)ns;
 }
+
+#include "Python.h"
+
+static PyObject *
+namespace_update(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (kwds == NULL) {
+        Py_RETURN_NONE;
+    }
+
+    PyObject *dict = PyObject_GetAttrString(self, "__dict__");
+    if (dict == NULL) {
+        return NULL;
+    }
+
+    int result = PyDict_Update(dict, kwds);
+    Py_DECREF(dict);
+
+    if (result < 0) {
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
+}
+


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Closes #136140
## Summary

This PR adds an `update(**kwargs)` method to `types.SimpleNamespace`, allowing users to update the namespace's attributes in place using keyword arguments.

### Example

```python
from types import SimpleNamespace

ns = SimpleNamespace(a=1)
ns.update(b=2)
print(ns)  # namespace(a=1, b=2)

Why?
Improves usability by providing an intuitive way to update attributes

Avoids reliance on internal .__dict__ access

Matches expectations from dict.update()

Implementation Notes
Implemented in C (Objects/namespaceobject.c)

Uses PyDict_Update(self->__dict__, kwargs)

Supports inspect.signature() via __text_signature__

Unit test added to test_types.py




<!-- gh-issue-number: gh-136140 -->
* Issue: gh-136140
<!-- /gh-issue-number -->
