### PR TITLE
gh-136145: Define 'standard library' and 'stdlib' in the glossary

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1283,9 +1283,12 @@ Glossary
    standard library
       The collection of :term:`packages <package>`, :term:`modules <module>`
       and :term:`extension modules <extension module>` distributed as a part
-      of the official Python interpreter package, or an individual member of
-      that collection.  The exact membership of the collection may vary based
-      on platform, available system packages, or other criteria.
+      of the official Python interpreter package.  The exact membership of the
+      collection may vary based on platform, available system packages, or
+      other criteria.  Documentation can be found at :ref:`library-index`.
+
+      See also :data:`sys.stdlib_module_names` for a list of all possible
+      standard library module names.
 
    statement
       A statement is part of a suite (a "block" of code).  A statement is either

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1298,7 +1298,7 @@ Glossary
       and the :mod:`typing` module.
 
    stdlib
-      A synonym for :term:`standard library`.
+      An abbreviation of :term:`standard library`.
 
    strong reference
       In Python's C API, a strong reference is a reference to an object

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1287,9 +1287,6 @@ Glossary
       that collection.  The exact membership of the collection may vary based
       on platform, available system packages, or other criteria.
 
-   stdlib
-      A synonym for :term:`standard library`.
-
    statement
       A statement is part of a suite (a "block" of code).  A statement is either
       an :term:`expression` or one of several constructs with a keyword, such
@@ -1299,6 +1296,9 @@ Glossary
       An external tool that reads Python code and analyzes it, looking for
       issues such as incorrect types. See also :term:`type hints <type hint>`
       and the :mod:`typing` module.
+
+   stdlib
+      A synonym for :term:`standard library`.
 
    strong reference
       In Python's C API, a strong reference is a reference to an object

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1280,6 +1280,16 @@ Glossary
       and ending with double underscores.  Special methods are documented in
       :ref:`specialnames`.
 
+   standard library
+      The collection of :term:`packages <package>`, :term:`modules <module>`
+      and :term:`extension modules <extension module>` distributed as a part
+      of the official Python interpreter package, or an individual member of
+      that collection.  The exact membership of the collection may vary based
+      on platform, available system packages, or other criteria.
+
+   stdlib
+      A synonym for :term:`standard library`.
+
    statement
       A statement is part of a suite (a "block" of code).  A statement is either
       an :term:`expression` or one of several constructs with a keyword, such

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1284,7 +1284,7 @@ Glossary
       The collection of :term:`packages <package>`, :term:`modules <module>`
       and :term:`extension modules <extension module>` distributed as a part
       of the official Python interpreter package.  The exact membership of the
-      collection may vary based on platform, available system packages, or
+      collection may vary based on platform, available system libraries, or
       other criteria.  Documentation can be found at :ref:`library-index`.
 
       See also :data:`sys.stdlib_module_names` for a list of all possible


### PR DESCRIPTION


<!-- gh-issue-number: gh-136145 -->
* Issue: gh-136145
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136146.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->