### PR TITLE
gh-101100: Fix sphinx warnings in `whatsnew/3.9`

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -447,6 +447,11 @@ Alternative Generator
       Override this method in subclasses to customise the
       :meth:`~random.getrandbits` behaviour of :class:`!Random` instances.
 
+   .. method:: Random.randbytes(n)
+
+      Override this method in subclasses to customise the
+      :meth:`~random.randbytes` behaviour of :class:`!Random` instances.
+
 
 .. class:: SystemRandom([seed])
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -73,6 +73,3 @@ Doc/whatsnew/3.5.rst
 Doc/whatsnew/3.6.rst
 Doc/whatsnew/3.7.rst
 Doc/whatsnew/3.8.rst
-Doc/whatsnew/3.9.rst
-Doc/whatsnew/3.10.rst
-Doc/whatsnew/3.11.rst

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -73,3 +73,5 @@ Doc/whatsnew/3.5.rst
 Doc/whatsnew/3.6.rst
 Doc/whatsnew/3.7.rst
 Doc/whatsnew/3.8.rst
+Doc/whatsnew/3.10.rst
+Doc/whatsnew/3.11.rst

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -776,7 +776,7 @@ Optimizations
   :pep:`590` vectorcall protocol.
   (Contributed by Donghee Na, Mark Shannon, Jeroen Demeyer and Petr Viktorin in :issue:`37207`.)
 
-* Optimized :meth:`~set.difference_update` for the case when the other set
+* Optimized :meth:`!set.difference_update` for the case when the other set
   is much larger than the base set.
   (Suggested by Evgeny Kapun with code contributed by Michele Orrù in :issue:`8425`.)
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -423,8 +423,8 @@ digests. It skips MD5 on platforms that block MD5 digest.
 fcntl
 -----
 
-Added constants :const:`~fcntl.F_OFD_GETLK`, :const:`~fcntl.F_OFD_SETLK`
-and :const:`~fcntl.F_OFD_SETLKW`.
+Added constants :const:`!fcntl.F_OFD_GETLK`, :const:`!fcntl.F_OFD_SETLK`
+and :const:`!fcntl.F_OFD_SETLKW`.
 (Contributed by Donghee Na in :issue:`38602`.)
 
 ftplib
@@ -644,7 +644,7 @@ attribute.
 random
 ------
 
-Added a new :attr:`random.Random.randbytes` method: generate random bytes.
+Added a new :meth:`random.Random.randbytes` method: generate random bytes.
 (Contributed by Victor Stinner in :issue:`40286`.)
 
 signal
@@ -776,7 +776,7 @@ Optimizations
   :pep:`590` vectorcall protocol.
   (Contributed by Donghee Na, Mark Shannon, Jeroen Demeyer and Petr Viktorin in :issue:`37207`.)
 
-* Optimized :func:`~set.difference_update` for the case when the other set
+* Optimized :meth:`~set.difference_update` for the case when the other set
   is much larger than the base set.
   (Suggested by Evgeny Kapun with code contributed by Michele Orrù in :issue:`8425`.)
 
@@ -1139,7 +1139,7 @@ Changes in the Python API
   (Contributed by Christian Heimes in :issue:`36384`).
 
 * :func:`codecs.lookup` now normalizes the encoding name the same way as
-  :func:`encodings.normalize_encoding`, except that :func:`codecs.lookup` also
+  :func:`!encodings.normalize_encoding`, except that :func:`codecs.lookup` also
   converts the name to lower case. For example, ``"latex+latin1"`` encoding
   name is now normalized to ``"latex_latin1"``.
   (Contributed by Jordon Xu in :issue:`37751`.)


### PR DESCRIPTION
It used to be:

```
/Users/sobolev/Desktop/cpython/Doc/whatsnew/3.9.rst:426: WARNING: py:const reference target not found: fcntl.F_OFD_GETLK [ref.const]
/Users/sobolev/Desktop/cpython/Doc/whatsnew/3.9.rst:426: WARNING: py:const reference target not found: fcntl.F_OFD_SETLK [ref.const]
/Users/sobolev/Desktop/cpython/Doc/whatsnew/3.9.rst:426: WARNING: py:const reference target not found: fcntl.F_OFD_SETLKW [ref.const]
/Users/sobolev/Desktop/cpython/Doc/whatsnew/3.9.rst:647: WARNING: py:attr reference target not found: random.Random.randbytes [ref.attr]
/Users/sobolev/Desktop/cpython/Doc/whatsnew/3.9.rst:779: WARNING: py:func reference target not found: set.difference_update [ref.func]
/Users/sobolev/Desktop/cpython/Doc/whatsnew/3.9.rst:1141: WARNING: py:func reference target not found: encodings.normalize_encoding [ref.func]
```

I opened https://github.com/python/cpython/issues/136162 about the `encodings` part.

I had to use 

```
:meth:`!set.difference_update`
```

because `stdtypes` defines this method as `frozenset.difference_update`

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136163.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->