### PR TITLE
gh-130979: Doc: Generate ids for audit_events using docname

### DIFF
--- a/Doc/tools/extensions/audit_events.py
+++ b/Doc/tools/extensions/audit_events.py
@@ -68,8 +68,13 @@ class AuditEvents:
             logger.warning(msg)
             return
 
-    def id_for(self, name) -> str:
-        source_count = len(self.sources.get(name, set()))
+    def _source_count(self, name, docname) -> int:
+        """Count the event name in the same source"""
+        sources = self.sources.get(name, set())
+        return len([s for s, t in sources if s == docname])
+
+    def id_for(self, name, docname) -> str:
+        source_count = self._source_count(name, docname)
         name_clean = re.sub(r"\W", "_", name)
         return f"audit_event_{name_clean}_{source_count}"
 
@@ -142,7 +147,7 @@ class AuditEvent(SphinxDirective):
         except (IndexError, TypeError):
             target = None
         if not target:
-            target = self.env.audit_events.id_for(name)
+            target = self.env.audit_events.id_for(name, self.env.docname)
             ids.append(target)
         self.env.audit_events.add_event(name, args, (self.env.docname, target))
 


### PR DESCRIPTION
This patch generates ids for audit_events using the docname so the id is not global but depend on the source file. This make the doc build reproducible with multiple cores because it doesn't which file is parsed first, the id for audit_events will always be consistent independently of what file is parsed first.

https://github.com/python/cpython/issues/130979

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130979 -->
* Issue: gh-130979
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136165.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->