### PR TITLE
gh-136170: Use earliest zinfo.header_offset as ZipFile.data_offset

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -3505,11 +3505,27 @@ class TestDataOffsetZipWrite(unittest.TestCase):
             fp.write(b"this is a prefix")
             with zipfile.ZipFile(fp, "w") as zipfp:
                 self.assertEqual(zipfp.data_offset, 16)
+            fp.seek(0)
+            with zipfile.ZipFile(fp) as zipfp:
+                self.assertEqual(zipfp.data_offset, 16)
+
+    def test_data_offset_write_with_prefix_and_entry(self):
+        with io.BytesIO() as fp:
+            fp.write(b"this is a prefix")
+            with zipfile.ZipFile(fp, "w") as zipfp:
+                self.assertEqual(zipfp.data_offset, 16)
+                zipfp.writestr("test.txt", "content")
+            fp.seek(0)
+            with zipfile.ZipFile(fp) as zipfp:
+                self.assertEqual(zipfp.data_offset, 16)
 
     def test_data_offset_append_with_bad_zip(self):
         with io.BytesIO() as fp:
             fp.write(b"this is a prefix")
             with zipfile.ZipFile(fp, "a") as zipfp:
+                self.assertEqual(zipfp.data_offset, 16)
+            fp.seek(0)
+            with zipfile.ZipFile(fp) as zipfp:
                 self.assertEqual(zipfp.data_offset, 16)
 
     def test_data_offset_write_no_tell(self):

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1535,10 +1535,6 @@ class ZipFile:
         # self.start_dir:  Position of start of central directory
         self.start_dir = offset_cd + concat
 
-        # store the offset to the beginning of data for the
-        # .data_offset property
-        self._data_offset = concat
-
         if self.start_dir < 0:
             raise BadZipFile("Bad offset for central directory")
         fp.seek(self.start_dir, 0)
@@ -1594,10 +1590,18 @@ class ZipFile:
                 print("total", total)
 
         end_offset = self.start_dir
+        zinfo = None
         for zinfo in reversed(sorted(self.filelist,
                                      key=lambda zinfo: zinfo.header_offset)):
             zinfo._end_offset = end_offset
             end_offset = zinfo.header_offset
+
+        # store the offset to the beginning of data for the
+        # .data_offset property
+        if zinfo is None:
+            self._data_offset = self.start_dir
+        else:
+            self._data_offset = zinfo.header_offset
 
     @property
     def data_offset(self):


### PR DESCRIPTION
Use the earliest `zinfo.header_offset` for `ZipFile.data_offset`.

We already sort the `zinfo`s by their `header_offset` in `_RealGetContents` so it is cheap to grab the zinfo with the lowest `header_offset`.

Happy to add a news entry if required (given that 3.14 which introduced `ZipFile.data_offset` hasn't been released yet?) 

<!-- gh-issue-number: gh-136170 -->
* Issue: gh-136170
<!-- /gh-issue-number -->
