### PR TITLE
gh-136155: Docs: only add custom OpenGraph protocol meta tags for HTML builds

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -635,7 +635,7 @@ ogp_social_cards = {  # Used when matplotlib is installed
     'image': '_static/og-image.png',
     'line_color': '#3776ab',
 }
-if 'epub' not in tags:  # noqa: F821
+if 'builder_html' in tags:  # noqa: F821
     ogp_custom_meta_tags = [
         '<meta name="theme-color" content="#3776ab">',
     ]

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -635,13 +635,14 @@ ogp_social_cards = {  # Used when matplotlib is installed
     'image': '_static/og-image.png',
     'line_color': '#3776ab',
 }
-ogp_custom_meta_tags = [
-    '<meta name="theme-color" content="#3776ab">',
-]
-if 'create-social-cards' not in tags:  # noqa: F821
-    # Define a static preview image when not creating social cards
-    ogp_image = '_static/og-image.png'
-    ogp_custom_meta_tags += [
-        '<meta property="og:image:width" content="200">',
-        '<meta property="og:image:height" content="200">',
+if 'epub' not in tags:  # noqa: F821
+    ogp_custom_meta_tags = [
+        '<meta name="theme-color" content="#3776ab">',
     ]
+    if 'create-social-cards' not in tags:  # noqa: F821
+        # Define a static preview image when not creating social cards
+        ogp_image = '_static/og-image.png'
+        ogp_custom_meta_tags += [
+            '<meta property="og:image:width" content="200">',
+            '<meta property="og:image:height" content="200">',
+        ]

--- a/Misc/NEWS.d/next/Documentation/2025-07-01-21-04-47.gh-issue-136155.ufmH4Q.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-07-01-21-04-47.gh-issue-136155.ufmH4Q.rst
@@ -1,0 +1,1 @@
+EPUB builds are fixed by excluding non-XHTML-compatible tags.


### PR DESCRIPTION
Confirmed locally that it fixes broken EPUB builds.

<!-- gh-issue-number: gh-136155 -->
* Issue: gh-136155
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136187.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->