### PR TITLE
gh-136134: Fallback to next auth method when CRAM-MD5 fails due to unsupported hash (e.g. FIPS)

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -54,7 +54,7 @@ from email.base64mime import body_encode as encode_base64
 
 __all__ = ["SMTPException", "SMTPNotSupportedError", "SMTPServerDisconnected", "SMTPResponseException",
            "SMTPSenderRefused", "SMTPRecipientsRefused", "SMTPDataError",
-           "SMTPConnectError", "SMTPHeloError", "SMTPAuthenticationError",
+           "SMTPConnectError", "SMTPHeloError", "SMTPAuthenticationError", "SMTPAuthHashUnsupportedError",
            "quoteaddr", "quotedata", "SMTP"]
 
 SMTP_PORT = 25
@@ -140,6 +140,10 @@ class SMTPAuthenticationError(SMTPResponseException):
     Most probably the server didn't accept the username/password
     combination provided.
     """
+
+class SMTPAuthHashUnsupportedError(SMTPException):
+    """Raised when the authentication mechanism uses a hash algorithm unsupported by the system."""
+
 
 def quoteaddr(addrstring):
     """Quote a subset of the email addresses defined by RFC 821.
@@ -665,8 +669,11 @@ class SMTP:
         # CRAM-MD5 does not support initial-response.
         if challenge is None:
             return None
-        return self.user + " " + hmac.HMAC(
-            self.password.encode('ascii'), challenge, 'md5').hexdigest()
+        try:
+            return self.user + " " + hmac.HMAC(
+                self.password.encode('ascii'), challenge, 'md5').hexdigest()
+        except ValueError as e:
+            raise SMTPAuthHashUnsupportedError(f'CRAM-MD5 failed: {e}') from e
 
     def auth_plain(self, challenge=None):
         """ Authobject to use with PLAIN authentication. Requires self.user and
@@ -743,13 +750,12 @@ class SMTP:
                     return (code, resp)
             except SMTPAuthenticationError as e:
                 last_exception = e
-            except ValueError as e:
+            except SMTPAuthHashUnsupportedError as e:
                 # Some environments (e.g., FIPS) disable certain hashing algorithms like MD5,
                 # which are required by CRAM-MD5. This raises a ValueError when trying to use HMAC.
                 # If this happens, we catch the exception and continue trying the next auth method.
                 last_exception = e
-                if 'unsupported' in str(e).lower():
-                    continue
+                continue
 
         # We could not login successfully.  Return result of last attempt.
         raise last_exception

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -744,6 +744,9 @@ class SMTP:
             except SMTPAuthenticationError as e:
                 last_exception = e
             except ValueError as e:
+                # Some environments (e.g., FIPS) disable certain hashing algorithms like MD5,
+                # which are required by CRAM-MD5. This raises a ValueError when trying to use HMAC.
+                # If this happens, we catch the exception and continue trying the next auth method.
                 last_exception = e
                 if 'unsupported' in str(e).lower():
                     continue

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -743,6 +743,10 @@ class SMTP:
                     return (code, resp)
             except SMTPAuthenticationError as e:
                 last_exception = e
+            except ValueError as e:
+                last_exception = e
+                if 'unsupported' in str(e).lower():
+                    continue
 
         # We could not login successfully.  Return result of last attempt.
         raise last_exception

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -752,7 +752,7 @@ class SMTP:
                 last_exception = e
             except SMTPAuthHashUnsupportedError as e:
                 # Some environments (e.g., FIPS) disable certain hashing algorithms like MD5,
-                # which are required by CRAM-MD5. This raises a ValueError when trying to use HMAC.
+                # which are required by CRAM-MD5. This raises a SMTPAuthHashUnsupportedError when trying to use HMAC.
                 # If this happens, we catch the exception and continue trying the next auth method.
                 last_exception = e
                 continue

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -1572,7 +1572,7 @@ class SMTPAUTHInitialResponseSimTests(unittest.TestCase):
 
 class TestSMTPLoginValueError(unittest.TestCase):
     def broken_hmac(*args, **kwargs):
-        raise ValueError("[digital envelope routines] unsupported")
+        raise smtplib.SMTPAuthHashUnsupportedError("CRAM-MD5 failed: [digital envelope routines] unsupported")
 
     def test_login_raises_valueerror_when_cram_md5_fails(self):
         with patch("hmac.HMAC", self.broken_hmac):
@@ -1593,7 +1593,7 @@ class TestSMTPLoginValueError(unittest.TestCase):
                     return 334, b"Y2hhbGxlbmdl"
 
             smtp = FakeSMTP()
-            with self.assertRaises(ValueError) as ctx:
+            with self.assertRaises(smtplib.SMTPAuthHashUnsupportedError) as ctx:
                 smtp.login("user", "pass")
             self.assertIn("unsupported", str(ctx.exception).lower())
 

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -23,7 +23,7 @@ from test.support import socket_helper
 from test.support import threading_helper
 from test.support import asyncore
 from test.support import smtpd
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 
 support.requires_working_socket(module=True)
@@ -1568,6 +1568,61 @@ class SMTPAUTHInitialResponseSimTests(unittest.TestCase):
         code, response = smtp.auth('plain', smtp.auth_plain)
         smtp.close()
         self.assertEqual(code, 235)
+
+
+class TestSMTPLoginValueError(unittest.TestCase):
+    def broken_hmac(*args, **kwargs):
+        raise ValueError("[digital envelope routines] unsupported")
+
+    def test_login_raises_valueerror_when_cram_md5_fails(self):
+        with patch("hmac.HMAC", self.broken_hmac):
+            class FakeSMTP(smtplib.SMTP):
+                def __init__(self):
+                    super().__init__(host='', port=0)
+                    self.esmtp_features = {"auth": "CRAM-MD5"}
+                    self._host = "localhost"
+
+                def ehlo_or_helo_if_needed(self):
+                    pass
+
+                def has_extn(self, ext):
+                    return ext.lower() == "auth"
+
+                def docmd(self, *args, **kwargs):
+                    # Retorna uma challenge base64 válida
+                    return 334, b"Y2hhbGxlbmdl"
+
+            smtp = FakeSMTP()
+            with self.assertRaises(ValueError) as ctx:
+                smtp.login("user", "pass")
+            self.assertIn("unsupported", str(ctx.exception).lower())
+
+    def test_login_fallbacks_when_cram_md5_raises_valueerror(self):
+        with patch("hmac.HMAC", self.broken_hmac):
+            class FakeSMTP(smtplib.SMTP):
+                def __init__(self):
+                    super().__init__(host='', port=0)
+                    self.esmtp_features = {"auth": "CRAM-MD5 LOGIN"}
+                    self._host = "localhost"
+
+                def ehlo_or_helo_if_needed(self):
+                    pass
+
+                def has_extn(self, ext):
+                    return ext.lower() == "auth"
+
+                def docmd(self, *args, **kwargs):
+                    if args[0] == "AUTH" and args[1].startswith("CRAM-MD5"):
+                        return 334, b"Y2hhbGxlbmdl"  # base64('challenge')
+                    return 235, b"Authentication successful"
+
+                def auth_login(self, challenge=None):
+                    return "login response"
+
+            smtp = FakeSMTP()
+            code, resp = smtp.login("user", "pass")
+            self.assertEqual(code, 235)
+            self.assertEqual(resp, b"Authentication successful")
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2025-07-01-21-37-17.gh-issue-136134.NhFpu3.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-01-21-37-17.gh-issue-136134.NhFpu3.rst
@@ -1,0 +1,2 @@
+Make smtplib fallback to next auth method if CRAM-MD5 fails due to
+unsupported hash (e.g. FIPS). Contributed by Raphael Rodrigues.


### PR DESCRIPTION
This change improves the `smtplib.SMTP.login()` method to handle the case where CRAM-MD5 fails due to missing or unsupported MD5 digest (e.g. in FIPS-compliant environments). Instead of crashing with a `ValueError`, the client now skips CRAM-MD5 and tries the next available mechanism.

A regression test has been added to verify this fallback behavior.
