### PR TITLE
Remove mention of 'Unicode' strings in  documentation

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -640,7 +640,7 @@ strings only contain ASCII characters.
 
 Other than the *ensure_ascii* parameter, this module is defined strictly in
 terms of conversion between Python objects and
-:class:`Unicode strings <str>`, and thus does not otherwise directly address
+:class:`strings <str>`, and thus does not otherwise directly address
 the issue of character encodings.
 
 The RFC prohibits adding a byte order mark (BOM) to the start of a JSON text,


### PR DESCRIPTION
This [was written](https://github.com/python/cpython/commit/331624b67d1b86187b13b4b0030dbca60003fa1e) when Python 2 was still relevant, so I think we can remove the explicit 'Unicode' mention here.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136215.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->