### PR TITLE
gh-133982: Test _pyio.BytesIO in free-threaded tests

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -720,7 +720,7 @@ than raw I/O does.
    contains initial data.
 
    Methods may be used from multiple threads without external locking in
-   :term:`free-threaded <free-threading>` builds.
+   :term:`free threading` builds.
 
    :class:`BytesIO` provides or overrides these methods in addition to those
    from :class:`BufferedIOBase` and :class:`IOBase`:

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -719,6 +719,9 @@ than raw I/O does.
    The optional argument *initial_bytes* is a :term:`bytes-like object` that
    contains initial data.
 
+   Methods may be used from multiple threads without external locking in
+   :term:`free-threaded <free-threading>` builds.
+
    :class:`BytesIO` provides or overrides these methods in addition to those
    from :class:`BufferedIOBase` and :class:`IOBase`:
 

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -876,16 +876,27 @@ class BytesIO(BufferedIOBase):
     _buffer = None
 
     def __init__(self, initial_bytes=None):
+        # Use to keep self._buffer and self._pos consistent.
+        self._lock = Lock()
+
         buf = bytearray()
         if initial_bytes is not None:
             buf += initial_bytes
-        self._buffer = buf
-        self._pos = 0
+
+        with self._lock:
+            self._buffer = buf
+            self._pos = 0
 
     def __getstate__(self):
         if self.closed:
             raise ValueError("__getstate__ on closed file")
-        return self.__dict__.copy()
+        state = self.__dict__.copy()
+        del state['_lock']
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._lock = Lock()
 
     def getvalue(self):
         """Return the bytes value (contents) of the buffer
@@ -909,23 +920,25 @@ class BytesIO(BufferedIOBase):
     def read(self, size=-1):
         if self.closed:
             raise ValueError("read from closed file")
-        if size is None:
-            size = -1
-        else:
-            try:
-                size_index = size.__index__
-            except AttributeError:
-                raise TypeError(f"{size!r} is not an integer")
+
+        with self._lock:
+            if size is None:
+                size = -1
             else:
-                size = size_index()
-        if size < 0:
-            size = len(self._buffer)
-        if len(self._buffer) <= self._pos:
-            return b""
-        newpos = min(len(self._buffer), self._pos + size)
-        b = self._buffer[self._pos : newpos]
-        self._pos = newpos
-        return bytes(b)
+                try:
+                    size_index = size.__index__
+                except AttributeError:
+                    raise TypeError(f"{size!r} is not an integer")
+                else:
+                    size = size_index()
+            if size < 0:
+                size = len(self._buffer)
+            if len(self._buffer) <= self._pos:
+                return b""
+            newpos = min(len(self._buffer), self._pos + size)
+            b = self._buffer[self._pos : newpos]
+            self._pos = newpos
+            return bytes(b)
 
     def read1(self, size=-1):
         """This is the same as read.
@@ -941,12 +954,14 @@ class BytesIO(BufferedIOBase):
             n = view.nbytes  # Size of any bytes-like object
         if n == 0:
             return 0
-        pos = self._pos
-        if pos > len(self._buffer):
-            # Pad buffer to pos with null bytes.
-            self._buffer.resize(pos)
-        self._buffer[pos:pos + n] = b
-        self._pos += n
+
+        with self._lock:
+            pos = self._pos
+            if pos > len(self._buffer):
+                # Pad buffer to pos with null bytes.
+                self._buffer.resize(pos)
+            self._buffer[pos:pos + n] = b
+            self._pos += n
         return n
 
     def seek(self, pos, whence=0):
@@ -978,18 +993,20 @@ class BytesIO(BufferedIOBase):
     def truncate(self, pos=None):
         if self.closed:
             raise ValueError("truncate on closed file")
-        if pos is None:
-            pos = self._pos
-        else:
-            try:
-                pos_index = pos.__index__
-            except AttributeError:
-                raise TypeError(f"{pos!r} is not an integer")
+
+        with self._lock:
+            if pos is None:
+                pos = self._pos
             else:
-                pos = pos_index()
-            if pos < 0:
-                raise ValueError("negative truncate position %r" % (pos,))
-        del self._buffer[pos:]
+                try:
+                    pos_index = pos.__index__
+                except AttributeError:
+                    raise TypeError(f"{pos!r} is not an integer")
+                else:
+                    pos = pos_index()
+                if pos < 0:
+                    raise ValueError("negative truncate position %r" % (pos,))
+            del self._buffer[pos:]
         return pos
 
     def readable(self):

--- a/Lib/test/test_free_threading/test_io.py
+++ b/Lib/test/test_free_threading/test_io.py
@@ -104,9 +104,8 @@ class ThreadSafetyMixin:
         self.check([truncate] + [getbuffer] * 10, self.ioclass(b'0\n'*204800))
         self.check([truncate] + [iter] * 10, self.ioclass(b'0\n'*20480))
         self.check([truncate] + [getstate] * 10, self.ioclass(b'0\n'*204800))
-        # _pyio uses default __setstate__
-        if hasattr(self.ioclass, '__setstate__'):
-            self.check([truncate] + [setstate] * 10, self.ioclass(b'0\n'*204800), (b'123', 0, None))
+        state = self.ioclass(b'123').__getstate__()
+        self.check([truncate] + [setstate] * 10, self.ioclass(b'0\n'*204800), state)
         self.check([truncate] + [sizeof] * 10, self.ioclass(b'0\n'*204800))
 
         # no tests for seek or tell because they don't break anything

--- a/Lib/test/test_free_threading/test_io.py
+++ b/Lib/test/test_free_threading/test_io.py
@@ -1,12 +1,13 @@
+import io
+import _pyio as pyio
 import threading
 from unittest import TestCase
 from test.support import threading_helper
 from random import randint
-from io import BytesIO
 from sys import getsizeof
 
 
-class TestBytesIO(TestCase):
+class ThreadSafetyMixin:
     # Test pretty much everything that can break under free-threading.
     # Non-deterministic, but at least one of these things will fail if
     # BytesIO object is not free-thread safe.
@@ -90,20 +91,28 @@ class TestBytesIO(TestCase):
             barrier.wait()
             getsizeof(b)
 
-        self.check([write] * 10, BytesIO())
-        self.check([writelines] * 10, BytesIO())
-        self.check([write] * 10 + [truncate] * 10, BytesIO())
-        self.check([truncate] + [read] * 10, BytesIO(b'0\n'*204800))
-        self.check([truncate] + [read1] * 10, BytesIO(b'0\n'*204800))
-        self.check([truncate] + [readline] * 10, BytesIO(b'0\n'*20480))
-        self.check([truncate] + [readlines] * 10, BytesIO(b'0\n'*20480))
-        self.check([truncate] + [readinto] * 10, BytesIO(b'0\n'*204800), bytearray(b'0\n'*204800))
-        self.check([close] + [write] * 10, BytesIO())
-        self.check([truncate] + [getvalue] * 10, BytesIO(b'0\n'*204800))
-        self.check([truncate] + [getbuffer] * 10, BytesIO(b'0\n'*204800))
-        self.check([truncate] + [iter] * 10, BytesIO(b'0\n'*20480))
-        self.check([truncate] + [getstate] * 10, BytesIO(b'0\n'*204800))
-        self.check([truncate] + [setstate] * 10, BytesIO(b'0\n'*204800), (b'123', 0, None))
-        self.check([truncate] + [sizeof] * 10, BytesIO(b'0\n'*204800))
+        self.check([write] * 10, self.ioclass())
+        self.check([writelines] * 10, self.ioclass())
+        self.check([write] * 10 + [truncate] * 10, self.ioclass())
+        self.check([truncate] + [read] * 10, self.ioclass(b'0\n'*204800))
+        self.check([truncate] + [read1] * 10, self.ioclass(b'0\n'*204800))
+        self.check([truncate] + [readline] * 10, self.ioclass(b'0\n'*20480))
+        self.check([truncate] + [readlines] * 10, self.ioclass(b'0\n'*20480))
+        self.check([truncate] + [readinto] * 10, self.ioclass(b'0\n'*204800), bytearray(b'0\n'*204800))
+        self.check([close] + [write] * 10, self.ioclass())
+        self.check([truncate] + [getvalue] * 10, self.ioclass(b'0\n'*204800))
+        self.check([truncate] + [getbuffer] * 10, self.ioclass(b'0\n'*204800))
+        self.check([truncate] + [iter] * 10, self.ioclass(b'0\n'*20480))
+        self.check([truncate] + [getstate] * 10, self.ioclass(b'0\n'*204800))
+        # _pyio uses default __setstate__
+        if hasattr(self.ioclass, '__setstate__'):
+            self.check([truncate] + [setstate] * 10, self.ioclass(b'0\n'*204800), (b'123', 0, None))
+        self.check([truncate] + [sizeof] * 10, self.ioclass(b'0\n'*204800))
 
         # no tests for seek or tell because they don't break anything
+
+class CBytesIOTest(ThreadSafetyMixin, TestCase):
+    ioclass = io.BytesIO
+
+class PyBytesIOTest(ThreadSafetyMixin, TestCase):
+     ioclass = pyio.BytesIO

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -9,6 +9,7 @@
 # * test_univnewlines - tests universal newline support
 # * test_largefile - tests operations on a file greater than 2**32 bytes
 #     (only enabled with -ulargefile)
+# * test_free_threading/test_io - tests thread safety of io objects
 
 ################################################################################
 # ATTENTION TEST WRITERS!!!

--- a/Misc/NEWS.d/next/Library/2025-07-02-18-41-45.gh-issue-133982.7qqAn6.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-02-18-41-45.gh-issue-133982.7qqAn6.rst
@@ -1,0 +1,1 @@
+Update Python implementation of :class:`io.BytesIO` to be thread safe.


### PR DESCRIPTION
The test was only checking one of the two I/O implementations. Ideally the two implementations should match behavior (and guarantees) in free-threaded Python.

Followed https://py-free-threading.github.io/porting/#general-considerations-for-porting as a general guide for "make multi-threaded safe". I have a general project to build benchmarks around I/O in my backlog (https://github.com/python/pyperformance/issues/399) where I will likely work on optimizing `_io` / `_pyio` / `_experimentalio` performance down the line including in threaded contexts. For now though, goal is simple functional thread safety iterating to better.

`_pyio.BytesIO` has two parts to its state, `_pos` and `_buffer` that get updated independently at times (ex. `seek` just changes `_pos`) but often together (ex. `write` updates `_pos`, maybe extends `_buffer`, and copies data into `_buffer`). When updated together multiple threads simultaneously operating could cause issues, so introduced a lock `self._lock` to cover those cases.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133982 -->
* Issue: gh-133982
<!-- /gh-issue-number -->
