### PR TITLE
gh-127146: Skip test_netrc.test_security on Emscripten

### DIFF
--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -273,6 +273,7 @@ class NetrcTestCase(unittest.TestCase):
 
     @unittest.skipUnless(os.name == 'posix', 'POSIX only test')
     @unittest.skipUnless(hasattr(os, 'getuid'), "os.getuid is required")
+    @unittest.skipIf(support.is_emscripten, "Doesn't work")
     @os_helper.skip_unless_working_chmod
     def test_security(self):
         # This test is incomplete since we are normally not run as root and


### PR DESCRIPTION
Before #135816 it was skipped because pwd is missing on Emscripten. Now it isn't skipped because the test no longer requires pwd but it still doesn't work on Emscripten.

<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
