### PR TITLE
gh-133740: Fix regression in locale.nl_langinfo(ALT_DIGITS)

### DIFF
--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -692,7 +692,7 @@ _locale_nl_langinfo_impl(PyObject *module, int item)
             result = result != NULL ? result : "";
             char *oldloc = NULL;
             if (langinfo_constants[i].category != LC_CTYPE
-                && (
+                && *result && (
 #ifdef __GLIBC__
                     // gh-133740: Always change the locale for ALT_DIGITS and ERA
 #  ifdef ALT_DIGITS


### PR DESCRIPTION
There is no need to temporary switch locale for items ALT_DIGITS and ERA if the nl_langinfo() result is empty (most locales).


<!-- gh-issue-number: gh-133740 -->
* Issue: gh-133740
<!-- /gh-issue-number -->
