### PR TITLE
gh-101100: Fix references in http.cookiejar docs #114658

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -555,12 +555,6 @@ Netscape protocol strictness switches:
    Apply :rfc:`2965` rules on unverifiable transactions even to Netscape cookies.
 
 
-.. attribute:: DefaultCookiePolicy.strict_ns_domain
-
-   Flags indicating how strict to be with domain-matching rules for Netscape
-   cookies.  See below for acceptable values.
-
-
 .. attribute:: DefaultCookiePolicy.strict_ns_set_initial_dollar
 
    Ignore cookies in Set-Cookie: headers that have names starting with ``'$'``.
@@ -570,9 +564,15 @@ Netscape protocol strictness switches:
 
    Don't allow setting cookies whose path doesn't path-match request URI.
 
-:attr:`strict_ns_domain` is a collection of flags.  Its value is constructed by
-or-ing together (for example, ``DomainStrictNoDots|DomainStrictNonDomain`` means
-both flags are set).
+
+.. attribute:: DefaultCookiePolicy.strict_ns_domain
+
+   Flags indicating how strict to be with domain-matching rules for Netscape
+   cookies.
+
+   :attr:`strict_ns_domain` is a collection of flags. The acceptable value is
+   constructed by or-ing together (for example,
+   ``DomainStrictNoDots|DomainStrictNonDomain`` means both flags are set).
 
 
 .. attribute:: DefaultCookiePolicy.DomainStrictNoDots

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -555,6 +555,12 @@ Netscape protocol strictness switches:
    Apply :rfc:`2965` rules on unverifiable transactions even to Netscape cookies.
 
 
+.. attribute:: DefaultCookiePolicy.strict_ns_domain
+
+   Flags indicating how strict to be with domain-matching rules for Netscape
+   cookies.  See below for acceptable values.
+
+
 .. attribute:: DefaultCookiePolicy.strict_ns_set_initial_dollar
 
    Ignore cookies in Set-Cookie: headers that have names starting with ``'$'``.
@@ -564,15 +570,9 @@ Netscape protocol strictness switches:
 
    Don't allow setting cookies whose path doesn't path-match request URI.
 
-
-.. attribute:: DefaultCookiePolicy.strict_ns_domain
-
-   Flags indicating how strict to be with domain-matching rules for Netscape
-   cookies.
-
-   :attr:`strict_ns_domain` is a collection of flags. The acceptable value is
-   constructed by or-ing together (for example,
-   ``DomainStrictNoDots|DomainStrictNonDomain`` means both flags are set).
+:attr:`~DefaultCookiePolicy.strict_ns_domain` is a collection of flags.  Its value is constructed by
+or-ing together (for example, ``DomainStrictNoDots|DomainStrictNonDomain`` means
+both flags are set).
 
 
 .. attribute:: DefaultCookiePolicy.DomainStrictNoDots


### PR DESCRIPTION
The [origial doc](https://docs.python.org/3.15/library/http.cookiejar.html#http.cookiejar.DefaultCookiePolicy.strict_ns_domain) is:

![image](https://github.com/user-attachments/assets/d2a9e3f2-4d01-4d7f-b67d-14c6f966e35a)

Since there is no highlights or any reference, I see no reason to split the doc of `strict_ns_domain`. I think maybe we can make the description of the acceptable value just below `strict_ns_domain`? The two addtributes within are likely to be added in the wrong place.

Another thing is the referrence link of `strict_ns_domain` is invalid in the original doc, since it's been interrupted and can't locate the attribute. (The .rst file is [here](https://github.com/python/cpython/edit/main/Doc/library/http.cookiejar.rst#L573))

This PR change it to:

![image](https://github.com/user-attachments/assets/7e527530-0044-4377-abce-acc6282d19f2)


Skipping issues and news ;)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136238.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
