### PR TITLE
gh-135846: Add zstd dependency to Android build script

### DIFF
--- a/Android/android.py
+++ b/Android/android.py
@@ -175,7 +175,7 @@ def unpack_deps(host, prefix_dir):
     os.chdir(prefix_dir)
     deps_url = "https://github.com/beeware/cpython-android-source-deps/releases/download"
     for name_ver in ["bzip2-1.0.8-3", "libffi-3.4.4-3", "openssl-3.0.15-4",
-                     "sqlite-3.49.1-0", "xz-5.4.6-1"]:
+                     "sqlite-3.49.1-0", "xz-5.4.6-1", "zstd-1.5.7-0"]:
         filename = f"{name_ver}-{host}.tar.gz"
         download(f"{deps_url}/{name_ver}/{filename}")
         shutil.unpack_archive(filename)

--- a/Android/android.py
+++ b/Android/android.py
@@ -175,7 +175,7 @@ def unpack_deps(host, prefix_dir):
     os.chdir(prefix_dir)
     deps_url = "https://github.com/beeware/cpython-android-source-deps/releases/download"
     for name_ver in ["bzip2-1.0.8-3", "libffi-3.4.4-3", "openssl-3.0.15-4",
-                     "sqlite-3.49.1-0", "xz-5.4.6-1", "zstd-1.5.7-0"]:
+                     "sqlite-3.49.1-0", "xz-5.4.6-1", "zstd-1.5.7-1"]:
         filename = f"{name_ver}-{host}.tar.gz"
         download(f"{deps_url}/{name_ver}/{filename}")
         shutil.unpack_archive(filename)


### PR DESCRIPTION
This PR adds libzstd to the Android platform build script. The source deps build script was added in https://github.com/beeware/cpython-android-source-deps/pull/5.

The host configure found the libraries to enable `_zstd`:
```
checking for libzstd >= 1.4.5... yes
...
checking for stdlib extension module _zstd... yes
```


<!-- gh-issue-number: gh-135846 -->
* Issue: gh-135846
<!-- /gh-issue-number -->
