### PR TITLE
gh-136288: Correct error display in _testcapi/vectorcall.c

### DIFF
--- a/Modules/_testcapi/vectorcall.c
+++ b/Modules/_testcapi/vectorcall.c
@@ -179,14 +179,14 @@ _testcapi_VectorCallClass_set_vectorcall_impl(PyObject *self,
     if (!PyObject_TypeCheck(self, type)) {
         return PyErr_Format(
             PyExc_TypeError,
-            "expected %S instance",
-            PyType_GetName(type));
+            "expected %N instance",
+            type);
     }
     if (!type->tp_vectorcall_offset) {
         return PyErr_Format(
             PyExc_TypeError,
-            "type %S has no vectorcall offset",
-            PyType_GetName(type));
+            "type %N has no vectorcall offset",
+            type);
     }
     *(vectorcallfunc*)((char*)self + type->tp_vectorcall_offset) = (
         VectorCallClass_vectorcall);

--- a/Modules/_testcapi/vectorcall.c
+++ b/Modules/_testcapi/vectorcall.c
@@ -179,13 +179,13 @@ _testcapi_VectorCallClass_set_vectorcall_impl(PyObject *self,
     if (!PyObject_TypeCheck(self, type)) {
         return PyErr_Format(
             PyExc_TypeError,
-            "expected %s instance",
+            "expected %S instance",
             PyType_GetName(type));
     }
     if (!type->tp_vectorcall_offset) {
         return PyErr_Format(
             PyExc_TypeError,
-            "type %s has no vectorcall offset",
+            "type %S has no vectorcall offset",
             PyType_GetName(type));
     }
     *(vectorcallfunc*)((char*)self + type->tp_vectorcall_offset) = (


### PR DESCRIPTION
Correct incorrect conversion specifier in test from %s to %S for `PyObject *`. I could have added a test, but that would be testing the test!

<!-- gh-issue-number: gh-136288 -->
* Issue: gh-136288
<!-- /gh-issue-number -->
