### PR TITLE
gh-136264: Fix PEP-739 build-details generation with relative-paths

### DIFF
--- a/Tools/build/generate-build-details.py
+++ b/Tools/build/generate-build-details.py
@@ -149,7 +149,12 @@ def make_paths_relative(data: dict[str, Any], config_path: str | None = None) ->
         try:
             container = data
             for part in parent.split('.'):
-                container = container[part]
+                if part:
+                    if part not in container:
+                        raise KeyError(part)
+                    container = container[part]
+            if child not in container:
+                raise KeyError(part)
             current_path = container[child]
         except KeyError:
             continue


### PR DESCRIPTION
there were two issues with the `make_paths_relative` implementation:

1. for top-level entries (i.e. `base_interpreter`), the `parent` is `""`, leading to the part loop to set the `container` to the non-existent top-level `""` key, which becomes `{}` because it's a `defaultdict`
2. for dotted-entries that don't exist in the data, `current_path` ends up being `{}`, again, because it's a `defaultdict`

this PR proposes one (granted, somewhat sus) way to fix it, by:
1. checking the truthyness of `part` before indexing into the `container` (fixing the first issue)
2. explicitly raising the `KeyError` when it would have been otherwise raised by a non-defaultdict dict (fixing the second issue)

<!-- gh-issue-number: gh-136264 -->
* Issue: gh-136264
<!-- /gh-issue-number -->
