### PR TITLE
gh-136156: Allow using linkat() with TemporaryFile

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -656,7 +656,7 @@ else:
             fd = None
             def opener(*args):
                 nonlocal fd
-                flags2 = (flags | _os.O_TMPFILE) & ~_os.O_CREAT
+                flags2 = (flags | _os.O_TMPFILE) & ~_os.O_CREAT & ~_os.O_EXCL
                 fd = _os.open(dir, flags2, 0o600)
                 return fd
             try:

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1594,6 +1594,29 @@ if tempfile.NamedTemporaryFile is not tempfile.TemporaryFile:
             mock_close.assert_called()
             self.assertEqual(os.listdir(dir), [])
 
+        @unittest.skipUnless(tempfile._O_TMPFILE_WORKS, 'need os.O_TMPFILE')
+        @unittest.skipUnless(os.path.exists('/proc/self/fd'),
+                             'need /proc/self/fd')
+        def test_link_tmpfile(self):
+            dir = tempfile.mkdtemp()
+            self.addCleanup(os_helper.rmtree, dir)
+            filename = os.path.join(dir, "link")
+
+            with tempfile.TemporaryFile('w', dir=dir) as tmp:
+                # the flag can become False on Linux <= 3.11
+                if not tempfile._O_TMPFILE_WORKS:
+                    self.skipTest("O_TMPFILE doesn't work")
+
+                tmp.write("hello")
+                tmp.flush()
+                fd = tmp.fileno()
+
+                os.link(f'/proc/self/fd/{fd}',
+                        filename,
+                        follow_symlinks=True)
+                with open(filename) as fp:
+                    self.assertEqual(fp.read(), "hello")
+
 
 # Helper for test_del_on_shutdown
 class NulledModules:

--- a/Misc/NEWS.d/next/Library/2025-07-04-12-53-02.gh-issue-136156.OYlXoz.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-04-12-53-02.gh-issue-136156.OYlXoz.rst
@@ -1,0 +1,3 @@
+:func:`tempfile.TemporaryFile` no longer uses :data:`os.O_EXCL` with
+:data:`os.O_TMPFILE`, so it's possible to use ``linkat()`` on the file
+descriptor. Patch by Victor Stinner.


### PR DESCRIPTION
tempfile.TemporaryFile() no longer uses os.O_EXCL with os.O_TMPFILE, so it's possible to use linkat() on the file descriptor.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136156 -->
* Issue: gh-136156
<!-- /gh-issue-number -->
