### PR TITLE
Fix a unstable link in urllib in stdlib tutorial

### DIFF
--- a/Doc/tutorial/stdlib.rst
+++ b/Doc/tutorial/stdlib.rst
@@ -183,7 +183,7 @@ protocols. Two of the simplest are :mod:`urllib.request` for retrieving data
 from URLs and :mod:`smtplib` for sending mail::
 
    >>> from urllib.request import urlopen
-   >>> with urlopen('http://worldtimeapi.org/api/timezone/etc/UTC.txt') as response:
+   >>> with urlopen('https://worldtimeapi.org/api/timezone/etc/UTC.txt') as response:
    ...     for line in response:
    ...         line = line.decode()             # Convert bytes to a str
    ...         if line.startswith('datetime'):


### PR DESCRIPTION
in the tutorial doc of [Internet access](https://docs.python.org/3/tutorial/stdlib.html#internet-access) . We've got an example of urllib.

![image](https://github.com/user-attachments/assets/00841590-54a0-4c06-8582-a6d05de40674)

The example script:

```python
from urllib.request import urlopen
with urlopen('http://worldtimeapi.org/api/timezone/etc/UTC.txt') as response:
    for line in response:
        line = line.decode()             # Convert bytes to a str
        if line.startswith('datetime'):
            print(line.rstrip())         # Remove trailing newline
```

So if you run this example it will always return 500. I've tested it in different network environments, and the original link doesn't work at all.

cc @ZeroIntensity similar to the former fix. I've overlooked this before, sry. Skiping news and issues as well. 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136296.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->