### PR TITLE
gh-136300: Modify C tests to conform to PEP-737

### DIFF
--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -1855,8 +1855,8 @@ ndarray_subscript(PyObject *op, PyObject *key)
 
 type_error:
     PyErr_Format(PyExc_TypeError,
-        "cannot index memory using \"%.200s\"",
-        Py_TYPE(key)->tp_name);
+        "cannot index memory using \"%T\"",
+        key);
 err_occurred:
     Py_DECREF(nd);
     return NULL;

--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -1855,8 +1855,7 @@ ndarray_subscript(PyObject *op, PyObject *key)
 
 type_error:
     PyErr_Format(PyExc_TypeError,
-        "cannot index memory using \"%T\"",
-        key);
+        "cannot index memory using \"%T\"", key);
 err_occurred:
     Py_DECREF(nd);
     return NULL;

--- a/Modules/_testcapi/monitoring.c
+++ b/Modules/_testcapi/monitoring.c
@@ -109,7 +109,7 @@ static PyTypeObject PyCodeLike_Type = {
 };
 
 #define RAISE_UNLESS_CODELIKE(v)  if (!Py_IS_TYPE((v), &PyCodeLike_Type)) { \
-        PyErr_Format(PyExc_TypeError, "expected a code-like, got %s", Py_TYPE(v)->tp_name); \
+        PyErr_Format(PyExc_TypeError, "expected a code-like, got %T", v); \
         return NULL; \
     }
 

--- a/Modules/_testcapi/time.c
+++ b/Modules/_testcapi/time.c
@@ -5,8 +5,8 @@ static int
 pytime_from_nanoseconds(PyTime_t *tp, PyObject *obj)
 {
     if (!PyLong_Check(obj)) {
-        PyErr_Format(PyExc_TypeError, "expect int, got %s",
-                     Py_TYPE(obj)->tp_name);
+        PyErr_Format(PyExc_TypeError, "expect int, got %T",
+                     obj);
         return -1;
     }
 

--- a/Modules/_testcapi/time.c
+++ b/Modules/_testcapi/time.c
@@ -5,8 +5,7 @@ static int
 pytime_from_nanoseconds(PyTime_t *tp, PyObject *obj)
 {
     if (!PyLong_Check(obj)) {
-        PyErr_Format(PyExc_TypeError, "expect int, got %T",
-                     obj);
+        PyErr_Format(PyExc_TypeError, "expect int, got %T", obj);
         return -1;
     }
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -515,8 +515,8 @@ test_thread_state(PyObject *self, PyObject *args)
         return NULL;
 
     if (!PyCallable_Check(fn)) {
-        PyErr_Format(PyExc_TypeError, "'%s' object is not callable",
-            Py_TYPE(fn)->tp_name);
+        PyErr_Format(PyExc_TypeError, "'%T' object is not callable",
+            fn);
         return NULL;
     }
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -515,8 +515,7 @@ test_thread_state(PyObject *self, PyObject *args)
         return NULL;
 
     if (!PyCallable_Check(fn)) {
-        PyErr_Format(PyExc_TypeError, "'%T' object is not callable",
-            fn);
+        PyErr_Format(PyExc_TypeError, "'%T' object is not callable", fn);
         return NULL;
     }
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -2207,8 +2207,8 @@ get_code(PyObject *obj)
         return (PyCodeObject *)PyFunction_GetCode(obj);
     }
     return (PyCodeObject *)PyErr_Format(
-        PyExc_TypeError, "expected function or code object, got %s",
-        Py_TYPE(obj)->tp_name);
+        PyExc_TypeError, "expected function or code object, got %T",
+        obj);
 }
 
 static PyObject *

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -2207,8 +2207,7 @@ get_code(PyObject *obj)
         return (PyCodeObject *)PyFunction_GetCode(obj);
     }
     return (PyCodeObject *)PyErr_Format(
-        PyExc_TypeError, "expected function or code object, got %T",
-        obj);
+        PyExc_TypeError, "expected function or code object, got %T", obj);
 }
 
 static PyObject *


### PR DESCRIPTION
- Use %T format specifier instead of %s and Py_TYPE(x)->tp_name.
- Remove legacy %.200s format specifier for truncating type names.

<!-- gh-issue-number: gh-136300 -->
* Issue: gh-136300
<!-- /gh-issue-number -->
