### PR TITLE
[3.12] gh-125893: Add type check for category argument in warnings.simplefilter and warnings.filterwarning

### DIFF
--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -130,6 +130,12 @@ def _formatwarnmsg(msg):
                       msg.filename, msg.lineno, msg.line)
     return _formatwarnmsg_impl(msg)
 
+def _valid_warning_category(category):
+    """Return True if category is a Warning subclass or tuple of such."""
+    if isinstance(category, tuple):
+        return all(isinstance(c, type) and issubclass(c, Warning) for c in category)
+    return isinstance(category, type) and issubclass(category, Warning)
+
 def filterwarnings(action, message="", category=Warning, module="", lineno=0,
                    append=False):
     """Insert an entry into the list of warnings filters (at the front).
@@ -145,7 +151,7 @@ def filterwarnings(action, message="", category=Warning, module="", lineno=0,
     assert action in ("error", "ignore", "always", "default", "module",
                       "once"), "invalid action: %r" % (action,)
     assert isinstance(message, str), "message must be a string"
-    if not (isinstance(category, type) and issubclass(category, Warning)):
+    if not _valid_warning_category(category):
         raise TypeError("category must be a Warning subclass, "
                         "not '{:s}'".format(type(category).__name__))
     assert isinstance(module, str), "module must be a string"
@@ -178,7 +184,7 @@ def simplefilter(action, category=Warning, lineno=0, append=False):
     """
     assert action in ("error", "ignore", "always", "default", "module",
                       "once"), "invalid action: %r" % (action,)
-    if not (isinstance(category, type) and issubclass(category, Warning)):
+    if not _valid_warning_category(category):
         raise TypeError("category must be a Warning subclass, "
                         "not '{:s}'".format(type(category).__name__))
     assert isinstance(lineno, int) and lineno >= 0, \

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -145,8 +145,9 @@ def filterwarnings(action, message="", category=Warning, module="", lineno=0,
     assert action in ("error", "ignore", "always", "default", "module",
                       "once"), "invalid action: %r" % (action,)
     assert isinstance(message, str), "message must be a string"
-    assert isinstance(category, type), "category must be a class"
-    assert issubclass(category, Warning), "category must be a Warning subclass"
+    if not (isinstance(category, type) and issubclass(category, Warning)):
+        raise TypeError("category must be a Warning subclass, "
+                        "not '{:s}'".format(type(category).__name__))
     assert isinstance(module, str), "module must be a string"
     assert isinstance(lineno, int) and lineno >= 0, \
            "lineno must be an int >= 0"
@@ -177,6 +178,9 @@ def simplefilter(action, category=Warning, lineno=0, append=False):
     """
     assert action in ("error", "ignore", "always", "default", "module",
                       "once"), "invalid action: %r" % (action,)
+    if not (isinstance(category, type) and issubclass(category, Warning)):
+        raise TypeError("category must be a Warning subclass, "
+                        "not '{:s}'".format(type(category).__name__))
     assert isinstance(lineno, int) and lineno >= 0, \
            "lineno must be an int >= 0"
     _add_filter(action, None, category, None, lineno, append=append)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -2093,5 +2093,6 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
+Hasrat Ali Arzoo
 
 (Entries should be added in rough alphabetical order by last names)


### PR DESCRIPTION
This PR addresses gh-125893 by adding a type check for the category argument in warnings.simplefilter  and warnings.filterwarning, 

Previously, warnings.filterwarnings correctly raised an error when the category argument was not a class, but warnings.simplefilter accepted invalid types without raising any error. This inconsistency could lead to confusion and improper warning filtering.

Both  warnings.simplefilter  and warnings.filterwarning were not raising any warnings while ran with `python -O` but now this is also handled.

```
$ ./amd64/python.exe -O -c "import warnings; warnings.resetwarnings(); warnings.simplefilter('default', category='Hello');  print(warnings.filters)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\hasra\OneDrive\Documents\opensource\cpython\Lib\warnings.py", line 182, in simplefilter
    raise TypeError("category must be a Warning subclass, "
TypeError: category must be a Warning subclass, not 'str'
```

```
./amd64/python.exe -O -c "import warnings; warnings.resetwarnings(); warnings.filterwarnings('ignore', category=Warning); warnings.filterwarnings('ignore', category='Hello'); print(warnings.filters)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\hasra\OneDrive\Documents\opensource\cpython\Lib\warnings.py", line 149, in filterwarnings
    raise TypeError("category must be a Warning subclass, "
TypeError: category must be a Warning subclass, not 'str'
```