### PR TITLE
gh-136282: Configparser: create unnamed sections via mapping protocol access

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -794,7 +794,8 @@ class RawConfigParser(MutableMapping):
         """
         elements_added = set()
         for section, keys in dictionary.items():
-            section = str(section)
+            if section is not UNNAMED_SECTION:
+                section = str(section)
             try:
                 self.add_section(section)
             except (DuplicateSectionError, ValueError):

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -2215,6 +2215,16 @@ class SectionlessTestCase(unittest.TestCase):
         cfg.add_section(configparser.UNNAMED_SECTION)
         cfg.set(configparser.UNNAMED_SECTION, 'a', '1')
         self.assertEqual('1', cfg[configparser.UNNAMED_SECTION]['a'])
+        output = io.StringIO()
+        cfg.write(output)
+        self.assertEqual(output.getvalue(), 'a = 1\n\n')
+
+        cfg = configparser.ConfigParser(allow_unnamed_section=True)
+        cfg[configparser.UNNAMED_SECTION] = {'a': '1'}
+        self.assertEqual('1', cfg[configparser.UNNAMED_SECTION]['a'])
+        output = io.StringIO()
+        cfg.write(output)
+        self.assertEqual(output.getvalue(), 'a = 1\n\n')
 
     def test_disabled_error(self):
         with self.assertRaises(configparser.MissingSectionHeaderError):
@@ -2222,6 +2232,9 @@ class SectionlessTestCase(unittest.TestCase):
 
         with self.assertRaises(configparser.UnnamedSectionDisabledError):
             configparser.ConfigParser().add_section(configparser.UNNAMED_SECTION)
+
+        with self.assertRaises(configparser.UnnamedSectionDisabledError):
+            configparser.ConfigParser()[configparser.UNNAMED_SECTION] = {'a': '1'}
 
     def test_multiple_configs(self):
         cfg = configparser.ConfigParser(allow_unnamed_section=True)

--- a/Misc/NEWS.d/next/Library/2025-07-05-08-30-07.gh-issue-136282.K3JKyD.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-05-08-30-07.gh-issue-136282.K3JKyD.rst
@@ -1,0 +1,2 @@
+Add support for :const:`~configparser.UNNAMED_SECTION` when creating a
+section via the mapping protocol access


### PR DESCRIPTION
Using the _mapping protocol access_ to create unnamed section was not supported.

With this PR you can use it:

```py
>>> cfg = configparser.ConfigParser(allow_unnamed_section=True)
>>> cfg[configparser.UNNAMED_SECTION] = {"foo": "bar"}
>>> cfg.write(fobj)
```

<!-- gh-issue-number: gh-136282 -->
* Issue: gh-136282
<!-- /gh-issue-number -->
