### PR TITLE
gh-101100: Fix Sphinx warnings in library/email.compat32-message.rst

### DIFF
--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -181,7 +181,7 @@ Here are the methods of the :class:`Message` class:
       :meth:`set_payload` instead.
 
       This is a legacy method.  On the
-      :class:`~email.emailmessage.EmailMessage` class its functionality is
+      :class:`~email.message.EmailMessage` class its functionality is
       replaced by :meth:`~email.message.EmailMessage.set_content` and the
       related ``make`` and ``add`` methods.
 
@@ -224,7 +224,7 @@ Here are the methods of the :class:`Message` class:
       ASCII charset.
 
       This is a legacy method.  On the
-      :class:`~email.emailmessage.EmailMessage` class its functionality is
+      :class:`~email.message.EmailMessage` class its functionality is
       replaced by :meth:`~email.message.EmailMessage.get_content` and
       :meth:`~email.message.EmailMessage.iter_parts`.
 
@@ -236,7 +236,7 @@ Here are the methods of the :class:`Message` class:
       the message's default character set; see :meth:`set_charset` for details.
 
       This is a legacy method.  On the
-      :class:`~email.emailmessage.EmailMessage` class its functionality is
+      :class:`~email.message.EmailMessage` class its functionality is
       replaced by :meth:`~email.message.EmailMessage.set_content`.
 
 
@@ -265,9 +265,9 @@ Here are the methods of the :class:`Message` class:
       using that :mailheader:`Content-Transfer-Encoding` and is not modified.
 
       This is a legacy method.  On the
-      :class:`~email.emailmessage.EmailMessage` class its functionality is
+      :class:`~email.message.EmailMessage` class its functionality is
       replaced by the *charset* parameter of the
-      :meth:`email.emailmessage.EmailMessage.set_content` method.
+      :meth:`email.message.EmailMessage.set_content` method.
 
 
    .. method:: get_charset()
@@ -276,7 +276,7 @@ Here are the methods of the :class:`Message` class:
       message's payload.
 
       This is a legacy method.  On the
-      :class:`~email.emailmessage.EmailMessage` class it always returns
+      :class:`~email.message.EmailMessage` class it always returns
       ``None``.
 
 
@@ -486,7 +486,7 @@ Here are the methods of the :class:`Message` class:
       search instead of :mailheader:`Content-Type`.
 
       This is a legacy method.  On the
-      :class:`~email.emailmessage.EmailMessage` class its functionality is
+      :class:`~email.message.EmailMessage` class its functionality is
       replaced by the *params* property of the individual header objects
       returned by the header access methods.
 
@@ -524,7 +524,7 @@ Here are the methods of the :class:`Message` class:
       to ``False``.
 
       This is a legacy method.  On the
-      :class:`~email.emailmessage.EmailMessage` class its functionality is
+      :class:`~email.message.EmailMessage` class its functionality is
       replaced by the *params* property of the individual header objects
       returned by the header access methods.
 
@@ -579,7 +579,7 @@ Here are the methods of the :class:`Message` class:
       header is also added.
 
       This is a legacy method.  On the
-      :class:`~email.emailmessage.EmailMessage` class its functionality is
+      :class:`~email.message.EmailMessage` class its functionality is
       replaced by the ``make_`` and ``add_`` methods.
 
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -15,7 +15,6 @@ Doc/extending/extending.rst
 Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
 Doc/library/email.charset.rst
-Doc/library/email.compat32-message.rst
 Doc/library/email.parser.rst
 Doc/library/exceptions.rst
 Doc/library/functools.rst


### PR DESCRIPTION
before:

```
C:\Users\admin\Downloads\cpython-main\Doc\library\email.compat32-message.rst:226: WARNING: py:class reference target not found: email.emailmessage.EmailMessage [ref.class]
C:\Users\admin\Downloads\cpython-main\Doc\library\email.compat32-message.rst:238: WARNING: py:class reference target not found: email.emailmessage.EmailMessage [ref.class]
C:\Users\admin\Downloads\cpython-main\Doc\library\email.compat32-message.rst:267: WARNING: py:class reference target not found: email.emailmessage.EmailMessage [ref.class]
C:\Users\admin\Downloads\cpython-main\Doc\library\email.compat32-message.rst:267: WARNING: py:meth reference target not found: email.emailmessage.EmailMessage.set_content [ref.meth]
C:\Users\admin\Downloads\cpython-main\Doc\library\email.compat32-message.rst:278: WARNING: py:class reference target not found: email.emailmessage.EmailMessage [ref.class]
C:\Users\admin\Downloads\cpython-main\Doc\library\email.compat32-message.rst:488: WARNING: py:class reference target not found: email.emailmessage.EmailMessage [ref.class]
C:\Users\admin\Downloads\cpython-main\Doc\library\email.compat32-message.rst:526: WARNING: py:class reference target not found: email.emailmessage.EmailMessage [ref.class]
C:\Users\admin\Downloads\cpython-main\Doc\library\email.compat32-message.rst:581: WARNING: py:class reference target not found: email.emailmessage.EmailMessage [ref.class]
```

The warnings are raised in a same reason. An example:

```
      This is a legacy method.  On the
      :class:`~email.emailmessage.EmailMessage` class its functionality is
      replaced by :meth:`~email.message.EmailMessage.get_content` and
      :meth:`~email.message.EmailMessage.iter_parts`.
```

![image](https://github.com/user-attachments/assets/d6641763-75a2-4acc-b58f-b7c5f86b0152)

The referrence to `EmailMessage` is invalid, because the moudle is actually `email.message.EmailMessage` not `email.emailmessage.EmailMessage` . This PR fix them all.

After:

![image](https://github.com/user-attachments/assets/2bed11b7-ec19-48f3-8f2b-a40aa9e2d884)

and the example:

![image](https://github.com/user-attachments/assets/627b2b79-7c67-4785-8164-a24de883103b)

In this example, you can check the `set_content` method, which is a method of `email.message.EmailMessage` not `email.emailmessage.EmailMessage`

The preview doc of this moudle: https://cpython-previews--136323.org.readthedocs.build/en/136323/library/email.compat32-message.html?readthedocs-diff=true&readthedocs-diff-chunk=1



<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136323.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->