### PR TITLE
gh-72327: Suggest using system terminal for pip install in PyREPL

### DIFF
--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -27,6 +27,7 @@ import code
 import linecache
 from dataclasses import dataclass, field
 import os.path
+import re
 import sys
 
 
@@ -195,7 +196,19 @@ class InteractiveColoredConsole(code.InteractiveConsole):
                 ast.PyCF_ONLY_AST,
                 incomplete_input=False,
             )
-        except (SyntaxError, OverflowError, ValueError):
+        except SyntaxError as e:
+            # If it looks like pip install was entered (a common beginner
+            # mistake), provide a hint to use the system command prompt.
+            if re.match(r"^\s*(py(thon3?)? -m pip|pip3?) install.*", source):
+                e.add_note(
+                    "The Python package manager (pip) can only be used"
+                    " outside of the Python REPL.\n"
+                    "Try the 'pip' command in a separate terminal or"
+                    " command prompt."
+                )
+            self.showsyntaxerror(filename, source=source)
+            return False
+        except (OverflowError, ValueError):
             self.showsyntaxerror(filename, source=source)
             return False
         if tree.body:

--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -199,7 +199,7 @@ class InteractiveColoredConsole(code.InteractiveConsole):
         except SyntaxError as e:
             # If it looks like pip install was entered (a common beginner
             # mistake), provide a hint to use the system command prompt.
-            if re.match(r"^\s*(py(thon3?)? -m pip|pip3?) install.*", source):
+            if re.match(r"^\s*(pip3?|py(thon3?)? -m pip) install.*", source):
                 e.add_note(
                     "The Python package manager (pip) can only be used"
                     " outside of the Python REPL.\n"

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1757,3 +1757,14 @@ class TestMain(ReplTestCase):
         output, _ = self.run_repl("1\n1+2\nexit()\n", cmdline_args=['-Xshowrefcount'], env=env)
         matches = re.findall(r'\[-?\d+ refs, \d+ blocks\]', output)
         self.assertEqual(len(matches), 3)
+
+    def test_detect_pip_usage_in_repl(self):
+        for pip_cmd in ("pip", "pip3", "python -m pip", "python3 -m pip"):
+            with self.subTest(pip_cmd=pip_cmd):
+                output, exit_code = self.run_repl([f"{pip_cmd} install antigravity", "exit"])
+                self.assertIn("SyntaxError", output)
+                hint = (
+                    "The Python package manager (pip) can only be used"
+                    " outside of the Python REPL"
+                )
+                self.assertIn(hint, output)

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1761,7 +1761,7 @@ class TestMain(ReplTestCase):
     def test_detect_pip_usage_in_repl(self):
         for pip_cmd in ("pip", "pip3", "python -m pip", "python3 -m pip"):
             with self.subTest(pip_cmd=pip_cmd):
-                output, exit_code = self.run_repl([f"{pip_cmd} install antigravity", "exit"])
+                output, exit_code = self.run_repl([f"{pip_cmd} install sampleproject", "exit"])
                 self.assertIn("SyntaxError", output)
                 hint = (
                     "The Python package manager (pip) can only be used"

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1742,6 +1742,7 @@ Joel Shprentz
 Yue Shuaijie
 Jaysinh Shukla
 Terrel Shumway
+Richard Si
 Eric Siegerman
 Reilly Tucker Siemens
 Paul Sijben
@@ -1986,6 +1987,7 @@ Olivier Vielpeau
 Kannan Vijayan
 Kurt Vile
 Norman Vine
+Tom Viner
 Pauli Virtanen
 Frank Visser
 Long Vo

--- a/Misc/NEWS.d/next/Library/2025-07-07-16-46-55.gh-issue-72327.wLvRuj.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-07-16-46-55.gh-issue-72327.wLvRuj.rst
@@ -1,0 +1,2 @@
+Suggest using the system command prompt when ``pip install`` is typed into
+the REPL. Patch by Tom Viner, Richard Si, and Brian Schubert.


### PR DESCRIPTION
Users new to Python packaging often try to use pip from the REPL only to be met with a confusing `SyntaxError`. If this happens, guide the user to use a system terminal instead to invoke pip. The pip project still receives the occasional issue from users lamenting that "pip is not working!" (pypa/pip#13409)

![image](https://github.com/user-attachments/assets/3b50aebc-572b-4d3b-a288-89b02d694f56)

This is an updated version of https://github.com/python/cpython/pull/8536. 

cc @ncoghlan

<!-- gh-issue-number: gh-72327 -->
* Issue: gh-72327
<!-- /gh-issue-number -->
