### PR TITLE
gh-124486: Fix test_whichdb_ndbm in test_dbm on NetBSD

### DIFF
--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -274,7 +274,8 @@ class WhichDBTestCase(unittest.TestCase):
     @unittest.skipUnless(ndbm, reason='Test requires ndbm')
     def test_whichdb_ndbm(self):
         # Issue 17198: check that ndbm which is referenced in whichdb is defined
-        with open(_fname + '.db', 'wb'): pass
+        with open(_fname + '.db', 'wb') as f:
+            f.write(b'spam')
         _bytes_fname = os.fsencode(_fname)
         fnames = [_fname, os_helper.FakePath(_fname),
                   _bytes_fname, os_helper.FakePath(_bytes_fname)]


### PR DESCRIPTION
On NetBSD, ndbm.open() does not fail for empty file.


<!-- gh-issue-number: gh-124486 -->
* Issue: gh-124486
<!-- /gh-issue-number -->
