### PR TITLE
gh-135675: Document 10.16 vs 11.0 / 16.0 vs 26.0 behavior of platform.mac_ver()

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -234,6 +234,17 @@ macOS platform
    Entries which cannot be determined are set to ``''``.  All tuple entries are
    strings.
 
+    .. note::
+
+        Where macOS has changed its versioning scheme, it reports the next
+        logical version assuming the old scheme to applications built with any
+        prior macOS SDK version unless a ``SYSTEM_VERSION_COMPAT=0`` environment
+        variable is set, or the application is rebuilt with a matching SDK. On
+        macOS >= 11.0, if Python is built with SDK < 11 then the ``release``
+        field is ``'10.16'``. And on macOS >= 26, it's ``'16.0'`` unless Python
+        was built with SDK >= 26.0.
+
+
 iOS platform
 ------------
 


### PR DESCRIPTION
The macOS version reported in `/System/Library/CoreServices/SystemVersion.plist` can vary depending on what version of the macOS SDK Python was built with. This discrepancy bleeds into the output of `platform.mac_ver()`.

Closes #135675.

<!-- gh-issue-number: gh-135675 -->
* Issue: gh-135675
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136339.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->