### PR TITLE
gh-136380: Fix import behavior for concurrent.futures.InterpreterPoolExecutor

### DIFF
--- a/Lib/concurrent/futures/__init__.py
+++ b/Lib/concurrent/futures/__init__.py
@@ -64,8 +64,7 @@ def __getattr__(name):
         return te
 
     if _have__interpreters and name == 'InterpreterPoolExecutor':
-        from .interpreter import InterpreterPoolExecutor as ie
-        InterpreterPoolExecutor = ie
-        return ie
+        from .interpreter import InterpreterPoolExecutor
+        return InterpreterPoolExecutor
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/concurrent/futures/__init__.py
+++ b/Lib/concurrent/futures/__init__.py
@@ -34,12 +34,10 @@ __all__ = [
 ]
 
 
-_interpreters = None
-
 try:
     import _interpreters
-except ModuleNotFoundError:
-    pass
+except ImportError:
+    _interpreters = None
 
 if _interpreters:
     __all__.append('InterpreterPoolExecutor')

--- a/Lib/concurrent/futures/__init__.py
+++ b/Lib/concurrent/futures/__init__.py
@@ -17,7 +17,7 @@ from concurrent.futures._base import (FIRST_COMPLETED,
                                       wait,
                                       as_completed)
 
-__all__ = (
+__all__ = [
     'FIRST_COMPLETED',
     'FIRST_EXCEPTION',
     'ALL_COMPLETED',
@@ -29,22 +29,29 @@ __all__ = (
     'Executor',
     'wait',
     'as_completed',
-    'InterpreterPoolExecutor',
     'ProcessPoolExecutor',
     'ThreadPoolExecutor',
-)
+]
+
+
+_have__interpreters = False
+
+try:
+    import _interpreters
+    _have__interpreters = True
+except ModuleNotFoundError:
+    pass
+
+if _have__interpreters:
+    __all__.append('InterpreterPoolExecutor')
 
 
 def __dir__():
     return __all__ + ('__author__', '__doc__')
 
 
-_no_interpreter_pool_executor = False
-
-
 def __getattr__(name):
     global ProcessPoolExecutor, ThreadPoolExecutor, InterpreterPoolExecutor
-    global _no_interpreter_pool_executor
 
     if name == 'ProcessPoolExecutor':
         from .process import ProcessPoolExecutor as pe
@@ -56,13 +63,9 @@ def __getattr__(name):
         ThreadPoolExecutor = te
         return te
 
-    if name == 'InterpreterPoolExecutor' and not _no_interpreter_pool_executor:
-        try:
-            from .interpreter import InterpreterPoolExecutor as ie
-        except ModuleNotFoundError:
-            _no_interpreter_pool_executor = True
-        else:
-            InterpreterPoolExecutor = ie
-            return ie
+    if _have__interpreters and name == 'InterpreterPoolExecutor':
+        from .interpreter import InterpreterPoolExecutor as ie
+        InterpreterPoolExecutor = ie
+        return ie
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/concurrent/futures/__init__.py
+++ b/Lib/concurrent/futures/__init__.py
@@ -34,15 +34,14 @@ __all__ = [
 ]
 
 
-_have__interpreters = False
+_interpreters = None
 
 try:
     import _interpreters
-    _have__interpreters = True
 except ModuleNotFoundError:
     pass
 
-if _have__interpreters:
+if _interpreters:
     __all__.append('InterpreterPoolExecutor')
 
 
@@ -54,16 +53,14 @@ def __getattr__(name):
     global ProcessPoolExecutor, ThreadPoolExecutor, InterpreterPoolExecutor
 
     if name == 'ProcessPoolExecutor':
-        from .process import ProcessPoolExecutor as pe
-        ProcessPoolExecutor = pe
-        return pe
+        from .process import ProcessPoolExecutor
+        return ProcessPoolExecutor
 
     if name == 'ThreadPoolExecutor':
-        from .thread import ThreadPoolExecutor as te
-        ThreadPoolExecutor = te
-        return te
+        from .thread import ThreadPoolExecutor
+        return ThreadPoolExecutor
 
-    if _have__interpreters and name == 'InterpreterPoolExecutor':
+    if _interpreters and name == 'InterpreterPoolExecutor':
         from .interpreter import InterpreterPoolExecutor
         return InterpreterPoolExecutor
 

--- a/Lib/concurrent/futures/__init__.py
+++ b/Lib/concurrent/futures/__init__.py
@@ -39,8 +39,12 @@ def __dir__():
     return __all__ + ('__author__', '__doc__')
 
 
+_no_interpreter_pool_executor = False
+
+
 def __getattr__(name):
     global ProcessPoolExecutor, ThreadPoolExecutor, InterpreterPoolExecutor
+    global _no_interpreter_pool_executor
 
     if name == 'ProcessPoolExecutor':
         from .process import ProcessPoolExecutor as pe
@@ -52,13 +56,13 @@ def __getattr__(name):
         ThreadPoolExecutor = te
         return te
 
-    if name == 'InterpreterPoolExecutor':
+    if name == 'InterpreterPoolExecutor' and not _no_interpreter_pool_executor:
         try:
             from .interpreter import InterpreterPoolExecutor as ie
         except ModuleNotFoundError:
-            ie = InterpreterPoolExecutor = None
+            _no_interpreter_pool_executor = True
         else:
             InterpreterPoolExecutor = ie
-        return ie
+            return ie
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -485,11 +485,18 @@ class InterpreterPoolExecutorTest(
             sys.exit(1)
 
         from concurrent.futures import *
+
+        if 'InterpreterPoolExecutor' in globals():
+            print('InterpreterPoolExecutor should not be imported!',
+                  file=sys.stderr)
+            sys.exit(1)
         """)
 
         cmd = [sys.executable, '-c', code]
         p = subprocess.run(cmd, capture_output=True)
         self.assertEqual(p.returncode, 0, p.stderr.decode())
+        self.assertEqual(p.stdout.decode(), '')
+        self.assertEqual(p.stderr.decode(), '')
 
 
 class AsyncioTest(InterpretersMixin, testasyncio_utils.TestCase):

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -463,10 +463,10 @@ class InterpreterPoolExecutorTest(
     def test_import_interpreter_pool_executor(self):
         # Test the import behavior normally if _interpreters is unavailable.
         code = textwrap.dedent(f"""
-        from concurrent import futures
         import sys
         # Set it to None to emulate the case when _interpreter is unavailable.
-        futures._interpreters = None
+        sys.modules['_interpreters'] = None
+        from concurrent import futures
 
         try:
             futures.InterpreterPoolExecutor
@@ -483,6 +483,8 @@ class InterpreterPoolExecutorTest(
         else:
             print('ImportError not raised!', file=sys.stderr)
             sys.exit(1)
+
+        from concurrent.futures import *
         """)
 
         cmd = [sys.executable, '-c', code]

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -462,7 +462,7 @@ class InterpreterPoolExecutorTest(
     @support.requires_subprocess()
     def test_import_interpreter_pool_executor(self):
         # Test the import behavior normally if _interpreters is unavailable.
-        code = textwrap.dedent(f"""
+        code = textwrap.dedent("""
         import sys
         # Set it to None to emulate the case when _interpreter is unavailable.
         sys.modules['_interpreters'] = None

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -459,6 +459,7 @@ class InterpreterPoolExecutorTest(
         # Weak references don't cross between interpreters.
         raise unittest.SkipTest('not applicable')
 
+    @support.requires_subprocess()
     def test_import_interpreter_pool_executor(self):
         # Test the import behavior normally if _interpreters is unavailable.
         code = textwrap.dedent(f"""

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -483,9 +483,6 @@ class InterpreterPoolExecutorTest(
         else:
             print('ImportError not raised!', file=sys.stderr)
             sys.exit(1)
-
-
-        from concurrent.futures import *
         """)
 
         cmd = [sys.executable, '-c', code]

--- a/Misc/NEWS.d/next/Library/2025-07-07-22-12-32.gh-issue-136380.1b_nXl.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-07-22-12-32.gh-issue-136380.1b_nXl.rst
@@ -1,3 +1,3 @@
 Raises :exc:`AttributeError` when accessing
-``concurrent.futures.InterpreterPoolExecutor`` and :mod:`_interpreter` is
+``concurrent.futures.InterpreterPoolExecutor`` and ``_interpreter`` is
 not available.

--- a/Misc/NEWS.d/next/Library/2025-07-07-22-12-32.gh-issue-136380.1b_nXl.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-07-22-12-32.gh-issue-136380.1b_nXl.rst
@@ -1,3 +1,3 @@
 Raises :exc:`AttributeError` when accessing
-``concurrent.futures.InterpreterPoolExecutor`` and ``_interpreter`` is
+:class:`concurrent.futures.InterpreterPoolExecutor` and subinterpreters are
 not available.

--- a/Misc/NEWS.d/next/Library/2025-07-07-22-12-32.gh-issue-136380.1b_nXl.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-07-22-12-32.gh-issue-136380.1b_nXl.rst
@@ -1,0 +1,3 @@
+Raises :exc:`AttributeError` when accessing
+``concurrent.futures.InterpreterPoolExecutor`` and :mod:`_interpreter` is
+not available.


### PR DESCRIPTION
It's hard to write the test, but on my local machine, when remove the `_interpreters` module or raise a `ModuleNotFoundError` in the try branch, the behavior is correct compare to a normal non-exist field:

```
>>> from concurrent.futures import InterpreterPoolExecutor
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    from concurrent.futures import InterpreterPoolExecutor
ImportError: cannot import name 'InterpreterPoolExecutor' from 'concurrent.futures' (C:\Users\xxxxx\Source\cpython\Lib\concurrent\futures\__init__.py)
>>> from concurrent import futures
>>> futures.InterpreterPoolExecutor
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    futures.InterpreterPoolExecutor
  File "C:\Users\xxxxx\Source\cpython\Lib\concurrent\futures\__init__.py", line 69, in __getattr__      
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
AttributeError: module 'concurrent.futures' has no attribute 'InterpreterPoolExecutor'
```

```
>>> from concurrent.futures import NotExist
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    from concurrent.futures import NotExist
ImportError: cannot import name 'NotExist' from 'concurrent.futures' (C:\Users\xxxxx\Source\cpython\Lib\concurrent\futures\__init__.py)
>>> from concurrent import futures
>>> futures.NotExist
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    futures.NotExist
  File "C:\Users\xxxxx\Source\cpython\Lib\concurrent\futures\__init__.py", line 69, in __getattr__      
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
AttributeError: module 'concurrent.futures' has no attribute 'NotExist'
```

We must `import _interpreters` in `__init__.py` to determine whether to append the `InterpreterPoolExecutor` to `__all__`. This may have a negative impact on importing performance.

<!-- gh-issue-number: gh-136380 -->
* Issue: gh-136380
<!-- /gh-issue-number -->
