### PR TITLE
gh-136297: Fix `hypothesis` and `subTest` usage in `test_zoneinfo_property.py`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -426,7 +426,7 @@ jobs:
         #
         # (GH-104097) test_sysconfig is skipped because it has tests that are
         # failing when executed from inside a virtual environment.
-        "${VENV_PYTHON}" -We -m test \
+        "${VENV_PYTHON}" -m test \
           -W \
           --slowest \
           -j4 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,7 +427,7 @@ jobs:
         # (GH-104097) test_sysconfig is skipped because it has tests that are
         # failing when executed from inside a virtual environment.
         "${VENV_PYTHON}" -m test \
-          -W \
+          -We \
           --slowest \
           -j4 \
           --timeout 900 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -426,8 +426,8 @@ jobs:
         #
         # (GH-104097) test_sysconfig is skipped because it has tests that are
         # failing when executed from inside a virtual environment.
-        "${VENV_PYTHON}" -m test \
-          -We \
+        "${VENV_PYTHON}" -We -m test \
+          -W \
           --slowest \
           -j4 \
           --timeout 900 \

--- a/Lib/test/test_zoneinfo/test_zoneinfo_property.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo_property.py
@@ -147,23 +147,21 @@ class ZoneInfoPickleTest(ZoneInfoTestBase):
     def test_pickle_unpickle_cache(self, key):
         zi = self.klass(key)
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            with self.subTest(proto=proto):
-                pkl_str = pickle.dumps(zi, proto)
-                zi_rt = pickle.loads(pkl_str)
+            pkl_str = pickle.dumps(zi, proto)
+            zi_rt = pickle.loads(pkl_str)
 
-                self.assertIs(zi, zi_rt)
+            self.assertIs(zi, zi_rt)
 
     @hypothesis.given(key=valid_keys())
     @add_key_examples
     def test_pickle_unpickle_no_cache(self, key):
         zi = self.klass.no_cache(key)
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            with self.subTest(proto=proto):
-                pkl_str = pickle.dumps(zi, proto)
-                zi_rt = pickle.loads(pkl_str)
+            pkl_str = pickle.dumps(zi, proto)
+            zi_rt = pickle.loads(pkl_str)
 
-                self.assertIsNot(zi, zi_rt)
-                self.assertEqual(str(zi), str(zi_rt))
+            self.assertIsNot(zi, zi_rt)
+            self.assertEqual(str(zi), str(zi_rt))
 
     @hypothesis.given(key=valid_keys())
     @add_key_examples

--- a/Lib/test/test_zoneinfo/test_zoneinfo_property.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo_property.py
@@ -147,11 +147,10 @@ class ZoneInfoPickleTest(ZoneInfoTestBase):
     def test_pickle_unpickle_cache(self, key):
         zi = self.klass(key)
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            with self.subTest(proto=proto):
-                pkl_str = pickle.dumps(zi, proto)
-                zi_rt = pickle.loads(pkl_str)
+            pkl_str = pickle.dumps(zi, proto)
+            zi_rt = pickle.loads(pkl_str)
 
-                self.assertIs(zi, zi_rt)
+            self.assertIs(zi, zi_rt)
 
     @hypothesis.given(key=valid_keys())
     @add_key_examples

--- a/Lib/test/test_zoneinfo/test_zoneinfo_property.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo_property.py
@@ -147,10 +147,11 @@ class ZoneInfoPickleTest(ZoneInfoTestBase):
     def test_pickle_unpickle_cache(self, key):
         zi = self.klass(key)
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            pkl_str = pickle.dumps(zi, proto)
-            zi_rt = pickle.loads(pkl_str)
+            with self.subTest(proto=proto):
+                pkl_str = pickle.dumps(zi, proto)
+                zi_rt = pickle.loads(pkl_str)
 
-            self.assertIs(zi, zi_rt)
+                self.assertIs(zi, zi_rt)
 
     @hypothesis.given(key=valid_keys())
     @add_key_examples

--- a/Tools/requirements-hypothesis.txt
+++ b/Tools/requirements-hypothesis.txt
@@ -1,4 +1,4 @@
 # Requirements file for hypothesis that
 # we use to run our property-based tests in CI.
 
-hypothesis==6.111.2
+hypothesis==6.135.26


### PR DESCRIPTION
CC @kulikjak 

<!-- gh-issue-number: gh-136297 -->
* Issue: gh-136297
<!-- /gh-issue-number -->
