### PR TITLE
GH-115802: Optimize JIT stencils for size

### DIFF
--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -137,6 +137,14 @@ class _Target(typing.Generic[_S, _R]):
             f"-I{CPYTHON / 'Include' / 'internal' / 'mimalloc'}",
             f"-I{CPYTHON / 'Python'}",
             f"-I{CPYTHON / 'Tools' / 'jit'}",
+            # -O2 and -O3 include some optimizations that make sense for
+            # standalone functions, but not for snippets of code that are going
+            # to be laid out end-to-end (like ours)... common examples include
+            # passes like tail-duplication, or aligning jump targets with nops.
+            # -Os is equivalent to -O2 with many of these problematic passes
+            # disabled. Based on manual review, for *our* purposes it usually
+            # generates better code than -O2 (and -O2 usually generates better
+            # code than -O3). As a nice benefit, it uses less memory too:
             "-Os",
             "-S",
             # Shorten full absolute file paths in the generated code (like the

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -137,7 +137,7 @@ class _Target(typing.Generic[_S, _R]):
             f"-I{CPYTHON / 'Include' / 'internal' / 'mimalloc'}",
             f"-I{CPYTHON / 'Python'}",
             f"-I{CPYTHON / 'Tools' / 'jit'}",
-            "-O3",
+            "-Os",
             "-S",
             # Shorten full absolute file paths in the generated code (like the
             # __FILE__ macro and assert failure messages) for reproducibility:


### PR DESCRIPTION
As the new comment says, upon manual review of `-O3`, `-O2`, and `-Os`, it seems that `-Os` generates the best code for the JIT's use-case. Perf impact is close to noise, but slightly positive on x86-64 Linux and AArch64 macOS, neutral on AArch64 Linux, and slightly negative on x86-64 Windows. According to the stats, the size of JIT code is down by about 1-2%: https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20250628-3.15.0a0-33054dd-JIT/README.md

Here's an example of how skipping tail-duplication removes an extra jump and a duplicate instruction from `_POP_TOP` (also reducing its size by 19%):

```diff
-    // 11: 75 04                         jne     0x17 <_JIT_ENTRY+0x17>
+    // 11: 75 0f                         jne     0x22 <_JIT_ENTRY+0x22>
     // 13: ff 0f                         decl    (%rdi)
-    // 15: 74 07                         je      0x1e <_JIT_ENTRY+0x1e>
-    // 17: 4d 8b 6c 24 40                movq    0x40(%r12), %r13
-    // 1c: eb 10                         jmp     0x2e <_JIT_CONTINUE>
-    // 1e: 50                            pushq   %rax
-    // 1f: ff 15 00 00 00 00             callq   *(%rip)                 # 0x25 <_JIT_ENTRY+0x25>
-    // 0000000000000021:  R_X86_64_GOTPCRELX   _Py_Dealloc-0x4
-    // 25: 48 83 c4 08                   addq    $0x8, %rsp
-    // 29: 4d 8b 6c 24 40                movq    0x40(%r12), %r13
-    const unsigned char code_body[46] = {
+    // 15: 75 0b                         jne     0x22 <_JIT_ENTRY+0x22>
+    // 17: 50                            pushq   %rax
+    // 18: ff 15 00 00 00 00             callq   *(%rip)                 # 0x1e <_JIT_ENTRY+0x1e>
+    // 000000000000001a:  R_X86_64_GOTPCRELX   _Py_Dealloc-0x4
+    // 1e: 48 83 c4 08                   addq    $0x8, %rsp
+    // 22: 4d 8b 6c 24 40                movq    0x40(%r12), %r13
+    const unsigned char code_body[39] = {
         0x49, 0x8b, 0x7d, 0xf8, 0x49, 0x83, 0xc5, 0xf8,
         0x4d, 0x89, 0x6c, 0x24, 0x40, 0x40, 0xf6, 0xc7,
-        0x01, 0x75, 0x04, 0xff, 0x0f, 0x74, 0x07, 0x4d,
-        0x8b, 0x6c, 0x24, 0x40, 0xeb, 0x10, 0x50, 0xff,
-        0x15, 0x00, 0x00, 0x00, 0x00, 0x48, 0x83, 0xc4,
-        0x08, 0x4d, 0x8b, 0x6c, 0x24, 0x40,
+        0x01, 0x75, 0x0f, 0xff, 0x0f, 0x75, 0x0b, 0x50,
+        0xff, 0x15, 0x00, 0x00, 0x00, 0x00, 0x48, 0x83,
+        0xc4, 0x08, 0x4d, 0x8b, 0x6c, 0x24, 0x40,
     };
```

Full diff for the stencils here:

https://gist.github.com/brandtbucher/7340be56f2d2cf7061b5c9bf1c87939c

<!-- gh-issue-number: gh-115802 -->
* Issue: gh-115802
<!-- /gh-issue-number -->
