### PR TITLE
GH-91636: Clear weakrefs created by finalizers.

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-07-17-26-06.gh-issue-91636.GyHU72.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-07-17-26-06.gh-issue-91636.GyHU72.rst
@@ -1,0 +1,3 @@
+While performing garbage collection, clear weakrefs to unreachable objects
+that are created during running of finalizers.  If those weakrefs were are
+not cleared, they could reveal unreachable objects.

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1492,9 +1492,9 @@ move_legacy_finalizer_reachable(struct collection_state *state)
 }
 
 // Clear all weakrefs to unreachable objects. Weakrefs with callbacks are
-// enqueued in `wrcb_to_call`, but not invoked yet.
+// optionally enqueued in `wrcb_to_call`, but not invoked yet.
 static void
-handle_weakrefs(struct collection_state *state)
+clear_weakrefs(struct collection_state *state, bool enqueue_callbacks)
 {
     PyObject *op;
     WORKSTACK_FOR_EACH(&state->unreachable, op) {
@@ -1526,6 +1526,10 @@ handle_weakrefs(struct collection_state *state)
             _PyWeakref_ClearRef(wr);
             _PyObject_ASSERT((PyObject *)wr, wr->wr_object == Py_None);
 
+            if (!enqueue_callbacks) {
+                continue;
+            }
+
             // We do not invoke callbacks for weakrefs that are themselves
             // unreachable. This is partly for historical reasons: weakrefs
             // predate safe object finalization, and a weakref that is itself
@@ -1541,42 +1545,6 @@ handle_weakrefs(struct collection_state *state)
 
             // Enqueue weakref to be called later.
             worklist_push(&state->wrcb_to_call, (PyObject *)wr);
-        }
-    }
-}
-
-// Clear all weakrefs to unreachable objects.
-static void
-clear_weakrefs(struct collection_state *state)
-{
-    PyObject *op;
-    WORKSTACK_FOR_EACH(&state->unreachable, op) {
-        if (PyWeakref_Check(op)) {
-            // Clear weakrefs that are themselves unreachable to ensure their
-            // callbacks will not be executed later from a `tp_clear()`
-            // inside delete_garbage(). That would be unsafe: it could
-            // resurrect a dead object or access a an already cleared object.
-            // See bpo-38006 for one example.
-            _PyWeakref_ClearRef((PyWeakReference *)op);
-        }
-
-        if (!_PyType_SUPPORTS_WEAKREFS(Py_TYPE(op))) {
-            continue;
-        }
-
-        // NOTE: This is never triggered for static types so we can avoid the
-        // (slightly) more costly _PyObject_GET_WEAKREFS_LISTPTR().
-        PyWeakReference **wrlist = _PyObject_GET_WEAKREFS_LISTPTR_FROM_OFFSET(op);
-
-        // `op` may have some weakrefs.  March over the list, clear
-        // all the weakrefs.
-        for (PyWeakReference *wr = *wrlist; wr != NULL; wr = *wrlist) {
-            // _PyWeakref_ClearRef clears the weakref but leaves
-            // the callback pointer intact.  Obscure: it also
-            // changes *wrlist.
-            _PyObject_ASSERT((PyObject *)wr, wr->wr_object == op);
-            _PyWeakref_ClearRef(wr);
-            _PyObject_ASSERT((PyObject *)wr, wr->wr_object == Py_None);
         }
     }
 }
@@ -2247,7 +2215,7 @@ gc_collect_internal(PyInterpreterState *interp, struct collection_state *state, 
     interp->gc.long_lived_total = state->long_lived_total;
 
     // Clear weakrefs and enqueue callbacks (but do not call them).
-    handle_weakrefs(state);
+    clear_weakrefs(state, true);
     _PyEval_StartTheWorld(interp);
 
     // Deallocate any object from the refcount merge step
@@ -2269,7 +2237,7 @@ gc_collect_internal(PyInterpreterState *interp, struct collection_state *state, 
         // delete_garbage(), finalizers outside the unreachable set might
         // run and create new weakrefs.  If those weakrefs were not cleared,
         // they could reveal unreachable objects.
-        clear_weakrefs(state);
+        clear_weakrefs(state, false);
     }
     _PyEval_StartTheWorld(interp);
 


### PR DESCRIPTION
Weakrefs to unreachable garbage that are created during running of finalizers need to be cleared.  This avoids exposing objects that have `tp_clear` called on them to Python-level code.

Note that this is part of the GH-136189 change, split out to make it easier for back-porting.  This change is conceptually quite simple and is a candidate to backport to all older Python versions (this bug existed for a *long* time, perhaps in version 2.3).  There is some duplicated code between `handle_finalizers` and `clear_finalizers` but I think it's simpler just to leave that duplication.  In the "main" branch I'll clean that up.

<!-- gh-issue-number: gh-91636 -->
* Issue: gh-91636
<!-- /gh-issue-number -->
