### PR TITLE
gh-101100: Fix sphinx warnings in `whatsnew/3.11.rst`

### DIFF
--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -73,4 +73,3 @@ Doc/whatsnew/3.6.rst
 Doc/whatsnew/3.7.rst
 Doc/whatsnew/3.8.rst
 Doc/whatsnew/3.10.rst
-Doc/whatsnew/3.11.rst

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1292,7 +1292,7 @@ This section covers specific optimizations independent of the
   (Contributed by Stefan Behnel in :gh:`68264`.)
 
 * Resizing lists is streamlined for the common case,
-  speeding up :meth:`list.append` by ≈15%
+  speeding up :meth:`!list.append` by ≈15%
   and simple :term:`list comprehension`\s by up to 20-30%
   (Contributed by Dennis Sweeney in :gh:`91165`.)
 


### PR DESCRIPTION
There was a single warning:

```
C:\Users\admin\Downloads\cpython-main\Doc\whatsnew\3.11.rst:1294: WARNING: py:meth reference target not found: list.append [ref.meth]
```

caused by:

```
* Resizing lists is streamlined for the common case,
  speeding up :meth:`list.append` by ≈15%
  and simple :term:`list comprehension`\s by up to 20-30%
  (Contributed by Dennis Sweeney in :gh:`91165`.)
```

This PR change :meth:\`list.append\` to :meth:\`!list.append\`. Thanks!

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
