### PR TITLE
gh-136421: Fix crash when _datetime is been initialized in multiple sub-interpreters

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-08-23-00-58.gh-issue-136421.uzieFA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-08-23-00-58.gh-issue-136421.uzieFA.rst
@@ -1,2 +1,2 @@
-Fix a crash when :mod:`_datetime` is being initialized in multiple
+Fix a crash when ``_datetime`` is being imported in multiple
 sub-interpreters at the same time.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-08-23-00-58.gh-issue-136421.uzieFA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-08-23-00-58.gh-issue-136421.uzieFA.rst
@@ -1,0 +1,2 @@
+Fix a crash when :mod:`_datetime` is being initialized in multiple
+sub-interpreters at the same time.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-08-23-00-58.gh-issue-136421.uzieFA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-08-23-00-58.gh-issue-136421.uzieFA.rst
@@ -1,2 +1,2 @@
-Fix a crash when ``_datetime`` is being imported in multiple
+Fix a crash when :mod:`datetime` is being imported in multiple
 sub-interpreters at the same time.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -7344,11 +7344,16 @@ init_static_types(PyInterpreterState *interp, int reloading)
 
     /* Bases classes must be initialized before subclasses,
      * so capi_types must have the types in the appropriate order. */
+    static PyMutex mutex = {0};
     for (size_t i = 0; i < Py_ARRAY_LENGTH(capi_types); i++) {
         PyTypeObject *type = capi_types[i];
-        if (_PyStaticType_InitForExtension(interp, type) < 0) {
+        PyMutex_Lock(&mutex);
+        int ret = _PyStaticType_InitForExtension(interp, type);
+        if (ret < 0) {
+            PyMutex_Unlock(&mutex);
             return -1;
         }
+        PyMutex_Unlock(&mutex);
     }
 
     return 0;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -7349,11 +7349,10 @@ init_static_types(PyInterpreterState *interp, int reloading)
         PyTypeObject *type = capi_types[i];
         PyMutex_Lock(&mutex);
         int ret = _PyStaticType_InitForExtension(interp, type);
+        PyMutex_Unlock(&mutex);
         if (ret < 0) {
-            PyMutex_Unlock(&mutex);
             return -1;
         }
-        PyMutex_Unlock(&mutex);
     }
 
     return 0;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136421 -->
* Issue: gh-136421
<!-- /gh-issue-number -->
