### PR TITLE
gh-136434: Fix docs generation of `UnboundItem` in subinterpreters

### DIFF
--- a/Lib/concurrent/interpreters/_crossinterp.py
+++ b/Lib/concurrent/interpreters/_crossinterp.py
@@ -40,16 +40,21 @@ class UnboundItem:
 
     @classonly
     def singleton(cls, kind, module, name='UNBOUND'):
-        doc = cls.__doc__.replace('cross-interpreter container', kind)
-        doc = doc.replace('cross-interpreter', kind)
+        doc = cls.__doc__
+        if doc:
+            doc = doc.replace(
+                'cross-interpreter container', kind,
+            ).replace(
+                'cross-interpreter', kind,
+            )
         subclass = type(
             f'Unbound{kind.capitalize()}Item',
             (cls,),
-            dict(
-                _MODULE=module,
-                _NAME=name,
-                __doc__=doc,
-            ),
+            {
+                "_MODULE": module,
+                "_NAME": name,
+                "__doc__": doc,
+            },
         )
         return object.__new__(subclass)
 

--- a/Misc/NEWS.d/next/Library/2025-07-08-20-58-01.gh-issue-136434.uuJsjS.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-08-20-58-01.gh-issue-136434.uuJsjS.rst
@@ -1,0 +1,2 @@
+Fix docs generation of ``UnboundItem`` in :mod:`concurrent.interpreters`
+when running with :option:`-OO`.


### PR DESCRIPTION
I also did a small refactoring of `dict()` -> `{}`, because `{}` is faster. and there's no need in using `dict()`. Since we are touching this code anyway, why not do a micro-speed-up?

Tests after:

```
» ./python.exe -OO -m test test_concurrent_futures
Using random seed: 4123239281
0:00:00 load avg: 1.79 Run 9 tests sequentially in a single process
0:00:00 load avg: 1.79 [1/9] test_concurrent_futures.test_as_completed
0:00:16 load avg: 1.63 [1/9] test_concurrent_futures.test_as_completed passed
0:00:16 load avg: 1.63 [2/9] test_concurrent_futures.test_deadlock
0:00:30 load avg: 1.61 [2/9] test_concurrent_futures.test_deadlock passed
0:00:30 load avg: 1.61 [3/9] test_concurrent_futures.test_future
0:00:33 load avg: 1.64 [3/9] test_concurrent_futures.test_future passed
0:00:33 load avg: 1.64 [4/9] test_concurrent_futures.test_init
0:00:34 load avg: 1.64 [4/9] test_concurrent_futures.test_init passed
0:00:34 load avg: 1.64 [5/9] test_concurrent_futures.test_interpreter_pool
0:00:45 load avg: 1.60 [5/9] test_concurrent_futures.test_interpreter_pool passed
0:00:45 load avg: 1.60 [6/9] test_concurrent_futures.test_process_pool
0:00:54 load avg: 1.55 [6/9] test_concurrent_futures.test_process_pool passed
0:00:54 load avg: 1.55 [7/9] test_concurrent_futures.test_shutdown
0:01:09 load avg: 1.88 [7/9] test_concurrent_futures.test_shutdown passed
0:01:09 load avg: 1.88 [8/9] test_concurrent_futures.test_thread_pool
0:01:09 load avg: 1.88 [8/9] test_concurrent_futures.test_thread_pool passed
0:01:09 load avg: 1.88 [9/9] test_concurrent_futures.test_wait
0:01:11 load avg: 1.88 [9/9] test_concurrent_futures.test_wait passed

== Tests result: SUCCESS ==

All 9 tests OK.

Total duration: 1 min 11 sec
Total tests: run=375 skipped=19
Total test files: run=9/9
Result: SUCCESS
```

<!-- gh-issue-number: gh-136434 -->
* Issue: gh-136434
<!-- /gh-issue-number -->
