### PR TITLE
gh-136447: Use `self.loop` instead of global `loop` variable in asyncio REPL

### DIFF
--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -64,7 +64,7 @@ class AsyncIOInteractiveConsole(InteractiveColoredConsole):
             except BaseException as exc:
                 future.set_exception(exc)
 
-        loop.call_soon_threadsafe(callback, context=self.context)
+        self.loop.call_soon_threadsafe(callback, context=self.context)
 
         try:
             return future.result()


### PR DESCRIPTION
`loop` is passed to `AsyncIOInteractiveConsole` and assigned to the instance attribute `self.loop`.

This PR fixes the one place where `AsyncIOInteractiveConsole` uses the global `loop` variable instead of `self.loop`.

<!-- gh-issue-number: gh-136447 -->
* Issue: gh-136447
<!-- /gh-issue-number -->
