### PR TITLE
gh-136438: Make sure `test_builtins` pass with all optimization levels

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -436,7 +436,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             # test both direct compilation and compilation via AST
                 codeobjs = []
                 codeobjs.append(compile(codestr, "<test>", "exec", optimize=optval))
-                tree = ast.parse(codestr)
+                tree = ast.parse(codestr, optimize=optval)
                 codeobjs.append(compile(tree, "<test>", "exec", optimize=optval))
                 for code in codeobjs:
                     ns = {}
@@ -624,7 +624,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         for opt in [opt1, opt2]:
             opt_right = opt.value.right
             self.assertIsInstance(opt_right, ast.Constant)
-            self.assertEqual(opt_right.value, True)
+            self.assertEqual(opt_right.value, __debug__)
 
     def test_delattr(self):
         sys.spam = 1


### PR DESCRIPTION
Now tests pass with all combinations of `-OO` and `--without-doc-strings`.

Before:

```
======================================================================
FAIL: test_compile (test.test_builtin.BuiltinTest.test_compile) (optval=0)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/Lib/test/test_builtin.py", line 445, in test_compile
    self.assertEqual(rv, tuple(expected))
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
AssertionError: Tuples differ: (True, None, True, True) != (True, 'doc', True, True)

First differing element 1:
None
'doc'

- (True, None, True, True)
?        ^ ^^

+ (True, 'doc', True, True)
?        ^^ ^^


======================================================================
FAIL: test_compile (test.test_builtin.BuiltinTest.test_compile) (optval=1)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/Lib/test/test_builtin.py", line 445, in test_compile
    self.assertEqual(rv, tuple(expected))
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
AssertionError: Tuples differ: (False, None, False, False) != (False, 'doc', False, False)

First differing element 1:
None
'doc'

- (False, None, False, False)
?         ^ ^^

+ (False, 'doc', False, False)
?         ^^ ^^


======================================================================
FAIL: test_compile_ast (test.test_builtin.BuiltinTest.test_compile_ast)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/Lib/test/test_builtin.py", line 627, in test_compile_ast
    self.assertEqual(opt_right.value, True)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: False != True

----------------------------------------------------------------------
Ran 131 tests in 0.211s
```

<!-- gh-issue-number: gh-136438 -->
* Issue: gh-136438
<!-- /gh-issue-number -->
