### PR TITLE
gh-101100: Fix sphinx warnings in `library/email.parser.rst`

### DIFF
--- a/Doc/library/email.parser.rst
+++ b/Doc/library/email.parser.rst
@@ -48,8 +48,8 @@ methods.
 FeedParser API
 ^^^^^^^^^^^^^^
 
-The :class:`BytesFeedParser`, imported from the :mod:`email.feedparser` module,
-provides an API that is conducive to incremental parsing of email messages,
+The :class:`BytesFeedParser`, imported from the :mod:`email.parser.FeedParser`
+module, provides an API that is conducive to incremental parsing of email messages,
 such as would be necessary when reading the text of an email message from a
 source that can block (such as a socket).  The :class:`BytesFeedParser` can of
 course be used to parse an email message fully contained in a :term:`bytes-like
@@ -116,7 +116,7 @@ Here is the API for the :class:`BytesFeedParser`:
    Works like :class:`BytesFeedParser` except that the input to the
    :meth:`~BytesFeedParser.feed` method must be a string.  This is of limited
    utility, since the only way for such a message to be valid is for it to
-   contain only ASCII text or, if :attr:`~email.policy.Policy.utf8` is
+   contain only ASCII text or, if :attr:`~email.policy.EmailPolicy.utf8` is
    ``True``, no binary attachments.
 
    .. versionchanged:: 3.3 Added the *policy* keyword.
@@ -155,11 +155,11 @@ message body, instead setting the payload to the raw body.
 
       Read all the data from the binary file-like object *fp*, parse the
       resulting bytes, and return the message object.  *fp* must support
-      both the :meth:`~io.IOBase.readline` and the :meth:`~io.IOBase.read`
+      both the :meth:`~io.IOBase.readline` and the :meth:`~io.TextIOBase.read`
       methods.
 
       The bytes contained in *fp* must be formatted as a block of :rfc:`5322`
-      (or, if :attr:`~email.policy.Policy.utf8` is ``True``, :rfc:`6532`)
+      (or, if :attr:`~email.policy.EmailPolicy.utf8` is ``True``, :rfc:`6532`)
       style headers and header continuation lines, optionally preceded by an
       envelope header.  The header block is terminated either by the end of the
       data or by a blank line.  Following the header block is the body of the

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -15,7 +15,6 @@ Doc/extending/extending.rst
 Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
 Doc/library/email.charset.rst
-Doc/library/email.parser.rst
 Doc/library/functools.rst
 Doc/library/http.cookiejar.rst
 Doc/library/http.server.rst


### PR DESCRIPTION
before:
```
C:\Users\admin\Downloads\cpython-main\Doc\library\email.parser.rst:51: WARNING: py:mod reference target not found: email.feedparser [ref.mod]
C:\Users\admin\Downloads\cpython-main\Doc\library\email.parser.rst:116: WARNING: py:attr reference target not found: email.policy.Policy.utf8 [ref.attr]
C:\Users\admin\Downloads\cpython-main\Doc\library\email.parser.rst:156: WARNING: py:meth reference target not found: io.IOBase.read [ref.meth]
C:\Users\admin\Downloads\cpython-main\Doc\library\email.parser.rst:161: WARNING: py:attr reference target not found: email.policy.Policy.utf8 [ref.attr]
```

This PR fix them all. The changes:

- `email.feedparser` is actually referring to [email.parser.FeedParser](https://docs.python.org/3/library/email.parser.html#email.parser.FeedParser). It is changed to `email.parser.FeedParser`. See also [other places of referrence](https://github.com/python/cpython/blob/main/Doc/library/email.parser.rst?plain=1#L317) to `email.parser.feedparser` to check.
- `email.policy.Policy.utf8` is actually referring to [email.policy.EmailPolicy.utf8](https://docs.python.org/3/library/email.policy.html#email.policy.EmailPolicy.utf8). It is changed to `email.policy.EmailPolicy.utf8`
- `io.IOBase.read` is actually referring to [io.TextIOBase.read](https://docs.python.org/3/library/email.policy.html#email.policy.EmailPolicy.utf8). See also [other places of referrence](https://github.com/python/cpython/blob/main/Doc/library/email.parser.rst?plain=1#L208) to `io.TextIOBase.read` to check. I'm not pretty sure about this.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136475.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->