### PR TITLE
gh-136438: Make sure test.test_pydoc.test_pydoc pass with all optimization levels

### DIFF
--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -1461,7 +1461,7 @@ class TestDescriptions(unittest.TestCase):
             self.assertIn('NoReturn = typing.NoReturn', doc)
             self.assertIn(typing.NoReturn.__doc__.strip().splitlines()[0], doc)
         else:
-            self.assertIn('NoReturn = class _SpecialForm(_Final)', doc)
+            self.assertIn('NoReturn = class _SpecialForm(_Final, _NotIterable)', doc)
 
     def test_typing_pydoc(self):
         def foo(data: typing.List[typing.Any],


### PR DESCRIPTION
Output before: 

```
test test.test_pydoc.test_pydoc failed -- Traceback (most recent call last):
  File "/home/grivvus/cpython/Lib/test/test_pydoc/test_pydoc.py", line 1464, in test_special_form
    self.assertIn('NoReturn = class _SpecialForm(_Final)', doc)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 'NoReturn = class _SpecialForm(_Final)' not found in 'Python Library Documentation: _SpecialForm in module typing object\n\nNoReturn = class _SpecialForm(_Final, _NotIterable)\n |  NoReturn(getitem)\n |\n |  # Internal indicator of special typing constructs.\n |  # See __doc__ instance attribute for specific docs.\n |\n |  Method resolution order:\n |      _SpecialForm\n |      _Final\n |      _NotIterable\n |      builtins.object\n |\n |  Methods defined here:\n |\n |  __call__(self, *args, **kwds)\n |      Call self as a function.\n |\n |  __getattr__(self, item)\n |\n |  __getitem__(self, parameters)\n |\n |  __init__(self, getitem)\n |      Initialize self.  See help(type(self)) for accurate signature.\n |\n |  __instancecheck__(self, obj)\n |      Check if an object is an instance.\n |\n |  __mro_entries__(self, bases)\n |\n |  __or__(self, other)\n |      Return self|value.\n |\n |  __reduce__(self)\n |      Helper for pickle.\n |\n |  __repr__(self)\n |      Return repr(self).\n |\n |  __ror__(self, other)\n |      Return value|self.\n |\n |  __subclasscheck__(self, cls)\n |      Check if a class is a subclass.\n |\n |  ----------------------------------------------------------------------\n |  Class methods inherited from _Final:\n |\n |  __init_subclass__(*args, **kwds)\n |      This method is called when a class is subclassed.\n |\n |      The default implementation does nothing. It may be\n |      overridden to extend subclasses.\n |\n |  ----------------------------------------------------------------------\n |  Data descriptors inherited from _Final:\n |\n |  __weakref__\n |      list of weak references to the object\n |\n |  ----------------------------------------------------------------------\n |  Data and other attributes inherited from _NotIterable:\n |\n |  __iter__ = None\n'

0:00:02 load avg: 0.60 [1/1/1] test.test_pydoc.test_pydoc failed (1 failure)

== Tests result: FAILURE ==
```

<!-- gh-issue-number: gh-136438 -->
* Issue: gh-136438
<!-- /gh-issue-number -->
