### PR TITLE
gh-136231: Document xml.etree.ElementTree.iselement behavior when used with types

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -611,8 +611,11 @@ Functions
 
 .. function:: iselement(element)
 
-   Check if an object appears to be a valid element object.  *element* is an
-   element instance.  Return ``True`` if this is an element object.
+   Check if *element* appears to be a valid element object or type. Return
+   ``True`` if this is an element object or type.
+
+   Because ``iselement`` behaves identically for both objects and types, code
+   requiring an object should check for this, see :func:`iselement`.
 
 
 .. function:: iterparse(source, events=None, parser=None)

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -218,6 +218,42 @@ class ElementTreeTest(unittest.TestCase):
     def serialize_check(self, elem, expected):
         self.assertEqual(serialize(elem), expected)
 
+    def test_constructor(self):
+        # Test constructor behavior.
+
+        with self.assertRaises(TypeError):
+            tree = ET.ElementTree("")
+        with self.assertRaises(TypeError):
+            tree = ET.ElementTree(ET.ElementTree())
+
+        # Test _setroot as well, since it also sets the _root object.
+
+        tree = ET.ElementTree()
+        with self.assertRaises(TypeError):
+            tree._setroot("")
+        with self.assertRaises(TypeError):
+            tree._setroot(ET.ElementTree())
+
+        # Make sure it accepts an Element-like object.
+
+        class ElementLike:
+            def __init__(self):
+                self.tag = "tag"
+                self.text = None
+                self.tail = None
+            def iter(self):
+                pass
+            def items(self):
+                pass
+            def __len__(self):
+                pass
+
+        element_like = ElementLike()
+        try:
+            tree = ET.ElementTree(element_like)
+        except Exception as err:
+            self.fail(err)
+
     def test_interface(self):
         # Test element tree interface.
 
@@ -246,13 +282,6 @@ class ElementTreeTest(unittest.TestCase):
         tree = ET.ElementTree(element)
         self.assertRegex(repr(element), r"^<Element 't\xe4g' at 0x.*>$")
         element = ET.Element("tag", key="value")
-
-        # Verify type checking for ElementTree constructor
-
-        with self.assertRaises(TypeError):
-            tree = ET.ElementTree("")
-        with self.assertRaises(TypeError):
-            tree = ET.ElementTree(ET.ElementTree())
 
         # Make sure all standard element methods exist.
 

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -226,25 +226,24 @@ class ElementTreeTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             tree = ET.ElementTree(ET.ElementTree())
 
-        # Test _setroot as well, since it also sets the _root object.
+    def test_setroot(self):
+        # Test _setroot behavior.
+
+        tree = ET.ElementTree()
+        element = ET.Element("tag")
+        tree._setroot(element)
+        self.assertEqual(tree.getroot().tag, "tag")
+        self.assertEqual(tree.getroot(), element)
+
+        # Test behavior with an invalid root element
 
         tree = ET.ElementTree()
         with self.assertRaises(TypeError):
             tree._setroot("")
         with self.assertRaises(TypeError):
             tree._setroot(ET.ElementTree())
-
-        # Make sure it accepts an Element-like object.
-
-        class ElementLike:
-            def __init__(self):
-                self.tag = "tag"
-
-        element_like = ElementLike()
-        try:
-            tree = ET.ElementTree(element_like)
-        except Exception as err:
-            self.fail(err)
+        with self.assertRaises(TypeError):
+            tree._setroot(None)
 
     def test_interface(self):
         # Test element tree interface.

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -239,14 +239,6 @@ class ElementTreeTest(unittest.TestCase):
         class ElementLike:
             def __init__(self):
                 self.tag = "tag"
-                self.text = None
-                self.tail = None
-            def iter(self):
-                pass
-            def items(self):
-                pass
-            def __len__(self):
-                pass
 
         element_like = ElementLike()
         try:

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -247,6 +247,13 @@ class ElementTreeTest(unittest.TestCase):
         self.assertRegex(repr(element), r"^<Element 't\xe4g' at 0x.*>$")
         element = ET.Element("tag", key="value")
 
+        # Verify type checking for ElementTree constructor
+
+        with self.assertRaises(TypeError):
+            tree = ET.ElementTree("")
+        with self.assertRaises(TypeError):
+            tree = ET.ElementTree(ET.ElementTree())
+
         # Make sure all standard element methods exist.
 
         def check_method(method):

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -711,10 +711,8 @@ class ElementTree:
                                     of start/end tags
 
         """
-        if not iselement(self._root):
-            raise TypeError(f"Root element must be "
-                            f"xml.etree.ElementTree.Element "
-                            f"or Element-like object")
+        if self._root is None:
+            raise TypeError('ElementTree not initialized')
         if not method:
             method = "xml"
         elif method not in _serialize:

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -528,9 +528,7 @@ class ElementTree:
     """
     def __init__(self, element=None, file=None):
         if element is not None and not iselement(element):
-            raise TypeError(f"expected an xml.etree.ElementTree.Element or "
-                            f"Element-like object, not "
-                            f"{type(element).__name__}")
+            raise TypeError('expected an Element, not %s' % type(e).__name__)
         self._root = element # first node
         if file:
             self.parse(file)
@@ -547,9 +545,7 @@ class ElementTree:
 
         """
         if not iselement(element):
-            raise TypeError(f"expected an xml.etree.ElementTree.Element or "
-                            f"Element-like object, not "
-                            f"{type(element).__name__}")
+            raise TypeError('expected an Element, not %s' % type(e).__name__)
         self._root = element
 
     def parse(self, source, parser=None):

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -120,8 +120,9 @@ class ParseError(SyntaxError):
 
 def iselement(element):
     """Return True if *element* appears to be an Element."""
-    return hasattr(element, 'tag')
-
+    return (hasattr(element, 'tag') and hasattr(element, 'text') and
+        hasattr(element, 'tail') and callable(element.iter) and
+        callable(element.items) and callable(element.__len__))
 
 class Element:
     """An XML element.
@@ -528,7 +529,7 @@ class ElementTree:
     """
     def __init__(self, element=None, file=None):
         if element is not None and not iselement(element):
-            raise TypeError(f"element must be etree.Element, "
+            raise TypeError(f"element must be xml.etree.Element, "
                             f"not {type(element).__name__}")
         self._root = element # first node
         if file:
@@ -546,7 +547,7 @@ class ElementTree:
 
         """
         if not iselement(element):
-            raise TypeError(f"element must be etree.Element, "
+            raise TypeError(f"element must be xml.etree.Element, "
                             f"not {type(element).__name__}")
         self._root = element
 

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -527,8 +527,9 @@ class ElementTree:
     """
     def __init__(self, element=None, file=None):
         if element is not None and not iselement(element):
-            raise TypeError(f"element must be xml.etree.Element, "
-                            f"not {type(element).__name__}")
+            raise TypeError(f"element must be xml.etree.Element or "
+                            f"Element-like object, not "
+                            f"{type(element).__name__}")
         self._root = element # first node
         if file:
             self.parse(file)
@@ -545,8 +546,9 @@ class ElementTree:
 
         """
         if not iselement(element):
-            raise TypeError(f"element must be xml.etree.Element, "
-                            f"not {type(element).__name__}")
+            raise TypeError(f"element must be xml.etree.Element or "
+                            f"Element-like object, not "
+                            f"{type(element).__name__}")
         self._root = element
 
     def parse(self, source, parser=None):

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -120,9 +120,7 @@ class ParseError(SyntaxError):
 
 def iselement(element):
     """Return True if *element* appears to be an Element."""
-    return (hasattr(element, 'tag') and hasattr(element, 'text') and
-        hasattr(element, 'tail') and callable(element.iter) and
-        callable(element.items) and callable(element.__len__))
+    return hasattr(element, 'tag')
 
 class Element:
     """An XML element.

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -528,7 +528,8 @@ class ElementTree:
     """
     def __init__(self, element=None, file=None):
         if element is not None and not iselement(element):
-            raise TypeError('expected an Element, not %s' % type(e).__name__)
+            raise TypeError('expected an Element, not %s' %
+                            type(element).__name__)
         self._root = element # first node
         if file:
             self.parse(file)
@@ -545,7 +546,8 @@ class ElementTree:
 
         """
         if not iselement(element):
-            raise TypeError('expected an Element, not %s' % type(e).__name__)
+            raise TypeError('expected an Element, not %s'
+                            % type(element).__name__)
         self._root = element
 
     def parse(self, source, parser=None):

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -528,7 +528,7 @@ class ElementTree:
     """
     def __init__(self, element=None, file=None):
         if element is not None and not iselement(element):
-            raise TypeError(f"element must be xml.etree.Element or "
+            raise TypeError(f"expected an xml.etree.ElementTree.Element or "
                             f"Element-like object, not "
                             f"{type(element).__name__}")
         self._root = element # first node
@@ -547,7 +547,7 @@ class ElementTree:
 
         """
         if not iselement(element):
-            raise TypeError(f"element must be xml.etree.Element or "
+            raise TypeError(f"expected an xml.etree.ElementTree.Element or "
                             f"Element-like object, not "
                             f"{type(element).__name__}")
         self._root = element
@@ -716,7 +716,8 @@ class ElementTree:
 
         """
         if not iselement(self._root):
-            raise TypeError(f"Root element must be of type xml.etree.Element "
+            raise TypeError(f"Root element must be "
+                            f"xml.etree.ElementTree.Element "
                             f"or Element-like object")
         if not method:
             method = "xml"

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -712,6 +712,9 @@ class ElementTree:
                                     of start/end tags
 
         """
+        if not iselement(self._root):
+            raise TypeError(f"Root element must be of type xml.etree.Element "
+                            f"or Element-like object")
         if not method:
             method = "xml"
         elif method not in _serialize:

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -122,6 +122,7 @@ def iselement(element):
     """Return True if *element* appears to be an Element."""
     return hasattr(element, 'tag')
 
+
 class Element:
     """An XML element.
 

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -528,6 +528,9 @@ class ElementTree:
     """
     def __init__(self, element=None, file=None):
         # assert element is None or iselement(element)
+        if element is not None and not iselement(element):
+            raise TypeError(f"element must be etree.Element, "
+                            f"not {type(element).__name__}")
         self._root = element # first node
         if file:
             self.parse(file)
@@ -544,6 +547,8 @@ class ElementTree:
 
         """
         # assert iselement(element)
+        if not iselement(element):
+            raise TypeError
         self._root = element
 
     def parse(self, source, parser=None):

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -527,7 +527,6 @@ class ElementTree:
 
     """
     def __init__(self, element=None, file=None):
-        # assert element is None or iselement(element)
         if element is not None and not iselement(element):
             raise TypeError(f"element must be etree.Element, "
                             f"not {type(element).__name__}")
@@ -546,7 +545,6 @@ class ElementTree:
         with the given element.  Use with care!
 
         """
-        # assert iselement(element)
         if not iselement(element):
             raise TypeError
         self._root = element

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -546,7 +546,8 @@ class ElementTree:
 
         """
         if not iselement(element):
-            raise TypeError
+            raise TypeError(f"element must be etree.Element, "
+                            f"not {type(element).__name__}")
         self._root = element
 
     def parse(self, source, parser=None):

--- a/Misc/NEWS.d/next/Documentation/2025-07-09-15-06-27.gh-issue-136231.Wx8W-w.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-07-09-15-06-27.gh-issue-136231.Wx8W-w.rst
@@ -1,0 +1,2 @@
+Document that :func:`xml.etree.ElementTree.iselement` works identically on
+both object instances and types.

--- a/Misc/NEWS.d/next/Library/2025-06-22-02-16-17.gh-issue-135640.FXyFL6.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-22-02-16-17.gh-issue-135640.FXyFL6.rst
@@ -1,0 +1,3 @@
+Address bug where calling :func:`xml.etree.ElementTree.ElementTree.write` on
+an ElementTree object with an invalid root element would blank the file
+passed to ``write`` if it already existed.

--- a/Misc/NEWS.d/next/Library/2025-06-22-02-16-17.gh-issue-135640.FXyFL6.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-22-02-16-17.gh-issue-135640.FXyFL6.rst
@@ -1,3 +1,4 @@
-Address bug where calling :func:`xml.etree.ElementTree.ElementTree.write` on
-an ElementTree object with an invalid root element would blank the file
-passed to ``write`` if it already existed.
+Address bug where it was possible to call
+:func:`xml.etree.ElementTree.ElementTree.write` on an ElementTree object with
+an invalid root element. This behavior blanked the file passed to ``write``
+if it already existed.


### PR DESCRIPTION
Following discussion in [ElementTree.iselement() returns true for the Element type #136231](https://github.com/python/cpython/issues/136231), this documents the behavior of `iselement` when passed a type. I'm submitting this as a draft so more input can be given.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136231 -->
* Issue: gh-136231
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136482.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->