### PR TITLE
gh-136231: Document xml.etree.ElementTree.iselement behavior when used with types

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -610,8 +610,11 @@ Functions
 
 .. function:: iselement(element)
 
-   Check if an object appears to be a valid element object.  *element* is an
-   element instance.  Return ``True`` if this is an element object.
+   Check if *element* appears to be a valid element object or type. Return
+   ``True`` if this is an element object or type.
+
+   Because ``iselement`` behaves identically for both objects and types, code
+   requiring an object should check for this, see :func:`iselement`.
 
 
 .. function:: iterparse(source, events=None, parser=None)

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -614,7 +614,7 @@ Functions
    ``True`` if this is an element object or type.
 
    Because ``iselement`` behaves identically for both objects and types, code
-   requiring an object should check for this, see :func:`iselement`.
+   requiring an object should check for this, see :func:`isinstance`.
 
 
 .. function:: iterparse(source, events=None, parser=None)

--- a/Misc/NEWS.d/next/Documentation/2025-07-09-15-06-27.gh-issue-136231.Wx8W-w.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-07-09-15-06-27.gh-issue-136231.Wx8W-w.rst
@@ -1,0 +1,2 @@
+Document that :func:`xml.etree.ElementTree.iselement` works identically on
+both object instances and types.


### PR DESCRIPTION
Following discussion in #136231, this documents the behavior of `iselement` when passed a type. I'm submitting this as a draft so more input can be given.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136231 -->
* Issue: gh-136231
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136484.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->