### PR TITLE
gh-52876: Implement missing parameter in `codecs.StreamReaderWriter` functions

### DIFF
--- a/Lib/codecs.py
+++ b/Lib/codecs.py
@@ -618,7 +618,7 @@ class StreamReader(Codec):
             method and are included in the list entries.
 
             sizehint, if given, is ignored since there is no efficient
-            way to finding the true end-of-line.
+            way to find the true end-of-line.
 
         """
         data = self.read()
@@ -709,13 +709,13 @@ class StreamReaderWriter:
 
         return self.reader.read(size)
 
-    def readline(self, size=None):
+    def readline(self, size=None, keepends=True):
 
-        return self.reader.readline(size)
+        return self.reader.readline(size, keepends)
 
-    def readlines(self, sizehint=None):
+    def readlines(self, sizehint=None, keepends=True):
 
-        return self.reader.readlines(sizehint)
+        return self.reader.readlines(sizehint, keepends)
 
     def __next__(self):
 

--- a/Lib/codecs.py
+++ b/Lib/codecs.py
@@ -618,7 +618,7 @@ class StreamReader(Codec):
             method and are included in the list entries.
 
             sizehint, if given, is ignored since there is no efficient
-            way to find the true end-of-line.
+            way of finding the true end-of-line.
 
         """
         data = self.read()

--- a/Misc/NEWS.d/next/Library/2025-07-10-10-18-19.gh-issue-52876.9Vjrd8.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-10-10-18-19.gh-issue-52876.9Vjrd8.rst
@@ -1,0 +1,3 @@
+Add missing ``keepends`` (default ``True``) parameter to
+:meth:`codecs.StreamReaderWriter.readline` and
+:meth:`codecs.StreamReaderWriter.readlines`.

--- a/Misc/NEWS.d/next/Library/2025-07-10-10-18-19.gh-issue-52876.9Vjrd8.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-10-10-18-19.gh-issue-52876.9Vjrd8.rst
@@ -1,3 +1,3 @@
 Add missing ``keepends`` (default ``True``) parameter to
-:meth:`codecs.StreamReaderWriter.readline` and
-:meth:`codecs.StreamReaderWriter.readlines`.
+:meth:`!codecs.StreamReaderWriter.readline` and
+:meth:`!codecs.StreamReaderWriter.readlines`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This is a bug since, per docs:

> [StreamReaderWriter](https://docs.python.org/3.15/library/codecs.html#codecs.StreamReaderWriter) instances define the combined interfaces of [StreamReader](https://docs.python.org/3.15/library/codecs.html#codecs.StreamReader) and [StreamWriter](https://docs.python.org/3.15/library/codecs.html#codecs.StreamWriter) classes. They inherit all other methods and attributes from the underlying stream.

<!-- gh-issue-number: gh-52876 -->
* Issue: gh-52876
<!-- /gh-issue-number -->
