### PR TITLE
[3.13] gh-136438: Make sure `test_builtins` pass with all optimization levels (GH-136474)

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -380,7 +380,7 @@ class BuiltinTest(unittest.TestCase):
             # test both direct compilation and compilation via AST
                 codeobjs = []
                 codeobjs.append(compile(codestr, "<test>", "exec", optimize=optval))
-                tree = ast.parse(codestr)
+                tree = ast.parse(codestr, optimize=optval)
                 codeobjs.append(compile(tree, "<test>", "exec", optimize=optval))
                 for code in codeobjs:
                     ns = {}


### PR DESCRIPTION
(cherry picked from commit c17654334946b232aa296696cf70ec93a09d8156)


<!-- gh-issue-number: gh-136438 -->
* Issue: gh-136438
<!-- /gh-issue-number -->
