### PR TITLE
gh-136517: Print uncollectable objects if DEBUG_UNCOLLECTABLE mode was set

### DIFF
--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -733,7 +733,7 @@ class GCTests(unittest.TestCase):
                       b"shutdown; use", stderr)
         self.assertNotIn(b"<X 'first'>", stderr)
         one_line_re = b"gc: uncollectable <X 0x[0-9A-Fa-f]+>"
-        expected_re = one_line_re + b".*" + one_line_re
+        expected_re = one_line_re + b"\r?\n" + one_line_re
         self.assertNotRegex(stderr, expected_re)
         # With DEBUG_UNCOLLECTABLE, the garbage list gets printed
         stderr = run_command(code % "gc.DEBUG_UNCOLLECTABLE")

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -732,8 +732,8 @@ class GCTests(unittest.TestCase):
         self.assertIn(b"ResourceWarning: gc: 2 uncollectable objects at "
                       b"shutdown; use", stderr)
         self.assertNotIn(b"<X 'first'>", stderr)
-        one_line_re = b"gc: uncollectable <X 0x[0-9A-F]+>"
-        expected_re = one_line_re + b"\\r?\\n" + one_line_re
+        one_line_re = b"gc: uncollectable <X 0x[0-9A-Fa-f]+>"
+        expected_re = one_line_re + b".*" + one_line_re
         self.assertNotRegex(stderr, expected_re)
         # With DEBUG_UNCOLLECTABLE, the garbage list gets printed
         stderr = run_command(code % "gc.DEBUG_UNCOLLECTABLE")

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -732,6 +732,9 @@ class GCTests(unittest.TestCase):
         self.assertIn(b"ResourceWarning: gc: 2 uncollectable objects at "
                       b"shutdown; use", stderr)
         self.assertNotIn(b"<X 'first'>", stderr)
+        one_line_re = b"gc: uncollectable <X 0x[0-9A-F]+>"
+        expected_re = one_line_re + b"\\r?\\n" + one_line_re
+        self.assertNotRegex(stderr, expected_re)
         # With DEBUG_UNCOLLECTABLE, the garbage list gets printed
         stderr = run_command(code % "gc.DEBUG_UNCOLLECTABLE")
         self.assertIn(b"ResourceWarning: gc: 2 uncollectable objects at "
@@ -739,6 +742,8 @@ class GCTests(unittest.TestCase):
         self.assertTrue(
             (b"[<X 'first'>, <X 'second'>]" in stderr) or
             (b"[<X 'second'>, <X 'first'>]" in stderr), stderr)
+        # we expect two lines with uncollectable objects
+        self.assertRegex(stderr, expected_re)
         # With DEBUG_SAVEALL, no additional message should get printed
         # (because gc.garbage also contains normally reclaimable cyclic
         # references, and its elements get printed at runtime anyway).

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-10-23-23-50.gh-issue-136517._NHJyv.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-10-23-23-50.gh-issue-136517._NHJyv.rst
@@ -1,0 +1,2 @@
+Fixed a typo that prevented printing of uncollectable objects when the
+DEBUG_UNCOLLECTABLE mode was set

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-10-23-23-50.gh-issue-136517._NHJyv.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-10-23-23-50.gh-issue-136517._NHJyv.rst
@@ -1,2 +1,2 @@
 Fixed a typo that prevented printing of uncollectable objects when the
-DEBUG_UNCOLLECTABLE mode was set
+:const:`gc.DEBUG_UNCOLLECTABLE` mode was set.

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1782,7 +1782,7 @@ gc_collect_region(PyThreadState *tstate,
     Py_ssize_t n = 0;
     for (gc = GC_NEXT(&finalizers); gc != &finalizers; gc = GC_NEXT(gc)) {
         n++;
-        if (gcstate->debug & _PyGC_DEBUG_COLLECTABLE)
+        if (gcstate->debug & _PyGC_DEBUG_UNCOLLECTABLE)
             debug_cycle("uncollectable", FROM_GC(gc));
     }
     stats->uncollectable = n;


### PR DESCRIPTION
There was a typo, and uncollectable objects printed only if DEBUG_COLLECTABLE mode is set.
Affected main and 3.14 (183b020cb5960e17b87c34a98ec02fcf2b840578)

https://github.com/python/cpython/blob/59acdba820f75081cfb47ad6e71044d022854cbc/Python/gc.c#L1783-L1787

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136517 -->
* Issue: gh-136517
<!-- /gh-issue-number -->
