### PR TITLE
Omit `Python/perf_jit_trampoline.c` from the `**/*jit*` CODEOWNERS rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,7 @@ Modules/Setup*                @erlend-aasland
 **/*genobject*                @markshannon
 **/*hamt*                     @1st1
 **/*jit*                      @brandtbucher @savannahostrowski @diegorusso
+Python/perf_jit_trampoline.c  # Exclude the owners of "**/*jit*", above.
 Objects/set*                  @rhettinger
 Objects/dict*                 @methane @markshannon
 Objects/typevarobject.c       @JelleZijlstra


### PR DESCRIPTION
I *think* this works the way I'm intending?

@pablogsal, let me know if you (or anyone else) belongs on this line.