### PR TITLE
gh-136523: fix wave.Wave_write emitting an unraisable when open raises

### DIFF
--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -169,6 +169,26 @@ def make_bad_fd():
         unlink(TESTFN)
 
 
+@contextlib.contextmanager
+def unwritable_filepath():
+    """
+    Create a filepath that is not writable by the current user.
+    """
+    import tempfile
+    fd, path = tempfile.mkstemp()
+    original_permissions = stat.S_IMODE(os.lstat(path).st_mode)
+    os.close(fd)
+
+    try:
+        os.chmod(path, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+        yield path
+    finally:
+        try:
+            os.chmod(path, original_permissions)
+            os.remove(path)
+        except OSError as e:
+            pass
+
 _can_symlink = None
 
 

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -169,26 +169,6 @@ def make_bad_fd():
         unlink(TESTFN)
 
 
-@contextlib.contextmanager
-def unwritable_filepath():
-    """
-    Create a filepath that is not writable by the current user.
-    """
-    import tempfile
-    fd, path = tempfile.mkstemp()
-    original_permissions = stat.S_IMODE(os.lstat(path).st_mode)
-    os.close(fd)
-
-    try:
-        os.chmod(path, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
-        yield path
-    finally:
-        try:
-            os.chmod(path, original_permissions)
-            os.remove(path)
-        except OSError as e:
-            pass
-
 _can_symlink = None
 
 

--- a/Lib/test/test_wave.py
+++ b/Lib/test/test_wave.py
@@ -2,6 +2,7 @@ import unittest
 from test import audiotests
 from test import support
 from test.support import os_helper
+import contextlib
 import io
 import struct
 import sys
@@ -200,11 +201,9 @@ class WaveLowLevelTest(unittest.TestCase):
     def test_write_to_protected_location(self):
         # gh-136523: Wave_write.__del__ should not throw
         with support.catch_unraisable_exception() as cm:
-            try:
+            with contextlib.suppress(OSError):
                 with os_helper.temp_dir() as path:
                     wave.open(path, "wb")
-            except IsADirectoryError:
-                pass
             support.gc_collect()
             self.assertIsNone(cm.unraisable)
 

--- a/Lib/test/test_wave.py
+++ b/Lib/test/test_wave.py
@@ -1,7 +1,7 @@
 import unittest
 from test import audiotests
 from test import support
-from test.support.os_helper import unwritable_filepath, skip_unless_working_chmod
+from test.support import os_helper
 import io
 import struct
 import sys
@@ -197,21 +197,16 @@ class WaveLowLevelTest(unittest.TestCase):
         with self.assertRaisesRegex(wave.Error, 'bad sample width'):
             wave.open(io.BytesIO(b))
 
-    @skip_unless_working_chmod
-    def test_write_to_protected_file(self):
+    def test_write_to_protected_location(self):
         # gh-136523: Wave_write.__del__ should not throw
-        stderr = io.StringIO()
-        sys.stderr = stderr
-        try:
+        with support.catch_unraisable_exception() as cm:
             try:
-                with unwritable_filepath() as path:
-                    with wave.open(path, "wb"):
-                        pass
-            except PermissionError:
+                with os_helper.temp_dir() as path:
+                    wave.open(path, "wb")
+            except IsADirectoryError:
                 pass
-            self.assertEqual(stderr.getvalue(), "")
-        finally:
-            sys.stderr = sys.__stderr__
+            support.gc_collect()
+            self.assertIsNone(cm.unraisable)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_wave.py
+++ b/Lib/test/test_wave.py
@@ -1,7 +1,7 @@
 import unittest
 from test import audiotests
 from test import support
-from test.support.os_helper import unwritable_filepath
+from test.support.os_helper import unwritable_filepath, skip_unless_working_chmod
 import io
 import struct
 import sys
@@ -197,6 +197,7 @@ class WaveLowLevelTest(unittest.TestCase):
         with self.assertRaisesRegex(wave.Error, 'bad sample width'):
             wave.open(io.BytesIO(b))
 
+    @skip_unless_working_chmod
     def test_write_to_protected_file(self):
         # gh-136523: Wave_write.__del__ should not throw
         stderr = io.StringIO()

--- a/Lib/test/test_wave.py
+++ b/Lib/test/test_wave.py
@@ -1,9 +1,8 @@
 import unittest
 from test import audiotests
 from test import support
-from test.support import os_helper
-import contextlib
 import io
+import os
 import struct
 import sys
 import wave
@@ -198,12 +197,11 @@ class WaveLowLevelTest(unittest.TestCase):
         with self.assertRaisesRegex(wave.Error, 'bad sample width'):
             wave.open(io.BytesIO(b))
 
-    def test_write_to_protected_location(self):
+    def test_open_in_write_raises(self):
         # gh-136523: Wave_write.__del__ should not throw
         with support.catch_unraisable_exception() as cm:
-            with contextlib.suppress(OSError):
-                with os_helper.temp_dir() as path:
-                    wave.open(path, "wb")
+            with self.assertRaises(OSError):
+                wave.open(os.curdir, "wb")
             support.gc_collect()
             self.assertIsNone(cm.unraisable)
 

--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -429,15 +429,15 @@ class Wave_write:
 
     def __init__(self, f):
         self._i_opened_the_file = None
-        if isinstance(f, str):
-            f = builtins.open(f, 'wb')
-            self._i_opened_the_file = f
         try:
-            self.initfp(f)
+            if isinstance(f, str):
+                f = builtins.open(f, 'wb')
+                self._i_opened_the_file = f
         except:
-            if self._i_opened_the_file:
-                f.close()
+            f = None
             raise
+        finally:
+            self.initfp(f)
 
     def initfp(self, file):
         self._file = file

--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -427,17 +427,19 @@ class Wave_write:
     _datawritten -- the size of the audio samples actually written
     """
 
+    _file = None
+
     def __init__(self, f):
         self._i_opened_the_file = None
+        if isinstance(f, str):
+            f = builtins.open(f, 'wb')
+            self._i_opened_the_file = f
         try:
-            if isinstance(f, str):
-                f = builtins.open(f, 'wb')
-                self._i_opened_the_file = f
-        except:
-            f = None
-            raise
-        finally:
             self.initfp(f)
+        except:
+            if self._i_opened_the_file:
+                f.close()
+            raise
 
     def initfp(self, file):
         self._file = file

--- a/Misc/NEWS.d/next/Library/2025-07-11-03-39-15.gh-issue-136523.s7caKL.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-11-03-39-15.gh-issue-136523.s7caKL.rst
@@ -1,1 +1,1 @@
-Fix ``wave.Wave_write.__del__`` raising :exc:`AttributeError` when attempting to open an unwritable file.
+Fix :class:`wave.Wave_write` emitting an unraisable :exc:`AttributeError` when attempting to open an unwritable file.

--- a/Misc/NEWS.d/next/Library/2025-07-11-03-39-15.gh-issue-136523.s7caKL.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-11-03-39-15.gh-issue-136523.s7caKL.rst
@@ -1,0 +1,1 @@
+Fix :func:`wave.Wave_write.__del__` raising :exc:`AttributeError` when attempting to open an unwritable file.

--- a/Misc/NEWS.d/next/Library/2025-07-11-03-39-15.gh-issue-136523.s7caKL.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-11-03-39-15.gh-issue-136523.s7caKL.rst
@@ -1,1 +1,1 @@
-Fix :func:`wave.Wave_write.__del__` raising :exc:`AttributeError` when attempting to open an unwritable file.
+Fix ``wave.Wave_write.__del__`` raising :exc:`AttributeError` when attempting to open an unwritable file.

--- a/Misc/NEWS.d/next/Library/2025-07-11-03-39-15.gh-issue-136523.s7caKL.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-11-03-39-15.gh-issue-136523.s7caKL.rst
@@ -1,1 +1,1 @@
-Fix :class:`wave.Wave_write` emitting an unraisable :exc:`AttributeError` when attempting to open an unwritable file.
+Fix :class:`wave.Wave_write` emitting an unraisable when open raises.


### PR DESCRIPTION
Fixes #136523, by moving `builtins.open` inside the `try-except` block and always calling `initfp` (which does not raise) for `Wave_write`.

<!-- gh-issue-number: gh-136523 -->
* Issue: gh-136523
<!-- /gh-issue-number -->
