### PR TITLE
gh-136535: Tests: Correct `Py_TPFLAGS_MANAGED_DICT` in `test_class.py`

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -859,7 +859,10 @@ class ClassTests(unittest.TestCase):
 
 from _testinternalcapi import has_inline_values
 
-Py_TPFLAGS_MANAGED_DICT = (1 << 2)
+Py_TPFLAGS_MANAGED_DICT = (1 << 4)
+
+class NoManagedDict:
+    __slots__ = ('a',)
 
 class Plain:
     pass
@@ -873,6 +876,13 @@ class WithAttrs:
         self.c = 3
         self.d = 4
 
+class TestNoManagedValues(unittest.TestCase):
+    def test_flags(self):
+        self.assertEqual(NoManagedDict.__flags__ & Py_TPFLAGS_MANAGED_DICT, 0)
+
+    def test_no_inline_values_for_slots_class(self):
+        c = NoManagedDict()
+        self.assertFalse(has_inline_values(c))
 
 class TestInlineValues(unittest.TestCase):
 

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -883,6 +883,10 @@ class VarSizedSubclass(tuple):
 
 class TestInlineValues(unittest.TestCase):
 
+    def test_flags(self):
+        self.assertEqual(Plain.__flags__ & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)
+        self.assertEqual(WithAttrs.__flags__ & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)
+
     def test_no_flags_for_slots_class(self):
         flags = NoManagedDict.__flags__
         self.assertEqual(flags & Py_TPFLAGS_MANAGED_DICT, 0)

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -865,6 +865,7 @@ Py_TPFLAGS_MANAGED_DICT = (1 << 4)
 class NoManagedDict:
     __slots__ = ('a',)
 
+
 class Plain:
     pass
 
@@ -876,6 +877,7 @@ class WithAttrs:
         self.b = 2
         self.c = 3
         self.d = 4
+
 
 class VarSizedSubclass(tuple):
     pass

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -859,6 +859,7 @@ class ClassTests(unittest.TestCase):
 
 from _testinternalcapi import has_inline_values
 
+Py_TPFLAGS_INLINE_VALUES = (1 << 2)
 Py_TPFLAGS_MANAGED_DICT = (1 << 4)
 
 class NoManagedDict:
@@ -876,19 +877,31 @@ class WithAttrs:
         self.c = 3
         self.d = 4
 
-class TestNoManagedValues(unittest.TestCase):
-    def test_flags(self):
-        self.assertEqual(NoManagedDict.__flags__ & Py_TPFLAGS_MANAGED_DICT, 0)
+class VarSizedSubclass(tuple):
+    pass
 
-    def test_no_inline_values_for_slots_class(self):
-        c = NoManagedDict()
-        self.assertFalse(has_inline_values(c))
 
 class TestInlineValues(unittest.TestCase):
 
-    def test_flags(self):
-        self.assertEqual(Plain.__flags__ & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)
-        self.assertEqual(WithAttrs.__flags__ & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)
+    def test_no_flags_for_slots_class(self):
+        flags = NoManagedDict.__flags__
+        self.assertEqual(flags & Py_TPFLAGS_MANAGED_DICT, 0)
+        self.assertEqual(flags & Py_TPFLAGS_INLINE_VALUES, 0)
+        self.assertFalse(has_inline_values(NoManagedDict()))
+
+    def test_both_flags_for_regular_class(self):
+        for cls in (Plain, WithAttrs):
+            with self.subTest(cls=cls.__name__):
+                flags = cls.__flags__
+                self.assertEqual(flags & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)
+                self.assertEqual(flags & Py_TPFLAGS_INLINE_VALUES, Py_TPFLAGS_INLINE_VALUES)
+                self.assertTrue(has_inline_values(cls()))
+
+    def test_managed_dict_only_for_varsized_subclass(self):
+        flags = VarSizedSubclass.__flags__
+        self.assertEqual(flags & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)
+        self.assertEqual(flags & Py_TPFLAGS_INLINE_VALUES, 0)
+        self.assertFalse(has_inline_values(VarSizedSubclass()))
 
     def test_has_inline_values(self):
         c = Plain()

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -885,10 +885,6 @@ class VarSizedSubclass(tuple):
 
 class TestInlineValues(unittest.TestCase):
 
-    def test_flags(self):
-        self.assertEqual(Plain.__flags__ & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)
-        self.assertEqual(WithAttrs.__flags__ & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)
-
     def test_no_flags_for_slots_class(self):
         flags = NoManagedDict.__flags__
         self.assertEqual(flags & Py_TPFLAGS_MANAGED_DICT, 0)


### PR DESCRIPTION
The `Py_TPFLAGS_MANAGED_DICT` constant in `Lib/test/test_class.py` was incorrectly set to (1 << 2) instead of the correct (1 << 4) from object.h.

issue: #136535 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136535 -->
* Issue: gh-136535
<!-- /gh-issue-number -->
