### PR TITLE
gh-89083: Add CLI tests for `UUIDv{6,7,8}`

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1143,6 +1143,20 @@ class BaseTestUUID:
 
 class TestUUIDCli(BaseTestUUID, unittest.TestCase):
     uuid = py_uuid
+
+    def do_test_standalone_uuid(self, version):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            self.uuid.main()
+        output = stdout.getvalue().strip()
+        u = self.uuid.UUID(output)
+        self.assertEqual(output, str(u))
+        self.assertEqual(u.version, version)
+
+    @mock.patch.object(sys, "argv", ["", "-u", "uuid1"])
+    def test_uuid1(self):
+        self.do_test_standalone_uuid(1)
+
     @mock.patch.object(sys, "argv", ["", "-u", "uuid3", "-n", "@dns"])
     @mock.patch('sys.stderr', new_callable=io.StringIO)
     def test_cli_namespace_required_for_uuid3(self, mock_err):
@@ -1217,61 +1231,17 @@ class TestUUIDCli(BaseTestUUID, unittest.TestCase):
         self.assertEqual(output, str(uuid_output))
         self.assertEqual(uuid_output.version, 5)
 
-    @mock.patch.object(sys, "argv",
-                       ["", "-u", "uuid1"])
-    def test_cli_uuid1(self):
-        stdout = io.StringIO()
-        with contextlib.redirect_stdout(stdout):
-            self.uuid.main()
+    @mock.patch.object(sys, "argv", ["", "-u", "uuid6"])
+    def test_uuid1(self):
+        self.do_test_standalone_uuid(6)
 
-        output = stdout.getvalue().strip()
-        uuid_output = self.uuid.UUID(output)
+    @mock.patch.object(sys, "argv", ["", "-u", "uuid7"])
+    def test_uuid1(self):
+        self.do_test_standalone_uuid(7)
 
-        # Output should be in the form of uuid1
-        self.assertEqual(output, str(uuid_output))
-        self.assertEqual(uuid_output.version, 1)
-
-    @mock.patch.object(sys, "argv",
-                       ["", "-u", "uuid6"])
-    def test_cli_uuid6(self):
-        stdout = io.StringIO()
-        with contextlib.redirect_stdout(stdout):
-            self.uuid.main()
-
-        output = stdout.getvalue().strip()
-        uuid_output = self.uuid.UUID(output)
-
-        # Output should be in the form of uuid6
-        self.assertEqual(output, str(uuid_output))
-        self.assertEqual(uuid_output.version, 6)
-
-    @mock.patch.object(sys, "argv",
-                       ["", "-u", "uuid7"])
-    def test_cli_uuid7(self):
-        stdout = io.StringIO()
-        with contextlib.redirect_stdout(stdout):
-            self.uuid.main()
-
-        output = stdout.getvalue().strip()
-        uuid_output = self.uuid.UUID(output)
-
-        # Output should be in the form of uuid7
-        self.assertEqual(output, str(uuid_output))
-        self.assertEqual(uuid_output.version, 7)
-
-    @mock.patch.object(sys, "argv",
-                       ["", "-u", "uuid8"])
-    def test_cli_uuid8(self):
-        stdout = io.StringIO()
-        with contextlib.redirect_stdout(stdout):
-            self.uuid.main()
-
-        output = stdout.getvalue().strip()
-        uuid_output = self.uuid.UUID(output)
-
-        # Output should be in the form of uuid8
-        self.assertEqual(output, str(uuid_output))
-        self.assertEqual(uuid_output.version, 8)
+    @mock.patch.object(sys, "argv", ["", "-u", "uuid8"])
+    def test_uuid1(self):
+        self.do_test_standalone_uuid(8)
 
 
 class TestUUIDWithoutExtModule(BaseTestUUID, unittest.TestCase):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1242,12 +1242,12 @@ class CommandLineRunTime:
         self.do_test_standalone_uuid(8)
 
 
-class TestUUIDWithoutExtModule(TestUUIDCommandLineRunTimeMixin, BaseTestUUID, unittest.TestCase):
+class TestUUIDWithoutExtModule(CommandLineRunTime, BaseTestUUID, unittest.TestCase):
     uuid = py_uuid
 
 
 @unittest.skipUnless(c_uuid, 'requires the C _uuid module')
-class TestUUIDWithExtModule(TestUUIDCommandLineRunTimeMixin, BaseTestUUID, unittest.TestCase):
+class TestUUIDWithExtModule(CommandLineRunTime, BaseTestUUID, unittest.TestCase):
     uuid = c_uuid
 
     def check_has_stable_libuuid_extractable_node(self):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1214,6 +1214,64 @@ class BaseTestUUID:
         self.assertEqual(output, str(uuid_output))
         self.assertEqual(uuid_output.version, 5)
 
+    @mock.patch.object(sys, "argv",
+                       ["", "-u", "uuid1"])
+    def test_cli_uuid1(self):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            self.uuid.main()
+
+        output = stdout.getvalue().strip()
+        uuid_output = self.uuid.UUID(output)
+
+        # Output should be in the form of uuid1
+        self.assertEqual(output, str(uuid_output))
+        self.assertEqual(uuid_output.version, 1)
+
+
+    @mock.patch.object(sys, "argv",
+                       ["", "-u", "uuid6"])
+    def test_cli_uuid6(self):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            self.uuid.main()
+
+        output = stdout.getvalue().strip()
+        uuid_output = self.uuid.UUID(output)
+
+        # Output should be in the form of uuid6
+        self.assertEqual(output, str(uuid_output))
+        self.assertEqual(uuid_output.version, 6)
+
+
+    @mock.patch.object(sys, "argv",
+                       ["", "-u", "uuid7"])
+    def test_cli_uuid7(self):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            self.uuid.main()
+
+        output = stdout.getvalue().strip()
+        uuid_output = self.uuid.UUID(output)
+
+        # Output should be in the form of uuid7
+        self.assertEqual(output, str(uuid_output))
+        self.assertEqual(uuid_output.version, 7)
+
+
+    @mock.patch.object(sys, "argv",
+                       ["", "-u", "uuid8"])
+    def test_cli_uuid8(self):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            self.uuid.main()
+
+        output = stdout.getvalue().strip()
+        uuid_output = self.uuid.UUID(output)
+
+        # Output should be in the form of uuid8
+        self.assertEqual(output, str(uuid_output))
+        self.assertEqual(uuid_output.version, 8)
 
 class TestUUIDWithoutExtModule(BaseTestUUID, unittest.TestCase):
     uuid = py_uuid

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1140,6 +1140,9 @@ class BaseTestUUID:
         weak = weakref.ref(strong)
         self.assertIs(strong, weak())
 
+
+class TestUUIDCli(BaseTestUUID, unittest.TestCase):
+    uuid = py_uuid
     @mock.patch.object(sys, "argv", ["", "-u", "uuid3", "-n", "@dns"])
     @mock.patch('sys.stderr', new_callable=io.StringIO)
     def test_cli_namespace_required_for_uuid3(self, mock_err):
@@ -1228,7 +1231,6 @@ class BaseTestUUID:
         self.assertEqual(output, str(uuid_output))
         self.assertEqual(uuid_output.version, 1)
 
-
     @mock.patch.object(sys, "argv",
                        ["", "-u", "uuid6"])
     def test_cli_uuid6(self):
@@ -1242,7 +1244,6 @@ class BaseTestUUID:
         # Output should be in the form of uuid6
         self.assertEqual(output, str(uuid_output))
         self.assertEqual(uuid_output.version, 6)
-
 
     @mock.patch.object(sys, "argv",
                        ["", "-u", "uuid7"])
@@ -1258,7 +1259,6 @@ class BaseTestUUID:
         self.assertEqual(output, str(uuid_output))
         self.assertEqual(uuid_output.version, 7)
 
-
     @mock.patch.object(sys, "argv",
                        ["", "-u", "uuid8"])
     def test_cli_uuid8(self):
@@ -1272,7 +1272,6 @@ class BaseTestUUID:
         # Output should be in the form of uuid8
         self.assertEqual(output, str(uuid_output))
         self.assertEqual(uuid_output.version, 8)
-
 
 class TestUUIDWithoutExtModule(BaseTestUUID, unittest.TestCase):
     uuid = py_uuid

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1244,12 +1244,12 @@ class CommandLineTestCases:
         self.do_test_standalone_uuid(8)
 
 
-class TestUUIDWithoutExtModule(CommandLineRunTime, BaseTestUUID, unittest.TestCase):
+class TestUUIDWithoutExtModule(CommandLineTestCases, BaseTestUUID, unittest.TestCase):
     uuid = py_uuid
 
 
 @unittest.skipUnless(c_uuid, 'requires the C _uuid module')
-class TestUUIDWithExtModule(CommandLineRunTime, BaseTestUUID, unittest.TestCase):
+class TestUUIDWithExtModule(CommandLineTestCases, BaseTestUUID, unittest.TestCase):
     uuid = c_uuid
 
     def check_has_stable_libuuid_extractable_node(self):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1141,9 +1141,7 @@ class BaseTestUUID:
         self.assertIs(strong, weak())
 
 
-class TestUUIDCommandLineRunTime(unittest.TestCase):
-    uuid = py_uuid
-
+class TestUUIDCommandLineRunTimeMixin:
     def do_test_standalone_uuid(self, version):
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):
@@ -1244,12 +1242,12 @@ class TestUUIDCommandLineRunTime(unittest.TestCase):
         self.do_test_standalone_uuid(8)
 
 
-class TestUUIDWithoutExtModule(BaseTestUUID, unittest.TestCase):
+class TestUUIDWithoutExtModule(TestUUIDCommandLineRunTimeMixin, BaseTestUUID, unittest.TestCase):
     uuid = py_uuid
 
 
 @unittest.skipUnless(c_uuid, 'requires the C _uuid module')
-class TestUUIDWithExtModule(BaseTestUUID, unittest.TestCase):
+class TestUUIDWithExtModule(TestUUIDCommandLineRunTimeMixin, BaseTestUUID, unittest.TestCase):
     uuid = c_uuid
 
     def check_has_stable_libuuid_extractable_node(self):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1273,6 +1273,7 @@ class TestUUIDCli(BaseTestUUID, unittest.TestCase):
         self.assertEqual(output, str(uuid_output))
         self.assertEqual(uuid_output.version, 8)
 
+
 class TestUUIDWithoutExtModule(BaseTestUUID, unittest.TestCase):
     uuid = py_uuid
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1141,7 +1141,7 @@ class BaseTestUUID:
         self.assertIs(strong, weak())
 
 
-class TestUUIDCli(unittest.TestCase):
+class TestUUIDCommandLineRunTime(unittest.TestCase):
     uuid = py_uuid
 
     def do_test_standalone_uuid(self, version):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1273,6 +1273,7 @@ class BaseTestUUID:
         self.assertEqual(output, str(uuid_output))
         self.assertEqual(uuid_output.version, 8)
 
+
 class TestUUIDWithoutExtModule(BaseTestUUID, unittest.TestCase):
     uuid = py_uuid
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1154,7 +1154,7 @@ class TestUUIDCli(BaseTestUUID, unittest.TestCase):
         self.assertEqual(u.version, version)
 
     @mock.patch.object(sys, "argv", ["", "-u", "uuid1"])
-    def test_uuid1(self):
+    def test_cli_uuid1(self):
         self.do_test_standalone_uuid(1)
 
     @mock.patch.object(sys, "argv", ["", "-u", "uuid3", "-n", "@dns"])
@@ -1232,15 +1232,15 @@ class TestUUIDCli(BaseTestUUID, unittest.TestCase):
         self.assertEqual(uuid_output.version, 5)
 
     @mock.patch.object(sys, "argv", ["", "-u", "uuid6"])
-    def test_uuid1(self):
+    def test_cli_uuid6(self):
         self.do_test_standalone_uuid(6)
 
     @mock.patch.object(sys, "argv", ["", "-u", "uuid7"])
-    def test_uuid1(self):
+    def test_cli_uuid7(self):
         self.do_test_standalone_uuid(7)
 
     @mock.patch.object(sys, "argv", ["", "-u", "uuid8"])
-    def test_uuid1(self):
+    def test_cli_uuid8(self):
         self.do_test_standalone_uuid(8)
 
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1141,7 +1141,7 @@ class BaseTestUUID:
         self.assertIs(strong, weak())
 
 
-class TestUUIDCommandLineRunTimeMixin:
+class CommandLineRunTime:
     def do_test_standalone_uuid(self, version):
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1141,7 +1141,9 @@ class BaseTestUUID:
         self.assertIs(strong, weak())
 
 
-class CommandLineRunTime:
+class CommandLineTestCases:
+    uuid = None  # to be defined in subclasses
+
     def do_test_standalone_uuid(self, version):
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1141,7 +1141,7 @@ class BaseTestUUID:
         self.assertIs(strong, weak())
 
 
-class TestUUIDCli(BaseTestUUID, unittest.TestCase):
+class TestUUIDCli(unittest.TestCase):
     uuid = py_uuid
 
     def do_test_standalone_uuid(self, version):


### PR DESCRIPTION
This PR add simple cli test cases to UUIDv6, v7, v8 added in #89083 , as well as a test case to UUID v1.

There are only one test cases for each, since they can't be customized through CLI.

Skipping news ;)

<!-- gh-issue-number: gh-89083 -->
* Issue: gh-89083
<!-- /gh-issue-number -->
