### PR TITLE
[3.13] gh-101100: Fix sphinx warnings in Doc/library/functools.rst (GH-136424)

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -199,12 +199,18 @@ The :mod:`functools` module defines the following functions:
    and *typed*.  This is for information purposes only.  Mutating the values
    has no effect.
 
+   .. method:: lru_cache.cache_info()
+      :no-typesetting:
+
    To help measure the effectiveness of the cache and tune the *maxsize*
-   parameter, the wrapped function is instrumented with a :func:`cache_info`
+   parameter, the wrapped function is instrumented with a :func:`!cache_info`
    function that returns a :term:`named tuple` showing *hits*, *misses*,
    *maxsize* and *currsize*.
 
-   The decorator also provides a :func:`cache_clear` function for clearing or
+   .. method:: lru_cache.cache_clear()
+      :no-typesetting:
+
+   The decorator also provides a :func:`!cache_clear` function for clearing or
    invalidating the cache.
 
    The original underlying function is accessible through the
@@ -284,9 +290,9 @@ The :mod:`functools` module defines the following functions:
    class decorator supplies the rest.  This simplifies the effort involved
    in specifying all of the possible rich comparison operations:
 
-   The class must define one of :meth:`__lt__`, :meth:`__le__`,
-   :meth:`__gt__`, or :meth:`__ge__`.
-   In addition, the class should supply an :meth:`__eq__` method.
+   The class must define one of :meth:`~object.__lt__`, :meth:`~object.__le__`,
+   :meth:`~object.__gt__`, or :meth:`~object.__ge__`.
+   In addition, the class should supply an :meth:`~object.__eq__` method.
 
    For example::
 
@@ -369,7 +375,7 @@ The :mod:`functools` module defines the following functions:
    like normal functions, are handled as descriptors).
 
    When *func* is a descriptor (such as a normal Python function,
-   :func:`classmethod`, :func:`staticmethod`, :func:`abstractmethod` or
+   :func:`classmethod`, :func:`staticmethod`, :func:`~abc.abstractmethod` or
    another instance of :class:`partialmethod`), calls to ``__get__`` are
    delegated to the underlying descriptor, and an appropriate
    :ref:`partial object<partial-objects>` returned as the result.
@@ -447,7 +453,10 @@ The :mod:`functools` module defines the following functions:
      ...         print("Let me just say,", end=" ")
      ...     print(arg)
 
-   To add overloaded implementations to the function, use the :func:`register`
+   .. method:: singledispatch.register()
+      :no-typesetting:
+
+   To add overloaded implementations to the function, use the :func:`!register`
    attribute of the generic function, which can be used as a decorator.  For
    functions annotated with types, the decorator will infer the type of the
    first argument automatically::
@@ -513,14 +522,14 @@ The :mod:`functools` module defines the following functions:
       runtime impact.
 
    To enable registering :term:`lambdas<lambda>` and pre-existing functions,
-   the :func:`register` attribute can also be used in a functional form::
+   the :func:`~singledispatch.register` attribute can also be used in a functional form::
 
      >>> def nothing(arg, verbose=False):
      ...     print("Nothing.")
      ...
      >>> fun.register(type(None), nothing)
 
-   The :func:`register` attribute returns the undecorated function. This
+   The :func:`~singledispatch.register` attribute returns the undecorated function. This
    enables decorator stacking, :mod:`pickling<pickle>`, and the creation
    of unit tests for each variant independently::
 
@@ -598,10 +607,10 @@ The :mod:`functools` module defines the following functions:
    .. versionadded:: 3.4
 
    .. versionchanged:: 3.7
-      The :func:`register` attribute now supports using type annotations.
+      The :func:`~singledispatch.register` attribute now supports using type annotations.
 
    .. versionchanged:: 3.11
-      The :func:`register` attribute now supports :data:`types.UnionType`
+      The :func:`~singledispatch.register` attribute now supports :data:`types.UnionType`
       and :data:`typing.Union` as type annotations.
 
 
@@ -731,7 +740,7 @@ The :mod:`functools` module defines the following functions:
       'Docstring'
 
    Without the use of this decorator factory, the name of the example function
-   would have been ``'wrapper'``, and the docstring of the original :func:`example`
+   would have been ``'wrapper'``, and the docstring of the original :func:`!example`
    would have been lost.
 
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -16,7 +16,6 @@ Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
 Doc/library/asyncio-policy.rst
 Doc/library/email.charset.rst
-Doc/library/functools.rst
 Doc/library/http.cookiejar.rst
 Doc/library/http.server.rst
 Doc/library/importlib.rst


### PR DESCRIPTION
Add index entries and anchors for cache_info, cache_clear and register. (cherry picked from commit 252e2f710ea376a38c4545dd758e03d331c1eaad)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136554.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->