### PR TITLE
gh-136549: Fix signature of threading.excepthook()

### DIFF
--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -5916,6 +5916,7 @@ class TestSignatureDefinitions(unittest.TestCase):
     def test_threading_module_has_signatures(self):
         import threading
         self._test_module_has_signatures(threading)
+        self.assertIsNotNone(inspect.signature(threading.__excepthook__))
 
     def test_thread_module_has_signatures(self):
         import _thread

--- a/Misc/NEWS.d/next/Library/2025-07-11-23-04-39.gh-issue-136549.oAi8u4.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-11-23-04-39.gh-issue-136549.oAi8u4.rst
@@ -1,0 +1,1 @@
+Fix signature of :func:`threading.excepthook`.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -2330,7 +2330,7 @@ thread_excepthook(PyObject *module, PyObject *args)
 }
 
 PyDoc_STRVAR(excepthook_doc,
-"_excepthook($module, (exc_type, exc_value, exc_traceback, thread), /)\n\
+"_excepthook($module, args, /)\n\
 --\n\
 \n\
 Handle uncaught Thread.run() exception.");


### PR DESCRIPTION


<!-- gh-issue-number: gh-136549 -->
* Issue: gh-136549
<!-- /gh-issue-number -->
