### PR TITLE
gh-101100: Fix sphinx warnings in `Doc/library/platform.rst`

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -176,8 +176,8 @@ Cross platform
    :attr:`processor` is resolved late, on demand.
 
    Note: the first two attribute names differ from the names presented by
-   :func:`os.uname`, where they are named :attr:`sysname` and
-   :attr:`nodename`.
+   :func:`os.uname`, where they are named :attr:`!sysname` and
+   :attr:`!nodename`.
 
    Entries which cannot be determined are set to ``''``.
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -26,7 +26,6 @@ Doc/library/multiprocessing.rst
 Doc/library/optparse.rst
 Doc/library/os.rst
 Doc/library/pickletools.rst
-Doc/library/platform.rst
 Doc/library/profile.rst
 Doc/library/pyexpat.rst
 Doc/library/resource.rst


### PR DESCRIPTION
There are two warnings:

```
C:\Users\admin\Downloads\cpython-main\Doc\library\platform.rst:178: WARNING: py:attr reference target not found: sysname [ref.attr]
C:\Users\admin\Downloads\cpython-main\Doc\library\platform.rst:178: WARNING: py:attr reference target not found: nodename [ref.attr]
```

The original rst file is:

```
   Note: the first two attribute names differ from the names presented by
   :func:`os.uname`, where they are named :attr:`sysname` and
   :attr:`nodename`.
```

The [Doc of func os.uname](https://docs.python.org/3/library/os.html#os.uname) indicates that `sysname` and `nodename` is it's attr.

<img width="1673" height="1158" alt="image" src="https://github.com/user-attachments/assets/4f91391e-43f4-4fc8-bec5-b2ce347a3992" />

Since we've already got a ref to func `os.uname`, I suggest we can subpress those two links.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136562.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->