### PR TITLE
gh-136572: fix `IndexError` in `pydoc.replace`

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -262,9 +262,11 @@ def isdata(object):
 
 def replace(text, *pairs):
     """Do a series of global replacements on a string."""
-    while pairs:
-        text = pairs[1].join(text.split(pairs[0]))
-        pairs = pairs[2:]
+    if len(pairs) % 2:
+        # len(pairs) must be even, so len(pairs) + 1 must be odd
+        raise TypeError("an odd number of arguments must be given")
+    for ind in range(0, len(pairs), 2):
+        text = pairs[ind + 1].join(text.split(pairs[ind]))
     return text
 
 def cram(text, maxlen):

--- a/Misc/NEWS.d/next/Library/2025-07-12-13-21-34.gh-issue-136572.PLssWH.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-12-13-21-34.gh-issue-136572.PLssWH.rst
@@ -1,0 +1,3 @@
+:func:`!pydoc.replace` now raises a :exc:`TypeError` instead of an
+:exc:`IndexError` when the number of variadic arguments is odd (or
+equivalently, if the total number of arguments is even).


### PR DESCRIPTION
I don't think those functions are part of the public API, but as they are publicly named, I'll still add the NEWS entry just in case.

@serhiy-storchaka I actually wondered between raising a TypeError and a ValueError but I went with a TypeError as it's what we raise when something doesn't match a signature (in some sense, we can assume that we have infinitely many overloads of the form `replace(text, p1, p2, ..., pN, p{N+1})`).

<!-- gh-issue-number: gh-136572 -->
* Issue: gh-136572
<!-- /gh-issue-number -->
