### PR TITLE
gh-136421: Load `_datetime` static types during interpreter initialization

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -41,6 +41,7 @@ extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 
 extern PyStatus _PyGC_Init(PyInterpreterState *interp);
 extern PyStatus _PyAtExit_Init(PyInterpreterState *interp);
+extern PyStatus _PyDateTime_Init(PyInterpreterState *interp);
 
 /* Various internal finalizers */
 

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -41,7 +41,7 @@ extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 
 extern PyStatus _PyGC_Init(PyInterpreterState *interp);
 extern PyStatus _PyAtExit_Init(PyInterpreterState *interp);
-extern PyStatus _PyDateTime_Init(PyInterpreterState *interp);
+extern PyStatus _PyDateTime_InitTypes(PyInterpreterState *interp);
 
 /* Various internal finalizers */
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3671,7 +3671,7 @@ class TestDateTime(TestDate):
         self.assertEqual(err, b"")
 
         # Now test against concurrent reinitialization
-        script += "\nimport _datetime"
+        script = "import _datetime\n" + script
         rc, out, err = script_helper.assert_python_ok("-c", script)
         self.assertEqual(rc, 0)
         self.assertEqual(out, b"a" * 8)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3652,7 +3652,7 @@ class TestDateTime(TestDate):
         self.assertEqual(repr(td), "SubclassDatetime(2010, 10, 2, 0, 0, 3)")
 
     @support.cpython_only
-    def test_concurrent_initialization(self):
+    def test_concurrent_initialization_subinterpreter(self):
         # Run in a subprocess to ensure we get a clean version of _datetime
         script = """if True:
         from concurrent.futures import InterpreterPoolExecutor
@@ -3665,6 +3665,13 @@ class TestDateTime(TestDate):
             for _ in range(8):
                 executor.submit(func)
         """
+        rc, out, err = script_helper.assert_python_ok("-c", script)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, b"a" * 8)
+        self.assertEqual(err, b"")
+
+        # Now test against concurrent reinitialization
+        script += "\nimport _datetime"
         rc, out, err = script_helper.assert_python_ok("-c", script)
         self.assertEqual(rc, 0)
         self.assertEqual(out, b"a" * 8)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3653,16 +3653,6 @@ class TestDateTime(TestDate):
 
     @support.cpython_only
     def test_concurrent_initialization(self):
-        try:
-            from concurrent.futures import InterpreterPoolExecutor as _
-        except ImportError:
-            self.skipTest("requires subinterpreters")
-
-        try:
-            import _datetime as _
-        except ImportError:
-            self.skipTest("requires C implementation of datetime")
-
         # Run in a subprocess to ensure we get a clean version of _datetime
         script = """if True:
         from concurrent.futures import InterpreterPoolExecutor

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3653,6 +3653,9 @@ class TestDateTime(TestDate):
 
     @support.cpython_only
     def test_concurrent_initialization_subinterpreter(self):
+        # gh-136421: Concurrent initialization of _datetime across multiple
+        # interpreters wasn't thread-safe due to its static types.
+
         # Run in a subprocess to ensure we get a clean version of _datetime
         script = """if True:
         from concurrent.futures import InterpreterPoolExecutor

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3651,35 +3651,6 @@ class TestDateTime(TestDate):
         td = SubclassDatetime(2010, 10, 2, second=3)
         self.assertEqual(repr(td), "SubclassDatetime(2010, 10, 2, 0, 0, 3)")
 
-    @support.cpython_only
-    def test_concurrent_initialization_subinterpreter(self):
-        # gh-136421: Concurrent initialization of _datetime across multiple
-        # interpreters wasn't thread-safe due to its static types.
-
-        # Run in a subprocess to ensure we get a clean version of _datetime
-        script = """if True:
-        from concurrent.futures import InterpreterPoolExecutor
-
-        def func():
-            import _datetime
-            print('a', end='')
-
-        with InterpreterPoolExecutor() as executor:
-            for _ in range(8):
-                executor.submit(func)
-        """
-        rc, out, err = script_helper.assert_python_ok("-c", script)
-        self.assertEqual(rc, 0)
-        self.assertEqual(out, b"a" * 8)
-        self.assertEqual(err, b"")
-
-        # Now test against concurrent reinitialization
-        script = "import _datetime\n" + script
-        rc, out, err = script_helper.assert_python_ok("-c", script)
-        self.assertEqual(rc, 0)
-        self.assertEqual(out, b"a" * 8)
-        self.assertEqual(err, b"")
-
 
 class TestSubclassDateTime(TestDateTime):
     theclass = SubclassDatetime
@@ -7323,6 +7294,34 @@ class ExtensionModuleTests(unittest.TestCase):
                 del sys.modules['_datetime']
             """)
         script_helper.assert_python_ok('-c', script)
+
+    def test_concurrent_initialization_subinterpreter(self):
+        # gh-136421: Concurrent initialization of _datetime across multiple
+        # interpreters wasn't thread-safe due to its static types.
+
+        # Run in a subprocess to ensure we get a clean version of _datetime
+        script = """if True:
+        from concurrent.futures import InterpreterPoolExecutor
+
+        def func():
+            import _datetime
+            print('a', end='')
+
+        with InterpreterPoolExecutor() as executor:
+            for _ in range(8):
+                executor.submit(func)
+        """
+        rc, out, err = script_helper.assert_python_ok("-c", script)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, b"a" * 8)
+        self.assertEqual(err, b"")
+
+        # Now test against concurrent reinitialization
+        script = "import _datetime\n" + script
+        rc, out, err = script_helper.assert_python_ok("-c", script)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, b"a" * 8)
+        self.assertEqual(err, b"")
 
 
 def load_tests(loader, standard_tests, pattern):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-12-09-59-14.gh-issue-136421.ZD1rNj.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-12-09-59-14.gh-issue-136421.ZD1rNj.rst
@@ -1,0 +1,1 @@
+Fix crash when initializing :mod:`datetime` concurrently.

--- a/Modules/Setup.bootstrap.in
+++ b/Modules/Setup.bootstrap.in
@@ -12,6 +12,8 @@ posix posixmodule.c
 _signal signalmodule.c
 _tracemalloc _tracemalloc.c
 _suggestions _suggestions.c
+# needs libm and on some platforms librt
+_datetime _datetimemodule.c
 
 # modules used by importlib, deepfreeze, freeze, runpy, and sysconfig
 _codecs _codecsmodule.c

--- a/Modules/Setup.stdlib.in
+++ b/Modules/Setup.stdlib.in
@@ -56,9 +56,6 @@
 @MODULE_CMATH_TRUE@cmath cmathmodule.c
 @MODULE__STATISTICS_TRUE@_statistics _statisticsmodule.c
 
-# needs libm and on some platforms librt
-@MODULE__DATETIME_TRUE@_datetime _datetimemodule.c
-
 # _decimal uses libmpdec
 # either static libmpdec.a from Modules/_decimal/libmpdec or libmpdec.so
 # with ./configure --with-system-libmpdec

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4478,7 +4478,7 @@ static PyTypeObject PyDateTime_TimeZoneType = {
     timezone_methods,                 /* tp_methods */
     0,                                /* tp_members */
     0,                                /* tp_getset */
-    0,                                /* tp_base; filled in PyInit__datetime */
+    &PyDateTime_TZInfoType,           /* tp_base */
     0,                                /* tp_dict */
     0,                                /* tp_descr_get */
     0,                                /* tp_descr_set */
@@ -7143,8 +7143,7 @@ static PyTypeObject PyDateTime_DateTimeType = {
     datetime_methods,                           /* tp_methods */
     0,                                          /* tp_members */
     datetime_getset,                            /* tp_getset */
-    0,                                          /* tp_base; filled in
-                                                   PyInit__datetime */
+    &PyDateTime_DateType,                       /* tp_base */
     0,                                          /* tp_dict */
     0,                                          /* tp_descr_get */
     0,                                          /* tp_descr_set */
@@ -7328,10 +7327,6 @@ clear_state(datetime_state *st)
 PyStatus
 _PyDateTime_InitTypes(PyInterpreterState *interp)
 {
-    // `&...` is not a constant expression according to a strict reading
-    // of C standards. Fill tp_base at run-time rather than statically.
-    // See https://bugs.python.org/issue40777
-    PyDateTime_TimeZoneType.tp_base = &PyDateTime_TZInfoType;
     PyDateTime_DateTimeType.tp_base = &PyDateTime_DateType;
 
     /* Bases classes must be initialized before subclasses,

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -7331,8 +7331,8 @@ _PyDateTime_InitTypes(PyInterpreterState *interp)
     // `&...` is not a constant expression according to a strict reading
     // of C standards. Fill tp_base at run-time rather than statically.
     // See https://bugs.python.org/issue40777
-    _Py_atomic_store_ptr_relaxed(&PyDateTime_TimeZoneType.tp_base, &PyDateTime_TZInfoType);
-    _Py_atomic_store_ptr_relaxed(&PyDateTime_DateTimeType.tp_base , &PyDateTime_DateType);
+    PyDateTime_TimeZoneType.tp_base = &PyDateTime_TZInfoType;
+    PyDateTime_DateTimeType.tp_base = &PyDateTime_DateType;
 
     /* Bases classes must be initialized before subclasses,
      * so capi_types must have the types in the appropriate order. */

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -7327,8 +7327,6 @@ clear_state(datetime_state *st)
 PyStatus
 _PyDateTime_InitTypes(PyInterpreterState *interp)
 {
-    PyDateTime_DateTimeType.tp_base = &PyDateTime_DateType;
-
     /* Bases classes must be initialized before subclasses,
      * so capi_types must have the types in the appropriate order. */
     for (size_t i = 0; i < Py_ARRAY_LENGTH(capi_types); i++) {

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -7331,8 +7331,8 @@ _PyDateTime_InitTypes(PyInterpreterState *interp)
     // `&...` is not a constant expression according to a strict reading
     // of C standards. Fill tp_base at run-time rather than statically.
     // See https://bugs.python.org/issue40777
-    PyDateTime_TimeZoneType.tp_base = &PyDateTime_TZInfoType;
-    PyDateTime_DateTimeType.tp_base = &PyDateTime_DateType;
+    _Py_atomic_store_ptr_relaxed(&PyDateTime_TimeZoneType.tp_base, &PyDateTime_TZInfoType);
+    _Py_atomic_store_ptr_relaxed(&PyDateTime_DateTimeType.tp_base , &PyDateTime_DateType);
 
     /* Bases classes must be initialized before subclasses,
      * so capi_types must have the types in the appropriate order. */

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -7331,7 +7331,7 @@ clear_state(datetime_state *st)
 
 
 PyStatus
-_PyDateTime_Init(PyInterpreterState *interp)
+_PyDateTime_InitTypes(PyInterpreterState *interp)
 {
     // `&...` is not a constant expression according to a strict reading
     // of C standards. Fill tp_base at run-time rather than statically.

--- a/PCbuild/_freeze_module.vcxproj
+++ b/PCbuild/_freeze_module.vcxproj
@@ -106,6 +106,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Modules\atexitmodule.c" />
+    <ClCompile Include="..\Modules\_datetimemodule.c" />
     <ClCompile Include="..\Modules\faulthandler.c" />
     <ClCompile Include="..\Modules\gcmodule.c" />
     <ClCompile Include="..\Modules\getbuildinfo.c" />

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -915,6 +915,11 @@ pycore_interp_init(PyThreadState *tstate)
         goto done;
     }
 
+    status = _PyDateTime_Init(tstate->interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        goto done;
+    }
+
     const PyConfig *config = _PyInterpreterState_GetConfig(interp);
 
     status = _PyImport_InitCore(tstate, sysmod, config->_install_importlib);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -760,6 +760,11 @@ pycore_init_types(PyInterpreterState *interp)
         return status;
     }
 
+    status = _PyDateTime_InitTypes(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     return _PyStatus_OK();
 }
 
@@ -911,11 +916,6 @@ pycore_interp_init(PyThreadState *tstate)
     }
 
     status = _PyXI_Init(interp);
-    if (_PyStatus_EXCEPTION(status)) {
-        goto done;
-    }
-
-    status = _PyDateTime_Init(tstate->interp);
     if (_PyStatus_EXCEPTION(status)) {
         goto done;
     }


### PR DESCRIPTION
`_datetime` is a special module, because it's the only non-builtin C extension that contains static types. As such, it would initialize static types in the module's execution function, which can run concurrently. Since static type initialization is not thread-safe, this caused crashes. This fixes it by moving the initialization of `_datetime`'s static types to interpreter startup (where all other static types are initialized), which is already properly protected through other locks.

<!-- gh-issue-number: gh-136421 -->
* Issue: gh-136421
<!-- /gh-issue-number -->
