### PR TITLE
gh-136438: Make sure `test_generated_cases` pass with all optimization levels

### DIFF
--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -2037,7 +2037,7 @@ class TestGeneratedAbstractCases(unittest.TestCase):
         """
         output = """
         """
-        with self.assertRaisesRegex(AssertionError, "All abstract uops"):
+        with self.assertRaisesRegex(ValueError, "All abstract uops"):
             self.run_cases_test(input, input2, output)
 
     def test_validate_uop_input_length_mismatch(self):

--- a/Tools/cases_generator/optimizer_generator.py
+++ b/Tools/cases_generator/optimizer_generator.py
@@ -398,9 +398,9 @@ def generate_abstract_interpreter(
     out.emit("\n")
     base_uop_names = set([uop.name for uop in base.uops.values()])
     for abstract_uop_name in abstract.uops:
-        assert (
-            abstract_uop_name in base_uop_names
-        ), f"All abstract uops should override base uops, but {abstract_uop_name} is not."
+        if abstract_uop_name not in base_uop_names:
+            raise AssertionError(f"All abstract uops should override base uops, "
+                                 "but {abstract_uop_name} is not.")
 
     for uop in base.uops.values():
         override: Uop | None = None

--- a/Tools/cases_generator/optimizer_generator.py
+++ b/Tools/cases_generator/optimizer_generator.py
@@ -399,7 +399,7 @@ def generate_abstract_interpreter(
     base_uop_names = set([uop.name for uop in base.uops.values()])
     for abstract_uop_name in abstract.uops:
         if abstract_uop_name not in base_uop_names:
-            raise AssertionError(f"All abstract uops should override base uops, "
+            raise ValueError(f"All abstract uops should override base uops, "
                                  "but {abstract_uop_name} is not.")
 
     for uop in base.uops.values():


### PR DESCRIPTION
Now tests pass with all combinations of -OO and --without-doc-strings.

Before:

```
======================================================================
FAIL: test_missing_override_failure (test.test_generated_cases.TestGeneratedAbstractCases.test_missing_override_failure)
----------------------------------------------------------------------
AssertionError: 'case OP: {\n            JitOptRef out;\n [104 chars]   }' != ''
- case OP: {
-             JitOptRef out;
-             out = sym_new_not_null(ctx);
-             stack_pointer[-1] = out;
-             break;
-         }


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/sikko/projects/cpython/Lib/test/test_generated_cases.py", line 2040, in test_missing_override_failure
    with self.assertRaisesRegex(AssertionError, "All abstract uops"):
         ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: "All abstract uops" does not match "'case OP: {\n            JitOptRef out;\n [104 chars]   }' != ''
- case OP: {
-             JitOptRef out;
-             out = sym_new_not_null(ctx);
-             stack_pointer[-1] = out;
-             break;
-         }
"
```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136438 -->
* Issue: gh-136438
<!-- /gh-issue-number -->
