### PR TITLE
gh-101100: Resolve reference warnings in library/xml.sax.handler.rst

### DIFF
--- a/Doc/library/xml.sax.handler.rst
+++ b/Doc/library/xml.sax.handler.rst
@@ -248,8 +248,8 @@ events in the input document:
 
    The *name* parameter contains the raw XML 1.0 name of the element type as a
    string and the *attrs* parameter holds an object of the
-   :ref:`Attributes <attributes-object>` interface
-   (see :ref:`attributes-objects`) containing the attributes of
+   :ref:`Attributes <attributes-object>`
+   interface (see :ref:`attributes-objects`) containing the attributes of
    the element.  The object passed as *attrs* may be re-used by the parser; holding
    on to a reference to it is not a reliable way to keep a copy of the attributes.
    To keep a copy of the attributes, use the :meth:`copy` method of the *attrs*

--- a/Doc/library/xml.sax.handler.rst
+++ b/Doc/library/xml.sax.handler.rst
@@ -248,8 +248,8 @@ events in the input document:
 
    The *name* parameter contains the raw XML 1.0 name of the element type as a
    string and the *attrs* parameter holds an object of the
-   :class:`~xml.sax.xmlreader.AttributesImpl`
-   interface (see :ref:`attributes-objects`) containing the attributes of
+   :ref:`Attributes <attributes-object>` interface
+   (see :ref:`attributes-objects`) containing the attributes of
    the element.  The object passed as *attrs* may be re-used by the parser; holding
    on to a reference to it is not a reliable way to keep a copy of the attributes.
    To keep a copy of the attributes, use the :meth:`copy` method of the *attrs*
@@ -271,7 +271,7 @@ events in the input document:
    The *name* parameter contains the name of the element type as a ``(uri,
    localname)`` tuple, the *qname* parameter contains the raw XML 1.0 name used in
    the source document, and the *attrs* parameter holds an instance of the
-   :class:`~xml.sax.xmlreader.AttributesNSImpl` interface (see
+   :ref:`Attributes <attributes-ns-object>` interface (see
    :ref:`attributes-ns-objects`)
    containing the attributes of the element.  If no namespace is associated with
    the element, the *uri* component of *name* will be ``None``.  The object passed

--- a/Doc/library/xml.sax.handler.rst
+++ b/Doc/library/xml.sax.handler.rst
@@ -248,8 +248,7 @@ events in the input document:
 
    The *name* parameter contains the raw XML 1.0 name of the element type as a
    string and the *attrs* parameter holds an object of the
-   :ref:`Attributes <attributes-object>`
-   interface (see :ref:`attributes-objects`) containing the attributes of
+   :ref:`Attributes <attributes-objects>` interface containing the attributes of
    the element.  The object passed as *attrs* may be re-used by the parser; holding
    on to a reference to it is not a reliable way to keep a copy of the attributes.
    To keep a copy of the attributes, use the :meth:`copy` method of the *attrs*
@@ -271,8 +270,7 @@ events in the input document:
    The *name* parameter contains the name of the element type as a ``(uri,
    localname)`` tuple, the *qname* parameter contains the raw XML 1.0 name used in
    the source document, and the *attrs* parameter holds an instance of the
-   :ref:`Attributes <attributes-ns-object>` interface (see
-   :ref:`attributes-ns-objects`)
+   :ref:`AttributesNS <attributes-ns-objects>` interface
    containing the attributes of the element.  If no namespace is associated with
    the element, the *uri* component of *name* will be ``None``.  The object passed
    as *attrs* may be re-used by the parser; holding on to a reference to it is not

--- a/Doc/library/xml.sax.handler.rst
+++ b/Doc/library/xml.sax.handler.rst
@@ -248,7 +248,7 @@ events in the input document:
 
    The *name* parameter contains the raw XML 1.0 name of the element type as a
    string and the *attrs* parameter holds an object of the
-   :class:`~xml.sax.xmlreader.Attributes`
+   :class:`~xml.sax.xmlreader.AttributesImpl`
    interface (see :ref:`attributes-objects`) containing the attributes of
    the element.  The object passed as *attrs* may be re-used by the parser; holding
    on to a reference to it is not a reliable way to keep a copy of the attributes.
@@ -271,7 +271,7 @@ events in the input document:
    The *name* parameter contains the name of the element type as a ``(uri,
    localname)`` tuple, the *qname* parameter contains the raw XML 1.0 name used in
    the source document, and the *attrs* parameter holds an instance of the
-   :class:`~xml.sax.xmlreader.AttributesNS` interface (see
+   :class:`~xml.sax.xmlreader.AttributesNSImpl` interface (see
    :ref:`attributes-ns-objects`)
    containing the attributes of the element.  If no namespace is associated with
    the element, the *uri* component of *name* will be ``None``.  The object passed

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -49,7 +49,6 @@ Doc/library/wsgiref.rst
 Doc/library/xml.dom.minidom.rst
 Doc/library/xml.dom.pulldom.rst
 Doc/library/xml.dom.rst
-Doc/library/xml.sax.handler.rst
 Doc/library/xml.sax.reader.rst
 Doc/library/xml.sax.rst
 Doc/library/xmlrpc.client.rst


### PR DESCRIPTION
There are two warnings:
```
C:\Users\admin\Downloads\cpython-main\Doc\library\xml.sax.handler.rst:249: WARNING: py:class reference target not found: xml.sax.xmlreader.Attributes [ref.class]
C:\Users\admin\Downloads\cpython-main\Doc\library\xml.sax.handler.rst:271: WARNING: py:class reference target not found: xml.sax.xmlreader.AttributesNS [ref.class]
```

This warning happens in many doc of xml (`xml.sax.reader`, `xml.sax.handler`, `xml.sax`) in the same reason. After staring the doc for a while, I think the original doc want to refer to [xml.sax.xmlreader.AttributesImpl](https://docs.python.org/3/library/xml.sax.reader.html#xml.sax.xmlreader.AttributesImpl) and [xml.sax.xmlreader.AttributesNSImpl](https://docs.python.org/3/library/xml.sax.reader.html#xml.sax.xmlreader.AttributesNSImpl) as an implemention of [attributes-interface](https://docs.python.org/3/library/xml.sax.reader.html#the-attributes-interface). This doc fix it to the correct ref.

If this is approved, I will fix up those occurrence in other docs, an example of this in [xml.sax](https://docs.python.org/3/library/xml.sax.html#module-xml.sax) is as below to double check.

<img width="1625" height="363" alt="image" src="https://github.com/user-attachments/assets/f1096615-f04b-4c82-8fbf-f931a65765d3" /> 

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136612.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->