### PR TITLE
gh-136601: Always set `TarInfo.size` to the real file size for sparse files

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1616,14 +1616,19 @@ class TarInfo(object):
         """Replace fields with supplemental information from a previous
            pax extended or global header.
         """
+        real_size_updated = False
         for keyword, value in pax_headers.items():
             if keyword == "GNU.sparse.name":
                 setattr(self, "path", value)
             elif keyword == "GNU.sparse.size":
                 setattr(self, "size", int(value))
+                real_size_updated = True
             elif keyword == "GNU.sparse.realsize":
                 setattr(self, "size", int(value))
+                real_size_updated = True
             elif keyword in PAX_FIELDS:
+                if keyword == "size" and real_size_updated:
+                    continue
                 if keyword in PAX_NUMBER_FIELDS:
                     try:
                         value = PAX_NUMBER_FIELDS[keyword](value)

--- a/Misc/NEWS.d/next/Library/2025-07-13-12-37-49.gh-issue-136601.ZBiMIN.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-13-12-37-49.gh-issue-136601.ZBiMIN.rst
@@ -1,0 +1,1 @@
+Always set ``TarInfo.size`` to the real file size for sparse files.


### PR DESCRIPTION
My attempt to fix #136601.

 - [ ] This should be merged after #136621 because it would make my case even worse, because the TAR offset recomputation would use the real file size instead of the TAR data size.
 - [ ] Should I add the minimal reproducer from #136602 into `Lib/test/archivetestdata/` and add a test into `Lib/test/test_tarfile.py`? The test setup seems a bit complicated. I'm unsure whether I would do it the right way. That reproducer would be a test case for both bugs / pull requests.

<!-- gh-issue-number: gh-136601 -->
* Issue: gh-136601
<!-- /gh-issue-number -->
