### PR TITLE
Partially revert "gh-101100: Fix sphinx warnings in `library/email.parser.rst` (#136475)"

### DIFF
--- a/Doc/library/email.parser.rst
+++ b/Doc/library/email.parser.rst
@@ -116,7 +116,7 @@ Here is the API for the :class:`BytesFeedParser`:
    Works like :class:`BytesFeedParser` except that the input to the
    :meth:`~BytesFeedParser.feed` method must be a string.  This is of limited
    utility, since the only way for such a message to be valid is for it to
-   contain only ASCII text or, if :attr:`~email.policy.Policy.utf8` is
+   contain only ASCII text or, if :attr:`~email.policy.EmailPolicy.utf8` is
    ``True``, no binary attachments.
 
    .. versionchanged:: 3.3 Added the *policy* keyword.
@@ -159,7 +159,7 @@ message body, instead setting the payload to the raw body.
       methods.
 
       The bytes contained in *fp* must be formatted as a block of :rfc:`5322`
-      (or, if :attr:`~email.policy.Policy.utf8` is ``True``, :rfc:`6532`)
+      (or, if :attr:`~email.policy.EmailPolicy.utf8` is ``True``, :rfc:`6532`)
       style headers and header continuation lines, optionally preceded by an
       envelope header.  The header block is terminated either by the end of the
       data or by a blank line.  Following the header block is the body of the

--- a/Doc/library/email.parser.rst
+++ b/Doc/library/email.parser.rst
@@ -48,8 +48,8 @@ methods.
 FeedParser API
 ^^^^^^^^^^^^^^
 
-The :class:`BytesFeedParser`, imported from the :mod:`email.parser.FeedParser`
-module, provides an API that is conducive to incremental parsing of email messages,
+The :class:`BytesFeedParser`, imported from the :mod:`email.feedparser` module,
+provides an API that is conducive to incremental parsing of email messages,
 such as would be necessary when reading the text of an email message from a
 source that can block (such as a socket).  The :class:`BytesFeedParser` can of
 course be used to parse an email message fully contained in a :term:`bytes-like
@@ -116,7 +116,7 @@ Here is the API for the :class:`BytesFeedParser`:
    Works like :class:`BytesFeedParser` except that the input to the
    :meth:`~BytesFeedParser.feed` method must be a string.  This is of limited
    utility, since the only way for such a message to be valid is for it to
-   contain only ASCII text or, if :attr:`~email.policy.EmailPolicy.utf8` is
+   contain only ASCII text or, if :attr:`~email.policy.Policy.utf8` is
    ``True``, no binary attachments.
 
    .. versionchanged:: 3.3 Added the *policy* keyword.
@@ -155,11 +155,11 @@ message body, instead setting the payload to the raw body.
 
       Read all the data from the binary file-like object *fp*, parse the
       resulting bytes, and return the message object.  *fp* must support
-      both the :meth:`~io.IOBase.readline` and the :meth:`~io.TextIOBase.read`
+      both the :meth:`~io.IOBase.readline` and the :meth:`~io.IOBase.read`
       methods.
 
       The bytes contained in *fp* must be formatted as a block of :rfc:`5322`
-      (or, if :attr:`~email.policy.EmailPolicy.utf8` is ``True``, :rfc:`6532`)
+      (or, if :attr:`~email.policy.Policy.utf8` is ``True``, :rfc:`6532`)
       style headers and header continuation lines, optionally preceded by an
       envelope header.  The header block is terminated either by the end of the
       data or by a blank line.  Following the header block is the body of the

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -15,6 +15,7 @@ Doc/extending/extending.rst
 Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
 Doc/library/email.charset.rst
+Doc/library/email.parser.rst
 Doc/library/http.cookiejar.rst
 Doc/library/http.server.rst
 Doc/library/importlib.rst


### PR DESCRIPTION
This partially reverts commit 515b3d18edfce00ce441e0e41091d0dd57f201ad.

Re: https://github.com/python/cpython/pull/136475#pullrequestreview-3011251190

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136629.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->