### PR TITLE
gh-134567: Move unittest What’s New entry

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -278,6 +278,14 @@ tarfile
   and :cve:`2025-4435`.)
 
 
+unittest
+--------
+
+* :func:`unittest.TestCase.assertLogs` will now accept a formatter
+  to control how messages are formatted.
+  (Contributed by Garry Cairns in :gh:`134567`.)
+
+
 zlib
 ----
 
@@ -386,15 +394,6 @@ typing
   longer supported. Use ``class TD(TypedDict): pass``
   or ``TD = TypedDict("TD", {})`` instead.
   (Contributed by Bénédikt Tran in :gh:`133823`.)
-
-
-unittest
---------
-
-* Lets users specify formatter in TestCase.assertLogs.
-  :func:`unittest.TestCase.assertLogs` will now accept a formatter
-  to control how messages are formatted.
-  (Contributed by Garry Cairns in :gh:`134567`.)
 
 
 wave


### PR DESCRIPTION
This corrects a docs error spotter after [134570](https://github.com/python/cpython/pull/134570) was merged.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136630.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-134567 -->
* Issue: gh-134567
<!-- /gh-issue-number -->
