### PR TITLE
gh-136595: Normalize surrogate pairs in REPL input to fix UnicodeEnco…

### DIFF
--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -40,7 +40,7 @@ from .types import Callback, SimpleContextManager, KeySpec, CommandName
 # syntax classes
 SYNTAX_WHITESPACE, SYNTAX_WORD, SYNTAX_SYMBOL = range(3)
 
-def normalize_surrogates(s):
+def normalize_surrogates(s: str) -> str:
     # Encode with surrogatepass, decode to normalize surrogate pairs
     try:
         return s.encode('utf-16', 'surrogatepass').decode('utf-16')

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -40,6 +40,12 @@ from .types import Callback, SimpleContextManager, KeySpec, CommandName
 # syntax classes
 SYNTAX_WHITESPACE, SYNTAX_WORD, SYNTAX_SYMBOL = range(3)
 
+def normalize_surrogates(s):
+    # Encode with surrogatepass, decode to normalize surrogate pairs
+    try:
+        return s.encode('utf-16', 'surrogatepass').decode('utf-16')
+    except UnicodeEncodeError:
+        return s  # fallback if encoding somehow fails
 
 def make_default_syntax_table() -> dict[str, int]:
     # XXX perhaps should use some unicodedata here?
@@ -759,4 +765,5 @@ class Reader:
 
     def get_unicode(self) -> str:
         """Return the current buffer as a unicode string."""
-        return "".join(self.buffer)
+        text = "".join(self.buffer)
+        return normalize_surrogates(text)

--- a/Misc/NEWS.d/next/Windows/2025-07-14-01-27-42.gh-issue-136595.964PbL.rst
+++ b/Misc/NEWS.d/next/Windows/2025-07-14-01-27-42.gh-issue-136595.964PbL.rst
@@ -1,0 +1,1 @@
+Fix a crash in the REPL on Windows when typing Unicode characters outside the Basic Multilingual Plane (≥ U+10000), such as emoji. These characters are now properly handled as surrogate pairs.


### PR DESCRIPTION

The new REPL implementation (_pyrepl) crashes on Windows when the user inputs Unicode characters outside the Basic Multilingual Plane (≥ U+10000), such as emoji (e.g. 🐍). This happens because the Windows input layer provides surrogate pairs (UTF-16 code units) that _pyrepl attempts to process and tokenize directly, leading to unpaired surrogate handling issues.

This commit introduces a `normalize_surrogates()` helper in `Reader` to explicitly normalize surrogate pairs by encoding to UTF-16 with 'surrogatepass' and decoding back. The `get_unicode()` method is patched to use this normalization so that any code consuming REPL input (e.g. syntax highlighting via tokenize) receives valid Unicode text.

This resolves UnicodeEncodeError crashes in the REPL when typing emoji or other non-BMP characters on Windows.

Fixes #136595

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136595 -->
* Issue: gh-136595
<!-- /gh-issue-number -->
