### PR TITLE
[3.13] gh-109700: fix memory error handling in `PyDict_SetDefault` (#136338)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2025-07-06-14-53-19.gh-issue-109700.KVNQQi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-07-06-14-53-19.gh-issue-109700.KVNQQi.rst
@@ -1,0 +1,1 @@
+Fix memory error handling in :c:func:`PyDict_SetDefault`.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4340,6 +4340,7 @@ dict_setdefault_ref_lock_held(PyObject *d, PyObject *key, PyObject *default_valu
             if (result) {
                 *result = NULL;
             }
+            return -1;
         }
 
         MAINTAIN_TRACKING(mp, key, value);


### PR DESCRIPTION
(cherry picked from commit d22e073d2b49313bbf42d40cbe74afa2b69385df)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109700 -->
* Issue: gh-109700
<!-- /gh-issue-number -->
