### PR TITLE
gh-136660: fix UB in dictobject memcpy when there are 0 entries

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2095,7 +2095,10 @@ dictresize(PyInterpreterState *interp, PyDictObject *mp,
             if (unicode) { // combined unicode -> combined unicode
                 PyDictUnicodeEntry *newentries = DK_UNICODE_ENTRIES(newkeys);
                 if (oldkeys->dk_nentries == numentries && mp->ma_keys->dk_kind == DICT_KEYS_UNICODE) {
-                    memcpy(newentries, oldentries, numentries * sizeof(PyDictUnicodeEntry));
+                    /* avoid memcpy on 0 entries to avoid UB on oldentries */
+                    if (numentries > 0) {
+                        memcpy(newentries, oldentries, numentries * sizeof(PyDictUnicodeEntry));
+                    }
                 }
                 else {
                     PyDictUnicodeEntry *ep = oldentries;


### PR DESCRIPTION


<!-- gh-issue-number: gh-136660 -->
* Issue: gh-136660
<!-- /gh-issue-number -->
