### PR TITLE
Fix index entry and anchor for module.__test__

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -311,8 +311,12 @@ Which Docstrings Are Examined?
 The module docstring, and all function, class and method docstrings are
 searched.  Objects imported into the module are not searched.
 
+.. currentmodule:: None
+
 .. attribute:: module.__test__
    :no-typesetting:
+
+.. currentmodule:: doctest
 
 In addition, there are cases when you want tests to be part of a module but not part
 of the help text, which requires that the tests not be included in the docstring.


### PR DESCRIPTION
It was "doctest.module attribute". Now it is "module attribute".


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136674.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->