### PR TITLE
Add `.gram` file to the `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,11 @@
 root = true
 
-[*.{py,c,cpp,h,js,rst,md,yml,yaml}]
+[*.{py,c,cpp,h,js,rst,md,yml,yaml,gram}]
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 
-[*.{py,c,cpp,h}]
+[*.{py,c,cpp,h,gram}]
 indent_size = 4
 
 [*.rst]


### PR DESCRIPTION
```
 trim trailing whitespace.................................................Failed
- hook id: trailing-whitespace
- exit code: 1
- files were modified by this hook

Fixing Grammar/python.gram
```

See https://github.com/python/cpython/actions/runs/16288817490/job/45993680092?pr=136653