### PR TITLE
gh-136682: Remove incorrect doc statement that `os.path.samestat` accepts file-like objects

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -508,9 +508,6 @@ the :mod:`glob` module.)
    .. versionchanged:: 3.4
       Added Windows support.
 
-   .. versionchanged:: 3.6
-      Accepts a :term:`path-like object`.
-
 
 .. function:: split(path)
 


### PR DESCRIPTION
Fix #136682

<!-- gh-issue-number: gh-136682 -->
* Issue: gh-136682
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136683.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->