### PR TITLE
gh-136693: Add link to original post about moving unreachable objects in GC

### DIFF
--- a/InternalDocs/garbage_collector.md
+++ b/InternalDocs/garbage_collector.md
@@ -302,7 +302,7 @@ Why moving unreachable objects is better
 
 It sounds logical to move the unreachable objects under the premise that most objects
 are usually reachable, until you think about it: the reason it pays isn't actually
-obvious.
+obvious ([[Python-Dev] Some dull gc stats](https://mail.python.org/pipermail/python-dev/2002-July/026062.html)).
 
 Suppose we create objects A, B, C in that order. They appear in the young generation
 in the same order. If B points to A, and C to B, and C is reachable from outside,

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1211,7 +1211,7 @@ deduce_unreachable(PyGC_Head *base, PyGC_Head *unreachable) {
      * set instead.  But most things usually turn out to be reachable,
      * so it's more efficient to move the unreachable things.  It "sounds slick"
      * to move the unreachable objects, until you think about it - the reason it
-     * pays isn't actually obvious.
+     * pays isn't actually obvious. (https://mail.python.org/pipermail/python-dev/2002-July/026062.html)
      *
      * Suppose we create objects A, B, C in that order.  They appear in the young
      * generation in the same order.  If B points to A, and C to B, and C is


### PR DESCRIPTION
After reading the source code in gc.c and the garbage collector documentation in garbage_collector.md, I wondered why most objects turned out to be reachable.
I found an old thread on the Python-Dev mailing list, and I think it would be useful to add a link to it in the documentation and source code.

<!-- gh-issue-number: gh-136693 -->
* Issue: gh-136693
<!-- /gh-issue-number -->
