### PR TITLE
gh-116738: Make pwd module thread-safe

### DIFF
--- a/Lib/test/test_free_threading/test_pwd.py
+++ b/Lib/test/test_free_threading/test_pwd.py
@@ -1,0 +1,33 @@
+import unittest
+
+from test.support import threading_helper
+from test.support.threading_helper import run_concurrently
+
+from test import test_pwd
+
+
+NTHREADS = 10
+
+
+@threading_helper.requires_working_threading()
+class TestPwd(unittest.TestCase):
+    def setUp(self):
+        self.test_pwd = test_pwd.PwdTest()
+
+    def test_racing_test_values(self):
+        # test_pwd.test_values() calls pwd.getpwall() and checks the entries
+        run_concurrently(
+            worker_func=self.test_pwd.test_values, nthreads=NTHREADS
+        )
+
+    def test_racing_test_values_extended(self):
+        # test_pwd.test_values_extended() calls pwd.getpwall(), pwd.getpwnam(),
+        # pwd.getpwduid() and checks the entries
+        run_concurrently(
+            worker_func=self.test_pwd.test_values_extended,
+            nthreads=NTHREADS,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-15-10-03-57.gh-issue-116738.oFttKl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-15-10-03-57.gh-issue-116738.oFttKl.rst
@@ -1,0 +1,1 @@
+Make functions in :mod:`pwd` thread-safe on the :term:`free threaded <free threading>` build.

--- a/Modules/clinic/pwdmodule.c.h
+++ b/Modules/clinic/pwdmodule.c.h
@@ -2,6 +2,8 @@
 preserve
 [clinic start generated code]*/
 
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
+
 PyDoc_STRVAR(pwd_getpwuid__doc__,
 "getpwuid($module, uidobj, /)\n"
 "--\n"
@@ -34,7 +36,7 @@ pwd_getpwnam(PyObject *module, PyObject *arg)
     PyObject *name;
 
     if (!PyUnicode_Check(arg)) {
-        PyErr_Format(PyExc_TypeError, "getpwnam() argument must be str, not %T", arg);
+        _PyArg_BadArgument("getpwnam", "argument", "str", arg);
         goto exit;
     }
     name = arg;
@@ -71,4 +73,4 @@ pwd_getpwall(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef PWD_GETPWALL_METHODDEF
     #define PWD_GETPWALL_METHODDEF
 #endif /* !defined(PWD_GETPWALL_METHODDEF) */
-/*[clinic end generated code: output=dac88d500f6d6f49 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5a8fb12939ff4ea3 input=a9049054013a1b77]*/

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -168,6 +168,7 @@ Python/sysmodule.c	-	_preinit_xoptions	-
 Modules/faulthandler.c	faulthandler_dump_traceback	reentrant	-
 Modules/faulthandler.c	faulthandler_dump_c_stack	reentrant	-
 Modules/grpmodule.c	-	group_db_mutex	-
+Modules/pwdmodule.c	-	pwd_db_mutex	-
 Python/pylifecycle.c	_Py_FatalErrorFormat	reentrant	-
 Python/pylifecycle.c	fatal_error	reentrant	-
 


### PR DESCRIPTION
Make the `pwd` module functions `getpwuid()`, `getpwnam()`, and `getpwall()` thread-safe. These changes apply to scenarios where the GIL is disabled or in subinterpreter use cases.

- PR removes `Py_LIMITED_API` to use `PyMutex`, necessary for both FT-Python and subinterpreter use cases, similar to changes in the grp module (#127055).

cc: @mpage @colesbury @Yhg1s

<!-- gh-issue-number: gh-116738 -->
* Issue: gh-116738
<!-- /gh-issue-number -->
