### PR TITLE
Improved venv docs to indicate that isolation is the default.

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -24,8 +24,8 @@ their :mod:`site` directories.
 A virtual environment is created on top of an existing
 Python installation, known as the virtual environment's "base" Python, and by
 default is isolated from the packages in the base environment,
-so only those explicitly installed in the virtual environment are available.
-See :ref:`sys-path-init-virtual-environments` and :mod:`site`'s
+so that only those explicitly installed in the virtual environment are
+available. See :ref:`sys-path-init-virtual-environments` and :mod:`site`'s
 :ref:`virtual environments documentation <site-virtual-environments-configuration>`
 for more information.
 

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -24,7 +24,7 @@ their :mod:`site` directories.
 A virtual environment is created on top of an existing
 Python installation, known as the virtual environment's "base" Python, and by
 default is isolated from the packages in the base environment,
-so only those explicitly installed in the virtual environment are available.
+so that only those explicitly installed in the virtual environment are available.
 See :ref:`sys-path-init-virtual-environments` and :mod:`site`'s
 :ref:`virtual environments documentation <site-virtual-environments-configuration>`
 for more information.

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -22,8 +22,8 @@ The :mod:`!venv` module supports creating lightweight "virtual environments",
 each with their own independent set of Python packages installed in
 their :mod:`site` directories.
 A virtual environment is created on top of an existing
-Python installation, known as the virtual environment's "base" Python, and may
-optionally be isolated from the packages in the base environment,
+Python installation, known as the virtual environment's "base" Python, and by
+default is isolated from the packages in the base environment,
 so only those explicitly installed in the virtual environment are available.
 See :ref:`sys-path-init-virtual-environments` and :mod:`site`'s
 :ref:`virtual environments documentation <site-virtual-environments-configuration>`


### PR DESCRIPTION
This PR idea originated in the forum: https://discuss.python.org/t/creation-of-virtual-environments-isolation/98859

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136698.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->