### PR TITLE
gh-127146: Emscripten: Make os.umask() actually work

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1918,11 +1918,9 @@ class MakedirTests(unittest.TestCase):
         support.is_wasi,
         "WASI's umask is a stub."
     )
-    @unittest.skipIf(
-        support.is_emscripten,
-        "TODO: Fails in buildbot; see #135783"
-    )
     def test_mode(self):
+        # Note: in some cases, the umask might already be 2 in which case this
+        # will pass even if os.umask is actually broken.
         with os_helper.temp_umask(0o002):
             base = os_helper.TESTFN
             parent = os.path.join(base, 'dir1')


### PR DESCRIPTION
At least when run in Node.

Fixes #135783.

umask still has a lot of issues, but will require upstream fixes in Emscripten.

<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
