### PR TITLE
gh-127146: Emscripten: more regular stack overflow skips

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -570,7 +570,7 @@ is_emscripten = sys.platform == "emscripten"
 is_wasi = sys.platform == "wasi"
 
 def skip_emscripten_stack_overflow():
-    return unittest.skipIf(is_emscripten, "Exhausts limited stack on Emscripten")
+    return unittest.skipIf(is_emscripten, "Exhausts stack on Emscripten")
 
 def skip_wasi_stack_overflow():
     return unittest.skipIf(is_wasi, "Exhausts stack on WASI")

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -3942,7 +3942,7 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         # it as a leak.
         del C.__del__
 
-    @unittest.skipIf(support.is_emscripten, "Seems to works in Pyodide?")
+    @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     def test_slots_trash(self):
         # Testing slot trash...

--- a/Lib/test/test_xml_etree_c.py
+++ b/Lib/test/test_xml_etree_c.py
@@ -58,7 +58,7 @@ class MiscTests(unittest.TestCase):
         self.assertEqual(element.attrib, {'A': 'B', 'C': 'D'})
 
     @support.skip_wasi_stack_overflow()
-    @unittest.skip_emscripten_stack_overflow()
+    @support.skip_emscripten_stack_overflow()
     def test_trashcan(self):
         # If this test fails, it will most likely die via segfault.
         e = root = cET.Element('root')

--- a/Lib/test/test_xml_etree_c.py
+++ b/Lib/test/test_xml_etree_c.py
@@ -58,7 +58,7 @@ class MiscTests(unittest.TestCase):
         self.assertEqual(element.attrib, {'A': 'B', 'C': 'D'})
 
     @support.skip_wasi_stack_overflow()
-    @unittest.skipIf(support.is_emscripten, "segfaults")
+    @unittest.skip_emscripten_stack_overflow()
     def test_trashcan(self):
         # If this test fails, it will most likely die via segfault.
         e = root = cET.Element('root')


### PR DESCRIPTION
In two places use skip_emscripten_stack_overflow instead of skipIf with an ad-hoc message. Also, make the skip_emscripten_stack_overflow message match wasi's message.


<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
