### PR TITLE
gh-136710: posixmodule.c: fix `chdir` docstring

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2025-07-16-13-28-30.gh-issue-136710.NrGnSZ.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-07-16-13-28-30.gh-issue-136710.NrGnSZ.rst
@@ -1,0 +1,1 @@
+Fixes invalid rst in posix.chdir's docstring

--- a/Misc/NEWS.d/next/Documentation/2025-07-16-13-28-30.gh-issue-136710.NrGnSZ.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-07-16-13-28-30.gh-issue-136710.NrGnSZ.rst
@@ -1,1 +1,0 @@
-Fixes invalid rst in posix.chdir's docstring

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -380,7 +380,7 @@ PyDoc_STRVAR(os_chdir__doc__,
 "\n"
 "path may always be specified as a string.\n"
 "On some platforms, path may also be specified as an open file descriptor.\n"
-"  If this functionality is unavailable, using it raises an exception.");
+"If this functionality is unavailable, using it raises an exception.");
 
 #define OS_CHDIR_METHODDEF    \
     {"chdir", _PyCFunction_CAST(os_chdir), METH_FASTCALL|METH_KEYWORDS, os_chdir__doc__},
@@ -13440,4 +13440,4 @@ os__emscripten_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__EMSCRIPTEN_DEBUGGER_METHODDEF
     #define OS__EMSCRIPTEN_DEBUGGER_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_DEBUGGER_METHODDEF) */
-/*[clinic end generated code: output=5341daae6581a62b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6cfddb3b77dc7a40 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -3477,7 +3477,7 @@ Change the current working directory to the specified path.
 
 path may always be specified as a string.
 On some platforms, path may also be specified as an open file descriptor.
-  If this functionality is unavailable, using it raises an exception.
+If this functionality is unavailable, using it raises an exception.
 [clinic start generated code]*/
 
 static PyObject *

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -3482,7 +3482,7 @@ If this functionality is unavailable, using it raises an exception.
 
 static PyObject *
 os_chdir_impl(PyObject *module, path_t *path)
-/*[clinic end generated code: output=3be6400eee26eaae input=1a4a15b4d12cb15d]*/
+/*[clinic end generated code: output=3be6400eee26eaae input=a74ceab5d72adf74]*/
 {
     int result;
 


### PR DESCRIPTION
Fixes the following issue:

```python
>>> from docutils.core import publish_doctree
>>> from posix import chdir
>>> publish_doctree(chdir.__doc__)
<string>:5: (ERROR/3) Unexpected indentation.
```


<!-- gh-issue-number: gh-136710 -->
* Issue: gh-136710
<!-- /gh-issue-number -->
