### PR TITLE
Fix traceback.FrameSummary docstring by adding end_lineno, colno, and end_colno

### DIFF
--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -287,6 +287,12 @@ class FrameSummary:
       of code that was running when the frame was captured.
     - :attr:`locals` Either None if locals were not supplied, or a dict
       mapping the name to the repr() of the variable.
+    - :attr:`end_lineno` The last line number of the source code for this frame.
+      By default, it is set to lineno and indexation starts from 1.
+    - :attr:`colno` The column number of the source code for this frame.
+      By default, it is None and indexation starts from 0.
+    - :attr:`end_colno` The last column number of the source code for this frame.
+      By default, it is None and indexation starts from 0.
     """
 
     __slots__ = ('filename', 'lineno', 'end_lineno', 'colno', 'end_colno',


### PR DESCRIPTION
It seems some linters use this information to warn about unknown attributes
(We use pyright, pyflakes, and flake8).

The explanations are copied from the documentation:
https://docs.python.org/3/library/traceback.html#traceback.FrameSummary

I am assuming this change is trivial enough that a GitHub issue is not required.