### PR TITLE
[3.13] Improved venv docs to indicate that isolation is the default. (GH-136698)

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -22,9 +22,9 @@ The :mod:`!venv` module supports creating lightweight "virtual environments",
 each with their own independent set of Python packages installed in
 their :mod:`site` directories.
 A virtual environment is created on top of an existing
-Python installation, known as the virtual environment's "base" Python, and may
-optionally be isolated from the packages in the base environment,
-so only those explicitly installed in the virtual environment are available.
+Python installation, known as the virtual environment's "base" Python, and by
+default is isolated from the packages in the base environment, so
+that only those explicitly installed in the virtual environment are available.
 
 When used from within a virtual environment, common installation tools such as
 :pypi:`pip` will install Python packages into a virtual environment


### PR DESCRIPTION
* Improved venv docs to note that isolation is the default.

* Insert "that" so that a sentence reads better.

* Improved wording.

---------
(cherry picked from commit 8e2f4b448380b4c835442534d566618f06e32573)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136725.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->