### PR TITLE
gh-118469: Document sqlite3.Binary in module constants

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -500,7 +500,7 @@ Module constants
 
 .. data:: Binary
 
-   A type object used to describe columns containing :abbr:`BLOB (Binary Large OBject)` data.
+   A type object used to describe columns containing :abbr:`BLOB (Binary Large Object)` data.
    Implemented as an alias for :class:`memoryview`.
 
    .. note::

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -498,6 +498,16 @@ Module constants
 
       The ``named`` DB-API parameter style is also supported.
 
+.. data:: Binary
+
+   A type object used to describe columns containing :abbr:`BLOB (Binary Large OBject)` data.
+   Implemented as an alias for :class:`memoryview`.
+
+   .. note::
+
+      Binary data can also be stored and retrieved using bytes-like objects
+      directly without using :data:`!Binary`. This is the current behavior.
+
 .. data:: sqlite_version
 
    Version number of the runtime SQLite library as a :class:`string <str>`.

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -501,7 +501,7 @@ Module constants
 .. data:: Binary
 
    A type object used to describe columns containing :abbr:`BLOB (Binary Large Object)` data.
-   Implemented as an alias for :class:`memoryview`.
+   This is currently implemented as an alias for :class:`memoryview`.
 
    .. note::
 


### PR DESCRIPTION
gh-118469: Add documentation for sqlite3.Binary

Documents sqlite3.Binary as a memoryview alias for handling BLOB data per DB-API 2.0 specification.

Key additions:
- Explains Binary as memoryview alias for SQL BLOB values
- Notes that bytes objects can also handle binary data directly  
- Includes cross-references to related types
- Follows DB-API 2.0 specification requirements

Fixes gh-118469

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136734.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->