### PR TITLE
Update test_math.py skip issue

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1781,6 +1781,14 @@ class MathTests(unittest.TestCase):
         self.assertEqual(math.pow(2.3, -0.), 1.)
         self.assertEqual(math.pow(-2.3, -0.), 1.)
         self.assertEqual(math.pow(NAN, -0.), 1.)
+        self.assertEqual(math.pow(0, -0.), 1.)
+        self.assertEqual(math.pow(0.0, -0.), 1.)
+        self.assertEqual(math.pow(-0, -0.), 1.)
+        self.assertEqual(math.pow(-0.0, -0.), 1.)
+        self.assertEqual(math.pow(-0, 0.), 1.)
+        self.assertEqual(math.pow(-0.0, -.), 1.)
+        self.assertEqual(math.pow(0, 0.), 1.)
+        self.assertEqual(math.pow(0.0, 0.), 1.)
 
         # pow(x, y) is invalid if x is negative and y is not integral
         self.assertRaises(ValueError, math.pow, -1., 2.3)


### PR DESCRIPTION
Tests about pow(0, 0). According to the documentation it should return 1. Currently there is no checking for this.

<!--

# Add tests to test_math.py

```
gh-NNNNNN: Add 8 tests about pow(O, O)
```

Where: No issue related.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.
