### PR TITLE
gh-127146: Emscripten: Set umask to zero in test_apropos_empty_doc

### DIFF
--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -1303,6 +1303,11 @@ class PydocImportTest(PydocBaseTest):
     @os_helper.skip_unless_working_chmod
     def test_apropos_empty_doc(self):
         pkgdir = os.path.join(TESTFN, 'walkpkg')
+        if support.is_emscripten:
+            # Emscripten's readdir implementation is buggy on directories
+            # with read permission but no execute permission.
+            old_umask = os.umask(0)
+            self.addCleanup(os.umask, old_umask)
         os.mkdir(pkgdir)
         self.addCleanup(rmtree, pkgdir)
         init_path = os.path.join(pkgdir, '__init__.py')

--- a/Tools/wasm/emscripten/__main__.py
+++ b/Tools/wasm/emscripten/__main__.py
@@ -263,6 +263,10 @@ def configure_emscripten_python(context, working_dir):
                 REALPATH=abs_path
             fi
 
+            # Set umask to 0. The buildbot seems to run sometimes with a umask
+            # of 0o077 which causes one test to fail.
+            umask 0
+
             # We compute our own path, not following symlinks and pass it in so that
             # node_entry.mjs can set sys.executable correctly.
             # Intentionally allow word splitting on NODEFLAGS.

--- a/Tools/wasm/emscripten/__main__.py
+++ b/Tools/wasm/emscripten/__main__.py
@@ -263,10 +263,6 @@ def configure_emscripten_python(context, working_dir):
                 REALPATH=abs_path
             fi
 
-            # Set umask to 0. The buildbot seems to run sometimes with a umask
-            # of 0o077 which causes one test to fail.
-            umask 0
-
             # We compute our own path, not following symlinks and pass it in so that
             # node_entry.mjs can set sys.executable correctly.
             # Intentionally allow word splitting on NODEFLAGS.


### PR DESCRIPTION
This fixes `test_apropos_empty_doc`. Much thanks to @freakboy3742 for the investigation.

<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
