### PR TITLE
gh-136744: Remove unnecessary chmod from pydoc.apropos() test.

### DIFF
--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -11,7 +11,6 @@ import keyword
 import _pickle
 import pkgutil
 import re
-import stat
 import tempfile
 import test.support
 import time
@@ -1303,24 +1302,14 @@ class PydocImportTest(PydocBaseTest):
     @os_helper.skip_unless_working_chmod
     def test_apropos_empty_doc(self):
         pkgdir = os.path.join(TESTFN, 'walkpkg')
-        if support.is_emscripten:
-            # Emscripten's readdir implementation is buggy on directories
-            # with read permission but no execute permission.
-            old_umask = os.umask(0)
-            self.addCleanup(os.umask, old_umask)
         os.mkdir(pkgdir)
         self.addCleanup(rmtree, pkgdir)
         init_path = os.path.join(pkgdir, '__init__.py')
         with open(init_path, 'w') as fobj:
             fobj.write("foo = 1")
-        current_mode = stat.S_IMODE(os.stat(pkgdir).st_mode)
-        try:
-            os.chmod(pkgdir, current_mode & ~stat.S_IEXEC)
-            with self.restrict_walk_packages(path=[TESTFN]), captured_stdout() as stdout:
-                pydoc.apropos('')
-            self.assertIn('walkpkg', stdout.getvalue())
-        finally:
-            os.chmod(pkgdir, current_mode)
+        with self.restrict_walk_packages(path=[TESTFN]), captured_stdout() as stdout:
+            pydoc.apropos('')
+        self.assertIn('walkpkg', stdout.getvalue())
 
     def test_url_search_package_error(self):
         # URL handler search should cope with packages that raise exceptions


### PR DESCRIPTION
The test added as part of fixing #65747 includes a chmod call that appears to be unrelated to the problem that was reported.

Part of the triage of that issue included the observation that the problem could be reproduced by removing execute permissions from a directory. However, this appears to be unrelated to the reported problem.
 
By removing the execute permission from the directory, the module is converted into a namespace package - at which point, it _can't_ have a docstring. However, you can also validate empty docstring handling by... having a module without a docstring. Which is what the test implements.

Adding to the confusion - the test only removes _user_ execute permissions. Group and Global execute permissions are retained. The original report removed _all_ execute permissions, not just user execute permissions; so the test isn't reproducing the triage example. The only explanation I can think of for this is that the buildbots run with a umask of 0o77, which means removing user execute permissions _is_ effectively equivalent to `chmod a-x`... but it won't be for anyone who isn't running under buildbot.

This PR removes the chmod call, which also allows for removing the workaround for Emscripten.

Thanks to @hoodmane for help diagnosing what was going on here.

<!-- gh-issue-number: gh-136744 -->
* Issue: gh-136744
<!-- /gh-issue-number -->
