### PR TITLE
[3.13] gh-136697: Use the standard audit event format for sys.monitor…

### DIFF
--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -314,13 +314,17 @@ To register a callable for events call
    it is unregistered and returned.
    Otherwise :func:`register_callback` returns ``None``.
 
+   .. audit-event:: sys.monitoring.register_callback func sys.monitoring.register_callback
 
 Functions can be unregistered by calling
 ``sys.monitoring.register_callback(tool_id, event, None)``.
 
 Callback functions can be registered and unregistered at any time.
 
-Registering or unregistering a callback function will generate a :func:`sys.audit` event.
+Callbacks are called only once regardless if the event is turned on both
+globally and locally. As such, if an event could be turned on for both global
+and local events by your code then the callback needs to be written to handle
+either trigger.
 
 
 Callback function arguments

--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -319,13 +319,6 @@ To register a callable for events call
 Functions can be unregistered by calling
 ``sys.monitoring.register_callback(tool_id, event, None)``.
 
-Callback functions can be registered and unregistered at any time.
-
-Callbacks are called only once regardless if the event is turned on both
-globally and locally. As such, if an event could be turned on for both global
-and local events by your code then the callback needs to be written to handle
-either trigger.
-
 
 Callback function arguments
 '''''''''''''''''''''''''''

--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -319,6 +319,8 @@ To register a callable for events call
 Functions can be unregistered by calling
 ``sys.monitoring.register_callback(tool_id, event, None)``.
 
+Callback functions can be registered and unregistered at any time.
+
 
 Callback function arguments
 '''''''''''''''''''''''''''


### PR DESCRIPTION
…ing docs (GH-136747)

(cherry picked from commit 28937d3a21cf8168c853ae43374a8287c21f71c9)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136697 -->
* Issue: gh-136697
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136750.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->