### PR TITLE
Fix test name in test_ctypes.test_errno

### DIFF
--- a/Lib/test/test_ctypes/test_errno.py
+++ b/Lib/test/test_ctypes/test_errno.py
@@ -47,7 +47,7 @@ class Test(unittest.TestCase):
         set_errno(0)
 
     @unittest.skipUnless(os.name == "nt", 'Test specific to Windows')
-    def test_GetLastError(self):
+    def test_get_last_error(self):
         dll = ctypes.WinDLL("kernel32", use_last_error=True)
         GetModuleHandle = dll.GetModuleHandleA
         GetModuleHandle.argtypes = [c_wchar_p]


### PR DESCRIPTION
This function is actually testing `get_last_error()` instead of `GetLastError()`, which is also a valid Windows API but have different behaviors. Although this is not really a problem, I think it's better to make the test code clearer.