### PR TITLE
gh-116738: Make syslog module thread-safe

### DIFF
--- a/Lib/test/test_free_threading/test_syslog.py
+++ b/Lib/test/test_free_threading/test_syslog.py
@@ -1,0 +1,42 @@
+import unittest
+import threading
+
+from test.support import import_helper, threading_helper
+from test.support.threading_helper import run_concurrently
+
+syslog = import_helper.import_module("syslog")
+
+NTHREADS = 32
+
+# Similar to Lib/test/test_syslog.py, this test's purpose is to verify that
+# the code neither crashes nor leaks.
+
+
+@threading_helper.requires_working_threading()
+class TestSyslog(unittest.TestCase):
+    def test_racing_syslog(self):
+        def worker():
+            """
+            The syslog module provides the following functions:
+            openlog(), syslog(), closelog(), and setlogmask().
+            """
+            thread_id = threading.get_ident()
+            syslog.openlog(f"thread-id: {thread_id}")
+            for _ in range(5):
+                syslog.syslog("logline")
+                syslog.setlogmask(syslog.LOG_MASK(syslog.LOG_INFO))
+                syslog.syslog(syslog.LOG_INFO, "logline LOG_INFO")
+                syslog.setlogmask(syslog.LOG_MASK(syslog.LOG_ERR))
+                syslog.syslog(syslog.LOG_ERR, "logline LOG_ERR")
+                syslog.setlogmask(syslog.LOG_UPTO(syslog.LOG_DEBUG))
+            syslog.closelog()
+
+        # Run the worker concurrently to exercise all these syslog functions
+        run_concurrently(
+            worker_func=worker,
+            nthreads=NTHREADS,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_free_threading/test_syslog.py
+++ b/Lib/test/test_free_threading/test_syslog.py
@@ -22,14 +22,16 @@ class TestSyslog(unittest.TestCase):
             """
             thread_id = threading.get_ident()
             syslog.openlog(f"thread-id: {thread_id}")
-            for _ in range(5):
-                syslog.syslog("logline")
-                syslog.setlogmask(syslog.LOG_MASK(syslog.LOG_INFO))
-                syslog.syslog(syslog.LOG_INFO, "logline LOG_INFO")
-                syslog.setlogmask(syslog.LOG_MASK(syslog.LOG_ERR))
-                syslog.syslog(syslog.LOG_ERR, "logline LOG_ERR")
-                syslog.setlogmask(syslog.LOG_UPTO(syslog.LOG_DEBUG))
-            syslog.closelog()
+            try:
+                for _ in range(5):
+                    syslog.syslog("logline")
+                    syslog.setlogmask(syslog.LOG_MASK(syslog.LOG_INFO))
+                    syslog.syslog(syslog.LOG_INFO, "logline LOG_INFO")
+                    syslog.setlogmask(syslog.LOG_MASK(syslog.LOG_ERR))
+                    syslog.syslog(syslog.LOG_ERR, "logline LOG_ERR")
+                    syslog.setlogmask(syslog.LOG_UPTO(syslog.LOG_DEBUG))
+            finally:
+                syslog.closelog()
 
         # Run the worker concurrently to exercise all these syslog functions
         run_concurrently(

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-18-08-43-35.gh-issue-116738.i0HWtP.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-18-08-43-35.gh-issue-116738.i0HWtP.rst
@@ -1,0 +1,2 @@
+Make functions in :mod:`syslog` thread-safe on the :term:`free threaded
+<free threading>` build.

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -298,7 +298,13 @@ syslog_setlogmask_impl(PyObject *module, long maskpri)
         return -1;
     }
 
-    return setlogmask(maskpri);
+    static PyMutex setlogmask_mutex = {0};
+    PyMutex_Lock(&setlogmask_mutex);
+    // Linux man page (3): setlogmask() is MT-Unsafe race:LogMask.
+    long previous_mask = setlogmask(maskpri);
+    PyMutex_Unlock(&setlogmask_mutex);
+
+    return previous_mask;
 }
 
 /*[clinic input]


### PR DESCRIPTION
Make the `setlogmask()` function in the `syslog` module thread-safe. These changes are relevant for scenarios where the GIL is disabled or when using subinterpreters.

-  The functions `syslog()`, `openlog()`, and `closelog()` in the syslog module are already handled for FT-Python using the `@critical_section` on the `module`. However, there might be an issue with `syslog()` for subinterpreters on macOS.

https://github.com/python/cpython/blob/03017a8cc2242d881a3042b1eb9084c9bae9f85d/Modules/syslogmodule.c#L242-L245

 I will check/test the macOS subinterpreter and create a separate PR if necessary.
 
 
- Linux man page (3): [setlogmast()](https://man.archlinux.org/man/setlogmask.3)

cc: @mpage @colesbury

<!-- gh-issue-number: gh-116738 -->
* Issue: gh-116738
<!-- /gh-issue-number -->
