### PR TITLE
gh-136567: Add information about lost prefixes to `Tools/cases_generator/interpreter_definition.md`

### DIFF
--- a/Tools/cases_generator/interpreter_definition.md
+++ b/Tools/cases_generator/interpreter_definition.md
@@ -174,7 +174,7 @@ list of annotations and their meanings are as follows:
 * `override`. For external use by other interpreter definitions to override the current
    instruction definition.
 * `pure`. This instruction has no side effects.
-* 'tierN'. This instruction is only used by the tier N interpreter.
+* `tierN`. This instruction is only used by the tier N interpreter.
 
 ### Special functions/macros
 

--- a/Tools/cases_generator/interpreter_definition.md
+++ b/Tools/cases_generator/interpreter_definition.md
@@ -175,6 +175,12 @@ list of annotations and their meanings are as follows:
    instruction definition.
 * `pure`. This instruction has no side effects.
 * `tierN`. This instruction is only used by the tier N interpreter.
+* `specializing`. A prefix for an instructions related to adaptive interpreter.
+* `replaced`. This instruction will be replaced in the final bytecode by its directed
+   version (either forward or backward).
+* `register`. Currently does nothing.
+* `replicate(N)`. Replicate the instruction N times to store the oparg "inside" the instruction.
+* `no_save_ip`. This instruction does not affect the instruction pointer.
 
 ### Special functions/macros
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Hey @Eclips4!
 
I'm trying to research some more prefixes in `Python/bytecodes.c` and `Tools/cases_generator/` and found `guard` annotation in [here](https://github.com/python/cpython/blob/main/Python/bytecodes.c#L60) but can't find any using of it and not sure should it be added or not.

So, my work here was Ctrl+C Ctrl+V annotations that [you](https://github.com/python/cpython/issues/136567#issuecomment-3075208324) found :)

<!-- gh-issue-number: gh-136567 -->
* Issue: gh-136567
<!-- /gh-issue-number -->
