### PR TITLE
gh-74598: document that fnmatch.filterfalse is affected by cache limitation

### DIFF
--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -53,7 +53,7 @@ a :class:`!str` filename, and vice-versa.
 
 Finally, note that :func:`functools.lru_cache` with a *maxsize* of 32768
 is used to cache the (typed) compiled regex patterns in the following
-functions: :func:`fnmatch`, :func:`fnmatchcase`, :func:`.filter`.
+functions: :func:`fnmatch`, :func:`fnmatchcase`, :func:`.filter`, :func:`.filterfalse`.
 
 
 .. function:: fnmatch(name, pat)


### PR DESCRIPTION
trivial fix: mentioning limitations of the recently (3.14) introduced filterfalse function

[ EuroPython 2025 Sprints with the supervision of @AA-Turner ]


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136781.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-74598 -->
* Issue: gh-74598
<!-- /gh-issue-number -->
