### PR TITLE
Doc/c-api/memory.rst: extend --without-pymalloc doc with ASan information

### DIFF
--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -672,6 +672,13 @@ This allocator is disabled if Python is configured with the
 :option:`--without-pymalloc` option. It can also be disabled at runtime using
 the :envvar:`PYTHONMALLOC` environment variable (ex: ``PYTHONMALLOC=malloc``).
 
+Typically, it makes sense to disable the pymalloc allocator when building
+Python with AddressSanitizer (ASan) which helps uncover low level bugs within
+the C code. While pymalloc doesn't break under ASan, the ASan works more
+effectively with the system allocator (since we do not add any padding in
+between the objects managed/allocated by pymalloc and we do not annotate/poison
+the "inaccessible" memory between the pymalloc allocated objects).
+
 Customize pymalloc Arena Allocator
 ----------------------------------
 

--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -673,10 +673,8 @@ This allocator is disabled if Python is configured with the
 the :envvar:`PYTHONMALLOC` environment variable (ex: ``PYTHONMALLOC=malloc``).
 
 Typically, it makes sense to disable the pymalloc allocator when building
-Python with AddressSanitizer (ASan) which helps uncover low level bugs within
-the C code. While pymalloc doesn't break under ASan, the ASan works more
-effectively with the system allocator (ASan does not track
-individual allocations done by pymalloc).
+Python with AddressSanitizer (:option:`--with-address-sanitizer`) which helps
+uncover low level bugs within the C code.
 
 Customize pymalloc Arena Allocator
 ----------------------------------

--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -675,9 +675,8 @@ the :envvar:`PYTHONMALLOC` environment variable (ex: ``PYTHONMALLOC=malloc``).
 Typically, it makes sense to disable the pymalloc allocator when building
 Python with AddressSanitizer (ASan) which helps uncover low level bugs within
 the C code. While pymalloc doesn't break under ASan, the ASan works more
-effectively with the system allocator (since we do not add any padding in
-between the objects managed/allocated by pymalloc and we do not annotate/poison
-the "inaccessible" memory between the pymalloc allocated objects).
+effectively with the system allocator (ASan does not track
+individual allocations done by pymalloc).
 
 Customize pymalloc Arena Allocator
 ----------------------------------

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -802,6 +802,9 @@ Debug options
 .. option:: --with-address-sanitizer
 
    Enable AddressSanitizer memory error detector, ``asan`` (default is no).
+   To improve ASan detection capabilities you may also want to combine this
+   with :option:`--without-pymalloc` to disable the specialized small-object
+   allocator whose allocations are not tracked by ASan.
 
    .. versionadded:: 3.6
 


### PR DESCRIPTION

This commit extends the documentation for disabling pymalloc with the `--without-pymalloc` flag regarding why it is worth to use it when enabling AddressSanitizer for Python build (which is done, e.g., in CPython's CI builds).

I have tested the CPython latest main build with both ASan and pymalloc enabled and it seems to work just fine. I did run the `python -m test` suite which didn't uncover any ASan crashes (though, it detected some memory leaks, which I believe are irrelevant here).

I have discussed ASan and this flag with @encukou on the CPython Core sprint on EuroPython 2025. We initially thought that the `--without-pymalloc` flag is needed for ASan builds due to the fact pymalloc must hit the begining of page when determining if the memory to be freed comes from pymalloc or was allocated by the system malloc. In other words, we thought, that ASan would crash CPython during free of big objects (allocated by system malloc). It may be that this was the case in the past, but it is not the case anymore as the `address_in_range` function used by pymalloc is annotated to be skipped from the ASan instrumentation.

This code can be seen here:
https://github.com/python/cpython/blob/acefb978dcb5dd554e3c49a3015ee5c2ad6bfda1/Objects/obmalloc.c#L2096-L2110

While the annotation macro is defined here:
https://github.com/python/cpython/blob/acefb978dcb5dd554e3c49a3015ee5c2ad6bfda1/Include/pyport.h#L582-L598

And the corresponding attribute is documented in:
* for gcc: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-no_005fsanitize_005faddress-function-attribute
* for clang: https://clang.llvm.org/docs/AttributeReference.html#no-sanitize-address-no-address-safety-analysis



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136790.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->