### PR TITLE
gh-135468: Improve ``BaseHandler.http_error_default()`` parameter descriptions

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -911,11 +911,17 @@ HTTPRedirectHandler Objects
       do allow automatic redirection of these responses, changing the POST to a
       ``GET``, and the default implementation reproduces this behavior.
 
-
 .. method:: HTTPRedirectHandler.http_error_301(req, fp, code, msg, hdrs)
 
    Redirect to the ``Location:`` or ``URI:`` URL.  This method is called by the
-   parent :class:`OpenerDirector` when getting an HTTP 'moved permanently' response.
+   parent :class:`OpenerDirector` when getting an HTTP 'moved permanently' response. 
+   :class:`OpenerDirector` will call this method with five positional arguments:
+
+* a :class:`Request` object,
+* a file-like object with the HTTP error body,
+* the three-digit code of the error, as a string,
+* the user-visible explanation of the code, as as string, and
+* the headers of the error, as a mapping object.
 
 
 .. method:: HTTPRedirectHandler.http_error_302(req, fp, code, msg, hdrs)

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -829,10 +829,13 @@ The following attribute and methods should only be used by classes derived from
    errors.  It will be called automatically by the  :class:`OpenerDirector` getting
    the error, and should not normally be called in other circumstances.
 
-   *req* will be a :class:`Request` object, *fp* will be a file-like object with
-   the HTTP error body, *code* will be the three-digit code of the error, *msg*
-   will be the user-visible explanation of the code and *hdrs* will be a mapping
-   object with the headers of the error.
+   :class:`OpenerDirector` will call this method with five positional arguments:
+
+   1. a :class:`Request` object,
+   #. a file-like object with the HTTP error body,
+   #. the three-digit code of the error, as a string,
+   #. the user-visible explanation of the code, as as string, and
+   #. the headers of the error, as a mapping object.
 
    Return values and exceptions raised should be the same as those of
    :func:`urlopen`.
@@ -916,13 +919,6 @@ HTTPRedirectHandler Objects
 
    Redirect to the ``Location:`` or ``URI:`` URL.  This method is called by the
    parent :class:`OpenerDirector` when getting an HTTP 'moved permanently' response.
-   :class:`OpenerDirector` will call this method with five positional arguments:
-
-   * a :class:`Request` object,
-   * a file-like object with the HTTP error body,
-   * the three-digit code of the error, as a string,
-   * the user-visible explanation of the code, as as string, and
-   * the headers of the error, as a mapping object.
 
 
 .. method:: HTTPRedirectHandler.http_error_302(req, fp, code, msg, hdrs)

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -911,6 +911,7 @@ HTTPRedirectHandler Objects
       do allow automatic redirection of these responses, changing the POST to a
       ``GET``, and the default implementation reproduces this behavior.
 
+
 .. method:: HTTPRedirectHandler.http_error_301(req, fp, code, msg, hdrs)
 
    Redirect to the ``Location:`` or ``URI:`` URL.  This method is called by the

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -915,14 +915,14 @@ HTTPRedirectHandler Objects
 .. method:: HTTPRedirectHandler.http_error_301(req, fp, code, msg, hdrs)
 
    Redirect to the ``Location:`` or ``URI:`` URL.  This method is called by the
-   parent :class:`OpenerDirector` when getting an HTTP 'moved permanently' response. 
+   parent :class:`OpenerDirector` when getting an HTTP 'moved permanently' response.
    :class:`OpenerDirector` will call this method with five positional arguments:
 
-* a :class:`Request` object,
-* a file-like object with the HTTP error body,
-* the three-digit code of the error, as a string,
-* the user-visible explanation of the code, as as string, and
-* the headers of the error, as a mapping object.
+   * a :class:`Request` object,
+   * a file-like object with the HTTP error body,
+   * the three-digit code of the error, as a string,
+   * the user-visible explanation of the code, as as string, and
+   * the headers of the error, as a mapping object.
 
 
 .. method:: HTTPRedirectHandler.http_error_302(req, fp, code, msg, hdrs)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135468 -->
* Issue: gh-135468
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136797.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->