### PR TITLE
gh-136839: Refactor simple dict.update calls

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1265,7 +1265,7 @@ def _create_slots(defined_fields, inherited_slots, field_names, weakref_slot):
         doc = getattr(defined_fields.get(slot), 'doc', None)
         if doc is not None:
             seen_docs = True
-        slots.update({slot: doc})
+        slots[slot] = doc
 
     # We only return dict if there's at least one doc member,
     # otherwise we return tuple, which is the old default format.

--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -47,12 +47,8 @@ if os.name == 'posix':
     # absence of POSIX named semaphores. In that case, no named semaphores were
     # ever opened, so no cleanup would be necessary.
     if hasattr(_multiprocessing, 'sem_unlink'):
-        _CLEANUP_FUNCS.update({
-            'semaphore': _multiprocessing.sem_unlink,
-        })
-    _CLEANUP_FUNCS.update({
-        'shared_memory': _posixshmem.shm_unlink,
-    })
+        _CLEANUP_FUNCS['semaphore'] = _multiprocessing.sem_unlink
+    _CLEANUP_FUNCS['shared_memory'] = _posixshmem.shm_unlink
 
 
 class ReentrantCallError(RuntimeError):

--- a/Lib/tkinter/scrolledtext.py
+++ b/Lib/tkinter/scrolledtext.py
@@ -23,7 +23,7 @@ class ScrolledText(Text):
         self.vbar = Scrollbar(self.frame)
         self.vbar.pack(side=RIGHT, fill=Y)
 
-        kw.update({'yscrollcommand': self.vbar.set})
+        kw['yscrollcommand'] = self.vbar.set
         Text.__init__(self, self.frame, **kw)
         self.pack(side=LEFT, fill=BOTH, expand=True)
         self.vbar['command'] = self.yview

--- a/Lib/xmlrpc/server.py
+++ b/Lib/xmlrpc/server.py
@@ -239,7 +239,7 @@ class SimpleXMLRPCDispatcher:
 
         see http://www.xmlrpc.com/discuss/msgReader$1208"""
 
-        self.funcs.update({'system.multicall' : self.system_multicall})
+        self.funcs['system.multicall'] = self.system_multicall
 
     def _marshaled_dispatch(self, data, dispatch_method = None, path = None):
         """Dispatches an XML-RPC method from marshalled (XML) data.


### PR DESCRIPTION
This commit refactors simple `dict.update({key: value})` calls which can be done via `dict[key] = value` instead.

I found those cases with the [semgrep](https://semgrep.dev/) tool:

```
$ semgrep --lang python --pattern '$DICT.update({$A: ...})'

┌─────────────────┐
│ 5 Code Findings │
└─────────────────┘

    Lib/dataclasses.py
         1268┆ slots.update({slot: doc})

    Lib/multiprocessing/resource_tracker.py
           50┆ _CLEANUP_FUNCS.update({
           51┆     'semaphore': _multiprocessing.sem_unlink,
           52┆ })
            ⋮┆----------------------------------------
           53┆ _CLEANUP_FUNCS.update({
           54┆     'shared_memory': _posixshmem.shm_unlink,
           55┆ })

    Lib/tkinter/scrolledtext.py
           26┆ kw.update({'yscrollcommand': self.vbar.set})

    Lib/xmlrpc/server.py
          242┆ self.funcs.update({'system.multicall' : self.system_multicall})
```


<!-- gh-issue-number: gh-136839 -->
* Issue: gh-136839
<!-- /gh-issue-number -->
