### PR TITLE
gh-136437: Document some `os.path` functions as requiring pos-only

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -64,7 +64,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: basename(path)
+.. function:: basename(path, /)
 
    Return the base name of pathname *path*.  This is the second element of the
    pair returned by passing *path* to the function :func:`split`.  Note that
@@ -237,7 +237,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: isabs(path)
+.. function:: isabs(path, /)
 
    Return ``True`` if *path* is an absolute pathname.  On Unix, that means it
    begins with a slash, on Windows that it begins with two (back)slashes, or a
@@ -261,7 +261,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: isdir(path)
+.. function:: isdir(path, /)
 
    Return ``True`` if *path* is an :func:`existing <exists>` directory.  This
    follows symbolic links, so both :func:`islink` and :func:`isdir` can be true
@@ -372,7 +372,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object` for *path* and *paths*.
 
 
-.. function:: normcase(path)
+.. function:: normcase(path, /)
 
    Normalize the case of a pathname.  On Windows, convert all characters in the
    pathname to lowercase, and also convert forward slashes to backward slashes.
@@ -509,7 +509,7 @@ the :mod:`glob` module.)
       Added Windows support.
 
 
-.. function:: split(path)
+.. function:: split(path, /)
 
    Split the pathname *path* into a pair, ``(head, tail)`` where *tail* is the
    last pathname component and *head* is everything leading up to that.  The
@@ -525,7 +525,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: splitdrive(path)
+.. function:: splitdrive(path, /)
 
    Split the pathname *path* into a pair ``(drive, tail)`` where *drive* is either
    a mount point or the empty string.  On systems which do not use drive
@@ -550,7 +550,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: splitroot(path)
+.. function:: splitroot(path, /)
 
    Split the pathname *path* into a 3-item tuple ``(drive, root, tail)`` where
    *drive* is a device name or mount point, *root* is a string of separators
@@ -583,7 +583,7 @@ the :mod:`glob` module.)
    .. versionadded:: 3.12
 
 
-.. function:: splitext(path)
+.. function:: splitext(path, /)
 
    Split the pathname *path* into a pair ``(root, ext)``  such that ``root + ext ==
    path``, and the extension, *ext*, is empty or begins with a period and contains at


### PR DESCRIPTION
@chirizxc reached out to me and asked to take this issue over. So, here's mine PR :)

I scanned through all `os.path` functions that do use different pos-or-keyword parameter name from the documented one. And added `/` to them. See https://github.com/python/cpython/issues/136437#issuecomment-3058152238

I plan that we can backport this.

The second PR that I am working on is to actually make these functions pos-only in 3.15

<!-- gh-issue-number: gh-136437 -->
* Issue: gh-136437
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136812.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->