### PR TITLE
gh-127598: Improve ModuleNotFoundError when -S is passed

### DIFF
--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1106,6 +1106,10 @@ class TracebackException:
             suggestion = _compute_suggestion_error(exc_value, exc_traceback, wrong_name)
             if suggestion:
                 self._str += f". Did you mean: '{suggestion}'?"
+        elif exc_type and issubclass(exc_type, ModuleNotFoundError) and \
+                sys.flags.no_site:
+            self._str += ". Site initialization is disabled, did you forget to add the \
+                site-package directory to sys.path?"
         elif exc_type and issubclass(exc_type, (NameError, AttributeError)) and \
                 getattr(exc_value, "name", None) is not None:
             wrong_name = getattr(exc_value, "name", None)
@@ -1286,7 +1290,7 @@ class TracebackException:
     def _find_keyword_typos(self):
         assert self._is_syntax_error
         try:
-            import _suggestions
+            import _suggestions # type: ignore
         except ImportError:
             _suggestions = None
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
This partially solves GH-127598.
It adds flavor text to the exception ModuleNotFoundError when the argument '-S' is passed.