### PR TITLE
gh-127598: Improve ModuleNotFoundError when -S is passed

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4758,9 +4758,7 @@ class MiscTest(unittest.TestCase):
         )
 
         code = """
-            import sys
-            sys.builtin_module_names = sys.builtin_module_names + ("boo",)
-            import boo
+            import msvcrt
         """
         _, _, stderr = assert_python_failure('-S', '-c', code)
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4758,7 +4758,9 @@ class MiscTest(unittest.TestCase):
         )
 
         code = """
-            import msvcrt
+            import sys
+            sys.stdlib_module_names = sys.stdlib_module_names + ("boo",)
+            import boo
         """
         _, _, stderr = assert_python_failure('-S', '-c', code)
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4748,7 +4748,39 @@ class MiscTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             _suggestions._generate_suggestions(MyList(), "")
 
+    @support.requires_subprocess()
+    def test_no_site_package_flavour(self):
+        import subprocess
 
+        cmd = [sys.executable, '-S', '-c', 'import boo']
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(
+            ("Site initialization is disabled, did you forget to "
+                + "add the site-packages directory to sys.path?") in result.stderr
+        )
+
+        cmd = [sys.executable, '-S', '-c',
+            'import sys; sys.builtin_module_names = sys.builtin_module_names + ("boo",); import boo']
+
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(
+            ("Site initialization is disabled, did you forget to "
+                + "add the site-packages directory to sys.path?") not in result.stderr
+        )
 
 
 class TestColorizedTraceback(unittest.TestCase):

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4748,38 +4748,25 @@ class MiscTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             _suggestions._generate_suggestions(MyList(), "")
 
-    @support.requires_subprocess()
     def test_no_site_package_flavour(self):
-        import subprocess
+        code = """import boo"""
+        _, _, stderr = assert_python_failure('-S', '-c', code)
 
-        cmd = [sys.executable, '-S', '-c', 'import boo']
-        result = subprocess.run(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True
+        self.assertIn(
+            (b"Site initialization is disabled, did you forget to "
+                b"add the site-packages directory to sys.path?"), stderr
         )
 
-        self.assertNotEqual(result.returncode, 0)
-        self.assertTrue(
-            ("Site initialization is disabled, did you forget to "
-                + "add the site-packages directory to sys.path?") in result.stderr
-        )
+        code = """
+            import sys
+            sys.builtin_module_names = sys.builtin_module_names + ("boo",)
+            import boo
+        """
+        _, _, stderr = assert_python_failure('-S', '-c', code)
 
-        cmd = [sys.executable, '-S', '-c',
-            'import sys; sys.builtin_module_names = sys.builtin_module_names + ("boo",); import boo']
-
-        result = subprocess.run(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True
-        )
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertTrue(
-            ("Site initialization is disabled, did you forget to "
-                + "add the site-packages directory to sys.path?") not in result.stderr
+        self.assertNotIn(
+            (b"Site initialization is disabled, did you forget to "
+                b"add the site-packages directory to sys.path?"), stderr
         )
 
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1106,6 +1106,10 @@ class TracebackException:
             suggestion = _compute_suggestion_error(exc_value, exc_traceback, wrong_name)
             if suggestion:
                 self._str += f". Did you mean: '{suggestion}'?"
+        elif exc_type and issubclass(exc_type, ModuleNotFoundError) and \
+                sys.flags.no_site:
+            self._str += ". Site initialization is disabled, did you forget to add the \
+                site-package directory to sys.path?"
         elif exc_type and issubclass(exc_type, (NameError, AttributeError)) and \
                 getattr(exc_value, "name", None) is not None:
             wrong_name = getattr(exc_value, "name", None)

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1108,7 +1108,7 @@ class TracebackException:
                 self._str += f". Did you mean: '{suggestion}'?"
         elif exc_type and issubclass(exc_type, ModuleNotFoundError) and \
                 sys.flags.no_site and \
-                getattr(exc_value, "name", None) not in sys.builtin_module_names:
+                getattr(exc_value, "name", None) not in sys.stdlib_module_names:
             self._str += (". Site initialization is disabled, did you forget to "
                 + "add the site-packages directory to sys.path?")
         elif exc_type and issubclass(exc_type, (NameError, AttributeError)) and \

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1110,7 +1110,7 @@ class TracebackException:
                 sys.flags.no_site and \
                 getattr(exc_value, "name", None) not in sys.builtin_module_names:
             self._str += (". Site initialization is disabled, did you forget to "
-                + "add the site-package directory to sys.path?")
+                + "add the site-packages directory to sys.path?")
         elif exc_type and issubclass(exc_type, (NameError, AttributeError)) and \
                 getattr(exc_value, "name", None) is not None:
             wrong_name = getattr(exc_value, "name", None)

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1107,9 +1107,10 @@ class TracebackException:
             if suggestion:
                 self._str += f". Did you mean: '{suggestion}'?"
         elif exc_type and issubclass(exc_type, ModuleNotFoundError) and \
-                sys.flags.no_site:
-            self._str += ". Site initialization is disabled, did you forget to add the \
-                site-package directory to sys.path?"
+                sys.flags.no_site and \
+                getattr(exc_value, "name", None) not in sys.builtin_module_names:
+            self._str += (". Site initialization is disabled, did you forget to "
+                + "add the site-package directory to sys.path?")
         elif exc_type and issubclass(exc_type, (NameError, AttributeError)) and \
                 getattr(exc_value, "name", None) is not None:
             wrong_name = getattr(exc_value, "name", None)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-19-17-08-09.gh-issue-127598.Mx8S-y.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-19-17-08-09.gh-issue-127598.Mx8S-y.rst
@@ -1,2 +1,2 @@
-Improve :exc:`ModuleNotFoundError` by adding flavour text to exception when the
+Improve :exc:`ModuleNotFoundError` by adding flavour text to the exception when the
 :option:`-S` option is passed. Patch by Andrea Mattei.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-19-17-08-09.gh-issue-127598.Mx8S-y.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-19-17-08-09.gh-issue-127598.Mx8S-y.rst
@@ -1,2 +1,2 @@
-Improve ModuleNotFoundError by adding flavour text to exception when the
-argument '-S' is passed. Contributed by Andrea Mattei
+Improve :exc:`ModuleNotFoundError` by adding flavour text to exception when the
+:option:`-S` option is passed. Patch by Andrea Mattei.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-19-17-08-09.gh-issue-127598.Mx8S-y.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-19-17-08-09.gh-issue-127598.Mx8S-y.rst
@@ -1,0 +1,2 @@
+Improve ModuleNotFoundError by adding flavour text to exception when the
+argument '-S' is passed. Contributed by Andrea Mattei


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
This (partially) solves gh-127598 by adding flavour text to exception when the argument '-S' is passed.

<!-- gh-issue-number: gh-127598 -->
* Issue: gh-127598
<!-- /gh-issue-number -->
