### PR TITLE
GH-45322: Add test for glob slash and backslash consistency

### DIFF
--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -160,6 +160,13 @@ class GlobTests(unittest.TestCase):
                                              self.norm('a', 'bcd', 'efg')])
         eq(self.glob('a', 'bcd', '*g'), [self.norm('a', 'bcd', 'efg')])
 
+    def test_glob_consistency(self):
+        eq = self.assertSequencesEqual_noorder
+        if sys.platform.startswith("win"):
+            eq(self.glob(r'a\\\\bcd/efg', '*'), [(rf'{self.tempdir}\a\\\\bcd/efg\ha')])
+        else:
+            eq(self.glob('a////bcd/efg', '*'), [(f'{self.tempdir}/a////bcd/efg/ha')])
+
     def test_glob_directory_names(self):
         eq = self.assertSequencesEqual_noorder
         eq(self.glob('*', 'D'), [self.norm('a', 'D')])


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Hello,

wrote the test case for the glob issue mentioned in https://github.com/python/cpython/issues/45322.

This PR adds tests for multiple slashes in posix and Windows backslash and slash case.

The test run successful locally on Debian 12 with `Python 3.15.0.a.0`.
I can't run test on Windows, as I don't a PC with it installed.  

Regards,

<!-- gh-issue-number: gh-45322 -->
* Issue: gh-45322
<!-- /gh-issue-number -->
