### PR TITLE
gh-74585: Fix race condition in shutil.copyfile

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -444,7 +444,11 @@ def copyfile(src, dst, *, follow_symlinks=True):
                 elif _WINDOWS and file_size > 0:
                     _copyfileobj_readinto(fsrc, fdst, min(file_size, COPY_BUFSIZE))
                     return dst
-                copyfileobj(fsrc, fdst)
+                from unittest import mock
+                if isinstance(copyfileobj, mock.Mock):
+                    copyfileobj(fsrc, f"_WINDOWS: {_WINDOWS}\nfile_size: {file_size}")
+                else:
+                    copyfileobj(fsrc, fdst)
 
         # Issue 43219, raise a less confusing exception
         except IsADirectoryError as e:

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -5,6 +5,7 @@ XXX The functions here don't copy the resource fork or other metadata on Mac.
 """
 
 import os
+import fcntl
 import sys
 import stat
 import fnmatch
@@ -280,6 +281,11 @@ def _stat(fn):
 def _islink(fn):
     return fn.is_symlink() if isinstance(fn, os.DirEntry) else os.path.islink(fn)
 
+def _samefilef(fsrc, fdst):
+    if os.path.abspath(fsrc.name) == os.path.abspath(fdst.name):
+        return True
+    return False
+
 def copyfile(src, dst, *, follow_symlinks=True):
     """Copy data from src to dst in the most efficient way possible.
 
@@ -307,48 +313,121 @@ def copyfile(src, dst, *, follow_symlinks=True):
             if _WINDOWS and i == 0:
                 file_size = st.st_size
 
+    # XXX Is there a race issue here with os.path.islink() operating on a
+    # path rather than a file descriptor
     if not follow_symlinks and _islink(src):
         os.symlink(os.readlink(src), dst)
+        return dst
+
+    # In Unix, we must open the files non-blocking initially as opening a
+    # FIFO without data present in it will block.
+    if os.name == 'posix':
+        src_flags = os.O_RDONLY | os.O_NONBLOCK
+        ### Do we need os.O_EXCL?
+        dst_flags = os.O_CREAT | os.O_WRONLY | os.O_NONBLOCK
     else:
-        with open(src, 'rb') as fsrc:
+        src_flags = os.O_RDONLY
+        dst_flags = os.O_WRONLY
+
+    def _src_opener(path, flags):
+        return os.open(path, flags)
+
+    # dst's opener is more complex.  We need to atomically check and open the
+    # destination if it doesn't exist.  If it does exist, we need to detect so
+    # we don't destroy it later should we have to fail out for some reason.
+    dst_was_created = False
+    def _dst_opener(path, flags):
+        nonlocal dst_was_created
+        try:
+            dst_was_created = True
+            return os.open(path, flags | dst_flags | os.O_EXCL)
+        except FileExistsError:
+            dst_was_created = False
             try:
-                with open(dst, 'wb') as fdst:
-                    # macOS
-                    if _HAS_FCOPYFILE:
+                # Open the already existing file in as non-blocking
+                ### We have O_CREATE and O_NONBLOCK in dst_flags.  Is that intended?
+                fd = os.open(path, flags | dst_flags)
+            # If the destination is already a FIFO for some reason, we'll get an
+            # OSError here as we've opened a FIFO for a non-blocking write with
+            # no reader on the other end.
+            except OSError as e:
+                # Use errno to decide whether the OSError we caught is due to
+                # the above reason or some other reason.  For the above reason,
+                # raise the appropriate special file error.  Otherwise, we need
+                # to re-raise the OSError
+                if e.errno == errno.ENXIO:
+                    raise SpecialFileError("`%s` is a named pipe" % path)
+                else:
+                    raise e
+            # This check is required to catch the case where the destination
+            # file is a FIFO that's we successfully opened non-blocking because
+            # for some reason there was a reader listening preventing an ENXIO
+            # situation.
+            st = os.fstat(fd)
+            if stat.S_ISFIFO(st.st_mode):
+                raise SpecialFileError("`%s` is a named pipe" % path)
+            return fd
+
+    with open(src, 'rb', opener=_src_opener) as fsrc:
+        try:
+            with open(dst, 'wb', opener=_dst_opener) as fdst:
+                file_size = 0
+                # file.name is not populated when using os.fdopen()
+                st = os.fstat(fsrc.fileno())
+                if stat.S_ISFIFO(st.st_mode):
+                    # Don't unlink dst unless we created it above
+                    if dst_was_created:
+                        os.unlink(dst)
+                    raise SpecialFileError("`%s` is a named pipe" % src)
+                if _WINDOWS and i == 0:
+                    file_size = st.st_size
+
+                # In Unix, we must set the file descriptors back to blocking as that's
+                # what the rest of this function expects.
+                # Additonally, fsrc, and fdst must be turned into file objects
+                if os.name == 'posix':
+                    srcfl = fcntl.fcntl(fsrc.fileno(), fcntl.F_GETFL)
+                    dstfl = fcntl.fcntl(fdst.fileno(), fcntl.F_GETFL)
+
+                    # Unset the non-blocking flag
+                    fcntl.fcntl(fsrc.fileno(), fcntl.F_SETFL, srcfl & ~os.O_NONBLOCK)
+                    fcntl.fcntl(fdst.fileno(), fcntl.F_SETFL, dstfl & ~os.O_NONBLOCK)
+
+                # macOS
+                if _HAS_FCOPYFILE:
+                    try:
+                        _fastcopy_fcopyfile(fsrc, fdst, posix._COPYFILE_DATA)
+                        return dst
+                    except _GiveupOnFastCopy:
+                        pass
+                # Linux / Android / Solaris
+                elif _USE_CP_SENDFILE or _USE_CP_COPY_FILE_RANGE:
+                    # reflink may be implicit in copy_file_range.
+                    if _USE_CP_COPY_FILE_RANGE:
                         try:
-                            _fastcopy_fcopyfile(fsrc, fdst, posix._COPYFILE_DATA)
+                            _fastcopy_copy_file_range(fsrc, fdst)
                             return dst
                         except _GiveupOnFastCopy:
                             pass
-                    # Linux / Android / Solaris
-                    elif _USE_CP_SENDFILE or _USE_CP_COPY_FILE_RANGE:
-                        # reflink may be implicit in copy_file_range.
-                        if _USE_CP_COPY_FILE_RANGE:
-                            try:
-                                _fastcopy_copy_file_range(fsrc, fdst)
-                                return dst
-                            except _GiveupOnFastCopy:
-                                pass
-                        if _USE_CP_SENDFILE:
-                            try:
-                                _fastcopy_sendfile(fsrc, fdst)
-                                return dst
-                            except _GiveupOnFastCopy:
-                                pass
-                    # Windows, see:
-                    # https://github.com/python/cpython/pull/7160#discussion_r195405230
-                    elif _WINDOWS and file_size > 0:
-                        _copyfileobj_readinto(fsrc, fdst, min(file_size, COPY_BUFSIZE))
-                        return dst
+                    if _USE_CP_SENDFILE:
+                        try:
+                            _fastcopy_sendfile(fsrc, fdst)
+                            return dst
+                        except _GiveupOnFastCopy:
+                            pass
 
-                    copyfileobj(fsrc, fdst)
+                # Windows, see:
+                # https://github.com/python/cpython/pull/7160#discussion_r195405230
+                elif _WINDOWS and file_size > 0:
+                    _copyfileobj_readinto(fsrc, fdst, min(file_size, COPY_BUFSIZE))
+                    return dst
+                copyfileobj(fsrc, fdst)
 
-            # Issue 43219, raise a less confusing exception
-            except IsADirectoryError as e:
-                if not os.path.exists(dst):
-                    raise FileNotFoundError(f'Directory does not exist: {dst}') from e
-                else:
-                    raise
+        # Issue 43219, raise a less confusing exception
+        except IsADirectoryError as e:
+            if not os.path.exists(dst):
+                raise FileNotFoundError(f'Directory does not exist: {dst}') from e
+            raise
 
     return dst
 

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -3127,8 +3127,13 @@ class TestCopyFileObj(unittest.TestCase):
     def test_win_impl(self):
         # Make sure alternate Windows implementation is called.
         with unittest.mock.patch("shutil._copyfileobj_readinto") as m:
-            shutil.copyfile(TESTFN, TESTFN2)
-        assert m.called
+            with unittest.mock.patch("shutil._fastcopy_fcopyfile") as m1:
+                with unittest.mock.patch("shutil._fastcopy_copy_file_range") as m2:
+                    with unittest.mock.patch("shutil._fastcopy_sendfile") as m3:
+                        with unittest.mock.patch("shutil.copyfileobj") as m4:
+                            shutil.copyfile(TESTFN, TESTFN2)
+
+        assert m.called, f"_copyfileobj_readinto: {m.called}\n_fastcopy_fcopyfile: {m1.called}\n_fastcopy_copy_file_range: {m2.called}\n_fastcopy_sendfile: {m3.called}\ncopyfileobj: {m4.called}\ncalled_with: {m4.call_args}"
 
         # File size is 2 MiB but max buf size should be 1 MiB.
         self.assertEqual(m.call_args[0][2], 1 * 1024 * 1024)

--- a/Misc/NEWS.d/next/Library/2018-07-07.bpo-30400.Pjhd8.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-07.bpo-30400.Pjhd8.rst
@@ -1,0 +1,2 @@
+Fix race condition in shutil.copyfile() by ensuring the inode of the source
+file does not change while it is being copied.  Patch by Preston Moore.


### PR DESCRIPTION
This PR fixes a race condition in `shutil.copyfile` (there are several other `shutil` functions that should also be fixed. The current state is that only `copyfile` is fixed.)  Unittests are passing but there are a few things that I'd like to look into:

Reading through the issue, the following questions were asked and should be looked into:
- [x] [giampaolo](https://github.com/python/cpython/issues/74585#issuecomment-1093748678): I wonder whether this can introduce any change in semantic though:
  ``` python
  >>> import os
  >>> os.stat('foobar')
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
  FileNotFoundError: [Errno 2] No such file or directory: 'foobar'
  >>> os.stat(333)
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
  OSError: [Errno 9] Bad file descriptor: 333
  ```
  - https://github.com/python/cpython/pull/136836#issuecomment-3318422660
- [ ] [vstinner](https://github.com/python/cpython/issues/74585#issuecomment-1093748679): Python doesn't use FD of directories by default because it introduces issues of FD limit with deep directory tree, issue of managing FD lifetime, etc. That's why some API have one flavor for path and another for FD.
- [ ] Look through the `copyfile` changes for operations that are duplicated/should be done inside of the openers.  For instance, this PR presently stats a file twice.  I think that's unnecessary.
- [_] Look into whether there's other ways to pass the information about whether the file was created or not than via a closured variable.
  - We could subclass `int` and then return an instance of the subclass from `dst_opener` with a `dst_was_created` attribute set.  I don't think this makes the code any cleaner than it is now.  If there's some other reason a `nonlocal` variable won't work in later revisions of the code, this is a strategy that can be explored. 
  - Looking into fixing the WASI error, it seems like replacing `open()` is needed instead of simply implementing an opener for `src` and `dst`.  With that being the case, we can probably move `dst_was_created` into there.
- [ ] fix other `shutil` functions: [giampaulo:](https://github.com/python/cpython/issues/74585#issuecomment-1093748675) ```All copy* functions and move() are subjects to race conditions (the only exception is rmtree()).```
- [ ] [Vstinner](https://github.com/python/cpython/issues/74585#issuecomment-1093748676) proposed that fixing `copyfile` is good in and of itself, regardless of whether we fix the rest of the `shutil` functions.  I'll take a look at how similar they are before commenting on this.

This is a forward-port of https://github.com/python/cpython/pull/1659 from @pkmoore 

<!-- gh-issue-number: gh-74585 -->
* Issue: gh-74585
<!-- /gh-issue-number -->
