### PR TITLE
gh-124621: Emscripten: Fix regression in use-after-close error handling

### DIFF
--- a/Python/emscripten_syscalls.c
+++ b/Python/emscripten_syscalls.c
@@ -148,8 +148,15 @@ EM_JS_MACROS(__externref_t, __maybe_fd_read_async, (
     size_t iovcnt,
     __wasi_size_t *nread
 ), {
-    var stream = SYSCALLS.getStreamFromFD(fd);
     if (!WebAssembly.promising) {
+        return null;
+    }
+    var stream;
+    try {
+        stream = SYSCALLS.getStreamFromFD(fd);
+    } catch (e) {
+        // If the fd was already closed or never existed, getStreamFromFD()
+        // raises. We'll let fd_read_orig() handle setting errno.
         return null;
     }
     if (!stream.stream_ops.readAsync) {


### PR DESCRIPTION
Introduced in GH-136822. If the fd is already closed, `SYSCALLS.getStreamFromFD()` throws an error. We need to catch it and discard it. The `__wasi_fd_read_orig()` fallback will use it to set errno.



<!-- gh-issue-number: gh-124621 -->
* Issue: gh-124621
<!-- /gh-issue-number -->
