### PR TITLE
Pedantic rewording of why relative importing doesn't work in main modules

### DIFF
--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -579,8 +579,8 @@ module for example, you might use::
    from .. import formats
    from ..filters import equalizer
 
-Note that relative imports are based on the name of the current module.  Since
-the name of the main module is always ``"__main__"``, modules intended for use
+Note that relative imports are based on the name of the current module's package.
+Since the main module does not have a package, modules intended for use
 as the main module of a Python application must always use absolute imports.
 
 


### PR DESCRIPTION
Was writing a blog post and wanted to quote this, but realized it's technically incorrect so thought I'd give a whirl fixing it.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136846.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->