### PR TITLE
small typo in debugging tools for instrumentation

### DIFF
--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -556,7 +556,7 @@ sanity_check_instrumentation(PyCodeObject *code)
         active_monitors));
     int code_len = (int)Py_SIZE(code);
     PyCodeAddressRange range;
-    _PyCode_InitAddressRange(co, &range);
+    _PyCode_InitAddressRange(code, &range);
     for (int i = 0; i < code_len;) {
         _Py_CODEUNIT *instr = &_PyCode_CODE(code)[i];
         int opcode = instr->op.code;


### PR DESCRIPTION
This is fixing a minor typo in the debugging tools for instrumentation. It only becomes active if `#define INSTRUMENT_DEBUG 1` is actually used.
