### PR TITLE
[3.14] gh-136438: Make sure `test_remote_pdb` pass with all optimization levels (GH-136788)

### DIFF
--- a/Lib/test/test_remote_pdb.py
+++ b/Lib/test/test_remote_pdb.py
@@ -1,5 +1,4 @@
 import io
-import time
 import itertools
 import json
 import os
@@ -8,16 +7,13 @@ import signal
 import socket
 import subprocess
 import sys
-import tempfile
 import textwrap
-import threading
 import unittest
 import unittest.mock
 from contextlib import closing, contextmanager, redirect_stdout, redirect_stderr, ExitStack
-from pathlib import Path
-from test.support import is_wasi, cpython_only, force_color, requires_subprocess, SHORT_TIMEOUT
-from test.support.os_helper import temp_dir, TESTFN, unlink
-from typing import Dict, List, Optional, Tuple, Union, Any
+from test.support import is_wasi, cpython_only, force_color, requires_subprocess, SHORT_TIMEOUT, subTests
+from test.support.os_helper import TESTFN, unlink
+from typing import List
 
 import pdb
 from pdb import _PdbServer, _PdbClient
@@ -283,37 +279,50 @@ class PdbClientTestCase(unittest.TestCase):
             expected_stdout="Some message.\n",
         )
 
-    def test_handling_help_for_command(self):
-        """Test handling a request to display help for a command."""
+    @unittest.skipIf(sys.flags.optimize >= 2, "Help not available for -OO")
+    @subTests(
+        "help_request,expected_substring",
+        [
+            # a request to display help for a command
+            ({"help": "ll"}, "Usage: ll | longlist"),
+            # a request to display a help overview
+            ({"help": ""}, "type help <topic>"),
+            # a request to display the full PDB manual
+            ({"help": "pdb"}, ">>> import pdb"),
+        ],
+    )
+    def test_handling_help_when_available(self, help_request, expected_substring):
+        """Test handling help requests when help is available."""
         incoming = [
-            ("server", {"help": "ll"}),
+            ("server", help_request),
         ]
         self.do_test(
             incoming=incoming,
             expected_outgoing=[],
-            expected_stdout_substring="Usage: ll | longlist",
+            expected_stdout_substring=expected_substring,
         )
 
-    def test_handling_help_without_a_specific_topic(self):
-        """Test handling a request to display a help overview."""
+    @unittest.skipIf(sys.flags.optimize < 2, "Needs -OO")
+    @subTests(
+        "help_request,expected_substring",
+        [
+            # a request to display help for a command
+            ({"help": "ll"}, "No help for 'll'"),
+            # a request to display a help overview
+            ({"help": ""}, "Undocumented commands"),
+            # a request to display the full PDB manual
+            ({"help": "pdb"}, "No help for 'pdb'"),
+        ],
+    )
+    def test_handling_help_when_not_available(self, help_request, expected_substring):
+        """Test handling help requests when help is not available."""
         incoming = [
-            ("server", {"help": ""}),
+            ("server", help_request),
         ]
         self.do_test(
             incoming=incoming,
             expected_outgoing=[],
-            expected_stdout_substring="type help <topic>",
-        )
-
-    def test_handling_help_pdb(self):
-        """Test handling a request to display the full PDB manual."""
-        incoming = [
-            ("server", {"help": "pdb"}),
-        ]
-        self.do_test(
-            incoming=incoming,
-            expected_outgoing=[],
-            expected_stdout_substring=">>> import pdb",
+            expected_stdout_substring=expected_substring,
         )
 
     def test_handling_pdb_prompts(self):
@@ -1434,7 +1443,6 @@ class PdbConnectTestCase(unittest.TestCase):
 
 
 def _supports_remote_attaching():
-    from contextlib import suppress
     PROCESS_VM_READV_SUPPORTED = False
 
     try:


### PR DESCRIPTION
(cherry picked from commit 588d9fb84ae014502811ec8580411ea0df7200fe)

Original PR: https://github.com/python/cpython/pull/136788
Issue: #136438


---- 
At [EuroPython Sprints](https://ep2025.europython.eu/sprints/#heading-8) with @encukou

----

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136438 -->
* Issue: gh-136438
<!-- /gh-issue-number -->
