### PR TITLE
gh-136854: Exit on error in `make venv`

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -170,6 +170,7 @@ venv:
 		echo "venv already exists."; \
 		echo "To recreate it, remove it first with \`make clean-venv'."; \
 	else \
+		set -e; \
 		echo "Creating venv in $(VENVDIR)"; \
 		if $(UV) --version >/dev/null 2>&1; then \
 			$(UV) venv --python=$(PYTHON) $(VENVDIR); \


### PR DESCRIPTION
Fixes #136854 

<!-- gh-issue-number: gh-136854 -->
* Issue: gh-136854
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136856.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->