### PR TITLE
gh-136859: Improve `StrEnum` docs

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -510,15 +510,20 @@ Data Types
    of the enumeration.
 
    >>> from enum import StrEnum
-   >>> class Name(StrEnum):
-   ...     IDENTIFIER = 'id'
-   ...     PROPERTY = 'pro'
-   ...     ATTRIBUTE = 'attr'
-   ...
-   >>> Name.IDENTIFIER
-   <Name.IDENTIFIER: 'id'>
-   >>> str(Name.IDENTIFIER)
-   'id'
+    >>> class Color(StrEnum):
+    ...     RED = 'r'
+    ...     GREEN = 'g'
+    ...     BLUE = 'b'
+    ...     UNKNOWN = auto()
+    ...     
+    >>> Color.RED
+    <Color.RED: 'r'>
+    >>> str(Color.RED)
+    'r'
+    >>> Color.UNKNOWN
+    <Color.UNKNOWN: 'unknown'>
+    >>> str(Color.UNKNOWN)
+    'unknown'
 
    .. note::
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -509,21 +509,19 @@ Data Types
    of any string operation performed on or with a *StrEnum* member is not part
    of the enumeration.
 
-   >>> from enum import StrEnum
-    >>> class Color(StrEnum):
-    ...     RED = 'r'
-    ...     GREEN = 'g'
-    ...     BLUE = 'b'
-    ...     UNKNOWN = auto()
-    ...     
-    >>> Color.RED
-    <Color.RED: 'r'>
-    >>> str(Color.RED)
-    'r'
-    >>> Color.UNKNOWN
-    <Color.UNKNOWN: 'unknown'>
-    >>> str(Color.UNKNOWN)
-    'unknown'
+   >>> from enum import StrEnum, auto
+   >>> class Color(StrEnum):
+   ...     RED = 'r'
+   ...     GREEN = 'g'
+   ...     BLUE = 'b'
+   ...     UNKNOWN = auto()
+   ...
+   >>> Color.RED
+   <Color.RED: 'r'>
+   >>> Color.UNKNOWN
+   <Color.UNKNOWN: 'unknown'>
+   >>> str(Color.UNKNOWN)
+   'unknown'
 
    .. note::
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -504,16 +504,28 @@ Data Types
 
 .. class:: StrEnum
 
-   ``StrEnum`` is the same as :class:`Enum`, but its members are also strings and can be used
-   in most of the same places that a string can be used.  The result of any string
-   operation performed on or with a *StrEnum* member is not part of the enumeration.
+   *StrEnum* is the same as :class:`Enum`, but its members are also strings and
+   can be used in most of the same places that a string can be used. The result
+   of any string operation performed on or with a *StrEnum* member is not part
+   of the enumeration.
+
+   >>> from enum import StrEnum
+   >>> class Name(StrEnum):
+   ...     IDENTIFIER = 'id'
+   ...     PROPERTY = 'pro'
+   ...     ATTRIBUTE = 'attr'
+   ...
+   >>> Name.IDENTIFIER
+   <Name.IDENTIFIER: 'id'>
+   >>> str(Name.IDENTIFIER)
+   'id'
 
    .. note::
 
       There are places in the stdlib that check for an exact :class:`str`
       instead of a :class:`str` subclass (i.e. ``type(unknown) == str``
       instead of ``isinstance(unknown, str)``), and in those locations you
-      will need to use ``str(StrEnum.member)``.
+      will need to use ``str(MyStrEnum.MY_MEMBER)``.
 
    .. note::
 


### PR DESCRIPTION
- Replace `str(StrEnum.member)` with something that doesn't seem seem like `member` is a method of the `StrEnum` class.
- Fix quoting/emphasis inconsistency and re-wrap the paragraph to 80 characters.
- Add an illustrative example (to match `IntEnum`)

Fixes #136859

<!-- gh-issue-number: gh-136859 -->
* Issue: gh-136859
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136864.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->