### PR TITLE
gh-136640: Clarify the documentation of the AST module

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -91,11 +91,12 @@ Node classes
                   end_lineno
                   end_col_offset
 
-      Instances of :class:`ast.expr` and :class:`ast.stmt` subclasses have
-      :attr:`lineno`, :attr:`col_offset`, :attr:`end_lineno`, and
-      :attr:`end_col_offset` attributes.  The :attr:`lineno` and :attr:`end_lineno`
-      are the first and last line numbers of source text span (1-indexed so the
-      first line is line 1) and the :attr:`col_offset` and :attr:`end_col_offset`
+      Most instances of classes part of this module, e.g. instances of subclasses of
+      :class:`ast.expr`, :class:`ast.stmt` and others (see
+      `Abstract Grammar <abstract-grammar_>`__), have :attr:`lineno`, :attr:`col_offset`,
+      :attr:`end_lineno`, and :attr:`end_col_offset` attributes.  The :attr:`lineno` and
+      :attr:`end_lineno` are the first and last line numbers of source text span (1-indexed
+      so the first line is line 1) and the :attr:`col_offset` and :attr:`end_col_offset`
       are the corresponding UTF-8 byte offsets of the first and last tokens that
       generated the node. The UTF-8 offset is recorded because the parser uses
       UTF-8 internally.

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -91,10 +91,10 @@ Node classes
                   end_lineno
                   end_col_offset
 
-      Most instances of classes part of this module, e.g. instances of subclasses of
+      Most classes part of the AST module have the :attr:`lineno`, :attr:`col_offset`,
+      :attr:`end_lineno`, and :attr:`end_col_offset` attributes, including subclasses of
       :class:`ast.expr`, :class:`ast.stmt` and others (see
-      `Abstract Grammar <abstract-grammar_>`__), have :attr:`lineno`, :attr:`col_offset`,
-      :attr:`end_lineno`, and :attr:`end_col_offset` attributes.  The :attr:`lineno` and
+      `Abstract Grammar <abstract-grammar_>`__). The :attr:`lineno` and
       :attr:`end_lineno` are the first and last line numbers of source text span (1-indexed
       so the first line is line 1) and the :attr:`col_offset` and :attr:`end_col_offset`
       are the corresponding UTF-8 byte offsets of the first and last tokens that


### PR DESCRIPTION
This PR clarifies the documentation describing the attributes of classes part of the AST module

<!-- gh-issue-number: gh-136640 -->
* Issue: gh-136640
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136868.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->