### PR TITLE
gh-124098: Fix incorrect inclusion of handler methods without protocol prefix in OpenerDirector

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -577,6 +577,23 @@ class OpenerDirectorTests(unittest.TestCase):
         self.assertRaises(TypeError,
                           OpenerDirector().add_handler, NonHandler())
 
+    def test_no_protocol_methods(self):
+        # test the case that methods starts with handler type without the protocol
+        # like open*() or _open*().
+        # These methods should be ignored
+
+        o = OpenerDirector()
+        meth_spec = [
+            ["open"],
+            ["_open"],
+            ["error"]
+        ]
+
+        add_ordered_mock_handlers(o, meth_spec)
+
+        self.assertEqual(len(o.handle_open), 0)
+        self.assertEqual(len(o.handle_error), 0)
+
     def test_badly_named_methods(self):
         # test work-around for three methods that accidentally follow the
         # naming conventions for handler methods

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -415,6 +415,8 @@ class OpenerDirector:
                 continue
 
             i = meth.find("_")
+            if i < 1:
+                continue
             protocol = meth[:i]
             condition = meth[i+1:]
 

--- a/Misc/NEWS.d/next/Library/2025-07-20-15-39-54.gh-issue-124098.znFPIp.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-20-15-39-54.gh-issue-124098.znFPIp.rst
@@ -1,4 +1,4 @@
 Fix issue where methods in handlers that lacked the protocol name but
 matched a valid base handler method (e.g., ``_open()`` or ``error()``)
-were incorrectly added to :class:`OpenerDirector`'s handlers.
-Contributed by Andrea Mattei.
+were incorrectly added to :class:`urllib.request.OpenerDirector`'s
+handlers. Contributed by Andrea Mattei.

--- a/Misc/NEWS.d/next/Library/2025-07-20-15-39-54.gh-issue-124098.znFPIp.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-20-15-39-54.gh-issue-124098.znFPIp.rst
@@ -1,0 +1,4 @@
+Fix issue where methods in handlers that lacked the protocol name but
+matched a valid base handler method (e.g., ``_open()`` or ``error()``)
+were incorrectly added to :class:`OpenerDirector`'s handlers.
+Contributed by Andrea Mattei.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
This resolves GH-124098 an issue where handler methods that did not start with a protocol name but matched a valid base handler method (e.g., _open() or error()) were mistakenly added to OpenerDirector's handlers.
