### PR TITLE
GH-136874: `url2pathname()`: discard query and fragment components

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -211,6 +211,9 @@ The :mod:`urllib.request` module defines the following functions:
       :exc:`~urllib.error.URLError` is raised.
 
    .. versionchanged:: 3.14
+      The URL query and fragment components are discarded if present.
+
+   .. versionchanged:: 3.14
       The *require_scheme* and *resolve_host* parameters were added.
 
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2193,6 +2193,7 @@ urllib
   - Discard URL authority if it matches the local hostname.
   - Discard URL authority if it resolves to a local IP address when the new
     *resolve_host* argument is set to true.
+  - Discard URL query and fragment components.
   - Raise :exc:`~urllib.error.URLError` if a URL authority isn't local,
     except on Windows where we return a UNC path as before.
 

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1526,6 +1526,10 @@ class Pathname_Tests(unittest.TestCase):
         self.assertEqual(fn('////foo/bar'), f'{sep}{sep}foo{sep}bar')
         self.assertEqual(fn('data:blah'), 'data:blah')
         self.assertEqual(fn('data://blah'), f'data:{sep}{sep}blah')
+        self.assertEqual(fn('foo?bar'), 'foo')
+        self.assertEqual(fn('foo#bar'), 'foo')
+        self.assertEqual(fn('foo?bar=baz'), 'foo')
+        self.assertEqual(fn('foo?bar#baz'), 'foo')
 
     def test_url2pathname_require_scheme(self):
         sep = os.path.sep

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1530,6 +1530,10 @@ class Pathname_Tests(unittest.TestCase):
         self.assertEqual(fn('foo#bar'), 'foo')
         self.assertEqual(fn('foo?bar=baz'), 'foo')
         self.assertEqual(fn('foo?bar#baz'), 'foo')
+        self.assertEqual(fn('foo%3Fbar'), 'foo?bar')
+        self.assertEqual(fn('foo%23bar'), 'foo#bar')
+        self.assertEqual(fn('foo%3Fbar%3Dbaz'), 'foo?bar=baz')
+        self.assertEqual(fn('foo%3Fbar%23baz'), 'foo?bar#baz')
 
     def test_url2pathname_require_scheme(self):
         sep = os.path.sep

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1654,11 +1654,11 @@ def url2pathname(url, *, require_scheme=False, resolve_host=False):
     The URL authority may be resolved with gethostbyname() if
     *resolve_host* is set to true.
     """
-    if require_scheme:
-        scheme, url = _splittype(url)
-        if scheme != 'file':
-            raise URLError("URL is missing a 'file:' scheme")
-    authority, url = _splithost(url)
+    if not require_scheme:
+        url = 'file:' + url
+    scheme, authority, url = urlsplit(url)[:3]  # Discard query and fragment.
+    if scheme != 'file':
+        raise URLError("URL is missing a 'file:' scheme")
     if os.name == 'nt':
         if not _is_local_authority(authority, resolve_host):
             # e.g. file://server/share/file.txt

--- a/Misc/NEWS.d/next/Library/2025-07-20-16-02-00.gh-issue-136874.cLC3o1.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-20-16-02-00.gh-issue-136874.cLC3o1.rst
@@ -1,0 +1,1 @@
+Discard URL query and fragment in :func:`urllib.request.url2pathname`.


### PR DESCRIPTION
In `urllib.request.url2pathname()`, ignore any query or fragment components in the given URL.


<!-- gh-issue-number: gh-136874 -->
* Issue: gh-136874
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136875.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->