### PR TITLE
gh-87112: Ensure that only digits convertible to integers are accepted as section number in MIME header parameter

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2398,22 +2398,19 @@ def get_section(value):
     The caller should already have dealt with leading CFWS.
 
     """
-    def is_allowed_digit(c):
-        # We don't use str.isdigit because only 0-9 are accepted, not
-        # super-script and other types of digits.
-        return c in {'0','1','2','3','4','5','6','7','8','9'}
-
     section = Section()
     if not value or value[0] != '*':
         raise errors.HeaderParseError("Expected section but found {}".format(
                                         value))
     section.append(ValueTerminal('*', 'section-marker'))
     value = value[1:]
-    if not value or not is_allowed_digit(value[0]):
+    # We don't use str.isdigit because only 0-9 are accepted, not super-script
+    # and other types of digits.
+    if not value or not '0' <= value[0] <= '9':
         raise errors.HeaderParseError("Expected section number but "
                                       "found {}".format(value))
     digits = ''
-    while value and is_allowed_digit(value[0]):
+    while value and '0' <= value[0] <= '9':
         digits += value[0]
         value = value[1:]
     if digits[0] == '0' and digits != '0':

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2398,18 +2398,21 @@ def get_section(value):
     The caller should already have dealt with leading CFWS.
 
     """
+    def is_ascii_digit(d):
+        # We don't use str.isdigit because only ASCII digits are allowed.
+        return '0' <= d <= '9'
+
     section = Section()
     if not value or value[0] != '*':
         raise errors.HeaderParseError("Expected section but found {}".format(
                                         value))
     section.append(ValueTerminal('*', 'section-marker'))
     value = value[1:]
-    # We don't use str.isdigit because only ASCII digits are allowed.
-    if not value or not ('0' <= value[0] <= '9'):
+    if not value or not is_ascii_digit(value[0]):
         raise errors.HeaderParseError("Expected section number but "
                                       "found {}".format(value))
     digits = ''
-    while value and ('0' <= value[0] <= '9'):
+    while value and is_ascii_digit(value[0]):
         digits += value[0]
         value = value[1:]
     if digits[0] == '0' and digits != '0':

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2404,13 +2404,12 @@ def get_section(value):
                                         value))
     section.append(ValueTerminal('*', 'section-marker'))
     value = value[1:]
-    # We don't use str.isdigit because only 0-9 are accepted, not super-script
-    # and other types of digits.
-    if not value or not '0' <= value[0] <= '9':
+    # We don't use str.isdigit because only ASCII digits are allowed.
+    if not value or not ('0' <= value[0] <= '9'):
         raise errors.HeaderParseError("Expected section number but "
                                       "found {}".format(value))
     digits = ''
-    while value and '0' <= value[0] <= '9':
+    while value and ('0' <= value[0] <= '9'):
         digits += value[0]
         value = value[1:]
     if digits[0] == '0' and digits != '0':

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2398,9 +2398,16 @@ def get_section(value):
     The caller should already have dealt with leading CFWS.
 
     """
-    def is_ascii_digit(d):
-        # We don't use str.isdigit because only ASCII digits are allowed.
-        return '0' <= d <= '9'
+    def is_accepted_digit(d):
+        # While only ASCII digits are allowed by the RFC, we accept any digit
+        # that can be converted to an int for backwards compatibility purposes.
+        # We don't use str.isdigit() as some Unicode digits are not convertible
+        # (e.g. superscript digits).
+        try:
+            int(d)
+            return True
+        except ValueError:
+            return False
 
     section = Section()
     if not value or value[0] != '*':
@@ -2408,11 +2415,14 @@ def get_section(value):
                                         value))
     section.append(ValueTerminal('*', 'section-marker'))
     value = value[1:]
-    if not value or not is_ascii_digit(value[0]):
+    if not value or not is_accepted_digit(value[0]):
         raise errors.HeaderParseError("Expected section number but "
                                       "found {}".format(value))
     digits = ''
-    while value and is_ascii_digit(value[0]):
+    while value and is_accepted_digit(value[0]):
+        if not '0' <= value[0] <= '9':
+            section.defects.append(errors.InvalidHeaderDefect(
+                    "section number has a non-ASCII digit {}".format(value[0])))
         digits += value[0]
         value = value[1:]
     if digits[0] == '0' and digits != '0':

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2398,17 +2398,22 @@ def get_section(value):
     The caller should already have dealt with leading CFWS.
 
     """
+    def is_allowed_digit(c):
+        # We don't use str.isdigit because only 0-9 are accepted, not
+        # super-script and other types of digits.
+        return c in {'0','1','2','3','4','5','6','7','8','9'}
+
     section = Section()
     if not value or value[0] != '*':
         raise errors.HeaderParseError("Expected section but found {}".format(
                                         value))
     section.append(ValueTerminal('*', 'section-marker'))
     value = value[1:]
-    if not value or not value[0].isdigit():
+    if not value or not is_allowed_digit(value[0]):
         raise errors.HeaderParseError("Expected section number but "
                                       "found {}".format(value))
     digits = ''
-    while value and value[0].isdigit():
+    while value and is_allowed_digit(value[0]):
         digits += value[0]
         value = value[1:]
     if digits[0] == '0' and digits != '0':

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2983,8 +2983,7 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
             [('r', '"')],
             [errors.InvalidHeaderDefect]*2),
 
-        # gh-87112: Unicode super-script digits (and others) are not allowed
-        # as section numbers.
+        # gh-87112: Only ASCII digits can be section numbers.
         'non_allowed_digits': (
             'foo*0=bar; foo*²=baz',
             ' foo="bar"',

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2983,12 +2983,19 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
             [('r', '"')],
             [errors.InvalidHeaderDefect]*2),
 
-        # gh-87112: Only ASCII digits can be section numbers.
-        'non_allowed_digits': (
+        # gh-87112: Only digits convertible to integers can be section numbers.
+        'non_accepted_digit': (
             'foo*0=bar; foo*²=baz',
             ' foo="bar"',
             'foo*0=bar; foo*²=baz',
             [('foo', 'bar')],
+            [errors.InvalidHeaderDefect]),
+
+        'non_ascii_digit_backwards_compatibility': (
+            'foo*0=bar; foo*߁=baz',  # NKO digit '1'
+            ' foo="barbaz"',
+            'foo*0=bar; foo*߁=baz',
+            [('foo', 'barbaz')],
             [errors.InvalidHeaderDefect]),
     }
 

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2991,7 +2991,6 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
             'foo*0=bar; foo*²=baz',
             [('foo', 'bar')],
             [errors.InvalidHeaderDefect]),
-
     }
 
 @parameterize

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2982,6 +2982,16 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
             'r*=\'a\'"',
             [('r', '"')],
             [errors.InvalidHeaderDefect]*2),
+
+        # bpo-42946: Unicode super-script digits (and others) are not allowed
+        # as section numbers.
+        'non_allowed_digits': (
+            'foo*0=bar; foo*²=baz',
+            ' foo="bar"',
+            'foo*0=bar; foo*²=baz',
+            [('foo', 'bar')],
+            [errors.InvalidHeaderDefect]),
+
     }
 
 @parameterize

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2983,7 +2983,7 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
             [('r', '"')],
             [errors.InvalidHeaderDefect]*2),
 
-        # bpo-42946: Unicode super-script digits (and others) are not allowed
+        # gh-87112: Unicode super-script digits (and others) are not allowed
         # as section numbers.
         'non_allowed_digits': (
             'foo*0=bar; foo*²=baz',

--- a/Misc/NEWS.d/next/Library/2025-07-20-17-57-39.gh-issue-87112.sKU2V8.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-20-17-57-39.gh-issue-87112.sKU2V8.rst
@@ -1,0 +1,2 @@
+Do not fail when non-0-9 digit (e.g. super-script digit) is used as section
+number in MIME parameter.

--- a/Misc/NEWS.d/next/Library/2025-07-20-17-57-39.gh-issue-87112.sKU2V8.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-20-17-57-39.gh-issue-87112.sKU2V8.rst
@@ -1,2 +1,2 @@
-Ensure that only ASCII digits are accepted as section number in MIME header
-parameter.
+Ensure that only digits convertible to integers are accepted as section number
+in MIME header parameter.

--- a/Misc/NEWS.d/next/Library/2025-07-20-17-57-39.gh-issue-87112.sKU2V8.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-20-17-57-39.gh-issue-87112.sKU2V8.rst
@@ -1,2 +1,2 @@
-Do not fail when non-0-9 digit (e.g. super-script digit) is used as section
-number in MIME parameter.
+Ensure that only ASCII digits are accepted as section number in MIME header
+parameter.


### PR DESCRIPTION
With those changes, the MIME parameter parser discards parameters with an invalid section number that uses a digit not convertible to integer such as super-script "²" or "𐩃" (Kharosthi number).

For backwards compatibility, keep accepting non-ASCII digits that can be converted to integers, such as NKO digits.

Before:
```python
>>> import email.headerregistry
>>> reg = email.headerregistry.HeaderRegistry()
>>> reg('Content-Disposition', 'inline; foo*0=bar')
'inline; foo="bar"'
>>> reg('Content-Disposition', 'inline; foo*X=bar')
'inline;'
>>> reg('Content-Disposition', 'inline; foo*0=bar; foo*߁=baz')
'inline; foo="barbaz"'
>>> reg('Content-Disposition', 'inline; foo*²=bar')
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    reg('Content-Disposition', 'inline; foo*²=bar')
    ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthieu/git/cpython/Lib/email/headerregistry.py", line 604, in __call__
    return self[name](name, value)
           ~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/matthieu/git/cpython/Lib/email/headerregistry.py", line 192, in __new__
    cls.parse(value, kwds)
    ~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/matthieu/git/cpython/Lib/email/headerregistry.py", line 448, in parse
    kwds['parse_tree'] = parse_tree = cls.value_parser(value)
                                      ~~~~~~~~~~~~~~~~^^^^^^^
  File "/Users/matthieu/git/cpython/Lib/email/_header_value_parser.py", line 2736, in parse_content_disposition_header
    disp_header.append(parse_mime_parameters(value[1:]))
                       ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/Users/matthieu/git/cpython/Lib/email/_header_value_parser.py", line 2601, in parse_mime_parameters
    token, value = get_parameter(value)
                   ~~~~~~~~~~~~~^^^^^^^
  File "/Users/matthieu/git/cpython/Lib/email/_header_value_parser.py", line 2464, in get_parameter
    token, value = get_section(value)
                   ~~~~~~~~~~~^^^^^^^
  File "/Users/matthieu/git/cpython/Lib/email/_header_value_parser.py", line 2417, in get_section
    section.number = int(digits)
                     ~~~^^^^^^^^
ValueError: invalid literal for int() with base 10: '²'
```

After:
```python
>>> import email.headerregistry
>>> reg = email.headerregistry.HeaderRegistry()
>>> reg('Content-Disposition', 'inline; foo*0=bar')
'inline; foo="bar"'
>>> reg('Content-Disposition', 'inline; foo*X=bar')
'inline;'
>>> reg('Content-Disposition', 'inline; foo*0=bar; foo*߁=baz')
'inline; foo="barbaz"'
>>> reg('Content-Disposition', 'inline; foo*²=bar')
'inline;'
```

<!-- gh-issue-number: gh-87112 -->
* Issue: gh-87112
<!-- /gh-issue-number -->
