### PR TITLE
Fix various user-visible typos

### DIFF
--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -9,7 +9,7 @@ stability.  In order to maintain this reputation, the developers would like to
 know of any deficiencies you find in Python.
 
 It can sometimes be faster to fix bugs yourself and contribute patches to
-Python as it streamlines the process and involves fewer people. Learn how to
+Python as it streamlines the process and involves less people. Learn how to
 :ref:`contribute <contributing-to-python>`.
 
 Documentation bugs

--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -8,8 +8,8 @@ Python is a mature programming language which has established a reputation for
 stability.  In order to maintain this reputation, the developers would like to
 know of any deficiencies you find in Python.
 
-It can be sometimes faster to fix bugs yourself and contribute patches to
-Python as it streamlines the process and involves less people. Learn how to
+It can sometimes be faster to fix bugs yourself and contribute patches to
+Python as it streamlines the process and involves fewer people. Learn how to
 :ref:`contribute <contributing-to-python>`.
 
 Documentation bugs

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -425,7 +425,7 @@ Initializing and finalizing the interpreter
 
    Note that Python will do a best effort at freeing all memory allocated by the Python
    interpreter.  Therefore, any C-Extension should make sure to correctly clean up all
-   of the preveiously allocated PyObjects before using them in subsequent calls to
+   of the previously allocated PyObjects before using them in subsequent calls to
    :c:func:`Py_Initialize`.  Otherwise it could introduce vulnerabilities and incorrect
    behavior.
 

--- a/Lib/_py_warnings.py
+++ b/Lib/_py_warnings.py
@@ -33,7 +33,7 @@ def _set_module(module):
 # - a class representing the warning category
 # - a compiled regex that must match the module that is being warned
 # - a line number for the line being warning, or 0 to mean any line
-# If either if the compiled regexs are None, match anything.
+# If either of the compiled regexs are None, match anything.
 filters = []
 
 

--- a/Mac/BuildScript/README.rst
+++ b/Mac/BuildScript/README.rst
@@ -12,7 +12,7 @@ package. This format is deprecated and is no longer supported by modern
 macOS systems; it is usable on macOS 10.6 and earlier systems.
 To be usable on newer versions of macOS, the bits in the bundle package
 must be assembled in a macOS flat installer package, using current
-versions of the pkgbuild and productbuild utilities. To pass macoS
+versions of the pkgbuild and productbuild utilities. To pass macOS
 Gatekeeper download quarantine, the final package must be signed
 with a valid Apple Developer ID certificate using productsign.
 Starting with macOS 10.15 Catalina, Gatekeeper now also requires

--- a/Misc/rhel7/README.md
+++ b/Misc/rhel7/README.md
@@ -12,7 +12,7 @@ command.
 sudo yum install pkgconfig 'tcl-devel >= 8.5.12' 'tk-devel >= 8.5.12' openssl11-devel
 ```
 
-The run `configure` with `PKG_CONFIG_PATH` environment variable.
+Then run `configure` with `PKG_CONFIG_PATH` environment variable.
 
 ```shell
 PKG_CONFIG_PATH=Misc/rhel7 ./configure -C

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -554,7 +554,7 @@ Internal ABC helper for subclass registration. Should be never used outside abc 
 
 static PyObject *
 _abc__abc_register_impl(PyObject *module, PyObject *self, PyObject *subclass)
-/*[clinic end generated code: output=7851e7668c963524 input=ca589f8c3080e67f]*/
+/*[clinic end generated code: output=7851e7668c963524 input=fdf6a8117da33121]*/
 {
     if (!PyType_Check(subclass)) {
         PyErr_SetString(PyExc_TypeError, "Can only register classes");

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -549,7 +549,7 @@ _abc._abc_register
     subclass: object
     /
 
-Internal ABC helper for subclasss registration. Should be never used outside abc module.
+Internal ABC helper for subclass registration. Should be never used outside abc module.
 [clinic start generated code]*/
 
 static PyObject *

--- a/Modules/clinic/_abc.c.h
+++ b/Modules/clinic/_abc.c.h
@@ -52,7 +52,7 @@ PyDoc_STRVAR(_abc__abc_register__doc__,
 "_abc_register($module, self, subclass, /)\n"
 "--\n"
 "\n"
-"Internal ABC helper for subclasss registration. Should be never used outside abc module.");
+"Internal ABC helper for subclass registration. Should be never used outside abc module.");
 
 #define _ABC__ABC_REGISTER_METHODDEF    \
     {"_abc_register", _PyCFunction_CAST(_abc__abc_register), METH_FASTCALL, _abc__abc_register__doc__},
@@ -161,4 +161,4 @@ _abc_get_cache_token(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _abc_get_cache_token_impl(module);
 }
-/*[clinic end generated code: output=1989b6716c950e17 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=dde8efe9ff1ac4cc input=a9049054013a1b77]*/

--- a/iOS/README.rst
+++ b/iOS/README.rst
@@ -359,7 +359,7 @@ automatic breakpoints can be inconvenient. However, they can be disabled by
 creating a symbolic breakpoint that is triggered at the start of the test run.
 
 Select "Debug > Breakpoints > Create Symbolic Breakpoint" from the Xcode menu, and
-populate the new brewpoint with the following details:
+populate the new breakpoint with the following details:
 
 * **Name**: IgnoreSignals
 * **Symbol**: UIApplicationMain


### PR DESCRIPTION
Typos were identified by https://jules.google and manually reviewed for correctness (there were a bunch of false positives).

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136884.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->