### PR TITLE
Fix typos in `Doc/extending/extending.rst` and `Doc/library/shelve.rst`

### DIFF
--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -214,7 +214,7 @@ and initialize it by calling :c:func:`PyErr_NewException` in the module's
 
    SpamError = PyErr_NewException("spam.error", NULL, NULL);
 
-Since :c:data:`!SpamError` is a global variable, it will be overwitten every time
+Since :c:data:`!SpamError` is a global variable, it will be overwritten every time
 the module is reinitialized, when the :c:data:`Py_mod_exec` function is called.
 
 For now, let's avoid the issue: we will block repeated initialization by raising an

--- a/Doc/library/shelve.rst
+++ b/Doc/library/shelve.rst
@@ -144,7 +144,7 @@ Restrictions
   which can cause hard crashes when trying to read from the database.
 
 * :meth:`Shelf.reorganize` may not be available for all database packages and
-  may temporarely increase resource usage (especially disk space) when called.
+  may temporarily increase resource usage (especially disk space) when called.
   Additionally, it will never run automatically and instead needs to be called
   explicitly.
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1051,7 +1051,7 @@ Concurrent safe warnings control
 The :class:`warnings.catch_warnings` context manager will now optionally
 use a context variable for warning filters.  This is enabled by setting
 the :data:`~sys.flags.context_aware_warnings` flag, either with the ``-X``
-command-line option or an environment variable.  This gives predictable
+command-line option or an environment variable.  This gives predicable
 warnings control when using :class:`~warnings.catch_warnings` combined with
 multiple threads or asynchronous tasks. The flag defaults to true for the
 free-threaded build and false for the GIL-enabled build.

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1051,7 +1051,7 @@ Concurrent safe warnings control
 The :class:`warnings.catch_warnings` context manager will now optionally
 use a context variable for warning filters.  This is enabled by setting
 the :data:`~sys.flags.context_aware_warnings` flag, either with the ``-X``
-command-line option or an environment variable.  This gives predicable
+command-line option or an environment variable.  This gives predictable
 warnings control when using :class:`~warnings.catch_warnings` combined with
 multiple threads or asynchronous tasks. The flag defaults to true for the
 free-threaded build and false for the GIL-enabled build.


### PR DESCRIPTION
Focused PR with just the Doc/ changes from #136887

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136890.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->