### PR TITLE
Fix 3 typos in "Next" News items

### DIFF
--- a/Misc/NEWS.d/3.14.0b1.rst
+++ b/Misc/NEWS.d/3.14.0b1.rst
@@ -1756,7 +1756,7 @@ Add support for macOS multi-arch builds with the JIT enabled
 .. nonce: q9fvyM
 .. section: Core and Builtins
 
-PyREPL now supports syntax highlighing. Contributed by Łukasz Langa.
+PyREPL now supports syntax highlighting. Contributed by Łukasz Langa.
 
 ..
 
@@ -1797,7 +1797,7 @@ non-``None`` ``closure``. Patch by Bartosz Sławecki.
 .. nonce: Uj7lyY
 .. section: Core and Builtins
 
-Fix a bug that was allowing newlines inconsitently in format specifiers for
+Fix a bug that was allowing newlines inconsistently in format specifiers for
 single-quoted f-strings. Patch by Pablo Galindo.
 
 ..

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-19-12-37-05.gh-issue-136801.XU_tF2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-19-12-37-05.gh-issue-136801.XU_tF2.rst
@@ -1,1 +1,1 @@
-Fix PyREPL syntax highlightning on match cases after multi-line case. Contributed by Olga Matoula.
+Fix PyREPL syntax highlighting on match cases after multi-line case. Contributed by Olga Matoula.

--- a/Misc/NEWS.d/next/Library/2025-07-05-09-45-04.gh-issue-136286.N67Amr.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-05-09-45-04.gh-issue-136286.N67Amr.rst
@@ -1,2 +1,2 @@
-Fix pickling failures for protocols 0 and 1 for many objects realted to
+Fix pickling failures for protocols 0 and 1 for many objects related to
 subinterpreters.

--- a/Misc/NEWS.d/next/Tools-Demos/2025-06-11-12-14-06.gh-issue-135379.25ttXq.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-06-11-12-14-06.gh-issue-135379.25ttXq.rst
@@ -1,4 +1,4 @@
 The cases generator no longer accepts type annotations on stack items.
-Conversions to non-default types are now done explictly in bytecodes.c and
+Conversions to non-default types are now done explicitly in bytecodes.c and
 optimizer_bytecodes.c. This will simplify code generation for top-of-stack
 caching and other future features.


### PR DESCRIPTION
These typos will be end-user visible

Derived from #136887 