### PR TITLE
gh-135228: When @dataclass(slots=True) replaces a dataclass, make the original class collectible

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1342,7 +1342,8 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
     # Bypass mapping proxy to allow __dict__ to be removed
     old_cls_dict = cls.__dict__ | _deproxier
     old_cls_dict.pop('__dict__', None)
-    del cls.__weakref__
+    if "__weakref__" in cls.__dict__:
+        del cls.__weakref__
 
     return newcls
 

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1338,6 +1338,11 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
                 or _update_func_cell_for__class__(member.fdel, cls, newcls)):
                 break
 
+    # gh-135228: Make sure the original class can be garbage collected.
+    old_cls_dict = cls.__dict__ | _deproxier
+    old_cls_dict.pop('__weakref__', None)
+    old_cls_dict.pop('__dict__', None)
+
     return newcls
 
 
@@ -1732,3 +1737,11 @@ def _replace(self, /, **changes):
     # changes that aren't fields, this will correctly raise a
     # TypeError.
     return self.__class__(**changes)
+
+
+# Hack to the get the underlying dict out of a mappingproxy
+# Use it with: cls.__dict__ | _deproxier
+class _Deproxier:
+    def __ror__(self, other):
+        return other
+_deproxier = _Deproxier()

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1339,9 +1339,10 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
                 break
 
     # gh-135228: Make sure the original class can be garbage collected.
+    # Bypass mapping proxy to allow __dict__ to be removed
     old_cls_dict = cls.__dict__ | _deproxier
-    old_cls_dict.pop('__weakref__', None)
     old_cls_dict.pop('__dict__', None)
+    del cls.__weakref__
 
     return newcls
 

--- a/Misc/NEWS.d/next/Library/2025-07-20-16-56-55.gh-issue-135228.n_XIao.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-20-16-56-55.gh-issue-135228.n_XIao.rst
@@ -1,0 +1,4 @@
+When :mod:`dataclasses` replaces a class with a slotted dataclass, the
+original class is now garbage collected again. Earlier changes in Python
+3.14 caused this class to remain in existence together with the replacement
+class synthesized by :mod:`dataclasses`.


### PR DESCRIPTION
An interesting hack, but more localized in scope than #135230.

This may be a breaking change if people intentionally keep the original class around
when using `@dataclass(slots=True)`, and then use `__dict__` or `__weakref__` on the
original class.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135228 -->
* Issue: gh-135228
<!-- /gh-issue-number -->
