### PR TITLE
[3.14] gh-135661: Fix parsing attributes with whitespaces around the "=" separator in HTMLParser (GH-136908)

### DIFF
--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -45,7 +45,7 @@ attrfind_tolerant = re.compile(r"""
   (
     (?<=['"\t\n\r\f /])[^\t\n\r\f />][^\t\n\r\f /=>]*  # attribute name
    )
-  (=                                # value indicator
+  ([\t\n\r\f ]*=[\t\n\r\f ]*        # value indicator
     ('[^']*'                        # LITA-enclosed value
     |"[^"]*"                        # LIT-enclosed value
     |(?!['"])[^>\t\n\r\f ]*         # bare value
@@ -57,7 +57,7 @@ locatetagend = re.compile(r"""
   [a-zA-Z][^\t\n\r\f />]*           # tag name
   [\t\n\r\f /]*                     # optional whitespace before attribute name
   (?:(?<=['"\t\n\r\f /])[^\t\n\r\f />][^\t\n\r\f /=>]*  # attribute name
-    (?:=                            # value indicator
+    (?:[\t\n\r\f ]*=[\t\n\r\f ]*    # value indicator
       (?:'[^']*'                    # LITA-enclosed value
         |"[^"]*"                    # LIT-enclosed value
         |(?!['"])[^>\t\n\r\f ]*     # bare value

--- a/Lib/test/test_htmlparser.py
+++ b/Lib/test/test_htmlparser.py
@@ -623,7 +623,7 @@ text
 
         html = '<div style="", foo = "bar" ><b>The <a href="some_url">rain</a>'
         expected = [
-            ('starttag', 'div', [('style', ''), (',', None), ('foo', None), ('=', None), ('"bar"', None)]),
+            ('starttag', 'div', [('style', ''), (',', None), ('foo', 'bar')]),
             ('starttag', 'b', []),
             ('data', 'The '),
             ('starttag', 'a', [('href', 'some_url')]),
@@ -813,12 +813,12 @@ class AttributesTestCase(TestCaseBase):
         ]
         self._run_check("""<a b='v' c="v" d=v e>""", output)
         self._run_check("<a foo==bar>", [('starttag', 'a', [('foo', '=bar')])])
-        self._run_check("<a foo =bar>", [('starttag', 'a', [('foo', None), ('=bar', None)])])
-        self._run_check("<a foo\t=bar>", [('starttag', 'a', [('foo', None), ('=bar', None)])])
+        self._run_check("<a foo =bar>", [('starttag', 'a', [('foo', 'bar')])])
+        self._run_check("<a foo\t=bar>", [('starttag', 'a', [('foo', 'bar')])])
         self._run_check("<a foo\v=bar>", [('starttag', 'a', [('foo\v', 'bar')])])
         self._run_check("<a foo\xa0=bar>", [('starttag', 'a', [('foo\xa0', 'bar')])])
-        self._run_check("<a foo= bar>", [('starttag', 'a', [('foo', ''), ('bar', None)])])
-        self._run_check("<a foo=\tbar>", [('starttag', 'a', [('foo', ''), ('bar', None)])])
+        self._run_check("<a foo= bar>", [('starttag', 'a', [('foo', 'bar')])])
+        self._run_check("<a foo=\tbar>", [('starttag', 'a', [('foo', 'bar')])])
         self._run_check("<a foo=\vbar>", [('starttag', 'a', [('foo', '\vbar')])])
         self._run_check("<a foo=\xa0bar>", [('starttag', 'a', [('foo', '\xa0bar')])])
 
@@ -829,8 +829,8 @@ class AttributesTestCase(TestCaseBase):
                                             ("d", "\txyz\n")])])
         self._run_check("""<a b='' c="">""",
                         [("starttag", "a", [("b", ""), ("c", "")])])
-        self._run_check("<a b=\t c=\n>",
-                        [("starttag", "a", [("b", ""), ("c", "")])])
+        self._run_check("<a b=\tx c=\ny>",
+                        [('starttag', 'a', [('b', 'x'), ('c', 'y')])])
         self._run_check("<a b=\v c=\xa0>",
                         [("starttag", "a", [("b", "\v"), ("c", "\xa0")])])
         # Regression test for SF patch #669683.
@@ -899,13 +899,17 @@ class AttributesTestCase(TestCaseBase):
         )
         expected = [
             ('starttag', 'a', [('href', "test'style='color:red;bad1'")]),
-            ('data', 'test - bad1'), ('endtag', 'a'),
+            ('data', 'test - bad1'),
+            ('endtag', 'a'),
             ('starttag', 'a', [('href', "test'+style='color:red;ba2'")]),
-            ('data', 'test - bad2'), ('endtag', 'a'),
+            ('data', 'test - bad2'),
+            ('endtag', 'a'),
             ('starttag', 'a', [('href', "test'\xa0style='color:red;bad3'")]),
-            ('data', 'test - bad3'), ('endtag', 'a'),
-            ('starttag', 'a', [('href', None), ('=', None), ("test'&nbsp;style", 'color:red;bad4')]),
-            ('data', 'test - bad4'), ('endtag', 'a')
+            ('data', 'test - bad3'),
+            ('endtag', 'a'),
+            ('starttag', 'a', [('href', "test'\xa0style='color:red;bad4'")]),
+            ('data', 'test - bad4'),
+            ('endtag', 'a'),
         ]
         self._run_check(html, expected)
 

--- a/Misc/NEWS.d/3.14.0b4.rst
+++ b/Misc/NEWS.d/3.14.0b4.rst
@@ -75,7 +75,7 @@ to the HTML5 standard.
 * Multiple ``=`` between attribute name and value are no longer collapsed.
   E.g. ``<a foo==bar>`` produces attribute "foo" with value "=bar".
 
-* [REVERTED] Whitespaces between the ``=`` separator and attribute name or value are no
+* [Reverted in :gh:`136927`] Whitespaces between the ``=`` separator and attribute name or value are no
   longer ignored. E.g. ``<a foo =bar>`` produces two attributes "foo" and
   "=bar", both with value None; ``<a foo= bar>`` produces two attributes:
   "foo" with value "" and "bar" with value None.

--- a/Misc/NEWS.d/3.14.0b4.rst
+++ b/Misc/NEWS.d/3.14.0b4.rst
@@ -75,7 +75,7 @@ to the HTML5 standard.
 * Multiple ``=`` between attribute name and value are no longer collapsed.
   E.g. ``<a foo==bar>`` produces attribute "foo" with value "=bar".
 
-* Whitespaces between the ``=`` separator and attribute name or value are no
+* [REVERTED] Whitespaces between the ``=`` separator and attribute name or value are no
   longer ignored. E.g. ``<a foo =bar>`` produces two attributes "foo" and
   "=bar", both with value None; ``<a foo= bar>`` produces two attributes:
   "foo" with value "" and "bar" with value None.

--- a/Misc/NEWS.d/next/Security/2025-07-21-14-15-25.gh-issue-135661.nAxXw5.rst
+++ b/Misc/NEWS.d/next/Security/2025-07-21-14-15-25.gh-issue-135661.nAxXw5.rst
@@ -1,0 +1,2 @@
+Fix parsing attributes with whitespaces around the ``=`` separator in
+:class:`html.parser.HTMLParser` according to the HTML5 standard.


### PR DESCRIPTION
This fixes a regression introduced in GH-135930.
(cherry picked from commit dee650189497735edbc08a54edabb5b06ef1bd09)


<!-- gh-issue-number: gh-135661 -->
* Issue: gh-135661
<!-- /gh-issue-number -->
