### PR TITLE
gh-136914: Use inspect.isroutine() in DocTest's lineno computation

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1141,7 +1141,7 @@ class DocTestFinder:
         if inspect.ismethod(obj): obj = obj.__func__
         if isinstance(obj, property):
             obj = obj.fget
-        if inspect.isfunction(obj) and getattr(obj, '__doc__', None):
+        if inspect.isroutine(obj) and getattr(obj, '__doc__', None):
             # We don't use `docstring` var here, because `obj` can be changed.
             obj = inspect.unwrap(obj)
             try:

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -94,6 +94,7 @@ __all__ = [
 
 import __future__
 import difflib
+import functools
 import inspect
 import linecache
 import os
@@ -1141,6 +1142,8 @@ class DocTestFinder:
         if inspect.ismethod(obj): obj = obj.__func__
         if isinstance(obj, property):
             obj = obj.fget
+        if isinstance(obj, functools.cached_property):
+            obj = obj.func
         if inspect.isroutine(obj) and getattr(obj, '__doc__', None):
             # We don't use `docstring` var here, because `obj` can be changed.
             obj = inspect.unwrap(obj)

--- a/Lib/test/test_doctest/doctest_lineno.py
+++ b/Lib/test/test_doctest/doctest_lineno.py
@@ -76,3 +76,21 @@ from test.test_doctest.decorator_mod import decorator
 @decorator
 def func_with_docstring_wrapped():
     """Some unrelated info."""
+
+
+# https://github.com/python/cpython/issues/136914
+import functools
+
+
+@functools.cache
+def cached_func_with_doctest(value):
+    """
+    >>> cached_func_with_doctest(1)
+    -1
+    """
+    return -value
+
+
+@functools.cache
+def cached_func_without_docstring(value):
+    return value + 1

--- a/Lib/test/test_doctest/doctest_lineno.py
+++ b/Lib/test/test_doctest/doctest_lineno.py
@@ -94,3 +94,14 @@ def cached_func_with_doctest(value):
 @functools.cache
 def cached_func_without_docstring(value):
     return value + 1
+
+
+class ClassWithACachedProperty:
+
+    @functools.cached_property
+    def cached(self):
+        """
+        >>> X().cached
+        -1
+        """
+        return 0

--- a/Lib/test/test_doctest/test_doctest.py
+++ b/Lib/test/test_doctest/test_doctest.py
@@ -678,6 +678,8 @@ It used to be broken for quite some time until `bpo-28249`.
     >>> for t in tests:
     ...     print('%5s  %s' % (t.lineno, t.name))
      None  test.test_doctest.doctest_lineno
+     None  test.test_doctest.doctest_lineno.ClassWithACachedProperty
+      102  test.test_doctest.doctest_lineno.ClassWithACachedProperty.cached
        22  test.test_doctest.doctest_lineno.ClassWithDocstring
        30  test.test_doctest.doctest_lineno.ClassWithDoctest
      None  test.test_doctest.doctest_lineno.ClassWithoutDocstring

--- a/Lib/test/test_doctest/test_doctest.py
+++ b/Lib/test/test_doctest/test_doctest.py
@@ -687,6 +687,8 @@ It used to be broken for quite some time until `bpo-28249`.
        45  test.test_doctest.doctest_lineno.MethodWrapper.method_with_doctest
      None  test.test_doctest.doctest_lineno.MethodWrapper.method_without_docstring
        61  test.test_doctest.doctest_lineno.MethodWrapper.property_with_doctest
+       86  test.test_doctest.doctest_lineno.cached_func_with_doctest
+     None  test.test_doctest.doctest_lineno.cached_func_without_docstring
         4  test.test_doctest.doctest_lineno.func_with_docstring
        77  test.test_doctest.doctest_lineno.func_with_docstring_wrapped
        12  test.test_doctest.doctest_lineno.func_with_doctest

--- a/Misc/NEWS.d/next/Library/2025-07-21-15-40-00.gh-issue-136914.-GNG-d.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-21-15-40-00.gh-issue-136914.-GNG-d.rst
@@ -1,0 +1,1 @@
+Fix retrieval of :attr:`doctest.DocTest.lineno` for :func:`functools.cache`-decorated functions.

--- a/Misc/NEWS.d/next/Library/2025-07-21-15-40-00.gh-issue-136914.-GNG-d.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-21-15-40-00.gh-issue-136914.-GNG-d.rst
@@ -1,1 +1,2 @@
-Fix retrieval of :attr:`doctest.DocTest.lineno` for :func:`functools.cache`-decorated functions.
+Fix retrieval of :attr:`doctest.DocTest.lineno` for objects decorated with
+:func:`functools.cache` or :class:`functools.cached_property`.


### PR DESCRIPTION
Previously, DocTest's lineno of `functools.cache()`-decorated functions was not properly returned (None was returned) because the underlying computation, in `DocTest._find_lineno()`, relied on `inspect.isfunction()` which does not consider the decorated result as a function.

We now use the more generic `inspect.isroutine()`, as elsewhere in doctest's logic, thus fixing lineno computation for functools.cache()-decorated functions.


<!-- gh-issue-number: gh-136914 -->
* Issue: gh-136914
<!-- /gh-issue-number -->
