### PR TITLE
gh-136437: Document `os.path.dirname` as accepting only pos-only

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -118,7 +118,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: dirname(path)
+.. function:: dirname(path, /)
 
    Return the directory name of pathname *path*.  This is the first element of
    the pair returned by passing *path* to the function :func:`split`.


### PR DESCRIPTION
I've missed it during https://github.com/python/cpython/pull/136812 and found while working on the next PR.

<!-- gh-issue-number: gh-136437 -->
* Issue: gh-136437
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136946.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->