### PR TITLE
gh-136170: Revert adding `ZipFile.data_offset`

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -558,14 +558,6 @@ The following data attributes are also available:
    it should be no longer than 65535 bytes.  Comments longer than this will be
    truncated.
 
-.. attribute:: ZipFile.data_offset
-
-   The offset to the start of ZIP data from the beginning of the file. When the
-   :class:`ZipFile` is opened in either mode ``'w'`` or ``'x'`` and the
-   underlying file does not support ``tell()``, the value will be ``None``
-   instead.
-
-   .. versionadded:: 3.14
 
 .. _path-objects:
 

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -3470,54 +3470,6 @@ class TestExecutablePrependedZip(unittest.TestCase):
         self.assertIn(b'number in executable: 5', output)
 
 
-class TestDataOffsetPrependedZip(unittest.TestCase):
-    """Test .data_offset on reading zip files with an executable prepended."""
-
-    def setUp(self):
-        self.exe_zip = findfile('exe_with_zip', subdir='archivetestdata')
-        self.exe_zip64 = findfile('exe_with_z64', subdir='archivetestdata')
-
-    def _test_data_offset(self, name):
-        with zipfile.ZipFile(name) as zipfp:
-            self.assertEqual(zipfp.data_offset, 713)
-
-    def test_data_offset_with_exe_prepended(self):
-        self._test_data_offset(self.exe_zip)
-
-    def test_data_offset_with_exe_prepended_zip64(self):
-        self._test_data_offset(self.exe_zip64)
-
-class TestDataOffsetZipWrite(unittest.TestCase):
-    """Test .data_offset for ZipFile opened in write mode."""
-
-    def setUp(self):
-        os.mkdir(TESTFNDIR)
-        self.addCleanup(rmtree, TESTFNDIR)
-        self.test_path = os.path.join(TESTFNDIR, 'testoffset.zip')
-
-    def test_data_offset_write_no_prefix(self):
-        with io.BytesIO() as fp:
-            with zipfile.ZipFile(fp, "w") as zipfp:
-                self.assertEqual(zipfp.data_offset, 0)
-
-    def test_data_offset_write_with_prefix(self):
-        with io.BytesIO() as fp:
-            fp.write(b"this is a prefix")
-            with zipfile.ZipFile(fp, "w") as zipfp:
-                self.assertEqual(zipfp.data_offset, 16)
-
-    def test_data_offset_write_no_tell(self):
-        # The initializer in ZipFile checks if tell raises AttributeError or
-        # OSError when creating a file in write mode when deducing the offset
-        # of the beginning of zip data
-        class NoTellBytesIO(io.BytesIO):
-            def tell(self):
-                raise OSError("Unimplemented!")
-        with NoTellBytesIO() as fp:
-            with zipfile.ZipFile(fp, "w") as zipfp:
-                self.assertIs(zipfp.data_offset, None)
-
-
 class EncodedMetadataTests(unittest.TestCase):
     file_names = ['\u4e00', '\u4e8c', '\u4e09']  # Han 'one', 'two', 'three'
     file_content = [

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -3506,12 +3506,6 @@ class TestDataOffsetZipWrite(unittest.TestCase):
             with zipfile.ZipFile(fp, "w") as zipfp:
                 self.assertEqual(zipfp.data_offset, 16)
 
-    def test_data_offset_append_with_bad_zip(self):
-        with io.BytesIO() as fp:
-            fp.write(b"this is a prefix")
-            with zipfile.ZipFile(fp, "a") as zipfp:
-                self.assertEqual(zipfp.data_offset, 16)
-
     def test_data_offset_write_no_tell(self):
         # The initializer in ZipFile checks if tell raises AttributeError or
         # OSError when creating a file in write mode when deducing the offset
@@ -3521,7 +3515,7 @@ class TestDataOffsetZipWrite(unittest.TestCase):
                 raise OSError("Unimplemented!")
         with NoTellBytesIO() as fp:
             with zipfile.ZipFile(fp, "w") as zipfp:
-                self.assertIsNone(zipfp.data_offset)
+                self.assertIs(zipfp.data_offset, None)
 
 
 class EncodedMetadataTests(unittest.TestCase):

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1462,12 +1462,10 @@ class ZipFile:
                 self._didModify = True
                 try:
                     self.start_dir = self.fp.tell()
-                    self._data_offset = self.start_dir
                 except (AttributeError, OSError):
                     self.fp = _Tellable(self.fp)
                     self.start_dir = 0
                     self._seekable = False
-                    self._data_offset = None
                 else:
                     # Some file-like objects can provide tell() but not seek()
                     try:
@@ -1534,10 +1532,6 @@ class ZipFile:
         # self.start_dir:  Position of start of central directory
         self.start_dir = offset_cd + concat
 
-        # store the offset to the beginning of data for the
-        # .data_offset property
-        self._data_offset = concat
-
         if self.start_dir < 0:
             raise BadZipFile("Bad offset for central directory")
         fp.seek(self.start_dir, 0)
@@ -1597,12 +1591,6 @@ class ZipFile:
                                      key=lambda zinfo: zinfo.header_offset)):
             zinfo._end_offset = end_offset
             end_offset = zinfo.header_offset
-
-    @property
-    def data_offset(self):
-        """The offset to the start of zip data in the file or None if
-        unavailable."""
-        return self._data_offset
 
     def namelist(self):
         """Return a list of file names in the archive."""

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1452,7 +1452,6 @@ class ZipFile:
         self._lock = threading.RLock()
         self._seekable = True
         self._writing = False
-        self._data_offset = None
 
         try:
             if mode == 'r':
@@ -1468,6 +1467,7 @@ class ZipFile:
                     self.fp = _Tellable(self.fp)
                     self.start_dir = 0
                     self._seekable = False
+                    self._data_offset = None
                 else:
                     # Some file-like objects can provide tell() but not seek()
                     try:
@@ -1488,7 +1488,6 @@ class ZipFile:
                     # even if no files are added to the archive
                     self._didModify = True
                     self.start_dir = self.fp.tell()
-                    self._data_offset = self.start_dir
             else:
                 raise ValueError("Mode must be 'r', 'w', 'x', or 'a'")
         except:

--- a/Misc/NEWS.d/next/Library/2025-07-21-22-35-50.gh-issue-136170.QUlc78.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-21-22-35-50.gh-issue-136170.QUlc78.rst
@@ -1,3 +1,3 @@
-Removed the unreleased ``zipfile.ZipFile.data_offset`` property added in 3.14a7
+Removed the unreleased ``zipfile.ZipFile.data_offset`` property added in 3.14.0a7
 as it wasn't fully clear which behavior it should have in some situations so
 the result was not always what a user might expect.

--- a/Misc/NEWS.d/next/Library/2025-07-21-22-35-50.gh-issue-136170.QUlc78.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-21-22-35-50.gh-issue-136170.QUlc78.rst
@@ -1,0 +1,3 @@
+Removed the new in 3.14alpha ``zipfile.ZipFile.data_offset`` property as it
+wasn't fully clear which behavior it should have in some situations so the
+result was not always what a user might expect.

--- a/Misc/NEWS.d/next/Library/2025-07-21-22-35-50.gh-issue-136170.QUlc78.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-21-22-35-50.gh-issue-136170.QUlc78.rst
@@ -1,3 +1,3 @@
-Removed the new in 3.14alpha ``zipfile.ZipFile.data_offset`` property as it
-wasn't fully clear which behavior it should have in some situations so the
-result was not always what a user might expect.
+Removed the unreleased ``zipfile.ZipFile.data_offset`` property added in 3.14a7
+as it wasn't fully clear which behavior it should have in some situations so
+the result was not always what a user might expect.


### PR DESCRIPTION
As reported in https://github.com/python/cpython/issues/136170, `ZipFile.data_offset` isn't always correct depending on how one measures offsets. With 3.14rc1 tomorrow, I decided it would be best to push this to 3.15 and take more time to think about the feature and it's implementation.

This PR reverts PRs https://github.com/python/cpython/pull/132165 and https://github.com/python/cpython/pull/132178.

Note that I had to resolve a merge conflict in `ZipFile._RealGetContents` due to https://github.com/python/cpython/pull/134250 landing after the two PRs adding `data_offset`, so this isn't quite a clean revert of the two above PRs.

<!-- gh-issue-number: gh-136170 -->
* Issue: gh-136170
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136950.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->