### PR TITLE
gh-136870: fix race in `PyThreadState_Clear` on `sys_tracing_threads`

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1682,6 +1682,10 @@ PyThreadState_Clear(PyThreadState *tstate)
           "PyThreadState_Clear: warning: thread still has a generator\n");
     }
 
+#ifdef Py_GIL_DISABLED
+    PyMutex_Lock(&_PyRuntime.ceval.sys_trace_profile_mutex);
+#endif
+
     if (tstate->c_profilefunc != NULL) {
         tstate->interp->sys_profiling_threads--;
         tstate->c_profilefunc = NULL;
@@ -1690,6 +1694,11 @@ PyThreadState_Clear(PyThreadState *tstate)
         tstate->interp->sys_tracing_threads--;
         tstate->c_tracefunc = NULL;
     }
+
+#ifdef Py_GIL_DISABLED
+    PyMutex_Unlock(&_PyRuntime.ceval.sys_trace_profile_mutex);
+#endif
+
     Py_CLEAR(tstate->c_profileobj);
     Py_CLEAR(tstate->c_traceobj);
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

In free-threading multiple threads can be cleared concurrently as such the modifications on `sys_tracing_threads` should be done while holding the profile lock otherwise it can race with other threads setting up profiling. 


<!-- gh-issue-number: gh-136870 -->
* Issue: gh-136870
<!-- /gh-issue-number -->
