### PR TITLE
gh-136437: Convert more `os.path` functions to pos-only in the docs

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -94,7 +94,7 @@ the :mod:`glob` module.)
       Any iterable can now be passed, rather than just sequences.
 
 
-.. function:: commonprefix(list)
+.. function:: commonprefix(list, /)
 
    Return the longest path prefix (taken character-by-character) that is a
    prefix of all paths in  *list*.  If *list* is empty, return the empty string
@@ -199,14 +199,14 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: getatime(path)
+.. function:: getatime(path, /)
 
    Return the time of last access of *path*.  The return value is a floating-point number giving
    the number of seconds since the epoch (see the  :mod:`time` module).  Raise
    :exc:`OSError` if the file does not exist or is inaccessible.
 
 
-.. function:: getmtime(path)
+.. function:: getmtime(path, /)
 
    Return the time of last modification of *path*.  The return value is a floating-point number
    giving the number of seconds since the epoch (see the  :mod:`time` module).
@@ -216,7 +216,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: getctime(path)
+.. function:: getctime(path, /)
 
    Return the system's ctime which, on some systems (like Unix) is the time of the
    last metadata change, and, on others (like Windows), is the creation time for *path*.
@@ -228,7 +228,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: getsize(path)
+.. function:: getsize(path, /)
 
    Return the size, in bytes, of *path*.  Raise :exc:`OSError` if the file does
    not exist or is inaccessible.
@@ -351,7 +351,7 @@ the :mod:`glob` module.)
    .. versionadded:: 3.13
 
 
-.. function:: join(path, *paths)
+.. function:: join(path, /, *paths)
 
    Join one or more path segments intelligently.  The return value is the
    concatenation of *path* and all members of *\*paths*, with exactly one
@@ -402,7 +402,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: realpath(path, *, strict=False)
+.. function:: realpath(path, /, *, strict=False)
 
    Return the canonical path of the specified filename, eliminating any symbolic
    links encountered in the path (if they are supported by the operating
@@ -471,7 +471,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: samefile(path1, path2)
+.. function:: samefile(path1, path2, /)
 
    Return ``True`` if both pathname arguments refer to the same file or directory.
    This is determined by the device number and i-node number and raises an
@@ -498,7 +498,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: samestat(stat1, stat2)
+.. function:: samestat(stat1, stat2, /)
 
    Return ``True`` if the stat tuples *stat1* and *stat2* refer to the same file.
    These structures may have been returned by :func:`os.fstat`,


### PR DESCRIPTION
Notes for reviewing:
- `os.path.join` has `(a, *p)` real signature vs `(path, *paths)` documented in `posixpath`
- `realpath` has `(filename, *, strict=False)` real vs `(path, *, strict=False)` documented
- `commonprefix`: `(m)` real vs `(list)` documented
- several functions like `getsize` and `get[a,m,c]time` that have `(filename)` real vs `(path)` documented
- `samestat` has `(s1, s2)` real vs `(stat1, stat2)` documented
- `samefile` has `(f1, f2)` real vs `(path1, path2)` documented

Any others that I've missed?

<!-- gh-issue-number: gh-136437 -->
* Issue: gh-136437
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136970.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->