### PR TITLE
gh-136980: Remove unused C tracing code in bdb

### DIFF
--- a/Doc/library/bdb.rst
+++ b/Doc/library/bdb.rst
@@ -193,7 +193,7 @@ The :mod:`bdb` module also defines two classes:
       * ``"return"``: A function or other code block is about to return.
       * ``"exception"``: An exception has occurred.
 
-      For the Python events, specialized functions (see below) are called.
+      For all the events, specialized functions (see below) are called.
 
       The *arg* parameter depends on the previous event.
 

--- a/Doc/library/bdb.rst
+++ b/Doc/library/bdb.rst
@@ -192,12 +192,8 @@ The :mod:`bdb` module also defines two classes:
         entered.
       * ``"return"``: A function or other code block is about to return.
       * ``"exception"``: An exception has occurred.
-      * ``"c_call"``: A C function is about to be called.
-      * ``"c_return"``: A C function has returned.
-      * ``"c_exception"``: A C function has raised an exception.
 
-      For the Python events, specialized functions (see below) are called.  For
-      the C events, no action is taken.
+      For the Python events, specialized functions (see below) are called.
 
       The *arg* parameter depends on the previous event.
 

--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -268,7 +268,7 @@ class Bdb:
             return: A function or other code block is about to return.
             exception: An exception has occurred.
 
-        For the Python events, specialized functions (see the dispatch_*()
+        For all the events, specialized functions (see the dispatch_*() 
         methods) are called.
 
         The arg parameter depends on the previous event.

--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -267,12 +267,9 @@ class Bdb:
                   is entered.
             return: A function or other code block is about to return.
             exception: An exception has occurred.
-            c_call: A C function is about to be called.
-            c_return: A C function has returned.
-            c_exception: A C function has raised an exception.
 
         For the Python events, specialized functions (see the dispatch_*()
-        methods) are called.  For the C events, no action is taken.
+        methods) are called.
 
         The arg parameter depends on the previous event.
         """
@@ -288,12 +285,6 @@ class Bdb:
                 return self.dispatch_return(frame, arg)
             if event == 'exception':
                 return self.dispatch_exception(frame, arg)
-            if event == 'c_call':
-                return self.trace_dispatch
-            if event == 'c_exception':
-                return self.trace_dispatch
-            if event == 'c_return':
-                return self.trace_dispatch
             if event == 'opcode':
                 return self.dispatch_opcode(frame, arg)
             print('bdb.Bdb.dispatch: unknown debugging event:', repr(event))

--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -268,7 +268,7 @@ class Bdb:
             return: A function or other code block is about to return.
             exception: An exception has occurred.
 
-        For all the events, specialized functions (see the dispatch_*() 
+        For all the events, specialized functions (see the dispatch_*()
         methods) are called.
 
         The arg parameter depends on the previous event.

--- a/Misc/NEWS.d/next/Library/2025-07-23-11-59-48.gh-issue-136980.BIJzkB.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-23-11-59-48.gh-issue-136980.BIJzkB.rst
@@ -1,1 +1,1 @@
-Remove unused C tracing code in bdb for event type `c_call`, `c_return` and `c_exception`
+Remove unused C tracing code in bdb for event type ``c_call``, ``c_return`` and ``c_exception``

--- a/Misc/NEWS.d/next/Library/2025-07-23-11-59-48.gh-issue-136980.BIJzkB.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-23-11-59-48.gh-issue-136980.BIJzkB.rst
@@ -1,0 +1,1 @@
+Remove unused C tracing code in bdb for event type `c_call`, `c_return` and `c_exception`


### PR DESCRIPTION
Since bdb was created, it uses `sys.settrace` for tracing.

The `c_call`, `c_return`, and `c_exception` events have historically (since c69ebe8d50529eae281275c841428eb9b375a442) been dispatched to `c_profilefunc` and never `c_tracefunc`. This commit removes the dead code related to `c_tracefunc` dispatching.

Refers to https://github.com/python/cpython/commit/c69ebe8d50529eae281275c841428eb9b375a442#diff-c22186367cbe20233e843261998dc027ae5f1f8c0d2e778abfa454ae74cc59deR3426-R3461


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136981.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-136980 -->
* Issue: gh-136980
<!-- /gh-issue-number -->
