### PR TITLE
Revert "gh-66234: Add flag to disable the use of mmap in dbm.gnu (GH-135005)"

### DIFF
--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -254,9 +254,6 @@ functionality like crash tolerance.
       * ``'s'``: Synchronized mode.
         Changes to the database will be written immediately to the file.
       * ``'u'``: Do not lock database.
-      * ``'m'``: Do not use :manpage:`mmap(2)`.
-        This may harm performance, but improve crash tolerance.
-        .. versionadded:: next
 
       Not all flags are valid for all versions of GDBM.
       See the :data:`open_flags` member for a list of supported flag characters.

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -217,10 +217,6 @@ dbm
   which allow to recover unused free space previously occupied by deleted entries.
   (Contributed by Andrea Oliveri in :gh:`134004`.)
 
-* Add the ``'m'`` flag for :func:`dbm.gnu.open` which allows to disable
-  the use of :manpage:`mmap(2)`.
-  This may harm performance, but improve crash tolerance.
-  (Contributed by Serhiy Storchaka in :gh:`66234`.)
 
 difflib
 -------

--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -74,12 +74,12 @@ class TestGdbm(unittest.TestCase):
         # Test the flag parameter open() by trying all supported flag modes.
         all = set(gdbm.open_flags)
         # Test standard flags (presumably "crwn").
-        modes = all - set('fsum')
+        modes = all - set('fsu')
         for mode in sorted(modes):  # put "c" mode first
             self.g = gdbm.open(filename, mode)
             self.g.close()
 
-        # Test additional flags (presumably "fsum").
+        # Test additional flags (presumably "fsu").
         flags = all - set('crwn')
         for mode in modes:
             for flag in flags:
@@ -216,29 +216,6 @@ class TestGdbm(unittest.TestCase):
         with temp_dir() as d:
             create_empty_file(os.path.join(d, 'test'))
             self.assertRaises(gdbm.error, gdbm.open, filename, 'r')
-
-    @unittest.skipUnless('m' in gdbm.open_flags, "requires 'm' in open_flags")
-    def test_nommap_no_crash(self):
-        self.g = g = gdbm.open(filename, 'nm')
-        os.truncate(filename, 0)
-
-        g.get(b'a', b'c')
-        g.keys()
-        g.firstkey()
-        g.nextkey(b'a')
-        with self.assertRaises(KeyError):
-            g[b'a']
-        with self.assertRaises(gdbm.error):
-            len(g)
-
-        with self.assertRaises(gdbm.error):
-            g[b'a'] = b'c'
-        with self.assertRaises(gdbm.error):
-            del g[b'a']
-        with self.assertRaises(gdbm.error):
-            g.setdefault(b'a', b'c')
-        with self.assertRaises(gdbm.error):
-            g.reorganize()
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2025-06-01-15-13-07.gh-issue-66234.Jw7OdC.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-01-15-13-07.gh-issue-66234.Jw7OdC.rst
@@ -1,3 +1,0 @@
-Add the ``'m'`` flag for :func:`dbm.gnu.open` which allows to disable the
-use of :manpage:`mmap(2)`. This may harm performance, but improve crash
-tolerance.

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -814,11 +814,6 @@ dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
                 iflags |= GDBM_NOLOCK;
                 break;
 #endif
-#ifdef GDBM_NOMMAP
-            case 'm':
-                iflags |= GDBM_NOMMAP;
-                break;
-#endif
             default:
                 PyErr_Format(state->gdbm_error,
                              "Flag '%c' is not supported.", (unsigned char)*flags);
@@ -851,9 +846,6 @@ static const char gdbmmodule_open_flags[] = "rwcn"
 #endif
 #ifdef GDBM_NOLOCK
                                      "u"
-#endif
-#ifdef GDBM_NOMMAP
-                                     "m"
 #endif
                                      ;
 


### PR DESCRIPTION
This reverts commit 0cec424af5904b3d23ad6e3c6d1a27f89d238d64.


<!-- gh-issue-number: gh-66234 -->
* Issue: gh-66234
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--136989.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->