### PR TITLE
gh-124621: Emscripten: Fix __syscall_ioctl patch

### DIFF
--- a/Python/emscripten_syscalls.c
+++ b/Python/emscripten_syscalls.c
@@ -1,6 +1,10 @@
 #include "emscripten.h"
 #include "stdio.h"
 
+// All system calls: return nonnegative number on success, return -errno on
+// failure. Negative results get stored back into errno here:
+// https://github.com/emscripten-core/emscripten/blob/main/system/lib/libc/musl/src/internal/syscall_ret.c#L7
+
 // If we're running in node, report the UID of the user in the native system as
 // the UID of the user. Since the nodefs will report the uid correctly, if we
 // don't make getuid report it correctly too we'll see some permission errors.

--- a/Python/emscripten_syscalls.c
+++ b/Python/emscripten_syscalls.c
@@ -302,7 +302,7 @@ int __syscall_ioctl(int fd, int request, void* varargs) {
         int flags = fcntl(fd, F_GETFL, 0);
         int nonblock = **((int**)varargs);
         if (flags < 0) {
-            return errno;
+            return -errno;
         }
         if (nonblock) {
             flags |= O_NONBLOCK;
@@ -311,7 +311,7 @@ int __syscall_ioctl(int fd, int request, void* varargs) {
         }
         int res = fcntl(fd, F_SETFL, flags);
         if (res < 0) {
-            return errno;
+            return -errno;
         }
         return res;
     }


### PR DESCRIPTION
If there is an error, we have to return `-errno` not positive errno. Included in backport of GH-136931: #136988


<!-- gh-issue-number: gh-124621 -->
* Issue: gh-124621
<!-- /gh-issue-number -->
