### PR TITLE
Strengthen warning against using 'import *' in tutorial

### DIFF
--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -112,8 +112,8 @@ an unknown set of names into the interpreter, possibly hiding some things
 you have already defined.
 
 Note that in general the practice of importing ``*`` from a module or package is
-frowned upon, since it often causes poorly readable code. However, it is okay to
-use it to save typing in interactive sessions.
+frowned upon, since it often causes poorly readable code. However, it's acceptable
+only in interactive sessions for exploration; avoid in production code.
 
 If the module name is followed by :keyword:`!as`, then the name
 following :keyword:`!as` is bound directly to the imported module.


### PR DESCRIPTION
trivial fix: 
In Doc/tutorial/modules.rst, the current wording about import * usage is not sufficiently strong:

    - "However, it is okay to use it to save typing in interactive sessions."

This phrasing has two main issues:

    - Understates risks: Framing it as "okay" minimizes the potential problems with wildcard imports

    - Incomplete guidance: Fails to explicitly warn against using this pattern in production code

    - Ambiguous justification: "Save typing" implies convenience is the primary consideration, ignoring namespace pollution risks

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137011.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->