### PR TITLE
[3.14] Revert "[3.14] gh-135228: When @dataclass(slots=True) replaces…

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1338,13 +1338,6 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
                 or _update_func_cell_for__class__(member.fdel, cls, newcls)):
                 break
 
-    # gh-135228: Make sure the original class can be garbage collected.
-    # Bypass mapping proxy to allow __dict__ to be removed
-    old_cls_dict = cls.__dict__ | _deproxier
-    old_cls_dict.pop('__dict__', None)
-    if "__weakref__" in cls.__dict__:
-        del cls.__weakref__
-
     return newcls
 
 
@@ -1739,11 +1732,3 @@ def _replace(self, /, **changes):
     # changes that aren't fields, this will correctly raise a
     # TypeError.
     return self.__class__(**changes)
-
-
-# Hack to the get the underlying dict out of a mappingproxy
-# Use it with: cls.__dict__ | _deproxier
-class _Deproxier:
-    def __ror__(self, other):
-        return other
-_deproxier = _Deproxier()

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -3804,41 +3804,6 @@ class TestSlots(unittest.TestCase):
         # that we create internally.
         self.assertEqual(CorrectSuper.args, ["default", "default"])
 
-    def test_original_class_is_gced(self):
-        # gh-135228: Make sure when we replace the class with slots=True, the original class
-        # gets garbage collected.
-        def make_simple():
-            @dataclass(slots=True)
-            class SlotsTest:
-                pass
-
-            return SlotsTest
-
-        def make_with_annotations():
-            @dataclass(slots=True)
-            class SlotsTest:
-                x: int
-
-            return SlotsTest
-
-        def make_with_annotations_and_method():
-            @dataclass(slots=True)
-            class SlotsTest:
-                x: int
-
-                def method(self) -> int:
-                    return self.x
-
-            return SlotsTest
-
-        for make in (make_simple, make_with_annotations, make_with_annotations_and_method):
-            with self.subTest(make=make):
-                C = make()
-                support.gc_collect()
-                candidates = [cls for cls in object.__subclasses__() if cls.__name__ == 'SlotsTest'
-                              and cls.__firstlineno__ == make.__code__.co_firstlineno + 1]
-                self.assertEqual(candidates, [C])
-
 
 class TestDescriptors(unittest.TestCase):
     def test_set_name(self):

--- a/Misc/NEWS.d/next/Library/2025-07-20-16-56-55.gh-issue-135228.n_XIao.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-20-16-56-55.gh-issue-135228.n_XIao.rst
@@ -1,4 +1,0 @@
-When :mod:`dataclasses` replaces a class with a slotted dataclass, the
-original class is now garbage collected again. Earlier changes in Python
-3.14 caused this class to remain in existence together with the replacement
-class synthesized by :mod:`dataclasses`.


### PR DESCRIPTION
… a dataclass, make the original class collectible (GH-136893) (#136960)"

This reverts commit 6e1b31b87e7a42c7911b517b78fc418217e6480c.

Modifying the `__dict__` is likely to cause crashes

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135228 -->
* Issue: gh-135228
<!-- /gh-issue-number -->
