### PR TITLE
gh-106318: Add example for str.format()

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -279,4 +279,3 @@ Examples::
 
    `NumPy <https://numpy.org/>`_
       The NumPy package defines another array type.
-

--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -279,3 +279,4 @@ Examples::
 
    `NumPy <https://numpy.org/>`_
       The NumPy package defines another array type.
+

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1933,6 +1933,8 @@ expression support in the :mod:`re` module).
 
       >>> "The sum of 1 + 2 is {0}".format(1+2)
       'The sum of 1 + 2 is 3'
+      >>> "The sum of {a} + {b} is {answer}".format(answer=1+2, a=1, b=2)
+      'The sum of 1 + 2 is 3'
       >>> "{1} expects the {0} Inquisition!".format("Spanish", "Nobody")
       'Nobody expects the Spanish Inquisition!'
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1927,10 +1927,14 @@ expression support in the :mod:`re` module).
    ``{}``.  Each replacement field contains either the numeric index of a
    positional argument, or the name of a keyword argument.  Returns a copy of
    the string where each replacement field is replaced with the string value of
-   the corresponding argument.
+   the corresponding argument. For example:
+
+   .. doctest::
 
       >>> "The sum of 1 + 2 is {0}".format(1+2)
       'The sum of 1 + 2 is 3'
+      >>> "{1} expects the {0} Inquisition!".format("Spanish", "Nobody")
+      'Nobody expects the Spanish Inquisition!'
 
    See :ref:`formatstrings` for a description of the various formatting options
    that can be specified in format strings.


### PR DESCRIPTION
WIP to https://github.com/python/cpython/issues/106318 

Besides adding two more examples to make the argument positions more explicit, I added the `.. doctest::` directive.

<!-- gh-issue-number: gh-106318 -->
* Issue: gh-106318
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137018.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->