### PR TITLE
Fix docs for Queue.shutdown

### DIFF
--- a/Doc/library/asyncio-queue.rst
+++ b/Doc/library/asyncio-queue.rst
@@ -110,7 +110,7 @@ Queue
       and will raise :exc:`QueueShutDown` in the formerly blocked thread.
 
       If *immediate* is false (the default), the queue can be wound
-      down normally with calls :meth:`~Queue.get` to extract tasks
+      down normally with :meth:`~Queue.get` calls to extract tasks
       that have already been loaded.
 
       And if :meth:`~Queue.task_done` is called for each remaining task, a

--- a/Doc/library/asyncio-queue.rst
+++ b/Doc/library/asyncio-queue.rst
@@ -105,9 +105,9 @@ Queue
       Put a :class:`Queue` instance into a shutdown mode.
 
       The queue can no longer grow.
-      Future calls to :meth:`~Queue.put` raise :exc:`ShutDown`.
+      Future calls to :meth:`~Queue.put` raise :exc:`QueueShutDown`.
       Currently blocked callers of :meth:`~Queue.put` will be unblocked
-      and will raise :exc:`ShutDown` in the formerly blocked thread.
+      and will raise :exc:`QueueShutDown` in the formerly blocked thread.
 
       If *immediate* is false (the default), the queue can be wound
       down normally with calls :meth:`~Queue.get` to extract tasks
@@ -117,13 +117,13 @@ Queue
       pending :meth:`~Queue.join` will be unblocked normally.
 
       Once the queue is empty, future calls to :meth:`~Queue.get` will
-      raise :exc:`ShutDown`.
+      raise :exc:`QueueShutDown`.
 
       If *immediate* is true, the queue is terminated immediately.
       The queue is drained to be completely empty.  All callers of
       :meth:`~Queue.join` are unblocked regardless of the number
       of unfinished tasks.  Blocked callers of :meth:`~Queue.get`
-      are unblocked and will raise :exc:`ShutDown` because the
+      are unblocked and will raise :exc:`QueueShutDown` because the
       queue is empty.
 
       Use caution when using :meth:`~Queue.join` with *immediate* set

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -246,10 +246,6 @@ until empty or terminated immediately (a hard shutdown).
    down normally with calls :meth:`~Queue.get` to extract tasks
    that have already been loaded.
 
-   If the shutdown occurs during the brief window where the queue still
-   has data and callers to :meth:`~Queue.get` are blocked, those callers
-   will be unblocked.
-
    And if :meth:`~Queue.task_done` is called for each remaining task, a
    pending :meth:`~Queue.join` will be unblocked normally.
 

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -258,7 +258,7 @@ or terminated immediately.
 
    If *immediate* is true, the queue is terminated immediately.
    The queue is drained to be completely empty.  The count of
-   unfinished tasks is reduced to zero but without calling
+   unfinished tasks is reduced by number drained but without calling
    :meth:`~Queue.task_done`.  That then unblocks all callers of
    :meth:`~Queue.join`.  In addition, blocked callers of
    :meth:`~Queue.get` are unblocked and will raise :exc:`ShutDown`.

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -259,8 +259,9 @@ or terminated immediately.
    If *immediate* is true, the queue is terminated immediately.
    The queue is drained to be completely empty.  The count of
    unfinished tasks is reduced by number drained but without calling
-   :meth:`~Queue.task_done`.  That then unblocks all callers of
-   :meth:`~Queue.join`.  In addition, blocked callers of
+   :meth:`~Queue.task_done`.  All callers of :meth:`~Queue.join`
+   are unblocked even if the unfinished tasks is more than zero.
+   In addition, blocked callers of
    :meth:`~Queue.get` are unblocked and will raise :exc:`ShutDown`.
 
    Use caution when using :meth:`~Queue.join` with *immediate* set

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -201,6 +201,9 @@ fully processed by daemon consumer threads.
    count of unfinished tasks drops to zero, :meth:`join` unblocks.
 
 
+Waiting for task completion
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Example of how to wait for enqueued tasks to be completed::
 
     import threading

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -231,7 +231,7 @@ Terminating queues
 ^^^^^^^^^^^^^^^^^^
 
 When no longer needed, :class:`Queue` objects can be wound down
-or terminated immediately.
+until empty or terminated immediately (a hard shutdown).
 
 .. method:: Queue.shutdown(immediate=False)
 
@@ -258,7 +258,7 @@ or terminated immediately.
 
    If *immediate* is true, the queue is terminated immediately.
    The queue is drained to be completely empty.  The count of
-   unfinished tasks is reduced by number drained but without calling
+   unfinished tasks is reduced by the number drained but without calling
    :meth:`~Queue.task_done`.  All callers of :meth:`~Queue.join`
    are unblocked even if the unfinished tasks is more than zero.
    In addition, blocked callers of

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -257,12 +257,11 @@ until empty or terminated immediately (a hard shutdown).
    raise :exc:`ShutDown`.
 
    If *immediate* is true, the queue is terminated immediately.
-   The queue is drained to be completely empty.  The count of
-   unfinished tasks is reduced by the number drained but without calling
-   :meth:`~Queue.task_done`.  All callers of :meth:`~Queue.join`
-   are unblocked even if the unfinished tasks is more than zero.
-   In addition, blocked callers of
-   :meth:`~Queue.get` are unblocked and will raise :exc:`ShutDown`.
+   The queue is drained to be completely empty.  All callers of
+   :meth:`~Queue.join` are unblocked regardless of the number
+   of unfinished tasks.  Blocked callers of :meth:`~Queue.get`
+   are unblocked and will raise :exc:`ShutDown` because the
+   queue is empty.
 
    Use caution when using :meth:`~Queue.join` with *immediate* set
    to true. This unblocks the join even when no work has been done

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -243,7 +243,7 @@ until empty or terminated immediately (a hard shutdown).
    and will raise :exc:`ShutDown` in the formerly blocked thread.
 
    If *immediate* is false (the default), the queue can be wound
-   down normally with calls :meth:`~Queue.get` to extract tasks
+   down normally with :meth:`~Queue.get` calls to extract tasks
    that have already been loaded.
 
    And if :meth:`~Queue.task_done` is called for each remaining task, a

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -234,7 +234,7 @@ Terminating queues
 ^^^^^^^^^^^^^^^^^^
 
 When no longer needed, :class:`Queue` objects can be wound down
-until empty or terminated immediately (a hard shutdown).
+until empty or terminated immediately with a hard shutdown.
 
 .. method:: Queue.shutdown(immediate=False)
 

--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -227,9 +227,6 @@ class Queue(mixins._LoopBoundMixin):
         been processed (meaning that a task_done() call was received for every
         item that had been put() into the queue).
 
-        shutdown(immediate=True) calls task_done() for each remaining item in
-        the queue.
-
         Raises ValueError if called more times than there were items placed in
         the queue.
         """

--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -257,8 +257,8 @@ class Queue(mixins._LoopBoundMixin):
         'immediate' to True to make gets raise immediately instead.
 
         All blocked callers of put() and get() will be unblocked. If
-        'immediate', a task is marked as done for each item remaining in
-        the queue, which may unblock callers of join().
+        'immediate', unblock callers of join() regardless of the
+        number of unfinished tasks.
         """
         self._is_shutdown = True
         if immediate:

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -80,9 +80,6 @@ class Queue:
         have been processed (meaning that a task_done() call was received
         for every item that had been put() into the queue).
 
-        shutdown(immediate=True) calls task_done() for each remaining item in
-        the queue.
-
         Raises a ValueError if called more times than there were items
         placed in the queue.
         '''

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -240,8 +240,8 @@ class Queue:
         'immediate' to True to make gets raise immediately instead.
 
         All blocked callers of put() and get() will be unblocked. If
-        'immediate', a task is marked as done for each item remaining in
-        the queue, which may unblock callers of join().
+        'immediate', callers of join() are unblocked regardless of
+        the number of unfinished tasks.
         '''
         with self.mutex:
             self.is_shutdown = True


### PR DESCRIPTION
Fix errors. Clarify ambiguities. Improve presentation. Add cautionary note.

* Removed incorrect note in the `task_done` docs.  That method is *not* called by `shutdown`.
* Separate the discussions of the normal case (the default) and the immediate case.
* For the normal case, note that blocked callers of `put` will be unblocked but will also immediately raise 'ShutDown' in the formerly blocked thread.
* For the normal case, note that `get` and `task_done` continue to operate normally except that a `get` on an empty queue will now raise `ShutDown` instead of `Empty`.
* For the immediate case, present the actions in the order that they actually occur (drain the queue, reduce the unfinished tasks by the number drained, notify `Queue.join` waiters, notify `get` and `put` waiters.
* For the immediate case, note that unfinished tasks is updated without calling `task_done`.
* For the immediate case, note the `Queue.join` is unblocked even if the unfinished tasks are more than zero.
* Add cautionary note about using `Queue.join` with `immediate=True`.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137028.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->