### PR TITLE
gh-136459: Use platform-specific type in perf_jit_trampoline

### DIFF
--- a/Python/perf_jit_trampoline.c
+++ b/Python/perf_jit_trampoline.c
@@ -214,7 +214,11 @@ struct BaseEvent {
 typedef struct {
     struct BaseEvent base;   // Common event header
     uint32_t process_id;     // Process ID where code was generated
+#if defined(__APPLE__)
     uint64_t thread_id;      // Thread ID where code was generated
+#else
+    uint32_t thread_id;      // Thread ID where code was generated
+#endif
     uint64_t vma;            // Virtual memory address where code is loaded
     uint64_t code_address;   // Address of the actual machine code
     uint64_t code_size;      // Size of the machine code in bytes


### PR DESCRIPTION
gh-136461 added perf support for macOS, with ifdefs around all changes except increasing thread_id to 64 bits.
Make that change Apple-specific too.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136459 -->
* Issue: gh-136459
<!-- /gh-issue-number -->
