### PR TITLE
Doc: Fix minor typo in `Doc/library/string.templatlib.rst`

### DIFF
--- a/Doc/library/string.templatelib.rst
+++ b/Doc/library/string.templatelib.rst
@@ -56,7 +56,7 @@ reassigned.
    >>> type(template)
    <class 'string.templatelib.Template'>
 
-   Templates ars stored as sequences of literal :attr:`~Template.strings`
+   Templates are stored as sequences of literal :attr:`~Template.strings`
    and dynamic :attr:`~Template.interpolations`.
    A :attr:`~Template.values` attribute holds the interpolation values:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Just a fix of an extremely minor typo that I noticed while reading through the new t-strings docs (`ars` -> `are`).

No issue opened first due to this being a quite trivial change.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137032.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->