### PR TITLE
gh-123441: Correct the supported languages of the `iso-8859-4` codec

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1251,11 +1251,7 @@ particular, the following variants typically exist:
 +-----------------+--------------------------------+--------------------------------+
 | iso8859_3       | iso-8859-3, latin3, L3         | Esperanto, Maltese             |
 +-----------------+--------------------------------+--------------------------------+
-| iso8859_4       | iso-8859-4, latin4, L4         | Danish, English, Estonian,     |
-|                 |                                | Finnish, German, Greenlandic,  |
-|                 |                                | Latin, Latvian, Lithuanian,    |
-|                 |                                | Norwegian, Sámi, Slovene,      |
-|                 |                                | Swedish                        |
+| iso8859_4       | iso-8859-4, latin4, L4         | Northern Europe                |
 +-----------------+--------------------------------+--------------------------------+
 | iso8859_5       | iso-8859-5, cyrillic           | Belarusian, Bulgarian,         |
 |                 |                                | Macedonian, Russian, Serbian   |

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1251,7 +1251,11 @@ particular, the following variants typically exist:
 +-----------------+--------------------------------+--------------------------------+
 | iso8859_3       | iso-8859-3, latin3, L3         | Esperanto, Maltese             |
 +-----------------+--------------------------------+--------------------------------+
-| iso8859_4       | iso-8859-4, latin4, L4         | Baltic languages               |
+| iso8859_4       | iso-8859-4, latin4, L4         | Danish, English, Estonian,     |
+|                 |                                | Finnish, German, Greenlandic,  |
+|                 |                                | Latin, Latvian, Lithuanian,    |
+|                 |                                | Norwegian, Sámi, Slovene,      |
+|                 |                                | Swedish                        |
 +-----------------+--------------------------------+--------------------------------+
 | iso8859_5       | iso-8859-5, cyrillic           | Belarusian, Bulgarian,         |
 |                 |                                | Macedonian, Russian, Serbian   |


### PR DESCRIPTION
As I said in the issue:

ISO-8859-4 states:

> The set contains graphic characters used for general purpose applications in typical office environments in at least the following languages:
> Danish, English, Estonian, Finnish, German, Greenlandic, Latin, Latvian, Lithuanian, Norwegian, Sámi (but see Annex A.1, Notes), Slovene and Swedish.

I was unable to find a term that would encompass all of the above languages, since per the [UN Standard](https://unstats.un.org/unsd/methodology/m49) the definition of *Northern Europe* does not include several of the previously mentioned countries. Therefore, I propose to simply list all of the supported languages.

<!-- gh-issue-number: gh-123441 -->
* Issue: gh-123441
<!-- /gh-issue-number -->
