### PR TITLE
gh-136992: Add 'None' as valid SameSite value as per RFC6265bis

### DIFF
--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -154,8 +154,6 @@ Morsel Objects
    requests and top-level navigations), and "None" (sent with same-site and
    cross-site requests). When using "None", the "secure" attribute must also
    be set, as required by modern browsers.
-
-
    The attribute :attr:`partitioned` indicates to user agents that these
    cross-site cookies *should* only be available in the same top-level context
    that the cookie was first set in. For this to be accepted by the user agent,

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -150,9 +150,10 @@ Morsel Objects
 
    The attribute :attr:`samesite` controls when the browser sends the cookie with
    cross-site requests. This helps to mitigate CSRF attacks. Valid values are
-   "Strict" (never sent with cross-site requests), "Lax" (sent with top-level
-   navigation), and "None" (always sent). When using "None", the "secure"
-   attribute must also be set, as required by modern browsers.
+   "Strict" (only sent with same-site requests), "Lax" (sent with same-site
+   requests and top-level navigations), and "None" (sent with same-site and
+   cross-site requests). When using "None", the "secure" attribute must also
+   be set, as required by modern browsers.
 
 
    The attribute :attr:`partitioned` indicates to user agents that these

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -152,8 +152,8 @@ Morsel Objects
    cross-site requests. This helps to mitigate CSRF attacks. Valid values are
    "Strict" (never sent with cross-site requests), "Lax" (sent with top-level
    navigation), and "None" (always sent). When using "None", the "secure"
-   attribute must also be set, as required by modern browsers per
-   `RFC6265bis <https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis>`_.
+   attribute must also be set, as required by modern browsers.
+
 
    The attribute :attr:`partitioned` indicates to user agents that these
    cross-site cookies *should* only be available in the same top-level context

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -154,7 +154,7 @@ Morsel Objects
    requests and top-level navigations), and "None" (sent with same-site and
    cross-site requests). When using "None", the "secure" attribute must also
    be set, as required by modern browsers.
-   
+
    The attribute :attr:`partitioned` indicates to user agents that these
    cross-site cookies *should* only be available in the same top-level context
    that the cookie was first set in. For this to be accepted by the user agent,

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -159,7 +159,7 @@ Morsel Objects
    cross-site cookies *should* only be available in the same top-level context
    that the cookie was first set in. For this to be accepted by the user agent,
    you **must** also set ``Secure``.
-   
+
    In addition, it is recommended to use the ``__Host`` prefix when setting
    partitioned cookies to make them bound to the hostname and not the
    registrable domain. Read

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -148,9 +148,12 @@ Morsel Objects
    in HTTP requests, and is not accessible through JavaScript. This is intended
    to mitigate some forms of cross-site scripting.
 
-   The attribute :attr:`samesite` specifies that the browser is not allowed to
-   send the cookie along with cross-site requests. This helps to mitigate CSRF
-   attacks. Valid values for this attribute are "Strict" and "Lax".
+   The attribute :attr:`samesite` controls when the browser sends the cookie with
+   cross-site requests. This helps to mitigate CSRF attacks. Valid values are
+   "Strict" (never sent with cross-site requests), "Lax" (sent with top-level
+   navigation), and "None" (always sent). When using "None", the "secure"
+   attribute must also be set, as required by modern browsers per
+   `RFC6265bis <https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis>`_.
 
    The attribute :attr:`partitioned` indicates to user agents that these
    cross-site cookies *should* only be available in the same top-level context

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -154,11 +154,12 @@ Morsel Objects
    requests and top-level navigations), and "None" (sent with same-site and
    cross-site requests). When using "None", the "secure" attribute must also
    be set, as required by modern browsers.
+   
    The attribute :attr:`partitioned` indicates to user agents that these
    cross-site cookies *should* only be available in the same top-level context
    that the cookie was first set in. For this to be accepted by the user agent,
    you **must** also set ``Secure``.
-
+   
    In addition, it is recommended to use the ``__Host`` prefix when setting
    partitioned cookies to make them bound to the hostname and not the
    registrable domain. Read


### PR DESCRIPTION
This PR adds missing documentation for the samesite attribute in the http.cookies module.

While the attribute was already listed among valid Morsel attributes, it lacked an explanation. This change adds clear and complete documentation explaining:

-The attribute’s role in CSRF protection.

-The valid values: "Strict", "Lax", and "None".

-The requirement that "secure" must be set when using "SameSite=None".

This update brings the documentation in line with [RFC6265bis](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis) and reflects current browser behaviour.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137040.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-136992 -->
* Issue: gh-136992
<!-- /gh-issue-number -->
