### PR TITLE
gh-135228: When @dataclass(slots=True) replaces a dataclass, make the original class collectible (take 2)

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1338,6 +1338,13 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
                 or _update_func_cell_for__class__(member.fdel, cls, newcls)):
                 break
 
+    # gh-135228: Make sure the original class can be garbage collected.
+    # Bypass mapping proxy to allow __dict__ to be removed
+    old_cls_dict = cls.__dict__ | _deproxier
+    old_cls_dict.pop('__dict__', None)
+    if "__weakref__" in cls.__dict__:
+        del cls.__weakref__
+
     return newcls
 
 
@@ -1732,3 +1739,11 @@ def _replace(self, /, **changes):
     # changes that aren't fields, this will correctly raise a
     # TypeError.
     return self.__class__(**changes)
+
+
+# Hack to the get the underlying dict out of a mappingproxy
+# Use it with: cls.__dict__ | _deproxier
+class _Deproxier:
+    def __ror__(self, other):
+        return other
+_deproxier = _Deproxier()

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1340,10 +1340,7 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
 
     # gh-135228: Make sure the original class can be garbage collected.
     # Bypass mapping proxy to allow __dict__ to be removed
-    old_cls_dict = cls.__dict__ | _deproxier
-    old_cls_dict.pop('__dict__', None)
-    if "__weakref__" in cls.__dict__:
-        del cls.__weakref__
+    sys._clear_type_descriptors(cls)
 
     return newcls
 
@@ -1739,11 +1736,3 @@ def _replace(self, /, **changes):
     # changes that aren't fields, this will correctly raise a
     # TypeError.
     return self.__class__(**changes)
-
-
-# Hack to the get the underlying dict out of a mappingproxy
-# Use it with: cls.__dict__ | _deproxier
-class _Deproxier:
-    def __ror__(self, other):
-        return other
-_deproxier = _Deproxier()

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1339,7 +1339,6 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
                 break
 
     # gh-135228: Make sure the original class can be garbage collected.
-    # Bypass mapping proxy to allow __dict__ to be removed
     sys._clear_type_descriptors(cls)
 
     return newcls

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1283,6 +1283,10 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
     if '__slots__' in cls.__dict__:
         raise TypeError(f'{cls.__name__} already specifies __slots__')
 
+    # gh-102069: Remove existing __weakref__ descriptor.
+    # gh-135228: Make sure the original class can be garbage collected.
+    sys._clear_type_descriptors(cls)
+
     # Create a new dict for our new class.
     cls_dict = dict(cls.__dict__)
     field_names = tuple(f.name for f in fields(cls))
@@ -1299,12 +1303,6 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
         # Remove our attributes, if present. They'll still be
         #  available in _MARKER.
         cls_dict.pop(field_name, None)
-
-    # Remove __dict__ itself.
-    cls_dict.pop('__dict__', None)
-
-    # Clear existing `__weakref__` descriptor, it belongs to a previous type:
-    cls_dict.pop('__weakref__', None)  # gh-102069
 
     # And finally create the class.
     qualname = getattr(cls, '__qualname__', None)
@@ -1337,9 +1335,6 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
                 or _update_func_cell_for__class__(member.fset, cls, newcls)
                 or _update_func_cell_for__class__(member.fdel, cls, newcls)):
                 break
-
-    # gh-135228: Make sure the original class can be garbage collected.
-    sys._clear_type_descriptors(cls)
 
     return newcls
 

--- a/Misc/NEWS.d/next/Library/2025-07-20-16-56-55.gh-issue-135228.n_XIao.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-20-16-56-55.gh-issue-135228.n_XIao.rst
@@ -1,0 +1,4 @@
+When :mod:`dataclasses` replaces a class with a slotted dataclass, the
+original class is now garbage collected again. Earlier changes in Python
+3.14 caused this class to remain in existence together with the replacement
+class synthesized by :mod:`dataclasses`.

--- a/Misc/NEWS.d/next/Library/2025-07-20-16-56-55.gh-issue-135228.n_XIao.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-20-16-56-55.gh-issue-135228.n_XIao.rst
@@ -1,4 +1,4 @@
 When :mod:`dataclasses` replaces a class with a slotted dataclass, the
-original class is now garbage collected again. Earlier changes in Python
-3.14 caused this class to remain in existence together with the replacement
+original class can now be garbage collected again. Earlier changes in Python
+3.14 caused this class to always remain in existence together with the replacement
 class synthesized by :mod:`dataclasses`.

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -1793,6 +1793,17 @@ sys__baserepl(PyObject *module, PyObject *Py_UNUSED(ignored))
     return sys__baserepl_impl(module);
 }
 
+PyDoc_STRVAR(sys__clear_type_descriptors__doc__,
+"_clear_type_descriptors($module, type, /)\n"
+"--\n"
+"\n"
+"Private function for clearing certain descriptors from a type\'s dictionary.\n"
+"\n"
+"See gh-135228 for context.");
+
+#define SYS__CLEAR_TYPE_DESCRIPTORS_METHODDEF    \
+    {"_clear_type_descriptors", (PyCFunction)sys__clear_type_descriptors, METH_O, sys__clear_type_descriptors__doc__},
+
 PyDoc_STRVAR(sys__is_gil_enabled__doc__,
 "_is_gil_enabled($module, /)\n"
 "--\n"
@@ -1948,4 +1959,4 @@ exit:
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=449d16326e69dcf6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f75cd2babc1841db input=a9049054013a1b77]*/

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -1804,6 +1804,26 @@ PyDoc_STRVAR(sys__clear_type_descriptors__doc__,
 #define SYS__CLEAR_TYPE_DESCRIPTORS_METHODDEF    \
     {"_clear_type_descriptors", (PyCFunction)sys__clear_type_descriptors, METH_O, sys__clear_type_descriptors__doc__},
 
+static PyObject *
+sys__clear_type_descriptors_impl(PyObject *module, PyObject *type);
+
+static PyObject *
+sys__clear_type_descriptors(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    PyObject *type;
+
+    if (!PyObject_TypeCheck(arg, &PyType_Type)) {
+        _PyArg_BadArgument("_clear_type_descriptors", "argument", (&PyType_Type)->tp_name, arg);
+        goto exit;
+    }
+    type = arg;
+    return_value = sys__clear_type_descriptors_impl(module, type);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(sys__is_gil_enabled__doc__,
 "_is_gil_enabled($module, /)\n"
 "--\n"
@@ -1959,4 +1979,4 @@ exit:
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=f75cd2babc1841db input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9052f399f40ca32d input=a9049054013a1b77]*/

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2661,6 +2661,10 @@ sys__clear_type_descriptors(PyObject *module, PyObject *type)
         return NULL;
     }
     PyTypeObject *typeobj = (PyTypeObject *)(type);
+    if (!_PyType_HasFeature(typeobj, Py_TPFLAGS_HEAPTYPE)) {
+        PyErr_SetString(PyExc_TypeError, "argument must be a heap type");
+        return NULL;
+    }
     PyObject *dict = _PyType_GetDict(typeobj);
     if (PyDict_PopString(dict, "__dict__", NULL) < 0) {
         return NULL;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2661,7 +2661,7 @@ sys__clear_type_descriptors(PyObject *module, PyObject *type)
         return NULL;
     }
     PyTypeObject *typeobj = (PyTypeObject *)(type);
-    if (!_PyType_HasFeature(typeobj, Py_TPFLAGS_IMMUTABLETYPE)) {
+    if (_PyType_HasFeature(typeobj, Py_TPFLAGS_IMMUTABLETYPE)) {
         PyErr_SetString(PyExc_TypeError, "argument is immutable");
         return NULL;
     }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2661,17 +2661,17 @@ sys__clear_type_descriptors(PyObject *module, PyObject *type)
         return NULL;
     }
     PyTypeObject *typeobj = (PyTypeObject *)(type);
-    if (!_PyType_HasFeature(typeobj, Py_TPFLAGS_HEAPTYPE)) {
-        PyErr_SetString(PyExc_TypeError, "argument must be a heap type");
+    if (!_PyType_HasFeature(typeobj, Py_TPFLAGS_IMMUTABLETYPE)) {
+        PyErr_SetString(PyExc_TypeError, "argument is immutable");
         return NULL;
     }
     PyObject *dict = _PyType_GetDict(typeobj);
     PyObject *dunder_dict = NULL;
-    if (PyDict_PopString(dict, "__dict__", &dunder_dict) < 0) {
+    if (PyDict_Pop(dict, &_Py_ID(__dict__), &dunder_dict) < 0) {
         return NULL;
     }
     PyObject *dunder_weakref = NULL;
-    if (PyDict_PopString(dict, "__weakref__", &dunder_weakref) < 0) {
+    if (PyDict_Pop(dict, &_Py_ID(__weakref__), &dunder_weakref) < 0) {
         PyType_Modified(typeobj);
         Py_XDECREF(dunder_dict);
         return NULL;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2642,6 +2642,38 @@ sys__baserepl_impl(PyObject *module)
 }
 
 /*[clinic input]
+sys._clear_type_descriptors
+
+    type: object
+    /
+
+Private function for clearing certain descriptors from a type's dictionary.
+
+See gh-135228 for context.
+[clinic start generated code]*/
+
+static PyObject *
+sys__clear_type_descriptors(PyObject *module, PyObject *type)
+/*[clinic end generated code: output=7d5cefcf861909e0 input=5fdc23500d477de6]*/
+{
+    if (!PyType_Check(type)) {
+        PyErr_SetString(PyExc_TypeError, "argument must be a type");
+        return NULL;
+    }
+    PyTypeObject *typeobj = (PyTypeObject *)(type);
+    PyObject *dict = _PyType_GetDict(typeobj);
+    if (PyDict_PopString(dict, "__dict__", NULL) < 0) {
+        return NULL;
+    }
+    if (PyDict_PopString(dict, "__weakref__", NULL) < 0) {
+        return NULL;
+    }
+    PyType_Modified(typeobj);
+    Py_RETURN_NONE;
+}
+
+
+/*[clinic input]
 sys._is_gil_enabled -> bool
 
 Return True if the GIL is currently enabled and False otherwise.
@@ -2837,6 +2869,7 @@ static PyMethodDef sys_methods[] = {
     SYS__STATS_DUMP_METHODDEF
 #endif
     SYS__GET_CPU_COUNT_CONFIG_METHODDEF
+    SYS__CLEAR_TYPE_DESCRIPTORS_METHODDEF
     SYS__IS_GIL_ENABLED_METHODDEF
     SYS__DUMP_TRACELETS_METHODDEF
     {NULL, NULL}  // sentinel

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2644,7 +2644,7 @@ sys__baserepl_impl(PyObject *module)
 /*[clinic input]
 sys._clear_type_descriptors
 
-    type: object
+    type: object(subclass_of='&PyType_Type')
     /
 
 Private function for clearing certain descriptors from a type's dictionary.
@@ -2653,14 +2653,10 @@ See gh-135228 for context.
 [clinic start generated code]*/
 
 static PyObject *
-sys__clear_type_descriptors(PyObject *module, PyObject *type)
-/*[clinic end generated code: output=7d5cefcf861909e0 input=5fdc23500d477de6]*/
+sys__clear_type_descriptors_impl(PyObject *module, PyObject *type)
+/*[clinic end generated code: output=5ad17851b762b6d9 input=dc536c97fde07251]*/
 {
-    if (!PyType_Check(type)) {
-        PyErr_SetString(PyExc_TypeError, "argument must be a type");
-        return NULL;
-    }
-    PyTypeObject *typeobj = (PyTypeObject *)(type);
+    PyTypeObject *typeobj = (PyTypeObject *)type;
     if (_PyType_HasFeature(typeobj, Py_TPFLAGS_IMMUTABLETYPE)) {
         PyErr_SetString(PyExc_TypeError, "argument is immutable");
         return NULL;


### PR DESCRIPTION
This is a redo of #136893 without relying on a hack to get to the type dictionary. 

<!-- gh-issue-number: gh-135228 -->
* Issue: gh-135228
<!-- /gh-issue-number -->
