### PR TITLE
gh-137054: Remove obsolete counting of objects in young generation

### DIFF
--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1331,15 +1331,6 @@ gc_collect_young(PyThreadState *tstate,
     PyGC_Head *visited = &gcstate->old[gcstate->visited_space].head;
     untrack_tuples(young);
     GC_STAT_ADD(0, collections, 1);
-#ifdef Py_STATS
-    {
-        Py_ssize_t count = 0;
-        PyGC_Head *gc;
-        for (gc = GC_NEXT(young); gc != young; gc = GC_NEXT(gc)) {
-            count++;
-        }
-    }
-#endif
 
     PyGC_Head survivors;
     gc_list_init(&survivors);


### PR DESCRIPTION
I have found a dead code in gc.c for young generation. https://github.com/python/cpython/blob/ec7fad79d24e79961b86e17177a32b32bb340fe5/Python/gc.c#L1334-L1342

It is superseded by counting of `object_visits` via `OBJECT_STAT_INC` and adjusted `gc_stats[gen].object_visits` at the end of the collection.
https://github.com/python/cpython/blob/ec7fad79d24e79961b86e17177a32b32bb340fe5/Python/gc.c#L2073-L2079

I believe it is worth to remove dead code to decrease code base (yeah, by 9 lines).

### Has this already been discussed elsewhere?

This is a minor feature, which does not need previous discussion elsewhere

### Links to previous discussion of this feature:

_No response_

<!-- gh-issue-number: gh-137054 -->
* Issue: gh-137054
<!-- /gh-issue-number -->
