### PR TITLE
GH-137059: `url2pathname()`: fix support for drive letter in netloc

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1590,8 +1590,10 @@ class Pathname_Tests(unittest.TestCase):
     def test_url2pathname_win(self):
         fn = urllib.request.url2pathname
         self.assertEqual(fn('/C:/'), 'C:\\')
+        self.assertEqual(fn('//C:'), 'C:')
         self.assertEqual(fn('//C:/'), 'C:\\')
         self.assertEqual(fn('//C:\\'), 'C:\\')
+        self.assertEqual(fn('//C:80/'), 'C:80\\')
         self.assertEqual(fn("///C|"), 'C:')
         self.assertEqual(fn("///C:"), 'C:')
         self.assertEqual(fn('///C:/'), 'C:\\')

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1590,6 +1590,8 @@ class Pathname_Tests(unittest.TestCase):
     def test_url2pathname_win(self):
         fn = urllib.request.url2pathname
         self.assertEqual(fn('/C:/'), 'C:\\')
+        self.assertEqual(fn('//C:/'), 'C:\\')
+        self.assertEqual(fn('//C:\\'), 'C:\\')
         self.assertEqual(fn("///C|"), 'C:')
         self.assertEqual(fn("///C:"), 'C:')
         self.assertEqual(fn('///C:/'), 'C:\\')

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1660,7 +1660,10 @@ def url2pathname(url, *, require_scheme=False, resolve_host=False):
     if scheme != 'file':
         raise URLError("URL is missing a 'file:' scheme")
     if os.name == 'nt':
-        if not _is_local_authority(authority, resolve_host):
+        if authority[1:2] == ':':
+            # e.g. file://c:/file.txt
+            url = authority + url
+        elif not _is_local_authority(authority, resolve_host):
             # e.g. file://server/share/file.txt
             url = '//' + authority + url
         elif url[:3] == '///':

--- a/Misc/NEWS.d/next/Library/2025-07-24-00-38-07.gh-issue-137059.fr64oW.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-24-00-38-07.gh-issue-137059.fr64oW.rst
@@ -1,0 +1,3 @@
+Fix handling of file URLs with a Windows drive letter in the URL authority
+by :func:`urllib.request.url2pathname`. This fixes a regression in earlier
+pre-releases of Python 3.14.


### PR DESCRIPTION
Support file URLs like `file://c:/foo` in `urllib.request.url2pathname()` on Windows. This restores behaviour from 3.13.


<!-- gh-issue-number: gh-137059 -->
* Issue: gh-137059
<!-- /gh-issue-number -->
