### PR TITLE
gh-137063: Remove notice about ast node types no longer available

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -139,13 +139,6 @@ Node classes
     The :meth:`~object.__repr__` output of :class:`~ast.AST` nodes includes
     the values of the node fields.
 
-.. deprecated:: 3.8
-
-   Old classes :class:`!ast.Num`, :class:`!ast.Str`, :class:`!ast.Bytes`,
-   :class:`!ast.NameConstant` and :class:`!ast.Ellipsis` are still available,
-   but they will be removed in future Python releases.  In the meantime,
-   instantiating them will return an instance of a different class.
-
 .. deprecated:: 3.9
 
    Old classes :class:`!ast.Index` and :class:`!ast.ExtSlice` are still

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -143,8 +143,9 @@ Node classes
 
    Previous versions of Python provided the AST classes :class:`!ast.Num`,
    :class:`!ast.Str`, :class:`!ast.Bytes`, :class:`!ast.NameConstant` and
-   :class:`!ast.Ellipsis`, which were deprecated in Python 3.8 and removed in
-   Python 3.14, and which have been replaced with :class:`ast.Constant`.
+   :class:`!ast.Ellipsis`, which were deprecated in Python 3.8. These classes
+   were removed in Python 3.14, and their functionality has been replaced with
+   :class:`ast.Constant`.
 
 .. deprecated:: 3.9
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -139,6 +139,13 @@ Node classes
     The :meth:`~object.__repr__` output of :class:`~ast.AST` nodes includes
     the values of the node fields.
 
+.. deprecated-removed:: 3.8 3.14
+
+   Previous versions of Python provided the AST classes :class:`!ast.Num`,
+   :class:`!ast.Str`, :class:`!ast.Bytes`, :class:`!ast.NameConstant` and
+   :class:`!ast.Ellipsis`, which were deprecated in Python 3.8 and removed in
+   Python 3.14, and which have been replaced with :class:`ast.Constant`.
+
 .. deprecated:: 3.9
 
    Old classes :class:`!ast.Index` and :class:`!ast.ExtSlice` are still

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2360,12 +2360,12 @@ and classes for traversing abstract syntax trees:
    during traversal.  For this a special visitor exists
    (:class:`NodeTransformer`) that allows modifications.
 
-   .. deprecated:: 3.8
+   .. deprecated-removed:: 3.8 3.14
 
       Methods :meth:`!visit_Num`, :meth:`!visit_Str`, :meth:`!visit_Bytes`,
-      :meth:`!visit_NameConstant` and :meth:`!visit_Ellipsis` are deprecated
-      now and will not be called in future Python versions.  Add the
-      :meth:`visit_Constant` method to handle all constant nodes.
+      :meth:`!visit_NameConstant` and :meth:`!visit_Ellipsis` will not be called
+      in Python 3.14+.  Add the :meth:`visit_Constant` method instead to handle
+      all constant nodes.
 
 
 .. class:: NodeTransformer()


### PR DESCRIPTION
Fixes #137063


<!-- gh-issue-number: gh-137063 -->
* Issue: gh-137063
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137064.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->