### PR TITLE
gh-132551: add missing critical sections on BytesIO methods

### DIFF
--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -270,6 +270,7 @@ bytesio_get_closed(PyObject *op, void *Py_UNUSED(closure))
 }
 
 /*[clinic input]
+@critical_section
 _io.BytesIO.readable
 
 Returns True if the IO object can be read.
@@ -277,13 +278,14 @@ Returns True if the IO object can be read.
 
 static PyObject *
 _io_BytesIO_readable_impl(bytesio *self)
-/*[clinic end generated code: output=4e93822ad5b62263 input=96c5d0cccfb29f5c]*/
+/*[clinic end generated code: output=4e93822ad5b62263 input=ab7816facef48bfd]*/
 {
     CHECK_CLOSED(self);
     Py_RETURN_TRUE;
 }
 
 /*[clinic input]
+@critical_section
 _io.BytesIO.writable
 
 Returns True if the IO object can be written.
@@ -291,13 +293,14 @@ Returns True if the IO object can be written.
 
 static PyObject *
 _io_BytesIO_writable_impl(bytesio *self)
-/*[clinic end generated code: output=64ff6a254b1150b8 input=700eed808277560a]*/
+/*[clinic end generated code: output=64ff6a254b1150b8 input=4f35d49d26dab024]*/
 {
     CHECK_CLOSED(self);
     Py_RETURN_TRUE;
 }
 
 /*[clinic input]
+@critical_section
 _io.BytesIO.seekable
 
 Returns True if the IO object can be seeked.
@@ -305,13 +308,14 @@ Returns True if the IO object can be seeked.
 
 static PyObject *
 _io_BytesIO_seekable_impl(bytesio *self)
-/*[clinic end generated code: output=6b417f46dcc09b56 input=9421f65627a344dd]*/
+/*[clinic end generated code: output=6b417f46dcc09b56 input=9cc78d15aa1deaa3]*/
 {
     CHECK_CLOSED(self);
     Py_RETURN_TRUE;
 }
 
 /*[clinic input]
+@critical_section
 _io.BytesIO.flush
 
 Does nothing.
@@ -319,7 +323,7 @@ Does nothing.
 
 static PyObject *
 _io_BytesIO_flush_impl(bytesio *self)
-/*[clinic end generated code: output=187e3d781ca134a0 input=561ea490be4581a7]*/
+/*[clinic end generated code: output=187e3d781ca134a0 input=c60842743910b381]*/
 {
     CHECK_CLOSED(self);
     Py_RETURN_NONE;
@@ -385,6 +389,7 @@ _io_BytesIO_getvalue_impl(bytesio *self)
 }
 
 /*[clinic input]
+@critical_section
 _io.BytesIO.isatty
 
 Always returns False.
@@ -394,7 +399,7 @@ BytesIO objects are not connected to a TTY-like device.
 
 static PyObject *
 _io_BytesIO_isatty_impl(bytesio *self)
-/*[clinic end generated code: output=df67712e669f6c8f input=6f97f0985d13f827]*/
+/*[clinic end generated code: output=df67712e669f6c8f input=50487b74dc5ae8a9]*/
 {
     CHECK_CLOSED(self);
     Py_RETURN_FALSE;

--- a/Modules/_io/clinic/bytesio.c.h
+++ b/Modules/_io/clinic/bytesio.c.h
@@ -25,7 +25,13 @@ _io_BytesIO_readable_impl(bytesio *self);
 static PyObject *
 _io_BytesIO_readable(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
-    return _io_BytesIO_readable_impl((bytesio *)self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _io_BytesIO_readable_impl((bytesio *)self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_io_BytesIO_writable__doc__,
@@ -43,7 +49,13 @@ _io_BytesIO_writable_impl(bytesio *self);
 static PyObject *
 _io_BytesIO_writable(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
-    return _io_BytesIO_writable_impl((bytesio *)self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _io_BytesIO_writable_impl((bytesio *)self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_io_BytesIO_seekable__doc__,
@@ -61,7 +73,13 @@ _io_BytesIO_seekable_impl(bytesio *self);
 static PyObject *
 _io_BytesIO_seekable(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
-    return _io_BytesIO_seekable_impl((bytesio *)self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _io_BytesIO_seekable_impl((bytesio *)self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_io_BytesIO_flush__doc__,
@@ -79,7 +97,13 @@ _io_BytesIO_flush_impl(bytesio *self);
 static PyObject *
 _io_BytesIO_flush(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
-    return _io_BytesIO_flush_impl((bytesio *)self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _io_BytesIO_flush_impl((bytesio *)self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_io_BytesIO_getbuffer__doc__,
@@ -152,7 +176,13 @@ _io_BytesIO_isatty_impl(bytesio *self);
 static PyObject *
 _io_BytesIO_isatty(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
-    return _io_BytesIO_isatty_impl((bytesio *)self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _io_BytesIO_isatty_impl((bytesio *)self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_io_BytesIO_tell__doc__,
@@ -607,4 +637,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=580205daa01def2e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=daa81dfdae5ccc57 input=a9049054013a1b77]*/


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Follow up for https://github.com/python/cpython/pull/132616 and adds missing critical sections, this fixes data races on `self->buf` when checking for closed object:

```console
ARNING: ThreadSanitizer: data race (pid=80476)
  Write of size 8 at 0x000118135d60 by thread T26239:
    #0 resize_buffer_lock_held bytesio.c:172 (libpython3.15t.dylib:arm64+0x3d484c)
    #1 write_bytes_lock_held bytesio.c:216 (libpython3.15t.dylib:arm64+0x3d4658)
    #2 _io_BytesIO_write bytesio.c.h:489 (libpython3.15t.dylib:arm64+0x3d1e84)
    #3 _PyEval_EvalFrameDefault generated_cases.c.h:2487 (libpython3.15t.dylib:arm64+0x277ea0)
    #4 _PyEval_Vector ceval.c:1977 (libpython3.15t.dylib:arm64+0x26a148)
    #5 _PyFunction_Vectorcall call.c (libpython3.15t.dylib:arm64+0x7fe5c)
    #6 method_vectorcall classobject.c:73 (libpython3.15t.dylib:arm64+0x8439c)
    #7 context_run context.c:728 (libpython3.15t.dylib:arm64+0x2b4bfc)
    #8 _PyEval_EvalFrameDefault generated_cases.c.h:3766 (libpython3.15t.dylib:arm64+0x27f484)
    #9 _PyEval_Vector ceval.c:1977 (libpython3.15t.dylib:arm64+0x26a148)
    #10 _PyFunction_Vectorcall call.c (libpython3.15t.dylib:arm64+0x7fe5c)
    #11 method_vectorcall classobject.c:73 (libpython3.15t.dylib:arm64+0x8439c)
    #12 _PyObject_Call call.c:348 (libpython3.15t.dylib:arm64+0x7fad4)
    #13 PyObject_Call call.c:373 (libpython3.15t.dylib:arm64+0x7fb48)
    #14 thread_run _threadmodule.c:373 (libpython3.15t.dylib:arm64+0x4174f4)
    #15 pythread_wrapper thread_pthread.h:232 (libpython3.15t.dylib:arm64+0x356b4c)

  Previous read of size 8 at 0x000118135d60 by thread T26238:
    #0 _io_BytesIO_isatty bytesio.c.h:155 (libpython3.15t.dylib:arm64+0x3d1c10)
    #1 method_vectorcall_NOARGS descrobject.c:448 (libpython3.15t.dylib:arm64+0x96e1c)
    #2 PyObject_VectorcallMethod call.c:859 (libpython3.15t.dylib:arm64+0x81550)
    #3 _io_TextIOWrapper_isatty textio.c.h:1114 (libpython3.15t.dylib:arm64+0x3e7c5c)
    #4 method_vectorcall_NOARGS descrobject.c:448 (libpython3.15t.dylib:arm64+0x96e1c)
    #5 PyObject_Vectorcall call.c:327 (libpython3.15t.dylib:arm64+0x7f824)
    #6 _PyEval_EvalFrameDefault generated_cases.c.h:1620 (libpython3.15t.dylib:arm64+0x276f24)
    #7 _PyEval_Vector ceval.c:1977 (libpython3.15t.dylib:arm64+0x26a148)
    #8 _PyFunction_Vectorcall call.c (libpython3.15t.dylib:arm64+0x7fe5c)
    #9 method_vectorcall classobject.c:73 (libpython3.15t.dylib:arm64+0x8439c)
    #10 context_run context.c:728 (libpython3.15t.dylib:arm64+0x2b4bfc)
    #11 _PyEval_EvalFrameDefault generated_cases.c.h:3766 (libpython3.15t.dylib:arm64+0x27f484)
    #12 _PyEval_Vector ceval.c:1977 (libpython3.15t.dylib:arm64+0x26a148)
    #13 _PyFunction_Vectorcall call.c (libpython3.15t.dylib:arm64+0x7fe5c)
    #14 method_vectorcall classobject.c:73 (libpython3.15t.dylib:arm64+0x8439c)
    #15 _PyObject_Call call.c:348 (libpython3.15t.dylib:arm64+0x7fad4)
    #16 PyObject_Call call.c:373 (libpython3.15t.dylib:arm64+0x7fb48)
    #17 thread_run _threadmodule.c:373 (libpython3.15t.dylib:arm64+0x4174f4)
    #18 pythread_wrapper thread_pthread.h:232 (libpython3.15t.dylib:arm64+0x356b4c)

```

<!-- gh-issue-number: gh-132551 -->
* Issue: gh-132551
<!-- /gh-issue-number -->
