### PR TITLE
gh-137084: Do not call get_gc_state from inside loop in expand_region_transitivly_reachable

### DIFF
--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1396,7 +1396,7 @@ expand_region_transitively_reachable(PyGC_Head *container, PyGC_Head *gc, GCStat
         assert(_PyObject_GC_IS_TRACKED(op));
         if (_Py_IsImmortal(op)) {
             PyGC_Head *next = GC_NEXT(gc);
-            gc_list_move(gc, &get_gc_state()->permanent_generation.head);
+            gc_list_move(gc, &gcstate->permanent_generation.head);
             gc = next;
             continue;
         }


### PR DESCRIPTION
It is minor refactoring. But I believe it is worth to do in the light of increasing usage of Immortal objects.
get_gc_state is not so lightweight and may have extra costs when calling for large number of immortal objects.

<!-- gh-issue-number: gh-137084 -->
* Issue: gh-137084
<!-- /gh-issue-number -->
