### PR TITLE
Fix Queue.shutdown docs for condition to unblock a join

### DIFF
--- a/Doc/library/asyncio-queue.rst
+++ b/Doc/library/asyncio-queue.rst
@@ -120,9 +120,10 @@ Queue
       raise :exc:`QueueShutDown`.
 
       If *immediate* is true, the queue is terminated immediately.
-      The queue is drained to be completely empty.  All callers of
-      :meth:`~Queue.join` are unblocked regardless of the number
-      of unfinished tasks.  Blocked callers of :meth:`~Queue.get`
+      The queue is drained to be completely empty and the count
+      of unfinished tasks is reduced by the number of tasks drained.
+      If unfinished tasks is zero, callers of :meth:`~Queue.join`
+      are unblocked.  Also, blocked callers of :meth:`~Queue.get`
       are unblocked and will raise :exc:`QueueShutDown` because the
       queue is empty.
 

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -256,9 +256,10 @@ until empty or terminated immediately with a hard shutdown.
    raise :exc:`ShutDown`.
 
    If *immediate* is true, the queue is terminated immediately.
-   The queue is drained to be completely empty.  All callers of
-   :meth:`~Queue.join` are unblocked regardless of the number
-   of unfinished tasks.  Blocked callers of :meth:`~Queue.get`
+   The queue is drained to be completely empty and the count
+   of unfinished tasks is reduced by the number of tasks drained.
+   If unfinished tasks is zero, callers of :meth:`~Queue.join`
+   are unblocked.  Also, blocked callers of :meth:`~Queue.get`
    are unblocked and will raise :exc:`ShutDown` because the
    queue is empty.
 

--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -253,9 +253,11 @@ class Queue(mixins._LoopBoundMixin):
         By default, gets will only raise once the queue is empty. Set
         'immediate' to True to make gets raise immediately instead.
 
-        All blocked callers of put() and get() will be unblocked. If
-        'immediate', unblock callers of join() regardless of the
-        number of unfinished tasks.
+        All blocked callers of put() and get() will be unblocked.
+
+        If 'immediate', the queue is drained and unfinished tasks
+        is reduced by the number of drained tasks.  If unfinished tasks
+        is reduced to zero, callers of Queue.join are unblocked.
         """
         self._is_shutdown = True
         if immediate:

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -236,9 +236,11 @@ class Queue:
         By default, gets will only raise once the queue is empty. Set
         'immediate' to True to make gets raise immediately instead.
 
-        All blocked callers of put() and get() will be unblocked. If
-        'immediate', callers of join() are unblocked regardless of
-        the number of unfinished tasks.
+        All blocked callers of put() and get() will be unblocked.
+
+        If 'immediate', the queue is drained and unfinished tasks
+        is reduced by the number of drained tasks.  If unfinished tasks
+        is reduced to zero, callers of Queue.join are unblocked.
         '''
         with self.mutex:
             self.is_shutdown = True


### PR DESCRIPTION
I missed this before.  A hard shutdown only unblocks a join if all previous gets had a corresponding `task_done`.

Demonstration:

```python
from threading import Thread
from queue import Queue
from time import sleep
from random import random
    
q = Queue()

def all_done():
    print('Waiting')
    q.join()
    print('All tasks finished')

# Load two tasks
q.put(0)
q.put(1)

# Wait for them to finish
Thread(target=all_done).start()
sleep(1)

# One task fetched and completed
print('Working on one task')
q.get()
if random() < 0.5:
    print('Finished one task')
    q.task_done()                     

# One task remains unfetched. One or two remain unfinished.
print(f'Pre shutdown: {q.qsize()=} {q.unfinished_tasks=}')

# Hard shutdown fetchs and decrements unfinished
q.shutdown(immediate=True)
sleep(1)
print(f'Post shutdown: {q.qsize()=} {q.unfinished_tasks=}')
```


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137088.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->