### PR TITLE
gh-137110: Untrack immortal objects from expand_region_transitivity_reachable

### DIFF
--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1396,7 +1396,7 @@ expand_region_transitively_reachable(PyGC_Head *container, PyGC_Head *gc, GCStat
         assert(_PyObject_GC_IS_TRACKED(op));
         if (_Py_IsImmortal(op)) {
             PyGC_Head *next = GC_NEXT(gc);
-            gc_list_move(gc, &gcstate->permanent_generation.head);
+            _PyObject_GC_UNTRACK(op);
             gc = next;
             continue;
         }


### PR DESCRIPTION
There is some inconsistency in handling of immortal objects in default-build's GC.

In `update_refs` immortal objects just untracked (all immortal objects that we face in GC is an accidentally immortalized). https://github.com/python/cpython/blob/1e69cd1634e4f0f8c375be85d11925bd12deef23/Python/gc.c#L495-L500

`update_refs` called for all collections (young, increment and full). But for incremental collection if `increment_size < gcstate->work_to_do` we steal some objects from neighbor gen and call `expand_region_transitively_reachable` where immortal objects moved to permanent generation: https://github.com/python/cpython/blob/1e69cd1634e4f0f8c375be85d11925bd12deef23/Python/gc.c#L1397-L1402

So, one part of immortal objects can be untracked, and other part can be moved to perm gen. 

As I understand from https://github.com/python/cpython/pull/127519 it is preferring to untrack immortal objects in all cases.


### CPython versions tested on:

CPython main branch


<!-- gh-issue-number: gh-137110 -->
* Issue: gh-137110
<!-- /gh-issue-number -->
