### PR TITLE
gh-137058: use __STDC_VERSION__ >= 202311L instead of __STDC_VERSION__ > 201710L

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -50,7 +50,7 @@
 // to prevent C++ compiler warnings. On C23 and newer and on C++11 and newer,
 // _Py_NULL is defined as nullptr.
 #if !defined(_MSC_VER) && \
-    ((defined (__STDC_VERSION__) && __STDC_VERSION__ > 201710L) \
+    ((defined (__STDC_VERSION__) && __STDC_VERSION__ >= 202311L) \
         || (defined(__cplusplus) && __cplusplus >= 201103))
 #  define _Py_NULL nullptr
 #else


### PR DESCRIPTION
Updates the preprocessor check in `pyport.h` to use C23 `__STDC_VERSION__` value (202311L)

Issue: [pyport.h: use __STDC_VERSION__ >= 202311L instead of __STDC_VERSION__ > 201710L](https://github.com/python/cpython/issues/137058)


<!-- gh-issue-number: gh-137058 -->
* Issue: gh-137058
<!-- /gh-issue-number -->
