### PR TITLE
Link to plaintext for "show source" links

### DIFF
--- a/Doc/tools/templates/customsourcelink.html
+++ b/Doc/tools/templates/customsourcelink.html
@@ -4,7 +4,7 @@
     <ul class="this-page-menu">
       <li><a href="{{ pathto('bugs') }}">{% trans %}Report a bug{% endtrans %}</a></li>
       <li>
-        <a href="https://github.com/python/cpython/blob/main/Doc/{{ sourcename|replace('.rst.txt', '.rst') }}"
+        <a href="https://github.com/python/cpython/blob/main/Doc/{{ sourcename|replace('.rst.txt', '.rst') }}?plain=1"
             rel="nofollow">{{ _('Show source') }}
         </a>
       </li>


### PR DESCRIPTION
@nedbat [brought this up at this month's community docs meeting](https://github.com/python/docs-community/pull/160/files#diff-2c5434e68098c50d50ee195fed9510562b43cd38251d14f3f09ea672a80524ccR72).  The idea is if someone opts to see the raw source for the docs, they should be taken to plaintext source code, not the rendered markdown.

Not making a Github Issue because I think this change is simple enough.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137131.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->