### PR TITLE
gh-133951: Remove lib64->lib symlink in venv creation

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -12,7 +12,6 @@ import os.path
 import pathlib
 import re
 import shutil
-import struct
 import subprocess
 import sys
 import sysconfig

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -138,14 +138,9 @@ class BasicTest(BaseTest):
         self.isdir(self.bindir)
         self.isdir(self.include)
         self.isdir(*self.lib)
-        # Issue 21197
         p = self.get_env_file('lib64')
-        conditions = ((struct.calcsize('P') == 8) and (os.name == 'posix') and
-                      (sys.platform != 'darwin'))
-        if conditions:
-            self.assertTrue(os.path.islink(p))
-        else:
-            self.assertFalse(os.path.exists(p))
+        if os.path.exists(p):
+            self.assertFalse(os.path.islink(p))
         data = self.get_text_file_contents('pyvenv.cfg')
         executable = sys._base_executable
         path = os.path.dirname(executable)

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -174,6 +174,7 @@ class EnvBuilder:
         context.python_exe = exename
         binpath = self._venv_path(env_dir, 'scripts')
         libpath = self._venv_path(env_dir, 'purelib')
+        platlibpath = self._venv_path(env_dir, 'platlib')
 
         # PEP 405 says venvs should create a local include directory.
         # See https://peps.python.org/pep-0405/#include-files
@@ -191,12 +192,8 @@ class EnvBuilder:
         create_if_needed(incpath)
         context.lib_path = libpath
         create_if_needed(libpath)
-        # Issue 21197: create lib64 as a symlink to lib on 64-bit non-OS X POSIX
-        if ((sys.maxsize > 2**32) and (os.name == 'posix') and
-            (sys.platform != 'darwin')):
-            link_path = os.path.join(env_dir, 'lib64')
-            if not os.path.exists(link_path):   # Issue #21643
-                os.symlink('lib', link_path)
+        context.platlib_path = platlibpath
+        create_if_needed(platlibpath)
         context.bin_path = binpath
         context.bin_name = os.path.relpath(binpath, env_dir)
         context.env_exe = os.path.join(binpath, exename)

--- a/Misc/NEWS.d/next/Library/2025-07-27-17-03-17.gh-issue-133951.7kwt78.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-27-17-03-17.gh-issue-133951.7kwt78.rst
@@ -1,0 +1,2 @@
+Remove lib64-lib symlink creation when creating new virtual environments in
+:mod:`venv` module


### PR DESCRIPTION
venv creates a lib64->lib symlink on posix platforms (except osx) to make purelib and platlib always share the same directory in all dists (#65396). This can cause problems on filesystems without symlink support. It is also not necessary anymore because venv now creates lib paths in venv directory based on sysconfig. Others should also use sysconfig to get the correct lib paths.


<!-- gh-issue-number: gh-133951 -->
* Issue: gh-133951
<!-- /gh-issue-number -->
