### PR TITLE
gh-137146: Restrict IPvFuture address parsing to RFC 3986-valid characters

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -3,6 +3,7 @@ import unicodedata
 import unittest
 import urllib.parse
 from test import support
+from strings import ascii_letters, digits
 
 RFC1808_BASE = "http://a/b/c/d;p?q#f"
 RFC2396_BASE = "http://a/b/c/d;p?q"
@@ -1419,6 +1420,17 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertRaises(ValueError, urllib.parse.urlsplit, 'scheme://prefix]v6a.ip[suffix')
         self.assertRaises(ValueError, urllib.parse.urlsplit, 'scheme://prefix]v6a.ip')
         self.assertRaises(ValueError, urllib.parse.urlsplit, 'scheme://v6a.ip[suffix')
+        # unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+        unreserved = ascii_letters + digits + "-" + "." + "_" + "~"
+        # sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+        sub_delims = "!" + "$" + "&" + "'" + "(" + ")" + "*" + "+" + "," + ";" + "="
+        ipvfuture_authorized_characters = unreserved + sub_delims + ":"
+        removed_characters = "\t\n\r"
+        for character in range(256):
+            character = chr(character)
+            if character in ipvfuture_authorized_characters or character in removed_characters:
+                continue
+            self.assertRaises(ValueError, urllib.parse.urlsplit, f'scheme://[v7.invalid{character}invalid]/')
 
     def test_splitting_bracketed_hosts(self):
         p1 = urllib.parse.urlsplit('scheme://user@[v6a.ip]:1234/path?query')

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -3,7 +3,7 @@ import unicodedata
 import unittest
 import urllib.parse
 from test import support
-from strings import ascii_letters, digits
+from string import ascii_letters, digits
 
 RFC1808_BASE = "http://a/b/c/d;p?q#f"
 RFC2396_BASE = "http://a/b/c/d;p?q"

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -460,7 +460,7 @@ def _check_bracketed_netloc(netloc):
 # https://www.rfc-editor.org/rfc/rfc3986#page-49 and https://url.spec.whatwg.org/
 def _check_bracketed_host(hostname):
     if hostname.startswith('v'):
-        if not re.match(r"\Av[a-fA-F0-9]+\.[\w\.~!$&*+,;=:'()-]+\z", hostname):
+        if not re.match(r"\Av[a-fA-F0-9]+\.[\w\.~!$&*+,;=:'()-]+\z", hostname, flags=re.ASCII):
             raise ValueError(f"IPvFuture address is invalid")
     else:
         ip = ipaddress.ip_address(hostname) # Throws Value Error if not IPv6 or IPv4

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -460,7 +460,7 @@ def _check_bracketed_netloc(netloc):
 # https://www.rfc-editor.org/rfc/rfc3986#page-49 and https://url.spec.whatwg.org/
 def _check_bracketed_host(hostname):
     if hostname.startswith('v'):
-        if not re.match(r"\Av[a-fA-F0-9]+\..+\z", hostname):
+        if not re.match(r"\Av[a-fA-F0-9]+\.[\w\.~!$&*+,;=:'()-]+\z", hostname):
             raise ValueError(f"IPvFuture address is invalid")
     else:
         ip = ipaddress.ip_address(hostname) # Throws Value Error if not IPv6 or IPv4

--- a/Misc/NEWS.d/next/Library/2025-07-27-15-17-43.gh-issue-137146.4QsMAT.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-27-15-17-43.gh-issue-137146.4QsMAT.rst
@@ -1,0 +1,1 @@
+Fix overly permissive validation of IPvFuture hostnames in `urllib.parse`, in compliance with RFC 3986. Invalid characters are now correctly rejected.

--- a/Misc/NEWS.d/next/Library/2025-07-27-15-17-43.gh-issue-137146.4QsMAT.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-27-15-17-43.gh-issue-137146.4QsMAT.rst
@@ -1,1 +1,1 @@
-Fix overly permissive validation of IPvFuture hostnames in `urllib.parse`, in compliance with RFC 3986. Invalid characters are now correctly rejected.
+Fix overly permissive validation of IPvFuture hostnames in :func:`urllib.parse.urlparse`, in compliance with RFC 3986. Invalid characters are now correctly rejected.


### PR DESCRIPTION
This PR fixes overly permissive validation of IPvFuture hostnames in `urllib.parse` (#137146).

Previously, the regex used to match IPvFuture (`v...`) components allowed all characters (`.+`), which is incorrect. According to [RFC 3986 §3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2), an IPvFuture should match the following structure:

```
"v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
```

Where:

* `unreserved` = ALPHA / DIGIT / "-" / "." / "\_" / "\~"
* `sub-delims` = "!" / "\$" / "&" / "'" / "(" / ")" / "\*" / "+" / "," / ";" / "="

This patch replaces the permissive regex with one that strictly enforces this allowed character set.

### Before the fix:

```python
>>> import urllib.parse
>>> urllib.parse.urlparse("http://[v45.test|bad]/path")
ParseResult(scheme='http', netloc='[v45.test|bad]', path='/path', ...)
```

### After the fix:

```python
>>> urllib.parse.urlparse("http://[v45.test|bad]/path")
ValueError: IPvFuture address is invalid
```

This improves standards compliance and helps prevent silent acceptance of malformed or unsafe host components.

<!-- gh-issue-number: gh-137146 -->
* Issue: gh-137146
<!-- /gh-issue-number -->
