### PR TITLE
gh-137146: Validate IPv6 ZoneID characters against RFC 6874 in urllib.parse

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1428,7 +1428,7 @@ class UrlParseTestCase(unittest.TestCase):
             character = chr(character)
             if character in zoneid_authorized_characters or character in removed_characters:
                 continue
-            self.assertRaises(ValueError, parse.urlsplit, f'scheme://[::1%invalid{character}invalid]/')
+            self.assertRaises(ValueError, urllib.parse.urlsplit, f'scheme://[::1%invalid{character}invalid]/')
 
     def test_splitting_bracketed_hosts(self):
         p1 = urllib.parse.urlsplit('scheme://user@[v6a.ip]:1234/path?query')

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -3,6 +3,7 @@ import unicodedata
 import unittest
 import urllib.parse
 from test import support
+from string import ascii_letters, digits
 
 RFC1808_BASE = "http://a/b/c/d;p?q#f"
 RFC2396_BASE = "http://a/b/c/d;p?q"
@@ -1419,6 +1420,15 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertRaises(ValueError, urllib.parse.urlsplit, 'scheme://prefix]v6a.ip[suffix')
         self.assertRaises(ValueError, urllib.parse.urlsplit, 'scheme://prefix]v6a.ip')
         self.assertRaises(ValueError, urllib.parse.urlsplit, 'scheme://v6a.ip[suffix')
+        # unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+        unreserved = ascii_letters + digits + "-" + "." + "_" + "~"
+        zoneid_authorized_characters = unreserved
+        removed_characters = "\t\n\r"
+        for character in range(256):
+            character = chr(character)
+            if character in zoneid_authorized_characters or character in removed_characters:
+                continue
+            self.assertRaises(ValueError, parse.urlsplit, f'scheme://[::1%invalid{character}invalid]/')
 
     def test_splitting_bracketed_hosts(self):
         p1 = urllib.parse.urlsplit('scheme://user@[v6a.ip]:1234/path?query')

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -466,7 +466,7 @@ def _check_bracketed_host(hostname):
         ip = ipaddress.ip_address(hostname) # Throws Value Error if not IPv6 or IPv4
         if isinstance(ip, ipaddress.IPv4Address):
             raise ValueError(f"An IPv4 address cannot be in brackets")
-        if "%" in hostname and not re.match(r"\A(%[a-fA-F0-9]{2}|[\w\.~-])+\z", hostname.split("%", 1)[1]):
+        if "%" in hostname and not re.match(r"\A(%[a-fA-F0-9]{2}|[\w\.~-])+\z", hostname.split("%", 1)[1], flags=re.ASCII):
             raise ValueError(f"IPv6 ZoneID is invalid")
 
 # typed=True avoids BytesWarnings being emitted during cache key

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -466,6 +466,8 @@ def _check_bracketed_host(hostname):
         ip = ipaddress.ip_address(hostname) # Throws Value Error if not IPv6 or IPv4
         if isinstance(ip, ipaddress.IPv4Address):
             raise ValueError(f"An IPv4 address cannot be in brackets")
+        if "%" in hostname and not re.match(r"\A(%[a-fA-F0-9]{2}|[\w\.~-])+\z", hostname.split("%", 1)[1]):
+            raise ValueError(f"IPv6 ZoneID is invalid")
 
 # typed=True avoids BytesWarnings being emitted during cache key
 # comparison since this API supports both bytes and str input.

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -92,7 +92,7 @@ _WHATWG_C0_CONTROL_OR_SPACE = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\
 _UNSAFE_URL_BYTES_TO_REMOVE = ['\t', '\r', '\n']
 
 # Zone ID regex as defined in RFC 6874
-zone_id_regex = re.compile(r"(%[a-fA-F0-9]{2}|[\w\.~-])+")
+zone_id_regex = re.compile(r"(%[a-fA-F0-9]{2}|[\w\.~-])+", flags=re.ASCII)
 
 def clear_cache():
     """Clear internal performance caches. Undocumented; some tests want it."""
@@ -469,7 +469,7 @@ def _check_bracketed_host(hostname):
         ip = ipaddress.ip_address(hostname) # Throws Value Error if not IPv6 or IPv4
         if isinstance(ip, ipaddress.IPv4Address):
             raise ValueError("An IPv4 address cannot be in brackets")
-        if "%" in hostname and not zone_id_regex.fullmatch(hostname.split("%", 1)[1], flags=re.ASCII):
+        if "%" in hostname and not zone_id_regex.fullmatch(hostname.split("%", 1)[1]):
             raise ValueError("IPv6 ZoneID is invalid")
 
 # typed=True avoids BytesWarnings being emitted during cache key

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -91,6 +91,9 @@ _WHATWG_C0_CONTROL_OR_SPACE = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\
 # Unsafe bytes to be removed per WHATWG spec
 _UNSAFE_URL_BYTES_TO_REMOVE = ['\t', '\r', '\n']
 
+# Zone ID regex as defined in RFC 6874
+zone_id_regex = re.compile(r"(%[a-fA-F0-9]{2}|[\w\.~-])+")
+
 def clear_cache():
     """Clear internal performance caches. Undocumented; some tests want it."""
     urlsplit.cache_clear()
@@ -461,13 +464,13 @@ def _check_bracketed_netloc(netloc):
 def _check_bracketed_host(hostname):
     if hostname.startswith('v'):
         if not re.match(r"\Av[a-fA-F0-9]+\..+\z", hostname):
-            raise ValueError(f"IPvFuture address is invalid")
+            raise ValueError("IPvFuture address is invalid")
     else:
         ip = ipaddress.ip_address(hostname) # Throws Value Error if not IPv6 or IPv4
         if isinstance(ip, ipaddress.IPv4Address):
-            raise ValueError(f"An IPv4 address cannot be in brackets")
-        if "%" in hostname and not re.match(r"\A(%[a-fA-F0-9]{2}|[\w\.~-])+\z", hostname.split("%", 1)[1], flags=re.ASCII):
-            raise ValueError(f"IPv6 ZoneID is invalid")
+            raise ValueError("An IPv4 address cannot be in brackets")
+        if "%" in hostname and not zone_id_regex.fullmatch(hostname.split("%", 1)[1], flags=re.ASCII):
+            raise ValueError("IPv6 ZoneID is invalid")
 
 # typed=True avoids BytesWarnings being emitted during cache key
 # comparison since this API supports both bytes and str input.

--- a/Misc/NEWS.d/next/Library/2025-07-27-15-23-32.gh-issue-137146.BE_ylT.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-27-15-23-32.gh-issue-137146.BE_ylT.rst
@@ -1,1 +1,1 @@
-Validate IPv6 ZoneID characters in bracketed hostnames to match RFC 6874. `urllib.parse` now rejects ZoneIDs containing invalid or unsafe characters.
+Validate IPv6 ZoneID characters in bracketed hostnames to match RFC 6874. :func:`urllib.parse.urlparse` now rejects ZoneIDs containing invalid or unsafe characters.

--- a/Misc/NEWS.d/next/Library/2025-07-27-15-23-32.gh-issue-137146.BE_ylT.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-27-15-23-32.gh-issue-137146.BE_ylT.rst
@@ -1,0 +1,1 @@
+Validate IPv6 ZoneID characters in bracketed hostnames to match RFC 6874. `urllib.parse` now rejects ZoneIDs containing invalid or unsafe characters.

--- a/Misc/NEWS.d/next/Library/2025-07-27-15-23-32.gh-issue-137146.BE_ylT.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-27-15-23-32.gh-issue-137146.BE_ylT.rst
@@ -1,1 +1,2 @@
-Validate IPv6 ZoneID characters in bracketed hostnames to match RFC 6874. :func:`urllib.parse.urlparse` now rejects ZoneIDs containing invalid or unsafe characters.
+:func:`urllib.parse.urlparse` now rejects IPv6 ZoneIDs containing
+invalid or unsafe characters as per :rfc:`6874`.


### PR DESCRIPTION
This PR tightens the validation of IPv6 Zone Identifiers (ZoneIDs) in bracketed hostnames handled by `urllib.parse` (#137146).

### Problem

Currently, `urllib.parse` accepts any non-null string as a ZoneID, because it delegates IPv6 parsing to the `ipaddress` module, which follows [RFC 4007](https://datatracker.ietf.org/doc/html/rfc4007). However, [RFC 6874 §2.1](https://datatracker.ietf.org/doc/html/rfc6874#section-2.1) defines a stricter character set for ZoneIDs when used in URLs:

> Characters allowed in ZoneIDs (after percent-decoding):
> `ALPHA / DIGIT / "-" / "." / "_" / "~"`

ZoneIDs in URIs must be percent-encoded and may optionally begin with a literal `%` (e.g., `%25`) as described in the RFC.

### Fix

This patch adds an explicit validation step to check that any ZoneID in a URL conforms to the allowed character set.

### Before the fix:

```python
>>> import urllib.parse
>>> urllib.parse.urlparse("http://[fe80::1%zone|bad]/")
ParseResult(scheme='http', netloc='[fe80::1%zone|bad]', path='/', ...)
```

### After the fix:

```python
>>> urllib.parse.urlparse("http://[fe80::1%zone|bad]/")
ValueError: IPv6 ZoneID is invalid
```

### Notes

* This does **not** affect parsing of valid IPv6 addresses or ZoneIDs that comply with RFC 6874.
* The new check is only triggered if a `%` is present in the hostname (i.e., it's a ZoneID).

This improves RFC compliance, reduces risk of incorrect or insecure behavior, and ensures more predictable URL parsing.

<!-- gh-issue-number: gh-137146 -->
* Issue: gh-137146
<!-- /gh-issue-number -->
