### PR TITLE
Fix typo in library/string.templatelib.rst

### DIFF
--- a/Doc/library/string.templatelib.rst
+++ b/Doc/library/string.templatelib.rst
@@ -56,7 +56,7 @@ reassigned.
    >>> type(template)
    <class 'string.templatelib.Template'>
 
-   Templates ars stored as sequences of literal :attr:`~Template.strings`
+   Templates are stored as sequences of literal :attr:`~Template.strings`
    and dynamic :attr:`~Template.interpolations`.
    A :attr:`~Template.values` attribute holds the interpolation values:
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137157.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->