### PR TITLE
[3.14] gh-136968: fortify macro usage in cryptographic modules (GH-136973)

### DIFF
--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -1017,14 +1017,11 @@ exit:
     return (PyObject *)self;
 }
 
+// In Python 3.19, we can remove the "STRING" argument and would also be able
+// to remove the macro (or keep it as an alias for better naming) since calls
+// to _hashlib_new_impl() would fit on 80 characters.
 #define CALL_HASHLIB_NEW(MODULE, NAME, DATA, STRING, USEDFORSECURITY)   \
-    do {                                                                \
-        PyObject *data_obj;                                             \
-        if (_Py_hashlib_data_argument(&data_obj, DATA, STRING) < 0) {   \
-            return NULL;                                                \
-        }                                                               \
-        return _hashlib_HASH(MODULE, NAME, data_obj, USEDFORSECURITY);  \
-    } while (0)
+    return _hashlib_new_impl(MODULE, NAME, DATA, USEDFORSECURITY, STRING)
 
 /* The module-level function: new() */
 
@@ -1050,7 +1047,11 @@ _hashlib_new_impl(PyObject *module, const char *name, PyObject *data,
                   int usedforsecurity, PyObject *string)
 /*[clinic end generated code: output=c01feb4ad6a6303d input=f5ec9bf1fa749d07]*/
 {
-    CALL_HASHLIB_NEW(module, name, data, string, usedforsecurity);
+    PyObject *data_obj;
+    if (_Py_hashlib_data_argument(&data_obj, data, string) < 0) {
+        return NULL;
+    }
+    return _hashlib_HASH(module, name, data_obj, usedforsecurity);
 }
 
 

--- a/Modules/hashlib.h
+++ b/Modules/hashlib.h
@@ -3,34 +3,51 @@
 #include "pycore_lock.h"        // PyMutex
 
 /*
- * Given a PyObject* obj, fill in the Py_buffer* viewp with the result
- * of PyObject_GetBuffer.  Sets an exception and issues the erraction
- * on any errors, e.g. 'return NULL' or 'goto error'.
+ * Obtain a buffer view from a buffer-like object 'obj'.
+ *
+ * On success, store the result in 'view' and return 0.
+ * On error, set an exception and return -1.
  */
-#define GET_BUFFER_VIEW_OR_ERROR(obj, viewp, erraction) do { \
-        if (PyUnicode_Check((obj))) { \
-            PyErr_SetString(PyExc_TypeError, \
-                            "Strings must be encoded before hashing");\
-            erraction; \
-        } \
-        if (!PyObject_CheckBuffer((obj))) { \
-            PyErr_SetString(PyExc_TypeError, \
-                            "object supporting the buffer API required"); \
-            erraction; \
-        } \
-        if (PyObject_GetBuffer((obj), (viewp), PyBUF_SIMPLE) == -1) { \
-            erraction; \
-        } \
-        if ((viewp)->ndim > 1) { \
-            PyErr_SetString(PyExc_BufferError, \
-                            "Buffer must be single dimension"); \
-            PyBuffer_Release((viewp)); \
-            erraction; \
-        } \
-    } while(0)
+static inline int
+_Py_hashlib_get_buffer_view(PyObject *obj, Py_buffer *view)
+{
+    if (PyUnicode_Check(obj)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Strings must be encoded before hashing");
+        return -1;
+    }
+    if (!PyObject_CheckBuffer(obj)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "object supporting the buffer API required");
+        return -1;
+    }
+    if (PyObject_GetBuffer(obj, view, PyBUF_SIMPLE) == -1) {
+        return -1;
+    }
+    if (view->ndim > 1) {
+        PyErr_SetString(PyExc_BufferError,
+                        "Buffer must be single dimension");
+        PyBuffer_Release(view);
+        return -1;
+    }
+    return 0;
+}
 
-#define GET_BUFFER_VIEW_OR_ERROUT(obj, viewp) \
-    GET_BUFFER_VIEW_OR_ERROR(obj, viewp, return NULL)
+/*
+ * Call _Py_hashlib_get_buffer_view() and check if it succeeded.
+ *
+ * On error, set an exception and execute the ERRACTION statements.
+ */
+#define GET_BUFFER_VIEW_OR_ERROR(OBJ, VIEW, ERRACTION)      \
+    do {                                                    \
+        if (_Py_hashlib_get_buffer_view(OBJ, VIEW) < 0) {   \
+            assert(PyErr_Occurred());                       \
+            ERRACTION;                                      \
+        }                                                   \
+    } while (0)
+
+#define GET_BUFFER_VIEW_OR_ERROUT(OBJ, VIEW)                \
+    GET_BUFFER_VIEW_OR_ERROR(OBJ, VIEW, return NULL)
 
 /*
  * Helper code to synchronize access to the hash object when the GIL is

--- a/Modules/hmacmodule.c
+++ b/Modules/hmacmodule.c
@@ -1259,42 +1259,60 @@ _hmac_compute_digest_impl(PyObject *module, PyObject *key, PyObject *msg,
 }
 
 /*
- * One-shot HMAC-HASH using the given HACL_HID.
+ * Obtain a view for 'key' and 'msg', storing it in 'keyview' and 'msgview'.
+ *
+ * Return 0 on success; otherwise set an exception and return -1.
  *
  * The length of the key and message buffers must not exceed UINT32_MAX,
  * lest an OverflowError is raised. The Python implementation takes care
  * of dispatching to the OpenSSL implementation in this case.
  */
-#define Py_HMAC_HACL_ONESHOT(HACL_HID, KEY, MSG)                \
-    do {                                                        \
-        Py_buffer keyview, msgview;                             \
-        GET_BUFFER_VIEW_OR_ERROUT((KEY), &keyview);             \
-        if (!has_uint32_t_buffer_length(&keyview)) {            \
-            PyBuffer_Release(&keyview);                         \
-            set_invalid_key_length_error();                     \
-            return NULL;                                        \
-        }                                                       \
-        GET_BUFFER_VIEW_OR_ERROR((MSG), &msgview,               \
-                                 PyBuffer_Release(&keyview);    \
-                                 return NULL);                  \
-        if (!has_uint32_t_buffer_length(&msgview)) {            \
-            PyBuffer_Release(&msgview);                         \
-            PyBuffer_Release(&keyview);                         \
-            set_invalid_msg_length_error();                     \
-            return NULL;                                        \
-        }                                                       \
-        uint8_t out[Py_hmac_## HACL_HID ##_digest_size];        \
-        Py_hmac_## HACL_HID ##_compute_func(                    \
-            out,                                                \
-            (uint8_t *)keyview.buf, (uint32_t)keyview.len,      \
-            (uint8_t *)msgview.buf, (uint32_t)msgview.len       \
-        );                                                      \
-        PyBuffer_Release(&msgview);                             \
-        PyBuffer_Release(&keyview);                             \
-        return PyBytes_FromStringAndSize(                       \
-            (const char *)out,                                  \
-            Py_hmac_## HACL_HID ##_digest_size                  \
-        );                                                      \
+static int
+hmac_get_buffer_views(PyObject *key, Py_buffer *keyview,
+                      PyObject *msg, Py_buffer *msgview)
+{
+    if (_Py_hashlib_get_buffer_view(key, keyview) < 0) {
+        return -1;
+    }
+    if (!has_uint32_t_buffer_length(keyview)) {
+        PyBuffer_Release(keyview);
+        set_invalid_key_length_error();
+        return -1;
+    }
+    if (_Py_hashlib_get_buffer_view(msg, msgview) < 0) {
+        PyBuffer_Release(keyview);
+        return -1;
+    }
+    if (!has_uint32_t_buffer_length(msgview)) {
+        PyBuffer_Release(msgview);
+        PyBuffer_Release(keyview);
+        set_invalid_msg_length_error();
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * One-shot HMAC-HASH using the given HACL_HID.
+ */
+#define HACL_HMAC_COMPUTE_NAMED_DIGEST(HACL_HID, KEY, MSG)              \
+    do {                                                                \
+        Py_buffer keyview, msgview;                                     \
+        if (hmac_get_buffer_views(key, &keyview, msg, &msgview) < 0) {  \
+            return NULL;                                                \
+        }                                                               \
+        uint8_t out[Py_hmac_## HACL_HID ##_digest_size];                \
+        Py_hmac_## HACL_HID ##_compute_func(                            \
+            out,                                                        \
+            (uint8_t *)keyview.buf, (uint32_t)keyview.len,              \
+            (uint8_t *)msgview.buf, (uint32_t)msgview.len               \
+        );                                                              \
+        PyBuffer_Release(&msgview);                                     \
+        PyBuffer_Release(&keyview);                                     \
+        return PyBytes_FromStringAndSize(                               \
+            (const char *)out,                                          \
+            Py_hmac_## HACL_HID ##_digest_size                          \
+        );                                                              \
     } while (0)
 
 /*[clinic input]
@@ -1310,7 +1328,7 @@ static PyObject *
 _hmac_compute_md5_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=7837a4ceccbbf636 input=77a4b774c7d61218]*/
 {
-    Py_HMAC_HACL_ONESHOT(md5, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(md5, key, msg);
 }
 
 /*[clinic input]
@@ -1326,7 +1344,7 @@ static PyObject *
 _hmac_compute_sha1_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=79fd7689c83691d8 input=3b64dccc6bdbe4ba]*/
 {
-    Py_HMAC_HACL_ONESHOT(sha1, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(sha1, key, msg);
 }
 
 /*[clinic input]
@@ -1342,7 +1360,7 @@ static PyObject *
 _hmac_compute_sha2_224_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=7f21f1613e53979e input=a1a75f25f23449af]*/
 {
-    Py_HMAC_HACL_ONESHOT(sha2_224, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(sha2_224, key, msg);
 }
 
 /*[clinic input]
@@ -1358,7 +1376,7 @@ static PyObject *
 _hmac_compute_sha2_256_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=d4a291f7d9a82459 input=5c9ccf2df048ace3]*/
 {
-    Py_HMAC_HACL_ONESHOT(sha2_256, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(sha2_256, key, msg);
 }
 
 /*[clinic input]
@@ -1374,7 +1392,7 @@ static PyObject *
 _hmac_compute_sha2_384_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=f211fa26e3700c27 input=2fee2c14766af231]*/
 {
-    Py_HMAC_HACL_ONESHOT(sha2_384, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(sha2_384, key, msg);
 }
 
 /*[clinic input]
@@ -1390,7 +1408,7 @@ static PyObject *
 _hmac_compute_sha2_512_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=d5c20373762cecca input=3371eaac315c7864]*/
 {
-    Py_HMAC_HACL_ONESHOT(sha2_512, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(sha2_512, key, msg);
 }
 
 /*[clinic input]
@@ -1406,7 +1424,7 @@ static PyObject *
 _hmac_compute_sha3_224_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=a242ccac9ad9c22b input=d0ab0c7d189c3d87]*/
 {
-    Py_HMAC_HACL_ONESHOT(sha3_224, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(sha3_224, key, msg);
 }
 
 /*[clinic input]
@@ -1422,7 +1440,7 @@ static PyObject *
 _hmac_compute_sha3_256_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=b539dbb61af2fe0b input=f05d7b6364b35d02]*/
 {
-    Py_HMAC_HACL_ONESHOT(sha3_256, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(sha3_256, key, msg);
 }
 
 /*[clinic input]
@@ -1438,7 +1456,7 @@ static PyObject *
 _hmac_compute_sha3_384_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=5eb372fb5c4ffd3a input=d842d393e7aa05ae]*/
 {
-    Py_HMAC_HACL_ONESHOT(sha3_384, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(sha3_384, key, msg);
 }
 
 /*[clinic input]
@@ -1454,7 +1472,7 @@ static PyObject *
 _hmac_compute_sha3_512_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=154bcbf8c2eacac1 input=166fe5baaeaabfde]*/
 {
-    Py_HMAC_HACL_ONESHOT(sha3_512, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(sha3_512, key, msg);
 }
 
 /*[clinic input]
@@ -1470,7 +1488,7 @@ static PyObject *
 _hmac_compute_blake2s_32_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=cfc730791bc62361 input=d22c36e7fe31a985]*/
 {
-    Py_HMAC_HACL_ONESHOT(blake2s_32, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(blake2s_32, key, msg);
 }
 
 /*[clinic input]
@@ -1486,8 +1504,10 @@ static PyObject *
 _hmac_compute_blake2b_32_impl(PyObject *module, PyObject *key, PyObject *msg)
 /*[clinic end generated code: output=765c5c4fb9124636 input=4a35ee058d172f4b]*/
 {
-    Py_HMAC_HACL_ONESHOT(blake2b_32, key, msg);
+    HACL_HMAC_COMPUTE_NAMED_DIGEST(blake2b_32, key, msg);
 }
+
+#undef HACL_HMAC_COMPUTE_NAMED_DIGEST
 
 // --- HMAC module methods ----------------------------------------------------
 


### PR DESCRIPTION
Macros used in cryptographic extension modules are partially rewritten to use `static inline` functions when possible to help code completion. (cherry picked from commit eefd70f0ed51e46fa9ff3d465dcf977bd4af28de)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136968 -->
* Issue: gh-136968
<!-- /gh-issue-number -->
