### PR TITLE
gh-137179: Fix flaky test_history_survive_crash test

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1740,8 +1740,10 @@ class TestMain(ReplTestCase):
             self.assertIn("2", history)
             self.assertIn("exit()", history)
             self.assertIn("spam", history)
-            self.assertIn("0xcafe", history)
             self.assertIn("import time", history)
+            # History is written after each command's output is printed to the
+            # console, so depending on how quickly the process is killed,
+            # the last command may or may not be written to the history file.
             self.assertNotIn("sleep", history)
             self.assertNotIn("quit", history)
 

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1732,7 +1732,7 @@ class TestMain(ReplTestCase):
             # process to simulate a crash. Note that the output also includes
             # the echoed input commands.
             commands = "spam\nimport time\n0xcafe\ntime.sleep(1000)\nquit\n"
-            output, exit_code = self.run_repl(commands, env=env, timeout=3,
+            output, exit_code = self.run_repl(commands, env=env,
                                               exit_on_output="51966")
             self.assertNotEqual(exit_code, 0)
 
@@ -1740,6 +1740,7 @@ class TestMain(ReplTestCase):
             self.assertIn("2", history)
             self.assertIn("exit()", history)
             self.assertIn("spam", history)
+            self.assertIn("0xcafe", history)
             self.assertIn("import time", history)
             self.assertNotIn("sleep", history)
             self.assertNotIn("quit", history)


### PR DESCRIPTION
Kill the REPL subprocess once it prints the output from the command immediately before the `time.sleep()`.


<!-- gh-issue-number: gh-137179 -->
* Issue: gh-137179
<!-- /gh-issue-number -->
