### PR TITLE
gh-137183: Document that `array.array` typecode `w` is new in 3.13

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -24,7 +24,7 @@ defined:
 +-----------+--------------------+-------------------+-----------------------+-------+
 | ``'u'``   | wchar_t            | Unicode character | 2                     | \(1)  |
 +-----------+--------------------+-------------------+-----------------------+-------+
-| ``'w'``   | Py_UCS4            | Unicode character | 4                     |       |
+| ``'w'``   | Py_UCS4            | Unicode character | 4                     | \(2)  |
 +-----------+--------------------+-------------------+-----------------------+-------+
 | ``'h'``   | signed short       | int               | 2                     |       |
 +-----------+--------------------+-------------------+-----------------------+-------+
@@ -59,6 +59,9 @@ Notes:
 
    .. deprecated-removed:: 3.3 3.16
       Please migrate to ``'w'`` typecode.
+
+(2)
+   .. versionadded:: 3.13
 
 
 The actual representation of values is determined by the machine architecture


### PR DESCRIPTION
Document that `'w'` is new in Python 3.13.

<!-- gh-issue-number: gh-137183 -->
* Issue: gh-137183
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137184.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->