### PR TITLE
gh-137185: Fix `_Py_DumpStack()` async signal safety

### DIFF
--- a/Include/internal/pycore_traceback.h
+++ b/Include/internal/pycore_traceback.h
@@ -100,6 +100,7 @@ extern int _Py_WriteIndentedMargin(int, const char*, PyObject *);
 extern int _Py_WriteIndent(int, PyObject *);
 
 // Export for the faulthandler module
+PyAPI_FUNC(void) _Py_InitDumpStack(void);
 PyAPI_FUNC(void) _Py_DumpStack(int fd);
 
 #ifdef __cplusplus

--- a/Misc/NEWS.d/next/Library/2025-07-28-20-48-32.gh-issue-137185.fgI7-B.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-28-20-48-32.gh-issue-137185.fgI7-B.rst
@@ -1,0 +1,2 @@
+Fix a potential async-signal-safety issue in :mod:`faulthandler` when
+printing C stack traces.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -524,6 +524,11 @@ faulthandler_enable(void)
     }
 #endif
 
+    // gh-137185: Initialize C stack trace dumping outside of the signal
+    // handler. Specifically, we call backtrace() to ensure that libgcc is
+    // dynamically loaded outside of the signal handler.
+    _Py_InitDumpStack();
+
     for (size_t i=0; i < faulthandler_nsignals; i++) {
         fault_handler_t *handler;
         int err;

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -1333,6 +1333,6 @@ _Py_InitDumpStack(void)
 #ifdef CAN_C_BACKTRACE
     // gh-137185: Call backtrace() once to force libgcc to be loaded early.
     void *callstack[1];
-    backtrace(callstack, 1);
+    (void)backtrace(callstack, 1);
 #endif
 }

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -1326,3 +1326,13 @@ _Py_DumpStack(int fd)
     PUTS(fd, "  <cannot get C stack on this system>\n");
 }
 #endif
+
+void
+_Py_InitDumpStack(void)
+{
+#ifdef CAN_C_BACKTRACE
+    // gh-137185: Call backtrace() once to force libgcc to be loaded early.
+    void *callstack[1];
+    backtrace(callstack, 1);
+#endif
+}


### PR DESCRIPTION
Call backtrace() once when installing the signal handler to ensure that libgcc is dynamically loaded outside the signal handler.

This fixes a "signal-unsafe call inside of a signal" TSan error from test_faulthandler.test_enable_fd.


<!-- gh-issue-number: gh-137185 -->
* Issue: gh-137185
<!-- /gh-issue-number -->
