### PR TITLE
gh-137197: Add SSLContext.set_ciphersuites to set TLS 1.3 ciphers

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -2860,7 +2860,7 @@ of TLS/SSL. Some new TLS 1.3 features are not yet available.
 
 - TLS 1.3 uses a disjunct set of cipher suites.  All AES-GCM and ChaCha20
   cipher suites are enabled by default.  To restrict which TLS 1.3 ciphers
-  are allowed, the method :meth:`SSLContext.set_ciphersuites` should be
+  are allowed, the :meth:`SSLContext.set_ciphersuites` method should be
   called instead of :meth:`SSLContext.set_ciphers`, which only affects
   ciphers in older TLS versions.  The :meth:`SSLContext.get_ciphers` method
   returns information about ciphers for both TLS 1.3 and earlier versions

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1685,28 +1685,29 @@ to speed up repeated connections from the same clients.
 .. method:: SSLContext.set_ciphers(ciphers)
 
    Set the allowed ciphers for sockets created with this context when
-   connecting using TLS 1.2 and earlier.  It should be a string in the `OpenSSL
-   cipher list format <https://docs.openssl.org/master/man1/ciphers/>`_.
+   connecting using TLS 1.2 and earlier.  The *ciphers* argument should
+   be a string in the `OpenSSL cipher list format
+   <https://docs.openssl.org/master/man1/ciphers/>`_.
    To set allowed TLS 1.3 ciphers, use :meth:`SSLContext.set_ciphersuites`.
-   below.  If no cipher can be selected (because compile-time options or other
+   If no cipher can be selected (because compile-time options or other
    configuration forbids use of all the specified ciphers), an
    :class:`SSLError` will be raised.
 
    .. note::
       when connected, the :meth:`SSLSocket.cipher` method of SSL sockets will
-      return the negotiated cipher and associated TLS version.
+      return details about the negotiated cipher.
 
 .. method:: SSLContext.set_ciphersuites(ciphersuites)
 
    Set the allowed ciphers for sockets created with this context when
-   connecting using TLS 1.3.  It should be a colon-separate string of TLS 1.3
-   cipher names.  If no cipher can be selected (because compile-time options
-   or other configuration forbids use of all the specified ciphers), an
-   :class:`SSLError` will be raised.
+   connecting using TLS 1.3.  The *ciphersuites* argument should be a
+   colon-separate string of TLS 1.3 cipher names.  If no cipher can be
+   selected (because compile-time options or other configuration forbids
+   use of all the specified ciphers), an :class:`SSLError` will be raised.
 
    .. note::
       when connected, the :meth:`SSLSocket.cipher` method of SSL sockets will
-      return the negotiated cipher and associated TLS version.
+      return details about the negotiated cipher.
 
 .. method:: SSLContext.set_groups(groups)
 
@@ -2860,8 +2861,9 @@ of TLS/SSL. Some new TLS 1.3 features are not yet available.
   called instead of :meth:`SSLContext.set_ciphers`, which only affects
   ciphers in older TLS versions.  The method :meth:`SSLContext.get_ciphers`
   returns information about ciphers for both TLS 1.3 and earlier versions
-  and the method :meth:`SSLSocket.cipher` returns the negotiated cipher and
-  the associated TLS version once a connection is established.
+  and the method :meth:`SSLSocket.cipher` returns information about the
+  negotiated cipher for both TLS 1.3 and earlier versions once a connection
+  is established.
 - Session tickets are no longer sent as part of the initial handshake and
   are handled differently.  :attr:`SSLSocket.session` and :class:`SSLSession`
   are not compatible with TLS 1.3.

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1689,6 +1689,7 @@ to speed up repeated connections from the same clients.
    be a string in the `OpenSSL cipher list format
    <https://docs.openssl.org/master/man1/ciphers/>`_.
    To set allowed TLS 1.3 ciphers, use :meth:`SSLContext.set_ciphersuites`.
+
    If no cipher can be selected (because compile-time options or other
    configuration forbids use of all the specified ciphers), an
    :class:`SSLError` will be raised.
@@ -1708,6 +1709,8 @@ to speed up repeated connections from the same clients.
    .. note::
       When connected, the :meth:`SSLSocket.cipher` method of SSL sockets will
       return details about the negotiated cipher.
+
+   .. versionadded:: next
 
 .. method:: SSLContext.set_groups(groups)
 
@@ -2856,10 +2859,10 @@ The TLS 1.3 protocol behaves slightly differently than previous version
 of TLS/SSL. Some new TLS 1.3 features are not yet available.
 
 - TLS 1.3 uses a disjunct set of cipher suites.  All AES-GCM and ChaCha20
-  cipher suites are enabled by default.  To restrict which TLS1.3 ciphers
+  cipher suites are enabled by default.  To restrict which TLS 1.3 ciphers
   are allowed, the method :meth:`SSLContext.set_ciphersuites` should be
   called instead of :meth:`SSLContext.set_ciphers`, which only affects
-  ciphers in older TLS versions.  The method :meth:`SSLContext.get_ciphers`
+  ciphers in older TLS versions.  The :meth:`SSLContext.get_ciphers` method
   returns information about ciphers for both TLS 1.3 and earlier versions
   and the method :meth:`SSLSocket.cipher` returns information about the
   negotiated cipher for both TLS 1.3 and earlier versions once a connection

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1687,7 +1687,7 @@ to speed up repeated connections from the same clients.
    Set the allowed ciphers for sockets created with this context when
    connecting using TLS 1.2 and earlier.  It should be a string in the `OpenSSL
    cipher list format <https://docs.openssl.org/master/man1/ciphers/>`_.
-   To set allowed TLS 1.3 ciphers, use :meth:`SSHContext.set_ciphersuites`.
+   To set allowed TLS 1.3 ciphers, use :meth:`SSLContext.set_ciphersuites`.
    below.  If no cipher can be selected (because compile-time options or other
    configuration forbids use of all the specified ciphers), an
    :class:`SSLError` will be raised.

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1684,19 +1684,29 @@ to speed up repeated connections from the same clients.
 
 .. method:: SSLContext.set_ciphers(ciphers)
 
-   Set the available ciphers for sockets created with this context.
-   It should be a string in the `OpenSSL cipher list format
-   <https://docs.openssl.org/master/man1/ciphers/>`_.
-   If no cipher can be selected (because compile-time options or other
+   Set the allowed ciphers for sockets created with this context when
+   connecting using TLS 1.2 and earlier.  It should be a string in the `OpenSSL
+   cipher list format <https://docs.openssl.org/master/man1/ciphers/>`_.
+   To set allowed TLS 1.3 ciphers, use :meth:`SSHContext.set_ciphersuites`.
+   below.  If no cipher can be selected (because compile-time options or other
    configuration forbids use of all the specified ciphers), an
    :class:`SSLError` will be raised.
 
    .. note::
       when connected, the :meth:`SSLSocket.cipher` method of SSL sockets will
-      give the currently selected cipher.
+      return the negotiated cipher and associated TLS version.
 
-      TLS 1.3 cipher suites cannot be disabled with
-      :meth:`~SSLContext.set_ciphers`.
+.. method:: SSLContext.set_ciphersuites(ciphersuites)
+
+   Set the allowed ciphers for sockets created with this context when
+   connecting using TLS 1.3.  It should be a colon-separate string of TLS 1.3
+   cipher names.  If no cipher can be selected (because compile-time options
+   or other configuration forbids use of all the specified ciphers), an
+   :class:`SSLError` will be raised.
+
+   .. note::
+      when connected, the :meth:`SSLSocket.cipher` method of SSL sockets will
+      return the negotiated cipher and associated TLS version.
 
 .. method:: SSLContext.set_groups(groups)
 
@@ -2844,10 +2854,14 @@ TLS 1.3
 The TLS 1.3 protocol behaves slightly differently than previous version
 of TLS/SSL. Some new TLS 1.3 features are not yet available.
 
-- TLS 1.3 uses a disjunct set of cipher suites. All AES-GCM and
-  ChaCha20 cipher suites are enabled by default.  The method
-  :meth:`SSLContext.set_ciphers` cannot enable or disable any TLS 1.3
-  ciphers yet, but :meth:`SSLContext.get_ciphers` returns them.
+- TLS 1.3 uses a disjunct set of cipher suites.  All AES-GCM and ChaCha20
+  cipher suites are enabled by default.  To restrict which TLS1.3 ciphers
+  are allowed, the method :meth:`SSLContext.set_ciphersuites` should be
+  called instead of :meth:`SSLContext.set_ciphers`, which only affects
+  ciphers in older TLS versions.  The method :meth:`SSLContext.get_ciphers`
+  returns information about ciphers for both TLS 1.3 and earlier versions
+  and the method :meth:`SSLSocket.cipher` returns the negotiated cipher and
+  the associated TLS version once a connection is established.
 - Session tickets are no longer sent as part of the initial handshake and
   are handled differently.  :attr:`SSLSocket.session` and :class:`SSLSession`
   are not compatible with TLS 1.3.

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1694,7 +1694,7 @@ to speed up repeated connections from the same clients.
    :class:`SSLError` will be raised.
 
    .. note::
-      when connected, the :meth:`SSLSocket.cipher` method of SSL sockets will
+      When connected, the :meth:`SSLSocket.cipher` method of SSL sockets will
       return details about the negotiated cipher.
 
 .. method:: SSLContext.set_ciphersuites(ciphersuites)
@@ -1706,7 +1706,7 @@ to speed up repeated connections from the same clients.
    use of all the specified ciphers), an :class:`SSLError` will be raised.
 
    .. note::
-      when connected, the :meth:`SSLSocket.cipher` method of SSL sockets will
+      When connected, the :meth:`SSLSocket.cipher` method of SSL sockets will
       return details about the negotiated cipher.
 
 .. method:: SSLContext.set_groups(groups)

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -333,10 +333,12 @@ ssl
    (Contributed by Ron Frederick in :gh:`136306`)
 
 * Added new method :meth:`ssl.SSLContext.set_ciphersuites` for setting TLS 1.3
-  ciphers and updated the documentation on :meth:`ssl.SSLContext.set_ciphers`
-  to mention that it only applies to TLS 1.2 and earlier and that this new
-  method must be used to set TLS 1.3 cipher suites.
+  ciphers. For TLS 1.2 or earlier, :meth:`ssl.SSLContext.set_ciphers` should
+  continue to be used. Both calls can be made on the same context and the
+  selected cipher suite will depend on the TLS version negotiated when a
+  connection is made.
   (Contributed by Ron Frederick in :gh:`137197`)
+
 
 tarfile
 -------

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -337,7 +337,7 @@ ssl
   continue to be used. Both calls can be made on the same context and the
   selected cipher suite will depend on the TLS version negotiated when a
   connection is made.
-  (Contributed by Ron Frederick in :gh:`137197`)
+  (Contributed by Ron Frederick in :gh:`137197`.)
 
 
 tarfile

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -332,7 +332,7 @@ ssl
 
    (Contributed by Ron Frederick in :gh:`136306`)
 
-* Added new method :meth:`ssl.SSLContext.set_ciphersuites` for setting TLS 1.3
+* Added a new method :meth:`ssl.SSLContext.set_ciphersuites` for setting TLS 1.3
   ciphers. For TLS 1.2 or earlier, :meth:`ssl.SSLContext.set_ciphers` should
   continue to be used. Both calls can be made on the same context and the
   selected cipher suite will depend on the TLS version negotiated when a

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -332,6 +332,11 @@ ssl
 
    (Contributed by Ron Frederick in :gh:`136306`)
 
+* Added new method :meth:`ssl.SSLContext.set_ciphersuites` for setting TLS 1.3
+  ciphers and updated the documentation on :meth:`ssl.SSLContext.set_ciphers`
+  to mention that it only applies to TLS 1.2 and earlier and that this new
+  method must be used to set TLS 1.3 cipher suites.
+  (Contributed by Ron Frederick in :gh:`137197`)
 
 tarfile
 -------

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2246,10 +2246,10 @@ class SimpleBackgroundTests(unittest.TestCase):
             self.assertRaises(ssl.SSLEOFError, sslobj.read)
 
 
+@unittest.skipUnless(has_tls_version('TLSv1_3'), "TLS 1.3 is not available")
 class SimpleBackgroundTestsTLS_1_3(unittest.TestCase):
     """Tests that connect to a simple server running in the background."""
 
-    @requires_tls_version('TLSv1_3')
     def setUp(self):
         server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         ciphers = [cipher['name'] for cipher in server_ctx.get_ciphers()

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2259,7 +2259,8 @@ class SimpleBackgroundTestsTLS_1_3(unittest.TestCase):
             self.skipTest("No cipher supports TLSv1.3")
 
         self.matching_cipher = ciphers[0]
-        # Some tests need at least two ciphers.
+        # Some tests need at least two ciphers, and are responsible
+        # to skip themselves if matching_cipher == mismatched_cipher.
         self.mismatched_cipher = ciphers[-1]
 
         server_ctx.set_ciphersuites(self.matching_cipher)

--- a/Misc/NEWS.d/next/Library/2025-07-29-05-12-50.gh-issue-137197.bMK3sO.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-29-05-12-50.gh-issue-137197.bMK3sO.rst
@@ -1,1 +1,2 @@
-:mod:`ssl` can now set TLS 1.3 cipher suites.
+:class:`~ssl.SSLContext` objects can now set TLS 1.3 cipher suites
+via :meth:`~ssl.SSLContext.set_ciphersuites`.

--- a/Misc/NEWS.d/next/Library/2025-07-29-05-12-50.gh-issue-137197.bMK3sO.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-29-05-12-50.gh-issue-137197.bMK3sO.rst
@@ -1,0 +1,1 @@
+:mod:`ssl` can now set TLS 1.3 cipher suites.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3595,12 +3595,27 @@ _ssl__SSLContext_set_ciphers_impl(PySSLContext *self, const char *cipherlist)
 {
     int ret = SSL_CTX_set_cipher_list(self->ctx, cipherlist);
     if (ret == 0) {
-        /* Clearing the error queue is necessary on some OpenSSL versions,
-           otherwise the error will be reported again when another SSL call
-           is done. */
-        ERR_clear_error();
-        PyErr_SetString(get_state_ctx(self)->PySSLErrorObject,
-                        "No cipher can be selected.");
+        _setSSLError(get_state_ctx(self), "No cipher can be selected.", 0, __FILE__, __LINE__);
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+/*[clinic input]
+@critical_section
+_ssl._SSLContext.set_ciphersuites
+    ciphersuites: str
+    /
+[clinic start generated code]*/
+
+static PyObject *
+_ssl__SSLContext_set_ciphersuites_impl(PySSLContext *self,
+                                       const char *ciphersuites)
+/*[clinic end generated code: output=9915bec58e54d76d input=2afcc3693392be41]*/
+{
+    int ret = SSL_CTX_set_ciphersuites(self->ctx, ciphersuites);
+    if (ret == 0) {
+        _setSSLError(get_state_ctx(self), "No cipher suite can be selected.", 0, __FILE__, __LINE__);
         return NULL;
     }
     Py_RETURN_NONE;
@@ -5583,6 +5598,7 @@ static struct PyMethodDef context_methods[] = {
     _SSL__SSLCONTEXT__WRAP_SOCKET_METHODDEF
     _SSL__SSLCONTEXT__WRAP_BIO_METHODDEF
     _SSL__SSLCONTEXT_SET_CIPHERS_METHODDEF
+    _SSL__SSLCONTEXT_SET_CIPHERSUITES_METHODDEF
     _SSL__SSLCONTEXT_SET_GROUPS_METHODDEF
     _SSL__SSLCONTEXT__SET_ALPN_PROTOCOLS_METHODDEF
     _SSL__SSLCONTEXT_LOAD_CERT_CHAIN_METHODDEF

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3618,8 +3618,7 @@ _ssl__SSLContext_set_ciphersuites_impl(PySSLContext *self,
                                        const char *ciphersuites)
 /*[clinic end generated code: output=9915bec58e54d76d input=2afcc3693392be41]*/
 {
-    int ret = SSL_CTX_set_ciphersuites(self->ctx, ciphersuites);
-    if (ret == 0) {
+    if (!SSL_CTX_set_ciphersuites(self->ctx, ciphersuites)) {
         _setSSLError(get_state_ctx(self), "No cipher suite can be selected.", 0, __FILE__, __LINE__);
         return NULL;
     }

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3595,7 +3595,12 @@ _ssl__SSLContext_set_ciphers_impl(PySSLContext *self, const char *cipherlist)
 {
     int ret = SSL_CTX_set_cipher_list(self->ctx, cipherlist);
     if (ret == 0) {
-        _setSSLError(get_state_ctx(self), "No cipher can be selected.", 0, __FILE__, __LINE__);
+        /* Clearing the error queue is necessary on some OpenSSL versions,
+           otherwise the error will be reported again when another SSL call
+           is done. */
+        ERR_clear_error();
+        PyErr_SetString(get_state_ctx(self)->PySSLErrorObject,
+                        "No cipher can be selected.");
         return NULL;
     }
     Py_RETURN_NONE;

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -969,6 +969,45 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(_ssl__SSLContext_set_ciphersuites__doc__,
+"set_ciphersuites($self, ciphersuites, /)\n"
+"--\n"
+"\n");
+
+#define _SSL__SSLCONTEXT_SET_CIPHERSUITES_METHODDEF    \
+    {"set_ciphersuites", (PyCFunction)_ssl__SSLContext_set_ciphersuites, METH_O, _ssl__SSLContext_set_ciphersuites__doc__},
+
+static PyObject *
+_ssl__SSLContext_set_ciphersuites_impl(PySSLContext *self,
+                                       const char *ciphersuites);
+
+static PyObject *
+_ssl__SSLContext_set_ciphersuites(PyObject *self, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    const char *ciphersuites;
+
+    if (!PyUnicode_Check(arg)) {
+        _PyArg_BadArgument("set_ciphersuites", "argument", "str", arg);
+        goto exit;
+    }
+    Py_ssize_t ciphersuites_length;
+    ciphersuites = PyUnicode_AsUTF8AndSize(arg, &ciphersuites_length);
+    if (ciphersuites == NULL) {
+        goto exit;
+    }
+    if (strlen(ciphersuites) != (size_t)ciphersuites_length) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        goto exit;
+    }
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_set_ciphersuites_impl((PySSLContext *)self, ciphersuites);
+    Py_END_CRITICAL_SECTION();
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl__SSLContext_get_ciphers__doc__,
 "get_ciphers($self, /)\n"
 "--\n"
@@ -3142,4 +3181,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=c409bdf3c123b28b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4e35d2ea2fc46023 input=a9049054013a1b77]*/


### PR DESCRIPTION
This commit adds a new method SSLContext.set_ciphersuites which can be used to set TLS 1.3 cipher suites. It also updates the documentation, unit tests, and "what's new" text. A NEWS blurb will be added shortly.


<!-- gh-issue-number: gh-137197 -->
* Issue: gh-137197
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137198.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->