### PR TITLE
GH-134291: Support older macOS deployment targets for JIT builds

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -117,6 +117,10 @@ jobs:
           find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
           brew install llvm@${{ matrix.llvm }}
           export SDKROOT="$(xcrun --show-sdk-path)"
+          # Set MACOSX_DEPLOYMENT_TARGET and -Werror=unguarded-availability to
+          # make sure we don't break downstream distributors (like uv):
+          export CFLAGS_JIT='-Werror=unguarded-availability'
+          export MACOSX_DEPLOYMENT_TARGET=10.15
           ./configure --enable-experimental-jit --enable-universalsdk --with-universal-archs=universal2 ${{ matrix.debug && '--with-pydebug' || '' }}
           make all --jobs 4
           ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-28-19-11-34.gh-issue-134291.IiB9Id.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-28-19-11-34.gh-issue-134291.IiB9Id.rst
@@ -1,0 +1,2 @@
+Remove some newer macOS API usage from the JIT compiler in order to restore
+compatibility with older OSX 10.15 deployment targets.

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -69,10 +69,6 @@ jit_alloc(size_t size)
 #else
     int flags = MAP_ANONYMOUS | MAP_PRIVATE;
     int prot = PROT_READ | PROT_WRITE;
-# ifdef MAP_JIT
-    flags |= MAP_JIT;
-    prot |= PROT_EXEC;
-# endif
     unsigned char *memory = mmap(NULL, size, prot, flags, -1, 0);
     int failed = memory == MAP_FAILED;
 #endif
@@ -118,11 +114,8 @@ mark_executable(unsigned char *memory, size_t size)
     int old;
     int failed = !VirtualProtect(memory, size, PAGE_EXECUTE_READ, &old);
 #else
-    int failed = 0;
     __builtin___clear_cache((char *)memory, (char *)memory + size);
-#ifndef MAP_JIT
-    failed = mprotect(memory, size, PROT_EXEC | PROT_READ);
-#endif
+    int failed = mprotect(memory, size, PROT_EXEC | PROT_READ);
 #endif
     if (failed) {
         jit_error("unable to protect executable memory");
@@ -531,9 +524,6 @@ _PyJIT_Compile(_PyExecutorObject *executor, const _PyUOpInstruction trace[], siz
     if (memory == NULL) {
         return -1;
     }
-#ifdef MAP_JIT
-    pthread_jit_write_protect_np(0);
-#endif
     // Collect memory stats
     OPT_STAT_ADD(jit_total_memory_size, total_size);
     OPT_STAT_ADD(jit_code_size, code_size);
@@ -571,9 +561,6 @@ _PyJIT_Compile(_PyExecutorObject *executor, const _PyUOpInstruction trace[], siz
     data += group->data_size;
     assert(code == memory + code_size);
     assert(data == memory + code_size + state.trampolines.size + code_padding + data_size);
-#ifdef MAP_JIT
-    pthread_jit_write_protect_np(1);
-#endif
     if (mark_executable(memory, total_size)) {
         jit_free(memory, total_size);
         return -1;


### PR DESCRIPTION
This rolls back GH-126196 and adds stricter checks for newer APIs in JIT CI. We don't really need the superpowers of the newer API (rapid flip-flopping permissions on JIT pages) since our JIT doesn't use self-modifying code.

This allows downstream distributors (like `uv`, CC @zanieb) to ship the JIT for more users.

<!-- gh-issue-number: gh-134291 -->
* Issue: gh-134291
<!-- /gh-issue-number -->
