### PR TITLE
gh-137282: Fix tab completion and dir() on concurrent.futures

### DIFF
--- a/Lib/concurrent/futures/__init__.py
+++ b/Lib/concurrent/futures/__init__.py
@@ -44,7 +44,7 @@ if _interpreters:
 
 
 def __dir__():
-    return __all__ + ('__author__', '__doc__')
+    return __all__ + ['__author__', '__doc__']
 
 
 def __getattr__(name):

--- a/Lib/test/test___all__.py
+++ b/Lib/test/test___all__.py
@@ -48,7 +48,6 @@ class AllTest(unittest.TestCase):
                 raise FailedImport(modname)
         if not hasattr(sys.modules[modname], "__all__"):
             raise NoAll(modname)
-
         names = {}
         with self.subTest(module=modname):
             with warnings_helper.check_warnings(
@@ -75,7 +74,6 @@ class AllTest(unittest.TestCase):
                 self.assertEqual(keys, all_set, "in module {}".format(modname))
                 # Verify __dir__ is non-empty and doesn't produce an error
                 self.assertTrue(dir(sys.modules[modname]))
-
 
     def walk_modules(self, basedir, modpath):
         for fn in sorted(os.listdir(basedir)):

--- a/Lib/test/test___all__.py
+++ b/Lib/test/test___all__.py
@@ -48,6 +48,7 @@ class AllTest(unittest.TestCase):
                 raise FailedImport(modname)
         if not hasattr(sys.modules[modname], "__all__"):
             raise NoAll(modname)
+
         names = {}
         with self.subTest(module=modname):
             with warnings_helper.check_warnings(
@@ -72,6 +73,9 @@ class AllTest(unittest.TestCase):
                 all_set = set(all_list)
                 self.assertCountEqual(all_set, all_list, "in module {}".format(modname))
                 self.assertEqual(keys, all_set, "in module {}".format(modname))
+                # Verify __dir__ is non-empty and doesn't produce an error
+                self.assertTrue(dir(sys.modules[modname]))
+
 
     def walk_modules(self, basedir, modpath):
         for fn in sorted(os.listdir(basedir)):

--- a/Misc/NEWS.d/next/Library/2025-07-31-10-31-56.gh-issue-137282.GOCwIC.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-31-10-31-56.gh-issue-137282.GOCwIC.rst
@@ -1,0 +1,1 @@
+Fixed tab completion / ``dir()`` on ``concurrent.futures``.

--- a/Misc/NEWS.d/next/Library/2025-07-31-10-31-56.gh-issue-137282.GOCwIC.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-31-10-31-56.gh-issue-137282.GOCwIC.rst
@@ -1,1 +1,1 @@
-Fixed tab completion / ``dir()`` on ``concurrent.futures``.
+Fix tab completion and :func:`dir` on :mod:`concurrent.futures`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

I just noticed that in 3.14rc1, tab completion is broken on `concurrent.futures`. Trying `dir`, I got:

```
>>> import concurrent.futures
>>> dir(concurrent.futures)
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    dir(concurrent.futures)
    ~~~^^^^^^^^^^^^^^^^^^^^
  File "/Users/henryschreiner/.local/share/uv/python/cpython-3.14.0rc1+freethreaded-macos-x86_64-none/lib/python3.14t/concurrent/futures/__init__.py", line 47, in __dir__
    return __all__ + ('__author__', '__doc__')
           ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: can only concatenate list (not "tuple") to list
```

There's a typo in the `__dir__` function; it is trying to concatenate a list and a tuple. I could do `[*__all__ , '__author__', '__doc__']` instead if that's preferred.

I didn't make an issue, but I can if that's preferred. Needs backport to 3.14. Also didn't add a test, but a test that checks `dir` on all modules would be useful. Static typing would have caught this.

Bug introduced in https://github.com/python/cpython/pull/136381.

<!-- gh-issue-number: gh-137282 -->
* Issue: gh-137282
<!-- /gh-issue-number -->
