### PR TITLE
gh-131591: Fix syntax in remote debugger doc

### DIFF
--- a/Doc/howto/remote_debugging.rst
+++ b/Doc/howto/remote_debugging.rst
@@ -374,7 +374,7 @@ To locate a thread:
    reliable thread to target.
 
 3. Optionally, use the offset ``interpreter_state.threads_head`` to iterate
-   through the linked list of all thread states. Each ``PyThreadState`` 
+   through the linked list of all thread states. Each ``PyThreadState``
    structure contains a ``native_thread_id`` field, which may be compared to
    a target thread ID to find a specific thread.
 

--- a/Doc/howto/remote_debugging.rst
+++ b/Doc/howto/remote_debugging.rst
@@ -374,13 +374,13 @@ To locate a thread:
    reliable thread to target.
 
 3. Optionally, use the offset ``interpreter_state.threads_head`` to iterate
-through the linked list of all thread states. Each ``PyThreadState`` structure
-contains a ``native_thread_id`` field, which may be compared to a target thread
-ID to find a specific thread.
+   through the linked list of all thread states. Each ``PyThreadState`` 
+   structure contains a ``native_thread_id`` field, which may be compared to
+   a target thread ID to find a specific thread.
 
-1. Once a valid ``PyThreadState`` has been found, its address can be used in
-later steps of the protocol, such as writing debugger control fields and
-scheduling execution.
+4. Once a valid ``PyThreadState`` has been found, its address can be used in
+   later steps of the protocol, such as writing debugger control fields and
+   scheduling execution.
 
 The following is an example implementation that locates the main thread state::
 

--- a/Doc/howto/remote_debugging.rst
+++ b/Doc/howto/remote_debugging.rst
@@ -454,15 +454,15 @@ its fields are defined by the ``_Py_DebugOffsets`` structure and include the
 following:
 
 - ``debugger_script_path``: A fixed-size buffer that holds the full path to a
-   Python source file (``.py``).  This file must be accessible and readable by
-   the target process when execution is triggered.
+  Python source file (``.py``).  This file must be accessible and readable by
+  the target process when execution is triggered.
 
 - ``debugger_pending_call``: An integer flag. Setting this to ``1`` tells the
-   interpreter that a script is ready to be executed.
+  interpreter that a script is ready to be executed.
 
 - ``eval_breaker``: A field checked by the interpreter during execution.
-   Setting bit 5 (``_PY_EVAL_PLEASE_STOP_BIT``, value ``1U << 5``) in this
-   field causes the interpreter to pause and check for debugger activity.
+  Setting bit 5 (``_PY_EVAL_PLEASE_STOP_BIT``, value ``1U << 5``) in this
+  field causes the interpreter to pause and check for debugger activity.
 
 To complete the injection, the debugger must perform the following steps:
 


### PR DESCRIPTION
Numbered list

Before:</br><img width="60%" height="60%" alt="image" src="https://github.com/user-attachments/assets/315651ea-0041-4ab1-bd90-8bd406070afa" />

After:</br><img width="60%" height="60%" alt="image" src="https://github.com/user-attachments/assets/aed18137-6db2-4d39-98e1-fbf64a270fad" />

Unnumbered list

Before:</br><img width="60%" height="60%" alt="image" src="https://github.com/user-attachments/assets/ef41815c-3f17-42ef-817d-d34708172768" />


After:</br><img width="60%" height="60%" alt="image" src="https://github.com/user-attachments/assets/9823c79f-9af5-4726-aec7-456480c9e222" />


<!-- gh-issue-number: gh-131591 -->
* Issue: gh-131591
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137225.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->