### PR TITLE
gh-137228: Improve get_type_hints()

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -158,21 +158,13 @@ class ForwardRef:
             # as a way of emulating annotation scopes when calling `eval()`
             type_params = getattr(owner, "__type_params__", None)
 
-        # type parameters require some special handling,
-        # as they exist in their own scope
-        # but `eval()` does not have a dedicated parameter for that scope.
-        # For classes, names in type parameter scopes should override
-        # names in the global scope (which here are called `localns`!),
-        # but should in turn be overridden by names in the class scope
-        # (which here are called `globalns`!)
+        # Type parameters exist in their own scope, which is logically
+        # between the locals and the globals. We simulate this by adding
+        # them to the globals.
         if type_params is not None:
             globals = dict(globals)
-            locals = dict(locals)
             for param in type_params:
-                param_name = param.__name__
-                if not self.__forward_is_class__ or param_name not in globals:
-                    globals[param_name] = param
-                    locals.pop(param_name, None)
+                globals[param.__name__] = param
         if self.__extra_names__:
             locals = {**locals, **self.__extra_names__}
 

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1365,6 +1365,11 @@ class TestAnnotationsToString(unittest.TestCase):
 class A:
     pass
 
+TypeParamsAlias1 = int
+
+class TypeParamsSample[TypeParamsAlias1, TypeParamsAlias2]:
+    TypeParamsAlias2 = str
+
 
 class TestForwardRefClass(unittest.TestCase):
     def test_forwardref_instance_type_error(self):
@@ -1596,6 +1601,21 @@ class TestForwardRefClass(unittest.TestCase):
         self.assertIs(
             ForwardRef("alias").evaluate(owner=Gen, locals={"alias": str}), str
         )
+
+    def test_evaluate_with_type_params_and_scope_conflict(self):
+        for is_class in (False, True):
+            with self.subTest(is_class=is_class):
+                fwdref1 = ForwardRef("TypeParamsAlias1", owner=TypeParamsSample, is_class=is_class)
+                fwdref2 = ForwardRef("TypeParamsAlias2", owner=TypeParamsSample, is_class=is_class)
+
+                self.assertIs(
+                    fwdref1.evaluate(),
+                    TypeParamsSample.__type_params__[0],
+                )
+                self.assertIs(
+                    fwdref2.evaluate(),
+                    TypeParamsSample.TypeParamsAlias2,
+                )
 
     def test_fwdref_with_module(self):
         self.assertIs(ForwardRef("Format", module="annotationlib").evaluate(), Format)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6633,7 +6633,7 @@ class GetTypeHintsTests(BaseTestCase):
         self.assertEqual(gth(mod_generics_cache.B),
                          {'my_inner_a1': mod_generics_cache.B.A,
                           'my_inner_a2': mod_generics_cache.B.A,
-                          'my_outer_a': mod_generics_cache.A})
+                          'my_outer_a': mod_generics_cache.B.A})
 
     def test_get_type_hints_classes_no_implicit_optional(self):
         class WithNoneDefault:
@@ -8762,7 +8762,7 @@ class TypedDictTests(BaseTestCase):
     def test_get_type_hints_generic(self):
         self.assertEqual(
             get_type_hints(BarGeneric),
-            {'a': typing.Optional[T], 'b': int}
+            {'a': typing.Optional[_typed_dict_helper.T], 'b': int}
         )
 
         class FooBarGeneric(BarGeneric[int]):
@@ -8770,7 +8770,7 @@ class TypedDictTests(BaseTestCase):
 
         self.assertEqual(
             get_type_hints(FooBarGeneric),
-            {'a': typing.Optional[T], 'b': int, 'c': str}
+            {'a': typing.Optional[_typed_dict_helper.T], 'b': int, 'c': str}
         )
 
     def test_pep695_generic_typeddict(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2342,10 +2342,13 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False,
                 # *base_globals* first rather than *base_locals*.
                 # This only affects ForwardRefs.
                 base_globals, base_locals = base_locals, base_globals
+            type_params = base.__type_params__
+            base_globals, base_locals = _add_type_params_to_scope(
+                type_params, base_globals, base_locals, True)
             for name, value in ann.items():
                 if isinstance(value, str):
                     value = _make_forward_ref(value, is_argument=False, is_class=True)
-                value = _eval_type(value, base_globals, base_locals, base.__type_params__,
+                value = _eval_type(value, base_globals, base_locals, (),
                                    format=format, owner=obj)
                 if value is None:
                     value = type(None)
@@ -2381,6 +2384,7 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False,
     elif localns is None:
         localns = globalns
     type_params = getattr(obj, "__type_params__", ())
+    globalns, localns = _add_type_params_to_scope(type_params, globalns, localns, False)
     for name, value in hints.items():
         if isinstance(value, str):
             # class-level forward refs were handled above, this must be either
@@ -2390,11 +2394,25 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False,
                 is_argument=not isinstance(obj, types.ModuleType),
                 is_class=False,
             )
-        value = _eval_type(value, globalns, localns, type_params, format=format, owner=obj)
+        value = _eval_type(value, globalns, localns, (), format=format, owner=obj)
         if value is None:
             value = type(None)
         hints[name] = value
     return hints if include_extras else {k: _strip_annotations(t) for k, t in hints.items()}
+
+
+# Add type parameters to the globals and locals scope. This is needed for
+# compatibility.
+def _add_type_params_to_scope(type_params, globalns, localns, is_class):
+    if not type_params:
+        return globalns, localns
+    globalns = dict(globalns)
+    localns = dict(localns)
+    for param in type_params:
+        if not is_class or param.__name__ not in globalns:
+            globalns[param.__name__] = param
+            localns.pop(param.__name__, None)
+    return globalns, localns
 
 
 def _strip_annotations(t):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2329,27 +2329,12 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False,
             if format == Format.STRING:
                 hints.update(ann)
                 continue
-            if globalns is None:
-                base_globals = getattr(sys.modules.get(base.__module__, None), '__dict__', {})
-            else:
-                base_globals = globalns
-            base_locals = dict(vars(base)) if localns is None else localns
-            if localns is None and globalns is None:
-                # This is surprising, but required.  Before Python 3.10,
-                # get_type_hints only evaluated the globalns of
-                # a class.  To maintain backwards compatibility, we reverse
-                # the globalns and localns order so that eval() looks into
-                # *base_globals* first rather than *base_locals*.
-                # This only affects ForwardRefs.
-                base_globals, base_locals = base_locals, base_globals
-            type_params = base.__type_params__
-            base_globals, base_locals = _add_type_params_to_scope(
-                type_params, base_globals, base_locals, True)
             for name, value in ann.items():
                 if isinstance(value, str):
-                    value = _make_forward_ref(value, is_argument=False, is_class=True)
-                value = _eval_type(value, base_globals, base_locals, (),
-                                   format=format, owner=obj)
+                    value = _make_forward_ref(value, is_argument=False, is_class=True,
+                                              owner=base)
+                value = _eval_type(value, globalns, localns, base.__type_params__,
+                                   format=format, owner=base)
                 if value is None:
                     value = type(None)
                 hints[name] = value
@@ -2370,21 +2355,14 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False,
     if format == Format.STRING:
         return hints
 
-    if globalns is None:
-        if isinstance(obj, types.ModuleType):
-            globalns = obj.__dict__
-        else:
-            nsobj = obj
-            # Find globalns for the unwrapped object.
-            while hasattr(nsobj, '__wrapped__'):
-                nsobj = nsobj.__wrapped__
-            globalns = getattr(nsobj, '__globals__', {})
-        if localns is None:
-            localns = globalns
-    elif localns is None:
-        localns = globalns
-    type_params = getattr(obj, "__type_params__", ())
-    globalns, localns = _add_type_params_to_scope(type_params, globalns, localns, False)
+    if isinstance(obj, types.ModuleType):
+        nsobj = obj
+    else:
+        nsobj = obj
+        # Find globalns for the unwrapped object.
+        while hasattr(nsobj, '__wrapped__'):
+            nsobj = nsobj.__wrapped__
+    type_params = getattr(nsobj, "__type_params__", ())
     for name, value in hints.items():
         if isinstance(value, str):
             # class-level forward refs were handled above, this must be either
@@ -2393,26 +2371,13 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False,
                 value,
                 is_argument=not isinstance(obj, types.ModuleType),
                 is_class=False,
+                owner=nsobj,
             )
-        value = _eval_type(value, globalns, localns, (), format=format, owner=obj)
+        value = _eval_type(value, globalns, localns, type_params, format=format, owner=nsobj)
         if value is None:
             value = type(None)
         hints[name] = value
     return hints if include_extras else {k: _strip_annotations(t) for k, t in hints.items()}
-
-
-# Add type parameters to the globals and locals scope. This is needed for
-# compatibility.
-def _add_type_params_to_scope(type_params, globalns, localns, is_class):
-    if not type_params:
-        return globalns, localns
-    globalns = dict(globalns)
-    localns = dict(localns)
-    for param in type_params:
-        if not is_class or param.__name__ not in globalns:
-            globalns[param.__name__] = param
-            localns.pop(param.__name__, None)
-    return globalns, localns
 
 
 def _strip_annotations(t):

--- a/Misc/NEWS.d/next/Library/2025-07-29-21-18-31.gh-issue-137226.B_4lpu.rst
+++ b/Misc/NEWS.d/next/Library/2025-07-29-21-18-31.gh-issue-137226.B_4lpu.rst
@@ -1,0 +1,3 @@
+Fix behavior of :meth:`annotationlib.ForwardRef.evaluate` when the
+*type_params* parameter is passed and the name of a type param is also
+present in an enclosing scope.


### PR DESCRIPTION
This fixes the two incorrect behaviors flagged in #137228 and more generally makes get_type_hints() lean more into using the owner concept from annotationlib instead of trying to infer globals and locals namespaces itself.


<!-- gh-issue-number: gh-137228 -->
* Issue: gh-137228
<!-- /gh-issue-number -->
