### PR TITLE
gh-128813: soft-deprecate _Py_c_*() functions

### DIFF
--- a/Doc/c-api/complex.rst
+++ b/Doc/c-api/complex.rst
@@ -43,11 +43,17 @@ pointers.  This is consistent throughout the API.
    Return the sum of two complex numbers, using the C :c:type:`Py_complex`
    representation.
 
+   .. deprecated:: 3.15
+      This function is :term:`soft deprecated`.
+
 
 .. c:function:: Py_complex _Py_c_diff(Py_complex left, Py_complex right)
 
    Return the difference between two complex numbers, using the C
    :c:type:`Py_complex` representation.
+
+   .. deprecated:: 3.15
+      This function is :term:`soft deprecated`.
 
 
 .. c:function:: Py_complex _Py_c_neg(Py_complex num)
@@ -55,11 +61,17 @@ pointers.  This is consistent throughout the API.
    Return the negation of the complex number *num*, using the C
    :c:type:`Py_complex` representation.
 
+   .. deprecated:: 3.15
+      This function is :term:`soft deprecated`.
+
 
 .. c:function:: Py_complex _Py_c_prod(Py_complex left, Py_complex right)
 
    Return the product of two complex numbers, using the C :c:type:`Py_complex`
    representation.
+
+   .. deprecated:: 3.15
+      This function is :term:`soft deprecated`.
 
 
 .. c:function:: Py_complex _Py_c_quot(Py_complex dividend, Py_complex divisor)
@@ -69,6 +81,9 @@ pointers.  This is consistent throughout the API.
 
    If *divisor* is null, this method returns zero and sets
    :c:data:`errno` to :c:macro:`!EDOM`.
+
+   .. deprecated:: 3.15
+      This function is :term:`soft deprecated`.
 
 
 .. c:function:: Py_complex _Py_c_pow(Py_complex num, Py_complex exp)
@@ -80,6 +95,19 @@ pointers.  This is consistent throughout the API.
    this method returns zero and sets :c:data:`errno` to :c:macro:`!EDOM`.
 
    Set :c:data:`errno` to :c:macro:`!ERANGE` on overflows.
+
+   .. deprecated:: 3.15
+      This function is :term:`soft deprecated`.
+
+
+.. c:function:: double _Py_c_abs(Py_complex num)
+
+   Return the absolute value of the complex number *num*.
+
+   Set :c:data:`errno` to :c:macro:`!ERANGE` on overflows.
+
+   .. deprecated:: 3.15
+      This function is :term:`soft deprecated`.
 
 
 Complex Numbers as Python Objects

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -548,6 +548,11 @@ Deprecated C APIs
   signed integer type of the same size is now deprecated.
   (Contributed by Serhiy Storchaka in :gh:`132629`.)
 
+* Functions :c:func:`_Py_c_sum`, :c:func:`_Py_c_diff`, :c:func:`_Py_c_neg`,
+  :c:func:`_Py_c_prod`, :c:func:`_Py_c_quot`, :c:func:`_Py_c_pow` and
+  :c:func:`_Py_c_abs` are :term:`soft deprecated`.
+  (Contributed by Sergey B Kirpichev in :gh:`128813`.)
+
 .. Add C API deprecations above alphabetically, not here at the end.
 
 Removed C APIs

--- a/Include/cpython/complexobject.h
+++ b/Include/cpython/complexobject.h
@@ -7,7 +7,8 @@ typedef struct {
     double imag;
 } Py_complex;
 
-// Operations on complex numbers.
+/* Operations on complex numbers (soft deprecated
+   since Python 3.15). */
 PyAPI_FUNC(Py_complex) _Py_c_sum(Py_complex, Py_complex);
 PyAPI_FUNC(Py_complex) _Py_c_diff(Py_complex, Py_complex);
 PyAPI_FUNC(Py_complex) _Py_c_neg(Py_complex);

--- a/Misc/NEWS.d/next/C_API/2025-07-31-04-30-42.gh-issue-128813.opL-Pv.rst
+++ b/Misc/NEWS.d/next/C_API/2025-07-31-04-30-42.gh-issue-128813.opL-Pv.rst
@@ -1,0 +1,4 @@
+Functions :c:func:`_Py_c_sum`, :c:func:`_Py_c_diff`, :c:func:`_Py_c_neg`,
+:c:func:`_Py_c_prod`, :c:func:`_Py_c_quot`, :c:func:`_Py_c_pow` and
+previously undocumented :c:func:`_Py_c_abs` are :term:`soft deprecated`.
+Patch by Sergey B Kirpichev.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128813 -->
* Issue: gh-128813
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137261.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->