### PR TITLE
gh-137267: Clarify bytes.isalnum and bytearray.isalnum doc wording

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -3641,8 +3641,8 @@ place, and instead produce new objects.
 .. method:: bytes.isalnum()
             bytearray.isalnum()
 
-   Return ``True`` if all bytes in the sequence are alphabetical ASCII characters
-   or ASCII decimal digits and the sequence is not empty, ``False`` otherwise.
+   Return ``True`` if all bytes in the sequence are alphabetic ASCII characters
+   and/or ASCII decimal digits and the sequence is not empty, ``False`` otherwise.
    Alphabetic ASCII characters are those byte values in the sequence
    ``b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'``. ASCII decimal
    digits are those byte values in the sequence ``b'0123456789'``.


### PR DESCRIPTION
This PR fixes a minor wording issue in the documentation of `bytes.isalnum()` and `bytearray.isalnum()` in `Doc/library/stdtypes.rst`.

Changes:
- Replaced "alphabetical" with "alphabetic"
- Changed "or" to "and/or" to more accurately reflect the actual behavior of these methods

These methods return True when all bytes are alphabetic ASCII characters **and/or** digits, so the updated wording improves clarity and correctness.


<!-- gh-issue-number: gh-137267 -->
* Issue: gh-137267
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137269.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->