### PR TITLE
gh-133467: fix data race in type_set_name

### DIFF
--- a/Lib/test/test_free_threading/test_type.py
+++ b/Lib/test/test_free_threading/test_type.py
@@ -137,7 +137,7 @@ class TestType(TestCase):
 
         def reader():
             for _ in range(1000):
-                self.assertEqual(Foo.__name__, 'Bar')
+                Foo.__name__
 
         self.run_one(writer, reader)
 

--- a/Lib/test/test_free_threading/test_type.py
+++ b/Lib/test/test_free_threading/test_type.py
@@ -127,6 +127,20 @@ class TestType(TestCase):
         obj.__class__ = ClassB
 
 
+    def test_name_change(self):
+        class Foo:
+            pass
+
+        def writer():
+            for _ in range(1000):
+                Foo.__name__ = 'Bar'
+
+        def reader():
+            for _ in range(1000):
+                self.assertEqual(Foo.__name__, 'Bar')
+
+        self.run_one(writer, reader)
+
     def run_one(self, writer_func, reader_func):
         barrier = threading.Barrier(NTHREADS)
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1538,8 +1538,10 @@ type_set_name(PyObject *tp, PyObject *value, void *Py_UNUSED(closure))
     PyInterpreterState *interp = _PyInterpreterState_GET();
     _PyEval_StopTheWorld(interp);
     type->tp_name = tp_name;
-    Py_SETREF(((PyHeapTypeObject*)type)->ht_name, Py_NewRef(value));
+    PyObject *old_name = ((PyHeapTypeObject*)type)->ht_name;
+    ((PyHeapTypeObject*)type)->ht_name = Py_NewRef(value);
     _PyEval_StartTheWorld(interp);
+    Py_DECREF(old_name);
     return 0;
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1535,9 +1535,11 @@ type_set_name(PyObject *tp, PyObject *value, void *Py_UNUSED(closure))
         return -1;
     }
 
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    _PyEval_StopTheWorld(interp);
     type->tp_name = tp_name;
     Py_SETREF(((PyHeapTypeObject*)type)->ht_name, Py_NewRef(value));
-
+    _PyEval_StartTheWorld(interp);
     return 0;
 }
 
@@ -10706,9 +10708,11 @@ slot_tp_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 
     get = _PyType_LookupRef(tp, &_Py_ID(__get__));
     if (get == NULL) {
+#ifndef Py_GIL_DISABLED
         /* Avoid further slowdowns */
         if (tp->tp_descr_get == slot_tp_descr_get)
             tp->tp_descr_get = NULL;
+#endif
         return Py_NewRef(self);
     }
     if (obj == NULL)

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -44,7 +44,5 @@ race:PyObject_Realloc
 
 # gh-133467.  Some of these could be hard to trigger.
 race_top:_Py_slot_tp_getattr_hook
-race_top:slot_tp_descr_get
-race_top:type_set_name
 race_top:set_tp_bases
 race_top:type_set_bases_unlocked


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
This fixes two data races: 
- `type_set_name`: Assign the new name under stop the world pause to avoid data races with threads concurrently reading and writing name. 
- `slot_tp_descr_get`: Avoid assignment in `slot_tp_descr_get` as it is not thread safe in free-threading and is a minor optimization. 


<!-- gh-issue-number: gh-133467 -->
* Issue: gh-133467
<!-- /gh-issue-number -->
