### PR TITLE
gh-137293: Ignore Exceptions when searching ELF File in Remote Debug

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-01-20-31-30.gh-issue-137293.4x3JbV.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-01-20-31-30.gh-issue-137293.4x3JbV.rst
@@ -1,1 +1,1 @@
-Ignore Exceptions when searching ELF Files in remote debug since the file containing PyRuntime is the only one that matters.
+Fix :exc:`SystemError` when searching ELF Files in :func:`sys.remote_exec`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-01-20-31-30.gh-issue-137293.4x3JbV.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-01-20-31-30.gh-issue-137293.4x3JbV.rst
@@ -1,0 +1,1 @@
+Ignore Exceptions when searching ELF Files in remote debug since the file containing PyRuntime is the only one that matters.

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -572,25 +572,16 @@ search_elf_file_for_section(
 
     int fd = open(elf_file, O_RDONLY);
     if (fd < 0) {
-        PyErr_Format(PyExc_OSError,
-            "Cannot open ELF file '%s' for section '%s' search: %s",
-            elf_file, secname, strerror(errno));
         goto exit;
     }
 
     struct stat file_stats;
     if (fstat(fd, &file_stats) != 0) {
-        PyErr_Format(PyExc_OSError,
-            "Cannot get file size for ELF file '%s' during section '%s' search: %s",
-            elf_file, secname, strerror(errno));
         goto exit;
     }
 
     file_memory = mmap(NULL, file_stats.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (file_memory == MAP_FAILED) {
-        PyErr_Format(PyExc_OSError,
-            "Cannot memory map ELF file '%s' (size: %lld bytes) for section '%s' search: %s",
-            elf_file, (long long)file_stats.st_size, secname, strerror(errno));
         goto exit;
     }
 
@@ -598,9 +589,6 @@ search_elf_file_for_section(
 
     // Validate ELF header
     if (elf_header->e_shstrndx >= elf_header->e_shnum) {
-        PyErr_Format(PyExc_RuntimeError,
-            "Invalid ELF file '%s': string table index %u >= section count %u",
-            elf_file, elf_header->e_shstrndx, elf_header->e_shnum);
         goto exit;
     }
 
@@ -635,9 +623,6 @@ search_elf_file_for_section(
     }
 
     if (first_load_segment == NULL) {
-        PyErr_Format(PyExc_RuntimeError,
-            "No PT_LOAD segment found in ELF file '%s' (%u program headers examined)",
-            elf_file, elf_header->e_phnum);
         goto exit;
     }
 
@@ -650,9 +635,6 @@ exit:
         munmap(file_memory, file_stats.st_size);
     }
     if (fd >= 0 && close(fd) != 0) {
-        PyErr_Format(PyExc_OSError,
-            "Failed to close ELF file '%s': %s",
-            elf_file, strerror(errno));
         result = 0;
     }
     return result;
@@ -731,9 +713,6 @@ search_linux_map_for_section(proc_handle_t *handle, const char* secname, const c
             retval = search_elf_file_for_section(handle, secname, start, path);
             if (retval) {
                 break;
-            }
-            if (PyErr_Occurred()){
-                PyErr_Clear();
             }
         }
     }

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -732,6 +732,9 @@ search_linux_map_for_section(proc_handle_t *handle, const char* secname, const c
             if (retval) {
                 break;
             }
+            if (PyErr_Occured()){
+                PyErr_Clear();
+            }
         }
     }
 

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -733,7 +733,7 @@ search_linux_map_for_section(proc_handle_t *handle, const char* secname, const c
                 break;
             }
             if (PyErr_Occurred()){
-                PyErr_Print();
+                PyErr_Clear();
             }
         }
     }

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -732,8 +732,8 @@ search_linux_map_for_section(proc_handle_t *handle, const char* secname, const c
             if (retval) {
                 break;
             }
-            if (PyErr_Occured()){
-                PyErr_Clear();
+            if (PyErr_Occurred()){
+                PyErr_Print();
             }
         }
     }

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -572,16 +572,25 @@ search_elf_file_for_section(
 
     int fd = open(elf_file, O_RDONLY);
     if (fd < 0) {
+        PyErr_Format(PyExc_OSError,
+            "Cannot open ELF file '%s' for section '%s' search: %s",
+            elf_file, secname, strerror(errno));
         goto exit;
     }
 
     struct stat file_stats;
     if (fstat(fd, &file_stats) != 0) {
+        PyErr_Format(PyExc_OSError,
+            "Cannot get file size for ELF file '%s' during section '%s' search: %s",
+            elf_file, secname, strerror(errno));
         goto exit;
     }
 
     file_memory = mmap(NULL, file_stats.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (file_memory == MAP_FAILED) {
+        PyErr_Format(PyExc_OSError,
+            "Cannot memory map ELF file '%s' (size: %lld bytes) for section '%s' search: %s",
+            elf_file, (long long)file_stats.st_size, secname, strerror(errno));
         goto exit;
     }
 
@@ -589,6 +598,9 @@ search_elf_file_for_section(
 
     // Validate ELF header
     if (elf_header->e_shstrndx >= elf_header->e_shnum) {
+        PyErr_Format(PyExc_RuntimeError,
+            "Invalid ELF file '%s': string table index %u >= section count %u",
+            elf_file, elf_header->e_shstrndx, elf_header->e_shnum);
         goto exit;
     }
 
@@ -623,6 +635,9 @@ search_elf_file_for_section(
     }
 
     if (first_load_segment == NULL) {
+        PyErr_Format(PyExc_RuntimeError,
+            "No PT_LOAD segment found in ELF file '%s' (%u program headers examined)",
+            elf_file, elf_header->e_phnum);
         goto exit;
     }
 
@@ -635,6 +650,9 @@ exit:
         munmap(file_memory, file_stats.st_size);
     }
     if (fd >= 0 && close(fd) != 0) {
+        PyErr_Format(PyExc_OSError,
+            "Failed to close ELF file '%s': %s",
+            elf_file, strerror(errno));
         result = 0;
     }
     return result;
@@ -710,6 +728,7 @@ search_linux_map_for_section(proc_handle_t *handle, const char* secname, const c
         }
 
         if (strstr(filename, substr)) {
+            PyErr_Clear();
             retval = search_elf_file_for_section(handle, secname, start, path);
             if (retval) {
                 break;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

When calling `search_elf_file_for_section` from `search_linux_map_for_section` passing a file that either doesn't exist or can't be opened correctly for a variety of reasons, this will throw an exception regardless of whether that file contains `PyRuntime`. The call to `search_linux_map_for_section` can behave as expected  if it does eventually open the file with `PyRuntime`. After discussion, this fix removes exceptions from `search_linux_map_for_section`

Tested manually with the following script:

```
import sys
import os
import time

os.chmod("/cpython/python.exe", 0x0000)
sys.remote_exec(77223, "./remote_code.py")
```

Before:

```
/cpython# ./python.exe trigger_script.py
OSError: Cannot open ELF file '/cpython/Modules/readline.cpython-315-aarch64-linux-gnu.so (deleted)' for section 'PyRuntime' search: No such file or directory

During handling of the above exception, another exception occurred:

RuntimeError: Failed to find the PyRuntime section in process 77223 on Linux platform

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/cpython/trigger_script.py", line 11, in <module>
    sys.remote_exec(77223, "./remote_code.py")
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: PyRuntime address lookup failed during debug offsets initialization
```

Now
```
/cpython# ./python.exe trigger_script.py
RuntimeError: Failed to find the PyRuntime section in process 77223 on Linux platform

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/cpython/trigger_script.py", line 11, in <module>
    sys.remote_exec(77223, "./remote_code.py")
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: PyRuntime address lookup failed during debug offsets initialization
```



<!-- gh-issue-number: gh-137293 -->
* Issue: gh-137293
<!-- /gh-issue-number -->
