### PR TITLE
gh-137025: Update Emscripten Build Docs

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2025-08-01-13-27-43.gh-issue-137025.ubuhQC.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-08-01-13-27-43.gh-issue-137025.ubuhQC.rst
@@ -1,0 +1,3 @@
+The ``wasm_build.py`` script has been removed.  ``Tools/wasm/emscripten``
+and ``Tools/wasm/wasi`` should be used instead, as described in the `Dev
+Guide <https://devguide.python.org/contrib/workflows/compile/>`__.

--- a/Tools/wasm/README.md
+++ b/Tools/wasm/README.md
@@ -9,11 +9,6 @@ compilation of CPython to WebAssembly (WASM). Python supports Emscripten
 run in modern browsers and JavaScript runtimes like *Node.js*. WASI builds
 use WASM runtimes such as *wasmtime*.
 
-Users and developers are encouraged to use `Tools/wasm/emscripten` and
-`Tools/wasm/wasi` for building CPython for WebAssembly, as described below.
-These tools automate the build process and provide assistance with installation
-of SDKs, running tests, etc.
-
 **NOTE**: If you are looking for general information about WebAssembly that is
 not directly related to CPython, please see https://github.com/psf/webassembly.
 

--- a/Tools/wasm/README.md
+++ b/Tools/wasm/README.md
@@ -9,68 +9,19 @@ compilation of CPython to WebAssembly (WASM). Python supports Emscripten
 run in modern browsers and JavaScript runtimes like *Node.js*. WASI builds
 use WASM runtimes such as *wasmtime*.
 
-Users and developers are encouraged to use the script
-`Tools/wasm/wasm_build.py`. The tool automates the build process and provides
-assistance with installation of SDKs, running tests, etc.
+Users and developers are encouraged to use the `Tools/wasm/emscripten` and
+`Tools/wasm/wasi` for building CPython for WebAssembly. These tools automate
+the build process and provide assistance with installation of SDKs, running
+tests, etc.
 
-**NOTE**: If you are looking for information that is not directly related to
-building CPython for WebAssembly (or the resulting build), please see
-https://github.com/psf/webassembly for more information.
+**NOTE**: If you are looking for general information about WebAssembly that is
+not directly related to CPython, please see https://github.com/psf/webassembly.
 
-## wasm32-emscripten
+## Emscripten (wasm32-emscripten)
 
 ### Build
 
-To cross compile to the ``wasm32-emscripten`` platform you need
-[the Emscripten compiler toolchain](https://emscripten.org/),
-a Python interpreter, and an installation of Node version 18 or newer.
-Emscripten version 4.0.2 is recommended; newer versions may also work, but all
-official testing is performed with that version. All commands below are relative
-to a checkout of the Python repository.
-
-#### Install [the Emscripten compiler toolchain](https://emscripten.org/docs/getting_started/downloads.html)
-
-You can install the Emscripten toolchain as follows:
-```shell
-git clone https://github.com/emscripten-core/emsdk.git --depth 1
-./emsdk/emsdk install latest
-./emsdk/emsdk activate latest
-```
-To add the Emscripten compiler to your path:
-```shell
-source ./emsdk/emsdk_env.sh
-```
-This adds `emcc` and `emconfigure` to your path.
-
-##### Optionally: enable ccache for EMSDK
-
-The ``EM_COMPILER_WRAPPER`` must be set after the EMSDK environment is
-sourced. Otherwise the source script removes the environment variable.
-
-```shell
-export EM_COMPILER_WRAPPER=ccache
-```
-
-#### Compile and build Python interpreter
-
-You can use `python Tools/wasm/emscripten` to compile and build targeting
-Emscripten. You can do everything at once with:
-```shell
-python Tools/wasm/emscripten build
-```
-or you can break it out into four separate steps:
-```shell
-python Tools/wasm/emscripten configure-build-python
-python Tools/wasm/emscripten make-build-python
-python Tools/wasm/emscripten make-libffi
-python Tools/wasm/emscripten configure-host
-python Tools/wasm/emscripten make-host
-```
-Extra arguments to the configure steps are passed along to configure. For
-instance, to do a debug build, you can use:
-```shell
-python Tools/wasm/emscripten build --with-py-debug
-```
+See [the devguide instructions for building for Emscripten](https://devguide.python.org/getting-started/setup-building/#emscripten).
 
 ### Running from node
 

--- a/Tools/wasm/README.md
+++ b/Tools/wasm/README.md
@@ -9,10 +9,10 @@ compilation of CPython to WebAssembly (WASM). Python supports Emscripten
 run in modern browsers and JavaScript runtimes like *Node.js*. WASI builds
 use WASM runtimes such as *wasmtime*.
 
-Users and developers are encouraged to use the `Tools/wasm/emscripten` and
-`Tools/wasm/wasi` for building CPython for WebAssembly. These tools automate
-the build process and provide assistance with installation of SDKs, running
-tests, etc.
+Users and developers are encouraged to use `Tools/wasm/emscripten` and
+`Tools/wasm/wasi` for building CPython for WebAssembly, as described below.
+These tools automate the build process and provide assistance with installation
+of SDKs, running tests, etc.
 
 **NOTE**: If you are looking for general information about WebAssembly that is
 not directly related to CPython, please see https://github.com/psf/webassembly.
@@ -48,8 +48,8 @@ You can run the browser smoke test with:
 
 ### The Web Example
 
-When building for Emscripten, the web example will be built automatically. It
-is in the ``web_example`` directory. To run the web example, ``cd`` into the
+When building for Emscripten, a small web example will be built automatically
+in the ``web_example`` directory. To run the web example, ``cd`` into the
 ``web_example`` directory, then run ``python server.py``. This will start a web
 server; you can then visit ``http://localhost:8000/`` in a browser to see a
 simple REPL example.


### PR DESCRIPTION
Following the discussion in #137025, this patch updates `Tools/wasm/README.md` to link to the dev guide instead of replicating Emscripten build instructions.  It also adds a news item about the removal of `Tools/wasm/wasm_build.py` (which looks like it happened back in May, in ee49644cc9975f0ad3756b394b77043195ea08fc).

I think the build instructions in the dev guide may also want to be updated since they don't match the instructions being removed here:

* The dev guide recommends a specific `emsdk` version instead of `latest`.
* The dev guide doesn't mention `ccache`.

Maybe the dev guide should also link to this README for more information about using these builds in `node` or for the web?  Or maybe those sections should be moved to the dev guide, too?

Certainly happy for other feedback as well.

CC @hoodmane, @emmatyping 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-137025 -->
* Issue: gh-137025
<!-- /gh-issue-number -->
