### PR TITLE
gh-132983: _zstd: use Py_UNREACHABLE in _zstd_load_impl

### DIFF
--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -157,10 +157,7 @@ _zstd_load_impl(ZstdDecompressor *self, ZstdDict *zd,
                                        zd->dict_len);
     }
     else {
-        /* Impossible code path */
-        PyErr_SetString(PyExc_SystemError,
-                        "load_d_dict() impossible code path");
-        return -1;
+        Py_UNREACHABLE();
     }
 
     /* Check error */


### PR DESCRIPTION
There are 2 functions called `_zstd_load_impl`: one for compression and one for decompression.

In these functions, the `type` variable is supposed to represent the dict type. Due to the way the function is called, the dict type is always one of `DICT_TYPE_DIGESTED`/`DICT_TYPE_UNDIGESTED`/`DICT_TYPE_PREFIX`. However, the implementations differs in the unreachable case:
 - For compression: [call to `Py_UNREACHABLE`](https://github.com/python/cpython/blob/v3.14.0rc1/Modules/_zstd/compressor.c#L295)
 - For decompression: [`SystemError` exception](https://github.com/python/cpython/blob/v3.14.0rc1/Modules/_zstd/decompressor.c#L160-L163)

This PR harmonizes the two implementations by using `Py_UNREACHABLE`.

---

<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->
