### PR TITLE
gh-57943: disambiguate issue number in `os._fwalk` comment

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -491,7 +491,7 @@ if {open, stat} <= supports_dir_fd and {scandir, stat} <= supports_fd:
     def _fwalk(stack, isbytes, topdown, onerror, follow_symlinks):
         # Note: This uses O(depth of the directory tree) file descriptors: if
         # necessary, it can be adapted to only require O(1) FDs, see issue
-        # bpo-13734 (gh-57943).
+        # https://github.com/python/cpython/issues/57943
 
         action, value = stack.pop()
         if action == _fwalk_close:

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -491,7 +491,7 @@ if {open, stat} <= supports_dir_fd and {scandir, stat} <= supports_fd:
     def _fwalk(stack, isbytes, topdown, onerror, follow_symlinks):
         # Note: This uses O(depth of the directory tree) file descriptors: if
         # necessary, it can be adapted to only require O(1) FDs, see issue
-        # #13734.
+        # bpo-13734 (gh-57943).
 
         action, value = stack.pop()
         if action == _fwalk_close:

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -490,8 +490,8 @@ if {open, stat} <= supports_dir_fd and {scandir, stat} <= supports_fd:
 
     def _fwalk(stack, isbytes, topdown, onerror, follow_symlinks):
         # Note: This uses O(depth of the directory tree) file descriptors: if
-        # necessary, it can be adapted to only require O(1) FDs, see issue
-        # https://github.com/python/cpython/issues/57943
+        # necessary, it can be adapted to only require O(1) FDs.
+        # See https://github.com/python/cpython/issues/57943
 
         action, value = stack.pop()
         if action == _fwalk_close:

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -491,7 +491,7 @@ if {open, stat} <= supports_dir_fd and {scandir, stat} <= supports_fd:
     def _fwalk(stack, isbytes, topdown, onerror, follow_symlinks):
         # Note: This uses O(depth of the directory tree) file descriptors: if
         # necessary, it can be adapted to only require O(1) FDs.
-        # See https://github.com/python/cpython/issues/57943
+        # See https://github.com/python/cpython/issues/57943.
 
         action, value = stack.pop()
         if action == _fwalk_close:


### PR DESCRIPTION
Reference to bpo issue: https://bugs.python.org/issue13734 made in an inline comment, I've added the `bpo-` prefix and `gh` reference to disambiguate to which issue tracker the reference is making.

I'm not sure if it's preferred to get rid of `bpo` references and keep only `gh` references. 🤷🏼 

gh ref: https://github.com/python/cpython/issues/57943


<!-- gh-issue-number: gh-57943 -->
* Issue: gh-57943
<!-- /gh-issue-number -->
