### PR TITLE
gh-137314: Fix incorrect treatment of format specs in raw fstrings

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1832,11 +1832,10 @@ print(f'''{{
             compile(case, "<string>", "exec")
 
     def test_raw_fstring_format_spec(self):
-        """Test raw f-string format spec behavior (Issue #137314).
-
-        Raw f-strings should preserve literal backslashes in format specifications,
-        not interpret them as escape sequences.
-        """
+        # Test raw f-string format spec behavior (Issue #137314).
+        #
+        # Raw f-strings should preserve literal backslashes in format specifications,
+        # not interpret them as escape sequences.
         class UnchangedFormat:
             """Test helper that returns the format spec unchanged."""
             def __format__(self, format):

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1841,30 +1841,23 @@ print(f'''{{
             def __format__(self, format):
                 return format
 
-        # Test basic Unicode escape
-        non_raw = f"{UnchangedFormat():\xFF}"
-        self.assertEqual(non_raw, 'ÿ')
-
-        raw = rf"{UnchangedFormat():\xFF}"
-        self.assertEqual(raw, '\\xFF')
-
-        # Test newline escape
-        non_raw = f"{UnchangedFormat():\n}"
-        self.assertEqual(non_raw, '\n')
-
-        raw = rf"{UnchangedFormat():\n}"
-        self.assertEqual(raw, '\\n')
-
-        # Test tab escape
-        non_raw = f"{UnchangedFormat():\t}"
-        self.assertEqual(non_raw, '\t')
-
-        raw = rf"{UnchangedFormat():\t}"
-        self.assertEqual(raw, '\\t')
-
+        # Test basic escape sequences
+        self.assertEqual(f"{UnchangedFormat():\xFF}", 'ÿ')
+        self.assertEqual(rf"{UnchangedFormat():\xFF}", '\\xFF')
+        
+        # Test nested expressions with raw/non-raw combinations
+        self.assertEqual(rf"{UnchangedFormat():{'\xFF'}}", 'ÿ')
+        self.assertEqual(f"{UnchangedFormat():{r'\xFF'}}", '\\xFF')
+        self.assertEqual(rf"{UnchangedFormat():{r'\xFF'}}", '\\xFF')
+        
+        # Test continuation character in format specs
+        self.assertEqual(f"""{UnchangedFormat():{'a'\
+                        'b'}}""", 'ab')
+        self.assertEqual(rf"""{UnchangedFormat():{'a'\
+                         'b'}}""", 'ab')
+        
         # Test multiple format specs in same raw f-string
-        result = rf"{UnchangedFormat():\xFF} {UnchangedFormat():\n}"
-        self.assertEqual(result, '\\xFF \\n')
+        self.assertEqual(rf"{UnchangedFormat():\xFF} {UnchangedFormat():\n}", '\\xFF \\n')
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1844,18 +1844,18 @@ print(f'''{{
         # Test basic escape sequences
         self.assertEqual(f"{UnchangedFormat():\xFF}", 'ÿ')
         self.assertEqual(rf"{UnchangedFormat():\xFF}", '\\xFF')
-        
+
         # Test nested expressions with raw/non-raw combinations
         self.assertEqual(rf"{UnchangedFormat():{'\xFF'}}", 'ÿ')
         self.assertEqual(f"{UnchangedFormat():{r'\xFF'}}", '\\xFF')
         self.assertEqual(rf"{UnchangedFormat():{r'\xFF'}}", '\\xFF')
-        
+
         # Test continuation character in format specs
         self.assertEqual(f"""{UnchangedFormat():{'a'\
                         'b'}}""", 'ab')
         self.assertEqual(rf"""{UnchangedFormat():{'a'\
                          'b'}}""", 'ab')
-        
+
         # Test multiple format specs in same raw f-string
         self.assertEqual(rf"{UnchangedFormat():\xFF} {UnchangedFormat():\n}", '\\xFF \\n')
 

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1831,6 +1831,42 @@ print(f'''{{
         for case in valid_cases:
             compile(case, "<string>", "exec")
 
+    def test_raw_fstring_format_spec(self):
+        """Test raw f-string format spec behavior (Issue #137314).
+
+        Raw f-strings should preserve literal backslashes in format specifications,
+        not interpret them as escape sequences.
+        """
+        class UnchangedFormat:
+            """Test helper that returns the format spec unchanged."""
+            def __format__(self, format):
+                return format
+
+        # Test basic Unicode escape
+        non_raw = f"{UnchangedFormat():\xFF}"
+        self.assertEqual(non_raw, 'ÿ')
+
+        raw = rf"{UnchangedFormat():\xFF}"
+        self.assertEqual(raw, '\\xFF')
+
+        # Test newline escape
+        non_raw = f"{UnchangedFormat():\n}"
+        self.assertEqual(non_raw, '\n')
+
+        raw = rf"{UnchangedFormat():\n}"
+        self.assertEqual(raw, '\\n')
+
+        # Test tab escape
+        non_raw = f"{UnchangedFormat():\t}"
+        self.assertEqual(non_raw, '\t')
+
+        raw = rf"{UnchangedFormat():\t}"
+        self.assertEqual(raw, '\\t')
+
+        # Test multiple format specs in same raw f-string
+        result = rf"{UnchangedFormat():\xFF} {UnchangedFormat():\n}"
+        self.assertEqual(result, '\\xFF \\n')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-02-23-04-57.gh-issue-137314.wjEdzD.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-02-23-04-57.gh-issue-137314.wjEdzD.rst
@@ -1,0 +1,5 @@
+Fixed a regression where raw f-strings incorrectly interpreted
+escape sequences in format specifications. Raw f-strings now properly preserve
+literal backslashes in format specs, matching the behavior from Python 3.11.
+For example, ``rf"{obj:\xFF}"`` now correctly produces ``'\\xFF'`` instead of
+``'ÿ'``. Patch by Pablo Galindo.

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -1404,7 +1404,15 @@ expr_ty _PyPegen_decoded_constant_from_token(Parser* p, Token* tok) {
     if (PyBytes_AsStringAndSize(tok->bytes, &bstr, &bsize) == -1) {
         return NULL;
     }
-    PyObject* str = _PyPegen_decode_string(p, 0, bstr, bsize, tok);
+
+    // Check if we're inside a raw f-string for format spec decoding
+    int is_raw = 0;
+    if (INSIDE_FSTRING(p->tok)) {
+        tokenizer_mode *mode = TOK_GET_MODE(p->tok);
+        is_raw = mode->raw;
+    }
+
+    PyObject* str = _PyPegen_decode_string(p, is_raw, bstr, bsize, tok);
     if (str == NULL) {
         return NULL;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-137314 -->
* Issue: gh-137314
<!-- /gh-issue-number -->
