### PR TITLE
gh-137335: Remove use of ``mktemp()`` in ``asyncio.windows_utils``

### DIFF
--- a/Lib/asyncio/windows_utils.py
+++ b/Lib/asyncio/windows_utils.py
@@ -32,7 +32,7 @@ _mmap_counter = itertools.count()
 
 def pipe(*, duplex=False, overlapped=(True, True), bufsize=BUFSIZE):
     """Like os.pipe() but with overlapped support and using handles not fds."""
-    pipename = f'python-pipe-{os.getpid()}-{uuid.uuid4()}'
+    pipename = f'python-pipe-{os.getpid()}-{uuid.uuid4().hex}'
     address = fr'\\.\pipe\{pipename}'
 
     if duplex:

--- a/Lib/asyncio/windows_utils.py
+++ b/Lib/asyncio/windows_utils.py
@@ -32,8 +32,8 @@ _mmap_counter = itertools.count()
 
 def pipe(*, duplex=False, overlapped=(True, True), bufsize=BUFSIZE):
     """Like os.pipe() but with overlapped support and using handles not fds."""
-    address = r'\\.\pipe\python-pipe-{:d}-{:s}'.format(os.getpid(),
-                                                       str(uuid.uuid4()))
+    address = tempfile.mkstemp(r'\\.\pipe\python-pipe-{:d}-{:s}'.format(os.getpid(),
+                                                       str(uuid.uuid4())))
 
     if duplex:
         openmode = _winapi.PIPE_ACCESS_DUPLEX

--- a/Lib/asyncio/windows_utils.py
+++ b/Lib/asyncio/windows_utils.py
@@ -32,8 +32,8 @@ _mmap_counter = itertools.count()
 
 def pipe(*, duplex=False, overlapped=(True, True), bufsize=BUFSIZE):
     """Like os.pipe() but with overlapped support and using handles not fds."""
-    address = tempfile.mkstemp(r'\\.\pipe\python-pipe-{:d}-{:s}'.format(os.getpid(),
-                                                       str(uuid.uuid4())))
+    pipename = f'python-pipe-{os.getpid()}-{uuid.uuid4()}'
+    address = fr'\\.\pipe\{pipename}'
 
     if duplex:
         openmode = _winapi.PIPE_ACCESS_DUPLEX

--- a/Lib/asyncio/windows_utils.py
+++ b/Lib/asyncio/windows_utils.py
@@ -32,7 +32,7 @@ _mmap_counter = itertools.count()
 
 def pipe(*, duplex=False, overlapped=(True, True), bufsize=BUFSIZE):
     """Like os.pipe() but with overlapped support and using handles not fds."""
-    address = r'\\.\pipe\python-pipe-{:d}-{:s}'.format(os.getpid(), 
+    address = r'\\.\pipe\python-pipe-{:d}-{:s}'.format(os.getpid(),
                                                        str(uuid.uuid4()))
 
     if duplex:

--- a/Lib/asyncio/windows_utils.py
+++ b/Lib/asyncio/windows_utils.py
@@ -12,6 +12,7 @@ import os
 import subprocess
 import tempfile
 import warnings
+import uuid
 
 
 __all__ = 'pipe', 'Popen', 'PIPE', 'PipeHandle'

--- a/Lib/asyncio/windows_utils.py
+++ b/Lib/asyncio/windows_utils.py
@@ -31,9 +31,8 @@ _mmap_counter = itertools.count()
 
 def pipe(*, duplex=False, overlapped=(True, True), bufsize=BUFSIZE):
     """Like os.pipe() but with overlapped support and using handles not fds."""
-    address = tempfile.mktemp(
-        prefix=r'\\.\pipe\python-pipe-{:d}-{:d}-'.format(
-            os.getpid(), next(_mmap_counter)))
+    address = r'\\.\pipe\python-pipe-{:d}-{:s}'.format(os.getpid(), 
+                                                       str(uuid.uuid4()))
 
     if duplex:
         openmode = _winapi.PIPE_ACCESS_DUPLEX

--- a/Misc/NEWS.d/next/Library/2025-08-04-00-25-48.gh-issue-137335.yRgZib.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-04-00-25-48.gh-issue-137335.yRgZib.rst
@@ -1,0 +1,13 @@
+matemp() function is unsafe,so I use safety function.
+bandit tool:
+```
+Issue: [B306:blacklist] Use of insecure and deprecated function (mktemp).
+Severity: Medium Confidence: High
+CWE: CWE-377 (https://cwe.mitre.org/data/definitions/377.html)
+More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b306-mktemp-q
+Location: C:\Users\Administrator\Desktop\cpython\lib\asyncio\windows_utils.py:34:14
+33 """Like os.pipe() but with overlapped support and using handles not fds."""
+34 address = tempfile.mktemp(
+35 prefix=r'\.\pipe\python-pipe-{:d}-{:d}-'.format(
+36 os.getpid(), next(_mmap_counter)))
+```


### PR DESCRIPTION
matemp() function is unsafe,so I use safety function.
bandit tool:

>> Issue: [B306:blacklist] Use of insecure and deprecated function (mktemp).
   Severity: Medium   Confidence: High
   CWE: CWE-377 (https://cwe.mitre.org/data/definitions/377.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b306-mktemp-q
   Location: C:\Users\Administrator\Desktop\cpython\lib\asyncio\windows_utils.py:34:14
33	    """Like os.pipe() but with overlapped support and using handles not fds."""
34	    address = tempfile.mktemp(
35	        prefix=r'\\.\pipe\python-pipe-{:d}-{:d}-'.format(
36	            os.getpid(), next(_mmap_counter)))
37	


<!-- gh-issue-number: gh-137335 -->
* Issue: gh-137335
<!-- /gh-issue-number -->
