### PR TITLE
[3.14] Fix typo in Doc/extending/extending.rst (GH-136890)

### DIFF
--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -214,7 +214,7 @@ and initialize it by calling :c:func:`PyErr_NewException` in the module's
 
    SpamError = PyErr_NewException("spam.error", NULL, NULL);
 
-Since :c:data:`!SpamError` is a global variable, it will be overwitten every time
+Since :c:data:`!SpamError` is a global variable, it will be overwritten every time
 the module is reinitialized, when the :c:data:`Py_mod_exec` function is called.
 
 For now, let's avoid the issue: we will block repeated initialization by raising an


### PR DESCRIPTION
(cherry picked from commit 80a7017d2649ad5d7d1f83758eeeef50e5eba6b1)




<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137355.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->