### PR TITLE
[3.13] Fix typo in `Lib/test/test_ast/test_ast.py` (GH-136767)

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -3236,7 +3236,7 @@ class ASTMainTests(unittest.TestCase):
 def compare(left, right):
     return ast.dump(left) == ast.dump(right)
 
-class ASTOptimiziationTests(unittest.TestCase):
+class ASTOptimizationTests(unittest.TestCase):
     binop = {
         "+": ast.Add(),
         "-": ast.Sub(),


### PR DESCRIPTION
(cherry picked from commit 60146f4f6f24f37e3bfcb9f101565f6e86cf0146)

