### PR TITLE
Remove Alex Waygood as a codeowner for pre-commit config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 .github/**                    @ezio-melotti @hugovk @AA-Turner
 
 # pre-commit
-.pre-commit-config.yaml       @hugovk @AlexWaygood
+.pre-commit-config.yaml       @hugovk
 .ruff.toml                    @hugovk @AlexWaygood @AA-Turner
 
 # Build system


### PR DESCRIPTION
I don't really have the bandwidth to review all the PRs making changes to this file right now (most of which make pretty minimal/uncontroversial to the file!) :-)
