### PR TITLE
[3.13] Remove Alex Waygood as a codeowner for pre-commit config (#137372)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 .github/**                    @ezio-melotti @hugovk
 
 # pre-commit
-.pre-commit-config.yaml       @hugovk @AlexWaygood
+.pre-commit-config.yaml       @hugovk
 .ruff.toml                    @hugovk @AlexWaygood
 
 # Build system


### PR DESCRIPTION
(cherry-picked from #137372)