### PR TITLE
gh-137376: ensure that `SyntaxError` are properly detected in REPL

### DIFF
--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -950,6 +950,7 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(fd));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(fd2));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(fdel));
+    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(feature_version));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(fget));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(fields));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(file));

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -441,6 +441,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(fd)
         STRUCT_FOR_ID(fd2)
         STRUCT_FOR_ID(fdel)
+        STRUCT_FOR_ID(feature_version)
         STRUCT_FOR_ID(fget)
         STRUCT_FOR_ID(fields)
         STRUCT_FOR_ID(file)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -948,6 +948,7 @@ extern "C" {
     INIT_ID(fd), \
     INIT_ID(fd2), \
     INIT_ID(fdel), \
+    INIT_ID(feature_version), \
     INIT_ID(fget), \
     INIT_ID(fields), \
     INIT_ID(file), \

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -1552,6 +1552,10 @@ _PyUnicode_InitStaticStrings(PyInterpreterState *interp) {
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));
     assert(PyUnicode_GET_LENGTH(string) != 1);
+    string = &_Py_ID(feature_version);
+    _PyUnicode_InternStatic(interp, &string);
+    assert(_PyUnicode_CheckConsistency(string, 1));
+    assert(PyUnicode_GET_LENGTH(string) != 1);
     string = &_Py_ID(fget);
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));

--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import _colorize
-import _symtable
+import _symtable  # type: ignore[import-not-found]
 
 from abc import ABC, abstractmethod
 import ast
@@ -214,11 +214,11 @@ class InteractiveColoredConsole(code.InteractiveConsole):
             self.showsyntaxerror(filename, source=source)
             return False
 
+        # validate stuff that cannot be validated with AST parsing only
+        flags = self.compile.compiler.flags
+        flags &= ~codeop.PyCF_DONT_IMPLY_DEDENT
+        flags &= ~codeop.PyCF_ALLOW_INCOMPLETE_INPUT
         try:
-            # validate stuff that cannot be validated with AST parsing only
-            flags = self.compile.compiler.flags
-            flags &= ~codeop.PyCF_DONT_IMPLY_DEDENT
-            flags &= ~codeop.PyCF_ALLOW_INCOMPLETE_INPUT
             _symtable.symtable(source, filename, "exec", flags=flags)
         except (SyntaxError, OverflowError, ValueError):
             self.showsyntaxerror(filename, source=source)

--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -214,8 +214,15 @@ class InteractiveColoredConsole(code.InteractiveConsole):
             self.showsyntaxerror(filename, source=source)
             return False
 
-        # validate stuff that cannot be validated with AST parsing only
-        flags = self.compile.compiler.flags
+        # Validate stuff that cannot be validated with AST parsing only,
+        # such as assigning to a variable before a global declaration,
+        #
+        # While runsource("x = 1; global x") would fail, runsource("x = 1")
+        # followed by runsource("global x") would still work since preventing
+        # this requires the REPL to remember the global names whose number
+        # grows faster than in a regular program, which then becomes less
+        # efficient or relevant for the user.
+        flags = self.compile.compiler.flags  # may contain active futures
         flags &= ~codeop.PyCF_DONT_IMPLY_DEDENT
         flags &= ~codeop.PyCF_ALLOW_INCOMPLETE_INPUT
         try:

--- a/Lib/test/test_pyrepl/test_interact.py
+++ b/Lib/test/test_pyrepl/test_interact.py
@@ -131,6 +131,15 @@ SyntaxError: duplicate parameter 'x' in function definition"""
             console.runsource(source)
             mock_showsyntaxerror.assert_called_once()
 
+    def test_runsource_shows_syntax_error_for_failed_symtable_checks(self):
+        # Some checks cannot be performed by AST parsing only.
+        # See https://github.com/python/cpython/issues/137376.
+        console = InteractiveColoredConsole()
+        source = "x = 1; global x; x = 2"
+        with patch.object(console, "showsyntaxerror") as mock_showsyntaxerror:
+            console.runsource(source)
+            mock_showsyntaxerror.assert_called_once()
+
     def test_runsource_survives_null_bytes(self):
         console = InteractiveColoredConsole()
         source = "\x00\n"

--- a/Misc/NEWS.d/next/Library/2025-08-04-14-38-28.gh-issue-137376.iHSKBL.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-04-14-38-28.gh-issue-137376.iHSKBL.rst
@@ -1,0 +1,3 @@
+Ensure that :exc:`SyntaxError` is raised when given incorrect REPL inputs
+that are only detected when processing symbol tables. Patch by Bénédikt
+Tran.

--- a/Modules/clinic/symtablemodule.c.h
+++ b/Modules/clinic/symtablemodule.c.h
@@ -10,7 +10,7 @@ preserve
 
 PyDoc_STRVAR(_symtable_symtable__doc__,
 "symtable($module, source, filename, startstr, /, *, flags=0,\n"
-"         feature_version=0)\n"
+"         feature_version=-1)\n"
 "--\n"
 "\n"
 "Return symbol and scope dictionaries used internally by compiler.");
@@ -60,7 +60,7 @@ _symtable_symtable(PyObject *module, PyObject *const *args, Py_ssize_t nargs, Py
     PyObject *filename;
     const char *startstr;
     int flags = 0;
-    int feature_version = 0;
+    int feature_version = -1;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 3, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -106,4 +106,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=71571c035470d288 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f30a99893fa9de05 input=a9049054013a1b77]*/

--- a/Modules/clinic/symtablemodule.c.h
+++ b/Modules/clinic/symtablemodule.c.h
@@ -2,30 +2,69 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+#  include "pycore_gc.h"          // PyGC_Head
+#  include "pycore_runtime.h"     // _Py_ID()
+#endif
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(_symtable_symtable__doc__,
-"symtable($module, source, filename, startstr, /)\n"
+"symtable($module, source, filename, startstr, /, *, flags=0,\n"
+"         feature_version=0)\n"
 "--\n"
 "\n"
 "Return symbol and scope dictionaries used internally by compiler.");
 
 #define _SYMTABLE_SYMTABLE_METHODDEF    \
-    {"symtable", _PyCFunction_CAST(_symtable_symtable), METH_FASTCALL, _symtable_symtable__doc__},
+    {"symtable", _PyCFunction_CAST(_symtable_symtable), METH_FASTCALL|METH_KEYWORDS, _symtable_symtable__doc__},
 
 static PyObject *
 _symtable_symtable_impl(PyObject *module, PyObject *source,
-                        PyObject *filename, const char *startstr);
+                        PyObject *filename, const char *startstr, int flags,
+                        int feature_version);
 
 static PyObject *
-_symtable_symtable(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+_symtable_symtable(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 2
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        Py_hash_t ob_hash;
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_hash = -1,
+        .ob_item = { &_Py_ID(flags), &_Py_ID(feature_version), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"", "", "", "flags", "feature_version", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "symtable",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[5];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 3;
     PyObject *source;
     PyObject *filename;
     const char *startstr;
+    int flags = 0;
+    int feature_version = 0;
 
-    if (!_PyArg_CheckPositional("symtable", nargs, 3, 3)) {
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
+            /*minpos*/ 3, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
+    if (!args) {
         goto exit;
     }
     source = args[0];
@@ -45,9 +84,26 @@ _symtable_symtable(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
-    return_value = _symtable_symtable_impl(module, source, filename, startstr);
+    if (!noptargs) {
+        goto skip_optional_kwonly;
+    }
+    if (args[3]) {
+        flags = PyLong_AsInt(args[3]);
+        if (flags == -1 && PyErr_Occurred()) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_kwonly;
+        }
+    }
+    feature_version = PyLong_AsInt(args[4]);
+    if (feature_version == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+skip_optional_kwonly:
+    return_value = _symtable_symtable_impl(module, source, filename, startstr, flags, feature_version);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=931964a76a72f850 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=71571c035470d288 input=a9049054013a1b77]*/

--- a/Modules/symtablemodule.c
+++ b/Modules/symtablemodule.c
@@ -18,7 +18,7 @@ _symtable.symtable
     /
     *
     flags: int = 0
-    feature_version: int = 0
+    feature_version: int = -1
 
 Return symbol and scope dictionaries used internally by compiler.
 [clinic start generated code]*/
@@ -27,7 +27,7 @@ static PyObject *
 _symtable_symtable_impl(PyObject *module, PyObject *source,
                         PyObject *filename, const char *startstr, int flags,
                         int feature_version)
-/*[clinic end generated code: output=1e766ac3387e156a input=5ccfb94e8a19a975]*/
+/*[clinic end generated code: output=1e766ac3387e156a input=03e9deda7ab5a9d7]*/
 {
     struct symtable *st;
     PyObject *t;

--- a/Modules/symtablemodule.c
+++ b/Modules/symtablemodule.c
@@ -16,14 +16,18 @@ _symtable.symtable
     filename:  object(converter='PyUnicode_FSDecoder')
     startstr:  str
     /
+    *
+    flags: int = 0
+    feature_version: int = 0
 
 Return symbol and scope dictionaries used internally by compiler.
 [clinic start generated code]*/
 
 static PyObject *
 _symtable_symtable_impl(PyObject *module, PyObject *source,
-                        PyObject *filename, const char *startstr)
-/*[clinic end generated code: output=59eb0d5fc7285ac4 input=9dd8a50c0c36a4d7]*/
+                        PyObject *filename, const char *startstr, int flags,
+                        int feature_version)
+/*[clinic end generated code: output=1e766ac3387e156a input=5ccfb94e8a19a975]*/
 {
     struct symtable *st;
     PyObject *t;
@@ -31,7 +35,14 @@ _symtable_symtable_impl(PyObject *module, PyObject *source,
     PyCompilerFlags cf = _PyCompilerFlags_INIT;
     PyObject *source_copy = NULL;
 
-    cf.cf_flags = PyCF_SOURCE_IS_UTF8;
+    cf.cf_flags = flags | PyCF_SOURCE_IS_UTF8;
+    if (feature_version >= 0 && (flags & PyCF_ONLY_AST)) {
+        cf.cf_feature_version = feature_version;
+    }
+    if (flags & ~(PyCF_MASK | PyCF_MASK_OBSOLETE | PyCF_COMPILE_MASK)) {
+        PyErr_SetString(PyExc_ValueError, "_symtable.symtable(): unrecognised flags");
+        return NULL;
+    }
 
     const char *str = _Py_SourceAsString(source, "symtable", "string or bytes", &cf, &source_copy);
     if (str == NULL) {


### PR DESCRIPTION
This is very fast hack because I need to go and won't be able to do any work. I plan to handle better the arguments to `symtable.symtable` but the idea is to re-use the same flags that were passed to the compiler since otherwise some tests fail (the barry test fails because the future is added separately, and symtable on `<>` would fail as it doesn't know about the future).

<!-- gh-issue-number: gh-137376 -->
* Issue: gh-137376
<!-- /gh-issue-number -->
