### PR TITLE
gh-137390: Add missing line continuation character in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5219,7 +5219,7 @@ AC_CHECK_FUNCS([ \
   posix_spawn_file_actions_addclosefrom_np \
   pread preadv preadv2 process_vm_readv \
   pthread_cond_timedwait_relative_np pthread_condattr_setclock pthread_init \
-  pthread_kill pthread_get_name_np pthread_getname_np pthread_set_name_np
+  pthread_kill pthread_get_name_np pthread_getname_np pthread_set_name_np \
   pthread_setname_np pthread_getattr_np \
   ptsname ptsname_r pwrite pwritev pwritev2 readlink readlinkat readv realpath renameat \
   rtpSpawn sched_get_priority_max sched_rr_get_interval sched_setaffinity \


### PR DESCRIPTION
`configure.ac` is missing a line continuation character causing failures when the configure script is recreated. This change adds the missing character.

<!-- gh-issue-number: gh-137390 -->
* Issue: gh-137390
<!-- /gh-issue-number -->
