### PR TITLE
gh-137403: Pass auto to -flto with gcc to parallelize LTO build on linux

### DIFF
--- a/configure
+++ b/configure
@@ -8863,7 +8863,7 @@ fi
           LTOCFLAGS="-flto"
           ;;
         *)
-          LTOFLAGS="-flto -fuse-linker-plugin -ffat-lto-objects"
+          LTOFLAGS="-flto=auto -fuse-linker-plugin -ffat-lto-objects"
           ;;
       esac
       ;;


### PR DESCRIPTION
Currently when building CPython with loto (./configure --with-lto) on linux with gcc gives a number of similar warnings:

  lto-wrapper: warning: using serial compilation of 70 LTRANS jobs
  lto-wrapper: note: see the ‘-flto’ option documentation for more information

To fix this pass the -flot=auto to allow gcc to run the lto jobs in parallel. If no value is passed the default in 1 at a time.

The ability to pass auto goes back goc at least gcc 10 [1].

A similar change can be made on Darwin, but did not make that change without testing.

This significantly speeds up the build process when using lto (dependent on the number of cores available).

[1] https://gcc.gnu.org/onlinedocs/gcc-10.1.0/gcc/Optimize-Options.html

<!-- gh-issue-number: gh-137403 -->
* Issue: gh-137403
<!-- /gh-issue-number -->
