### PR TITLE
Fix buildbot release status link in CONTRIBUTING.rst

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -4,7 +4,7 @@ Contributing to Python
 Build Status
 ------------
 
-- `Buildbot status overview <https://buildbot.python.org/all/#/release_status>`_
+- `Buildbot status overview <https://buildbot.python.org/#/release_status>`_
 
 - `GitHub Actions status <https://github.com/python/cpython/actions/workflows/build.yml>`_
 


### PR DESCRIPTION
The existing link works, but includes the legacy `/all` part of the path
which causes a scary-looking banner about a misconfiguration on the
`Home` page when in reality it's the link that includes a deprecated path.
