### PR TITLE
gh-133390: Amend gh-135659 (sqlite3 docs update)

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -509,12 +509,12 @@ Module constants
 
 .. data:: SQLITE_KEYWORDS
 
-   A :class:`tuple` containing all sqlite3 keywords.
+   A :class:`tuple` containing all SQLite keywords.
 
    This constant is only available if Python was compiled with SQLite
    3.24.0 or greater.
 
-   .. versionadded:: next
+   .. versionadded:: 3.14
 
 .. data:: threadsafety
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -514,7 +514,7 @@ Module constants
    This constant is only available if Python was compiled with SQLite
    3.24.0 or greater.
 
-   .. versionadded:: 3.14
+   .. versionadded:: next
 
 .. data:: threadsafety
 


### PR DESCRIPTION
- The SQLITE_KEYWORDS constant describes SQLite, not sqlite3, keywords
- ~~SQLITE_KEYWORDS were added in 3.14, not in upcoming 3.15~~


<!-- gh-issue-number: gh-133390 -->
* Issue: gh-133390
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137447.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->