### PR TITLE
Standardize translation of `Doc/bugs.rst`

### DIFF
--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -19,6 +19,12 @@ If you find a bug in this documentation or would like to propose an improvement,
 please submit a bug report on the :ref:`issue tracker <using-the-tracker>`.  If you
 have a suggestion on how to fix it, include that as well.
 
+.. only:: translation
+
+   If the bug or suggested improvement concerns the translation of this
+   documentation, submit the report to the
+   `translation’s repository <TRANSLATION_REPO_>`_ instead.
+
 You can also open a discussion item on our
 `Documentation Discourse forum <https://discuss.python.org/c/documentation/26>`_.
 

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -454,6 +454,25 @@ epub_exclude_files = ('index.xhtml', 'download.xhtml')
 # https://github.com/sphinx-doc/sphinx/issues/12359
 epub_use_index = False
 
+# translation tag
+# ---------------
+
+language_code = None
+for arg in sys.argv:
+    if arg.startswith('language='):
+        language_code = arg.split('=', 1)[1]
+
+if language_code:
+    tags.add('translation')  # noqa: F821
+
+    rst_epilog += f"""\
+.. _TRANSLATION_REPO: https://github.com/python/python-docs-{language_code}
+"""  # noqa: F821
+else:
+    rst_epilog += """\
+.. _TRANSLATION_REPO: https://github.com/python
+"""
+
 # Options for the coverage checker
 # --------------------------------
 

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -466,7 +466,7 @@ if language_code:
     tags.add('translation')  # noqa: F821
 
     rst_epilog += f"""\
-.. _TRANSLATION_REPO: https://github.com/python/python-docs-{language_code}
+.. _TRANSLATION_REPO: https://github.com/python/python-docs-{language_code.replace("_", "-").lower()}
 """  # noqa: F821
 else:
     rst_epilog += """\


### PR DESCRIPTION
PEP 545 (and soon, the devguide with my PR) states that:

> ... bugs.html [should be translated] with proper links to the language repository issue tracker.

There is however, no clear way of doing this, and it is sometimes not added at all. I therefore propose to add a section that will only appear in translations and the gettext builder, that will allow for this to be standardized.

The tag will also be useful in other places, namely @nedbat's "Improve this page" page (https://github.com/python/cpython/pull/136246)

I have verified that this will work with [docsbuild-scripts](https://github.com/python/docsbuild-scripts/blob/a601ce67c6c2f3be7fde3376d3e5d3851f19950b/build_docs.py#L636).

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137449.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->