### PR TITLE
GH-137466: Remove deprecated and undocumented `glob.glob0()` and `glob1()`

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -418,6 +418,14 @@ ctypes
   (Contributed by Bénédikt Tran in :gh:`133866`.)
 
 
+glob
+----
+
+* Removed the undocumented :func:`!glob.glob0` and :func:`!glob.glob1`
+  functions, which have been deprecated since Python 3.13.
+  (Contributed by Barney Gale in :gh:`137466`.)
+
+
 http.server
 -----------
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -422,7 +422,8 @@ glob
 ----
 
 * Removed the undocumented :func:`!glob.glob0` and :func:`!glob.glob1`
-  functions, which have been deprecated since Python 3.13.
+  functions, which have been deprecated since Python 3.13. Use
+  :func:`glob.glob` and pass a directory to its *root_dir* argument instead.
   (Contributed by Barney Gale in :gh:`137466`.)
 
 

--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -122,21 +122,6 @@ def _glob0(dirname, basename, dir_fd, dironly, include_hidden=False):
             return [basename]
     return []
 
-_deprecated_function_message = (
-    "{name} is deprecated and will be removed in Python {remove}. Use "
-    "glob.glob and pass a directory to its root_dir argument instead."
-)
-
-def glob0(dirname, pattern):
-    import warnings
-    warnings._deprecated("glob.glob0", _deprecated_function_message, remove=(3, 15))
-    return _glob0(dirname, pattern, None, False)
-
-def glob1(dirname, pattern):
-    import warnings
-    warnings._deprecated("glob.glob1", _deprecated_function_message, remove=(3, 15))
-    return _glob1(dirname, pattern, None, False)
-
 # This helper function recursively yields relative pathnames inside a literal
 # directory.
 

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -393,36 +393,6 @@ class GlobTests(unittest.TestCase):
             for it in iters:
                 self.assertEqual(next(it), p)
 
-    def test_glob0(self):
-        with self.assertWarns(DeprecationWarning):
-            glob.glob0(self.tempdir, 'a')
-
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            eq = self.assertSequencesEqual_noorder
-            eq(glob.glob0(self.tempdir, 'a'), ['a'])
-            eq(glob.glob0(self.tempdir, '.bb'), ['.bb'])
-            eq(glob.glob0(self.tempdir, '.b*'), [])
-            eq(glob.glob0(self.tempdir, 'b'), [])
-            eq(glob.glob0(self.tempdir, '?'), [])
-            eq(glob.glob0(self.tempdir, '*a'), [])
-            eq(glob.glob0(self.tempdir, 'a*'), [])
-
-    def test_glob1(self):
-        with self.assertWarns(DeprecationWarning):
-            glob.glob1(self.tempdir, 'a')
-
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            eq = self.assertSequencesEqual_noorder
-            eq(glob.glob1(self.tempdir, 'a'), ['a'])
-            eq(glob.glob1(self.tempdir, '.bb'), ['.bb'])
-            eq(glob.glob1(self.tempdir, '.b*'), ['.bb'])
-            eq(glob.glob1(self.tempdir, 'b'), [])
-            eq(glob.glob1(self.tempdir, '?'), ['a'])
-            eq(glob.glob1(self.tempdir, '*a'), ['a', 'aaa'])
-            eq(glob.glob1(self.tempdir, 'a*'), ['a', 'aaa', 'aab'])
-
     def test_translate_matching(self):
         match = re.compile(glob.translate('*')).match
         self.assertIsNotNone(match('foo'))

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -4,7 +4,6 @@ import re
 import shutil
 import sys
 import unittest
-import warnings
 
 from test.support import is_wasi, Py_DEBUG
 from test.support.os_helper import (TESTFN, skip_unless_symlink,

--- a/Misc/NEWS.d/next/Library/2025-08-06-16-13-47.gh-issue-137466.Whv0-A.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-06-16-13-47.gh-issue-137466.Whv0-A.rst
@@ -1,0 +1,3 @@
+Remove undocumented :func:`!glob.glob0` and :func:`!glob.glob1` functions,
+which have been deprecated since Python 3.13. Use :func:`glob.glob` and pass
+a directory to its *root_dir* argument instead.


### PR DESCRIPTION


<!-- gh-issue-number: gh-137466 -->
* Issue: gh-137466
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137467.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->