### PR TITLE
[3.13] gh-134262: Add retries to generate_sbom.py (GH-134263)

### DIFF
--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -7,6 +7,9 @@ import glob
 from pathlib import Path, PurePosixPath, PureWindowsPath
 import subprocess
 import sys
+import time
+import typing
+import urllib.error
 import urllib.request
 import typing
 
@@ -163,6 +166,21 @@ def get_externals() -> list[str]:
     return externals
 
 
+def download_with_retries(download_location: str,
+                          max_retries: int = 5,
+                          base_delay: float = 2.0) -> typing.Any:
+    """Download a file with exponential backoff retry."""
+    for attempt in range(max_retries):
+        try:
+            resp = urllib.request.urlopen(download_location)
+        except urllib.error.URLError as ex:
+            if attempt == max_retries:
+                raise ex
+            time.sleep(base_delay**attempt)
+        else:
+            return resp
+
+
 def check_sbom_packages(sbom_data: dict[str, typing.Any]) -> None:
     """Make a bunch of assertions about the SBOM package data to ensure it's consistent."""
 
@@ -177,7 +195,7 @@ def check_sbom_packages(sbom_data: dict[str, typing.Any]) -> None:
         # and that the download URL is valid.
         if "checksums" not in package or "CI" in os.environ:
             download_location = package["downloadLocation"]
-            resp = urllib.request.urlopen(download_location)
+            resp = download_with_retries(download_location)
             error_if(resp.status != 200, f"Couldn't access URL: {download_location}'")
 
             package["checksums"] = [{


### PR DESCRIPTION
(cherry picked from commit 0c5a8b0b55238a45b9073d06a10c3a59568cdf3c)

Realized several changes didn't get backported to 3.13, so wanted to get these in sync.

I don't think cherry_picker supports picking multiple commits, so I will probably need to add these one-by-one.

<!-- gh-issue-number: gh-134262 -->
* Issue: gh-134262
<!-- /gh-issue-number -->
