### PR TITLE
gh-137400: Stop the world when swapping profile functions

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-06-11-56-15.gh-issue-137472.Pr_BLB.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-06-11-56-15.gh-issue-137472.Pr_BLB.rst
@@ -1,0 +1,3 @@
+Fix a crash that can occur in free-threading builds when
+``sys._setprofileallthreads`` or ``sys._settraceallthreads`` changes the
+profile function underneath a running thread.

--- a/Python/legacy_tracing.c
+++ b/Python/legacy_tracing.c
@@ -484,13 +484,19 @@ setup_profile(PyThreadState *tstate, Py_tracefunc func, PyObject *arg, PyObject 
         }
     }
 
+    _PyEval_StopTheWorld(tstate->interp);
+
     int delta = (func != NULL) - (tstate->c_profilefunc != NULL);
     tstate->c_profilefunc = func;
     *old_profileobj = tstate->c_profileobj;
     tstate->c_profileobj = Py_XNewRef(arg);
     tstate->interp->sys_profiling_threads += delta;
     assert(tstate->interp->sys_profiling_threads >= 0);
-    return tstate->interp->sys_profiling_threads;
+    Py_ssize_t ret = tstate->interp->sys_profiling_threads;
+
+    _PyEval_StartTheWorld(tstate->interp);
+
+    return ret;
 }
 
 int


### PR DESCRIPTION
One thread's profile function or profile object can be changed from another thread, for instance by `sys._setprofileallthreads`. This can lead to crashes unless the two threads are synchronized. We need a stop-the-world to ensure that the thread whose profile function or profile object is being changed is in a state where it's not in the middle of using either of those pointers.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

<!-- gh-issue-number: gh-137400 -->
* Issue: gh-137400
<!-- /gh-issue-number -->
