### PR TITLE
Fix typo: Changed "to much" to "too much"

### DIFF
--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1345,7 +1345,7 @@ class TracebackException:
                 continue
 
             # Limit the number of valid tokens to consider to not spend
-            # to much time in this function
+            # too much time in this function
             tokens_left_to_process -= 1
             if tokens_left_to_process < 0:
                 break


### PR DESCRIPTION
Changed the comment on line 1348 from "to much time in this function" to "too much time in this function"