### PR TITLE
gh-137477: Extend regex pattern check in `inspect.findsource`

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1002,6 +1002,15 @@ def findsource(object):
         lnum = object.co_firstlineno - 1
         if lnum >= len(lines):
             raise OSError('lineno is out of bounds')
+        pat = re.compile(r'^(\s*def\s)|(\s*class\s)|(\s*async\s+def\s)|(.*(?<!\w)lambda(:|\s))|^(\s*@)')
+        while lnum > 0:
+            try:
+                line = lines[lnum]
+            except IndexError:
+                raise OSError('lineno is out of bounds')
+            if pat.match(line):
+                break
+            lnum = lnum - 1
         return lines, lnum
     raise OSError('could not find code object')
 

--- a/Lib/test/test_inspect/inspect_fodder2.py
+++ b/Lib/test/test_inspect/inspect_fodder2.py
@@ -369,3 +369,11 @@ class dc364:
 # line 369
 dc370 = dataclasses.make_dataclass('dc370', (('x', int), ('y', int)))
 dc371 = dataclasses.make_dataclass('dc370', (('x', int), ('y', int)), module=__name__)
+
+# line 373
+from inspect import currentframe
+def generator_frame():
+    loops = (
+        currentframe() for _ in [0]
+    )
+    return list(loops)[0]

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -1195,6 +1195,11 @@ class TestBuggyCases(GetSourceBase):
         self.assertSourceEqual(mod2.cls296, 296, 298)
         self.assertSourceEqual(mod2.cls310, 310, 312)
 
+    def test_generator_frame(self):
+        frame = mod2.generator_frame()
+        assert frame is not None
+        self.assertSourceEqual(frame, 375, 379)
+
 class TestNoEOL(GetSourceBase):
     def setUp(self):
         self.tempdir = TESTFN + '_dir'


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This reintroduces the regex removed in #117025 with an additional case for classes.
While this is still a more hacky solution than AST parsing, etc, it handles class definitions and edge cases where the source code line is incorrect (generator bytecode).


<!-- gh-issue-number: gh-137477 -->
* Issue: gh-137477
<!-- /gh-issue-number -->
