### PR TITLE
Introduce a structure for .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,150 +3,118 @@
 
 # It uses the same pattern rule for gitignore file
 # https://git-scm.com/docs/gitignore#_pattern_format
+# Notably, a later match overrides earlier matches, so order matters.
+# If using a wildcard pattern, try to be as specific as possible to avoid
+# matching unintended files or overriding previous entries.
+# To exclude a file from ownership, add a line with only the file.
+# See the exclusions section at the end of the file for examples.
+
+# =========
+# Structure
+# =========
+#
+# The CODEOWNERS file is organised by topic area.
+# Please add new entries in alphabetical order within the relevant section.
+# Top-level sections are:
+#
+# * Buildbots, Continuous Integration, and Testing
+# * Build System
+# * Interpreter Core
+# * Documentation
+# * Other / Misc (Tools, Programs, Integration, etc)
+# * Platform Support
+# * Standard Library
+
+# ----------------------------------------------------------------------------
+# Buildbots, Continuous Integration, and Testing
+# ----------------------------------------------------------------------------
 
 # Azure Pipelines
 .azure-pipelines/             @AA-Turner
 
 # GitHub & related scripts
-.github/**                    @ezio-melotti @hugovk @AA-Turner
+.github/                      @ezio-melotti @hugovk @AA-Turner
 Tools/build/compute-changes.py @AA-Turner
-Tools/build/verify_ensurepip_wheels.py @AA-Turner
+Tools/build/verify_ensurepip_wheels.py @AA-Turner @pfmoore @pradyunsg
 
 # pre-commit
 .pre-commit-config.yaml       @hugovk
 .ruff.toml                    @hugovk @AlexWaygood @AA-Turner
 
-# Build system (autotools)
+# Patchcheck
+Tools/patchcheck/             @AA-Turner
+
+# ----------------------------------------------------------------------------
+# Build System
+# ----------------------------------------------------------------------------
+
+# autotools
 configure*                    @erlend-aasland @corona10 @AA-Turner
 Makefile.pre.in               @erlend-aasland @AA-Turner
 Modules/Setup*                @erlend-aasland @AA-Turner
 Tools/build/regen-configure.sh @AA-Turner
 
-# argparse
-**/*argparse*                 @savannahostrowski
+# ----------------------------------------------------------------------------
+# Interpreter Core
+# ----------------------------------------------------------------------------
 
-# asyncio
-**/*asyncio*                  @1st1 @asvetlov @kumaraditya303 @willingc
-
-# Core
-**/*context*                  @1st1
-**/*genobject*                @markshannon
-**/*hamt*                     @1st1
-**/*jit*                      @brandtbucher @savannahostrowski @diegorusso
-Python/perf_jit_trampoline.c  # Exclude the owners of "**/*jit*", above.
-Objects/set*                  @rhettinger
+# Built-in types
+Objects/call.c                @markshannon
+Objects/codeobject.c          @markshannon
 Objects/dict*                 @methane @markshannon
+Objects/frameobject.c         @markshannon
+**/*genobject*                @markshannon
+Objects/object.c              @ZeroIntensity
+Objects/set*                  @rhettinger
+Objects/type*                 @markshannon
 Objects/typevarobject.c       @JelleZijlstra
 Objects/unionobject.c         @JelleZijlstra
-Objects/type*                 @markshannon
-Objects/codeobject.c          @markshannon
-Objects/frameobject.c         @markshannon
-Objects/call.c                @markshannon
-Objects/object.c              @ZeroIntensity
-Python/ceval*.c               @markshannon
-Python/ceval*.h               @markshannon
+
+# Byte code interpreter ('the eval loop')
+Python/bytecodes.c            @markshannon
+Python/ceval*                 @markshannon
+Tools/cases_generator/        @markshannon
+
+# Compiler (AST to byte code)
+Python/assemble.c             @markshannon @iritkatriel
 Python/codegen.c              @markshannon @iritkatriel
 Python/compile.c              @markshannon @iritkatriel
-Python/assemble.c             @markshannon @iritkatriel
 Python/flowgraph.c            @markshannon @iritkatriel
 Python/instruction_sequence.c @iritkatriel
-Python/bytecodes.c            @markshannon
-Python/optimizer*.c           @markshannon
-Python/optimizer_analysis.c   @Fidget-Spinner @tomasr8
-Python/optimizer_bytecodes.c  @Fidget-Spinner @tomasr8
-Python/optimizer_symbols.c    @tomasr8
 Python/symtable.c             @JelleZijlstra @carljm
-Lib/_pyrepl/*                 @pablogsal @lysnikolaou @ambv
-Lib/test/test_patma.py        @brandtbucher
-Lib/test/test_type_*.py       @JelleZijlstra
-Lib/test/test_capi/test_misc.py  @markshannon
-Lib/test/test_pyrepl/*        @pablogsal @lysnikolaou @ambv
-Tools/c-analyzer/             @ericsnowcurrently
 
-# dbm
-**/*dbm*                      @corona10 @erlend-aasland @serhiy-storchaka
-
-# Doc/ tools
-Doc/conf.py                   @AA-Turner @hugovk
-Doc/Makefile                  @AA-Turner @hugovk
-Doc/make.bat                  @AA-Turner @hugovk
-Doc/requirements.txt          @AA-Turner @hugovk
-Doc/_static/**                @AA-Turner @hugovk
-Doc/tools/**                  @AA-Turner @hugovk
-.readthedocs.yml              @AA-Turner
-
-# runtime state/lifecycle
-**/*pylifecycle*              @ericsnowcurrently @ZeroIntensity
-**/*pystate*                  @ericsnowcurrently @ZeroIntensity
-**/*preconfig*                @ericsnowcurrently
-**/*initconfig*               @ericsnowcurrently
-**/*pathconfig*               @ericsnowcurrently
-**/*sysmodule*                @ericsnowcurrently
+# Core Modules
 **/*bltinmodule*              @ericsnowcurrently
-**/*gil*                      @ericsnowcurrently
-Include/internal/pycore_runtime.h   @ericsnowcurrently
-Include/internal/pycore_interp.h    @ericsnowcurrently
-Include/internal/pycore_tstate.h    @ericsnowcurrently
-Include/internal/pycore_*_state.h   @ericsnowcurrently
-Include/internal/pycore_*_init.h    @ericsnowcurrently
-Include/internal/pycore_atexit.h    @ericsnowcurrently
-Include/internal/pycore_freelist.h  @ericsnowcurrently
-Include/internal/pycore_global_objects.h  @ericsnowcurrently
-Include/internal/pycore_obmalloc.h  @ericsnowcurrently
-Include/internal/pycore_pymem.h     @ericsnowcurrently
-Include/internal/pycore_stackref.h  @Fidget-Spinner
-Modules/main.c                @ericsnowcurrently
-Programs/_bootstrap_python.c  @ericsnowcurrently
-Programs/python.c             @ericsnowcurrently
-Tools/build/generate_global_objects.py  @ericsnowcurrently
+**/*sysmodule*                @ericsnowcurrently
 
-# Initialization
-Doc/library/sys_path_init.rst @FFY00
-Doc/c-api/init_config.rst     @FFY00
+# AST
+Lib/_ast_unparse.py           @isidentical @JelleZijlstra @eclips4 @tomasr8
+Lib/ast.py                    @isidentical @JelleZijlstra @eclips4 @tomasr8
+Lib/test/test_ast/            @eclips4 @tomasr8
+Parser/asdl.py                @isidentical @JelleZijlstra @eclips4 @tomasr8
+Parser/asdl_c.py              @isidentical @JelleZijlstra @eclips4 @tomasr8
+Python/ast.c                  @isidentical @JelleZijlstra @eclips4 @tomasr8
+Python/ast_preprocess.c       @isidentical @eclips4 @tomasr8
 
-# getpath
-**/*getpath*                  @FFY00
-
-# site
-**/*site.py                   @FFY00
-Doc/library/site.rst          @FFY00
+# Context variables & HAMT
+**/contextvars*               @1st1
+**/*hamt*                     @1st1
+Include/cpython/context.h     @1st1
+Include/internal/pycore_context.h @1st1
+Lib/test/test_context.py      @1st1
+Python/context.c              @1st1
 
 # Exceptions
 Lib/test/test_except*.py      @iritkatriel
 Objects/exceptions.c          @iritkatriel
 
-# Hashing & cryptographic primitives
-**/*hashlib*                  @gpshead @tiran @picnixz
-**/*hashopenssl*              @gpshead @tiran @picnixz
-**/*pyhash*                   @gpshead @tiran @picnixz
-Modules/*blake*               @gpshead @tiran @picnixz
-Modules/*md5*                 @gpshead @tiran @picnixz
-Modules/*sha*                 @gpshead @tiran @picnixz
-Modules/_hacl/**              @gpshead @picnixz
-**/*hmac*                     @gpshead @picnixz
+# getpath
+Lib/test/test_getpath.py      @FFY00
+Modules/getpath*              @FFY00
 
-# libssl
-**/*ssl*                      @gpshead @picnixz
-
-# logging
-**/*logging*                  @vsajip
-
-# venv
-**/*venv*                     @vsajip @FFY00
-
-# Launcher
-/PC/launcher.c                @vsajip
-
-# HTML
-/Lib/html/                    @ezio-melotti
-/Lib/_markupbase.py           @ezio-melotti
-/Lib/test/test_html*.py       @ezio-melotti
-/Tools/build/parse_html5_entities.py   @ezio-melotti
-
-# Import (including importlib).
+# The import system (including importlib)
 **/*import*                   @brettcannon @ericsnowcurrently @ncoghlan @warsaw
-/Python/import.c              @kumaraditya303
-Python/dynload_*.c            @ericsnowcurrently
+Python/import.c               @brettcannon @ericsnowcurrently @ncoghlan @warsaw @kumaraditya303
 **/*freeze*                   @ericsnowcurrently
 **/*frozen*                   @ericsnowcurrently
 **/*modsupport*               @ericsnowcurrently
@@ -157,23 +125,269 @@ Python/dynload_*.c            @ericsnowcurrently
 **/*pythonrun*                @ericsnowcurrently
 **/*runpy*                    @ericsnowcurrently
 **/*singlephase*              @ericsnowcurrently
-Lib/test/test_module/         @ericsnowcurrently
 Doc/c-api/module.rst          @ericsnowcurrently
-**/*importlib/resources/*     @jaraco @warsaw @FFY00
-**/*importlib/metadata/*       @jaraco @warsaw
+Lib/test/test_module/         @ericsnowcurrently
+Python/dynload_*.c            @ericsnowcurrently
+
+# Initialisation
+**/*initconfig*               @ericsnowcurrently
+**/*pathconfig*               @ericsnowcurrently
+**/*preconfig*                @ericsnowcurrently
+Doc/library/sys_path_init.rst @FFY00
+Doc/c-api/init_config.rst     @FFY00
+
+# Interpreter main program
+Modules/main.c                @ericsnowcurrently
+Programs/_bootstrap_python.c  @ericsnowcurrently
+Programs/python.c             @ericsnowcurrently
+
+# JIT
+Include/internal/pycore_jit.h @brandtbucher @savannahostrowski @diegorusso
+Python/jit.c                  @brandtbucher @savannahostrowski @diegorusso
+Tools/jit/                    @brandtbucher @savannahostrowski @diegorusso
+
+# Micro-op / μop / Tier 2 Optimiser
+Python/optimizer.c            @markshannon
+Python/optimizer_analysis.c   @markshannon @Fidget-Spinner @tomasr8
+Python/optimizer_bytecodes.c  @markshannon @Fidget-Spinner @tomasr8
+Python/optimizer_symbols.c    @markshannon @tomasr8
+
+# Parser, Lexer, and Grammar
+Grammar/python.gram           @pablogsal @lysnikolaou
+Lib/test/test_peg_generator/  @pablogsal @lysnikolaou
+Lib/test/test_tokenize.py     @pablogsal @lysnikolaou
+Lib/tokenize.py               @pablogsal @lysnikolaou
+Parser/                       @pablogsal @lysnikolaou
+Tools/peg_generator/          @pablogsal @lysnikolaou
+
+# Runtime state/lifecycle
+**/*gil*                      @ericsnowcurrently
+**/*pylifecycle*              @ericsnowcurrently @ZeroIntensity
+**/*pystate*                  @ericsnowcurrently @ZeroIntensity
+Include/internal/pycore_*_init.h    @ericsnowcurrently
+Include/internal/pycore_*_state.h   @ericsnowcurrently
+Include/internal/pycore_atexit.h    @ericsnowcurrently
+Include/internal/pycore_freelist.h  @ericsnowcurrently
+Include/internal/pycore_global_objects.h  @ericsnowcurrently
+Include/internal/pycore_interp.h    @ericsnowcurrently
+Include/internal/pycore_obmalloc.h  @ericsnowcurrently
+Include/internal/pycore_pymem.h     @ericsnowcurrently
+Include/internal/pycore_runtime.h   @ericsnowcurrently
+Include/internal/pycore_stackref.h  @Fidget-Spinner
+Include/internal/pycore_tstate.h    @ericsnowcurrently
+Tools/build/generate_global_objects.py  @ericsnowcurrently
+
+# Remote Debugging
+Python/remote_debug.h         @pablogsal
+Python/remote_debugging.c     @pablogsal
+Modules/_remote_debugging_module.c @pablogsal @ambv @1st1
+
+# Sub-Interpreters
+**/*crossinterp*              @ericsnowcurrently
+**/*interpreteridobject.*     @ericsnowcurrently
+Doc/library/concurrent.interpreters.rst  @ericsnowcurrently
+Lib/concurrent/futures/interpreter.py  @ericsnowcurrently
+Lib/concurrent/interpreters/  @ericsnowcurrently
+Lib/test/support/channels.py  @ericsnowcurrently
+Lib/test/test__interp*.py     @ericsnowcurrently
+Lib/test/test_interpreters/   @ericsnowcurrently
+Modules/_interp*module.c      @ericsnowcurrently
+
+# Template string literals (t-strings)
+Lib/test/test_tstring.py      @lysnikolaou
+Objects/interpolationobject.c @lysnikolaou
+Objects/templateobject.c      @lysnikolaou
+
+# Tests
+Lib/test/test_patma.py        @brandtbucher
+Lib/test/test_type_*.py       @JelleZijlstra
+Lib/test/test_capi/test_misc.py  @markshannon
+
+
+# ----------------------------------------------------------------------------
+# Documentation
+# ----------------------------------------------------------------------------
+
+# Internal Docs
+InternalDocs/                 @AA-Turner
+InternalDocs/asyncio.md       @1st1 @asvetlov @kumaraditya303 @willingc @AA-Turner
+InternalDocs/jit.md           @brandtbucher @savannahostrowski @diegorusso @AA-Turner
+
+# Tools, Configuration, etc
+Doc/Makefile                  @AA-Turner @hugovk
+Doc/_static/                  @AA-Turner @hugovk
+Doc/conf.py                   @AA-Turner @hugovk
+Doc/make.bat                  @AA-Turner @hugovk
+Doc/requirements.txt          @AA-Turner @hugovk
+Doc/tools/                    @AA-Turner @hugovk
+
+# PR Previews
+.readthedocs.yml              @AA-Turner
+
+# Sections
+Doc/reference/                @willingc @AA-Turner
+Doc/whatsnew/                 @AA-Turner
+
+
+# ----------------------------------------------------------------------------
+# Other / Misc (Tools, Programs, Integration, etc)
+# ----------------------------------------------------------------------------
+
+# Argument Clinic
+Tools/clinic/                 @erlend-aasland @AA-Turner
+Lib/test/test_clinic.py       @erlend-aasland @AA-Turner
+Doc/howto/clinic.rst          @erlend-aasland @AA-Turner
+
+# C Analyser
+Tools/c-analyzer/             @ericsnowcurrently
+
+# Fuzzing
+Modules/_xxtestfuzz/          @ammaraskar
+
+# Hashing & Cryptographic Primitives
+**/*hashlib*                  @gpshead @tiran @picnixz
+**/*hashopenssl*              @gpshead @tiran @picnixz
+**/*hmac*                     @gpshead @picnixz
+**/*pyhash*                   @gpshead @tiran @picnixz
+Modules/_hacl/                @gpshead @picnixz
+Modules/*blake*               @gpshead @tiran @picnixz
+Modules/*md5*                 @gpshead @tiran @picnixz
+Modules/*sha*                 @gpshead @tiran @picnixz
+
+# IDLE
+Doc/library/idle.rst          @terryjreedy
+Lib/idlelib/                  @terryjreedy
+Lib/turtledemo/               @terryjreedy
+
+# Limited C API & stable ABI
+Doc/c-api/stable.rst          @encukou
+Doc/data/*.abi                @encukou
+Misc/stable_abi.toml          @encukou
+Tools/build/stable_abi.py     @encukou
+
+# SBOM
+Misc/externals.spdx.json      @sethmlarson
+Misc/sbom.spdx.json           @sethmlarson
+Tools/build/generate_sbom.py  @sethmlarson
+
+# Libssl / TLS
+**/*ssl*                      @gpshead @picnixz
+
+
+# ----------------------------------------------------------------------------
+# Platform Support
+# ----------------------------------------------------------------------------
+
+# Android
+Android/                      @mhsmith @freakboy3742
+Doc/using/android.rst         @mhsmith @freakboy3742
+Lib/_android_support.py       @mhsmith @freakboy3742
+Lib/test/test_android.py      @mhsmith @freakboy3742
+
+# iOS
+Doc/using/ios.rst             @freakboy3742
+Lib/_ios_support.py           @freakboy3742
+iOS/                          @freakboy3742
+
+# macOS
+Mac/                          @python/macos-team
+Lib/_osx_support.py           @python/macos-team
+Lib/test/test__osx_support.py @python/macos-team
+
+# Windows
+PC/                           @python/windows-team
+PCbuild/                      @python/windows-team
+
+# Windows Launcher
+PC/launcher.c                 @python/windows-team @vsajip
+
+# Windows installer packages
+Tools/msi/                    @python/windows-team
+Tools/nuget/                  @python/windows-team
+
+# WebAssembly
+Tools/wasm/README.md          @brettcannon @freakboy3742
+
+# WebAssembly (Emscripten)
+Tools/wasm/config.site-wasm32-emscripten  @freakboy3742
+Tools/wasm/emscripten         @freakboy3742
+
+# WebAssembly (WASI)
+Tools/wasm/wasi-env           @brettcannon
+Tools/wasm/wasi.py            @brettcannon
+Tools/wasm/wasi               @brettcannon
+
+
+# ----------------------------------------------------------------------------
+# Standard Library
+# ----------------------------------------------------------------------------
+
+# Annotationlib
+Doc/library/annotationlib.rst @JelleZijlstra
+Lib/annotationlib.py          @JelleZijlstra
+Lib/test/test_annotationlib.py @JelleZijlstra
+
+# Argparse
+Doc/**/argparse*.rst          @savannahostrowski
+Lib/argparse.py               @savannahostrowski
+Lib/test/test_argparse.py     @savannahostrowski
+
+# Asyncio
+Doc/library/asyncio*.rst      @1st1 @asvetlov @kumaraditya303 @willingc
+Lib/asyncio/                  @1st1 @asvetlov @kumaraditya303 @willingc
+Lib/test/test_asyncio/        @1st1 @asvetlov @kumaraditya303 @willingc
+Modules/_asynciomodule.c      @1st1 @asvetlov @kumaraditya303 @willingc
+
+# Bisect
+Doc/library/bisect.rst        @rhettinger
+Lib/bisect.py                 @rhettinger
+Lib/test/test_bisect.py       @rhettinger
+Modules/_bisectmodule.c       @rhettinger
 
 # Calendar
 Lib/calendar.py               @AA-Turner
 Lib/test/test_calendar.py     @AA-Turner
 
+# Codecs
+Modules/cjkcodecs/            @corona10
+Tools/unicode/gencjkcodecs.py @corona10
+
+# Collections
+Doc/library/collections.abc.rst @rhettinger
+Doc/library/collections.rst   @rhettinger
+Lib/_collections_abc.py       @rhettinger
+Lib/collections/              @rhettinger
+Lib/test/test_collections.py  @rhettinger
+Modules/_collectionsmodule.c  @rhettinger
+
+# Colorize
+Lib/_colorize.py              @hugovk
+Lib/test/test__colorize.py    @hugovk
+
+# Config Parser
+Lib/configparser.py           @jaraco
+Lib/test/test_configparser.py @jaraco
+
+# Dataclasses
+Doc/library/dataclasses.rst   @ericvsmith
+Lib/dataclasses.py            @ericvsmith
+Lib/test/test_dataclasses/    @ericvsmith
+
 # Dates and times
-**/*datetime*                 @pganssle @abalkin
-**/*str*time*                 @pganssle @abalkin
-Doc/library/time.rst          @pganssle @abalkin
-Lib/test/test_time.py         @pganssle @abalkin
-Modules/timemodule.c          @pganssle @abalkin
+Doc/**/*time.rst              @pganssle @abalkin
+Include/datetime.h            @pganssle @abalkin
+Include/internal/pycore_time.h @pganssle @abalkin
+Lib/*time.py                  @pganssle @abalkin
+Lib/test/datetimetester.py    @pganssle @abalkin
+Lib/test/test_*time.py        @pganssle @abalkin
+Modules/*time*                @pganssle @abalkin
 Python/pytime.c               @pganssle @abalkin
-Include/internal/pycore_time.h  @pganssle @abalkin
+
+# Dbm
+Doc/library/dbm.rst           @corona10 @erlend-aasland @serhiy-storchaka
+Lib/dbm/                      @corona10 @erlend-aasland @serhiy-storchaka
+Lib/test/test_dbm*.py         @corona10 @erlend-aasland @serhiy-storchaka
+Modules/*dbm*                 @corona10 @erlend-aasland @serhiy-storchaka
 
 # Email and related
 **/*mail*                     @python/email-team
@@ -182,200 +396,200 @@ Include/internal/pycore_time.h  @pganssle @abalkin
 **/*imap*                     @python/email-team
 **/*poplib*                   @python/email-team
 
-# Exclude .mailmap from being owned by @python/email-team
-/.mailmap
+# Ensurepip
+Doc/library/ensurepip.rst     @pfmoore @pradyunsg
+Lib/ensurepip/                @pfmoore @pradyunsg
+Lib/test/test_ensurepip.py    @pfmoore @pradyunsg
+
+# Enum
+Doc/howto/enum.rst            @ethanfurman
+Doc/library/enum.rst          @ethanfurman
+Lib/enum.py                   @ethanfurman
+Lib/test/test_enum.py         @ethanfurman
+Lib/test/test_json/test_enum.py @ethanfurman
+
+# FTP
+Doc/library/ftplib.rst        @giampaolo
+Lib/ftplib.py                 @giampaolo
+Lib/test/test_ftplib.py       @giampaolo
+
+# Functools
+Doc/library/functools.rst     @rhettinger
+Lib/functools.py              @rhettinger
+Lib/test/test_functools.py    @rhettinger
+Modules/_functoolsmodule.c    @rhettinger
 
 # Garbage collector
-/Modules/gcmodule.c           @pablogsal
-/Doc/library/gc.rst           @pablogsal
+Modules/gcmodule.c            @pablogsal
+Doc/library/gc.rst            @pablogsal
 
-# Parser
-/Parser/                      @pablogsal @lysnikolaou
-/Tools/peg_generator/         @pablogsal @lysnikolaou
-/Lib/test/test_peg_generator/ @pablogsal @lysnikolaou
-/Grammar/python.gram          @pablogsal @lysnikolaou
-/Lib/tokenize.py              @pablogsal @lysnikolaou
-/Lib/test/test_tokenize.py    @pablogsal @lysnikolaou
+# Gettext
+Doc/library/gettext.rst       @tomasr8
+Lib/gettext.py                @tomasr8
+Lib/test/test_gettext.py      @tomasr8
+Tools/i18n/pygettext.py       @tomasr8
 
-# Code generator
-/Tools/cases_generator/        @markshannon
+# Heapq
+Doc/library/heapq*            @rhettinger
+Lib/heapq.py                  @rhettinger
+Lib/test/test_heapq.py        @rhettinger
+Modules/_heapqmodule.c        @rhettinger
 
-# AST
-Python/ast.c                  @isidentical @JelleZijlstra @eclips4 @tomasr8
-Python/ast_preprocess.c       @isidentical @eclips4 @tomasr8
-Parser/asdl.py                @isidentical @JelleZijlstra @eclips4 @tomasr8
-Parser/asdl_c.py              @isidentical @JelleZijlstra @eclips4 @tomasr8
-Lib/ast.py                    @isidentical @JelleZijlstra @eclips4 @tomasr8
-Lib/_ast_unparse.py           @isidentical @JelleZijlstra @eclips4 @tomasr8
-Lib/test/test_ast/            @eclips4 @tomasr8
+# HTML
+Lib/html/                     @ezio-melotti
+Lib/_markupbase.py            @ezio-melotti
+Lib/test/test_html*.py        @ezio-melotti
+Tools/build/parse_html5_entities.py   @ezio-melotti
 
-# Mock
-/Lib/unittest/mock.py         @cjw296
-/Lib/test/test_unittest/testmock/* @cjw296
+# importlib.metadata
+Doc/library/importlib.metadata.rst @jaraco @warsaw
+Lib/importlib/metadata/       @jaraco @warsaw
+Lib/test/test_importlib/metadata/ @jaraco @warsaw
+
+# importlib.resources
+Doc/library/importlib.resources.abc.rst @jaraco @warsaw
+Doc/library/importlib.resources.rst @jaraco @warsaw
+Lib/importlib/resources/      @jaraco @warsaw @FFY00
+Lib/test/test_importlib/resources/ @jaraco @warsaw @FFY00
+
+# itertools
+Doc/library/itertools.rst     @rhettinger
+Lib/test/test_itertools.py    @rhettinger
+Modules/itertoolsmodule.c     @rhettinger
+
+# logging
+Doc/**/logging*               @vsajip
+Lib/logging/                  @vsajip
+Lib/test/test_logging.py      @vsajip
 
 # multiprocessing
-**/*multiprocessing*          @gpshead
+Doc/library/multiprocessing*.rst @gpshead
+Lib/multiprocessing/          @gpshead
+Lib/test/*multiprocessing.py  @gpshead
+Lib/test/test_multiprocessing*/ @gpshead
+Modules/_multiprocessing/     @gpshead
 
-# pydoc
+# pathlib
+Doc/library/pathlib.rst       @barneygale
+Lib/pathlib/                  @barneygale
+Lib/test/test_pathlib/        @barneygale
+
+# pdb & bdb
+Doc/library/[bp]db.rst        @gaogaotiantian
+Lib/[bp]db.py                 @gaogaotiantian
+Lib/test/test_[bp]db.py       @gaogaotiantian
+Lib/test/test_remote_pdb.py   @gaogaotiantian
+
+# Pydoc
 Lib/pydoc.py                  @AA-Turner
 Lib/pydoc_data/               @AA-Turner
 Lib/test/test_pydoc/          @AA-Turner
 
+# PyREPL
+Lib/_pyrepl/                  @pablogsal @lysnikolaou @ambv
+Lib/test/test_pyrepl/         @pablogsal @lysnikolaou @ambv
+
+# Random
+Doc/library/random.rst        @rhettinger
+Lib/random.py                 @rhettinger
+Lib/test/test_random.py       @rhettinger
+Modules/_randommodule.c       @rhettinger
+
+# Shutil
+Doc/library/shutil.rst        @giampaolo
+Lib/shutil.py                 @giampaolo
+Lib/test/test_shutil.py       @giampaolo
+
+# Site
+Lib/site.py                   @FFY00
+Lib/test/test_site.py         @FFY00
+Doc/library/site.rst          @FFY00
+
+# string.templatelib
+Doc/library/string.templatelib.rst @lysnikolaou @AA-Turner
+Lib/string/templatelib.py     @lysnikolaou @AA-Turner
+Lib/test/test_string/test_templatelib.py @lysnikolaou @AA-Turner
+
+# Sysconfig
+**/*sysconfig*                @FFY00
+
 # SQLite 3
-**/*sqlite*                   @berkerpeksag @erlend-aasland
+Doc/library/sqlite3.rst       @berkerpeksag @erlend-aasland
+Lib/sqlite3/                  @berkerpeksag @erlend-aasland
+Lib/test/test_sqlite3/        @berkerpeksag @erlend-aasland
+Modules/_sqlite/              @berkerpeksag @erlend-aasland
 
 # subprocess
-/Lib/subprocess.py            @gpshead
-/Lib/test/test_subprocess.py  @gpshead
-/Modules/*subprocess*         @gpshead
+Lib/subprocess.py             @gpshead
+Lib/test/test_subprocess.py   @gpshead
+Modules/*subprocess*          @gpshead
 
-# debugger
-**/*pdb*                      @gaogaotiantian
-**/*bdb*                      @gaogaotiantian
+# Tarfile
+Doc/library/tarfile.rst       @ethanfurman
+Lib/tarfile.py                @ethanfurman
+Lib/test/test_tarfile.py      @ethanfurman
 
-# types
+# Tomllib
+Doc/library/tomllib.rst       @encukou @hauntsaninja
+Lib/test/test_tomllib/        @encukou @hauntsaninja
+Lib/tomllib/                  @encukou @hauntsaninja
+
+# Typing
+Doc/library/typing.rst        @JelleZijlstra @AlexWaygood
+Lib/test/test_typing.py       @JelleZijlstra @AlexWaygood
+Lib/test/typinganndata/       @JelleZijlstra @AlexWaygood
+Lib/typing.py                 @JelleZijlstra @AlexWaygood
+Modules/_typingmodule.c       @JelleZijlstra @AlexWaygood
+
+# Types
 Lib/test/test_types.py        @AA-Turner
 Lib/types.py                  @AA-Turner
 Modules/_typesmodule.c        @AA-Turner
 
-# Limited C API & stable ABI
-Tools/build/stable_abi.py     @encukou
-Misc/stable_abi.toml          @encukou
-Doc/data/*.abi                @encukou
-Doc/c-api/stable.rst          @encukou
-
-# Windows
-/PC/                          @python/windows-team
-/PCbuild/                     @python/windows-team
+# Unittest
+Lib/unittest/mock.py          @cjw296
+Lib/test/test_unittest/testmock/  @cjw296
 
 # Urllib
 **/*robotparser*              @berkerpeksag
 
-# Windows installer packages
-/Tools/msi/                   @python/windows-team
-/Tools/nuget/                 @python/windows-team
+# Venv
+**/*venv*                     @vsajip @FFY00
+
+# Weakref
+**/*weakref*                  @kumaraditya303
+
+# Zipfile.Path
+Lib/test/test_zipfile/_path/  @jaraco
+Lib/zipfile/_path/            @jaraco
 
 # Zstandard
 Lib/compression/zstd/         @AA-Turner
 Lib/test/test_zstd.py         @AA-Turner
 Modules/_zstd/                @AA-Turner
 
-# Misc
-**/*itertools*                @rhettinger
-**/*collections*              @rhettinger
-**/*random*                   @rhettinger
-**/*bisect*                   @rhettinger
-**/*heapq*                    @rhettinger
-**/*functools*                @rhettinger
+# ----------------------------------------------------------------------------
 
-**/*dataclasses*              @ericvsmith
+# Exclusions from .github/CODEOWNERS should go at the very end
+# because the final matching pattern will take precedence.
 
-**/*ensurepip*                @pfmoore @pradyunsg
+# Exclude .mailmap from being owned by @python/email-team
+.mailmap
 
-/Doc/library/idle.rst         @terryjreedy
-**/*idlelib*                  @terryjreedy
-**/*turtledemo*               @terryjreedy
-
-**/*annotationlib*            @JelleZijlstra
-**/*typing*                   @JelleZijlstra @AlexWaygood
-
-**/*ftplib                    @giampaolo
-**/*shutil                    @giampaolo
-
-**/*enum*                     @ethanfurman
-**/*cgi*                      @ethanfurman
-**/*tarfile*                  @ethanfurman
-
-**/*tomllib*                  @encukou @hauntsaninja
-
-**/*sysconfig*                @FFY00
-
-**/*cjkcodecs*                @corona10
-
-# Patchcheck
-Tools/patchcheck/             @AA-Turner
-
-# macOS
-/Mac/                         @python/macos-team
-**/*osx_support*              @python/macos-team
-
-# pathlib
-**/*pathlib*                  @barneygale
-
-# zipfile.Path
-**/*zipfile/_path/*           @jaraco
-
-# Argument Clinic
-/Tools/clinic/**              @erlend-aasland @AA-Turner
-/Lib/test/test_clinic.py      @erlend-aasland @AA-Turner
-Doc/howto/clinic.rst          @erlend-aasland @AA-Turner
-
-# Subinterpreters
-**/*interpreteridobject.*     @ericsnowcurrently
-**/*crossinterp*              @ericsnowcurrently
-Modules/_interp*module.c      @ericsnowcurrently
-Lib/test/test__interp*.py     @ericsnowcurrently
-Lib/concurrent/interpreters/  @ericsnowcurrently
-Lib/test/support/channels.py  @ericsnowcurrently
-Doc/library/concurrent.interpreters.rst  @ericsnowcurrently
-Lib/test/test_interpreters/   @ericsnowcurrently
-Lib/concurrent/futures/interpreter.py  @ericsnowcurrently
-
-# Android
-**/*Android*                  @mhsmith @freakboy3742
-**/*android*                  @mhsmith @freakboy3742
-
-# iOS (but not termios)
-**/iOS*                       @freakboy3742
-**/ios*                       @freakboy3742
-**/*_iOS*                     @freakboy3742
-**/*_ios*                     @freakboy3742
-**/*-iOS*                     @freakboy3742
-**/*-ios*                     @freakboy3742
-
-# WebAssembly
-Tools/wasm/config.site-wasm32-emscripten  @freakboy3742
-/Tools/wasm/README.md         @brettcannon @freakboy3742
-/Tools/wasm/wasi-env          @brettcannon
-/Tools/wasm/wasi.py           @brettcannon
-/Tools/wasm/emscripten        @freakboy3742
-/Tools/wasm/wasi              @brettcannon
-
-# SBOM
-/Misc/externals.spdx.json     @sethmlarson
-/Misc/sbom.spdx.json          @sethmlarson
-/Tools/build/generate_sbom.py @sethmlarson
-
-# Config Parser
-Lib/configparser.py           @jaraco
-Lib/test/test_configparser.py @jaraco
-
-# Doc sections
-Doc/reference/                @willingc @AA-Turner
-Doc/whatsnew/                 @AA-Turner
-
-**/*weakref*                  @kumaraditya303
-
-# Colorize
-Lib/_colorize.py              @hugovk
-Lib/test/test__colorize.py    @hugovk
-
-# Fuzzing
-Modules/_xxtestfuzz/          @ammaraskar
-
-# t-strings
-**/*interpolationobject*      @lysnikolaou
-**/*templateobject*           @lysnikolaou
-**/*templatelib*              @lysnikolaou @AA-Turner
-**/*tstring*                  @lysnikolaou
-
-# Remote debugging
-Python/remote_debug.h         @pablogsal
-Python/remote_debugging.c     @pablogsal
-Modules/_remote_debugging_module.c @pablogsal @ambv @1st1
-
-# gettext
-**/*gettext*                  @tomasr8
-
-# Internal Docs
-InternalDocs/                 @AA-Turner
+# Exclude Argument Clinic directories
+Modules/_ctypes/clinic/
+Modules/_io/clinic/
+Modules/_multiprocessing/clinic/
+Modules/_sqlite/clinic/
+Modules/_sre/clinic/
+Modules/_ssl/clinic/
+Modules/_testcapi/clinic/
+Modules/_testinternalcapi/clinic/
+Modules/_testlimitedcapi/clinic/
+Modules/_zstd/clinic/
+Modules/cjkcodecs/clinic/
+Modules/clinic/
+Objects/clinic/
+Objects/stringlib/clinic/
+PC/clinic/
+Python/clinic/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # See https://help.github.com/articles/about-codeowners/
-# for more info about CODEOWNERS file
+# for further details about the .github/CODEOWNERS file.
 
 # It uses the same pattern rule for gitignore file
 # https://git-scm.com/docs/gitignore#_pattern_format
@@ -9,21 +9,43 @@
 # To exclude a file from ownership, add a line with only the file.
 # See the exclusions section at the end of the file for examples.
 
+# =======
+# Purpose
+# =======
+#
+# An entry in this file does not imply 'ownership', despite the name of the
+# file, but instead that those listed take an interest in that part of the
+# project, and would like to be notified of any proposed changes to it.
+# See also the Experts Index in the Python Developer's Guide:
+# https://devguide.python.org/core-developers/experts/
+#
 # =========
 # Structure
 # =========
 #
 # The CODEOWNERS file is organised by topic area.
 # Please add new entries in alphabetical order within the relevant section.
+# Where possible, keep related files together. For example, documentation,
+# code, and tests for a given item should all be listed in the same place.
+#
 # Top-level sections are:
 #
 # * Buildbots, Continuous Integration, and Testing
+#     e.g. project-wide configuration files, internal tools for use in CI,
+#     linting.
 # * Build System
-# * Interpreter Core
+#     e.g. the Makefile, autoconf.
 # * Documentation
+#     broader sections of documentation, documentation tools
 # * Other / Misc (Tools, Programs, Integration, etc)
+#     internal tools, integration with external systems,
+#     entries that don't fit elsewhere
 # * Platform Support
+#     relating to support for specific platforms
+# * Interpreter Core
+#     the grammar, parser, compiler, interpreter, etc
 # * Standard Library
+#     standard library modules & related files
 
 # ----------------------------------------------------------------------------
 # Buildbots, Continuous Integration, and Testing
@@ -44,6 +66,7 @@ Tools/build/verify_ensurepip_wheels.py @AA-Turner @pfmoore @pradyunsg
 # Patchcheck
 Tools/patchcheck/             @AA-Turner
 
+
 # ----------------------------------------------------------------------------
 # Build System
 # ----------------------------------------------------------------------------
@@ -53,6 +76,106 @@ configure*                    @erlend-aasland @corona10 @AA-Turner
 Makefile.pre.in               @erlend-aasland @AA-Turner
 Modules/Setup*                @erlend-aasland @AA-Turner
 Tools/build/regen-configure.sh @AA-Turner
+
+
+# ----------------------------------------------------------------------------
+# Documentation
+# ----------------------------------------------------------------------------
+
+# Internal Docs
+InternalDocs/                 @AA-Turner
+
+# Tools, Configuration, etc
+Doc/Makefile                  @AA-Turner @hugovk
+Doc/_static/                  @AA-Turner @hugovk
+Doc/conf.py                   @AA-Turner @hugovk
+Doc/make.bat                  @AA-Turner @hugovk
+Doc/requirements.txt          @AA-Turner @hugovk
+Doc/tools/                    @AA-Turner @hugovk
+
+# PR Previews
+.readthedocs.yml              @AA-Turner
+
+# Sections
+Doc/reference/                @willingc @AA-Turner
+Doc/whatsnew/                 @AA-Turner
+
+
+# ----------------------------------------------------------------------------
+# Other / Misc (Tools, Programs, Integration, etc)
+# ----------------------------------------------------------------------------
+
+# Argument Clinic
+Tools/clinic/                 @erlend-aasland @AA-Turner
+Lib/test/test_clinic.py       @erlend-aasland @AA-Turner
+Doc/howto/clinic.rst          @erlend-aasland @AA-Turner
+
+# C Analyser
+Tools/c-analyzer/             @ericsnowcurrently
+
+# Fuzzing
+Modules/_xxtestfuzz/          @ammaraskar
+
+# IDLE
+Doc/library/idle.rst          @terryjreedy
+Lib/idlelib/                  @terryjreedy
+Lib/turtledemo/               @terryjreedy
+
+# Limited C API & stable ABI
+Doc/c-api/stable.rst          @encukou
+Doc/data/*.abi                @encukou
+Misc/stable_abi.toml          @encukou
+Tools/build/stable_abi.py     @encukou
+
+# SBOM
+Misc/externals.spdx.json      @sethmlarson
+Misc/sbom.spdx.json           @sethmlarson
+Tools/build/generate_sbom.py  @sethmlarson
+
+
+# ----------------------------------------------------------------------------
+# Platform Support
+# ----------------------------------------------------------------------------
+
+# Android
+Android/                      @mhsmith @freakboy3742
+Doc/using/android.rst         @mhsmith @freakboy3742
+Lib/_android_support.py       @mhsmith @freakboy3742
+Lib/test/test_android.py      @mhsmith @freakboy3742
+
+# iOS
+Doc/using/ios.rst             @freakboy3742
+Lib/_ios_support.py           @freakboy3742
+iOS/                          @freakboy3742
+
+# macOS
+Mac/                          @python/macos-team
+Lib/_osx_support.py           @python/macos-team
+Lib/test/test__osx_support.py @python/macos-team
+
+# Windows
+PC/                           @python/windows-team
+PCbuild/                      @python/windows-team
+
+# Windows Launcher
+PC/launcher.c                 @python/windows-team @vsajip
+
+# Windows installer packages
+Tools/msi/                    @python/windows-team
+Tools/nuget/                  @python/windows-team
+
+# WebAssembly
+Tools/wasm/README.md          @brettcannon @freakboy3742
+
+# WebAssembly (Emscripten)
+Tools/wasm/config.site-wasm32-emscripten @freakboy3742
+Tools/wasm/emscripten         @freakboy3742
+
+# WebAssembly (WASI)
+Tools/wasm/wasi-env           @brettcannon
+Tools/wasm/wasi.py            @brettcannon
+Tools/wasm/wasi               @brettcannon
+
 
 # ----------------------------------------------------------------------------
 # Interpreter Core
@@ -112,6 +235,12 @@ Objects/exceptions.c          @iritkatriel
 Lib/test/test_getpath.py      @FFY00
 Modules/getpath*              @FFY00
 
+# Hashing / ``hash()`` and related
+Include/cpython/pyhash.h      @gpshead @picnixz @tiran
+Include/internal/pycore_pyhash.h @gpshead @picnixz @tiran
+Include/pyhash.h              @gpshead @picnixz @tiran
+Python/pyhash.c               @gpshead @picnixz @tiran
+
 # The import system (including importlib)
 **/*import*                   @brettcannon @ericsnowcurrently @ncoghlan @warsaw
 Python/import.c               @brettcannon @ericsnowcurrently @ncoghlan @warsaw @kumaraditya303
@@ -145,6 +274,7 @@ Programs/python.c             @ericsnowcurrently
 Include/internal/pycore_jit.h @brandtbucher @savannahostrowski @diegorusso
 Python/jit.c                  @brandtbucher @savannahostrowski @diegorusso
 Tools/jit/                    @brandtbucher @savannahostrowski @diegorusso
+InternalDocs/jit.md           @brandtbucher @savannahostrowski @diegorusso @AA-Turner
 
 # Micro-op / μop / Tier 2 Optimiser
 Python/optimizer.c            @markshannon
@@ -185,8 +315,8 @@ Modules/_remote_debugging_module.c @pablogsal @ambv @1st1
 # Sub-Interpreters
 **/*crossinterp*              @ericsnowcurrently
 **/*interpreteridobject.*     @ericsnowcurrently
-Doc/library/concurrent.interpreters.rst  @ericsnowcurrently
-Lib/concurrent/futures/interpreter.py  @ericsnowcurrently
+Doc/library/concurrent.interpreters.rst @ericsnowcurrently
+Lib/concurrent/futures/interpreter.py @ericsnowcurrently
 Lib/concurrent/interpreters/  @ericsnowcurrently
 Lib/test/support/channels.py  @ericsnowcurrently
 Lib/test/test__interp*.py     @ericsnowcurrently
@@ -201,121 +331,7 @@ Objects/templateobject.c      @lysnikolaou
 # Tests
 Lib/test/test_patma.py        @brandtbucher
 Lib/test/test_type_*.py       @JelleZijlstra
-Lib/test/test_capi/test_misc.py  @markshannon
-
-
-# ----------------------------------------------------------------------------
-# Documentation
-# ----------------------------------------------------------------------------
-
-# Internal Docs
-InternalDocs/                 @AA-Turner
-InternalDocs/asyncio.md       @1st1 @asvetlov @kumaraditya303 @willingc @AA-Turner
-InternalDocs/jit.md           @brandtbucher @savannahostrowski @diegorusso @AA-Turner
-
-# Tools, Configuration, etc
-Doc/Makefile                  @AA-Turner @hugovk
-Doc/_static/                  @AA-Turner @hugovk
-Doc/conf.py                   @AA-Turner @hugovk
-Doc/make.bat                  @AA-Turner @hugovk
-Doc/requirements.txt          @AA-Turner @hugovk
-Doc/tools/                    @AA-Turner @hugovk
-
-# PR Previews
-.readthedocs.yml              @AA-Turner
-
-# Sections
-Doc/reference/                @willingc @AA-Turner
-Doc/whatsnew/                 @AA-Turner
-
-
-# ----------------------------------------------------------------------------
-# Other / Misc (Tools, Programs, Integration, etc)
-# ----------------------------------------------------------------------------
-
-# Argument Clinic
-Tools/clinic/                 @erlend-aasland @AA-Turner
-Lib/test/test_clinic.py       @erlend-aasland @AA-Turner
-Doc/howto/clinic.rst          @erlend-aasland @AA-Turner
-
-# C Analyser
-Tools/c-analyzer/             @ericsnowcurrently
-
-# Fuzzing
-Modules/_xxtestfuzz/          @ammaraskar
-
-# Hashing & Cryptographic Primitives
-**/*hashlib*                  @gpshead @tiran @picnixz
-**/*hashopenssl*              @gpshead @tiran @picnixz
-**/*hmac*                     @gpshead @picnixz
-**/*pyhash*                   @gpshead @tiran @picnixz
-Modules/_hacl/                @gpshead @picnixz
-Modules/*blake*               @gpshead @tiran @picnixz
-Modules/*md5*                 @gpshead @tiran @picnixz
-Modules/*sha*                 @gpshead @tiran @picnixz
-
-# IDLE
-Doc/library/idle.rst          @terryjreedy
-Lib/idlelib/                  @terryjreedy
-Lib/turtledemo/               @terryjreedy
-
-# Limited C API & stable ABI
-Doc/c-api/stable.rst          @encukou
-Doc/data/*.abi                @encukou
-Misc/stable_abi.toml          @encukou
-Tools/build/stable_abi.py     @encukou
-
-# SBOM
-Misc/externals.spdx.json      @sethmlarson
-Misc/sbom.spdx.json           @sethmlarson
-Tools/build/generate_sbom.py  @sethmlarson
-
-# Libssl / TLS
-**/*ssl*                      @gpshead @picnixz
-
-
-# ----------------------------------------------------------------------------
-# Platform Support
-# ----------------------------------------------------------------------------
-
-# Android
-Android/                      @mhsmith @freakboy3742
-Doc/using/android.rst         @mhsmith @freakboy3742
-Lib/_android_support.py       @mhsmith @freakboy3742
-Lib/test/test_android.py      @mhsmith @freakboy3742
-
-# iOS
-Doc/using/ios.rst             @freakboy3742
-Lib/_ios_support.py           @freakboy3742
-iOS/                          @freakboy3742
-
-# macOS
-Mac/                          @python/macos-team
-Lib/_osx_support.py           @python/macos-team
-Lib/test/test__osx_support.py @python/macos-team
-
-# Windows
-PC/                           @python/windows-team
-PCbuild/                      @python/windows-team
-
-# Windows Launcher
-PC/launcher.c                 @python/windows-team @vsajip
-
-# Windows installer packages
-Tools/msi/                    @python/windows-team
-Tools/nuget/                  @python/windows-team
-
-# WebAssembly
-Tools/wasm/README.md          @brettcannon @freakboy3742
-
-# WebAssembly (Emscripten)
-Tools/wasm/config.site-wasm32-emscripten  @freakboy3742
-Tools/wasm/emscripten         @freakboy3742
-
-# WebAssembly (WASI)
-Tools/wasm/wasi-env           @brettcannon
-Tools/wasm/wasi.py            @brettcannon
-Tools/wasm/wasi               @brettcannon
+Lib/test/test_capi/test_misc.py @markshannon
 
 
 # ----------------------------------------------------------------------------
@@ -334,6 +350,7 @@ Lib/test/test_argparse.py     @savannahostrowski
 
 # Asyncio
 Doc/library/asyncio*.rst      @1st1 @asvetlov @kumaraditya303 @willingc
+InternalDocs/asyncio.md       @1st1 @asvetlov @kumaraditya303 @willingc @AA-Turner
 Lib/asyncio/                  @1st1 @asvetlov @kumaraditya303 @willingc
 Lib/test/test_asyncio/        @1st1 @asvetlov @kumaraditya303 @willingc
 Modules/_asynciomodule.c      @1st1 @asvetlov @kumaraditya303 @willingc
@@ -347,6 +364,16 @@ Modules/_bisectmodule.c       @rhettinger
 # Calendar
 Lib/calendar.py               @AA-Turner
 Lib/test/test_calendar.py     @AA-Turner
+
+# Cryptographic Primitives and Applications
+**/*hashlib*                  @gpshead @picnixz @tiran
+**/*hashopenssl*              @gpshead @picnixz @tiran
+**/*hmac*                     @gpshead @picnixz
+**/*ssl*                      @gpshead @picnixz
+Modules/_hacl/                @gpshead @picnixz
+Modules/*blake*               @gpshead @picnixz @tiran
+Modules/*md5*                 @gpshead @picnixz @tiran
+Modules/*sha*                 @gpshead @picnixz @tiran
 
 # Codecs
 Modules/cjkcodecs/            @corona10
@@ -440,7 +467,7 @@ Doc/library/html*             @ezio-melotti
 Lib/html/                     @ezio-melotti
 Lib/_markupbase.py            @ezio-melotti
 Lib/test/test_html*.py        @ezio-melotti
-Tools/build/parse_html5_entities.py   @ezio-melotti
+Tools/build/parse_html5_entities.py @ezio-melotti
 
 # importlib.metadata
 Doc/library/importlib.metadata.rst @jaraco @warsaw
@@ -476,12 +503,12 @@ Lib/pathlib/                  @barneygale
 Lib/test/test_pathlib/        @barneygale
 
 # pdb & bdb
-Doc/library/bdb.rst        @gaogaotiantian
-Doc/library/pdb.rst        @gaogaotiantian
-Lib/bdb.py                 @gaogaotiantian
-Lib/pdb.py                 @gaogaotiantian
-Lib/test/test_bdb.py       @gaogaotiantian
-Lib/test/test_pdb.py       @gaogaotiantian
+Doc/library/bdb.rst           @gaogaotiantian
+Doc/library/pdb.rst           @gaogaotiantian
+Lib/bdb.py                    @gaogaotiantian
+Lib/pdb.py                    @gaogaotiantian
+Lib/test/test_bdb.py          @gaogaotiantian
+Lib/test/test_pdb.py          @gaogaotiantian
 Lib/test/test_remote_pdb.py   @gaogaotiantian
 
 # Pydoc
@@ -552,7 +579,7 @@ Modules/_typesmodule.c        @AA-Turner
 
 # Unittest
 Lib/unittest/mock.py          @cjw296
-Lib/test/test_unittest/testmock/  @cjw296
+Lib/test/test_unittest/testmock/ @cjw296
 
 # Urllib
 **/*robotparser*              @berkerpeksag
@@ -582,8 +609,6 @@ Modules/_zstd/                @AA-Turner
 
 # Exclude Argument Clinic directories
 Modules/**/clinic/
-Modules/clinic/
-Objects/clinic/
-Objects/stringlib/clinic/
-PC/clinic/
-Python/clinic/
+Objects/**/clinic/
+PC/**/clinic/
+Python/**/clinic/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -580,17 +580,7 @@ Modules/_zstd/                @AA-Turner
 .mailmap
 
 # Exclude Argument Clinic directories
-Modules/_ctypes/clinic/
-Modules/_io/clinic/
-Modules/_multiprocessing/clinic/
-Modules/_sqlite/clinic/
-Modules/_sre/clinic/
-Modules/_ssl/clinic/
-Modules/_testcapi/clinic/
-Modules/_testinternalcapi/clinic/
-Modules/_testlimitedcapi/clinic/
-Modules/_zstd/clinic/
-Modules/cjkcodecs/clinic/
+Modules/**/clinic/
 Modules/clinic/
 Objects/clinic/
 Objects/stringlib/clinic/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,7 +67,7 @@
 Tools/build/compute-changes.py         @AA-Turner
 Tools/build/verify_ensurepip_wheels.py @AA-Turner @pfmoore @pradyunsg
 
-# pre-commit
+# Pre-commit
 .pre-commit-config.yaml       @hugovk
 .ruff.toml                    @hugovk @AlexWaygood @AA-Turner
 
@@ -79,7 +79,7 @@ Tools/patchcheck/             @AA-Turner
 # Build System
 # ----------------------------------------------------------------------------
 
-# autotools
+# Autotools
 configure*                       @erlend-aasland @corona10 @AA-Turner
 Makefile.pre.in                  @erlend-aasland @AA-Turner
 Modules/Setup*                   @erlend-aasland @AA-Turner
@@ -156,17 +156,6 @@ Mac/                          @python/macos-team
 Lib/_osx_support.py           @python/macos-team
 Lib/test/test__osx_support.py @python/macos-team
 
-# Windows
-PC/                           @python/windows-team
-PCbuild/                      @python/windows-team
-
-# Windows Launcher
-PC/launcher.c                 @python/windows-team @vsajip
-
-# Windows installer packages
-Tools/msi/                    @python/windows-team
-Tools/nuget/                  @python/windows-team
-
 # WebAssembly
 Tools/wasm/README.md          @brettcannon @freakboy3742
 
@@ -178,6 +167,17 @@ Tools/wasm/emscripten                     @freakboy3742
 Tools/wasm/wasi-env           @brettcannon
 Tools/wasm/wasi.py            @brettcannon
 Tools/wasm/wasi               @brettcannon
+
+# Windows
+PC/                           @python/windows-team
+PCbuild/                      @python/windows-team
+
+# Windows Launcher
+PC/launcher.c                 @python/windows-team @vsajip
+
+# Windows installer packages
+Tools/msi/                    @python/windows-team
+Tools/nuget/                  @python/windows-team
 
 
 # ----------------------------------------------------------------------------
@@ -234,7 +234,7 @@ Python/context.c                    @1st1
 Lib/test/test_except*.py      @iritkatriel
 Objects/exceptions.c          @iritkatriel
 
-# getpath
+# Getpath
 Lib/test/test_getpath.py      @FFY00
 Modules/getpath*              @FFY00
 
@@ -488,7 +488,7 @@ Doc/library/importlib.resources.rst       @jaraco @warsaw
 Lib/importlib/resources/                  @jaraco @warsaw @FFY00
 Lib/test/test_importlib/resources/        @jaraco @warsaw @FFY00
 
-# itertools
+# Itertools
 Doc/library/itertools.rst     @rhettinger
 Lib/test/test_itertools.py    @rhettinger
 Modules/itertoolsmodule.c     @rhettinger

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,8 @@
 #
 # An entry in this file does not imply 'ownership', despite the name of the
 # file, but instead that those listed take an interest in that part of the
-# project, and would like to be notified of any proposed changes to it.
+# project and will automatically be added as reviewers to PRs that affect
+# the matching files.
 # See also the Experts Index in the Python Developer's Guide:
 # https://devguide.python.org/core-developers/experts/
 #
@@ -31,10 +32,10 @@
 # Top-level sections are:
 #
 # * Buildbots, Continuous Integration, and Testing
-#     e.g. project-wide configuration files, internal tools for use in CI,
+#     project-wide configuration files, internal tools for use in CI,
 #     linting.
 # * Build System
-#     e.g. the Makefile, autoconf.
+#     the Makefile, autoconf, and other autotools files.
 # * Documentation
 #     broader sections of documentation, documentation tools
 # * Other / Misc (Tools, Programs, Integration, etc)
@@ -43,9 +44,10 @@
 # * Platform Support
 #     relating to support for specific platforms
 # * Interpreter Core
-#     the grammar, parser, compiler, interpreter, etc
+#     the grammar, parser, compiler, interpreter, etc.
 # * Standard Library
-#     standard library modules & related files
+#     standard library modules (from both Lib and Modules)
+#     and related files (such as their tests and docs)
 
 # ----------------------------------------------------------------------------
 # Buildbots, Continuous Integration, and Testing

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,11 +121,6 @@ Tools/c-analyzer/             @ericsnowcurrently
 # Fuzzing
 Modules/_xxtestfuzz/          @ammaraskar
 
-# IDLE
-Doc/library/idle.rst          @terryjreedy
-Lib/idlelib/                  @terryjreedy
-Lib/turtledemo/               @terryjreedy
-
 # Limited C API & stable ABI
 Doc/c-api/stable.rst          @encukou
 Doc/data/*.abi                @encukou
@@ -473,6 +468,11 @@ Lib/html/                           @ezio-melotti
 Lib/_markupbase.py                  @ezio-melotti
 Lib/test/test_html*.py              @ezio-melotti
 Tools/build/parse_html5_entities.py @ezio-melotti
+
+# IDLE
+Doc/library/idle.rst          @terryjreedy
+Lib/idlelib/                  @terryjreedy
+Lib/turtledemo/               @terryjreedy
 
 # importlib.metadata
 Doc/library/importlib.metadata.rst  @jaraco @warsaw

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -172,12 +172,12 @@ Tools/wasm/wasi               @brettcannon
 PC/                           @python/windows-team
 PCbuild/                      @python/windows-team
 
-# Windows Launcher
-PC/launcher.c                 @python/windows-team @vsajip
-
 # Windows installer packages
 Tools/msi/                    @python/windows-team
 Tools/nuget/                  @python/windows-team
+
+# Windows Launcher
+PC/launcher.c                 @python/windows-team @vsajip
 
 
 # ----------------------------------------------------------------------------

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,6 +77,7 @@ Makefile.pre.in                  @erlend-aasland @AA-Turner
 Modules/Setup*                   @erlend-aasland @AA-Turner
 Tools/build/regen-configure.sh   @AA-Turner
 
+
 # ----------------------------------------------------------------------------
 # Documentation
 # ----------------------------------------------------------------------------

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,7 @@
 # Where possible, keep related files together. For example, documentation,
 # code, and tests for a given item should all be listed in the same place.
 #
-# GitHub usernames  should be aligned to column 31, or the next multiple
+# GitHub usernames should be aligned to column 31, or the next multiple
 # of three if the relevant paths are too long to fit.
 #
 # Top-level sections are:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -436,6 +436,7 @@ Lib/test/test_heapq.py        @rhettinger
 Modules/_heapqmodule.c        @rhettinger
 
 # HTML
+Doc/library/html*             @ezio-melotti
 Lib/html/                     @ezio-melotti
 Lib/_markupbase.py            @ezio-melotti
 Lib/test/test_html*.py        @ezio-melotti

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,7 +76,6 @@ configure*                       @erlend-aasland @corona10 @AA-Turner
 Makefile.pre.in                  @erlend-aasland @AA-Turner
 Modules/Setup*                   @erlend-aasland @AA-Turner
 Tools/build/regen-configure.sh   @AA-Turner
-                                 @AA-Turner
 
 # ----------------------------------------------------------------------------
 # Documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,8 +55,8 @@
 .azure-pipelines/             @AA-Turner
 
 # GitHub & related scripts
-.github/                      @ezio-melotti @hugovk @AA-Turner
-Tools/build/compute-changes.py @AA-Turner
+.github/                               @ezio-melotti @hugovk @AA-Turner
+Tools/build/compute-changes.py         @AA-Turner
 Tools/build/verify_ensurepip_wheels.py @AA-Turner @pfmoore @pradyunsg
 
 # pre-commit
@@ -72,11 +72,11 @@ Tools/patchcheck/             @AA-Turner
 # ----------------------------------------------------------------------------
 
 # autotools
-configure*                    @erlend-aasland @corona10 @AA-Turner
-Makefile.pre.in               @erlend-aasland @AA-Turner
-Modules/Setup*                @erlend-aasland @AA-Turner
-Tools/build/regen-configure.sh @AA-Turner
-
+configure*                       @erlend-aasland @corona10 @AA-Turner
+Makefile.pre.in                  @erlend-aasland @AA-Turner
+Modules/Setup*                   @erlend-aasland @AA-Turner
+Tools/build/regen-configure.sh   @AA-Turner
+                                 @AA-Turner
 
 # ----------------------------------------------------------------------------
 # Documentation
@@ -168,8 +168,8 @@ Tools/nuget/                  @python/windows-team
 Tools/wasm/README.md          @brettcannon @freakboy3742
 
 # WebAssembly (Emscripten)
-Tools/wasm/config.site-wasm32-emscripten @freakboy3742
-Tools/wasm/emscripten         @freakboy3742
+Tools/wasm/config.site-wasm32-emscripten  @freakboy3742
+Tools/wasm/emscripten                     @freakboy3742
 
 # WebAssembly (WASI)
 Tools/wasm/wasi-env           @brettcannon
@@ -220,12 +220,12 @@ Python/ast.c                  @isidentical @JelleZijlstra @eclips4 @tomasr8
 Python/ast_preprocess.c       @isidentical @eclips4 @tomasr8
 
 # Context variables & HAMT
-**/contextvars*               @1st1
-**/*hamt*                     @1st1
-Include/cpython/context.h     @1st1
-Include/internal/pycore_context.h @1st1
-Lib/test/test_context.py      @1st1
-Python/context.c              @1st1
+**/contextvars*                     @1st1
+**/*hamt*                           @1st1
+Include/cpython/context.h           @1st1
+Include/internal/pycore_context.h   @1st1
+Lib/test/test_context.py            @1st1
+Python/context.c                    @1st1
 
 # Exceptions
 Lib/test/test_except*.py      @iritkatriel
@@ -236,10 +236,10 @@ Lib/test/test_getpath.py      @FFY00
 Modules/getpath*              @FFY00
 
 # Hashing / ``hash()`` and related
-Include/cpython/pyhash.h      @gpshead @picnixz @tiran
+Include/cpython/pyhash.h         @gpshead @picnixz @tiran
 Include/internal/pycore_pyhash.h @gpshead @picnixz @tiran
-Include/pyhash.h              @gpshead @picnixz @tiran
-Python/pyhash.c               @gpshead @picnixz @tiran
+Include/pyhash.h                 @gpshead @picnixz @tiran
+Python/pyhash.c                  @gpshead @picnixz @tiran
 
 # The import system (including importlib)
 **/*import*                   @brettcannon @ericsnowcurrently @ncoghlan @warsaw
@@ -294,34 +294,34 @@ Tools/peg_generator/          @pablogsal @lysnikolaou
 **/*gil*                      @ericsnowcurrently
 **/*pylifecycle*              @ericsnowcurrently @ZeroIntensity
 **/*pystate*                  @ericsnowcurrently @ZeroIntensity
-Include/internal/pycore_*_init.h    @ericsnowcurrently
-Include/internal/pycore_*_state.h   @ericsnowcurrently
-Include/internal/pycore_atexit.h    @ericsnowcurrently
-Include/internal/pycore_freelist.h  @ericsnowcurrently
+Include/internal/pycore_*_init.h          @ericsnowcurrently
+Include/internal/pycore_*_state.h         @ericsnowcurrently
+Include/internal/pycore_atexit.h          @ericsnowcurrently
+Include/internal/pycore_freelist.h        @ericsnowcurrently
 Include/internal/pycore_global_objects.h  @ericsnowcurrently
-Include/internal/pycore_interp.h    @ericsnowcurrently
-Include/internal/pycore_obmalloc.h  @ericsnowcurrently
-Include/internal/pycore_pymem.h     @ericsnowcurrently
-Include/internal/pycore_runtime.h   @ericsnowcurrently
-Include/internal/pycore_stackref.h  @Fidget-Spinner
-Include/internal/pycore_tstate.h    @ericsnowcurrently
-Tools/build/generate_global_objects.py  @ericsnowcurrently
+Include/internal/pycore_interp.h          @ericsnowcurrently
+Include/internal/pycore_obmalloc.h        @ericsnowcurrently
+Include/internal/pycore_pymem.h           @ericsnowcurrently
+Include/internal/pycore_runtime.h         @ericsnowcurrently
+Include/internal/pycore_stackref.h        @Fidget-Spinner
+Include/internal/pycore_tstate.h          @ericsnowcurrently
+Tools/build/generate_global_objects.py    @ericsnowcurrently
 
 # Remote Debugging
-Python/remote_debug.h         @pablogsal
-Python/remote_debugging.c     @pablogsal
-Modules/_remote_debugging_module.c @pablogsal @ambv @1st1
+Python/remote_debug.h               @pablogsal
+Python/remote_debugging.c           @pablogsal
+Modules/_remote_debugging_module.c  @pablogsal @ambv @1st1
 
 # Sub-Interpreters
-**/*crossinterp*              @ericsnowcurrently
-**/*interpreteridobject.*     @ericsnowcurrently
-Doc/library/concurrent.interpreters.rst @ericsnowcurrently
-Lib/concurrent/futures/interpreter.py @ericsnowcurrently
-Lib/concurrent/interpreters/  @ericsnowcurrently
-Lib/test/support/channels.py  @ericsnowcurrently
-Lib/test/test__interp*.py     @ericsnowcurrently
-Lib/test/test_interpreters/   @ericsnowcurrently
-Modules/_interp*module.c      @ericsnowcurrently
+**/*crossinterp*                          @ericsnowcurrently
+**/*interpreteridobject.*                 @ericsnowcurrently
+Doc/library/concurrent.interpreters.rst   @ericsnowcurrently
+Lib/concurrent/futures/interpreter.py     @ericsnowcurrently
+Lib/concurrent/interpreters/              @ericsnowcurrently
+Lib/test/support/channels.py              @ericsnowcurrently
+Lib/test/test__interp*.py                 @ericsnowcurrently
+Lib/test/test_interpreters/               @ericsnowcurrently
+Modules/_interp*module.c                  @ericsnowcurrently
 
 # Template string literals (t-strings)
 Lib/test/test_tstring.py      @lysnikolaou
@@ -329,9 +329,9 @@ Objects/interpolationobject.c @lysnikolaou
 Objects/templateobject.c      @lysnikolaou
 
 # Tests
-Lib/test/test_patma.py        @brandtbucher
-Lib/test/test_type_*.py       @JelleZijlstra
-Lib/test/test_capi/test_misc.py @markshannon
+Lib/test/test_patma.py           @brandtbucher
+Lib/test/test_type_*.py          @JelleZijlstra
+Lib/test/test_capi/test_misc.py  @markshannon
 
 
 # ----------------------------------------------------------------------------
@@ -339,9 +339,9 @@ Lib/test/test_capi/test_misc.py @markshannon
 # ----------------------------------------------------------------------------
 
 # Annotationlib
-Doc/library/annotationlib.rst @JelleZijlstra
-Lib/annotationlib.py          @JelleZijlstra
-Lib/test/test_annotationlib.py @JelleZijlstra
+Doc/library/annotationlib.rst    @JelleZijlstra
+Lib/annotationlib.py             @JelleZijlstra
+Lib/test/test_annotationlib.py   @JelleZijlstra
 
 # Argparse
 Doc/**/argparse*.rst          @savannahostrowski
@@ -380,12 +380,12 @@ Modules/cjkcodecs/            @corona10
 Tools/unicode/gencjkcodecs.py @corona10
 
 # Collections
-Doc/library/collections.abc.rst @rhettinger
-Doc/library/collections.rst   @rhettinger
-Lib/_collections_abc.py       @rhettinger
-Lib/collections/              @rhettinger
-Lib/test/test_collections.py  @rhettinger
-Modules/_collectionsmodule.c  @rhettinger
+Doc/library/collections.abc.rst  @rhettinger
+Doc/library/collections.rst      @rhettinger
+Lib/_collections_abc.py          @rhettinger
+Lib/collections/                 @rhettinger
+Lib/test/test_collections.py     @rhettinger
+Modules/_collectionsmodule.c     @rhettinger
 
 # Colorize
 Lib/_colorize.py              @hugovk
@@ -401,14 +401,14 @@ Lib/dataclasses.py            @ericvsmith
 Lib/test/test_dataclasses/    @ericvsmith
 
 # Dates and times
-Doc/**/*time.rst              @pganssle @abalkin
-Include/datetime.h            @pganssle @abalkin
-Include/internal/pycore_time.h @pganssle @abalkin
-Lib/*time.py                  @pganssle @abalkin
-Lib/test/datetimetester.py    @pganssle @abalkin
-Lib/test/test_*time.py        @pganssle @abalkin
-Modules/*time*                @pganssle @abalkin
-Python/pytime.c               @pganssle @abalkin
+Doc/**/*time.rst                 @pganssle @abalkin
+Include/datetime.h               @pganssle @abalkin
+Include/internal/pycore_time.h   @pganssle @abalkin
+Lib/*time.py                     @pganssle @abalkin
+Lib/test/datetimetester.py       @pganssle @abalkin
+Lib/test/test_*time.py           @pganssle @abalkin
+Modules/*time*                   @pganssle @abalkin
+Python/pytime.c                  @pganssle @abalkin
 
 # Dbm
 Doc/library/dbm.rst           @corona10 @erlend-aasland @serhiy-storchaka
@@ -429,11 +429,11 @@ Lib/ensurepip/                @pfmoore @pradyunsg
 Lib/test/test_ensurepip.py    @pfmoore @pradyunsg
 
 # Enum
-Doc/howto/enum.rst            @ethanfurman
-Doc/library/enum.rst          @ethanfurman
-Lib/enum.py                   @ethanfurman
-Lib/test/test_enum.py         @ethanfurman
-Lib/test/test_json/test_enum.py @ethanfurman
+Doc/howto/enum.rst               @ethanfurman
+Doc/library/enum.rst             @ethanfurman
+Lib/enum.py                      @ethanfurman
+Lib/test/test_enum.py            @ethanfurman
+Lib/test/test_json/test_enum.py  @ethanfurman
 
 # FTP
 Doc/library/ftplib.rst        @giampaolo
@@ -463,22 +463,22 @@ Lib/test/test_heapq.py        @rhettinger
 Modules/_heapqmodule.c        @rhettinger
 
 # HTML
-Doc/library/html*             @ezio-melotti
-Lib/html/                     @ezio-melotti
-Lib/_markupbase.py            @ezio-melotti
-Lib/test/test_html*.py        @ezio-melotti
+Doc/library/html*                   @ezio-melotti
+Lib/html/                           @ezio-melotti
+Lib/_markupbase.py                  @ezio-melotti
+Lib/test/test_html*.py              @ezio-melotti
 Tools/build/parse_html5_entities.py @ezio-melotti
 
 # importlib.metadata
-Doc/library/importlib.metadata.rst @jaraco @warsaw
-Lib/importlib/metadata/       @jaraco @warsaw
-Lib/test/test_importlib/metadata/ @jaraco @warsaw
+Doc/library/importlib.metadata.rst  @jaraco @warsaw
+Lib/importlib/metadata/             @jaraco @warsaw
+Lib/test/test_importlib/metadata/   @jaraco @warsaw
 
 # importlib.resources
-Doc/library/importlib.resources.abc.rst @jaraco @warsaw
-Doc/library/importlib.resources.rst @jaraco @warsaw
-Lib/importlib/resources/      @jaraco @warsaw @FFY00
-Lib/test/test_importlib/resources/ @jaraco @warsaw @FFY00
+Doc/library/importlib.resources.abc.rst   @jaraco @warsaw
+Doc/library/importlib.resources.rst       @jaraco @warsaw
+Lib/importlib/resources/                  @jaraco @warsaw @FFY00
+Lib/test/test_importlib/resources/        @jaraco @warsaw @FFY00
 
 # itertools
 Doc/library/itertools.rst     @rhettinger
@@ -492,10 +492,10 @@ Lib/test/test_logging.py      @vsajip
 
 # multiprocessing
 Doc/library/multiprocessing*.rst @gpshead
-Lib/multiprocessing/          @gpshead
-Lib/test/*multiprocessing.py  @gpshead
-Lib/test/test_multiprocessing*/ @gpshead
-Modules/_multiprocessing/     @gpshead
+Lib/multiprocessing/             @gpshead
+Lib/test/*multiprocessing.py     @gpshead
+Lib/test/test_multiprocessing*/  @gpshead
+Modules/_multiprocessing/        @gpshead
 
 # pathlib
 Doc/library/pathlib.rst       @barneygale
@@ -537,9 +537,9 @@ Lib/test/test_site.py         @FFY00
 Doc/library/site.rst          @FFY00
 
 # string.templatelib
-Doc/library/string.templatelib.rst @lysnikolaou @AA-Turner
-Lib/string/templatelib.py     @lysnikolaou @AA-Turner
-Lib/test/test_string/test_templatelib.py @lysnikolaou @AA-Turner
+Doc/library/string.templatelib.rst        @lysnikolaou @AA-Turner
+Lib/string/templatelib.py                 @lysnikolaou @AA-Turner
+Lib/test/test_string/test_templatelib.py  @lysnikolaou @AA-Turner
 
 # Sysconfig
 **/*sysconfig*                @FFY00
@@ -578,7 +578,7 @@ Lib/types.py                  @AA-Turner
 Modules/_typesmodule.c        @AA-Turner
 
 # Unittest
-Lib/unittest/mock.py          @cjw296
+Lib/unittest/mock.py             @cjw296
 Lib/test/test_unittest/testmock/ @cjw296
 
 # Urllib

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -148,8 +148,8 @@ Tools/jit/                    @brandtbucher @savannahostrowski @diegorusso
 
 # Micro-op / μop / Tier 2 Optimiser
 Python/optimizer.c            @markshannon
-Python/optimizer_analysis.c   @markshannon @Fidget-Spinner @tomasr8
-Python/optimizer_bytecodes.c  @markshannon @Fidget-Spinner @tomasr8
+Python/optimizer_analysis.c   @markshannon @tomasr8 @Fidget-Spinner
+Python/optimizer_bytecodes.c  @markshannon @tomasr8 @Fidget-Spinner
 Python/optimizer_symbols.c    @markshannon @tomasr8
 
 # Parser, Lexer, and Grammar

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -475,9 +475,12 @@ Lib/pathlib/                  @barneygale
 Lib/test/test_pathlib/        @barneygale
 
 # pdb & bdb
-Doc/library/[bp]db.rst        @gaogaotiantian
-Lib/[bp]db.py                 @gaogaotiantian
-Lib/test/test_[bp]db.py       @gaogaotiantian
+Doc/library/bdb.rst        @gaogaotiantian
+Doc/library/pdb.rst        @gaogaotiantian
+Lib/bdb.py                 @gaogaotiantian
+Lib/pdb.py                 @gaogaotiantian
+Lib/test/test_bdb.py       @gaogaotiantian
+Lib/test/test_pdb.py       @gaogaotiantian
 Lib/test/test_remote_pdb.py   @gaogaotiantian
 
 # Pydoc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,7 @@
 #     the Makefile, autoconf, and other autotools files.
 # * Documentation
 #     broader sections of documentation, documentation tools
-# * Other / Misc (Tools, Programs, Integration, etc)
+# * Other / Misc (Tools, Programs, Integration, etc.)
 #     internal tools, integration with external systems,
 #     entries that don't fit elsewhere
 # * Platform Support
@@ -48,6 +48,9 @@
 # * Standard Library
 #     standard library modules (from both Lib and Modules)
 #     and related files (such as their tests and docs)
+# * Exclusions
+#     exclusions from .github/CODEOWNERS should go at the very end
+#     because the final matching pattern will take precedence.
 
 # ----------------------------------------------------------------------------
 # Buildbots, Continuous Integration, and Testing
@@ -104,7 +107,7 @@ Doc/whatsnew/                 @AA-Turner
 
 
 # ----------------------------------------------------------------------------
-# Other / Misc (Tools, Programs, Integration, etc)
+# Other / Misc (Tools, Programs, Integration, etc.)
 # ----------------------------------------------------------------------------
 
 # Argument Clinic

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,9 @@
 # Where possible, keep related files together. For example, documentation,
 # code, and tests for a given item should all be listed in the same place.
 #
+# GitHub usernames  should be aligned to column 31, or the next multiple
+# of three if the relevant paths are too long to fit.
+#
 # Top-level sections are:
 #
 # * Buildbots, Continuous Integration, and Testing
@@ -38,7 +41,7 @@
 #     the Makefile, autoconf, and other autotools files.
 # * Documentation
 #     broader sections of documentation, documentation tools
-# * Other / Misc (Tools, Programs, Integration, etc.)
+# * Internal Tools & Data
 #     internal tools, integration with external systems,
 #     entries that don't fit elsewhere
 # * Platform Support
@@ -107,7 +110,7 @@ Doc/whatsnew/                 @AA-Turner
 
 
 # ----------------------------------------------------------------------------
-# Other / Misc (Tools, Programs, Integration, etc.)
+# Internal Tools and Data
 # ----------------------------------------------------------------------------
 
 # Argument Clinic
@@ -121,7 +124,7 @@ Tools/c-analyzer/             @ericsnowcurrently
 # Fuzzing
 Modules/_xxtestfuzz/          @ammaraskar
 
-# Limited C API & stable ABI
+# Limited C API & Stable ABI
 Doc/c-api/stable.rst          @encukou
 Doc/data/*.abi                @encukou
 Misc/stable_abi.toml          @encukou

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -181,6 +181,15 @@ Tools/wasm/wasi               @brettcannon
 # Interpreter Core
 # ----------------------------------------------------------------------------
 
+# AST
+Lib/_ast_unparse.py           @isidentical @JelleZijlstra @eclips4 @tomasr8
+Lib/ast.py                    @isidentical @JelleZijlstra @eclips4 @tomasr8
+Lib/test/test_ast/            @eclips4 @tomasr8
+Parser/asdl.py                @isidentical @JelleZijlstra @eclips4 @tomasr8
+Parser/asdl_c.py              @isidentical @JelleZijlstra @eclips4 @tomasr8
+Python/ast.c                  @isidentical @JelleZijlstra @eclips4 @tomasr8
+Python/ast_preprocess.c       @isidentical @eclips4 @tomasr8
+
 # Built-in types
 Objects/call.c                @markshannon
 Objects/codeobject.c          @markshannon
@@ -206,19 +215,6 @@ Python/flowgraph.c            @markshannon @iritkatriel
 Python/instruction_sequence.c @iritkatriel
 Python/symtable.c             @JelleZijlstra @carljm
 
-# Core Modules
-**/*bltinmodule*              @ericsnowcurrently
-**/*sysmodule*                @ericsnowcurrently
-
-# AST
-Lib/_ast_unparse.py           @isidentical @JelleZijlstra @eclips4 @tomasr8
-Lib/ast.py                    @isidentical @JelleZijlstra @eclips4 @tomasr8
-Lib/test/test_ast/            @eclips4 @tomasr8
-Parser/asdl.py                @isidentical @JelleZijlstra @eclips4 @tomasr8
-Parser/asdl_c.py              @isidentical @JelleZijlstra @eclips4 @tomasr8
-Python/ast.c                  @isidentical @JelleZijlstra @eclips4 @tomasr8
-Python/ast_preprocess.c       @isidentical @eclips4 @tomasr8
-
 # Context variables & HAMT
 **/contextvars*                     @1st1
 **/*hamt*                           @1st1
@@ -226,6 +222,10 @@ Include/cpython/context.h           @1st1
 Include/internal/pycore_context.h   @1st1
 Lib/test/test_context.py            @1st1
 Python/context.c                    @1st1
+
+# Core Modules
+**/*bltinmodule*              @ericsnowcurrently
+**/*sysmodule*                @ericsnowcurrently
 
 # Exceptions
 Lib/test/test_except*.py      @iritkatriel

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -485,24 +485,24 @@ Doc/library/itertools.rst     @rhettinger
 Lib/test/test_itertools.py    @rhettinger
 Modules/itertoolsmodule.c     @rhettinger
 
-# logging
+# Logging
 Doc/**/logging*               @vsajip
 Lib/logging/                  @vsajip
 Lib/test/test_logging.py      @vsajip
 
-# multiprocessing
+# Multiprocessing
 Doc/library/multiprocessing*.rst @gpshead
 Lib/multiprocessing/             @gpshead
 Lib/test/*multiprocessing.py     @gpshead
 Lib/test/test_multiprocessing*/  @gpshead
 Modules/_multiprocessing/        @gpshead
 
-# pathlib
+# Pathlib
 Doc/library/pathlib.rst       @barneygale
 Lib/pathlib/                  @barneygale
 Lib/test/test_pathlib/        @barneygale
 
-# pdb & bdb
+# Pdb & Bdb
 Doc/library/bdb.rst           @gaogaotiantian
 Doc/library/pdb.rst           @gaogaotiantian
 Lib/bdb.py                    @gaogaotiantian
@@ -550,7 +550,7 @@ Lib/sqlite3/                  @berkerpeksag @erlend-aasland
 Lib/test/test_sqlite3/        @berkerpeksag @erlend-aasland
 Modules/_sqlite/              @berkerpeksag @erlend-aasland
 
-# subprocess
+# Subprocess
 Lib/subprocess.py             @gpshead
 Lib/test/test_subprocess.py   @gpshead
 Modules/*subprocess*          @gpshead
@@ -560,7 +560,7 @@ Doc/library/tarfile.rst       @ethanfurman
 Lib/tarfile.py                @ethanfurman
 Lib/test/test_tarfile.py      @ethanfurman
 
-# Tomllib
+# TOML
 Doc/library/tomllib.rst       @encukou @hauntsaninja
 Lib/test/test_tomllib/        @encukou @hauntsaninja
 Lib/tomllib/                  @encukou @hauntsaninja


### PR DESCRIPTION
cc @ezio-melotti @hugovk 

The CODEOWNERS file is getting a little disorganised. This PR is an attempt to add more of a structure & grouping, so future entries are less slapdash. For example, I was unsure the best place to add new lines in #137483.

I've organised the file by 'topic area': CI, build systems, core interpreter, docs, misc, platforms, and stdlib. Entries are kept alphabetically within each top-level section, and are grouped/subtitled with a comment.

I have tried to ensure that thre are no behavioural changes to `CODEOWNERS` from this PR, but there is one exception -- I've removed the `**/*cgi*` entry as `cgi.py` etc was removed in 3.13.

Unresolved thoughts:

* It would be nice to put the Windows build system in the build-systems section, but I don't know if we prefer keeping it with the platform support group, as it presently is.
* I didn't have a good group for the interpreter-core tests (now labelled "tests"). For the rest of the old "Core" group, I've split it up into constituent parts (built in types, eval loop, compiler, core modules, tier 2 optimiser, etc).
* I wasn't sure where best to put hashing / SSL -- it could go into either the "core" section or the "stdlib" section. (cc @picnixz for thoughts if any)
* IDLE feels out of place in the "Misc" section, but it is bigger than just a stdlib module, so didn't feel right putting it there.

A



