### PR TITLE
gh-137499: Fixed dead link to NIST website

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -935,7 +935,7 @@ These constants are used as parameters for :func:`clock_getres` and
 
 .. data:: CLOCK_TAI
 
-   `International Atomic Time <https://www.nist.gov/pml/time-and-frequency-division/nist-time-frequently-asked-questions-faq#tai>`_
+   `International Atomic Time <https://www.nist.gov/pml/time-and-frequency-division/how-utcnist-related-coordinated-universal-time-utc-international>`_
 
    The system must have a current leap second table in order for this to give
    the correct answer.  PTP or NTP software can maintain a leap second table.


### PR DESCRIPTION
https://github.com/python/cpython/issues/137499
Just swaps out a dead link for a live one

<!-- gh-issue-number: gh-137499 -->
* Issue: gh-137499
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137500.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->