### PR TITLE
gh-137044: Make resource.RLIM_INFINITY always positive

### DIFF
--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -50,6 +50,11 @@ this module for those platforms.
 .. data:: RLIM_INFINITY
 
    Constant used to represent the limit for an unlimited resource.
+   Its value is larger than any limited resource value.
+
+   .. versionchanged:: next
+      It is now always positive.
+      Previously, it could be negative, such as -1 or -3.
 
 
 .. function:: getrlimit(resource)

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -560,6 +560,12 @@ Porting to Python 3.15
   The |pythoncapi_compat_project| can be used to get most of these new
   functions on Python 3.14 and older.
 
+* :data:`resource.RLIM_INFINITY` is now always positive.
+  Passing a negative integer value that corresponded to its old value
+  (such as ``-1`` or ``-3``, depending on platform) to
+  :func:`resource.setrlimit` and :func:`resource.prlimit` is now deprecated.
+  (Contributed by Serhiy Storchaka in :gh:`137044`.)
+
 
 Deprecated C APIs
 -----------------

--- a/Lib/test/test_resource.py
+++ b/Lib/test/test_resource.py
@@ -150,10 +150,18 @@ class ResourceTest(unittest.TestCase):
     def test_fsize_negative(self):
         self.assertGreater(resource.RLIM_INFINITY, 0)
         (cur, max) = resource.getrlimit(resource.RLIMIT_FSIZE)
-        for value in -5, -3, -1, -2**31, -2**32-5, -2**63, -2**64-5, -2**1000:
+        for value in -5, -2**31, -2**32-5, -2**63, -2**64-5, -2**1000:
             with self.subTest(value=value):
                 self.assertRaises(ValueError, resource.setrlimit, resource.RLIMIT_FSIZE, (value, max))
                 self.assertRaises(ValueError, resource.setrlimit, resource.RLIMIT_FSIZE, (cur, value))
+
+        if resource.RLIM_INFINITY in (2**32-3, 2**32-1, 2**64-3, 2**64-1):
+            value = (resource.RLIM_INFINITY & 0xffff) - 0x10000
+            with self.assertWarnsRegex(DeprecationWarning, "RLIM_INFINITY"):
+                resource.setrlimit(resource.RLIMIT_FSIZE, (value, max))
+            with self.assertWarnsRegex(DeprecationWarning, "RLIM_INFINITY"):
+                resource.setrlimit(resource.RLIMIT_FSIZE, (cur, value))
+
 
     @unittest.skipUnless(hasattr(resource, "getrusage"), "needs getrusage")
     def test_getrusage(self):

--- a/Lib/test/test_resource.py
+++ b/Lib/test/test_resource.py
@@ -40,7 +40,10 @@ class ResourceTest(unittest.TestCase):
         # we need to test that the get/setrlimit functions properly convert
         # the number to a C long long and that the conversion doesn't raise
         # an error.
+        self.assertGreater(resource.RLIM_INFINITY, 0)
         self.assertEqual(resource.RLIM_INFINITY, max)
+        self.assertLessEqual(cur, max)
+        resource.setrlimit(resource.RLIMIT_FSIZE, (max, max))
         resource.setrlimit(resource.RLIMIT_FSIZE, (cur, max))
 
     @unittest.skipIf(sys.platform == "vxworks",
@@ -113,53 +116,42 @@ class ResourceTest(unittest.TestCase):
         self.addCleanup(resource.setrlimit, resource.RLIMIT_FSIZE, (cur, max))
 
         def expected(cur):
-            if resource.RLIM_INFINITY < 0:
-                return [(cur, max), (resource.RLIM_INFINITY, max)]
-            elif resource.RLIM_INFINITY < cur:
-                return [(resource.RLIM_INFINITY, max)]
-            else:
-                return [(cur, max)]
+            return (min(cur, resource.RLIM_INFINITY), max)
 
         resource.setrlimit(resource.RLIMIT_FSIZE, (2**31-5, max))
         self.assertEqual(resource.getrlimit(resource.RLIMIT_FSIZE), (2**31-5, max))
+        resource.setrlimit(resource.RLIMIT_FSIZE, (2**31, max))
+        self.assertEqual(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**31))
+        resource.setrlimit(resource.RLIMIT_FSIZE, (2**32-5, max))
+        self.assertEqual(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**32-5))
 
         try:
             resource.setrlimit(resource.RLIMIT_FSIZE, (2**32, max))
         except OverflowError:
-            resource.setrlimit(resource.RLIMIT_FSIZE, (2**31, max))
-            self.assertIn(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**31))
-            resource.setrlimit(resource.RLIMIT_FSIZE, (2**32-5, max))
-            self.assertIn(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**32-5))
+            pass
         else:
-            self.assertIn(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**32))
-            resource.setrlimit(resource.RLIMIT_FSIZE, (2**31, max))
-            self.assertEqual(resource.getrlimit(resource.RLIMIT_FSIZE), (2**31, max))
-            resource.setrlimit(resource.RLIMIT_FSIZE, (2**32-5, max))
-            self.assertEqual(resource.getrlimit(resource.RLIMIT_FSIZE), (2**32-5, max))
+            self.assertEqual(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**32))
 
             resource.setrlimit(resource.RLIMIT_FSIZE, (2**63-5, max))
-            self.assertIn(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**63-5))
+            self.assertEqual(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**63-5))
             try:
                 resource.setrlimit(resource.RLIMIT_FSIZE, (2**63, max))
             except ValueError:
                 # There is a hard limit on macOS.
                 pass
             else:
-                self.assertIn(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**63))
+                self.assertEqual(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**63))
                 resource.setrlimit(resource.RLIMIT_FSIZE, (2**64-5, max))
-                self.assertIn(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**64-5))
+                self.assertEqual(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**64-5))
 
     @unittest.skipIf(sys.platform == "vxworks",
                      "setting RLIMIT_FSIZE is not supported on VxWorks")
     @unittest.skipUnless(hasattr(resource, 'RLIMIT_FSIZE'), 'requires resource.RLIMIT_FSIZE')
     def test_fsize_negative(self):
+        self.assertGreater(resource.RLIM_INFINITY, 0)
         (cur, max) = resource.getrlimit(resource.RLIMIT_FSIZE)
-        for value in -5, -2**31, -2**32-5, -2**63, -2**64-5, -2**1000:
+        for value in -5, -3, -1, -2**31, -2**32-5, -2**63, -2**64-5, -2**1000:
             with self.subTest(value=value):
-                # This test assumes that the values don't map to RLIM_INFINITY,
-                # though Posix doesn't guarantee it.
-                self.assertNotEqual(value, resource.RLIM_INFINITY)
-
                 self.assertRaises(ValueError, resource.setrlimit, resource.RLIMIT_FSIZE, (value, max))
                 self.assertRaises(ValueError, resource.setrlimit, resource.RLIMIT_FSIZE, (cur, value))
 

--- a/Misc/NEWS.d/next/Library/2025-08-07-12-32-23.gh-issue-137044.abNoIy.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-07-12-32-23.gh-issue-137044.abNoIy.rst
@@ -1,0 +1,4 @@
+:data:`resource.RLIM_INFINITY` is now always a positive integer larger than
+any limited resource value. This simplifies comparison of the resource
+values. Previously, it could be negative, such as -1 or -3, depending on
+platform.


### PR DESCRIPTION
It is now a positive integer larger than any limited resource value. This simplifies comparison of the resource values. Previously, it could be negative, such as -1 or -3, depending on platform.


<!-- gh-issue-number: gh-137044 -->
* Issue: gh-137044
<!-- /gh-issue-number -->
