### PR TITLE
gh-137514: Add a free-threading wrapper for mutexes

### DIFF
--- a/Include/internal/pycore_pyatomic_ft_wrappers.h
+++ b/Include/internal/pycore_pyatomic_ft_wrappers.h
@@ -111,6 +111,8 @@ extern "C" {
     _Py_atomic_load_ullong_relaxed(&value)
 #define FT_ATOMIC_ADD_SSIZE(value, new_value) \
     (void)_Py_atomic_add_ssize(&value, new_value)
+#define FT_MUTEX_LOCK(lock) PyMutex_Lock(lock)
+#define FT_MUTEX_UNLOCK(lock) PyMutex_Unlock(lock)
 
 #else
 #define FT_ATOMIC_LOAD_PTR(value) value
@@ -159,7 +161,8 @@ extern "C" {
 #define FT_ATOMIC_LOAD_ULLONG_RELAXED(value) value
 #define FT_ATOMIC_STORE_ULLONG_RELAXED(value, new_value) value = new_value
 #define FT_ATOMIC_ADD_SSIZE(value, new_value) (void)(value += new_value)
-
+#define FT_MUTEX_LOCK(lock) do {} while (0)
+#define FT_MUTEX_UNLOCK(lock) do {} while (0)
 #endif
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_pyatomic_ft_wrappers.h
+++ b/Include/internal/pycore_pyatomic_ft_wrappers.h
@@ -163,6 +163,7 @@ extern "C" {
 #define FT_ATOMIC_ADD_SSIZE(value, new_value) (void)(value += new_value)
 #define FT_MUTEX_LOCK(lock) do {} while (0)
 #define FT_MUTEX_UNLOCK(lock) do {} while (0)
+
 #endif
 
 #ifdef __cplusplus

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -550,16 +550,12 @@ init_code(PyCodeObject *co, struct _PyCodeConstructor *con)
     co->co_framesize = nlocalsplus + con->stacksize + FRAME_SPECIALS_SIZE;
     co->co_ncellvars = ncellvars;
     co->co_nfreevars = nfreevars;
-#ifdef Py_GIL_DISABLED
-    PyMutex_Lock(&interp->func_state.mutex);
-#endif
+    FT_MUTEX_LOCK(&interp->func_state.mutex);
     co->co_version = interp->func_state.next_version;
     if (interp->func_state.next_version != 0) {
         interp->func_state.next_version++;
     }
-#ifdef Py_GIL_DISABLED
-    PyMutex_Unlock(&interp->func_state.mutex);
-#endif
+    FT_MUTEX_UNLOCK(&interp->func_state.mutex);
     co->_co_monitoring = NULL;
     co->_co_instrumentation_version = 0;
     /* not set */
@@ -689,7 +685,7 @@ intern_code_constants(struct _PyCodeConstructor *con)
 #ifdef Py_GIL_DISABLED
     PyInterpreterState *interp = _PyInterpreterState_GET();
     struct _py_code_state *state = &interp->code_state;
-    PyMutex_Lock(&state->mutex);
+    FT_MUTEX_LOCK(&state->mutex);
 #endif
     if (intern_strings(con->names) < 0) {
         goto error;
@@ -700,15 +696,11 @@ intern_code_constants(struct _PyCodeConstructor *con)
     if (intern_strings(con->localsplusnames) < 0) {
         goto error;
     }
-#ifdef Py_GIL_DISABLED
-    PyMutex_Unlock(&state->mutex);
-#endif
+    FT_MUTEX_UNLOCK(&state->mutex);
     return 0;
 
 error:
-#ifdef Py_GIL_DISABLED
-    PyMutex_Unlock(&state->mutex);
-#endif
+    FT_MUTEX_UNLOCK(&state->mutex);
     return -1;
 }
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15984,14 +15984,16 @@ intern_common(PyInterpreterState *interp, PyObject *s /* stolen */,
     /* Do a setdefault on the per-interpreter cache. */
     PyObject *interned = get_interned_dict(interp);
     assert(interned != NULL);
-
-    FT_MUTEX_LOCK(&_Py_INTERP_CACHED_OBJECT(interp, interned_mutex));
+#ifdef Py_GIL_DISABLED
+#  define INTERN_MUTEX &_Py_INTERP_CACHED_OBJECT(interp, interned_mutex)
+#endif
+    FT_MUTEX_LOCK(INTERN_MUTEX);
     PyObject *t;
     {
         int res = PyDict_SetDefaultRef(interned, s, s, &t);
         if (res < 0) {
             PyErr_Clear();
-            FT_MUTEX_UNLOCK(&_Py_INTERP_CACHED_OBJECT(interp, interned_mutex));
+            FT_MUTEX_UNLOCK(INTERN_MUTEX);
             return s;
         }
         else if (res == 1) {
@@ -16001,7 +16003,7 @@ intern_common(PyInterpreterState *interp, PyObject *s /* stolen */,
                     PyUnicode_CHECK_INTERNED(t) == SSTATE_INTERNED_MORTAL) {
                 immortalize_interned(t);
             }
-            FT_MUTEX_UNLOCK(&_Py_INTERP_CACHED_OBJECT(interp, interned_mutex));
+            FT_MUTEX_UNLOCK(INTERN_MUTEX);
             return t;
         }
         else {
@@ -16034,7 +16036,7 @@ intern_common(PyInterpreterState *interp, PyObject *s /* stolen */,
         immortalize_interned(s);
     }
 
-    FT_MUTEX_UNLOCK(&_Py_INTERP_CACHED_OBJECT(interp, interned_mutex));
+    FT_MUTEX_UNLOCK(INTERN_MUTEX);
     return s;
 }
 

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -5,6 +5,7 @@
 #include "pycore_pyerrors.h"      // PyExc_IncompleteInputError
 #include "pycore_runtime.h"     // _PyRuntime
 #include "pycore_unicodeobject.h" // _PyUnicode_InternImmortal
+#include "pycore_pyatomic_ft_wrappers.h"
 #include <errcode.h>
 
 #include "lexer/lexer.h"

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -299,22 +299,14 @@ error:
 #define NSTATISTICS _PYPEGEN_NSTATISTICS
 #define memo_statistics _PyRuntime.parser.memo_statistics
 
-#ifdef Py_GIL_DISABLED
-#define MUTEX_LOCK() PyMutex_Lock(&_PyRuntime.parser.mutex)
-#define MUTEX_UNLOCK() PyMutex_Unlock(&_PyRuntime.parser.mutex)
-#else
-#define MUTEX_LOCK()
-#define MUTEX_UNLOCK()
-#endif
-
 void
 _PyPegen_clear_memo_statistics(void)
 {
-    MUTEX_LOCK();
+    FT_MUTEX_LOCK(&_PyRuntime.parser.mutex);
     for (int i = 0; i < NSTATISTICS; i++) {
         memo_statistics[i] = 0;
     }
-    MUTEX_UNLOCK();
+    FT_MUTEX_UNLOCK(&_PyRuntime.parser.mutex);
 }
 
 PyObject *
@@ -325,22 +317,22 @@ _PyPegen_get_memo_statistics(void)
         return NULL;
     }
 
-    MUTEX_LOCK();
+    FT_MUTEX_LOCK(&_PyRuntime.parser.mutex);
     for (int i = 0; i < NSTATISTICS; i++) {
         PyObject *value = PyLong_FromLong(memo_statistics[i]);
         if (value == NULL) {
-            MUTEX_UNLOCK();
+            FT_MUTEX_UNLOCK(&_PyRuntime.parser.mutex);
             Py_DECREF(ret);
             return NULL;
         }
         // PyList_SetItem borrows a reference to value.
         if (PyList_SetItem(ret, i, value) < 0) {
-            MUTEX_UNLOCK();
+            FT_MUTEX_UNLOCK(&_PyRuntime.parser.mutex);
             Py_DECREF(ret);
             return NULL;
         }
     }
-    MUTEX_UNLOCK();
+    FT_MUTEX_UNLOCK(&_PyRuntime.parser.mutex);
     return ret;
 }
 #endif
@@ -366,9 +358,9 @@ _PyPegen_is_memoized(Parser *p, int type, void *pres)
                 if (count <= 0) {
                     count = 1;
                 }
-                MUTEX_LOCK();
+                FT_MUTEX_LOCK(&_PyRuntime.parser.mutex);
                 memo_statistics[type] += count;
-                MUTEX_UNLOCK();
+                FT_MUTEX_UNLOCK(&_PyRuntime.parser.mutex);
             }
 #endif
             p->mark = m->mark;

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -910,7 +910,6 @@ clear_pending_handling_thread(struct _pending_calls *pending)
     FT_MUTEX_LOCK(&pending->mutex);
     pending->handling_thread = NULL;
     FT_MUTEX_UNLOCK(&pending->mutex);
-    pending->handling_thread = NULL;
 }
 
 static int

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -907,13 +907,10 @@ unsignal_pending_calls(PyThreadState *tstate, PyInterpreterState *interp)
 static void
 clear_pending_handling_thread(struct _pending_calls *pending)
 {
-#ifdef Py_GIL_DISABLED
-    PyMutex_Lock(&pending->mutex);
+    FT_MUTEX_LOCK(&pending->mutex);
     pending->handling_thread = NULL;
-    PyMutex_Unlock(&pending->mutex);
-#else
+    FT_MUTEX_UNLOCK(&pending->mutex);
     pending->handling_thread = NULL;
-#endif
 }
 
 static int

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -43,7 +43,6 @@ int PyCodec_Register(PyObject *search_function)
     FT_MUTEX_LOCK(&interp->codecs.search_path_mutex);
     int ret = PyList_Append(interp->codecs.search_path, search_function);
     FT_MUTEX_UNLOCK(&interp->codecs.search_path_mutex);
-
     return ret;
 
  onError:

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -40,13 +40,10 @@ int PyCodec_Register(PyObject *search_function)
         PyErr_SetString(PyExc_TypeError, "argument must be callable");
         goto onError;
     }
-#ifdef Py_GIL_DISABLED
-    PyMutex_Lock(&interp->codecs.search_path_mutex);
-#endif
+    FT_MUTEX_LOCK(&interp->codecs.search_path_mutex);
     int ret = PyList_Append(interp->codecs.search_path, search_function);
-#ifdef Py_GIL_DISABLED
-    PyMutex_Unlock(&interp->codecs.search_path_mutex);
-#endif
+    FT_MUTEX_UNLOCK(&interp->codecs.search_path_mutex);
+
     return ret;
 
  onError:
@@ -66,9 +63,7 @@ PyCodec_Unregister(PyObject *search_function)
     PyObject *codec_search_path = interp->codecs.search_path;
     assert(PyList_CheckExact(codec_search_path));
     for (Py_ssize_t i = 0; i < PyList_GET_SIZE(codec_search_path); i++) {
-#ifdef Py_GIL_DISABLED
-        PyMutex_Lock(&interp->codecs.search_path_mutex);
-#endif
+        FT_MUTEX_LOCK(&interp->codecs.search_path_mutex);
         PyObject *item = PyList_GetItemRef(codec_search_path, i);
         int ret = 1;
         if (item == search_function) {
@@ -76,9 +71,7 @@ PyCodec_Unregister(PyObject *search_function)
             // while we hold search_path_mutex.
             ret = PyList_SetSlice(codec_search_path, i, i+1, NULL);
         }
-#ifdef Py_GIL_DISABLED
-        PyMutex_Unlock(&interp->codecs.search_path_mutex);
-#endif
+        FT_MUTEX_UNLOCK(&interp->codecs.search_path_mutex);
         Py_DECREF(item);
         if (ret != 1) {
             assert(interp->codecs.search_cache != NULL);

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -16,7 +16,7 @@ Copyright (c) Corporation for National Research Initiatives.
 #include "pycore_runtime.h"       // _Py_ID()
 #include "pycore_ucnhash.h"       // _PyUnicode_Name_CAPI
 #include "pycore_unicodeobject.h" // _PyUnicode_InternMortal()
-
+#include "pycore_pyatomic_ft_wrappers.h"
 
 static const char *codecs_builtin_error_handlers[] = {
     "strict", "ignore", "replace",

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -43,6 +43,7 @@ int PyCodec_Register(PyObject *search_function)
     FT_MUTEX_LOCK(&interp->codecs.search_path_mutex);
     int ret = PyList_Append(interp->codecs.search_path, search_function);
     FT_MUTEX_UNLOCK(&interp->codecs.search_path_mutex);
+
     return ret;
 
  onError:

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1689,9 +1689,7 @@ PyThreadState_Clear(PyThreadState *tstate)
           "PyThreadState_Clear: warning: thread still has a generator\n");
     }
 
-#ifdef Py_GIL_DISABLED
-    PyMutex_Lock(&_PyRuntime.ceval.sys_trace_profile_mutex);
-#endif
+    FT_MUTEX_LOCK(&_PyRuntime.ceval.sys_trace_profile_mutex);
 
     if (tstate->c_profilefunc != NULL) {
         tstate->interp->sys_profiling_threads--;
@@ -1702,9 +1700,7 @@ PyThreadState_Clear(PyThreadState *tstate)
         tstate->c_tracefunc = NULL;
     }
 
-#ifdef Py_GIL_DISABLED
-    PyMutex_Unlock(&_PyRuntime.ceval.sys_trace_profile_mutex);
-#endif
+    FT_MUTEX_UNLOCK(&_PyRuntime.ceval.sys_trace_profile_mutex);
 
     Py_CLEAR(tstate->c_profileobj);
     Py_CLEAR(tstate->c_traceobj);


### PR DESCRIPTION
Add `FT_MUTEX_LOCK`/`FT_MUTEX_UNLOCK`, which call `PyMutex_Lock` and `PyMutex_Unlock` on the free-threaded build, and no-op otherwise. 

<!-- gh-issue-number: gh-137514 -->
* Issue: gh-137514
<!-- /gh-issue-number -->
