### PR TITLE
gh-137490: Fix signal.sigwaitinfo() on NetBSD

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-08-07-17-18-57.gh-issue-137490.s89ieZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-07-17-18-57.gh-issue-137490.s89ieZ.rst
@@ -1,0 +1,2 @@
+Handle :data:`~errno.ECANCELED` in the same way as :data:`~errno.EINTR` in
+:func:`signal.sigwaitinfo` on NetBSD.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -1180,7 +1180,13 @@ signal_sigwaitinfo_impl(PyObject *module, sigset_t sigset)
         err = sigwaitinfo(&sigset, &si);
         Py_END_ALLOW_THREADS
     } while (err == -1
-             && errno == EINTR && !(async_err = PyErr_CheckSignals()));
+             && (errno == EINTR
+#if defined(__NetBSD__)
+                 /* NetBSD's implementation violates POSIX by setting
+                  * errno to ECANCELED instead of EINTR. */
+                 || errno == ECANCELED
+#endif
+            ) && !(async_err = PyErr_CheckSignals()));
     if (err == -1)
         return (!async_err) ? PyErr_SetFromErrno(PyExc_OSError) : NULL;
 


### PR DESCRIPTION
Handle ECANCELED in the same way as EINTR to work around the Posix violation in the NetBSD's implementation.


<!-- gh-issue-number: gh-137490 -->
* Issue: gh-137490
<!-- /gh-issue-number -->
