### PR TITLE
Remove redundant assignment in `asyncio.streams.StreamReaderProtocol.connection_lost()`

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -271,7 +271,6 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
                 self._closed.set_exception(exc)
         super().connection_lost(exc)
         self._stream_reader_wr = None
-        self._stream_writer = None
         self._task = None
         self._transport = None
 


### PR DESCRIPTION
Nothing fancy.

The variable is never used. The only other occurences of the string are completely not related:

```
% rg _stream_writer
Modules/_testcapi/codec.c
115:codec_stream_writer(PyObject *Py_UNUSED(module), PyObject *args)
200:    {"codec_stream_writer", codec_stream_writer, METH_VARARGS},

Lib/test/test_capi/test_codecs.py
734:    def test_codec_stream_writer(self):
735:        codec_stream_writer = _testcapi.codec_stream_writer
741:                    writer = codec_stream_writer(encoding, stream, errors)
745:                codec_stream_writer(NULL, stream, 'strict')
%
```

I don't think this requires a NEWS entry. It has no user-visible effects.