### PR TITLE
gh-137526: Fix broken link to drdobbs journal in difflib.rst

### DIFF
--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -351,9 +351,9 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
 
 .. seealso::
 
-   `Pattern Matching: The Gestalt Approach <https://www.drdobbs.com/database/pattern-matching-the-gestalt-approach/184407970>`_
+   `Pattern Matching: The Gestalt Approach <https://jacobfilipp.com/DrDobbs/articles/DDJ/1988/8807/8807c/8807c.htm>`_
       Discussion of a similar algorithm by John W. Ratcliff and D. E. Metzener. This
-      was published in `Dr. Dobb's Journal <https://www.drdobbs.com/>`_ in July, 1988.
+      was published in Dr. Dobb's Journal in July, 1988.
 
 
 .. _sequence-matcher:


### PR DESCRIPTION
I’ve updated the broken link, it now links to a version of the page that is being hosted by an amateur archivist. (This was done after looking for a surviving link via web.archive).

Much later I found this link: https://web.archive.org/web/20071216020031/http://www.ddj.com/184407970?pgno=5 however I've kept the link to https://jacobfilipp.com/DrDobbs/ as it's more navigable than the web archive.

Since the journal doesn’t exist there are 4 options for the second link.
1. [Link the wiki page](https://en.wikipedia.org/wiki/Dr._Dobb%27s_Journal)
2. [Link the base url of the archive](https://jacobfilipp.com/DrDobbs/)
3. Remove it.
4. [Linking something from web.archive](https://web.archive.org/web/20100205122310/https://www.drdobbs.com/)

I went with 3. 

Here’s a post by the archivist on the EOL of DDJ: https://jacobfilipp.com/thedoctor/

Another solution is removing the “See Also” block completely.


<!-- gh-issue-number: gh-137526 -->
* Issue: gh-137526
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137527.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->