### PR TITLE
add floss.fund manifest provenance

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://www.python.org/funding.json


### PR DESCRIPTION
The PSF is going to be applying to https://floss.fund, this file is necessary to establish the relationship between this repository and the PSF CPython sponsorship program.

ref: https://fundingjson.org/#wellknown