### PR TITLE
gh-137533: document key type coercion limitations in `json.loads`

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -371,13 +371,6 @@ Basic Usage
    .. versionchanged:: 3.9
       The keyword argument *encoding* has been removed.
 
-   .. note::
-
-      As mandated by :rfc:`7159`, JSON keys must be :class:`str` objects.
-      In particular, ``json.loads('{"42": "spam"}')`` returns ``{'42': 'spam'}``,
-      but ``json.loads('{42: "spam"}')`` fails since ``42`` is not a valid JSON key.
-
-
 Encoders and Decoders
 ---------------------
 

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -146,12 +146,6 @@ See :ref:`json-commandline` for detailed documentation.
    This module's encoders and decoders preserve input and output order by
    default.  Order is only lost if the underlying containers are unordered.
 
-.. note::
-   :rfc:`7159` requires that keys in key/value pairs of JSON are always of the
-   type :class:`str`. When a dictionary is converted into JSON, all the keys
-   of the dictionary arecoerced to strings.When a JSON object is converted into
-   dictionaries,all the keys of the dictionary are strings.
-
 Basic Usage
 -----------
 

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -261,12 +261,10 @@ Basic Usage
 
    .. note::
 
-      Keys in key/value pairs of JSON are always of the type :class:`str`. When
-      a dictionary is converted into JSON, all the keys of the dictionary are
-      coerced to strings. As a result of this, if a dictionary is converted
-      into JSON and then back into a dictionary, the dictionary may not equal
-      the original one. That is, ``loads(dumps(x)) != x`` if x has non-string
-      keys.
+      The encoder will convert all non-string keys in dictionaries into string,
+      if a dictionary is converted into JSON and then back into a dictionary,
+      the dictionary may not equal the original one.
+      That is, ``loads(dumps(x)) != x`` if x has non-string keys.
 
 .. function:: load(fp, *, cls=None, object_hook=None, parse_float=None, \
                    parse_int=None, parse_constant=None, \

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -147,12 +147,9 @@ See :ref:`json-commandline` for detailed documentation.
    default.  Order is only lost if the underlying containers are unordered.
 
 .. note::
-   According to :rfc:`7159`, the keys of all objects in JSON are strings.
-   Under normal circumstances,the encoder of this module
-   will convert the keys of all Python dictionaries into strings as the
-   keys of JSON objects, and the decoder of this module will
-   decode the keys of all JSON objects into strings as the keys
-   of Python dictionaries
+   Per RFC 7159, JSON keys are strings.
+   This module's encoder converts dictionary keys to strings,
+   and its decoder produces dictionaries with string keys.
 
 Basic Usage
 -----------

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -259,6 +259,10 @@ Basic Usage
    table <py-to-json-table>`.  The arguments have the same meaning as in
    :func:`dump`.
 
+   .. note::
+
+      The encoder dose not preserve the types of dictionary keys in Python.Read more at :ref:`json-key-convertion`
+
 .. function:: load(fp, *, cls=None, object_hook=None, parse_float=None, \
                    parse_int=None, parse_constant=None, \
                    object_pairs_hook=None, **kw)
@@ -359,6 +363,10 @@ Basic Usage
 
    .. versionchanged:: 3.9
       The keyword argument *encoding* has been removed.
+
+   .. note::
+
+      The decoder preserves the keys in JSON text as :class:`str`.Read more at :ref:`json-key-convertion`
 
 
 Encoders and Decoders
@@ -573,6 +581,28 @@ Encoders and Decoders
             for chunk in json.JSONEncoder().iterencode(bigobject):
                 mysocket.write(chunk)
 
+.. _json-key-convertion:
+
+JSON Key Convertion
+^^^^^^^^^^^^^^^^^^^
+
+:rfc:`7159` requires that keys in key/value pairs of JSON are always of the
+type :class:`str`. When a dictionary is converted into JSON, all the keys
+of the dictionary arecoerced to strings.When a JSON object is converted into
+dictionaries,all the keys of the dictionary are strings.
+For example:
+
+   >>> import json
+   >>> foo={1:"spam"}
+   >>> result=json.dumps(foo)
+   >>> print(result)
+   {"1": "spam"}
+   >>> print(foo)
+   {1: 'spam'}
+   >>> print(foo==result)
+   False
+
+It can be seen that non-string keys are converted into strings after being encoded as JSON
 
 Exceptions
 ----------

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -259,13 +259,6 @@ Basic Usage
    table <py-to-json-table>`.  The arguments have the same meaning as in
    :func:`dump`.
 
-   .. note::
-
-      The encoder will convert all non-string keys in dictionaries into string,
-      if a dictionary is converted into JSON and then back into a dictionary,
-      the dictionary may not equal the original one.
-      That is, ``loads(dumps(x)) != x`` if x has non-string keys.
-
 .. function:: load(fp, *, cls=None, object_hook=None, parse_float=None, \
                    parse_int=None, parse_constant=None, \
                    object_pairs_hook=None, **kw)
@@ -367,11 +360,6 @@ Basic Usage
    .. versionchanged:: 3.9
       The keyword argument *encoding* has been removed.
 
-   .. note::
-
-      The decoder will convert all JSON objects' keys into string as
-      the key of dictionaries,for example,
-      ``json.loads('{"spam":"foo"}')`` returns ``{'spam':'foo'}``
 
 Encoders and Decoders
 ---------------------

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -22,6 +22,7 @@ is a lightweight data interchange format inspired by
    The term "object" in the context of JSON processing in Python can be
    ambiguous. All values in Python are objects. In JSON, an object refers to
    any data wrapped in curly braces, similar to a Python dictionary.
+
 .. warning::
    Be cautious when parsing JSON data from untrusted sources. A malicious
    JSON string may cause the decoder to consume considerable CPU and memory
@@ -146,7 +147,7 @@ See :ref:`json-commandline` for detailed documentation.
    default.  Order is only lost if the underlying containers are unordered.
 
 .. note::
-   According to RFC 7159, the keys of all objects in JSON are strings.
+   According to :rfc:`7159`, the keys of all objects in JSON are strings.
    Under normal circumstances,the encoder of this module
    will convert the keys of all Python dictionaries into strings as the
    keys of JSON objects, and the decoder of this module will
@@ -372,7 +373,7 @@ Basic Usage
 
    .. note::
 
-      As mandated by :rfc:`8259`, JSON keys must be :class:`str` objects.
+      As mandated by :rfc:`7159`, JSON keys must be :class:`str` objects.
       In particular, ``json.loads('{"42": "spam"}')`` returns ``{'42': 'spam'}``,
       but ``json.loads('{42: "spam"}')`` fails since ``42`` is not a valid JSON key.
 

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -366,7 +366,7 @@ Basic Usage
 
    .. note::
 
-      As mandated by RFC 8259, keys in JSON key-value pairs are always of
+      As mandated by :rfc:`8259`, keys in JSON key-value pairs are always of
       type :class:`str`. Therefore, dictionary keys obtained by
       deserializing JSON objects will always be strings.
       For Example,

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -370,8 +370,10 @@ Basic Usage
       type :class:`str`. Therefore, dictionary keys obtained by
       deserializing JSON objects will always be strings.
       For Example,
-      ``json.loads('{"42":"value"}')`` returns the dictionary
-      ``{'42': 'value'}``.
+      ``json.loads('{"42":"spam"}')`` returns the dictionary
+      ``{'42': 'spam'}`,but ``json.loads('{42:"spam"}')``
+      will raise a exception,because it is not a correct
+      JSON text
 
 Encoders and Decoders
 ---------------------

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -366,14 +366,10 @@ Basic Usage
 
    .. note::
 
-      As mandated by :rfc:`8259`, keys in JSON key-value pairs are always of
-      type :class:`str`. Therefore, dictionary keys obtained by
-      deserializing JSON objects will always be strings.
-      For Example,
-      ``json.loads('{"42":"spam"}')`` returns the dictionary
-      ``{'42': 'spam'}``,but ``json.loads('{42:"spam"}')``
-      will raise a exception,because it is not a correct
-      JSON text
+      As mandated by :rfc:`8259`, JSON keys must be :class:`str` objects.
+      In particular, ``json.loads('{"42": "spam"}')`` returns ``{'42': 'spam'}``,
+      but ``json.loads('{42: "spam"}')`` fails since ``42`` is not a valid JSON key.
+
 
 Encoders and Decoders
 ---------------------

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -366,8 +366,12 @@ Basic Usage
 
    .. note::
 
-      As mandated by RFC 8259,the key in key-value pairs in JSON is always of type of :class:`str`,so the key of the dictionary that is got by serializing a JSON object is always a string.
-      Example:``json.loads('{"42":"value"}')`` will get a dictionary ``{'42':'value'}``
+      As mandated by RFC 8259, keys in JSON key-value pairs are always of
+      type :class:`str`. Therefore, dictionary keys obtained by
+      deserializing JSON objects will always be strings.
+      For Example,
+      ``json.loads('{"42":"value"}')`` returns the dictionary
+      ``{'42': 'value'}``.
 
 Encoders and Decoders
 ---------------------

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -364,6 +364,10 @@ Basic Usage
    .. versionchanged:: 3.9
       The keyword argument *encoding* has been removed.
 
+   .. note::
+
+      As mandated by RFC 8259,the key in key-value pairs in JSON is always of type of :class:`str`,so the key of the dictionary that is got by serializing a JSON object is always a string.
+      Example:``json.loads('{"42":"value"}')`` will get a dictionary ``{'42':'value'}``
 
 Encoders and Decoders
 ---------------------

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -22,7 +22,6 @@ is a lightweight data interchange format inspired by
    The term "object" in the context of JSON processing in Python can be
    ambiguous. All values in Python are objects. In JSON, an object refers to
    any data wrapped in curly braces, similar to a Python dictionary.
-
 .. warning::
    Be cautious when parsing JSON data from untrusted sources. A malicious
    JSON string may cause the decoder to consume considerable CPU and memory
@@ -146,6 +145,13 @@ See :ref:`json-commandline` for detailed documentation.
    This module's encoders and decoders preserve input and output order by
    default.  Order is only lost if the underlying containers are unordered.
 
+.. note::
+   According to RFC 7159, the keys of all objects in JSON are strings.
+   Under normal circumstances,the encoder of this module
+   will convert the keys of all Python dictionaries into strings as the
+   keys of JSON objects, and the decoder of this module will
+   decode the keys of all JSON objects into strings as the keys
+   of Python dictionaries
 
 Basic Usage
 -----------

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -147,9 +147,9 @@ See :ref:`json-commandline` for detailed documentation.
    default.  Order is only lost if the underlying containers are unordered.
 
 .. note::
-   Per RFC 7159, JSON keys are strings.
-   This module's encoder converts dictionary keys to strings,
-   and its decoder produces dictionaries with string keys.
+   Per :rfc:`7159`, JSON objects' keys must be strings.
+   This module's encoder converts Python dictionary's keys to strings,
+   and its decoder produces Python dictionaries with string keys.
 
 Basic Usage
 -----------

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -367,6 +367,12 @@ Basic Usage
    .. versionchanged:: 3.9
       The keyword argument *encoding* has been removed.
 
+   .. note::
+
+      The decoder will convert all JSON objects' keys into string as
+      the key of dictionaries,for example,
+      ``json.loads('{"spam":"foo"}')`` returns ``{'spam':'foo'}``
+
 Encoders and Decoders
 ---------------------
 

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -371,7 +371,7 @@ Basic Usage
       deserializing JSON objects will always be strings.
       For Example,
       ``json.loads('{"42":"spam"}')`` returns the dictionary
-      ``{'42': 'spam'}`,but ``json.loads('{42:"spam"}')``
+      ``{'42': 'spam'}``,but ``json.loads('{42:"spam"}')``
       will raise a exception,because it is not a correct
       JSON text
 

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -147,9 +147,10 @@ See :ref:`json-commandline` for detailed documentation.
    default.  Order is only lost if the underlying containers are unordered.
 
 .. note::
-   Per :rfc:`7159`, JSON objects' keys must be strings.
-   This module's encoder converts Python dictionary's keys to strings,
-   and its decoder produces Python dictionaries with string keys.
+   :rfc:`7159` requires that keys in key/value pairs of JSON are always of the
+   type :class:`str`. When a dictionary is converted into JSON, all the keys
+   of the dictionary arecoerced to strings.When a JSON object is converted into
+   dictionaries,all the keys of the dictionary are strings.
 
 Basic Usage
 -----------

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -255,7 +255,8 @@ Basic Usage
 
    .. note::
 
-      The encoder dose not preserve the types of dictionary keys in Python.Read more at :ref:`json-key-convertion`
+      The encoder dose not preserve the types of dictionary keys in Python.
+      Read more at :ref:`json-key-convertion`
 
 .. function:: load(fp, *, cls=None, object_hook=None, parse_float=None, \
                    parse_int=None, parse_constant=None, \
@@ -360,7 +361,8 @@ Basic Usage
 
    .. note::
 
-      The decoder preserves the keys in JSON text as :class:`str`.Read more at :ref:`json-key-convertion`
+      The decoder preserves the keys in JSON text as :class:`str`.
+      Read more at :ref:`json-key-convertion`
 
 
 Encoders and Decoders


### PR DESCRIPTION
<!-- gh-issue-number: gh-106318 -->
* Issue: gh-137533
<!-- /gh-issue-number -->

**TIP**: Partially fixes gh-137533, do not close the issue


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137545.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->