### PR TITLE
Replace "ordered arguments" with "positional arguments" in unittest.mock documentation

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -639,7 +639,7 @@ the *new_callable* argument to :func:`patch`.
         This is either ``None`` (if the mock hasn't been called), or the
         arguments that the mock was last called with. This will be in the
         form of a tuple: the first member, which can also be accessed through
-        the ``args`` property, is any non-keyword arguments the mock was
+        the ``args`` property, is any positional arguments the mock was
         called with (or an empty tuple) and the second member, which can
         also be accessed through the ``kwargs`` property, is any keyword
         arguments (or an empty dictionary).

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -639,7 +639,7 @@ the *new_callable* argument to :func:`patch`.
         This is either ``None`` (if the mock hasn't been called), or the
         arguments that the mock was last called with. This will be in the
         form of a tuple: the first member, which can also be accessed through
-        the ``args`` property, is any ordered arguments the mock was
+        the ``args`` property, is any non-keyword arguments the mock was
         called with (or an empty tuple) and the second member, which can
         also be accessed through the ``kwargs`` property, is any keyword
         arguments (or an empty dictionary).


### PR DESCRIPTION
This is a trivial change, replacing "ordered arguments" with "non-keyword arguments" inside the `unittest.mock` documentation.

## Rationale

The confusing and unique terminology was pointed out to me whilst helping a new developer get started with mocks. They are quite familiar with python functions and arguments, but they where very confused by the phrase "ordered arguments". As far as I can tell, this is the only place that refers to non-keyword arguments as "ordered arguments" - arguments are ordered by virtue of them being arguments.

I'm happy to fiddle with the wording some more, but I figured simply changing it to "non-keyword" arguments makes things a bit clearer for newer developers?

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137552.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->