### PR TITLE
gh-137562: Remove reference for GC_REACHABLE because it is obsolete

### DIFF
--- a/Python/gc.c
+++ b/Python/gc.c
@@ -570,8 +570,7 @@ _PyGC_VisitFrameStack(_PyInterpreterFrame *frame, visitproc visit, void *arg)
 }
 
 /* Subtract internal references from gc_refs.  After this, gc_refs is >= 0
- * for all objects in containers, and is GC_REACHABLE for all tracked gc
- * objects not in containers.  The ones with gc_refs > 0 are directly
+ * for all objects in containers. The ones with gc_refs > 0 are directly
  * reachable from outside containers, and so can't be collected.
  */
 static void


### PR DESCRIPTION
subtract_refs references an obsolete constant `GC_REACHABLE` 
https://github.com/python/cpython/blob/34d7351ac770ac49875fc39396b2a97828ba05ad/Python/gc.c#L572-L577

It is obsolete since https://github.com/python/cpython/pull/7043

<!-- gh-issue-number: gh-137562 -->
* Issue: gh-137562
<!-- /gh-issue-number -->
