### PR TITLE
gh-92936: update `http.cookies` docs post GH-113663

### DIFF
--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -322,4 +322,4 @@ The following example demonstrates how to use the :mod:`http.cookies` module.
    >>> print(C)
    Set-Cookie: cookies=7
    Set-Cookie: mixins="{"chips": "dark chocolate"}"
-   Set-Cookie: state="gooey"
+   Set-Cookie: state=gooey

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -30,7 +30,7 @@ in a cookie name (as :attr:`~Morsel.key`).
 .. versionchanged:: 3.3
    Allowed ':' as a valid cookie name character.
 
-.. versionchanged:: 3.15
+.. versionchanged:: next
    Allowed '"' as a valid cookie value character.
 
 .. note::

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -316,8 +316,9 @@ The following example demonstrates how to use the :mod:`http.cookies` module.
    >>> print(C)
    Set-Cookie: number=7
    Set-Cookie: string=seven
+   >>> import json
    >>> C = cookies.SimpleCookie()
-   >>> C.load('cookies=7; mixins="{"chips": "dark chocolate"}"; state="gooey"')
+   >>> C.load(f'cookies=7; mixins="{json.dumps({"chips": "dark chocolate"})}"; state=gooey')
    >>> print(C)
    Set-Cookie: cookies=7
    Set-Cookie: mixins="{"chips": "dark chocolate"}"

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -30,6 +30,8 @@ in a cookie name (as :attr:`~Morsel.key`).
 .. versionchanged:: 3.3
    Allowed ':' as a valid cookie name character.
 
+.. versionchanged:: 3.15
+   Allowed '"' as a valid cookie value character.
 
 .. note::
 
@@ -314,3 +316,9 @@ The following example demonstrates how to use the :mod:`http.cookies` module.
    >>> print(C)
    Set-Cookie: number=7
    Set-Cookie: string=seven
+   >>> C = cookies.SimpleCookie()
+   >>> C.load('cookies=7; mixins="{"chips": "dark chocolate"}"; state="gooey"')
+   >>> print(C)
+   Set-Cookie: cookies=7
+   Set-Cookie: mixins="{"chips": "dark chocolate"}"
+   Set-Cookie: state="gooey"

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -28,10 +28,10 @@ The character set, :data:`string.ascii_letters`, :data:`string.digits` and
 in a cookie name (as :attr:`~Morsel.key`).
 
 .. versionchanged:: 3.3
-   Allowed ':' as a valid cookie name character.
+   Allowed '``:``' as a valid cookie name character.
 
 .. versionchanged:: next
-   Allowed '"' as a valid cookie value character.
+   Allowed '``"``' as a valid cookie value character.
 
 .. note::
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -263,6 +263,14 @@ http.client
   (Contributed by Alexander Enrique Urieles Nieto in :gh:`131724`.)
 
 
+http.cookies
+------------
+
+* Allow double quotes in cookie values with a more linient regex for
+  doublequoted strings.
+  (Contributed by Nick Burns and Senthil Kumaran in :gh:`137566`.)
+
+
 math
 ----
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -268,7 +268,7 @@ http.cookies
 
 * Allow double quotes in cookie values with a more linient regex for
   doublequoted strings.
-  (Contributed by Nick Burns and Senthil Kumaran in :gh:`137566`.)
+  (Contributed by Nick Burns and Senthil Kumaran in :gh:`92936`.)
 
 
 math

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -266,8 +266,7 @@ http.client
 http.cookies
 ------------
 
-* Allow '``"``' double quotes in cookie values with a more lenient regex for
-  double-quoted strings.
+* Allow '``"``' double quotes in cookie values.
   (Contributed by Nick Burns and Senthil Kumaran in :gh:`92936`.)
 
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -266,7 +266,7 @@ http.client
 http.cookies
 ------------
 
-* Allow ``"`` double quotes in cookie values with a more linient regex for
+* Allow '``"``' double quotes in cookie values with a more lenient regex for
   double-quoted strings.
   (Contributed by Nick Burns and Senthil Kumaran in :gh:`92936`.)
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -266,8 +266,8 @@ http.client
 http.cookies
 ------------
 
-* Allow double quotes in cookie values with a more linient regex for
-  doublequoted strings.
+* Allow ``"`` double quotes in cookie values with a more linient regex for
+  double-quoted strings.
   (Contributed by Nick Burns and Senthil Kumaran in :gh:`92936`.)
 
 


### PR DESCRIPTION
https://github.com/python/cpython/issues/92936#issuecomment-3169085639

Updates `http.cookie` docs to reflect changes from https://github.com/python/cpython/pull/113663

<!-- gh-issue-number: gh-92936 -->
* Issue: gh-92936
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137566.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->