### PR TITLE
gh-137583: Only lock the SSL context, not the SSL socket

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4642,6 +4642,7 @@ class ThreadedTests(unittest.TestCase):
                                             server_hostname=hostname) as sock:
                 sock.connect((HOST, server.port))
                 sock.settimeout(1)
+                sock.setblocking(1)
                 # Ensure that the server is ready to accept requests
                 sock.sendall(b"123")
                 self.assertEqual(sock.recv(3), b"123")

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4647,6 +4647,9 @@ class ThreadedTests(unittest.TestCase):
                                               args=(sock,), daemon=True)
                     thread.start()
                     event.wait()
+                    # We need to yield the GIL to prevent some silly race
+                    # condition in ThreadedEchoServer
+                    time.sleep(0)
                     sock.sendall(b"1" * 50)
                     thread.join()
                     if cm.exc_value is not None:

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4630,7 +4630,6 @@ class ThreadedTests(unittest.TestCase):
         # that the recv() call held.
         data = b"1" * 50
         event = threading.Event()
-        import time
         def background(sock):
             event.set()
             received = sock.recv(50)
@@ -4648,7 +4647,6 @@ class ThreadedTests(unittest.TestCase):
                                               args=(sock,), daemon=True)
                     thread.start()
                     event.wait()
-                    time.sleep(0)
                     sock.sendall(b"1" * 50)
                     thread.join()
                     if cm.exc_value is not None:

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4630,16 +4630,13 @@ class ThreadedTests(unittest.TestCase):
         # that the recv() call held.
         data = b"1" * 50
         event = threading.Event()
-        event2 = threading.Event()
         def background(sock):
             event.set()
-            event2.wait()
             received = sock.recv(50)
             self.assertEqual(received, data)
 
         client_context, server_context, hostname = testing_context()
-        server = ThreadedEchoServer(context=server_context,
-                                    chatty=False, connectionchatty=False)
+        server = ThreadedEchoServer(context=server_context)
         with server:
             with client_context.wrap_socket(socket.socket(),
                                             server_hostname=hostname) as sock:
@@ -4651,7 +4648,6 @@ class ThreadedTests(unittest.TestCase):
                     thread.start()
                     # Use two events to prevent some race conditions here.
                     event.wait()
-                    event2.set()
                     sock.sendall(b"1" * 50)
                     thread.join()
                     if cm.exc_value is not None:

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4630,6 +4630,7 @@ class ThreadedTests(unittest.TestCase):
         # that the recv() call held.
         data = b"1" * 50
         event = threading.Event()
+        import time
         def background(sock):
             event.set()
             received = sock.recv(50)
@@ -4646,8 +4647,8 @@ class ThreadedTests(unittest.TestCase):
                     thread = threading.Thread(target=background,
                                               args=(sock,), daemon=True)
                     thread.start()
-                    # Use two events to prevent some race conditions here.
                     event.wait()
+                    time.sleep(0)
                     sock.sendall(b"1" * 50)
                     thread.join()
                     if cm.exc_value is not None:

--- a/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
@@ -1,4 +1,4 @@
-Fix a deadlock introduced in the :mod:`ssl` module when a call to
-``recv()`` was blocked in one thread, while another
-attempted to call ``send()`` to unblock it in another
+Fix a deadlock introduced in 3.13.6 when a call to
+:meth:`ssl.SSLSocket.recv <socket.socket.recv>` was blocked in one thread, while another
+attempted to call :meth:`ssl.SSLSocket.send <socket.socket.send>` to unblock it in another
 thread.

--- a/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
@@ -1,4 +1,4 @@
 Fix a deadlock introduced in the :mod:`ssl` module when a call to
-:meth:`~ssl.SSLSocket.recv` was blocked in one thread, while another
-attempted to call :meth:`~ssl.SSLSocket.send` to unblock it in another
+:meth:`ssl.SSLSocket.recv` was blocked in one thread, while another
+attempted to call :meth:`ssl.SSLSocket.send` to unblock it in another
 thread.

--- a/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
@@ -1,0 +1,4 @@
+Fix a deadlock introduced in the :mod:`ssl` module when a call to
+:class:`~ssl.SSLSocket.recv` was blocked in one thread, while another
+attempted to call :class:`~ssl.SSLSocket.send` to unblock it in another
+thread.

--- a/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
@@ -1,4 +1,4 @@
 Fix a deadlock introduced in 3.13.6 when a call to
-:meth:`ssl.SSLSocket.recv <socket.socket.recv>` was blocked in one thread, while another
-attempted to call :meth:`ssl.SSLSocket.send <socket.socket.send>` to unblock it in another
-thread.
+:meth:`ssl.SSLSocket.recv <socket.socket.recv>` was blocked in one thread,
+and then another method on the object (such as :meth:`ssl.SSLSocket.send`)
+was subsequently called in another thread.

--- a/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
@@ -1,4 +1,4 @@
 Fix a deadlock introduced in the :mod:`ssl` module when a call to
-:meth:`ssl.SSLSocket.recv` was blocked in one thread, while another
-attempted to call :meth:`ssl.SSLSocket.send` to unblock it in another
+``recv()`` was blocked in one thread, while another
+attempted to call ``send()`` to unblock it in another
 thread.

--- a/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
@@ -1,4 +1,4 @@
 Fix a deadlock introduced in the :mod:`ssl` module when a call to
-:class:`~ssl.SSLSocket.recv` was blocked in one thread, while another
-attempted to call :class:`~ssl.SSLSocket.send` to unblock it in another
+:meth:`~ssl.SSLSocket.recv` was blocked in one thread, while another
+attempted to call :meth:`~ssl.SSLSocket.send` to unblock it in another
 thread.

--- a/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-09-08-53-32.gh-issue-137583.s6OZud.rst
@@ -1,4 +1,4 @@
 Fix a deadlock introduced in 3.13.6 when a call to
 :meth:`ssl.SSLSocket.recv <socket.socket.recv>` was blocked in one thread,
-and then another method on the object (such as :meth:`ssl.SSLSocket.send`)
+and then another method on the object (such as :meth:`ssl.SSLSocket.send <socket.socket.send>`)
 was subsequently called in another thread.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -990,11 +990,12 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
         BIO_set_nbio(SSL_get_wbio(self->ssl), 1);
     }
 
-    // No other threads can have access to this, so no need to lock it.
+    Py_BEGIN_ALLOW_THREADS;
     if (socket_type == PY_SSL_CLIENT)
         SSL_set_connect_state(self->ssl);
     else
         SSL_set_accept_state(self->ssl);
+    Py_END_ALLOW_THREADS;
 
     self->socket_type = socket_type;
     if (sock != NULL) {

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -366,9 +366,6 @@ typedef struct {
      * and shutdown methods check for chained exceptions.
      */
     PyObject *exc;
-    /* Lock to synchronize calls when the thread state is detached.
-       See also gh-134698. */
-    PyMutex tstate_mutex;
 } PySSLSocket;
 
 #define PySSLSocket_CAST(op)    ((PySSLSocket *)(op))
@@ -918,7 +915,6 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
     self->server_hostname = NULL;
     self->err = err;
     self->exc = NULL;
-    self->tstate_mutex = (PyMutex){0};
 
     /* Make sure the SSL error state is initialized */
     ERR_clear_error();

--- a/Modules/_ssl/debughelpers.c
+++ b/Modules/_ssl/debughelpers.c
@@ -140,7 +140,6 @@ _PySSL_keylog_callback(const SSL *ssl, const char *line)
      * critical debug helper.
      */
 
-    assert(PyMutex_IsLocked(&ssl_obj->tstate_mutex));
     Py_BEGIN_ALLOW_THREADS
     PyThread_acquire_lock(lock, 1);
     res = BIO_printf(ssl_obj->ctx->keylog_bio, "%s\n", line);


### PR DESCRIPTION
Remove locking around `SSLSocket` calls (and more importantly, calls to `send` and `recv`). I think they were unnecessary, as OpenSSL seems to be fine with those being called concurrently.

~~The test here is likely a bit flaky and I'm not really sure why. It deadlocks on the current `main`, but also seems to have periodic deadlocks even when e047a35 is not applied. It's either a bug in OpenSSL, an existing bug in `ssl`, or most likely, a bug in the `ThreadedEchoServer` used for the tests. I've added a `time.sleep(0)` to intentionally yield the GIL, and that seems to somewhat fix the race condition.~~ (Test now works correctly without flakiness.)

<!-- gh-issue-number: gh-137583 -->
* Issue: gh-137583
<!-- /gh-issue-number -->
