### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,8 +178,8 @@ jobs:
       free-threading: ${{ matrix.free-threading }}
 
   build-windows-msi:
-    name: >-  # ${{ '' } is a hack to nest jobs under the same sidebar category
-      Windows MSI${{ '' }}
+    # ${{ '' } is a hack to nest jobs under the same sidebar category.
+    name: Windows MSI${{ '' }}  # zizmor: ignore[obfuscation]
     needs: build-context
     if: fromJSON(needs.build-context.outputs.run-windows-msi)
     strategy:
@@ -586,8 +586,8 @@ jobs:
       run: xvfb-run make ci
 
   build-san:
-    name: >-  # ${{ '' } is a hack to nest jobs under the same sidebar category
-      Sanitizers${{ '' }}
+    # ${{ '' } is a hack to nest jobs under the same sidebar category.
+    name: Sanitizers${{ '' }}  # zizmor: ignore[obfuscation]
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
       - id: actionlint
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.6.0
+    rev: v1.11.0
     hooks:
       - id: zizmor
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.12.8
     hooks:
       - id: ruff
         name: Run Ruff (lint) on Doc/
@@ -8,7 +8,7 @@ repos:
         files: ^Doc/
       - id: ruff
         name: Run Ruff (lint) on Lib/test/
-        args: [--exit-non-zero-on-fix]
+        args: [--exit-non-zero-on-fix, --target-version=py313]
         files: ^Lib/test/
       - id: ruff
         name: Run Ruff (lint) on Tools/build/
@@ -42,7 +42,7 @@ repos:
         exclude: ^Tools/c-analyzer/cpython/_parser.py
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -60,7 +60,7 @@ repos:
         files: '^\.github/CODEOWNERS|\.(gram)$'
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.33.0
+    rev: 0.33.2
     hooks:
       - id: check-dependabot
       - id: check-github-workflows

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         files: ^Doc/
       - id: ruff
         name: Run Ruff (lint) on Lib/test/
-        args: [--exit-non-zero-on-fix, --target-version=py313]
+        args: [--exit-non-zero-on-fix]
         files: ^Lib/test/
       - id: ruff
         name: Run Ruff (lint) on Tools/build/

--- a/Lib/test/.ruff.toml
+++ b/Lib/test/.ruff.toml
@@ -1,5 +1,7 @@
 extend = "../../.ruff.toml"  # Inherit the project-wide settings
 
+target-version = "py313"
+
 extend-exclude = [
     # Excluded (run with the other AC files in its own separate ruff job in pre-commit)
     "test_clinic.py",
@@ -8,14 +10,16 @@ extend-exclude = [
     # Non UTF-8 files
     "encoded_modules/module_iso_8859_1.py",
     "encoded_modules/module_koi8_r.py",
-    # SyntaxError because of t-strings
-    "test_annotationlib.py",
-    "test_string/test_templatelib.py",
-    "test_tstring.py",
     # New grammar constructions may not yet be recognized by Ruff,
     # and tests re-use the same names as only the grammar is being checked.
     "test_grammar.py",
 ]
+
+[per-file-target-version]
+# t-strings
+"test_annotationlib.py" = "py314"
+"test_string/test_templatelib.py" = "py314"
+"test_tstring.py" = "py314"
 
 [lint]
 select = [

--- a/Lib/test/.ruff.toml
+++ b/Lib/test/.ruff.toml
@@ -1,6 +1,6 @@
 extend = "../../.ruff.toml"  # Inherit the project-wide settings
 
-target-version = "py313"
+target-version = "py312"
 
 extend-exclude = [
     # Excluded (run with the other AC files in its own separate ruff job in pre-commit)
@@ -16,7 +16,10 @@ extend-exclude = [
 ]
 
 [per-file-target-version]
-# t-strings
+# Type parameter defaults
+"test_type_params.py" = "py313"
+
+# Template string literals
 "test_annotationlib.py" = "py314"
 "test_string/test_templatelib.py" = "py314"
 "test_tstring.py" = "py314"


### PR DESCRIPTION
Split from #137186. That PR no longer needs the zizmor update, but since I've worked out exactly how to do it, we might as well merge it anyway.