### PR TITLE
[DOC] Add label to Unicode Properties subsection on how-to

### DIFF
--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -352,6 +352,8 @@ If you don't include such a comment, the default encoding used will be UTF-8 as
 already mentioned.  See also :pep:`263` for more information.
 
 
+.. _unicode-properties:
+
 Unicode Properties
 ------------------
 


### PR DESCRIPTION
I believe it has a value in itself, but also a prerequisite to #137557

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137592.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->