### PR TITLE
Fix documentation of hash in PyHash_FuncDef

### DIFF
--- a/Doc/c-api/hash.rst
+++ b/Doc/c-api/hash.rst
@@ -51,7 +51,7 @@ See also the :c:member:`PyTypeObject.tp_hash` member and :ref:`numeric-hash`.
 
    Hash function definition used by :c:func:`PyHash_GetFuncDef`.
 
-   .. c::member:: Py_hash_t (*const hash)(const void *, Py_ssize_t)
+   .. c:member:: Py_hash_t (*const hash)(const void *, Py_ssize_t)
 
       Hash function.
 


### PR DESCRIPTION
Because of a small typo, it wasn't showing up in the generated docs.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137595.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->