### PR TITLE
gh-137560: Speed up ssl.create_default_context() on Windows

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-08-09-22-43-33.gh-issue-137560.JFUI4F.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-09-22-43-33.gh-issue-137560.JFUI4F.rst
@@ -1,0 +1,2 @@
+Speed up :func:`ssl.create_default_context` on Windows if all certificates
+in the Windows certificate store are valid.


### PR DESCRIPTION
Try to load all certificates at once. This speeds up the process if all certificates in the Windows certificate store are valid. But slows down it if there are invalid ones.


<!-- gh-issue-number: gh-137560 -->
* Issue: gh-137560
<!-- /gh-issue-number -->
