### PR TITLE
gh-137597: Clarify flattening and bugfix for itertools.tee

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -730,6 +730,29 @@ loops that truncate the stream.
    produced by the upstream :func:`tee` call.  This "flattening step"
    allows nested :func:`tee` calls to share the same underlying data
    chain and to have a single update step rather than a chain of calls.
+   
+   .. note::
+
+    :func:`tee` automatically "flattens" existing tee objects,
+    sharing the same underlying buffer instead of nesting them, to avoid
+    performance degradation. This flattening behavior has existed since Python 3.7.
+
+   .. versionchanged:: 3.13
+      Fixed a bug where re-teeing the first iterator did not correctly flatten
+      the iterator chain in all cases. Previously, this could lead to unnecessary
+      nesting and performance degradation in rare scenarios.
+
+   .. doctest::
+
+       >>> it = iter([1, 2, 3])
+       >>> a, b = tee(it)
+       >>> c, d = tee(a)
+       >>> list(b)
+       [1, 2, 3]
+       >>> list(c)
+       [1, 2, 3]
+       >>> list(d)
+       [1, 2, 3]
 
    The flattening property makes tee iterators efficiently peekable:
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -730,16 +730,17 @@ loops that truncate the stream.
    produced by the upstream :func:`tee` call.  This "flattening step"
    allows nested :func:`tee` calls to share the same underlying data
    chain and to have a single update step rather than a chain of calls.
+
    .. note::
 
     :func:`tee` automatically "flattens" existing tee objects,
     sharing the same underlying buffer instead of nesting them, to avoid
-    performance degradation. This flattening behavior has existed since Python 3.7.
+    performance degradation.
 
    .. versionchanged:: 3.13
-      Fixed a bug where re-teeing the first iterator did not correctly flatten
-      the iterator chain in all cases. Previously, this could lead to unnecessary
-      nesting and performance degradation in rare scenarios.
+      Fixed a bug where re-teeing a tee iterator did not always return independent iterators.
+      Previously, the first iterator in the result could be the same object as the
+      input, causing inconsistent behavior.
 
    .. doctest::
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -730,7 +730,6 @@ loops that truncate the stream.
    produced by the upstream :func:`tee` call.  This "flattening step"
    allows nested :func:`tee` calls to share the same underlying data
    chain and to have a single update step rather than a chain of calls.
-   
    .. note::
 
     :func:`tee` automatically "flattens" existing tee objects,

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -742,18 +742,6 @@ loops that truncate the stream.
       Previously, the first iterator in the result could be the same object as the
       input, causing inconsistent behavior.
 
-   .. doctest::
-
-       >>> it = iter([1, 2, 3])
-       >>> a, b = tee(it)
-       >>> c, d = tee(a)
-       >>> list(b)
-       [1, 2, 3]
-       >>> list(c)
-       [1, 2, 3]
-       >>> list(d)
-       [1, 2, 3]
-
    The flattening property makes tee iterators efficiently peekable:
 
    .. testcode::


### PR DESCRIPTION
(GH#137597)

This PR updates the documentation for itertools.tee to clarify its flattening behavior when called on existing tee objects. It adds a "Changed in version 3.13" note describing the bugfix for re-teeing the first iterator, and includes a doctest example to illustrate that repeated tee calls do not cause deep nesting.

Please let me know if this fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou!

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137599.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->