### PR TITLE
gh-89905: Correct `-R` option doc

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -369,7 +369,7 @@ Miscellaneous options
 .. option:: -R
 
    Turn on hash randomization. This option only has an effect if the
-   :envvar:`PYTHONHASHSEED` environment variable is set to ``0``, since hash
+   :envvar:`PYTHONHASHSEED` environment variable is set, since hash
    randomization is enabled by default.
 
    On previous versions of Python, this option turns on hash randomization,

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -369,7 +369,7 @@ Miscellaneous options
 .. option:: -R
 
    Turn on hash randomization. This option only has an effect if the
-   :envvar:`PYTHONHASHSEED` environment variable is set to a specific seed,
+   :envvar:`PYTHONHASHSEED` environment variable is set,
    since hash randomization is enabled by default.
 
    On previous versions of Python, this option turns on hash randomization,

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -369,8 +369,8 @@ Miscellaneous options
 .. option:: -R
 
    Turn on hash randomization. This option only has an effect if the
-   :envvar:`PYTHONHASHSEED` environment variable is set,
-   since hash randomization is enabled by default.
+   :envvar:`PYTHONHASHSEED` environment variable is set to anything other
+   than ``random``, since hash randomization is enabled by default.
 
    On previous versions of Python, this option turns on hash randomization,
    so that the :meth:`~object.__hash__` values of str and bytes objects

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -369,8 +369,8 @@ Miscellaneous options
 .. option:: -R
 
    Turn on hash randomization. This option only has an effect if the
-   :envvar:`PYTHONHASHSEED` environment variable is set, since hash
-   randomization is enabled by default.
+   :envvar:`PYTHONHASHSEED` environment variable is set to a specific seed,
+   since hash randomization is enabled by default.
 
    On previous versions of Python, this option turns on hash randomization,
    so that the :meth:`~object.__hash__` values of str and bytes objects

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -273,8 +273,6 @@ Options (and corresponding environment variables):\n\
 -P     : don't prepend a potentially unsafe path to sys.path; also\n\
          PYTHONSAFEPATH\n\
 -q     : don't print version and copyright messages on interactive startup\n\
--R     : enable hash randomization;\n\
-         this option overrides PYTHONHASHSEED to use the default behavior\n\
 -s     : don't add user site directory to sys.path; also PYTHONNOUSERSITE=x\n\
 -S     : don't imply 'import site' on initialization\n\
 -u     : force the stdout and stderr streams to be unbuffered;\n\

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -273,6 +273,8 @@ Options (and corresponding environment variables):\n\
 -P     : don't prepend a potentially unsafe path to sys.path; also\n\
          PYTHONSAFEPATH\n\
 -q     : don't print version and copyright messages on interactive startup\n\
+-R     : enable hash randomization;
+         this option overrides PYTHONHASHSEED to use the default behavior\n\
 -s     : don't add user site directory to sys.path; also PYTHONNOUSERSITE=x\n\
 -S     : don't imply 'import site' on initialization\n\
 -u     : force the stdout and stderr streams to be unbuffered;\n\

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -273,7 +273,7 @@ Options (and corresponding environment variables):\n\
 -P     : don't prepend a potentially unsafe path to sys.path; also\n\
          PYTHONSAFEPATH\n\
 -q     : don't print version and copyright messages on interactive startup\n\
--R     : enable hash randomization;
+-R     : enable hash randomization;\n\
          this option overrides PYTHONHASHSEED to use the default behavior\n\
 -s     : don't add user site directory to sys.path; also PYTHONNOUSERSITE=x\n\
 -S     : don't imply 'import site' on initialization\n\


### PR DESCRIPTION
I can split if it is so desired, but since both are small errors/omissions and need the same backports, I see little need.

<!-- gh-issue-number: gh-89905 -->
* Issue: gh-89905
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137608.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->