### PR TITLE
gh-135052: Fix bug that XID_Continue Unicode characters in function/class names highlighted incorrectly (colorizer.py)

### DIFF
--- a/Lib/idlelib/colorizer.py
+++ b/Lib/idlelib/colorizer.py
@@ -64,7 +64,7 @@ def make_pat():
 
 
 prog = make_pat()
-idprog = re.compile(r"\s+(\w+)")
+idprog = re.compile(r"\s+([^\\\s([:]+)")
 prog_group_name_to_tag = {
     "MATCH_SOFTKW": "KEYWORD",
     "CASE_SOFTKW": "KEYWORD",
@@ -346,8 +346,9 @@ class ColorDelegator(Delegator):
                 self._add_tag(a, b, head, name)
                 if matched_text in ("def", "class"):
                     if m1 := self.idprog.match(chars, b):
-                        a, b = m1.span(1)
-                        self._add_tag(a, b, head, "DEFINITION")
+                        if m1.groups()[0].isidentifier():
+                            a, b = m1.span(1)
+                            self._add_tag(a, b, head, "DEFINITION")
 
     def removecolors(self):
         "Remove all colorizing tags."

--- a/Lib/idlelib/idle_test/test_colorizer.py
+++ b/Lib/idlelib/idle_test/test_colorizer.py
@@ -97,7 +97,7 @@ class FunctionTest(unittest.TestCase):
         self.assertTrue(m.groups()[0].isidentifier())
         m = idprog.match(' 42')
         self.assertFalse(m.groups()[0].isidentifier())
-        m = idprog.match('dot·[T]')
+        m = idprog.match(' dot·[T]')
         self.assertTrue(m.groups()[0].isidentifier())
         m = idprog.match(' cls()')
         self.assertTrue(m.groups()[0].isidentifier())

--- a/Lib/idlelib/idle_test/test_colorizer.py
+++ b/Lib/idlelib/idle_test/test_colorizer.py
@@ -93,6 +93,14 @@ class FunctionTest(unittest.TestCase):
         self.assertIsNone(m)
         m = idprog.match(' space')
         self.assertEqual(m.group(0), ' space')
+        m = idprog.match('  space')
+        self.assertTrue(m.groups()[0].isidentifier())
+        m = idprog.match(' 42')
+        self.assertFalse(m.groups()[0].isidentifier())
+        m = idprog.match('dot·[T]')
+        self.assertTrue(m.groups()[0].isidentifier())
+        m = idprog.match(' cls()')
+        self.assertTrue(m.groups()[0].isidentifier())
 
 
 class ColorConfigTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/IDLE/2025-08-10-15-01-48.gh-issue-135052._pUw6u.rst
+++ b/Misc/NEWS.d/next/IDLE/2025-08-10-15-01-48.gh-issue-135052._pUw6u.rst
@@ -1,0 +1,2 @@
+Fix a bug that XID_Continue Unicode characters in function/class names
+highlighted incorrectly.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135052 -->
* Issue: gh-135052
<!-- /gh-issue-number -->
