### PR TITLE
Fix typo in `Lib/difflib.py`

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -928,7 +928,7 @@ class Differ:
         dump_i, dump_j = alo, blo # smallest indices not yet resolved
         for j in range(blo, bhi):
             cruncher.set_seq2(b[j])
-            # Search the corresponding i's within WINDOW for rhe highest
+            # Search the corresponding i's within WINDOW for the highest
             # ratio greater than `cutoff`.
             aequiv = alo + (j - blo)
             arange = range(max(aequiv - WINDOW, dump_i),


### PR DESCRIPTION
The line was introduce in 3.14. `rhe` -> `the` in the commit: de19694cfbcaa1c85c3a4b7184a24ff21b1c0919
