### PR TITLE
gh-137576: Fix for Basic REPL Showing Incorrect Code in Tracebacks with PYTHONSTARTUP

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -203,7 +203,7 @@ class CmdLineTest(unittest.TestCase):
             p.stdin.flush()
             stderr = p.stderr if separate_stderr else p.stdout
             self.assertIn(b'Traceback ', stderr.readline())
-            self.assertIn(b'File "<stdin>"', stderr.readline())
+            self.assertIn(b'File "<stdin-0>"', stderr.readline())
             self.assertIn(b'1/0', stderr.readline())
             self.assertIn(b'    ~^~', stderr.readline())
             self.assertIn(b'ZeroDivisionError', stderr.readline())

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -203,7 +203,7 @@ class CmdLineTest(unittest.TestCase):
             p.stdin.flush()
             stderr = p.stderr if separate_stderr else p.stdout
             self.assertIn(b'Traceback ', stderr.readline())
-            self.assertIn(b'File "<stdin-0>"', stderr.readline())
+            self.assertIn(b'File "<stdin>"', stderr.readline())
             self.assertIn(b'1/0', stderr.readline())
             self.assertIn(b'    ~^~', stderr.readline())
             self.assertIn(b'ZeroDivisionError', stderr.readline())

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -156,7 +156,7 @@ class TestInteractiveInterpreter(unittest.TestCase):
         traceback_lines = output.splitlines()[-6:-1]
         expected_lines = [
             "Traceback (most recent call last):",
-            "  File \"<stdin-0>\", line 1, in <module>",
+            "  File \"<stdin>\", line 1, in <module>",
             "    1 / 0 / 3 / 4",
             "    ~~^~~",
             "ZeroDivisionError: division by zero",
@@ -178,10 +178,10 @@ class TestInteractiveInterpreter(unittest.TestCase):
 
         traceback_lines = output.splitlines()[-8:-1]
         expected_lines = [
-            '  File "<stdin-2>", line 1, in <module>',
+            '  File "<stdin>", line 1, in <module>',
             '    foo(0)',
             '    ~~~^^^',
-            '  File "<stdin-1>", line 2, in foo',
+            '  File "<stdin>", line 2, in foo',
             '    1 / x',
             '    ~~^~~',
             'ZeroDivisionError: division by zero'
@@ -216,7 +216,7 @@ class TestInteractiveInterpreter(unittest.TestCase):
             output = kill_python(p)
         expected = dedent("""
             Traceback (most recent call last):
-              File "<stdin-0>", line 1, in <module>
+              File "<stdin>", line 1, in <module>
                 1/0
                 ~^~
             ZeroDivisionError: division by zero
@@ -238,7 +238,7 @@ class TestInteractiveInterpreter(unittest.TestCase):
             output = kill_python(p)
         expected = dedent("""
             Traceback (most recent call last):
-              File "<stdin-0>", line 1, in <module>
+              File "<stdin>", line 1, in <module>
                 foo()
                 ~~~^^
               File "%s", line 2, in foo

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -188,6 +188,68 @@ class TestInteractiveInterpreter(unittest.TestCase):
         ]
         self.assertEqual(traceback_lines, expected_lines)
 
+    def test_pythonstartup_error_reporting(self):
+        # errors based on https://github.com/python/cpython/issues/137576
+
+        def make_repl(env):
+            return subprocess.Popen(
+                [os.path.join(os.path.dirname(sys.executable), '<stdin>'), "-i"],
+                executable=sys.executable,
+                text=True,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                env=env,
+            )
+
+        # case 1: error in user input, but PYTHONSTARTUP is fine
+        with os_helper.temp_dir() as tmpdir:
+            script = os.path.join(tmpdir, "pythonstartup.py")
+            with open(script, "w") as f:
+                f.write("print('from pythonstartup')" + os.linesep)
+
+            env = os.environ.copy()
+            env['PYTHONSTARTUP'] = script
+            env["PYTHON_HISTORY"] = os.path.join(tmpdir, ".pythonhist")
+            p = make_repl(env)
+            p.stdin.write("1/0")
+            output = kill_python(p)
+        expected = dedent("""
+            Traceback (most recent call last):
+              File "<stdin-0>", line 1, in <module>
+                1/0
+                ~^~
+            ZeroDivisionError: division by zero
+        """)
+        self.assertIn("from pythonstartup", output)
+        self.assertIn(expected, output)
+
+        # case 2: error in PYTHONSTARTUP triggered by user input
+        with os_helper.temp_dir() as tmpdir:
+            script = os.path.join(tmpdir, "pythonstartup.py")
+            with open(script, "w") as f:
+                f.write("def foo():\n    1/0\n")
+
+            env = os.environ.copy()
+            env['PYTHONSTARTUP'] = script
+            env["PYTHON_HISTORY"] = os.path.join(tmpdir, ".pythonhist")
+            p = make_repl(env)
+            p.stdin.write('foo()')
+            output = kill_python(p)
+        expected = dedent("""
+            Traceback (most recent call last):
+              File "<stdin-0>", line 1, in <module>
+                foo()
+                ~~~^^
+              File "%s", line 2, in foo
+                1/0
+                ~^~
+            ZeroDivisionError: division by zero
+        """) % script
+        self.assertIn(expected, output)
+
+
+
     def test_runsource_show_syntax_error_location(self):
         user_input = dedent("""def f(x, x): ...
                             """)

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -156,7 +156,7 @@ class TestInteractiveInterpreter(unittest.TestCase):
         traceback_lines = output.splitlines()[-6:-1]
         expected_lines = [
             "Traceback (most recent call last):",
-            "  File \"<stdin>\", line 1, in <module>",
+            "  File \"<stdin-0>\", line 1, in <module>",
             "    1 / 0 / 3 / 4",
             "    ~~^~~",
             "ZeroDivisionError: division by zero",
@@ -178,10 +178,10 @@ class TestInteractiveInterpreter(unittest.TestCase):
 
         traceback_lines = output.splitlines()[-8:-1]
         expected_lines = [
-            '  File "<stdin>", line 1, in <module>',
+            '  File "<stdin-2>", line 1, in <module>',
             '    foo(0)',
             '    ~~~^^^',
-            '  File "<stdin>", line 2, in foo',
+            '  File "<stdin-1>", line 2, in foo',
             '    1 / x',
             '    ~~^~~',
             'ZeroDivisionError: division by zero'

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -541,7 +541,7 @@ class StackSummary(list):
         colorize = kwargs.get("colorize", False)
         row = []
         filename = frame_summary.filename
-        if frame_summary.filename.startswith("<stdin>-"):
+        if frame_summary.filename.startswith("<stdin-") and frame_summary.filename.endswith('>'):
             filename = "<stdin>"
         if colorize:
             theme = _colorize.get_theme(force_color=True).traceback

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-10-21-34-12.gh-issue-137576.0ZicS-.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-10-21-34-12.gh-issue-137576.0ZicS-.rst
@@ -1,2 +1,2 @@
 Fix for incorrect source code being shown in tracebacks from the Basic REPL
-when ``PYTHONSTARTUP`` is given.  Patch by Adam Hartz.
+when :envvar:`PYTHONSTARTUP` is given. Patch by Adam Hartz.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-10-21-34-12.gh-issue-137576.0ZicS-.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-10-21-34-12.gh-issue-137576.0ZicS-.rst
@@ -1,0 +1,2 @@
+Fix for incorrect source code being shown in tracebacks from the Basic REPL
+when ``PYTHONSTARTUP`` is given.  Patch by Adam Hartz.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1366,7 +1366,8 @@ run_eval_code_obj(PyThreadState *tstate, PyCodeObject *co, PyObject *globals, Py
 }
 
 static PyObject *
-get_interactive_filename(PyObject *filename, Py_ssize_t count){
+get_interactive_filename(PyObject *filename, Py_ssize_t count)
+{
     PyObject *result;
     Py_ssize_t len = PyUnicode_GET_LENGTH(filename);
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1375,6 +1375,9 @@ get_interactive_filename(PyObject *filename, Py_ssize_t count)
             && PyUnicode_ReadChar(filename, 0) == '<'
             && PyUnicode_ReadChar(filename, len - 1) == '>') {
         PyObject *middle = PyUnicode_Substring(filename, 1, len-1);
+        if (middle == NULL) {
+            return NULL;
+        }
         result = PyUnicode_FromFormat("<%U-%d>", middle, count);
         Py_DECREF(middle);
     } else {

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1365,6 +1365,25 @@ run_eval_code_obj(PyThreadState *tstate, PyCodeObject *co, PyObject *globals, Py
     return PyEval_EvalCode((PyObject*)co, globals, locals);
 }
 
+PyObject *
+get_interactive_filename(PyObject *filename, Py_ssize_t count){
+    PyObject *result;
+    Py_ssize_t len = PyUnicode_GET_LENGTH(filename);
+
+    if (len >= 2
+            && PyUnicode_ReadChar(filename, 0) == '<'
+            && PyUnicode_ReadChar(filename, len - 1) == '>') {
+        PyObject *middle = PyUnicode_Substring(filename, 1, len-1);
+        result = PyUnicode_FromFormat("<%U-%d>", middle, count);
+        Py_DECREF(middle);
+    } else {
+        result = PyUnicode_FromFormat(
+            "%U-%d", filename, count);
+    }
+    return result;
+
+}
+
 static PyObject *
 run_mod(mod_ty mod, PyObject *filename, PyObject *globals, PyObject *locals,
             PyCompilerFlags *flags, PyArena *arena, PyObject* interactive_src,
@@ -1375,8 +1394,8 @@ run_mod(mod_ty mod, PyObject *filename, PyObject *globals, PyObject *locals,
     if (interactive_src) {
         PyInterpreterState *interp = tstate->interp;
         if (generate_new_source) {
-            interactive_filename = PyUnicode_FromFormat(
-                "%U-%d", filename, interp->_interactive_src_count++);
+            interactive_filename = get_interactive_filename(
+                filename, interp->_interactive_src_count++);
         } else {
             Py_INCREF(interactive_filename);
         }

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1365,7 +1365,7 @@ run_eval_code_obj(PyThreadState *tstate, PyCodeObject *co, PyObject *globals, Py
     return PyEval_EvalCode((PyObject*)co, globals, locals);
 }
 
-PyObject *
+static PyObject *
 get_interactive_filename(PyObject *filename, Py_ssize_t count){
     PyObject *result;
     Py_ssize_t len = PyUnicode_GET_LENGTH(filename);


### PR DESCRIPTION
This patch attempts to fix #137576 by changing the way `interactive_filename` is computed for the basic REPL to make sure that it always begins with `<` and ends with `>` so that doesn't get an entry in `linecache.cache` (which was causing the source from `PYTHONSTARTUP` to be used instead of the interactive input when generating tracebacks).

Updated behavior:

```
$ echo "print('hello from PYTHONSTARTUP')" > /tmp/foo.py
$ PYTHON_BASIC_REPL=1 PYTHONSTARTUP=/tmp/foo.py ./python
Python 3.15.0a0 (heads/basic_repl_error_reporting:3d46e8feed, Aug 10 2025, 21:12:17) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
hello from PYTHONSTARTUP
>>> 1/0
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    1/0
    ~^~
ZeroDivisionError: division by zero
```

```
$ echo "def foo(x):  return 1/x" > /tmp/foo.py
$ PYTHON_BASIC_REPL=1 PYTHONSTARTUP=/tmp/foo.py ./python
Python 3.15.0a0 (heads/basic_repl_error_reporting:3d46e8feed, Aug 10 2025, 21:12:17) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> def bar(x):
...     return foo(x)
... 
>>> bar(0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    bar(0)
    ~~~^^^
  File "<stdin>", line 2, in bar
    return foo(x)
  File "/tmp/foo.py", line 1, in foo
    def foo(x):  return 1/x
                        ~^~
ZeroDivisionError: division by zero
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-137576 -->
* Issue: gh-137576
<!-- /gh-issue-number -->
