### PR TITLE
gh-137681: Always initialize exception handler for new instruction

### DIFF
--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -453,52 +453,53 @@ dis_compound_stmt_str = """\
 """
 
 dis_traceback = """\
-%4d           RESUME                   0
+%4d            RESUME                   0
 
-%4d           NOP
+%4d            NOP
 
-%4d   L1:     LOAD_SMALL_INT           1
-               LOAD_SMALL_INT           0
-           --> BINARY_OP               11 (/)
-               POP_TOP
+%4d    L1:     LOAD_SMALL_INT           1
+                LOAD_SMALL_INT           0
+            --> BINARY_OP               11 (/)
+                POP_TOP
 
-%4d   L2:     LOAD_FAST_CHECK          1 (tb)
-               RETURN_VALUE
+%4d    L2:     LOAD_FAST_CHECK          1 (tb)
+                RETURN_VALUE
 
-  --   L3:     PUSH_EXC_INFO
+  --    L3:     PUSH_EXC_INFO
 
-%4d           LOAD_GLOBAL              0 (Exception)
-               CHECK_EXC_MATCH
-               POP_JUMP_IF_FALSE       24 (to L7)
-               NOT_TAKEN
-               STORE_FAST               0 (e)
+%4d            LOAD_GLOBAL              0 (Exception)
+                CHECK_EXC_MATCH
+                POP_JUMP_IF_FALSE       24 (to L9)
+        L4:     NOT_TAKEN
+        L5:     STORE_FAST               0 (e)
 
-%4d   L4:     LOAD_FAST                0 (e)
-               LOAD_ATTR                2 (__traceback__)
-               STORE_FAST               1 (tb)
-       L5:     POP_EXCEPT
-               LOAD_CONST               1 (None)
-               STORE_FAST               0 (e)
-               DELETE_FAST              0 (e)
+%4d    L6:     LOAD_FAST                0 (e)
+                LOAD_ATTR                2 (__traceback__)
+                STORE_FAST               1 (tb)
+        L7:     POP_EXCEPT
+                LOAD_CONST               1 (None)
+                STORE_FAST               0 (e)
+                DELETE_FAST              0 (e)
 
-%4d           LOAD_FAST                1 (tb)
-               RETURN_VALUE
+%4d            LOAD_FAST                1 (tb)
+                RETURN_VALUE
 
-  --   L6:     LOAD_CONST               1 (None)
-               STORE_FAST               0 (e)
-               DELETE_FAST              0 (e)
-               RERAISE                  1
+  --    L8:     LOAD_CONST               1 (None)
+                STORE_FAST               0 (e)
+                DELETE_FAST              0 (e)
+                RERAISE                  1
 
-%4d   L7:     RERAISE                  0
+%4d    L9:     RERAISE                  0
 
-  --   L8:     COPY                     3
-               POP_EXCEPT
-               RERAISE                  1
+  --   L10:     COPY                     3
+                POP_EXCEPT
+                RERAISE                  1
 ExceptionTable:
   L1 to L2 -> L3 [0]
-  L3 to L4 -> L8 [1] lasti
-  L4 to L5 -> L6 [1] lasti
-  L6 to L8 -> L8 [1] lasti
+  L3 to L4 -> L10 [1] lasti
+  L5 to L6 -> L10 [1] lasti
+  L6 to L7 -> L8 [1] lasti
+  L8 to L10 -> L10 [1] lasti
 """ % (TRACEBACK_CODE.co_firstlineno,
        TRACEBACK_CODE.co_firstlineno + 1,
        TRACEBACK_CODE.co_firstlineno + 2,
@@ -567,11 +568,11 @@ dis_with = """\
 %4d   L3:     PUSH_EXC_INFO
                WITH_EXCEPT_START
                TO_BOOL
-               POP_JUMP_IF_TRUE         2 (to L4)
-               NOT_TAKEN
-               RERAISE                  2
-       L4:     POP_TOP
-       L5:     POP_EXCEPT
+               POP_JUMP_IF_TRUE         2 (to L6)
+       L4:     NOT_TAKEN
+       L5:     RERAISE                  2
+       L6:     POP_TOP
+       L7:     POP_EXCEPT
                POP_TOP
                POP_TOP
                POP_TOP
@@ -581,12 +582,13 @@ dis_with = """\
                LOAD_CONST               1 (None)
                RETURN_VALUE
 
-  --   L6:     COPY                     3
+  --   L8:     COPY                     3
                POP_EXCEPT
                RERAISE                  1
 ExceptionTable:
   L1 to L2 -> L3 [2] lasti
-  L3 to L5 -> L6 [4] lasti
+  L3 to L4 -> L8 [4] lasti
+  L5 to L7 -> L8 [4] lasti
 """ % (_with.__code__.co_firstlineno,
        _with.__code__.co_firstlineno + 1,
        _with.__code__.co_firstlineno + 2,

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -199,8 +199,10 @@ basicblock_addop(basicblock *b, int opcode, int oparg, location loc)
     cfg_instr *i = &b->b_instr[off];
     i->i_opcode = opcode;
     i->i_oparg = oparg;
-    i->i_target = NULL;
     i->i_loc = loc;
+    // memory is already zero initialized
+    assert(i->i_target == NULL);
+    assert(i->i_except == NULL);
 
     return SUCCESS;
 }
@@ -1104,6 +1106,7 @@ basicblock_remove_redundant_nops(basicblock *bb) {
     assert(dest <= bb->b_iused);
     int num_removed = bb->b_iused - dest;
     bb->b_iused = dest;
+    memset(&bb->b_instr[dest], 0, sizeof(cfg_instr) * num_removed);
     return num_removed;
 }
 


### PR DESCRIPTION
`basicblock_addop` zero initializes some members but not all. If we remove some nops and then later re-add an instruction we can have previously initialized memory that can include an exception handler. If we compile something like:
```
def foo():
    try:
        [x for x in abc]
    except OSError:
        pass

    return```

We'll end up with different exception handling table because the `NOT_TAKEN` instruction is inserted after we do the exception handling analysis and gets a previously initialized exception handler.

<!-- gh-issue-number: gh-137681 -->
* Issue: gh-137681
<!-- /gh-issue-number -->
