### PR TITLE
gh-131146: Fall back to `month_name` if `standalone_month_name`s aren't distinct

### DIFF
--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -149,6 +149,14 @@ try:
 except ValueError:
     standalone_month_name = month_name
     standalone_month_abbr = month_abbr
+else:
+    # Some systems that do not support '%OB' will keep it as-is (i.e.,
+    # we get [..., '%OB', '%OB', '%OB']), so if for non-distinct names,
+    # we fall back to month_name/month_abbr.
+    if len(set(standalone_month_name)) != len(set(month_name)):
+        standalone_month_name = month_name
+    if len(set(standalone_month_abbr)) != len(set(month_abbr)):
+        standalone_month_abbr = month_abbr
 
 
 def isleap(year):

--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -151,7 +151,7 @@ except ValueError:
     standalone_month_abbr = month_abbr
 else:
     # Some systems that do not support '%OB' will keep it as-is (i.e.,
-    # we get [..., '%OB', '%OB', '%OB']), so if for non-distinct names,
+    # we get [..., '%OB', '%OB', '%OB']), so for non-distinct names,
     # we fall back to month_name/month_abbr.
     if len(set(standalone_month_name)) != len(set(month_name)):
         standalone_month_name = month_name


### PR DESCRIPTION
Some systems reportedly don't expand '%OB' and '%Ob'. In this case (and similar theoretically possible ones, like expanding to empty string or 'OB'), fall back to the month_name & month_abbr.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131146 -->
* Issue: gh-131146
<!-- /gh-issue-number -->
