### PR TITLE
GH-137630: Argument Clinic: Reduce use of 'as' for renaming in ``_interpretersmodule.c``

### DIFF
--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -1376,7 +1376,7 @@ _interpreters_is_running_impl(PyObject *module, PyObject *id, int restrict)
 
 /*[clinic input]
 _interpreters.get_config
-    id as idobj: object
+    id: object
     *
     restrict: bool = False
 
@@ -1384,17 +1384,16 @@ Return a representation of the config used to initialize the interpreter.
 [clinic start generated code]*/
 
 static PyObject *
-_interpreters_get_config_impl(PyObject *module, PyObject *idobj,
-                              int restrict)
-/*[clinic end generated code: output=eb69d3a5cafb6b17 input=57c06ac75061acf0]*/
+_interpreters_get_config_impl(PyObject *module, PyObject *id, int restrict)
+/*[clinic end generated code: output=b739277cc30cf365 input=d268b92b96b0712b]*/
 {
-    if (idobj == Py_None) {
-        idobj = NULL;
+    if (id == Py_None) {
+        id = NULL;
     }
 
     int reqready = 0;
     PyInterpreterState *interp = \
-            resolve_interp(idobj, restrict, reqready, "get the config of");
+            resolve_interp(id, restrict, reqready, "get the config of");
     if (interp == NULL) {
         return NULL;
     }

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -1276,8 +1276,8 @@ _interpreters_run_func_impl(PyObject *module, PyObject *id, PyObject *func,
 _interpreters.call
     id: object
     callable: object
-    args as args_obj: object(subclass_of='&PyTuple_Type', c_default='NULL') = ()
-    kwargs as kwargs_obj: object(subclass_of='&PyDict_Type', c_default='NULL') = {}
+    args: object(subclass_of='&PyTuple_Type', c_default='NULL') = ()
+    kwargs: object(subclass_of='&PyDict_Type', c_default='NULL') = {}
     *
     preserve_exc: bool = False
     restrict: bool = False
@@ -1289,9 +1289,9 @@ Pass the given args and kwargs, if possible.
 
 static PyObject *
 _interpreters_call_impl(PyObject *module, PyObject *id, PyObject *callable,
-                        PyObject *args_obj, PyObject *kwargs_obj,
-                        int preserve_exc, int restrict)
-/*[clinic end generated code: output=d0de009172792592 input=b2b9f147c08b35fa]*/
+                        PyObject *args, PyObject *kwargs, int preserve_exc,
+                        int restrict)
+/*[clinic end generated code: output=e04c697326e0f482 input=858caec5becc34ed]*/
 {
     PyThreadState *tstate = _PyThreadState_GET();
     int reqready = 1;

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -1302,7 +1302,7 @@ _interpreters_call_impl(PyObject *module, PyObject *id, PyObject *callable,
     }
 
     struct interp_call call = {0};
-    if (_interp_call_pack(tstate, &call, callable, args_obj, kwargs_obj) < 0) {
+    if (_interp_call_pack(tstate, &call, callable, args, kwargs) < 0) {
         return NULL;
     }
 

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -742,7 +742,7 @@ get_whence(PyInterpreterState *interp)
 
 
 static PyInterpreterState *
-resolve_interp(PyObject *idobj, int restrict, int reqready, const char *op)
+resolve_interp(PyObject *idobj, int restricted, int reqready, const char *op)
 {
     PyInterpreterState *interp;
     if (idobj == NULL) {
@@ -767,7 +767,7 @@ resolve_interp(PyObject *idobj, int restrict, int reqready, const char *op)
         return NULL;
     }
 
-    if (restrict && get_whence(interp) != _PyInterpreterState_WHENCE_STDLIB) {
+    if (restricted && get_whence(interp) != _PyInterpreterState_WHENCE_STDLIB) {
         if (idobj == NULL) {
             PyErr_Format(PyExc_InterpreterError,
                          "cannot %s unrecognized current interpreter", op);
@@ -907,7 +907,7 @@ _interpreters_create_impl(PyObject *module, PyObject *configobj, int reqrefs)
 _interpreters.destroy
     id: object
     *
-    restrict: bool = False
+    restrict as restricted: bool = False
 
 Destroy the identified interpreter.
 
@@ -916,13 +916,13 @@ So does an unrecognized ID.
 [clinic start generated code]*/
 
 static PyObject *
-_interpreters_destroy_impl(PyObject *module, PyObject *id, int restrict)
-/*[clinic end generated code: output=3887e3c350597df5 input=43fd109df8e851f9]*/
+_interpreters_destroy_impl(PyObject *module, PyObject *id, int restricted)
+/*[clinic end generated code: output=0bc20da8700ab4dd input=561bdd6537639d40]*/
 {
     // Look up the interpreter.
     int reqready = 0;
     PyInterpreterState *interp = \
-            resolve_interp(id, restrict, reqready, "destroy");
+            resolve_interp(id, restricted, reqready, "destroy");
     if (interp == NULL) {
         return NULL;
     }
@@ -1034,20 +1034,20 @@ _interpreters.set___main___attrs
     id: object
     updates: object(subclass_of='&PyDict_Type')
     *
-    restrict: bool = False
+    restrict as restricted: bool = False
 
 Bind the given attributes in the interpreter's __main__ module.
 [clinic start generated code]*/
 
 static PyObject *
 _interpreters_set___main___attrs_impl(PyObject *module, PyObject *id,
-                                      PyObject *updates, int restrict)
-/*[clinic end generated code: output=494c8fc4be971936 input=4235567e63091172]*/
+                                      PyObject *updates, int restricted)
+/*[clinic end generated code: output=f3803010cb452bf0 input=d16ab8d81371f86a]*/
 {
     // Look up the interpreter.
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restrict, reqready, "update __main__ for");
+            resolve_interp(id, restricted, reqready, "update __main__ for");
     if (interp == NULL) {
         return NULL;
     }
@@ -1109,7 +1109,7 @@ _interpreters.exec
     code: object
     shared: object(subclass_of='&PyDict_Type', c_default='NULL') = {}
     *
-    restrict: bool = False
+    restrict as restricted: bool = False
 
 Execute the provided code in the identified interpreter.
 
@@ -1129,13 +1129,13 @@ is ignored, including its __globals__ dict.
 
 static PyObject *
 _interpreters_exec_impl(PyObject *module, PyObject *id, PyObject *code,
-                        PyObject *shared, int restrict)
-/*[clinic end generated code: output=1e47a912017ea298 input=0591915eb37dc8ca]*/
+                        PyObject *shared, int restricted)
+/*[clinic end generated code: output=492057c4f10dc304 input=5a22c1ed0c5dbcf3]*/
 {
     PyThreadState *tstate = _PyThreadState_GET();
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restrict, reqready, "exec code for");
+            resolve_interp(id, restricted, reqready, "exec code for");
     if (interp == NULL) {
         return NULL;
     }
@@ -1165,7 +1165,7 @@ _interpreters.run_string
     script: unicode
     shared: object(subclass_of='&PyDict_Type', c_default='NULL') = {}
     *
-    restrict: bool = False
+    restrict as restricted: bool = False
 
 Execute the provided string in the identified interpreter.
 
@@ -1175,14 +1175,14 @@ Execute the provided string in the identified interpreter.
 static PyObject *
 _interpreters_run_string_impl(PyObject *module, PyObject *id,
                               PyObject *script, PyObject *shared,
-                              int restrict)
-/*[clinic end generated code: output=aa0b7383aca83202 input=f6fb336564bfe090]*/
+                              int restricted)
+/*[clinic end generated code: output=a30a64fb9ad396a2 input=51ce549b9a8dbe21]*/
 {
 #define FUNCNAME MODULE_NAME_STR ".run_string"
     PyThreadState *tstate = _PyThreadState_GET();
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restrict, reqready, "run a string in");
+            resolve_interp(id, restricted, reqready, "run a string in");
     if (interp == NULL) {
         return NULL;
     }
@@ -1216,7 +1216,7 @@ _interpreters.run_func
     func: object
     shared: object(subclass_of='&PyDict_Type', c_default='NULL') = {}
     *
-    restrict: bool = False
+    restrict as restricted: bool = False
 
 Execute the body of the provided function in the identified interpreter.
 
@@ -1228,14 +1228,14 @@ are not supported.  Methods and other callables are not supported either.
 
 static PyObject *
 _interpreters_run_func_impl(PyObject *module, PyObject *id, PyObject *func,
-                            PyObject *shared, int restrict)
-/*[clinic end generated code: output=80c7ab83886e5497 input=08d2724bce5e5d8c]*/
+                            PyObject *shared, int restricted)
+/*[clinic end generated code: output=131f7202ca4a0c5e input=2d62bb9b9eaf4948]*/
 {
 #define FUNCNAME MODULE_NAME_STR ".run_func"
     PyThreadState *tstate = _PyThreadState_GET();
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restrict, reqready, "run a function in");
+            resolve_interp(id, restricted, reqready, "run a function in");
     if (interp == NULL) {
         return NULL;
     }
@@ -1280,7 +1280,7 @@ _interpreters.call
     kwargs: object(subclass_of='&PyDict_Type', c_default='NULL') = {}
     *
     preserve_exc: bool = False
-    restrict: bool = False
+    restrict as restricted: bool = False
 
 Call the provided object in the identified interpreter.
 
@@ -1290,13 +1290,13 @@ Pass the given args and kwargs, if possible.
 static PyObject *
 _interpreters_call_impl(PyObject *module, PyObject *id, PyObject *callable,
                         PyObject *args, PyObject *kwargs, int preserve_exc,
-                        int restrict)
-/*[clinic end generated code: output=e04c697326e0f482 input=858caec5becc34ed]*/
+                        int restricted)
+/*[clinic end generated code: output=b7a4a27d72df3ebc input=b026d0b212a575e6]*/
 {
     PyThreadState *tstate = _PyThreadState_GET();
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restrict, reqready, "make a call in");
+            resolve_interp(id, restricted, reqready, "make a call in");
     if (interp == NULL) {
         return NULL;
     }
@@ -1351,18 +1351,18 @@ _interpreters_is_shareable_impl(PyObject *module, PyObject *obj)
 _interpreters.is_running
     id: object
     *
-    restrict: bool = False
+    restrict as restricted: bool = False
 
 Return whether or not the identified interpreter is running.
 [clinic start generated code]*/
 
 static PyObject *
-_interpreters_is_running_impl(PyObject *module, PyObject *id, int restrict)
-/*[clinic end generated code: output=807f93da48f682cd input=ab3e5e07a870d506]*/
+_interpreters_is_running_impl(PyObject *module, PyObject *id, int restricted)
+/*[clinic end generated code: output=32a6225d5ded9bdb input=3291578d04231125]*/
 {
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restrict, reqready, "check if running for");
+            resolve_interp(id, restricted, reqready, "check if running for");
     if (interp == NULL) {
         return NULL;
     }
@@ -1378,14 +1378,14 @@ _interpreters_is_running_impl(PyObject *module, PyObject *id, int restrict)
 _interpreters.get_config
     id: object
     *
-    restrict: bool = False
+    restrict as restricted: bool = False
 
 Return a representation of the config used to initialize the interpreter.
 [clinic start generated code]*/
 
 static PyObject *
-_interpreters_get_config_impl(PyObject *module, PyObject *id, int restrict)
-/*[clinic end generated code: output=b739277cc30cf365 input=d268b92b96b0712b]*/
+_interpreters_get_config_impl(PyObject *module, PyObject *id, int restricted)
+/*[clinic end generated code: output=56773353b9b7224a input=59519a01c22d96d1]*/
 {
     if (id == Py_None) {
         id = NULL;
@@ -1393,7 +1393,7 @@ _interpreters_get_config_impl(PyObject *module, PyObject *id, int restrict)
 
     int reqready = 0;
     PyInterpreterState *interp = \
-            resolve_interp(id, restrict, reqready, "get the config of");
+            resolve_interp(id, restricted, reqready, "get the config of");
     if (interp == NULL) {
         return NULL;
     }
@@ -1439,18 +1439,18 @@ _interpreters.incref
     id: object
     *
     implieslink: bool = False
-    restrict: bool = False
+    restrict as restricted: bool = False
 
 [clinic start generated code]*/
 
 static PyObject *
 _interpreters_incref_impl(PyObject *module, PyObject *id, int implieslink,
-                          int restrict)
-/*[clinic end generated code: output=07ac7d417e19ea14 input=d83785796c100d14]*/
+                          int restricted)
+/*[clinic end generated code: output=eccaa4e03fbe8ee2 input=a0a614748f2e348c]*/
 {
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restrict, reqready, "incref");
+            resolve_interp(id, restricted, reqready, "incref");
     if (interp == NULL) {
         return NULL;
     }
@@ -1469,17 +1469,17 @@ _interpreters_incref_impl(PyObject *module, PyObject *id, int implieslink,
 _interpreters.decref
     id: object
     *
-    restrict: bool = False
+    restrict as restricted: bool = False
 
 [clinic start generated code]*/
 
 static PyObject *
-_interpreters_decref_impl(PyObject *module, PyObject *id, int restrict)
-/*[clinic end generated code: output=1b9b5a4b9f16b914 input=3eb5e65dffddffe3]*/
+_interpreters_decref_impl(PyObject *module, PyObject *id, int restricted)
+/*[clinic end generated code: output=5c54db4b22086171 input=c4aa34f09c44e62a]*/
 {
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restrict, reqready, "decref");
+            resolve_interp(id, restricted, reqready, "decref");
     if (interp == NULL) {
         return NULL;
     }

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -742,7 +742,7 @@ get_whence(PyInterpreterState *interp)
 
 
 static PyInterpreterState *
-resolve_interp(PyObject *idobj, int restricted, int reqready, const char *op)
+resolve_interp(PyObject *idobj, int restrict, int reqready, const char *op)
 {
     PyInterpreterState *interp;
     if (idobj == NULL) {
@@ -767,7 +767,7 @@ resolve_interp(PyObject *idobj, int restricted, int reqready, const char *op)
         return NULL;
     }
 
-    if (restricted && get_whence(interp) != _PyInterpreterState_WHENCE_STDLIB) {
+    if (restrict && get_whence(interp) != _PyInterpreterState_WHENCE_STDLIB) {
         if (idobj == NULL) {
             PyErr_Format(PyExc_InterpreterError,
                          "cannot %s unrecognized current interpreter", op);
@@ -907,7 +907,7 @@ _interpreters_create_impl(PyObject *module, PyObject *configobj, int reqrefs)
 _interpreters.destroy
     id: object
     *
-    restrict as restricted: bool = False
+    restrict: bool = False
 
 Destroy the identified interpreter.
 
@@ -916,13 +916,13 @@ So does an unrecognized ID.
 [clinic start generated code]*/
 
 static PyObject *
-_interpreters_destroy_impl(PyObject *module, PyObject *id, int restricted)
-/*[clinic end generated code: output=0bc20da8700ab4dd input=561bdd6537639d40]*/
+_interpreters_destroy_impl(PyObject *module, PyObject *id, int restrict)
+/*[clinic end generated code: output=3887e3c350597df5 input=43fd109df8e851f9]*/
 {
     // Look up the interpreter.
     int reqready = 0;
     PyInterpreterState *interp = \
-            resolve_interp(id, restricted, reqready, "destroy");
+            resolve_interp(id, restrict, reqready, "destroy");
     if (interp == NULL) {
         return NULL;
     }
@@ -1034,20 +1034,20 @@ _interpreters.set___main___attrs
     id: object
     updates: object(subclass_of='&PyDict_Type')
     *
-    restrict as restricted: bool = False
+    restrict: bool = False
 
 Bind the given attributes in the interpreter's __main__ module.
 [clinic start generated code]*/
 
 static PyObject *
 _interpreters_set___main___attrs_impl(PyObject *module, PyObject *id,
-                                      PyObject *updates, int restricted)
-/*[clinic end generated code: output=f3803010cb452bf0 input=d16ab8d81371f86a]*/
+                                      PyObject *updates, int restrict)
+/*[clinic end generated code: output=494c8fc4be971936 input=4235567e63091172]*/
 {
     // Look up the interpreter.
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restricted, reqready, "update __main__ for");
+            resolve_interp(id, restrict, reqready, "update __main__ for");
     if (interp == NULL) {
         return NULL;
     }
@@ -1109,7 +1109,7 @@ _interpreters.exec
     code: object
     shared: object(subclass_of='&PyDict_Type', c_default='NULL') = {}
     *
-    restrict as restricted: bool = False
+    restrict: bool = False
 
 Execute the provided code in the identified interpreter.
 
@@ -1129,13 +1129,13 @@ is ignored, including its __globals__ dict.
 
 static PyObject *
 _interpreters_exec_impl(PyObject *module, PyObject *id, PyObject *code,
-                        PyObject *shared, int restricted)
-/*[clinic end generated code: output=492057c4f10dc304 input=5a22c1ed0c5dbcf3]*/
+                        PyObject *shared, int restrict)
+/*[clinic end generated code: output=1e47a912017ea298 input=0591915eb37dc8ca]*/
 {
     PyThreadState *tstate = _PyThreadState_GET();
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restricted, reqready, "exec code for");
+            resolve_interp(id, restrict, reqready, "exec code for");
     if (interp == NULL) {
         return NULL;
     }
@@ -1165,7 +1165,7 @@ _interpreters.run_string
     script: unicode
     shared: object(subclass_of='&PyDict_Type', c_default='NULL') = {}
     *
-    restrict as restricted: bool = False
+    restrict: bool = False
 
 Execute the provided string in the identified interpreter.
 
@@ -1175,14 +1175,14 @@ Execute the provided string in the identified interpreter.
 static PyObject *
 _interpreters_run_string_impl(PyObject *module, PyObject *id,
                               PyObject *script, PyObject *shared,
-                              int restricted)
-/*[clinic end generated code: output=a30a64fb9ad396a2 input=51ce549b9a8dbe21]*/
+                              int restrict)
+/*[clinic end generated code: output=aa0b7383aca83202 input=f6fb336564bfe090]*/
 {
 #define FUNCNAME MODULE_NAME_STR ".run_string"
     PyThreadState *tstate = _PyThreadState_GET();
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restricted, reqready, "run a string in");
+            resolve_interp(id, restrict, reqready, "run a string in");
     if (interp == NULL) {
         return NULL;
     }
@@ -1216,7 +1216,7 @@ _interpreters.run_func
     func: object
     shared: object(subclass_of='&PyDict_Type', c_default='NULL') = {}
     *
-    restrict as restricted: bool = False
+    restrict: bool = False
 
 Execute the body of the provided function in the identified interpreter.
 
@@ -1228,14 +1228,14 @@ are not supported.  Methods and other callables are not supported either.
 
 static PyObject *
 _interpreters_run_func_impl(PyObject *module, PyObject *id, PyObject *func,
-                            PyObject *shared, int restricted)
-/*[clinic end generated code: output=131f7202ca4a0c5e input=2d62bb9b9eaf4948]*/
+                            PyObject *shared, int restrict)
+/*[clinic end generated code: output=80c7ab83886e5497 input=08d2724bce5e5d8c]*/
 {
 #define FUNCNAME MODULE_NAME_STR ".run_func"
     PyThreadState *tstate = _PyThreadState_GET();
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restricted, reqready, "run a function in");
+            resolve_interp(id, restrict, reqready, "run a function in");
     if (interp == NULL) {
         return NULL;
     }
@@ -1280,7 +1280,7 @@ _interpreters.call
     kwargs as kwargs_obj: object(subclass_of='&PyDict_Type', c_default='NULL') = {}
     *
     preserve_exc: bool = False
-    restrict as restricted: bool = False
+    restrict: bool = False
 
 Call the provided object in the identified interpreter.
 
@@ -1290,13 +1290,13 @@ Pass the given args and kwargs, if possible.
 static PyObject *
 _interpreters_call_impl(PyObject *module, PyObject *id, PyObject *callable,
                         PyObject *args_obj, PyObject *kwargs_obj,
-                        int preserve_exc, int restricted)
-/*[clinic end generated code: output=983ee27b3c43f6ef input=77590fdb3f519d65]*/
+                        int preserve_exc, int restrict)
+/*[clinic end generated code: output=d0de009172792592 input=b2b9f147c08b35fa]*/
 {
     PyThreadState *tstate = _PyThreadState_GET();
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restricted, reqready, "make a call in");
+            resolve_interp(id, restrict, reqready, "make a call in");
     if (interp == NULL) {
         return NULL;
     }
@@ -1351,18 +1351,18 @@ _interpreters_is_shareable_impl(PyObject *module, PyObject *obj)
 _interpreters.is_running
     id: object
     *
-    restrict as restricted: bool = False
+    restrict: bool = False
 
 Return whether or not the identified interpreter is running.
 [clinic start generated code]*/
 
 static PyObject *
-_interpreters_is_running_impl(PyObject *module, PyObject *id, int restricted)
-/*[clinic end generated code: output=32a6225d5ded9bdb input=3291578d04231125]*/
+_interpreters_is_running_impl(PyObject *module, PyObject *id, int restrict)
+/*[clinic end generated code: output=807f93da48f682cd input=ab3e5e07a870d506]*/
 {
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restricted, reqready, "check if running for");
+            resolve_interp(id, restrict, reqready, "check if running for");
     if (interp == NULL) {
         return NULL;
     }
@@ -1378,15 +1378,15 @@ _interpreters_is_running_impl(PyObject *module, PyObject *id, int restricted)
 _interpreters.get_config
     id as idobj: object
     *
-    restrict as restricted: bool = False
+    restrict: bool = False
 
 Return a representation of the config used to initialize the interpreter.
 [clinic start generated code]*/
 
 static PyObject *
 _interpreters_get_config_impl(PyObject *module, PyObject *idobj,
-                              int restricted)
-/*[clinic end generated code: output=63f81d35c2fe1387 input=aa38d50f534eb3c5]*/
+                              int restrict)
+/*[clinic end generated code: output=eb69d3a5cafb6b17 input=57c06ac75061acf0]*/
 {
     if (idobj == Py_None) {
         idobj = NULL;
@@ -1394,7 +1394,7 @@ _interpreters_get_config_impl(PyObject *module, PyObject *idobj,
 
     int reqready = 0;
     PyInterpreterState *interp = \
-            resolve_interp(idobj, restricted, reqready, "get the config of");
+            resolve_interp(idobj, restrict, reqready, "get the config of");
     if (interp == NULL) {
         return NULL;
     }
@@ -1440,18 +1440,18 @@ _interpreters.incref
     id: object
     *
     implieslink: bool = False
-    restrict as restricted: bool = False
+    restrict: bool = False
 
 [clinic start generated code]*/
 
 static PyObject *
 _interpreters_incref_impl(PyObject *module, PyObject *id, int implieslink,
-                          int restricted)
-/*[clinic end generated code: output=eccaa4e03fbe8ee2 input=a0a614748f2e348c]*/
+                          int restrict)
+/*[clinic end generated code: output=07ac7d417e19ea14 input=d83785796c100d14]*/
 {
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restricted, reqready, "incref");
+            resolve_interp(id, restrict, reqready, "incref");
     if (interp == NULL) {
         return NULL;
     }
@@ -1470,17 +1470,17 @@ _interpreters_incref_impl(PyObject *module, PyObject *id, int implieslink,
 _interpreters.decref
     id: object
     *
-    restrict as restricted: bool = False
+    restrict: bool = False
 
 [clinic start generated code]*/
 
 static PyObject *
-_interpreters_decref_impl(PyObject *module, PyObject *id, int restricted)
-/*[clinic end generated code: output=5c54db4b22086171 input=c4aa34f09c44e62a]*/
+_interpreters_decref_impl(PyObject *module, PyObject *id, int restrict)
+/*[clinic end generated code: output=1b9b5a4b9f16b914 input=3eb5e65dffddffe3]*/
 {
     int reqready = 1;
     PyInterpreterState *interp = \
-            resolve_interp(id, restricted, reqready, "decref");
+            resolve_interp(id, restrict, reqready, "decref");
     if (interp == NULL) {
         return NULL;
     }

--- a/Modules/clinic/_interpretersmodule.c.h
+++ b/Modules/clinic/_interpretersmodule.c.h
@@ -107,7 +107,7 @@ PyDoc_STRVAR(_interpreters_destroy__doc__,
     {"destroy", _PyCFunction_CAST(_interpreters_destroy), METH_FASTCALL|METH_KEYWORDS, _interpreters_destroy__doc__},
 
 static PyObject *
-_interpreters_destroy_impl(PyObject *module, PyObject *id, int restrict);
+_interpreters_destroy_impl(PyObject *module, PyObject *id, int restricted);
 
 static PyObject *
 _interpreters_destroy(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -143,7 +143,7 @@ _interpreters_destroy(PyObject *module, PyObject *const *args, Py_ssize_t nargs,
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *id;
-    int restrict = 0;
+    int restricted = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -154,12 +154,12 @@ _interpreters_destroy(PyObject *module, PyObject *const *args, Py_ssize_t nargs,
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restrict = PyObject_IsTrue(args[1]);
-    if (restrict < 0) {
+    restricted = PyObject_IsTrue(args[1]);
+    if (restricted < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_destroy_impl(module, id, restrict);
+    return_value = _interpreters_destroy_impl(module, id, restricted);
 
 exit:
     return return_value;
@@ -278,7 +278,7 @@ PyDoc_STRVAR(_interpreters_set___main___attrs__doc__,
 
 static PyObject *
 _interpreters_set___main___attrs_impl(PyObject *module, PyObject *id,
-                                      PyObject *updates, int restrict);
+                                      PyObject *updates, int restricted);
 
 static PyObject *
 _interpreters_set___main___attrs(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -315,7 +315,7 @@ _interpreters_set___main___attrs(PyObject *module, PyObject *const *args, Py_ssi
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 2;
     PyObject *id;
     PyObject *updates;
-    int restrict = 0;
+    int restricted = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 2, /*maxpos*/ 2, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -331,12 +331,12 @@ _interpreters_set___main___attrs(PyObject *module, PyObject *const *args, Py_ssi
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restrict = PyObject_IsTrue(args[2]);
-    if (restrict < 0) {
+    restricted = PyObject_IsTrue(args[2]);
+    if (restricted < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_set___main___attrs_impl(module, id, updates, restrict);
+    return_value = _interpreters_set___main___attrs_impl(module, id, updates, restricted);
 
 exit:
     return return_value;
@@ -366,7 +366,7 @@ PyDoc_STRVAR(_interpreters_exec__doc__,
 
 static PyObject *
 _interpreters_exec_impl(PyObject *module, PyObject *id, PyObject *code,
-                        PyObject *shared, int restrict);
+                        PyObject *shared, int restricted);
 
 static PyObject *
 _interpreters_exec(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -404,7 +404,7 @@ _interpreters_exec(PyObject *module, PyObject *const *args, Py_ssize_t nargs, Py
     PyObject *id;
     PyObject *code;
     PyObject *shared = NULL;
-    int restrict = 0;
+    int restricted = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 2, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -430,12 +430,12 @@ skip_optional_pos:
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restrict = PyObject_IsTrue(args[3]);
-    if (restrict < 0) {
+    restricted = PyObject_IsTrue(args[3]);
+    if (restricted < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_exec_impl(module, id, code, shared, restrict);
+    return_value = _interpreters_exec_impl(module, id, code, shared, restricted);
 
 exit:
     return return_value;
@@ -455,7 +455,7 @@ PyDoc_STRVAR(_interpreters_run_string__doc__,
 static PyObject *
 _interpreters_run_string_impl(PyObject *module, PyObject *id,
                               PyObject *script, PyObject *shared,
-                              int restrict);
+                              int restricted);
 
 static PyObject *
 _interpreters_run_string(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -493,7 +493,7 @@ _interpreters_run_string(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *id;
     PyObject *script;
     PyObject *shared = NULL;
-    int restrict = 0;
+    int restricted = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 2, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -523,12 +523,12 @@ skip_optional_pos:
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restrict = PyObject_IsTrue(args[3]);
-    if (restrict < 0) {
+    restricted = PyObject_IsTrue(args[3]);
+    if (restricted < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_run_string_impl(module, id, script, shared, restrict);
+    return_value = _interpreters_run_string_impl(module, id, script, shared, restricted);
 
 exit:
     return return_value;
@@ -550,7 +550,7 @@ PyDoc_STRVAR(_interpreters_run_func__doc__,
 
 static PyObject *
 _interpreters_run_func_impl(PyObject *module, PyObject *id, PyObject *func,
-                            PyObject *shared, int restrict);
+                            PyObject *shared, int restricted);
 
 static PyObject *
 _interpreters_run_func(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -588,7 +588,7 @@ _interpreters_run_func(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *id;
     PyObject *func;
     PyObject *shared = NULL;
-    int restrict = 0;
+    int restricted = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 2, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -614,12 +614,12 @@ skip_optional_pos:
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restrict = PyObject_IsTrue(args[3]);
-    if (restrict < 0) {
+    restricted = PyObject_IsTrue(args[3]);
+    if (restricted < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_run_func_impl(module, id, func, shared, restrict);
+    return_value = _interpreters_run_func_impl(module, id, func, shared, restricted);
 
 exit:
     return return_value;
@@ -640,7 +640,7 @@ PyDoc_STRVAR(_interpreters_call__doc__,
 static PyObject *
 _interpreters_call_impl(PyObject *module, PyObject *id, PyObject *callable,
                         PyObject *args, PyObject *kwargs, int preserve_exc,
-                        int restrict);
+                        int restricted);
 
 static PyObject *
 _interpreters_call(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -680,7 +680,7 @@ _interpreters_call(PyObject *module, PyObject *const *args, Py_ssize_t nargs, Py
     PyObject *__clinic_args = NULL;
     PyObject *__clinic_kwargs = NULL;
     int preserve_exc = 0;
-    int restrict = 0;
+    int restricted = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 2, /*maxpos*/ 4, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -725,12 +725,12 @@ skip_optional_pos:
             goto skip_optional_kwonly;
         }
     }
-    restrict = PyObject_IsTrue(args[5]);
-    if (restrict < 0) {
+    restricted = PyObject_IsTrue(args[5]);
+    if (restricted < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_call_impl(module, id, callable, __clinic_args, __clinic_kwargs, preserve_exc, restrict);
+    return_value = _interpreters_call_impl(module, id, callable, __clinic_args, __clinic_kwargs, preserve_exc, restricted);
 
 exit:
     return return_value;
@@ -804,7 +804,7 @@ PyDoc_STRVAR(_interpreters_is_running__doc__,
     {"is_running", _PyCFunction_CAST(_interpreters_is_running), METH_FASTCALL|METH_KEYWORDS, _interpreters_is_running__doc__},
 
 static PyObject *
-_interpreters_is_running_impl(PyObject *module, PyObject *id, int restrict);
+_interpreters_is_running_impl(PyObject *module, PyObject *id, int restricted);
 
 static PyObject *
 _interpreters_is_running(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -840,7 +840,7 @@ _interpreters_is_running(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *id;
-    int restrict = 0;
+    int restricted = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -851,12 +851,12 @@ _interpreters_is_running(PyObject *module, PyObject *const *args, Py_ssize_t nar
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restrict = PyObject_IsTrue(args[1]);
-    if (restrict < 0) {
+    restricted = PyObject_IsTrue(args[1]);
+    if (restricted < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_is_running_impl(module, id, restrict);
+    return_value = _interpreters_is_running_impl(module, id, restricted);
 
 exit:
     return return_value;
@@ -872,7 +872,7 @@ PyDoc_STRVAR(_interpreters_get_config__doc__,
     {"get_config", _PyCFunction_CAST(_interpreters_get_config), METH_FASTCALL|METH_KEYWORDS, _interpreters_get_config__doc__},
 
 static PyObject *
-_interpreters_get_config_impl(PyObject *module, PyObject *id, int restrict);
+_interpreters_get_config_impl(PyObject *module, PyObject *id, int restricted);
 
 static PyObject *
 _interpreters_get_config(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -908,7 +908,7 @@ _interpreters_get_config(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *id;
-    int restrict = 0;
+    int restricted = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -919,12 +919,12 @@ _interpreters_get_config(PyObject *module, PyObject *const *args, Py_ssize_t nar
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restrict = PyObject_IsTrue(args[1]);
-    if (restrict < 0) {
+    restricted = PyObject_IsTrue(args[1]);
+    if (restricted < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_get_config_impl(module, id, restrict);
+    return_value = _interpreters_get_config_impl(module, id, restricted);
 
 exit:
     return return_value;
@@ -998,7 +998,7 @@ PyDoc_STRVAR(_interpreters_incref__doc__,
 
 static PyObject *
 _interpreters_incref_impl(PyObject *module, PyObject *id, int implieslink,
-                          int restrict);
+                          int restricted);
 
 static PyObject *
 _interpreters_incref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -1035,7 +1035,7 @@ _interpreters_incref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *id;
     int implieslink = 0;
-    int restrict = 0;
+    int restricted = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -1055,12 +1055,12 @@ _interpreters_incref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
             goto skip_optional_kwonly;
         }
     }
-    restrict = PyObject_IsTrue(args[2]);
-    if (restrict < 0) {
+    restricted = PyObject_IsTrue(args[2]);
+    if (restricted < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_incref_impl(module, id, implieslink, restrict);
+    return_value = _interpreters_incref_impl(module, id, implieslink, restricted);
 
 exit:
     return return_value;
@@ -1075,7 +1075,7 @@ PyDoc_STRVAR(_interpreters_decref__doc__,
     {"decref", _PyCFunction_CAST(_interpreters_decref), METH_FASTCALL|METH_KEYWORDS, _interpreters_decref__doc__},
 
 static PyObject *
-_interpreters_decref_impl(PyObject *module, PyObject *id, int restrict);
+_interpreters_decref_impl(PyObject *module, PyObject *id, int restricted);
 
 static PyObject *
 _interpreters_decref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -1111,7 +1111,7 @@ _interpreters_decref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *id;
-    int restrict = 0;
+    int restricted = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -1122,12 +1122,12 @@ _interpreters_decref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restrict = PyObject_IsTrue(args[1]);
-    if (restrict < 0) {
+    restricted = PyObject_IsTrue(args[1]);
+    if (restricted < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_decref_impl(module, id, restrict);
+    return_value = _interpreters_decref_impl(module, id, restricted);
 
 exit:
     return return_value;
@@ -1198,4 +1198,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=407e2f173a3ad602 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c80f73761f860f6c input=a9049054013a1b77]*/

--- a/Modules/clinic/_interpretersmodule.c.h
+++ b/Modules/clinic/_interpretersmodule.c.h
@@ -639,8 +639,8 @@ PyDoc_STRVAR(_interpreters_call__doc__,
 
 static PyObject *
 _interpreters_call_impl(PyObject *module, PyObject *id, PyObject *callable,
-                        PyObject *args_obj, PyObject *kwargs_obj,
-                        int preserve_exc, int restrict);
+                        PyObject *args, PyObject *kwargs, int preserve_exc,
+                        int restrict);
 
 static PyObject *
 _interpreters_call(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -677,8 +677,8 @@ _interpreters_call(PyObject *module, PyObject *const *args, Py_ssize_t nargs, Py
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 2;
     PyObject *id;
     PyObject *callable;
-    PyObject *args_obj = NULL;
-    PyObject *kwargs_obj = NULL;
+    PyObject *__clinic_args = NULL;
+    PyObject *__clinic_kwargs = NULL;
     int preserve_exc = 0;
     int restrict = 0;
 
@@ -697,7 +697,7 @@ _interpreters_call(PyObject *module, PyObject *const *args, Py_ssize_t nargs, Py
             _PyArg_BadArgument("call", "argument 'args'", "tuple", args[2]);
             goto exit;
         }
-        args_obj = args[2];
+        __clinic_args = args[2];
         if (!--noptargs) {
             goto skip_optional_pos;
         }
@@ -707,7 +707,7 @@ _interpreters_call(PyObject *module, PyObject *const *args, Py_ssize_t nargs, Py
             _PyArg_BadArgument("call", "argument 'kwargs'", "dict", args[3]);
             goto exit;
         }
-        kwargs_obj = args[3];
+        __clinic_kwargs = args[3];
         if (!--noptargs) {
             goto skip_optional_pos;
         }
@@ -730,7 +730,7 @@ skip_optional_pos:
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_call_impl(module, id, callable, args_obj, kwargs_obj, preserve_exc, restrict);
+    return_value = _interpreters_call_impl(module, id, callable, __clinic_args, __clinic_kwargs, preserve_exc, restrict);
 
 exit:
     return return_value;
@@ -1199,4 +1199,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=255754d4eba52c98 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=17de7de23608e491 input=a9049054013a1b77]*/

--- a/Modules/clinic/_interpretersmodule.c.h
+++ b/Modules/clinic/_interpretersmodule.c.h
@@ -107,7 +107,7 @@ PyDoc_STRVAR(_interpreters_destroy__doc__,
     {"destroy", _PyCFunction_CAST(_interpreters_destroy), METH_FASTCALL|METH_KEYWORDS, _interpreters_destroy__doc__},
 
 static PyObject *
-_interpreters_destroy_impl(PyObject *module, PyObject *id, int restricted);
+_interpreters_destroy_impl(PyObject *module, PyObject *id, int restrict);
 
 static PyObject *
 _interpreters_destroy(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -143,7 +143,7 @@ _interpreters_destroy(PyObject *module, PyObject *const *args, Py_ssize_t nargs,
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *id;
-    int restricted = 0;
+    int restrict = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -154,12 +154,12 @@ _interpreters_destroy(PyObject *module, PyObject *const *args, Py_ssize_t nargs,
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restricted = PyObject_IsTrue(args[1]);
-    if (restricted < 0) {
+    restrict = PyObject_IsTrue(args[1]);
+    if (restrict < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_destroy_impl(module, id, restricted);
+    return_value = _interpreters_destroy_impl(module, id, restrict);
 
 exit:
     return return_value;
@@ -278,7 +278,7 @@ PyDoc_STRVAR(_interpreters_set___main___attrs__doc__,
 
 static PyObject *
 _interpreters_set___main___attrs_impl(PyObject *module, PyObject *id,
-                                      PyObject *updates, int restricted);
+                                      PyObject *updates, int restrict);
 
 static PyObject *
 _interpreters_set___main___attrs(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -315,7 +315,7 @@ _interpreters_set___main___attrs(PyObject *module, PyObject *const *args, Py_ssi
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 2;
     PyObject *id;
     PyObject *updates;
-    int restricted = 0;
+    int restrict = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 2, /*maxpos*/ 2, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -331,12 +331,12 @@ _interpreters_set___main___attrs(PyObject *module, PyObject *const *args, Py_ssi
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restricted = PyObject_IsTrue(args[2]);
-    if (restricted < 0) {
+    restrict = PyObject_IsTrue(args[2]);
+    if (restrict < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_set___main___attrs_impl(module, id, updates, restricted);
+    return_value = _interpreters_set___main___attrs_impl(module, id, updates, restrict);
 
 exit:
     return return_value;
@@ -366,7 +366,7 @@ PyDoc_STRVAR(_interpreters_exec__doc__,
 
 static PyObject *
 _interpreters_exec_impl(PyObject *module, PyObject *id, PyObject *code,
-                        PyObject *shared, int restricted);
+                        PyObject *shared, int restrict);
 
 static PyObject *
 _interpreters_exec(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -404,7 +404,7 @@ _interpreters_exec(PyObject *module, PyObject *const *args, Py_ssize_t nargs, Py
     PyObject *id;
     PyObject *code;
     PyObject *shared = NULL;
-    int restricted = 0;
+    int restrict = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 2, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -430,12 +430,12 @@ skip_optional_pos:
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restricted = PyObject_IsTrue(args[3]);
-    if (restricted < 0) {
+    restrict = PyObject_IsTrue(args[3]);
+    if (restrict < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_exec_impl(module, id, code, shared, restricted);
+    return_value = _interpreters_exec_impl(module, id, code, shared, restrict);
 
 exit:
     return return_value;
@@ -455,7 +455,7 @@ PyDoc_STRVAR(_interpreters_run_string__doc__,
 static PyObject *
 _interpreters_run_string_impl(PyObject *module, PyObject *id,
                               PyObject *script, PyObject *shared,
-                              int restricted);
+                              int restrict);
 
 static PyObject *
 _interpreters_run_string(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -493,7 +493,7 @@ _interpreters_run_string(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *id;
     PyObject *script;
     PyObject *shared = NULL;
-    int restricted = 0;
+    int restrict = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 2, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -523,12 +523,12 @@ skip_optional_pos:
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restricted = PyObject_IsTrue(args[3]);
-    if (restricted < 0) {
+    restrict = PyObject_IsTrue(args[3]);
+    if (restrict < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_run_string_impl(module, id, script, shared, restricted);
+    return_value = _interpreters_run_string_impl(module, id, script, shared, restrict);
 
 exit:
     return return_value;
@@ -550,7 +550,7 @@ PyDoc_STRVAR(_interpreters_run_func__doc__,
 
 static PyObject *
 _interpreters_run_func_impl(PyObject *module, PyObject *id, PyObject *func,
-                            PyObject *shared, int restricted);
+                            PyObject *shared, int restrict);
 
 static PyObject *
 _interpreters_run_func(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -588,7 +588,7 @@ _interpreters_run_func(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *id;
     PyObject *func;
     PyObject *shared = NULL;
-    int restricted = 0;
+    int restrict = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 2, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -614,12 +614,12 @@ skip_optional_pos:
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restricted = PyObject_IsTrue(args[3]);
-    if (restricted < 0) {
+    restrict = PyObject_IsTrue(args[3]);
+    if (restrict < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_run_func_impl(module, id, func, shared, restricted);
+    return_value = _interpreters_run_func_impl(module, id, func, shared, restrict);
 
 exit:
     return return_value;
@@ -640,7 +640,7 @@ PyDoc_STRVAR(_interpreters_call__doc__,
 static PyObject *
 _interpreters_call_impl(PyObject *module, PyObject *id, PyObject *callable,
                         PyObject *args_obj, PyObject *kwargs_obj,
-                        int preserve_exc, int restricted);
+                        int preserve_exc, int restrict);
 
 static PyObject *
 _interpreters_call(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -680,7 +680,7 @@ _interpreters_call(PyObject *module, PyObject *const *args, Py_ssize_t nargs, Py
     PyObject *args_obj = NULL;
     PyObject *kwargs_obj = NULL;
     int preserve_exc = 0;
-    int restricted = 0;
+    int restrict = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 2, /*maxpos*/ 4, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -725,12 +725,12 @@ skip_optional_pos:
             goto skip_optional_kwonly;
         }
     }
-    restricted = PyObject_IsTrue(args[5]);
-    if (restricted < 0) {
+    restrict = PyObject_IsTrue(args[5]);
+    if (restrict < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_call_impl(module, id, callable, args_obj, kwargs_obj, preserve_exc, restricted);
+    return_value = _interpreters_call_impl(module, id, callable, args_obj, kwargs_obj, preserve_exc, restrict);
 
 exit:
     return return_value;
@@ -804,7 +804,7 @@ PyDoc_STRVAR(_interpreters_is_running__doc__,
     {"is_running", _PyCFunction_CAST(_interpreters_is_running), METH_FASTCALL|METH_KEYWORDS, _interpreters_is_running__doc__},
 
 static PyObject *
-_interpreters_is_running_impl(PyObject *module, PyObject *id, int restricted);
+_interpreters_is_running_impl(PyObject *module, PyObject *id, int restrict);
 
 static PyObject *
 _interpreters_is_running(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -840,7 +840,7 @@ _interpreters_is_running(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *id;
-    int restricted = 0;
+    int restrict = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -851,12 +851,12 @@ _interpreters_is_running(PyObject *module, PyObject *const *args, Py_ssize_t nar
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restricted = PyObject_IsTrue(args[1]);
-    if (restricted < 0) {
+    restrict = PyObject_IsTrue(args[1]);
+    if (restrict < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_is_running_impl(module, id, restricted);
+    return_value = _interpreters_is_running_impl(module, id, restrict);
 
 exit:
     return return_value;
@@ -873,7 +873,7 @@ PyDoc_STRVAR(_interpreters_get_config__doc__,
 
 static PyObject *
 _interpreters_get_config_impl(PyObject *module, PyObject *idobj,
-                              int restricted);
+                              int restrict);
 
 static PyObject *
 _interpreters_get_config(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -909,7 +909,7 @@ _interpreters_get_config(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *idobj;
-    int restricted = 0;
+    int restrict = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -920,12 +920,12 @@ _interpreters_get_config(PyObject *module, PyObject *const *args, Py_ssize_t nar
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restricted = PyObject_IsTrue(args[1]);
-    if (restricted < 0) {
+    restrict = PyObject_IsTrue(args[1]);
+    if (restrict < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_get_config_impl(module, idobj, restricted);
+    return_value = _interpreters_get_config_impl(module, idobj, restrict);
 
 exit:
     return return_value;
@@ -999,7 +999,7 @@ PyDoc_STRVAR(_interpreters_incref__doc__,
 
 static PyObject *
 _interpreters_incref_impl(PyObject *module, PyObject *id, int implieslink,
-                          int restricted);
+                          int restrict);
 
 static PyObject *
 _interpreters_incref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -1036,7 +1036,7 @@ _interpreters_incref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *id;
     int implieslink = 0;
-    int restricted = 0;
+    int restrict = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -1056,12 +1056,12 @@ _interpreters_incref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
             goto skip_optional_kwonly;
         }
     }
-    restricted = PyObject_IsTrue(args[2]);
-    if (restricted < 0) {
+    restrict = PyObject_IsTrue(args[2]);
+    if (restrict < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_incref_impl(module, id, implieslink, restricted);
+    return_value = _interpreters_incref_impl(module, id, implieslink, restrict);
 
 exit:
     return return_value;
@@ -1076,7 +1076,7 @@ PyDoc_STRVAR(_interpreters_decref__doc__,
     {"decref", _PyCFunction_CAST(_interpreters_decref), METH_FASTCALL|METH_KEYWORDS, _interpreters_decref__doc__},
 
 static PyObject *
-_interpreters_decref_impl(PyObject *module, PyObject *id, int restricted);
+_interpreters_decref_impl(PyObject *module, PyObject *id, int restrict);
 
 static PyObject *
 _interpreters_decref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -1112,7 +1112,7 @@ _interpreters_decref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *id;
-    int restricted = 0;
+    int restrict = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -1123,12 +1123,12 @@ _interpreters_decref(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    restricted = PyObject_IsTrue(args[1]);
-    if (restricted < 0) {
+    restrict = PyObject_IsTrue(args[1]);
+    if (restrict < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_decref_impl(module, id, restricted);
+    return_value = _interpreters_decref_impl(module, id, restrict);
 
 exit:
     return return_value;
@@ -1199,4 +1199,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=cf3f54caaa2dd6a2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=255754d4eba52c98 input=a9049054013a1b77]*/

--- a/Modules/clinic/_interpretersmodule.c.h
+++ b/Modules/clinic/_interpretersmodule.c.h
@@ -872,8 +872,7 @@ PyDoc_STRVAR(_interpreters_get_config__doc__,
     {"get_config", _PyCFunction_CAST(_interpreters_get_config), METH_FASTCALL|METH_KEYWORDS, _interpreters_get_config__doc__},
 
 static PyObject *
-_interpreters_get_config_impl(PyObject *module, PyObject *idobj,
-                              int restrict);
+_interpreters_get_config_impl(PyObject *module, PyObject *id, int restrict);
 
 static PyObject *
 _interpreters_get_config(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -908,7 +907,7 @@ _interpreters_get_config(PyObject *module, PyObject *const *args, Py_ssize_t nar
     #undef KWTUPLE
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
-    PyObject *idobj;
+    PyObject *id;
     int restrict = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
@@ -916,7 +915,7 @@ _interpreters_get_config(PyObject *module, PyObject *const *args, Py_ssize_t nar
     if (!args) {
         goto exit;
     }
-    idobj = args[0];
+    id = args[0];
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
@@ -925,7 +924,7 @@ _interpreters_get_config(PyObject *module, PyObject *const *args, Py_ssize_t nar
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _interpreters_get_config_impl(module, idobj, restrict);
+    return_value = _interpreters_get_config_impl(module, id, restrict);
 
 exit:
     return return_value;
@@ -1199,4 +1198,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=17de7de23608e491 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=407e2f173a3ad602 input=a9049054013a1b77]*/


### PR DESCRIPTION
Follows on from #137631.

A

<!-- gh-issue-number: gh-137630 -->
* Issue: gh-137630
<!-- /gh-issue-number -->
