### PR TITLE
gh-133403: Run `mypy` on `Tools/build/mypy.ini` changes

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -13,6 +13,7 @@ on:
       - "Lib/test/libregrtest/**"
       - "Lib/tomllib/**"
       - "Misc/mypy/**"
+      - "Tools/build/mypy.ini"
       - "Tools/build/check_extension_modules.py"
       - "Tools/build/compute-changes.py"
       - "Tools/build/deepfreeze.py"


### PR DESCRIPTION
We missed this file, while it is very important :)

<!-- gh-issue-number: gh-133403 -->
* Issue: gh-133403
<!-- /gh-issue-number -->
