### PR TITLE
[3.14] GH-134291: Support older macOS deployment targets for JIT builds (GH-137211)

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -113,6 +113,10 @@ jobs:
           find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
           brew install llvm@${{ matrix.llvm }}
           export SDKROOT="$(xcrun --show-sdk-path)"
+          # Set MACOSX_DEPLOYMENT_TARGET and -Werror=unguarded-availability to
+          # make sure we don't break downstream distributors (like uv):
+          export CFLAGS_JIT='-Werror=unguarded-availability'
+          export MACOSX_DEPLOYMENT_TARGET=10.15
           ./configure --enable-experimental-jit --enable-universalsdk --with-universal-archs=universal2 ${{ matrix.debug && '--with-pydebug' || '' }}
           make all --jobs 4
           ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-28-19-11-34.gh-issue-134291.IiB9Id.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-28-19-11-34.gh-issue-134291.IiB9Id.rst
@@ -1,0 +1,2 @@
+Remove some newer macOS API usage from the JIT compiler in order to restore
+compatibility with older OSX 10.15 deployment targets.


### PR DESCRIPTION
This rolls back GH-126196 and adds stricter checks for newer APIs in JIT CI. We don't really need the superpowers of the newer API (rapid flip-flopping permissions on JIT pages) since our JIT doesn't use self-modifying code.

This allows downstream distributors (like `uv`, CC @zanieb) to ship the JIT for more users.

<!-- gh-issue-number: gh-134291 -->
* Issue: gh-134291
<!-- /gh-issue-number -->
