### PR TITLE
gh-137716:  Fix double period in AttributeError message for invalid mock assertions

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -700,7 +700,7 @@ class NonCallableMock(Base):
             if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')) or name in _ATTRIB_DENY_LIST:
                 raise AttributeError(
                     f"{name!r} is not a valid assertion. Use a spec "
-                    f"for the mock if {name!r} is meant to be an attribute.")
+                    f"for the mock if {name!r} is meant to be an attribute")
 
         with NonCallableMock._lock:
             result = self._mock_children.get(name)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-13-16-58-58.gh-issue-137716.ZcZSyi.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-13-16-58-58.gh-issue-137716.ZcZSyi.rst
@@ -1,0 +1,1 @@
+Fix double period in AttributeError message for invalid mock assertions

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-13-16-58-58.gh-issue-137716.ZcZSyi.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-13-16-58-58.gh-issue-137716.ZcZSyi.rst
@@ -1,1 +1,1 @@
-Fix double period in AttributeError message for invalid mock assertions
+Fix double period in :exc:`AttributeError` message for invalid mock assertions


### PR DESCRIPTION
Issue: https://github.com/python/cpython/issues/137716

<!-- gh-issue-number: gh-137716 -->
* Issue: gh-137716
<!-- /gh-issue-number -->
