### PR TITLE
gh-137626: fix error messages of dict() and dict().update()

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -28,6 +28,23 @@ class DictTest(unittest.TestCase):
         self.assertEqual(dict(), {})
         self.assertIsNot(dict(), {})
 
+    def test_constructor_positional_argument_error_messages(self):
+        with self.assertRaisesRegex(TypeError,
+                                   r"dict expected at most 1 positional argument, got 2"):
+            dict('John', 36)
+        with self.assertRaisesRegex(TypeError,
+                                   r"dict expected at most 1 positional argument, got 3"):
+            dict('a', 'b', 'c')
+
+    def test_update_positional_argument_error_messages(self):
+        d = {}
+        with self.assertRaisesRegex(TypeError,
+                                   r"update expected at most 1 positional argument, got 2"):
+            d.update('John', 36)
+        with self.assertRaisesRegex(TypeError,
+                                   r"update expected at most 1 positional argument, got 3"):
+            d.update('a', 'b', 'c')
+
     def test_literal_constructor(self):
         # check literal constructor for different sized dicts
         # (to exercise the BUILD_MAP oparg).

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2740,11 +2740,14 @@ _PyArg_CheckPositional(const char *name, Py_ssize_t nargs,
     assert(min <= max);
 
     if (nargs < min) {
-        if (name != NULL)
+        if (name != NULL) {
+            const char *arg_type = (strcmp(name, "dict") == 0 || strcmp(name, "update") == 0)
+                                   ? "positional argument" : "argument";
             PyErr_Format(
                 PyExc_TypeError,
-                "%.200s expected %s%zd argument%s, got %zd",
-                name, (min == max ? "" : "at least "), min, min == 1 ? "" : "s", nargs);
+                "%.200s expected %s%zd %s%s, got %zd",
+                name, (min == max ? "" : "at least "), min, arg_type, min == 1 ? "" : "s", nargs);
+        }
         else
             PyErr_Format(
                 PyExc_TypeError,
@@ -2759,11 +2762,14 @@ _PyArg_CheckPositional(const char *name, Py_ssize_t nargs,
     }
 
     if (nargs > max) {
-        if (name != NULL)
+        if (name != NULL) {
+            const char *arg_type = (strcmp(name, "dict") == 0 || strcmp(name, "update") == 0)
+                                   ? "positional argument" : "argument";
             PyErr_Format(
                 PyExc_TypeError,
-                "%.200s expected %s%zd argument%s, got %zd",
-                name, (min == max ? "" : "at most "), max, max == 1 ? "" : "s", nargs);
+                "%.200s expected %s%zd %s%s, got %zd",
+                name, (min == max ? "" : "at most "), max, arg_type, max == 1 ? "" : "s", nargs);
+        }
         else
             PyErr_Format(
                 PyExc_TypeError,


### PR DESCRIPTION
fix error messages of `dict()` and `dict().update()`

> TypeError: dict expected at most 1 positional argument, got 2
> 
> TypeError: update expected at most 1 positional argument, got 2

instead of 

> TypeError: dict expected at most 1 argument, got 2
> 
> TypeError: update expected at most 1 argument, got 2




<!-- gh-issue-number: gh-137626 -->
* Issue: gh-137626
<!-- /gh-issue-number -->
