### PR TITLE
GH-137573: mark _PyOptimizer_Optimize as no inline

### DIFF
--- a/Misc/NEWS.d/next/C_API/2025-08-13-13-41-04.gh-issue-137573.r6uwRf.rst
+++ b/Misc/NEWS.d/next/C_API/2025-08-13-13-41-04.gh-issue-137573.r6uwRf.rst
@@ -1,2 +1,2 @@
-Mark :c:func:`_PyOptimizer_Optimize` as :c:macro:`Py_NO_INLINE` to
-prevent stack overflow crashes on MacOS.
+Mark ``_PyOptimizer_Optimize`` as :c:macro:`Py_NO_INLINE` to
+prevent stack overflow crashes on macOS.

--- a/Misc/NEWS.d/next/C_API/2025-08-13-13-41-04.gh-issue-137573.r6uwRf.rst
+++ b/Misc/NEWS.d/next/C_API/2025-08-13-13-41-04.gh-issue-137573.r6uwRf.rst
@@ -1,0 +1,2 @@
+Mark :c:func:`_PyOptimizer_Optimize` as :c:macro:`Py_NO_INLINE` to
+prevent stack overflow crashes on MacOS.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -109,7 +109,7 @@ uop_optimize(_PyInterpreterFrame *frame, _Py_CODEUNIT *instr,
 /* Returns 1 if optimized, 0 if not optimized, and -1 for an error.
  * If optimized, *executor_ptr contains a new reference to the executor
  */
-int
+Py_NO_INLINE int
 _PyOptimizer_Optimize(
     _PyInterpreterFrame *frame, _Py_CODEUNIT *start,
     _PyExecutorObject **executor_ptr, int chain_depth)

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -109,6 +109,7 @@ uop_optimize(_PyInterpreterFrame *frame, _Py_CODEUNIT *instr,
 /* Returns 1 if optimized, 0 if not optimized, and -1 for an error.
  * If optimized, *executor_ptr contains a new reference to the executor
  */
+// gh-137573: inlining this function causes stack overflows
 Py_NO_INLINE int
 _PyOptimizer_Optimize(
     _PyInterpreterFrame *frame, _Py_CODEUNIT *start,


### PR DESCRIPTION
Needs backport to 3.14.

<!-- gh-issue-number: gh-137573 -->
* Issue: gh-137573
<!-- /gh-issue-number -->
