### PR TITLE
gh-137740: Clarify __del__ invocation mechanism in reference counting

### DIFF
--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -1086,7 +1086,7 @@ user-defined class, and let's further suppose that the class defined a
 :meth:`!__del__` method.  If this class instance has a reference count of 1,
 disposing of it will call its :meth:`!__del__` method. Internally,
 :c:func:`PyList_SetItem` calls :c:func:`Py_DECREF` on the replaced item,
-which invokes replaced item's corrresponding
+which invokes replaced item's corresponding
 :c:member:`~PyTypeObject.tp_dealloc` function (that is
 :c:func:`subtype_dealloc` in case of Python class instance). During
 deallocation, :c:func:`subtype_dealloc` calls

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -1084,7 +1084,12 @@ references to all its items, so when item 1 is replaced, it has to dispose of
 the original item 1.  Now let's suppose the original item 1 was an instance of a
 user-defined class, and let's further suppose that the class defined a
 :meth:`!__del__` method.  If this class instance has a reference count of 1,
-disposing of it will call its :meth:`!__del__` method.
+disposing of it will call its :meth:`!__del__` method. Internally,
+:c:func:`PyList_SetItem` calls :c:func:`Py_XDECREF` on the replaced item,
+which invokes the object's ``tp_dealloc`` function (``subtype_dealloc`` for Python
+class instances). During deallocation, ``subtype_dealloc`` calls ``tp_finalize``,
+which is mapped to the ``__del__`` method for Python classes (see :pep:`442`).
+This entire sequence happens synchronously within the :c:func:`PyList_SetItem` call.
 
 Since it is written in Python, the :meth:`!__del__` method can execute arbitrary
 Python code.  Could it perhaps do something to invalidate the reference to

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -1086,10 +1086,9 @@ user-defined class, and let's further suppose that the class defined a
 :meth:`!__del__` method.  If this class instance has a reference count of 1,
 disposing of it will call its :meth:`!__del__` method. Internally,
 :c:func:`PyList_SetItem` calls :c:func:`Py_DECREF` on the replaced item,
-which invokes replaced item's corresponding
-:c:member:`~PyTypeObject.tp_dealloc` function (that is
-:c:func:`subtype_dealloc` in case of Python class instance). During
-deallocation, :c:func:`subtype_dealloc` calls
+which invokes replaced item's corrresponding
+:c:member:`~PyTypeObject.tp_dealloc` function. During
+deallocation, :c:member:`~PyTypeObject.tp_dealloc` calls
 :c:member:`~PyTypeObject.tp_finalize`, which is mapped to the
 :meth:`!__del__` method for class instances (see :pep:`442`). This entire
 sequence happens synchronously within the :c:func:`PyList_SetItem` call.

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -1086,10 +1086,13 @@ user-defined class, and let's further suppose that the class defined a
 :meth:`!__del__` method.  If this class instance has a reference count of 1,
 disposing of it will call its :meth:`!__del__` method. Internally,
 :c:func:`PyList_SetItem` calls :c:func:`Py_DECREF` on the replaced item,
-which invokes replaced item's corrresponding :c:member:`~PyTypeObject.tp_dealloc` function (i.e :c:func:`subtype_dealloc` in case of Python
-class instance). During deallocation, :c:func:`subtype_dealloc` calls :c:member:`~PyTypeObject.tp_finalize`,
-which is mapped to the :meth:`!__del__` method for class instances (see :pep:`442`).
-This entire sequence happens synchronously within the :c:func:`PyList_SetItem` call.
+which invokes replaced item's corrresponding
+:c:member:`~PyTypeObject.tp_dealloc` function (that is
+:c:func:`subtype_dealloc` in case of Python class instance). During
+deallocation, :c:func:`subtype_dealloc` calls
+:c:member:`~PyTypeObject.tp_finalize`, which is mapped to the
+:meth:`!__del__` method for class instances (see :pep:`442`). This entire
+sequence happens synchronously within the :c:func:`PyList_SetItem` call.
 
 Since it is written in Python, the :meth:`!__del__` method can execute arbitrary
 Python code.  Could it perhaps do something to invalidate the reference to

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -1086,7 +1086,7 @@ user-defined class, and let's further suppose that the class defined a
 :meth:`!__del__` method.  If this class instance has a reference count of 1,
 disposing of it will call its :meth:`!__del__` method. Internally,
 :c:func:`PyList_SetItem` calls :c:func:`Py_DECREF` on the replaced item,
-which invokes replaced item's corrresponding
+which invokes replaced item's corresponding
 :c:member:`~PyTypeObject.tp_dealloc` function. During
 deallocation, :c:member:`~PyTypeObject.tp_dealloc` calls
 :c:member:`~PyTypeObject.tp_finalize`, which is mapped to the

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -1085,10 +1085,10 @@ the original item 1.  Now let's suppose the original item 1 was an instance of a
 user-defined class, and let's further suppose that the class defined a
 :meth:`!__del__` method.  If this class instance has a reference count of 1,
 disposing of it will call its :meth:`!__del__` method. Internally,
-:c:func:`PyList_SetItem` calls :c:func:`Py_XDECREF` on the replaced item,
-which invokes the object's ``tp_dealloc`` function (``subtype_dealloc`` for Python
-class instances). During deallocation, ``subtype_dealloc`` calls ``tp_finalize``,
-which is mapped to the ``__del__`` method for Python classes (see :pep:`442`).
+:c:func:`PyList_SetItem` calls :c:func:`Py_DECREF` on the replaced item,
+which invokes replaced item's corrresponding :c:member:`~PyTypeObject.tp_dealloc` function (i.e :c:func:`subtype_dealloc` in case of Python
+class instance). During deallocation, :c:func:`subtype_dealloc` calls :c:member:`~PyTypeObject.tp_finalize`,
+which is mapped to the :meth:`!__del__` method for class instances (see :pep:`442`).
 This entire sequence happens synchronously within the :c:func:`PyList_SetItem` call.
 
 Since it is written in Python, the :meth:`!__del__` method can execute arbitrary


### PR DESCRIPTION
Issue : gh-137740: Clarify reference counting details in "Thin Ice" section in `extending` documentation


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137741.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->