### PR TITLE
gh-137728 gh-137762: Fix bugs in the JIT with many local variables

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-14-14-18-29.gh-issue-137728.HdYS9R.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-14-14-18-29.gh-issue-137728.HdYS9R.rst
@@ -1,0 +1,1 @@
+Fix a bug in the JIT with many local variables causing a segfault.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-14-14-18-29.gh-issue-137728.HdYS9R.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-14-14-18-29.gh-issue-137728.HdYS9R.rst
@@ -1,1 +1,1 @@
-Fix a bug in the JIT with many local variables causing a segfault.
+Fix the JIT handling of many local variables. This previously caused a segfault.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-14-14-18-29.gh-issue-137728.HdYS9R.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-14-14-18-29.gh-issue-137728.HdYS9R.rst
@@ -1,1 +1,1 @@
-Fix the JIT handling of many local variables. This previously caused a segfault.
+Fix the JIT's handling of many local variables. This previously caused a segfault.

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -482,13 +482,6 @@ optimize_uops(
     _PyUOpInstruction *corresponding_check_stack = NULL;
 
     _Py_uop_abstractcontext_init(ctx);
-
-    // Note: this must happen before frame_new, as it might override
-    // the result should frame_new set things to bottom.
-    ctx->done = false;
-    ctx->out_of_space = false;
-    ctx->contradiction = false;
-
     _Py_UOpsAbstractFrame *frame = _Py_uop_frame_new(ctx, co, curr_stacklen, NULL, 0);
     if (frame == NULL) {
         return 0;

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -482,15 +482,19 @@ optimize_uops(
     _PyUOpInstruction *corresponding_check_stack = NULL;
 
     _Py_uop_abstractcontext_init(ctx);
+
+    // Note: this must happen before frame_new, as it might override
+    // the result should frame_new set things to bottom.
+    ctx->done = false;
+    ctx->out_of_space = false;
+    ctx->contradiction = false;
+
     _Py_UOpsAbstractFrame *frame = _Py_uop_frame_new(ctx, co, curr_stacklen, NULL, 0);
     if (frame == NULL) {
         return -1;
     }
     ctx->curr_frame_depth++;
     ctx->frame = frame;
-    ctx->done = false;
-    ctx->out_of_space = false;
-    ctx->contradiction = false;
 
     _PyUOpInstruction *this_instr = NULL;
     for (int i = 0; !ctx->done; i++) {

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -491,7 +491,7 @@ optimize_uops(
 
     _Py_UOpsAbstractFrame *frame = _Py_uop_frame_new(ctx, co, curr_stacklen, NULL, 0);
     if (frame == NULL) {
-        return -1;
+        return 0;
     }
     ctx->curr_frame_depth++;
     ctx->frame = frame;

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -888,6 +888,13 @@ _Py_uop_abstractcontext_init(JitOptContext *ctx)
 
     // Frame setup
     ctx->curr_frame_depth = 0;
+
+    // Ctx signals.
+    // Note: this must happen before frame_new, as it might override
+    // the result should frame_new set things to bottom.
+    ctx->done = false;
+    ctx->out_of_space = false;
+    ctx->contradiction = false;
 }
 
 int


### PR DESCRIPTION
It's not really feasible to add a test case for this. As it requires a gigantic frame that just so happens to also pass the frame initialization, but exhaust the symbol arena memory. Furthermore, that test would be tied to the size of the symbol arena, which we will tweak over time anyways, so the test will quickly go out of date.

<!-- gh-issue-number: gh-137728 -->
* Issue: gh-137728
<!-- /gh-issue-number -->
