### PR TITLE
gh-137242: Build Android artifacts in a reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,10 +398,10 @@ jobs:
       run: ./python Lib/test/ssltests.py
 
   build-android:
-    name: Android (${{ matrix.arch }})
+    # ${{ '' } is a hack to nest jobs under the same sidebar category.
+    name: Android${{ '' }}  # zizmor: ignore[obfuscation]
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
-    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -412,13 +412,12 @@ jobs:
           - arch: x86_64
             runs-on: ubuntu-24.04
 
-    runs-on: ${{ matrix.runs-on }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Build and test
-        run: ./Android/android.py ci ${{ matrix.arch }}-linux-android
+    uses: ./.github/workflows/reusable-android.yml
+    with:
+      arch: ${{ matrix.arch }}
+      check-name: ${{ matrix.arch }}
+      runner-vm-os: ${{ matrix.runs-on }}
+      timeout-minutes: 60
 
   build-wasi:
     name: 'WASI'

--- a/.github/workflows/reusable-android.yml
+++ b/.github/workflows/reusable-android.yml
@@ -11,23 +11,10 @@ on:
         description: A custom name for the Checks API-reported status
         required: false
         type: string
-      checkout-ref:
-        description: A custom repository committish to fetch from Git
-        required: false
-        type: string
-      checkout-repository:
-        description: A custom repository slug to fetch from Git
-        required: false
-        type: string
       runner-vm-os:
         description: VM OS to use
         required: true
         type: string
-      store-built-artifacts:
-        default: false
-        description: Whether to preserve output as workflow run artifacts
-        required: false
-        type: boolean
       timeout-minutes:
         description: Deadline for the job to complete
         required: true
@@ -63,30 +50,10 @@ jobs:
       steps: ${{ toJSON(steps) }}
 
     steps:
-    - name: >-
-        Fetch CPython source from ${{
-          inputs.checkout-repository
-          && inputs.checkout-repository
-          || 'Git'
-        }}${{
-          inputs.checkout-ref
-          && format(' @ {0}', inputs.checkout-ref)
-          || ''
-        }}
+    - name: Fetch CPython source from Git
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         persist-credentials: false
-        repository: ${{ inputs.checkout-repository }}
-        ref: ${{ inputs.checkout-ref }}
 
     - name: Build and test
       run: ./Android/android.py ci "${ANDROID_CI_SCRIPT_TRIPLET}"
-
-    - name: Upload Built artifacts
-      if: inputs.store-built-artifacts
-      id: artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.ANDROID_CI_SCRIPT_TRIPLET }}
-        path: cross-build/${{ env.ANDROID_CI_SCRIPT_TRIPLET }}/dist/*
-        if-no-files-found: error

--- a/.github/workflows/reusable-android.yml
+++ b/.github/workflows/reusable-android.yml
@@ -1,0 +1,92 @@
+name: Reusable Android
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        description: CPU architecture
+        required: true
+        type: string
+      check-name:
+        description: A custom name for the Checks API-reported status
+        required: false
+        type: string
+      checkout-ref:
+        description: A custom repository committish to fetch from Git
+        required: false
+        type: string
+      checkout-repository:
+        description: A custom repository slug to fetch from Git
+        required: false
+        type: string
+      runner-vm-os:
+        description: VM OS to use
+        required: true
+        type: string
+      store-built-artifacts:
+        default: false
+        description: Whether to preserve output as workflow run artifacts
+        required: false
+        type: boolean
+      timeout-minutes:
+        description: Deadline for the job to complete
+        required: true
+        type: number
+    outputs:
+      steps:
+        description: >-
+          JSON-formatted collection of all build steps with their outputs
+        value: ${{ jobs.build.outputs.steps }}
+
+env:
+  FORCE_COLOR: 1
+  ANDROID_CI_SCRIPT_TRIPLET: ${{ inputs.arch }}-linux-android
+
+jobs:
+  build:
+    name: >-
+      ${{
+        inputs.check-name
+        && inputs.check-name
+        || format(
+             '{0}@💻{1}',
+             inputs.runner-vm-os,
+             inputs.arch
+           )
+      }}
+
+    runs-on: ${{ inputs.runner-vm-os }}
+
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+
+    outputs:
+      steps: ${{ toJSON(steps) }}
+
+    steps:
+    - name: >-
+        Fetch CPython source from ${{
+          inputs.checkout-repository
+          && inputs.checkout-repository
+          || 'Git'
+        }}${{
+          inputs.checkout-ref
+          && format(' @ {0}', inputs.checkout-ref)
+          || ''
+        }}
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+        repository: ${{ inputs.checkout-repository }}
+        ref: ${{ inputs.checkout-ref }}
+
+    - name: Build and test
+      run: ./Android/android.py ci "${ANDROID_CI_SCRIPT_TRIPLET}"
+
+    - name: Upload Built artifacts
+      if: inputs.store-built-artifacts
+      id: artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.ANDROID_CI_SCRIPT_TRIPLET }}
+        path: cross-build/${{ env.ANDROID_CI_SCRIPT_TRIPLET }}/dist/*
+        if-no-files-found: error


### PR DESCRIPTION
This is a follow-up for #137186 aiming to make the initially added automation live in its own "module" rather than the top-level workflow and make it possible to reuse it externally.

It will also enable a companion change externally: https://github.com/python/release-tools/pull/270.


<!-- gh-issue-number: gh-137242 -->
* Issue: gh-137242
<!-- /gh-issue-number -->
