### PR TITLE
gh-137780: Python - Windows: Fix Unicode abort in AI gen'd code

### DIFF
--- a/Misc/NEWS.d/next/Windows/2025-08-14-20-46-13.gh-issue-137780.i_Fwz9.rst
+++ b/Misc/NEWS.d/next/Windows/2025-08-14-20-46-13.gh-issue-137780.i_Fwz9.rst
@@ -1,0 +1,1 @@
+Windows Python print(...) no longer errors by default, when printing emoticons like 🎯

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -251,7 +251,7 @@ _io_IncrementalNewlineDecoder___init___impl(nldecoder_object *self,
 {
 
     if (errors == NULL) {
-        errors = &_Py_ID(strict);
+        errors = &_Py_ID(replace);
     }
     else {
         errors = Py_NewRef(errors);


### PR DESCRIPTION
With the rise of AI generate code, python Windows is suffering from this bug at an exponentiate rate. I hope that this commit can be accepted as-is, or a conversation can be had about the proper target for a fix like this. Perhaps `textio.c` is too coarse grained, and it needs to be an attribute to the print function (and logging).

https://github.com/python/cpython/issues/137780

This commit represents fixing it for a whole class of the python standard library functions.

<!-- gh-issue-number: gh-137780 -->
* Issue: gh-137780
<!-- /gh-issue-number -->
