### PR TITLE
gh-125676: Make shutil documentation consistent about copy2/copy behavior and remove ambiguity

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -394,9 +394,8 @@ Directory and files operations
    *src* and the destination, and will be used to copy *src* to the destination
    if :func:`os.rename` cannot be used.  If the source is a directory,
    :func:`copytree` is called, passing it the *copy_function*. The
-   default *copy_function* is :func:`copy2`.  Using :func:`~shutil.copy` as the
-   *copy_function* allows the move to succeed when it is not possible to also
-   copy the metadata, at the expense of not copying any of the metadata.
+   default *copy_function* is :func:`copy2`. Any copy function with a signature
+   compatible with copy2() can be used (for instance, :func:`~shutil.copy`).
 
    .. audit-event:: shutil.move src,dst shutil.move
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -204,9 +204,13 @@ Directory and files operations
    *src* symbolic link to the newly created *dst* symbolic link.
    However, this functionality is not available on all platforms.
    On platforms where some or all of this functionality is
-   unavailable, :func:`copy2` will preserve all the metadata
-   it can; :func:`copy2` never raises an exception because it
-   cannot preserve file metadata.
+   unavailable, :func:`copy2` will preserve as much metadata as it
+   can.  However, individual metadata-copy operations (for example
+   changing ownership or setting certain flags) may fail on some
+   platforms or when the current process lacks privileges; such
+   failures can raise exceptions. If you need to avoid metadata-related
+   errors, use :func:`~shutil.copy`, which copies file data and the
+   permission bits but does not attempt to preserve other metadata.
 
    :func:`copy2` uses :func:`copystat` to copy the file metadata.
    Please see :func:`copystat` for more information


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

**Summary**
Fix documentation in `shutil.rst` that contained two conflicting descriptions about `shutil.copy2` and `shutil.move`. Clarify that `copy2` attempts to preserve metadata but that individual metadata-copy operations may raise exceptions on some platforms or when privileges are insufficient; recommend using `shutil.copy` as the `copy_function` when higher robustness (avoiding metadata-related failures) is desired.



**Motivation**
The original text contained two mutually contradictory statements: one suggested that `copy2` "never raises an exception because it cannot preserve file metadata", while another said that using `copy` as the fallback `copy_function` for `move` allows the move to succeed when it is not possible to also copy metadata. After inspecting `Lib/shutil.py`, `copy2` calls `copystat()`, and `copystat()` may raise `OSError` for some metadata operations (for example, due to lack of privileges or platform limitations). The documentation should therefore state the behavior more precisely to avoid misleading users.

**Files changed**
- `Doc/library/shutil.rst` — modify a few lines to make the descriptions of `copy2` and `copy` consistent and clear:
  - State that `copy2` attempts to preserve additional metadata but that individual metadata-copy operations may fail and raise exceptions on certain platforms or when privileges are insufficient.
  - Recommend `shutil.copy` when callers want to avoid metadata-related errors (it copies only the file data and permission bits).

<!-- gh-issue-number: gh-125676 -->
* Issue: gh-125676
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137792.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->