### PR TITLE
gh-137777: Fix remove Program Frameworks chapter and relocate its modules

### DIFF
--- a/Doc/library/cmdlinelibs.rst
+++ b/Doc/library/cmdlinelibs.rst
@@ -19,3 +19,4 @@ Here's an overview:
    curses.rst
    curses.ascii.rst
    curses.panel.rst
+   cmd.rst

--- a/Doc/library/cmdlinelibs.rst
+++ b/Doc/library/cmdlinelibs.rst
@@ -1,7 +1,7 @@
 .. _cmdlinelibs:
 
 ********************************
-Command Line Interface Libraries
+Command-Line interface libraries
 ********************************
 
 The modules described in this chapter assist with implementing

--- a/Doc/library/cmdlinelibs.rst
+++ b/Doc/library/cmdlinelibs.rst
@@ -1,7 +1,7 @@
 .. _cmdlinelibs:
 
 ********************************
-Command-Line interface libraries
+Command-line interface libraries
 ********************************
 
 The modules described in this chapter assist with implementing

--- a/Doc/library/frameworks.rst
+++ b/Doc/library/frameworks.rst
@@ -3,7 +3,7 @@
 .. _frameworks:
 
 ******************
-Program Frameworks
+Program frameworks
 ******************
 
 This chapter is no longer maintained, and the modules it contained have been moved to their respective topical documentation.

--- a/Doc/library/frameworks.rst
+++ b/Doc/library/frameworks.rst
@@ -7,9 +7,7 @@ Program Frameworks
 ******************
 
 This chapter is no longer maintained, and the modules it contained have been moved to their respective topical documentation.
-Please see the following pages for their new locations:
 
-
-* :mod:`turtle` — :doc:`Graphical User Interfaces with Tk <./tk>`
 * :mod:`cmd` — :doc:`Command Line Interface Libraries <./cmdlinelibs>`
 * :mod:`shlex` — :doc:`Unix Specific Services <./unix>`
+* :mod:`turtle` — :doc:`Graphical User Interfaces with Tk <./tk>`

--- a/Doc/library/frameworks.rst
+++ b/Doc/library/frameworks.rst
@@ -10,6 +10,6 @@ This chapter is no longer maintained, and the modules it contained have been mov
 Please see the following pages for their new locations:
 
 
-* :mod:`turtle` — :doc:`Graphical User Interfaces with Tk <library/tk>`
-* :mod:`cmd` — :doc:`Command Line Interface Libraries <library/cmdlinelibs>`
-* :mod:`shlex` — :doc:`Unix Specific Services <library/unix>`
+* :mod:`turtle` — :doc:`Graphical User Interfaces with Tk <./tk>`
+* :mod:`cmd` — :doc:`Command Line Interface Libraries <./cmdlinelibs>`
+* :mod:`shlex` — :doc:`Unix Specific Services <./unix>`

--- a/Doc/library/frameworks.rst
+++ b/Doc/library/frameworks.rst
@@ -1,18 +1,15 @@
+:orphan:
+
 .. _frameworks:
 
 ******************
 Program Frameworks
 ******************
 
-The modules described in this chapter are frameworks that will largely dictate
-the structure of your program.  Currently the modules described  here are all
-oriented toward writing command-line interfaces.
-
-The full list of modules described in this chapter is:
+This chapter is no longer maintained, and the modules it contained have been moved to their respective topical documentation.
+Please see the following pages for their new locations:
 
 
-.. toctree::
-
-   turtle.rst
-   cmd.rst
-   shlex.rst
+* :mod:`turtle` — :doc:`Graphical User Interfaces with Tk <library/tk>`
+* :mod:`cmd` — :doc:`Command Line Interface Libraries <library/cmdlinelibs>`
+* :mod:`shlex` — :doc:`Unix Specific Services <library/unix>`

--- a/Doc/library/index.rst
+++ b/Doc/library/index.rst
@@ -63,7 +63,6 @@ the `Python Package Index <https://pypi.org>`_.
    internet.rst
    mm.rst
    i18n.rst
-   frameworks.rst
    tk.rst
    development.rst
    debug.rst

--- a/Doc/library/tk.rst
+++ b/Doc/library/tk.rst
@@ -1,7 +1,7 @@
 .. _tkinter:
 
 *********************************
-Graphical User Interfaces with Tk
+Graphical user interfaces with Tk
 *********************************
 
 .. index::

--- a/Doc/library/tk.rst
+++ b/Doc/library/tk.rst
@@ -39,6 +39,7 @@ alternative `GUI frameworks and tools <https://wiki.python.org/moin/GuiProgrammi
    tkinter.dnd.rst
    tkinter.ttk.rst
    idle.rst
+   turtle.rst
 
 .. Other sections I have in mind are
    Tkinter internals

--- a/Doc/library/unix.rst
+++ b/Doc/library/unix.rst
@@ -1,7 +1,7 @@
 .. _unix:
 
 **********************
-Unix Specific Services
+Unix-specific services
 **********************
 
 The modules described in this chapter provide interfaces to features that are
@@ -11,6 +11,7 @@ of it.  Here's an overview:
 
 .. toctree::
 
+   shlex.rst
    posix.rst
    pwd.rst
    grp.rst
@@ -20,4 +21,3 @@ of it.  Here's an overview:
    fcntl.rst
    resource.rst
    syslog.rst
-   shlex.rst

--- a/Doc/library/unix.rst
+++ b/Doc/library/unix.rst
@@ -20,3 +20,4 @@ of it.  Here's an overview:
    fcntl.rst
    resource.rst
    syslog.rst
+   shlex.rst


### PR DESCRIPTION
<!-- gh-issue-number: gh-137777 -->
* Issue: gh-137777
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137796.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->