### PR TITLE
gh-137760: Update REPL constants documentation

### DIFF
--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -97,15 +97,17 @@ should not be used in programs.
           exit(code=None)
 
    Objects that when printed, print a message like "Use quit() or Ctrl-D
-   (i.e. EOF) to exit", and when called, raise :exc:`SystemExit` with the
+   (i.e. EOF) to exit", and when accessed directly in the interactive 
+   interpreter or called as functions, raise :exc:`SystemExit` with the
    specified exit code.
 
 .. data:: help
    :noindex:
 
    Object that when printed, prints the message "Type help() for interactive
-   help, or help(object) for help about object.", and when called,
-   acts as described :func:`elsewhere <help>`.
+   help, or help(object) for help about object.", and when accessed directly
+   in the interactive interpreter, invokes the built-in help system 
+   (see :func:`help`).
 
 .. data:: copyright
           credits

--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -106,7 +106,7 @@ should not be used in programs.
 
    Object that when printed, prints the message "Type help() for interactive
    help, or help(object) for help about object.", and when accessed directly
-   in the interactive interpreter, invokes the built-in help system 
+   in the interactive interpreter, invokes the built-in help system
    (see :func:`help`).
 
 .. data:: copyright

--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -97,7 +97,7 @@ should not be used in programs.
           exit(code=None)
 
    Objects that when printed, print a message like "Use quit() or Ctrl-D
-   (i.e. EOF) to exit", and when accessed directly in the interactive 
+   (i.e. EOF) to exit", and when accessed directly in the interactive
    interpreter or called as functions, raise :exc:`SystemExit` with the
    specified exit code.
 


### PR DESCRIPTION
- #137760 

Update documentation for help, quit, and exit constants to reflect that they can be accessed directly in the interactive interpreter without parentheses, in addition to the traditional function call syntax.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-137760 -->
* Issue: gh-137760
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137798.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->