### PR TITLE
gh-137847: Add typical usage for uuid 6,7,8 in `/lib/uuid.py`

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -32,6 +32,19 @@ Typical usage:
     >>> uuid.uuid5(uuid.NAMESPACE_DNS, 'python.org')
     UUID('886313e1-3b8a-5372-9b90-0c9aee199e5d')
 
+    # make a UUID based on the host ID and current time
+    # reordered for improved DB locality
+    >>> uuid.uuid6()
+    UUID('1f0799c0-98b9-62db-92c6-a0d365b91053')
+
+    # make a UUID using time-ordered value field
+    >>> uuid.uuid7()
+    UUID('0198ac49-534e-7149-941a-12f66dec646a')
+
+    # make a UUID using three customizable fields
+    >>> uuid.uuid8(0x12345678, 0x9abcdef0, 0x11223344)
+    UUID('00001234-5678-8ef0-8000-000011223344')
+
     # make a UUID from a string of hex digits (braces and hyphens ignored)
     >>> x = uuid.UUID('{00010203-0405-0607-0809-0a0b0c0d0e0f}')
 


### PR DESCRIPTION
Before we've got some typical usage in the very beginning of uuid.py

```python
r"""UUID objects (universally unique identifiers) according to RFC 4122/9562.

This module provides immutable UUID objects (class UUID) and functions for
generating UUIDs corresponding to a specific UUID version as specified in
RFC 4122/9562, e.g., uuid1() for UUID version 1, uuid3() for UUID version 3,
and so on.

Note that UUID version 2 is deliberately omitted as it is outside the scope
of the RFC.

If all you want is a unique ID, you should probably call uuid1() or uuid4().
Note that uuid1() may compromise privacy since it creates a UUID containing
the computer's network address.  uuid4() creates a random UUID.

Typical usage:

    >>> import uuid

    # make a UUID based on the host ID and current time
    >>> uuid.uuid1()    # doctest: +SKIP
    UUID('a8098c1a-f86e-11da-bd1a-00112444be1e')

    # make a UUID using an MD5 hash of a namespace UUID and a name
    >>> uuid.uuid3(uuid.NAMESPACE_DNS, 'python.org')
    UUID('6fa459ea-ee8a-3ca4-894e-db77e160355e')

    # make a random UUID
    >>> uuid.uuid4()    # doctest: +SKIP
    UUID('16fd2706-8baf-433b-82eb-8c7fada847da')

    # make a UUID using a SHA-1 hash of a namespace UUID and a name
    >>> uuid.uuid5(uuid.NAMESPACE_DNS, 'python.org')
    UUID('886313e1-3b8a-5372-9b90-0c9aee199e5d')

    # make a UUID from a string of hex digits (braces and hyphens ignored)
    >>> x = uuid.UUID('{00010203-0405-0607-0809-0a0b0c0d0e0f}')

    # convert a UUID to a string of hex digits in standard form
    >>> str(x)
    '00010203-0405-0607-0809-0a0b0c0d0e0f'

    # get the raw 16 bytes of the UUID
    >>> x.bytes
    b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f'

    # make a UUID from a 16-byte string
    >>> uuid.UUID(bytes=x.bytes)
    UUID('00010203-0405-0607-0809-0a0b0c0d0e0f')

    # get the Nil UUID
    >>> uuid.NIL
    UUID('00000000-0000-0000-0000-000000000000')

    # get the Max UUID
    >>> uuid.MAX
    UUID('ffffffff-ffff-ffff-ffff-ffffffffffff')
"""
```
 but the typical usage stops at uuid5. This PR add more for newly uuids (6, 7, 8)
I'm using the old issue here XD.
skipping news.

<!-- gh-issue-number: gh-137847 -->
* Issue: gh-137847
<!-- /gh-issue-number -->
