### PR TITLE
gh-137790 Add an option to `logging.Formatter` to always set `record.exc_text` even if it's not None

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4926,6 +4926,20 @@ class FormatterTest(unittest.TestCase, AssertErrorMessage):
         f.format(r)
         self.assertEqual(exc_text, r.exc_text)
 
+    def test_multiple_formatters_set_exc_text(self):
+        # Tests that exc_text is changed when set_exc_text option is set on the Formatter
+        r = self.get_record()
+        r.exc_info = (ZeroDivisionError, ZeroDivisionError(), None)
+
+        f = logging.Formatter('${%(message)s}')
+        f.format(r)
+        self.assertIsNotNone(r.exc_text)
+        exc_text = r.exc_text
+
+        f = logging.Formatter('%(asctime)s', set_exc_text=True)
+        f.format(r)
+        self.assertNotEqual(exc_text, r.exc_text)
+
 
 class TestBufferingFormatter(logging.BufferingFormatter):
     def formatHeader(self, records):


### PR DESCRIPTION
Adds an optional field `set_exc_text` to `logging.Formatter` so that the `exc_text` field of the log record is always set even if it is not None.

Provides an option to bypass the issue in #137790 where only the first formatter will update `exc_text` if multiple handlers with formatters are added to a logger.

<!-- gh-issue-number: gh-137790 -->
* Issue: gh-137790
<!-- /gh-issue-number -->
