### PR TITLE
gh-96863: Fix subprocess.Popen.wait to raise ProcessLookupError for external waits

### DIFF
--- a/Lib/test/_test_eintr.py
+++ b/Lib/test/_test_eintr.py
@@ -101,7 +101,11 @@ class OSEINTRTest(EINTRBaseTest):
             wait_func()
         # Call the Popen method to avoid a ResourceWarning
         for proc in processes:
-            proc.wait()
+            try:
+                proc.wait()
+            except ProcessLookupError:
+                # Process already exited, which is expected but not always raised
+                pass
 
     def test_wait(self):
         self._test_wait_multiple(os.wait)
@@ -114,7 +118,11 @@ class OSEINTRTest(EINTRBaseTest):
         proc = self.new_sleep_process()
         wait_func(proc.pid)
         # Call the Popen method to avoid a ResourceWarning
-        proc.wait()
+        try:
+            proc.wait()
+        except ProcessLookupError:
+            # Process already exited, which is expected but not always raised
+            pass
 
     def test_waitpid(self):
         self._test_wait_single(lambda pid: os.waitpid(pid, 0))

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -607,11 +607,8 @@ class SubprocessMixin:
 
             # kill the process (but asyncio is not notified immediately)
             proc.kill()
-            try:
+            with self.assertRaises(ProcessLookupError):
                 proc.wait()
-            except ProcessLookupError:
-                # Process already exited, which is expected
-                pass
 
             proc.kill = mock.Mock()
             proc_returncode = proc.poll()

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -607,8 +607,12 @@ class SubprocessMixin:
 
             # kill the process (but asyncio is not notified immediately)
             proc.kill()
-            with self.assertRaises(ProcessLookupError):
+            try:
                 proc.wait()
+            except ProcessLookupError:
+                # Process already exited, which is expected but not always
+                # raised
+                pass
 
             proc.kill = mock.Mock()
             proc_returncode = proc.poll()

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -607,7 +607,11 @@ class SubprocessMixin:
 
             # kill the process (but asyncio is not notified immediately)
             proc.kill()
-            proc.wait()
+            try:
+                proc.wait()
+            except ProcessLookupError:
+                # Process already exited, which is expected
+                pass
 
             proc.kill = mock.Mock()
             proc_returncode = proc.poll()

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -3377,8 +3377,8 @@ class POSIXProcessTestCase(BaseTestCase):
             proc.wait()
 
         # Verify the exception contains proper information
-        exc = cm.exception
-        self.assertIn('%d is already waited on externally' % proc.pid, str(exc))
+        self.assertIn(f'{proc.pid} is already waited on externally',
+                      str(cm.exception))
         proc.kill()
 
     def test_send_signal_race(self):

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -3379,6 +3379,7 @@ class POSIXProcessTestCase(BaseTestCase):
         # Verify the exception contains proper information
         exc = cm.exception
         self.assertIn('%d is already waited on externally' % proc.pid, str(exc))
+        proc.kill()
 
     def test_send_signal_race(self):
         # bpo-38630: send_signal() must poll the process exit status to reduce

--- a/Misc/NEWS.d/next/Library/2025-08-15-14-06-33.gh-issue-96863.rUk3aJ.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-15-14-06-33.gh-issue-96863.rUk3aJ.rst
@@ -1,0 +1,3 @@
+Fix :meth:`subprocess.Popen.wait` returning zero always when process already
+waited on externally. Now raises :exc:`ProcessLookupError` instead of losing
+exit status. Preserves ``SIGCHLD=SIG_IGN`` compatibility.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Patch for the Issue: https://github.com/python/cpython/issues/96863

<!-- gh-issue-number: gh-96863 -->
* Issue: gh-96863
<!-- /gh-issue-number -->
