### PR TITLE
gh-131178: Fix `test_unknown_flag` for platform CLI

### DIFF
--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -762,13 +762,14 @@ class CommandLineTest(unittest.TestCase):
             platform._main(args=flags)
         return output.getvalue()
 
+    @support.force_not_colorized
     def test_unknown_flag(self):
+        output = io.StringIO()
         with self.assertRaises(SystemExit):
-            output = io.StringIO()
             # suppress argparse error message
             with contextlib.redirect_stderr(output):
                 _ = self.invoke_platform('--unknown')
-            self.assertStartsWith(output, "usage: ")
+        self.assertStartsWith(output.getvalue(), "usage: ")
 
     def test_invocation(self):
         flags = (


### PR DESCRIPTION
Issue is that `self.assertStartsWith` will ordinarily never be called due to the `SystemExit`.

<!-- gh-issue-number: gh-131178 -->
* Issue: gh-131178
<!-- /gh-issue-number -->
