### PR TITLE
gh-90483: fix docs of `SubprocessTransport.get_pipe_transport `

### DIFF
--- a/Doc/library/asyncio-protocol.rst
+++ b/Doc/library/asyncio-protocol.rst
@@ -390,11 +390,11 @@ Subprocess Transports
    Return the transport for the communication pipe corresponding to the
    integer file descriptor *fd*:
 
-   * ``0``: readable streaming transport of the standard input (*stdin*),
+   * ``0``: writable streaming transport of the standard input (*stdin*),
      or :const:`None` if the subprocess was not created with ``stdin=PIPE``
-   * ``1``: writable streaming transport of the standard output (*stdout*),
+   * ``1``: readable streaming transport of the standard output (*stdout*),
      or :const:`None` if the subprocess was not created with ``stdout=PIPE``
-   * ``2``: writable streaming transport of the standard error (*stderr*),
+   * ``2``: readable streaming transport of the standard error (*stderr*),
      or :const:`None` if the subprocess was not created with ``stderr=PIPE``
    * other *fd*: :const:`None`
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-90483 -->
* Issue: gh-90483
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137852.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->