### PR TITLE
gh-137846: Add missing 'be' to profile doc.

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -791,7 +791,7 @@ Analysis of the profiler data is done using the :class:`~pstats.Stats` class.
       significant entries.  Initially, the list is taken to be the complete set
       of profiled functions.  Each restriction is either an integer (to select a
       count of lines), or a decimal fraction between 0.0 and 1.0 inclusive (to
-      select a percentage of lines), or a string that will interpreted as a
+      select a percentage of lines), or a string that will be interpreted as a
       regular expression (to pattern match the standard name that is printed).
       If several restrictions are provided, then they are applied sequentially.
       For example::


### PR DESCRIPTION
Insert 'be' into 'will interpreted'.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-137846 -->
* Issue: gh-137846
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137856.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->