### PR TITLE
gh-90548: Fix musl version detection with --strip-all

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -223,7 +223,7 @@ def libc_ver(executable=None, lib='', version='', chunksize=16384):
             decoded_groups = [s.decode('latin1') if s is not None else s
                               for s in m.groups()]
             (libcinit, glibc, glibcversion, so, threads, soversion,
-             musl, muslversion, musl_so, musl_sover) = decoded_groups 
+             musl, muslversion, musl_so, musl_sover) = decoded_groups
             if libcinit and not lib:
                 lib = 'libc'
             elif glibc:

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -194,6 +194,7 @@ def libc_ver(executable=None, lib='', version='', chunksize=16384):
         | (GLIBC_([0-9.]+))
         | (libc(_\w+)?\.so(?:\.(\d[0-9.]*))?)
         | (musl-([0-9.]+))
+        | (libc.musl(?:-\w+)?.so(?:\.(\d[0-9.]*))?)
         """,
         re.ASCII | re.VERBOSE)
 
@@ -219,7 +220,10 @@ def libc_ver(executable=None, lib='', version='', chunksize=16384):
                     continue
                 if not m:
                     break
-            libcinit, glibc, glibcversion, so, threads, soversion, musl, muslversion = [
+            (
+                libcinit, glibc, glibcversion, so, threads, soversion,
+                musl, muslversion, musl_so, musl_sover
+            ) = [
                 s.decode('latin1') if s is not None else s
                 for s in m.groups()]
             if libcinit and not lib:
@@ -241,6 +245,10 @@ def libc_ver(executable=None, lib='', version='', chunksize=16384):
                 lib = 'musl'
                 if not ver or V(muslversion) > V(ver):
                     ver = muslversion
+            elif musl_so:
+                lib = 'musl'
+                if musl_sover and (not ver or V(musl_sover) > V(ver)):
+                    ver = musl_sover
             pos = m.end()
     return lib, version if ver is None else ver
 

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -220,12 +220,10 @@ def libc_ver(executable=None, lib='', version='', chunksize=16384):
                     continue
                 if not m:
                     break
-            (
-                libcinit, glibc, glibcversion, so, threads, soversion,
-                musl, muslversion, musl_so, musl_sover
-            ) = [
-                s.decode('latin1') if s is not None else s
-                for s in m.groups()]
+            decoded_groups = [s.decode('latin1') if s is not None else s
+                              for s in m.groups()]
+            (libcinit, glibc, glibcversion, so, threads, soversion,
+             musl, muslversion, musl_so, musl_sover) = decoded_groups 
             if libcinit and not lib:
                 lib = 'libc'
             elif glibc:

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -565,6 +565,8 @@ class PlatformTest(unittest.TestCase):
                 # musl uses semver, but we accept some variations anyway:
                 (b'/aports/main/musl/src/musl-12.5', ('musl', '12.5')),
                 (b'/aports/main/musl/src/musl-1.2.5.7', ('musl', '1.2.5.7')),
+                (b'libc.musl.so.1', ('musl', '1')),
+                (b'libc.musl-x86_64.so.1.2.5', ('musl', '1.2.5')),
                 (b'', ('', '')),
             ):
                 with open(filename, 'wb') as fp:
@@ -583,6 +585,10 @@ class PlatformTest(unittest.TestCase):
                 (b'GLIBC_1.23.4\0GLIBC_1.9\0GLIBC_1.21\0', ('glibc', '1.23.4')),
                 (b'libc.so.2.4\0libc.so.9\0libc.so.23.1\0', ('libc', '23.1')),
                 (b'musl-1.4.1\0musl-2.1.1\0musl-2.0.1\0', ('musl', '2.1.1')),
+                (
+                    b'libc.musl-x86_64.so.1.4.1\0libc.musl-x86_64.so.2.1.1\0libc.musl-x86_64.so.2.0.1',
+                    ('musl', '2.1.1'),
+                ),
                 (b'no match here, so defaults are used', ('test', '100.1.0')),
             ):
             with open(filename, 'wb') as f:

--- a/Misc/NEWS.d/next/Library/2025-08-16-18-11-41.gh-issue-90548.q3aJUK.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-16-18-11-41.gh-issue-90548.q3aJUK.rst
@@ -1,0 +1,2 @@
+Fix ``musl`` detection for :func:`platform.libc_ver` on Alpine Linux if
+compiled with --strip-all.


### PR DESCRIPTION
The change introduced in #131313 accidentally broke the musl version detection for `test.support.linked_with_musl` if cpython is compiled with `--strip-all`. In these cases the regex in `platform.libc_ver` should match the filename: `libc.musl-x86_64.so.1`.
https://pkgs.alpinelinux.org/contents?file=libc.*&path=&name=musl&branch=edge&repo=main&arch=

`--strip-all` is used among other things by the Alpine based Python docker image.
https://github.com/docker-library/python/blob/19c93d12094b07ecc21f67144a309c2fa0a10ef0/3.14-rc/alpine3.22/Dockerfile#L74

With this change:
```
./configure
make LDFLAGS="-Wl,--strip-all"

/usr/src # LD_LIBRARY_PATH=$PWD ./python.exe
Python 3.14.0rc2 (main, Aug 16 2025, 14:50:44) [GCC 14.2.0] on linux
>>> import test.support
>>> test.support.linked_to_musl()
(1,)

/usr/src # LD_LIBRARY_PATH=$PWD ./python.exe -m test.pythoninfo|grep libc
platform.libc_ver: musl 1
```

/CC @bitdancer

<!-- gh-issue-number: gh-90548 -->
* Issue: gh-90548
<!-- /gh-issue-number -->
