### PR TITLE
Fix double period typo in unittest.mock AttributeError message

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -664,7 +664,7 @@ class NonCallableMock(Base):
             if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')) or name in _ATTRIB_DENY_LIST:
                 raise AttributeError(
                     f"{name!r} is not a valid assertion. Use a spec "
-                    f"for the mock if {name!r} is meant to be an attribute.")
+                    f"for the mock if {name!r} is meant to be an attribute")
 
         with NonCallableMock._lock:
             result = self._mock_children.get(name)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


## Summary

Fix a typo in the unittest.mock error message where a double period (`..`) appeared in the AttributeError when an invalid assertion method is used.

**Before:**

```bash
>>> from unittest import mock
>>> m = mock.Mock()
>>> m(1,2)
<Mock name='mock()' id='4344084816'>
>>> m.assert_called_twice()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/mock.py", line 665, in __getattr__
    raise AttributeError(
AttributeError: 'assert_called_twice' is not a valid assertion. Use a spec for the mock if 'assert_called_twice' is meant to be an attribute.. Did you mean: 'assert_called_once'?
```
**After:**

```bash
>>> from unittest import mock
>>> m = mock.Mock()
>>> m(1,2)
<Mock name='mock()' id='4345214112'>
>>> m.assert_called_twice()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/mock.py", line 665, in __getattr__
    raise AttributeError(
AttributeError: 'assert_called_twice' is not a valid assertion. Use a spec for the mock if 'assert_called_twice' is meant to be an attribute. Did you mean: 'assert_called_once'?
```

This is a trivial typo fix that improves the user experience when debugging mock assertion errors.
