### PR TITLE
gh-137871: Clarify cmath.nan documentation by linking to math module

### DIFF
--- a/Doc/library/cmath.rst
+++ b/Doc/library/cmath.rst
@@ -322,7 +322,7 @@ Constants
 
 .. data:: inf
 
-   Floating-point positive infinity. Equivalent to ``float('inf')``.
+   Floating-point positive infinity. Equivalent to :data:`math.inf`.
 
    .. versionadded:: 3.6
 
@@ -338,7 +338,7 @@ Constants
 .. data:: nan
 
    A floating-point "not a number" (NaN) value.  Equivalent to
-   ``float('nan')``.
+   :data:`math.nan`.
 
    .. versionadded:: 3.6
 

--- a/Doc/library/cmath.rst
+++ b/Doc/library/cmath.rst
@@ -338,7 +338,9 @@ Constants
 .. data:: nan
 
    A floating-point "not a number" (NaN) value.  Equivalent to
-   :data:`math.nan`.
+   ``float('nan')``.
+
+   See also :data:`math.nan`.
 
    .. versionadded:: 3.6
 

--- a/Doc/library/cmath.rst
+++ b/Doc/library/cmath.rst
@@ -322,7 +322,7 @@ Constants
 
 .. data:: inf
 
-   Floating-point positive infinity. Equivalent to :data:`math.inf`.
+   Floating-point positive infinity. Equivalent to ``float('inf')``.
 
    .. versionadded:: 3.6
 

--- a/Doc/library/cmath.rst
+++ b/Doc/library/cmath.rst
@@ -338,9 +338,7 @@ Constants
 .. data:: nan
 
    A floating-point "not a number" (NaN) value.  Equivalent to
-   ``float('nan')``.
-
-   See also :data:`math.nan`.
+   ``float('nan')``. See also :data:`math.nan`.
 
    .. versionadded:: 3.6
 


### PR DESCRIPTION
The documentation for `cmath.nan`  is updated to cross-reference the equivalent constants in the `math` module.

The `math` module's documentation contains a more thorough explanation of the properties of these special floating-point values, as required by the IEEE 754 standard (e.g., that NaN does not compare equal to itself).


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-137871 -->
* Issue: gh-137871
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137876.org.readthedocs.build/en/137876/library/cmath.html#cmath.nan

<!-- readthedocs-preview cpython-previews end -->