### PR TITLE
Emend an error in ``string.templatelib`` example output

### DIFF
--- a/Doc/library/string.templatelib.rst
+++ b/Doc/library/string.templatelib.rst
@@ -34,7 +34,7 @@ To write a t-string, use a ``'t'`` prefix instead of an ``'f'``, like so:
    >>> pi = 3.14
    >>> t't-strings are new in Python {pi!s}!'
    Template(
-      strings=('t-strings are new in Python ', '.'),
+      strings=('t-strings are new in Python ', '!'),
       interpolations=(Interpolation(3.14, 'pi', 's', ''),)
    )
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Fixes a subtle typo in templatelib documentation

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137890.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->