### PR TITLE
gh-137894: Fix segmentation fault in deeply nested filter() iterator chains

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1132,8 +1132,6 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         del i
         gc.collect()
 
-    @support.skip_wasi_stack_overflow()
-    @support.skip_emscripten_stack_overflow()
     @support.requires_resource('cpu')
     def test_filter_deep_nesting_recursion_error(self):
         # gh-137894: Test that deeply nested filter() iterator chains

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1143,7 +1143,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         i = filter(bool, range(1000000))
         for _ in range(100000):
             i = filter(bool, i)
-        
+
         # Should raise RecursionError, not segmentation fault
         with self.assertRaises(RecursionError):
             list(i)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1132,7 +1132,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         del i
         gc.collect()
 
-    
+
     def test_filter_deep_nesting_recursion_error(self):
         # gh-137894: Test that deeply nested filter() iterator chains
         # raise RecursionError instead of causing segmentation fault.

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1132,7 +1132,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         del i
         gc.collect()
 
-    @support.requires_resource('cpu')
+    
     def test_filter_deep_nesting_recursion_error(self):
         # gh-137894: Test that deeply nested filter() iterator chains
         # raise RecursionError instead of causing segmentation fault.
@@ -1142,9 +1142,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         for _ in range(100000):
             i = filter(bool, i)
 
-        # Should raise RecursionError, not segmentation fault
-        with self.assertRaises(RecursionError):
-            list(i)
+        self.assertRaises(RecursionError, list, i)
 
     def test_getattr(self):
         self.assertTrue(getattr(sys, 'stdout') is sys.stdout)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1121,7 +1121,6 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
 
     @support.skip_wasi_stack_overflow()
     @support.skip_emscripten_stack_overflow()
-    @support.requires_resource('cpu')
     def test_filter_dealloc(self):
         # Tests recursive deallocation of nested filter objects using the
         # thrashcan mechanism. See gh-102356 for more details.
@@ -1131,8 +1130,10 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             i = filter(bool, i)
         del i
         gc.collect()
-
-
+    6
+    @support.skip_wasi_stack_overflow()
+    @support.skip_emscripten_stack_overflow()
+    @support.requires_resource('cpu')
     def test_filter_deep_nesting_recursion_error(self):
         # gh-137894: Test that deeply nested filter() iterator chains
         # raise RecursionError instead of causing segmentation fault.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-18-08-14-52.gh-issue-137894.SrkIA_.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-18-08-14-52.gh-issue-137894.SrkIA_.rst
@@ -1,6 +1,3 @@
-Fix segmentation fault in deeply nested :func:`filter` iterator chains by
-adding a ``tp_clear`` method to the filter object. Previously, creating
-thousands of nested filter iterators and then consuming them would cause
-a stack overflow during garbage collection, leading to interpreter crashes.
-Now such cases properly raise :exc:`RecursionError` instead of crashing
-the interpreter.
+Fix segmentation fault in deeply nested :func:`filter` iterator chains.
+Deeply nested filter iterators now properly raise :exc:`RecursionError`
+instead of crashing the interpreter.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-18-08-14-52.gh-issue-137894.SrkIA_.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-18-08-14-52.gh-issue-137894.SrkIA_.rst
@@ -1,0 +1,6 @@
+Fix segmentation fault in deeply nested :func:`filter` iterator chains by
+adding a ``tp_clear`` method to the filter object. Previously, creating
+thousands of nested filter iterators and then consuming them would cause
+a stack overflow during garbage collection, leading to interpreter crashes.
+Now such cases properly raise :exc:`RecursionError` instead of crashing
+the interpreter.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -670,7 +670,7 @@ PyTypeObject PyFilter_Type = {
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
     filter_doc,                         /* tp_doc */
     filter_traverse,                    /* tp_traverse */
-    filter_clear,              /* tp_clear */
+    filter_clear,                       /* tp_clear */
     0,                                  /* tp_richcompare */
     0,                                  /* tp_weaklistoffset */
     PyObject_SelfIter,                  /* tp_iter */

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -580,8 +580,9 @@ filter_traverse(PyObject *self, visitproc visit, void *arg)
 }
 
 static int
-filter_clear(filterobject *lz)
+filter_clear(PyObject *self)
 {
+    filterobject *lz = _filterobject_CAST(self);
     Py_CLEAR(lz->it);
     Py_CLEAR(lz->func);
     return 0;
@@ -668,7 +669,7 @@ PyTypeObject PyFilter_Type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
     filter_doc,                         /* tp_doc */
-    (traverseproc)filter_traverse,      /* tp_traverse */
+    filter_traverse,                    /* tp_traverse */
     (inquiry)filter_clear,              /* tp_clear */
     0,                                  /* tp_richcompare */
     0,                                  /* tp_weaklistoffset */

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -579,6 +579,14 @@ filter_traverse(PyObject *self, visitproc visit, void *arg)
     return 0;
 }
 
+static int
+filter_clear(filterobject *lz)
+{
+    Py_CLEAR(lz->it);
+    Py_CLEAR(lz->func);
+    return 0;
+}
+
 static PyObject *
 filter_next(PyObject *self)
 {
@@ -660,8 +668,8 @@ PyTypeObject PyFilter_Type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
     filter_doc,                         /* tp_doc */
-    filter_traverse,                    /* tp_traverse */
-    0,                                  /* tp_clear */
+    (traverseproc)filter_traverse,      /* tp_traverse */
+    (inquiry)filter_clear,              /* tp_clear */
     0,                                  /* tp_richcompare */
     0,                                  /* tp_weaklistoffset */
     PyObject_SelfIter,                  /* tp_iter */

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -670,7 +670,7 @@ PyTypeObject PyFilter_Type = {
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
     filter_doc,                         /* tp_doc */
     filter_traverse,                    /* tp_traverse */
-    (inquiry)filter_clear,              /* tp_clear */
+    filter_clear,              /* tp_clear */
     0,                                  /* tp_richcompare */
     0,                                  /* tp_weaklistoffset */
     PyObject_SelfIter,                  /* tp_iter */


### PR DESCRIPTION
## Summary

Fixed a critical segmentation fault bug in Python 3.13 where creating deeply nested chains of `filter()` iterators would crash the interpreter instead of raising a proper Python exception. The fix adds a `tp_clear` method to the filter object to prevent stack overflow during garbage collection of cyclic references.

## Problem

When creating deeply nested `filter()` iterator chains (e.g., applying `filter()` thousands of times in a loop), Python 3.13 would crash with a segmentation fault instead of raising a `RecursionError`. This violates Python's fundamental principle that user code should never be able to crash the interpreter.

Example problematic code:
```python
i = filter(bool, range(1000000))
for _ in range(100000):
    i = filter(bool, i)
print(list(i))  # Segmentation fault in Python 3.13
```

**Expected behavior**: Should raise `RecursionError` or similar Python exception
**Actual behavior**: Segmentation fault (interpreter crash)

## Root Cause

The `filter` object type in `Python/bltinmodule.c` was missing a `tp_clear` method implementation. During garbage collection of deeply nested filter iterator chains, the garbage collector would attempt to deallocate objects through recursive calls to `filter_dealloc()`, eventually exceeding the C stack limit and causing a segmentation fault.

## Solution

Added a `tp_clear` method to the filter object type:

1. **Implemented `filter_clear()` function**:
   ```c
   static int
   filter_clear(filterobject *lz)
   {
       Py_CLEAR(lz->it);
       Py_CLEAR(lz->func);
       return 0;
   }
   ```

2. **Updated `PyFilter_Type` definition**:
   ```c
   // Changed from:
   0,                                  /* tp_clear */
   // To:
   (inquiry)filter_clear,              /* tp_clear */
   ```

The `tp_clear` method allows the garbage collector to break reference cycles safely without relying on deep recursive deallocation, preventing stack overflow crashes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-137894 -->
* Issue: gh-137894
<!-- /gh-issue-number -->
