### PR TITLE
gh-137897: Deprecate the `-R` option

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.17.rst
+++ b/Doc/deprecations/pending-removal-in-3.17.rst
@@ -8,3 +8,9 @@ Pending removal in Python 3.17
     but it has been retained for backward compatibility, with removal scheduled for Python
     3.17. Users should use documented introspection helpers like :func:`typing.get_origin`
     and :func:`typing.get_args` instead of relying on private implementation details.
+
+* CLI:
+
+  - The :option:`-R` option. This option is does not have an effect
+    in most cases as hash randomization is enabled by default since Python 3.3.
+    See :gh:`137897` and :meth:`~object.__hash__` for more information.

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -372,16 +372,7 @@ Miscellaneous options
    :envvar:`PYTHONHASHSEED` environment variable is set to ``0``, since hash
    randomization is enabled by default.
 
-   On previous versions of Python, this option turns on hash randomization,
-   so that the :meth:`~object.__hash__` values of str and bytes objects
-   are "salted" with an unpredictable random value.  Although they remain
-   constant within an individual Python process, they are not predictable
-   between repeated invocations of Python.
-
-   Hash randomization is intended to provide protection against a
-   denial-of-service caused by carefully chosen inputs that exploit the worst
-   case performance of a dict construction, *O*\ (*n*\ :sup:`2`) complexity.  See
-   http://ocert.org/advisories/ocert-2011-003.html for details.
+   See :meth:`~object.__hash__` for more information about hash randomization.
 
    :envvar:`PYTHONHASHSEED` allows you to set a fixed value for the hash
    seed secret.
@@ -390,6 +381,8 @@ Miscellaneous options
 
    .. versionchanged:: 3.7
       The option is no longer ignored.
+
+   .. deprecated-removed:: next 3.17
 
 
 .. option:: -s

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -417,6 +417,16 @@ module_name
 Deprecated
 ==========
 
+CLI
+___
+
+* The :option:`-R` option. This option is does not have an effect
+  in most cases as hash randomization is enabled by default since Python 3.3.
+  See :meth:`~object.__hash__` for more information about hash randomization.
+
+  (Contributed by Stan Ulbrych in :gh:`137897`)
+
+
 hashlib
 -------
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -418,7 +418,7 @@ Deprecated
 ==========
 
 CLI
-___
+---
 
 * The :option:`-R` option. This option is does not have an effect
   in most cases as hash randomization is enabled by default since Python 3.3.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-18-12-07-31.gh-issue-137897.HkbF2f.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-18-12-07-31.gh-issue-137897.HkbF2f.rst
@@ -1,0 +1,2 @@
+Deprecate the :option:`-R` command line option, and schedule for removal in
+3.17

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -3019,6 +3019,9 @@ config_parse_cmdline(PyConfig *config, PyWideStringList *warnoptions,
             break;
 
         case 'R':
+            fprintf(stderr,
+                    "The -R option is deprecated since Python 3.15 and "
+                    "will be removed in Python 3.17\n");
             config->use_hash_seed = 0;
             break;
 


### PR DESCRIPTION
I have also removed the duplicated docs, which can be found under the `__hash__` doc.

https://github.com/python/cpython/blob/0c8fecc4cfc41e82307a089c474dc69b009bdbcc/Doc/reference/datamodel.rst?plain=1#L2220-L2236

<!-- gh-issue-number: gh-137897 -->
* Issue: gh-137897
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137898.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->