### PR TITLE
gh-114212:Note 3.13 stack order change for LOAD_GLOBAL/LOAD_ATTR/LOAD_SUPER_ATTR

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1259,12 +1259,17 @@ iterations of the loop.
    correct name, the bytecode pushes the unbound method and ``STACK[-1]``.
    ``STACK[-1]`` will be used as the first argument (``self``) by :opcode:`CALL`
    or :opcode:`CALL_KW` when calling the unbound method.
-   Otherwise, ``NULL`` and the object returned by
-   the attribute lookup are pushed.
+   Otherwise, the object returned by the attribute lookup and ``NULL`` are
+   pushed (in that order).
 
    .. versionchanged:: 3.12
-      If the low bit of ``namei`` is set, then a ``NULL`` or ``self`` is
+      If the low bit of ``namei`` is set, then a ``NULL`` or ``self`` was
       pushed to the stack before the attribute or unbound method respectively.
+
+   .. versionchanged:: 3.13
+      The push order changed to keep the callable at a fixed stack position for
+      :opcode:`CALL`: the attribute or unbound method is now pushed before the
+      ``NULL``/``self`` marker (previously the marker was pushed first).
 
 
 .. opcode:: LOAD_SUPER_ATTR (namei)
@@ -1283,13 +1288,19 @@ iterations of the loop.
    except that ``namei`` is shifted left by 2 bits instead of 1.
 
    The low bit of ``namei`` signals to attempt a method load, as with
-   :opcode:`LOAD_ATTR`, which results in pushing ``NULL`` and the loaded method.
+   :opcode:`LOAD_ATTR`, which results in pushing the loaded method and ``NULL``
+   (in that order).
    When it is unset a single value is pushed to the stack.
 
    The second-low bit of ``namei``, if set, means that this was a two-argument
    call to :func:`super` (unset means zero-argument).
 
    .. versionadded:: 3.12
+
+   .. versionchanged:: 3.13
+      The push order for method loads changed to keep the callable at a fixed
+      stack position for :opcode:`CALL`: the loaded method is now pushed before
+      the ``NULL`` marker (previously the marker was pushed first).
 
 
 .. opcode:: COMPARE_OP (opname)
@@ -1421,6 +1432,11 @@ iterations of the loop.
    .. versionchanged:: 3.11
       If the low bit of ``namei`` is set, then a ``NULL`` is pushed to the
       stack before the global variable.
+
+   .. versionchanged:: 3.13
+      The push order changed to keep the callable at a fixed stack position for
+      :opcode:`CALL`: the global is now pushed before the ``NULL`` marker
+      (previously the marker was pushed first).
 
 .. opcode:: LOAD_FAST (var_num)
 


### PR DESCRIPTION
### Summary

Document the Python 3.13 change in the stack push order for LOAD_GLOBAL, LOAD_ATTR, and LOAD_SUPER_ATTR so that the callable stays at a fixed position for CALL/CALL_KW.
### Changes
* dis.rst:
1.  Add versionchanged:: 3.13 for the three opcodes.
2. Clarify that the value (global/attribute/method) is pushed before NULL/self.
3. Keep 3.11/3.12 notes accurate by using past tense to avoid conflict with 3.13.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-114212 -->
* Issue: gh-114212
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137909.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->