### PR TITLE
gh-137986: Fix `csv.register_dialect` docstring

### DIFF
--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1735,7 +1735,7 @@ PyDoc_STRVAR(csv_writer_doc,
 
 PyDoc_STRVAR(csv_register_dialect_doc,
 "Create a mapping from a string name to a dialect class.\n"
-"    dialect = csv.register_dialect(name[, dialect[, **fmtparams]])");
+"    csv.register_dialect(name[, dialect[, **fmtparams]])");
 
 static struct PyMethodDef csv_methods[] = {
     { "reader", _PyCFunction_CAST(csv_reader),


### PR DESCRIPTION
The current docstring:

- https://github.com/python/cpython/blob/719e5c3f7111bcda5eee72fe648786c427c4d4c2/Modules/_csv.c#L1738

is incorrect, since the function does not return the dialect:

- https://github.com/python/cpython/blob/719e5c3f7111bcda5eee72fe648786c427c4d4c2/Modules/_csv.c#L1610

This is a public method:

- https://docs.python.org/3/library/csv.html#csv.register_dialect

I'm not sure if it warrants a `NEWS.d` entry.