### PR TITLE
gh-137952: update `csv.Sniffer().has_header()` docs to describe the actual off-by-onish behavior

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -294,8 +294,8 @@ The :mod:`csv` module defines the following classes:
       - the second through n-th rows contain strings where at least one value's
         length differs from that of the putative header of that column.
 
-      Twenty rows after the first row are sampled; if more than half of columns +
-      rows meet the criteria, :const:`True` is returned.
+      Twenty-one rows after the first row are sampled; if more than half of
+      columns + rows meet the criteria, :const:`True` is returned.
 
    .. note::
 

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -294,7 +294,7 @@ The :mod:`csv` module defines the following classes:
       - the second through n-th rows contain strings where at least one value's
         length differs from that of the putative header of that column.
 
-      Twenty-one rows after the first row are sampled; if more than half of
+      Twenty-one rows after the first row are sampled; if more than half of the
       columns + rows meet the criteria, :const:`True` is returned.
 
    .. note::

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -294,7 +294,7 @@ The :mod:`csv` module defines the following classes:
       - the second through n-th rows contain strings where at least one value's
         length differs from that of the putative header of that column.
 
-      Twenty-one rows after the first row are sampled; if more than half of the
+      Twenty-one rows after the header are sampled; if more than half of the
       columns + rows meet the criteria, :const:`True` is returned.
 
    .. note::


### PR DESCRIPTION
Please see gh-137952 for the context.

The question is whether we should fix the docs or the code.

I err on the docs: `csv.Sniffer()` is very old, users may rely on this behavior without knowing it.

<!-- gh-issue-number: gh-137952 -->
* Issue: gh-137952
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137953.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->