### PR TITLE
gh-137944: use `argparse` instead of `getopt` in `timeit`

### DIFF
--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -353,6 +353,14 @@ class TestTimeit(unittest.TestCase):
             s = self.run_main(switches=['-n1', '1/0'])
         self.assert_exc_string(error_stringio.getvalue(), 'ZeroDivisionError')
 
+    def test_main_with_option_like_at_the_end(self):
+        with captured_stderr() as s:
+            self.run_main(switches=['-n1', '1 + 1', '-n1'])
+        self.assert_exc_string(s.getvalue(), "NameError: name 'n1' is not defined")
+
+        out = self.run_main(switches=['-n2', '-r2', 'n2=1', '-n2'])
+        self.assertEqual(out, "2 loops, best of 2: 1 sec per loop\n")
+
     def autorange(self, seconds_per_increment=1/1024, callback=None):
         timer = FakeTimer(seconds_per_increment=seconds_per_increment)
         t = timeit.Timer(stmt=self.fake_stmt, setup=self.fake_setup, timer=timer)

--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -252,11 +252,9 @@ class TestTimeit(unittest.TestCase):
         return s.getvalue()
 
     def test_main_bad_switch(self):
-        s = self.run_main(switches=['--bad-switch'])
-        self.assertEqual(s, dedent("""\
-            option --bad-switch not recognized
-            use -h/--help for command line help
-            """))
+        with self.assertRaises(SystemExit), captured_stderr() as s:
+            self.run_main(switches=['--bad-switch'])
+        self.assertIn("unrecognized arguments: --bad-switch", s.getvalue())
 
     def test_main_seconds(self):
         s = self.run_main(seconds_per_increment=5.5)
@@ -293,11 +291,6 @@ class TestTimeit(unittest.TestCase):
     def test_main_negative_reps(self):
         s = self.run_main(seconds_per_increment=60.0, switches=['-r-5'])
         self.assertEqual(s, "1 loop, best of 1: 60 sec per loop\n")
-
-    @unittest.skipIf(sys.flags.optimize >= 2, "need __doc__")
-    def test_main_help(self):
-        s = self.run_main(switches=['-h'])
-        self.assertEqual(s, timeit.__doc__)
 
     def test_main_verbose(self):
         s = self.run_main(switches=['-v'])
@@ -345,11 +338,10 @@ class TestTimeit(unittest.TestCase):
         self.assertEqual(unit_usec,
                 "100 loops, best of 5: 3e+03 usec per loop\n")
         # Test invalid unit input
-        with captured_stderr() as error_stringio:
-            invalid = self.run_main(seconds_per_increment=0.003,
-                    switches=['-u', 'parsec'])
-        self.assertEqual(error_stringio.getvalue(),
-                    "Unrecognized unit. Please select nsec, usec, msec, or sec.\n")
+        with self.assertRaises(SystemExit), captured_stderr() as s:
+            self.run_main(seconds_per_increment=0.003,
+                          switches=['-u', 'parsec'])
+        self.assertIn("invalid choice: 'parsec'", s.getvalue())
 
     def test_main_exception(self):
         with captured_stderr() as error_stringio:

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -227,6 +227,9 @@ separate argument; indented lines are possible by enclosing an
 argument in quotes and using leading spaces.  Multiple -s options are
 treated similarly.
 
+Use "--" to separate command-line options from actual statements,
+or when a statement starts with '-'.
+
 If -n is not given, a suitable number of loops is calculated by trying
 increasing numbers from the sequence 1, 2, 5, 10, 20, 50, ... until the
 total time is at least 0.2 seconds.
@@ -265,13 +268,9 @@ measured by invoking the program without arguments.""",
         "-v", "--verbose", action="count", default=0,
         help="print raw timing results; repeat for more digits precision",
     )
-    # add a dummy option to document '--'
-    group.add_argument(
-        "--", dest="_", action="store_const", const=None,
-        help="separate options from statement; "
-             "use when statement starts with -",
-    )
-    # use argparse.REMAINDER to ignore option-like argument found at the end
+    # Use argparse.REMAINDER to ignore option-like argument found at the end.
+    # If '--' is being specified as the "first" statement, it will be ignored
+    # and used to separate the options from the list of statements.
     group.add_argument(
         "statement", nargs=argparse.REMAINDER,
         help="statement to be timed (default: 'pass')",
@@ -300,6 +299,8 @@ def main(args=None, *, _wrap_timer=None):
     args = parser.parse_args(args)
 
     setup = "\n".join(args.setup) or "pass"
+    if args.statement and args.statement[0] == '--':
+        args.statement.pop(0)
     stmt = "\n".join(args.statement) or "pass"
     timer = time.process_time if args.process else default_timer
     number = args.number  # will be deduced if 0

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -271,8 +271,9 @@ measured by invoking the program without arguments.""",
         help="separate options from statement; "
              "use when statement starts with -",
     )
+    # use argparse.REMAINDER to ignore option-like argument found at the end
     group.add_argument(
-        "statement", nargs="*",
+        "statement", nargs=argparse.REMAINDER,
         help="statement to be timed (default: 'pass')",
     )
     return parser

--- a/Misc/NEWS.d/next/Library/2025-08-19-14-52-27.gh-issue-137944.gAFxTV.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-19-14-52-27.gh-issue-137944.gAFxTV.rst
@@ -1,0 +1,2 @@
+Improve command-line interface for :mod:`timeit`. The ``--help`` option now
+shows a colored help by default. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-08-19-14-52-27.gh-issue-137944.gAFxTV.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-19-14-52-27.gh-issue-137944.gAFxTV.rst
@@ -1,2 +1,3 @@
-Improve command-line interface for :mod:`timeit`. The ``--help`` option now
-shows a colored help by default. Patch by Bénédikt Tran.
+Improve :ref:`command-line interface <timeit-command-line-interface>` for
+:mod:`timeit`. The ``--help`` option now shows a colored help by default.
+Patch by Bénédikt Tran.


### PR DESCRIPTION
At some point, I wanted to reduce the cyclotomic complexity of `main()`, but I ended up with more lines than before, which defeated the purpose. While the function is a bit long, it's not that hard to follow, so I would rather keep a smaller diff.

<!-- gh-issue-number: gh-137944 -->
* Issue: gh-137944
<!-- /gh-issue-number -->
