### PR TITLE
[3.14] Update the dbm documentation (GH-137919)

### DIFF
--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -84,10 +84,13 @@ the Oracle Berkeley DB.
    .. versionchanged:: 3.11
       *file* accepts a :term:`path-like object`.
 
-The object returned by :func:`~dbm.open` supports the same basic functionality as a
-:class:`dict`; keys and their corresponding values can be stored, retrieved, and
-deleted, and the :keyword:`in` operator and the :meth:`!keys` method are
-available, as well as :meth:`!get` and :meth:`!setdefault` methods.
+The object returned by :func:`~dbm.open` supports the basic
+functionality of mutable :term:`mappings <mapping>`;
+keys and their corresponding values can be stored, retrieved, and
+deleted, and iteration, the :keyword:`in` operator and methods :meth:`!keys`,
+:meth:`!get`, :meth:`!setdefault` and :meth:`!clear` are available.
+The :meth:`!keys` method returns a list instead of a view object.
+The :meth:`!setdefault` method requires two arguments.
 
 Key and values are always stored as :class:`bytes`. This means that when
 strings are used they are implicitly converted to the default encoding before
@@ -107,6 +110,10 @@ will automatically close them when done.
 .. versionchanged:: 3.8
    Deleting a key from a read-only database raises a database module specific exception
    instead of :exc:`KeyError`.
+
+.. versionchanged:: 3.13
+   :meth:`!clear` methods are now available for all :mod:`dbm` backends.
+
 
 The following example records some hostnames and a corresponding title,  and
 then prints out the contents of the database::
@@ -167,9 +174,6 @@ or any other SQLite browser, including the SQLite CLI.
 .. function:: open(filename, /, flag="r", mode=0o666)
 
    Open an SQLite database.
-   The returned object behaves like a :term:`mapping`,
-   implements a :meth:`!close` method,
-   and supports a "closing" context manager via the :keyword:`with` keyword.
 
    :param filename:
       The path to the database to be opened.
@@ -185,6 +189,17 @@ or any other SQLite browser, including the SQLite CLI.
    :param mode:
       The Unix file access mode of the file (default: octal ``0o666``),
       used only when the database has to be created.
+
+   The returned database object behaves similar to a mutable :term:`mapping`,
+   but the :meth:`!keys` method returns a list, and
+   the :meth:`!setdefault` method requires two arguments.
+   It also supports a "closing" context manager via the :keyword:`with` keyword.
+
+   The following method is also provided:
+
+   .. method:: sqlite3.close()
+
+      Close the SQLite database.
 
 
 :mod:`dbm.gnu` --- GNU database manager
@@ -213,6 +228,11 @@ functionality like crash tolerance.
 
    Raised on :mod:`dbm.gnu`-specific errors, such as I/O errors. :exc:`KeyError` is
    raised for general mapping errors like specifying an incorrect key.
+
+
+.. data:: open_flags
+
+   A string of characters the *flag* parameter of :meth:`~dbm.gnu.open` supports.
 
 
 .. function:: open(filename, flag="r", mode=0o666, /)
@@ -250,13 +270,24 @@ functionality like crash tolerance.
    .. versionchanged:: 3.11
       *filename* accepts a :term:`path-like object`.
 
-   .. data:: open_flags
+   :class:`!gdbm` objects behave similar to mutable :term:`mappings <mapping>`,
+   but methods :meth:`!items`, :meth:`!values`, :meth:`!pop`, :meth:`!popitem`,
+   and :meth:`!update` are not supported,
+   the :meth:`!keys` method returns a list, and
+   the :meth:`!setdefault` method requires two arguments.
+   It also supports a "closing" context manager via the :keyword:`with` keyword.
 
-      A string of characters the *flag* parameter of :meth:`~dbm.gnu.open` supports.
+   .. versionchanged:: 3.2
+      Added the :meth:`!get` and :meth:`!setdefault` methods.
 
-   :class:`!gdbm` objects behave similar to :term:`mappings <mapping>`,
-   but :meth:`!items` and :meth:`!values` methods are not supported.
+   .. versionchanged:: 3.13
+      Added the :meth:`!clear` method.
+
    The following methods are also provided:
+
+   .. method:: gdbm.close()
+
+      Close the GDBM database.
 
    .. method:: gdbm.firstkey()
 
@@ -288,16 +319,6 @@ functionality like crash tolerance.
 
       When the database has been opened in fast mode, this method forces any
       unwritten data to be written to the disk.
-
-   .. method:: gdbm.close()
-
-      Close the GDBM database.
-
-   .. method:: gdbm.clear()
-
-      Remove all items from the GDBM database.
-
-      .. versionadded:: 3.13
 
 
 :mod:`dbm.ndbm` --- New Database Manager
@@ -359,22 +380,27 @@ This module can be used with the "classic" NDBM interface or the
    :param int mode:
       |mode_param_doc|
 
-   :class:`!ndbm` objects behave similar to :term:`mappings <mapping>`,
-   but :meth:`!items` and :meth:`!values` methods are not supported.
-   The following methods are also provided:
-
    .. versionchanged:: 3.11
       Accepts :term:`path-like object` for filename.
+
+   :class:`!ndbm` objects behave similar to mutable :term:`mappings <mapping>`,
+   but methods :meth:`!items`, :meth:`!values`, :meth:`!pop`, :meth:`!popitem`,
+   and :meth:`!update` are not supported,
+   the :meth:`!keys` method returns a list, and
+   the :meth:`!setdefault` method requires two arguments.
+   It also supports a "closing" context manager via the :keyword:`with` keyword.
+
+   .. versionchanged:: 3.2
+      Added the :meth:`!get` and :meth:`!setdefault` methods.
+
+   .. versionchanged:: 3.13
+      Added the :meth:`!clear` method.
+
+   The following method is also provided:
 
    .. method:: ndbm.close()
 
       Close the NDBM database.
-
-   .. method:: ndbm.clear()
-
-      Remove all items from the NDBM database.
-
-      .. versionadded:: 3.13
 
 
 :mod:`dbm.dumb` --- Portable DBM implementation
@@ -412,9 +438,6 @@ The :mod:`!dbm.dumb` module defines the following:
 .. function:: open(filename, flag="c", mode=0o666)
 
    Open a :mod:`!dbm.dumb` database.
-   The returned database object behaves similar to a :term:`mapping`,
-   in addition to providing :meth:`~dumbdbm.sync` and :meth:`~dumbdbm.close`
-   methods.
 
    :param filename:
       The basename of the database file (without extensions).
@@ -448,15 +471,18 @@ The :mod:`!dbm.dumb` module defines the following:
    .. versionchanged:: 3.11
       *filename* accepts a :term:`path-like object`.
 
-   In addition to the methods provided by the
-   :class:`collections.abc.MutableMapping` class,
-   the following methods are provided:
+   The returned database object behaves similar to a mutable :term:`mapping`,
+   but the :meth:`!keys` and :meth:`!items` methods return lists, and
+   the :meth:`!setdefault` method requires two arguments.
+   It also supports a "closing" context manager via the :keyword:`with` keyword.
+
+   The following methods are also provided:
+
+   .. method:: dumbdbm.close()
+
+      Close the database.
 
    .. method:: dumbdbm.sync()
 
       Synchronize the on-disk directory and data files.  This method is called
       by the :meth:`shelve.Shelf.sync` method.
-
-   .. method:: dumbdbm.close()
-
-      Close the database.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -834,7 +834,7 @@ dbm
   (Contributed by Raymond Hettinger and Erlend E. Aasland in :gh:`100414`.)
 
 * Allow removing all items from the database through
-  the new :meth:`.gdbm.clear` and :meth:`.ndbm.clear` methods.
+  the new :meth:`!clear` methods of the GDBM and NDBM database objects.
   (Contributed by Donghee Na in :gh:`107122`.)
 
 


### PR DESCRIPTION
Unify documentation for all backends, enumerate all not implemented mapping methods, document particularities of implemented mapping methods.

(cherry picked from commit 8700404f8688d6a56279dce47a5a5802ec53ed06)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--137962.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->