### PR TITLE
gh-137976: Exclude symlinks from zoneinfo.available_timezones() results

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1941,6 +1941,27 @@ class TestModule(ZoneInfoTestBase):
                 actual = self.module.available_timezones()
                 self.assertEqual(actual, expected)
 
+    def test_exclude_symlinks(self):
+        expected = {
+            "America/New_York",
+            "Europe/London",
+        }
+
+        tree = list(expected) + ["localtime"]
+
+        with tempfile.TemporaryDirectory() as td:
+            # Create regular timezone files
+            for key in expected:
+                self.touch_zone(key, td)
+            
+            # Create a symlink named "localtime" pointing to one of the timezone files
+            os.symlink("America/New_York", os.path.join(td, "localtime"))
+
+            with self.tzpath_context([td]):
+                actual = self.module.available_timezones()
+                self.assertEqual(actual, expected)
+                self.assertNotIn("localtime", actual)
+
 
 class CTestModule(TestModule):
     module = c_zoneinfo

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1953,7 +1953,7 @@ class TestModule(ZoneInfoTestBase):
             # Create regular timezone files
             for key in expected:
                 self.touch_zone(key, td)
-            
+
             # Create a symlink named "localtime" pointing to one of the timezone files
             os.symlink("America/New_York", os.path.join(td, "localtime"))
 

--- a/Lib/zoneinfo/_tzpath.py
+++ b/Lib/zoneinfo/_tzpath.py
@@ -9,7 +9,7 @@ def _reset_tzpath(to=None, stacklevel=4):
     if tzpaths is not None:
         if isinstance(tzpaths, (str, bytes)):
             raise TypeError(
-                f"tzpaths must be a list or tuple, "
+                "tzpaths must be a list or tuple, "
                 + f"not {type(tzpaths)}: {tzpaths!r}"
             )
 
@@ -155,7 +155,7 @@ def available_timezones():
 
             for file in files:
                 fpath = os.path.join(root, file)
-                
+
                 # Skip symlinks to avoid including files like 'localtime'
                 if os.path.islink(fpath):
                     continue

--- a/Lib/zoneinfo/_tzpath.py
+++ b/Lib/zoneinfo/_tzpath.py
@@ -155,6 +155,10 @@ def available_timezones():
 
             for file in files:
                 fpath = os.path.join(root, file)
+                
+                # Skip symlinks to avoid including files like 'localtime'
+                if os.path.islink(fpath):
+                    continue
 
                 key = os.path.relpath(fpath, start=tz_root)
                 if os.sep != "/":  # pragma: nocover

--- a/Misc/NEWS.d/next/Library/2025-08-20-14-01-13.gh-issue-137976.Ql3ZCr.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-20-14-01-13.gh-issue-137976.Ql3ZCr.rst
@@ -1,0 +1,1 @@
+exclude symlinks from zoneinfo.available_timezones() results


### PR DESCRIPTION
Sometimes available_timezones() was including 'localtime' in its results because it wasn't properly handling symlinks. 

This change ensures that symlinks like 'localtime' are excluded from the available timezones list, providing consistent results across different systems. 

Added a test case to verify that symlinks are properly excluded.


<!-- gh-issue-number: gh-137976 -->
* Issue: gh-137976
<!-- /gh-issue-number -->
