### PR TITLE
gh-137638: Remove macos-13 from GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,13 +202,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Cirrus and macos-14 are M1, macos-13 is default GHA Intel.
-        # macOS 13 only runs tests against the GIL-enabled CPython.
         # Cirrus used for upstream, macos-14 for forks.
         os:
         - ghcr.io/cirruslabs/macos-runner:sonoma
         - macos-14
-        - macos-13
         is-fork:  # only used for the exclusion trick
         - ${{ github.repository_owner != 'python' }}
         free-threading:
@@ -219,8 +216,6 @@ jobs:
           is-fork: true
         - os: macos-14
           is-fork: false
-        - os: macos-13
-          free-threading: true
     uses: ./.github/workflows/reusable-macos.yml
     with:
       config_hash: ${{ needs.build-context.outputs.config-hash }}

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -60,7 +60,6 @@ jobs:
           - i686-pc-windows-msvc/msvc
           - x86_64-pc-windows-msvc/msvc
           - aarch64-pc-windows-msvc/msvc
-          - x86_64-apple-darwin/clang
           - aarch64-apple-darwin/clang
           - x86_64-unknown-linux-gnu/gcc
           - aarch64-unknown-linux-gnu/gcc
@@ -79,9 +78,6 @@ jobs:
           - target: aarch64-pc-windows-msvc/msvc
             architecture: ARM64
             runner: windows-11-arm
-          - target: x86_64-apple-darwin/clang
-            architecture: x86_64
-            runner: macos-13
           - target: aarch64-apple-darwin/clang
             architecture: aarch64
             runner: macos-14
@@ -106,15 +102,10 @@ jobs:
           ./PCbuild/build.bat --experimental-jit ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }}
           ./PCbuild/rt.bat ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }} -q --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
-        # The `find` line is required as a result of https://github.com/actions/runner-images/issues/9966.
-        # This is a bug in the macOS runner image where the pre-installed Python is installed in the same
-        # directory as the Homebrew Python, which causes the build to fail for macos-13. This line removes
-        # the symlink to the pre-installed Python so that the Homebrew Python is used instead.
       - name: macOS
         if: runner.os == 'macOS'
         run: |
           brew update
-          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
           brew install llvm@${{ matrix.llvm }}
           export SDKROOT="$(xcrun --show-sdk-path)"
           # Set MACOSX_DEPLOYMENT_TARGET and -Werror=unguarded-availability to

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -60,15 +60,15 @@ jobs:
           --prefix=/opt/python-dev \
           --with-openssl="$(brew --prefix openssl@3.0)"
     - name: Build CPython
-      if : ${{ inputs.free-threading || inputs.os != 'macos-13' }}
+      if : ${{ inputs.free-threading }}
       run: gmake -j8
     - name: Build CPython for compiler warning check
-      if : ${{ !inputs.free-threading && inputs.os == 'macos-13' }}
+      if : ${{ !inputs.free-threading }}
       run: set -o pipefail; gmake -j8 --output-sync 2>&1 | tee compiler_output_macos.txt
     - name: Display build info
       run: make pythoninfo
     - name: Check compiler warnings
-      if : ${{ !inputs.free-threading && inputs.os == 'macos-13' }}
+      if : ${{ !inputs.free-threading }}
       run: >-
         python3 Tools/build/check_warnings.py
         --compiler-output-file-path=compiler_output_macos.txt

--- a/.github/workflows/tail-call.yml
+++ b/.github/workflows/tail-call.yml
@@ -39,7 +39,6 @@ jobs:
 #          - i686-pc-windows-msvc/msvc
           - x86_64-pc-windows-msvc/msvc
 #          - aarch64-pc-windows-msvc/msvc
-          - x86_64-apple-darwin/clang
           - aarch64-apple-darwin/clang
           - x86_64-unknown-linux-gnu/gcc
           - aarch64-unknown-linux-gnu/gcc
@@ -56,9 +55,6 @@ jobs:
 #          - target: aarch64-pc-windows-msvc/msvc
 #            architecture: ARM64
 #            runner: windows-latest
-          - target: x86_64-apple-darwin/clang
-            architecture: x86_64
-            runner: macos-13
           - target: aarch64-apple-darwin/clang
             architecture: aarch64
             runner: macos-14
@@ -101,17 +97,12 @@ jobs:
           set LLVMInstallDir=C:\Program Files\LLVM
           ./PCbuild/build.bat --tail-call-interp -p ${{ matrix.architecture }}
 
-        # The `find` line is required as a result of https://github.com/actions/runner-images/issues/9966.
-        # This is a bug in the macOS runner image where the pre-installed Python is installed in the same
-        # directory as the Homebrew Python, which causes the build to fail for macos-13. This line removes
-        # the symlink to the pre-installed Python so that the Homebrew Python is used instead.
         # Note: when a new LLVM is released, the homebrew installation directory changes, so the builds will fail.
         # We either need to upgrade LLVM or change the directory being pointed to.
       - name: Native macOS (release)
         if: runner.os == 'macOS'
         run: |
           brew update
-          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
           brew install llvm@${{ matrix.llvm }}
           export SDKROOT="$(xcrun --show-sdk-path)"
           export PATH="/usr/local/opt/llvm/bin:$PATH"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

GitHub Actions will be removing `macos-13` between September and November, and because that was the Intel runner (`macos-14` and `macos-15` are Apple Silicon), we've dropped Intel macOS (x86_64-apple-darwin) to tier 2 support:

* https://discuss.python.org/t/dropping-intel-mac-to-tier-2/102100
* https://github.com/python/peps/pull/4548
* https://peps.python.org/pep-0011/#tier-2

I suggest we keep testing on `macos-13` whilst it's available, as it'll help surface failures sooner.

But because the removal window is quite long ("This process will begin September 1, 2025, and the image will be fully retired on November 14, 2025"), here's a PR. Whenever `macos-13` is actually removed, this should be ready to merge, and minimise the disruption.

<!-- gh-issue-number: gh-137638 -->
* Issue: gh-137638
<!-- /gh-issue-number -->
