### PR TITLE
[3.12] gh-137638: Remove macos-13 from GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,13 +240,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Cirrus and macos-14 are M1, macos-13 is default GHA Intel.
-        # macOS 13 only runs tests against the GIL-enabled CPython.
         # Cirrus used for upstream, macos-14 for forks.
         os:
         - ghcr.io/cirruslabs/macos-runner:sonoma
         - macos-14
-        - macos-13
         is-fork:  # only used for the exclusion trick
         - ${{ github.repository_owner != 'python' }}
         free-threading:
@@ -257,8 +254,6 @@ jobs:
           is-fork: true
         - os: macos-14
           is-fork: false
-        - os: macos-13
-          free-threading: true
     uses: ./.github/workflows/reusable-macos.yml
     with:
       config_hash: ${{ needs.build-context.outputs.config-hash }}


### PR DESCRIPTION
Adapted from GH-137989.

Co-Authored-By: Zachary Ware <zach@python.org>


<!-- gh-issue-number: gh-137638 -->
* Issue: gh-137638
<!-- /gh-issue-number -->
