### PR TITLE
[3.11] gh-137638: Remove macos-13 from GitHub Actions

### DIFF
--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         os: [
           "macos-14",  # M1
-          "macos-13",  # Intel
         ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Adapted from GH-137989.

Co-Authored-By: Zachary Ware <zach@python.org>


<!-- gh-issue-number: gh-137638 -->
* Issue: gh-137638
<!-- /gh-issue-number -->
