### PR TITLE
gh-138005: Document that CSV `skipinitialspace=True` and `delimiter=' '` require quotation for empty fields

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -467,25 +467,8 @@ Dialects support the following attributes:
 .. attribute:: Dialect.skipinitialspace
 
    When :const:`True`, spaces immediately following the *delimiter* are ignored.
-   The default is :const:`False`.
-
-   .. note::
-
-      When combining ``delimiter=' '`` (a space) with ``skipinitialspace=True``,
-      the writer must quote empty fields.
-
-      If an unquoted empty field would be emitted (for example writing ``''`` or
-      values that become empty like :data:`None` under some quoting modes),
-      :class:`writer` raises :exc:`csv.Error`. Quoting (the default
-      :data:`QUOTE_MINIMAL` is sufficient) avoids this error.
-
-      Example::
-
-          >>> import csv, io
-          >>> buf = io.StringIO()
-          >>> w = csv.writer(buf, delimiter=' ', skipinitialspace=True,
-          ...                 quoting=csv.QUOTE_NONE)
-          >>> w.writerow(['', 'x'])  # raises csv.Error
+   The default is :const:`False`.  When combining ``delimiter=' '`` with
+   ``skipinitialspace=True``, unquoted empty fields are not allowed.
 
 .. attribute:: Dialect.strict
 

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -469,6 +469,23 @@ Dialects support the following attributes:
    When :const:`True`, spaces immediately following the *delimiter* are ignored.
    The default is :const:`False`.
 
+   .. note::
+
+      When combining ``delimiter=' '`` (a space) with ``skipinitialspace=True``,
+      the writer must quote empty fields.
+
+      If an unquoted empty field would be emitted (for example writing ``''`` or
+      values that become empty like :data:`None` under some quoting modes),
+      :class:`writer` raises :exc:`csv.Error`. Quoting (the default
+      :data:`QUOTE_MINIMAL` is sufficient) avoids this error.
+
+      Example::
+
+          >>> import csv, io
+          >>> buf = io.StringIO()
+          >>> w = csv.writer(buf, delimiter=' ', skipinitialspace=True,
+          ...                 quoting=csv.QUOTE_NONE)
+          >>> w.writerow(['', 'x'])  # raises csv.Error
 
 .. attribute:: Dialect.strict
 

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -636,7 +636,7 @@ done::
 .. rubric:: Footnotes
 
 .. [1] If ``newline=''`` is not specified, newlines embedded inside quoted fields
-   will not be interpreted correctly, and on platforms that use ``\r\n`` linendings
+   will not be interpreted correctly, and on platforms that use ``\r\n`` line endings
    on write an extra ``\r`` will be added.  It should always be safe to specify
    ``newline=''``, since the csv module does its own
    (:term:`universal <universal newlines>`) newline handling.

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -470,6 +470,7 @@ Dialects support the following attributes:
    The default is :const:`False`.  When combining ``delimiter=' '`` with
    ``skipinitialspace=True``, unquoted empty fields are not allowed.
 
+
 .. attribute:: Dialect.strict
 
    When ``True``, raise exception :exc:`Error` on bad CSV input.


### PR DESCRIPTION
Please see for the code:

- https://github.com/python/cpython/blob/7dc42b67a75f58a2b1c0a4560bd4bf8ff25cac8b/Modules/_csv.c#L1253-L1267

Please see the test:

- https://github.com/python/cpython/pull/115721/files#diff-dd5e5efc1566b1c1dc988769a04cc403d2416c8af5bf4785bec235d02a780813R352-R354

The behavior is intentional since gh-115721, so the only sensible route is to update the docs.

<!-- gh-issue-number: gh-138005 -->
* Issue: gh-138005
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138006.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->