### PR TITLE
gh-138011: add note about instantiating MyClass with ( )

### DIFF
--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -288,6 +288,13 @@ For example (assuming the above class)::
 creates a new *instance* of the class and assigns this object to the local
 variable ``x``.
 
+.. note::
+
+   Be careful to include the parentheses ``()`` when instantiating.  
+   Writing ``x = MyClass`` (without ``()``) will not create an instance,  
+   and calling ``x.f()`` will raise ``TypeError: missing 1 required positional argument: 'self'``.  
+   The correct usage is ``x = MyClass()``.
+
 The instantiation operation ("calling" a class object) creates an empty object.
 Many classes like to create objects with instances customized to a specific
 initial state. Therefore a class may define a special method named


### PR DESCRIPTION
### Summary:
This PR adds a clarifying note to the class tutorial section.

- Emphasizes that writing `x = MyClass` (without parentheses) does not create an instance.
- Explains that calling `x.f()` in this case raises `TypeError: missing 1 required positional argument: 'self'`.
- Shows the correct usage: `x = MyClass()`.

### Related Issue
Addresses confusion reported in issue #138011.

### Verification
- ✅ Built docs locally with `make html`
- ✅ Verified that the new note renders correctly

### Screenshot
<img width="1029" height="153" alt="Screenshot 2025-08-21 100929" src="https://github.com/user-attachments/assets/3bf8fef4-a134-466d-b950-26bca2b3ed8a" />



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138016.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-138011 -->
* Issue: gh-138011
<!-- /gh-issue-number -->
