### PR TITLE
`Include/exports.h`: Just check for the visibility attribute.

### DIFF
--- a/Include/exports.h
+++ b/Include/exports.h
@@ -35,14 +35,7 @@
         #define Py_LOCAL_SYMBOL
     #endif
 #else
-/*
- * If we only ever used gcc >= 5, we could use __has_attribute(visibility)
- * as a cross-platform way to determine if visibility is supported. However,
- * we may still need to support gcc >= 4, as some Ubuntu LTS and Centos versions
- * have 4 < gcc < 5.
- */
-    #if (defined(__GNUC__) && (__GNUC__ >= 4)) ||\
-        (defined(__clang__) && _Py__has_attribute(visibility))
+    #if _Py__has_attribute(visibility)
         #define Py_IMPORTED_SYMBOL __attribute__ ((visibility ("default")))
         #define Py_EXPORTED_SYMBOL __attribute__ ((visibility ("default")))
         #define Py_LOCAL_SYMBOL  __attribute__ ((visibility ("hidden")))


### PR DESCRIPTION
The comment alludes to releases that are no longer relevant. Ubuntu 20.04 LTS is no longer supported, but even it has gcc 9. CentOS is in a much different state, but even the spiritual successor rockylinux 8.9 (out of its support window as well) has gcc 8.

In short the compilers that do not support the has_attribute directive are no longer supported.

Build tested on Ubuntu 24.04 and rockylinux 8.9.

Reference:
https://ubuntu.com/about/release-cycle
https://wiki.rockylinux.org/rocky/version/#__tabbed_1_1