### PR TITLE
gh-137996: Fix path to __main__ in forkserver preload logic

### DIFF
--- a/Lib/multiprocessing/forkserver.py
+++ b/Lib/multiprocessing/forkserver.py
@@ -146,9 +146,9 @@ class ForkServer(object):
                    'main(%d, %d, %r, **%r)')
 
             if self._preload_modules:
-                desired_keys = {'main_path', 'sys_path'}
+                desired_keys = {'main_path': 'init_main_from_path', 'sys_path': 'sys_path'}
                 data = spawn.get_preparation_data('ignore')
-                main_kws = {x: y for x, y in data.items() if x in desired_keys}
+                main_kws = {x: data[y] for x, y in desired_keys.items() if y in data}
             else:
                 main_kws = {}
 

--- a/Misc/NEWS.d/next/Library/2025-08-23-00-59-59.gh-issue-137996.6pkMXl.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-23-00-59-59.gh-issue-137996.6pkMXl.rst
@@ -1,1 +1,3 @@
-Fix preloading of __main__ for forkserver multiprocessing.
+:mod:`multiprocessing`: Fix preloading of ``__main__`` for
+:ref:`forkserver <multiprocessing-start-method-forkserver>`
+start method.

--- a/Misc/NEWS.d/next/Library/2025-08-23-00-59-59.gh-issue-137996.6pkMXl.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-23-00-59-59.gh-issue-137996.6pkMXl.rst
@@ -1,0 +1,1 @@
+Fix preloading of __main__ for forkserver multiprocessing.


### PR DESCRIPTION
Let the \_\_main__ module be preloaded by extracting the necessary path from the spawn.get_preparation_data() result.

<!-- gh-issue-number: gh-137996 -->
* Issue: gh-137996
<!-- /gh-issue-number -->
