### PR TITLE
gh-138044: Remove deprecated parameter alias for `importlib.resources.files`

### DIFF
--- a/Doc/library/importlib.resources.rst
+++ b/Doc/library/importlib.resources.rst
@@ -72,13 +72,12 @@ for example, a package and its resources can be imported from a zip file using
 
     .. versionadded:: 3.9
 
-    .. versionchanged:: 3.12
-       *package* parameter was renamed to *anchor*. *anchor* can now
-       be a non-package module and if omitted will default to the caller's
-       module. *package* is still accepted for compatibility but will raise
-       a :exc:`DeprecationWarning`. Consider passing the anchor positionally or
-       using ``importlib_resources >= 5.10`` for a compatible interface
-       on older Pythons.
+    .. deprecated-removed:: 3.12 3.15
+       *package* parameter was renamed to *anchor*. *anchor* can now be a
+       non-package module and if omitted will default to the caller's module.
+       *package* is no longer accepted since Python 3.15. Consider passing the
+       anchor positionally or using ``importlib_resources >= 5.10`` for a
+       compatible interface on older Pythons.
 
 .. function:: as_file(traversable)
 

--- a/Lib/importlib/resources/_common.py
+++ b/Lib/importlib/resources/_common.py
@@ -6,7 +6,6 @@ import contextlib
 import types
 import importlib
 import inspect
-import warnings
 import itertools
 
 from typing import Union, Optional, cast
@@ -16,39 +15,6 @@ Package = Union[types.ModuleType, str]
 Anchor = Package
 
 
-def package_to_anchor(func):
-    """
-    Replace 'package' parameter as 'anchor' and warn about the change.
-
-    Other errors should fall through.
-
-    >>> files('a', 'b')
-    Traceback (most recent call last):
-    TypeError: files() takes from 0 to 1 positional arguments but 2 were given
-
-    Remove this compatibility in Python 3.14.
-    """
-    undefined = object()
-
-    @functools.wraps(func)
-    def wrapper(anchor=undefined, package=undefined):
-        if package is not undefined:
-            if anchor is not undefined:
-                return func(anchor, package)
-            warnings.warn(
-                "First parameter to files is renamed to 'anchor'",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return func(package)
-        elif anchor is undefined:
-            return func()
-        return func(anchor)
-
-    return wrapper
-
-
-@package_to_anchor
 def files(anchor: Optional[Anchor] = None) -> Traversable:
     """
     Get a Traversable resource for an anchor.

--- a/Lib/test/test_importlib/resources/test_files.py
+++ b/Lib/test/test_importlib/resources/test_files.py
@@ -38,14 +38,6 @@ class FilesTests:
         binfile = files.joinpath('subdirectory', 'binary.file')
         self.assertTrue(binfile.is_file())
 
-    def test_old_parameter(self):
-        """
-        Files used to take a 'package' parameter. Make sure anyone
-        passing by name is still supported.
-        """
-        with suppress_known_deprecation():
-            resources.files(package=self.data)
-
 
 class OpenDiskTests(FilesTests, util.DiskSetup, unittest.TestCase):
     pass

--- a/Misc/NEWS.d/next/Library/2025-08-22-12-48-14.gh-issue-138044.lEQULC.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-22-12-48-14.gh-issue-138044.lEQULC.rst
@@ -1,0 +1,2 @@
+Remove compatibility shim for deprecated parameter *package* in
+:func:`importlib.resources.files`. Patch by Semyon Moroz.


### PR DESCRIPTION


<!-- gh-issue-number: gh-138044 -->
* Issue: gh-138044
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138059.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->