### PR TITLE
gh-110936: Improve string literal definition in Lexical Analysis

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -628,10 +628,10 @@ to indicate that an ending quote ends the literal.
    STRING:          [`stringprefix`] (`stringcontent`)
    stringprefix:    <("r" | "u" | "b" | "br" | "rb"), case-insensitive>
    stringcontent:
-      | "'" ( !"'" `stringitem`)* "'"
-      | '"' ( !'"' `stringitem`)* '"'
       | "'''" ( !"'''" `longstringitem`)* "'''"
       | '"""' ( !'"""' `longstringitem`)* '"""'
+      | "'" ( !"'" `stringitem`)* "'"
+      | '"' ( !'"' `stringitem`)* '"'
    stringitem:      `stringchar` | `stringescapeseq`
    stringchar:      <any `source_character`, except backslash and newline>
    longstringitem:  `stringitem` | newline


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110936 -->
* Issue: gh-110936
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138063.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->