### PR TITLE
gh-138071: Clarify curses.color_pair doc about style vs extraction masks

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -122,10 +122,15 @@ The module :mod:`curses` defines the following functions:
 .. function:: color_pair(pair_number)
 
    Return the attribute value for displaying text in the specified color pair.
-   Only the first 256 color pairs are supported. This
-   attribute value can be combined with :const:`A_STANDOUT`, :const:`A_REVERSE`,
-   and the other :const:`!A_\*` attributes.  :func:`pair_number` is the counterpart
-   to this function.
+   Only the first 256 color pairs are supported. The value returned by
+   ``color_pair(n)`` is an attribute mask. It can be combined (using bitwise OR, ``|``)
+   with other style attributes such as :const:`A_BOLD`, :const:`A_REVERSE`,
+   :const:`A_UNDERLINE`, etc. Note that :const:`A_COLOR`, :const:`A_ATTRIBUTES`,
+   and :const:`A_CHARTEXT` are extraction masks used with bitwise AND (``&``) on
+   values returned from functions like :meth:`window.inch`. They are not style
+   attributes and must not be combined with :func:`color_pair`. :func:`pair_number`
+   is the counterpart to this function.
+
 
 
 .. function:: curs_set(visibility)


### PR DESCRIPTION
### Documentation fix

This PR clarifies the wording in the `curses.color_pair` documentation.

Previously it said:
> This attribute value can be combined with A_STANDOUT, A_REVERSE, and the other A_* attributes.

This was ambiguous because constants like `A_COLOR`, `A_ATTRIBUTES`, and `A_CHARTEXT` also follow the `A_*` pattern, but those are extraction masks and cannot be combined with `curses.color_pair()`.

### Changes made
- Updated `Doc/library/curses.rst`:
  - Explicitly clarified that the value returned by `curses.color_pair(n)` is an attribute mask that can be combined (using `|`) with style attributes like `A_BOLD`, `A_REVERSE`, `A_UNDERLINE`.
  - Added a note that `A_COLOR`, `A_ATTRIBUTES`, and `A_CHARTEXT` are extraction masks used with `&` on values returned from `window.inch()`, and must not be combined with `color_pair()`.

### Why this is needed
- Avoids confusion for new users who may assume all `A_*` constants can be OR'ed with `curses.color_pair`.
- Matches the behavior of curses in practice.

### Example
```python
# Valid
attr = curses.color_pair(3) | curses.A_BOLD | curses.A_REVERSE
win.addstr("Hello", attr)

# Invalid (no effect, misleading)
attr = curses.color_pair(3) | curses.A_COLOR


<!-- gh-issue-number: gh-138071 -->
* Issue: gh-138071
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138079.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->