### PR TITLE
gh-138081: fix some dead links in InternalDocs

### DIFF
--- a/InternalDocs/compiler.md
+++ b/InternalDocs/compiler.md
@@ -604,4 +604,4 @@ References
        pp. 213--227, 1997.
 
 [^2]: The Zephyr Abstract Syntax Description Language.:
-      https://www.cs.princeton.edu/research/techreps/TR-554-97
+      https://www.cs.princeton.edu/research/techreps/254

--- a/InternalDocs/generators.md
+++ b/InternalDocs/generators.md
@@ -64,7 +64,7 @@ Iteration
 
 The [`FOR_ITER`](https://docs.python.org/dev/library/dis.html#opcode-FOR_ITER)
 instruction calls `__next__` on the iterator which is on the top of the stack,
-and pushes the result to the stack. It has [`specializations`](adaptive.md)
+and pushes the result to the stack. It has [`specializations`](interpreter.md)
 for a few common iterator types, including `FOR_ITER_GEN`, for iterating over
 a generator. `FOR_ITER_GEN` bypasses the call to `__next__`, and instead
 directly pushes the generator stack and resumes its execution from the

--- a/InternalDocs/jit.md
+++ b/InternalDocs/jit.md
@@ -89,7 +89,7 @@ When the full jit is enabled (python was configured with
 [`--enable-experimental-jit`](https://docs.python.org/dev/using/configure.html#cmdoption-enable-experimental-jit),
 the uop executor's `jit_code` field is populated with a pointer to a compiled
 C function that implements the executor logic. This function's signature is
-defined by `jit_func` in [`pycore_jit.h`](Include/internal/pycore_jit.h).
+defined by `jit_func` in [`pycore_jit.h`](../Include/internal/pycore_jit.h).
 When the executor is invoked by `ENTER_EXECUTOR`, instead of jumping to
 the uop interpreter at `tier2_dispatch`, the executor runs the function
 that `jit_code` points to. This function returns the instruction pointer


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This patch follow 138075 to fix some of the dead links

for https://www.cs.princeton.edu/research/techreps/TR-554-97 I checked it had been changed

for `adaptive.md` in `InternalDocs/generators.md` followed this commit https://github.com/python/cpython/commit/fe4dd07a84ba423179a93ed84bdcc2b4c99b35a9

for `Include/internal/pycore_jit.h` it just a wrong place.

and FYI there are still some dead link but I am not quite sure


<!-- gh-issue-number: gh-138081 -->
* Issue: gh-138081
<!-- /gh-issue-number -->
