### PR TITLE
gh-138094: Fix misleading suggestions in interactive `help` prompt

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1771,7 +1771,7 @@ def render_doc(thing, title='Python Library Documentation: %s', forceload=0,
     return title % desc + '\n\n' + renderer.document(object, name)
 
 def doc(thing, title='Python Library Documentation: %s', forceload=0,
-        output=None, is_cli=False):
+        output=None, is_cli=False, is_interactive=False):
     """Display text documentation, given an object or a path to an object."""
     if output is None:
         try:
@@ -1787,7 +1787,11 @@ def doc(thing, title='Python Library Documentation: %s', forceload=0,
         except ImportError as exc:
             if is_cli:
                 raise
-            print(exc)
+            if is_interactive:
+                # don't show the usual hints if we're running interactively
+                print(exc.args[0].splitlines(False)[0])
+            else:
+                print(exc)
     else:
         try:
             s = render_doc(thing, title, forceload, plaintext)
@@ -2070,10 +2074,7 @@ has the same effect as typing a particular string at the help> prompt.
                     and request[0] not in request[1:-1]):
                 request = request[1:-1]
             if request.lower() in ('q', 'quit', 'exit'): break
-            if request == 'help':
-                self.intro()
-            else:
-                self.help(request)
+            self.help(request, is_interactive=True)
 
     def getline(self, prompt):
         """Read one line, using input() when appropriate."""
@@ -2084,7 +2085,7 @@ has the same effect as typing a particular string at the help> prompt.
             self.output.flush()
             return self.input.readline()
 
-    def help(self, request, is_cli=False):
+    def help(self, request, is_cli=False, is_interactive=False):
         if isinstance(request, str):
             request = request.strip()
             if request == 'keywords': self.listkeywords()
@@ -2099,7 +2100,8 @@ has the same effect as typing a particular string at the help> prompt.
                 doc(eval(request), 'Help on %s:', output=self._output, is_cli=is_cli)
             elif request in self.keywords: self.showtopic(request)
             elif request in self.topics: self.showtopic(request)
-            elif request: doc(request, 'Help on %s:', output=self._output, is_cli=is_cli)
+            elif request:
+                doc(request, 'Help on %s:', output=self._output, is_cli=is_cli, is_interactive=is_interactive)
             else: doc(str, 'Help on %s:', output=self._output, is_cli=is_cli)
         elif isinstance(request, Helper): self()
         else: doc(request, 'Help on %s:', output=self._output, is_cli=is_cli)

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2117,21 +2117,25 @@ has the same effect as typing a particular string at the help> prompt.
             pager(textwrap.dedent("""\
                 help - Interactive Help
                 =======================
+
                 The built-in help function implements an interactive help utility.  You
                 can make use of it in a few different ways:
 
                 * Calling help() with no arguments starts an interactive help session.
 
-                * Calling help(x) will have one of two behaviors depending on the type
-                  of the argument:
+                * The behavior of help(x) depends on the type of the argument:
 
                     * If x is a string, help(x) provides information about the given
                       topic.  For example, help("class") will provide information about
                       the "class" keyword, and help("math.sqrt") will provide
                       information about the "math.sqrt" function.
 
-                    * If x is not a string, help(x) prints information about x's type.
-                      For example, help(42) will provide information about the int type.
+                    * If x is a class or a built-in type, help(x) provides information
+                      about that type.  For example, help(str) will provide information
+                      about the str type.
+
+                    * Otherwise, help(x) provides information about x's type. For
+                      example, help(42) will provide information about the int type.
             """))
 
     def intro(self):

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2112,7 +2112,7 @@ has the same effect as typing a particular string at the help> prompt.
 
     def helphelp(self, is_interactive=False):
         if is_interactive:
-            self.output.write(_introdoc())
+            self.intro()
         else:
             pager(textwrap.dedent("""\
                 help - Interactive Help

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2088,7 +2088,9 @@ has the same effect as typing a particular string at the help> prompt.
     def help(self, request, is_cli=False, is_interactive=False):
         if isinstance(request, str):
             request = request.strip()
-            if request == 'keywords': self.listkeywords()
+            if request == 'help':
+                self.helphelp(is_interactive=is_interactive)
+            elif request == 'keywords': self.listkeywords()
             elif request == 'symbols': self.listsymbols()
             elif request == 'topics': self.listtopics()
             elif request == 'modules': self.listmodules()
@@ -2103,9 +2105,34 @@ has the same effect as typing a particular string at the help> prompt.
             elif request:
                 doc(request, 'Help on %s:', output=self._output, is_cli=is_cli, is_interactive=is_interactive)
             else: doc(str, 'Help on %s:', output=self._output, is_cli=is_cli)
-        elif isinstance(request, Helper): self()
+        elif isinstance(request, (Helper, type(builtins.help))):
+            self.helphelp(is_interactive=is_interactive)
         else: doc(request, 'Help on %s:', output=self._output, is_cli=is_cli)
         self.output.write('\n')
+
+    def helphelp(self, is_interactive=False):
+        if is_interactive:
+            self.output.write(_introdoc())
+        else:
+            pager(textwrap.dedent("""\
+                help - Interactive Help
+                =======================
+                The built-in help function implements an interactive help utility.  You
+                can make use of it in a few different ways:
+
+                * Calling help() with no arguments starts an interactive help session.
+
+                * Calling help(x) will have one of two behaviors depending on the type
+                  of the argument:
+
+                    * If x is a string, help(x) provides information about the given
+                      topic.  For example, help("class") will provide information about
+                      the "class" keyword, and help("math.sqrt") will provide
+                      information about the "math.sqrt" function.
+
+                    * If x is not a string, help(x) prints information about x's type.
+                      For example, help(42) will provide information about the int type.
+            """))
 
     def intro(self):
         self.output.write(_introdoc())

--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -664,10 +664,10 @@ class PydocDocTest(unittest.TestCase):
         self.assertNotIn('Built-in subclasses', text)
 
     def test_fail_help_cli(self):
-        elines = (missing_pattern % 'abd').splitlines()
+        elines = (missing_pattern % 'abd').splitlines(False)[:1]
         with spawn_python("-c" "help()") as proc:
             out, _ = proc.communicate(b"abd")
-            olines = out.decode().splitlines()[-9:-6]
+            olines = out.decode().splitlines(False)[-7:-6]
             olines[0] = olines[0].removeprefix('help> ')
             self.assertEqual(elines, olines)
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-23-14-07-56.gh-issue-138094.U92SHS.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-23-14-07-56.gh-issue-138094.U92SHS.rst
@@ -1,2 +1,2 @@
-Removed potentially-misleading suggestions from the interactive ``help``
+Removed potentially-misleading suggestions from the interactive :func:`help`
 prompt.  Patch by Adam Hartz.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-23-14-07-56.gh-issue-138094.U92SHS.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-23-14-07-56.gh-issue-138094.U92SHS.rst
@@ -1,0 +1,2 @@
+Removed potentially-misleading suggestions from the interactive ``help``
+prompt.  Patch by Adam Hartz.


### PR DESCRIPTION
This PR represents an attempt to address both of the issues raised in #138094 by changing how `help(help)` is handled, and by removing suggested calls to `help(...)` in the output when we can't find a given topic in interactive mode.

Happy to adjust if need be (or to separate this into 2 PR's if that would be better).

<!-- gh-issue-number: gh-138094 -->
* Issue: gh-138094
<!-- /gh-issue-number -->
