### PR TITLE
Doc: Add exponentiation example to tutorial introduction

### DIFF
--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -63,6 +63,8 @@ For example::
    5.0
    >>> 8 / 5  # division always returns a floating-point number
    1.6
+   >>> 2 ** 9 #2 raised to the power of 9
+   512
 
 The integer numbers (e.g. ``2``, ``4``, ``20``) have type :class:`int`,
 the ones with a fractional part (e.g. ``5.0``, ``1.6``) have type


### PR DESCRIPTION
This PR updates the tutorial's introduction section by adding an example of the
`**` operator (exponentiation). It demonstrates how to raise a number to a power,
using `2 ** 9` as the example for clarity.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138096.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->