### PR TITLE
gh-138098: Clarify strong references in PyDict_Next docs for free-threaded build

### DIFF
--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -295,20 +295,23 @@ Dictionary Objects
    :c:macro:`Py_BEGIN_CRITICAL_SECTION` to lock the dictionary while iterating
    over it::
 
-   .. note::
+.. note::
 
-      On the :term:`free threaded <free threading>` build, this function can be used safely inside
-      a critical section. However, the references returned for *pkey* and
-      *pvalue* are :term:`borrowed <borrowed reference>` and only valid while the critical section is
-      held. If you need to use these objects outside the critical section or when the critical section
-      can be suspended, create :term:`strong references <strong reference>` (for example, with
-      :c:func:`Py_NewRef`).
+   On the :term:`free threaded <free threading>` build, this function can be used safely inside
+   a critical section. However, the references returned for *pkey* and
+   *pvalue* are :term:`borrowed <borrowed reference>` and only valid while the critical section is
+   held. If you need to use these objects outside the critical section or when the critical section
+   can be suspended, create :term:`strong reference <strong reference>` (for example, with
+   :c:func:`Py_NewRef`).
 
-      Py_BEGIN_CRITICAL_SECTION(self->dict);
-      while (PyDict_Next(self->dict, &pos, &key, &value)) {
-          ...
-      }
-      Py_END_CRITICAL_SECTION();
+.. code-block:: c
+
+   Py_BEGIN_CRITICAL_SECTION(self->dict);
+   while (PyDict_Next(self->dict, &pos, &key, &value)) {
+       ...
+   }
+   Py_END_CRITICAL_SECTION();
+
 
 
 .. c:function:: int PyDict_Merge(PyObject *a, PyObject *b, int override)

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -258,17 +258,6 @@ Dictionary Objects
    value represents offsets within the internal dictionary structure, and
    since the structure is sparse, the offsets are not consecutive.
 
-   .. note::
-
-      On the free-threaded build, this function can be used safely inside a
-      critical section. However, the references returned for *pkey* and *pvalue*
-      are :term:`borrowed <borrowed reference>` and are only valid while the
-      critical section is held. If you need to use these objects outside the
-      critical section or when the critical section can be suspended, create a
-      :term:`strong reference <strong reference>` (for example, using
-      :c:func:`Py_NewRef`).
-
-
    For example::
 
       PyObject *key, *value;
@@ -308,10 +297,19 @@ Dictionary Objects
 
       Py_BEGIN_CRITICAL_SECTION(self->dict);
       while (PyDict_Next(self->dict, &pos, &key, &value)) {
-         ...
+          ...
       }
       Py_END_CRITICAL_SECTION();
 
+   .. note::
+
+      On the free-threaded build, this function can be used safely inside a
+      critical section. However, the references returned for *pkey* and *pvalue*
+      are :term:`borrowed <borrowed reference>` and are only valid while the
+      critical section is held. If you need to use these objects outside the
+      critical section or when the critical section can be suspended, create a
+      :term:`strong reference <strong reference>` (for example, using
+      :c:func:`Py_NewRef`).
 
 .. c:function:: int PyDict_Merge(PyObject *a, PyObject *b, int override)
 

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -260,11 +260,12 @@ Dictionary Objects
 
    .. note::
 
-      In the free-threaded build, this function can be used safely inside
+      On the :term:`free threaded <free threading>` build, this function can be used safely inside
       a critical section. However, the references returned for *pkey* and
-      *pvalue* are borrowed and only valid while the critical section is
-      held. If you need to use these objects outside the critical section,
-      create strong references (for example, with :c:func:`Py_NewRef`).
+      *pvalue* are :term:`borrowed <borrowed reference>` and only valid while the critical section is
+      held. If you need to use these objects outside the critical section or when the critical section
+      can be suspended, create :term:`strong references <strong reference>` (for example, with
+      :c:func:`Py_NewRef`).
 
    For example::
 

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -299,20 +299,18 @@ Dictionary Objects
 
    On the :term:`free threaded <free threading>` build, this function can be used safely inside
    a critical section. However, the references returned for *pkey* and
-   *pvalue* are :term:`borrowed <borrowed reference>` and only valid while the critical section is
-   held. If you need to use these objects outside the critical section or when the critical section
+   *pvalue* are :term:`borrowed <borrowed reference>` and only valid while the critical section
+   is held. If you need to use these objects outside the critical section or when the critical section
    can be suspended, create :term:`strong reference <strong reference>` (for example, with
    :c:func:`Py_NewRef`).
 
-.. code-block:: c
+   .. code-block:: c
 
-   Py_BEGIN_CRITICAL_SECTION(self->dict);
-   while (PyDict_Next(self->dict, &pos, &key, &value)) {
-       ...
-   }
-   Py_END_CRITICAL_SECTION();
-
-
+      Py_BEGIN_CRITICAL_SECTION(self->dict);
+      while (PyDict_Next(self->dict, &pos, &key, &value)) {
+          ...
+      }
+      Py_END_CRITICAL_SECTION();
 
 .. c:function:: int PyDict_Merge(PyObject *a, PyObject *b, int override)
 

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -258,6 +258,17 @@ Dictionary Objects
    value represents offsets within the internal dictionary structure, and
    since the structure is sparse, the offsets are not consecutive.
 
+   .. note::
+
+      On the free-threaded build, this function can be used safely inside a
+      critical section. However, the references returned for *pkey* and *pvalue*
+      are :term:`borrowed <borrowed reference>` and are only valid while the
+      critical section is held. If you need to use these objects outside the
+      critical section or when the critical section can be suspended, create a
+      :term:`strong reference <strong reference>` (for example, using
+      :c:func:`Py_NewRef`).
+
+
    For example::
 
       PyObject *key, *value;
@@ -295,23 +306,12 @@ Dictionary Objects
    :c:macro:`Py_BEGIN_CRITICAL_SECTION` to lock the dictionary while iterating
    over it::
 
-.. note::
-
-   On the :term:`free-threaded <free threading>` build, this function can be
-   used safely inside a critical section. However, the references returned
-   for *pkey* and *pvalue* are :term:`borrowed <borrowed reference>` and only
-   valid while the critical section is held. If you need to use these objects
-   outside the critical section or when the critical section can be suspended,
-   create :term:`strong reference <strong reference>` (for example, with
-   :c:func:`Py_NewRef`).
-
-   .. code-block:: c
-
       Py_BEGIN_CRITICAL_SECTION(self->dict);
       while (PyDict_Next(self->dict, &pos, &key, &value)) {
-          ...
+         ...
       }
       Py_END_CRITICAL_SECTION();
+
 
 .. c:function:: int PyDict_Merge(PyObject *a, PyObject *b, int override)
 

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -297,11 +297,12 @@ Dictionary Objects
 
 .. note::
 
-   On the :term:`free threaded <free threading>` build, this function can be used safely inside
-   a critical section. However, the references returned for *pkey* and
-   *pvalue* are :term:`borrowed <borrowed reference>` and only valid while the critical section
-   is held. If you need to use these objects outside the critical section or when the critical section
-   can be suspended, create :term:`strong reference <strong reference>` (for example, with
+   On the :term:`free-threaded <free threading>` build, this function can be
+   used safely inside a critical section. However, the references returned
+   for *pkey* and *pvalue* are :term:`borrowed <borrowed reference>` and only
+   valid while the critical section is held. If you need to use these objects
+   outside the critical section or when the critical section can be suspended,
+   create :term:`strong reference <strong reference>` (for example, with
    :c:func:`Py_NewRef`).
 
    .. code-block:: c

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -258,6 +258,14 @@ Dictionary Objects
    value represents offsets within the internal dictionary structure, and
    since the structure is sparse, the offsets are not consecutive.
 
+   .. note::
+
+      In the free-threaded build, this function can be used safely inside
+      a critical section. However, the references returned for *pkey* and
+      *pvalue* are borrowed and only valid while the critical section is
+      held. If you need to use these objects outside the critical section,
+      create strong references (for example, with :c:func:`Py_NewRef`).
+
    For example::
 
       PyObject *key, *value;

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -258,15 +258,6 @@ Dictionary Objects
    value represents offsets within the internal dictionary structure, and
    since the structure is sparse, the offsets are not consecutive.
 
-   .. note::
-
-      On the :term:`free threaded <free threading>` build, this function can be used safely inside
-      a critical section. However, the references returned for *pkey* and
-      *pvalue* are :term:`borrowed <borrowed reference>` and only valid while the critical section is
-      held. If you need to use these objects outside the critical section or when the critical section
-      can be suspended, create :term:`strong references <strong reference>` (for example, with
-      :c:func:`Py_NewRef`).
-
    For example::
 
       PyObject *key, *value;
@@ -303,6 +294,15 @@ Dictionary Objects
    build without external synchronization.  You can use
    :c:macro:`Py_BEGIN_CRITICAL_SECTION` to lock the dictionary while iterating
    over it::
+
+   .. note::
+
+      On the :term:`free threaded <free threading>` build, this function can be used safely inside
+      a critical section. However, the references returned for *pkey* and
+      *pvalue* are :term:`borrowed <borrowed reference>` and only valid while the critical section is
+      held. If you need to use these objects outside the critical section or when the critical section
+      can be suspended, create :term:`strong references <strong reference>` (for example, with
+      :c:func:`Py_NewRef`).
 
       Py_BEGIN_CRITICAL_SECTION(self->dict);
       while (PyDict_Next(self->dict, &pos, &key, &value)) {


### PR DESCRIPTION
This PR updates the documentation of :c:func:`PyDict_Next` to clarify the
handling of references in the free-threaded build.

Currently, the docs mention that `PyDict_Next` is not safe in the free-threaded
build and suggest using a critical section. However, the returned `pkey` and
`pvalue` are borrowed references, which are only valid while the critical
section is held. If they need to be accessed outside of that critical section,
strong references must be created.

This PR adds a `.. note::` block explaining this behavior explicitly, and
suggests using :c:func:`Py_NewRef` to obtain strong references.

### Rationale
- Makes the documentation safer and clearer for users of the free-threaded
  build.
- Resolves issue [gh-138098](https://github.com/python/cpython/issues/138098).
- Matches the behavior noted in [gh-119438](https://github.com/python/cpython/pull/119438).

### Example of new docs rendering
<img width="976" height="177" alt="Screenshot 2025-08-24 125023" src="https://github.com/user-attachments/assets/589bcea5-3674-480c-bad6-a946f4727908" />


---

Thanks!



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138106.org.readthedocs.build/en/138106/c-api/dict.html#c.PyDict_Next

<!-- readthedocs-preview cpython-previews end -->