### PR TITLE
[3.13] gh-135261: bring back CI job for testing OpenSSL 1.1.1w (GH-135262)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,7 +307,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        openssl_ver: [3.0.15, 3.1.7, 3.2.3, 3.3.2]
+        # Keep 1.1.1w in our list despite it being upstream EOL and otherwise
+        # unsupported as it most resembles other 1.1.1-work-a-like ssl APIs
+        # supported by important vendors such as AWS-LC.
+        openssl_ver: [1.1.1w, 3.0.15, 3.1.7, 3.2.3, 3.3.2]
     env:
       OPENSSL_VER: ${{ matrix.openssl_ver }}
       MULTISSL_DIR: ${{ github.workspace }}/multissl


### PR DESCRIPTION
This partially reverts commit ad944b5e1f304be1a8c2cc03e9f15005bcb97108 by bringing back the CI job for testing OpenSSL 1.1.1w. Despite this version being upstream EOL, the rationale for keeping it as follows:

- It most resembles other 1.1.1-work-a-like ssl APIs supported by important vendors.
- Python officially requires OpenSSL 1.1.1 or later, although OpenSSL 3.0 or later is recommended for cryptographic modules. Since changing the build requirements requires a transition period, we need to keep testing the allowed versions.
- The code base still contains calls to OpenSSL functions that are deprecated since OpenSSL 3.0 as well as `ifdef` blocks constrained to OpenSSL 1.1.1.

(cherry picked from commit 96b7a2eba423b42320f15fd4974740e3e930bb8b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135261 -->
* Issue: gh-135261
<!-- /gh-issue-number -->
