### PR TITLE
gh-138115: Move stackref buffer to thread state to reduce interp stack usage

### DIFF
--- a/Include/internal/pycore_tstate.h
+++ b/Include/internal/pycore_tstate.h
@@ -21,6 +21,10 @@ struct _gc_thread_state {
 };
 #endif
 
+/* How much scratch space to give stackref to PyObject* conversion. */
+#define MAX_STACKREF_SCRATCH 10
+
+
 // Every PyThreadState is actually allocated as a _PyThreadStateImpl. The
 // PyThreadState fields are exposed as part of the C API, although most fields
 // are intended to be private. The _PyThreadStateImpl fields not exposed.
@@ -47,6 +51,9 @@ typedef struct _PyThreadStateImpl {
     struct _qsbr_thread_state *qsbr;  // only used by free-threaded build
     struct llist_node mem_free_queue; // delayed free queue
 
+    // Scratch space to convert _PyStackRef to PyObject *
+    // +1 to account for possible vectorcalls.
+    PyObject *stackref_scratch[MAX_STACKREF_SCRATCH + 1];
 #ifdef Py_GIL_DISABLED
     // Stack references for the current thread that exist on the C stack
     struct _PyCStackRef *c_stack_refs;

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -394,7 +394,7 @@ do {                                                   \
     /* +1 because vectorcall might use -1 to write self */ \
     _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate; \
     PyObject **NAME##_temp = _tstate->stackref_scratch; \
-    PyObject **NAME = _PyObjectArray_FromStackRefArray(ARGS, ARG_COUNT,
+    PyObject **NAME = _PyObjectArray_FromStackRefArray(ARGS, ARG_COUNT, NAME##_temp + 1);
 
 #define STACKREFS_TO_PYOBJECTS_CLEANUP(NAME) \
     /* +1 because we +1 previously */ \

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -390,13 +390,11 @@ do {                                                   \
 
 /* Stackref macros */
 
-/* How much scratch space to give stackref to PyObject* conversion. */
-#define MAX_STACKREF_SCRATCH 10
-
 #define STACKREFS_TO_PYOBJECTS(ARGS, ARG_COUNT, NAME) \
     /* +1 because vectorcall might use -1 to write self */ \
-    PyObject *NAME##_temp[MAX_STACKREF_SCRATCH+1]; \
-    PyObject **NAME = _PyObjectArray_FromStackRefArray(ARGS, ARG_COUNT, NAME##_temp + 1);
+    _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate; \
+    PyObject **NAME##_temp = _tstate->stackref_scratch; \
+    PyObject **NAME = _PyObjectArray_FromStackRefArray(ARGS, ARG_COUNT,
 
 #define STACKREFS_TO_PYOBJECTS_CLEANUP(NAME) \
     /* +1 because we +1 previously */ \


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138115 -->
* Issue: gh-138115
<!-- /gh-issue-number -->
