### PR TITLE
gh-136021: Remove dead code for internal sentinel in `typing`

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -453,12 +453,6 @@ def _deprecation_warning_for_no_type_params_passed(funcname: str) -> None:
     warnings.warn(depr_message, category=DeprecationWarning, stacklevel=3)
 
 
-class _Sentinel:
-    __slots__ = ()
-    def __repr__(self):
-        return '<sentinel>'
-
-
 def _eval_type(t, globalns, localns, type_params, *, recursive_guard=frozenset(),
                format=None, owner=None, parent_fwdref=None):
     """Evaluate all forward references in the given type t.


### PR DESCRIPTION
The last use of this sentinel was removed in #136332

I *think* this is `skip-news`, since there's no user facing change in behavior and the global instance (`typing._sentinel`) was already unceremoniously removed without a news mention.

<!-- gh-issue-number: gh-136021 -->
* Issue: gh-136021
<!-- /gh-issue-number -->
