### PR TITLE
Remove some dead code from `gzip` and `tarfile`

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -268,8 +268,6 @@ class GzipFile(_streams.BaseStream):
         self.name = filename
         self.crc = zlib.crc32(b"")
         self.size = 0
-        self.writebuf = []
-        self.bufsize = 0
         self.offset = 0  # Current file offset for seek(), tell(), etc
 
     def tell(self):

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -201,7 +201,6 @@ def itn(n, digits=8, format=DEFAULT_FORMAT):
     # base-256 representation. This allows values up to (256**(digits-1))-1.
     # A 0o200 byte indicates a positive number, a 0o377 byte a negative
     # number.
-    original_n = n
     n = int(n)
     if 0 <= n < 8 ** (digits - 1):
         s = bytes("%0*o" % (digits - 1, n), "ascii") + NUL


### PR DESCRIPTION
I noticed these, while taking a look at gh-138117.

I don't think it warrants a blurb, nor an issue.