### PR TITLE
gh-138119: Remove obsolete (flags) from CALL_FUNCTION_EX docs

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1621,16 +1621,14 @@ iterations of the loop.
     The positional arguments tuple and the keyword arguments dict are each
     "unpacked" and passed to the callable. ``CALL_FUNCTION_EX`` pops all these
     items and pushes the callable's return value.
-
-    Earlier Python versions documented an integer *flags* operand indicating
-    the presence of a mapping object for keyword arguments; this no longer
-    applies. The opcode itself no longer has a separate operand or flag bits
-    for this purpose in Python 3.14 and later.
+   The presence of keyword arguments is indicated solely by whether the
+   last stack item is ``NULL`` or a :class:`dict`; there is no operand or
+   flag associated with this opcode.
 
     .. versionadded:: 3.6
     .. versionchanged:: 3.14
-         The obsolete *flags* argument was removed from the documentation; the
-         opcode no longer uses an operand to signal presence of ``**kwargs``.
+       The opcode no longer uses a flags operand to signal the presence of
+       ``**kwargs``; the stack layout alone determines this.
 
 
 .. opcode:: PUSH_NULL

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1607,19 +1607,30 @@ iterations of the loop.
    .. versionadded:: 3.13
 
 
-.. opcode:: CALL_FUNCTION_EX (flags)
+.. opcode:: CALL_FUNCTION_EX
 
-   Calls a callable object with variable set of positional and keyword
-   arguments.  If the lowest bit of *flags* is set, the top of the stack
-   contains a mapping object containing additional keyword arguments.
-   Before the callable is called, the mapping object and iterable object
-   are each "unpacked" and their contents passed in as keyword and
-   positional arguments respectively.
-   ``CALL_FUNCTION_EX`` pops all arguments and the callable object off the stack,
-   calls the callable object with those arguments, and pushes the return value
-   returned by the callable object.
+    Calls a callable object with a variable set of positional and keyword
+    arguments collected at runtime. It expects (in ascending order):
 
-   .. versionadded:: 3.6
+    * the callable object
+    * ``NULL`` (a marker used in the calling convention; may be elided in
+       optimized internal forms)
+    * a :class:`tuple` containing the positional arguments
+    * either ``NULL`` or a :class:`dict` containing the keyword arguments
+
+    The positional arguments tuple and the keyword arguments dict are each
+    "unpacked" and passed to the callable. ``CALL_FUNCTION_EX`` pops all these
+    items and pushes the callable's return value.
+
+    Earlier Python versions documented an integer *flags* operand indicating
+    the presence of a mapping object for keyword arguments; this no longer
+    applies. The opcode itself no longer has a separate operand or flag bits
+    for this purpose in Python 3.14 and later.
+
+    .. versionadded:: 3.6
+    .. versionchanged:: 3.14
+         The obsolete *flags* argument was removed from the documentation; the
+         opcode no longer uses an operand to signal presence of ``**kwargs``.
 
 
 .. opcode:: PUSH_NULL

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1621,9 +1621,9 @@ iterations of the loop.
     The positional arguments tuple and the keyword arguments dict are each
     "unpacked" and passed to the callable. ``CALL_FUNCTION_EX`` pops all these
     items and pushes the callable's return value.
-   The presence of keyword arguments is indicated solely by whether the
-   last stack item is ``NULL`` or a :class:`dict`; there is no operand or
-   flag associated with this opcode.
+    The presence of keyword arguments is indicated solely by whether the
+    last stack item is ``NULL`` or a :class:`dict`; there is no operand or
+    flag associated with this opcode.
 
     .. versionadded:: 3.6
     .. versionchanged:: 3.14


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138119 -->
* Issue: gh-138119
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138126.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->