### PR TITLE
gh-138061: Exclude __pycache__ directory  from the computed digest in the jit stencils

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-08-27-09-52-45.gh-issue-138061.fMVS9w.rst
+++ b/Misc/NEWS.d/next/Build/2025-08-27-09-52-45.gh-issue-138061.fMVS9w.rst
@@ -1,1 +1,1 @@
-Make JIT stencil header generation reproducible by excluding `__pycache__` directories from the computed digest.
+Ensure reproducible builds by making JIT stencil header generation deterministic.

--- a/Misc/NEWS.d/next/Build/2025-08-27-09-52-45.gh-issue-138061.fMVS9w.rst
+++ b/Misc/NEWS.d/next/Build/2025-08-27-09-52-45.gh-issue-138061.fMVS9w.rst
@@ -1,0 +1,1 @@
+Make JIT stencil header generation reproducible by excluding `__pycache__` directories from the computed digest.

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -71,10 +71,10 @@ class _Target(typing.Generic[_S, _R]):
         hasher.update(PYTHON_EXECUTOR_CASES_C_H.read_bytes())
         hasher.update((self.pyconfig_dir / "pyconfig.h").read_bytes())
         for dirpath, _, filenames in sorted(os.walk(TOOLS_JIT)):
+            # Exclude cache files from digest computation to ensure reproducible builds.
+            if dirpath.endswith("__pycache__"):
+                continue
             for filename in filenames:
-                # Exclude .pyc files from digest computation to ensure reproducible builds.
-                if filename.endswith(".pyc"):
-                    continue
                 hasher.update(pathlib.Path(dirpath, filename).read_bytes())
         return hasher.hexdigest()
 

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -72,6 +72,9 @@ class _Target(typing.Generic[_S, _R]):
         hasher.update((self.pyconfig_dir / "pyconfig.h").read_bytes())
         for dirpath, _, filenames in sorted(os.walk(TOOLS_JIT)):
             for filename in filenames:
+                # Exclude .pyc files from digest computation to ensure reproducible builds.
+                if filename.endswith(".pyc"):
+                    continue
                 hasher.update(pathlib.Path(dirpath, filename).read_bytes())
         return hasher.hexdigest()
 


### PR DESCRIPTION
Fix #138061


<!-- gh-issue-number: gh-138061 -->
* Issue: gh-138061
<!-- /gh-issue-number -->
