### PR TITLE
gh-138135: allow ignoring line breaks in doctest output

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -643,7 +643,7 @@ doctest decides whether actual output matches an example's expected output:
       to split'
 
    Note that any leading whitespaces on each expected output line are retained.
-   In other words, the following expected outputs are equivalent under the
+   In other words, the following expected outputs are equivalent under
    :data:`!IGNORE_LINEBREAK`:
 
    .. code-block::
@@ -659,7 +659,8 @@ doctest decides whether actual output matches an example's expected output:
    leading whitespaces for visual indentation purposes should
    be avoided, for instance:
 
-   .. code-block:: pycon
+   .. doctest::
+      :no-trim-doctest-flags:
 
       >>> list("abc123")            # doctest: +IGNORE_LINEBREAK
       ['a', 'b', 'c',

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -693,12 +693,14 @@ doctest decides whether actual output matches an example's expected output:
    In other words, the following expected outputs are equivalent under the
    :data:`!IGNORE_LINEBREAK`:
 
+   .. code-block::
+
       [
-         'a', 'b', 'c',
-         '1', '2', '3'
+          'a', 'b', 'c',
+        '1', '2', '3'
       ]
 
-      [    'a', 'b', 'c',    '1', '2', '3']
+      [    'a', 'b', 'c',  '1', '2', '3']
 
    To break a list-like output with :data:`!IGNORE_LINEBREAK`,
    leading whitespaces for visual indentation purposes should

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -616,7 +616,8 @@ doctest decides whether actual output matches an example's expected output:
    sequence of whitespace within the actual output. By default, whitespace must
    match exactly. :const:`NORMALIZE_WHITESPACE` is especially useful when a line of
    expected output is very long, and you want to wrap it across multiple lines in
-   your source.
+   your source. If the expected output does not contain any whitespace, consider
+   using :data:`IGNORE_LINEBREAK` or :data:`ELLIPSIS`.
 
 
 .. index:: single: ...; in doctests
@@ -664,6 +665,31 @@ doctest decides whether actual output matches an example's expected output:
    .. versionchanged:: 3.2
       :const:`IGNORE_EXCEPTION_DETAIL` now also ignores any information relating
       to the module containing the exception under test.
+
+
+.. data:: IGNORE_LINEBREAK
+
+   When specified, single line breaks in the expected output are eliminated,
+   thereby allowing strings without whitespaces to span multiple lines.
+
+   .. doctest::
+      :no-trim-doctest-flags:
+
+      >>> "foobar123456"            # doctest: +IGNORE_LINEBREAK
+      'foobar
+      123456'
+
+   Consider using :data:`NORMALIZE_WHITESPACE` when strings with whitespaces
+   need to be split across multiple lines:
+
+   .. doctest::
+      :no-trim-doctest-flags:
+
+      >>> "the string to split"     # doctest: +NORMALIZE_WHITESPACE
+      'the string
+      to split'
+
+   .. versionadded:: next
 
 
 .. data:: SKIP

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -689,6 +689,29 @@ doctest decides whether actual output matches an example's expected output:
       'the string
       to split'
 
+   Note that any leading whitespaces on each expected output line are retained.
+   In other words, the following expected outputs are equivalent under the
+   :data:`!IGNORE_LINEBREAK`:
+
+      [
+         'a', 'b', 'c',
+         '1', '2', '3'
+      ]
+
+      [    'a', 'b', 'c',    '1', '2', '3']
+
+   To break a list-like output with :data:`!IGNORE_LINEBREAK`,
+   leading whitespaces for visual indentation purposes should
+   be avoided, for instance:
+
+   .. code-block:: pycon
+
+      >>> list("abc123")            # doctest: +IGNORE_LINEBREAK
+      ['a', 'b', 'c',
+       '1', '2', '3']
+
+   For more complex outputs, consider using :func:`pprint.pprint` instead.
+
    .. versionadded:: next
 
 

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -620,53 +620,6 @@ doctest decides whether actual output matches an example's expected output:
    using :data:`IGNORE_LINEBREAK` or :data:`ELLIPSIS`.
 
 
-.. index:: single: ...; in doctests
-.. data:: ELLIPSIS
-
-   When specified, an ellipsis marker (``...``) in the expected output can match
-   any substring in the actual output.  This includes substrings that span line
-   boundaries, and empty substrings, so it's best to keep usage of this simple.
-   Complicated uses can lead to the same kinds of "oops, it matched too much!"
-   surprises that ``.*`` is prone to in regular expressions.
-
-
-.. data:: IGNORE_EXCEPTION_DETAIL
-
-   When specified, doctests expecting exceptions pass so long as an exception
-   of the expected type is raised, even if the details
-   (message and fully qualified exception name) don't match.
-
-   For example, an example expecting ``ValueError: 42`` will pass if the actual
-   exception raised is ``ValueError: 3*14``, but will fail if, say, a
-   :exc:`TypeError` is raised instead.
-   It will also ignore any fully qualified name included before the
-   exception class, which can vary between implementations and versions
-   of Python and the code/libraries in use.
-   Hence, all three of these variations will work with the flag specified:
-
-   .. code-block:: pycon
-
-      >>> raise Exception('message')
-      Traceback (most recent call last):
-      Exception: message
-
-      >>> raise Exception('message')
-      Traceback (most recent call last):
-      builtins.Exception: message
-
-      >>> raise Exception('message')
-      Traceback (most recent call last):
-      __main__.Exception: message
-
-   Note that :const:`ELLIPSIS` can also be used to ignore the
-   details of the exception message, but such a test may still fail based
-   on whether the module name is present or matches exactly.
-
-   .. versionchanged:: 3.2
-      :const:`IGNORE_EXCEPTION_DETAIL` now also ignores any information relating
-      to the module containing the exception under test.
-
-
 .. data:: IGNORE_LINEBREAK
 
    When specified, single line breaks in the expected output are eliminated,
@@ -715,6 +668,53 @@ doctest decides whether actual output matches an example's expected output:
    For more complex outputs, consider using :func:`pprint.pprint` instead.
 
    .. versionadded:: next
+
+
+.. index:: single: ...; in doctests
+.. data:: ELLIPSIS
+
+   When specified, an ellipsis marker (``...``) in the expected output can match
+   any substring in the actual output.  This includes substrings that span line
+   boundaries, and empty substrings, so it's best to keep usage of this simple.
+   Complicated uses can lead to the same kinds of "oops, it matched too much!"
+   surprises that ``.*`` is prone to in regular expressions.
+
+
+.. data:: IGNORE_EXCEPTION_DETAIL
+
+   When specified, doctests expecting exceptions pass so long as an exception
+   of the expected type is raised, even if the details
+   (message and fully qualified exception name) don't match.
+
+   For example, an example expecting ``ValueError: 42`` will pass if the actual
+   exception raised is ``ValueError: 3*14``, but will fail if, say, a
+   :exc:`TypeError` is raised instead.
+   It will also ignore any fully qualified name included before the
+   exception class, which can vary between implementations and versions
+   of Python and the code/libraries in use.
+   Hence, all three of these variations will work with the flag specified:
+
+   .. code-block:: pycon
+
+      >>> raise Exception('message')
+      Traceback (most recent call last):
+      Exception: message
+
+      >>> raise Exception('message')
+      Traceback (most recent call last):
+      builtins.Exception: message
+
+      >>> raise Exception('message')
+      Traceback (most recent call last):
+      __main__.Exception: message
+
+   Note that :const:`ELLIPSIS` can also be used to ignore the
+   details of the exception message, but such a test may still fail based
+   on whether the module name is present or matches exactly.
+
+   .. versionchanged:: 3.2
+      :const:`IGNORE_EXCEPTION_DETAIL` now also ignores any information relating
+      to the module containing the exception under test.
 
 
 .. data:: SKIP

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -666,7 +666,8 @@ doctest decides whether actual output matches an example's expected output:
       ['a', 'b', 'c',
        '1', '2', '3']
 
-   For more complex outputs, consider using :func:`pprint.pprint` instead.
+   For more complex outputs, consider using :func:`pprint.pp` and matching
+   its output directly.
 
    .. versionadded:: next
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -311,6 +311,23 @@ difflib
   (Contributed by Jiahao Li in :gh:`134580`.)
 
 
+doctest
+-------
+
+* Add :data:`~doctest.IGNORE_LINEBREAK` option to allow breaking expected
+  output strings without whitespaces into multiple lines:
+
+  .. doctest::
+     :no-trim-doctest-flags:
+
+     >>> import string
+     >>> print(string.ascii_letters)  # doctest: +IGNORE_LINEBREAK
+     abcdefghijklmnopqrstuvwxyz
+     ABCDEFGHIJKLMNOPQRSTUVWXYZ
+
+  (Contributed by Bénédikt Tran in :gh:`138135`.)
+
+
 hashlib
 -------
 

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1758,7 +1758,7 @@ class OutputChecker:
         # the NORMALIZE_WHITESPACE and ELLIPSIS flags.
         if optionflags & IGNORE_LINEBREAK:
             # `want` originally ends with '\n' so we add it back
-            want = ''.join(want.split('\n')) + '\n'
+            want = ''.join(want.splitlines()) + '\n'
             if got == want:
                 return True
 

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -53,6 +53,7 @@ __all__ = [
     'DONT_ACCEPT_TRUE_FOR_1',
     'DONT_ACCEPT_BLANKLINE',
     'NORMALIZE_WHITESPACE',
+    'IGNORE_LINEBREAK',
     'ELLIPSIS',
     'SKIP',
     'IGNORE_EXCEPTION_DETAIL',
@@ -156,6 +157,7 @@ def register_optionflag(name):
 DONT_ACCEPT_TRUE_FOR_1 = register_optionflag('DONT_ACCEPT_TRUE_FOR_1')
 DONT_ACCEPT_BLANKLINE = register_optionflag('DONT_ACCEPT_BLANKLINE')
 NORMALIZE_WHITESPACE = register_optionflag('NORMALIZE_WHITESPACE')
+IGNORE_LINEBREAK = register_optionflag('IGNORE_LINEBREAK')
 ELLIPSIS = register_optionflag('ELLIPSIS')
 SKIP = register_optionflag('SKIP')
 IGNORE_EXCEPTION_DETAIL = register_optionflag('IGNORE_EXCEPTION_DETAIL')
@@ -1751,9 +1753,18 @@ class OutputChecker:
             if got == want:
                 return True
 
+        # This flag causes doctest to ignore '\n' in `want`.
+        # Note that this can be used in conjunction with
+        # the NORMALIZE_WHITESPACE and ELLIPSIS flags.
+        if optionflags & IGNORE_LINEBREAK:
+            # `want` originally ends with '\n' so we add it back
+            want = ''.join(want.split('\n')) + '\n'
+            if got == want:
+                return True
+
         # This flag causes doctest to ignore any differences in the
         # contents of whitespace strings.  Note that this can be used
-        # in conjunction with the ELLIPSIS flag.
+        # in conjunction with the IGNORE_LINEBREAK and ELLIPSIS flags.
         if optionflags & NORMALIZE_WHITESPACE:
             got = ' '.join(got.split())
             want = ' '.join(want.split())
@@ -2268,7 +2279,7 @@ def set_unittest_reportflags(flags):
       >>> doctest.set_unittest_reportflags(ELLIPSIS)
       Traceback (most recent call last):
       ...
-      ValueError: ('Only reporting flags allowed', 8)
+      ValueError: ('Only reporting flags allowed', 16)
 
       >>> doctest.set_unittest_reportflags(old) == (REPORT_NDIFF |
       ...                                   REPORT_ONLY_FIRST_FAILURE)
@@ -2923,6 +2934,13 @@ __test__ = {"_TestClass": _TestClass,
                     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
                      15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
                      27, 28, 29]
+            """,
+
+            "line break elimination": r"""
+                >>> "foobar"  # doctest: +IGNORE_LINEBREAK
+                'foo
+                bar
+                '
             """,
            }
 

--- a/Lib/test/test_doctest/test_doctest.py
+++ b/Lib/test/test_doctest/test_doctest.py
@@ -1445,6 +1445,22 @@ The IGNORE_LINEBREAK flag causes all sequences of newlines to be removed:
     abcdefghijklmnopqrstuvwxyz
     ABCDEFGHIJKLMNOPQRSTUVWXYZ
 
+    ... mixing flags:
+
+    >>> import string
+    >>> print(string.ascii_letters)  # doctest: +ELLIPSIS, +IGNORE_LINEBREAK
+    abc...xyz
+    ABC...
+
+    ... mixing flags:
+
+    >>> import string
+    >>> print(list(string.ascii_letters))  # doctest: +IGNORE_LINEBREAK
+    ...                                    # doctest: +ELLIPSIS
+    ...                                    # doctest: +NORMALIZE_WHITESPACE
+    ['a', ..., 'z',
+     'A', ..., 'Z']
+
 The ELLIPSIS flag causes ellipsis marker ("...") in the expected
 output to match any substring in the actual output:
 

--- a/Lib/test/test_doctest/test_doctest.py
+++ b/Lib/test/test_doctest/test_doctest.py
@@ -204,7 +204,7 @@ keyword arguments:
     ...                           options={doctest.ELLIPSIS: True})
     >>> (example.source, example.want, example.exc_msg,
     ...  example.lineno, example.indent, example.options)
-    ('[].pop()\n', '', 'IndexError: pop from an empty list\n', 5, 4, {8: True})
+    ('[].pop()\n', '', 'IndexError: pop from an empty list\n', 5, 4, {16: True})
 
 The constructor normalizes the `source` string to end in a newline:
 
@@ -1395,6 +1395,55 @@ treated as equal:
     >>> print(list(range(20))) #doctest: +NORMALIZE_WHITESPACE
     [0,   1,  2,  3,  4,  5,  6,  7,  8,  9,
     10,  11, 12, 13, 14, 15, 16, 17, 18, 19]
+
+The IGNORE_LINEBREAK flag causes all sequences of newlines to be removed:
+
+    >>> def f(x):
+    ...     '\n>>> "foobar"\n\'foo\nbar\''
+
+    >>> # Without the flag:
+    >>> test = doctest.DocTestFinder().find(f)[0]
+    >>> doctest.DocTestRunner(verbose=False).run(test)
+    ... # doctest: +ELLIPSIS
+    **********************************************************************
+    File ..., line 3, in f
+    Failed example:
+        "foobar"
+    Expected:
+        'foo
+        bar'
+    Got:
+        'foobar'
+    TestResults(failed=1, attempted=1)
+
+    >>> # With the flag:
+    >>> test = doctest.DocTestFinder().find(f)[0]
+    >>> flags = doctest.IGNORE_LINEBREAK
+    >>> doctest.DocTestRunner(verbose=False, optionflags=flags).run(test)
+    TestResults(failed=0, attempted=1)
+
+    ... ignore surrounding new lines
+
+    >>> "foobar"  # doctest: +IGNORE_LINEBREAK
+    '
+    foo
+    bar'
+    >>> "foobar"  # doctest: +IGNORE_LINEBREAK
+    'foo
+    bar
+    '
+    >>> "foobar"  # doctest: +IGNORE_LINEBREAK
+    '
+    foo
+    bar
+    '
+
+    ... non-quoted output:
+
+    >>> import string
+    >>> print(string.ascii_letters)  # doctest: +IGNORE_LINEBREAK
+    abcdefghijklmnopqrstuvwxyz
+    ABCDEFGHIJKLMNOPQRSTUVWXYZ
 
 The ELLIPSIS flag causes ellipsis marker ("...") in the expected
 output to match any substring in the actual output:

--- a/Misc/NEWS.d/next/Library/2025-08-25-13-31-25.gh-issue-138135.yo5w-T.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-25-13-31-25.gh-issue-138135.yo5w-T.rst
@@ -1,0 +1,3 @@
+:mod:`doctest`: Add :data:`~doctest.IGNORE_LINEBREAK` option to allow
+breaking expected output strings without whitespaces into multiple lines.
+Patch by Bénédikt Tran.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138135 -->
* Issue: gh-138135
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138136.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->