### PR TITLE
[3.13] gh-137609: Update signatures of builtins in the documentation (GH-137610)

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -54,7 +54,7 @@ are always available.  They are listed here in alphabetical order.
 .. |func-bytearray| replace:: ``bytearray()``
 .. |func-bytes| replace:: ``bytes()``
 
-.. function:: abs(x)
+.. function:: abs(number, /)
 
    Return the absolute value of a number.  The argument may be an
    integer, a floating-point number, or an object implementing
@@ -62,7 +62,7 @@ are always available.  They are listed here in alphabetical order.
    If the argument is a complex number, its magnitude is returned.
 
 
-.. function:: aiter(async_iterable)
+.. function:: aiter(async_iterable, /)
 
    Return an :term:`asynchronous iterator` for an :term:`asynchronous iterable`.
    Equivalent to calling ``x.__aiter__()``.
@@ -71,7 +71,7 @@ are always available.  They are listed here in alphabetical order.
 
    .. versionadded:: 3.10
 
-.. function:: all(iterable)
+.. function:: all(iterable, /)
 
    Return ``True`` if all elements of the *iterable* are true (or if the iterable
    is empty).  Equivalent to::
@@ -83,8 +83,8 @@ are always available.  They are listed here in alphabetical order.
           return True
 
 
-.. awaitablefunction:: anext(async_iterator)
-                       anext(async_iterator, default)
+.. awaitablefunction:: anext(async_iterator, /)
+                       anext(async_iterator, default, /)
 
    When awaited, return the next item from the given :term:`asynchronous
    iterator`, or *default* if given and the iterator is exhausted.
@@ -99,7 +99,7 @@ are always available.  They are listed here in alphabetical order.
 
    .. versionadded:: 3.10
 
-.. function:: any(iterable)
+.. function:: any(iterable, /)
 
    Return ``True`` if any element of the *iterable* is true.  If the iterable
    is empty, return ``False``.  Equivalent to::
@@ -111,7 +111,7 @@ are always available.  They are listed here in alphabetical order.
           return False
 
 
-.. function:: ascii(object)
+.. function:: ascii(object, /)
 
    As :func:`repr`, return a string containing a printable representation of an
    object, but escape the non-ASCII characters in the string returned by
@@ -119,10 +119,10 @@ are always available.  They are listed here in alphabetical order.
    similar to that returned by :func:`repr` in Python 2.
 
 
-.. function:: bin(x)
+.. function:: bin(integer, /)
 
    Convert an integer number to a binary string prefixed with "0b". The result
-   is a valid Python expression. If *x* is not a Python :class:`int` object, it
+   is a valid Python expression. If *integer* is not a Python :class:`int` object, it
    has to define an :meth:`~object.__index__` method that returns an integer. Some
    examples:
 
@@ -183,8 +183,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. _func-bytearray:
 .. class:: bytearray(source=b'')
-           bytearray(source, encoding)
-           bytearray(source, encoding, errors)
+           bytearray(source, encoding, errors='strict')
    :noindex:
 
    Return a new array of bytes.  The :class:`bytearray` class is a mutable
@@ -215,8 +214,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. _func-bytes:
 .. class:: bytes(source=b'')
-           bytes(source, encoding)
-           bytes(source, encoding, errors)
+           bytes(source, encoding, errors='strict')
    :noindex:
 
    Return a new "bytes" object which is an immutable sequence of integers in
@@ -231,7 +229,7 @@ are always available.  They are listed here in alphabetical order.
    See also :ref:`binaryseq`, :ref:`typebytes`, and :ref:`bytes-methods`.
 
 
-.. function:: callable(object)
+.. function:: callable(object, /)
 
    Return :const:`True` if the *object* argument appears callable,
    :const:`False` if not.  If this returns ``True``, it is still possible that a
@@ -244,14 +242,14 @@ are always available.  They are listed here in alphabetical order.
       in Python 3.2.
 
 
-.. function:: chr(i)
+.. function:: chr(codepoint, /)
 
-   Return the string representing a character whose Unicode code point is the
-   integer *i*.  For example, ``chr(97)`` returns the string ``'a'``, while
+   Return the string representing a character with the specified Unicode code point.
+   For example, ``chr(97)`` returns the string ``'a'``, while
    ``chr(8364)`` returns the string ``'€'``. This is the inverse of :func:`ord`.
 
    The valid range for the argument is from 0 through 1,114,111 (0x10FFFF in
-   base 16).  :exc:`ValueError` will be raised if *i* is outside that range.
+   base 16).  :exc:`ValueError` will be raised if it is outside that range.
 
 
 .. decorator:: classmethod
@@ -452,7 +450,7 @@ are always available.  They are listed here in alphabetical order.
       :meth:`~object.__float__` are not defined.
 
 
-.. function:: delattr(object, name)
+.. function:: delattr(object, name, /)
 
    This is a relative of :func:`setattr`.  The arguments are an object and a
    string.  The string must be the name of one of the object's attributes.  The
@@ -462,9 +460,9 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. _func-dict:
-.. class:: dict(**kwarg)
-           dict(mapping, **kwarg)
-           dict(iterable, **kwarg)
+.. class:: dict(**kwargs)
+           dict(mapping, /, **kwargs)
+           dict(iterable, /, **kwargs)
    :noindex:
 
    Create a new dictionary.  The :class:`dict` object is the dictionary class.
@@ -475,7 +473,7 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. function:: dir()
-              dir(object)
+              dir(object, /)
 
    Without arguments, return the list of names in the current local scope.  With an
    argument, attempt to return a list of valid attributes for that object.
@@ -535,7 +533,7 @@ are always available.  They are listed here in alphabetical order.
       class.
 
 
-.. function:: divmod(a, b)
+.. function:: divmod(a, b, /)
 
    Take two (non-complex) numbers as arguments and return a pair of numbers
    consisting of their quotient and remainder when using integer division.  With
@@ -723,7 +721,7 @@ are always available.  They are listed here in alphabetical order.
       described for the :func:`locals` builtin.
 
 
-.. function:: filter(function, iterable)
+.. function:: filter(function, iterable, /)
 
    Construct an iterator from those elements of *iterable* for which *function*
    is true.  *iterable* may be either a sequence, a container which
@@ -815,7 +813,7 @@ are always available.  They are listed here in alphabetical order.
    single: __format__
    single: string; format() (built-in function)
 
-.. function:: format(value, format_spec="")
+.. function:: format(value, format_spec="", /)
 
    Convert a *value* to a "formatted" representation, as controlled by
    *format_spec*.  The interpretation of *format_spec* will depend on the type
@@ -838,7 +836,7 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. _func-frozenset:
-.. class:: frozenset(iterable=set())
+.. class:: frozenset(iterable=(), /)
    :noindex:
 
    Return a new :class:`frozenset` object, optionally with elements taken from
@@ -850,8 +848,8 @@ are always available.  They are listed here in alphabetical order.
    module.
 
 
-.. function:: getattr(object, name)
-              getattr(object, name, default)
+.. function:: getattr(object, name, /)
+              getattr(object, name, default, /)
 
    Return the value of the named attribute of *object*.  *name* must be a string.
    If the string is the name of one of the object's attributes, the result is the
@@ -875,7 +873,7 @@ are always available.  They are listed here in alphabetical order.
    regardless of where the function is called.
 
 
-.. function:: hasattr(object, name)
+.. function:: hasattr(object, name, /)
 
    The arguments are an object and a string.  The result is ``True`` if the
    string is the name of one of the object's attributes, ``False`` if not. (This
@@ -883,7 +881,7 @@ are always available.  They are listed here in alphabetical order.
    raises an :exc:`AttributeError` or not.)
 
 
-.. function:: hash(object)
+.. function:: hash(object, /)
 
    Return the hash value of the object (if it has one).  Hash values are
    integers.  They are used to quickly compare dictionary keys during a
@@ -918,10 +916,10 @@ are always available.  They are listed here in alphabetical order.
       signatures for callables are now more comprehensive and consistent.
 
 
-.. function:: hex(x)
+.. function:: hex(integer, /)
 
    Convert an integer number to a lowercase hexadecimal string prefixed with
-   "0x". If *x* is not a Python :class:`int` object, it has to define an
+   "0x". If *integer* is not a Python :class:`int` object, it has to define an
    :meth:`~object.__index__` method that returns an integer. Some examples:
 
       >>> hex(255)
@@ -950,7 +948,7 @@ are always available.  They are listed here in alphabetical order.
       :meth:`float.hex` method.
 
 
-.. function:: id(object)
+.. function:: id(object, /)
 
    Return the "identity" of an object.  This is an integer which
    is guaranteed to be unique and constant for this object during its lifetime.
@@ -963,7 +961,7 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. function:: input()
-              input(prompt)
+              input(prompt, /)
 
    If the *prompt* argument is present, it is written to standard output without
    a trailing newline.  The function then reads a line from input, converts it
@@ -1064,7 +1062,8 @@ are always available.  They are listed here in alphabetical order.
       See the :ref:`integer string conversion length limitation
       <int_max_str_digits>` documentation.
 
-.. function:: isinstance(object, classinfo)
+
+.. function:: isinstance(object, classinfo, /)
 
    Return ``True`` if the *object* argument is an instance of the *classinfo*
    argument, or of a (direct, indirect, or :term:`virtual <abstract base
@@ -1081,7 +1080,7 @@ are always available.  They are listed here in alphabetical order.
       *classinfo* can be a :ref:`types-union`.
 
 
-.. function:: issubclass(class, classinfo)
+.. function:: issubclass(class, classinfo, /)
 
    Return ``True`` if *class* is a subclass (direct, indirect, or :term:`virtual
    <abstract base class>`) of *classinfo*.  A
@@ -1095,19 +1094,19 @@ are always available.  They are listed here in alphabetical order.
       *classinfo* can be a :ref:`types-union`.
 
 
-.. function:: iter(object)
-              iter(object, sentinel)
+.. function:: iter(iterable, /)
+              iter(callable, sentinel, /)
 
    Return an :term:`iterator` object.  The first argument is interpreted very
    differently depending on the presence of the second argument. Without a
-   second argument, *object* must be a collection object which supports the
+   second argument, the single argument must be a collection object which supports the
    :term:`iterable` protocol (the :meth:`~object.__iter__` method),
    or it must support
    the sequence protocol (the :meth:`~object.__getitem__` method with integer arguments
    starting at ``0``).  If it does not support either of those protocols,
    :exc:`TypeError` is raised. If the second argument, *sentinel*, is given,
-   then *object* must be a callable object.  The iterator created in this case
-   will call *object* with no arguments for each call to its
+   then the first argument must be a callable object.  The iterator created in this case
+   will call *callable* with no arguments for each call to its
    :meth:`~iterator.__next__` method; if the value returned is equal to
    *sentinel*, :exc:`StopIteration` will be raised, otherwise the value will
    be returned.
@@ -1124,7 +1123,7 @@ are always available.  They are listed here in alphabetical order.
               process_block(block)
 
 
-.. function:: len(s)
+.. function:: len(object, /)
 
    Return the length (the number of items) of an object.  The argument may be a
    sequence (such as a string, bytes, tuple, list, or range) or a collection
@@ -1137,8 +1136,7 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. _func-list:
-.. class:: list()
-           list(iterable)
+.. class:: list(iterable=(), /)
    :noindex:
 
    Rather than being a function, :class:`list` is actually a mutable
@@ -1276,8 +1274,8 @@ are always available.  They are listed here in alphabetical order.
       The *key* can be ``None``.
 
 
-.. function:: next(iterator)
-              next(iterator, default)
+.. function:: next(iterator, /)
+              next(iterator, default, /)
 
    Retrieve the next item from the :term:`iterator` by calling its
    :meth:`~iterator.__next__` method.  If *default* is given, it is returned
@@ -1298,10 +1296,10 @@ are always available.  They are listed here in alphabetical order.
       :class:`object`.
 
 
-.. function:: oct(x)
+.. function:: oct(integer, /)
 
   Convert an integer number to an octal string prefixed with "0o".  The result
-  is a valid Python expression. If *x* is not a Python :class:`int` object, it
+  is a valid Python expression. If *integer* is not a Python :class:`int` object, it
   has to define an :meth:`~object.__index__` method that returns an integer. For
   example:
 
@@ -1731,7 +1729,7 @@ are always available.  They are listed here in alphabetical order.
    sequence type, as documented in :ref:`typesseq-range` and :ref:`typesseq`.
 
 
-.. function:: repr(object)
+.. function:: repr(object, /)
 
    Return a string containing a printable representation of an object.  For many
    types, this function makes an attempt to return a string that would yield an
@@ -1755,9 +1753,9 @@ are always available.  They are listed here in alphabetical order.
             return f"Person('{self.name}', {self.age})"
 
 
-.. function:: reversed(seq)
+.. function:: reversed(object, /)
 
-   Return a reverse :term:`iterator`.  *seq* must be an object which has
+   Return a reverse :term:`iterator`.  The argument must be an object which has
    a :meth:`~object.__reversed__` method or supports the sequence protocol (the
    :meth:`~object.__len__` method and the :meth:`~object.__getitem__` method
    with integer arguments starting at ``0``).
@@ -1791,8 +1789,7 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. _func-set:
-.. class:: set()
-           set(iterable)
+.. class:: set(iterable=(), /)
    :noindex:
 
    Return a new :class:`set` object, optionally with elements taken from
@@ -1804,7 +1801,7 @@ are always available.  They are listed here in alphabetical order.
    module.
 
 
-.. function:: setattr(object, name, value)
+.. function:: setattr(object, name, value, /)
 
    This is the counterpart of :func:`getattr`.  The arguments are an object, a
    string, and an arbitrary value.  The string may name an existing attribute or a
@@ -1826,8 +1823,8 @@ are always available.  They are listed here in alphabetical order.
       :func:`setattr`.
 
 
-.. class:: slice(stop)
-           slice(start, stop, step=None)
+.. class:: slice(stop, /)
+           slice(start, stop, step=None, /)
 
    Return a :term:`slice` object representing the set of indices specified by
    ``range(start, stop, step)``.  The *start* and *step* arguments default to
@@ -1932,8 +1929,10 @@ are always available.  They are listed here in alphabetical order.
    single: string; str() (built-in function)
 
 .. _func-str:
-.. class:: str(object='')
-           str(object=b'', encoding='utf-8', errors='strict')
+.. class:: str(*, encoding='utf-8', errors='strict')
+           str(object)
+           str(object, encoding, errors='strict')
+           str(object, *, errors)
    :noindex:
 
    Return a :class:`str` version of *object*.  See :func:`str` for details.
@@ -1962,7 +1961,7 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. class:: super()
-           super(type, object_or_type=None)
+           super(type, object_or_type=None, /)
 
    Return a proxy object that delegates method calls to a parent or sibling
    class of *type*.  This is useful for accessing inherited methods that have
@@ -2040,16 +2039,15 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. _func-tuple:
-.. class:: tuple()
-           tuple(iterable)
+.. class:: tuple(iterable=(), /)
    :noindex:
 
    Rather than being a function, :class:`tuple` is actually an immutable
    sequence type, as documented in :ref:`typesseq-tuple` and :ref:`typesseq`.
 
 
-.. class:: type(object)
-           type(name, bases, dict, **kwds)
+.. class:: type(object, /)
+           type(name, bases, dict, /, **kwargs)
 
    .. index:: pair: object; type
 
@@ -2092,7 +2090,7 @@ are always available.  They are listed here in alphabetical order.
       longer use the one-argument form to get the type of an object.
 
 .. function:: vars()
-              vars(object)
+              vars(object, /)
 
    Return the :attr:`~object.__dict__` attribute for a module, class, instance,
    or any other object with a :attr:`!__dict__` attribute.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1270,7 +1270,7 @@ Lists are mutable sequences, typically used to store collections of
 homogeneous items (where the precise degree of similarity will vary by
 application).
 
-.. class:: list([iterable])
+.. class:: list(iterable=(), /)
 
    Lists may be constructed in several ways:
 
@@ -1351,7 +1351,7 @@ built-in). Tuples are also used for cases where an immutable sequence of
 homogeneous data is needed (such as allowing storage in a :class:`set` or
 :class:`dict` instance).
 
-.. class:: tuple([iterable])
+.. class:: tuple(iterable=(), /)
 
    Tuples may be constructed in a number of ways:
 
@@ -1393,8 +1393,8 @@ The :class:`range` type represents an immutable sequence of numbers and is
 commonly used for looping a specific number of times in :keyword:`for`
 loops.
 
-.. class:: range(stop)
-           range(start, stop[, step])
+.. class:: range(stop, /)
+           range(start, stop, step=1, /)
 
    The arguments to the range constructor must be integers (either built-in
    :class:`int` or any object that implements the :meth:`~object.__index__` special
@@ -1560,8 +1560,10 @@ multiple fragments.
 .. index::
    single: string; str (built-in class)
 
-.. class:: str(object='')
-           str(object=b'', encoding='utf-8', errors='strict')
+.. class:: str(*, encoding='utf-8', errors='strict')
+           str(object)
+           str(object, encoding, errors='strict')
+           str(object, *, errors)
 
    Return a :ref:`string <textseq>` version of *object*.  If *object* is not
    provided, returns the empty string.  Otherwise, the behavior of ``str()``
@@ -1655,7 +1657,7 @@ expression support in the :mod:`re` module).
    .. versionadded:: 3.3
 
 
-.. method:: str.center(width[, fillchar])
+.. method:: str.center(width, fillchar=' ', /)
 
    Return centered in a string of length *width*. Padding is done using the
    specified *fillchar* (default is an ASCII space). The original string is
@@ -1973,7 +1975,7 @@ expression support in the :mod:`re` module).
 
 .. _meth-str-join:
 
-.. method:: str.join(iterable)
+.. method:: str.join(iterable, /)
 
    Return a string which is the concatenation of the strings in *iterable*.
    A :exc:`TypeError` will be raised if there are any non-string values in
@@ -1981,7 +1983,7 @@ expression support in the :mod:`re` module).
    elements is the string providing this method.
 
 
-.. method:: str.ljust(width[, fillchar])
+.. method:: str.ljust(width, fillchar=' ', /)
 
    Return the string left justified in a string of length *width*. Padding is
    done using the specified *fillchar* (default is an ASCII space). The
@@ -1998,7 +2000,7 @@ expression support in the :mod:`re` module).
    <https://www.unicode.org/versions/Unicode15.1.0/ch03.pdf>`__.
 
 
-.. method:: str.lstrip([chars])
+.. method:: str.lstrip(chars=None, /)
 
    Return a copy of the string with leading characters removed.  The *chars*
    argument is a string specifying the set of characters to be removed.  If omitted
@@ -2019,7 +2021,8 @@ expression support in the :mod:`re` module).
       'three!'
 
 
-.. staticmethod:: str.maketrans(x[, y[, z]])
+.. staticmethod:: str.maketrans(dict, /)
+                  str.maketrans(from, to, remove='', /)
 
    This static method returns a translation table usable for :meth:`str.translate`.
 
@@ -2029,12 +2032,12 @@ expression support in the :mod:`re` module).
    converted to ordinals.
 
    If there are two arguments, they must be strings of equal length, and in the
-   resulting dictionary, each character in x will be mapped to the character at
-   the same position in y.  If there is a third argument, it must be a string,
+   resulting dictionary, each character in *from* will be mapped to the character at
+   the same position in *to*.  If there is a third argument, it must be a string,
    whose characters will be mapped to ``None`` in the result.
 
 
-.. method:: str.partition(sep)
+.. method:: str.partition(sep, /)
 
    Split the string at the first occurrence of *sep*, and return a 3-tuple
    containing the part before the separator, the separator itself, and the part
@@ -2070,7 +2073,7 @@ expression support in the :mod:`re` module).
    .. versionadded:: 3.9
 
 
-.. method:: str.replace(old, new, count=-1)
+.. method:: str.replace(old, new, /, count=-1)
 
    Return a copy of the string with all occurrences of substring *old* replaced by
    *new*.  If *count* is given, only the first *count* occurrences are replaced.
@@ -2093,14 +2096,14 @@ expression support in the :mod:`re` module).
    found.
 
 
-.. method:: str.rjust(width[, fillchar])
+.. method:: str.rjust(width, fillchar=' ', /)
 
    Return the string right justified in a string of length *width*. Padding is
    done using the specified *fillchar* (default is an ASCII space). The
    original string is returned if *width* is less than or equal to ``len(s)``.
 
 
-.. method:: str.rpartition(sep)
+.. method:: str.rpartition(sep, /)
 
    Split the string at the last occurrence of *sep*, and return a 3-tuple
    containing the part before the separator, the separator itself, and the part
@@ -2117,7 +2120,7 @@ expression support in the :mod:`re` module).
    :meth:`split` which is described in detail below.
 
 
-.. method:: str.rstrip([chars])
+.. method:: str.rstrip(chars=None, /)
 
    Return a copy of the string with trailing characters removed.  The *chars*
    argument is a string specifying the set of characters to be removed.  If omitted
@@ -2266,7 +2269,7 @@ expression support in the :mod:`re` module).
    string at that position.
 
 
-.. method:: str.strip([chars])
+.. method:: str.strip(chars=None, /)
 
    Return a copy of the string with the leading and trailing characters removed.
    The *chars* argument is a string specifying the set of characters to be removed.
@@ -2331,7 +2334,7 @@ expression support in the :mod:`re` module).
         "They're Bill's Friends."
 
 
-.. method:: str.translate(table)
+.. method:: str.translate(table, /)
 
    Return a copy of the string in which each character has been mapped through
    the given translation table.  The table must be an object that implements
@@ -2362,7 +2365,7 @@ expression support in the :mod:`re` module).
    <https://www.unicode.org/versions/Unicode15.1.0/ch03.pdf>`__.
 
 
-.. method:: str.zfill(width)
+.. method:: str.zfill(width, /)
 
    Return a copy of the string left filled with ASCII ``'0'`` digits to
    make a string of length *width*. A leading sign prefix (``'+'``/``'-'``)
@@ -2753,7 +2756,8 @@ binary protocols are based on the ASCII text encoding, bytes objects offer
 several methods that are only valid when working with ASCII compatible
 data and are closely related to string objects in a variety of other ways.
 
-.. class:: bytes([source[, encoding[, errors]]])
+.. class:: bytes(source=b'')
+           bytes(source, encoding, errors='strict')
 
    Firstly, the syntax for bytes literals is largely the same as that for string
    literals, except that a ``b`` prefix is added:
@@ -2793,7 +2797,7 @@ data and are closely related to string objects in a variety of other ways.
    numbers are a commonly used format for describing binary data. Accordingly,
    the bytes type has an additional class method to read data in that format:
 
-   .. classmethod:: fromhex(string)
+   .. classmethod:: fromhex(string, /)
 
       This :class:`bytes` class method returns a bytes object, decoding the
       given string object.  The string must contain two hexadecimal digits per
@@ -2809,7 +2813,8 @@ data and are closely related to string objects in a variety of other ways.
    A reverse conversion function exists to transform a bytes object into its
    hexadecimal representation.
 
-   .. method:: hex([sep[, bytes_per_sep]])
+   .. method:: hex(*, bytes_per_sep=1)
+               hex(sep, bytes_per_sep=1)
 
       Return a string object containing two hexadecimal digits for each
       byte in the instance.
@@ -2858,7 +2863,8 @@ Bytearray Objects
 :class:`bytearray` objects are a mutable counterpart to :class:`bytes`
 objects.
 
-.. class:: bytearray([source[, encoding[, errors]]])
+.. class:: bytearray(source=b'')
+           bytearray(source, encoding, errors='strict')
 
    There is no dedicated literal syntax for bytearray objects, instead
    they are always created by calling the constructor:
@@ -2878,7 +2884,7 @@ objects.
    numbers are a commonly used format for describing binary data. Accordingly,
    the bytearray type has an additional class method to read data in that format:
 
-   .. classmethod:: fromhex(string)
+   .. classmethod:: fromhex(string, /)
 
       This :class:`bytearray` class method returns bytearray object, decoding
       the given string object.  The string must contain two hexadecimal digits
@@ -2894,7 +2900,8 @@ objects.
    A reverse conversion function exists to transform a bytearray object into its
    hexadecimal representation.
 
-   .. method:: hex([sep[, bytes_per_sep]])
+   .. method:: hex(*, bytes_per_sep=1)
+               hex(sep, bytes_per_sep=1)
 
       Return a string object containing two hexadecimal digits for each
       byte in the instance.
@@ -3100,8 +3107,8 @@ arbitrary binary data.
       Also accept an integer in the range 0 to 255 as the subsequence.
 
 
-.. method:: bytes.join(iterable)
-            bytearray.join(iterable)
+.. method:: bytes.join(iterable, /)
+            bytearray.join(iterable, /)
 
    Return a bytes or bytearray object which is the concatenation of the
    binary data sequences in *iterable*.  A :exc:`TypeError` will be raised
@@ -3111,8 +3118,8 @@ arbitrary binary data.
    bytearray object providing this method.
 
 
-.. staticmethod:: bytes.maketrans(from, to)
-                  bytearray.maketrans(from, to)
+.. staticmethod:: bytes.maketrans(from, to, /)
+                  bytearray.maketrans(from, to, /)
 
    This static method returns a translation table usable for
    :meth:`bytes.translate` that will map each character in *from* into the
@@ -3122,8 +3129,8 @@ arbitrary binary data.
    .. versionadded:: 3.1
 
 
-.. method:: bytes.partition(sep)
-            bytearray.partition(sep)
+.. method:: bytes.partition(sep, /)
+            bytearray.partition(sep, /)
 
    Split the sequence at the first occurrence of *sep*, and return a 3-tuple
    containing the part before the separator, the separator itself or its
@@ -3135,8 +3142,8 @@ arbitrary binary data.
    The separator to search for may be any :term:`bytes-like object`.
 
 
-.. method:: bytes.replace(old, new[, count])
-            bytearray.replace(old, new[, count])
+.. method:: bytes.replace(old, new, count=-1, /)
+            bytearray.replace(old, new, count=-1, /)
 
    Return a copy of the sequence with all occurrences of subsequence *old*
    replaced by *new*.  If the optional argument *count* is given, only the
@@ -3179,8 +3186,8 @@ arbitrary binary data.
       Also accept an integer in the range 0 to 255 as the subsequence.
 
 
-.. method:: bytes.rpartition(sep)
-            bytearray.rpartition(sep)
+.. method:: bytes.rpartition(sep, /)
+            bytearray.rpartition(sep, /)
 
    Split the sequence at the last occurrence of *sep*, and return a 3-tuple
    containing the part before the separator, the separator itself or its
@@ -3230,8 +3237,8 @@ with arbitrary binary data by passing appropriate arguments. Note that all of
 the bytearray methods in this section do *not* operate in place, and instead
 produce new objects.
 
-.. method:: bytes.center(width[, fillbyte])
-            bytearray.center(width[, fillbyte])
+.. method:: bytes.center(width, fillbyte=b' ', /)
+            bytearray.center(width, fillbyte=b' ', /)
 
    Return a copy of the object centered in a sequence of length *width*.
    Padding is done using the specified *fillbyte* (default is an ASCII
@@ -3244,8 +3251,8 @@ produce new objects.
       it always produces a new object, even if no changes were made.
 
 
-.. method:: bytes.ljust(width[, fillbyte])
-            bytearray.ljust(width[, fillbyte])
+.. method:: bytes.ljust(width, fillbyte=b' ', /)
+            bytearray.ljust(width, fillbyte=b' ', /)
 
    Return a copy of the object left justified in a sequence of length *width*.
    Padding is done using the specified *fillbyte* (default is an ASCII
@@ -3258,14 +3265,13 @@ produce new objects.
       it always produces a new object, even if no changes were made.
 
 
-.. method:: bytes.lstrip([chars])
-            bytearray.lstrip([chars])
+.. method:: bytes.lstrip(bytes=None, /)
+            bytearray.lstrip(bytes=None, /)
 
    Return a copy of the sequence with specified leading bytes removed.  The
-   *chars* argument is a binary sequence specifying the set of byte values to
-   be removed - the name refers to the fact this method is usually used with
-   ASCII characters.  If omitted or ``None``, the *chars* argument defaults
-   to removing ASCII whitespace.  The *chars* argument is not a prefix;
+   *bytes* argument is a binary sequence specifying the set of byte values to
+   be removed.  If omitted or ``None``, the *bytes* argument defaults
+   to removing ASCII whitespace.  The *bytes* argument is not a prefix;
    rather, all combinations of its values are stripped::
 
       >>> b'   spacious   '.lstrip()
@@ -3289,8 +3295,8 @@ produce new objects.
       it always produces a new object, even if no changes were made.
 
 
-.. method:: bytes.rjust(width[, fillbyte])
-            bytearray.rjust(width[, fillbyte])
+.. method:: bytes.rjust(width, fillbyte=b' ', /)
+            bytearray.rjust(width, fillbyte=b' ', /)
 
    Return a copy of the object right justified in a sequence of length *width*.
    Padding is done using the specified *fillbyte* (default is an ASCII
@@ -3314,14 +3320,13 @@ produce new objects.
    :meth:`split` which is described in detail below.
 
 
-.. method:: bytes.rstrip([chars])
-            bytearray.rstrip([chars])
+.. method:: bytes.rstrip(bytes=None, /)
+            bytearray.rstrip(bytes=None, /)
 
    Return a copy of the sequence with specified trailing bytes removed.  The
-   *chars* argument is a binary sequence specifying the set of byte values to
-   be removed - the name refers to the fact this method is usually used with
-   ASCII characters.  If omitted or ``None``, the *chars* argument defaults to
-   removing ASCII whitespace.  The *chars* argument is not a suffix; rather,
+   *bytes* argument is a binary sequence specifying the set of byte values to
+   be removed.  If omitted or ``None``, the *bytes* argument defaults to
+   removing ASCII whitespace.  The *bytes* argument is not a suffix; rather,
    all combinations of its values are stripped::
 
       >>> b'   spacious   '.rstrip()
@@ -3391,14 +3396,13 @@ produce new objects.
       [b'1', b'2', b'3']
 
 
-.. method:: bytes.strip([chars])
-            bytearray.strip([chars])
+.. method:: bytes.strip(bytes=None, /)
+            bytearray.strip(bytes=None, /)
 
    Return a copy of the sequence with specified leading and trailing bytes
-   removed. The *chars* argument is a binary sequence specifying the set of
-   byte values to be removed - the name refers to the fact this method is
-   usually used with ASCII characters.  If omitted or ``None``, the *chars*
-   argument defaults to removing ASCII whitespace. The *chars* argument is
+   removed. The *bytes* argument is a binary sequence specifying the set of
+   byte values to be removed.  If omitted or ``None``, the *bytes*
+   argument defaults to removing ASCII whitespace. The *bytes* argument is
    not a prefix or suffix; rather, all combinations of its values are
    stripped::
 
@@ -3720,8 +3724,8 @@ place, and instead produce new objects.
       always produces a new object, even if no changes were made.
 
 
-.. method:: bytes.zfill(width)
-            bytearray.zfill(width)
+.. method:: bytes.zfill(width, /)
+            bytearray.zfill(width, /)
 
    Return a copy of the sequence left filled with ASCII ``b'0'`` digits to
    make a sequence of length *width*. A leading sign prefix (``b'+'``/
@@ -4130,7 +4134,8 @@ copying.
          in-memory Fortran order is preserved. For non-contiguous views, the
          data is converted to C first. *order=None* is the same as *order='C'*.
 
-   .. method:: hex([sep[, bytes_per_sep]])
+   .. method:: hex(*, bytes_per_sep=1)
+               hex(sep, bytes_per_sep=1)
 
       Return a string object containing two hexadecimal digits for each
       byte in the buffer. ::
@@ -4215,7 +4220,8 @@ copying.
 
       .. versionadded:: 3.2
 
-   .. method:: cast(format[, shape])
+   .. method:: cast(format, /)
+               cast(format, shape, /)
 
       Cast a memoryview to a new format or shape. *shape* defaults to
       ``[byte_length//new_itemsize]``, which means that the result view
@@ -4462,8 +4468,8 @@ of elements within braces, for example: ``{'jack', 'sjoerd'}``, in addition to t
 
 The constructors for both classes work the same:
 
-.. class:: set([iterable])
-           frozenset([iterable])
+.. class:: set(iterable=(), /)
+           frozenset(iterable=(), /)
 
    Return a new set or frozenset object whose elements are taken from
    *iterable*.  The elements of a set must be :term:`hashable`.  To
@@ -4492,12 +4498,12 @@ The constructors for both classes work the same:
 
       Test *x* for non-membership in *s*.
 
-   .. method:: isdisjoint(other)
+   .. method:: isdisjoint(other, /)
 
       Return ``True`` if the set has no elements in common with *other*.  Sets are
       disjoint if and only if their intersection is the empty set.
 
-   .. method:: issubset(other)
+   .. method:: issubset(other, /)
                set <= other
 
       Test whether every element in the set is in *other*.
@@ -4507,7 +4513,7 @@ The constructors for both classes work the same:
       Test whether the set is a proper subset of *other*, that is,
       ``set <= other and set != other``.
 
-   .. method:: issuperset(other)
+   .. method:: issuperset(other, /)
                set >= other
 
       Test whether every element in *other* is in the set.
@@ -4532,7 +4538,7 @@ The constructors for both classes work the same:
 
       Return a new set with elements in the set that are not in the others.
 
-   .. method:: symmetric_difference(other)
+   .. method:: symmetric_difference(other, /)
                set ^ other
 
       Return a new set with elements in either the set or *other* but not both.
@@ -4592,21 +4598,21 @@ The constructors for both classes work the same:
 
       Update the set, removing elements found in others.
 
-   .. method:: symmetric_difference_update(other)
+   .. method:: symmetric_difference_update(other, /)
                set ^= other
 
       Update the set, keeping only elements found in either set, but not in both.
 
-   .. method:: add(elem)
+   .. method:: add(elem, /)
 
       Add element *elem* to the set.
 
-   .. method:: remove(elem)
+   .. method:: remove(elem, /)
 
       Remove element *elem* from the set.  Raises :exc:`KeyError` if *elem* is
       not contained in the set.
 
-   .. method:: discard(elem)
+   .. method:: discard(elem, /)
 
       Remove element *elem* from the set if it is present.
 
@@ -4658,8 +4664,8 @@ Values that compare equal (such as ``1``, ``1.0``, and ``True``)
 can be used interchangeably to index the same dictionary entry.
 
 .. class:: dict(**kwargs)
-           dict(mapping, **kwargs)
-           dict(iterable, **kwargs)
+           dict(mapping, /, **kwargs)
+           dict(iterable, /, **kwargs)
 
    Return a new dictionary initialized from an optional positional argument
    and a possibly empty set of keyword arguments.
@@ -4827,7 +4833,8 @@ can be used interchangeably to index the same dictionary entry.
       Return a new view of the dictionary's keys.  See the :ref:`documentation
       of view objects <dict-views>`.
 
-   .. method:: pop(key[, default])
+   .. method:: pop(key, /)
+               pop(key, default, /)
 
       If *key* is in the dictionary, remove it and return its value, else return
       *default*.  If *default* is not given and *key* is not in the dictionary,
@@ -4859,9 +4866,11 @@ can be used interchangeably to index the same dictionary entry.
       with a value of *default* and return *default*.  *default* defaults to
       ``None``.
 
-   .. method:: update([other])
+   .. method:: update(**kwargs)
+               update(mapping, /, **kwargs)
+               update(iterable, /, **kwargs)
 
-      Update the dictionary with the key/value pairs from *other*, overwriting
+      Update the dictionary with the key/value pairs from *mapping* or *iterable* and *kwargs*, overwriting
       existing keys.  Return ``None``.
 
       :meth:`update` accepts either another object with a ``keys()`` method (in


### PR DESCRIPTION
Show signatures that match the actual signatures or future multisignatures for all functions, classes and methods in the "builtins" module.

(cherry picked from commit 65fb4d11a0f3f3e4aea373bd84918e4445cbfe67)


<!-- gh-issue-number: gh-137609 -->
* Issue: gh-137609
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138138.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->