### PR TITLE
gh-138158: Use the `"data"` tarfile extraction filter in `Tools/ssl/multissltests.py`

### DIFF
--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -288,51 +288,52 @@ class AbstractBuilder(object):
             f.write(data)
 
     def _unpack_src(self):
-    	"""Unpack tar.gz bundle"""
-    	# cleanup
-    	if os.path.isdir(self.build_dir):
-        	shutil.rmtree(self.build_dir)
-    	os.makedirs(self.build_dir)
+        """Unpack tar.gz bundle"""
+        # cleanup
+        if os.path.isdir(self.build_dir):
+            shutil.rmtree(self.build_dir)
+        os.makedirs(self.build_dir)
+        
+        tf = tarfile.open(self.src_file)
+        name = self.build_template.format(self.version)
+        base = name + '/'
+        # force extraction into build dir
+        members = tf.getmembers()
+        
+        log.info("Unpacking files to {}".format(self.build_dir))
+        build_dir_real = os.path.realpath(self.build_dir)
+        
+        for member in members:
+            if member.name == name:
+                continue
+            elif not member.name.startswith(base):
+                raise ValueError(member.name, base)
+            
+            # Strip the base directory and normalize the path
+            member.name = member.name[len(base):].lstrip('/')
+            
+            # Security checks for safe extraction
+            if member.islnk() or member.issym():
+                log.warning("Skipping symbolic/hard link: {}".format(member.name))
+                continue
+            
+            # Normalize the member path
+            normalized_path = os.path.normpath(member.name)
+            
+            # Check for directory traversal attempts
+            if normalized_path.startswith('/') or '..' in normalized_path.split(os.sep):
+                log.warning("Skipping potentially malicious member: {}".format(member.name))
+                continue
+            
+            # Construct final path and validate it's within build directory
+            final_path = os.path.realpath(os.path.join(self.build_dir, normalized_path))
+            if not final_path.startswith(build_dir_real + os.sep) and final_path != build_dir_real:
+                log.warning("Skipping member attempting directory traversal: {}".format(member.name))
+                continue
+            
+            # Safe extraction
+            tf.extract(member, self.build_dir)
 
-    	tf = tarfile.open(self.src_file)
-    	name = self.build_template.format(self.version)
-    	base = name + '/'
-    	# force extraction into build dir
-    	members = tf.getmembers()
-    
-    	log.info("Unpacking files to {}".format(self.build_dir))
-    	build_dir_real = os.path.realpath(self.build_dir)
-    
-    	for member in members:
-        	if member.name == name:
-            		continue
-        	elif not member.name.startswith(base):
-            		raise ValueError(member.name, base)
-            
-       		# Strip the base directory and normalize the path
-        	member.name = member.name[len(base):].lstrip('/')
-        
-        	# Security checks for safe extraction
-        	if member.islnk() or member.issym():
-            		log.warning("Skipping symbolic/hard link: {}".format(member.name))
-            		continue
-            
-        	# Normalize the member path
-        	normalized_path = os.path.normpath(member.name)
-        
-        	# Check for directory traversal attempts
-       		if normalized_path.startswith('/') or '..' in normalized_path.split(os.sep):
-            		log.warning("Skipping potentially malicious member: {}".format(member.name))
-            		continue
-            
-        		# Construct final path and validate it's within build directory
-       		final_path = os.path.realpath(os.path.join(self.build_dir, normalized_path))
-        	if not final_path.startswith(build_dir_real + os.sep) and final_path != build_dir_real:
-            		log.warning("Skipping member attempting directory traversal: {}".format(member.name))
-            		continue
-            
-        # Safe extraction
-    	tf.extract(member, self.build_dir)
     def _build_src(self, config_args=()):
         """Now build openssl"""
         log.info("Running build in {}".format(self.build_dir))

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -293,6 +293,7 @@ class AbstractBuilder(object):
         if os.path.isdir(self.build_dir):
             shutil.rmtree(self.build_dir)
         os.makedirs(self.build_dir)
+
         tf = tarfile.open(self.src_file)
         name = self.build_template.format(self.version)
         base = name + '/'

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -293,45 +293,20 @@ class AbstractBuilder(object):
         if os.path.isdir(self.build_dir):
             shutil.rmtree(self.build_dir)
         os.makedirs(self.build_dir)
+    
         tf = tarfile.open(self.src_file)
         name = self.build_template.format(self.version)
         base = name + '/'
         # force extraction into build dir
         members = tf.getmembers()
-        
-        log.info("Unpacking files to {}".format(self.build_dir))
-        build_dir_real = os.path.realpath(self.build_dir)
-        
-        for member in members:
+        for member in list(members):
             if member.name == name:
-                continue
+                members.remove(member)
             elif not member.name.startswith(base):
                 raise ValueError(member.name, base)
-            
-            # Strip the base directory and normalize the path
             member.name = member.name[len(base):].lstrip('/')
-            
-            # Security checks for safe extraction
-            if member.islnk() or member.issym():
-                log.warning("Skipping symbolic/hard link: {}".format(member.name))
-                continue
-            
-            # Normalize the member path
-            normalized_path = os.path.normpath(member.name)
-            
-            # Check for directory traversal attempts
-            if normalized_path.startswith('/') or '..' in normalized_path.split(os.sep):
-                log.warning("Skipping potentially malicious member: {}".format(member.name))
-                continue
-            
-            # Construct final path and validate it's within build directory
-            final_path = os.path.realpath(os.path.join(self.build_dir, normalized_path))
-            if not final_path.startswith(build_dir_real + os.sep) and final_path != build_dir_real:
-                log.warning("Skipping member attempting directory traversal: {}".format(member.name))
-                continue
-            
-            # Safe extraction
-            tf.extract(member, self.build_dir)
+        log.info("Unpacking files to {}".format(self.build_dir))
+        tf.extractall(self.build_dir, members, filter='data')
 
     def _build_src(self, config_args=()):
         """Now build openssl"""

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -293,7 +293,6 @@ class AbstractBuilder(object):
         if os.path.isdir(self.build_dir):
             shutil.rmtree(self.build_dir)
         os.makedirs(self.build_dir)
-        
         tf = tarfile.open(self.src_file)
         name = self.build_template.format(self.version)
         base = name + '/'

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -293,7 +293,6 @@ class AbstractBuilder(object):
         if os.path.isdir(self.build_dir):
             shutil.rmtree(self.build_dir)
         os.makedirs(self.build_dir)
-    
         tf = tarfile.open(self.src_file)
         name = self.build_template.format(self.version)
         base = name + '/'


### PR DESCRIPTION
This pull request addresses a path traversal vulnerability in the Tools/ssl/multissltests.py script. The vulnerability allows for a crafted tarball to write an arbitrary file to a location outside of the intended build directory due to a lack of sanitization in the _unpack_src method's handling of tarball member names.

A comprehensive, self-contained PoC script was used to demonstrate the issue (and shared with the PSRT), confirming the Path Traversal. The fix implemented in this PR ensures that each tarball member is manually extracted with a path check, preventing any file from escaping the designated directory. This approach provides a clear and robust solution to the issue.

As this is a test script, and not a production component, the Python Security Response Team (PSRT) has advised me to submitt it as a public enhancement. This fix ensures the integrity and robustness of the tool, by preventing an unprivileged file write that could lead to unexpected behavior.

I am submitting this enhancement to improve the overall quality of the CPython test suite. If necessary, I'm available to provide any additional information required for review.

<!-- gh-issue-number: gh-138158 -->
* Issue: gh-138158
<!-- /gh-issue-number -->
