### PR TITLE
gh-138013: Move test.test_io to be a module

### DIFF
--- a/Lib/test/test_io/__init__.py
+++ b/Lib/test/test_io/__init__.py
@@ -1,0 +1,5 @@
+import os
+from test.support import load_package_tests
+
+def load_tests(*args):
+    return load_package_tests(os.path.dirname(__file__), *args)

--- a/Lib/test/test_io/__main__.py
+++ b/Lib/test/test_io/__main__.py
@@ -1,0 +1,4 @@
+from . import load_tests
+import unittest
+
+unittest.main()

--- a/Lib/test/test_io/test_general.py
+++ b/Lib/test/test_io/test_general.py
@@ -5,7 +5,7 @@
 # * test_memoryio - tests BytesIO and StringIO
 # * test_fileio - tests FileIO
 # * test_file - tests the file interface
-# * test_io - tests everything else in the io module
+# * test_io.test_general - tests everything else in the io module
 # * test_univnewlines - tests universal newline support
 # * test_largefile - tests operations on a file greater than 2**32 bytes
 #     (only enabled with -ulargefile)

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2669,6 +2669,7 @@ TESTSUBDIRS=	idlelib/idle_test \
 		test/test_importlib/source \
 		test/test_inspect \
 		test/test_interpreters \
+		test/test_io \
 		test/test_json \
 		test/test_module \
 		test/test_multiprocessing_fork \


### PR DESCRIPTION
This sets up for having a test_io._support which contains the I/O mocks for sharing between multiple `io` module test files. Also starts a path for all the `io` module tests to live in a single module for simpler running rather than requiring knowledge of the list of `io` tests which lives in a comment in `test_io`.

Common test invocatoins (ex. `python -m test test_io -uall -M8G` and `python -m test.test_io`) run the same set of tests after this change as before.

---
I copied `__init__.py` and `__main__.py` from other python test sub directory instances; happy to tweak if needed.

It is possible to split out the Buffered I/O tests without moving `test_io` to be a module. In that case still will need a module where the common "mocks" live (My tentative plan is `test.test_io._support`). I think this sets up for more understandable structure to the `io` tests overall, but happy to explore the problem space if desired.

<!-- gh-issue-number: gh-138013 -->
* Issue: gh-138013
<!-- /gh-issue-number -->
