### PR TITLE
gh-138148: Fix grammatical error in `asynchronous generator iterator`

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -107,7 +107,7 @@ Glossary
       statements.
 
    asynchronous generator iterator
-      An object created by a :term:`asynchronous generator` function.
+      An object created by an :term:`asynchronous generator` function.
 
       This is an :term:`asynchronous iterator` which when called using the
       :meth:`~object.__anext__` method returns an awaitable object which will execute


### PR DESCRIPTION


<!-- gh-issue-number: gh-138148 -->
* Issue: gh-138148
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138155.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->