### PR TITLE
gh-137481: fix test expectations on some platforms

### DIFF
--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -735,12 +735,15 @@ class CalendarTestCase(unittest.TestCase):
     def test_locale_calendar_long_weekday_names(self):
         names = (datetime.date(2001, 1, i+1).strftime('%A') for i in range(7))
         max_length = max(map(len, names))
-        if max_length <= 9:
-            self.skipTest('weekday names are too short')
+        abbrev_names = (datetime.date(2001, 1, i+1).strftime('%a') for i in range(7))
+        abbrev_max_length = max(map(len, abbrev_names))
+
+        if max_length - abbrev_max_length < 3:
+            self.skipTest('standard and abbreviated weekday names have too similar lengths')
 
         def get_weekday_names(width):
             return calendar.TextCalendar().formatweekheader(width).split()
-        self.assertEqual(get_weekday_names(4), get_weekday_names(9))
+        self.assertEqual(get_weekday_names(abbrev_max_length+1), get_weekday_names(max_length-1))
 
     def test_locale_calendar_formatmonthname(self):
         try:

--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -743,7 +743,7 @@ class CalendarTestCase(unittest.TestCase):
 
         def get_weekday_names(width):
             return calendar.TextCalendar().formatweekheader(width).split()
-        self.assertEqual(get_weekday_names(abbrev_max_length+1), get_weekday_names(max_length-1))
+        self.assertEqual(get_weekday_names(abbrev_max_length), get_weekday_names(max_length-1))
 
     def test_locale_calendar_formatmonthname(self):
         try:

--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -738,8 +738,10 @@ class CalendarTestCase(unittest.TestCase):
         abbrev_names = (datetime.date(2001, 1, i+1).strftime('%a') for i in range(7))
         abbrev_max_length = max(map(len, abbrev_names))
 
-        if max_length - abbrev_max_length < 3:
-            self.skipTest('standard and abbreviated weekday names have too similar lengths')
+        if max_length <= 9:
+            self.skipTest('weekday names are too short')
+        if abbrev_max_length >= 9:
+            self.skipTest('abbreviated weekday names are too long')
 
         def get_weekday_names(width):
             return calendar.TextCalendar().formatweekheader(width).split()


### PR DESCRIPTION
The recently introduced `test_locale_calendar_long_weekday_names` expects abbreviated weekday names to be three characters long, which is not the case on Oracle Solaris. In case of `"pt_PT.UTF-8"` locale:

```python
>>> import calendar
>>> print(list(calendar.day_name))
['segunda-feira', 'terça-feira', 'quarta-feira', 'quinta-feira', 'sexta-feira', 'sábado', 'domingo']
>>> print(list(calendar.day_abbr))
['segunda', 'terça', 'quarta', 'quinta', 'sexta', 'sábado', 'domingo']
```
This makes the test work in such cases as well.

<!-- gh-issue-number: gh-137481 -->
* Issue: gh-137481
<!-- /gh-issue-number -->
