### PR TITLE
gh-138151: Fix `ForwardRef.evaluate()` for locally defined generics

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -167,6 +167,13 @@ class ForwardRef:
                 globals[param.__name__] = param
         if self.__extra_names__:
             locals = {**locals, **self.__extra_names__}
+        if (annotate := getattr(owner, "__annotate__", None)) and annotate.__closure__:
+            for name, cell in zip(annotate.__code__.co_freevars, annotate.__closure__):
+                if name != "__classdict__":
+                    try:
+                        locals[name] = cell.cell_contents
+                    except ValueError:
+                        pass
 
         arg = self.__forward_arg__
         if arg.isidentifier() and not keyword.iskeyword(arg):

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1617,6 +1617,32 @@ class TestForwardRefClass(unittest.TestCase):
                     TypeParamsSample.TypeParamsAlias2,
                 )
 
+    def test_evaluate_local_generic(self):
+        class Cls:
+            x: alias
+            y: alias2
+            z: alias3
+
+        fwdref = ForwardRef("alias[int]", owner=Cls)
+        with self.assertRaises(NameError):
+            fwdref.evaluate()
+
+        alias = list
+        self.assertEqual(fwdref.evaluate(), list[int])
+
+        del alias
+        fwdref = ForwardRef("alias[alias]", owner=Cls)
+        alias = list
+        self.assertEqual(fwdref.evaluate(), list[list])
+
+        del alias
+        fwdref = ForwardRef("alias[alias2, alias3]", owner=Cls)
+        alias = dict
+        alias2 = int
+        alias3 = str
+        self.assertEqual(fwdref.evaluate(), dict[int, str])
+
+
     def test_fwdref_with_module(self):
         self.assertIs(ForwardRef("Format", module="annotationlib").evaluate(), Format)
         self.assertIs(

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1619,11 +1619,12 @@ class TestForwardRefClass(unittest.TestCase):
 
     def test_evaluate_local_generic(self):
         class Cls:
-            x: alias
-            y: alias2
-            z: alias3
+            nonlocal alias, alias2, alias3
+            x: alias[int]
+            y: alias[alias]
+            z: alias[alias2, alias3]
 
-        fwdref = ForwardRef("alias[int]", owner=Cls)
+        fwdref = get_annotations(Cls, format=Format.FORWARDREF)["x"]
         with self.assertRaises(NameError):
             fwdref.evaluate()
 
@@ -1631,12 +1632,12 @@ class TestForwardRefClass(unittest.TestCase):
         self.assertEqual(fwdref.evaluate(), list[int])
 
         del alias
-        fwdref = ForwardRef("alias[alias]", owner=Cls)
+        fwdref = get_annotations(Cls, format=Format.FORWARDREF)["y"]
         alias = list
         self.assertEqual(fwdref.evaluate(), list[list])
 
         del alias
-        fwdref = ForwardRef("alias[alias2, alias3]", owner=Cls)
+        fwdref = get_annotations(Cls, format=Format.FORWARDREF)["z"]
         alias = dict
         alias2 = int
         alias3 = str

--- a/Misc/NEWS.d/next/Library/2025-08-27-12-06-52.gh-issue-138151.ajQpH5.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-27-12-06-52.gh-issue-138151.ajQpH5.rst
@@ -1,0 +1,2 @@
+Fix :meth:`annotationlib.ForwardRef.evaluate` not handling generics with
+nonlocal variables that are defined after the annotation.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Fixes #138151 with new associated tests.
Could be some edge cases (not covered in the test suite) which it doesn't consider.

<!-- gh-issue-number: gh-138151 -->
* Issue: gh-138151
<!-- /gh-issue-number -->
