### PR TITLE
gh-138178: Doc: Clarify that range is an immutable sequence

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1734,9 +1734,9 @@ are always available.  They are listed here in alphabetical order.
    :noindex:
 
    Rather than being a function, :class:`range` is actually an immutable
-   sequence type, as documented in :ref:`typesseq-range` and :ref:`typesseq`.
+   :term:`sequence` type, as documented in :ref:`typesseq-range` and :ref:`typesseq`.
 
-   The :class:`range` type is iterable and supports iteration.
+
 .. function:: repr(object)
 
    Return a string containing a printable representation of an object.  For many

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1735,7 +1735,10 @@ are always available.  They are listed here in alphabetical order.
 
    Rather than being a function, :class:`range` is actually an immutable
    sequence type, as documented in :ref:`typesseq-range` and :ref:`typesseq`.
-
+   
+   The object returned by :class:`range` is an :term:`iterator` and supports iteration.
+   See also :ref:`iterator` for more information about iterators and how to implement
+   custom iterable classes.
 
 .. function:: repr(object)
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1735,11 +1735,10 @@ are always available.  They are listed here in alphabetical order.
 
    Rather than being a function, :class:`range` is actually an immutable
    sequence type, as documented in :ref:`typesseq-range` and :ref:`typesseq`.
-   
+
    The object returned by :class:`range` is an :term:`iterator` and supports iteration.
    See also :ref:`iterator` for more information about iterators and how to implement
    custom iterable classes.
-
 .. function:: repr(object)
 
    Return a string containing a printable representation of an object.  For many

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1736,9 +1736,7 @@ are always available.  They are listed here in alphabetical order.
    Rather than being a function, :class:`range` is actually an immutable
    sequence type, as documented in :ref:`typesseq-range` and :ref:`typesseq`.
 
-   The object returned by :class:`range` is an :term:`iterator` and supports iteration.
-   See also :ref:`iterator` for more information about iterators and how to implement
-   custom iterable classes.
+   The :class:`range` type is iterable and supports iteration.
 .. function:: repr(object)
 
    Return a string containing a printable representation of an object.  For many

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -24,12 +24,10 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
 .. class:: SMTP(host='', port=0, local_hostname=None[, timeout], source_address=None)
 
    An :class:`SMTP` instance encapsulates an SMTP connection.  It has methods
-   that support a full repertoire of SMTP and ESMTP operations. If the optional
-   *host* and *port* parameters are given, the SMTP :meth:`connect` method is
-   called with those parameters during initialization.If *host* is omitted or
-   an empty string, no connection is made during initialization; you must
+   that support a full repertoire of SMTP and ESMTP operations.
+   If *host* is omitted or set to an empty string, no connection is made during initialization; you must
    call :meth:`connect` manually before using the instance.
-   If *port* is zero, the default SMTP port (25) is used.  If specified,
+   If *port* is zero,the value of the :attr:`default_port` attribute is used. If specified,
    *local_hostname* is used as the FQDN of the local host in the HELO/EHLO
    command.  Otherwise, the local hostname is found using
    :func:`socket.getfqdn`.  If the :meth:`connect` call returns anything other

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -26,7 +26,10 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
    An :class:`SMTP` instance encapsulates an SMTP connection.  It has methods
    that support a full repertoire of SMTP and ESMTP operations. If the optional
    *host* and *port* parameters are given, the SMTP :meth:`connect` method is
-   called with those parameters during initialization.  If specified,
+   called with those parameters during initialization.If *host* is omitted or
+   an empty string, no connection is made during initialization; you must
+   call :meth:`connect` manually before using the instance.
+   If *port* is zero, the default SMTP port (25) is used.  If specified,
    *local_hostname* is used as the FQDN of the local host in the HELO/EHLO
    command.  Otherwise, the local hostname is found using
    :func:`socket.getfqdn`.  If the :meth:`connect` call returns anything other
@@ -81,7 +84,10 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
    An :class:`SMTP_SSL` instance behaves exactly the same as instances of
    :class:`SMTP`. :class:`SMTP_SSL` should be used for situations where SSL is
    required from the beginning of the connection and using :meth:`starttls` is
-   not appropriate. If *host* is not specified, the local host is used. If
+   not appropriate. If the optional *host* and *port* parameters are given, the
+   SMTP_SSL :meth:`connect` method is called with those parameters during initialization.
+   If *host* is omitted or an empty string, no connection is made during initialization;
+   you must call :meth:`connect` manually before using the instance. If
    *port* is zero, the standard SMTP-over-SSL port (465) is used.  The optional
    arguments *local_hostname*, *timeout* and *source_address* have the same
    meaning as they do in the :class:`SMTP` class.  *context*, also optional,

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -24,12 +24,10 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
 .. class:: SMTP(host='', port=0, local_hostname=None[, timeout], source_address=None)
 
    An :class:`SMTP` instance encapsulates an SMTP connection.  It has methods
-   that support a full repertoire of SMTP and ESMTP operations.
-   If *host* is omitted or set to an empty string, no connection is made during initialization; you must
-   call :meth:`connect` manually before using the instance.
-   If *port* is zero,the value of the :attr:`default_port` attribute is used.
-
-   If specified, *local_hostname* is used as the FQDN of the local host in the HELO/EHLO
+   that support a full repertoire of SMTP and ESMTP operations. If the optional
+   *host* and *port* parameters are given, the SMTP :meth:`connect` method is
+   called with those parameters during initialization.  If specified,
+   *local_hostname* is used as the FQDN of the local host in the HELO/EHLO
    command.  Otherwise, the local hostname is found using
    :func:`socket.getfqdn`.  If the :meth:`connect` call returns anything other
    than a success code, an :exc:`SMTPConnectError` is raised. The optional
@@ -83,13 +81,9 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
    An :class:`SMTP_SSL` instance behaves exactly the same as instances of
    :class:`SMTP`. :class:`SMTP_SSL` should be used for situations where SSL is
    required from the beginning of the connection and using :meth:`starttls` is
-   not appropriate. If the optional *host* and *port* parameters are given, the
-   SMTP_SSL :meth:`connect` method is called with those parameters during initialization.
-   If *host* is omitted or an empty string, no connection is made during initialization;
-   you must call :meth:`connect` manually before using the instance. If
-   *port* is zero, the standard SMTP-over-SSL port (465) is used.
-
-   The optional arguments *local_hostname*, *timeout* and *source_address* have the same
+   not appropriate. If *host* is not specified, the local host is used. If
+   *port* is zero, the standard SMTP-over-SSL port (465) is used.  The optional
+   arguments *local_hostname*, *timeout* and *source_address* have the same
    meaning as they do in the :class:`SMTP` class.  *context*, also optional,
    can contain a :class:`~ssl.SSLContext` and allows configuring various
    aspects of the secure connection.  Please read :ref:`ssl-security` for

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -27,8 +27,9 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
    that support a full repertoire of SMTP and ESMTP operations.
    If *host* is omitted or set to an empty string, no connection is made during initialization; you must
    call :meth:`connect` manually before using the instance.
-   If *port* is zero,the value of the :attr:`default_port` attribute is used. If specified,
-   *local_hostname* is used as the FQDN of the local host in the HELO/EHLO
+   If *port* is zero,the value of the :attr:`default_port` attribute is used.
+
+   If specified, *local_hostname* is used as the FQDN of the local host in the HELO/EHLO
    command.  Otherwise, the local hostname is found using
    :func:`socket.getfqdn`.  If the :meth:`connect` call returns anything other
    than a success code, an :exc:`SMTPConnectError` is raised. The optional
@@ -86,8 +87,9 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
    SMTP_SSL :meth:`connect` method is called with those parameters during initialization.
    If *host* is omitted or an empty string, no connection is made during initialization;
    you must call :meth:`connect` manually before using the instance. If
-   *port* is zero, the standard SMTP-over-SSL port (465) is used.  The optional
-   arguments *local_hostname*, *timeout* and *source_address* have the same
+   *port* is zero, the standard SMTP-over-SSL port (465) is used.
+
+   The optional arguments *local_hostname*, *timeout* and *source_address* have the same
    meaning as they do in the :class:`SMTP` class.  *context*, also optional,
    can contain a :class:`~ssl.SSLContext` and allows configuring various
    aspects of the secure connection.  Please read :ref:`ssl-security` for


### PR DESCRIPTION
(GH#138178)

This PR Clarifies that :class:range is an immutable :term:sequence type.

Please let me know if this fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou!

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138184.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->