### PR TITLE
Fix typo in shutil.make_archive example

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -860,7 +860,7 @@ In the final archive, :file:`please_add.txt` should be included, but
     ...     root_dir='tmp/root',
     ...     base_dir='structure/content',
     ... )
-    '/Users/tarek/my_archive.tar'
+    '/Users/tarek/myarchive.tar'
 
 Listing the files in the resulting archive gives us:
 


### PR DESCRIPTION
This PR fixes a trivial typo in the shutil.make_archive example.

- The problem can be seen in the current docs here: https://docs.python.org/3.15/library/shutil.html#archiving-example-with-base-dir
- The fixed version from this PR: https://cpython-previews--138188.org.readthedocs.build/en/138188/library/shutil.html#archiving-example-with-base-dir


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138188.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->