### PR TITLE
gh-138206: Eliminate duplication of the check for the MS_WINDOWS macro.

### DIFF
--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -34,9 +34,6 @@
 
 #ifdef MS_WINDOWS
 #  include "malloc.h"             // alloca()
-#endif
-
-#ifdef MS_WINDOWS
 #  undef BYTE
 #  include "windows.h"
 #endif


### PR DESCRIPTION
Duplication of the check for the `MS_WINDOWS` macro is eliminated.


<!-- gh-issue-number: gh-138206 -->
* Issue: gh-138206
<!-- /gh-issue-number -->
