### PR TITLE
gh-138257: Fix internal `RuleCollectorVisitor` attribute name

### DIFF
--- a/Tools/peg_generator/pegen/parser_generator.py
+++ b/Tools/peg_generator/pegen/parser_generator.py
@@ -45,7 +45,7 @@ class RuleCollectorVisitor(GrammarVisitor):
     """Visitor that invokes a provided callmaker visitor with just the NamedItem nodes"""
 
     def __init__(self, rules: Dict[str, Rule], callmakervisitor: GrammarVisitor) -> None:
-        self.rulses = rules
+        self.rules = rules
         self.callmaker = callmakervisitor
 
     def visit_Rule(self, rule: Rule) -> None:


### PR DESCRIPTION
Trivial changes, like fixing a typo, do not need an issue.

Typo in `parser_generator`.  Not used anywhere else

```
[localhost cpython]$ git grep rulses
Tools/peg_generator/pegen/parser_generator.py:        self.rulses = rules
```

<!-- gh-issue-number: gh-138257 -->
* Issue: gh-138257
<!-- /gh-issue-number -->
