### PR TITLE
gh-138010: Fix `__init_subclass__` forwarding by `warnings.deprecated`

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -1863,6 +1863,25 @@ class DeprecatedTests(PyPublicAPITests):
 
         self.assertEqual(D.inited, 3)
 
+    def test_existing_init_subclass_in_sibling_base(self):
+        @deprecated("A will go away soon")
+        class A:
+            pass
+        class B:
+            def __init_subclass__(cls, x):
+                super().__init_subclass__()
+                cls.inited = x
+
+        with self.assertWarnsRegex(DeprecationWarning, "A will go away soon"):
+            class C(A, B, x=42):
+                pass
+        self.assertEqual(C.inited, 42)
+
+        with self.assertWarnsRegex(DeprecationWarning, "A will go away soon"):
+            class D(B, A, x=42):
+                pass
+        self.assertEqual(D.inited, 42)
+
     def test_init_subclass_has_correct_cls(self):
         init_subclass_saw = None
 

--- a/Misc/NEWS.d/next/Library/2025-08-27-17-05-36.gh-issue-138010.ZZJmPL.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-27-17-05-36.gh-issue-138010.ZZJmPL.rst
@@ -1,4 +1,4 @@
-Fix an issue where defining a class with a :func:`@warnings.deprecated
-<warnings.deprecated>`-decorated base class would sometimes not invoke the
-correct :meth:`!__init_subclass__` method in cases involving multiple
+Fix an issue where defining a class with an :func:`@warnings.deprecated
+<warnings.deprecated>`-decorated base class may not invoke the correct
+:meth:`~object.__init_subclass__` method in cases involving multiple
 inheritance. Patch by Brian Schubert.

--- a/Misc/NEWS.d/next/Library/2025-08-27-17-05-36.gh-issue-138010.ZZJmPL.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-27-17-05-36.gh-issue-138010.ZZJmPL.rst
@@ -1,0 +1,4 @@
+Fix an issue where defining a class with a :func:`@warnings.deprecated
+<warnings.deprecated>`-decorated base class would sometimes not invoke the
+correct :meth:`!__init_subclass__` method in cases involving multiple
+inheritance. Patch by Brian Schubert.


### PR DESCRIPTION


<!-- gh-issue-number: gh-138010 -->
* Issue: gh-138010
<!-- /gh-issue-number -->
