### PR TITLE
gh-138213: Make `csv.reader` up to 2x faster

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -427,7 +427,7 @@ csv
 ---
 
 * The :meth:`csv.reader` has been optimized, and is around 1.4x faster.
-  (Contributed by Maurycy Pawłowski-Wieroński in :gh:`XXX`.)
+  (Contributed by Maurycy Pawłowski-Wieroński in :gh:`138214`.)
 
 
 Deprecated

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -426,7 +426,7 @@ Optimizations
 csv
 ---
 
-* The :func:`csv.reader` has been optimized, and is around 1.4x faster.
+* The :func:`csv.reader` has been optimized, and is around 2x faster.
   (Contributed by Maurycy Pawłowski-Wieroński in :gh:`138214`.)
 
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -426,7 +426,7 @@ Optimizations
 csv
 ---
 
-* The :meth:`csv.reader` has been optimized, and is around 1.4x faster.
+* The :func:`csv.reader` has been optimized, and is around 1.4x faster.
   (Contributed by Maurycy Pawłowski-Wieroński in :gh:`138214`.)
 
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -423,11 +423,11 @@ zlib
 Optimizations
 =============
 
-module_name
------------
+csv
+---
 
-* TODO
-
+* The :meth:`csv.reader` has been optimized, and is around 1.4x faster.
+  (Contributed by Maurycy Pawłowski-Wieroński in :gh:`XXX`.)
 
 
 Deprecated

--- a/Misc/NEWS.d/next/Library/2025-08-28-02-41-14.gh-issue-138213.8m2OO9.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-28-02-41-14.gh-issue-138213.8m2OO9.rst
@@ -1,1 +1,1 @@
-Speed up :class:`~csv.reader` by 1.4x.
+Speed up :class:`~csv.reader` by 2x.

--- a/Misc/NEWS.d/next/Library/2025-08-28-02-41-14.gh-issue-138213.8m2OO9.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-28-02-41-14.gh-issue-138213.8m2OO9.rst
@@ -1,0 +1,1 @@
+Speed up :class:`~csv.reader` by 1.4x.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -964,7 +964,6 @@ Reader_iternext(PyObject *op)
     PyObject *fields = NULL;
     Py_ssize_t pos, linelen, chunk_end, p;
     PyObject *lineobj;
-    DialectObj *dialect;
     Py_UCS4 c;
 
 #define FIND_AND_UPDATE_CHUNK_END(c)                           \
@@ -1000,15 +999,13 @@ Reader_iternext(PyObject *op)
     if (parse_reset(self) < 0)
         return NULL;
 
-    dialect = self->dialect;
-
     do {
         lineobj = PyIter_Next(self->input_iter);
         if (lineobj == NULL) {
             /* End of input OR exception */
             if (!PyErr_Occurred() && (self->field_len != 0 ||
                                       self->state == IN_QUOTED_FIELD)) {
-                if (dialect->strict)
+                if (self->dialect->strict)
                     PyErr_SetString(module_state->error_obj,
                                     "unexpected end of data");
                 else if (parse_save_field(self) >= 0)
@@ -1039,9 +1036,9 @@ Reader_iternext(PyObject *op)
             case IN_FIELD:
                 chunk_end = linelen;
 
-                FIND_AND_UPDATE_CHUNK_END(dialect->delimiter);
-                if (dialect->escapechar != NOT_SET) {
-                    FIND_AND_UPDATE_CHUNK_END(dialect->escapechar);
+                FIND_AND_UPDATE_CHUNK_END(self->dialect->delimiter);
+                if (self->dialect->escapechar != NOT_SET) {
+                    FIND_AND_UPDATE_CHUNK_END(self->dialect->escapechar);
                 }
                 FIND_AND_UPDATE_CHUNK_END('\n');
                 FIND_AND_UPDATE_CHUNK_END('\r');
@@ -1061,9 +1058,9 @@ Reader_iternext(PyObject *op)
             case IN_QUOTED_FIELD:
                 chunk_end = linelen;
 
-                FIND_AND_UPDATE_CHUNK_END(dialect->quotechar);
-                if (dialect->escapechar != NOT_SET) {
-                    FIND_AND_UPDATE_CHUNK_END(dialect->escapechar);
+                FIND_AND_UPDATE_CHUNK_END(self->dialect->quotechar);
+                if (self->dialect->escapechar != NOT_SET) {
+                    FIND_AND_UPDATE_CHUNK_END(self->dialect->escapechar);
                 }
 
                 if (chunk_end > pos) {

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -962,9 +962,9 @@ Reader_iternext(PyObject *op)
     ReaderObj *self = _ReaderObj_CAST(op);
 
     PyObject *fields = NULL;
+    Py_UCS4 c;
     Py_ssize_t pos, linelen, chunk_end, p;
     PyObject *lineobj;
-    Py_UCS4 c;
 
 #define FIND_AND_UPDATE_CHUNK_END(c)                           \
     do                                                         \

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -998,7 +998,6 @@ Reader_iternext(PyObject *op)
 
     if (parse_reset(self) < 0)
         return NULL;
-
     do {
         lineobj = PyIter_Next(self->input_iter);
         if (lineobj == NULL) {

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -965,6 +965,7 @@ Reader_iternext(PyObject *op)
     Py_ssize_t pos, linelen, chunk_end, p;
     PyObject *lineobj;
     DialectObj *dialect;
+    Py_UCS4 c;
 
     _csvstate *module_state = _csv_state_from_type(Py_TYPE(self),
                                                    "Reader.__next__");
@@ -1051,7 +1052,7 @@ Reader_iternext(PyObject *op)
                 pos = chunk_end;
 
                 if (pos < linelen) {
-                    Py_UCS4 c = PyUnicode_READ_CHAR(lineobj, pos);
+                    c = PyUnicode_READ_CHAR(lineobj, pos);
                     if (parse_process_char(self, module_state, c) < 0) {
                         Py_DECREF(lineobj);
                         goto err;
@@ -1088,7 +1089,7 @@ Reader_iternext(PyObject *op)
                 pos = chunk_end;
 
                 if (pos < linelen) {
-                    Py_UCS4 c = PyUnicode_READ_CHAR(lineobj, pos);
+                    c = PyUnicode_READ_CHAR(lineobj, pos);
                     if (parse_process_char(self, module_state, c) < 0) {
                         Py_DECREF(lineobj);
                         goto err;
@@ -1097,7 +1098,7 @@ Reader_iternext(PyObject *op)
                 }
                 break;
             default:
-                Py_UCS4 c = PyUnicode_READ_CHAR(lineobj, pos);
+                c = PyUnicode_READ_CHAR(lineobj, pos);
                 if (parse_process_char(self, module_state, c) < 0) {
                     Py_DECREF(lineobj);
                     goto err;

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1027,9 +1027,8 @@ Reader_iternext(PyObject *op)
             return NULL;
         }
         ++self->line_num;
-
-        linelen = PyUnicode_GET_LENGTH(lineobj);
         pos = 0;
+        linelen = PyUnicode_GET_LENGTH(lineobj);
 
         while (pos < linelen) {
             /* For IN_FIELD and IN_QUOTED_FIELD states, optimize by finding

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1032,6 +1032,10 @@ Reader_iternext(PyObject *op)
         pos = 0;
 
         while (pos < linelen) {
+            /* For IN_FIELD and IN_QUOTED_FIELD states, optimize by finding
+             * chunks of characters that can be processed together up to the
+             * next special character (eg: delimiter, quote, escape).
+             */
             switch (self->state) {
             case IN_FIELD:
                 chunk_end = linelen;

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -723,6 +723,45 @@ parse_add_char(ReaderObj *self, _csvstate *module_state, Py_UCS4 c)
 }
 
 static int
+parse_add_substring(ReaderObj *self, _csvstate *module_state,
+                    PyObject* lineobj, Py_ssize_t start, Py_ssize_t end)
+{
+    int kind;
+    const void *data;
+    Py_UCS4 *dest;
+    Py_ssize_t field_limit;
+
+    Py_ssize_t len = end - start;
+    if (len <= 0) {
+        return 0;
+    }
+
+    field_limit = FT_ATOMIC_LOAD_SSIZE_RELAXED(module_state->field_limit);
+    if (self->field_len + len > field_limit) {
+        PyErr_Format(module_state->error_obj,
+                     "field larger than field limit (%zd)",
+                     field_limit);
+        return -1;
+    }
+
+    while (self->field_len + len > self->field_size) {
+        if (!parse_grow_buff(self))
+            return -1;
+    }
+
+    kind = PyUnicode_KIND(lineobj);
+    data = PyUnicode_DATA(lineobj);
+    dest = self->field + self->field_len;
+
+    for (Py_ssize_t i = 0; i < len; ++i) {
+        dest[i] = PyUnicode_READ(kind, data, start + i);
+    }
+
+    self->field_len += len;
+    return 0;
+}
+
+static int
 parse_process_char(ReaderObj *self, _csvstate *module_state, Py_UCS4 c)
 {
     DialectObj *dialect = self->dialect;
@@ -923,11 +962,9 @@ Reader_iternext(PyObject *op)
     ReaderObj *self = _ReaderObj_CAST(op);
 
     PyObject *fields = NULL;
-    Py_UCS4 c;
-    Py_ssize_t pos, linelen;
-    int kind;
-    const void *data;
+    Py_ssize_t pos, linelen, chunk_end, p;
     PyObject *lineobj;
+    DialectObj *dialect;
 
     _csvstate *module_state = _csv_state_from_type(Py_TYPE(self),
                                                    "Reader.__next__");
@@ -937,13 +974,16 @@ Reader_iternext(PyObject *op)
 
     if (parse_reset(self) < 0)
         return NULL;
+
+    dialect = self->dialect;
+
     do {
         lineobj = PyIter_Next(self->input_iter);
         if (lineobj == NULL) {
             /* End of input OR exception */
             if (!PyErr_Occurred() && (self->field_len != 0 ||
                                       self->state == IN_QUOTED_FIELD)) {
-                if (self->dialect->strict)
+                if (dialect->strict)
                     PyErr_SetString(module_state->error_obj,
                                     "unexpected end of data");
                 else if (parse_save_field(self) >= 0)
@@ -962,17 +1002,109 @@ Reader_iternext(PyObject *op)
             return NULL;
         }
         ++self->line_num;
-        kind = PyUnicode_KIND(lineobj);
-        data = PyUnicode_DATA(lineobj);
-        pos = 0;
+
         linelen = PyUnicode_GET_LENGTH(lineobj);
-        while (linelen--) {
-            c = PyUnicode_READ(kind, data, pos);
-            if (parse_process_char(self, module_state, c) < 0) {
-                Py_DECREF(lineobj);
-                goto err;
+        pos = 0;
+
+        while (pos < linelen) {
+            switch (self->state) {
+            case IN_FIELD:
+                chunk_end = linelen;
+
+                p = PyUnicode_FindChar(lineobj, dialect->delimiter, pos, linelen, 1);
+                if (p >= 0 && p < chunk_end) {
+                    chunk_end = p;
+                } else if (p == -2) {
+                    Py_DECREF(lineobj);
+                    goto err;
+                }
+                if (dialect->escapechar != NOT_SET) {
+                    p = PyUnicode_FindChar(lineobj, dialect->escapechar, pos, linelen, 1);
+                    if (p >= 0 && p < chunk_end) {
+                        chunk_end = p;
+                    } else if (p == -2) {
+                        Py_DECREF(lineobj);
+                        goto err;
+                    }
+                }
+                p = PyUnicode_FindChar(lineobj, '\n', pos, linelen, 1);
+                if (p >= 0 && p < chunk_end) {
+                    chunk_end = p;
+                } else if (p == -2) {
+                    Py_DECREF(lineobj);
+                    goto err;
+                }
+                p = PyUnicode_FindChar(lineobj, '\r', pos, linelen, 1);
+                if (p >= 0 && p < chunk_end) {
+                    chunk_end = p;
+                } else if (p == -2) {
+                    Py_DECREF(lineobj);
+                    goto err;
+                }
+
+                if (chunk_end > pos) {
+                    if (parse_add_substring(self, module_state, lineobj, pos, chunk_end) < 0) {
+                        Py_DECREF(lineobj);
+                        goto err;
+                    }
+                }
+                pos = chunk_end;
+
+                if (pos < linelen) {
+                    Py_UCS4 c = PyUnicode_READ_CHAR(lineobj, pos);
+                    if (parse_process_char(self, module_state, c) < 0) {
+                        Py_DECREF(lineobj);
+                        goto err;
+                    }
+                    pos++;
+                }
+                break;
+            case IN_QUOTED_FIELD:
+                chunk_end = linelen;
+
+                p = PyUnicode_FindChar(lineobj, dialect->quotechar, pos, linelen, 1);
+                if (p >= 0 && p < chunk_end) {
+                    chunk_end = p;
+                } else if (p == -2) {
+                    Py_DECREF(lineobj);
+                    goto err;
+                }
+                if (dialect->escapechar != NOT_SET) {
+                    p = PyUnicode_FindChar(lineobj, dialect->escapechar, pos, linelen, 1);
+                    if (p >= 0 && p < chunk_end) {
+                        chunk_end = p;
+                    } else if (p == -2) {
+                        Py_DECREF(lineobj);
+                        goto err;
+                    }
+                }
+
+                if (chunk_end > pos) {
+                    if (parse_add_substring(self, module_state, lineobj, pos, chunk_end) < 0) {
+                        Py_DECREF(lineobj);
+                        goto err;
+                    }
+                }
+                pos = chunk_end;
+
+                if (pos < linelen) {
+                    Py_UCS4 c = PyUnicode_READ_CHAR(lineobj, pos);
+                    if (parse_process_char(self, module_state, c) < 0) {
+                        Py_DECREF(lineobj);
+                        goto err;
+                    }
+                    pos++;
+                }
+                break;
+            default:
+                Py_UCS4 c = PyUnicode_READ_CHAR(lineobj, pos);
+                if (parse_process_char(self, module_state, c) < 0) {
+                    Py_DECREF(lineobj);
+                    goto err;
+                }
+                pos++;
+                break;
             }
-            pos++;
         }
         Py_DECREF(lineobj);
         if (parse_process_char(self, module_state, EOL) < 0)


### PR DESCRIPTION
The basic observation is that there's no need to process character by character, and call the state machine while we're in a field (`IN_FIELD`, `IN_QUOTED_FIELD`).

Most characters are ordinary (ie: they're not delimiters, escapes, quotes etc.), so we can find the next interesting character and copy the whole slice in between.

This is my very first C change in `cpython` so I'm more than happy to pair with someone.

# <a name="benchmark"></a>Benchmark

There's no `pyperformance` benchmark for `csv.reader`.

<details>
<summary>The script:</summary>

```python
import csv
import io
import os
import pyperf
import random

NUM_ROWS = (1_000, 10_000)
NUM_COLS = (5, 10)
FIELD_LENGTH = (300, 1000)

CASES = [
    # (label, field_chars, delimiter, escapechar)
    (
        "ascii",
        "a",
        None,
        None,
    ),
    (
        "nonascii_no_escape",
        "ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩαβγδεζηθικ",
        "λ",
        None,
    ),
    (
        "nonascii_escape",
        "ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩαβγδεζηθικ",
        "λ",
        "\\",
    ),
]


def generate_csv_data(rows, cols, field_len, ch, delim):
    # random.choice() so we're not that cache-friendly
    field = "".join(random.choices(ch, k=field_len))
    actual_delim = delim if delim is not None else ","
    row = actual_delim.join([field] * cols)
    return os.linesep.join([row] * rows) + os.linesep


def benchmark_csv_reader(csv_data, delim, escapechar):
    kwargs = {"delimiter": delim, "escapechar": escapechar}
    active_kwargs = {
        key: value for key, value in kwargs.items() if value is not None
    }
    rdr = csv.reader(io.StringIO(csv_data), **active_kwargs)
    for _ in rdr:
        pass


runner = pyperf.Runner()

for rows in NUM_ROWS:
    for cols in NUM_COLS:
        for field_len in FIELD_LENGTH:
            for label, ch, delim, esc in CASES:
                csv_data = generate_csv_data(rows, cols, field_len, ch, delim)
                runner.bench_func(
                    f"csv_reader({rows},{cols},{field_len})[{label}]",
                    benchmark_csv_reader,
                    csv_data,
                    delim,
                    esc,
                )
```
</details>

The results:

| Benchmark                                     | bench_csv_reader.main | bench_csv_reader.csv-read-chunks |
|-----------------------------------------------|:---------------------:|:--------------------------------:|
| csv_reader(1000,5,300)[ascii]                 | 5.45 ms               | 2.05 ms: 2.66x faster            |
| csv_reader(1000,5,300)[nonascii_no_escape]    | 5.68 ms               | 2.67 ms: 2.13x faster            |
| csv_reader(1000,5,300)[nonascii_escape]       | 5.55 ms               | 2.60 ms: 2.13x faster            |
| csv_reader(1000,5,1000)[ascii]                | 17.0 ms               | 6.65 ms: 2.55x faster            |
| csv_reader(1000,5,1000)[nonascii_no_escape]   | 18.2 ms               | 7.97 ms: 2.29x faster            |
| csv_reader(1000,5,1000)[nonascii_escape]      | 17.8 ms               | 7.80 ms: 2.29x faster            |
| csv_reader(1000,10,300)[ascii]                | 10.4 ms               | 3.89 ms: 2.66x faster            |
| csv_reader(1000,10,300)[nonascii_no_escape]   | 10.9 ms               | 5.08 ms: 2.15x faster            |
| csv_reader(1000,10,300)[nonascii_escape]      | 11.2 ms               | 5.81 ms: 1.94x faster            |
| csv_reader(1000,10,1000)[ascii]               | 38.2 ms               | 17.5 ms: 2.18x faster            |
| csv_reader(1000,10,1000)[nonascii_no_escape]  | 40.8 ms               | 21.0 ms: 1.94x faster            |
| csv_reader(1000,10,1000)[nonascii_escape]     | 40.6 ms               | 22.1 ms: 1.84x faster            |
| csv_reader(10000,5,300)[ascii]                | 60.9 ms               | 28.1 ms: 2.17x faster            |
| csv_reader(10000,5,300)[nonascii_no_escape]   | 64.8 ms               | 33.7 ms: 1.93x faster            |
| csv_reader(10000,5,300)[nonascii_escape]      | 64.7 ms               | 34.6 ms: 1.87x faster            |
| csv_reader(10000,5,1000)[ascii]               | 193 ms                | 90.7 ms: 2.13x faster            |
| csv_reader(10000,5,1000)[nonascii_no_escape]  | 206 ms                | 102 ms: 2.01x faster             |
| csv_reader(10000,5,1000)[nonascii_escape]     | 207 ms                | 106 ms: 1.96x faster             |
| csv_reader(10000,10,300)[ascii]               | 119 ms                | 54.1 ms: 2.20x faster            |
| csv_reader(10000,10,300)[nonascii_no_escape]  | 129 ms                | 69.5 ms: 1.86x faster            |
| csv_reader(10000,10,300)[nonascii_escape]     | 128 ms                | 72.4 ms: 1.76x faster            |
| csv_reader(10000,10,1000)[ascii]              | 383 ms                | 177 ms: 2.17x faster             |
| csv_reader(10000,10,1000)[nonascii_no_escape] | 408 ms                | 215 ms: 1.90x faster             |
| csv_reader(10000,10,1000)[nonascii_escape]    | 409 ms                | 222 ms: 1.84x faster             |
| Geometric mean                                | (ref)                 | 2.09x faster                     |
</details>

I observe similar results with real CSV files.

The environment:

```
% ./python -c "import sysconfig; print(sysconfig.get_config_var('CONFIG_ARGS'))"
'--enable-lto' '--with-optimizations'
```

`sudo ./python -m pyperf system tune` ensured.

<!-- gh-issue-number: gh-138213 -->
* Issue: gh-138213
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138214.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->