### PR TITLE
gh-78502: Add a trackfd parameter to mmap.mmap() on Windows

### DIFF
--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -48,10 +48,11 @@ update the underlying file.
 
 To map anonymous memory, -1 should be passed as the fileno along with the length.
 
-.. class:: mmap(fileno, length, tagname=None, access=ACCESS_DEFAULT, offset=0)
+.. class:: mmap(fileno, length, tagname=None, \
+                access=ACCESS_DEFAULT, offset=0, *, trackfd=True)
 
    **(Windows version)** Maps *length* bytes from the file specified by the
-   file handle *fileno*, and creates a mmap object.  If *length* is larger
+   file descriptor *fileno*, and creates a mmap object.  If *length* is larger
    than the current size of the file, the file is extended to contain *length*
    bytes.  If *length* is ``0``, the maximum length of the map is the current
    size of the file, except that if the file is empty Windows raises an
@@ -68,6 +69,17 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
    *offset* may be specified as a non-negative integer offset. mmap references
    will be relative to the offset from the beginning of the file. *offset*
    defaults to 0.  *offset* must be a multiple of the :const:`ALLOCATIONGRANULARITY`.
+
+   If *trackfd* is ``False``, the file handle corresponding to *fileno* will
+   not be duplicated, and the resulting :class:`!mmap` object will not
+   be associated with the map's underlying file.
+   This means that the :meth:`~mmap.mmap.size` and :meth:`~mmap.mmap.resize`
+   methods will fail.
+   This mode is useful to limit the number of open file handles.
+   The original file can be renamed (but not deleted) after closing *fileno*.
+
+   .. versionchanged:: next
+      The *trackfd* parameter was added.
 
    .. audit-event:: mmap.__new__ fileno,length,access,offset mmap.mmap
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -358,6 +358,15 @@ math
   (Contributed by Bénédikt Tran in :gh:`135853`.)
 
 
+mmap
+----
+
+* :class:`mmap.mmap` now has a *trackfd* parameter on Windows;
+  if it is ``False``, the file handle corresponding to *fileno* will
+  not be duplicated.
+  (Contributed by Serhiy Storchaka in :gh:`78502`.)
+
+
 os.path
 -------
 

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -281,9 +281,13 @@ class MmapTests(unittest.TestCase):
                 if close_original_fd:
                     f.close()
                 self.assertEqual(len(m), size)
-                with self.assertRaises(OSError) as err_cm:
-                    m.size()
-                self.assertEqual(err_cm.exception.errno, errno.EBADF)
+                if os.name == 'nt':
+                    with self.assertRaises(ValueError):
+                        m.size()
+                else:
+                    with self.assertRaises(OSError) as err_cm:
+                        m.size()
+                    self.assertEqual(err_cm.exception.errno, errno.EBADF)
                 with self.assertRaises(ValueError):
                     m.resize(size * 2)
                 with self.assertRaises(ValueError):

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1,3 +1,4 @@
+from test import support
 from test.support import (
     requires, _2G, _4G, gc_collect, cpython_only, is_emscripten, is_apple,
     in_systemd_nspawn_sync_suppressed,
@@ -270,42 +271,45 @@ class MmapTests(unittest.TestCase):
                     self.assertRaises(TypeError, m.write_byte, 0)
                     m.close()
 
-    @unittest.skipIf(os.name == 'nt', 'trackfd not present on Windows')
-    def test_trackfd_parameter(self):
+    @support.subTests('close_original_fd', (True, False))
+    def test_trackfd_parameter(self, close_original_fd):
         size = 64
         with open(TESTFN, "wb") as f:
             f.write(b"a"*size)
-        for close_original_fd in True, False:
-            with self.subTest(close_original_fd=close_original_fd):
-                with open(TESTFN, "r+b") as f:
-                    with mmap.mmap(f.fileno(), size, trackfd=False) as m:
-                        if close_original_fd:
-                            f.close()
-                        self.assertEqual(len(m), size)
-                        with self.assertRaises(OSError) as err_cm:
-                            m.size()
-                        self.assertEqual(err_cm.exception.errno, errno.EBADF)
-                        with self.assertRaises(ValueError):
-                            m.resize(size * 2)
-                        with self.assertRaises(ValueError):
-                            m.resize(size // 2)
-                        self.assertEqual(m.closed, False)
+        with open(TESTFN, "r+b") as f:
+            with mmap.mmap(f.fileno(), size, trackfd=False) as m:
+                if close_original_fd:
+                    f.close()
+                self.assertEqual(len(m), size)
+                with self.assertRaises(OSError) as err_cm:
+                    m.size()
+                self.assertEqual(err_cm.exception.errno, errno.EBADF)
+                with self.assertRaises(ValueError):
+                    m.resize(size * 2)
+                with self.assertRaises(ValueError):
+                    m.resize(size // 2)
+                self.assertIs(m.closed, False)
 
-                        # Smoke-test other API
-                        m.write_byte(ord('X'))
-                        m[2] = ord('Y')
-                        m.flush()
-                        with open(TESTFN, "rb") as f:
-                            self.assertEqual(f.read(4), b'XaYa')
-                        self.assertEqual(m.tell(), 1)
-                        m.seek(0)
-                        self.assertEqual(m.tell(), 0)
-                        self.assertEqual(m.read_byte(), ord('X'))
+                # Smoke-test other API
+                m.write_byte(ord('X'))
+                m[2] = ord('Y')
+                m.flush()
+                with open(TESTFN, "rb") as f:
+                    self.assertEqual(f.read(4), b'XaYa')
+                self.assertEqual(m.tell(), 1)
+                m.seek(0)
+                self.assertEqual(m.tell(), 0)
+                self.assertEqual(m.read_byte(), ord('X'))
 
-                self.assertEqual(m.closed, True)
-                self.assertEqual(os.stat(TESTFN).st_size, size)
+                if os.name == 'nt' and not close_original_fd:
+                    self.assertRaises(PermissionError, os.rename, TESTFN, TESTFN+'1')
+                else:
+                    os.rename(TESTFN, TESTFN+'1')
+                    os.rename(TESTFN+'1', TESTFN)
 
-    @unittest.skipIf(os.name == 'nt', 'trackfd not present on Windows')
+        self.assertIs(m.closed, True)
+        self.assertEqual(os.stat(TESTFN).st_size, size)
+
     def test_trackfd_neg1(self):
         size = 64
         with mmap.mmap(-1, size, trackfd=False) as m:
@@ -316,15 +320,6 @@ class MmapTests(unittest.TestCase):
             self.assertEqual(len(m), size)
             m[0] = ord('a')
             assert m[0] == ord('a')
-
-    @unittest.skipIf(os.name != 'nt', 'trackfd only fails on Windows')
-    def test_no_trackfd_parameter_on_windows(self):
-        # 'trackffd' is an invalid keyword argument for this function
-        size = 64
-        with self.assertRaises(TypeError):
-            mmap.mmap(-1, size, trackfd=True)
-        with self.assertRaises(TypeError):
-            mmap.mmap(-1, size, trackfd=False)
 
     def test_bad_file_desc(self):
         # Try opening a bad file descriptor...

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1,3 +1,4 @@
+from test import support
 from test.support import (
     requires, _2G, _4G, gc_collect, cpython_only, is_emscripten, is_apple,
     in_systemd_nspawn_sync_suppressed,
@@ -270,42 +271,45 @@ class MmapTests(unittest.TestCase):
                     self.assertRaises(TypeError, m.write_byte, 0)
                     m.close()
 
-    @unittest.skipIf(os.name == 'nt', 'trackfd not present on Windows')
-    def test_trackfd_parameter(self):
+    @support.subTests('close_original_fd', (True, False))
+    def test_trackfd_parameter(self, close_original_fd):
         size = 64
         with open(TESTFN, "wb") as f:
             f.write(b"a"*size)
-        for close_original_fd in True, False:
-            with self.subTest(close_original_fd=close_original_fd):
-                with open(TESTFN, "r+b") as f:
-                    with mmap.mmap(f.fileno(), size, trackfd=False) as m:
-                        if close_original_fd:
-                            f.close()
-                        self.assertEqual(len(m), size)
-                        with self.assertRaises(OSError) as err_cm:
-                            m.size()
-                        self.assertEqual(err_cm.exception.errno, errno.EBADF)
-                        with self.assertRaises(ValueError):
-                            m.resize(size * 2)
-                        with self.assertRaises(ValueError):
-                            m.resize(size // 2)
-                        self.assertEqual(m.closed, False)
+        with open(TESTFN, "r+b") as f:
+            with mmap.mmap(f.fileno(), size, trackfd=1|False) as m:
+                if close_original_fd:
+                    f.close()
+                self.assertEqual(len(m), size)
+                with self.assertRaises(OSError) as err_cm:
+                    m.size()
+                self.assertEqual(err_cm.exception.errno, errno.EBADF)
+                with self.assertRaises(ValueError):
+                    m.resize(size * 2)
+                with self.assertRaises(ValueError):
+                    m.resize(size // 2)
+                self.assertIs(m.closed, False)
 
-                        # Smoke-test other API
-                        m.write_byte(ord('X'))
-                        m[2] = ord('Y')
-                        m.flush()
-                        with open(TESTFN, "rb") as f:
-                            self.assertEqual(f.read(4), b'XaYa')
-                        self.assertEqual(m.tell(), 1)
-                        m.seek(0)
-                        self.assertEqual(m.tell(), 0)
-                        self.assertEqual(m.read_byte(), ord('X'))
+                # Smoke-test other API
+                m.write_byte(ord('X'))
+                m[2] = ord('Y')
+                m.flush()
+                with open(TESTFN, "rb") as f:
+                    self.assertEqual(f.read(4), b'XaYa')
+                self.assertEqual(m.tell(), 1)
+                m.seek(0)
+                self.assertEqual(m.tell(), 0)
+                self.assertEqual(m.read_byte(), ord('X'))
 
-                self.assertEqual(m.closed, True)
-                self.assertEqual(os.stat(TESTFN).st_size, size)
+                if os.name == 'nt' and not close_original_fd:
+                    self.assertRaises(PermissionError, os.rename, TESTFN, TESTFN+'1')
+                else:
+                    os.rename(TESTFN, TESTFN+'1')
+                    os.rename(TESTFN+'1', TESTFN)
 
-    @unittest.skipIf(os.name == 'nt', 'trackfd not present on Windows')
+        self.assertIs(m.closed, True)
+        self.assertEqual(os.stat(TESTFN).st_size, size)
+
     def test_trackfd_neg1(self):
         size = 64
         with mmap.mmap(-1, size, trackfd=False) as m:
@@ -316,15 +320,6 @@ class MmapTests(unittest.TestCase):
             self.assertEqual(len(m), size)
             m[0] = ord('a')
             assert m[0] == ord('a')
-
-    @unittest.skipIf(os.name != 'nt', 'trackfd only fails on Windows')
-    def test_no_trackfd_parameter_on_windows(self):
-        # 'trackffd' is an invalid keyword argument for this function
-        size = 64
-        with self.assertRaises(TypeError):
-            mmap.mmap(-1, size, trackfd=True)
-        with self.assertRaises(TypeError):
-            mmap.mmap(-1, size, trackfd=False)
 
     def test_bad_file_desc(self):
         # Try opening a bad file descriptor...

--- a/Misc/NEWS.d/next/Library/2025-08-29-12-05-33.gh-issue-78502.VpIMxg.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-29-12-05-33.gh-issue-78502.VpIMxg.rst
@@ -1,0 +1,2 @@
+:class:`mmap.mmap` now has a *trackfd* parameter on Windows; if it is
+``False``, the file handle corresponding to *fileno* will not be duplicated.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -716,7 +716,7 @@ mmap_size_method(PyObject *op, PyObject *Py_UNUSED(ignored))
     CHECK_VALID(NULL);
 
 #ifdef MS_WINDOWS
-    if (self->file_handle != INVALID_HANDLE_VALUE || !self->trackfd) {
+    if (self->file_handle != INVALID_HANDLE_VALUE) {
         DWORD low,high;
         long long size;
         low = GetFileSize(self->file_handle, &high);
@@ -731,8 +731,12 @@ mmap_size_method(PyObject *op, PyObject *Py_UNUSED(ignored))
             return PyLong_FromLong((long)low);
         size = (((long long)high)<<32) + low;
         return PyLong_FromLongLong(size);
-    } else {
+    else if (self->trackfd) {
         return PyLong_FromSsize_t(self->size);
+    } else {
+        PyErr_SetString(PyExc_ValueError,
+            "can't get size with trackfd=False");
+        return NULL;
     }
 #endif /* MS_WINDOWS */
 

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1723,7 +1723,8 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
     DWORD dwErr = 0;
     int fileno;
     HANDLE fh = INVALID_HANDLE_VALUE;
-    int access = (access_mode)ACCESS_DEFAULT, trackfd = 1;
+    int access = (access_mode)ACCESS_DEFAULT;
+    int trackfd = 1;
     DWORD flProtect, dwDesiredAccess;
     static char *keywords[] = { "fileno", "length",
                                 "tagname",


### PR DESCRIPTION
If trackfd is False, the file handle corresponding to fileno will not be duplicated.


<!-- gh-issue-number: gh-78502 -->
* Issue: gh-78502
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138238.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->