### PR TITLE
gh-138239: Fix incorrect highlighting of "type" in type statements in the REPL.

### DIFF
--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -262,9 +262,7 @@ def is_soft_keyword_used(*tokens: TI | None) -> bool:
             TI(string="type"),
             TI(T.NAME, string=s)
         ):
-            if keyword.iskeyword(s):
-                return False
-            return True
+            return not keyword.iskeyword(s):
         case _:
             return False
 

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -262,7 +262,7 @@ def is_soft_keyword_used(*tokens: TI | None) -> bool:
             TI(string="type"),
             TI(T.NAME, string=s)
         ):
-            return not keyword.iskeyword(s):
+            return not keyword.iskeyword(s)
         case _:
             return False
 

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -257,6 +257,14 @@ def is_soft_keyword_used(*tokens: TI | None) -> bool:
             return True
         case (TI(string="case"), TI(string="_"), TI(string=":")):
             return True
+        case (
+            None | TI(T.NEWLINE) | TI(T.INDENT) | TI(string=":"),
+            TI(string="type"),
+            TI(T.NAME, string=s)
+        ):
+            if keyword.iskeyword(s):
+                return False
+            return True
         case _:
             return False
 

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -258,7 +258,7 @@ def is_soft_keyword_used(*tokens: TI | None) -> bool:
         case (TI(string="case"), TI(string="_"), TI(string=":")):
             return True
         case (
-            None | TI(T.NEWLINE) | TI(T.INDENT) | TI(string=":"),
+            None | TI(T.NEWLINE) | TI(T.INDENT) | TI(T.DEDENT) | TI(string=":"),
             TI(string="type"),
             TI(T.NAME, string=s)
         ):

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -378,6 +378,7 @@ class TestReaderInColor(ScreenEqualMixin, TestCase):
                     case "ios" | "android":
                         print("on the phone")
                     case _: print('arms around', match.group(1))
+            type type = type[type]
             """
         )
         expected = dedent(
@@ -397,6 +398,7 @@ class TestReaderInColor(ScreenEqualMixin, TestCase):
                     {K}case{z} {s}"ios"{z} {o}|{z} {s}"android"{z}{o}:{z}
                         {b}print{z}{o}({z}{s}"on the phone"{z}{o}){z}
                     {K}case{z} {K}_{z}{o}:{z} {b}print{z}{o}({z}{s}'arms around'{z}{o},{z} match{o}.{z}group{o}({z}{n}1{z}{o}){z}{o}){z}
+            {K}type{z} {b}type{z} {o}={z} {b}type{z}{o}[{z}{b}type{z}{o}]{z}
             """
         )
         expected_sync = expected.format(a="", **colors)
@@ -404,14 +406,14 @@ class TestReaderInColor(ScreenEqualMixin, TestCase):
         reader, _ = handle_all_events(events)
         self.assert_screen_equal(reader, code, clean=True)
         self.assert_screen_equal(reader, expected_sync)
-        self.assertEqual(reader.pos, 396)
-        self.assertEqual(reader.cxy, (0, 15))
+        self.assertEqual(reader.pos, 419)
+        self.assertEqual(reader.cxy, (0, 16))
 
         async_msg = "{k}async{z} ".format(**colors)
         expected_async = expected.format(a=async_msg, **colors)
         more_events = itertools.chain(
             code_to_events(code),
-            [Event(evt="key", data="up", raw=bytearray(b"\x1bOA"))] * 14,
+            [Event(evt="key", data="up", raw=bytearray(b"\x1bOA"))] * 15,
             code_to_events("async "),
         )
         reader, _ = handle_all_events(more_events)

--- a/Misc/NEWS.d/next/Library/2025-08-29-12-56-55.gh-issue-138239.uthZFI.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-29-12-56-55.gh-issue-138239.uthZFI.rst
@@ -1,0 +1,1 @@
+The REPL now highlights "type" as a soft keyword in type statements.

--- a/Misc/NEWS.d/next/Library/2025-08-29-12-56-55.gh-issue-138239.uthZFI.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-29-12-56-55.gh-issue-138239.uthZFI.rst
@@ -1,1 +1,2 @@
-The REPL now highlights "type" as a soft keyword in type statements.
+The REPL now highlights :keyword:`type` as a soft keyword
+in :ref:`type statements <type>`.


### PR DESCRIPTION
- Add a check for the type statement in function `is_soft_keyword_used`.

<!-- gh-issue-number: gh-138239 -->
* Issue: gh-138239
<!-- /gh-issue-number -->
