### PR TITLE
gh-138250: load fast optimization should fall through to empty blocks

### DIFF
--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2993,11 +2993,8 @@ optimize_load_fast(cfg_builder *g)
         }
 
         // Push fallthrough block
-        cfg_instr *term = basicblock_last_instr(block);
-        if (term != NULL && block->b_next != NULL &&
-            !(IS_UNCONDITIONAL_JUMP_OPCODE(term->i_opcode) ||
-              IS_SCOPE_EXIT_OPCODE(term->i_opcode))) {
-            assert(BB_HAS_FALLTHROUGH(block));
+        if (BB_HAS_FALLTHROUGH(block)) {
+            assert(block->b_next != NULL);
             load_fast_push_block(&sp, block->b_next, refs.size);
         }
 


### PR DESCRIPTION
In code like:
```
def x(tz_str):
    try:
        start, end = 1, 2
    except ValueError as e:
        raise Exception()

    return f(start, end)
```

The compiler ends up producing an empty basic block. When the load fast optimization runs it sees that `term == NULL` and doesn't fall through to the following block. The end result is that the compiler doesn't properly produce a `LOAD_FAST_BORROWED_LOAD_FAST_BORROWED` opcode.

The analysis should just use the `BB_HAS_FALLTHROUGH` macro instead of duplicating the logic.

<!-- gh-issue-number: gh-138250 -->
* Issue: gh-138250
<!-- /gh-issue-number -->
