### PR TITLE
gh-116946: fully implement GC protocol for `bz2` objects

### DIFF
--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -373,7 +373,7 @@ _bz2_BZ2Compressor_impl(PyTypeObject *type, int compresslevel)
     if (catch_bz2_error(bzerror))
         goto error;
 
-    PyObject_GC_Track((PyObject *)self);
+    PyObject_GC_Track(self);
     return (PyObject *)self;
 
 error:
@@ -684,7 +684,7 @@ _bz2_BZ2Decompressor_impl(PyTypeObject *type)
     if (catch_bz2_error(bzerror))
         goto error;
 
-    PyObject_GC_Track((PyObject *)self);
+    PyObject_GC_Track(self);
     return (PyObject *)self;
 
 error:

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -371,7 +371,6 @@ _bz2_BZ2Compressor_impl(PyTypeObject *type, int compresslevel)
     if (catch_bz2_error(bzerror))
         goto error;
 
-    PyObject_GC_Track(self);
     return (PyObject *)self;
 
 error:
@@ -389,7 +388,7 @@ BZ2Compressor_dealloc(PyObject *op)
     if (self->lock != NULL) {
         PyThread_free_lock(self->lock);
     }
-    PyObject_GC_Del(self);
+    tp->tp_free(self);
     Py_DECREF(tp);
 }
 
@@ -679,7 +678,6 @@ _bz2_BZ2Decompressor_impl(PyTypeObject *type)
     if (catch_bz2_error(bzerror))
         goto error;
 
-    PyObject_GC_Track(self);
     return (PyObject *)self;
 
 error:
@@ -693,7 +691,8 @@ BZ2Decompressor_dealloc(PyObject *op)
     PyTypeObject *tp = Py_TYPE(op);
     PyObject_GC_UnTrack(op);
     BZ2Decompressor *self = _BZ2Decompressor_CAST(op);
-    if(self->input_buffer != NULL) {
+
+    if (self->input_buffer != NULL) {
         PyMem_Free(self->input_buffer);
     }
     BZ2_bzDecompressEnd(&self->bzs);
@@ -701,7 +700,7 @@ BZ2Decompressor_dealloc(PyObject *op)
     if (self->lock != NULL) {
         PyThread_free_lock(self->lock);
     }
-    PyObject_GC_Del(self);
+    tp->tp_free(self);
     Py_DECREF(tp);
 }
 

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -352,13 +352,10 @@ _bz2_BZ2Compressor_impl(PyTypeObject *type, int compresslevel)
     }
 
     assert(type != NULL && type->tp_alloc != NULL);
-    self = PyObject_GC_New(BZ2Compressor, type);
+    self = (BZ2Compressor *)type->tp_alloc(type, 0);
     if (self == NULL) {
         return NULL;
     }
-    /* Initialize the remaining fields (untouched by PyObject_GC_New()). */
-    const size_t offset = sizeof(struct { PyObject_HEAD });
-    memset((char *)self + offset, 0, sizeof(*self) - offset);
 
     self->lock = PyThread_allocate_lock();
     if (self->lock == NULL) {
@@ -657,14 +654,11 @@ _bz2_BZ2Decompressor_impl(PyTypeObject *type)
     BZ2Decompressor *self;
     int bzerror;
 
-    assert(type != NULL);
-    self = PyObject_GC_New(BZ2Decompressor, type);
+    assert(type != NULL && type->tp_alloc != NULL);
+    self = (BZ2Decompressor *)type->tp_alloc(type, 0);
     if (self == NULL) {
         return NULL;
     }
-    /* Initialize the remaining fields (untouched by PyObject_GC_New()). */
-    const size_t offset = sizeof(struct { PyObject_HEAD });
-    memset((char *)self + offset, 0, sizeof(*self) - offset);
 
     self->lock = PyThread_allocate_lock();
     if (self->lock == NULL) {
@@ -674,6 +668,9 @@ _bz2_BZ2Decompressor_impl(PyTypeObject *type)
     }
 
     self->needs_input = 1;
+    self->bzs_avail_in_real = 0;
+    self->input_buffer = NULL;
+    self->input_buffer_size = 0;
     self->unused_data = PyBytes_FromStringAndSize(NULL, 0);
     if (self->unused_data == NULL)
         goto error;

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -392,7 +392,7 @@ BZ2Compressor_dealloc(PyObject *op)
     if (self->lock != NULL) {
         PyThread_free_lock(self->lock);
     }
-    tp->tp_free((PyObject *)self);
+    PyObject_GC_Del(self);
     Py_DECREF(tp);
 }
 
@@ -704,7 +704,7 @@ BZ2Decompressor_dealloc(PyObject *op)
     if (self->lock != NULL) {
         PyThread_free_lock(self->lock);
     }
-    tp->tp_free((PyObject *)self);
+    PyObject_GC_Del(self);
     Py_DECREF(tp);
 }
 


### PR DESCRIPTION
AFAIU, `tp_traverse` will not be called if `Py_TPFLAGS_HAVE_GC` is not specified. Quoting the specs:

> Instances of [heap-allocated types](https://docs.python.org/3/c-api/typeobj.html#heap-types) hold a reference to their type. Their traversal function must therefore either visit [Py_TYPE(self)](https://docs.python.org/3/c-api/structures.html#c.Py_TYPE), or delegate this responsibility by calling tp_traverse of another heap-allocated type (such as a heap-allocated superclass). If they do not, the type object may not be garbage-collected.

As such, I believe that this is the correct fix (that is, we *need* `tp_traverse` to be called).

cc @vstinner 

<!-- gh-issue-number: gh-116946 -->
* Issue: gh-116946
<!-- /gh-issue-number -->
