### PR TITLE
gh-69605: Hardcode some stdlib submodules in PyREPL module completion (os.path, collections.abc...)

### DIFF
--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -109,8 +109,8 @@ class ModuleCompleter:
                        if mod_info.ispkg and mod_info.name == segment]
             modules = self.iter_submodules(modules)
 
-        module_names = ([module.name for module in modules]
-                        + HARDCODED_SUBMODULES.get(path, []))
+        module_names = [module.name for module in modules]
+        module_names.extend(HARDCODED_SUBMODULES.get(path, ()))
         return [module_name for module_name in module_names
                 if self.is_suggestion_match(module_name, prefix)]
 

--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
 HARDCODED_SUBMODULES = {
     # Standard library submodules that are not detected by pkgutil.iter_modules
     # but can be imported, so should be proposed in completion
-    "collections": ["abc"],
-    "os": ["path"],
-    "xml.parsers.expat": ["errors", "model"],
+    "collections": ("abc",),
+    "os": ("path",),
+    "xml.parsers.expat": ("errors", "model"),
 }
 
 
@@ -109,11 +109,8 @@ class ModuleCompleter:
                        if mod_info.ispkg and mod_info.name == segment]
             modules = self.iter_submodules(modules)
 
-        module_names = [module.name for module in modules]
-        try:
-            module_names += HARDCODED_SUBMODULES[path]
-        except KeyError:
-            pass
+        module_names = ([module.name for module in modules]
+                        + HARDCODED_SUBMODULES.get(path, []))
         return [module_name for module_name in module_names
                 if self.is_suggestion_match(module_name, prefix)]
 

--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -22,9 +22,9 @@ if TYPE_CHECKING:
 HARDCODED_SUBMODULES = {
     # Standard library submodules that are not detected by pkgutil.iter_modules
     # but can be imported, so should be proposed in completion
-    "collections": ("abc",),
-    "os": ("path",),
-    "xml.parsers.expat": ("errors", "model"),
+    "collections": ["abc"],
+    "os": ["path"],
+    "xml.parsers.expat": ["errors", "model"],
 }
 
 

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1,3 +1,4 @@
+import importlib
 import io
 import itertools
 import os
@@ -26,7 +27,8 @@ from .support import (
     code_to_events,
 )
 from _pyrepl.console import Event
-from _pyrepl._module_completer import ImportParser, ModuleCompleter
+from _pyrepl._module_completer import (ImportParser, ModuleCompleter,
+                                       HARDCODED_SUBMODULES)
 from _pyrepl.readline import (ReadlineAlikeReader, ReadlineConfig,
                               _ReadlineWrapper)
 from _pyrepl.readline import multiline_input as readline_multiline_input
@@ -930,7 +932,6 @@ class TestPyReplCompleter(TestCase):
 
 class TestPyReplModuleCompleter(TestCase):
     def setUp(self):
-        import importlib
         # Make iter_modules() search only the standard library.
         # This makes the test more reliable in case there are
         # other user packages/scripts on PYTHONPATH which can
@@ -1013,14 +1014,6 @@ class TestPyReplModuleCompleter(TestCase):
                 self.assertEqual(output, expected)
 
     def test_builtin_completion_top_level(self):
-        import importlib
-        # Make iter_modules() search only the standard library.
-        # This makes the test more reliable in case there are
-        # other user packages/scripts on PYTHONPATH which can
-        # intefere with the completions.
-        lib_path = os.path.dirname(importlib.__path__[0])
-        sys.path = [lib_path]
-
         cases = (
             ("import bui\t\n", "import builtins"),
             ("from bui\t\n", "from builtins"),
@@ -1068,6 +1061,20 @@ class TestPyReplModuleCompleter(TestCase):
             ("import pri\t\n", "import pri"),
             ("from pri\t\n", "from pri"),
             ("from typing import Na\t\n", "from typing import Na"),
+        )
+        for code, expected in cases:
+            with self.subTest(code=code):
+                events = code_to_events(code)
+                reader = self.prepare_reader(events, namespace={})
+                output = reader.readline()
+                self.assertEqual(output, expected)
+
+    def test_hardcoded_stdlib_submodules(self):
+        cases = (
+            ("import collections.\t\n", "import collections.abc"),
+            ("from os import \t\n", "from os import path"),
+            ("import xml.parsers.expat.\t\te\t\n\n", "import xml.parsers.expat.errors"),
+            ("from xml.parsers.expat import \t\tm\t\n\n", "from xml.parsers.expat import model"),
         )
         for code, expected in cases:
             with self.subTest(code=code):
@@ -1203,6 +1210,19 @@ class TestPyReplModuleCompleter(TestCase):
             actual = parser.parse()
             with self.subTest(code=code):
                 self.assertEqual(actual, None)
+
+
+class TestHardcodedSubmodules(TestCase):
+    def test_hardcoded_stdlib_submodules_are_importable(self):
+        for parent_path, submodules in HARDCODED_SUBMODULES.items():
+            for module_name in submodules:
+                path = f"{parent_path}.{module_name}"
+                with self.subTest(path=path):
+                    # We can't use importlib.util.find_spec here,
+                    # since some hardcoded submodules parents are
+                    # not proper packages
+                    importlib.import_module(path)
+
 
 class TestPasteEvent(TestCase):
     def prepare_reader(self, events):

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1083,6 +1083,18 @@ class TestPyReplModuleCompleter(TestCase):
                 output = reader.readline()
                 self.assertEqual(output, expected)
 
+    def test_hardcoded_stdlib_submodules_not_proposed_if_local_import(self):
+        with tempfile.TemporaryDirectory() as _dir:
+            dir = pathlib.Path(_dir)
+            (dir / "collections").mkdir()
+            (dir / "collections" / "__init__.py").touch()
+            (dir / "collections" / "foo.py").touch()
+            with patch.object(sys, "path", [dir, *sys.path]):
+                events = code_to_events("import collections.\t\n")
+                reader = self.prepare_reader(events, namespace={})
+                output = reader.readline()
+                self.assertEqual(output, "import collections.foo")
+
     def test_get_path_and_prefix(self):
         cases = (
             ('', ('', '')),

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -27,10 +27,16 @@ from .support import (
     code_to_events,
 )
 from _pyrepl.console import Event
-from _pyrepl._module_completer import (ImportParser, ModuleCompleter,
-                                       HARDCODED_SUBMODULES)
-from _pyrepl.readline import (ReadlineAlikeReader, ReadlineConfig,
-                              _ReadlineWrapper)
+from _pyrepl._module_completer import (
+    ImportParser,
+    ModuleCompleter,
+    HARDCODED_SUBMODULES,
+)
+from _pyrepl.readline import (
+    ReadlineAlikeReader,
+    ReadlineConfig,
+    _ReadlineWrapper,
+)
 from _pyrepl.readline import multiline_input as readline_multiline_input
 
 try:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-30-17-15-05.gh-issue-69605.KjBk99.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-30-17-15-05.gh-issue-69605.KjBk99.rst
@@ -1,1 +1,1 @@
-Fix some standard library sumbodules missing from the :term:`REPL` auto-completion of imports.
+Fix some standard library submodules missing from the :term:`REPL` auto-completion of imports.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-30-17-15-05.gh-issue-69605.KjBk99.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-30-17-15-05.gh-issue-69605.KjBk99.rst
@@ -1,0 +1,1 @@
+Fix some standard library sumbodules missing from the :term:`REPL` auto-completion of imports.


### PR DESCRIPTION
From https://github.com/python/cpython/issues/69605#issuecomment-2889033396:

> This is expected, collections.abc is not a real module, same for os.path so pkgutil won't find it. One thing we could do is hardcode these modules but I haven't had the time to look into it.

This PR adds a hardcoded dictionary of unusual standard library submodules that `pkgutil.iter_modules` can't find despite them being importable, so we can suggest them anyway.

The hardcoded dictionary comes from checking all [documented modules](https://docs.python.org/3/py-modindex.html) to find which submodules `_pyrepl._module_completer.ModuleCompleter` was unable to detect.

I wrote a test to ensure all hardcoded modules are indeed importable, but I'm not sure we can programatically detect eventual new modules so we don't forget to add them, but it should be rare enough to not be too much a concern.

cc @tomasr8 

<!-- gh-issue-number: gh-69605 -->
* Issue: gh-69605
<!-- /gh-issue-number -->
