### PR TITLE
gh-138279: Remove unused attr in RuleCollectorVisitor in parser_generator.py

### DIFF
--- a/Tools/peg_generator/pegen/parser_generator.py
+++ b/Tools/peg_generator/pegen/parser_generator.py
@@ -44,8 +44,7 @@ from pegen.grammar import (
 class RuleCollectorVisitor(GrammarVisitor):
     """Visitor that invokes a provided callmaker visitor with just the NamedItem nodes"""
 
-    def __init__(self, rules: Dict[str, Rule], callmakervisitor: GrammarVisitor) -> None:
-        self.rules = rules
+    def __init__(self, callmakervisitor: GrammarVisitor) -> None:
         self.callmaker = callmakervisitor
 
     def visit_Rule(self, rule: Rule) -> None:
@@ -163,7 +162,7 @@ class ParserGenerator:
         for rule in self.all_rules.values():
             keyword_collector.visit(rule)
 
-        rule_collector = RuleCollectorVisitor(self.rules, self.callmakervisitor)
+        rule_collector = RuleCollectorVisitor(self.callmakervisitor)
         done: Set[str] = set()
         while True:
             computed_rules = list(self.all_rules)


### PR DESCRIPTION
I fixed a typo in this [PR](https://github.com/python/cpython/pull/138208/files) for thinking didn't need to file an issue.  But since it did require an issue, a better fix would be to remove the attribute altogether.

```
[localhost cpython]$ git grep RuleCollectorVisitor
Tools/peg_generator/pegen/parser_generator.py:class RuleCollectorVisitor(GrammarVisitor):
Tools/peg_generator/pegen/parser_generator.py:        rule_collector = RuleCollectorVisitor(self.rules, self.callmakervisitor)
```

<!-- gh-issue-number: gh-138279 -->
* Issue: gh-138279
<!-- /gh-issue-number -->
