### PR TITLE
gh-138275: Fix error messages incorrectly using "starred expression"

### DIFF
--- a/Lib/test/test_unpack_ex.py
+++ b/Lib/test/test_unpack_ex.py
@@ -319,27 +319,27 @@ error)
       ...
     test.test_unpack_ex.BozoError
 
-Now some general starred expressions (all fail).
+Now some general starred targets/expressions (all fail).
 
     >>> a, *b, c, *d, e = range(10) # doctest:+ELLIPSIS
     Traceback (most recent call last):
       ...
-    SyntaxError: multiple starred expressions in assignment
+    SyntaxError: multiple starred targets in assignment
 
     >>> [*b, *c] = range(10) # doctest:+ELLIPSIS
     Traceback (most recent call last):
       ...
-    SyntaxError: multiple starred expressions in assignment
+    SyntaxError: multiple starred targets in assignment
 
     >>> a,*b,*c,*d = range(4) # doctest:+ELLIPSIS
     Traceback (most recent call last):
       ...
-    SyntaxError: multiple starred expressions in assignment
+    SyntaxError: multiple starred targets in assignment
 
     >>> *a = range(10) # doctest:+ELLIPSIS
     Traceback (most recent call last):
       ...
-    SyntaxError: starred assignment target must be in a list or tuple
+    SyntaxError: starred target must be in a list or tuple
 
     >>> *a # doctest:+ELLIPSIS
     Traceback (most recent call last):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-08-31-09-11-42.gh-issue-138275.3Sc2OK.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-08-31-09-11-42.gh-issue-138275.3Sc2OK.rst
@@ -1,0 +1,2 @@
+Error messages incorrectly using the term "starred expression" have been
+corrected.

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -3415,7 +3415,7 @@ unpack_helper(compiler *c, location loc, asdl_expr_seq *elts)
         }
         else if (elt->kind == Starred_kind) {
             return _PyCompile_Error(c, loc,
-                "multiple starred expressions in assignment");
+                "multiple starred targets in assignment");
         }
     }
     if (!seen_star) {
@@ -5289,7 +5289,7 @@ codegen_visit_expr(compiler *c, expr_ty e)
             /* In all legitimate cases, the Starred node was already replaced
              * by codegen_list/codegen_tuple. XXX: is that okay? */
             return _PyCompile_Error(c, loc,
-                "starred assignment target must be in a list or tuple");
+                "starred target must be in a list or tuple");
         default:
             return _PyCompile_Error(c, loc,
                 "can't use starred expression here");


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The message:
```
starred assignment target must be in a list or tuple
```
has been changed for consistency.

<!-- gh-issue-number: gh-138275 -->
* Issue: gh-138275
<!-- /gh-issue-number -->
