### PR TITLE
gh-116946: fully implement GC protocol for `lzma` objects

### DIFF
--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -856,7 +856,6 @@ Compressor_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
             goto error;
     }
 
-    PyObject_GC_Track(self);
     return (PyObject *)self;
 
 error:
@@ -874,7 +873,7 @@ Compressor_dealloc(PyObject *op)
     if (self->lock != NULL) {
         PyThread_free_lock(self->lock);
     }
-    PyObject_GC_Del(self);
+    tp->tp_free(self);
     Py_DECREF(tp);
 }
 
@@ -1306,7 +1305,6 @@ _lzma_LZMADecompressor_impl(PyTypeObject *type, int format,
             goto error;
     }
 
-    PyObject_GC_Track(self);
     return (PyObject *)self;
 
 error:
@@ -1328,7 +1326,7 @@ Decompressor_dealloc(PyObject *op)
     if (self->lock != NULL) {
         PyThread_free_lock(self->lock);
     }
-    PyObject_GC_Del(self);
+    tp->tp_free(self);
     Py_DECREF(tp);
 }
 

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -876,7 +876,7 @@ Compressor_dealloc(PyObject *op)
     if (self->lock != NULL) {
         PyThread_free_lock(self->lock);
     }
-    tp->tp_free(self);
+    PyObject_GC_Del(self);
     Py_DECREF(tp);
 }
 
@@ -1331,7 +1331,7 @@ Decompressor_dealloc(PyObject *op)
     if (self->lock != NULL) {
         PyThread_free_lock(self->lock);
     }
-    tp->tp_free(self);
+    PyObject_GC_Del(self);
     Py_DECREF(tp);
 }
 


### PR DESCRIPTION
<details>
<summary>Outdated conversation</summary>

@ZeroIntensity Using `tp_alloc` directly feels wrong to me even because it's about relying on implementation details that are not documented (and not explicitly recommended by our docs recommend), while using `PyObject_GC_New` forces me to actually memset the structure (with an additional offset!) as otherwise I need to initialize the fields manually (this is essentially to prevent a segfault when invoking the (external) LZMA interface).

So I really think we should have some `PyObject_GC_New`-like function that zeroes the remaining fields *or* a just a function for zeroing the rest of a PyObject fields, that is:

```c
void _PyObject_MemSetZero(PyObject *self, size_t basicsize) {
    assert(self != NULL);
    const size_t offset = sizeof(struct { PyObject_HEAD });
    assert(basicsize >= offset);
    memset((char *)self + offset, 0, basicsize - offset);
}
```

and that we also have a private constant indicating the size of `PyObject_HEAD`. WDYT?

EDIT: I was looking at the 3.13 docs but the recommendations were given in the 3.14 docs, which is why I missed them. 
</details>

<!-- gh-issue-number: gh-116946 -->
* Issue: gh-116946
<!-- /gh-issue-number -->
