### PR TITLE
gh-116946: fully implement GC protocol for `_hashlib` objects

### DIFF
--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -752,7 +752,7 @@ py_wrapper_EVP_MD_CTX_new(void)
 static HASHobject *
 new_hash_object(PyTypeObject *type)
 {
-    HASHobject *retval = PyObject_New(HASHobject, type);
+    HASHobject *retval = PyObject_GC_New(HASHobject, type);
     if (retval == NULL) {
         return NULL;
     }
@@ -764,6 +764,7 @@ new_hash_object(PyTypeObject *type)
         return NULL;
     }
 
+    PyObject_GC_Track(retval);
     return retval;
 }
 
@@ -792,11 +793,19 @@ _hashlib_HASH_hash(HASHobject *self, const void *vp, Py_ssize_t len)
 static void
 _hashlib_HASH_dealloc(PyObject *op)
 {
+    PyTypeObject *tp = Py_TYPE(op);
+    PyObject_GC_UnTrack(op);
     HASHobject *self = HASHobject_CAST(op);
-    PyTypeObject *tp = Py_TYPE(self);
     EVP_MD_CTX_free(self->ctx);
-    PyObject_Free(self);
+    PyObject_GC_Del(self);
     Py_DECREF(tp);
+}
+
+static int
+_hashlib_HASH_traverse(PyObject *op, visitproc visit, void *arg)
+{
+    Py_VISIT(Py_TYPE(op));
+    return 0;
 }
 
 static int
@@ -993,6 +1002,7 @@ PyDoc_STRVAR(HASHobject_type_doc,
 
 static PyType_Slot HASHobject_type_slots[] = {
     {Py_tp_dealloc, _hashlib_HASH_dealloc},
+    {Py_tp_traverse, _hashlib_HASH_traverse},
     {Py_tp_repr, _hashlib_HASH_repr},
     {Py_tp_doc, (char *)HASHobject_type_doc},
     {Py_tp_methods, HASH_methods},
@@ -1008,6 +1018,7 @@ static PyType_Spec HASHobject_type_spec = {
         | Py_TPFLAGS_BASETYPE
         | Py_TPFLAGS_DISALLOW_INSTANTIATION
         | Py_TPFLAGS_IMMUTABLETYPE
+        | Py_TPFLAGS_HAVE_GC
     ),
     .slots = HASHobject_type_slots
 };
@@ -1165,6 +1176,7 @@ PyDoc_STRVAR(HASHXOFobject_type_doc,
 "digest_size -- number of bytes in this hashes output");
 
 static PyType_Slot HASHXOFobject_type_slots[] = {
+    /* tp_dealloc and tp_traverse are inherited from _hashlib.HASH */
     {Py_tp_doc, (char *)HASHXOFobject_type_doc},
     {Py_tp_methods, HASHXOFobject_methods},
     {Py_tp_getset, HASHXOFobject_getsets},
@@ -1179,6 +1191,7 @@ static PyType_Spec HASHXOFobject_type_spec = {
         | Py_TPFLAGS_BASETYPE
         | Py_TPFLAGS_DISALLOW_INSTANTIATION
         | Py_TPFLAGS_IMMUTABLETYPE
+        | Py_TPFLAGS_HAVE_GC
     ),
     .slots = HASHXOFobject_type_slots
 };
@@ -1902,7 +1915,7 @@ _hashlib_hmac_new_impl(PyObject *module, Py_buffer *key, PyObject *msg_obj,
         goto error;
     }
 
-    self = PyObject_New(HMACobject, state->HMAC_type);
+    self = PyObject_GC_New(HMACobject, state->HMAC_type);
     if (self == NULL) {
         goto error;
     }
@@ -1910,6 +1923,7 @@ _hashlib_hmac_new_impl(PyObject *module, Py_buffer *key, PyObject *msg_obj,
     self->ctx = ctx;
     ctx = NULL;  // 'ctx' is now owned by 'self'
     HASHLIB_INIT_MUTEX(self);
+    PyObject_GC_Track(self);
 
     if ((msg_obj != NULL) && (msg_obj != Py_None)) {
         if (!_hmac_update(self, msg_obj)) {
@@ -2008,7 +2022,7 @@ _hashlib_HMAC_copy_impl(HMACobject *self)
         return NULL;
     }
 
-    retval = PyObject_New(HMACobject, Py_TYPE(self));
+    retval = PyObject_GC_New(HMACobject, Py_TYPE(self));
     if (retval == NULL) {
         HMAC_CTX_free(ctx);
         return NULL;
@@ -2016,20 +2030,29 @@ _hashlib_HMAC_copy_impl(HMACobject *self)
     retval->ctx = ctx;
     HASHLIB_INIT_MUTEX(retval);
 
+    PyObject_GC_Track(retval);
     return (PyObject *)retval;
 }
 
 static void
 _hmac_dealloc(PyObject *op)
 {
+    PyTypeObject *tp = Py_TYPE(op);
+    PyObject_GC_UnTrack(op);
     HMACobject *self = HMACobject_CAST(op);
-    PyTypeObject *tp = Py_TYPE(self);
     if (self->ctx != NULL) {
         HMAC_CTX_free(self->ctx);
         self->ctx = NULL;
     }
-    PyObject_Free(self);
+    PyObject_GC_Del(self);
     Py_DECREF(tp);
+}
+
+static int
+_hashlib_HMAC_traverse(PyObject *op, visitproc visit, void *arg)
+{
+    Py_VISIT(Py_TYPE(op));
+    return 0;
 }
 
 static PyObject *
@@ -2198,15 +2221,21 @@ static PyType_Slot HMACtype_slots[] = {
     {Py_tp_doc, (char *)hmactype_doc},
     {Py_tp_repr, _hmac_repr},
     {Py_tp_dealloc, _hmac_dealloc},
+    {Py_tp_traverse, _hashlib_HMAC_traverse},
     {Py_tp_methods, HMAC_methods},
     {Py_tp_getset, HMAC_getset},
     {0, NULL}
 };
 
 PyType_Spec HMACtype_spec = {
-    "_hashlib.HMAC",    /* name */
-    sizeof(HMACobject),     /* basicsize */
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION | Py_TPFLAGS_IMMUTABLETYPE,
+    .name = "_hashlib.HMAC",
+    .basicsize = sizeof(HMACobject),
+    .flags = (
+        Py_TPFLAGS_DEFAULT
+        | Py_TPFLAGS_DISALLOW_INSTANTIATION
+        | Py_TPFLAGS_IMMUTABLETYPE
+        | Py_TPFLAGS_HAVE_GC
+    ),
     .slots = HMACtype_slots,
 };
 

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -1176,7 +1176,8 @@ PyDoc_STRVAR(HASHXOFobject_type_doc,
 "digest_size -- number of bytes in this hashes output");
 
 static PyType_Slot HASHXOFobject_type_slots[] = {
-    /* tp_dealloc and tp_traverse are inherited from _hashlib.HASH */
+    /* tp_dealloc is inherited from _hashlib.HASH */
+    {Py_tp_traverse, _hashlib_HASH_traverse},
     {Py_tp_doc, (char *)HASHXOFobject_type_doc},
     {Py_tp_methods, HASHXOFobject_methods},
     {Py_tp_getset, HASHXOFobject_getsets},


### PR DESCRIPTION
I noticed that `HASHXOF` didn't explicitly specify its deallocation function because HASHXOF is inherting HASH (it's constructed using `PyType_FromSpecWithBases`).

<!-- gh-issue-number: gh-116946 -->
* Issue: gh-116946
<!-- /gh-issue-number -->
