### PR TITLE
gh-138284 : urllib.parse.parse_qsl now raises ValueError if illegal characters is passed, according to RFC 3986

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1233,7 +1233,7 @@ class UrlParseTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             urllib.parse.parse_qsl(b"foo", strict_parsing=True)
-            
+
     def test_parse_qsl_encoding(self):
         result = urllib.parse.parse_qsl("key=\u0141%E9", encoding="latin-1")
         self.assertEqual(result, [('key', '\u0141\xE9')])

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1227,6 +1227,13 @@ class UrlParseTestCase(unittest.TestCase):
                                                           errors="ignore")
         self.assertEqual(result, {'key': ['\u0141-']})
 
+    def test_qsl_strict_parsing_raises(self):
+        with self.assertRaises(ValueError):
+            urllib.parse.parse_qsl("foo", strict_parsing=True)
+
+        with self.assertRaises(ValueError):
+            urllib.parse.parse_qsl(b"foo", strict_parsing=True)
+            
     def test_parse_qsl_encoding(self):
         result = urllib.parse.parse_qsl("key=\u0141%E9", encoding="latin-1")
         self.assertEqual(result, [('key', '\u0141\xE9')])

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1229,10 +1229,10 @@ class UrlParseTestCase(unittest.TestCase):
 
     def test_qsl_strict_parsing_raises(self):
         with self.assertRaises(ValueError):
-            urllib.parse.parse_qsl("foo", strict_parsing=True)
+            urllib.parse.parse_qsl("foo=^", strict_parsing=True)
 
         with self.assertRaises(ValueError):
-            urllib.parse.parse_qsl(b"foo", strict_parsing=True)
+            urllib.parse.parse_qsl(b"foo=`", strict_parsing=True)
 
     def test_parse_qsl_encoding(self):
         result = urllib.parse.parse_qsl("key=\u0141%E9", encoding="latin-1")

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -92,7 +92,7 @@ _WHATWG_C0_CONTROL_OR_SPACE = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\
 _UNSAFE_URL_BYTES_TO_REMOVE = ['\t', '\r', '\n']
 
 # Allowed valid characters in parse_qsl
-_VALID_QUERY_CHARS = re.compile(r"^[A-Za-z0-9\-._~!$&'()*+,;=:@/?%]*$")
+_VALID_QUERY_CHARS = "-._~!$&'()*+,;=:@/?%"
 
 def clear_cache():
     """Clear internal performance caches. Undocumented; some tests want it."""
@@ -781,6 +781,15 @@ def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
             parsed_result[name] = [value]
     return parsed_result
 
+def _is_valid_query(to_check: str) -> bool:
+    """Return True if all characters are valid per RFC 3986."""
+    for ch in to_check:
+        if not ch.isascii():
+            return False
+        if ch.isalnum() or ch in _VALID_QUERY_CHARS:
+            continue
+        return False
+    return True
 
 def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
               encoding='utf-8', errors='replace', max_num_fields=None, separator='&', *, _stacklevel=1):
@@ -860,7 +869,7 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
             if strict_parsing:
                 # Validate RFC3986 characters
                 to_check = (name_value.decode() if isinstance(name_value, bytes) else name_value)
-                if not _VALID_QUERY_CHARS.match(to_check):
+                if not _is_valid_query(to_check):
                     raise ValueError(f"Invalid characters in query string per RFC 3986: {name_value!r}")
             if value or keep_blank_values:
                 name = _unquote(name)

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -92,7 +92,7 @@ _WHATWG_C0_CONTROL_OR_SPACE = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\
 _UNSAFE_URL_BYTES_TO_REMOVE = ['\t', '\r', '\n']
 
 # Allowed valid characters in parse_qsl
-_VALID_QUERY_CHARS = re.compile(r"^[A-Za-z0-9\-._~!$&'()*+,;=:@/?%]*$") 
+_VALID_QUERY_CHARS = re.compile(r"^[A-Za-z0-9\-._~!$&'()*+,;=:@/?%]*$")
 
 def clear_cache():
     """Clear internal performance caches. Undocumented; some tests want it."""

--- a/Misc/NEWS.d/next/Library/2025-08-31-13-00-22.gh-issue-138284.6MOp4k.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-31-13-00-22.gh-issue-138284.6MOp4k.rst
@@ -1,1 +1,1 @@
-Earlier  urllib.parse.parse_qsl was taking illegal characters like '^' , ' ` ' etc. which should not be the case according to RFC 3986. Hence added the check and now will throw ValueError in case of any illegal characters other than allowed ones. Also written test for it.
+:mod:`urllib.parse`: in strict parsing, :func:`~urllib.parse.parse_qsl` now properly rejects characters according to :rfc:`3986` and raises a :exc:`ValueError` when encountering them.

--- a/Misc/NEWS.d/next/Library/2025-08-31-13-00-22.gh-issue-138284.6MOp4k.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-31-13-00-22.gh-issue-138284.6MOp4k.rst
@@ -1,0 +1,1 @@
+Earlier  urllib.parse.parse_qsl was taking illegal characters like '^' , ' ` ' etc. which should not be the case according to RFC 3986. Hence added the check and now will throw ValueError in case of any illegal characters other than allowed ones. Also written test for it.


### PR DESCRIPTION
urllib.parse.parse_qsl earlier it was accepting the illegal characters as well.

Proof (that I reproduce) :
![Before_Fix](https://github.com/user-attachments/assets/d1765d33-f9fe-49d9-bec6-9047c56cc751)

Closes issue : #138284

Proof (after fixing error):
![After_fix](https://github.com/user-attachments/assets/01bf0f39-3f83-4b30-a219-7dc5f37ed5ae)

I added the test for it as well.
Test for urlparse only : 
![test](https://github.com/user-attachments/assets/2ff66c0a-8492-4ddf-b9b0-c7dfe94a479f)

All tests:
![all_tests](https://github.com/user-attachments/assets/c57d2bdc-78da-4837-9b04-5d8b449a5eba)

- [x] Passes all tests

<!-- gh-issue-number: gh-138284 -->
* Issue: gh-138284
<!-- /gh-issue-number -->
