### PR TITLE
gh-138295: Fix a grammar issue in error message in custom validator

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -420,7 +420,7 @@ Here are three practical data validation utilities:
 
         def validate(self, value):
             if not isinstance(value, str):
-                raise TypeError(f'Expected {value!r} to be an str')
+                raise TypeError(f'Expected {value!r} to be a str')
             if self.minsize is not None and len(value) < self.minsize:
                 raise ValueError(
                     f'Expected {value!r} to be no smaller than {self.minsize!r}'


### PR DESCRIPTION
"an str" -> "a str"

<!-- gh-issue-number: gh-138295 -->
* Issue: gh-138295
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138296.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->