### PR TITLE
gh-137242: Mention Android binary releases in documentation

### DIFF
--- a/Doc/using/android.rst
+++ b/Doc/using/android.rst
@@ -40,8 +40,14 @@ If you're sure you want to do all of this manually, read on. You can use the
 :source:`testbed app <Android/testbed>` as a guide; each step below contains a
 link to the relevant file.
 
-* Build Python by following the instructions in :source:`Android/README.md`.
-  This will create the directory ``cross-build/HOST/prefix``.
+* Either:
+
+  * Download an Android Python release from `python.org
+    <https://www.python.org/downloads/android/>`__, and extract the ``prefix``
+    directory.
+
+  * Or build it yourself by following the instructions in :source:`Android/README.md`.
+    This will create the directory ``cross-build/HOST/prefix``.
 
 * Add code to your :source:`build.gradle <Android/testbed/app/build.gradle.kts>`
   file to copy the following items into your project. All except your own Python

--- a/Doc/using/android.rst
+++ b/Doc/using/android.rst
@@ -40,14 +40,15 @@ If you're sure you want to do all of this manually, read on. You can use the
 :source:`testbed app <Android/testbed>` as a guide; each step below contains a
 link to the relevant file.
 
-* Either:
+* First, acquire a build of Python for Android:
 
-  * Download an Android Python release from `python.org
-    <https://www.python.org/downloads/android/>`__, and extract the ``prefix``
-    directory.
+  * The easiest way is to download an Android release from `python.org
+    <https://www.python.org/downloads/android/>`__. The ``prefix`` directory
+    mentioned below is at the top level of the package.
 
-  * Or build it yourself by following the instructions in :source:`Android/README.md`.
-    This will create the directory ``cross-build/HOST/prefix``.
+  * Or if you want to build it yourself, follow the instructions in
+    :source:`Android/README.md`. The ``prefix`` directory will be created under
+    ``cross-build/HOST``.
 
 * Add code to your :source:`build.gradle <Android/testbed/app/build.gradle.kts>`
   file to copy the following items into your project. All except your own Python

--- a/Doc/using/android.rst
+++ b/Doc/using/android.rst
@@ -48,7 +48,7 @@ link to the relevant file.
 
   * Or if you want to build it yourself, follow the instructions in
     :source:`Android/README.md`. The ``prefix`` directory will be created under
-    ``cross-build/HOST``.
+    :samp:`cross-build/{HOST}`.
 
 * Add code to your :source:`build.gradle <Android/testbed/app/build.gradle.kts>`
   file to copy the following items into your project. All except your own Python


### PR DESCRIPTION
If a developer for some reason doesn't want to use Briefcase or Buildozer,  these releases will make it much easier for them to manually embed Python in an Android app. 

<!-- gh-issue-number: gh-137242 -->
* Issue: gh-137242
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138305.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->