### PR TITLE
gh-138307: Update the Ellipsis documentation

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -21,7 +21,9 @@ Glossary
         right delimiters (parentheses, square brackets, curly braces or triple
         quotes), or after specifying a decorator.
 
-      * The :const:`Ellipsis` built-in constant.
+      .. index:: single: ...; ellipsis literal
+
+      * The three dots form of the :ref:`Ellipsis <bltin-ellipsis-object>` object.
 
    abstract base class
       Abstract base classes complement :term:`duck-typing` by

--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -66,7 +66,8 @@ A small number of constants live in the built-in namespace.  They are:
 .. data:: Ellipsis
 
    The same as the ellipsis literal "``...``", an object frequently used as a
-   placeholder of another values.
+   placeholder of another values. Assignments to  ``Ellipsis`` are possible.
+   However, assignments to  ``...`` are illegal and raise a :exc:`SyntaxError`.
    ``Ellipsis`` is the sole instance of the :data:`types.EllipsisType` type.
 
 

--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -66,8 +66,8 @@ A small number of constants live in the built-in namespace.  They are:
 .. data:: Ellipsis
 
    The same as the ellipsis literal "``...``", an object frequently used as a
-   placeholder of another values. Assignments to  ``Ellipsis`` are possible.
-   However, assignments to  ``...`` are illegal and raise a :exc:`SyntaxError`.
+   placeholder for another value. Assignment to  ``Ellipsis`` is possible, but
+   assignment to  ``...`` is not possible and raises a :exc:`SyntaxError`.
    ``Ellipsis`` is the sole instance of the :data:`types.EllipsisType` type.
 
 

--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -65,8 +65,8 @@ A small number of constants live in the built-in namespace.  They are:
 .. index:: single: ...; ellipsis literal
 .. data:: Ellipsis
 
-   The same as the ellipsis literal "``...``". Special value used mostly in conjunction
-   with extended slicing syntax for user-defined container data types.
+   The same as the ellipsis literal "``...``", an object frequently used as a
+   placeholder of another values.
    ``Ellipsis`` is the sole instance of the :data:`types.EllipsisType` type.
 
 

--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -67,7 +67,7 @@ A small number of constants live in the built-in namespace.  They are:
 
    The same as the ellipsis literal "``...``", an object frequently used to
    indicate that something is omitted. Assignment to ``Ellipsis`` is possible, but
-   assignment to  ``...`` is not possible and raises a :exc:`SyntaxError`.
+   assignment to  ``...`` raises a :exc:`SyntaxError`.
    ``Ellipsis`` is the sole instance of the :data:`types.EllipsisType` type.
 
 

--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -65,8 +65,8 @@ A small number of constants live in the built-in namespace.  They are:
 .. index:: single: ...; ellipsis literal
 .. data:: Ellipsis
 
-   The same as the ellipsis literal "``...``", an object frequently used as a
-   placeholder for another value. Assignment to  ``Ellipsis`` is possible, but
+   The same as the ellipsis literal "``...``", an object frequently used to
+   indicate that something is omitted. Assignment to ``Ellipsis`` is possible, but
    assignment to  ``...`` is not possible and raises a :exc:`SyntaxError`.
    ``Ellipsis`` is the sole instance of the :data:`types.EllipsisType` type.
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5869,7 +5869,7 @@ It is written as ``None``.
 The Ellipsis Object
 -------------------
 
-This object is commonly used as a placeholder of another objects, values or even
+This object is commonly used as a placeholder for other objects, values or even
 instructions.  It supports no
 special operations.  There is exactly one ellipsis object, named
 :const:`Ellipsis` (a built-in name).  ``type(Ellipsis)()`` produces the

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5878,7 +5878,7 @@ special operations.  There is exactly one ellipsis object, named
 It is written as ``Ellipsis`` or ``...``.
 
 For instance, in the standard library and its documentation, ``Ellipsis`` can
-appears in :ref:`pretty printers <prettyprinter-objects>`,
+appears in
 :const:`documentation tests <doctest.ELLIPSIS>`,
 :ref:`type annotations <annotating-callables>`,
 or instead of :ref:`pass statement <tut-pass>`.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5869,25 +5869,34 @@ It is written as ``None``.
 The Ellipsis Object
 -------------------
 
-This object is commonly used as a placeholder for other objects, values or even
-instructions.  It supports no
-special operations.  There is exactly one ellipsis object, named
+This object is commonly used used to indicate that something is omitted.
+It supports no special operations.  There is exactly one ellipsis object, named
 :const:`Ellipsis` (a built-in name).  ``type(Ellipsis)()`` produces the
 :const:`Ellipsis` singleton.
 
 It is written as ``Ellipsis`` or ``...``.
 
-For instance, in the standard library and its documentation, ``Ellipsis`` can
-appears in
-:const:`documentation tests <doctest.ELLIPSIS>`,
-:ref:`type annotations <annotating-callables>`,
-or instead of :ref:`pass statement <tut-pass>`.
+In typical use, ``...`` as the ``Ellipsis`` object appears in a few different
+places, for instance:
 
+- In type annotations, such as :ref:`callable arguments <annotating-callables>`
+  or :ref:`tuple elements <annotating-tuples>`.
 
-.. seealso::
+- As the body of a function instead of a :ref:`pass statement <tut-pass>`.
 
-   `NumPy's slicing and striding <https://numpy.org/doc/stable/user/basics.indexing.html#slicing-and-striding>`_
-      A well-known Ellipsis use in third party packages is for slicing in Numpy.
+- In third-party libraries, such as `Numpy's slicing and striding
+  <https://numpy.org/doc/stable/user/basics.indexing.html#slicing-and-striding>`_.
+
+Python also uses three dots in ways that are not ``Ellipsis`` objects, for instance:
+
+- Doctest's :const:`ELLIPSIS <doctest.ELLIPSIS>`, as a pattern for missing content.
+
+- The default Python prompt of the :term:`interactive` shell when entering the
+  code for an indented code block, meaning "please finish your statement".
+
+Lastly, the Python documentation often uses three dots in conventional English
+usage to mean omitted content, even in code examples that also use them as the
+``Ellipsis``.
 
 
 .. _bltin-notimplemented-object:

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5887,7 +5887,7 @@ or instead of :ref:`pass statement <tut-pass>`.
 .. seealso::
 
    `NumPy's slicing and striding <https://numpy.org/doc/stable/user/basics.indexing.html#slicing-and-striding>`_
-      A known-well Ellipsis use on third packages is the slicing on the Numpy.
+      A well-known Ellipsis use in third party packages is for slicing in Numpy.
 
 
 .. _bltin-notimplemented-object:

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5884,6 +5884,12 @@ appears in :ref:`pretty printers <prettyprinter-objects>`,
 or instead of :ref:`pass statement <tut-pass>`.
 
 
+.. seealso::
+
+   `NumPy's slicing and striding <https://numpy.org/doc/stable/user/basics.indexing.html#slicing-and-striding>`_
+      A known-well Ellipsis use on third packages is the slicing on the Numpy.
+
+
 .. _bltin-notimplemented-object:
 
 The NotImplemented Object

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5891,8 +5891,7 @@ Python also uses three dots in ways that are not ``Ellipsis`` objects, for insta
 
 - Doctest's :const:`ELLIPSIS <doctest.ELLIPSIS>`, as a pattern for missing content.
 
-- The default Python prompt of the :term:`interactive` shell when entering the
-  code for an indented code block, meaning "please finish your statement".
+- The default Python prompt of the :term:`interactive` shell when partial input is incomplete.
 
 Lastly, the Python documentation often uses three dots in conventional English
 usage to mean omitted content, even in code examples that also use them as the

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5869,12 +5869,19 @@ It is written as ``None``.
 The Ellipsis Object
 -------------------
 
-This object is commonly used by slicing (see :ref:`slicings`).  It supports no
+This object is commonly used as a placeholder of another objects, values or even
+instructions.  It supports no
 special operations.  There is exactly one ellipsis object, named
 :const:`Ellipsis` (a built-in name).  ``type(Ellipsis)()`` produces the
 :const:`Ellipsis` singleton.
 
 It is written as ``Ellipsis`` or ``...``.
+
+For instance, at the standard library and its documentation, ``Ellipsis`` can
+appears in :ref:`pretty printers <prettyprinter-objects>`,
+:const:`documentation tests <doctest.ELLIPSIS>`,
+:ref:`type annotations <annotating-callables>`,
+or instead of :ref:`pass statement <tut-pass>`.
 
 
 .. _bltin-notimplemented-object:

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5877,7 +5877,7 @@ special operations.  There is exactly one ellipsis object, named
 
 It is written as ``Ellipsis`` or ``...``.
 
-For instance, at the standard library and its documentation, ``Ellipsis`` can
+For instance, in the standard library and its documentation, ``Ellipsis`` can
 appears in :ref:`pretty printers <prettyprinter-objects>`,
 :const:`documentation tests <doctest.ELLIPSIS>`,
 :ref:`type annotations <annotating-callables>`,

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -230,9 +230,11 @@ For example:
 
    callback: Callable[[str], Awaitable[None]] = on_update
 
+.. index:: single: ...; ellipsis literal
+
 The subscription syntax must always be used with exactly two values: the
 argument list and the return type.  The argument list must be a list of types,
-a :class:`ParamSpec`, :data:`Concatenate`, or an ellipsis. The return type must
+a :class:`ParamSpec`, :data:`Concatenate`, or an ellipsis (``...``). The return type must
 be a single type.
 
 If a literal ellipsis ``...`` is given as the argument list, it indicates that
@@ -375,8 +377,11 @@ accepts *any number* of type arguments::
    # but ``z`` has been assigned to a tuple of length 3
    z: tuple[int] = (1, 2, 3)
 
+.. index:: single: ...; ellipsis literal
+
 To denote a tuple which could be of *any* length, and in which all elements are
-of the same type ``T``, use ``tuple[T, ...]``. To denote an empty tuple, use
+of the same type ``T``, use the literal ellipsis ``...``: ``tuple[T, ...]``.
+To denote an empty tuple, use
 ``tuple[()]``. Using plain ``tuple`` as an annotation is equivalent to using
 ``tuple[Any, ...]``::
 
@@ -1161,6 +1166,8 @@ These can be used as types in annotations. They all support subscription using
 .. data:: Concatenate
 
    Special form for annotating higher-order functions.
+
+   .. index:: single: ...; ellipsis literal
 
    ``Concatenate`` can be used in conjunction with :ref:`Callable <annotating-callables>` and
    :class:`ParamSpec` to annotate a higher-order callable which adds, removes,

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -251,7 +251,7 @@ statements: a ``try`` statement's ``else`` clause runs when no exception
 occurs, and a loop's ``else`` clause runs when no ``break`` occurs. For more on
 the ``try`` statement and exceptions, see :ref:`tut-handling`.
 
-.. index:: single: ...; placeholder
+.. index:: single: ...; ellipsis literal
 .. _tut-pass:
 
 :keyword:`!pass` Statements

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -279,7 +279,7 @@ at a more abstract level.  The :keyword:`!pass` is silently ignored::
    ...
 
 For this last case, many people use the ellipsis literal :code:`...` instead of
-:code:`pass`. This use has no special meaning to Python, and it is not part of
+:code:`pass`. This use has no special meaning to Python, and is not part of
 the language definition (you could use any constant expression here), but
 :code:`...` is used conventionally as a placeholder body as well.
 See :ref:`bltin-ellipsis-object`.

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -251,6 +251,7 @@ statements: a ``try`` statement's ``else`` clause runs when no exception
 occurs, and a loop's ``else`` clause runs when no ``break`` occurs. For more on
 the ``try`` statement and exceptions, see :ref:`tut-handling`.
 
+.. index:: single: ...; placeholder
 .. _tut-pass:
 
 :keyword:`!pass` Statements
@@ -276,6 +277,12 @@ at a more abstract level.  The :keyword:`!pass` is silently ignored::
    >>> def initlog(*args):
    ...     pass   # Remember to implement this!
    ...
+
+For this last case, many people use the ellipsis literal :code:`...` instead of
+:code:`pass`. This use has no special meaning to Python, and it is not part of
+the language definition (you could use any constant expression here), but
+:code:`...` is used conventionally as a placeholder body as well.
+See :ref:`bltin-ellipsis-object`.
 
 
 .. _tut-match:


### PR DESCRIPTION
After a [discuss thread](https://discuss.python.org/t/ellipsis-documentation/99481), this PR updates the Ellipsis documentation.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138306.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-138307 -->
* Issue: gh-138307
<!-- /gh-issue-number -->
