### PR TITLE
gh-138318, PyREPL: builtins should not be highlighted when used as attribute names

### DIFF
--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -196,7 +196,8 @@ def gen_colors_from_token_stream(
                     is_def_name = False
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "definition")
-                elif keyword.iskeyword(token.string):
+                elif (keyword.iskeyword(token.string)
+                      and not (prev_token and prev_token.type == T.OP and prev_token.string == ".")):
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "keyword")
                     if token.string in IDENTIFIERS_AFTER:
@@ -208,7 +209,8 @@ def gen_colors_from_token_stream(
                 ):
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "soft_keyword")
-                elif token.string in BUILTINS:
+                elif (token.string in BUILTINS
+                      and not (prev_token and prev_token.type == T.OP and prev_token.string == ".")):
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "builtin")
 

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -210,8 +210,7 @@ def gen_colors_from_token_stream(
                     yield ColorSpan(span, "soft_keyword")
                 elif (
                     token.string in BUILTINS
-                    and not (prev_token and prev_token.type == T.OP
-                                        and prev_token.string == ".")):
+                    and not (prev_token and prev_token.exact_type == T.DOT)):
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "builtin")
 

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -208,8 +208,10 @@ def gen_colors_from_token_stream(
                 ):
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "soft_keyword")
-                elif (token.string in BUILTINS
-                      and not (prev_token and prev_token.type == T.OP and prev_token.string == ".")):
+                elif (
+                    token.string in BUILTINS
+                    and not (prev_token and prev_token.type == T.OP
+                                        and prev_token.string == ".")):
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "builtin")
 

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -210,7 +210,8 @@ def gen_colors_from_token_stream(
                     yield ColorSpan(span, "soft_keyword")
                 elif (
                     token.string in BUILTINS
-                    and not (prev_token and prev_token.exact_type == T.DOT)):
+                    and not (prev_token and prev_token.exact_type == T.DOT)
+                ):
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "builtin")
 

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -196,8 +196,7 @@ def gen_colors_from_token_stream(
                     is_def_name = False
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "definition")
-                elif (keyword.iskeyword(token.string)
-                      and not (prev_token and prev_token.type == T.OP and prev_token.string == ".")):
+                elif keyword.iskeyword(token.string):
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "keyword")
                     if token.string in IDENTIFIERS_AFTER:

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -62,26 +62,16 @@ class TestUtils(TestCase):
             next(pnw)
 
     def test_gen_colors_keyword_highlighting(self):
-        no_highlight_cases = [
+        cases = [
+            # no highlights
             ("a.set", [(".", "op")]),
             ("obj.list", [(".", "op")]),
             ("obj.match", [(".", "op")]),
-        ]
-        for code, expected_highlights in no_highlight_cases:
-            with self.subTest(code=code):
-                colors = list(gen_colors(code))
-                # Extract (text, tag) pairs for comparison
-                actual_highlights = []
-                for color in colors:
-                    span_text = code[color.span.start:color.span.end + 1]
-                    actual_highlights.append((span_text, color.tag))
-                self.assertEqual(actual_highlights, expected_highlights,
-                               f"In '{code}', expected {expected_highlights}, got {actual_highlights}")
-        highlight_cases = [
+            # highlights
             ("set", [("set", "builtin")]),
             ("list", [("list", "builtin")]),
         ]
-        for code, expected_highlights in highlight_cases:
+        for code, expected_highlights in cases:
             with self.subTest(code=code):
                 colors = list(gen_colors(code))
                 # Extract (text, tag) pairs for comparison
@@ -89,5 +79,4 @@ class TestUtils(TestCase):
                 for color in colors:
                     span_text = code[color.span.start:color.span.end + 1]
                     actual_highlights.append((span_text, color.tag))
-                self.assertEqual(actual_highlights, expected_highlights,
-                               f"In '{code}', expected {expected_highlights}, got {actual_highlights}")
+                self.assertEqual(actual_highlights, expected_highlights)

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -71,6 +71,7 @@ class TestUtils(TestCase):
             # highlights
             ("set", [("set", "builtin")]),
             ("list", [("list", "builtin")]),
+            ("    \n dict", [("dict", "builtin")]),
         ]
         for code, expected_highlights in cases:
             with self.subTest(code=code):

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from _pyrepl.utils import str_width, wlen, prev_next_window
+from _pyrepl.utils import str_width, wlen, prev_next_window, gen_colors
 
 
 class TestUtils(TestCase):
@@ -60,3 +60,38 @@ class TestUtils(TestCase):
         self.assertEqual(next(pnw), (3, 4, None))
         with self.assertRaises(ZeroDivisionError):
             next(pnw)
+
+    def test_gen_colors_keyword_highlighting(self):
+        no_highlight_cases = [
+            ("a.set", [(".", "op")]),  # 'set' should not be highlighted after '.'
+            ("a.def", [(".", "op")]),  # 'def' should not be highlighted after '.'
+            ("obj.class", [(".", "op")]),  # 'class' should not be highlighted after '.'
+            ("obj.list", [(".", "op")]),  # 'list' should not be highlighted after '.'
+            ("obj.match", [(".", "op")]),  # 'match' should not be highlighted after '.'
+        ]
+        for code, expected_highlights in no_highlight_cases:
+            with self.subTest(code=code):
+                colors = list(gen_colors(code))
+                # Extract (text, tag) pairs for comparison
+                actual_highlights = []
+                for color in colors:
+                    span_text = code[color.span.start:color.span.end + 1]
+                    actual_highlights.append((span_text, color.tag))
+                self.assertEqual(actual_highlights, expected_highlights,
+                               f"In '{code}', expected {expected_highlights}, got {actual_highlights}")
+        highlight_cases = [
+            ("set", [("set", "builtin")]),
+            ("list", [("list", "builtin")]),
+            ("def func():", [("def", "keyword"), ("func", "definition"), ("(", "op"), (")", "op"), (":", "op")]),
+            ("class A:", [("class", "keyword"), ("A", "definition"), (":", "op")]),
+        ]
+        for code, expected_highlights in highlight_cases:
+            with self.subTest(code=code):
+                colors = list(gen_colors(code))
+                # Extract (text, tag) pairs for comparison
+                actual_highlights = []
+                for color in colors:
+                    span_text = code[color.span.start:color.span.end + 1]
+                    actual_highlights.append((span_text, color.tag))
+                self.assertEqual(actual_highlights, expected_highlights,
+                               f"In '{code}', expected {expected_highlights}, got {actual_highlights}")

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -67,6 +67,7 @@ class TestUtils(TestCase):
             ("a.set", [(".", "op")]),
             ("obj.list", [(".", "op")]),
             ("obj.match", [(".", "op")]),
+            ("b. \\\n format", [(".", "op")]),
             # highlights
             ("set", [("set", "builtin")]),
             ("list", [("list", "builtin")]),

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -63,11 +63,9 @@ class TestUtils(TestCase):
 
     def test_gen_colors_keyword_highlighting(self):
         no_highlight_cases = [
-            ("a.set", [(".", "op")]),  # 'set' should not be highlighted after '.'
-            ("a.def", [(".", "op")]),  # 'def' should not be highlighted after '.'
-            ("obj.class", [(".", "op")]),  # 'class' should not be highlighted after '.'
-            ("obj.list", [(".", "op")]),  # 'list' should not be highlighted after '.'
-            ("obj.match", [(".", "op")]),  # 'match' should not be highlighted after '.'
+            ("a.set", [(".", "op")]),
+            ("obj.list", [(".", "op")]),
+            ("obj.match", [(".", "op")]),
         ]
         for code, expected_highlights in no_highlight_cases:
             with self.subTest(code=code):
@@ -82,8 +80,6 @@ class TestUtils(TestCase):
         highlight_cases = [
             ("set", [("set", "builtin")]),
             ("list", [("list", "builtin")]),
-            ("def func():", [("def", "keyword"), ("func", "definition"), ("(", "op"), (")", "op"), (":", "op")]),
-            ("class A:", [("class", "keyword"), ("A", "definition"), (":", "op")]),
         ]
         for code, expected_highlights in highlight_cases:
             with self.subTest(code=code):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-01-16-09-02.gh-issue-138318.t-WEN5.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-01-16-09-02.gh-issue-138318.t-WEN5.rst
@@ -1,4 +1,3 @@
 The default REPL now avoids highlighting built-in names (for instance :class:`set`
 or :func:`format`) when they are used as attribute names (for instance in ``value.set``
 or ``text.format``).
-

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-01-16-09-02.gh-issue-138318.t-WEN5.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-01-16-09-02.gh-issue-138318.t-WEN5.rst
@@ -1,1 +1,3 @@
-fix: xxx.builtins the builtins keyword should not highlight in new repl
+The default REPL now avoids highlighting built-in names (for instance :class:`set`
+    or :func:`format`) when they are used as attribute names (for instance in ``value.set``
+    or ``text.format``).

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-01-16-09-02.gh-issue-138318.t-WEN5.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-01-16-09-02.gh-issue-138318.t-WEN5.rst
@@ -1,3 +1,4 @@
 The default REPL now avoids highlighting built-in names (for instance :class:`set`
-    or :func:`format`) when they are used as attribute names (for instance in ``value.set``
-    or ``text.format``).
+or :func:`format`) when they are used as attribute names (for instance in ``value.set``
+or ``text.format``).
+

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-01-16-09-02.gh-issue-138318.t-WEN5.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-01-16-09-02.gh-issue-138318.t-WEN5.rst
@@ -1,1 +1,1 @@
-fix: xxx.keyword the keyword should not highlight in new repl
+fix: xxx.builtins the builtins keyword should not highlight in new repl

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-01-16-09-02.gh-issue-138318.t-WEN5.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-01-16-09-02.gh-issue-138318.t-WEN5.rst
@@ -1,0 +1,1 @@
+fix: xxx.keyword the keyword should not highlight in new repl


### PR DESCRIPTION
We remove REPL highlighting when a builtin name is used as an attribute name. Keywords will still be highlighted as they can never be used as valid attribute names.

----

<details>
<summary>Previous discussion about keywords</summary>

as diff

before the patch:
<img width="1010" height="327" alt="image" src="https://github.com/user-attachments/assets/5fa1d525-9eea-4b44-a6bc-161305296b73" />

after the patch:

<img width="1432" height="700" alt="image" src="https://github.com/user-attachments/assets/79111b34-457e-4f7d-a175-41925e4c98a1" />

after the disscuss

<img width="603" height="255" alt="image" src="https://github.com/user-attachments/assets/37ffcd65-2001-4b1b-a08f-949d4ec0c01d" />

</details>


<!-- gh-issue-number: gh-138318 -->
* Issue: gh-138318
<!-- /gh-issue-number -->
