### PR TITLE
[3.13] gh-116946: Revert GC protocol for immutable empty heap types (GH-138322, GH-138323, GH-138326)

### DIFF
--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -129,9 +129,6 @@ typedef struct {
     PyThread_type_lock lock;
 } BZ2Decompressor;
 
-#define _BZ2Compressor_CAST(op)     ((BZ2Compressor *)(op))
-#define _BZ2Decompressor_CAST(op)   ((BZ2Decompressor *)(op))
-
 /* Helper functions. */
 
 static int
@@ -379,21 +376,19 @@ error:
 }
 
 static void
-BZ2Compressor_dealloc(PyObject *op)
+BZ2Compressor_dealloc(BZ2Compressor *self)
 {
-    PyTypeObject *tp = Py_TYPE(op);
-    PyObject_GC_UnTrack(op);
-    BZ2Compressor *self = _BZ2Compressor_CAST(op);
     BZ2_bzCompressEnd(&self->bzs);
     if (self->lock != NULL) {
         PyThread_free_lock(self->lock);
     }
-    tp->tp_free(self);
+    PyTypeObject *tp = Py_TYPE(self);
+    tp->tp_free((PyObject *)self);
     Py_DECREF(tp);
 }
 
 static int
-BZ2Compressor_traverse(PyObject *self, visitproc visit, void *arg)
+BZ2Compressor_traverse(BZ2Compressor *self, visitproc visit, void *arg)
 {
     Py_VISIT(Py_TYPE(self));
     return 0;
@@ -421,7 +416,7 @@ static PyType_Spec bz2_compressor_type_spec = {
     // bz2_compressor_type_spec does not have Py_TPFLAGS_BASETYPE flag
     // which prevents to create a subclass.
     // So calling PyType_GetModuleState() in this file is always safe.
-    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HAVE_GC),
+    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE),
     .slots = bz2_compressor_type_slots,
 };
 
@@ -685,11 +680,8 @@ error:
 }
 
 static void
-BZ2Decompressor_dealloc(PyObject *op)
+BZ2Decompressor_dealloc(BZ2Decompressor *self)
 {
-    PyTypeObject *tp = Py_TYPE(op);
-    PyObject_GC_UnTrack(op);
-    BZ2Decompressor *self = _BZ2Decompressor_CAST(op);
     if(self->input_buffer != NULL) {
         PyMem_Free(self->input_buffer);
     }
@@ -698,12 +690,14 @@ BZ2Decompressor_dealloc(PyObject *op)
     if (self->lock != NULL) {
         PyThread_free_lock(self->lock);
     }
-    tp->tp_free(self);
+
+    PyTypeObject *tp = Py_TYPE(self);
+    tp->tp_free((PyObject *)self);
     Py_DECREF(tp);
 }
 
 static int
-BZ2Decompressor_traverse(PyObject *self, visitproc visit, void *arg)
+BZ2Decompressor_traverse(BZ2Decompressor *self, visitproc visit, void *arg)
 {
     Py_VISIT(Py_TYPE(self));
     return 0;
@@ -750,7 +744,7 @@ static PyType_Spec bz2_decompressor_type_spec = {
     // bz2_decompressor_type_spec does not have Py_TPFLAGS_BASETYPE flag
     // which prevents to create a subclass.
     // So calling PyType_GetModuleState() in this file is always safe.
-    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HAVE_GC),
+    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE),
     .slots = bz2_decompressor_type_slots,
 };
 

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -282,8 +282,6 @@ typedef struct {
     PyMutex mutex;  /* OpenSSL context lock */
 } EVPobject;
 
-#define EVPobject_CAST(op)  ((EVPobject *)(op))
-
 typedef struct {
     PyObject_HEAD
     HMAC_CTX *ctx;            /* OpenSSL hmac context */
@@ -291,8 +289,6 @@ typedef struct {
     bool use_mutex;
     PyMutex mutex;  /* HMAC context lock */
 } HMACobject;
-
-#define HMACobject_CAST(op) ((HMACobject *)(op))
 
 #include "clinic/_hashopenssl.c.h"
 /*[clinic input]
@@ -501,9 +497,7 @@ py_digest_by_digestmod(PyObject *module, PyObject *digestmod, enum Py_hash_type 
 static EVPobject *
 newEVPobject(PyTypeObject *type)
 {
-    assert(type != NULL);
-    assert(type->tp_alloc != NULL);
-    EVPobject *retval = (EVPobject *)type->tp_alloc(type, 0);
+    EVPobject *retval = (EVPobject *)PyObject_New(EVPobject, type);
     if (retval == NULL) {
         return NULL;
     }
@@ -542,21 +536,12 @@ EVP_hash(EVPobject *self, const void *vp, Py_ssize_t len)
 /* Internal methods for a hash object */
 
 static void
-EVP_dealloc(PyObject *op)
+EVP_dealloc(EVPobject *self)
 {
-    PyTypeObject *tp = Py_TYPE(op);
-    PyObject_GC_UnTrack(op);
-    EVPobject *self = EVPobject_CAST(op);
+    PyTypeObject *tp = Py_TYPE(self);
     EVP_MD_CTX_free(self->ctx);
-    tp->tp_free(self);
+    PyObject_Free(self);
     Py_DECREF(tp);
-}
-
-static int
-EVP_traverse(PyObject *op, visitproc visit, void *arg)
-{
-    Py_VISIT(Py_TYPE(op));
-    return 0;
 }
 
 static int
@@ -796,7 +781,6 @@ PyDoc_STRVAR(hashtype_doc,
 
 static PyType_Slot EVPtype_slots[] = {
     {Py_tp_dealloc, EVP_dealloc},
-    {Py_tp_traverse, EVP_traverse},
     {Py_tp_repr, EVP_repr},
     {Py_tp_doc, (char *)hashtype_doc},
     {Py_tp_methods, EVP_methods},
@@ -805,16 +789,11 @@ static PyType_Slot EVPtype_slots[] = {
 };
 
 static PyType_Spec EVPtype_spec = {
-    .name = "_hashlib.HASH",
-    .basicsize = sizeof(EVPobject),
-    .flags = (
-        Py_TPFLAGS_DEFAULT
-        | Py_TPFLAGS_BASETYPE
-        | Py_TPFLAGS_DISALLOW_INSTANTIATION
-        | Py_TPFLAGS_IMMUTABLETYPE
-        | Py_TPFLAGS_HAVE_GC
-    ),
-    .slots = EVPtype_slots
+    "_hashlib.HASH",    /*tp_name*/
+    sizeof(EVPobject),  /*tp_basicsize*/
+    0,                  /*tp_itemsize*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION | Py_TPFLAGS_IMMUTABLETYPE,
+    EVPtype_slots
 };
 
 #ifdef PY_OPENSSL_HAS_SHAKE
@@ -955,8 +934,6 @@ PyDoc_STRVAR(hashxoftype_doc,
 "digest_size -- number of bytes in this hashes output");
 
 static PyType_Slot EVPXOFtype_slots[] = {
-    {Py_tp_dealloc, EVP_dealloc},
-    {Py_tp_traverse, EVP_traverse},
     {Py_tp_doc, (char *)hashxoftype_doc},
     {Py_tp_methods, EVPXOF_methods},
     {Py_tp_getset, EVPXOF_getseters},
@@ -964,16 +941,11 @@ static PyType_Slot EVPXOFtype_slots[] = {
 };
 
 static PyType_Spec EVPXOFtype_spec = {
-    .name = "_hashlib.HASHXOF",
-    .basicsize = sizeof(EVPobject),
-    .flags = (
-        Py_TPFLAGS_DEFAULT
-        | Py_TPFLAGS_BASETYPE
-        | Py_TPFLAGS_DISALLOW_INSTANTIATION
-        | Py_TPFLAGS_IMMUTABLETYPE
-        | Py_TPFLAGS_HAVE_GC
-    ),
-    .slots = EVPXOFtype_slots
+    "_hashlib.HASHXOF",    /*tp_name*/
+    sizeof(EVPobject),  /*tp_basicsize*/
+    0,                  /*tp_itemsize*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION | Py_TPFLAGS_IMMUTABLETYPE,
+    EVPXOFtype_slots
 };
 
 
@@ -1687,8 +1659,7 @@ _hashlib_hmac_new_impl(PyObject *module, Py_buffer *key, PyObject *msg_obj,
     }
 
     _hashlibstate *state = get_hashlib_state(module);
-    assert(state->HMACtype != NULL);
-    self = (HMACobject *)state->HMACtype->tp_alloc(state->HMACtype, 0);
+    self = PyObject_New(HMACobject, state->HMACtype);
     if (self == NULL) {
         goto error;
     }
@@ -1793,8 +1764,7 @@ _hashlib_HMAC_copy_impl(HMACobject *self)
         return NULL;
     }
 
-    PyTypeObject *type = Py_TYPE(self);
-    retval = (HMACobject *)type->tp_alloc(type, 0);
+    retval = PyObject_New(HMACobject, Py_TYPE(self));
     if (retval == NULL) {
         HMAC_CTX_free(ctx);
         return NULL;
@@ -1806,24 +1776,15 @@ _hashlib_HMAC_copy_impl(HMACobject *self)
 }
 
 static void
-_hmac_dealloc(PyObject *op)
+_hmac_dealloc(HMACobject *self)
 {
-    PyTypeObject *tp = Py_TYPE(op);
-    PyObject_GC_UnTrack(op);
-    HMACobject *self = HMACobject_CAST(op);
+    PyTypeObject *tp = Py_TYPE(self);
     if (self->ctx != NULL) {
         HMAC_CTX_free(self->ctx);
         self->ctx = NULL;
     }
-    tp->tp_free(self);
+    PyObject_Free(self);
     Py_DECREF(tp);
-}
-
-static int
-_hmac_traverse(PyObject *op, visitproc visit, void *arg)
-{
-    Py_VISIT(Py_TYPE(op));
-    return 0;
 }
 
 static PyObject *
@@ -1993,22 +1954,16 @@ digest_size -- number of bytes in digest() output\n");
 static PyType_Slot HMACtype_slots[] = {
     {Py_tp_doc, (char *)hmactype_doc},
     {Py_tp_repr, (reprfunc)_hmac_repr},
-    {Py_tp_dealloc, _hmac_dealloc},
-    {Py_tp_traverse, _hmac_traverse},
+    {Py_tp_dealloc,(destructor)_hmac_dealloc},
     {Py_tp_methods, HMAC_methods},
     {Py_tp_getset, HMAC_getset},
     {0, NULL}
 };
 
 PyType_Spec HMACtype_spec = {
-    .name = "_hashlib.HMAC",
-    .basicsize = sizeof(HMACobject),
-    .flags = (
-        Py_TPFLAGS_DEFAULT
-        | Py_TPFLAGS_DISALLOW_INSTANTIATION
-        | Py_TPFLAGS_IMMUTABLETYPE
-        | Py_TPFLAGS_HAVE_GC
-    ),
+    "_hashlib.HMAC",    /* name */
+    sizeof(HMACobject),     /* basicsize */
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = HMACtype_slots,
 };
 


### PR DESCRIPTION
This reverts commits 90036f51fe4bb2eed0e5161f26712cf08e1563d2 828682df868217788cda695a21bb63635f6fadc7 and 21b593219ad5cf444553afaebe12ff9137d4d55e. I mistakenly assumed that immutable empty types also needed to support the GC protocol but this is not the case.

<!-- gh-issue-number: gh-116946 -->
* Issue: gh-116946
<!-- /gh-issue-number -->
