### PR TITLE
gh-116738: Fix test_json_mutating_exact_dict

### DIFF
--- a/Lib/test/test_free_threading/test_json.py
+++ b/Lib/test/test_free_threading/test_json.py
@@ -56,7 +56,7 @@ class TestJsonEncoding(CTest):
                     if len(d) > 5:
                         try:
                             key = list(d)[0]
-                            d.pop()
+                            d.pop(key)
                         except (KeyError, IndexError):
                             pass
                     else:


### PR DESCRIPTION
The test intended to mutate the dict, but due to a missing `key` argument the `dict` was not changed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116738 -->
* Issue: gh-116738
<!-- /gh-issue-number -->
