### PR TITLE
gh-116946: add `Py_TPFLAGS_IMMUTABLETYPE` to `select.[e]poll`

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-09-02-10-27-21.gh-issue-116946.VxXNGD.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-02-10-27-21.gh-issue-116946.VxXNGD.rst
@@ -1,2 +1,2 @@
-The C type of :func:`select.epoll` objects is now immutable. Patch by
-Bénédikt Tran.
+The C types of :func:`select.poll` and :func:`select.epoll` objects are now
+immutable. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-09-02-10-27-21.gh-issue-116946.VxXNGD.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-02-10-27-21.gh-issue-116946.VxXNGD.rst
@@ -1,2 +1,2 @@
-The C types of :func:`select.poll` and :func:`select.epoll` objects are now
+The types of :func:`select.poll` and :func:`select.epoll` objects are now
 immutable. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-09-02-10-27-21.gh-issue-116946.VxXNGD.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-02-10-27-21.gh-issue-116946.VxXNGD.rst
@@ -1,0 +1,2 @@
+The C type of :func:`select.epoll` objects is now immutable. Patch by
+Bénédikt Tran.

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1413,14 +1413,6 @@ pyepoll_dealloc(PyObject *op)
     Py_DECREF(type);
 }
 
-static int
-pyepoll_traverse(PyObject *op, visitproc visit, void *arg)
-{
-    Py_VISIT(Py_TYPE(op));
-    return 0;
-}
-
-
 /*[clinic input]
 @critical_section
 select.epoll.close
@@ -2546,7 +2538,6 @@ static PyMethodDef pyepoll_methods[] = {
 
 static PyType_Slot pyEpoll_Type_slots[] = {
     {Py_tp_dealloc, pyepoll_dealloc},
-    {Py_tp_traverse, pyepoll_traverse},
     {Py_tp_doc, (void*)pyepoll_doc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_getset, pyepoll_getsetlist},
@@ -2558,7 +2549,7 @@ static PyType_Slot pyEpoll_Type_slots[] = {
 static PyType_Spec pyEpoll_Type_spec = {
     .name = "select.epoll",
     .basicsize = sizeof(pyEpoll_Object),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = pyEpoll_Type_slots
 };
 


### PR DESCRIPTION
I'm not sure about kqueue as I can't check this myself. However note the following leak on main:

```console
$ ./python -X showrefcount -c 'import select; s = select.poll(); t = type(s); t._do = s'
[74 refs, 43 blocks]
```

Instead of implementing the full GC protocol, we can make the types immutable.

Rationale for **not** backporting this: https://github.com/python/cpython/pull/138341#issuecomment-3246045735.

<!-- gh-issue-number: gh-116946 -->
* Issue: gh-116946
<!-- /gh-issue-number -->
