### PR TITLE
gh-116946: add `Py_TPFLAGS_IMMUTABLETYPE` to `_random.Random`

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-09-02-10-23-09.gh-issue-116946.U6RpwK.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-02-10-23-09.gh-issue-116946.U6RpwK.rst
@@ -1,0 +1,2 @@
+The :class:`!_random.Random` C type is now immutable. Patch by Bénédikt
+Tran.

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -572,12 +572,6 @@ random_init(PyObject *self, PyObject *args, PyObject *kwds)
     return random_seed(RandomObject_CAST(self), arg);
 }
 
-static int
-random_traverse(PyObject *op, visitproc visit, void *arg)
-{
-    Py_VISIT(Py_TYPE(op));
-    return 0;
-}
 
 static PyMethodDef random_methods[] = {
     _RANDOM_RANDOM_RANDOM_METHODDEF
@@ -596,14 +590,18 @@ static PyType_Slot Random_Type_slots[] = {
     {Py_tp_methods, random_methods},
     {Py_tp_new, PyType_GenericNew},
     {Py_tp_init, random_init},
-    {Py_tp_traverse, random_traverse},
+    {Py_tp_free, PyObject_Free},
     {0, 0},
 };
 
 static PyType_Spec Random_Type_spec = {
     .name = "_random.Random",
     .basicsize = sizeof(RandomObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    .flags = (
+        Py_TPFLAGS_DEFAULT
+        | Py_TPFLAGS_BASETYPE
+        | Py_TPFLAGS_IMMUTABLETYPE
+    ),
     .slots = Random_Type_slots
 };
 

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -572,6 +572,12 @@ random_init(PyObject *self, PyObject *args, PyObject *kwds)
     return random_seed(RandomObject_CAST(self), arg);
 }
 
+static int
+random_traverse(PyObject *op, visitproc visit, void *arg)
+{
+    Py_VISIT(Py_TYPE(op));
+    return 0;
+}
 
 static PyMethodDef random_methods[] = {
     _RANDOM_RANDOM_RANDOM_METHODDEF
@@ -590,16 +596,15 @@ static PyType_Slot Random_Type_slots[] = {
     {Py_tp_methods, random_methods},
     {Py_tp_new, PyType_GenericNew},
     {Py_tp_init, random_init},
-    {Py_tp_free, PyObject_Free},
+    {Py_tp_traverse, random_traverse},
     {0, 0},
 };
 
 static PyType_Spec Random_Type_spec = {
-    "_random.Random",
-    sizeof(RandomObject),
-    0,
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    Random_Type_slots
+    .name = "_random.Random",
+    .basicsize = sizeof(RandomObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    .slots = Random_Type_slots
 };
 
 PyDoc_STRVAR(module_doc,


### PR DESCRIPTION
On main the following leaks:

```console
$ ./python -X showrefcount -c 'import _random; s = _random.Random(); t = type(s); t._random = s'
[42 refs, 26 blocks]
```

<!-- gh-issue-number: gh-116946 -->
* Issue: gh-116946
<!-- /gh-issue-number -->
