### PR TITLE
gh-138360: Fix `test_free_threading` for IO objects

### DIFF
--- a/Lib/test/test_free_threading/test_io.py
+++ b/Lib/test/test_free_threading/test_io.py
@@ -41,7 +41,7 @@ class ThreadSafetyMixin:
         def truncate(barrier, b, *ignore):
             barrier.wait()
             try: b.truncate(0)
-            except: BufferError  # ignore exported buffer
+            except BufferError: pass  # ignore exported buffer
 
         def read(barrier, b, *ignore):
             barrier.wait()


### PR DESCRIPTION


<!-- gh-issue-number: gh-138360 -->
* Issue: gh-138360
<!-- /gh-issue-number -->
