### PR TITLE
gh-138361: Add N format unit for non-negative Py_ssize_t

### DIFF
--- a/Doc/c-api/arg.rst
+++ b/Doc/c-api/arg.rst
@@ -285,6 +285,9 @@ the minimal value for the corresponding signed integer type of the same size.
 ``n`` (:class:`int`) [:c:type:`Py_ssize_t`]
    Convert a Python integer to a C :c:type:`Py_ssize_t`.
 
+``N`` (:class:`int`) [:c:type:`Py_ssize_t`]
+   Convert a non-negative Python integer to a C :c:type:`Py_ssize_t`.
+
 ``c`` (:class:`bytes` or :class:`bytearray` of length 1) [char]
    Convert a Python byte, represented as a :class:`bytes` or
    :class:`bytearray` object of length 1, to a C :c:expr:`char`.

--- a/Lib/test/test_capi/test_getargs.py
+++ b/Lib/test/test_capi/test_getargs.py
@@ -290,6 +290,32 @@ class Unsigned_TestCase(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(UINT_MAX & -VERY_LARGE, getargs_I(-VERY_LARGE))
 
+    def test_N(self):
+        from _testcapi import getargs_N
+        # n returns 'Py_ssize_t', and does range checking
+        # (0 ... PY_SSIZE_T_MAX)
+        self.assertRaises(TypeError, getargs_N, 3.14)
+        self.assertEqual(99, getargs_N(Index()))
+        self.assertEqual(0, getargs_N(IndexIntSubclass()))
+        self.assertRaises(TypeError, getargs_N, BadIndex())
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(1, getargs_N(BadIndex2()))
+        self.assertEqual(0, getargs_N(BadIndex3()))
+        self.assertRaises(TypeError, getargs_N, Int())
+        self.assertEqual(0, getargs_N(IntSubclass()))
+        self.assertRaises(TypeError, getargs_N, BadInt())
+        self.assertRaises(TypeError, getargs_N, BadInt2())
+        self.assertEqual(0, getargs_N(BadInt3()))
+
+        self.assertRaises(OverflowError, getargs_N, PY_SSIZE_T_MIN-1)
+        self.assertRaises(OverflowError, getargs_N, PY_SSIZE_T_MIN)
+        self.assertRaises(OverflowError, getargs_N, -1)
+        self.assertEqual(PY_SSIZE_T_MAX, getargs_N(PY_SSIZE_T_MAX))
+        self.assertRaises(OverflowError, getargs_N, PY_SSIZE_T_MAX+1)
+
+        self.assertEqual(42, getargs_N(42))
+        self.assertRaises(OverflowError, getargs_N, VERY_LARGE)
+
     def test_k(self):
         from _testcapi import getargs_k
         # k returns 'unsigned long', no range checking

--- a/Misc/NEWS.d/next/C_API/2025-09-01-22-45-45.gh-issue-138361.okpmAJ.rst
+++ b/Misc/NEWS.d/next/C_API/2025-09-01-22-45-45.gh-issue-138361.okpmAJ.rst
@@ -1,0 +1,2 @@
+Added ``N`` as new ``PyArg_Parse`` format unit for non-negative ``Py_ssize_t``
+values.

--- a/Modules/_testcapi/getargs.c
+++ b/Modules/_testcapi/getargs.c
@@ -438,6 +438,16 @@ getargs_n(PyObject *self, PyObject *args)
 }
 
 static PyObject *
+getargs_N(PyObject *self, PyObject *args)
+{
+    Py_ssize_t value;
+    if (!PyArg_ParseTuple(args, "N", &value)) {
+        return NULL;
+    }
+    return PyLong_FromSsize_t(value);
+}
+
+static PyObject *
 getargs_p(PyObject *self, PyObject *args)
 {
     int value;
@@ -793,6 +803,7 @@ static PyMethodDef test_methods[] = {
     {"getargs_keywords", _PyCFunction_CAST(getargs_keywords), METH_VARARGS|METH_KEYWORDS},
     {"getargs_l",               getargs_l,                       METH_VARARGS},
     {"getargs_n",               getargs_n,                       METH_VARARGS},
+    {"getargs_N",               getargs_N,                       METH_VARARGS},
     {"getargs_p",               getargs_p,                       METH_VARARGS},
     {"getargs_positional_only_and_keywords", _PyCFunction_CAST(getargs_positional_only_and_keywords), METH_VARARGS|METH_KEYWORDS},
     {"getargs_s",               getargs_s,                       METH_VARARGS},


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138362.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-138361 -->
* Issue: gh-138361
<!-- /gh-issue-number -->
