### PR TITLE
gh-138013: Remove `test_io` load_tests namespace manipulation

### DIFF
--- a/Lib/test/test_io/test_general.py
+++ b/Lib/test/test_io/test_general.py
@@ -351,7 +351,7 @@ class CTestCase(unittest.TestCase):
 
     # Use the class as a proxy to the io module members.
     def __getattr__(self, name):
-        return getattr(self.io, name)
+        return getattr(io, name)
 
 
 class PyTestCase(unittest.TestCase):
@@ -368,9 +368,9 @@ class PyTestCase(unittest.TestCase):
     SlowFlushRawIO = PySlowFlushRawIO
     MockCharPseudoDevFileIO = PyMockCharPseudoDevFileIO
 
-    # Use the class as a proxy to the io module members.
+    # Use the class as a proxy to the _pyio module members.
     def __getattr__(self, name):
-        return getattr(self.io, name)
+        return getattr(pyio, name)
 
 
 class IOTest(unittest.TestCase):

--- a/Lib/test/test_io/test_general.py
+++ b/Lib/test/test_io/test_general.py
@@ -2259,14 +2259,14 @@ class BufferedRWPairTest:
             self.tp(self.MockRawIO(), self.MockRawIO(), 8, 12)
 
     def test_constructor_with_not_readable(self):
-        class NotReadable(MockRawIO):
+        class NotReadable(self.MockRawIO):
             def readable(self):
                 return False
 
         self.assertRaises(OSError, self.tp, NotReadable(), self.MockRawIO())
 
     def test_constructor_with_not_writeable(self):
-        class NotWriteable(MockRawIO):
+        class NotWriteable(self.MockRawIO):
             def writable(self):
                 return False
 
@@ -2412,9 +2412,9 @@ class BufferedRWPairTest:
         writer.close = lambda: None
 
     def test_isatty(self):
-        class SelectableIsAtty(MockRawIO):
+        class SelectableIsAtty(self.MockRawIO):
             def __init__(self, isatty):
-                MockRawIO.__init__(self)
+                super().__init__()
                 self._isatty = isatty
 
             def isatty(self):


### PR DESCRIPTION
Reduce what happens in `load_tests` so that the next change, moving the `Buffered*` tests to `test_bufferdio` is purely mechanical movement and updating imports.

This adds two classes, one per I/O implementation, to act as dispatch to the implementation-specific mocks as well as module members. Previously the mappings `CTestCase` and `PyTestCase` provide were injected directly during `load_tests`.

`CTestCase` and `PyTestCase` inherit from `unittest.TestCase` so when the split happens default test discovery will work for the classes in `test_bufferedio`. `test_general` keeps a manual test list for this refactoring; some of the tests (ex. `ProtocolsTest`) aren't currently run and fixing that + helpers to not be picked up as tests is out of my current scope.

`CTestCase` and `PyTestCase` have an `io` class member which points to the implementation meaning that can be removed from individual test cases which now inherit from them.


Tested locally with `./python -m test test_io -uall,walltime,largefile,extralargefile -M16G -j8 -v`

---
1. Could this get `skip news` as its a test-only change?
2. Could buildbots be run against this? Worried there are lots of platform-specific cases in these test cases and would rather proactively debug/fix than reactively (Ex. 4 tests are skipped for me on my 64 bit Linux box because: "only run in 32-bit address space" and "only when utf-8 mode is disabled")

<!-- gh-issue-number: gh-138013 -->
* Issue: gh-138013
<!-- /gh-issue-number -->
