### PR TITLE
gh-109975: Escaping an 's' after backquote in 3.13.0a5.rst

### DIFF
--- a/Misc/NEWS.d/3.13.0a5.rst
+++ b/Misc/NEWS.d/3.13.0a5.rst
@@ -742,7 +742,7 @@ Add ``windows_31j`` to aliases for ``cp932`` codec
 .. nonce: fv35wU
 .. section: Library
 
-:func:`functools.partial`s of :func:`repr` has been improved to include the
+:func:`functools.partial`\s of :func:`repr` has been improved to include the
 :term:`module` name. Patched by Furkan Onder and Anilyka Barry.
 
 ..


### PR DESCRIPTION
This lacks a "`" and fails to build with Swedish translation

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->
