### PR TITLE
gh-138372: Fix SyntaxWarning for erroneous t-string subscription

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -1554,6 +1554,8 @@ class GrammarTests(unittest.TestCase):
         check('[None [i, j]]')
         check('[True [i, j]]')
         check('[... [i, j]]')
+        check('[t"{x}" [i, j]]')
+        check('[t"x={x}" [i, j]]')
 
         msg=r'indices must be integers or slices, not tuple; perhaps you missed a comma\?'
         check('[(1, 2) [i, j]]')
@@ -1564,8 +1566,6 @@ class GrammarTests(unittest.TestCase):
         check('[f"x={x}" [i, j]]')
         check('["abc" [i, j]]')
         check('[b"abc" [i, j]]')
-        check('[t"{x}" [i, j]]')
-        check('[t"x={x}" [i, j]]')
 
         msg=r'indices must be integers or slices, not tuple;'
         check('[[1, 2] [3, 4]]')

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -1586,6 +1586,7 @@ class GrammarTests(unittest.TestCase):
         check('[[1, 2] [f"{x}"]]')
         check('[[1, 2] [f"x={x}"]]')
         check('[[1, 2] ["abc"]]')
+        msg=r'indices must be integers or slices, not string.templatelib.Template;'
         check('[[1, 2] [t"{x}"]]')
         check('[[1, 2] [t"x={x}"]]')
         msg=r'indices must be integers or slices, not'

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-02-09-10-06.gh-issue-138372.h1Xk4-.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-02-09-10-06.gh-issue-138372.h1Xk4-.rst
@@ -1,2 +1,2 @@
-Fix type name shown in :exc:`SyntaxWarning`\s involving :ref:`template string
-literals <t-strings>`. Patch by Brian Schubert.
+Fix :exc:`SyntaxWarning` emitted for erroneous subscript expressions involving
+:ref:`template string literals <t-strings>`. Patch by Brian Schubert.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-02-09-10-06.gh-issue-138372.h1Xk4-.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-02-09-10-06.gh-issue-138372.h1Xk4-.rst
@@ -1,0 +1,2 @@
+Fix type name shown in :exc:`SyntaxWarning`\s involving :ref:`template string
+literals <t-strings>`. Patch by Brian Schubert.

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -29,6 +29,7 @@
 #include "pycore_symtable.h"      // PySTEntryObject
 #include "pycore_unicodeobject.h" // _PyUnicode_EqualToASCIIString
 #include "pycore_ceval.h"         // SPECIAL___ENTER__
+#include "pycore_template.h"      // _PyTemplate_Type
 
 #define NEED_OPCODE_METADATA
 #include "pycore_opcode_metadata.h" // _PyOpcode_opcode_metadata, _PyOpcode_num_popped/pushed
@@ -3617,10 +3618,11 @@ infer_type(expr_ty e)
         return &PyGen_Type;
     case Lambda_kind:
         return &PyFunction_Type;
-    case JoinedStr_kind:
     case TemplateStr_kind:
-    case FormattedValue_kind:
     case Interpolation_kind:
+        return &_PyTemplate_Type;
+    case JoinedStr_kind:
+    case FormattedValue_kind:
         return &PyUnicode_Type;
     case Constant_kind:
         return Py_TYPE(e->v.Constant.value);

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -3676,6 +3676,8 @@ check_subscripter(compiler *c, expr_ty e)
     case Set_kind:
     case SetComp_kind:
     case GeneratorExp_kind:
+    case TemplateStr_kind:
+    case Interpolation_kind:
     case Lambda_kind: {
         location loc = LOC(e);
         return _PyCompile_Warn(c, loc, "'%.200s' object is not subscriptable; "
@@ -3710,9 +3712,7 @@ check_index(compiler *c, expr_ty e, expr_ty s)
     case List_kind:
     case ListComp_kind:
     case JoinedStr_kind:
-    case TemplateStr_kind:
-    case FormattedValue_kind:
-    case Interpolation_kind: {
+    case FormattedValue_kind: {
         location loc = LOC(e);
         return _PyCompile_Warn(c, loc, "%.200s indices must be integers "
                                        "or slices, not %.200s; "


### PR DESCRIPTION
Demonstration:
```python
>>> [][t""]
<python-input-2>:1: SyntaxWarning: list indices must be integers or slices, not string.templatelib.Template; perhaps you missed a comma?
...

>>> t""[0]
<python-input-3>:1: SyntaxWarning: 'string.templatelib.Template' object is not subscriptable; perhaps you missed a comma?
...

>>> t""()
<python-input-4>:1: SyntaxWarning: 'string.templatelib.Template' object is not callable; perhaps you missed a comma?
...
```

<!-- gh-issue-number: gh-138372 -->
* Issue: gh-138372
<!-- /gh-issue-number -->
