### PR TITLE
Doc: Track file downloads via plausible

### DIFF
--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -28,7 +28,7 @@
 {% block extrahead %}
     {% if builder == "html" %}
       {% if enable_analytics %}
-      <script defer file-types="zip,bz2" data-domain="docs.python.org" src="https://analytics.python.org/js/script.file-downloads.outbound-links.js"></script>
+      <script defer file-types="bz2,epub,zip" data-domain="docs.python.org" src="https://analytics.python.org/js/script.file-downloads.outbound-links.js"></script>
       {% endif %}
       <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html">
       {% if pagename == 'whatsnew/changelog' and not embedded %}

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -28,7 +28,7 @@
 {% block extrahead %}
     {% if builder == "html" %}
       {% if enable_analytics %}
-      <script defer data-domain="docs.python.org" src="https://analytics.python.org/js/script.file-downloads.outbound-links.js"></script>
+      <script defer file-types="zip,bz2" data-domain="docs.python.org" src="https://analytics.python.org/js/script.file-downloads.outbound-links.js"></script>
       {% endif %}
       <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html">
       {% if pagename == 'whatsnew/changelog' and not embedded %}

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -28,7 +28,7 @@
 {% block extrahead %}
     {% if builder == "html" %}
       {% if enable_analytics %}
-      <script defer data-domain="docs.python.org" src="https://analytics.python.org/js/script.outbound-links.js"></script>
+      <script defer data-domain="docs.python.org" src="https://analytics.python.org/js/script.file-downloads.outbound-links.js"></script>
       {% endif %}
       <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html">
       {% if pagename == 'whatsnew/changelog' and not embedded %}


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Trivial change to track zip files downloaded from https://docs.python.org/3/download.html
on our Plausible instance for docs: https://analytics.python.org/docs.python.org

ref: https://plausible.io/docs/file-downloads-tracking, https://hackmd.io/_vyolH-NR3GQHoOUjqdzuQ

We may want to add `file-types="zip, bz2"` if we also want the bz2 packed files? (ref: https://plausible.io/docs/file-downloads-tracking#which-file-types-are-tracked)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138393.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->