### PR TITLE
gh-116738: Audit thread-safety for termios module

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-02-09-14-42.gh-issue-116738.7Q3c8Y.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-02-09-14-42.gh-issue-116738.7Q3c8Y.rst
@@ -1,0 +1,2 @@
+Audit thread-safety for :mod:`termios` on the :term:`free threaded <free
+threading>` build.


### PR DESCRIPTION
This is a placeholder PR to mark the `termios` module as audited in gh-116738 for thread safety in the free-threading build.

- The POSIX functions used by `termios` are marked as MT-Safe in the Linux [termios(3)](https://www.man7.org/linux/man-pages/man3/termios.3.html). There are no thread safety issues noted in the POSIX documentation.
- The current CPython implementation [wraps posix functions](https://github.com/python/cpython/blob/main/Modules/termios.c#L107) with `Py_BEGIN_ALLOW_THREADS` and `Py_END_ALLOW_THREADS` which assumes they are thread-safe.
- Additionally, the module tests were run under thread-sanitizer, which did not report any errors.

cc: @mpage @colesbury @Yhg1s 

Note: This PR will be closed after termios is marked in gh-116738
