### PR TITLE
GH-123299: Copyedit 3.14 What's New: Move and consolidate Porting

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2819,41 +2819,6 @@ CPython bytecode changes
 * Replaced the opcode ``BINARY_SUBSCR`` by :opcode:`BINARY_OP` with oparg ``NB_SUBSCR``.
   (Contributed by Irit Katriel in :gh:`100239`.)
 
-Porting to Python 3.14
-======================
-
-This section lists previously described changes and other bugfixes
-that may require changes to your code.
-
-Changes in the Python API
--------------------------
-
-* :class:`functools.partial` is now a method descriptor.
-  Wrap it in :func:`staticmethod` if you want to preserve the old behavior.
-  (Contributed by Serhiy Storchaka and Dominykas Grigonis in :gh:`121027`.)
-
-* The :ref:`garbage collector is now incremental <whatsnew314-incremental-gc>`,
-  which means that the behavior of :func:`gc.collect` changes slightly:
-
-  * ``gc.collect(1)``: Performs an increment of garbage collection,
-    rather than collecting generation 1.
-  * Other calls to :func:`!gc.collect` are unchanged.
-
-* The :func:`locale.nl_langinfo` function now temporarily sets the ``LC_CTYPE``
-  locale in some cases.
-  This temporary change affects other threads.
-  (Contributed by Serhiy Storchaka in :gh:`69998`.)
-
-* :class:`types.UnionType` is now an alias for :class:`typing.Union`,
-  causing changes in some behaviors.
-  See :ref:`above <whatsnew314-typing-union>` for more details.
-  (Contributed by Jelle Zijlstra in :gh:`105499`.)
-
-* The runtime behavior of annotations has changed in various ways; see
-  :ref:`above <whatsnew314-pep649>` for details. While most code that interacts
-  with annotations should continue to work, some undocumented details may behave
-  differently.
-
 
 Build changes
 =============
@@ -3048,63 +3013,6 @@ Limited C API changes
   (Contributed by Victor Stinner in :gh:`91417`.)
 
 
-Porting to Python 3.14
-----------------------
-
-* :c:func:`Py_Finalize` now deletes all interned strings. This
-  is backwards incompatible to any C-Extension that holds onto an interned
-  string after a call to :c:func:`Py_Finalize` and is then reused after a
-  call to :c:func:`Py_Initialize`.  Any issues arising from this behavior will
-  normally result in crashes during the execution of the subsequent call to
-  :c:func:`Py_Initialize` from accessing uninitialized memory. To fix, use
-  an address sanitizer to identify any use-after-free coming from
-  an interned string and deallocate it during module shutdown.
-  (Contributed by Eddie Elizondo in :gh:`113601`.)
-
-* The :ref:`Unicode Exception Objects <unicodeexceptions>` C API
-  now raises a :exc:`TypeError` if its exception argument is not
-  a :exc:`UnicodeError` object.
-  (Contributed by Bénédikt Tran in :gh:`127691`.)
-
-.. _whatsnew314-refcount:
-
-* The interpreter internally avoids some reference count modifications when
-  loading objects onto the operands stack by :term:`borrowing <borrowed reference>`
-  references when possible. This can lead to smaller reference count values
-  compared to previous Python versions. C API extensions that checked
-  :c:func:`Py_REFCNT` of ``1`` to determine if an function argument is not
-  referenced by any other code should instead use
-  :c:func:`PyUnstable_Object_IsUniqueReferencedTemporary` as a safer replacement.
-
-
-* Private functions promoted to public C APIs:
-
-  * ``_PyBytes_Join()``: :c:func:`PyBytes_Join`
-  * ``_PyLong_IsNegative()``: :c:func:`PyLong_IsNegative`
-  * ``_PyLong_IsPositive()``: :c:func:`PyLong_IsPositive`
-  * ``_PyLong_IsZero()``: :c:func:`PyLong_IsZero`
-  * ``_PyLong_Sign()``: :c:func:`PyLong_GetSign`
-  * ``_PyUnicodeWriter_Dealloc()``: :c:func:`PyUnicodeWriter_Discard`
-  * ``_PyUnicodeWriter_Finish()``: :c:func:`PyUnicodeWriter_Finish`
-  * ``_PyUnicodeWriter_Init()``: use :c:func:`PyUnicodeWriter_Create`
-  * ``_PyUnicodeWriter_Prepare()``: (no replacement)
-  * ``_PyUnicodeWriter_PrepareKind()``: (no replacement)
-  * ``_PyUnicodeWriter_WriteChar()``: :c:func:`PyUnicodeWriter_WriteChar`
-  * ``_PyUnicodeWriter_WriteStr()``: :c:func:`PyUnicodeWriter_WriteStr`
-  * ``_PyUnicodeWriter_WriteSubstring()``: :c:func:`PyUnicodeWriter_WriteSubstring`
-  * ``_PyUnicode_EQ()``: :c:func:`PyUnicode_Equal`
-  * ``_PyUnicode_Equal()``: :c:func:`PyUnicode_Equal`
-  * ``_Py_GetConfig()``: :c:func:`PyConfig_Get` and :c:func:`PyConfig_GetInt`
-  * ``_Py_HashBytes()``: :c:func:`Py_HashBuffer`
-  * ``_Py_fopen_obj()``: :c:func:`Py_fopen`
-  * ``PyMutex_IsLocked()`` : :c:func:`PyMutex_IsLocked`
-
-  The `pythoncapi-compat project`_ can be used to get most of these new
-  functions on Python 3.13 and older.
-
-.. _pythoncapi-compat project: https://github.com/python/pythoncapi-compat/
-
-
 .. _whatsnew314-c-api-deprecated:
 
 Deprecated
@@ -3210,3 +3118,97 @@ Removed
   Please use :c:func:`Py_EnterRecursiveCall` to guard against runaway recursion
   in C code.
   (Removed in :gh:`133079`, see also :gh:`130396`.)
+
+
+Porting to Python 3.14
+======================
+
+This section lists previously described changes and other bugfixes
+that may require changes to your code.
+
+
+Changes in the Python API
+-------------------------
+
+* :class:`functools.partial` is now a method descriptor.
+  Wrap it in :func:`staticmethod` if you want to preserve the old behavior.
+  (Contributed by Serhiy Storchaka and Dominykas Grigonis in :gh:`121027`.)
+
+* The :ref:`garbage collector is now incremental <whatsnew314-incremental-gc>`,
+  which means that the behavior of :func:`gc.collect` changes slightly:
+
+  * ``gc.collect(1)``: Performs an increment of garbage collection,
+    rather than collecting generation 1.
+  * Other calls to :func:`!gc.collect` are unchanged.
+
+* The :func:`locale.nl_langinfo` function now temporarily sets the ``LC_CTYPE``
+  locale in some cases.
+  This temporary change affects other threads.
+  (Contributed by Serhiy Storchaka in :gh:`69998`.)
+
+* :class:`types.UnionType` is now an alias for :class:`typing.Union`,
+  causing changes in some behaviors.
+  See :ref:`above <whatsnew314-typing-union>` for more details.
+  (Contributed by Jelle Zijlstra in :gh:`105499`.)
+
+* The runtime behavior of annotations has changed in various ways; see
+  :ref:`above <whatsnew314-pep649>` for details. While most code that interacts
+  with annotations should continue to work, some undocumented details may behave
+  differently.
+
+
+Changes in the C API
+--------------------
+
+* :c:func:`Py_Finalize` now deletes all interned strings. This
+  is backwards incompatible to any C extension that holds onto an interned
+  string after a call to :c:func:`Py_Finalize` and is then reused after a
+  call to :c:func:`Py_Initialize`.  Any issues arising from this behavior will
+  normally result in crashes during the execution of the subsequent call to
+  :c:func:`Py_Initialize` from accessing uninitialized memory. To fix, use
+  an address sanitizer to identify any use-after-free coming from
+  an interned string and deallocate it during module shutdown.
+  (Contributed by Eddie Elizondo in :gh:`113601`.)
+
+* The :ref:`Unicode Exception Objects <unicodeexceptions>` C API
+  now raises a :exc:`TypeError` if its exception argument is not
+  a :exc:`UnicodeError` object.
+  (Contributed by Bénédikt Tran in :gh:`127691`.)
+
+.. _whatsnew314-refcount:
+
+* The interpreter internally avoids some reference count modifications when
+  loading objects onto the operands stack by :term:`borrowing <borrowed reference>`
+  references when possible. This can lead to smaller reference count values
+  compared to previous Python versions. C API extensions that checked
+  :c:func:`Py_REFCNT` of ``1`` to determine if an function argument is not
+  referenced by any other code should instead use
+  :c:func:`PyUnstable_Object_IsUniqueReferencedTemporary` as a safer replacement.
+
+
+* Private functions promoted to public C APIs:
+
+  * ``_PyBytes_Join()``: :c:func:`PyBytes_Join`
+  * ``_PyLong_IsNegative()``: :c:func:`PyLong_IsNegative`
+  * ``_PyLong_IsPositive()``: :c:func:`PyLong_IsPositive`
+  * ``_PyLong_IsZero()``: :c:func:`PyLong_IsZero`
+  * ``_PyLong_Sign()``: :c:func:`PyLong_GetSign`
+  * ``_PyUnicodeWriter_Dealloc()``: :c:func:`PyUnicodeWriter_Discard`
+  * ``_PyUnicodeWriter_Finish()``: :c:func:`PyUnicodeWriter_Finish`
+  * ``_PyUnicodeWriter_Init()``: use :c:func:`PyUnicodeWriter_Create`
+  * ``_PyUnicodeWriter_Prepare()``: (no replacement)
+  * ``_PyUnicodeWriter_PrepareKind()``: (no replacement)
+  * ``_PyUnicodeWriter_WriteChar()``: :c:func:`PyUnicodeWriter_WriteChar`
+  * ``_PyUnicodeWriter_WriteStr()``: :c:func:`PyUnicodeWriter_WriteStr`
+  * ``_PyUnicodeWriter_WriteSubstring()``: :c:func:`PyUnicodeWriter_WriteSubstring`
+  * ``_PyUnicode_EQ()``: :c:func:`PyUnicode_Equal`
+  * ``_PyUnicode_Equal()``: :c:func:`PyUnicode_Equal`
+  * ``_Py_GetConfig()``: :c:func:`PyConfig_Get` and :c:func:`PyConfig_GetInt`
+  * ``_Py_HashBytes()``: :c:func:`Py_HashBuffer`
+  * ``_Py_fopen_obj()``: :c:func:`Py_fopen`
+  * ``PyMutex_IsLocked()`` : :c:func:`PyMutex_IsLocked`
+
+  The `pythoncapi-compat project`_ can be used to get most of these new
+  functions on Python 3.13 and older.
+
+.. _pythoncapi-compat project: https://github.com/python/pythoncapi-compat/


### PR DESCRIPTION
This consolidates porting but does not make textual edits. This means each heading in porting now has a uniquely referenceable anchor.

A


<!-- gh-issue-number: gh-123299 -->
* Issue: gh-123299
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138400.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->