### PR TITLE
Docs: Fix typo in test.support.linked_to_musl function name

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -851,7 +851,7 @@ The :mod:`test.support` module defines the following functions:
    Decorator for tests that fill the address space.
 
 
-.. function:: linked_with_musl()
+.. function:: linked_to_musl()
 
    Return ``False`` if there is no evidence the interpreter was compiled with
    ``musl``, otherwise return a version triple, either ``(0, 0, 0)`` if the


### PR DESCRIPTION
Originally added in https://github.com/python/cpython/commit/6146295a5b8e9286ccb8f90818b764c9a0192090 (3.14.0a7). The function should be named `test.support.linked_to_musl`.

https://github.com/python/cpython/blob/e4e2390a64593b33d65567179265f9c2cd9acae1/Lib/test/support/__init__.py#L3145-L3150

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138406.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->