### PR TITLE
gh-138432: zoneinfo: improve error message for PathLike relative paths

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1797,7 +1797,6 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
             b"/etc/zoneinfo:/usr/share/zoneinfo",
             0,
             (b"/bytes/path", "/valid/path"),
-            (pathlib.Path(b"/bytes/path"),)
         ]
 
         for bad_value in bad_values:
@@ -1821,7 +1820,7 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
 
         self.assertSequenceEqual(tzpath_0, query_0)
         self.assertSequenceEqual(tzpath_1, query_1)
-        self.assertSequenceEqual(tzpath_pathlike, query_pathlike)
+        self.assertSequenceEqual(tuple([os.fspath(p) for p in tzpath_pathlike]), query_pathlike)
 
 
 class CTzPathTest(TzPathTest):

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1784,6 +1784,7 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
             ("/usr/share/zoneinfo", "../relative/path",),
             ("path/to/somewhere", "../relative/path",),
             ("/usr/share/zoneinfo", "path/to/somewhere", "../relative/path",),
+            (pathlib.Path("path/to/somewhere"),)
         ]
         for input_paths in bad_values:
             with self.subTest(input_paths=input_paths):

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1806,6 +1806,7 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
     def test_tzpath_attribute(self):
         tzpath_0 = [f"{DRIVE}/one", f"{DRIVE}/two"]
         tzpath_1 = [f"{DRIVE}/three"]
+        tzpath_pathlike = (pathlib.Path("/usr/share/zoneinfo"),)
 
         with self.tzpath_context(tzpath_0):
             query_0 = self.module.TZPATH
@@ -1813,8 +1814,12 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
         with self.tzpath_context(tzpath_1):
             query_1 = self.module.TZPATH
 
+        with self.tzpath_context(tzpath_pathlike):
+            query_pathlike = self.module.TZPATH
+
         self.assertSequenceEqual(tzpath_0, query_0)
         self.assertSequenceEqual(tzpath_1, query_1)
+        self.assertSequenceEqual(tzpath_pathlike, query_pathlike)
 
 
 class CTzPathTest(TzPathTest):

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1796,6 +1796,8 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
             "/etc/zoneinfo:/usr/share/zoneinfo",
             b"/etc/zoneinfo:/usr/share/zoneinfo",
             0,
+            (b"/bytes/path", "/valid/path"),
+            (pathlib.Path(b"/bytes/path"),)
         ]
 
         for bad_value in bad_values:

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1807,7 +1807,7 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
     def test_tzpath_attribute(self):
         tzpath_0 = [f"{DRIVE}/one", f"{DRIVE}/two"]
         tzpath_1 = [f"{DRIVE}/three"]
-        tzpath_pathlike = (pathlib.Path("/usr/share/zoneinfo"),)
+        tzpath_pathlike = (pathlib.Path("{DRIVE}/usr/share/zoneinfo"),)
 
         with self.tzpath_context(tzpath_0):
             query_0 = self.module.TZPATH

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -18,7 +18,7 @@ from datetime import date, datetime, time, timedelta, timezone
 from functools import cached_property
 
 from test.support import MISSING_C_DOCSTRINGS
-from test.support.os_helper import EnvironmentVarGuard
+from test.support.os_helper import EnvironmentVarGuard, FakePath
 from test.test_zoneinfo import _support as test_support
 from test.test_zoneinfo._support import TZPATH_TEST_LOCK, ZoneInfoTestBase
 from test.support.import_helper import import_module, CleanImport
@@ -1784,7 +1784,7 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
             ("/usr/share/zoneinfo", "../relative/path",),
             ("path/to/somewhere", "../relative/path",),
             ("/usr/share/zoneinfo", "path/to/somewhere", "../relative/path",),
-            (pathlib.Path("path/to/somewhere"),)
+            (FakePath("path/to/somewhere"),)
         ]
         for input_paths in bad_values:
             with self.subTest(input_paths=input_paths):
@@ -1797,6 +1797,8 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
             b"/etc/zoneinfo:/usr/share/zoneinfo",
             0,
             (b"/bytes/path", "/valid/path"),
+            (FakePath(b"/bytes/path"),),
+            (0,),
         ]
 
         for bad_value in bad_values:
@@ -1807,7 +1809,7 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
     def test_tzpath_attribute(self):
         tzpath_0 = [f"{DRIVE}/one", f"{DRIVE}/two"]
         tzpath_1 = [f"{DRIVE}/three"]
-        tzpath_pathlike = (pathlib.Path("{DRIVE}/usr/share/zoneinfo"),)
+        tzpath_pathlike = (FakePath(f"{DRIVE}/usr/share/zoneinfo"),)
 
         with self.tzpath_context(tzpath_0):
             query_0 = self.module.TZPATH

--- a/Lib/zoneinfo/_tzpath.py
+++ b/Lib/zoneinfo/_tzpath.py
@@ -14,8 +14,7 @@ def _reset_tzpath(to=None, stacklevel=4):
             )
 
         tzpaths = [os.fspath(p) for p in tzpaths]
-        nonstr_paths = [p for p in tzpaths if not isinstance(p, str)]
-        if nonstr_paths:
+        if not all(isinstance(p, str) for p in tzpaths):
             raise TypeError(
                 "All elements of a tzpath sequence must be strings or "
                 "os.PathLike objects which convert to strings."

--- a/Lib/zoneinfo/_tzpath.py
+++ b/Lib/zoneinfo/_tzpath.py
@@ -13,6 +13,14 @@ def _reset_tzpath(to=None, stacklevel=4):
                 + f"not {type(tzpaths)}: {tzpaths!r}"
             )
 
+        tzpaths = [os.fspath(p) for p in tzpaths]
+        nonstr_paths = [p for p in tzpaths if not isinstance(p, str)]
+        if nonstr_paths:
+            raise TypeError(
+                "All elements of a tzpath sequence must be strings or "
+                "os.PathLike objects which convert to strings."
+            )
+
         if not all(map(os.path.isabs, tzpaths)):
             raise ValueError(_get_invalid_paths_message(tzpaths))
         base_tzpath = tzpaths
@@ -57,7 +65,7 @@ def _parse_python_tzpath(env_var, stacklevel):
 
 
 def _get_invalid_paths_message(tzpaths):
-    invalid_paths = (os.fspath(path) for path in tzpaths if not os.path.isabs(path))
+    invalid_paths = (path for path in tzpaths if not os.path.isabs(path))
 
     prefix = "\n    "
     indented_str = prefix + prefix.join(invalid_paths)

--- a/Lib/zoneinfo/_tzpath.py
+++ b/Lib/zoneinfo/_tzpath.py
@@ -57,7 +57,7 @@ def _parse_python_tzpath(env_var, stacklevel):
 
 
 def _get_invalid_paths_message(tzpaths):
-    invalid_paths = (path for path in tzpaths if not os.path.isabs(path))
+    invalid_paths = (os.fspath(path) for path in tzpaths if not os.path.isabs(path))
 
     prefix = "\n    "
     indented_str = prefix + prefix.join(invalid_paths)

--- a/Misc/NEWS.d/next/Library/2025-09-03-15-20-10.gh-issue-138432.RMc7UX.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-03-15-20-10.gh-issue-138432.RMc7UX.rst
@@ -1,0 +1,4 @@
+:meth:`zoneinfo.reset_tzpath` will now raise ``ValueError`` if it encounters
+an :class:`os.PathLike` object representing a relative path, along with a
+more informative error message. It previously raised ``TypeError`` in this
+case.

--- a/Misc/NEWS.d/next/Library/2025-09-03-15-20-10.gh-issue-138432.RMc7UX.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-03-15-20-10.gh-issue-138432.RMc7UX.rst
@@ -1,4 +1,6 @@
-:meth:`zoneinfo.reset_tzpath` will now raise ``ValueError`` if it encounters
-an :class:`os.PathLike` object representing a relative path, along with a
-more informative error message. It previously raised ``TypeError`` in this
-case.
+:meth:`zoneinfo.reset_tzpath` will now convert any :class:`os.PathLike` objects
+it receives into strings before adding them to ``TZPATH``. It will raise
+``TypeError`` if anything other than a string is found after this conversion.
+If given an :class:`os.PathLike` object that represents a relative path, it
+will now raise ``ValueError`` instead of ``TypeError``, and present a more
+informative error message.


### PR DESCRIPTION
This corrects a small inconsistency with the error handling of `zoneinfo.reset_tzpath`. A sequence of `os.PathLike` instances is documented as valid input, but the error pathway for relative paths doesn't handle these correctly. This pull request corrects this, and adds a relevant test case.

<!-- gh-issue-number: gh-138432 -->
* Issue: gh-138432
<!-- /gh-issue-number -->
