### PR TITLE
gh-64063: Clarify safe usage of Queue in multiprocessing "Using a remote manager" section

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2104,7 +2104,7 @@ callables with the manager class.  For example::
 
 
 Using a remote manager
-""""""""""""""""""""""
+"""""""""""""""""""""""
 
 It is possible to run a manager server on one machine and have clients use it
 from other machines (assuming that the firewalls involved allow it).
@@ -2112,11 +2112,12 @@ from other machines (assuming that the firewalls involved allow it).
 Running the following commands creates a server for a single shared queue which
 remote clients can access::
 
+   >>> from multiprocessing import Manager
    >>> from multiprocessing.managers import BaseManager
-   >>> from queue import Queue
-   >>> queue = Queue()
+   >>> manager = Manager()
+   >>> queue = manager.Queue()
    >>> class QueueManager(BaseManager): pass
-   >>> QueueManager.register('get_queue', callable=lambda:queue)
+   >>> QueueManager.register('get_queue', callable=lambda: queue)
    >>> m = QueueManager(address=('', 50000), authkey=b'abracadabra')
    >>> s = m.get_server()
    >>> s.serve_forever()
@@ -2145,7 +2146,7 @@ Another client can also use it::
 Local processes can also access that queue, using the code from above on the
 client to access it remotely::
 
-    >>> from multiprocessing import Process, Queue
+    >>> from multiprocessing import Process, Manager
     >>> from multiprocessing.managers import BaseManager
     >>> class Worker(Process):
     ...     def __init__(self, q):
@@ -2154,7 +2155,8 @@ client to access it remotely::
     ...     def run(self):
     ...         self.q.put('local hello')
     ...
-    >>> queue = Queue()
+    >>> manager = Manager()
+    >>> queue = manager.Queue()
     >>> w = Worker(queue)
     >>> w.start()
     >>> class QueueManager(BaseManager): pass


### PR DESCRIPTION
### Summary
This PR updates the documentation in \`library/multiprocessing.rst\` under the *Using a remote manager* section.

### Changes
- Replaced direct \`Queue()\` usage with \`Manager().Queue()\`.
- Updated local process example for consistency with remote manager usage.
- Ensured examples reflect safe multiprocessing practices.

### Impact
- Clarifies correct usage for beginners following the docs.
- Prevents confusion around proxy objects and remote accessibility.
- Aligns the *Using a remote manager* section with other multiprocessing examples.

### Related Issue
Fixes #64063 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138454.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-64063 -->
* Issue: gh-64063
<!-- /gh-issue-number -->
