### PR TITLE
gh-138431: JIT Optimizer --- Fix round-tripping references for str and tuple

### DIFF
--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -252,6 +252,12 @@ PyJitRef_Wrap(JitOptSymbol *sym)
 }
 
 static inline JitOptRef
+PyJitRef_StripReferenceInfo(JitOptRef ref)
+{
+    return PyJitRef_Wrap(PyJitRef_Unwrap(ref));
+}
+
+static inline JitOptRef
 PyJitRef_Borrow(JitOptRef ref)
 {
     return (JitOptRef){ .bits = ref.bits | REF_IS_BORROWED };

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -2501,6 +2501,55 @@ class TestUopsOptimization(unittest.TestCase):
         # For now... until we constant propagate it away.
         self.assertIn("_BINARY_OP", uops)
 
+    def test_strip_reference_information_through_str(self):
+        # This test needs to be in another script due to Python's
+        # string interning details.
+        script_helper.assert_python_ok('-c', textwrap.dedent("""
+        import _testinternalcapi
+        import _opcode
+
+        def get_first_executor(func):
+            code = func.__code__
+            co_code = code.co_code
+            for i in range(0, len(co_code), 2):
+                try:
+                    return _opcode.get_executor(code, i)
+                except ValueError:
+                    pass
+            return None
+
+        def iter_opnames(ex):
+            for item in ex:
+                yield item[0]
+
+        def get_opnames(ex):
+            return list(iter_opnames(ex))
+
+        def testfunc(n):
+            for _ in range(n):
+                str("abcde")
+
+
+        testfunc(_testinternalcapi.TIER2_THRESHOLD)
+        ex = get_first_executor(testfunc)
+        assert ex is not None
+        uops = get_opnames(ex)
+        assert "_POP_TOP_NOP" not in uops
+        """))
+
+    def test_strip_reference_information_through_tuple(self):
+        def testfunc(n):
+            for _ in range(n):
+                tuple((1,))
+
+        testfunc(TIER2_THRESHOLD * 2)
+
+        ex = get_first_executor(testfunc)
+        self.assertIsNotNone(ex)
+        uops = get_opnames(ex)
+
+        self.assertNotIn("_POP_TOP_NOP", uops)
+
 
 def global_identity(x):
     return x

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-03-15-35-34.gh-issue-138431.EUsrtA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-03-15-35-34.gh-issue-138431.EUsrtA.rst
@@ -1,0 +1,1 @@
+Fix a bug in the JIT optimizer when round-tripping strings and tuples.

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1060,7 +1060,7 @@
             JitOptRef retval;
             JitOptRef res;
             retval = stack_pointer[-1];
-            JitOptRef temp = PyJitRef_Wrap(PyJitRef_Unwrap(retval));
+            JitOptRef temp = PyJitRef_StripReferenceInfo(retval);
             stack_pointer += -1;
             assert(WITHIN_STACK_BOUNDS());
             ctx->frame->stack_pointer = stack_pointer;
@@ -2496,7 +2496,7 @@
             JitOptRef res;
             arg = stack_pointer[-1];
             if (sym_matches_type(arg, &PyUnicode_Type)) {
-                res = arg;
+                res = PyJitRef_StripReferenceInfo(arg);
             }
             else {
                 res = sym_new_type(ctx, &PyUnicode_Type);
@@ -2522,7 +2522,7 @@
             JitOptRef res;
             arg = stack_pointer[-1];
             if (sym_matches_type(arg, &PyTuple_Type)) {
-                res = arg;
+                res = PyJitRef_StripReferenceInfo(arg);
             }
             else {
                 res = sym_new_type(ctx, &PyTuple_Type);


### PR DESCRIPTION
The problem is that when something round-trips through `str` or `tuple`, it isn't guaranteed to maintain the same reference information.

The test script deals \with some quirks of immortalization/interning in CPython. 

<!-- gh-issue-number: gh-138431 -->
* Issue: gh-138431
<!-- /gh-issue-number -->
