### PR TITLE
gh-72249: Correct wording of GH-101910 blurb

### DIFF
--- a/Misc/NEWS.d/3.13.0a5.rst
+++ b/Misc/NEWS.d/3.13.0a5.rst
@@ -742,8 +742,8 @@ Add ``windows_31j`` to aliases for ``cp932`` codec
 .. nonce: fv35wU
 .. section: Library
 
-:func:`functools.partial`s of :func:`repr` has been improved to include the
-:term:`module` name. Patched by Furkan Onder and Anilyka Barry.
+Always include the :term:`module` name in the :func:`repr` of
+:func:`functools.partial` objects.  Patch by Furkan Onder and Anilyka Barry.
 
 ..
 


### PR DESCRIPTION
This is an alternative to GH-138370, which I believe addresses a symptom rather than the underlying issue that the original message contains a thinko :)

This change is a more thorough rewording than my suggestion on the other PR.


<!-- gh-issue-number: gh-72249 -->
* Issue: gh-72249
<!-- /gh-issue-number -->
