### PR TITLE
gh-98896: Fix parsing issue in resource_tracker to allow shared memory names containing colons  

### DIFF
--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -285,7 +285,12 @@ def main(fd):
         with open(fd, 'rb') as f:
             for line in f:
                 try:
-                    cmd, name, rtype = line.strip().decode('ascii').split(':')
+                    parts = line.strip().decode('ascii').split(':')
+                    if len(parts) < 3:
+                        raise ValueError("malformed resource_tracker message: %r" % (parts,))
+                    cmd = parts[0]
+                    rtype = parts[-1]
+                    name = ':'.join(parts[1:-1])
                     cleanup_func = _CLEANUP_FUNCS.get(rtype, None)
                     if cleanup_func is None:
                         raise ValueError(

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -7369,20 +7369,7 @@ class TestSharedMemoryNames(unittest.TestCase):
             print("SUCCESS")
         """)
 
-        # Run the test script as a subprocess to capture all output
-        result = subprocess.run(
-            [sys.executable, '-c', test_script],
-            capture_output=True,
-            text=True
-        )
-
-        self.assertEqual(result.returncode, 0,
-                        f"Script failed with stderr: {result.stderr}")
-        self.assertIn("SUCCESS", result.stdout)
-
-        stderr_lower = result.stderr.lower()
-        self.assertNotIn("too many values to unpack", stderr_lower,
-                        f"Resource tracker parsing error found in stderr: {result.stderr}")
-
-        self.assertNotIn("valueerror", stderr_lower,
-                        f"ValueError found in stderr: {result.stderr}")
+        rc, out, err = assert_python_ok("-c", test_script)
+        self.assertIn(b"SUCCESS", out)
+        self.assertNotIn(b"traceback", err.lower(), err)
+        self.assertNotIn(b"resource_tracker.py", err, err)

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -7353,6 +7353,11 @@ class TestSharedMemoryNames(unittest.TestCase):
                 ":starts:with:colon",
                 "ends:with:colon:",
                 "::double::colons::",
+                "name\\nwithnewline",
+                "name-with-trailing-newline\\n",
+                "\\nname-starts-with-newline",
+                "colons:and\\nnewlines:mix",
+                "multi\\nline\\nname",
             ]
 
             for name in test_names:

--- a/Misc/NEWS.d/next/Library/2025-09-03-20-18-39.gh-issue-98896.tjez89.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-03-20-18-39.gh-issue-98896.tjez89.rst
@@ -1,0 +1,2 @@
+Fix a failure in multiprocessing resource_tracker when SharedMemory names contain colons.
+Patch by Rani Pinchuk.


### PR DESCRIPTION
Shared memory names containing colons were not parsed correctly as the code of `resource_tracker` assumed that these names contain no colons.

 @encukou

<!-- gh-issue-number: gh-98896 -->
* Issue: gh-98896
<!-- /gh-issue-number -->
