### PR TITLE
GH-138465: Improve documentation for common sequence methods

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -245,7 +245,6 @@ nitpick_ignore += [
     ('py:attr', '__annotations__'),
     ('py:meth', '__missing__'),
     ('py:attr', '__wrapped__'),
-    ('py:meth', 'index'),  # list.index, tuple.index, etc.
 ]
 
 # gh-106948: Copy standard C types declared in the "c:type" domain and C

--- a/Doc/faq/design.rst
+++ b/Doc/faq/design.rst
@@ -591,9 +591,9 @@ exhaustive test suites that exercise every line of code in a module.
 An appropriate testing discipline can help build large complex applications in
 Python as well as having interface specifications would.  In fact, it can be
 better because an interface specification cannot test certain properties of a
-program.  For example, the :meth:`!list.append` method is expected to add new elements
+program.  For example, the :meth:`list.append` method is expected to add new elements
 to the end of some internal list; an interface specification cannot test that
-your :meth:`!list.append` implementation will actually do this correctly, but it's
+your :meth:`list.append` implementation will actually do this correctly, but it's
 trivial to check this property in a test suite.
 
 Writing test suites is very helpful, and you might want to design your code to

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -454,7 +454,7 @@ There are two factors that produce this result:
    (the list), and both ``x`` and ``y`` refer to it.
 2) Lists are :term:`mutable`, which means that you can change their content.
 
-After the call to :meth:`!append`, the content of the mutable object has
+After the call to :meth:`~sequence.append`, the content of the mutable object has
 changed from ``[]`` to ``[10]``.  Since both the variables refer to the same
 object, using either name accesses the modified value ``[10]``.
 
@@ -1397,9 +1397,9 @@ To see why this happens, you need to know that (a) if an object implements an
 :meth:`~object.__iadd__` magic method, it gets called when the ``+=`` augmented
 assignment
 is executed, and its return value is what gets used in the assignment statement;
-and (b) for lists, :meth:`!__iadd__` is equivalent to calling :meth:`!extend` on the list
-and returning the list.  That's why we say that for lists, ``+=`` is a
-"shorthand" for :meth:`!list.extend`::
+and (b) for lists, :meth:`!__iadd__` is equivalent to calling
+:meth:`~sequence.extend` on the list and returning the list.
+That's why we say that for lists, ``+=`` is a "shorthand" for :meth:`list.extend`::
 
     >>> a_list = []
     >>> a_list += [1]

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1251,8 +1251,9 @@ Glossary
       The :class:`collections.abc.Sequence` abstract base class
       defines a much richer interface that goes beyond just
       :meth:`~object.__getitem__` and :meth:`~object.__len__`, adding
-      :meth:`!count`, :meth:`!index`, :meth:`~object.__contains__`, and
-      :meth:`~object.__reversed__`. Types that implement this expanded
+      :meth:`~sequence.count`, :meth:`~sequence.index`,
+      :meth:`~object.__contains__`, and :meth:`~object.__reversed__`.
+      Types that implement this expanded
       interface can be registered explicitly using
       :func:`~abc.ABCMeta.register`. For more documentation on sequence
       methods generally, see

--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -83,7 +83,7 @@ The following functions are provided:
    Insert *x* in *a* in sorted order.
 
    This function first runs :py:func:`~bisect.bisect_left` to locate an insertion point.
-   Next, it runs the :meth:`!insert` method on *a* to insert *x* at the
+   Next, it runs the :meth:`~sequence.insert` method on *a* to insert *x* at the
    appropriate position to maintain sort order.
 
    To support inserting records in a table, the *key* function (if any) is
@@ -103,7 +103,7 @@ The following functions are provided:
    entries of *x*.
 
    This function first runs :py:func:`~bisect.bisect_right` to locate an insertion point.
-   Next, it runs the :meth:`!insert` method on *a* to insert *x* at the
+   Next, it runs the :meth:`~sequence.insert` method on *a* to insert *x* at the
    appropriate position to maintain sort order.
 
    To support inserting records in a table, the *key* function (if any) is

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -264,8 +264,9 @@ Collections Abstract Base Classes -- Detailed Descriptions
    ABCs for read-only and mutable :term:`sequences <sequence>`.
 
    Implementation note: Some of the mixin methods, such as
-   :meth:`~container.__iter__`, :meth:`~object.__reversed__` and :meth:`index`, make
-   repeated calls to the underlying :meth:`~object.__getitem__` method.
+   :meth:`~container.__iter__`, :meth:`~object.__reversed__`,
+   and :meth:`~sequence.index` make repeated calls to the underlying
+   :meth:`~object.__getitem__` method.
    Consequently, if :meth:`~object.__getitem__` is implemented with constant
    access speed, the mixin methods will have linear performance;
    however, if the underlying method is linear (as it would be with a
@@ -281,8 +282,8 @@ Collections Abstract Base Classes -- Detailed Descriptions
       Supporting the *start* and *stop* arguments is optional, but recommended.
 
       .. versionchanged:: 3.5
-         The :meth:`!index` method added support for *stop* and *start*
-         arguments.
+         The :meth:`~sequence.index` method gained support for
+         the *stop* and *start* arguments.
 
 .. class:: Set
            MutableSet

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -783,10 +783,10 @@ sequence of key-value pairs into a dictionary of lists:
 
 When each key is encountered for the first time, it is not already in the
 mapping; so an entry is automatically created using the :attr:`~defaultdict.default_factory`
-function which returns an empty :class:`list`.  The :meth:`!list.append`
+function which returns an empty :class:`list`.  The :meth:`list.append`
 operation then attaches the value to the new list.  When keys are encountered
 again, the look-up proceeds normally (returning the list for that key) and the
-:meth:`!list.append` operation adds another value to the list. This technique is
+:meth:`list.append` operation adds another value to the list. This technique is
 simpler and faster than an equivalent technique using :meth:`dict.setdefault`:
 
     >>> d = {}

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -732,8 +732,8 @@ or both.
      These items will be appended to the object either using
      ``obj.append(item)`` or, in batch, using ``obj.extend(list_of_items)``.
      This is primarily used for list subclasses, but may be used by other
-     classes as long as they have
-     :ref:`append and extend methods <typesseq-common>` with
+     classes as long as they have :meth:`~sequence.append`
+     and :meth:`~sequence.extend` methods with
      the appropriate signature.  (Whether :meth:`!append` or :meth:`!extend` is
      used depends on which pickle protocol version is used as well as the number
      of items to append, so both must be supported.)

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1030,36 +1030,6 @@ operations have the same priority as the corresponding numeric operations. [3]_
 | ``max(s)``               | largest item of *s*            |          |
 +--------------------------+--------------------------------+----------+
 
-.. method:: list.count(value, /)
-            range.count(value, /)
-            tuple.count(value, /)
-   :no-contents-entry:
-   :no-index-entry:
-   :no-typesetting:
-.. method:: sequence.count(value, /)
-
-   Return the total number of occurrences of *value* in *sequence*.
-
-.. method:: list.index(value[, start[, stop])
-            range.index(value[, start[, stop])
-            tuple.index(value[, start[, stop])
-   :no-contents-entry:
-   :no-index-entry:
-   :no-typesetting:
-.. method:: sequence.index(value[, start[, stop])
-
-   Return the index of the first occurrence of *value* in *sequence*.
-
-   Raises :exc:`ValueError` if *value* is not found in *sequence*.
-
-   The *start* or *stop* arguments allow for efficient searching
-   of subsections of the sequence, beginning at *start* and ending at *stop*.
-   This is roughly equivalent to ``start + sequence[start:stop].index(value)``,
-   only without copying any data.
-
-   .. caution::
-      Not all sequence types support passing the *start* and *stop* arguments.
-
 Sequences of the same type also support comparisons.  In particular, tuples
 and lists are compared lexicographically by comparing corresponding elements.
 This means that to compare equal, every element must compare equal and the
@@ -1166,6 +1136,41 @@ Notes:
 (8)
    An :exc:`IndexError` is raised if *i* is outside the sequence range.
 
+.. rubric:: Sequence Methods
+
+Sequence types also support the following methods:
+
+.. method:: list.count(value, /)
+            range.count(value, /)
+            tuple.count(value, /)
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.count(value, /)
+
+   Return the total number of occurrences of *value* in *sequence*.
+
+.. method:: list.index(value[, start[, stop])
+            range.index(value[, start[, stop])
+            tuple.index(value[, start[, stop])
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.index(value[, start[, stop])
+
+   Return the index of the first occurrence of *value* in *sequence*.
+
+   Raises :exc:`ValueError` if *value* is not found in *sequence*.
+
+   The *start* or *stop* arguments allow for efficient searching
+   of subsections of the sequence, beginning at *start* and ending at *stop*.
+   This is roughly equivalent to ``start + sequence[start:stop].index(value)``,
+   only without copying any data.
+
+   .. caution::
+      Not all sequence types support passing the *start* and *stop* arguments.
+
+
 
 .. _typesseq-immutable:
 
@@ -1246,6 +1251,21 @@ accepts integers that meet the value restriction ``0 <= x <= 255``).
 | ``s *= n``                   | updates *s* with its contents  | \(2)                |
 |                              | repeated *n* times             |                     |
 +------------------------------+--------------------------------+---------------------+
+
+Notes:
+
+(1)
+   If *k* is not equal to ``1``, *t* must have the same length as the slice it is replacing.
+
+(2)
+   The value *n* is an integer, or an object implementing
+   :meth:`~object.__index__`.  Zero and negative values of *n* clear
+   the sequence.  Items in the sequence are not copied; they are referenced
+   multiple times, as explained for ``s * n`` under :ref:`typesseq-common`.
+
+.. rubric:: Mutable Sequence Methods
+
+Mutable sequence types also support the following methods:
 
 .. method:: bytearray.append(value, /)
             list.append(value, /)
@@ -1337,18 +1357,6 @@ accepts integers that meet the value restriction ``0 <= x <= 255``).
    Reverse the items of *sequence* in place.
    This method maintains economy of space when reversing a large sequence.
    To remind users that it operates by side-effect, it returns ``None``.
-
-
-Notes:
-
-(1)
-   If *k* is not equal to ``1``, *t* must have the same length as the slice it is replacing.
-
-(2)
-   The value *n* is an integer, or an object implementing
-   :meth:`~object.__index__`.  Zero and negative values of *n* clear
-   the sequence.  Items in the sequence are not copied; they are referenced
-   multiple times, as explained for ``s * n`` under :ref:`typesseq-common`.
 
 
 .. _typesseq-list:

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1018,7 +1018,7 @@ operations have the same priority as the corresponding numeric operations. [3]_
 | ``s * n`` or             | equivalent to adding *s* to    | (2)(7)   |
 | ``n * s``                | itself *n* times               |          |
 +--------------------------+--------------------------------+----------+
-| ``s[i]``                 | *i*\ th item of *s*, origin 0  | (3)(9)   |
+| ``s[i]``                 | *i*\ th item of *s*, origin 0  | (3)(8)   |
 +--------------------------+--------------------------------+----------+
 | ``s[i:j]``               | slice of *s* from *i* to *j*   | (3)(4)   |
 +--------------------------+--------------------------------+----------+
@@ -1031,13 +1031,36 @@ operations have the same priority as the corresponding numeric operations. [3]_
 +--------------------------+--------------------------------+----------+
 | ``max(s)``               | largest item of *s*            |          |
 +--------------------------+--------------------------------+----------+
-| ``s.index(x[, i[, j]])`` | index of the first occurrence  | \(8)     |
-|                          | of *x* in *s* (at or after     |          |
-|                          | index *i* and before index *j*)|          |
-+--------------------------+--------------------------------+----------+
-| ``s.count(x)``           | total number of occurrences of |          |
-|                          | *x* in *s*                     |          |
-+--------------------------+--------------------------------+----------+
+
+.. method:: list.count(value, /)
+            range.count(value, /)
+            tuple.count(value, /)
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.count(value, /)
+
+   Return the total number of occurrences of *value* in *sequence*.
+
+.. method:: list.index(value, start=0, stop=None, /)
+            range.index(value, start=0, stop=None, /)
+            tuple.index(value, start=0, stop=None, /)
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.index(value, start=0, stop=None, /)
+
+   Return the index of the first occurrence of *value* in *sequence*.
+
+   Raises :exc:`ValueError` if *value* is not found in *sequence*.
+
+   The *start* or *stop* arguments allow for efficient searching
+   of subsections of the sequence, beginning at *start* and ending at *stop*.
+   This is roughly equivalent to ``start + sequence[start:stop].index(value)``,
+   only without copying any data.
+
+   .. caution::
+      Not all sequence types support passing the *start* and *stop* arguments.
 
 Sequences of the same type also support comparisons.  In particular, tuples
 and lists are compared lexicographically by comparing corresponding elements.
@@ -1143,14 +1166,6 @@ Notes:
   concatenation or repetition.
 
 (8)
-   ``index`` raises :exc:`ValueError` when *x* is not found in *s*.
-   Not all implementations support passing the additional arguments *i* and *j*.
-   These arguments allow efficient searching of subsections of the sequence. Passing
-   the extra arguments is roughly equivalent to using ``s[i:j].index(x)``, only
-   without copying any data and with the returned index being relative to
-   the start of the sequence rather than the start of the slice.
-
-(9)
    An :exc:`IndexError` is raised if *i* is outside the sequence range.
 
 
@@ -1233,38 +1248,101 @@ accepts integers that meet the value restriction ``0 <= x <= 255``).
 | ``del s[i:j:k]``             | removes the elements of        |                     |
 |                              | ``s[i:j:k]`` from the list     |                     |
 +------------------------------+--------------------------------+---------------------+
-| ``s.append(x)``              | appends *x* to the end of the  |                     |
-|                              | sequence (same as              |                     |
-|                              | ``s[len(s):len(s)] = [x]``)    |                     |
-+------------------------------+--------------------------------+---------------------+
-| ``s.clear()``                | removes all items from *s*     | \(5)                |
-|                              | (same as ``del s[:]``)         |                     |
-+------------------------------+--------------------------------+---------------------+
-| ``s.copy()``                 | creates a shallow copy of *s*  | \(5)                |
-|                              | (same as ``s[:]``)             |                     |
-+------------------------------+--------------------------------+---------------------+
-| ``s.extend(t)`` or           | extends *s* with the           |                     |
-| ``s += t``                   | contents of *t* (for the       |                     |
+| ``s += t``                   | extends *s* with the           |                     |
+|                              | contents of *t* (for the       |                     |
 |                              | most part the same as          |                     |
 |                              | ``s[len(s):len(s)] = t``)      |                     |
 +------------------------------+--------------------------------+---------------------+
-| ``s *= n``                   | updates *s* with its contents  | \(6)                |
+| ``s *= n``                   | updates *s* with its contents  | \(2)                |
 |                              | repeated *n* times             |                     |
 +------------------------------+--------------------------------+---------------------+
-| ``s.insert(i, x)``           | inserts *x* into *s* at the    |                     |
-|                              | index given by *i*             |                     |
-|                              | (same as ``s[i:i] = [x]``)     |                     |
-+------------------------------+--------------------------------+---------------------+
-| ``s.pop()`` or ``s.pop(i)``  | retrieves the item at *i* and  | \(2)                |
-|                              | also removes it from *s*       |                     |
-+------------------------------+--------------------------------+---------------------+
-| ``s.remove(x)``              | removes the first item from    | \(3)                |
-|                              | *s* where ``s[i]`` is equal to |                     |
-|                              | *x*                            |                     |
-+------------------------------+--------------------------------+---------------------+
-| ``s.reverse()``              | reverses the items of *s* in   | \(4)                |
-|                              | place                          |                     |
-+------------------------------+--------------------------------+---------------------+
+
+.. method:: bytearray.append(value, /)
+            list.append(value, /)
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.append(value, /)
+
+   Append *value* to the end of the sequence
+   This is equivalent to writing ``seq[len(seq):len(seq)] = value``.
+
+.. method:: bytearray.clear()
+            list.clear()
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.clear()
+
+   Remove all items from *sequence*.
+   This is equivalent to writing ``del sequence[:]``.
+
+.. method:: bytearray.copy()
+            list.copy()
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.copy()
+
+   Create a shallow copy of *sequence*.
+   This is equivalent to writing ``sequence[:]``.
+
+   .. hint:: The :meth:`!copy` method is not part of the
+             :class:`~collections.abc.MutableSequence` :class:`~abc.ABC`,
+             but most concrete mutable sequence types provide it.
+
+.. method:: bytearray.extend(iterable, /)
+            list.extend(iterable, /)
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.extend(iterable, /)
+
+   Extend *sequence* with the contents of *iterable*.
+   For the most part, this is the same as writing
+   ``seq[len(seq):len(seq)] = iterable``.
+
+.. method:: bytearray.insert(index, value, /)
+            list.insert(index, value, /)
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.insert(index, value, /)
+
+   Insert *value* into *sequence* at the given *index*.
+   This is equivalent to writing ``sequence[index:index] = [value]``.
+
+.. method:: bytearray.pop(index=-1, /)
+            list.pop(index=-1, /)
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.pop(index=-1, /)
+
+   Retrieve the item at *index* and also removes it from *sequence*.
+   By default, the last item in *sequence* is removed and returned.
+
+.. method:: bytearray.remove(value, /)
+            list.remove(value, /)
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.remove(value, /)
+
+   Remove the first item from *sequence* where ``sequence[i] == value``.
+
+   Raises :exc:`ValueError` if *value* is not found in *sequence*.
+
+.. method:: bytearray.reverse()
+            list.reverse()
+   :no-contents-entry:
+   :no-index-entry:
+   :no-typesetting:
+.. method:: sequence.reverse()
+
+   Reverse the items of *sequence* in place.
+   This method maintains economy of space when reversing a large sequence.
+   To remind users that it operates by side-effect, it returns ``None``.
 
 
 Notes:
@@ -1273,28 +1351,6 @@ Notes:
    If *k* is not equal to ``1``, *t* must have the same length as the slice it is replacing.
 
 (2)
-   The optional argument *i* defaults to ``-1``, so that by default the last
-   item is removed and returned.
-
-(3)
-   :meth:`remove` raises :exc:`ValueError` when *x* is not found in *s*.
-
-(4)
-   The :meth:`reverse` method modifies the sequence in place for economy of
-   space when reversing a large sequence.  To remind users that it operates by
-   side effect, it does not return the reversed sequence.
-
-(5)
-   :meth:`clear` and :meth:`!copy` are included for consistency with the
-   interfaces of mutable containers that don't support slicing operations
-   (such as :class:`dict` and :class:`set`). :meth:`!copy` is not part of the
-   :class:`collections.abc.MutableSequence` ABC, but most concrete
-   mutable sequence classes provide it.
-
-   .. versionadded:: 3.3
-      :meth:`clear` and :meth:`!copy` methods.
-
-(6)
    The value *n* is an integer, or an object implementing
    :meth:`~object.__index__`.  Zero and negative values of *n* clear
    the sequence.  Items in the sequence are not copied; they are referenced
@@ -5761,9 +5817,10 @@ Methods
 
 .. index:: pair: object; method
 
-Methods are functions that are called using the attribute notation. There are
-two flavors: :ref:`built-in methods <builtin-methods>` (such as :meth:`append`
-on lists) and :ref:`class instance method <instance-methods>`.
+Methods are functions that are called using the attribute notation.
+There are two flavors: :ref:`built-in methods <builtin-methods>`
+(such as :meth:`~list.append` on lists)
+and :ref:`class instance method <instance-methods>`.
 Built-in methods are described with the types that support them.
 
 If you access a method (a function defined in a class namespace) through an

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1171,7 +1171,6 @@ Sequence types also support the following methods:
       Not all sequence types support passing the *start* and *stop* arguments.
 
 
-
 .. _typesseq-immutable:
 
 Immutable Sequence Types

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1265,7 +1265,7 @@ accepts integers that meet the value restriction ``0 <= x <= 255``).
 .. method:: sequence.append(value, /)
 
    Append *value* to the end of the sequence
-   This is equivalent to writing ``seq[len(seq):len(seq)] = value``.
+   This is equivalent to writing ``seq[len(seq):len(seq)] = [value]``.
 
 .. method:: bytearray.clear()
             list.clear()

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1040,13 +1040,13 @@ operations have the same priority as the corresponding numeric operations. [3]_
 
    Return the total number of occurrences of *value* in *sequence*.
 
-.. method:: list.index(value, start=0, stop=None, /)
-            range.index(value, start=0, stop=None, /)
-            tuple.index(value, start=0, stop=None, /)
+.. method:: list.index(value[, start[, stop])
+            range.index(value[, start[, stop])
+            tuple.index(value[, start[, stop])
    :no-contents-entry:
    :no-index-entry:
    :no-typesetting:
-.. method:: sequence.index(value, start=0, stop=None, /)
+.. method:: sequence.index(value[, start[, stop])
 
    Return the index of the first occurrence of *value* in *sequence*.
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1264,6 +1264,8 @@ accepts integers that meet the value restriction ``0 <= x <= 255``).
    :no-typesetting:
 .. method:: sequence.clear()
 
+   .. versionadded:: 3.3
+
    Remove all items from *sequence*.
    This is equivalent to writing ``del sequence[:]``.
 
@@ -1273,6 +1275,8 @@ accepts integers that meet the value restriction ``0 <= x <= 255``).
    :no-index-entry:
    :no-typesetting:
 .. method:: sequence.copy()
+
+   .. versionadded:: 3.3
 
    Create a shallow copy of *sequence*.
    This is equivalent to writing ``sequence[:]``.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1000,8 +1000,6 @@ operations have the same priority as the corresponding numeric operations. [3]_
    pair: slice; operation
    pair: operator; in
    pair: operator; not in
-   single: count() (sequence method)
-   single: index() (sequence method)
 
 +--------------------------+--------------------------------+----------+
 | Operation                | Result                         | Notes    |
@@ -1217,14 +1215,6 @@ accepts integers that meet the value restriction ``0 <= x <= 255``).
    pair: subscript; assignment
    pair: slice; assignment
    pair: statement; del
-   single: append() (sequence method)
-   single: clear() (sequence method)
-   single: copy() (sequence method)
-   single: extend() (sequence method)
-   single: insert() (sequence method)
-   single: pop() (sequence method)
-   single: remove() (sequence method)
-   single: reverse() (sequence method)
 
 +------------------------------+--------------------------------+---------------------+
 | Operation                    | Result                         | Notes               |

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -3135,11 +3135,12 @@ objects.  The :mod:`collections.abc` module provides a
 :term:`abstract base class` to help create those methods from a base set of
 :meth:`~object.__getitem__`, :meth:`~object.__setitem__`,
 :meth:`~object.__delitem__`, and :meth:`!keys`.
-Mutable sequences should provide methods :meth:`!append`, :meth:`!count`,
-:meth:`!index`, :meth:`!extend`, :meth:`!insert`, :meth:`!pop`, :meth:`!remove`,
-:meth:`!reverse` and :meth:`!sort`, like Python standard :class:`list`
-objects. Finally,
-sequence types should implement addition (meaning concatenation) and
+Mutable sequences should provide methods :meth:`~sequence.append`,
+:meth:`~sequence.count`, :meth:`~sequence.index`, :meth:`~sequence.extend`,
+:meth:`~sequence.insert`, :meth:`~sequence.pop`, :meth:`~sequence.remove`,
+:meth:`~sequence.reverse` and :meth:`~sequence.sort`,
+like Python standard :class:`list` objects.
+Finally, sequence types should implement addition (meaning concatenation) and
 multiplication (meaning repetition) by defining the methods
 :meth:`~object.__add__`, :meth:`~object.__radd__`, :meth:`~object.__iadd__`,
 :meth:`~object.__mul__`, :meth:`~object.__rmul__` and :meth:`~object.__imul__`

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -568,7 +568,7 @@ This example, as usual, demonstrates some new Python features:
   Different types define different methods.  Methods of different types may have
   the same name without causing ambiguity.  (It is possible to define your own
   object types and methods, using *classes*, see :ref:`tut-classes`)
-  The method :meth:`!append` shown in the example is defined for list objects; it
+  The method :meth:`~list.append` shown in the example is defined for list objects; it
   adds a new element at the end of the list.  In this example it is equivalent to
   ``result = result + [a]``, but more efficient.
 

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -142,8 +142,8 @@ Using Lists as Stacks
 
 The list methods make it very easy to use a list as a stack, where the last
 element added is the first element retrieved ("last-in, first-out").  To add an
-item to the top of the stack, use :meth:`!append`.  To retrieve an item from the
-top of the stack, use :meth:`!pop` without an explicit index.  For example::
+item to the top of the stack, use :meth:`~list.append`.  To retrieve an item from the
+top of the stack, use :meth:`~list.pop` without an explicit index.  For example::
 
    >>> stack = [3, 4, 5]
    >>> stack.append(6)
@@ -340,7 +340,7 @@ The :keyword:`!del` statement
 =============================
 
 There is a way to remove an item from a list given its index instead of its
-value: the :keyword:`del` statement.  This differs from the :meth:`!pop` method
+value: the :keyword:`del` statement.  This differs from the :meth:`~list.pop` method
 which returns a value.  The :keyword:`!del` statement can also be used to remove
 slices from a list or clear the entire list (which we did earlier by assignment
 of an empty list to the slice).  For example::
@@ -500,8 +500,8 @@ any immutable type; strings and numbers can always be keys.  Tuples can be used
 as keys if they contain only strings, numbers, or tuples; if a tuple contains
 any mutable object either directly or indirectly, it cannot be used as a key.
 You can't use lists as keys, since lists can be modified in place using index
-assignments, slice assignments, or methods like :meth:`!append` and
-:meth:`!extend`.
+assignments, slice assignments, or methods like :meth:`~list.append` and
+:meth:`~list.extend`.
 
 It is best to think of a dictionary as a set of *key: value* pairs,
 with the requirement that the keys are unique (within one dictionary). A pair of

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -420,7 +420,7 @@ type, i.e. it is possible to change their content::
     [1, 8, 27, 64, 125]
 
 You can also add new items at the end of the list, by using
-the :meth:`!list.append` *method* (we will see more about methods later)::
+the :meth:`list.append` *method* (we will see more about methods later)::
 
    >>> cubes.append(216)  # add the cube of 6
    >>> cubes.append(7 ** 3)  # and the cube of 7

--- a/Doc/whatsnew/2.0.rst
+++ b/Doc/whatsnew/2.0.rst
@@ -656,7 +656,8 @@ break.
 The change which will probably break the most code is tightening up the
 arguments accepted by some methods.  Some methods would take multiple arguments
 and treat them as a tuple, particularly various list methods such as
-:meth:`!append` and :meth:`!insert`. In earlier versions of Python, if ``L`` is
+:meth:`~list.append` and :meth:`~list.insert`.
+In earlier versions of Python, if ``L`` is
 a list, ``L.append( 1,2 )`` appends the tuple ``(1,2)`` to the list.  In Python
 2.0 this causes a :exc:`TypeError` exception to be raised, with the message:
 'append requires exactly 1 argument; 2 given'.  The fix is to simply add an

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -997,9 +997,10 @@ sequence of bytes::
     u'\u31ef \u3244'
 
 Byte arrays support most of the methods of string types, such as
-:meth:`startswith`/:meth:`endswith`, :meth:`find`/:meth:`rfind`,
-and some of the methods of lists, such as :meth:`append`,
-:meth:`pop`,  and :meth:`reverse`.
+:meth:`~bytearray.startswith`/:meth:`~bytearray.endswith`,
+:meth:`~bytearray.find`/:meth:`~bytearray.rfind`,
+and some of the methods of lists, such as :meth:`~bytearray.append`,
+:meth:`~bytearray.pop`,  and :meth:`~bytearray.reverse`.
 
 ::
 
@@ -1528,8 +1529,8 @@ Some smaller changes made to the core Python language are:
   the :exc:`StopIteration` exception will be raised.  (Backported
   in :issue:`2719`.)
 
-* Tuples now have :meth:`index` and :meth:`count` methods matching the
-  list type's :meth:`index` and :meth:`count` methods::
+* Tuples now have :meth:`~tuple.index` and :meth:`~tuple.count` methods
+  matching the list type's :meth:`~list.index` and :meth:`~list.count` methods::
 
     >>> t = (0,1,2,3,4,0,1,2)
     >>> t.index(3)

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1292,7 +1292,7 @@ This section covers specific optimizations independent of the
   (Contributed by Stefan Behnel in :gh:`68264`.)
 
 * Resizing lists is streamlined for the common case,
-  speeding up :meth:`!list.append` by ≈15%
+  speeding up :meth:`list.append` by ≈15%
   and simple :term:`list comprehension`\s by up to 20-30%
   (Contributed by Dennis Sweeney in :gh:`91165`.)
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2176,7 +2176,7 @@ New Features
   (Contributed by Sam Gross in :gh:`114329`.)
 
 * Add the :c:func:`PyList_Extend` and :c:func:`PyList_Clear` functions,
-  mirroring the Python :meth:`!list.extend` and :meth:`!list.clear` methods.
+  mirroring the Python :meth:`list.extend` and :meth:`list.clear` methods.
   (Contributed by Victor Stinner in :gh:`111138`.)
 
 * Add the :c:func:`PyLong_AsInt` function.

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -2380,8 +2380,8 @@ Porting Python code
   for top-level modules. E.g. ``__import__('sys', level=1)`` is now an error.
 
 * Because :data:`sys.meta_path` and :data:`sys.path_hooks` now have finders on
-  them by default, you will most likely want to use :meth:`!list.insert` instead
-  of :meth:`!list.append` to add to those lists.
+  them by default, you will most likely want to use :meth:`list.insert` instead
+  of :meth:`list.append` to add to those lists.
 
 * Because ``None`` is now inserted into :data:`sys.path_importer_cache`, if you
   are clearing out entries in the dictionary of paths that do not have a

--- a/Misc/NEWS.d/3.14.0a1.rst
+++ b/Misc/NEWS.d/3.14.0a1.rst
@@ -4913,11 +4913,11 @@ Allow tuples of length 20 in the freelist to be reused.
 .. nonce: lYKYYP
 .. section: Core and Builtins
 
-:exc:`ValueError` messages for :meth:`!list.index`, :meth:`!range.index`,
+:exc:`ValueError` messages for :meth:`list.index`, :meth:`range.index`,
 :meth:`!deque.index`, :meth:`!deque.remove` and :meth:`!ShareableList.index`
 no longer contain the repr of the searched value (which can be arbitrary
-large) and are consistent with error messages for other :meth:`!index` and
-:meth:`!remove` methods.
+large) and are consistent with error messages for other :meth:`~sequence.index` and
+:meth:`~sequence.remove` methods.
 
 ..
 
@@ -5604,7 +5604,7 @@ Using :data:`NotImplemented` in a boolean context now raises
 .. nonce: wNMKVd
 .. section: Core and Builtins
 
-Fix race condition in free-threaded build where :meth:`!list.extend` could
+Fix race condition in free-threaded build where :meth:`list.extend` could
 expose uninitialised memory to concurrent readers.
 
 ..

--- a/Misc/NEWS.d/3.14.0a7.rst
+++ b/Misc/NEWS.d/3.14.0a7.rst
@@ -671,7 +671,7 @@ Allow the JIT to remove an extra ``_TO_BOOL_BOOL`` instruction after
 .. nonce: dNh64H
 .. section: Core and Builtins
 
-Fix crash when calling :meth:`!list.append` as an unbound method.
+Fix crash when calling :meth:`list.append` as an unbound method.
 
 ..
 


### PR DESCRIPTION
cc @serhiy-storchaka 

As part of this I've gone through the rest of the documentation and updated cross-references to use `sequence.{method}` / `list.{method}` etc as appropriate.

A

<!-- gh-issue-number: gh-138465 -->
* Issue: gh-138465
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138474.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->