### PR TITLE
Fix Windows path in `venv` docs

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -78,7 +78,7 @@ It also creates a :file:`bin` (or :file:`Scripts` on Windows) subdirectory
 containing a copy or symlink of the Python executable
 (as appropriate for the platform or arguments used at environment creation time).
 It also creates a :file:`lib/pythonX.Y/site-packages` subdirectory
-(on Windows, this is :file:`Lib\site-packages`).
+(on Windows, this is :file:`Lib\\site-packages`).
 If an existing directory is specified, it will be re-used.
 
 .. versionchanged:: 3.5


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138476.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->