### PR TITLE
gh-138479: Ensure that `__typing_subst__` returns a tuple

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5847,14 +5847,14 @@ class GenericTests(BaseTestCase):
     def test_return_non_tuple_while_unpacking(self):
         # GH-138497: GenericAlias objects didn't ensure that __typing_subst__ actually
         # returned a tuple
-        class Generic:
-            def __call__(*_):
-                return None
+        class EvilTypeVar:
+            __typing_is_unpacked_typevartuple__ = True
+            def __typing_prepare_subst__(*_):
+                return None  # any value
+            def __typing_subst__(*_):
+                return 42  # not tuple
 
-            def __getattr__(self, _):
-                return Generic()
-
-        evil = Generic()
+        evil = EvilTypeVar()
         type type_alias[*_] = 0
         with self.assertRaises(TypeError):
             type_alias[evil][0]

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5855,6 +5855,8 @@ class GenericTests(BaseTestCase):
                 return 42  # not tuple
 
         evil = EvilTypeVar()
+        # Create a dummy TypeAlias that will be given the evil generic from
+        # above.
         type type_alias[*_] = 0
         with self.assertRaisesRegex(TypeError, ".+__typing_subst__.+tuple.+int.*"):
             type_alias[evil][0]

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5844,6 +5844,21 @@ class GenericTests(BaseTestCase):
                     with self.assertRaises(TypeError):
                         a[int]
 
+    def test_return_non_tuple_while_unpacking(self):
+        # GH-138497: GenericAlias objects didn't ensure that __typing_subst__ actually
+        # returned a tuple
+        class Generic:
+            def __call__(*_):
+                return None
+
+            def __getattr__(self, _):
+                return Generic()
+
+        evil = Generic()
+        type type_alias[*_] = 0
+        with self.assertRaises(TypeError):
+            type_alias[evil][0]
+
 
 class ClassVarTests(BaseTestCase):
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5856,7 +5856,7 @@ class GenericTests(BaseTestCase):
 
         evil = EvilTypeVar()
         type type_alias[*_] = 0
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, ".+__typing_subst__.+tuple.+int.*"):
             type_alias[evil][0]
 
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-03-17-00-30.gh-issue-138479.qUxgWs.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-03-17-00-30.gh-issue-138479.qUxgWs.rst
@@ -1,0 +1,2 @@
+Fix a crash when a generic object's ``__typing_subst__`` returns an object
+that isn't a :class:`tuple`.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -525,6 +525,14 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
             return NULL;
         }
         if (unpack) {
+            if (!PyTuple_Check(arg)) {
+                Py_DECREF(newargs);
+                Py_DECREF(item);
+                Py_XDECREF(tuple_args);
+                PyErr_Format(PyExc_TypeError,
+                             "expected a tuple, not %T", arg);
+                return NULL;
+            }
             jarg = tuple_extend(&newargs, jarg,
                     &PyTuple_GET_ITEM(arg, 0), PyTuple_GET_SIZE(arg));
             Py_DECREF(arg);

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -529,8 +529,10 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
                 Py_DECREF(newargs);
                 Py_DECREF(item);
                 Py_XDECREF(tuple_args);
+                PyObject *original = PyTuple_GET_ITEM(args, iarg);
                 PyErr_Format(PyExc_TypeError,
-                             "expected a tuple, not %T", arg);
+                             "expected __typing_subst__ of %T objects to return a tuple, not %T",
+                             original, arg);
                 Py_DECREF(arg);
                 return NULL;
             }
@@ -540,7 +542,7 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
             if (jarg < 0) {
                 Py_DECREF(item);
                 Py_XDECREF(tuple_args);
-                Py_DECREF(newargs);
+                /* newargs was stolen */
                 return NULL;
             }
         }

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -529,6 +529,7 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
                 Py_DECREF(newargs);
                 Py_DECREF(item);
                 Py_XDECREF(tuple_args);
+                Py_DECREF(arg);
                 PyErr_Format(PyExc_TypeError,
                              "expected a tuple, not %T", arg);
                 return NULL;

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -529,9 +529,9 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
                 Py_DECREF(newargs);
                 Py_DECREF(item);
                 Py_XDECREF(tuple_args);
-                Py_DECREF(arg);
                 PyErr_Format(PyExc_TypeError,
                              "expected a tuple, not %T", arg);
+                Py_DECREF(arg);
                 return NULL;
             }
             jarg = tuple_extend(&newargs, jarg,

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -540,6 +540,7 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
             if (jarg < 0) {
                 Py_DECREF(item);
                 Py_XDECREF(tuple_args);
+                Py_DECREF(newargs);
                 return NULL;
             }
         }

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -542,7 +542,7 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
             if (jarg < 0) {
                 Py_DECREF(item);
                 Py_XDECREF(tuple_args);
-                /* newargs was stolen */
+                assert(newargs == NULL);
                 return NULL;
             }
         }


### PR DESCRIPTION
Raise an exception if `__typing_subst__` returns a non-tuple object.

The test case is a little messy because it's based on fuzzer-generated code, so I can come up with my own repro if people aren't happy with using it.

<!-- gh-issue-number: gh-138479 -->
* Issue: gh-138479
<!-- /gh-issue-number -->
