### PR TITLE
DOC: Fix typo in `os.fwalk()` example

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3757,9 +3757,9 @@ features:
 
       import os
       for root, dirs, files, rootfd in os.fwalk('python/Lib/xml'):
-          print(root, "consumes", end="")
+          print(root, "consumes", end=" ")
           print(sum([os.stat(name, dir_fd=rootfd).st_size for name in files]),
-                end="")
+                end=" ")
           print("bytes in", len(files), "non-directory files")
           if '__pycache__' in dirs:
               dirs.remove('__pycache__')  # don't visit __pycache__ directories


### PR DESCRIPTION
Missing space; see `os.walk()` example.

---

To clarify, the output should look like this: `. consumes 25366 bytes in 24 non-directory files` (and that's what the `os.walk()` example produces)

But because of the typo, it looks like this: `. consumes25366bytes in 24 non-directory files`

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138486.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

Specifically: https://cpython-previews--138486.org.readthedocs.build/en/138486/library/os.html#os.fwalk