### PR TITLE
gh-138281: Remove unused `topsort` and bump minimal version in `peg_generator`

### DIFF
--- a/Tools/peg_generator/pegen/__main__.py
+++ b/Tools/peg_generator/pegen/__main__.py
@@ -187,7 +187,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    if sys.version_info < (3, 8):  # noqa: UP036
-        print("ERROR: using pegen requires at least Python 3.8!", file=sys.stderr)
+    if sys.version_info < (3, 10):  # noqa: UP036
+        print("ERROR: using pegen requires at least Python 3.10!", file=sys.stderr)
         sys.exit(1)
     main()

--- a/Tools/peg_generator/pegen/sccutils.py
+++ b/Tools/peg_generator/pegen/sccutils.py
@@ -49,54 +49,6 @@ def strongly_connected_components(
             yield from dfs(v)
 
 
-def topsort(
-    data: dict[Set[str], set[Set[str]]]
-) -> Iterable[Set[Set[str]]]:
-    """Topological sort.
-
-    Args:
-      data: A map from SCCs (represented as frozen sets of strings) to
-            sets of SCCs, its dependencies.  NOTE: This data structure
-            is modified in place -- for normalization purposes,
-            self-dependencies are removed and entries representing
-            orphans are added.
-
-    Returns:
-      An iterator yielding sets of SCCs that have an equivalent
-      ordering.  NOTE: The algorithm doesn't care about the internal
-      structure of SCCs.
-
-    Example:
-      Suppose the input has the following structure:
-
-        {A: {B, C}, B: {D}, C: {D}}
-
-      This is normalized to:
-
-        {A: {B, C}, B: {D}, C: {D}, D: {}}
-
-      The algorithm will yield the following values:
-
-        {D}
-        {B, C}
-        {A}
-
-    From https://code.activestate.com/recipes/577413-topological-sort/history/1/.
-    """
-    # TODO: Use a faster algorithm?
-    for k, v in data.items():
-        v.discard(k)  # Ignore self dependencies.
-    for item in set.union(*data.values()) - set(data.keys()):
-        data[item] = set()
-    while True:
-        ready = {item for item, dep in data.items() if not dep}
-        if not ready:
-            break
-        yield ready
-        data = {item: (dep - ready) for item, dep in data.items() if item not in ready}
-    assert not data, f"A cyclic dependency exists amongst {data}"
-
-
 def find_cycles_in_scc(
     graph: dict[str, Set[str]], scc: Set[str], start: str
 ) -> Iterable[list[str]]:


### PR DESCRIPTION
Follow up to https://github.com/python/cpython/issues/138281
@vstinner suggested to split this semantic change.

## Description from the original PR

Please, note this change:

```python
if sys.version_info < (3, 10):
    print("ERROR: using pegen requires at least Python 3.10!", file=sys.stderr)
```

Technically we did not test python3.8 for a long time and used `python_version = 3.10` for mypy, so I am pretty sure that 3.8 was not supported already.

I also removed `topsort` which was not used.

<!-- gh-issue-number: gh-138281 -->
* Issue: gh-138281
<!-- /gh-issue-number -->
