### PR TITLE
[3.13] gh-134163: fix: exec('_testcapi.set_nomemory(0)') hang in new repl 3.13

### DIFF
--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -100,7 +100,7 @@ class TestInteractiveInterpreter(unittest.TestCase):
 
     @cpython_only
     def test_exec_set_nomemory_hang(self):
-        # gh-134163 Test case that triggers no memory hang condition
+        # gh-134163: Test case that triggers no memory hang condition
         user_input = dedent("""
             a1 = list(range(1000, 2000))
             a2 = list(range(1000, 2000))

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -14,7 +14,7 @@ from test.support import (
     SuppressCrashReport,
     SHORT_TIMEOUT,
 )
-from test.support.script_helper import kill_python, spawn_python
+from test.support.script_helper import kill_python
 from test.support.import_helper import import_module
 
 try:
@@ -97,35 +97,6 @@ class TestInteractiveInterpreter(unittest.TestCase):
         self.assertIn('After the exception.', output)
         # Exit code 120: Py_FinalizeEx() failed to flush stdout and stderr.
         self.assertIn(p.returncode, (1, 120))
-
-    @cpython_only
-    # Python built with Py_TRACE_REFS fail with a fatal error in
-    # _PyRefchain_Trace() on memory allocation error.
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
-    def test_exec_set_nomemory_hang(self):
-        import_module("_testcapi")
-        # gh-134163: Test case that triggers no memory hang condition
-        # The frame_lasti need to upper 257,
-        # because when calling PyLong_FromLong, malloc is not invoked,
-        # so no MemError is triggered
-        # we need to warm up the memory to reproduce the issue
-        warmup_code = "a = list(range(0, 1))\n" * 20
-        user_input = warmup_code + dedent("""
-            try:
-                import _testcapi
-                _testcapi.set_nomemory(0)
-                b = list(range(1000, 2000))
-            except Exception as e:
-                import traceback
-                traceback.print_exc()
-            """)
-        with SuppressCrashReport():
-            p = spawn_python('-c', user_input)
-        output = kill_python(p)
-
-        self.assertIn(p.returncode, (0, 1, 120))
-        self.assertGreater(len(output), 0)  # At minimum, should not hang
-        self.assertIn(b"MemoryError", output)
 
     @cpython_only
     def test_multiline_string_parsing(self):

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -99,9 +99,9 @@ class TestInteractiveInterpreter(unittest.TestCase):
         self.assertIn(p.returncode, (1, 120))
 
     @cpython_only
-    def test_issue134163_exec_hang(self):
-        # Complete reproduction code that simulates REPL exec() behavior
-        # note these prints are used can not drop
+    def test_exec_set_nomemory_hang(self):
+        # gh-134163 Complete reproduction code that simulates REPL exec() no memory hang
+        # note these print are used can not drop for trigger the malloc
         user_input = dedent("""
             exec('''
             def test_repl_hanging():
@@ -152,8 +152,7 @@ class TestInteractiveInterpreter(unittest.TestCase):
         with SuppressCrashReport():
             p.stdin.write(user_input)
         output = kill_python(p)
-        # The test should complete without hanging and show expected output
-        # We expect either successful completion or controlled failure
+
         self.assertIn(p.returncode, (0, 1, 120))
         # Verify that the simulation steps were executed or that we got the expected memory error output
         # The key test is that it doesn't hang - if we get output, the test passed

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -121,7 +121,7 @@ class TestInteractiveInterpreter(unittest.TestCase):
         output = kill_python(p)
 
         self.assertIn(p.returncode, (0, 1, 120))
-        self.assertGreater(len(output), 0, f"Expected some output, got: {output}")  # At minimum, should not hang
+        self.assertGreater(len(output), 0)  # At minimum, should not hang
 
     @cpython_only
     def test_multiline_string_parsing(self):

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -101,12 +101,12 @@ class TestInteractiveInterpreter(unittest.TestCase):
     @cpython_only
     def test_exec_set_nomemory_hang(self):
         # gh-134163: Test case that triggers no memory hang condition
-        user_input = dedent("""
-            # The frame_lasti need to upper 257,
-            # because when calling PyLong_FromLong, malloc is not invoked,
-            # so no MemError is triggered
-            # we need to warm up the memory to reproduce the issue
-            "a = list(range(0, 1))\n" * 20
+        # The frame_lasti need to upper 257,
+        # because when calling PyLong_FromLong, malloc is not invoked,
+        # so no MemError is triggered
+        # we need to warm up the memory to reproduce the issue
+        warmup_code = "a = list(range(0, 1))\n" * 20
+        user_input = warmup_code + dedent("""
             try:
                 import _testcapi
                 _testcapi.set_nomemory(0)
@@ -122,6 +122,7 @@ class TestInteractiveInterpreter(unittest.TestCase):
 
         self.assertIn(p.returncode, (0, 1, 120))
         self.assertGreater(len(output), 0)  # At minimum, should not hang
+        self.assertIn("MemoryError", output)
 
     @cpython_only
     def test_multiline_string_parsing(self):

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -99,7 +99,11 @@ class TestInteractiveInterpreter(unittest.TestCase):
         self.assertIn(p.returncode, (1, 120))
 
     @cpython_only
+    # Python built with Py_TRACE_REFS fail with a fatal error in
+    # _PyRefchain_Trace() on memory allocation error.
+    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
     def test_exec_set_nomemory_hang(self):
+        import_module("_testcapi")
         # gh-134163: Test case that triggers no memory hang condition
         # The frame_lasti need to upper 257,
         # because when calling PyLong_FromLong, malloc is not invoked,
@@ -120,12 +124,10 @@ class TestInteractiveInterpreter(unittest.TestCase):
             p.stdin.write(user_input)
         output = kill_python(p)
 
-        # it can exit with MemoryError or Fatal Python error when --with-trace-refs
-        # it return -6 here
-        self.assertIn(p.returncode, (0, 1, 120, -6))
+        self.assertIn(p.returncode, (0, 1, 120))
         self.assertGreater(len(output), 0)  # At minimum, should not hang
         # Can result in either MemoryError exception or fatal error
-        self.assertTrue("MemoryError" in output or "Fatal Python error" in output)
+        self.assertTrue("MemoryError" in output)
 
     @cpython_only
     def test_multiline_string_parsing(self):

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -120,9 +120,12 @@ class TestInteractiveInterpreter(unittest.TestCase):
             p.stdin.write(user_input)
         output = kill_python(p)
 
-        self.assertIn(p.returncode, (0, 1, 120))
+        # it can exit with MemoryError or Fatal Python error when --with-trace-refs
+        # it return -6 here
+        self.assertIn(p.returncode, (0, 1, 120, -6))
         self.assertGreater(len(output), 0)  # At minimum, should not hang
-        self.assertIn("MemoryError", output)
+        # Can result in either MemoryError exception or fatal error
+        self.assertTrue("MemoryError" in output or "Fatal Python error" in output)
 
     @cpython_only
     def test_multiline_string_parsing(self):

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -14,7 +14,7 @@ from test.support import (
     SuppressCrashReport,
     SHORT_TIMEOUT,
 )
-from test.support.script_helper import kill_python
+from test.support.script_helper import kill_python, spawn_python
 from test.support.import_helper import import_module
 
 try:
@@ -119,14 +119,13 @@ class TestInteractiveInterpreter(unittest.TestCase):
                 import traceback
                 traceback.print_exc()
             """)
-        p = spawn_repl()
         with SuppressCrashReport():
-            p.stdin.write(user_input)
+            p = spawn_python('-c', user_input)
         output = kill_python(p)
 
         self.assertIn(p.returncode, (0, 1, 120))
         self.assertGreater(len(output), 0)  # At minimum, should not hang
-        self.assertIn("MemoryError", output)
+        self.assertIn(b"MemoryError", output)
 
     @cpython_only
     def test_multiline_string_parsing(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-04-11-52-23.gh-issue-134163.EqKyn8.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-04-11-52-23.gh-issue-134163.EqKyn8.rst
@@ -1,1 +1,1 @@
-fix in default repl exec('_testcapi.set_nomemory(0)') hang forever.
+Fix a hang when the process is out of memory inside an exception handler.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-04-11-52-23.gh-issue-134163.EqKyn8.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-04-11-52-23.gh-issue-134163.EqKyn8.rst
@@ -1,0 +1,1 @@
+fix in default repl exec('_testcapi.set_nomemory(0)') hang forever.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -912,8 +912,7 @@ exception_unwind:
                 int frame_lasti = _PyInterpreterFrame_LASTI(frame);
                 PyObject *lasti = PyLong_FromLong(frame_lasti);
                 if (lasti == NULL) {
-                    // gh-134163
-                    // If we can't allocate memory for lasti during exception handling,
+                    // gh-134163: If we can't allocate memory for lasti during exception handling,
                     // this likely means we're in a severe memory shortage situation.
                     // Instead of going back to exception_unwind (which would cause
                     // infinite recursion), directly exit to let the original exception

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -912,13 +912,6 @@ exception_unwind:
                 int frame_lasti = _PyInterpreterFrame_LASTI(frame);
                 PyObject *lasti = PyLong_FromLong(frame_lasti);
                 if (lasti == NULL) {
-                    // gh-134163: If we can't allocate memory for lasti during exception handling,
-                    // this likely means we're in a severe memory shortage situation.
-                    if (!_PyErr_Occurred(tstate)) {
-                        // PyLong_FromLong should have set an exception
-                        // like _testcapi.set_nomemory(0), it might not. Ensure one is set.
-                        PyErr_NoMemory();
-                    }
                     // Instead of going back to exception_unwind (which would cause
                     // infinite recursion), directly exit to let the original exception
                     // propagate up and hopefully be handled at a higher level.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -912,7 +912,14 @@ exception_unwind:
                 int frame_lasti = _PyInterpreterFrame_LASTI(frame);
                 PyObject *lasti = PyLong_FromLong(frame_lasti);
                 if (lasti == NULL) {
-                    goto exception_unwind;
+                    // gh-134163
+                    // If we can't allocate memory for lasti during exception handling,
+                    // this likely means we're in a severe memory shortage situation.
+                    // Instead of going back to exception_unwind (which would cause
+                    // infinite recursion), directly exit to let the original exception
+                    // propagate up and hopefully be handled at a higher level.
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    goto exit_unwind;
                 }
                 PUSH(lasti);
             }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -914,6 +914,11 @@ exception_unwind:
                 if (lasti == NULL) {
                     // gh-134163: If we can't allocate memory for lasti during exception handling,
                     // this likely means we're in a severe memory shortage situation.
+                    if (!_PyErr_Occurred(tstate)) {
+                        // PyLong_FromLong should have set an exception
+                        // like _testcapi.set_nomemory(0), it might not. Ensure one is set.
+                        PyErr_NoMemory();
+                    }
                     // Instead of going back to exception_unwind (which would cause
                     // infinite recursion), directly exit to let the original exception
                     // propagate up and hopefully be handled at a higher level.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134163 -->
* Issue: gh-134163
<!-- /gh-issue-number -->


debug process:

First step, of course, was trying to reproduce it. On 3.13, running the statement from the issue in the REPL hangs. On 3.14, it doesn’t. So it’s a 3.13-only problem.


- Running ./python xxx.py directly? Works fine
- Using pty? Works fine
- Using subprocess? Works fine
- only in the REPL?Force the old REPL with PYTHON_BASIC_REPL=1 ./python → also fine!
- Is it a C-level bug or a Python-level bug? Since it only happens in the new REPL, at first I thought it was Python-level.
- I wrapped every possible memory-error spot in except: — nothing worked.
- After more print-debugging, I found the culprit: exec(code, self.locals) in console.py.
- OK, so the bug simplifies to: running exec("_testcapi.set_nomemory(0)") in the new REPL.
- maybe it’s not actually 3.13-only?
- Fired up a git branch build — turns out I was right! 3.14’s very first release still had the bug.
- Since branch search works, I suddenly realized I could use git bisect.
- using bisect fixing commit:5fc6bb2754a25157575efc0b37da78c629fea46e.
- cherry-pick it? Nope — the changes were way too big.
- gdb found its a recursive in error if no memory and with the fix

cc @ZeroIntensity you can try this patch in 3.13

