### PR TITLE
gh-87595: Fix the docs for mmap.size()

### DIFF
--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -324,10 +324,10 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
 
       Return the length of the file, which can be larger than the size of the
       memory-mapped area.
-      For anonymous mapping, return its size.
+      For an anonymous mapping, return its size.
 
       .. versionchanged:: next
-         Supports anonymous mapping on Unix.
+         Anonymous mappings are now supported on Unix.
 
 
    .. method:: tell()

--- a/Misc/NEWS.d/next/Library/2021-03-07-16-31-36.bpo-43429.Koa0mf.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-07-16-31-36.bpo-43429.Koa0mf.rst
@@ -1,5 +1,5 @@
 The :meth:`~mmap.mmap.size` method of the :class:`mmap.mmap` class now
 returns the size of an anonymous mapping on both Unix and Windows.
 Previously, the size would be returned on Windows and an :exc:`OSError`
-would be raised on Unix.
-Raise :exc:`ValueError` instead of :exc:`OSError` with ``trackfd=False``.
+would be raised on Unix. :exc:`ValueError` is now raised instead of
+:exc:`OSError` when ``trackfd=False``.


### PR DESCRIPTION
Correct some parts of the docs added in 32032ee376 that weren't
written by me.


<!-- gh-issue-number: gh-87595 -->
* Issue: gh-87595
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138494.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->