### PR TITLE
gh-138192: Fix Context initialization so that all subinterpreters are assigned the MISSING value.

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -2209,14 +2209,10 @@ class LowLevelTests(TestBase):
             import contextvars
             print(getattr(contextvars.Token, "MISSING", "'doesn't exist'"))
             """
-        def parse_stdout(text):
-            interpid, whence = eval(text)
-            return interpid, whence
 
-        with self.subTest('from _interpreter'):
-            orig = _interpreters.create()
-            text = self.run_and_capture(orig, script)
-            self.assertEqual(text.strip(), "<Token.MISSING>")
+        orig = _interpreters.create()
+        text = self.run_and_capture(orig, script)
+        self.assertEqual(text.strip(), "<Token.MISSING>")
 
     def test_is_running(self):
         def check(interpid, expected):

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -2205,12 +2205,6 @@ class LowLevelTests(TestBase):
             self.assertEqual(whence, _interpreters.WHENCE_LEGACY_CAPI)
 
     def test_get_current_missing(self):
-        with self.subTest('main'):
-            main, *_ = _interpreters.get_main()
-            interpid, whence = _interpreters.get_current()
-            self.assertEqual(interpid, main)
-            self.assertEqual(whence, _interpreters.WHENCE_RUNTIME)
-
         script = f"""
             import contextvars
             from concurrent.interpreters import get_current

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -2204,10 +2204,9 @@ class LowLevelTests(TestBase):
             whence = eval(text)
             self.assertEqual(whence, _interpreters.WHENCE_LEGACY_CAPI)
 
-    def test_get_current_missing(self):
+    def test_contextvars_missing(self):
         script = f"""
             import contextvars
-            from concurrent.interpreters import get_current
             print(getattr(contextvars.Token, "MISSING", "'doesn't exist'"))
             """
         def parse_stdout(text):

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -2213,7 +2213,7 @@ class LowLevelTests(TestBase):
             interpid, whence = eval(text)
             return interpid, whence
 
-        with self.subTest('from concurrent.interpreters'):
+        with self.subTest('from _interpreter'):
             orig = _interpreters.create()
             text = self.run_and_capture(orig, script)
             self.assertEqual(text.strip(), "<Token.MISSING>")

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-05-01-19-04.gh-issue-138192.erluq5.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-05-01-19-04.gh-issue-138192.erluq5.rst
@@ -1,0 +1,2 @@
+Fix Context initialization so that all subinterpreters are assigned the
+MISSING value.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-05-01-19-04.gh-issue-138192.erluq5.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-05-01-19-04.gh-issue-138192.erluq5.rst
@@ -1,2 +1,2 @@
-Fix Context initialization so that all subinterpreters are assigned the
-MISSING value.
+Fix :mod:`contextvars` initialization so that all subinterpreters are assigned the
+:attr:`~contextvars.Token.MISSING` value.

--- a/Python/context.c
+++ b/Python/context.c
@@ -1361,7 +1361,7 @@ PyStatus
 _PyContext_Init(PyInterpreterState *interp)
 {
     PyObject *missing = get_token_missing();
-    assert(PyUnstable_IsImmortal(missing));  
+    assert(PyUnstable_IsImmortal(missing));
     if (PyDict_SetItemString(
         _PyType_GetDict(&PyContextToken_Type), "MISSING", missing))
     {

--- a/Python/context.c
+++ b/Python/context.c
@@ -1361,6 +1361,7 @@ PyStatus
 _PyContext_Init(PyInterpreterState *interp)
 {
     PyObject *missing = get_token_missing();
+    assert(PyUnstable_IsImmortal(missing));  
     if (PyDict_SetItemString(
         _PyType_GetDict(&PyContextToken_Type), "MISSING", missing))
     {

--- a/Python/context.c
+++ b/Python/context.c
@@ -1360,10 +1360,6 @@ get_token_missing(void)
 PyStatus
 _PyContext_Init(PyInterpreterState *interp)
 {
-    if (!_Py_IsMainInterpreter(interp)) {
-        return _PyStatus_OK();
-    }
-
     PyObject *missing = get_token_missing();
     if (PyDict_SetItemString(
         _PyType_GetDict(&PyContextToken_Type), "MISSING", missing))


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138192 -->
* Issue: gh-138192
<!-- /gh-issue-number -->
