### PR TITLE
gh-116738: Test resource module on FT Python build

### DIFF
--- a/Lib/test/test_free_threading/test_resource.py
+++ b/Lib/test/test_free_threading/test_resource.py
@@ -1,0 +1,41 @@
+import unittest
+from test.support import import_helper, threading_helper
+
+resource = import_helper.import_module("resource")
+
+
+NTHREADS = 10
+LOOP_PER_THREAD = 1000
+
+
+@threading_helper.requires_working_threading()
+class ResourceTest(unittest.TestCase):
+    @unittest.skipUnless(hasattr(resource, "getrusage"), "needs getrusage")
+    @unittest.skipUnless(
+        hasattr(resource, "RUSAGE_THREAD"), "needs RUSAGE_THREAD"
+    )
+    def test_getrusage(self):
+        ru_utime_lst = []
+
+        def dummy_work(ru_utime_lst):
+            for _ in range(LOOP_PER_THREAD):
+                pass
+
+            usage_process = resource.getrusage(resource.RUSAGE_SELF)
+            usage_thread = resource.getrusage(resource.RUSAGE_THREAD)
+            # Process user time should be greater than thread user time
+            self.assertGreater(usage_process.ru_utime, usage_thread.ru_utime)
+            ru_utime_lst.append(usage_thread.ru_utime)
+
+        threading_helper.run_concurrently(
+            worker_func=dummy_work, args=(ru_utime_lst,), nthreads=NTHREADS
+        )
+
+        usage_process = resource.getrusage(resource.RUSAGE_SELF)
+        self.assertEqual(len(ru_utime_lst), NTHREADS)
+        # Process user time should be greater than sum of all thread user times
+        self.assertGreater(usage_process.ru_utime, sum(ru_utime_lst))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Modules/resource.c
+++ b/Modules/resource.c
@@ -364,10 +364,10 @@ resource_getpagesize_impl(PyObject *module)
 /*[clinic end generated code: output=9ba93eb0f3d6c3a9 input=546545e8c1f42085]*/
 {
     long pagesize = 0;
-#if defined(HAVE_GETPAGESIZE)
-    pagesize = getpagesize();
-#elif defined(HAVE_SYSCONF) && defined(_SC_PAGE_SIZE)
+#if defined(HAVE_SYSCONF) && defined(_SC_PAGE_SIZE)
     pagesize = sysconf(_SC_PAGE_SIZE);
+#elif defined(HAVE_GETPAGESIZE)
+    pagesize = getpagesize();
 #else
 #   error "unsupported platform: resource.getpagesize()"
 #endif

--- a/Modules/resource.c
+++ b/Modules/resource.c
@@ -364,10 +364,10 @@ resource_getpagesize_impl(PyObject *module)
 /*[clinic end generated code: output=9ba93eb0f3d6c3a9 input=546545e8c1f42085]*/
 {
     long pagesize = 0;
-#if defined(HAVE_SYSCONF) && defined(_SC_PAGE_SIZE)
-    pagesize = sysconf(_SC_PAGE_SIZE);
-#elif defined(HAVE_GETPAGESIZE)
+#if defined(HAVE_GETPAGESIZE)
     pagesize = getpagesize();
+#elif defined(HAVE_SYSCONF) && defined(_SC_PAGE_SIZE)
+    pagesize = sysconf(_SC_PAGE_SIZE);
 #else
 #   error "unsupported platform: resource.getpagesize()"
 #endif


### PR DESCRIPTION
The `resource` module appears thread-safe. According to [Linux documentation](https://man7.org/linux/man-pages/man2/getrlimit.2.html), `getrlimit()`, `setrlimit()`, `prlimit()`, and `getrusage()` are marked as `MT-Safe`, and  didn’t find any thread-safety issues mentioned for other docs (posix, freebsd).

- Added a simple test for FT Python build to collect per-thread user time. This is only supported on some systems, like Linux. 

cc: @mpage @colesbury @Yhg1s 


<!-- gh-issue-number: gh-116738 -->
* Issue: gh-116738
<!-- /gh-issue-number -->
