### PR TITLE
gh-138516: fix typo in OrderedDict exception msg

### DIFF
--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1519,7 +1519,7 @@ odict_init(PyObject *self, PyObject *args, PyObject *kwds)
     if (len == -1)
         return -1;
     if (len > 1) {
-        const char *msg = "expected at most 1 arguments, got %zd";
+        const char *msg = "expected at most 1 argument, got %zd";
         PyErr_Format(PyExc_TypeError, msg, len);
         return -1;
     }


### PR DESCRIPTION
+ Remove trailing `s` in exception message of `collections.OrderedDict`.

<!-- gh-issue-number: gh-138516 -->
* Issue: gh-138516
<!-- /gh-issue-number -->
