### PR TITLE
gh-107194: Improved language of list.index in tutorial

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -62,7 +62,7 @@ objects:
 .. method:: list.index(x[, start[, end]])
    :noindex:
 
-   Return zero-based index in the list of the first item whose value is equal to *x*.
+   Return zero-based index of the first occurrence of *x* in the list.
    Raises a :exc:`ValueError` if there is no such item.
 
    The optional arguments *start* and *end* are interpreted as in the slice


### PR DESCRIPTION
Edited list.index documentation from 
- "Return zero-based index in the list of the first item whose value is equal to x." to 
- "Return zero-based index of the first occurrence of x in the list."



<!-- gh-issue-number: gh-107194 -->
* Issue: gh-107194
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138518.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->