### PR TITLE
gh-138515: Include email module in Emscripten build

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-09-05-07-50-18.gh-issue-138515.E3M-pu.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-05-07-50-18.gh-issue-138515.E3M-pu.rst
@@ -1,0 +1,1 @@
+:mod:`email` is added to Emscripten build.

--- a/Tools/wasm/emscripten/wasm_assets.py
+++ b/Tools/wasm/emscripten/wasm_assets.py
@@ -58,7 +58,6 @@ OMIT_FILES = (
 # socket.create_connection() raises an exception:
 # "BlockingIOError: [Errno 26] Operation in progress".
 OMIT_NETWORKING_FILES = (
-    "email/",
     "ftplib.py",
     "http/",
     "imaplib.py",


### PR DESCRIPTION
One line change to include the email module in the Emscripten build so the `importlib.metadata` package can be imported without an error.

<!-- gh-issue-number: gh-138515 -->
* Issue: gh-138515
<!-- /gh-issue-number -->
