### PR TITLE
gh-134746: implement Ctrl+Alt+L clear display keymap in pyREPL

### DIFF
--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -135,6 +135,13 @@ class clear_screen(Command):
         r.dirty = True
 
 
+class clear_display(Command):
+    def do(self) -> None:
+        r = self.reader
+        r.console.clear_all()
+        r.dirty = True
+
+
 class refresh(Command):
     def do(self) -> None:
         self.reader.dirty = True

--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -114,6 +114,7 @@ class Console(ABC):
         """Wipe the screen"""
         ...
 
+    @abstractmethod
     def clear_all(self) -> None:
         """Clear screen and scrollback buffer."""
         ...

--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -114,6 +114,10 @@ class Console(ABC):
         """Wipe the screen"""
         ...
 
+    def clear_all(self) -> None:
+        """Clear screen and scrollback buffer."""
+        ...
+
     @abstractmethod
     def finish(self) -> None:
         """Move the cursor to the end of the display and otherwise get

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -75,6 +75,7 @@ default_keymap: tuple[tuple[KeySpec, CommandName], ...] = tuple(
         (r"\<return>", "accept"),
         (r"\C-k", "kill-line"),
         (r"\C-l", "clear-screen"),
+        (r"\C-\M-l", "clear-display"),
         (r"\C-m", "accept"),
         (r"\C-t", "transpose-characters"),
         (r"\C-u", "unix-line-discard"),

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -561,6 +561,11 @@ class UnixConsole(Console):
         self.posxy = 0, 0
         self.screen = []
 
+    def clear_all(self) -> None:
+        """Clear screen and scrollback buffer."""
+        self.__write("\x1b[3J\x1b[2J\x1b[H")
+        self.clear()
+
     @property
     def input_hook(self):
         # avoid inline imports here so the repl doesn't get flooded

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -111,6 +111,7 @@ MOVE_RIGHT = "\x1b[{}C"
 MOVE_UP = "\x1b[{}A"
 MOVE_DOWN = "\x1b[{}B"
 CLEAR = "\x1b[H\x1b[J"
+CLEAR_ALL= "\x1b[3J\x1b[2J\x1b[H"
 
 # State of control keys: https://learn.microsoft.com/en-us/windows/console/key-event-record-str
 ALT_ACTIVE = 0x01 | 0x02
@@ -515,6 +516,12 @@ class WindowsConsole(Console):
         self.__write(CLEAR)
         self.posxy = 0, 0
         self.screen = [""]
+
+
+    def clear_all(self) -> None:
+        """Clear screen and scrollback buffer."""
+        self.__write(CLEAR_ALL)
+        self.clear()
 
     def finish(self) -> None:
         """Move the cursor to the end of the display and otherwise get

--- a/Lib/test/test_pyrepl/support.py
+++ b/Lib/test/test_pyrepl/support.py
@@ -155,6 +155,9 @@ class FakeConsole(Console):
     def clear(self) -> None:
         pass
 
+    def clear_all(self) -> None:
+        pass
+
     def finish(self) -> None:
         pass
 

--- a/Misc/NEWS.d/next/Library/2025-09-05-15-02-20.gh-issue-134746.9kiF6K.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-05-15-02-20.gh-issue-134746.9kiF6K.rst
@@ -1,0 +1,5 @@
+Added a new ``clear_display`` command in the REPL. ``Ctrl+Alt+L`` now clears
+the screen and, if possible, the terminal’s scrollback buffer, then redraws
+the current line at the top of the screen.
+
+Manually tested on Unix; Windows behavior not yet verified.


### PR DESCRIPTION
Changes:
- added a `clear_all()` method to console files that does what `clear()` does + clears scrollback
- added the `Ctrl+Alt+L` keymap

Note:
- description of clear_display behavior:  Clear the screen and, if possible, the terminal's scrollback buffer, then redraw the current line, leaving the current line at the top of the screen.

- Manually tested for unix but not yet tested for windows

<!-- gh-issue-number: gh-134746 -->
* Issue: gh-134746
<!-- /gh-issue-number -->
