### PR TITLE
gh-87209: Clarify ordering rule for default arguments in tutorial

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -587,9 +587,10 @@ There are three forms, which can be combined.
 Default Argument Values
 -----------------------
 
-The most useful form is to specify a default value for one or more arguments.
-This creates a function that can be called with fewer arguments than it is
-defined to allow.  For example::
+The most useful form is to specify a default value for one or more parameters.
+All positional only parameters (that is, without default values) must come
+first, followed by those with defaults. This allows a function to be called
+with fewer arguments than it is defined to allow. For example::
 
    def ask_ok(prompt, retries=4, reminder='Please try again!'):
        while True:


### PR DESCRIPTION
This PR updates section 4.9.1 of the tutorial to clarify that arguments without default values must come before arguments with default values.

**Current text:**

> The most useful form is to specify a default value for one or more arguments. This creates a function that can be called with fewer arguments than it is defined to allow.

**Proposed text:**

> The most useful form is to specify a default value for one or more arguments. All arguments without default values must come first, followed by those with defaults. This allows a function to be called with fewer arguments than it is defined to allow.

Closes gh-87209.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138529.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->