### PR TITLE
gh-138535: Optimize fill_time for typical timestamps

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1070,8 +1070,9 @@ class UtimeTests(unittest.TestCase):
             -9223372037, -9223372036, 9223372035, 9223372036,
         )
         for large in times:
-            os.utime(self.fname, (large, large))
-            self.assertEqual(os.stat(self.fname).st_mtime, large)
+            with self.subTest(large=large):
+                os.utime(self.fname, (large, large))
+                self.assertEqual(os.stat(self.fname).st_mtime, large)
 
     def test_utime_invalid_arguments(self):
         # seconds and nanoseconds parameters are mutually exclusive

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1064,9 +1064,14 @@ class UtimeTests(unittest.TestCase):
         if self.get_file_system(self.dirname) != "NTFS":
             self.skipTest("requires NTFS")
 
-        large = 5000000000   # some day in 2128
-        os.utime(self.fname, (large, large))
-        self.assertEqual(os.stat(self.fname).st_mtime, large)
+        times = (
+            5000000000,  # some day in 2128
+            # boundaries of the fast path cutoff in posixmodule.c:fill_time
+            -9223372037, -9223372036, 9223372035, 9223372036,
+        )
+        for large in times:
+            os.utime(self.fname, (large, large))
+            self.assertEqual(os.stat(self.fname).st_mtime, large)
 
     def test_utime_invalid_arguments(self):
         # seconds and nanoseconds parameters are mutually exclusive

--- a/Misc/NEWS.d/next/Library/2025-09-06-20-09-32.gh-issue-138535.mlntEe.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-06-20-09-32.gh-issue-138535.mlntEe.rst
@@ -1,0 +1,2 @@
+Speed up :func:`os.stat` for files with reasonable timestamps. Contributed
+by Jeffrey Bosboom.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2610,7 +2610,7 @@ fill_time(PyObject *module, PyObject *v, int s_index, int f_index, int ns_index,
     int res = -1;
     if (ns_index >= 0) {
         /* 1677-09-21 00:12:44 to 2262-04-11 23:47:15 UTC inclusive */
-        if ((LLONG_MIN / S_TO_NS) <= sec && sec <= (LONG_MAX / S_TO_NS - 1)) {
+        if ((LLONG_MIN / S_TO_NS) <= sec && sec <= (LLONG_MAX / S_TO_NS - 1)) {
             PyObject *ns_total = PyLong_FromLongLong(sec * S_TO_NS + nsec);
             if (!ns_total) {
                 return -1;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2616,6 +2616,7 @@ fill_time(PyObject *module, PyObject *v, int s_index, int f_index, int ns_index,
                 return -1;
             }
             PyStructSequence_SET_ITEM(v, ns_index, ns_total);
+            assert(!PyErr_Occurred());
             res = 0;
         }
         else {
@@ -2637,6 +2638,7 @@ fill_time(PyObject *module, PyObject *v, int s_index, int f_index, int ns_index,
                 goto exit;
             }
             PyStructSequence_SET_ITEM(v, ns_index, ns_total);
+            assert(!PyErr_Occurred());
             res = 0;
 
         exit:
@@ -2646,7 +2648,6 @@ fill_time(PyObject *module, PyObject *v, int s_index, int f_index, int ns_index,
         }
     }
 
-    assert(!PyErr_Occurred());
     return res;
     #undef S_TO_NS
 }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2588,12 +2588,43 @@ static int
 fill_time(PyObject *module, PyObject *v, int s_index, int f_index, int ns_index, time_t sec, unsigned long nsec)
 {
     assert(!PyErr_Occurred());
+#define S_TO_NS (1000000000LL)
+    assert(nsec < S_TO_NS);
+
+    if (f_index >= 0) {
+        PyObject *float_s = PyFloat_FromDouble(sec + 1e-9*nsec);
+        if (!float_s) {
+            return -1;
+        }
+        PyStructSequence_SET_ITEM(v, f_index, float_s);
+    }
+
+    /* 1677-09-21 00:12:44 to 2262-04-11 23:47:15 UTC inclusive */
+    if ((LLONG_MIN / S_TO_NS) <= sec && sec <= (LONG_MAX / S_TO_NS - 1)) {
+        if (s_index >= 0) {
+            PyObject *s = _PyLong_FromTime_t(sec);
+            if (!s) {
+                return -1;
+            }
+            PyStructSequence_SET_ITEM(v, s_index, s);
+        }
+
+        if (ns_index >= 0) {
+            PyObject *ns_total = PyLong_FromLongLong(sec * S_TO_NS + nsec);
+            if (!ns_total) {
+                return -1;
+            }
+            PyStructSequence_SET_ITEM(v, ns_index, ns_total);
+        }
+
+        assert(!PyErr_Occurred());
+        return 0;
+    }
+#undef S_TO_NS
 
     int res = -1;
     PyObject *s_in_ns = NULL;
     PyObject *ns_total = NULL;
-    PyObject *float_s = NULL;
-
     PyObject *s = _PyLong_FromTime_t(sec);
     PyObject *ns_fractional = PyLong_FromUnsignedLong(nsec);
     if (!(s && ns_fractional)) {
@@ -2606,21 +2637,13 @@ fill_time(PyObject *module, PyObject *v, int s_index, int f_index, int ns_index,
     }
 
     ns_total = PyNumber_Add(s_in_ns, ns_fractional);
-    if (!ns_total)
-        goto exit;
-
-    float_s = PyFloat_FromDouble(sec + 1e-9*nsec);
-    if (!float_s) {
+    if (!ns_total) {
         goto exit;
     }
 
     if (s_index >= 0) {
         PyStructSequence_SET_ITEM(v, s_index, s);
         s = NULL;
-    }
-    if (f_index >= 0) {
-        PyStructSequence_SET_ITEM(v, f_index, float_s);
-        float_s = NULL;
     }
     if (ns_index >= 0) {
         PyStructSequence_SET_ITEM(v, ns_index, ns_total);
@@ -2635,7 +2658,6 @@ exit:
     Py_XDECREF(ns_fractional);
     Py_XDECREF(s_in_ns);
     Py_XDECREF(ns_total);
-    Py_XDECREF(float_s);
     return res;
 }
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2588,20 +2588,20 @@ static int
 fill_time(PyObject *module, PyObject *v, int s_index, int f_index, int ns_index, time_t sec, unsigned long nsec)
 {
     assert(!PyErr_Occurred());
-#define S_TO_NS (1000000000LL)
-    assert(nsec < S_TO_NS);
+#define SEC_TO_NS (1000000000LL)
+    assert(nsec < SEC_TO_NS);
 
     if (s_index >= 0) {
         PyObject *s = _PyLong_FromTime_t(sec);
-        if (!s) {
+        if (s == NULL) {
             return -1;
         }
         PyStructSequence_SET_ITEM(v, s_index, s);
     }
 
     if (f_index >= 0) {
-        PyObject *float_s = PyFloat_FromDouble(sec + 1e-9 * nsec);
-        if (!float_s) {
+        PyObject *float_s = PyFloat_FromDouble((double)sec + 1e-9 * nsec);
+        if (float_s == NULL) {
             return -1;
         }
         PyStructSequence_SET_ITEM(v, f_index, float_s);
@@ -2610,9 +2610,9 @@ fill_time(PyObject *module, PyObject *v, int s_index, int f_index, int ns_index,
     int res = -1;
     if (ns_index >= 0) {
         /* 1677-09-21 00:12:44 to 2262-04-11 23:47:15 UTC inclusive */
-        if ((LLONG_MIN / S_TO_NS) <= sec && sec <= (LLONG_MAX / S_TO_NS - 1)) {
-            PyObject *ns_total = PyLong_FromLongLong(sec * S_TO_NS + nsec);
-            if (!ns_total) {
+        if ((LLONG_MIN/SEC_TO_NS) <= sec && sec <= (LLONG_MAX/SEC_TO_NS - 1)) {
+            PyObject *ns_total = PyLong_FromLongLong(sec * SEC_TO_NS + nsec);
+            if (ns_total == NULL) {
                 return -1;
             }
             PyStructSequence_SET_ITEM(v, ns_index, ns_total);
@@ -2624,17 +2624,17 @@ fill_time(PyObject *module, PyObject *v, int s_index, int f_index, int ns_index,
             PyObject *ns_total = NULL;
             PyObject *s = _PyLong_FromTime_t(sec);
             PyObject *ns_fractional = PyLong_FromUnsignedLong(nsec);
-            if (!(s && ns_fractional)) {
+            if (s == NULL || ns_fractional == NULL) {
                 goto exit;
             }
 
             s_in_ns = PyNumber_Multiply(s, get_posix_state(module)->billion);
-            if (!s_in_ns) {
+            if (s_in_ns == NULL) {
                 goto exit;
             }
 
             ns_total = PyNumber_Add(s_in_ns, ns_fractional);
-            if (!ns_total) {
+            if (ns_total == NULL) {
                 goto exit;
             }
             PyStructSequence_SET_ITEM(v, ns_index, ns_total);
@@ -2649,7 +2649,7 @@ fill_time(PyObject *module, PyObject *v, int s_index, int f_index, int ns_index,
     }
 
     return res;
-    #undef S_TO_NS
+    #undef SEC_TO_NS
 }
 
 #ifdef MS_WINDOWS


### PR DESCRIPTION
While file timestamps can be anything the file system can store, most lie between the recent past and the near future.  Optimize fill_time for typical timestamps in three ways:

- When possible, convert to nanoseconds with C arithmetic.
- When using C arithmetic and the seconds member is not required (for st_birthtime), avoid creating a long object.
- When using C arithmetic, reorder the code to avoid the null checks implied in Py_XDECREF.

This improves `python -m pyperf timeit -s 'import os' 'os.stat(".")'` from `1.26 us +- 0.02 us` to `1.15 us +- 0.01 us` on Linux 6.16.2.arch1-1 btrfs and `--enable-optimizations --with-lto`.

I found this while [implementing `os.stat_result.st_birthtime` on Linux](https://github.com/python/cpython/pull/136334) and trying not to regress performance.  This is a small change that should be an improvement on all platforms, so I've submitted it separately.

This needs tests, presumably in `test_os.py` `UtimeTests.test_large_time`, though it's actually testing `os.stat`.  But that test currently only runs on NTFS on Windows.  I'll look at Linux filesystem support tomorrow.

<!-- gh-issue-number: gh-138535 -->
* Issue: gh-138535
<!-- /gh-issue-number -->
