### PR TITLE
gh-138191: Document ``frame.f_generator`` in the data model

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1675,6 +1675,7 @@ Special read-only attributes
      - The "precise instruction" of the frame object
        (this is an index into the :term:`bytecode` string of the
        :ref:`code object <code-objects>`)
+
    * - .. attribute:: frame.f_generator
      - The :term:`generator` or :term:`coroutine` object that owns this frame,
        or ``None`` if the frame is a normal function.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1675,7 +1675,6 @@ Special read-only attributes
      - The "precise instruction" of the frame object
        (this is an index into the :term:`bytecode` string of the
        :ref:`code object <code-objects>`)
-   
    * - .. attribute:: frame.f_generator
      - The :term:`generator` or :term:`coroutine` object that owns this frame,
        or ``None`` if the frame is a normal function.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1680,6 +1680,8 @@ Special read-only attributes
      - The :term:`generator` or :term:`coroutine` object that owns this frame,
        or ``None`` if the frame is a normal function.
 
+       .. versionadded:: 3.14
+
 .. index::
    single: f_trace (frame attribute)
    single: f_trace_lines (frame attribute)

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1677,8 +1677,8 @@ Special read-only attributes
        :ref:`code object <code-objects>`)
    
    * - .. attribute:: frame.f_generator
-     - Returns the generator or coroutine object that owns this frame,
-       or ``None`` if the frame is of a regular function.
+     - The :term:`generator` or :term:`coroutine` object that owns this frame,
+       or ``None`` if the frame is a normal function.
 
 .. index::
    single: f_trace (frame attribute)

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1633,12 +1633,12 @@ and are also passed to registered trace functions.
 
 .. index::
    single: f_back (frame attribute)
-   single: f_generator (frame attribute)
    single: f_code (frame attribute)
    single: f_globals (frame attribute)
    single: f_locals (frame attribute)
    single: f_lasti (frame attribute)
    single: f_builtins (frame attribute)
+   single: f_generator (frame attribute)
 
 Special read-only attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1648,10 +1648,6 @@ Special read-only attributes
    * - .. attribute:: frame.f_back
      - Points to the previous stack frame (towards the caller),
        or ``None`` if this is the bottom stack frame
-
-   * - .. attribute:: frame.f_generator
-     - Returns the generator or coroutine object that owns this frame,
-       or ``None`` if the frame is of a regular function.
 
    * - .. attribute:: frame.f_code
      - The :ref:`code object <code-objects>` being executed in this frame.
@@ -1679,6 +1675,10 @@ Special read-only attributes
      - The "precise instruction" of the frame object
        (this is an index into the :term:`bytecode` string of the
        :ref:`code object <code-objects>`)
+   
+   * - .. attribute:: frame.f_generator
+     - Returns the generator or coroutine object that owns this frame,
+       or ``None`` if the frame is of a regular function.
 
 .. index::
    single: f_trace (frame attribute)

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1633,6 +1633,7 @@ and are also passed to registered trace functions.
 
 .. index::
    single: f_back (frame attribute)
+   single: f_generator (frame attribute)
    single: f_code (frame attribute)
    single: f_globals (frame attribute)
    single: f_locals (frame attribute)
@@ -1647,6 +1648,10 @@ Special read-only attributes
    * - .. attribute:: frame.f_back
      - Points to the previous stack frame (towards the caller),
        or ``None`` if this is the bottom stack frame
+
+   * - .. attribute:: frame.f_generator
+     - Returns the generator or coroutine object that owns this frame,
+       or ``None`` if the frame is of a regular function.
 
    * - .. attribute:: frame.f_code
      - The :ref:`code object <code-objects>` being executed in this frame.


### PR DESCRIPTION
This PR adds the `f_generator` attribute to the Data model documentation page 
(`Doc/reference/datamodel.rst`). 

The `f_generator` attribute was already described in `inspect.rst` but was missing 
from `datamodel.rst`. This change ensures that the Data model page is consistent 
with the inspection documentation and fully documents all frame object attributes.

Additionally, an index entry for `f_generator` has been added so it appears in the 
documentation search.

fixes #138191 


<!-- gh-issue-number: gh-138191 -->
* Issue: gh-138191
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138540.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->