### PR TITLE
gh-128715: CTypeField: Put intness, signedness and pointerness in flags

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2283,6 +2283,8 @@ static PyObject *CreateSwappedType(ctypes_state *st, PyTypeObject *type,
     stginfo->size = fmt->pffi_type->size;
     stginfo->setfunc = fmt->setfunc_swapped;
     stginfo->getfunc = fmt->getfunc_swapped;
+    stginfo->flags |= (fmt->flags & (TYPEFLAG_IS_INTEGER | TYPEFLAG_IS_SIGNED));
+    stginfo->flags |= TYPEFLAG_IS_SWAPPED;
 
     stginfo->proto = Py_NewRef(proto);
 
@@ -2326,7 +2328,7 @@ PyCSimpleType_init(PyObject *self, PyObject *args, PyObject *kwds)
     PyObject *proto;
     const char *proto_str;
     Py_ssize_t proto_len;
-    PyMethodDef *ml;
+    PyMethodDef *ml = NULL;
     struct fielddesc *fmt;
 
     if (PyType_Type.tp_init(self, args, kwds) < 0) {
@@ -2372,6 +2374,7 @@ PyCSimpleType_init(PyObject *self, PyObject *args, PyObject *kwds)
     if (!stginfo) {
         goto error;
     }
+    stginfo->flags |= fmt->flags;
 
     if (!fmt->pffi_type->elements) {
         stginfo->ffi_type_pointer = *fmt->pffi_type;
@@ -2418,24 +2421,12 @@ PyCSimpleType_init(PyObject *self, PyObject *args, PyObject *kwds)
         switch (*proto_str) {
         case 'z': /* c_char_p */
             ml = c_char_p_methods;
-            stginfo->flags |= TYPEFLAG_ISPOINTER;
             break;
         case 'Z': /* c_wchar_p */
             ml = c_wchar_p_methods;
-            stginfo->flags |= TYPEFLAG_ISPOINTER;
             break;
         case 'P': /* c_void_p */
             ml = c_void_p_methods;
-            stginfo->flags |= TYPEFLAG_ISPOINTER;
-            break;
-        case 's':
-        case 'X':
-        case 'O':
-            ml = NULL;
-            stginfo->flags |= TYPEFLAG_ISPOINTER;
-            break;
-        default:
-            ml = NULL;
             break;
         }
 

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -1501,26 +1501,38 @@ for nbytes in 8, 16, 32, 64:
             f'{sgn}{nbytes}_set_sw',
             f'{sgn}{nbytes}_get_sw',
         ]
+        flags = ['TYPEFLAG_IS_INTEGER']
+        if is_signed:
+            flags.append('TYPEFLAG_IS_SIGNED')
         print(f'    formattable.fmt_{sgn}{nbytes} = (struct fielddesc){{')
-        print(f'            {", ".join(parts)} }};')
+        print(f'            {", ".join(parts)},')
+        print(f'            .flags = {" | ".join(flags)} }};')
 [python start generated code]*/
     formattable.fmt_i8 = (struct fielddesc){
-            0, &ffi_type_sint8, i8_set, i8_get, i8_set_sw, i8_get_sw };
+            0, &ffi_type_sint8, i8_set, i8_get, i8_set_sw, i8_get_sw,
+            .flags = TYPEFLAG_IS_INTEGER | TYPEFLAG_IS_SIGNED };
     formattable.fmt_u8 = (struct fielddesc){
-            0, &ffi_type_uint8, u8_set, u8_get, u8_set_sw, u8_get_sw };
+            0, &ffi_type_uint8, u8_set, u8_get, u8_set_sw, u8_get_sw,
+            .flags = TYPEFLAG_IS_INTEGER };
     formattable.fmt_i16 = (struct fielddesc){
-            0, &ffi_type_sint16, i16_set, i16_get, i16_set_sw, i16_get_sw };
+            0, &ffi_type_sint16, i16_set, i16_get, i16_set_sw, i16_get_sw,
+            .flags = TYPEFLAG_IS_INTEGER | TYPEFLAG_IS_SIGNED };
     formattable.fmt_u16 = (struct fielddesc){
-            0, &ffi_type_uint16, u16_set, u16_get, u16_set_sw, u16_get_sw };
+            0, &ffi_type_uint16, u16_set, u16_get, u16_set_sw, u16_get_sw,
+            .flags = TYPEFLAG_IS_INTEGER };
     formattable.fmt_i32 = (struct fielddesc){
-            0, &ffi_type_sint32, i32_set, i32_get, i32_set_sw, i32_get_sw };
+            0, &ffi_type_sint32, i32_set, i32_get, i32_set_sw, i32_get_sw,
+            .flags = TYPEFLAG_IS_INTEGER | TYPEFLAG_IS_SIGNED };
     formattable.fmt_u32 = (struct fielddesc){
-            0, &ffi_type_uint32, u32_set, u32_get, u32_set_sw, u32_get_sw };
+            0, &ffi_type_uint32, u32_set, u32_get, u32_set_sw, u32_get_sw,
+            .flags = TYPEFLAG_IS_INTEGER };
     formattable.fmt_i64 = (struct fielddesc){
-            0, &ffi_type_sint64, i64_set, i64_get, i64_set_sw, i64_get_sw };
+            0, &ffi_type_sint64, i64_set, i64_get, i64_set_sw, i64_get_sw,
+            .flags = TYPEFLAG_IS_INTEGER | TYPEFLAG_IS_SIGNED };
     formattable.fmt_u64 = (struct fielddesc){
-            0, &ffi_type_uint64, u64_set, u64_get, u64_set_sw, u64_get_sw };
-/*[python end generated code: output=16806fe0ca3a9c4c input=96348a06e575f801]*/
+            0, &ffi_type_uint64, u64_set, u64_get, u64_set_sw, u64_get_sw,
+            .flags = TYPEFLAG_IS_INTEGER };
+/*[python end generated code: output=f4a64738bd0af9ee input=b050aa3aa6871a68]*/
 
 
     /* Native C integers.
@@ -1598,6 +1610,11 @@ for base_code, base_c_type in [
         SYMBOL ## _get, SYMBOL ## _set_sw, SYMBOL ## _get_sw)                 \
     ///////////////////////////////////////////////////////////////////////////
 
+#define POINTER_ENTRY(SYMBOL, FFI_TYPE)                                       \
+    _TABLE_ENTRY(SYMBOL, FFI_TYPE, SYMBOL ## _set, SYMBOL ## _get,            \
+                 .flags = TYPEFLAG_ISPOINTER)                                 \
+    ///////////////////////////////////////////////////////////////////////////
+
     TABLE_ENTRY_SW(d, &ffi_type_double);
 #if defined(_Py_FFI_SUPPORT_C_COMPLEX)
     if (Py_FFI_COMPLEX_AVAILABLE) {
@@ -1615,16 +1632,17 @@ for base_code, base_c_type in [
     // ctypes.c_wchar is signed for FFI, even where C wchar_t is unsigned.
     TABLE_ENTRY(u, _ctypes_fixint_fielddesc(sizeof(wchar_t), true)->pffi_type);
 
-    TABLE_ENTRY(s, &ffi_type_pointer);
-    TABLE_ENTRY(P, &ffi_type_pointer);
-    TABLE_ENTRY(z, &ffi_type_pointer);
+    POINTER_ENTRY(s, &ffi_type_pointer);
+    POINTER_ENTRY(P, &ffi_type_pointer);
+    POINTER_ENTRY(z, &ffi_type_pointer);
     TABLE_ENTRY(U, &ffi_type_pointer);
-    TABLE_ENTRY(Z, &ffi_type_pointer);
+    POINTER_ENTRY(Z, &ffi_type_pointer);
 #ifdef MS_WIN32
-    TABLE_ENTRY(X, &ffi_type_pointer);
+    POINTER_ENTRY(X, &ffi_type_pointer);
 #endif
-    TABLE_ENTRY(O, &ffi_type_pointer);
+    POINTER_ENTRY(O, &ffi_type_pointer);
 
+#undef POINTER_ENTRY
 #undef TABLE_ENTRY_SW
 #undef TABLE_ENTRY
 #undef _TABLE_ENTRY

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -31,6 +31,14 @@ static void pymem_destructor(PyObject *ptr)
     }
 }
 
+static PyObject *c_get(void *ptr, Py_ssize_t size);
+static PyObject *c_set(void *ptr, PyObject *value, Py_ssize_t length);
+static PyObject *u_get(void *ptr, Py_ssize_t size);
+static PyObject *u_set(void *ptr, PyObject *value, Py_ssize_t length);
+static PyObject *s_get(void *ptr, Py_ssize_t size);
+static PyObject *s_set(void *ptr, PyObject *value, Py_ssize_t length);
+static PyObject *U_get(void *ptr, Py_ssize_t size);
+static PyObject *U_set(void *ptr, PyObject *value, Py_ssize_t length);
 
 /******************************************************************/
 /*
@@ -117,9 +125,7 @@ PyCField_new_impl(PyTypeObject *type, PyObject *name, PyObject *proto,
             case FFI_TYPE_SINT8:
             case FFI_TYPE_SINT16:
             case FFI_TYPE_SINT32:
-                if (info->getfunc != _ctypes_get_fielddesc("c")->getfunc
-                    && info->getfunc != _ctypes_get_fielddesc("u")->getfunc)
-                {
+                if (info->getfunc != c_get && info->getfunc != u_get) {
                     break;
                 }
                 _Py_FALLTHROUGH;  /* else fall through */
@@ -214,15 +220,13 @@ PyCField_new_impl(PyTypeObject *type, PyObject *name, PyObject *proto,
                                 "has no _stginfo_");
                 goto error;
             }
-            if (iinfo->getfunc == _ctypes_get_fielddesc("c")->getfunc) {
-                struct fielddesc *fd = _ctypes_get_fielddesc("s");
-                self->getfunc = fd->getfunc;
-                self->setfunc = fd->setfunc;
+            if (iinfo->getfunc == c_get) {
+                self->getfunc = s_get;
+                self->setfunc = s_set;
             }
-            if (iinfo->getfunc == _ctypes_get_fielddesc("u")->getfunc) {
-                struct fielddesc *fd = _ctypes_get_fielddesc("U");
-                self->getfunc = fd->getfunc;
-                self->setfunc = fd->setfunc;
+            if (iinfo->getfunc == u_get) {
+                self->getfunc = U_get;
+                self->setfunc = U_set;
             }
         }
     }

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -286,6 +286,7 @@ struct fielddesc {
     GETFUNC getfunc;
     SETFUNC setfunc_swapped;
     GETFUNC getfunc_swapped;
+    uint16_t flags;     /* stginfo flags (TYPEFLAG_*) */
 };
 
 // Get all single-character type codes (for use in error messages)
@@ -402,7 +403,7 @@ typedef struct {
     PyObject *pointer_type;     /* __pointer_type__ attribute;
                                    arbitrary object or NULL */
     PyObject *module;
-    int flags;                  /* calling convention and such */
+    uint16_t flags;             /* calling convention and such */
 #ifdef Py_GIL_DISABLED
     PyMutex mutex;              /* critical section mutex */
 #endif
@@ -489,6 +490,9 @@ PyObject *_ctypes_callproc(ctypes_state *st,
 
 #define TYPEFLAG_ISPOINTER 0x100
 #define TYPEFLAG_HASPOINTER 0x200
+#define TYPEFLAG_IS_INTEGER 0x400 /* [u]intN_t & alliases & swapped variants */
+#define TYPEFLAG_IS_SIGNED 0x800 /* only meaningful for TYPEFLAG_BASIC_INT */
+#define TYPEFLAG_IS_SWAPPED 0x1000 /* non-native byte order */
 
 struct tagPyCArgObject {
     PyObject_HEAD


### PR DESCRIPTION
A bit more refactoring for gh-128715: use flags instead of some of the `switch` cases that need to list every type code with some property.

Also simplify code that went through `_ctypes_get_fielddesc` to get a function defined in the same file.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
