### PR TITLE
gh-138542: error message is wrong when inspect a custom module

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -819,9 +819,9 @@ def getfile(object):
     if ismodule(object):
         if getattr(object, '__file__', None):
             return object.__file__
-        if object.__spec__ is not None:
+        if getattr(object, '__spec__', None) is not None:
             raise TypeError(f'{object!r} is a built-in module')
-        raise TypeError(f'Custom module: {object!r} cannot get source')
+        raise TypeError(f'Cannot get source from {object!r}')
     if isclass(object):
         if hasattr(object, '__module__'):
             module = sys.modules.get(object.__module__)

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -821,7 +821,7 @@ def getfile(object):
             return object.__file__
         if getattr(object, '__spec__', None) is not None:
             raise TypeError(f'{object!r} is a built-in module')
-        raise TypeError(f'Cannot get source from {object!r}')
+        raise TypeError(f'cannot get source from {object!r}')
     if isclass(object):
         if hasattr(object, '__module__'):
             module = sys.modules.get(object.__module__)

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -822,7 +822,7 @@ def getfile(object):
         if object.__spec__ is not None:
             raise TypeError('{!r} is a built-in module'.format(object))
         else:
-            raise TypeError('Custom module: {!r} is can not get source'
+            raise TypeError('Custom module: {!r} cannot get source'
                             .format(object))
     if isclass(object):
         if hasattr(object, '__module__'):

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -819,7 +819,11 @@ def getfile(object):
     if ismodule(object):
         if getattr(object, '__file__', None):
             return object.__file__
-        raise TypeError('{!r} is a built-in module'.format(object))
+        if object.__spec__ is not None:
+            raise TypeError('{!r} is a built-in module'.format(object))
+        else:
+            raise TypeError('Custom module: {!r} is can not get source'
+                            .format(object))
     if isclass(object):
         if hasattr(object, '__module__'):
             module = sys.modules.get(object.__module__)

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -820,10 +820,8 @@ def getfile(object):
         if getattr(object, '__file__', None):
             return object.__file__
         if object.__spec__ is not None:
-            raise TypeError('{!r} is a built-in module'.format(object))
-        else:
-            raise TypeError('Custom module: {!r} cannot get source'
-                            .format(object))
+            raise TypeError(f'{object!r} is a built-in module')
+        raise TypeError(f'Custom module: {object!r} cannot get source')
     if isclass(object):
         if hasattr(object, '__module__'):
             module = sys.modules.get(object.__module__)

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -15,6 +15,7 @@ import dis
 from os.path import normcase
 import _pickle
 import pickle
+import re
 import shutil
 import stat
 import sys
@@ -6160,7 +6161,6 @@ class TestSignatureDefinitions(unittest.TestCase):
         self._test_module_has_signatures(pwd)
 
     def test_re_module_has_signatures(self):
-        import re
         methods_no_signature = {'Match': {'group'}}
         self._test_module_has_signatures(re,
                 methods_no_signature=methods_no_signature,

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -815,7 +815,7 @@ class TestRetrievingSourceCode(GetSourceBase):
         import re
         custom_module = types.ModuleType('custom_module')
         msg = re.escape(
-             f'Custom module: {custom_module!r} cannot get source'
+             f'Cannot get source from {custom_module!r}'
         )
         with self.assertRaisesRegex(TypeError, msg) as e:
             inspect.getfile(custom_module)

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -812,13 +812,10 @@ class TestRetrievingSourceCode(GetSourceBase):
         self.assertStartsWith(str(e.exception), '<module')
 
     def test_getfile_custom_module(self):
-        import re
-        custom_module = types.ModuleType('custom_module')
-        msg = re.escape(
-             f'Cannot get source from {custom_module!r}'
-        )
+        my_mod = types.ModuleType('my_mod')
+        msg = re.escape(f'cannot get source from {my_mod!r}')
         with self.assertRaisesRegex(TypeError, msg) as e:
-            inspect.getfile(custom_module)
+            inspect.getfile(my_mod)
 
     def test_getfile_builtin_class(self):
         with self.assertRaises(TypeError) as e:

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -811,6 +811,13 @@ class TestRetrievingSourceCode(GetSourceBase):
             inspect.getfile(sys)
         self.assertStartsWith(str(e.exception), '<module')
 
+    def test_getfile_custom_module(self):
+        import types
+        custom_module = types.ModuleType('custom_module')
+        with self.assertRaises(TypeError) as e:
+            inspect.getfile(custom_module)
+        self.assertStartsWith(str(e.exception), 'Custom module')
+
     def test_getfile_builtin_class(self):
         with self.assertRaises(TypeError) as e:
             inspect.getfile(int)

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -812,11 +812,13 @@ class TestRetrievingSourceCode(GetSourceBase):
         self.assertStartsWith(str(e.exception), '<module')
 
     def test_getfile_custom_module(self):
-        import types
+        import re
         custom_module = types.ModuleType('custom_module')
-        with self.assertRaises(TypeError) as e:
+        msg = re.escape(
+             f'Custom module: {custom_module!r} cannot get source'
+        )
+        with self.assertRaisesRegex(TypeError, msg) as e:
             inspect.getfile(custom_module)
-        self.assertStartsWith(str(e.exception), 'Custom module')
 
     def test_getfile_builtin_class(self):
         with self.assertRaises(TypeError) as e:

--- a/Misc/NEWS.d/next/Library/2025-09-05-23-18-51.gh-issue-138542.hQ9Q04.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-05-23-18-51.gh-issue-138542.hQ9Q04.rst
@@ -1,1 +1,1 @@
-the error message when when inspect getfile a custom module
+Fix :func:`inspect.getfile` error message for custom module objects.

--- a/Misc/NEWS.d/next/Library/2025-09-05-23-18-51.gh-issue-138542.hQ9Q04.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-05-23-18-51.gh-issue-138542.hQ9Q04.rst
@@ -1,0 +1,1 @@
+the error message when when inspect getfile a custom module


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

as diff and issues

for build-in module there's a  `object.__spec__`
this patch make the error message better.


<!-- gh-issue-number: gh-138542 -->
* Issue: gh-138542
<!-- /gh-issue-number -->
