### PR TITLE
gh-137210: Move PYTHON_API_VERSION & PYTHON_ABI_VERSION to patchlevel.h

### DIFF
--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -56,58 +56,6 @@ PyAPI_FUNC(int) PyModule_ExecDef(PyObject *module, PyModuleDef *def);
 
 #define Py_CLEANUP_SUPPORTED 0x20000
 
-#define PYTHON_API_VERSION 1013
-#define PYTHON_API_STRING "1013"
-/* The API version is maintained (independently from the Python version)
-   so we can detect mismatches between the interpreter and dynamically
-   loaded modules.  These are diagnosed by an error message but
-   the module is still loaded (because the mismatch can only be tested
-   after loading the module).  The error message is intended to
-   explain the core dump a few seconds later.
-
-   The symbol PYTHON_API_STRING defines the same value as a string
-   literal.  *** PLEASE MAKE SURE THE DEFINITIONS MATCH. ***
-
-   Please add a line or two to the top of this log for each API
-   version change:
-
-   22-Feb-2006  MvL     1013    PEP 353 - long indices for sequence lengths
-
-   19-Aug-2002  GvR     1012    Changes to string object struct for
-                                interning changes, saving 3 bytes.
-
-   17-Jul-2001  GvR     1011    Descr-branch, just to be on the safe side
-
-   25-Jan-2001  FLD     1010    Parameters added to PyCode_New() and
-                                PyFrame_New(); Python 2.1a2
-
-   14-Mar-2000  GvR     1009    Unicode API added
-
-   3-Jan-1999   GvR     1007    Decided to change back!  (Don't reuse 1008!)
-
-   3-Dec-1998   GvR     1008    Python 1.5.2b1
-
-   18-Jan-1997  GvR     1007    string interning and other speedups
-
-   11-Oct-1996  GvR     renamed Py_Ellipses to Py_Ellipsis :-(
-
-   30-Jul-1996  GvR     Slice and ellipses syntax added
-
-   23-Jul-1996  GvR     For 1.4 -- better safe than sorry this time :-)
-
-   7-Nov-1995   GvR     Keyword arguments (should've been done at 1.3 :-( )
-
-   10-Jan-1995  GvR     Renamed globals to new naming scheme
-
-   9-Jan-1995   GvR     Initial version (incompatible with older API)
-*/
-
-/* The PYTHON_ABI_VERSION is introduced in PEP 384. For the lifetime of
-   Python 3, it will stay at the value of 3; changes to the limited API
-   must be performed in a strictly backwards-compatible manner. */
-#define PYTHON_ABI_VERSION 3
-#define PYTHON_ABI_STRING "3"
-
 PyAPI_FUNC(PyObject *) PyModule_Create2(PyModuleDef*, int apiver);
 
 #ifdef Py_LIMITED_API
@@ -135,7 +83,7 @@ PyAPI_FUNC(PyObject *) PyModule_FromDefAndSpec2(PyModuleDef *def,
 #endif /* New in 3.5 */
 
 /* ABI info & checking (new in 3.15) */
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030f0000
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= _Py_PACK_VERSION(3, 15)
 typedef struct PyABIInfo {
     uint8_t abiinfo_major_version;
     uint8_t abiinfo_minor_version;

--- a/Include/patchlevel.h
+++ b/Include/patchlevel.h
@@ -6,6 +6,9 @@
    configure.ac must also be changed.
 
    There is also (independent) API version information in modsupport.h.
+
+   This header should self-contained; PC/python_ver_rc.h includes it
+   without the rest of Python.h.
 */
 
 /* Values for PY_RELEASE_LEVEL */
@@ -45,5 +48,17 @@
     PY_RELEASE_SERIAL)
 
 // Public Py_PACK_VERSION is declared in pymacro.h; it needs <inttypes.h>.
+
+
+/* The API and ABI versions are left for backwards compatibility.
+   They've not been updated since 2006 and 2010, respectively.
+   API/ABI versioning is now tied to the CPython version.
+   The *_VERSION and *_STRING symbols should define the same value; as
+   number and string literal respectively. Make sure the definitions match.
+*/
+#define PYTHON_API_VERSION 1013
+#define PYTHON_API_STRING "1013"
+#define PYTHON_ABI_VERSION 3
+#define PYTHON_ABI_STRING "3"
 
 #endif //_Py_PATCHLEVEL_H

--- a/PC/python_ver_rc.h
+++ b/PC/python_ver_rc.h
@@ -8,7 +8,6 @@
 #define PYTHON_COPYRIGHT "Copyright \xA9 2001 Python Software Foundation. Copyright \xA9 2000 BeOpen.com. Copyright \xA9 1995-2001 CNRI. Copyright \xA9 1991-1995 SMC."
 
 #define MS_WINDOWS
-#include "modsupport.h"
 #include "patchlevel.h"
 #ifdef Py_DEBUG
 #   define PYTHON_DEBUG_EXT "_d"


### PR DESCRIPTION
This allows removing #include "modsupport.h" from python_ver_rc.h, which allows modsupport.h to use common helpers from Python.h -- specifically, `_Py_PACK_VERSION` for defining limited API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-137210 -->
* Issue: gh-137210
<!-- /gh-issue-number -->
