### PR TITLE
gh-83765: indicate the maximum amount of memory on macOS

### DIFF
--- a/Doc/library/multiprocessing.shared_memory.rst
+++ b/Doc/library/multiprocessing.shared_memory.rst
@@ -69,7 +69,9 @@ copying of data.
       memory block may be larger or equal to the size requested.
       When attaching to an existing shared memory block,
       the *size* parameter is ignored.
-      On macOS, the maximum size of a shared memory block is 127 TiB (140,256,418,463,744 bytes).
+      On macOS, the theoretical addressable memory space for a 64-bit architecture
+      is limited to 128 TiB (:math:`128 \times 2^{40}` bytes). This amount
+      limits the maximum size of a shared memory block.
 
    :param bool track:
       When ``True``, register the shared memory block with a resource

--- a/Doc/library/multiprocessing.shared_memory.rst
+++ b/Doc/library/multiprocessing.shared_memory.rst
@@ -69,7 +69,7 @@ copying of data.
       memory block may be larger or equal to the size requested.
       When attaching to an existing shared memory block,
       the *size* parameter is ignored.
-      On macOS, the maximum size of a shared memory block is 140256418463744 bytes.
+      On macOS, the maximum size of a shared memory block is 127 TiB (140,256,418,463,744 bytes).
 
    :param bool track:
       When ``True``, register the shared memory block with a resource

--- a/Doc/library/multiprocessing.shared_memory.rst
+++ b/Doc/library/multiprocessing.shared_memory.rst
@@ -69,6 +69,7 @@ copying of data.
       memory block may be larger or equal to the size requested.
       When attaching to an existing shared memory block,
       the *size* parameter is ignored.
+      On macOS, the maximum size of a shared memory block is 140256418463744 bytes.
 
    :param bool track:
       When ``True``, register the shared memory block with a resource


### PR DESCRIPTION
Fixed following the suggestion https://github.com/python/cpython/issues/83765#issuecomment-1093856620


<!-- gh-issue-number: gh-83765 -->
* Issue: gh-83765
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138552.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->