### PR TITLE
gh-105487: Fix `__dir__` entries of `GenericAlias`

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -402,7 +402,10 @@ class BaseTest(unittest.TestCase):
         aliases = [
             GenericAlias(list, T),
             GenericAlias(deque, T),
-            GenericAlias(X, T)
+            GenericAlias(X, T),
+            X[T],
+            list[T],
+            deque[T],
         ] + _UNPACKED_TUPLES
         for alias in aliases:
             with self.subTest(alias=alias):
@@ -432,10 +435,26 @@ class BaseTest(unittest.TestCase):
         self.assertEqual(a.__parameters__, (T,))
 
     def test_dir(self):
-        dir_of_gen_alias = set(dir(list[int]))
+        ga = list[int]
+        dir_of_gen_alias = set(dir(ga))
         self.assertTrue(dir_of_gen_alias.issuperset(dir(list)))
-        for generic_alias_property in ("__origin__", "__args__", "__parameters__"):
-            self.assertIn(generic_alias_property, dir_of_gen_alias)
+        for generic_alias_property in (
+            "__origin__", "__args__", "__parameters__",
+            "__unpacked__",
+        ):
+            with self.subTest(generic_alias_property=generic_alias_property):
+                self.assertIn(generic_alias_property, dir_of_gen_alias)
+        for blocked in (
+            "__bases__",
+            "__copy__",
+            "__deepcopy__",
+        ):
+            with self.subTest(blocked=blocked):
+                self.assertNotIn(blocked, dir_of_gen_alias)
+
+        for entry in dir_of_gen_alias:
+            with self.subTest(entry=entry):
+                getattr(ga, entry)  # must not raise `AttributeError`
 
     def test_weakref(self):
         for t in self.generic_types:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-06-13-53-33.gh-issue-105487.a43YaY.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-06-13-53-33.gh-issue-105487.a43YaY.rst
@@ -1,1 +1,1 @@
-Fix :meth:`~object.__dir__` entries of :class:`types.GenericAlias`.
+Remove non-existent :meth:`~object.__copy__`, :meth:`~object.__deepcopy__`, and :attr:`~type.__bases__` from the :meth:`~object.__dir__` entries of :class:`types.GenericAlias`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-06-13-53-33.gh-issue-105487.a43YaY.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-06-13-53-33.gh-issue-105487.a43YaY.rst
@@ -1,0 +1,1 @@
+Fix :meth:`~object.__dir__` entries of :class:`types.GenericAlias`.


### PR DESCRIPTION
Basically, there are two use-cases why we used `attr_exceptions`:
1. To block access to `self.__origin__.ATTR`
2. To prefer `self.ATTR` over `self.__origin__.ATTR`

Now we have two arrays for just that.

Before:

```python
>>> dir(list[int])
['__add__', '__args__', '__bases__', '__class__', '__class_getitem__', '__contains__', '__copy__', '__deepcopy__', '__delattr__', '__delitem__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getitem__', '__getstate__', '__gt__', '__hash__', '__iadd__', '__imul__', '__init__', '__init_subclass__', '__iter__', '__le__', '__len__', '__lt__', '__mro_entries__', '__mul__', '__ne__', '__new__', '__origin__', '__parameters__', '__reduce__', '__reduce_ex__', '__repr__', '__reversed__', '__rmul__', '__setattr__', '__setitem__', '__sizeof__', '__str__', '__subclasshook__', '__typing_unpacked_tuple_args__', '__unpacked__', 'append', 'clear', 'copy', 'count', 'extend', 'index', 'insert', 'pop', 'remove', 'reverse', 'sort']
```

After:

```python
>>> dir(list[int])
['__add__', '__args__', '__class__', '__class_getitem__', '__contains__', '__delattr__', '__delitem__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getitem__', '__getstate__', '__gt__', '__hash__', '__iadd__', '__imul__', '__init__', '__init_subclass__', '__iter__', '__le__', '__len__', '__lt__', '__mro_entries__', '__mul__', '__ne__', '__new__', '__origin__', '__parameters__', '__reduce__', '__reduce_ex__', '__repr__', '__reversed__', '__rmul__', '__setattr__', '__setitem__', '__sizeof__', '__str__', '__subclasshook__', '__typing_unpacked_tuple_args__', '__unpacked__', 'append', 'clear', 'copy', 'count', 'extend', 'index', 'insert', 'pop', 'remove', 'reverse', 'sort']
```

`.symmetric_difference` of two:

```python
{'__deepcopy__', '__bases__', '__copy__'}
```

Reasoning:

```python
>>> list[int].__copy__
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    list[int].__copy__
AttributeError: 'types.GenericAlias' object has no attribute '__copy__'. Did you mean: '__doc__'?
>>> list[int].__deepcopy__
Traceback (most recent call last):
  File "<python-input-4>", line 1, in <module>
    list[int].__deepcopy__
AttributeError: 'types.GenericAlias' object has no attribute '__deepcopy__'
>>> list[int].__bases__
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    list[int].__bases__
AttributeError: 'types.GenericAlias' object has no attribute '__bases__'. Did you mean: '__args__'?
```

<!-- gh-issue-number: gh-105487 -->
* Issue: gh-105487
<!-- /gh-issue-number -->
