### PR TITLE
gh-116946: add `Py_TPFLAGS_IMMUTABLETYPE` to several internal types

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-09-06-14-47-23.gh-issue-116946.hj_u1t.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-06-14-47-23.gh-issue-116946.hj_u1t.rst
@@ -1,0 +1,5 @@
+:mod:`tkinter`: the types :class:`!_tkinter.Tcl_Obj` (wrapper for Tcl objects),
+:class:`!_tkinter.tktimertoken` (obtained by calling ``createtimerhandler()``
+on a :attr:`Tk <tkinter.Tk.tk>` application) and :class:`!_tkinter.tkapp`
+(the runtime type of Tk applications) are now immutable.
+Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-09-06-14-53-19.gh-issue-116946.c-npxd.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-06-14-53-19.gh-issue-116946.c-npxd.rst
@@ -1,0 +1,2 @@
+:mod:`os`: the :class:`os.DirEntry` type and the type of :func:`os.scandir`
+are now immutable. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-09-06-14-54-01.gh-issue-116946.hzQEWI.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-06-14-54-01.gh-issue-116946.hzQEWI.rst
@@ -1,0 +1,3 @@
+:mod:`zlib`: the types of :func:`zlib.compressobj`
+and :func:`zlib.decompressobj` are now immutable.
+Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-09-06-14-56-40.gh-issue-116946.GGIeyO.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-06-14-56-40.gh-issue-116946.GGIeyO.rst
@@ -1,0 +1,2 @@
+:mod:`curses.panel`: the type of :func:`curses.panel.new_panel` is now
+immutable. Patch by Bénédikt Tran.

--- a/Modules/_curses_panel.c
+++ b/Modules/_curses_panel.c
@@ -684,6 +684,7 @@ static PyType_Spec PyCursesPanel_Type_spec = {
     .flags = (
         Py_TPFLAGS_DEFAULT
         | Py_TPFLAGS_DISALLOW_INSTANTIATION
+        | Py_TPFLAGS_IMMUTABLETYPE
         | Py_TPFLAGS_HAVE_GC
     ),
     .slots = PyCursesPanel_Type_slots

--- a/Modules/_remote_debugging_module.c
+++ b/Modules/_remote_debugging_module.c
@@ -2994,7 +2994,10 @@ static PyType_Slot RemoteUnwinder_slots[] = {
 static PyType_Spec RemoteUnwinder_spec = {
     .name = "_remote_debugging.RemoteUnwinder",
     .basicsize = sizeof(RemoteUnwinderObject),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = (
+        Py_TPFLAGS_DEFAULT
+        | Py_TPFLAGS_IMMUTABLETYPE
+    ),
     .slots = RemoteUnwinder_slots,
 };
 

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -3270,11 +3270,14 @@ static PyType_Slot Tktt_Type_slots[] = {
 };
 
 static PyType_Spec Tktt_Type_spec = {
-    "_tkinter.tktimertoken",
-    sizeof(TkttObject),
-    0,
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
-    Tktt_Type_slots,
+    .name = "_tkinter.tktimertoken",
+    .basicsize = sizeof(TkttObject),
+    .flags = (
+        Py_TPFLAGS_DEFAULT
+        | Py_TPFLAGS_DISALLOW_INSTANTIATION
+        | Py_TPFLAGS_IMMUTABLETYPE
+    ),
+    .slots = Tktt_Type_slots,
 };
 
 

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -906,11 +906,14 @@ static PyType_Slot PyTclObject_Type_slots[] = {
 };
 
 static PyType_Spec PyTclObject_Type_spec = {
-    "_tkinter.Tcl_Obj",
-    sizeof(PyTclObject),
-    0,
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
-    PyTclObject_Type_slots,
+    .name = "_tkinter.Tcl_Obj",
+    .basicsize = sizeof(PyTclObject),
+    .flags = (
+        Py_TPFLAGS_DEFAULT
+        | Py_TPFLAGS_DISALLOW_INSTANTIATION
+        | Py_TPFLAGS_IMMUTABLETYPE
+    ),
+    .slots = PyTclObject_Type_slots,
 };
 
 

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -3326,11 +3326,14 @@ static PyType_Slot Tkapp_Type_slots[] = {
 
 
 static PyType_Spec Tkapp_Type_spec = {
-    "_tkinter.tkapp",
-    sizeof(TkappObject),
-    0,
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
-    Tkapp_Type_slots,
+    .name = "_tkinter.tkapp",
+    .basicsize = sizeof(TkappObject),
+    .flags = (
+        Py_TPFLAGS_DEFAULT
+        | Py_TPFLAGS_DISALLOW_INSTANTIATION
+        | Py_TPFLAGS_IMMUTABLETYPE
+    ),
+    .slots = Tkapp_Type_slots,
 };
 
 static PyMethodDef moduleMethods[] =

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -16035,11 +16035,14 @@ static PyType_Slot DirEntryType_slots[] = {
 };
 
 static PyType_Spec DirEntryType_spec = {
-    MODNAME ".DirEntry",
-    sizeof(DirEntry),
-    0,
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
-    DirEntryType_slots
+    .name = MODNAME ".DirEntry",
+    .basicsize = sizeof(DirEntry),
+    .flags = (
+        Py_TPFLAGS_DEFAULT
+        | Py_TPFLAGS_DISALLOW_INSTANTIATION
+        | Py_TPFLAGS_IMMUTABLETYPE
+    ),
+    .slots = DirEntryType_slots
 };
 
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -16477,14 +16477,17 @@ static PyType_Slot ScandirIteratorType_slots[] = {
 };
 
 static PyType_Spec ScandirIteratorType_spec = {
-    MODNAME ".ScandirIterator",
-    sizeof(ScandirIterator),
-    0,
+    .name = MODNAME ".ScandirIterator",
+    .basicsize = sizeof(ScandirIterator),
     // bpo-40549: Py_TPFLAGS_BASETYPE should not be used, since
     // PyType_GetModule(Py_TYPE(self)) doesn't work on a subclass instance.
-    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_FINALIZE
-        | Py_TPFLAGS_DISALLOW_INSTANTIATION),
-    ScandirIteratorType_slots
+    .flags = (
+        Py_TPFLAGS_DEFAULT
+        | Py_TPFLAGS_HAVE_FINALIZE
+        | Py_TPFLAGS_DISALLOW_INSTANTIATION
+        | Py_TPFLAGS_IMMUTABLETYPE
+    ),
+    .slots = ScandirIteratorType_slots
 };
 
 /*[clinic input]

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -2063,6 +2063,7 @@ static PyType_Spec Decomptype_spec = {
     .flags = (
         Py_TPFLAGS_DEFAULT
         | Py_TPFLAGS_DISALLOW_INSTANTIATION
+        | Py_TPFLAGS_IMMUTABLETYPE
         | Py_TPFLAGS_HAVE_GC
     ),
     .slots = Decomptype_slots,

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -2043,6 +2043,7 @@ static PyType_Spec Comptype_spec = {
     .flags = (
         Py_TPFLAGS_DEFAULT
         | Py_TPFLAGS_DISALLOW_INSTANTIATION
+        | Py_TPFLAGS_IMMUTABLETYPE
         | Py_TPFLAGS_HAVE_GC
     ),
     .slots= Comptype_slots,


### PR DESCRIPTION
This only adds the `Py_TPFLAGS_IMMUTABLETYPE` flag and assumes that other GC-related issues are solved (not all types are actually empty). I've added NEWS entries just because we also mention transforming extension modules from single-phase to multi-phase. It doesn't hurt mentioning this if a type can be observed with `obj = public_func(); print(type(obj))`.

@serhiy-storchaka Can I split the PR for immutable types into those that are in `_test*api` and `xxlimited*` with those that are used in release builds? There is just one type `_interpreters.CrossInterpreterBufferView` that I'm unsure of.

@pablogsal Am I correct to assume that `_remote_debugging.RemoteUnwinder` should be immutable and is really internal? It's only "publicly" accessible through `profiling.sampling.SampleProfiler.unwinder` but I don't know if it's meant to be used externally.

<!-- gh-issue-number: gh-116946 -->
* Issue: gh-116946
<!-- /gh-issue-number -->
