### PR TITLE
gh-138584: Fix missing type2test in Lib/tests/list_tests.py

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1633,12 +1633,12 @@ and are also passed to registered trace functions.
 
 .. index::
    single: f_back (frame attribute)
-   single: f_generator (frame attribute)
    single: f_code (frame attribute)
    single: f_globals (frame attribute)
    single: f_locals (frame attribute)
    single: f_lasti (frame attribute)
    single: f_builtins (frame attribute)
+   single: f_generator (frame attribute)
 
 Special read-only attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1648,10 +1648,6 @@ Special read-only attributes
    * - .. attribute:: frame.f_back
      - Points to the previous stack frame (towards the caller),
        or ``None`` if this is the bottom stack frame
-
-   * - .. attribute:: frame.f_generator
-     - Returns the generator or coroutine object that owns this frame,
-       or ``None`` if the frame is of a regular function.
 
    * - .. attribute:: frame.f_code
      - The :ref:`code object <code-objects>` being executed in this frame.
@@ -1679,6 +1675,10 @@ Special read-only attributes
      - The "precise instruction" of the frame object
        (this is an index into the :term:`bytecode` string of the
        :ref:`code object <code-objects>`)
+   
+   * - .. attribute:: frame.f_generator
+     - Returns the generator or coroutine object that owns this frame,
+       or ``None`` if the frame is of a regular function.
 
 .. index::
    single: f_trace (frame attribute)

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1633,6 +1633,7 @@ and are also passed to registered trace functions.
 
 .. index::
    single: f_back (frame attribute)
+   single: f_generator (frame attribute)
    single: f_code (frame attribute)
    single: f_globals (frame attribute)
    single: f_locals (frame attribute)
@@ -1647,6 +1648,10 @@ Special read-only attributes
    * - .. attribute:: frame.f_back
      - Points to the previous stack frame (towards the caller),
        or ``None`` if this is the bottom stack frame
+
+   * - .. attribute:: frame.f_generator
+     - Returns the generator or coroutine object that owns this frame,
+       or ``None`` if the frame is of a regular function.
 
    * - .. attribute:: frame.f_code
      - The :ref:`code object <code-objects>` being executed in this frame.

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -32,13 +32,13 @@ class CommonTest(seq_tests.CommonTest):
         self.assertEqual(a, b)
 
     def test_getitem_error(self):
-        a = []
+        a = self.type2test([])
         msg = "list indices must be integers or slices"
         with self.assertRaisesRegex(TypeError, msg):
             a['a']
 
     def test_setitem_error(self):
-        a = []
+        a = self.type2test([])
         msg = "list indices must be integers or slices"
         with self.assertRaisesRegex(TypeError, msg):
             a['a'] = "python"
@@ -561,7 +561,7 @@ class CommonTest(seq_tests.CommonTest):
         class F(object):
             def __iter__(self):
                 raise KeyboardInterrupt
-        self.assertRaises(KeyboardInterrupt, list, F())
+        self.assertRaises(KeyboardInterrupt, self.type2test, F())
 
     def test_exhausted_iterator(self):
         a = self.type2test([1, 2, 3])


### PR DESCRIPTION
This PR updates three tests in Lib/test/list_tests.py (CommonTest) to consistently use self.type2test instead of directly constructing a list (or []).

test_getitem_error

test_setitem_error

test_constructor_exception_handling

Previously, these tests only applied to the builtin list, and skipped other list-like classes (such as collections.UserList) that reuse CommonTest.

By switching to self.type2test, the tests now correctly apply to all list-like types under test, ensuring consistency across the test suite.

fixes #138584 

<!-- gh-issue-number: gh-138584 -->
* Issue: gh-138584
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138586.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->