### PR TITLE
gh-138584: Fix missing type2test in Lib/tests/list_tests.py 

### DIFF
--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -32,13 +32,13 @@ class CommonTest(seq_tests.CommonTest):
         self.assertEqual(a, b)
 
     def test_getitem_error(self):
-        a = []
+        a = self.type2test([])
         msg = "list indices must be integers or slices"
         with self.assertRaisesRegex(TypeError, msg):
             a['a']
 
     def test_setitem_error(self):
-        a = []
+        a = self.type2test([])
         msg = "list indices must be integers or slices"
         with self.assertRaisesRegex(TypeError, msg):
             a['a'] = "python"
@@ -561,7 +561,7 @@ class CommonTest(seq_tests.CommonTest):
         class F(object):
             def __iter__(self):
                 raise KeyboardInterrupt
-        self.assertRaises(KeyboardInterrupt, list, F())
+        self.assertRaises(KeyboardInterrupt, self.type2test, F())
 
     def test_exhausted_iterator(self):
         a = self.type2test([1, 2, 3])

--- a/Misc/NEWS.d/next/Tests/2025-09-06-21-50-00.gh-issue-138584.XyZ9Ab.rst
+++ b/Misc/NEWS.d/next/Tests/2025-09-06-21-50-00.gh-issue-138584.XyZ9Ab.rst
@@ -1,0 +1,1 @@
+gh-138584: Fixed list_tests.CommonTest to use type2test in test_getitem_error, test_setitem_error, and test_constructor_exception_handling in Lib/tests/list_tests.py.

--- a/Misc/NEWS.d/next/Tests/2025-09-06-21-50-00.gh-issue-138584.XyZ9Ab.rst
+++ b/Misc/NEWS.d/next/Tests/2025-09-06-21-50-00.gh-issue-138584.XyZ9Ab.rst
@@ -1,1 +1,0 @@
-gh-138584: Fixed list_tests.CommonTest to use type2test in test_getitem_error, test_setitem_error, and test_constructor_exception_handling in Lib/tests/list_tests.py.


### PR DESCRIPTION
This PR updates three tests in Lib/test/list_tests.py (CommonTest) to consistently use self.type2test instead of directly constructing a list (or []).

test_getitem_error

test_setitem_error

test_constructor_exception_handling

Previously, these tests only applied to the builtin list, and skipped other list-like classes (such as collections.UserList) that reuse CommonTest.

By switching to self.type2test, the tests now correctly apply to all list-like types under test, ensuring consistency across the test suite.

fixes #138584 

<!-- gh-issue-number: gh-138584 -->
* Issue: gh-138584
<!-- /gh-issue-number -->
