### PR TITLE
gh-90548: Skip ctypes test_null_dlsym when linked to musl

### DIFF
--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -32,6 +32,7 @@ void *foo(void)
 
 @unittest.skipUnless(sys.platform.startswith('linux'),
                      'test requires GNU IFUNC support')
+@unittest.skipIf(test.support.linked_to_musl(), "Requires glibc")
 class TestNullDlsym(unittest.TestCase):
     """GH-126554: Ensure that we catch NULL dlsym return values
 


### PR DESCRIPTION
The test relies on glibc-specific behavior.


<!-- gh-issue-number: gh-90548 -->
* Issue: gh-90548
<!-- /gh-issue-number -->
