### PR TITLE
gh-62814: Support ``U+XXXX`` notation in ``\N{...}`` and ``unicodedata.lookup``

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -273,6 +273,14 @@ Other language changes
   This speeds up class creation, and helps avoid reference cycles.
   (Contributed by Petr Viktorin in :gh:`135228`.)
 
+* Added support for Unicode ``U+XXXX`` notation in :func:`unicodedata.lookup`
+  and ``'\N{...}'``. For example::
+
+    >>> "\N{U+03BB}"
+    'λ'
+
+  (Contributed by Stan Ulbrych in :gh:`62814`.)
+
 
 New modules
 ===========

--- a/Include/internal/pycore_ucnhash.h
+++ b/Include/internal/pycore_ucnhash.h
@@ -26,6 +26,9 @@ typedef struct {
     int (*getcode)(const char* name, int namelen, Py_UCS4* code,
                    int with_named_seq);
 
+    /* Parse Unicode notation */
+    int (*parse_u_plus)(const char* name, int namelen, Py_UCS4* code);
+
 } _PyUnicode_Name_CAPI;
 
 extern _PyUnicode_Name_CAPI* _PyUnicode_GetNameCAPI(void);

--- a/Lib/test/test_ucn.py
+++ b/Lib/test/test_ucn.py
@@ -200,11 +200,20 @@ class UnicodeNamesTest(unittest.TestCase):
                 with self.assertRaises(KeyError):
                     unicodedata.ucd_3_2_0.lookup(seqname)
 
+    def test_u_plus_notation(self):
+        self.assertEqual(unicodedata.lookup("U+0041"), "A")
+        self.assertEqual(unicodedata.lookup("U+00410"), "А")  # Cyrillic capital A
+        self.assertEqual(unicodedata.lookup("U+004100"), "䄀")
+        self.assertEqual(unicodedata.lookup("U+03BB"), "λ")
+
     def test_errors(self):
         self.assertRaises(TypeError, unicodedata.name)
         self.assertRaises(TypeError, unicodedata.name, 'xx')
         self.assertRaises(TypeError, unicodedata.lookup)
         self.assertRaises(KeyError, unicodedata.lookup, 'unknown')
+        self.assertRaises(ValueError, unicodedata.lookup, 'U+00')
+        self.assertRaises(ValueError, unicodedata.lookup, 'U+0000000')
+        self.assertRaises(ValueError, unicodedata.lookup, 'U+000Z')
 
     def test_strict_error_handling(self):
         # bogus character name

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-06-20-31-48.gh-issue-62814.PdwlEc.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-06-20-31-48.gh-issue-62814.PdwlEc.rst
@@ -1,0 +1,1 @@
+``\N{}`` now supports ``U+XXXX`` notation.

--- a/Misc/NEWS.d/next/Library/2025-09-06-20-31-05.gh-issue-62814.Nt6o-t.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-06-20-31-05.gh-issue-62814.Nt6o-t.rst
@@ -1,0 +1,1 @@
+:func:`unicodedata.lookup` now supports ``U+XXXXXX`` notation.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -6783,9 +6783,21 @@ _PyUnicode_DecodeUnicodeEscapeInternal2(const char *s,
                     /* found a name.  look it up in the unicode database */
                     s++;
                     ch = 0xffffffff; /* in case 'getcode' messes up */
-                    if (namelen <= INT_MAX &&
-                        ucnhash_capi->getcode(start, (int)namelen,
-                                              &ch, 0)) {
+                    int ok = 0;
+
+                    if (namelen <= INT_MAX) {
+                        if (ucnhash_capi->getcode(start, (int)namelen, &ch, 0)) {
+                            ok = 1;
+                        }
+                        else {
+                            ok = ucnhash_capi->parse_u_plus(start, (int)namelen, &ch);
+                            if (ok == -1) {
+                                goto onError;
+                            }
+                        }
+                    }
+
+                    if (ok) {
                         assert(ch <= MAX_UNICODE);
                         WRITE_CHAR(ch);
                         continue;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Looking to get thoughts on this approach.


<!-- gh-issue-number: gh-62814 -->
* Issue: gh-62814
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138598.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->