### PR TITLE
Fix typo in `random_derangement` recipe

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -666,7 +666,7 @@ or the :pypi:`more-itertools` project:
        "Choose a permutation where no element is in its original position."
        seq = tuple(iterable)
        if len(seq) < 2:
-           raise ValueError('derangments require at least two values')
+           raise ValueError('derangements require at least two values')
        perm = list(seq)
        while True:
            random.shuffle(perm)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

A very minor typo fix for the recently added `random_derangement` recipe.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138599.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->