### PR TITLE
gh-130567: Fix locale.strxfrm() failure on FreeBSD

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-09-07-11-29-49.gh-issue-130567.zZRq0v.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-07-11-29-49.gh-issue-130567.zZRq0v.rst
@@ -1,0 +1,3 @@
+Fix :func:`locale.strxfrm` failure on FreeBSD and DragonFlyBSD for strings
+containing characters 'Å' (U+00C5 LATIN CAPITAL LETTER A WITH RING ABOVE) or
+'Å' (U+212B ANGSTROM SIGN).


### PR DESCRIPTION
Fix locale.strxfrm() failure on FreeBSD and DragonFlyBSD for strings containing characters 'Å' (U+00C5 LATIN CAPITAL LETTER A WITH RING ABOVE) or 'Å' (U+212B ANGSTROM SIGN).


<!-- gh-issue-number: gh-130567 -->
* Issue: gh-130567
<!-- /gh-issue-number -->
