### PR TITLE
[3.13] gh-126631: gh-137996: fix pre-loading of `__main__` (GH-135295)

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6545,6 +6545,18 @@ class MiscTestCase(unittest.TestCase):
         self.assertEqual(q.get_nowait(), "done")
         close_queue(q)
 
+    def test_preload_main(self):
+        # gh-126631: Check that __main__ can be pre-loaded
+        if multiprocessing.get_start_method() != "forkserver":
+            self.skipTest("forkserver specific test")
+
+        name = os.path.join(os.path.dirname(__file__), 'mp_preload_main.py')
+        _, out, err = test.support.script_helper.assert_python_ok(name)
+        self.assertEqual(err, b'')
+
+        # The trailing empty string comes from split() on output ending with \n
+        out = out.decode().split("\n")
+        self.assertEqual(out, ['__main__', '__mp_main__', 'f', 'f', ''])
 
 #
 # Mixins

--- a/Lib/test/mp_preload_main.py
+++ b/Lib/test/mp_preload_main.py
@@ -1,0 +1,14 @@
+import multiprocessing
+
+print(f"{__name__}")
+
+def f():
+    print("f")
+
+if __name__ == "__main__":
+    ctx = multiprocessing.get_context("forkserver")
+    ctx.set_forkserver_preload(['__main__'])
+    for _ in range(2):
+        p = ctx.Process(target=f)
+        p.start()
+        p.join()

--- a/Misc/NEWS.d/next/Library/2025-06-10-21-00-48.gh-issue-126631.eITVJd.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-10-21-00-48.gh-issue-126631.eITVJd.rst
@@ -1,0 +1,2 @@
+Fix :mod:`multiprocessing` ``forkserver`` bug which prevented ``__main__``
+from being preloaded.


### PR DESCRIPTION
gh-126631: gh-137996: fix pre-loading of `__main__`

The `main_path` parameter was renamed `init_main_from_name`, update the forkserver code accordingly.  This was leading to slower startup times when people were trying to preload the main module.

---------
(cherry picked from commit 0912b3a6dbd226bea79eb8d70d5a06230804d4cb)