### PR TITLE
gh-60107: avoid `io.RawIOBase.read` from reading into a temporary bytearray

### DIFF
--- a/Lib/test/test_io/test_general.py
+++ b/Lib/test/test_io/test_general.py
@@ -921,6 +921,49 @@ class IOTest(unittest.TestCase):
         self.assertEqual(rawio.read(2), None)
         self.assertEqual(rawio.read(2), b"")
 
+    def test_exact_RawIOBase(self):
+        rawio = self.MockRawIOWithoutRead((b"ab", b"cd"))
+        buf = bytearray(2)
+        n = rawio.readinto(buf)
+        self.assertEqual(n, 2)
+        self.assertEqual(buf, b"ab")
+
+        n = rawio.readinto(buf)
+        self.assertEqual(n, 2)
+        self.assertEqual(buf, b"cd")
+
+        n = rawio.readinto(buf)
+        self.assertEqual(n, 0)
+        self.assertEqual(buf, b"cd")
+
+    def test_partial_readinto_write_RawIOBase(self):
+        rawio = self.MockRawIOWithoutRead((b"abcdef",))
+        buf = bytearray(3)
+        n = rawio.readinto(buf)
+        self.assertEqual(n, 3)
+        self.assertEqual(buf, b"abc")
+
+        n2 = rawio.readinto(buf)
+        self.assertEqual(n2, 3)
+        self.assertEqual(buf, b"def")
+
+    def test_readinto_none_RawIOBase(self):
+        rawio = self.MockRawIOWithoutRead((None, b"x"))
+        buf = bytearray(2)
+        n = rawio.readinto(buf)
+        self.assertIsNone(n)
+
+        n2 = rawio.readinto(buf)
+        self.assertEqual(n2, 1)
+        self.assertEqual(buf[0], ord('x'))
+
+    def test_read_default_via_readinto_RawIOBase(self):
+        rawio = self.MockRawIOWithoutRead((b"abcdef",))
+        result = rawio.read(4)
+        self.assertEqual(result, b"abcd")
+        result2 = rawio.read(4)
+        self.assertEqual(result2, b"ef")
+
     def test_types_have_dict(self):
         test = (
             self.IOBase(),

--- a/Misc/NEWS.d/next/C_API/2025-09-07-10-52-09.gh-issue-60107.dhcb2Y.rst
+++ b/Misc/NEWS.d/next/C_API/2025-09-07-10-52-09.gh-issue-60107.dhcb2Y.rst
@@ -1,1 +1,2 @@
-* gh-60107: avoid io.RawIOBase.read from reading into a temporary bytearray (author: taskevich)
+Avoid :meth:`io.RawIOBase.read` from reading into a temporary :class:`bytearray`
+when calling its own :meth:`io.RawIOBase.readinto` internally.

--- a/Misc/NEWS.d/next/C_API/2025-09-07-10-52-09.gh-issue-60107.dhcb2Y.rst
+++ b/Misc/NEWS.d/next/C_API/2025-09-07-10-52-09.gh-issue-60107.dhcb2Y.rst
@@ -1,0 +1,1 @@
+Read directly to bytes object

--- a/Misc/NEWS.d/next/C_API/2025-09-07-10-52-09.gh-issue-60107.dhcb2Y.rst
+++ b/Misc/NEWS.d/next/C_API/2025-09-07-10-52-09.gh-issue-60107.dhcb2Y.rst
@@ -1,2 +1,0 @@
-Avoid :meth:`io.RawIOBase.read` from reading into a temporary :class:`bytearray`
-when calling its own :meth:`io.RawIOBase.readinto` internally.

--- a/Misc/NEWS.d/next/C_API/2025-09-07-10-52-09.gh-issue-60107.dhcb2Y.rst
+++ b/Misc/NEWS.d/next/C_API/2025-09-07-10-52-09.gh-issue-60107.dhcb2Y.rst
@@ -1,1 +1,1 @@
-Read directly to bytes object
+* gh-60107: avoid io.RawIOBase.read from reading into a temporary bytearray (author: taskevich)

--- a/Misc/NEWS.d/next/Library/2025-09-07-11-30-53.gh-issue-60107.TFrtr-.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-07-11-30-53.gh-issue-60107.TFrtr-.rst
@@ -1,0 +1,2 @@
+Avoid :meth:`io.RawIOBase.read` from reading into a temporary :class:`bytearray`
+when calling its own :meth:`io.RawIOBase.readinto` internally.

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -921,7 +921,7 @@ static PyObject *
 _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
 /*[clinic end generated code: output=6cdeb731e3c9f13c input=b6d0dcf6417d1374]*/
 {
-    PyObject *b, *res;
+    PyObject *b, *res, *mv;
 
     if (n < 0) {
         return PyObject_CallMethodNoArgs(self, &_Py_ID(readall));
@@ -931,7 +931,7 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
     if (b == NULL)
         return NULL;
 
-    PyObject *mv = PyMemoryView_FromMemory(PyBytes_AS_STRING(b), n, PyBUF_WRITE);
+    mv = PyMemoryView_FromMemory(PyBytes_AS_STRING(b), n, PyBUF_WRITE);
     if (mv == NULL) {
         Py_DECREF(b);
         return NULL;
@@ -952,11 +952,9 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
         return NULL;
     }
 
-    if (n != PyBytes_GET_SIZE(b)) {
-        if (_PyBytes_Resize(&b, n) < 0) {
-            Py_DECREF(b);
-            return NULL;
-        }
+    if (_PyBytes_Resize(&b, n) < 0) {
+        Py_DECREF(b);
+        return NULL;
     }
 
     return b;


### PR DESCRIPTION
implements: [https://github.com/python/cpython/issues/60107](#60107)

<!-- gh-issue-number: gh-60107 -->
* Issue: gh-60107
<!-- /gh-issue-number -->
