### PR TITLE
gh-138294: Fix Misleading error for ((a) := 1)

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -1261,6 +1261,9 @@ invalid_expression:
         RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "t-string: lambda expressions are not allowed without parentheses") }
 
 invalid_named_expression(memo):
+    | '(' a=NAME ')' ':=' expression {
+        RAISE_SYNTAX_ERROR_KNOWN_LOCATION(
+            a, "cannot parenthesize target name in assignment expression") }
     | a=expression ':=' expression {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(
             a, "cannot use assignment expressions with %s", _PyPegen_get_expr_name(a)) }

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2686,6 +2686,13 @@ Invalid expressions in type scopes:
     >>> f(x = 5, *:)
     Traceback (most recent call last):
     SyntaxError: Invalid star expression
+
+Invalid assignment expressions with parenthesized targets:
+
+    >>> ((a) := 1)
+    Traceback (most recent call last):
+       ...
+    SyntaxError: cannot parenthesize target name in assignment expression
 """
 
 import re
@@ -2851,11 +2858,6 @@ class SyntaxErrorTestCase(unittest.TestCase):
         # We don't have a special message for this, but make sure we don't
         # report "cannot delete name"
         self._check_error("del a += b", "invalid syntax")
-
-    def test_parenthesized_named_expression_target(self):
-        self._check_error(
-            "((a) := 1)",
-            "cannot parenthesize target name in assignment expression")
 
     def test_global_param_err_first(self):
         source = """if 1:

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2852,6 +2852,11 @@ class SyntaxErrorTestCase(unittest.TestCase):
         # report "cannot delete name"
         self._check_error("del a += b", "invalid syntax")
 
+    def test_parenthesized_named_expression_target(self):
+        self._check_error(
+            "((a) := 1)",
+            "cannot parenthesize target name in assignment expression")
+
     def test_global_param_err_first(self):
         source = """if 1:
             def error(a):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-08-12-30-00.gh-issue-138294.abcd12.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-08-12-30-00.gh-issue-138294.abcd12.rst
@@ -1,0 +1,1 @@
+Raise SyntaxError when using parentheses around a walrus target.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-08-12-30-00.gh-issue-138294.abcd12.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-08-12-30-00.gh-issue-138294.abcd12.rst
@@ -1,1 +1,1 @@
-Raise SyntaxError when using parentheses around a walrus target.
+Raise an improved :exc:`SyntaxError` when using parentheses around a walrus target.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -21587,6 +21587,7 @@ invalid_expression_rule(Parser *p)
 }
 
 // invalid_named_expression:
+//     | '(' NAME ')' ':=' expression
 //     | expression ':=' expression
 //     | NAME '=' bitwise_or !('=' | ':=')
 //     | !(list | tuple | genexp | 'True' | 'None' | 'False') bitwise_or '=' bitwise_or !('=' | ':=')
@@ -21606,6 +21607,42 @@ invalid_named_expression_rule(Parser *p)
         return _res;
     }
     int _mark = p->mark;
+    { // '(' NAME ')' ':=' expression
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_named_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' NAME ')' ':=' expression"));
+        Token * _literal;
+        Token * _literal_1;
+        Token * _literal_2;
+        expr_ty a;
+        expr_ty expression_var;
+        if (
+            (_literal = _PyPegen_expect_token(p, 7))  // token='('
+            &&
+            (a = _PyPegen_name_token(p))  // NAME
+            &&
+            (_literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
+            &&
+            (_literal_2 = _PyPegen_expect_token(p, 53))  // token=':='
+            &&
+            (expression_var = expression_rule(p))  // expression
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_named_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' NAME ')' ':=' expression"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "cannot parenthesize target name in assignment expression" );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_named_expression[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'(' NAME ')' ':=' expression"));
+    }
     { // expression ':=' expression
         if (p->error_indicator) {
             p->level--;


### PR DESCRIPTION
This PR fixes a corner-case in assignment expressions (walrus operator :=) where using parentheses around a target name incorrectly compiles, e.g., ((x) := 1).


<!-- gh-issue-number: gh-138294 -->
* Issue: gh-138294
<!-- /gh-issue-number -->
