### PR TITLE
gh-138402: Update documentation for LOAD_ATTR and LOAD_GLOBAL

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1259,12 +1259,16 @@ iterations of the loop.
    correct name, the bytecode pushes the unbound method and ``STACK[-1]``.
    ``STACK[-1]`` will be used as the first argument (``self``) by :opcode:`CALL`
    or :opcode:`CALL_KW` when calling the unbound method.
-   Otherwise, ``NULL`` and the object returned by
-   the attribute lookup are pushed.
+   Otherwise, the object returned by the attribute lookup
+   and ``NULL`` are pushed.
 
    .. versionchanged:: 3.12
       If the low bit of ``namei`` is set, then a ``NULL`` or ``self`` is
       pushed to the stack before the attribute or unbound method respectively.
+
+   .. versionchanged:: 3.13
+      ``NULL`` or ``self`` is now pushed to the stack after the attribute
+      or unbound method respectively.
 
 
 .. opcode:: LOAD_SUPER_ATTR (namei)
@@ -1421,6 +1425,9 @@ iterations of the loop.
    .. versionchanged:: 3.11
       If the low bit of ``namei`` is set, then a ``NULL`` is pushed to the
       stack before the global variable.
+
+   .. versionchanged:: 3.13
+      ``NULL`` is now pushed to the stack after the global variable.
 
 .. opcode:: LOAD_FAST (var_num)
 


### PR DESCRIPTION
Specifically that the null is now pushed after the object since 3.13.


The issue has as a recommended solution to use the exact wording of the original changes from 3.11/3.12 but with the "before" replaced with an after. That didnt seem fully aligned to me with how the other change notices look. Especially since i never saw any that had somethingin bold/highlighted which i think would have made it clear what the difference between the changes in 3.13 vs before are. But i can obviously change it to that wording if request.

<!-- gh-issue-number: gh-138402 -->
* Issue: gh-138402
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138631.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->