### PR TITLE
gh-138636: fix flaky tests when `PYTHONWARNINGS` is set

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1647,16 +1647,8 @@ class ProcessTestCase(BaseTestCase):
 class RunFuncTestCase(BaseTestCase):
 
     def setUp(self):
-        # clean the environment from pre-existing PYTHONWARNINGS to make
-        # test_subprocess results consistent
-        self.pythonwarnings = os.environ.get('PYTHONWARNINGS')
-        if self.pythonwarnings:
-            del os.environ['PYTHONWARNINGS']
-
-    def tearDown(self):
-        # bring back pre-existing PYTHONWARNINGS if present
-        if self.pythonwarnings:
-            os.environ['PYTHONWARNINGS'] = self.pythonwarnings
+        env = self.enterContext(os_helper.EnvironmentVarGuard())
+        del env['PYTHONWARNINGS']
 
     def run_python(self, code, **kwargs):
         """Run Python code in a subprocess using subprocess.run"""

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1647,6 +1647,8 @@ class ProcessTestCase(BaseTestCase):
 class RunFuncTestCase(BaseTestCase):
 
     def setUp(self):
+        # clean the environment from pre-existing PYTHONWARNINGS to make
+        # test_subprocess results consistent
         env = self.enterContext(os_helper.EnvironmentVarGuard())
         del env['PYTHONWARNINGS']
 

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1645,6 +1645,19 @@ class ProcessTestCase(BaseTestCase):
 
 
 class RunFuncTestCase(BaseTestCase):
+
+    def setUp(self):
+        # clean the environment from pre-existing PYTHONWARNINGS to make
+        # test_subprocess results consistent
+        self.pythonwarnings = os.environ.get('PYTHONWARNINGS')
+        if self.pythonwarnings:
+            del os.environ['PYTHONWARNINGS']
+
+    def tearDown(self):
+        # bring back pre-existing PYTHONWARNINGS if present
+        if self.pythonwarnings:
+            os.environ['PYTHONWARNINGS'] = self.pythonwarnings
+
     def run_python(self, code, **kwargs):
         """Run Python code in a subprocess using subprocess.run"""
         argv = [sys.executable, "-c", code]

--- a/Lib/test/test_unittest/test_runner.py
+++ b/Lib/test/test_unittest/test_runner.py
@@ -4,6 +4,7 @@ import sys
 import pickle
 import subprocess
 from test import support
+from test.support import os_helper
 
 import unittest
 from unittest.case import _Outcome
@@ -1227,16 +1228,8 @@ class Test_TextTestRunner(unittest.TestCase):
     """Tests for TextTestRunner."""
 
     def setUp(self):
-        # clean the environment from pre-existing PYTHONWARNINGS to make
-        # test_warnings results consistent
-        self.pythonwarnings = os.environ.get('PYTHONWARNINGS')
-        if self.pythonwarnings:
-            del os.environ['PYTHONWARNINGS']
-
-    def tearDown(self):
-        # bring back pre-existing PYTHONWARNINGS if present
-        if self.pythonwarnings:
-            os.environ['PYTHONWARNINGS'] = self.pythonwarnings
+        env = self.enterContext(os_helper.EnvironmentVarGuard())
+        del env['PYTHONWARNINGS']
 
     def test_init(self):
         runner = unittest.TextTestRunner()

--- a/Lib/test/test_unittest/test_runner.py
+++ b/Lib/test/test_unittest/test_runner.py
@@ -1228,6 +1228,8 @@ class Test_TextTestRunner(unittest.TestCase):
     """Tests for TextTestRunner."""
 
     def setUp(self):
+        # clean the environment from pre-existing PYTHONWARNINGS to make
+        # test_warnings results consistent
         env = self.enterContext(os_helper.EnvironmentVarGuard())
         del env['PYTHONWARNINGS']
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

like the code in test_runner.py to aviod the flaky test

--- seems no need for a news

```py
class Test_TextTestRunner(unittest.TestCase):
    """Tests for TextTestRunner."""

    def setUp(self):
        # clean the environment from pre-existing PYTHONWARNINGS to make
        # test_warnings results consistent
        self.pythonwarnings = os.environ.get('PYTHONWARNINGS')
        if self.pythonwarnings:
            del os.environ['PYTHONWARNINGS']

    def tearDown(self):
        # bring back pre-existing PYTHONWARNINGS if present
        if self.pythonwarnings:
            os.environ['PYTHONWARNINGS'] = self.pythonwarnings

```


<!-- gh-issue-number: gh-138636 -->
* Issue: gh-138636
<!-- /gh-issue-number -->
