### PR TITLE
gh-138633: synchronize documented signatures of SSL objects with runtime ones

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -125,7 +125,8 @@ Context creation
 A convenience function helps create :class:`SSLContext` objects for common
 purposes.
 
-.. function:: create_default_context(purpose=Purpose.SERVER_AUTH, cafile=None, capath=None, cadata=None)
+.. function:: create_default_context(purpose=Purpose.SERVER_AUTH, *,\
+                                     cafile=None, capath=None, cadata=None)
 
    Return a new :class:`SSLContext` object with default settings for
    the given *purpose*.  The settings are chosen by the :mod:`ssl` module,
@@ -333,7 +334,7 @@ Exceptions
 Random generation
 ^^^^^^^^^^^^^^^^^
 
-.. function:: RAND_bytes(num)
+.. function:: RAND_bytes(num, /)
 
    Return *num* cryptographically strong pseudo-random bytes. Raises an
    :class:`SSLError` if the PRNG has not been seeded with enough data or if the
@@ -357,7 +358,7 @@ Random generation
    :func:`ssl.RAND_egd` and :func:`ssl.RAND_add` to increase the randomness of
    the pseudo-random number generator.
 
-.. function:: RAND_add(bytes, entropy)
+.. function:: RAND_add(bytes, entropy, /)
 
    Mix the given *bytes* into the SSL pseudo-random number generator.  The
    parameter *entropy* (a float) is a lower bound on the entropy contained in
@@ -425,12 +426,12 @@ Certificate handling
    .. versionchanged:: 3.10
       The *timeout* parameter was added.
 
-.. function:: DER_cert_to_PEM_cert(DER_cert_bytes)
+.. function:: DER_cert_to_PEM_cert(der_cert_bytes)
 
    Given a certificate as a DER-encoded blob of bytes, returns a PEM-encoded
    string version of the same certificate.
 
-.. function:: PEM_cert_to_DER_cert(PEM_cert_string)
+.. function:: PEM_cert_to_DER_cert(pem_cert_string)
 
    Given a certificate as an ASCII PEM string, returns a DER-encoded sequence of
    bytes for that same certificate.
@@ -1160,10 +1161,10 @@ SSL sockets also have the following additional methods and attributes:
    .. deprecated:: 3.6
       Use :meth:`~SSLSocket.recv` instead of :meth:`~SSLSocket.read`.
 
-.. method:: SSLSocket.write(buf)
+.. method:: SSLSocket.write(data)
 
-   Write *buf* to the SSL socket and return the number of bytes written. The
-   *buf* argument must be an object supporting the buffer interface.
+   Write *data* to the SSL socket and return the number of bytes written. The
+   *data* argument must be an object supporting the buffer interface.
 
    Raise :exc:`SSLWantReadError` or :exc:`SSLWantWriteError` if the socket is
    :ref:`non-blocking <ssl-nonblocking>` and the write would block.
@@ -1173,7 +1174,7 @@ SSL sockets also have the following additional methods and attributes:
 
    .. versionchanged:: 3.5
       The socket timeout is no longer reset each time bytes are received or sent.
-      The socket timeout is now the maximum total duration to write *buf*.
+      The socket timeout is now the maximum total duration to write *data*.
 
    .. deprecated:: 3.6
       Use :meth:`~SSLSocket.send` instead of :meth:`~SSLSocket.write`.
@@ -1190,9 +1191,12 @@ SSL sockets also have the following additional methods and attributes:
    :meth:`~socket.socket.recv` and :meth:`~socket.socket.send` instead of these
    methods.
 
-.. method:: SSLSocket.do_handshake()
+.. method:: SSLSocket.do_handshake(block=False)
 
    Perform the SSL setup handshake.
+
+   If *block* is true and the timeout obtained by :meth:`~socket.gettimeout`
+   is zero, the socket is set in blocking mode until the handshake is performed.
 
    .. versionchanged:: 3.4
       The handshake method also performs :func:`match_hostname` when the
@@ -1717,7 +1721,7 @@ to speed up repeated connections from the same clients.
    provided as part of the operating system, though, it is likely to be
    configured properly.
 
-.. method:: SSLContext.set_ciphers(ciphers)
+.. method:: SSLContext.set_ciphers(ciphers, /)
 
    Set the allowed ciphers for sockets created with this context when
    connecting using TLS 1.2 and earlier.  The *ciphers* argument should
@@ -1733,7 +1737,7 @@ to speed up repeated connections from the same clients.
       When connected, the :meth:`SSLSocket.cipher` method of SSL sockets will
       return details about the negotiated cipher.
 
-.. method:: SSLContext.set_ciphersuites(ciphersuites)
+.. method:: SSLContext.set_ciphersuites(ciphersuites, /)
 
    Set the allowed ciphers for sockets created with this context when
    connecting using TLS 1.3.  The *ciphersuites* argument should be a
@@ -1747,7 +1751,7 @@ to speed up repeated connections from the same clients.
 
    .. versionadded:: next
 
-.. method:: SSLContext.set_groups(groups)
+.. method:: SSLContext.set_groups(groups, /)
 
    Set the groups allowed for key agreement for sockets created with this
    context.  It should be a string in the `OpenSSL group list format
@@ -1760,7 +1764,7 @@ to speed up repeated connections from the same clients.
 
    .. versionadded:: next
 
-.. method:: SSLContext.set_client_sigalgs(sigalgs)
+.. method:: SSLContext.set_client_sigalgs(sigalgs, /)
 
    Set the signature algorithms allowed for certificate-based client
    authentication. It should be a string in the `OpenSSL client sigalgs
@@ -1775,7 +1779,7 @@ to speed up repeated connections from the same clients.
 
    .. versionadded:: next
 
-.. method:: SSLContext.set_server_sigalgs(sigalgs)
+.. method:: SSLContext.set_server_sigalgs(sigalgs, /)
 
    Set the signature algorithms allowed for the server to complete the TLS
    handshake. It should be a string in the `OpenSSL sigalgs list format
@@ -1789,7 +1793,7 @@ to speed up repeated connections from the same clients.
 
    .. versionadded:: next
 
-.. method:: SSLContext.set_alpn_protocols(protocols)
+.. method:: SSLContext.set_alpn_protocols(alpn_protocols)
 
    Specify which protocols the socket should advertise during the SSL/TLS
    handshake. It should be a list of ASCII strings, like ``['http/1.1',
@@ -1803,7 +1807,7 @@ to speed up repeated connections from the same clients.
 
    .. versionadded:: 3.5
 
-.. method:: SSLContext.set_npn_protocols(protocols)
+.. method:: SSLContext.set_npn_protocols(npn_protocols)
 
    Specify which protocols the socket should advertise during the SSL/TLS
    handshake. It should be a list of strings, like ``['http/1.1', 'spdy/2']``,
@@ -1870,7 +1874,7 @@ to speed up repeated connections from the same clients.
 
    .. versionadded:: 3.7
 
-.. attribute:: SSLContext.set_servername_callback(server_name_callback)
+.. method:: SSLContext.set_servername_callback(server_name_callback)
 
    This is a legacy API retained for backwards compatibility. When possible,
    you should use :attr:`sni_callback` instead. The given *server_name_callback*
@@ -1884,7 +1888,7 @@ to speed up repeated connections from the same clients.
 
    .. versionadded:: 3.4
 
-.. method:: SSLContext.load_dh_params(dhfile)
+.. method:: SSLContext.load_dh_params(dhfile, /)
 
    Load the key generation parameters for Diffie-Hellman (DH) key exchange.
    Using DH key exchange improves forward secrecy at the expense of
@@ -1897,7 +1901,7 @@ to speed up repeated connections from the same clients.
 
    .. versionadded:: 3.3
 
-.. method:: SSLContext.set_ecdh_curve(curve_name)
+.. method:: SSLContext.set_ecdh_curve(curve_name, /)
 
    Set the curve name for Elliptic Curve-based Diffie-Hellman (ECDH) key
    exchange.  ECDH is significantly faster than regular DH while arguably
@@ -2771,12 +2775,12 @@ purpose.  It wraps an OpenSSL memory BIO (Basic IO) object:
       A boolean indicating whether the memory BIO is current at the end-of-file
       position.
 
-   .. method:: MemoryBIO.read(n=-1)
+   .. method:: MemoryBIO.read(n=-1, /)
 
       Read up to *n* bytes from the memory buffer. If *n* is not specified or
       negative, all bytes are returned.
 
-   .. method:: MemoryBIO.write(buf)
+   .. method:: MemoryBIO.write(buf, /)
 
       Write the bytes from *buf* to the memory BIO. The *buf* argument must be an
       object supporting the buffer protocol.


### PR DESCRIPTION
Ideally I would like to make all "weird" parameters positional-only, but this would be a long deprecation period that we would need. So let's just document the exact names of the signatures. It won't cleanly backport because there are new functions but I will take care of this later.



<!-- gh-issue-number: gh-138633 -->
* Issue: gh-138633
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138639.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->