### PR TITLE
gh-138641: prevent accessing non-existing `curframe` in pdb commands

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2111,6 +2111,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         exception was originally raised or propagated is indicated by
         ">>", if it differs from the current line.
         """
+        if not self.curframe:
+            self.error('No current frame.')
+            return
         self.lastcmd = 'list'
         last = None
         if arg and arg != '.':
@@ -2134,9 +2137,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             first = self.lineno + 1
         if last is None:
             last = first + 10
-        if not self.curframe:
-            self.error('No current frame.')
-            return
         filename = self.curframe.f_code.co_filename
         breaklist = self.get_file_breaks(filename)
         try:

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1412,6 +1412,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     # To be overridden in derived debuggers
     def defaultFile(self):
         """Produce a reasonable default."""
+        if self.curframe is None:
+            self.error("No current frame.")
+            return None
         filename = self.curframe.f_code.co_filename
         if filename == '<string>' and self.mainpyfile:
             filename = self.mainpyfile

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -926,6 +926,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     def default(self, line):
         if line[:1] == '!': line = line[1:].strip()
+        if not self.curframe:
+            self.error("No current frame.")
+            return
         locals = self.curframe.f_locals
         globals = self.curframe.f_globals
         try:
@@ -2131,6 +2134,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             first = self.lineno + 1
         if last is None:
             last = first + 10
+        if not self.curframe:
+            self.error('No current frame.')
+            return
         filename = self.curframe.f_code.co_filename
         breaklist = self.get_file_breaks(filename)
         try:
@@ -2152,6 +2158,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         if arg:
             self._print_invalid_arg(arg)
+            return
+        if not self.curframe:
+            self.error('No current frame.')
             return
         filename = self.curframe.f_code.co_filename
         breaklist = self.get_file_breaks(filename)

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -925,9 +925,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         return code, buffer, is_await_code
 
     def default(self, line):
-        if not self.curframe:
-            self.error("No current frame.")
-            return
         if line[:1] == '!': line = line[1:].strip()
         locals = self.curframe.f_locals
         globals = self.curframe.f_globals
@@ -1184,7 +1181,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         return self.completedefault(text, line, begidx, endidx)
 
     def completedefault(self, text, line, begidx, endidx):
-        assert self.curframe is not None
         if text.startswith("$"):
             # Complete convenience variables
             conv_vars = self.curframe.f_globals.get('__pdb_convenience_variables', {})
@@ -1953,9 +1949,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         if not arg:
             self._print_invalid_arg(arg)
             return
-        if not self.curframe:
-            self.error('No current frame.')
-            return
         self.stop_trace()
         globals = self.curframe.f_globals
         locals = self.curframe.f_locals
@@ -2118,9 +2111,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         exception was originally raised or propagated is indicated by
         ">>", if it differs from the current line.
         """
-        if not self.curframe:
-            self.error('No current frame.')
-            return
         self.lastcmd = 'list'
         last = None
         if arg and arg != '.':
@@ -2165,9 +2155,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         if arg:
             self._print_invalid_arg(arg)
-            return
-        if not self.curframe:
-            self.error('No current frame.')
             return
         filename = self.curframe.f_code.co_filename
         breaklist = self.get_file_breaks(filename)

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2647,12 +2647,12 @@ def set_trace(*, header=None, commands=None):
     just before debugging begins. *commands* is an optional list of
     pdb commands to run when the debugger starts.
     """
-    # Check if we're already in a pdb session by examining the call stack
+    # gh-138641: Check if we're already in a pdb session.
     frame = sys._getframe()
     while frame:
-        if frame.f_code.co_name == 'interaction' and frame.f_code.co_filename.endswith('pdb.py'):
-            # We're already in a pdb session, just print a message and return
-            print("*** Nested breakpoint calls are not supported. "
+        if (frame.f_code.co_name == 'interaction'
+            and frame.f_code.co_filename.endswith('pdb.py')):
+            print("Nested breakpoint calls are not supported. "
                   "Already running in the debugger.", file=sys.stderr)
             return
         frame = frame.f_back
@@ -2672,12 +2672,13 @@ async def set_trace_async(*, header=None, commands=None):
     if they enter the debugger with this function. Otherwise it's the same
     as set_trace().
     """
-    # Check if we're already in a pdb session by examining the call stack
+    # gh-138641: Check if we're already in a pdb session.
     frame = sys._getframe()
     while frame:
-        if frame.f_code.co_name == 'interaction' and frame.f_code.co_filename.endswith('pdb.py'):
+        if (frame.f_code.co_name == 'interaction' and
+            frame.f_code.co_filename.endswith('pdb.py')):
             # We're already in a pdb session, just print a message and return
-            print("*** Nested breakpoint calls are not supported. "
+            print("Nested breakpoint calls are not supported. "
                   "Already running in the debugger.", file=sys.stderr)
             return
         frame = frame.f_back

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1184,6 +1184,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         return self.completedefault(text, line, begidx, endidx)
 
     def completedefault(self, text, line, begidx, endidx):
+        assert self.curframe is not None
         if text.startswith("$"):
             # Complete convenience variables
             conv_vars = self.curframe.f_globals.get('__pdb_convenience_variables', {})
@@ -1332,9 +1333,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                     if bp:
                         self.message(bp.bpformat())
             return
-        if not self.curframe:
-            self.error('No current frame.')
-            return
         # parse arguments; comma has lowest precedence
         # and cannot occur in filename
         filename = None
@@ -1414,7 +1412,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     # To be overridden in derived debuggers
     def defaultFile(self):
         """Produce a reasonable default."""
-        assert self.curframe is not None
         filename = self.curframe.f_code.co_filename
         if filename == '<string>' and self.mainpyfile:
             filename = self.mainpyfile

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1332,6 +1332,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                     if bp:
                         self.message(bp.bpformat())
             return
+        if not self.curframe:
+            self.error('No current frame.')
+            return
         # parse arguments; comma has lowest precedence
         # and cannot occur in filename
         filename = None
@@ -1411,6 +1414,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     # To be overridden in derived debuggers
     def defaultFile(self):
         """Produce a reasonable default."""
+        assert self.curframe is not None
         filename = self.curframe.f_code.co_filename
         if filename == '<string>' and self.mainpyfile:
             filename = self.mainpyfile
@@ -1948,6 +1952,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         if not arg:
             self._print_invalid_arg(arg)
+            return
+        if not self.curframe:
+            self.error('No current frame.')
             return
         self.stop_trace()
         globals = self.curframe.f_globals

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -925,10 +925,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         return code, buffer, is_await_code
 
     def default(self, line):
-        if line[:1] == '!': line = line[1:].strip()
         if not self.curframe:
             self.error("No current frame.")
             return
+        if line[:1] == '!': line = line[1:].strip()
         locals = self.curframe.f_locals
         globals = self.curframe.f_globals
         try:

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1413,9 +1413,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def defaultFile(self):
         """Produce a reasonable default."""
         if self.curframe is None:
-            self.error("No current frame.")
-            return None
-        filename = self.curframe.f_code.co_filename
+            filename = '<string>'
+        else:
+            filename = self.curframe.f_code.co_filename
         if filename == '<string>' and self.mainpyfile:
             filename = self.mainpyfile
         return filename

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1408,10 +1408,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     # To be overridden in derived debuggers
     def defaultFile(self):
         """Produce a reasonable default."""
-        if self.curframe is None:
-            filename = '<string>'
-        else:
-            filename = self.curframe.f_code.co_filename
+        filename = self.curframe.f_code.co_filename
         if filename == '<string>' and self.mainpyfile:
             filename = self.mainpyfile
         return filename

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2647,6 +2647,16 @@ def set_trace(*, header=None, commands=None):
     just before debugging begins. *commands* is an optional list of
     pdb commands to run when the debugger starts.
     """
+    # Check if we're already in a pdb session by examining the call stack
+    frame = sys._getframe()
+    while frame:
+        if frame.f_code.co_name == 'interaction' and frame.f_code.co_filename.endswith('pdb.py'):
+            # We're already in a pdb session, just print a message and return
+            print("*** Nested breakpoint calls are not supported. "
+                  "Already running in the debugger.", file=sys.stderr)
+            return
+        frame = frame.f_back
+
     if Pdb._last_pdb_instance is not None:
         pdb = Pdb._last_pdb_instance
     else:
@@ -2662,6 +2672,16 @@ async def set_trace_async(*, header=None, commands=None):
     if they enter the debugger with this function. Otherwise it's the same
     as set_trace().
     """
+    # Check if we're already in a pdb session by examining the call stack
+    frame = sys._getframe()
+    while frame:
+        if frame.f_code.co_name == 'interaction' and frame.f_code.co_filename.endswith('pdb.py'):
+            # We're already in a pdb session, just print a message and return
+            print("*** Nested breakpoint calls are not supported. "
+                  "Already running in the debugger.", file=sys.stderr)
+            return
+        frame = frame.f_back
+
     if Pdb._last_pdb_instance is not None:
         pdb = Pdb._last_pdb_instance
     else:

--- a/Misc/NEWS.d/next/Library/2025-09-08-17-50-33.gh-issue-138641.nBPvKe.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-08-17-50-33.gh-issue-138641.nBPvKe.rst
@@ -1,0 +1,1 @@
+Fix: breakpoint() in pdb can cause crash.

--- a/Misc/NEWS.d/next/Library/2025-09-08-17-50-33.gh-issue-138641.nBPvKe.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-08-17-50-33.gh-issue-138641.nBPvKe.rst
@@ -1,1 +1,2 @@
-Fix: breakpoint() in pdb can cause crash.
+Prevent error when calling :func:`breakpoint` inside a :mod:`pdb` debugging session.
+Nested breakpoint calls now display a helpful error message instead of causing error.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

breakpoint() in pdb the self.curframe will be None
and run something will cause crash

this patch fix it. but not sure if it is worth. if not will close.


<!-- gh-issue-number: gh-138641 -->
* Issue: gh-138641
<!-- /gh-issue-number -->
