### PR TITLE
gh-138407: avoid useless join operation when calculate the hash vaule for pathlib.Path

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -209,14 +209,12 @@ class PurePath:
         try:
             return self._hash
         except AttributeError:
-            hash_data = self._tail
-            if self._drv or self._root:
-                hash_data = [self._drv + self._root] + self._tail
-            elif self._tail and self.parser.splitdrive(self._tail[0])[0]:
-                hash_data = ['.'] + self._tail
-            if self.parser is not posixpath:
-                hash_data = [part.lower() for part in hash_data]
-            self._hash = hash(tuple(hash_data))
+            if self.parser is posixpath:
+                self._hash = hash((self.root, tuple(self._tail)))
+            else:
+                self._hash = hash((self.drive.lower(),
+                                   self.root.lower(),
+                                   tuple([part.lower() for part in self._tail])))
             return self._hash
 
     def __eq__(self, other):

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -209,7 +209,12 @@ class PurePath:
         try:
             return self._hash
         except AttributeError:
-            self._hash = hash(self._str_normcase)
+            hash_data = self._tail
+            if self._drv or self._root:
+                hash_data = [self._drv + self._root] + self._tail
+            elif self._tail and self.parser.splitdrive(self._tail[0])[0]:
+                hash_data = ['.'] + self._tail
+            self._hash = hash(tuple(hash_data))
             return self._hash
 
     def __eq__(self, other):

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -214,6 +214,8 @@ class PurePath:
                 hash_data = [self._drv + self._root] + self._tail
             elif self._tail and self.parser.splitdrive(self._tail[0])[0]:
                 hash_data = ['.'] + self._tail
+            if self.parser is not posixpath:
+                hash_data = [part.lower() for part in hash_data]
             self._hash = hash(tuple(hash_data))
             return self._hash
 

--- a/Misc/NEWS.d/next/Library/2025-09-08-19-04-23.gh-issue-138407.BqNAfi.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-08-19-04-23.gh-issue-138407.BqNAfi.rst
@@ -1,0 +1,1 @@
+Avoid useless join operation when calculate the hash vaule for pathlib.Path.


### PR DESCRIPTION
Signed-off-by: Manjusaka <me@manjusaka.me><!--

Try to fix #138407 

The benchmark:

Before this patch

```text
╰─ python -m pyperf timeit -s 'from pathlib import Path' 'p = hash(Path("/tmp/foo/bar/12345"))'
.....................
WARNING: the benchmark result may be unstable
* Not enough samples to get a stable result (95% certainly of less than 1% variation)

Try to rerun the benchmark with more runs, values and/or loops.
Run 'python -m pyperf system tune' command to reduce the system jitter.
Use pyperf stats, pyperf dump and pyperf hist to analyze results.
Use --quiet option to hide these warnings.

Mean +- std dev: 3.76 us +- 0.11 us
```

After

```text
╰─ python -m pyperf timeit -s 'from pathlib import Path' 'p = hash(Path("/tmp/foo/bar/12345"))'
.....................
Mean +- std dev: 2.47 us +- 0.04 us
```

<!-- gh-issue-number: gh-138407 -->
* Issue: gh-138407
<!-- /gh-issue-number -->
