### PR TITLE
gh-138644: docs/c-api: Fix outdated PyInterpreterState doc about shared GIL

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1016,9 +1016,7 @@ code, or when embedding the Python interpreter:
    this structure.
 
    Threads belonging to different interpreters initially share nothing, except
-   process state like available memory, open file descriptors and such.  The global
-   interpreter lock is also shared by all threads, regardless of to which
-   interpreter they belong.
+   process state like available memory, open file descriptors and such.
 
 
 .. c:type:: PyThreadState

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1018,6 +1018,9 @@ code, or when embedding the Python interpreter:
    Threads belonging to different interpreters initially share nothing, except
    process state like available memory, open file descriptors and such.
 
+   .. versionchanged:: 3.12
+      Each subinterpreter now :ref:`has its own GIL <per-interpreter-gil>`.
+
 
 .. c:type:: PyThreadState
 
@@ -1709,6 +1712,8 @@ function. You can create and destroy them using the following functions:
    haven't been explicitly destroyed at that point.
 
 
+.. _per-interpreter-gil:
+
 A Per-Interpreter GIL
 ---------------------
 
@@ -1720,7 +1725,7 @@ being blocked by other interpreters or blocking any others.  Thus a
 single Python process can truly take advantage of multiple CPU cores
 when running Python code.  The isolation also encourages a different
 approach to concurrency than that of just using threads.
-(See :pep:`554`.)
+(See :pep:`554` and :pep:`684`.)
 
 Using an isolated interpreter requires vigilance in preserving that
 isolation.  That especially means not sharing any objects or mutable


### PR DESCRIPTION
I also tried to add a `versionchanged` entry but don't have the tooling set up to build this locally so it's untested... If desired I can restrict to just removing the note (just 83ad9269307f7597bc56457382f7ce79e4de637f)

<!-- gh-issue-number: gh-138644 -->
* Issue: gh-138644
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138650.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->