### PR TITLE
gh-138644: Update c-api docs of `PyInterpreterState` about PEP-684

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1022,7 +1022,7 @@ code, or when embedding the Python interpreter:
 
    .. versionchanged:: 3.12
 
-      :pep:`684` introduced a possibility of :ref:`per-interpreter` GIL.
+      :pep:`684` introduced the possibility of a :ref:`<per-interpreter-gil` GIL.
       See :c:func:`Py_NewInterpreterFromConfig`.
 
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1020,6 +1020,11 @@ code, or when embedding the Python interpreter:
    interpreter lock is also shared by all threads, regardless of to which
    interpreter they belong.
 
+   .. versionchanged:: 3.12
+
+      :pep:`684` introduced a possibility of :ref:`per-interpreter` GIL.
+      See :c:func:`Py_NewInterpreterFromConfig`.
+
 
 .. c:type:: PyThreadState
 
@@ -1711,6 +1716,8 @@ function. You can create and destroy them using the following functions:
    haven't been explicitly destroyed at that point.
 
 
+.. _per-interpreter-gil:
+
 A Per-Interpreter GIL
 ---------------------
 
@@ -1722,7 +1729,7 @@ being blocked by other interpreters or blocking any others.  Thus a
 single Python process can truly take advantage of multiple CPU cores
 when running Python code.  The isolation also encourages a different
 approach to concurrency than that of just using threads.
-(See :pep:`554`.)
+(See :pep:`554` and :pep:`684`.)
 
 Using an isolated interpreter requires vigilance in preserving that
 isolation.  That especially means not sharing any objects or mutable

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1022,7 +1022,8 @@ code, or when embedding the Python interpreter:
 
    .. versionchanged:: 3.12
 
-      :pep:`684` introduced the possibility of a :ref:`<per-interpreter-gil` GIL.
+      :pep:`684` introduced the possibility
+      of a :ref:`per-interpreter <per-interpreter-gil>` GIL.
       See :c:func:`Py_NewInterpreterFromConfig`.
 
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1023,7 +1023,7 @@ code, or when embedding the Python interpreter:
    .. versionchanged:: 3.12
 
       :pep:`684` introduced the possibility
-      of a :ref:`per-interpreter <per-interpreter-gil>` GIL.
+      of a :ref:`per-interpreter GIL <per-interpreter-gil>`.
       See :c:func:`Py_NewInterpreterFromConfig`.
 
 


### PR DESCRIPTION
Since @Oberon00 said that they can't sign CLA and is about to close the PR, I am opening this one. Context: https://github.com/python/cpython/pull/138650#issuecomment-3265869725

All credit goes to @Oberon00, but there's no `Co-authed-by`, because it also requires that all co-authors sign the CLA.

Feel free to close my PR if the original one is updated / signed.

<!-- gh-issue-number: gh-138644 -->
* Issue: gh-138644
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138651.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->