### PR TITLE
gh-138659: Typo in the gc module docstring

### DIFF
--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -478,7 +478,7 @@ PyDoc_STRVAR(gc__doc__,
 "set_debug() -- Set debugging flags.\n"
 "get_debug() -- Get debugging flags.\n"
 "set_threshold() -- Set the collection thresholds.\n"
-"get_threshold() -- Return the current the collection thresholds.\n"
+"get_threshold() -- Return the current collection thresholds.\n"
 "get_objects() -- Return a list of all objects tracked by the collector.\n"
 "is_tracked() -- Returns true if a given object is tracked.\n"
 "is_finalized() -- Returns true if a given object has been already finalized.\n"


### PR DESCRIPTION
Removes a duplicate "the" from the docstring for the `gc.get_threshold()` function.

### Linked Issue
https://github.com/python/cpython/issues/138659

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138659 -->
* Issue: gh-138659
<!-- /gh-issue-number -->
