### PR TITLE
gh-138669: Increase test coverage for difflib

### DIFF
--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -35,6 +35,8 @@ class TestWithAscii(unittest.TestCase):
         self.assertEqual(opcode,
             [   ('insert', 0, 0, 0, 1),
                 ('equal', 0, 100, 1, 101)])
+        # Implementation detail: opcodes are cached;
+        # `get_opcodes()` returns the same object
         self.assertIs(opcode, sm.get_opcodes())
 
     def test_bjunk(self):

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -29,6 +29,27 @@ class TestWithAscii(unittest.TestCase):
                 ('delete', 40, 41, 40, 40),
                 ('equal', 41, 81, 40, 80)])
 
+
+    def test_opcode_caching(self):
+        sm = difflib.SequenceMatcher(None, 'b' * 100, 'a' + 'b' * 100)
+        self.assertEqual(list(sm.get_opcodes()),
+            [   ('insert', 0, 0, 0, 1),
+                ('equal', 0, 100, 1, 101)])
+
+        sm.a = 'a' * 40 + 'c' + 'b' * 40
+        sm.b = 'a' * 40 + 'b' * 40
+        self.assertEqual(list(sm.get_opcodes()),
+            [   ('insert', 0, 0, 0, 1),
+                ('equal', 0, 100, 1, 101)])
+
+        # To avoid caching in set_seqs.
+        sm.set_seqs("".join(list(sm.a)), "".join(list(sm.b)))
+        self.assertEqual(list(sm.get_opcodes()),
+            [   ('equal', 0, 40, 0, 40),
+                ('delete', 40, 41, 40, 40),
+                ('equal', 41, 81, 40, 80)])
+
+
     def test_bjunk(self):
         sm = difflib.SequenceMatcher(isjunk=lambda x: x == ' ',
                 a='a' * 40 + 'b' * 40, b='a' * 44 + 'b' * 40)
@@ -292,6 +313,15 @@ class TestDiffer(unittest.TestCase):
                             '?             ^\n',
                             '+ kitten\n',
                             '+ puppy\n'])
+
+    def test_one_insert(self):
+        m = difflib.Differ().compare('b' * 2, 'a' + 'b' * 2)
+        self.assertEqual(list(m), ['+ a', '  b', '  b'])
+
+    def test_one_delete(self):
+        m = difflib.Differ().compare('a' + 'b' * 2, 'b' * 2)
+        self.assertEqual(list(m), ['- a', '  b', '  b'])
+
 
 class TestOutputFormat(unittest.TestCase):
     def test_tab_delimiter(self):
@@ -599,6 +629,22 @@ class TestFindLongest(unittest.TestCase):
         self.assertEqual(a[match.a: match.a + match.size],
                          b[match.b: match.b + match.size])
         self.assertFalse(self.longer_match_exists(a, b, match.size))
+
+
+class TestCloseMatches(unittest.TestCase):
+    def test_invalid_inputs(self):
+        self.assertRaises(ValueError, difflib.get_close_matches, "spam", ['egg'], n=0)
+        self.assertRaises(ValueError, difflib.get_close_matches, "spam", ['egg'], n=-1)
+        self.assertRaises(ValueError, difflib.get_close_matches, "spam", ['egg'], cutoff=1.1)
+        self.assertRaises(ValueError, difflib.get_close_matches, "spam", ['egg'], cutoff=-0.1)
+
+
+class TestRestore(unittest.TestCase):
+    def test_invalid_input(self):
+        with self.assertRaises(ValueError):
+            ''.join(difflib.restore([], 0))
+        with self.assertRaises(ValueError):
+            ''.join(difflib.restore([], 3))
 
 
 def setUpModule():

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -29,26 +29,13 @@ class TestWithAscii(unittest.TestCase):
                 ('delete', 40, 41, 40, 40),
                 ('equal', 41, 81, 40, 80)])
 
-
     def test_opcode_caching(self):
         sm = difflib.SequenceMatcher(None, 'b' * 100, 'a' + 'b' * 100)
-        self.assertEqual(list(sm.get_opcodes()),
+        opcode = sm.get_opcodes()
+        self.assertEqual(opcode,
             [   ('insert', 0, 0, 0, 1),
                 ('equal', 0, 100, 1, 101)])
-
-        sm.a = 'a' * 40 + 'c' + 'b' * 40
-        sm.b = 'a' * 40 + 'b' * 40
-        self.assertEqual(list(sm.get_opcodes()),
-            [   ('insert', 0, 0, 0, 1),
-                ('equal', 0, 100, 1, 101)])
-
-        # To avoid caching in set_seqs.
-        sm.set_seqs("".join(list(sm.a)), "".join(list(sm.b)))
-        self.assertEqual(list(sm.get_opcodes()),
-            [   ('equal', 0, 40, 0, 40),
-                ('delete', 40, 41, 40, 40),
-                ('equal', 41, 81, 40, 80)])
-
+        self.assertIs(opcode, sm.get_opcodes())
 
     def test_bjunk(self):
         sm = difflib.SequenceMatcher(isjunk=lambda x: x == ' ',

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -632,6 +632,8 @@ class TestFindLongest(unittest.TestCase):
 
 
 class TestCloseMatches(unittest.TestCase):
+    # Happy paths are tested in the doctests of `difflib.get_close_matches`.
+
     def test_invalid_inputs(self):
         self.assertRaises(ValueError, difflib.get_close_matches, "spam", ['egg'], n=0)
         self.assertRaises(ValueError, difflib.get_close_matches, "spam", ['egg'], n=-1)
@@ -640,6 +642,8 @@ class TestCloseMatches(unittest.TestCase):
 
 
 class TestRestore(unittest.TestCase):
+    # Happy paths are tested in the doctests of `difflib.restore`.
+
     def test_invalid_input(self):
         with self.assertRaises(ValueError):
             ''.join(difflib.restore([], 0))


### PR DESCRIPTION
Previously:
```
Name             Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------
Lib/difflib.py     677     19    328     21    96%   523, 697, 699, 865, 867, 871, 885-886, 974, 978, 1061, 1150->1157, 1170->1162, 1239->1246, 1252->1258, 1261->1238, 1263->1262, 1447, 1514-1516, 1526->1532, 1814-1815, 1981->1984, 2090-2091
------------------------------------------------------------
TOTAL              677     19    328     21    96%



```

Now:
```
Name             Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------
Lib/difflib.py     677     12    328     16    97%   871, 885-886, 974, 978, 1061, 1150->1157, 1170->1162, 1239->1246, 1252->1258, 1261->1238, 1263->1262, 1447, 1514-1516, 1526->1532, 1814-1815, 1981->1984
------------------------------------------------------------
TOTAL              677     12    328     16    97%


```

I thought about also testing the "pat" argument for `IS_LINE_JUNK`, but decided against it because it is completely undocumented.

Additionally i considered adding the raising tests to the doctests, but decided against that to keep them concise.

<!-- gh-issue-number: gh-138669 -->
* Issue: gh-138669
<!-- /gh-issue-number -->
