### PR TITLE
gh-138679: Opcodes which consume no inputs should indicate they produced the val…

### DIFF
--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1116,6 +1116,13 @@ class TestMarkingVariablesAsUnKnown(BytecodeTestCase):
         self.assertInBytecode(f, "LOAD_FAST_BORROW")
         self.assertNotInBytecode(f, "LOAD_FAST_CHECK")
 
+    def test_import_from_doesnt_clobber_load_fast_borrow(self):
+        def f(self):
+            if x: pass
+            self.x
+            from shutil import ExecError
+            print(ExecError)
+        self.assertInBytecode(f, "LOAD_FAST_BORROW", "self")
 
 class DirectCfgOptimizerTests(CfgOptimizationTestCase):
 

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2891,7 +2891,7 @@ optimize_load_fast(cfg_builder *g)
                     int num_pushed = _PyOpcode_num_pushed(opcode, oparg);
                     int net_pushed = num_pushed - num_popped;
                     assert(net_pushed >= 0);
-                    for (int i = 0; i < net_pushed; i++) {
+                    for (int j = 0; j < net_pushed; j++) {
                         PUSH_REF(i, NOT_LOCAL);
                     }
                     break;


### PR DESCRIPTION
The load fast borrow analysis is marking the instruction index of opcodes which produce no locals as the delta (so always 0, 1, etc...) and not as the instruction that consumes no opcodes (the outer i).

<!-- gh-issue-number: gh-138679 -->
* Issue: gh-138679
<!-- /gh-issue-number -->
