### PR TITLE
gh-138700:  Add :sorted: option to automatically sort glossary

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -7,6 +7,7 @@ Glossary
 .. if you add new entries, keep the alphabetical sorting!
 
 .. glossary::
+   :sorted:
 
    ``>>>``
       The default Python prompt of the :term:`interactive` shell.  Often


### PR DESCRIPTION
This PR adds the `:sorted:` option to `Doc/glossary.rst`.

Benefits:
- Ensures glossary entries are always alphabetically ordered.
- Uses locale-specific ordering, improving translations.
- Prevents manual ordering mistakes.

Collateral effects:
- "..." now appears before ">>>"
- Dunder entries (`__future__`, `__slots__`) appear before "a"

Discussion: https://discuss.python.org/t/glossary-alphabetically-ordering-for-all-language/101778/1

Fixes gh-138700

### Issue 
https://github.com/python/cpython/issues/138700#issuecomment-3271424887

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138708.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->