### PR TITLE
gh-138722: rephrased sys.excephook section about auditing events

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -450,10 +450,10 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
       Raise an auditing event ``sys.excepthook`` with arguments ``hook``,
       ``type``, ``value``, ``traceback`` when an uncaught exception occurs.
-      If no hook has been set, ``hook`` may be ``None``. If any hook raises
-      an exception derived from :class:`RuntimeError` the call to the hook will
-      be suppressed. Otherwise, the audit hook exception will be reported as
-      unraisable and ``sys.excepthook`` will be called.
+      If no hook has been set, ``hook`` may be ``None``. If any audit hook
+      raises an exception derived from :class:`RuntimeError` the call to that
+      audit hook will be suppressed. Otherwise, the audit hook exception will be
+      reported as unraisable and ``sys.excepthook`` will be called.
 
    .. seealso::
 


### PR DESCRIPTION
Changed the phrasing of the section of sys.excepthook docs to be clearer.

This phrasing seems less prone to misunderstanding IMO.

<!-- gh-issue-number: gh-138722 -->
* Issue: gh-138722
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138723.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->