### PR TITLE
gh-138720: Make Buffered closed check match flush

### DIFF
--- a/Lib/test/test_io/test_general.py
+++ b/Lib/test/test_io/test_general.py
@@ -2287,6 +2287,10 @@ class BufferedRWPairTest:
                 self.assertEqual(getattr(pair, method)(data), 5)
                 self.assertEqual(bytes(data), b"abcde")
 
+        # gh-138720: C BufferedRWPair would destruct in a bad order resulting in
+        # an unraisable exception.
+        support.gc_collect()
+
     def test_write(self):
         w = self.MockRawIO()
         pair = self.tp(self.MockRawIO(), w)

--- a/Misc/NEWS.d/next/Library/2025-09-09-17-57-49.gh-issue-138720.hAtsm-.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-09-17-57-49.gh-issue-138720.hAtsm-.rst
@@ -1,0 +1,3 @@
+Fix an issue where :meth:`~BufferedIOBase.close` would think the I/O object was
+open and call :meth:`~BufferedIOBase.flush` but flush would error that the
+file was already closed by making the two functions use the same logic.

--- a/Misc/NEWS.d/next/Library/2025-09-09-17-57-49.gh-issue-138720.hAtsm-.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-09-17-57-49.gh-issue-138720.hAtsm-.rst
@@ -1,4 +1,4 @@
-Fix an issue where the :class:`BufferedIOBase` implementation of
-:meth:`~IOBase.close` would think the I/O object was open and call
-:meth:`~IOBase.flush` which would error that the file was already closed by
+Fix an issue where the :class:`io.BufferedIOBase` implementation of
+:meth:`~io.IOBase.close` would think the I/O object was open and call
+:meth:`~io.IOBase.flush` which would error that the file was already closed by
 making the two implementations use the same logic.

--- a/Misc/NEWS.d/next/Library/2025-09-09-17-57-49.gh-issue-138720.hAtsm-.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-09-17-57-49.gh-issue-138720.hAtsm-.rst
@@ -1,4 +1,4 @@
-Fix an issue where the :class:`io.BufferedIOBase` implementation of
-:meth:`~io.IOBase.close` would think the I/O object was open and call
-:meth:`~io.IOBase.flush` which would error that the file was already closed by
-making the two implementations use the same logic.
+Fix an issue where :class:`io.BufferedWriter` and :class:`io.BufferedRandom`
+had different definitions of "closed" for :meth:`~io.IOBase.close` and
+:meth:`~io.IOBase.flush` which resulted in an exception when close called
+flush but flush thought the file was already closed.

--- a/Misc/NEWS.d/next/Library/2025-09-09-17-57-49.gh-issue-138720.hAtsm-.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-09-17-57-49.gh-issue-138720.hAtsm-.rst
@@ -1,3 +1,4 @@
-Fix an issue where :meth:`~BufferedIOBase.close` would think the I/O object was
-open and call :meth:`~BufferedIOBase.flush` but flush would error that the
-file was already closed by making the two functions use the same logic.
+Fix an issue where the :class:`BufferedIOBase` implementation of
+:meth:`~IOBase.close` would think the I/O object was open and call
+:meth:`~IOBase.flush` which would error that the file was already closed by
+making the two implementations use the same logic.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -553,8 +553,8 @@ _io__Buffered_close_impl(buffered *self)
     if (!ENTER_BUFFERED(self)) {
         return NULL;
     }
-
-    r = buffered_closed(self);
+    /* gh-138720: Use IS_CLOSED to match flush CHECK_CLOSED. */
+    r = IS_CLOSED(self);
     if (r < 0)
         goto end;
     if (r > 0) {


### PR DESCRIPTION
In `_io__Buffered_flush_impl` the macro `CHECK_CLOSED` is used to check the `buffered*` is in a good state to be flushed. That differs slightly from `buffered_closed`.

In some cases, that difference would result in `close()` (`_io__Buffered_close_impl`) thinking the file needed to be flushed and closed while `flush()` thought the file was already closed.

This could happen during GC and would result in an unraisable exception.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138720 -->
* Issue: gh-138720
<!-- /gh-issue-number -->
