### PR TITLE
gh-137396: tarfile: Guard against negative offset/length in GNU sparse headers

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1437,7 +1437,7 @@ class TarInfo(object):
                     numbytes = nti(buf[pos + 12:pos + 24])
                 except ValueError:
                     break
-                if offset and numbytes:
+                if offset >= 0 and numbytes >= 0:
                     structs.append((offset, numbytes))
                 pos += 24
             isextended = bool(buf[504])

--- a/Misc/NEWS.d/next/Library/2025-09-10-06-42-15.gh-issue-137396.dtx0B3.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-10-06-42-15.gh-issue-137396.dtx0B3.rst
@@ -1,0 +1,1 @@
+tarfile: Fix parsing of GNU sparse headers by disallowing negative values for offset and numbytes.


### PR DESCRIPTION
### Summary

This change fixes a bug in `tarfile.py` where negative `offset` and `numbytes` values were not properly handled when parsing GNU sparse file headers. The existing validation only checked for non-zero values, allowing negative integers to pass, which could lead to errors or a potential security vulnerability when processing a corrupted or malicious tar archive.

* Fixes gh-137396

The problem with the original code was twofold:
- It incorrectly allowed negative numbers, which was the critical issue.
- It incorrectly disallowed zero, which is a valid value for both `offset` and `numbytes` according to the tar specification. [(ref)](https://www.gnu.org/software/tar/manual/html_node/Standard.html)

The fix introduces a direct check to ensure these values are non-negative (`>= 0`) before they are used, making the parsing logic more robust.

### Additional Context

During the discussion in the issue, a more comprehensive refactoring of the module's integer handling and error reporting was suggested. While that is a valid long-term improvement, this pull request provides a focused, immediate, and safe fix for the specific vulnerability identified. The broader refactoring can be considered separately.