### PR TITLE
[3.13] gh-136006: fix `Py_NAN` expansion on Solaris systems (GH-136575)

### DIFF
--- a/Include/pymath.h
+++ b/Include/pymath.h
@@ -54,9 +54,24 @@
 
 /* Py_NAN: Value that evaluates to a quiet Not-a-Number (NaN).  The sign is
  * undefined and normally not relevant, but e.g. fixed for float("nan").
+ *
+ * Note: On Solaris, NAN is a function address, hence arithmetic is impossible.
+ * For that reason, we instead use the built-in call if available or fallback
+ * to a generic NaN computed from strtod() as a last resort.
+ *
+ * See https://github.com/python/cpython/issues/136006 for details.
  */
 #if !defined(Py_NAN)
-#    define Py_NAN ((double)NAN)
+#  if defined(__sun)
+#    if _Py__has_builtin(__builtin_nanf)
+#       define Py_NAN   ((double)__builtin_nanf(""))
+#    else
+#       include <stdlib.h>
+#       define Py_NAN   (strtod("NAN", NULL))
+#    endif
+#  else
+#    define Py_NAN      ((double)NAN)
+#  endif
 #endif
 
 #endif /* Py_PYMATH_H */

--- a/Misc/NEWS.d/next/C API/2025-07-08-22-07-54.gh-issue-136006.XRU5w4.rst
+++ b/Misc/NEWS.d/next/C API/2025-07-08-22-07-54.gh-issue-136006.XRU5w4.rst
@@ -1,0 +1,2 @@
+On Solaris, the :c:macro:`!Py_NAN` macro now expands to a :c:type:`!double`
+instead of a function address. Patch by Bénédikt Tran.


### PR DESCRIPTION
On Solaris, `Py_NAN` may expand as a function address instead of a floating-point number. This amends commit 7a3b03509e5e3e72d8c47137579cccb52548a318. (cherry picked from commit d54b1091d43b9d8f0da0ba081565bccca3f138fd)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136006 -->
* Issue: gh-136006
<!-- /gh-issue-number -->
