### PR TITLE
gh-138703: remove unnecessary and buggy type checks in asyncio

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -336,10 +336,6 @@ class _ProactorBaseWritePipeTransport(_ProactorBasePipeTransport,
         self._empty_waiter = None
 
     def write(self, data):
-        if not isinstance(data, (bytes, bytearray, memoryview)):
-            raise TypeError(
-                f"data argument must be a bytes-like object, "
-                f"not {type(data).__name__}")
         if self._eof_written:
             raise RuntimeError('write_eof() already called')
         if self._empty_waiter is not None:
@@ -485,10 +481,6 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport,
         self._force_close(None)
 
     def sendto(self, data, addr=None):
-        if not isinstance(data, (bytes, bytearray, memoryview)):
-            raise TypeError('data argument must be bytes-like object (%r)',
-                            type(data))
-
         if self._address is not None and addr not in (None, self._address):
             raise ValueError(
                 f'Invalid address: must be None or {self._address}')
@@ -500,7 +492,8 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport,
             return
 
         # Ensure that what we buffer is immutable.
-        self._buffer.append((bytes(data), addr))
+        data = bytes(data)
+        self._buffer.append((data, addr))
         self._buffer_size += len(data) + self._header_size
 
         if self._write_fut is None:

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -214,12 +214,10 @@ class _SSLProtocolTransport(transports._FlowControlMixin,
         This does not block; it buffers the data and arranges for it
         to be sent out asynchronously.
         """
-        if not isinstance(data, (bytes, bytearray, memoryview)):
-            raise TypeError(f"data: expecting a bytes-like instance, "
-                            f"got {type(data).__name__}")
         if not data:
             return
-        self._ssl_protocol._write_appdata((data,))
+        # Ensure that what we buffer is immutable.
+        self._ssl_protocol._write_appdata((bytes(data),))
 
     def writelines(self, list_of_data):
         """Write a list (or any iterable) of data bytes to the transport.

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -1499,6 +1499,9 @@ class SelectorDatagramTransportTests(test_utils.TestCase):
 
     def test_sendto_str(self):
         transport = self.datagram_transport()
+        def sendto(data, addr):
+            bytes(data)  # raises TypeError
+        self.sock.sendto = sendto
         self.assertRaises(TypeError, transport.sendto, 'str', ())
 
     def test_sendto_connected_addr(self):


### PR DESCRIPTION
Within asyncio, several `write`, `send` and `sendto` methods contained a check whether the `data` parameter is one of the *right* types, complaining that the data should be bytes-like.

This error message is very misleading if one hands over a byte-like object that happens not to be one of the *right* types.

Usually, these kinds of tests are not necessary at all, as the code the data is handed to will complain itself if the type is wrong. But in the case of the mentioned methods, the data may be put into a buffer if the data cannot be sent immediately. Any type errors will only be raised much later, when the buffer is finally sent.

Interestingly, the test is incorrect as well: any memoryview is considered *right*, although it may be passed to functions that cannot deal with non-contiguous memoryviews, in which case the all the problems that the test should protect from reappear.

There are several options one can go forward:

* one could update the documentation to reflect the fact that not all bytes-like objects can be passed, but only special ones. This would be unfortunate as the underlying code actually can deal with all bytes-like data.
* actually test whether the data is bytes-like. This is unfortunately not easy. The correct test would be to check whether the data can be parsed as by PyArg_Parse with a y* format. I am not aware of a simple test like this.
* Remove the test. In this case one should assure that only bytes-like data will be put into the buffers if the data cannot be sent immediately.

For simplicity I opted for the last option. One should note another problem here: if we accept objects like memoryview or bytearray (which we currently do), the user may modify the data after-the-fact, which will lead to weird, unexpected behavior. This could be mitigated by always copying the data. This is done in some of the modified methods, but not all, most likely for performance reasons. I think it would be beneficial to deal with this problem in a systematic way, but this is beyond the scope of this patch.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138703 -->
* Issue: gh-138703
<!-- /gh-issue-number -->
