### PR TITLE
gh-138744: GitHub Actions: pin to `windows-2022`

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -72,10 +72,10 @@ jobs:
         include:
           - target: i686-pc-windows-msvc/msvc
             architecture: Win32
-            runner: windows-latest
+            runner: windows-2022
           - target: x86_64-pc-windows-msvc/msvc
             architecture: x64
-            runner: windows-latest
+            runner: windows-2022
           - target: aarch64-pc-windows-msvc/msvc
             architecture: ARM64
             runner: windows-11-arm

--- a/.github/workflows/reusable-windows-msi.yml
+++ b/.github/workflows/reusable-windows-msi.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   build:
     name: installer for ${{ inputs.arch }}
-    runs-on: ${{ inputs.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'windows-11-arm' || 'windows-2022' }}
     timeout-minutes: 60
     env:
       ARCH: ${{ inputs.arch }}

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build:
     name: Build and test (${{ inputs.arch }})
-    runs-on: ${{ inputs.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'windows-11-arm' || 'windows-2022' }}
     timeout-minutes: 60
     env:
       ARCH: ${{ inputs.arch }}

--- a/.github/workflows/tail-call.yml
+++ b/.github/workflows/tail-call.yml
@@ -49,13 +49,13 @@ jobs:
         include:
 #          - target: i686-pc-windows-msvc/msvc
 #            architecture: Win32
-#            runner: windows-latest
+#            runner: windows-2022
           - target: x86_64-pc-windows-msvc/msvc
             architecture: x64
-            runner: windows-latest
+            runner: windows-2022
 #          - target: aarch64-pc-windows-msvc/msvc
 #            architecture: ARM64
-#            runner: windows-latest
+#            runner: windows-2022
           - target: x86_64-apple-darwin/clang
             architecture: x86_64
             runner: macos-13


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

GitHub Actions is in the process of migrating `windows-latest` from `windows-2022` to `windows-2025`:

> This change will be rolled out over a period of several weeks beginning 2025-09-02 and will complete on 2025-09-30

https://github.com/actions/runner-images/issues/12677


This is causing failures for forks which have already been migrated, for example:

```pytb
======================================================================
FAIL: test_function_entry_return (test.test_dtrace.DTraceNormalTests.test_function_entry_return)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\a\cpython\cpython\Lib\test\test_dtrace.py", line 38, in normalize_trace_output
    result.sort(key=lambda row: int(row[0]))
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\a\cpython\cpython\Lib\test\test_dtrace.py", line 38, in <lambda>
    result.sort(key=lambda row: int(row[0]))
                                ~~~^^^^^^^^
ValueError: invalid literal for int() with base 10: 'dtrace: failed to compile script D:\\a\\cpython\\cpython\\Lib\\test\\dtracedata\\call_stack.d: line 3: pid provider is not installed on this system'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "D:\a\cpython\cpython\Lib\test\test_dtrace.py", line 124, in test_function_entry_return
    self.run_case("call_stack")
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "D:\a\cpython\cpython\Lib\test\test_dtrace.py", line 119, in run_case
    actual_output, expected_output = self.backend.run_case(
                                     ~~~~~~~~~~~~~~~~~~~~~^
        name, optimize_python=self.optimize_python)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\a\cpython\cpython\Lib\test\test_dtrace.py", line 53, in run_case
    actual_output = normalize_trace_output(self.trace_python(
        script_file=abspath(name + self.EXTENSION),
        python_file=abspath(name + ".py"),
        optimize_python=optimize_python))
  File "D:\a\cpython\cpython\Lib\test\test_dtrace.py", line 42, in normalize_trace_output
    raise AssertionError(
        "tracer produced unparsable output:\n{}".format(output)
    )
AssertionError: tracer produced unparsable output:
dtrace: failed to compile script D:\a\cpython\cpython\Lib\test\dtracedata\call_stack.d: line 3: pid provider is not installed on this system
```

https://github.com/picnixz/cpython/actions/runs/17610564159/job/50031376950#step:1:9

Upstream and my fork are still on 2022, but let's pin to `windows-2022` so we can separately investigate and fix for 2025, and then pin to `windows-2025`.


<!-- gh-issue-number: gh-138744 -->
* Issue: gh-138744
<!-- /gh-issue-number -->
