### PR TITLE
Doc: Minor fix replacing "-" by ":" in whatsnew/3.14

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -455,7 +455,7 @@ to attach to the remote process and send the PDB commands to it.
 
 .. _whatsnew314-pep758:
 
-PEP 758 – Allow except and except* expressions without parentheses
+PEP 758: Allow except and except* expressions without parentheses
 ------------------------------------------------------------------
 
 The :keyword:`except` and :keyword:`except* <except_star>` expressions now allow


### PR DESCRIPTION
This slight change makes the sentence consistent with the others.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138761.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->