### PR TITLE
gh-138013: Remove load_tests in test_io.test_general

### DIFF
--- a/Lib/test/test_io/test_general.py
+++ b/Lib/test/test_io/test_general.py
@@ -356,7 +356,7 @@ class PyTestCase(unittest.TestCase):
         return getattr(pyio, name)
 
 
-class IOTest(unittest.TestCase):
+class IOTest:
 
     def setUp(self):
         os_helper.unlink(os_helper.TESTFN)
@@ -2842,7 +2842,7 @@ class StatefulIncrementalDecoderTest(unittest.TestCase):
         self.assertEqual(d.decode(b'oiabcd'), '')
         self.assertEqual(d.decode(b'', 1), 'abcd.')
 
-class TextIOWrapperTest(unittest.TestCase):
+class TextIOWrapperTest:
 
     def setUp(self):
         self.testdata = b"AAA\r\nBBB\rCCC\r\nDDD\nEEE\r\n"
@@ -4200,7 +4200,7 @@ class PyTextIOWrapperTest(TextIOWrapperTest, PyTestCase):
     shutdown_error = "LookupError: unknown encoding: ascii"
 
 
-class IncrementalNewlineDecoderTest(unittest.TestCase):
+class IncrementalNewlineDecoderTest:
 
     def check_newline_decoding_utf8(self, decoder):
         # UTF-8 specific tests for a newline decoder
@@ -4317,7 +4317,7 @@ class IncrementalNewlineDecoderTest(unittest.TestCase):
         decoder = self.IncrementalNewlineDecoder(decoder, translate=0)
         self.assertEqual(decoder.decode(b"\r\r\n"), "\r\r\n")
 
-class CIncrementalNewlineDecoderTest(IncrementalNewlineDecoderTest):
+class CIncrementalNewlineDecoderTest(IncrementalNewlineDecoderTest, unittest.TestCase):
     IncrementalNewlineDecoder = io.IncrementalNewlineDecoder
 
     @support.cpython_only
@@ -4330,13 +4330,13 @@ class CIncrementalNewlineDecoderTest(IncrementalNewlineDecoderTest):
         self.assertRaises(ValueError, uninitialized.reset)
 
 
-class PyIncrementalNewlineDecoderTest(IncrementalNewlineDecoderTest):
+class PyIncrementalNewlineDecoderTest(IncrementalNewlineDecoderTest, unittest.TestCase):
     IncrementalNewlineDecoder = pyio.IncrementalNewlineDecoder
 
 
 # XXX Tests for open()
 
-class MiscIOTest(unittest.TestCase):
+class MiscIOTest:
 
     # for test__all__, actual values are set in subclasses
     name_of_module = None
@@ -4772,7 +4772,7 @@ class PyMiscIOTest(MiscIOTest, PyTestCase):
 
 
 @unittest.skipIf(os.name == 'nt', 'POSIX signals required for this test.')
-class SignalsTest(unittest.TestCase):
+class SignalsTest:
 
     def setUp(self):
         self.oldalrm = signal.signal(signal.SIGALRM, self.alarm_interrupt)
@@ -5055,25 +5055,6 @@ class ProtocolsTest(unittest.TestCase):
         self.assertIsSubclass(self.MyWriter, io.Writer)
         self.assertNotIsSubclass(str, io.Writer)
 
-
-def load_tests(loader, tests, pattern):
-    tests = (CIOTest, PyIOTest, APIMismatchTest,
-             CBufferedReaderTest, PyBufferedReaderTest,
-             CBufferedWriterTest, PyBufferedWriterTest,
-             CBufferedRWPairTest, PyBufferedRWPairTest,
-             CBufferedRandomTest, PyBufferedRandomTest,
-             StatefulIncrementalDecoderTest,
-             CIncrementalNewlineDecoderTest, PyIncrementalNewlineDecoderTest,
-             CTextIOWrapperTest, PyTextIOWrapperTest,
-             CMiscIOTest, PyMiscIOTest,
-             CSignalsTest, PySignalsTest, TestIOCTypes,
-             ProtocolsTest,
-             )
-
-    suite = loader.suiteClass()
-    for test in tests:
-        suite.addTest(loader.loadTestsFromTestCase(test))
-    return suite
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Rely on default test discovery.

Validation:
```
 # Run before commit
./python -m test test_io -uall,walltime,largefile,cpu,extralargefile -M25G -o --fail-env-changed -j0 --list-cases | sort > old_cases.txt
 # Run after commit
./python -m test test_io -uall,walltime,largefile,cpu,extralargefile -M25G -o --fail-env-changed -j0 --list-cases | sort > new_cases.txt

diff new_cases.txt old_cases.
 # <outputs no changes in case list>
````

cc: @srittau (GH-138369 where a test was added but wasn't run because of the manual test list)

<!-- gh-issue-number: gh-138013 -->
* Issue: gh-138013
<!-- /gh-issue-number -->
