### PR TITLE
gh-138775: fix handle `python -m base64` stdin correct with EOF signal

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -605,10 +605,10 @@ def main():
             # gh-138775: read input data at once when reading from stdin.
             import io
             data = sys.stdin.buffer.read()
-            func(io.BytesIO(data), sys.stdout.buffer)
+            buffer = io.BytesIO(data)
         else:
-            # keep the old behaviour for non-interactive input
-            func(sys.stdin.buffer, sys.stdout.buffer)
+            buffer = sys.stdin.buffer
+        func(buffer, sys.stdout.buffer)
 
 
 if __name__ == '__main__':

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -601,13 +601,17 @@ def main():
         with open(args[0], 'rb') as f:
             func(f, sys.stdout.buffer)
     else:
-        # Read all input data at once when reading from stdin
-        # This allows proper handling of EOF (Ctrl+D)
-        input_data = sys.stdin.buffer.read()
-        if input_data:
-            import io
-            input_buffer = io.BytesIO(input_data)
-            func(input_buffer, sys.stdout.buffer)
+        if sys.stdin.isatty():
+            # gh-gh-138775: read input data at once when reading from stdin
+            # This allows proper handling of EOF (Ctrl+D)
+            input_data = sys.stdin.buffer.read()
+            if input_data:
+                import io
+                input_buffer = io.BytesIO(input_data)
+                func(input_buffer, sys.stdout.buffer)
+        else:
+            # keep the old behaviour for non-interactive input
+            func(sys.stdin.buffer, sys.stdout.buffer)
 
 
 if __name__ == '__main__':

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -602,13 +602,10 @@ def main():
             func(f, sys.stdout.buffer)
     else:
         if sys.stdin.isatty():
-            # gh-gh-138775: read input data at once when reading from stdin
-            # This allows proper handling of EOF (Ctrl+D)
-            input_data = sys.stdin.buffer.read()
-            if input_data:
-                import io
-                input_buffer = io.BytesIO(input_data)
-                func(input_buffer, sys.stdout.buffer)
+            # gh-138775: read input data at once when reading from stdin.
+            import io
+            data = sys.stdin.buffer.read()
+            func(io.BytesIO(data), sys.stdout.buffer)
         else:
             # keep the old behaviour for non-interactive input
             func(sys.stdin.buffer, sys.stdout.buffer)

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -601,7 +601,13 @@ def main():
         with open(args[0], 'rb') as f:
             func(f, sys.stdout.buffer)
     else:
-        func(sys.stdin.buffer, sys.stdout.buffer)
+        # Read all input data at once when reading from stdin
+        # This allows proper handling of EOF (Ctrl+D)
+        input_data = sys.stdin.buffer.read()
+        if input_data:
+            import io
+            input_buffer = io.BytesIO(input_data)
+            func(input_buffer, sys.stdout.buffer)
 
 
 if __name__ == '__main__':

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -602,7 +602,7 @@ def main():
             func(f, sys.stdout.buffer)
     else:
         if sys.stdin.isatty():
-            # gh-138775: read input data at once when reading from stdin.
+            # gh-138775: read terminal input data all at once to detect EOF
             import io
             data = sys.stdin.buffer.read()
             buffer = io.BytesIO(data)

--- a/Misc/NEWS.d/next/Library/2025-09-11-15-03-37.gh-issue-138775.w7rnSx.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-11-15-03-37.gh-issue-138775.w7rnSx.rst
@@ -1,1 +1,1 @@
-:mod:`base64`: fix reading from stdin for the command-line interface.
+:mod:`base64`: fix the EOF being ignored in command-line interface.

--- a/Misc/NEWS.d/next/Library/2025-09-11-15-03-37.gh-issue-138775.w7rnSx.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-11-15-03-37.gh-issue-138775.w7rnSx.rst
@@ -1,0 +1,1 @@
+Fix: handle "python -m base64" stdin correct with EOF single.

--- a/Misc/NEWS.d/next/Library/2025-09-11-15-03-37.gh-issue-138775.w7rnSx.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-11-15-03-37.gh-issue-138775.w7rnSx.rst
@@ -1,1 +1,1 @@
-Fix: handle "python -m base64" stdin correct with EOF single.
+:mod:`base64`: fix reading from stdin for the command-line interface.

--- a/Misc/NEWS.d/next/Library/2025-09-11-15-03-37.gh-issue-138775.w7rnSx.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-11-15-03-37.gh-issue-138775.w7rnSx.rst
@@ -1,1 +1,2 @@
-:mod:`base64`: fix the EOF being ignored in command-line interface.
+Use of ``python -m`` with :mod:`base64` has been fixed to detect input from a
+terminal so that it properly notices EOF.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This make `python -m base64` the same behavior as `ast` or `json`

<!-- gh-issue-number: gh-138775 -->
* Issue: gh-138775
<!-- /gh-issue-number -->
