### PR TITLE
gh-138779: Use the dev_t converter for st_rdev

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-09-11-11-09-28.gh-issue-138779.TNZnLr.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-11-11-09-28.gh-issue-138779.TNZnLr.rst
@@ -1,0 +1,3 @@
+Support device numbers larger than ``2**63-1`` for the
+:attr:`~os.stat_result.st_rdev` field of the :class:`os.stat_result`
+structure.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2759,7 +2759,7 @@ _pystat_fromstructstat(PyObject *module, STRUCT_STAT *st)
     SET_ITEM(ST_BLOCKS_IDX, PyLong_FromLong((long)st->st_blocks));
 #endif
 #ifdef HAVE_STRUCT_STAT_ST_RDEV
-    SET_ITEM(ST_RDEV_IDX, PyLong_FromLong((long)st->st_rdev));
+    SET_ITEM(ST_RDEV_IDX, _PyLong_FromDev(st->st_rdev));
 #endif
 #ifdef HAVE_STRUCT_STAT_ST_GEN
     SET_ITEM(ST_GEN_IDX, PyLong_FromLong((long)st->st_gen));


### PR DESCRIPTION
This allows to support device numbers larger than 2**63-1.


<!-- gh-issue-number: gh-138779 -->
* Issue: gh-138779
<!-- /gh-issue-number -->
