### PR TITLE
gh-138764: annotationlib - Check if the `VALUE_WITH_FAKE_GLOBALS` format is implemented before calling an `__annotate__` function with empty fake globals

### DIFF
--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -8,6 +8,7 @@ import functools
 import itertools
 import pickle
 from string.templatelib import Template
+import types
 import typing
 import unittest
 import unittest.mock
@@ -1248,15 +1249,27 @@ class TestCallAnnotateFunction(unittest.TestCase):
     def test_user_annotate_forwardref(self):
         annotate = self._annotate_mock()
 
-        with self.assertRaises(NotImplementedError):
-            annotations = annotationlib.call_annotate_function(
-                annotate,
-                Format.FORWARDREF,
-            )
+        new_annotate = None
+        functype = types.FunctionType
 
-        # The annotate function itself is not called the second time
-        # A new function built from the code is called instead
+        def functiontype_mock(*args, **kwargs):
+            nonlocal new_annotate
+            new_func = unittest.mock.MagicMock(wraps=functype(*args, **kwargs))
+            new_annotate = new_func
+            return new_func
+
+        with unittest.mock.patch("types.FunctionType", new=functiontype_mock):
+            with self.assertRaises(NotImplementedError):
+                annotations = annotationlib.call_annotate_function(
+                    annotate,
+                    Format.FORWARDREF,
+                )
+
+        # Test the direct call
         annotate.assert_called_once_with(Format.FORWARDREF)
+
+        # Test the call on the function with fake globals
+        new_annotate.assert_called_once_with(Format.VALUE_WITH_FAKE_GLOBALS)
 
     def test_user_annotate_string(self):
         annotate = self._annotate_mock()

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1255,8 +1255,8 @@ class TestCallAnnotateFunction(unittest.TestCase):
             )
 
         annotate.assert_has_calls([
-            unittest.mock.Call(Format.FORWARDREF),
-            unittest.mock.Call(Format.VALUE_WITH_FAKE_GLOBALS),
+            unittest.mock.call(Format.FORWARDREF),
+            unittest.mock.call(Format.VALUE_WITH_FAKE_GLOBALS),
         ])
 
     def test_user_annotate_string(self):
@@ -1269,8 +1269,8 @@ class TestCallAnnotateFunction(unittest.TestCase):
             )
 
         annotate.assert_has_calls([
-            unittest.mock.Call(Format.STRING),
-            unittest.mock.Call(Format.VALUE_WITH_FAKE_GLOBALS),
+            unittest.mock.call(Format.STRING),
+            unittest.mock.call(Format.VALUE_WITH_FAKE_GLOBALS),
         ])
 
 

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1254,10 +1254,9 @@ class TestCallAnnotateFunction(unittest.TestCase):
                 Format.FORWARDREF,
             )
 
-        annotate.assert_has_calls([
-            unittest.mock.call(Format.FORWARDREF),
-            unittest.mock.call(Format.VALUE_WITH_FAKE_GLOBALS),
-        ])
+        # The annotate function itself is not called the second time
+        # A new function built from the code is called instead
+        annotate.assert_called_once_with(Format.FORWARDREF)
 
     def test_user_annotate_string(self):
         annotate = self._annotate_mock()
@@ -1272,7 +1271,6 @@ class TestCallAnnotateFunction(unittest.TestCase):
             unittest.mock.call(Format.STRING),
             unittest.mock.call(Format.VALUE_WITH_FAKE_GLOBALS),
         ])
-
 
 
 class MetaclassTests(unittest.TestCase):


### PR DESCRIPTION
This fixes an issue where user defined `__annotate__` functions that do not support a specific format would be called with fake globals in a way that they couldn't correctly raise `NotImplementedError`.

One downside is that some `annotate` functions that may have appeared to 'work' before now correctly fail. It's possible we may want to add some kind of fallback to `VALUE` annotations in these cases, but calling with fake globals as it does now would only accidentally succeed depending on exactly how the function performs the comparisons.

```python
from annotationlib import Format, call_annotate_function
def annotate(format, /):
    if format == Format.VALUE:
        return {'x': str}
    else:
        raise NotImplementedError(format)

print(call_annotate_function(annotate, Format.STRING))
```

Current:
```python
{'x': 'str'}
```

With patch:
```python
NotImplementedError: 2
```

But change the comparison to check if the format is in a set:
```python
from annotationlib import Format, call_annotate_function

def annotate(format, /):
    if format in {Format.VALUE}:
        return {'x': str}
    else:
        raise NotImplementedError(format)

print(call_annotate_function(annotate, Format.STRING))
```

Current:
```python
TypeError: exceptions must derive from BaseException
```

With patch:
```python
NotImplementedError: 2
```

<!-- gh-issue-number: gh-138764 -->
* Issue: gh-138764
<!-- /gh-issue-number -->
