### PR TITLE
gh-138791: fix crash when visiting a non-consumed timer handler

### DIFF
--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -508,6 +508,23 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         widget.selection_range(0, 'end')
         self.assertEqual(widget.selection_get(), '\u20ac\0abc\x00def')
 
+    def test_settrace_gc(self):
+        # Regression test for https://github.com/python/cpython/issues/138791.
+        root = tkinter.Tk()
+        trace = lambda *_, **__: None
+        trace.evil = type(root.tk)
+        root.tk.settrace(trace)
+        root.destroy()
+
+    def test_createtimerhandler_gc(self):
+        # Regression test for https://github.com/python/cpython/issues/138791.
+        root = tkinter.Tk()
+        func = lambda *_, **__: None
+        func.evil = type(root.tk.createtimerhandler(0, print))
+        # Large timeout (in ms) so that the object is destroyed before.
+        root.tk.createtimerhandler(1234567, func)
+        root.destroy()
+
 
 class WmTest(AbstractTkTest, unittest.TestCase):
 

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -2764,7 +2764,14 @@ static int
 Tktt_Clear(PyObject *op)
 {
     TkttObject *self = TkttObject_CAST(op);
-    Py_CLEAR(self->func);
+    if (self->token != NULL) {
+        Tcl_DeleteTimerHandler(self->token);
+        self->token = NULL;
+    }
+    if (self->func != NULL) {
+        Py_CLEAR(self->func);
+        Py_DECREF(op); /* See Tktt_New() */
+    }
     return 0;
 }
 
@@ -2783,6 +2790,9 @@ Tktt_Traverse(PyObject *op, visitproc visit, void *arg)
 {
     TkttObject *self = TkttObject_CAST(op);
     Py_VISIT(Py_TYPE(op));
+    if (self->token != NULL) {
+        Py_VISIT(op); /* See Tktt_New() */
+    }
     Py_VISIT(self->func);
     return 0;
 }


### PR DESCRIPTION
In 283380a9417eebf1bf9d3a1e941cef94149712bb, I forgot to take into account the following:

- a timer handler may not necessarily be destroyed when we deallocate the window. 
- whenever a timer handler is created, there are actually **two** references that are created; one regular and one that is used as client data and sent to Tcl.

When the handler is called, this extra reference is cleared and the Tcl handler is destroyed. However, if the object is destroyed before that, this never happens, so we're having a leak.

cc @serhiy-storchaka 

<!-- gh-issue-number: gh-116946 -->
* Issue: gh-116946
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-138791 -->
* Issue: gh-138791
<!-- /gh-issue-number -->
