### PR TITLE
[3.11] gh-135374: Adjust test for setuptools' replacement of distutils

### DIFF
--- a/Lib/test/test___all__.py
+++ b/Lib/test/test___all__.py
@@ -81,7 +81,7 @@ class AllTest(unittest.TestCase):
 
     def walk_modules(self, basedir, modpath):
         if modpath == 'distutils.':
-            # gh-135374: when setuptools ins installed, it now replaces
+            # gh-135374: when setuptools is installed, it now replaces
             # 'distutils' with its own version.
             # In a security-fix only branch of CPython,
             # skip the __all__ test rather than deal with the fallout.

--- a/Lib/test/test___all__.py
+++ b/Lib/test/test___all__.py
@@ -80,6 +80,12 @@ class AllTest(unittest.TestCase):
                 self.assertEqual(keys, all_set, "in module {}".format(modname))
 
     def walk_modules(self, basedir, modpath):
+        if modpath == 'distutils.':
+            # gh-135374: when setuptools ins installed, it now replaces
+            # 'distutils' with its own version.
+            # In a security-fix only branch of CPython,
+            # skip the __all__ test rather than deal with the fallout.
+            return
         for fn in sorted(os.listdir(basedir)):
             path = os.path.join(basedir, fn)
             if os.path.isdir(path):


### PR DESCRIPTION
ensurepip installs a bundled copy of distutils, which overrides the stdlib module. This affects several tests. This commit:

- skips distutils in test___all__, as we're unlikely to break `__all__` in a security-fix-only branch (and if we do it's not much of a a big deal)
- skips importability tests of distutils submodules if the setuptools hack is detected

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135374 -->
* Issue: gh-135374
<!-- /gh-issue-number -->
