### PR TITLE
gh-138801: pyrepl tests on Windows aren't executed anymore

### DIFF
--- a/Lib/test/test_pyrepl/__init__.py
+++ b/Lib/test/test_pyrepl/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from test.support import import_helper, load_package_tests
-import unittest
+
 
 if sys.platform != "win32":
     import_helper.import_module("termios")

--- a/Lib/test/test_pyrepl/__init__.py
+++ b/Lib/test/test_pyrepl/__init__.py
@@ -1,15 +1,10 @@
 import os
 import sys
-from test.support import load_package_tests
+from test.support import import_helper, load_package_tests
 import unittest
 
 if sys.platform != "win32":
-    try:
-        import termios
-    except ImportError:
-        raise unittest.SkipTest("termios required")
-    else:
-        del termios
+    import_helper.import_module("termios")
 
 
 def load_tests(*args):

--- a/Lib/test/test_pyrepl/__init__.py
+++ b/Lib/test/test_pyrepl/__init__.py
@@ -1,14 +1,15 @@
 import os
+import sys
 from test.support import load_package_tests
 import unittest
 
-
-try:
-    import termios
-except ImportError:
-    raise unittest.SkipTest("termios required")
-else:
-    del termios
+if sys.platform != "win32":
+    try:
+        import termios
+    except ImportError:
+        raise unittest.SkipTest("termios required")
+    else:
+        del termios
 
 
 def load_tests(*args):


### PR DESCRIPTION
Since https://github.com/python/cpython/pull/136758 the pyrepl tests are skipped due to
```
test_pyrepl skipped -- termios required
```
see e.g. https://github.com/python/cpython/actions/runs/17614938779/job/50045564781#step:6:192.

With this PR applied, running `python -m test test_pyrepl` I get
```
Running Release|x64 interpreter...
Using random seed: 3290436162
0:00:00 Run 1 test sequentially in a single process
0:00:00 [1/1] test_pyrepl
0:00:02 [1/1] test_pyrepl passed

== Tests result: SUCCESS ==

1 test OK.

Total duration: 2.2 sec
Total tests: run=238 skipped=48
Total test files: run=1/1
Result: SUCCESS
```

I think this is a skip news?


<!-- gh-issue-number: gh-138801 -->
* Issue: gh-138801
<!-- /gh-issue-number -->
