### PR TITLE
gh-138764: annotationlib - Make `call_annotate_function` fallback to using `VALUE` annotations if both the requested format and `VALUE_WITH_FAKE_GLOBALS` are not implemented

### DIFF
--- a/Doc/library/annotationlib.rst
+++ b/Doc/library/annotationlib.rst
@@ -340,13 +340,28 @@ Functions
 
    * VALUE: :attr:`!object.__annotations__` is tried first; if that does not exist,
      the :attr:`!object.__annotate__` function is called if it exists.
+
    * FORWARDREF: If :attr:`!object.__annotations__` exists and can be evaluated successfully,
      it is used; otherwise, the :attr:`!object.__annotate__` function is called. If it
      does not exist either, :attr:`!object.__annotations__` is tried again and any error
      from accessing it is re-raised.
+
+     * When calling :attr:`!object.__annotate__` it is first called with :attr:`~Format.FORWARDREF`,
+       if this is not implemented it will then check if :attr:`~Format.VALUE_WITH_FAKE_GLOBALS`
+       is supported and use that in the fake globals environment.
+       If neither of these formats are supported it will fall back to using :attr:`~Format.VALUE`.
+       If :attr:`~Format.VALUE` fails, the error from this call will be raised.
+
    * STRING: If :attr:`!object.__annotate__` exists, it is called first;
      otherwise, :attr:`!object.__annotations__` is used and stringified
      using :func:`annotations_to_string`.
+
+     * When calling :attr:`!object.__annotate__` it is first called with :attr:`~Format.STRING`,
+       if this is not implemented it will then check if :attr:`~Format.VALUE_WITH_FAKE_GLOBALS`
+       is supported and use that in the fake globals environment.
+       If neither of these formats are supported it will fall back to using :attr:`~Format.VALUE`
+       with the result converted using :func:`annotations_to_string`.
+       If :attr:`~Format.VALUE` fails, the error from this call will be raised.
 
    Returns a dict. :func:`!get_annotations` returns a new dict every time
    it's called; calling it twice on the same object will return two

--- a/Doc/library/annotationlib.rst
+++ b/Doc/library/annotationlib.rst
@@ -346,20 +346,20 @@ Functions
      does not exist either, :attr:`!object.__annotations__` is tried again and any error
      from accessing it is re-raised.
 
-     * When calling :attr:`!object.__annotate__` it is first called with :attr:`~Format.FORWARDREF`,
-       if this is not implemented it will then check if :attr:`~Format.VALUE_WITH_FAKE_GLOBALS`
+     * When calling :attr:`!object.__annotate__` it is first called with :attr:`~Format.FORWARDREF`.
+       If this is not implemented, it will then check if :attr:`~Format.VALUE_WITH_FAKE_GLOBALS`
        is supported and use that in the fake globals environment.
-       If neither of these formats are supported it will fall back to using :attr:`~Format.VALUE`.
+       If neither of these formats are supported, it will fall back to using :attr:`~Format.VALUE`.
        If :attr:`~Format.VALUE` fails, the error from this call will be raised.
 
    * STRING: If :attr:`!object.__annotate__` exists, it is called first;
      otherwise, :attr:`!object.__annotations__` is used and stringified
      using :func:`annotations_to_string`.
 
-     * When calling :attr:`!object.__annotate__` it is first called with :attr:`~Format.STRING`,
-       if this is not implemented it will then check if :attr:`~Format.VALUE_WITH_FAKE_GLOBALS`
+     * When calling :attr:`!object.__annotate__` it is first called with :attr:`~Format.STRING`.
+       If this is not implemented, it will then check if :attr:`~Format.VALUE_WITH_FAKE_GLOBALS`
        is supported and use that in the fake globals environment.
-       If neither of these formats are supported it will fall back to using :attr:`~Format.VALUE`
+       If neither of these formats are supported, it will fall back to using :attr:`~Format.VALUE`
        with the result converted using :func:`annotations_to_string`.
        If :attr:`~Format.VALUE` fails, the error from this call will be raised.
 

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -671,7 +671,8 @@ def call_annotate_function(annotate, format, *, owner=None, _is_evaluate=False):
         try:
             annotate(Format.VALUE_WITH_FAKE_GLOBALS)
         except NotImplementedError:
-            raise
+            # Both STRING and VALUE_WITH_FAKE_GLOBALS are not implemented fallback to VALUE
+            return annotations_to_string(annotate(Format.VALUE))
         except Exception:
             pass
 
@@ -734,9 +735,8 @@ def call_annotate_function(annotate, format, *, owner=None, _is_evaluate=False):
         try:
             result = func(Format.VALUE_WITH_FAKE_GLOBALS)
         except NotImplementedError:
-            # If NotImplementedError is raised, don't try to call again with
-            # no globals.
-            raise
+            # FORWARDREF and VALUE_WITH_FAKE_GLOBALS not supported, fall back to VALUE
+            return annotate(Format.VALUE)
         except Exception:
             pass
         else:

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -671,7 +671,7 @@ def call_annotate_function(annotate, format, *, owner=None, _is_evaluate=False):
         try:
             annotate(Format.VALUE_WITH_FAKE_GLOBALS)
         except NotImplementedError:
-            # Both STRING and VALUE_WITH_FAKE_GLOBALS are not implemented fallback to VALUE
+            # Both STRING and VALUE_WITH_FAKE_GLOBALS are not implemented: fallback to VALUE
             return annotations_to_string(annotate(Format.VALUE))
         except Exception:
             pass

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1255,8 +1255,8 @@ class TestCallAnnotateFunction(unittest.TestCase):
             )
 
         annotate.assert_has_calls([
-            unittest.mock.Call(Format.FORWARDREF),
-            unittest.mock.Call(Format.VALUE_WITH_FAKE_GLOBALS),
+            unittest.mock.call(Format.FORWARDREF),
+            unittest.mock.call(Format.VALUE_WITH_FAKE_GLOBALS),
         ])
 
     def test_user_annotate_string(self):
@@ -1269,8 +1269,8 @@ class TestCallAnnotateFunction(unittest.TestCase):
             )
 
         annotate.assert_has_calls([
-            unittest.mock.Call(Format.STRING),
-            unittest.mock.Call(Format.VALUE_WITH_FAKE_GLOBALS),
+            unittest.mock.call(Format.STRING),
+            unittest.mock.call(Format.VALUE_WITH_FAKE_GLOBALS),
         ])
 
 

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1254,10 +1254,9 @@ class TestCallAnnotateFunction(unittest.TestCase):
                 Format.FORWARDREF,
             )
 
-        annotate.assert_has_calls([
-            unittest.mock.call(Format.FORWARDREF),
-            unittest.mock.call(Format.VALUE_WITH_FAKE_GLOBALS),
-        ])
+        # The annotate function itself is not called the second time
+        # A new function built from the code is called instead
+        annotate.assert_called_once_with(Format.FORWARDREF)
 
     def test_user_annotate_string(self):
         annotate = self._annotate_mock()
@@ -1272,7 +1271,6 @@ class TestCallAnnotateFunction(unittest.TestCase):
             unittest.mock.call(Format.STRING),
             unittest.mock.call(Format.VALUE_WITH_FAKE_GLOBALS),
         ])
-
 
 
 class MetaclassTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2025-09-12-09-34-37.gh-issue-138764.mokHoY.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-12-09-34-37.gh-issue-138764.mokHoY.rst
@@ -1,0 +1,2 @@
+Prevent ``annotationlib.call_annotate_function`` from calling ``annotate`` functions that don't support ``VALUE_WITH_FAKE_GLOBALS`` in a fake globals namespace with empty globals.
+Make ``FORWARDREF`` and ``STRING`` annotations fall back to using ``VALUE`` annotations in the case that neither their own format, nor ``VALUE_WITH_FAKE_GLOBALS`` are supported.

--- a/Misc/NEWS.d/next/Library/2025-09-12-09-34-37.gh-issue-138764.mokHoY.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-12-09-34-37.gh-issue-138764.mokHoY.rst
@@ -1,2 +1,3 @@
-Prevent ``annotationlib.call_annotate_function`` from calling ``annotate`` functions that don't support ``VALUE_WITH_FAKE_GLOBALS`` in a fake globals namespace with empty globals.
+Prevent :func:`annotationlib.call_annotate_function` from calling ``__annotate__`` functions that don't support ``VALUE_WITH_FAKE_GLOBALS`` in a fake globals namespace with empty globals.
+
 Make ``FORWARDREF`` and ``STRING`` annotations fall back to using ``VALUE`` annotations in the case that neither their own format, nor ``VALUE_WITH_FAKE_GLOBALS`` are supported.


### PR DESCRIPTION
Alternative to #138788 - instead of raising the `NotImplementedError` this falls back to calling an annotate function with `Format.VALUE` if both the specified format and `Format.VALUE_WITH_FAKE_GLOBALS` are both not implemented.

I think this may be more useful behaviour than #138788 ?

If `VALUE` also fails, then the only option was failure from the start. I think it's more consistent to raise the error from `VALUE` annotations in that case.

Using the examples from the other PR:

```python
from annotationlib import Format, call_annotate_function

def annotate(format, /):
    if format == Format.VALUE:
        return {'x': str}
    else:
        raise NotImplementedError(format)

print(call_annotate_function(annotate, Format.STRING))
```

On main, and with this patch:
```python
{'x': 'str'}
```

```python
from annotationlib import Format, call_annotate_function

def annotate(format, /):
    if format in {Format.VALUE}:
        return {'x': str}
    else:
        raise NotImplementedError(format)

print(call_annotate_function(annotate, Format.STRING))
```

Main:
```python
TypeError: exceptions must derive from BaseException
```

Patch:
```python
{'x': 'str'}
```

<!-- gh-issue-number: gh-138764 -->
* Issue: gh-138764
<!-- /gh-issue-number -->
