### PR TITLE
Make Android streams respect the unbuffered (`-u`) option

### DIFF
--- a/Lib/_android_support.py
+++ b/Lib/_android_support.py
@@ -29,15 +29,19 @@ def init_streams(android_log_write, stdout_prio, stderr_prio):
 
     global logcat
     logcat = Logcat(android_log_write)
-
-    sys.stdout = TextLogStream(
-        stdout_prio, "python.stdout", sys.stdout.fileno())
-    sys.stderr = TextLogStream(
-        stderr_prio, "python.stderr", sys.stderr.fileno())
+    sys.stdout = TextLogStream(stdout_prio, "python.stdout", sys.stdout)
+    sys.stderr = TextLogStream(stderr_prio, "python.stderr", sys.stderr)
 
 
 class TextLogStream(io.TextIOWrapper):
-    def __init__(self, prio, tag, fileno=None, **kwargs):
+    def __init__(self, prio, tag, original=None, **kwargs):
+        # Respect the -u option.
+        if original:
+            kwargs.setdefault("write_through", original.write_through)
+            fileno = original.fileno()
+        else:
+            fileno = None
+
         # The default is surrogateescape for stdout and backslashreplace for
         # stderr, but in the context of an Android log, readability is more
         # important than reversibility.


### PR DESCRIPTION
While working on #138805, I updated the Android stream tests to be compatible with unbuffered mode. However, this mode isn't very readable on Android, because it causes lines to be split into multiple log messages. So the Android CI and buildbots are still not using unbuffered mode, but we might as well be compatible with it anyway.

I'm putting this in a separate PR from #138805 because neither change depends on the other.