### PR TITLE
gh-138813: Fix mutable default kwargs={} in multiprocessing BaseProcess and DummyProcess to use None

### DIFF
--- a/Lib/multiprocessing/dummy/__init__.py
+++ b/Lib/multiprocessing/dummy/__init__.py
@@ -33,7 +33,7 @@ from queue import Queue
 
 class DummyProcess(threading.Thread):
 
-    def __init__(self, group=None, target=None, name=None, args=(), kwargs={}):
+    def __init__(self, group=None, target=None, name=None, args=(), kwargs=None):
         threading.Thread.__init__(self, group, target, name, args, kwargs)
         self._pid = None
         self._children = weakref.WeakKeyDictionary()

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -77,7 +77,7 @@ class BaseProcess(object):
     def _Popen(self):
         raise NotImplementedError
 
-    def __init__(self, group=None, target=None, name=None, args=(), kwargs={},
+    def __init__(self, group=None, target=None, name=None, args=(), kwargs=None,
                  *, daemon=None):
         assert group is None, 'group argument must be None for now'
         count = next(_process_counter)
@@ -89,7 +89,7 @@ class BaseProcess(object):
         self._closed = False
         self._target = target
         self._args = tuple(args)
-        self._kwargs = dict(kwargs)
+        self._kwargs = dict(kwargs) if kwargs else {}
         self._name = name or type(self).__name__ + '-' + \
                      ':'.join(str(i) for i in self._identity)
         if daemon is not None:

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5278,6 +5278,23 @@ class TestInvalidHandle(unittest.TestCase):
                           multiprocessing.connection.Connection, -1)
 
 
+#
+# Regression tests for BaseProcess kwargs handling
+#
+
+class TestBaseProcessKwargs(unittest.TestCase):
+    def test_default_kwargs_not_shared_between_instances(self):
+        # Creating multiple Process instances without passing kwargs
+        # must create independent empty dicts (no shared state).
+        p1 = multiprocessing.Process(target=lambda: None)
+        p2 = multiprocessing.Process(target=lambda: None)
+        self.assertIsInstance(p1._kwargs, dict)
+        self.assertIsInstance(p2._kwargs, dict)
+        self.assertIsNot(p1._kwargs, p2._kwargs)
+        # Mutating one should not affect the other
+        p1._kwargs['x'] = 1
+        self.assertNotIn('x', p2._kwargs)
+
 
 @hashlib_helper.requires_hashdigest('sha256')
 class OtherTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2025-09-17-08-32-43.gh-issue-138813.LHkHjX.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-17-08-32-43.gh-issue-138813.LHkHjX.rst
@@ -1,1 +1,1 @@
-:class:!`multiprocessing.BaseProcess` defaults ``kwargs`` to ``None`` instead of a shared dictionary.
+:class:`!multiprocessing.BaseProcess` defaults ``kwargs`` to ``None`` instead of a shared dictionary.

--- a/Misc/NEWS.d/next/Library/2025-09-17-08-32-43.gh-issue-138813.LHkHjX.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-17-08-32-43.gh-issue-138813.LHkHjX.rst
@@ -1,0 +1,1 @@
+:class:!`multiprocessing.BaseProcess` defaults ``kwargs`` to ``None`` instead of a shared dictionary.


### PR DESCRIPTION
Change the default value of the 'kwargs' parameter in DummyProcess.__init__() from {} to None to avoid mutable default argument issues. This makes DummyProcess consistent with threading.Thread and threading.Timer which already use this pattern.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

Reported by: Dmitrii Chuprov <cheese@altlinux.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138813 -->
* Issue: gh-138813
<!-- /gh-issue-number -->
