### PR TITLE
Added some more info on PyModule_GetState doc.

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -98,6 +98,7 @@ Module Objects
 
    See :pep:`489` for more details.
 
+
 .. c:function:: PyModuleDef* PyModule_GetDef(PyObject *module)
 
    Return a pointer to the :c:type:`PyModuleDef` struct from which the module was

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -96,7 +96,7 @@ Module Objects
    allocated at module creation time, or ``NULL``.  See
    :c:member:`PyModuleDef.m_size`.
 
-   See :PEP:`489` for more details.
+   See :pep:`489` for more details.
 
 .. c:function:: PyModuleDef* PyModule_GetDef(PyObject *module)
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -96,6 +96,7 @@ Module Objects
    allocated at module creation time, or ``NULL``.  See
    :c:member:`PyModuleDef.m_size`.
 
+   See :PEP:`489` for more details.
 
 .. c:function:: PyModuleDef* PyModule_GetDef(PyObject *module)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


This PR adds more information on how to use the `PyModule_GetState` function, clarifying what argument should be passed.

At first glance, people might incorrectly think they need to pass a pointer to a state struct that the function will populate, but that is not the case.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138823.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->