### PR TITLE
gh-129813, PEP 782: Add PyBytesWriter_Format()

### DIFF
--- a/Doc/c-api/bytes.rst
+++ b/Doc/c-api/bytes.rst
@@ -307,6 +307,15 @@ High-level API
    On success, return ``0``.
    On error, set an exception and return ``-1``.
 
+.. c:function:: int PyBytesWriter_Format(PyBytesWriter *writer, const char *format, ...)
+
+   Similar to :c:func:`PyBytes_FromFormat`, but write the output directly at
+   the writer end. Grow the writer internal buffer on demand. Then add the
+   written size to the writer size.
+
+   On success, return ``0``.
+   On error, set an exception and return ``-1``.
+
 
 Getters
 ^^^^^^^

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -714,6 +714,7 @@ New features
   * :c:func:`PyBytesWriter_FinishWithPointer`
   * :c:func:`PyBytesWriter_FinishWithSize`
   * :c:func:`PyBytesWriter_Finish`
+  * :c:func:`PyBytesWriter_Format`
   * :c:func:`PyBytesWriter_GetData`
   * :c:func:`PyBytesWriter_GetSize`
   * :c:func:`PyBytesWriter_GrowAndUpdatePointer`

--- a/Include/cpython/bytesobject.h
+++ b/Include/cpython/bytesobject.h
@@ -68,6 +68,10 @@ PyAPI_FUNC(int) PyBytesWriter_WriteBytes(
     PyBytesWriter *writer,
     const void *bytes,
     Py_ssize_t size);
+PyAPI_FUNC(int) PyBytesWriter_Format(
+    PyBytesWriter *writer,
+    const char *format,
+    ...);
 
 PyAPI_FUNC(int) PyBytesWriter_Resize(
     PyBytesWriter *writer,

--- a/Lib/test/test_capi/test_bytes.py
+++ b/Lib/test/test_capi/test_bytes.py
@@ -361,11 +361,25 @@ class BytesWriterTest(unittest.TestCase):
         writer.resize(len(b'number=123456'), b'456')
         self.assertEqual(writer.finish(), self.result_type(b'number=123456'))
 
+    def test_format_i(self):
+        # Test PyBytesWriter_Format()
+        writer = self.create_writer()
+        writer.format_i(b'x=%i', 123456)
+        self.assertEqual(writer.finish(), self.result_type(b'x=123456'))
+
+        writer = self.create_writer()
+        writer.format_i(b'x=%i, ', 123)
+        writer.format_i(b'y=%i', 456)
+        self.assertEqual(writer.finish(), self.result_type(b'x=123, y=456'))
+
     def test_example_abc(self):
         self.assertEqual(_testcapi.byteswriter_abc(), b'abc')
 
     def test_example_resize(self):
         self.assertEqual(_testcapi.byteswriter_resize(), b'Hello World')
+
+    def test_example_highlevel(self):
+        self.assertEqual(_testcapi.byteswriter_highlevel(), b'Hello World!')
 
 
 class ByteArrayWriterTest(BytesWriterTest):
@@ -373,6 +387,7 @@ class ByteArrayWriterTest(BytesWriterTest):
 
     def create_writer(self, alloc=0, string=b''):
         return _testcapi.PyBytesWriter(alloc, string, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/C_API/2025-09-12-13-05-20.gh-issue-129813.dJZpME.rst
+++ b/Misc/NEWS.d/next/C_API/2025-09-12-13-05-20.gh-issue-129813.dJZpME.rst
@@ -5,6 +5,7 @@ Implement :pep:`782`, the :c:type:`PyBytesWriter` API. Add functions:
 * :c:func:`PyBytesWriter_FinishWithPointer`
 * :c:func:`PyBytesWriter_FinishWithSize`
 * :c:func:`PyBytesWriter_Finish`
+* :c:func:`PyBytesWriter_Format`
 * :c:func:`PyBytesWriter_GetData`
 * :c:func:`PyBytesWriter_GetSize`
 * :c:func:`PyBytesWriter_GrowAndUpdatePointer`


### PR DESCRIPTION
Modify PyBytes_FromFormatV() to use the public PyBytesWriter API rather than the _PyBytesWriter private API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129813 -->
* Issue: gh-129813
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138824.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->