### PR TITLE
gh-117961: Fix grammar documentation for @ operator associativity

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1373,7 +1373,7 @@ from the power operator, there are only two levels, one for multiplicative
 operators and one for additive operators:
 
 .. productionlist:: python-grammar
-   m_expr: `u_expr` | `m_expr` "*" `u_expr` | `m_expr` "@" `m_expr` |
+   m_expr: `u_expr` | `m_expr` "*" `u_expr` | `m_expr` "@" `u_expr` |
          : `m_expr` "//" `u_expr` | `m_expr` "/" `u_expr` |
          : `m_expr` "%" `u_expr`
    a_expr: `m_expr` | `a_expr` "+" `m_expr` | `a_expr` "-" `m_expr`

--- a/Lib/pydoc_data/topics.py
+++ b/Lib/pydoc_data/topics.py
@@ -919,7 +919,7 @@ numeric types.  Apart from the power operator, there are only two
 levels, one for multiplicative operators and one for additive
 operators:
 
-   m_expr: u_expr | m_expr "*" u_expr | m_expr "@" u_expr |
+   m_expr: u_expr | m_expr "*" u_expr | m_expr "@" m_expr |
            m_expr "//" u_expr | m_expr "/" u_expr |
            m_expr "%" u_expr
    a_expr: m_expr | a_expr "+" m_expr | a_expr "-" m_expr

--- a/Lib/pydoc_data/topics.py
+++ b/Lib/pydoc_data/topics.py
@@ -919,7 +919,7 @@ numeric types.  Apart from the power operator, there are only two
 levels, one for multiplicative operators and one for additive
 operators:
 
-   m_expr: u_expr | m_expr "*" u_expr | m_expr "@" m_expr |
+   m_expr: u_expr | m_expr "*" u_expr | m_expr "@" u_expr |
            m_expr "//" u_expr | m_expr "/" u_expr |
            m_expr "%" u_expr
    a_expr: m_expr | a_expr "+" m_expr | a_expr "-" m_expr


### PR DESCRIPTION
The binary arithmetic operations grammar incorrectly showed the @ operator as right-associative (m_expr "@" m_expr) while all other multiplicative operators are left-associative (m_expr "*" u_expr).

According to PEP 465, the @ operator should have the same associativity as *. The actual parser implementation in Grammar/python.gram correctly implements left-associativity, but the documentation was inconsistent.

<!-- gh-issue-number: gh-117961 -->
* Issue: gh-117961
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138847.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->