### PR TITLE
gh-138859: Fix `TypeError` when there is a `ParamSpec` substitution with a default

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1172,6 +1172,28 @@ class GenericAliasSubstitutionTests(BaseTestCase):
                             eval(expected_str)
                         )
 
+    def test_paramspec_default_subst(self):
+        # See https://github.com/python/cpython/issues/138859
+
+        P_default = ParamSpec("P_default", default=...)
+        T = TypeVar("T")
+        T_default = TypeVar("T_default", default=object)
+
+        class A(Generic[T, P_default, T_default]): pass
+
+        # Must not raise:
+        ga = A[int]
+        self.assertEqual(ga.__args__, (int, ..., object))
+        self.assertEqual(ga.__parameters__, ())
+
+        ga = A[int, [str, complex]]
+        self.assertEqual(ga.__args__, (int, (str, complex), object))
+        self.assertEqual(ga.__parameters__, ())
+
+        ga = A[int, [str, complex], float]
+        self.assertEqual(ga.__args__, ((int, (str, complex), float)))
+        self.assertEqual(ga.__parameters__, ())
+
 
 class UnpackTests(BaseTestCase):
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1100,7 +1100,7 @@ def _paramspec_prepare_subst(self, alias, args):
     params = alias.__parameters__
     i = params.index(self)
     if i == len(args) and self.has_default():
-        args = [*args, self.__default__]
+        args = (*args, self.__default__)
     if i >= len(args):
         raise TypeError(f"Too few arguments for {alias}")
     # Special case where Z[[int, str, bool]] == Z[int, str, bool] in PEP 612.

--- a/Misc/NEWS.d/next/Library/2025-09-13-15-07-08.gh-issue-138859.74INn1.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-13-15-07-08.gh-issue-138859.74INn1.rst
@@ -1,0 +1,1 @@
+Fixes a :exc:`TypeError` when substituting ``ParamSpec`` with a default.


### PR DESCRIPTION


<!-- gh-issue-number: gh-138859 -->
* Issue: gh-138859
<!-- /gh-issue-number -->
