### PR TITLE
gh-138859: Account for `ParamSpec` defaults that are not lists …

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -762,6 +762,16 @@ class TypeParameterDefaultsTests(BaseTestCase):
         self.assertEqual(A[float, [range]].__args__, (float, (range,), float))
         self.assertEqual(A[float, [range], int].__args__, (float, (range,), int))
 
+    def test_paramspec_and_typevar_specialization_2(self):
+        T = TypeVar("T")
+        P = ParamSpec('P', default=...)
+        U = TypeVar("U", default=float)
+        self.assertEqual(P.__default__, ...)
+        class A(Generic[T, P, U]): ...
+        self.assertEqual(A[float].__args__, (float, ..., float))
+        self.assertEqual(A[float, [range]].__args__, (float, (range,), float))
+        self.assertEqual(A[float, [range], int].__args__, (float, (range,), int))
+
     def test_typevartuple_none(self):
         U = TypeVarTuple('U')
         U_None = TypeVarTuple('U_None', default=None)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1124,7 +1124,7 @@ def _paramspec_prepare_subst(self, alias, args):
     elif isinstance(args[i], list):
         args = (*args[:i], tuple(args[i]), *args[i+1:])
     else:
-        args = (*args[:i], args[i], *args[i + 1:])
+        args = tuple(args)
     return args
 
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1123,6 +1123,8 @@ def _paramspec_prepare_subst(self, alias, args):
     # Convert lists to tuples to help other libraries cache the results.
     elif isinstance(args[i], list):
         args = (*args[:i], tuple(args[i]), *args[i+1:])
+    else:
+        args = (*args[:i], args[i], *args[i + 1:])
     return args
 
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1113,7 +1113,7 @@ def _paramspec_prepare_subst(self, alias, args):
     params = alias.__parameters__
     i = params.index(self)
     if i == len(args) and self.has_default():
-        args = [*args, self.__default__]
+        args = (*args, self.__default__)
     if i >= len(args):
         raise TypeError(f"Too few arguments for {alias}")
     # Special case where Z[[int, str, bool]] == Z[int, str, bool] in PEP 612.
@@ -1123,8 +1123,6 @@ def _paramspec_prepare_subst(self, alias, args):
     # Convert lists to tuples to help other libraries cache the results.
     elif isinstance(args[i], list):
         args = (*args[:i], tuple(args[i]), *args[i+1:])
-    else:
-        args = tuple(args)
     return args
 
 

--- a/Misc/NEWS.d/next/Library/2025-09-13-12-19-17.gh-issue-138859.PxjIoN.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-13-12-19-17.gh-issue-138859.PxjIoN.rst
@@ -1,1 +1,1 @@
-Fix failure during parameterization of generics when a non-type-list ``ParamSpec`` default is followed by another type variable default, and the ``ParamSpec`` is not provided as a type argument.
+Fix generic type parameterization raising a :exc:`TypeError` when omitting a :class:`ParamSpec` that has a default which is not a list of types.

--- a/Misc/NEWS.d/next/Library/2025-09-13-12-19-17.gh-issue-138859.PxjIoN.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-13-12-19-17.gh-issue-138859.PxjIoN.rst
@@ -1,0 +1,1 @@
+Fix failure during parameterization of generics when a non-type-list `ParamSpec` default is followed by another type variable default, and the `ParamSpec` is not provided as a type argument.

--- a/Misc/NEWS.d/next/Library/2025-09-13-12-19-17.gh-issue-138859.PxjIoN.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-13-12-19-17.gh-issue-138859.PxjIoN.rst
@@ -1,1 +1,1 @@
-Fix failure during parameterization of generics when a non-type-list `ParamSpec` default is followed by another type variable default, and the `ParamSpec` is not provided as a type argument.
+Fix failure during parameterization of generics when a non-type-list ``ParamSpec`` default is followed by another type variable default, and the ``ParamSpec`` is not provided as a type argument.


### PR DESCRIPTION
…when converting type argument list to tuple

Allows omitting common `ParamSpec` defaults, like `...` or another `ParamSpec`.

* Issue: #138859 


<!-- gh-issue-number: gh-138859 -->
* Issue: gh-138859
<!-- /gh-issue-number -->
