### PR TITLE
Make sure `:keyword:` role works for `case`

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -590,6 +590,7 @@ the items are surrounded by parentheses. For example::
       statement.
 
 .. _match:
+.. _case:
 
 The :keyword:`!match` statement
 ===============================
@@ -618,7 +619,7 @@ The match statement is used for pattern matching.  Syntax:
    This section uses single quotes to denote
    :ref:`soft keywords <soft-keywords>`.
 
-Pattern matching takes a pattern as input (following ``case``) and a subject
+Pattern matching takes a pattern as input (following :keyword:`case`) and a subject
 value (following ``match``).  The pattern (which may contain subpatterns) is
 matched against the subject value.  The outcomes are:
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -619,7 +619,7 @@ The match statement is used for pattern matching.  Syntax:
    This section uses single quotes to denote
    :ref:`soft keywords <soft-keywords>`.
 
-Pattern matching takes a pattern as input (following :keyword:`case`) and a subject
+Pattern matching takes a pattern as input (following ``case``) and a subject
 value (following ``match``).  The pattern (which may contain subpatterns) is
 matched against the subject value.  The outcomes are:
 


### PR DESCRIPTION
Thanks a lot to @AA-Turner for help.

I decided not to change the heading, because it can be a part of the existing links: https://docs.python.org/3/reference/compound_stmts.html#the-match-statement And we can break it.

I also added a quick test for `:keyword:case`, let's see :)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138878.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->