### PR TITLE
gh-138899: fix make the same behavior in asyncio repl breakpoint() quit

### DIFF
--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -113,7 +113,7 @@ class REPLThread(threading.Thread):
                     run_multiline_interactive_console,
                 )
                 try:
-                    # sys.ps1 = ps1
+                    sys.ps1 = ps1
                     run_multiline_interactive_console(console)
                 except SystemExit:
                     # expected via the `exit` and `quit` commands

--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -113,6 +113,7 @@ class REPLThread(threading.Thread):
                     run_multiline_interactive_console,
                 )
                 try:
+                    # sys.ps1 = ps1
                     run_multiline_interactive_console(console)
                 except SystemExit:
                     # expected via the `exit` and `quit` commands

--- a/Misc/NEWS.d/next/Library/2025-09-15-08-57-39.gh-issue-138899.Uh6fvY.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-15-08-57-39.gh-issue-138899.Uh6fvY.rst
@@ -1,0 +1,3 @@
+Executing ``quit`` command in :mod:`pdb` will raise :exc:`bdb.BdbQuit` when
+:mod:`pdb` is started from an asyncio console using :func:`breakpoint` or
+:func:`pdb.set_trace`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

the change make sure in asyncio repl has a `ps1` in `sys`
behavior follow the PR https://github.com/python/cpython/pull/130395


<!-- gh-issue-number: gh-138899 -->
* Issue: gh-138899
<!-- /gh-issue-number -->
