### PR TITLE
gh-129813, PEP 782: Use PyBytesWriter in _io.FileIO.readall

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-09-14-18-21-17.gh-issue-129813.XN7EyU.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-14-18-21-17.gh-issue-129813.XN7EyU.rst
@@ -1,0 +1,2 @@
+Update :class:`io.FileIO` to use :pep:`782` :c:type:`PyBytesWriter` to
+implement :meth:`~io.RawIOBase.readall`

--- a/Misc/NEWS.d/next/Library/2025-09-14-18-21-17.gh-issue-129813.XN7EyU.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-14-18-21-17.gh-issue-129813.XN7EyU.rst
@@ -1,2 +1,0 @@
-Update :class:`io.FileIO` to use :pep:`782` :c:type:`PyBytesWriter` to
-implement :meth:`~io.RawIOBase.readall`

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -817,7 +817,7 @@ _io_FileIO_readall_impl(fileio *self)
         }
 
         n = _Py_read(self->fd,
-                     PyBytesWriter_GetData(writer) + bytes_read,
+                     (char*)PyBytesWriter_GetData(writer) + bytes_read,
                      bufsize - bytes_read);
 
         if (n == 0)


### PR DESCRIPTION
Performance largely flat, maybe faster on `bm_readall.py` from gh-120754 (read all python docs and py files using readall).

```bash
$ pyperf compare_to main.json pep782.json
read_file_small: Mean +- std dev: [main] 5.71 us +- 0.05 us -> [pep782] 5.68 us +- 0.05 us: 1.01x faster
read_file_large: Mean +- std dev: [main] 89.7 us +- 0.9 us -> [pep782] 86.9 us +- 0.8 us: 1.03x faster
read_all_rst_bytes: Mean +- std dev: [main] 926 us +- 8 us -> [pep782] 920 us +- 12 us: 1.01x faster
read_all_rst_text: Mean +- std dev: [main] 2.24 ms +- 0.02 ms -> [pep782] 2.17 ms +- 0.04 ms: 1.03x faster

Benchmark hidden because not significant (1): read_all_py_bytes

Geometric mean: 1.01x faster
```

<!-- gh-issue-number: gh-129813 -->
* Issue: gh-129813
<!-- /gh-issue-number -->
