### PR TITLE
gh-137992: fix `PyRefTracer_SetTracer` to start world before returning 

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -3292,6 +3292,7 @@ int PyRefTracer_SetTracer(PyRefTracer tracer, void *data) {
     if (_PyRuntime.ref_tracer.tracer_func != NULL) {
         _PyReftracerTrack(NULL, PyRefTracer_TRACKER_REMOVED);
         if (PyErr_Occurred()) {
+            _PyEval_StartTheWorldAll(&_PyRuntime);
             return -1;
         }
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-137992 -->
* Issue: gh-137992
<!-- /gh-issue-number -->
