### PR TITLE
gh-138896: Fix error installing C runtime on non-updated Windows machines

### DIFF
--- a/Misc/NEWS.d/next/Windows/2025-09-15-15-34-29.gh-issue-138896.lkiF_7.rst
+++ b/Misc/NEWS.d/next/Windows/2025-09-15-15-34-29.gh-issue-138896.lkiF_7.rst
@@ -1,0 +1,1 @@
+Fix error installing C runtime on non-updated Windows machines

--- a/Tools/msi/bundle/bundle.wxs
+++ b/Tools/msi/bundle/bundle.wxs
@@ -106,11 +106,11 @@
     <Variable Name="SimpleInstallDescription" Value="" bal:Overridable="yes" />
 
     <Chain ParallelCache="yes">
+      <PackageGroupRef Id="core" />
+      <PackageGroupRef Id="exe" />
       <?if $(var.Platform)!="ARM64" ?>
       <PackageGroupRef Id="crt" />
       <?endif ?>
-      <PackageGroupRef Id="core" />
-      <PackageGroupRef Id="exe" />
       <PackageGroupRef Id="dev" />
       <PackageGroupRef Id="lib" />
       <?if $(var.IncludeFreethreaded)~="true" ?>


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

I tested by taking the Python 3.13.7 source release, applying this change, and editing `Tools\msi\bundle\packagegroups\crt.wxs` to change `Compressed="no"` to `Compressed="yes"`. Then I ran `Tools\msi\buildrelease.bat` and successfully ran the 64-bit installer on my non-updated Windows 8.1 machine.

<!-- gh-issue-number: gh-138896 -->
* Issue: gh-138896
<!-- /gh-issue-number -->
