### PR TITLE
gh-130567: Fix possible crash in locale.strxfrm()

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-09-15-19-29-12.gh-issue-130567.shDEnT.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-15-19-29-12.gh-issue-130567.shDEnT.rst
@@ -1,0 +1,2 @@
+Fix possible crash in :func:`locale.strxfrm` due to a platform bug on
+macOS.

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -457,7 +457,9 @@ _locale_strxfrm_impl(PyObject *module, PyObject *str)
 
     /* assume no change in size, first */
     n1 = n1 + 1;
-    buf = PyMem_New(wchar_t, n1);
+    /* Yet one +1 is needed to work around a platform bug in wcsxfrm()
+     * on macOS. See gh-130567. */
+    buf = PyMem_New(wchar_t, n1+1);
     if (!buf) {
         PyErr_NoMemory();
         goto exit;

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -457,7 +457,7 @@ _locale_strxfrm_impl(PyObject *module, PyObject *str)
 
     /* assume no change in size, first */
     n1 = n1 + 1;
-    /* Yet one +1 is needed to work around a platform bug in wcsxfrm()
+    /* Yet another +1 is needed to work around a platform bug in wcsxfrm()
      * on macOS. See gh-130567. */
     buf = PyMem_New(wchar_t, n1+1);
     if (!buf) {


### PR DESCRIPTION
On some macOS versions there was an off-by-one error in wcsxfrm() which caused writing past the end of the array if its size was not calculated by running wcsxfrm() first.


<!-- gh-issue-number: gh-130567 -->
* Issue: gh-130567
<!-- /gh-issue-number -->
