### PR TITLE
gh-138946: `list.sort` enhancement proposal: Adaptivity for `binarysort`

### DIFF
--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1765,7 +1765,7 @@ struct s_MergeState {
    the input (nothing is lost or duplicated).
 */
 static int
-binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok)
+binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, float adapt)
 {
     Py_ssize_t k; /* for IFLT macro expansion */
     PyObject ** const a = ss->keys;
@@ -1778,6 +1778,120 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok)
     /* assert a[:ok] is sorted */
     if (! ok)
         ++ok;
+
+    Py_ssize_t L, R;
+    /* Adaptive step */
+    if (adapt) {
+        Py_ssize_t diff = ok;       // jump (jump out on 1st loop to not kick in)
+        Py_ssize_t last = ok >> 1;  // mid point (simple binary on 1st loop)
+        float ns = 5.0f;            // number of successes (a bit of head start)
+        float seen = 0.0f;          // number of loops done
+        // const float adapt = 1.3;    // adaptivity strength
+        for (; ok < n && ns * adapt >= seen; ++ok) {
+            pivot = a[ok];
+
+            IFLT(pivot, a[last]) {
+                L = 0;
+                R = last;
+                if (L < R) {
+                    if (diff == 0)
+                        diff = 1;
+                    M = R - diff;
+                    if (M < L)
+                        M = L;
+                    IFLT(pivot, a[M]) {
+                        R = M;
+                        if (L < R) {
+                            diff += 1;
+                            M = R - diff;
+                            if (M < L)
+                                M = L;
+                            IFLT(pivot, a[M])
+                                R = M;
+                            else
+                                L = M + 1;
+                            ns += (float)(R - L) * 8 < ok;
+                        }
+                        else {
+                            ns += 2.0f;
+                        }
+                    }
+                    else {
+                        L = M + 1;
+                        ns += (float)(R - L) * 4 < ok;
+                    }
+                }
+                else {
+                    ns += 2.0f;
+                }
+            }
+            else {
+                L = last + 1;
+                R = ok;
+                if (L < R) {
+                    M = L + diff;
+                    if (M >= R)
+                        M = R - 1;
+                    IFLT(pivot, a[M]) {
+                        R = M;
+                        ns += (float)(R - L) * 4 < ok;
+                    }
+                    else {
+                        L = M + 1;
+                        if (L < R) {
+                            diff += 1;
+                            M = L + diff;
+                            if (M >= R)
+                                M = R - 1;
+                            IFLT(pivot, a[M])
+                                R = M;
+                            else
+                                L = M + 1;
+                            ns += (float)(R - L) * 8 < ok;
+                        }
+                        else {
+                            ns += 2.0f;
+                        }
+                    }
+                }
+                else {
+                    ns += 2.0f;
+                }
+            }
+
+            // Binary Insertion
+            while (L < R) {
+                M = (L + R) >> 1;
+                IFLT(pivot, a[M])
+                    R = M;
+                else
+                    L = M + 1;
+            }
+
+            for (M = ok; M > L; --M)
+                a[M] = a[M - 1];
+            a[L] = pivot;
+            if (has_values) {
+                pivot = v[ok];
+                for (M = ok; M > L; --M)
+                    v[M] = v[M - 1];
+                v[L] = pivot;
+            }
+
+            // Update Adaptive runvars
+            diff = L - last;
+            if (diff < 0)
+                diff = -diff;
+            last = L;
+            seen += 1.0f;
+        }
+        if (ok >= n) {
+            // Successfully ran fully adaptive
+            // Else go to simple binary sort
+            return 1;
+        }
+    }
+
     /* Regular insertion sort has average- and worst-case O(n**2) cost
        for both # of comparisons and number of bytes moved. But its branches
        are highly predictable, and it loves sorted input (n-1 compares and no
@@ -1828,7 +1942,7 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok)
             v[M + 1] = vpivot;
     }
 #else // binary insertion sort
-    Py_ssize_t L, R;
+
     for (; ok < n; ++ok) {
         /* set L to where a[ok] belongs */
         L = 0;
@@ -3074,6 +3188,9 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
     /* March over the array once, left to right, finding natural runs,
      * and extending short natural runs to minrun elements.
      */
+    int bres;
+    Py_ssize_t cs = 0;
+    Py_ssize_t cd = 1;
     do {
         Py_ssize_t n;
 
@@ -3086,8 +3203,24 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
         if (n < minrun) {
             const Py_ssize_t force = nremaining <= minrun ?
                               nremaining : minrun;
-            if (binarysort(&ms, &lo, force, n) < 0)
-                goto fail;
+            if (cs) {
+                if (binarysort(&ms, &lo, force, n, 0.0) < 0)
+                    goto fail;
+                cs -= 1;
+            }
+            else {
+                bres = binarysort(&ms, &lo, force, n, 1.3);
+                if (bres < 0)
+                    goto fail;
+                if (bres) {
+                    cd = 1;
+                } else {
+                    cd += 2;
+                    if (cd > 11)
+                        cd = 11;
+                    cs = cd;
+                }
+            }
             n = force;
         }
         /* Maybe merge pending runs. */

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1784,7 +1784,7 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, flo
     if (adapt) {
         Py_ssize_t diff = ok;       // jump (jump out on 1st loop to not kick in)
         Py_ssize_t last = ok >> 1;  // mid point (simple binary on 1st loop)
-        float ns = 5.0f;            // number of successes (a bit of head start)
+        Py_ssize_t ns = 5;          // number of successes (a bit of head start)
         float seen = 0.0f;          // number of loops done
         // const float adapt = 1.3;    // adaptivity strength
         for (; ok < n && ns * adapt >= seen; ++ok) {
@@ -1802,7 +1802,6 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, flo
                     IFLT(pivot, a[M]) {
                         R = M;
                         if (L < R) {
-                            diff += 1;
                             M = R - diff;
                             if (M < L)
                                 M = L;
@@ -1810,19 +1809,19 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, flo
                                 R = M;
                             else
                                 L = M + 1;
-                            ns += (float)(R - L) * 8 < ok;
+                            ns += (R - L) * 8 < ok;
                         }
                         else {
-                            ns += 2.0f;
+                            ns += 2;
                         }
                     }
                     else {
                         L = M + 1;
-                        ns += (float)(R - L) * 4 < ok;
+                        ns += (R - L) * 4 < ok;
                     }
                 }
                 else {
-                    ns += 2.0f;
+                    ns += 2;
                 }
             }
             else {
@@ -1834,12 +1833,11 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, flo
                         M = R - 1;
                     IFLT(pivot, a[M]) {
                         R = M;
-                        ns += (float)(R - L) * 4 < ok;
+                        ns += (R - L) * 4 < ok;
                     }
                     else {
                         L = M + 1;
                         if (L < R) {
-                            diff += 1;
                             M = L + diff;
                             if (M >= R)
                                 M = R - 1;
@@ -1847,15 +1845,15 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, flo
                                 R = M;
                             else
                                 L = M + 1;
-                            ns += (float)(R - L) * 8 < ok;
+                            ns += (R - L) * 8 < ok;
                         }
                         else {
-                            ns += 2.0f;
+                            ns += 2;
                         }
                     }
                 }
                 else {
-                    ns += 2.0f;
+                    ns += 2;
                 }
             }
 
@@ -1887,9 +1885,9 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, flo
         }
         if (ok >= n) {
             // Successfully ran fully adaptive
-            // Else go to simple binary sort
             return 1;
         }
+        // Else go to simple binary sort
     }
 
     /* Regular insertion sort has average- and worst-case O(n**2) cost

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1911,7 +1911,7 @@ abinarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, in
         for (; ok < n; ++ok) {
             pivot = a[ok];
 
-            if (std < ok / 4) {
+            if (std < (ok >> 2)) {
                 M = mu;
                 IFLT(pivot, a[M]) {
                     L = 0;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1902,20 +1902,21 @@ abinarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, in
 
     Py_ssize_t M, L, R;
     Py_ssize_t nsorted = ok;
-    Py_ssize_t last = ok >> 1;
-    Py_ssize_t std = last;
-    Py_ssize_t mu = last;
+    Py_ssize_t mu = ok >> 1;
+    Py_ssize_t std = mu;
     Py_ssize_t nbad = 0;    // badness of fit
 
     if (adapt) {
         for (; ok < n; ++ok) {
             pivot = a[ok];
 
+            // NOTE: If abinarysort is actually working, there will be gains
+            //       And this is a relatively small insurance against adversity
+            //       However, subject to be removed if not helpful in practice
             if (std < (ok >> 2)) {
-                M = mu;
-                IFLT(pivot, a[M]) {
+                IFLT(pivot, a[mu]) {
                     L = 0;
-                    R = M;
+                    R = mu;
                     if (L < R) {
                         std += !std;
                         M = R - std;
@@ -1939,7 +1940,7 @@ abinarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, in
                     }
                 }
                 else {
-                    L = M + 1;
+                    L = mu + 1;
                     R = ok;
                     if (L < R) {
                         M = L + std;
@@ -2004,9 +2005,7 @@ abinarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, in
             // Update Adaptive runvars
             std = labs(L - mu);
             nbad += std;
-            mu = L + L - last;
-            mu = mu < 0 ? 0 : mu > ok ? ok : mu;
-            last = L;
+            mu = L;
         }
     }
     else {
@@ -2044,9 +2043,7 @@ abinarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, in
             // Update Adaptive runvars
             std = labs(L - mu);
             nbad += std;
-            mu = L + L - last;
-            mu = mu < 0 ? 0 : mu > ok ? ok : mu;
-            last = L;
+            mu = L;
         }
     }
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2048,6 +2048,7 @@ abinarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok, in
     }
 
     // Return Adaptivity measure (max 1000)
+    // This is: 1000 * nbad / sum(range(nsorted:n))
     return nbad * 2000 / ((n + 2 * nsorted - 1) * n);
 
  fail:
@@ -3277,8 +3278,6 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
         } while (nremaining);
     }
     else {
-        // NOTE:WIP: Only 1% difference is due to
-        //           extra calculations in simple binary sort
         int adapt = 0;  // do not run binarysort adaptivity on 1st run
         int cs = 0;     // but do check goodness of adaptive fit
         int cd = 1;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3222,8 +3222,9 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
     int binary_adapt = ms.listlen >= 100;
     if (!binary_adapt) {
         do {
-            /* Identify next run. */
             Py_ssize_t n;
+
+            /* Identify next run. */
             n = count_run(&ms, &lo, nremaining);
             if (n < 0)
                 goto fail;
@@ -3263,8 +3264,9 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
         int cd = 1;
         int abinret;
         do {
-            /* Identify next run. */
             Py_ssize_t n;
+
+            /* Identify next run. */
             n = count_run(&ms, &lo, nremaining);
             if (n < 0)
                 goto fail;


### PR DESCRIPTION
<details>
<summary>V1 Info (outdated)</summary>

Currently, adaptivity is simple.
1. Record index of last insorted value (`last`)
2. Record difference between last insorted value and the one before `diff = abs(new_idx - last)`
3. Start iteration with:
    1. Take the new midpoint to be `last`
    2. Take the next midpoint to be `last += diff`
    3. Repeat (2) once more
4. It always finishes off with simple `binarysort`

It is primarily targeted at data already sorted to significant degree (e.g. stock price data).
However it so happens that it handles some other patterns as well.

e.g.: `[-1, 1, -2, 2, -3, 3, ...]`.
`diff` will always be the full length of sorted part, so it will be jumping from one end to the next in 1 step.


### Microbenchmarks

```bash
PYMAIN=/Users/Edu/local/code/cpython/main/python.exe
PYNEW=/Users/Edu/local/code/cpython/wt1/python.exe

S="
import random
import itertools as itl
RND = [random.random() for _ in range(100_000)]
RWK = [random.randint(-1, 3) for _ in range(100_000)]
RWK = list(itl.accumulate(RWK))

RNDW = [[i] for i in RND]
RWKW = [[i] for i in RWK]
"
# RAW SMALL
$PYMAIN -m timeit -s $S "sorted(RND[:30])"  # 0.72 µs
$PYNEW -m timeit -s $S "sorted(RND[:30])"   # 0.85 µs
$PYMAIN -m timeit -s $S "sorted(RWK[:30])"  # 0.65 µs
$PYNEW -m timeit -s $S "sorted(RWK[:30])"   # 0.58 µs

# WRAPPED SMALL
$PYMAIN -m timeit -s $S "sorted(RNDW[:30])" # 4.3 µs
$PYNEW -m timeit -s $S "sorted(RNDW[:30])"  # 4.6 µs
$PYMAIN -m timeit -s $S "sorted(RWKW[:30])" # 2.8 µs
$PYNEW -m timeit -s $S "sorted(RWKW[:30])"  # 1.6 µs


# RAW
$PYMAIN -m timeit -s $S "sorted(RND)"   # 16.0 ms
$PYNEW -m timeit -s $S "sorted(RND)"    # 16.0 ms
$PYMAIN -m timeit -s $S "sorted(RWK)"   #  2.5 ms
$PYNEW -m timeit -s $S "sorted(RWK)"    #  2.3 ms

# WRAPPED
$PYMAIN -m timeit -s $S "sorted(RNDW)"  # 104 ms
$PYNEW -m timeit -s $S "sorted(RNDW)"   # 102 ms
$PYMAIN -m timeit -s $S "sorted(RWKW)"  #  14.5 ms
$PYNEW -m timeit -s $S "sorted(RWKW)"   #   8.3 ms
```

For optimised comparisons this has little effect.
As can be seen, the worst case is small random data.
But in the same way that small data feels the biggest adverse effect, the positive effect is also the largest as greater (or all) portion of data is sorted using `binarysort` only.

However, the impact is non-trivial for costly comparisons.
`list.__lt__` is probably the fastest of all the possible ones.
For Pure Python user implemented `__lt__`, the impact would be greater.

</details>

### V3 Getting closer to desirable result.

Raw integers & floats (specialised comparison functions)

<img width="444" height="444" alt="unwrapped" src="https://github.com/user-attachments/assets/627f6406-2fe0-4eee-8da3-62357c8b9af6" />

Above wrapped into lists

<img width="444" height="444" alt="wrapped" src="https://github.com/user-attachments/assets/25e2746a-1362-475b-b4c1-1f6b02630463" />

---
---

1. Any tips for low level optimisation are welcome.
2. Any ideas on better adaptivity strategy are welcome as well

<!-- gh-issue-number: gh-138946 -->
* Issue: gh-138946
<!-- /gh-issue-number -->
