### PR TITLE
gh-129813: Use `PyBytesWriter` in `_json:_match_number_unicode`

### DIFF
--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1092,17 +1092,22 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
         /* Straight conversion to ASCII, to avoid costly conversion of
            decimal unicode digits (which cannot appear here) */
         n = idx - start;
-        numstr = PyBytes_FromStringAndSize(NULL, n);
-        if (numstr == NULL)
+        PyBytesWriter *writer = PyBytesWriter_Create(n);
+        if (writer == NULL) {
             return NULL;
-        buf = PyBytes_AS_STRING(numstr);
+        }
+        buf = PyBytesWriter_GetData(writer);
         for (i = 0; i < n; i++) {
             buf[i] = (char) PyUnicode_READ(kind, str, i + start);
+        }
+        numstr = PyBytesWriter_Finish(writer);
+        if (numstr == NULL) {
+            return NULL;
         }
         if (is_float)
             rval = PyFloat_FromString(numstr);
         else
-            rval = PyLong_FromString(buf, NULL, 10);
+            rval = PyLong_FromString(PyBytes_AS_STRING(numstr), NULL, 10);
     }
     Py_DECREF(numstr);
     *next_idx_ptr = idx;


### PR DESCRIPTION
The change is very similar to #138956

Initially, I thought that there's a speed up, but I mixed the JSON files, and it's the reverse:

| Benchmark              | json-main | json-pybytes          |
|------------------------|:---------:|:---------------------:|
| json_loads_1000_ints   | 41.4 us   | 47.3 us: 1.14x slower |
| json_loads_1000_floats | 77.1 us   | 81.9 us: 1.06x slower |
| Geometric mean         | (ref)     | 1.10x slower          |

which makes perfect sense given the conversion:

https://github.com/python/cpython/pull/138957/files#diff-efe183ae0b85e5b8d9bbbc588452dd4de80b39fd5c5174ee499ba554217a39edR1110

I mixed up the JSONs; my bad.

~~I'm surprised with the speed up:~~

# Benchmark

<details>
<summary>The script:</summary>

```python
import pyperf
import json

runner = pyperf.Runner()

num_elements = 1000

int_data = json.dumps(list(range(num_elements)))
runner.bench_func(f'json_loads_{num_elements}_ints', json.loads, int_data)

float_data = json.dumps([float(i) for i in range(num_elements)])
runner.bench_func(f'json_loads_{num_elements}_floats', json.loads, float_data)
```
</details>

Where `main` is 4e00e2504fdcf06b5d55a773b31f49b1d3d6d35c

The environment:

```
% ./python -c "import sysconfig; print(sysconfig.get_config_var('CONFIG_ARGS'))"
'--enable-lto' '--with-optimizations'
```

`sudo ./python -m pyperf system tune` ensured.

<!-- gh-issue-number: gh-129813 -->
* Issue: gh-129813
<!-- /gh-issue-number -->
