### PR TITLE
gh-138952:  Document platform.machine() output casing inconsistency across platforms

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -58,10 +58,11 @@ Cross platform
 
    .. note::
 
-      The output of :func:`platform.machine` is system-dependent and may differ in casing
-      and naming conventions across platforms. For example, on Apple Silicon macOS it may
-      return ``'arm64'`` (lowercase), while on Windows-on-ARM it may return ``'ARM64'`` (uppercase).
-      If you need consistent results, normalize the output in your code.
+      The output of :func:`platform.machine` is system-dependent and may differ
+      in casing and naming conventions across platforms. For example, on Apple
+      Silicon macOS it may return ``'arm64'`` (lowercase), while on Windows-on-ARM
+      it may return ``'ARM64'`` (uppercase). If you need consistent results,
+      normalize the output in your code.
 
 
 .. function:: node()

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -56,13 +56,7 @@ Cross platform
    Returns the machine type, e.g. ``'AMD64'``. An empty string is returned if the
    value cannot be determined.
 
-   .. note::
-
-      The output of :func:`platform.machine` is system-dependent and may differ
-      in casing and naming conventions across platforms. For example, on Apple
-      Silicon macOS it may return ``'arm64'`` (lowercase), while on Windows-on-ARM
-      it may return ``'ARM64'`` (uppercase). If you need consistent results,
-      normalize the output in your code.
+   The output is platform-dependent and may differ in casing and naming conventions.
 
 
 .. function:: node()

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -56,6 +56,13 @@ Cross platform
    Returns the machine type, e.g. ``'AMD64'``. An empty string is returned if the
    value cannot be determined.
 
+   .. note::
+
+      The output of :func:`platform.machine` is system-dependent and may differ in casing
+      and naming conventions across platforms. For example, on Apple Silicon macOS it may
+      return ``'arm64'`` (lowercase), while on Windows-on-ARM it may return ``'ARM64'`` (uppercase).
+      If you need consistent results, normalize the output in your code.
+
 
 .. function:: node()
 

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -60,7 +60,7 @@ Cross platform
 
       The output of :func:`platform.machine` is system-dependent and may differ
       in casing and naming conventions across platforms. For example, on Apple
-      Silicon macOS it may return ``'arm64'`` (lowercase), while on Windows-on-ARM
+      Silicon based macOS it may return ``'arm64'`` (lowercase), while on Windows-on-ARM
       it may return ``'ARM64'`` (uppercase). If you need consistent results,
       normalize the output in your code.
 


### PR DESCRIPTION
This PR updates the documentation for `platform.machine()` in `platform.rst` to clarify that the output is system-dependent and may differ in casing and naming conventions across platforms.
For example, on Apple Silicon macOS it may return 'arm64' (lowercase), while on Windows-on-ARM it may return 'ARM64' (uppercase).

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou !

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138962.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-138952 -->
* Issue: gh-138952
<!-- /gh-issue-number -->
