### PR TITLE
gh-129813, PEP 782: Soft deprecate _PyBytes_Resize()

### DIFF
--- a/Doc/c-api/bytes.rst
+++ b/Doc/c-api/bytes.rst
@@ -47,6 +47,10 @@ called with a non-bytes parameter.
    *len* on success, and ``NULL`` on failure.  If *v* is ``NULL``, the contents of
    the bytes object are uninitialized.
 
+   .. deprecated:: 3.15
+      ``PyBytes_FromStringAndSize(NULL, len)`` is :term:`soft deprecated`,
+      use the :c:type:`PyBytesWriter` API instead.
+
 
 .. c:function:: PyObject* PyBytes_FromFormat(const char *format, ...)
 
@@ -219,6 +223,11 @@ called with a non-bytes parameter.
    reallocation fails, the original bytes object at *\*bytes* is deallocated,
    *\*bytes* is set to ``NULL``, :exc:`MemoryError` is set, and ``-1`` is
    returned.
+
+   .. deprecated:: 3.15
+      The function is :term:`soft deprecated`,
+      use the :c:type:`PyBytesWriter` API instead.
+
 
 PyBytesWriter
 -------------

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -774,6 +774,11 @@ Deprecated C APIs
   signed integer type of the same size is now deprecated.
   (Contributed by Serhiy Storchaka in :gh:`132629`.)
 
+* :c:func:`PyBytes_FromStringAndSize(NULL, len) <PyBytes_FromStringAndSize>`
+  and :c:func:`_PyBytes_Resize` are :term:`soft deprecated`,
+  use the :c:type:`PyBytesWriter` API instead.
+  (Contributed by Victor Stinner in :gh:`129813`.)
+
 * Deprecate :c:member:`~PyComplexObject.cval` field of the the
   :c:type:`PyComplexObject` type.
   Use :c:func:`PyComplex_AsCComplex` and :c:func:`PyComplex_FromCComplex`


### PR DESCRIPTION
Soft deprecate _PyBytes_Resize() and
PyBytes_FromStringAndSize(NULL, size).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129813 -->
* Issue: gh-129813
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138964.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->