### PR TITLE
gh-137065: Revert "gh-105499: Merge typing.Union and types.UnionType (#105511)"

### DIFF
--- a/Doc/deprecations/pending-removal-in-future.rst
+++ b/Doc/deprecations/pending-removal-in-future.rst
@@ -122,11 +122,6 @@ although there is currently no date scheduled for their removal.
 
 * :class:`typing.Text` (:gh:`92332`).
 
-* The internal class ``typing._UnionGenericAlias`` is no longer used to implement
-  :class:`typing.Union`. To preserve compatibility with users using this private
-  class, a compatibility shim will be provided until at least Python 3.17. (Contributed by
-  Jelle Zijlstra in :gh:`105499`.)
-
 * :class:`unittest.IsolatedAsyncioTestCase`: it is deprecated to return a value
   that is not ``None`` from a test case.
 

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -526,7 +526,7 @@ The :mod:`functools` module defines the following functions:
      ...     for i, elem in enumerate(arg):
      ...         print(i, elem)
 
-   :class:`typing.Union` can also be used::
+   :class:`types.UnionType` and :data:`typing.Union` can also be used::
 
     >>> @fun.register
     ... def _(arg: int | float, verbose=False):
@@ -662,8 +662,8 @@ The :mod:`functools` module defines the following functions:
       The :func:`~singledispatch.register` attribute now supports using type annotations.
 
    .. versionchanged:: 3.11
-      The :func:`~singledispatch.register` attribute now supports
-      :class:`typing.Union` as a type annotation.
+      The :func:`~singledispatch.register` attribute now supports :class:`types.UnionType`
+      and :data:`typing.Union` as type annotations.
 
 
 .. class:: singledispatchmethod(func)

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5649,7 +5649,7 @@ Union Type
 A union object holds the value of the ``|`` (bitwise or) operation on
 multiple :ref:`type objects <bltin-type-objects>`.  These types are intended
 primarily for :term:`type annotations <annotation>`. The union type expression
-enables cleaner type hinting syntax compared to subscripting :class:`typing.Union`.
+enables cleaner type hinting syntax compared to :data:`typing.Union`.
 
 .. describe:: X | Y | ...
 
@@ -5685,10 +5685,9 @@ enables cleaner type hinting syntax compared to subscripting :class:`typing.Unio
 
       int | str == str | int
 
-   * It creates instances of :class:`typing.Union`::
+   * It is compatible with :data:`typing.Union`::
 
       int | str == typing.Union[int, str]
-      type(int | str) is typing.Union
 
    * Optional types can be spelled as a union with ``None``::
 
@@ -5714,15 +5713,16 @@ enables cleaner type hinting syntax compared to subscripting :class:`typing.Unio
       TypeError: isinstance() argument 2 cannot be a parameterized generic
 
 The user-exposed type for the union object can be accessed from
-:class:`typing.Union` and used for :func:`isinstance` checks::
+:class:`types.UnionType` and used for :func:`isinstance` checks.  An object cannot be
+instantiated from the type::
 
-   >>> import typing
-   >>> isinstance(int | str, typing.Union)
+   >>> import types
+   >>> isinstance(int | str, types.UnionType)
    True
-   >>> typing.Union()
+   >>> types.UnionType()
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
-   TypeError: cannot create 'typing.Union' instances
+   TypeError: cannot create 'types.UnionType' instances
 
 .. note::
    The :meth:`!__or__` method for type objects was added to support the syntax
@@ -5748,11 +5748,6 @@ The user-exposed type for the union object can be accessed from
    :pep:`604` -- PEP proposing the ``X | Y`` syntax and the Union type.
 
 .. versionadded:: 3.10
-
-.. versionchanged:: 3.14
-
-   Union objects are now instances of :class:`typing.Union`. Previously, they were instances
-   of :class:`types.UnionType`, which remains an alias for :class:`typing.Union`.
 
 
 .. _typesother:

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -314,10 +314,6 @@ Standard names are defined for the following types:
 
    .. versionadded:: 3.10
 
-   .. versionchanged:: 3.14
-
-      This is now an alias for :class:`typing.Union`.
-
 .. class:: TracebackType(tb_next, tb_frame, tb_lasti, tb_lineno)
 
    The type of traceback objects such as found in ``sys.exception().__traceback__``.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1091,7 +1091,7 @@ Special forms
 These can be used as types in annotations. They all support subscription using
 ``[]``, but each has a unique syntax.
 
-.. class:: Union
+.. data:: Union
 
    Union type; ``Union[X, Y]`` is equivalent to ``X | Y`` and means either X or Y.
 
@@ -1131,14 +1131,6 @@ These can be used as types in annotations. They all support subscription using
    .. versionchanged:: 3.10
       Unions can now be written as ``X | Y``. See
       :ref:`union type expressions<types-union>`.
-
-   .. versionchanged:: 3.14
-      :class:`types.UnionType` is now an alias for :class:`Union`, and both
-      ``Union[int, str]`` and ``int | str`` create instances of the same class.
-      To check whether an object is a ``Union`` at runtime, use
-      ``isinstance(obj, Union)``. For compatibility with earlier versions of
-      Python, use
-      ``get_origin(obj) is typing.Union or get_origin(obj) is types.UnionType``.
 
 .. data:: Optional
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -723,10 +723,10 @@ PEP 604: New Type Union Operator
 
 A new type union operator was introduced which enables the syntax ``X | Y``.
 This provides a cleaner way of expressing 'either type X or type Y' instead of
-using :class:`typing.Union`, especially in type hints.
+using :data:`typing.Union`, especially in type hints.
 
 In previous versions of Python, to apply a type hint for functions accepting
-arguments of multiple types, :class:`typing.Union` was used::
+arguments of multiple types, :data:`typing.Union` was used::
 
    def square(number: Union[int, float]) -> Union[int, float]:
        return number ** 2

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -741,7 +741,7 @@ functools
 ---------
 
 * :func:`functools.singledispatch` now supports :class:`types.UnionType`
-  and :class:`typing.Union` as annotations to the dispatch argument.::
+  and :data:`typing.Union` as annotations to the dispatch argument.::
 
     >>> from functools import singledispatch
     >>> @singledispatch

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2071,55 +2071,8 @@ turtle
   (Contributed by Marie Roald and Yngve Mardal Moe in :gh:`126350`.)
 
 
-types
------
-
-* :class:`types.UnionType` is now an alias for :class:`typing.Union`.
-  See :ref:`below <whatsnew314-typing-union>` for more details.
-  (Contributed by Jelle Zijlstra in :gh:`105499`.)
-
-
 typing
 ------
-
-.. _whatsnew314-typing-union:
-
-* :class:`types.UnionType` and :class:`typing.Union` are now aliases for each other,
-  meaning that both old-style unions (created with ``Union[int, str]``) and new-style
-  unions (``int | str``) now create instances of the same runtime type. This unifies
-  the behavior between the two syntaxes, but leads to some differences in behavior that
-  may affect users who introspect types at runtime:
-
-  - Both syntaxes for creating a union now produce the same string representation in
-    ``repr()``. For example, ``repr(Union[int, str])``
-    is now ``"int | str"`` instead of ``"typing.Union[int, str]"``.
-  - Unions created using the old syntax are no longer cached. Previously, running
-    ``Union[int, str]`` multiple times would return the same object
-    (``Union[int, str] is Union[int, str]`` would be ``True``), but now it will
-    return two different objects. Users should use ``==`` to compare unions for equality, not
-    ``is``. New-style unions have never been cached this way.
-    This change could increase memory usage for some programs that use a large number of
-    unions created by subscripting ``typing.Union``. However, several factors offset this cost:
-    unions used in annotations are no longer evaluated by default in Python 3.14
-    because of :pep:`649`; an instance of :class:`types.UnionType` is
-    itself much smaller than the object returned by ``Union[]`` was on prior Python
-    versions; and removing the cache also saves some space. It is therefore
-    unlikely that this change will cause a significant increase in memory usage for most
-    users.
-  - Previously, old-style unions were implemented using the private class
-    ``typing._UnionGenericAlias``. This class is no longer needed for the implementation,
-    but it has been retained for backward compatibility, with removal scheduled for Python
-    3.17. Users should use documented introspection helpers like :func:`typing.get_origin`
-    and :func:`typing.get_args` instead of relying on private implementation details.
-  - It is now possible to use :class:`typing.Union` itself in :func:`isinstance` checks.
-    For example, ``isinstance(int | str, typing.Union)`` will return ``True``; previously
-    this raised :exc:`TypeError`.
-  - The ``__args__`` attribute of :class:`typing.Union` objects is no longer writable.
-  - It is no longer possible to set any attributes on :class:`typing.Union` objects.
-    This only ever worked for dunder attributes on previous versions, was never
-    documented to work, and was subtly broken in many cases.
-
-  (Contributed by Jelle Zijlstra in :gh:`105499`.)
 
 * :class:`typing.TypeAliasType` now supports star unpacking.
 
@@ -3188,11 +3141,6 @@ Changes in the Python API
   locale in some cases.
   This temporary change affects other threads.
   (Contributed by Serhiy Storchaka in :gh:`69998`.)
-
-* :class:`types.UnionType` is now an alias for :class:`typing.Union`,
-  causing changes in some behaviors.
-  See :ref:`above <whatsnew314-typing-union>` for more details.
-  (Contributed by Jelle Zijlstra in :gh:`105499`.)
 
 * The runtime behavior of annotations has changed in various ways; see
   :ref:`above <whatsnew314-pep649>` for details. While most code that interacts

--- a/Include/internal/pycore_unionobject.h
+++ b/Include/internal/pycore_unionobject.h
@@ -18,7 +18,6 @@ PyAPI_FUNC(PyObject *) _Py_union_type_or(PyObject *, PyObject *);
 extern PyObject *_Py_subs_parameters(PyObject *, PyObject *, PyObject *, PyObject *);
 extern PyObject *_Py_make_parameters(PyObject *);
 extern PyObject *_Py_union_args(PyObject *self);
-extern PyObject *_Py_union_from_tuple(PyObject *args);
 
 #ifdef __cplusplus
 }

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -284,10 +284,12 @@ class ForwardRef:
         ))
 
     def __or__(self, other):
-        return types.UnionType[self, other]
+        import typing
+        return typing.Union[self, other]
 
     def __ror__(self, other):
-        return types.UnionType[other, self]
+        import typing
+        return typing.Union[other, self]
 
     def __repr__(self):
         extra = []

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -137,7 +137,8 @@ class TestForwardRefFormat(unittest.TestCase):
             str | int,
         )
         union = annos["union"]
-        self.assertIsInstance(union, Union)
+        self.assertIs(typing.get_origin(union), Union)
+        # self.assertIsInstance(union, Union)
         arg1, arg2 = typing.get_args(union)
         self.assertIs(arg1, str)
         self.assertEqual(

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -2317,7 +2317,7 @@ class TestDocString(unittest.TestCase):
         class C:
             x: Union[int, type(None)] = None
 
-        self.assertDocStrEqual(C.__doc__, "C(x:int|None=None)")
+        self.assertDocStrEqual(C.__doc__, "C(x:Optional[int]=None)")
 
     def test_docstring_list_field(self):
         @dataclass

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3203,7 +3203,7 @@ class TestSingleDispatch(unittest.TestCase):
             "Invalid annotation for 'arg'."
         )
         self.assertEndsWith(str(exc.exception),
-            'int | typing.Iterable[str] not all arguments are classes.'
+            'typing.Union[int, typing.Iterable[str]] not all arguments are classes.'
         )
 
     def test_invalid_positional_argument(self):

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -1779,14 +1779,14 @@ class TestClassesAndFunctions(unittest.TestCase):
 class TestFormatAnnotation(unittest.TestCase):
     def test_typing_replacement(self):
         from test.typinganndata.ann_module9 import A, ann, ann1
-        self.assertEqual(inspect.formatannotation(ann), 'List[str] | int')
-        self.assertEqual(inspect.formatannotation(ann1), 'List[testModule.typing.A] | int')
+        self.assertEqual(inspect.formatannotation(ann), 'Union[List[str], int]')
+        self.assertEqual(inspect.formatannotation(ann1), 'Union[List[testModule.typing.A], int]')
 
         self.assertEqual(inspect.formatannotation(A, 'testModule.typing'), 'A')
         self.assertEqual(inspect.formatannotation(A, 'other'), 'testModule.typing.A')
         self.assertEqual(
             inspect.formatannotation(ann1, 'testModule.typing'),
-            'List[testModule.typing.A] | int',
+            'Union[List[testModule.typing.A], int]',
         )
 
     def test_forwardref(self):
@@ -1824,7 +1824,7 @@ class TestFormatAnnotation(unittest.TestCase):
         # Not an instance of "type":
         self.assertEqual(
             inspect.formatannotationrelativeto(A)(ann1),
-            'List[testModule.typing.A] | int',
+            'Union[List[testModule.typing.A], int]',
         )
 
 

--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -128,7 +128,7 @@ DATA
     c_alias = test.test_pydoc.pydoc_mod.C[int]
     list_alias1 = typing.List[int]
     list_alias2 = list[int]
-    type_union1 = int | str
+    type_union1 = typing.Union[int, str]
     type_union2 = int | str
 
 VERSION
@@ -215,7 +215,7 @@ Data
     c_alias = test.test_pydoc.pydoc_mod.C[int]
     list_alias1 = typing.List[int]
     list_alias2 = list[int]
-    type_union1 = int | str
+    type_union1 = typing.Union[int, str]
     type_union2 = int | str
 
 Author
@@ -1444,17 +1444,17 @@ class TestDescriptions(unittest.TestCase):
             self.assertIn(list.__doc__.strip().splitlines()[0], doc)
 
     def test_union_type(self):
-        self.assertEqual(pydoc.describe(typing.Union[int, str]), 'Union')
+        self.assertEqual(pydoc.describe(typing.Union[int, str]), '_UnionGenericAlias')
         doc = pydoc.render_doc(typing.Union[int, str], renderer=pydoc.plaintext)
-        self.assertIn('Union in module typing', doc)
-        self.assertIn('class Union(builtins.object)', doc)
+        self.assertIn('_UnionGenericAlias in module typing', doc)
+        self.assertIn('Union = typing.Union', doc)
         if typing.Union.__doc__:
             self.assertIn(typing.Union.__doc__.strip().splitlines()[0], doc)
 
-        self.assertEqual(pydoc.describe(int | str), 'Union')
+        self.assertEqual(pydoc.describe(int | str), 'UnionType')
         doc = pydoc.render_doc(int | str, renderer=pydoc.plaintext)
-        self.assertIn('Union in module typing', doc)
-        self.assertIn('class Union(builtins.object)', doc)
+        self.assertIn('UnionType in module types object', doc)
+        self.assertIn('\nclass UnionType(builtins.object)', doc)
         if not MISSING_C_DOCSTRINGS:
             self.assertIn(types.UnionType.__doc__.strip().splitlines()[0], doc)
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -509,7 +509,7 @@ class TypeVarTests(BaseTestCase):
 
     def test_bound_errors(self):
         with self.assertRaises(TypeError):
-            TypeVar('X', bound=Optional)
+            TypeVar('X', bound=Union)
         with self.assertRaises(TypeError):
             TypeVar('X', str, float, bound=Employee)
         with self.assertRaisesRegex(TypeError,
@@ -549,7 +549,7 @@ class TypeVarTests(BaseTestCase):
     def test_bad_var_substitution(self):
         T = TypeVar('T')
         bad_args = (
-            (), (int, str), Optional,
+            (), (int, str), Union,
             Generic, Generic[T], Protocol, Protocol[T],
             Final, Final[int], ClassVar, ClassVar[int],
         )
@@ -2056,6 +2056,10 @@ class UnionTests(BaseTestCase):
 
     def test_union_issubclass_type_error(self):
         with self.assertRaises(TypeError):
+            issubclass(int, Union)
+        with self.assertRaises(TypeError):
+            issubclass(Union, int)
+        with self.assertRaises(TypeError):
             issubclass(Union[int, str], int)
         with self.assertRaises(TypeError):
             issubclass(int, Union[str, list[int]])
@@ -2129,40 +2133,41 @@ class UnionTests(BaseTestCase):
 
         self.assertEqual(Union[A, B].__args__, (A, B))
         union1 = Union[A, B]
-        with self.assertRaisesRegex(TypeError, "unhashable type: 'UnhashableMeta'"):
+        with self.assertRaises(TypeError):
             hash(union1)
 
         union2 = Union[int, B]
-        with self.assertRaisesRegex(TypeError, "unhashable type: 'UnhashableMeta'"):
+        with self.assertRaises(TypeError):
             hash(union2)
 
         union3 = Union[A, int]
-        with self.assertRaisesRegex(TypeError, "unhashable type: 'UnhashableMeta'"):
+        with self.assertRaises(TypeError):
             hash(union3)
 
     def test_repr(self):
+        self.assertEqual(repr(Union), 'typing.Union')
         u = Union[Employee, int]
-        self.assertEqual(repr(u), f'{__name__}.Employee | int')
+        self.assertEqual(repr(u), 'typing.Union[%s.Employee, int]' % __name__)
         u = Union[int, Employee]
-        self.assertEqual(repr(u), f'int | {__name__}.Employee')
+        self.assertEqual(repr(u), 'typing.Union[int, %s.Employee]' % __name__)
         T = TypeVar('T')
         u = Union[T, int][int]
         self.assertEqual(repr(u), repr(int))
         u = Union[List[int], int]
-        self.assertEqual(repr(u), 'typing.List[int] | int')
+        self.assertEqual(repr(u), 'typing.Union[typing.List[int], int]')
         u = Union[list[int], dict[str, float]]
-        self.assertEqual(repr(u), 'list[int] | dict[str, float]')
+        self.assertEqual(repr(u), 'typing.Union[list[int], dict[str, float]]')
         u = Union[int | float]
-        self.assertEqual(repr(u), 'int | float')
+        self.assertEqual(repr(u), 'typing.Union[int, float]')
 
         u = Union[None, str]
-        self.assertEqual(repr(u), 'None | str')
+        self.assertEqual(repr(u), 'typing.Optional[str]')
         u = Union[str, None]
-        self.assertEqual(repr(u), 'str | None')
+        self.assertEqual(repr(u), 'typing.Optional[str]')
         u = Union[None, str, int]
-        self.assertEqual(repr(u), 'None | str | int')
+        self.assertEqual(repr(u), 'typing.Union[NoneType, str, int]')
         u = Optional[str]
-        self.assertEqual(repr(u), 'str | None')
+        self.assertEqual(repr(u), 'typing.Optional[str]')
 
     def test_dir(self):
         dir_items = set(dir(Union[str, int]))
@@ -2174,11 +2179,14 @@ class UnionTests(BaseTestCase):
 
     def test_cannot_subclass(self):
         with self.assertRaisesRegex(TypeError,
-                r"type 'typing\.Union' is not an acceptable base type"):
+                r'Cannot subclass typing\.Union'):
             class C(Union):
                 pass
+        with self.assertRaisesRegex(TypeError, CANNOT_SUBCLASS_TYPE):
+            class D(type(Union)):
+                pass
         with self.assertRaisesRegex(TypeError,
-                r'Cannot subclass int \| str'):
+                r'Cannot subclass typing\.Union\[int, str\]'):
             class E(Union[int, str]):
                 pass
 
@@ -2224,7 +2232,8 @@ class UnionTests(BaseTestCase):
 
     def test_function_repr_union(self):
         def fun() -> int: ...
-        self.assertEqual(repr(Union[fun, int]), f'{__name__}.{fun.__qualname__} | int')
+        self.assertEqual(repr(Union[fun, int]),
+                         f'typing.Union[{__name__}.{fun.__qualname__}, int]')
 
     def test_union_str_pattern(self):
         # Shouldn't crash; see http://bugs.python.org/issue25390
@@ -5046,11 +5055,11 @@ class GenericTests(BaseTestCase):
     def test_extended_generic_rules_repr(self):
         T = TypeVar('T')
         self.assertEqual(repr(Union[Tuple, Callable]).replace('typing.', ''),
-                         'Tuple | Callable')
+                         'Union[Tuple, Callable]')
         self.assertEqual(repr(Union[Tuple, Tuple[int]]).replace('typing.', ''),
-                         'Tuple | Tuple[int]')
+                         'Union[Tuple, Tuple[int]]')
         self.assertEqual(repr(Callable[..., Optional[T]][int]).replace('typing.', ''),
-                         'Callable[..., int | None]')
+                         'Callable[..., Optional[int]]')
         self.assertEqual(repr(Callable[[], List[T]][int]).replace('typing.', ''),
                          'Callable[[], List[int]]')
 
@@ -5230,9 +5239,9 @@ class GenericTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(Tuple[int, ...], typing.Iterable)
 
-    def test_fail_with_special_forms(self):
+    def test_fail_with_bare_union(self):
         with self.assertRaises(TypeError):
-            List[Final]
+            List[Union]
         with self.assertRaises(TypeError):
             Tuple[Optional]
         with self.assertRaises(TypeError):
@@ -5776,6 +5785,8 @@ class GenericTests(BaseTestCase):
         for obj in (
             ClassVar[int],
             Final[int],
+            Union[int, float],
+            Optional[int],
             Literal[1, 2],
             Concatenate[int, ParamSpec("P")],
             TypeGuard[int],
@@ -5807,7 +5818,7 @@ class GenericTests(BaseTestCase):
             __parameters__ = (T,)
         # Bare classes should be skipped
         for a in (List, list):
-            for b in (A, int, TypeVar, TypeVarTuple, ParamSpec, types.GenericAlias, Union):
+            for b in (A, int, TypeVar, TypeVarTuple, ParamSpec, types.GenericAlias, types.UnionType):
                 with self.subTest(generic=a, sub=b):
                     with self.assertRaisesRegex(TypeError, '.* is not a generic class'):
                         a[b][str]
@@ -5826,7 +5837,7 @@ class GenericTests(BaseTestCase):
 
         for s in (int, G, A, List, list,
                   TypeVar, TypeVarTuple, ParamSpec,
-                  types.GenericAlias, Union):
+                  types.GenericAlias, types.UnionType):
 
             for t in Tuple, tuple:
                 with self.subTest(tuple=t, sub=s):
@@ -7195,7 +7206,7 @@ class GetUtilitiesTestCase(TestCase):
         self.assertIs(get_origin(Callable), collections.abc.Callable)
         self.assertIs(get_origin(list[int]), list)
         self.assertIs(get_origin(list), None)
-        self.assertIs(get_origin(list | str), Union)
+        self.assertIs(get_origin(list | str), types.UnionType)
         self.assertIs(get_origin(P.args), P)
         self.assertIs(get_origin(P.kwargs), P)
         self.assertIs(get_origin(Required[int]), Required)
@@ -10524,6 +10535,7 @@ class SpecialAttrsTests(BaseTestCase):
             typing.TypeGuard: 'TypeGuard',
             typing.TypeIs: 'TypeIs',
             typing.TypeVar: 'TypeVar',
+            typing.Union: 'Union',
             typing.Self: 'Self',
             # Subscripted special forms
             typing.Annotated[Any, "Annotation"]: 'Annotated',
@@ -10534,7 +10546,7 @@ class SpecialAttrsTests(BaseTestCase):
             typing.Literal[Any]: 'Literal',
             typing.Literal[1, 2]: 'Literal',
             typing.Literal[True, 2]: 'Literal',
-            typing.Optional[Any]: 'Union',
+            typing.Optional[Any]: 'Optional',
             typing.TypeGuard[Any]: 'TypeGuard',
             typing.TypeIs[Any]: 'TypeIs',
             typing.Union[Any]: 'Any',
@@ -10553,10 +10565,7 @@ class SpecialAttrsTests(BaseTestCase):
                 for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                     s = pickle.dumps(cls, proto)
                     loaded = pickle.loads(s)
-                    if isinstance(cls, Union):
-                        self.assertEqual(cls, loaded)
-                    else:
-                        self.assertIs(cls, loaded)
+                    self.assertIs(cls, loaded)
 
     TypeName = typing.NewType('SpecialAttrsTests.TypeName', Any)
 
@@ -10829,37 +10838,6 @@ class TypeIterationTests(BaseTestCase):
     def test_is_not_instance_of_iterable(self):
         for type_to_test in self._UNITERABLE_TYPES:
             self.assertNotIsInstance(type_to_test, collections.abc.Iterable)
-
-
-class UnionGenericAliasTests(BaseTestCase):
-    def test_constructor(self):
-        # Used e.g. in typer, pydantic
-        with self.assertWarns(DeprecationWarning):
-            inst = typing._UnionGenericAlias(typing.Union, (int, str))
-        self.assertEqual(inst, int | str)
-        with self.assertWarns(DeprecationWarning):
-            # name is accepted but ignored
-            inst = typing._UnionGenericAlias(typing.Union, (int, None), name="Optional")
-        self.assertEqual(inst, int | None)
-
-    def test_isinstance(self):
-        # Used e.g. in pydantic
-        with self.assertWarns(DeprecationWarning):
-            self.assertTrue(isinstance(Union[int, str], typing._UnionGenericAlias))
-        with self.assertWarns(DeprecationWarning):
-            self.assertFalse(isinstance(int, typing._UnionGenericAlias))
-
-    def test_eq(self):
-        # type(t) == _UnionGenericAlias is used in vyos
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(Union, typing._UnionGenericAlias)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(typing._UnionGenericAlias, typing._UnionGenericAlias)
-        with self.assertWarns(DeprecationWarning):
-            self.assertNotEqual(int, typing._UnionGenericAlias)
-
-    def test_hashable(self):
-        self.assertEqual(hash(typing._UnionGenericAlias), hash(Union))
 
 
 def load_tests(loader, tests, pattern):

--- a/Misc/NEWS.d/3.14.0a4.rst
+++ b/Misc/NEWS.d/3.14.0a4.rst
@@ -164,8 +164,8 @@ with meta (i.e. :kbd:`Alt`), e.g. :kbd:`Alt-d` to ``kill-word`` or
 .. nonce: RIvgwc
 .. section: Library
 
-Unify the instance check for :class:`typing.Union` and
-:class:`types.UnionType`: :class:`!Union` now uses the instance checks
+Unify the instance check in :data:`typing.Union` and
+:class:`types.UnionType`: :data:`!Union` now uses the instance checks
 against its parameters instead of the subclass checks.
 
 ..

--- a/Misc/NEWS.d/3.14.0a6.rst
+++ b/Misc/NEWS.d/3.14.0a6.rst
@@ -834,7 +834,7 @@ performance. Patch by Romain Morotti.
 .. nonce: 7jV6cP
 .. section: Library
 
-Make :class:`types.UnionType` an alias for :class:`typing.Union`. Both ``int
+[Reverted in :gh:`137065`] Make :class:`types.UnionType` an alias for :data:`typing.Union`. Both ``int
 | str`` and ``Union[int, str]`` now create instances of the same type. Patch
 by Jelle Zijlstra.
 

--- a/Misc/NEWS.d/3.14.0b1.rst
+++ b/Misc/NEWS.d/3.14.0b1.rst
@@ -407,7 +407,7 @@ Speedup pasting in ``PyREPL`` on Windows. Fix by Chris Eibl.
 .. nonce: 6zoyp5
 .. section: Library
 
-Fix copying of :class:`typing.Union` objects containing objects that do not
+Fix copying of :data:`typing.Union` objects containing objects that do not
 support the ``|`` operator.
 
 ..

--- a/Misc/NEWS.d/next/Library/2025-09-16-11-49-21.gh-issue-137065.W2-dKY.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-16-11-49-21.gh-issue-137065.W2-dKY.rst
@@ -1,0 +1,2 @@
+Revert :gh:`105499`. Restore :data:`typing.Union` and
+:class:`types.UnionType`.

--- a/Modules/_typingmodule.c
+++ b/Modules/_typingmodule.c
@@ -5,10 +5,9 @@
 #endif
 
 #include "Python.h"
-#include "internal/pycore_interp.h"
-#include "internal/pycore_typevarobject.h"
-#include "internal/pycore_unionobject.h"  // _PyUnion_Type
+#include "pycore_interp.h"
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
+#include "pycore_typevarobject.h"
 #include "clinic/_typingmodule.c.h"
 
 /*[clinic input]
@@ -62,9 +61,6 @@ _typing_exec(PyObject *m)
     EXPORT_TYPE("Generic", generic_type);
 #undef EXPORT_TYPE
     if (PyModule_AddObjectRef(m, "TypeAliasType", (PyObject *)&_PyTypeAlias_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "Union", (PyObject *)&_PyUnion_Type) < 0) {
         return -1;
     }
     if (PyModule_AddObjectRef(m, "NoDefault", (PyObject *)&_Py_NoDefaultStruct) < 0) {

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -4,7 +4,7 @@
 #include "pycore_object.h"        // _PyObject_GC_TRACK/UNTRACK, PyAnnotateFormat
 #include "pycore_typevarobject.h"
 #include "pycore_unicodeobject.h" // _PyUnicode_EqualToASCIIString()
-#include "pycore_unionobject.h"   // _Py_union_type_or, _Py_union_from_tuple
+#include "pycore_unionobject.h"   // _Py_union_type_or
 #include "structmember.h"
 
 /*[clinic input]
@@ -372,13 +372,9 @@ type_check(PyObject *arg, const char *msg)
 static PyObject *
 make_union(PyObject *self, PyObject *other)
 {
-    PyObject *args = PyTuple_Pack(2, self, other);
-    if (args == NULL) {
-        return NULL;
-    }
-    PyObject *u = _Py_union_from_tuple(args);
-    Py_DECREF(args);
-    return u;
+    PyObject *args[2] = {self, other};
+    PyObject *result = call_typing_func_object("_make_union", args, 2);
+    return result;
 }
 
 static PyObject *

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -1,4 +1,4 @@
-// typing.Union -- used to represent e.g. Union[int, str], int | str
+// types.UnionType -- used to represent e.g. Union[int, str], int | str
 #include "Python.h"
 #include "pycore_object.h"  // _PyObject_GC_TRACK/UNTRACK
 #include "pycore_typevarobject.h"  // _PyTypeAlias_Type, _Py_typing_type_repr
@@ -7,13 +7,13 @@
 #include "pycore_weakref.h"       // FT_CLEAR_WEAKREFS()
 
 
+static PyObject *make_union(PyObject *);
+
+
 typedef struct {
     PyObject_HEAD
-    PyObject *args;  // all args (tuple)
-    PyObject *hashable_args;  // frozenset or NULL
-    PyObject *unhashable_args;  // tuple or NULL
+    PyObject *args;
     PyObject *parameters;
-    PyObject *weakreflist;
 } unionobject;
 
 static void
@@ -22,11 +22,8 @@ unionobject_dealloc(PyObject *self)
     unionobject *alias = (unionobject *)self;
 
     _PyObject_GC_UNTRACK(self);
-    FT_CLEAR_WEAKREFS(self, alias->weakreflist);
 
     Py_XDECREF(alias->args);
-    Py_XDECREF(alias->hashable_args);
-    Py_XDECREF(alias->unhashable_args);
     Py_XDECREF(alias->parameters);
     Py_TYPE(self)->tp_free(self);
 }
@@ -36,8 +33,6 @@ union_traverse(PyObject *self, visitproc visit, void *arg)
 {
     unionobject *alias = (unionobject *)self;
     Py_VISIT(alias->args);
-    Py_VISIT(alias->hashable_args);
-    Py_VISIT(alias->unhashable_args);
     Py_VISIT(alias->parameters);
     return 0;
 }
@@ -46,67 +41,13 @@ static Py_hash_t
 union_hash(PyObject *self)
 {
     unionobject *alias = (unionobject *)self;
-    // If there are any unhashable args, treat this union as unhashable.
-    // Otherwise, two unions might compare equal but have different hashes.
-    if (alias->unhashable_args) {
-        // Attempt to get an error from one of the values.
-        assert(PyTuple_CheckExact(alias->unhashable_args));
-        Py_ssize_t n = PyTuple_GET_SIZE(alias->unhashable_args);
-        for (Py_ssize_t i = 0; i < n; i++) {
-            PyObject *arg = PyTuple_GET_ITEM(alias->unhashable_args, i);
-            Py_hash_t hash = PyObject_Hash(arg);
-            if (hash == -1) {
-                return -1;
-            }
-        }
-        // The unhashable values somehow became hashable again. Still raise
-        // an error.
-        PyErr_Format(PyExc_TypeError, "union contains %d unhashable elements", n);
-        return -1;
+    PyObject *args = PyFrozenSet_New(alias->args);
+    if (args == NULL) {
+        return (Py_hash_t)-1;
     }
-    return PyObject_Hash(alias->hashable_args);
-}
-
-static int
-unions_equal(unionobject *a, unionobject *b)
-{
-    int result = PyObject_RichCompareBool(a->hashable_args, b->hashable_args, Py_EQ);
-    if (result == -1) {
-        return -1;
-    }
-    if (result == 0) {
-        return 0;
-    }
-    if (a->unhashable_args && b->unhashable_args) {
-        Py_ssize_t n = PyTuple_GET_SIZE(a->unhashable_args);
-        if (n != PyTuple_GET_SIZE(b->unhashable_args)) {
-            return 0;
-        }
-        for (Py_ssize_t i = 0; i < n; i++) {
-            PyObject *arg_a = PyTuple_GET_ITEM(a->unhashable_args, i);
-            int result = PySequence_Contains(b->unhashable_args, arg_a);
-            if (result == -1) {
-                return -1;
-            }
-            if (!result) {
-                return 0;
-            }
-        }
-        for (Py_ssize_t i = 0; i < n; i++) {
-            PyObject *arg_b = PyTuple_GET_ITEM(b->unhashable_args, i);
-            int result = PySequence_Contains(a->unhashable_args, arg_b);
-            if (result == -1) {
-                return -1;
-            }
-            if (!result) {
-                return 0;
-            }
-        }
-    }
-    else if (a->unhashable_args || b->unhashable_args) {
-        return 0;
-    }
-    return 1;
+    Py_hash_t hash = PyObject_Hash(args);
+    Py_DECREF(args);
+    return hash;
 }
 
 static PyObject *
@@ -116,128 +57,93 @@ union_richcompare(PyObject *a, PyObject *b, int op)
         Py_RETURN_NOTIMPLEMENTED;
     }
 
-    int equal = unions_equal((unionobject*)a, (unionobject*)b);
-    if (equal == -1) {
+    PyObject *a_set = PySet_New(((unionobject*)a)->args);
+    if (a_set == NULL) {
         return NULL;
     }
-    if (op == Py_EQ) {
-        return PyBool_FromLong(equal);
+    PyObject *b_set = PySet_New(((unionobject*)b)->args);
+    if (b_set == NULL) {
+        Py_DECREF(a_set);
+        return NULL;
     }
-    else {
-        return PyBool_FromLong(!equal);
-    }
+    PyObject *result = PyObject_RichCompare(a_set, b_set, op);
+    Py_DECREF(b_set);
+    Py_DECREF(a_set);
+    return result;
 }
 
-typedef struct {
-    PyObject *args;  // list
-    PyObject *hashable_args;  // set
-    PyObject *unhashable_args;  // list or NULL
-    bool is_checked;  // whether to call type_check()
-} unionbuilder;
-
-static bool unionbuilder_add_tuple(unionbuilder *, PyObject *);
-static PyObject *make_union(unionbuilder *);
-static PyObject *type_check(PyObject *, const char *);
-
-static bool
-unionbuilder_init(unionbuilder *ub, bool is_checked)
+static int
+is_same(PyObject *left, PyObject *right)
 {
-    ub->args = PyList_New(0);
-    if (ub->args == NULL) {
-        return false;
-    }
-    ub->hashable_args = PySet_New(NULL);
-    if (ub->hashable_args == NULL) {
-        Py_DECREF(ub->args);
-        return false;
-    }
-    ub->unhashable_args = NULL;
-    ub->is_checked = is_checked;
-    return true;
+    int is_ga = _PyGenericAlias_Check(left) && _PyGenericAlias_Check(right);
+    return is_ga ? PyObject_RichCompareBool(left, right, Py_EQ) : left == right;
 }
 
-static void
-unionbuilder_finalize(unionbuilder *ub)
+static int
+contains(PyObject **items, Py_ssize_t size, PyObject *obj)
 {
-    Py_DECREF(ub->args);
-    Py_DECREF(ub->hashable_args);
-    Py_XDECREF(ub->unhashable_args);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        int is_duplicate = is_same(items[i], obj);
+        if (is_duplicate) {  // -1 or 1
+            return is_duplicate;
+        }
+    }
+    return 0;
 }
 
-static bool
-unionbuilder_add_single_unchecked(unionbuilder *ub, PyObject *arg)
+static PyObject *
+merge(PyObject **items1, Py_ssize_t size1,
+      PyObject **items2, Py_ssize_t size2)
 {
-    Py_hash_t hash = PyObject_Hash(arg);
-    if (hash == -1) {
-        PyErr_Clear();
-        if (ub->unhashable_args == NULL) {
-            ub->unhashable_args = PyList_New(0);
-            if (ub->unhashable_args == NULL) {
-                return false;
+    PyObject *tuple = NULL;
+    Py_ssize_t pos = 0;
+
+    for (Py_ssize_t i = 0; i < size2; i++) {
+        PyObject *arg = items2[i];
+        int is_duplicate = contains(items1, size1, arg);
+        if (is_duplicate < 0) {
+            Py_XDECREF(tuple);
+            return NULL;
+        }
+        if (is_duplicate) {
+            continue;
+        }
+
+        if (tuple == NULL) {
+            tuple = PyTuple_New(size1 + size2 - i);
+            if (tuple == NULL) {
+                return NULL;
+            }
+            for (; pos < size1; pos++) {
+                PyObject *a = items1[pos];
+                PyTuple_SET_ITEM(tuple, pos, Py_NewRef(a));
             }
         }
-        else {
-            int contains = PySequence_Contains(ub->unhashable_args, arg);
-            if (contains < 0) {
-                return false;
-            }
-            if (contains == 1) {
-                return true;
-            }
-        }
-        if (PyList_Append(ub->unhashable_args, arg) < 0) {
-            return false;
-        }
+        PyTuple_SET_ITEM(tuple, pos, Py_NewRef(arg));
+        pos++;
     }
-    else {
-        int contains = PySet_Contains(ub->hashable_args, arg);
-        if (contains < 0) {
-            return false;
-        }
-        if (contains == 1) {
-            return true;
-        }
-        if (PySet_Add(ub->hashable_args, arg) < 0) {
-            return false;
-        }
+
+    if (tuple) {
+        (void) _PyTuple_Resize(&tuple, pos);
     }
-    return PyList_Append(ub->args, arg) == 0;
+    return tuple;
 }
 
-static bool
-unionbuilder_add_single(unionbuilder *ub, PyObject *arg)
+static PyObject **
+get_types(PyObject **obj, Py_ssize_t *size)
 {
-    if (Py_IsNone(arg)) {
-        arg = (PyObject *)&_PyNone_Type;  // immortal, so no refcounting needed
+    if (*obj == Py_None) {
+        *obj = (PyObject *)&_PyNone_Type;
     }
-    else if (_PyUnion_Check(arg)) {
-        PyObject *args = ((unionobject *)arg)->args;
-        return unionbuilder_add_tuple(ub, args);
-    }
-    if (ub->is_checked) {
-        PyObject *type = type_check(arg, "Union[arg, ...]: each arg must be a type.");
-        if (type == NULL) {
-            return false;
-        }
-        bool result = unionbuilder_add_single_unchecked(ub, type);
-        Py_DECREF(type);
-        return result;
+    if (_PyUnion_Check(*obj)) {
+        PyObject *args = ((unionobject *) *obj)->args;
+        *size = PyTuple_GET_SIZE(args);
+        return &PyTuple_GET_ITEM(args, 0);
     }
     else {
-        return unionbuilder_add_single_unchecked(ub, arg);
+        *size = 1;
+        return obj;
     }
-}
-
-static bool
-unionbuilder_add_tuple(unionbuilder *ub, PyObject *tuple)
-{
-    Py_ssize_t n = PyTuple_GET_SIZE(tuple);
-    for (Py_ssize_t i = 0; i < n; i++) {
-        if (!unionbuilder_add_single(ub, PyTuple_GET_ITEM(tuple, i))) {
-            return false;
-        }
-    }
-    return true;
 }
 
 static int
@@ -260,18 +166,19 @@ _Py_union_type_or(PyObject* self, PyObject* other)
         Py_RETURN_NOTIMPLEMENTED;
     }
 
-    unionbuilder ub;
-    // unchecked because we already checked is_unionable()
-    if (!unionbuilder_init(&ub, false)) {
-        return NULL;
-    }
-    if (!unionbuilder_add_single(&ub, self) ||
-        !unionbuilder_add_single(&ub, other)) {
-        unionbuilder_finalize(&ub);
-        return NULL;
+    Py_ssize_t size1, size2;
+    PyObject **items1 = get_types(&self, &size1);
+    PyObject **items2 = get_types(&other, &size2);
+    PyObject *tuple = merge(items1, size1, items2, size2);
+    if (tuple == NULL) {
+        if (PyErr_Occurred()) {
+            return NULL;
+        }
+        return Py_NewRef(self);
     }
 
-    PyObject *new_union = make_union(&ub);
+    PyObject *new_union = make_union(tuple);
+    Py_DECREF(tuple);
     return new_union;
 }
 
@@ -350,7 +257,21 @@ union_getitem(PyObject *self, PyObject *item)
         return NULL;
     }
 
-    PyObject *res = _Py_union_from_tuple(newargs);
+    PyObject *res;
+    Py_ssize_t nargs = PyTuple_GET_SIZE(newargs);
+    if (nargs == 0) {
+        res = make_union(newargs);
+    }
+    else {
+        res = Py_NewRef(PyTuple_GET_ITEM(newargs, 0));
+        for (Py_ssize_t iarg = 1; iarg < nargs; iarg++) {
+            PyObject *arg = PyTuple_GET_ITEM(newargs, iarg);
+            Py_SETREF(res, PyNumber_Or(res, arg));
+            if (res == NULL) {
+                break;
+            }
+        }
+    }
     Py_DECREF(newargs);
     return res;
 }
@@ -369,25 +290,7 @@ union_parameters(PyObject *self, void *Py_UNUSED(unused))
     return Py_NewRef(alias->parameters);
 }
 
-static PyObject *
-union_name(PyObject *Py_UNUSED(self), void *Py_UNUSED(ignored))
-{
-    return PyUnicode_FromString("Union");
-}
-
-static PyObject *
-union_origin(PyObject *Py_UNUSED(self), void *Py_UNUSED(ignored))
-{
-    return Py_NewRef(&_PyUnion_Type);
-}
-
 static PyGetSetDef union_properties[] = {
-    {"__name__", union_name, NULL,
-     PyDoc_STR("Name of the type"), NULL},
-    {"__qualname__", union_name, NULL,
-     PyDoc_STR("Qualified name of the type"), NULL},
-    {"__origin__", union_origin, NULL,
-     PyDoc_STR("Always returns the type"), NULL},
     {"__parameters__", union_parameters, NULL,
      PyDoc_STR("Type variables in the types.UnionType."), NULL},
     {0}
@@ -426,88 +329,10 @@ _Py_union_args(PyObject *self)
     return ((unionobject *) self)->args;
 }
 
-static PyObject *
-call_typing_func_object(const char *name, PyObject **args, size_t nargs)
-{
-    PyObject *typing = PyImport_ImportModule("typing");
-    if (typing == NULL) {
-        return NULL;
-    }
-    PyObject *func = PyObject_GetAttrString(typing, name);
-    if (func == NULL) {
-        Py_DECREF(typing);
-        return NULL;
-    }
-    PyObject *result = PyObject_Vectorcall(func, args, nargs, NULL);
-    Py_DECREF(func);
-    Py_DECREF(typing);
-    return result;
-}
-
-static PyObject *
-type_check(PyObject *arg, const char *msg)
-{
-    if (Py_IsNone(arg)) {
-        // NoneType is immortal, so don't need an INCREF
-        return (PyObject *)Py_TYPE(arg);
-    }
-    // Fast path to avoid calling into typing.py
-    if (is_unionable(arg)) {
-        return Py_NewRef(arg);
-    }
-    PyObject *message_str = PyUnicode_FromString(msg);
-    if (message_str == NULL) {
-        return NULL;
-    }
-    PyObject *args[2] = {arg, message_str};
-    PyObject *result = call_typing_func_object("_type_check", args, 2);
-    Py_DECREF(message_str);
-    return result;
-}
-
-PyObject *
-_Py_union_from_tuple(PyObject *args)
-{
-    unionbuilder ub;
-    if (!unionbuilder_init(&ub, true)) {
-        return NULL;
-    }
-    if (PyTuple_CheckExact(args)) {
-        if (!unionbuilder_add_tuple(&ub, args)) {
-            return NULL;
-        }
-    }
-    else {
-        if (!unionbuilder_add_single(&ub, args)) {
-            return NULL;
-        }
-    }
-    return make_union(&ub);
-}
-
-static PyObject *
-union_class_getitem(PyObject *cls, PyObject *args)
-{
-    return _Py_union_from_tuple(args);
-}
-
-static PyObject *
-union_mro_entries(PyObject *self, PyObject *args)
-{
-    return PyErr_Format(PyExc_TypeError,
-                        "Cannot subclass %R", self);
-}
-
-static PyMethodDef union_methods[] = {
-    {"__mro_entries__", union_mro_entries, METH_O},
-    {"__class_getitem__", union_class_getitem, METH_O|METH_CLASS, PyDoc_STR("See PEP 585")},
-    {0}
-};
-
 PyTypeObject _PyUnion_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    .tp_name = "typing.Union",
-    .tp_doc = PyDoc_STR("Represent a union type\n"
+    .tp_name = "types.UnionType",
+    .tp_doc = PyDoc_STR("Represent a PEP 604 union type\n"
               "\n"
               "E.g. for int | str"),
     .tp_basicsize = sizeof(unionobject),
@@ -519,64 +344,25 @@ PyTypeObject _PyUnion_Type = {
     .tp_hash = union_hash,
     .tp_getattro = union_getattro,
     .tp_members = union_members,
-    .tp_methods = union_methods,
     .tp_richcompare = union_richcompare,
     .tp_as_mapping = &union_as_mapping,
     .tp_as_number = &union_as_number,
     .tp_repr = union_repr,
     .tp_getset = union_properties,
-    .tp_weaklistoffset = offsetof(unionobject, weakreflist),
 };
 
 static PyObject *
-make_union(unionbuilder *ub)
+make_union(PyObject *args)
 {
-    Py_ssize_t n = PyList_GET_SIZE(ub->args);
-    if (n == 0) {
-        PyErr_SetString(PyExc_TypeError, "Cannot take a Union of no types.");
-        unionbuilder_finalize(ub);
-        return NULL;
-    }
-    if (n == 1) {
-        PyObject *result = PyList_GET_ITEM(ub->args, 0);
-        Py_INCREF(result);
-        unionbuilder_finalize(ub);
-        return result;
-    }
-
-    PyObject *args = NULL, *hashable_args = NULL, *unhashable_args = NULL;
-    args = PyList_AsTuple(ub->args);
-    if (args == NULL) {
-        goto error;
-    }
-    hashable_args = PyFrozenSet_New(ub->hashable_args);
-    if (hashable_args == NULL) {
-        goto error;
-    }
-    if (ub->unhashable_args != NULL) {
-        unhashable_args = PyList_AsTuple(ub->unhashable_args);
-        if (unhashable_args == NULL) {
-            goto error;
-        }
-    }
+    assert(PyTuple_CheckExact(args));
 
     unionobject *result = PyObject_GC_New(unionobject, &_PyUnion_Type);
     if (result == NULL) {
-        goto error;
+        return NULL;
     }
-    unionbuilder_finalize(ub);
 
     result->parameters = NULL;
-    result->args = args;
-    result->hashable_args = hashable_args;
-    result->unhashable_args = unhashable_args;
-    result->weakreflist = NULL;
+    result->args = Py_NewRef(args);
     _PyObject_GC_TRACK(result);
     return (PyObject*)result;
-error:
-    Py_XDECREF(args);
-    Py_XDECREF(hashable_args);
-    Py_XDECREF(unhashable_args);
-    unionbuilder_finalize(ub);
-    return NULL;
 }


### PR DESCRIPTION
This reverts commit d1db43c139121202898e2d75df43ed2eb06a8470.
This reverts commit 0f511d8b44dd9993474402411af8c83f4964bc95.
This reverts commit dc6d66f44c0a25b69dfec7e4ffc4a6fa5e4feada.


<!-- gh-issue-number: gh-137065 -->
* Issue: gh-137065
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138967.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->