### PR TITLE
Revert "gh-118803: Remove `ByteString` from `typing` and `collections.abc` (#118804)"

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.14.rst
+++ b/Doc/deprecations/pending-removal-in-3.14.rst
@@ -38,12 +38,6 @@ Pending removal in Python 3.14
     is no current event loop set and it decides to create one.
     (Contributed by Serhiy Storchaka and Guido van Rossum in :gh:`100160`.)
 
-* :mod:`collections.abc`: Deprecated :class:`!collections.abc.ByteString`.
-  Prefer :class:`!Sequence` or :class:`~collections.abc.Buffer`.
-  For use in typing, prefer a union, like ``bytes | bytearray``,
-  or :class:`collections.abc.Buffer`.
-  (Contributed by Shantanu Jain in :gh:`91896`.)
-
 * :mod:`email`: Deprecated the *isdst* parameter in :func:`email.utils.localtime`.
   (Contributed by Alan Williams in :gh:`72346`.)
 
@@ -95,9 +89,6 @@ Pending removal in Python 3.14
   * :meth:`~sqlite3.Cursor.execute` and :meth:`~sqlite3.Cursor.executemany`
     if :ref:`named placeholders <sqlite3-placeholders>` are used and
     *parameters* is a sequence instead of a :class:`dict`.
-
-* :mod:`typing`: :class:`!typing.ByteString`, deprecated since Python 3.9,
-  now causes a :exc:`DeprecationWarning` to be emitted when it is used.
 
 * :mod:`urllib`:
   :class:`!urllib.parse.Quoter` is deprecated: it was not intended to be a

--- a/Doc/deprecations/pending-removal-in-3.17.rst
+++ b/Doc/deprecations/pending-removal-in-3.17.rst
@@ -8,3 +8,15 @@ Pending removal in Python 3.17
     but it has been retained for backward compatibility, with removal scheduled for Python
     3.17. Users should use documented introspection helpers like :func:`typing.get_origin`
     and :func:`typing.get_args` instead of relying on private implementation details.
+  - :class:`typing.ByteString`, deprecated since Python 3.9, is scheduled for removal in
+    Python 3.17. Prefer :class:`~collections.abcSequence` or
+    :class:`~collections.abc.Buffer`. For use in type annotations, prefer a union, like
+    ``bytes | bytearray``, or :class:`collections.abc.Buffer`.
+    (Contributed by Shantanu Jain in :gh:`91896`.)
+
+* :mod:`collections.abc`:
+
+  - :class:`collections.abc.ByteString` is scheduled for removal in Python 3.17. Prefer
+    :class:`~collections.abcSequence` or :class:`~collections.abc.Buffer`. For use in
+    type annotations, prefer a union, like ``bytes | bytearray``, or
+    :class:`collections.abc.Buffer`. (Contributed by Shantanu Jain in :gh:`91896`.)

--- a/Doc/deprecations/pending-removal-in-3.17.rst
+++ b/Doc/deprecations/pending-removal-in-3.17.rst
@@ -9,7 +9,7 @@ Pending removal in Python 3.17
     3.17. Users should use documented introspection helpers like :func:`typing.get_origin`
     and :func:`typing.get_args` instead of relying on private implementation details.
   - :class:`typing.ByteString`, deprecated since Python 3.9, is scheduled for removal in
-    Python 3.17. Prefer :class:`~collections.abcSequence` or
+    Python 3.17. Prefer :class:`~collections.abc.Sequence` or
     :class:`~collections.abc.Buffer`. For use in type annotations, prefer a union, like
     ``bytes | bytearray``, or :class:`collections.abc.Buffer`.
     (Contributed by Shantanu Jain in :gh:`91896`.)
@@ -17,6 +17,6 @@ Pending removal in Python 3.17
 * :mod:`collections.abc`:
 
   - :class:`collections.abc.ByteString` is scheduled for removal in Python 3.17. Prefer
-    :class:`~collections.abcSequence` or :class:`~collections.abc.Buffer`. For use in
+    :class:`~collections.abc.Sequence` or :class:`~collections.abc.Buffer`. For use in
     type annotations, prefer a union, like ``bytes | bytearray``, or
     :class:`collections.abc.Buffer`. (Contributed by Shantanu Jain in :gh:`91896`.)

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -140,6 +140,9 @@ ABC                            Inherits from          Abstract Methods        Mi
                                                       ``__len__``,
                                                       ``insert``
 
+:class:`ByteString`            :class:`Sequence`      ``__getitem__``,        Inherited :class:`Sequence` methods
+                                                      ``__len__``
+
 :class:`Set`                   :class:`Collection`    ``__contains__``,       ``__le__``, ``__lt__``, ``__eq__``, ``__ne__``,
                                                       ``__iter__``,           ``__gt__``, ``__ge__``, ``__and__``, ``__or__``,
                                                       ``__len__``             ``__sub__``, ``__rsub__``, ``__xor__``, ``__rxor__``
@@ -260,6 +263,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
 .. class:: Sequence
            MutableSequence
+           ByteString
 
    ABCs for read-only and mutable :term:`sequences <sequence>`.
 
@@ -284,6 +288,12 @@ Collections Abstract Base Classes -- Detailed Descriptions
       .. versionchanged:: 3.5
          The :meth:`~sequence.index` method gained support for
          the *stop* and *start* arguments.
+
+   .. deprecated-removed:: 3.12 3.17
+      The :class:`ByteString` ABC has been deprecated.
+      For use in type annotations, prefer a union, like ``bytes | bytearray``, or
+      :class:`collections.abc.Buffer`.
+      For use as an ABC, prefer :class:`Sequence` or :class:`collections.abc.Buffer`.
 
 .. class:: Set
            MutableSet

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5544,6 +5544,7 @@ list is non-exhaustive.
 * :class:`collections.abc.MutableMapping`
 * :class:`collections.abc.Sequence`
 * :class:`collections.abc.MutableSequence`
+* :class:`collections.abc.ByteString`
 * :class:`collections.abc.MappingView`
 * :class:`collections.abc.KeysView`
 * :class:`collections.abc.ItemsView`

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3788,6 +3788,14 @@ Aliases to container ABCs in :mod:`collections.abc`
       :class:`collections.abc.Set` now supports subscripting (``[]``).
       See :pep:`585` and :ref:`types-genericalias`.
 
+.. class:: ByteString(Sequence[int])
+
+   This type represents the types :class:`bytes`, :class:`bytearray`,
+   and :class:`memoryview` of byte sequences.
+
+   .. deprecated-removed:: 3.9 3.17
+      Prefer :class:`collections.abc.Buffer`, or a union like ``bytes | bytearray | memoryview``.
+
 .. class:: Collection(Sized, Iterable[T_co], Container[T_co])
 
    Deprecated alias to :class:`collections.abc.Collection`.
@@ -4081,6 +4089,10 @@ convenience. This is subject to change, and not all deprecations are listed.
      - 3.9
      - Undecided (see :ref:`deprecated-aliases` for more information)
      - :pep:`585`
+   * - :class:`typing.ByteString`
+     - 3.9
+     - 3.17
+     - :gh:`91896`
    * - :data:`typing.Text`
      - 3.11
      - Undecided

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1191,9 +1191,9 @@ Deprecated
   replaced by :data:`calendar.JANUARY` and :data:`calendar.FEBRUARY`.
   (Contributed by Prince Roshan in :gh:`103636`.)
 
-* :mod:`collections.abc`: Deprecated :class:`!collections.abc.ByteString`.
+* :mod:`collections.abc`: Deprecated :class:`collections.abc.ByteString`.
   Prefer :class:`Sequence` or :class:`collections.abc.Buffer`.
-  For use in typing, prefer a union, like ``bytes | bytearray``, or :class:`collections.abc.Buffer`.
+  For use in type annotations, prefer a union, like ``bytes | bytearray``, or :class:`collections.abc.Buffer`.
   (Contributed by Shantanu Jain in :gh:`91896`.)
 
 * :mod:`datetime`: :class:`datetime.datetime`'s :meth:`~datetime.datetime.utcnow` and
@@ -1301,7 +1301,7 @@ Deprecated
     :class:`collections.abc.Hashable` and :class:`collections.abc.Sized` respectively, are
     deprecated. (:gh:`94309`.)
 
-  * :class:`!typing.ByteString`, deprecated since Python 3.9, now causes a
+  * :class:`typing.ByteString`, deprecated since Python 3.9, now causes a
     :exc:`DeprecationWarning` to be emitted when it is used.
     (Contributed by Alex Waygood in :gh:`91896`.)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2560,15 +2560,6 @@ asyncio
          blocking_code()
          runner.run(operation_two())
 
-
-collections.abc
----------------
-
-* Remove :class:`!ByteString`, which has been deprecated since Python 3.12.
-  (Contributed by Nikita Sobolev in :gh:`118803`.)
-
-
-
 email
 -----
 
@@ -2645,13 +2636,6 @@ sqlite3
   raises a :exc:`~sqlite3.ProgrammingError`,
   having been deprecated since Python 3.12.
   (Contributed by Erlend E. Aasland in :gh:`118928` and :gh:`101693`.)
-
-
-typing
-------
-
-* Remove :class:`!ByteString`, which has been deprecated since Python 3.12.
-  (Contributed by Nikita Sobolev in :gh:`118803`.)
 
 
 urllib

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -936,7 +936,7 @@ methods to match the corresponding methods of :class:`str`.
 collections.abc
 ---------------
 
-The :meth:`Sequence.index() <collections.abc.MutableSequence.index>` method now
+The :meth:`!Sequence.index` method now
 accepts *start* and *stop* arguments to match the corresponding methods
 of :class:`tuple`, :class:`list`, etc.
 (Contributed by Devin Jeanpierre in :issue:`23086`.)

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -49,7 +49,7 @@ __all__ = ["Awaitable", "Coroutine",
            "Mapping", "MutableMapping",
            "MappingView", "KeysView", "ItemsView", "ValuesView",
            "Sequence", "MutableSequence",
-           "Buffer",
+           "ByteString", "Buffer",
            ]
 
 # This module has been renamed from collections.abc to _collections_abc to
@@ -1057,9 +1057,39 @@ class Sequence(Reversible, Collection):
 
 Sequence.register(tuple)
 Sequence.register(str)
-Sequence.register(bytes)
 Sequence.register(range)
 Sequence.register(memoryview)
+
+class _DeprecateByteStringMeta(ABCMeta):
+    def __new__(cls, name, bases, namespace, **kwargs):
+        if name != "ByteString":
+            import warnings
+
+            warnings._deprecated(
+                "collections.abc.ByteString",
+                remove=(3, 17),
+            )
+        return super().__new__(cls, name, bases, namespace, **kwargs)
+
+    def __instancecheck__(cls, instance):
+        import warnings
+
+        warnings._deprecated(
+            "collections.abc.ByteString",
+            remove=(3, 17),
+        )
+        return super().__instancecheck__(instance)
+
+class ByteString(Sequence, metaclass=_DeprecateByteStringMeta):
+    """This unifies bytes and bytearray.
+
+    XXX Should add all their methods.
+    """
+
+    __slots__ = ()
+
+ByteString.register(bytes)
+ByteString.register(bytearray)
 
 
 class MutableSequence(Sequence):
@@ -1129,4 +1159,4 @@ class MutableSequence(Sequence):
 
 
 MutableSequence.register(list)
-MutableSequence.register(bytearray)
+MutableSequence.register(bytearray)  # Multiply inheriting, see ByteString

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -1057,6 +1057,7 @@ class Sequence(Reversible, Collection):
 
 Sequence.register(tuple)
 Sequence.register(str)
+Sequence.register(bytes)
 Sequence.register(range)
 Sequence.register(memoryview)
 
@@ -1159,4 +1160,4 @@ class MutableSequence(Sequence):
 
 
 MutableSequence.register(list)
-MutableSequence.register(bytearray)  # Multiply inheriting, see ByteString
+MutableSequence.register(bytearray)

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -253,6 +253,7 @@ def dash_R_cleanup(fs, ps, pic, zdc, abcs, linecache_data):
         zipimport._zip_directory_cache.update(zdc)
 
     # Clear ABC registries, restoring previously saved ABC registries.
+    # ignore deprecation warning for collections.abc.ByteString
     abs_classes = [getattr(collections.abc, a) for a in collections.abc.__all__]
     abs_classes = filter(isabstract, abs_classes)
     for abc in abs_classes:

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -253,7 +253,6 @@ def dash_R_cleanup(fs, ps, pic, zdc, abcs, linecache_data):
         zipimport._zip_directory_cache.update(zdc)
 
     # Clear ABC registries, restoring previously saved ABC registries.
-    # ignore deprecation warning for collections.abc.ByteString
     abs_classes = [getattr(collections.abc, a) for a in collections.abc.__all__]
     abs_classes = filter(isabstract, abs_classes)
     for abc in abs_classes:

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -26,7 +26,7 @@ from collections.abc import Sized, Container, Callable, Collection
 from collections.abc import Set, MutableSet
 from collections.abc import Mapping, MutableMapping, KeysView, ItemsView, ValuesView
 from collections.abc import Sequence, MutableSequence
-from collections.abc import Buffer
+from collections.abc import ByteString, Buffer
 
 
 class TestUserObjects(unittest.TestCase):
@@ -1933,6 +1933,28 @@ class TestCollectionABCs(ABCTestCase):
                     for stop in range(-3, len(nativeseq) + 3):
                         assert_index_same(
                             nativeseq, seqseq, (letter, start, stop))
+
+    def test_ByteString(self):
+        for sample in [bytes, bytearray]:
+            with self.assertWarns(DeprecationWarning):
+                self.assertIsInstance(sample(), ByteString)
+            self.assertTrue(issubclass(sample, ByteString))
+        for sample in [str, list, tuple]:
+            with self.assertWarns(DeprecationWarning):
+                self.assertNotIsInstance(sample(), ByteString)
+            self.assertFalse(issubclass(sample, ByteString))
+        with self.assertWarns(DeprecationWarning):
+            self.assertNotIsInstance(memoryview(b""), ByteString)
+        self.assertFalse(issubclass(memoryview, ByteString))
+        with self.assertWarns(DeprecationWarning):
+            self.validate_abstract_methods(ByteString, '__getitem__', '__len__')
+
+        with self.assertWarns(DeprecationWarning):
+            class X(ByteString): pass
+
+        with self.assertWarns(DeprecationWarning):
+            # No metaclass conflict
+            class Z(ByteString, Awaitable): pass
 
     def test_Buffer(self):
         for sample in [bytes, bytearray, memoryview]:

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7486,6 +7486,16 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsInstance([], typing.MutableSequence)
         self.assertNotIsInstance((), typing.MutableSequence)
 
+    def test_bytestring(self):
+        with self.assertWarns(DeprecationWarning):
+            self.assertIsInstance(b'', typing.ByteString)
+        with self.assertWarns(DeprecationWarning):
+            self.assertIsInstance(bytearray(b''), typing.ByteString)
+        with self.assertWarns(DeprecationWarning):
+            class Foo(typing.ByteString): ...
+        with self.assertWarns(DeprecationWarning):
+            class Bar(typing.ByteString, typing.Awaitable): ...
+
     def test_list(self):
         self.assertIsSubclass(list, typing.List)
 
@@ -10440,6 +10450,7 @@ class SpecialAttrsTests(BaseTestCase):
             typing.AsyncIterable: 'AsyncIterable',
             typing.AsyncIterator: 'AsyncIterator',
             typing.Awaitable: 'Awaitable',
+            typing.ByteString: 'ByteString',
             typing.Callable: 'Callable',
             typing.ChainMap: 'ChainMap',
             typing.Collection: 'Collection',

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -65,6 +65,7 @@ __all__ = [
 
     # ABCs (from collections.abc).
     'AbstractSet',  # collections.abc.Set.
+    'ByteString',
     'Container',
     'ContextManager',
     'Hashable',
@@ -1590,6 +1591,21 @@ class _SpecialGenericAlias(_NotIterable, _BaseGenericAlias, _root=True):
         return Union[left, self]
 
 
+class _DeprecatedGenericAlias(_SpecialGenericAlias, _root=True):
+    def __init__(
+        self, origin, nparams, *, removal_version, inst=True, name=None
+    ):
+        super().__init__(origin, nparams, inst=inst, name=name)
+        self._removal_version = removal_version
+
+    def __instancecheck__(self, inst):
+        import warnings
+        warnings._deprecated(
+            f"{self.__module__}.{self._name}", remove=self._removal_version
+        )
+        return super().__instancecheck__(inst)
+
+
 class _CallableGenericAlias(_NotIterable, _GenericAlias, _root=True):
     def __repr__(self):
         assert self._name == 'Callable'
@@ -2777,6 +2793,9 @@ Mapping = _alias(collections.abc.Mapping, 2)
 MutableMapping = _alias(collections.abc.MutableMapping, 2)
 Sequence = _alias(collections.abc.Sequence, 1)
 MutableSequence = _alias(collections.abc.MutableSequence, 1)
+ByteString = _DeprecatedGenericAlias(
+    collections.abc.ByteString, 0, removal_version=(3, 17)  # Not generic.
+)
 # Tuple accepts variable number of parameters.
 Tuple = _TupleType(tuple, -1, inst=False, name='Tuple')
 Tuple.__doc__ = \

--- a/Misc/NEWS.d/next/Library/2025-09-16-15-56-29.gh-issue-118803.aOPtmL.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-16-15-56-29.gh-issue-118803.aOPtmL.rst
@@ -1,0 +1,3 @@
+Add back :class:`collections.abc.ByteString` and :class:`typing.ByteString`.
+Both had been removed in prior alpha, beta and release candidates for Python
+3.14, but their removal has now been postponed to Python 3.17.


### PR DESCRIPTION
This is a more-or-less clean revert of commit 2f4db5a04d6fa7ba5c1c6b82b482dd7ca48f3382. The PR adds back `collections.abc.ByteString` and `typing.ByteString`, postponing their removals to Python 3.17.

Prior to https://github.com/python/cpython/commit/2f4db5a04d6fa7ba5c1c6b82b482dd7ca48f3382, we had deprecation warnings for `ByteString`, but they only triggered if you subclassed `ByteString` or used `ByteString` as the second argument to `isinstance()` or `issubclass()`. Since the removal of `ByteString`, we've had multiple reports from users that these deprecation warnings have been insufficient and that the removal of `ByteString` took them by surprise:
- https://github.com/python/cpython/pull/118804#issuecomment-2909237245
- https://github.com/aio-libs/aiohttp/pull/8408#issuecomment-2105346432
- https://github.com/python/cpython/issues/118803#issuecomment-3256653827

That's because many uses of `ByteString` do not subclass `ByteString` or use it as the second argument to `isinstance()`. Many uses of `ByteString` simply use it as a type annotation, and simply using it as a type annotation would not be sufficient to trigger a runtime deprecation warning informing you that the object would be removed in Python 3.14. Prior to removing the object from the `collections.abc` and `typing` modules entirely, it would be much better if we emitted a `DeprecationWarning` whenever the object is _accessed_ or _imported_ from `collections.abc`/`typing`.

Now, there's a good reason why we didn't do that in Python 3.12: `ByteString` is present both in `collections.abc.__all__` and `typing.__all__`. Naively emitting a deprecation warning every time it was imported or accessed would have caused deprecation warnings to be emitted on every `from collections.abc import *` or `from typing import *` statement, which was deemed at the time to be far too noisy and disruptive (https://github.com/python/cpython/pull/104424). One solution would have been to remove `ByteString` from `collections.abc.__all__` and `typing.__all__`, but we couldn't do that right away in Python 3.12 as it was a breaking change.

Nonetheless, removing `ByteString` from `collections.abc.__all__` and `typing.__all__` is much less of a breaking change than removing it entirely without prominent runtime deprecation warnings. Now that we're in a place where it's been deprecated in the docs for 2 releases and had _some_ runtime deprecation warnings for 2 releases, I think we're now in a position where we can:
1. Easily add it back at runtime (what this PR does) and backport the add-back PR to 3.14
2. Remove `ByteString` from `collections.abc.__all__` and `typing.__all__` in Python 3.15
3. Add stronger deprecation warnings at runtime that put us in a good position to remove it entirely in Python 3.17

This PR should strictly improve backwards compatibility. It will not break anything for users who have already removed their uses of `ByteString`; they will simply be extremely well prepared for when `ByteString` is removed for good in Python 3.17. For users who have been unaware of the deprecation up till now, however (and there may be many such users that we don't know about in closed-source projects), this will mean that they are given much better notice that they should adapt their code for the forthcoming removal of `ByteString` in Python 3.17.

<!-- gh-issue-number: gh-118803 -->
* Issue: gh-118803
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--138990.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->