### PR TITLE
gh-137165: Add non-zero-padded Windows support for `datetime.strftime`

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -213,6 +213,11 @@ def _need_normalize_century():
             _normalize_century = True
     return _normalize_century
 
+def _make_dash_replacement(ch, timetuple):
+    fmt = '%' + ch
+    val = _time.strftime(fmt, timetuple)
+    return val.lstrip('0') or '0'
+
 # Correctly substitute for %z and %Z escapes in strftime formats.
 def _wrap_strftime(object, format, timetuple):
     # Don't call utcoffset() or tzname() unless actually needed.
@@ -284,6 +289,16 @@ def _wrap_strftime(object, format, timetuple):
                         push('{:04}'.format(year))
                         if ch == 'F':
                             push('-{:02}-{:02}'.format(*timetuple[1:3]))
+                elif ch == '-':
+                    if i < n:
+                        next_ch = format[i]
+                        i += 1
+                        if sys.platform.startswith('win') or sys.platform.startswith('android'):
+                            push(_make_dash_replacement(next_ch, timetuple))
+                        else:
+                            push('%-' + next_ch)
+                    else:
+                        push('%-')
                 else:
                     push('%')
                     push(ch)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -14,6 +14,7 @@ import sys
 import textwrap
 import unittest
 import warnings
+import platform
 
 from array import array
 
@@ -1587,6 +1588,15 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         self.assertEqual(t.strftime("m:%m d:%d y:%y"), "m:03 d:02 y:05")
         self.assertEqual(t.strftime(""), "") # SF bug #761337
         self.assertEqual(t.strftime('x'*1000), 'x'*1000) # SF bug #1556784
+
+        # SF bug #137165
+        if platform.system() == 'Darwin':
+            self.assertEqual(t.strftime("m:%-m d:%-d y:%-y"), "m:3 d:2 y:05")
+        elif platform.system() == 'Windows':
+            self.assertEqual(t.strftime("m:%#m d:%#d y:%#y"), "m:3 d:2 y:5")
+            self.assertEqual(t.strftime("m:%-m d:%-d y:%-y"), "m:3 d:2 y:5")
+        else:
+            self.assertEqual(t.strftime("m:%-m d:%-d y:%-y"), "m:3 d:2 y:5")
 
         self.assertRaises(TypeError, t.strftime) # needs an arg
         self.assertRaises(TypeError, t.strftime, "one", "two") # too many args
@@ -3889,6 +3899,11 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         self.assertEqual(t.strftime('%H %M %S %f'), "01 02 03 000004")
         # A naive object replaces %z, %:z and %Z with empty strings.
         self.assertEqual(t.strftime("'%z' '%:z' '%Z'"), "'' '' ''")
+
+        # SF bug #137165
+        self.assertEqual(t.strftime('%-H %-M %-S %f'), "1 2 3 000004")
+        if platform.system() == 'Windows':
+            self.assertEqual(t.strftime('%#H %#M %#S %f'), "1 2 3 000004")
 
         # bpo-34482: Check that surrogates don't cause a crash.
         try:

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1592,10 +1592,9 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         # SF bug #137165
         if platform.system() == 'Darwin':
             self.assertEqual(t.strftime("m:%-m d:%-d y:%-y"), "m:3 d:2 y:05")
-        elif platform.system() == 'Windows':
-            self.assertEqual(t.strftime("m:%#m d:%#d y:%#y"), "m:3 d:2 y:5")
-            self.assertEqual(t.strftime("m:%-m d:%-d y:%-y"), "m:3 d:2 y:5")
         else:
+            if platform.system() == 'Windows':
+                self.assertEqual(t.strftime("m:%#m d:%#d y:%#y"), "m:3 d:2 y:5")
             self.assertEqual(t.strftime("m:%-m d:%-d y:%-y"), "m:3 d:2 y:5")
 
         self.assertRaises(TypeError, t.strftime) # needs an arg

--- a/Misc/NEWS.d/next/Library/2025-09-16-15-36-18.gh-issue-137165.AclPcn.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-16-15-36-18.gh-issue-137165.AclPcn.rst
@@ -1,0 +1,2 @@
+Add support for Windows non-zero-padded formatting directives in
+:func:`datetime.datetime.strftime` (e.g., ``"m:%-m d:%-d y:%-y"``).

--- a/Misc/NEWS.d/next/Library/2025-09-16-15-36-18.gh-issue-137165.AclPcn.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-16-15-36-18.gh-issue-137165.AclPcn.rst
@@ -1,2 +1,0 @@
-Add support for Windows non-zero-padded formatting directives in
-:func:`datetime.datetime.strftime` (e.g., ``"m:%-m d:%-d y:%-y"``).

--- a/Misc/NEWS.d/next/Library/2025-09-18-03-02-39.gh-issue-137165.7tJ6DS.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-18-03-02-39.gh-issue-137165.7tJ6DS.rst
@@ -1,0 +1,3 @@
+Standardized non-zero-padded date formatting in
+:func:`datetime.datetime.strftime` and :func:`datetime.date.strftime` across
+Windows and Unix. (e.g. ``"m:%-m d:%-d y:%-y"``).


### PR DESCRIPTION
<!-- gh-issue-number: gh-137165 -->
* Issue: gh-137165
<!-- /gh-issue-number -->
