### PR TITLE
gh-138966: Add description for gi_suspended attribute

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -253,8 +253,8 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
 +-----------------+-------------------+---------------------------+
 |                 | gi_running        | is the generator running? |
 +-----------------+-------------------+---------------------------+
-|                 | gi_suspended      | is the generator suspended|
-|                 |                   | ?                         |
+|                 | gi_suspended      | is the generator          |
+|                 |                   | suspended?                |
 +-----------------+-------------------+---------------------------+
 |                 | gi_code           | code                      |
 +-----------------+-------------------+---------------------------+

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -253,6 +253,9 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
 +-----------------+-------------------+---------------------------+
 |                 | gi_running        | is the generator running? |
 +-----------------+-------------------+---------------------------+
+|                 | gi_suspended      | is the generator suspended|
+|                 |                   | ?                         |
++-----------------+-------------------+---------------------------+
 |                 | gi_code           | code                      |
 +-----------------+-------------------+---------------------------+
 |                 | gi_yieldfrom      | object being iterated by  |


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Issue: #138966 

This pull request adds the `gi_suspended` attribute for generator objects within the `inspect` module's "Types and members" table.

The `gi_suspended` attribute is a read-only boolean that indicates whether a generator is currently paused at a `yield` expression. Its purpose is similar to `gi_running` but for the suspended state.


<!-- gh-issue-number: gh-138966 -->
* Issue: gh-138966
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139008.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->