### PR TITLE
gh-139006: Doc: Clarify html.escape function description

### DIFF
--- a/Doc/library/html.rst
+++ b/Doc/library/html.rst
@@ -14,9 +14,12 @@ This module defines utilities to manipulate HTML.
 
    Convert the characters ``&``, ``<`` and ``>`` in string *s* to HTML-safe
    sequences.  Use this if you need to display text that might contain such
-   characters in HTML.  If the optional flag *quote* is true, the characters
-   (``"``) and (``'``) are also translated; this helps for inclusion in an HTML
-   attribute value delimited by quotes, as in ``<a href="...">``.
+   characters in HTML.  If the optional flag *quote* is true (the default), the
+   characters (``"``) and (``'``) are also translated; this helps for inclusion
+   in an HTML attribute value delimited by quotes, as in ``<a href="...">``.
+   If *quote* is set to false, the characters (``"``) and (``'``) are not
+   translated.
+
 
    .. versionadded:: 3.2
 


### PR DESCRIPTION
This PR clarifies the documentation of `html.escape`.

Previously, the docs said:

> If the optional flag *quote* is true, the characters (") and (') are also translated...

This wording was slightly misleading because the default value of *quote* is already `True`.  
Readers might think they need to explicitly pass `quote=True`, but in reality, the default behavior already translates (") and (').

✅ Changes in this PR:
- Updated the wording to explicitly state that *quote* is `True` by default.
- Added a note explaining that if *quote* is set to `False`, (") and (') are not translated.

Issue: gh-139006

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139016.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->