### PR TITLE
gh-138997: Remove justify `fill` inexisting option from Tkinter docs

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -839,8 +839,7 @@ geometry
    For example: ``fred["geometry"] = "200x100"``.
 
 justify
-   Legal values are the strings: ``"left"``, ``"center"``, ``"right"``, and
-   ``"fill"``.
+   Legal values are the strings: ``"left"``, ``"center"``, and ``"right"``.
 
 region
    This is a string with four space-delimited elements, each of which is a legal


### PR DESCRIPTION
<!-- gh-issue-number: gh-138997 -->
* Issue: gh-138997
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139023.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->