### PR TITLE
Add pganssle to CODEOWNERS for zoneinfo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -409,7 +409,8 @@ Doc/**/*time.rst                 @pganssle @abalkin
 Doc/library/zoneinfo.rst         @pganssle
 Include/datetime.h               @pganssle @abalkin
 Include/internal/pycore_time.h   @pganssle @abalkin
-Lib/**/*zoneinfo*                @pganssle
+Lib/test/test_zoneinfo/          @pganssle
+Lib/zoneinfo/                    @pganssle
 Lib/*time.py                     @pganssle @abalkin
 Lib/test/datetimetester.py       @pganssle @abalkin
 Lib/test/test_*time.py           @pganssle @abalkin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -414,7 +414,7 @@ Lib/zoneinfo/                    @pganssle
 Lib/*time.py                     @pganssle @abalkin
 Lib/test/datetimetester.py       @pganssle @abalkin
 Lib/test/test_*time.py           @pganssle @abalkin
-Modules/**/*zoneinfo*            @pganssle
+Modules/*zoneinfo*               @pganssle
 Modules/*time*                   @pganssle @abalkin
 Python/pytime.c                  @pganssle @abalkin
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -406,7 +406,7 @@ Lib/test/test_dataclasses/    @ericvsmith
 
 # Dates and times
 Doc/**/*time.rst                 @pganssle @abalkin
-Doc/**/*zoneinfo*                @pganssle
+Doc/library/zoneinfo.rst         @pganssle
 Include/datetime.h               @pganssle @abalkin
 Include/internal/pycore_time.h   @pganssle @abalkin
 Lib/**/*zoneinfo*                @pganssle

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -406,16 +406,16 @@ Lib/test/test_dataclasses/    @ericvsmith
 
 # Dates and times
 Doc/**/*time.rst                 @pganssle @abalkin
+Doc/**/*zoneinfo*                @pganssle
 Include/datetime.h               @pganssle @abalkin
 Include/internal/pycore_time.h   @pganssle @abalkin
+Lib/**/*zoneinfo*                @pganssle
 Lib/*time.py                     @pganssle @abalkin
 Lib/test/datetimetester.py       @pganssle @abalkin
 Lib/test/test_*time.py           @pganssle @abalkin
+Modules/**/*zoneinfo*            @pganssle
 Modules/*time*                   @pganssle @abalkin
 Python/pytime.c                  @pganssle @abalkin
-Modules/**/*zoneinfo*            @pganssle
-Lib/**/*zoneinfo*                @pganssle
-Doc/**/*zoneinfo*                @pganssle
 
 # Dbm
 Doc/library/dbm.rst           @corona10 @erlend-aasland @serhiy-storchaka

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -413,6 +413,9 @@ Lib/test/datetimetester.py       @pganssle @abalkin
 Lib/test/test_*time.py           @pganssle @abalkin
 Modules/*time*                   @pganssle @abalkin
 Python/pytime.c                  @pganssle @abalkin
+Modules/**/*zoneinfo*            @pganssle
+Lib/**/*zoneinfo*                @pganssle
+Doc/**/*zoneinfo*                @pganssle
 
 # Dbm
 Doc/library/dbm.rst           @corona10 @erlend-aasland @serhiy-storchaka


### PR DESCRIPTION
As noticed by @StanFromIreland, it turns out I am not in `CODEOWNERS` or on the experts list for `zoneinfo`.