### PR TITLE
[3.14] gh-138736: Fix sqlite3.Connection.blobopen 'row' parameter type and naming (#138738)

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -614,7 +614,7 @@ Connection objects
       supplied, this must be a :term:`callable` returning
       an instance of :class:`Cursor` or its subclasses.
 
-   .. method:: blobopen(table, column, row, /, *, readonly=False, name="main")
+   .. method:: blobopen(table, column, rowid, /, *, readonly=False, name="main")
 
       Open a :class:`Blob` handle to an existing
       :abbr:`BLOB (Binary Large OBject)`.
@@ -625,8 +625,8 @@ Connection objects
       :param str column:
           The name of the column where the blob is located.
 
-      :param str row:
-          The name of the row where the blob is located.
+      :param int rowid:
+          The row id where the blob is located.
 
       :param bool readonly:
           Set to ``True`` if the blob should be opened without write

--- a/Modules/_sqlite/clinic/connection.c.h
+++ b/Modules/_sqlite/clinic/connection.c.h
@@ -235,7 +235,7 @@ exit:
 }
 
 PyDoc_STRVAR(blobopen__doc__,
-"blobopen($self, table, column, row, /, *, readonly=False, name=\'main\')\n"
+"blobopen($self, table, column, rowid, /, *, readonly=False, name=\'main\')\n"
 "--\n"
 "\n"
 "Open and return a BLOB object.\n"
@@ -244,8 +244,8 @@ PyDoc_STRVAR(blobopen__doc__,
 "    Table name.\n"
 "  column\n"
 "    Column name.\n"
-"  row\n"
-"    Row index.\n"
+"  rowid\n"
+"    Row id.\n"
 "  readonly\n"
 "    Open the BLOB without write permissions.\n"
 "  name\n"
@@ -1921,4 +1921,4 @@ exit:
 #ifndef DESERIALIZE_METHODDEF
     #define DESERIALIZE_METHODDEF
 #endif /* !defined(DESERIALIZE_METHODDEF) */
-/*[clinic end generated code: output=2f325c2444b4bb47 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7b502667df24ee41 input=a9049054013a1b77]*/

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -579,8 +579,8 @@ _sqlite3.Connection.blobopen as blobopen
         Table name.
     column as col: str
         Column name.
-    row: sqlite3_int64
-        Row index.
+    rowid as row: sqlite3_int64
+        Row id.
     /
     *
     readonly: bool = False
@@ -594,7 +594,7 @@ Open and return a BLOB object.
 static PyObject *
 blobopen_impl(pysqlite_Connection *self, const char *table, const char *col,
               sqlite3_int64 row, int readonly, const char *name)
-/*[clinic end generated code: output=6a02d43efb885d1c input=23576bd1108d8774]*/
+/*[clinic end generated code: output=6a02d43efb885d1c input=cc3d4b47dac08401]*/
 {
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return NULL;


### PR DESCRIPTION
The 'row' parameter represents a ROWID. Clarify this in docs and docstrings.

(cherry picked from commit 8eb106240f5d70baeabd4ad137de6213dd8cfb30)


<!-- gh-issue-number: gh-138736 -->
* Issue: gh-138736
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139062.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->