### PR TITLE
gh-139001: Fix thread-safety issue in `pathlib.Path`

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -335,13 +335,8 @@ class PurePath:
             return paths[0]
         elif paths:
             # Join path segments from the initializer.
-            path = self.parser.join(*paths)
-            # Cache the joined path.
-            paths.clear()
-            paths.append(path)
-            return path
+            return self.parser.join(*paths)
         else:
-            paths.append('')
             return ''
 
     @property

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -11,7 +11,6 @@ import posixpath
 import socket
 import stat
 import tempfile
-import threading
 import unittest
 from unittest import mock
 from urllib.request import pathname2url
@@ -21,7 +20,6 @@ from test.support import cpython_only
 from test.support import is_emscripten, is_wasi, is_wasm32
 from test.support import infinite_recursion
 from test.support import os_helper
-from test.support import threading_helper
 from test.support.os_helper import TESTFN, FS_NONASCII, FakePath
 try:
     import fcntl
@@ -1099,27 +1097,6 @@ class PurePathTest(unittest.TestCase):
         self.assertFalse(p.is_relative_to(P('c:/Server/Share/Foo')))
         self.assertFalse(p.is_relative_to(P('//z/Share/Foo')))
         self.assertFalse(p.is_relative_to(P('//Server/z/Foo')))
-
-    @threading_helper.requires_working_threading()
-    def test_raw_path_multithread(self):
-        P = self.cls
-        sep = self.sep
-
-        NUM_THREADS = 10
-        NUM_ITERS = 10
-
-        for _ in range(NUM_ITERS):
-            b = threading.Barrier(NUM_THREADS)
-            path = P('a') / 'b' / 'c' / 'd' / 'e'
-            expected = sep.join(['a', 'b', 'c', 'd', 'e'])
-
-            def check_raw_path():
-                b.wait()
-                self.assertEqual(path._raw_path, expected)
-
-            threads = [threading.Thread(target=check_raw_path) for _ in range(NUM_THREADS)]
-            with threading_helper.start_threads(threads):
-                pass
 
 
 class PurePosixPathTest(PurePathTest):

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -11,6 +11,7 @@ import posixpath
 import socket
 import stat
 import tempfile
+import threading
 import unittest
 from unittest import mock
 from urllib.request import pathname2url
@@ -20,6 +21,7 @@ from test.support import cpython_only
 from test.support import is_emscripten, is_wasi, is_wasm32
 from test.support import infinite_recursion
 from test.support import os_helper
+from test.support import threading_helper
 from test.support.os_helper import TESTFN, FS_NONASCII, FakePath
 try:
     import fcntl
@@ -1097,6 +1099,27 @@ class PurePathTest(unittest.TestCase):
         self.assertFalse(p.is_relative_to(P('c:/Server/Share/Foo')))
         self.assertFalse(p.is_relative_to(P('//z/Share/Foo')))
         self.assertFalse(p.is_relative_to(P('//Server/z/Foo')))
+
+    @threading_helper.requires_working_threading()
+    def test_raw_path_multithread(self):
+        P = self.cls
+        sep = self.sep
+
+        NUM_THREADS = 10
+        NUM_ITERS = 10
+
+        for _ in range(NUM_ITERS):
+            b = threading.Barrier(NUM_THREADS)
+            path = P('a') / 'b' / 'c' / 'd' / 'e'
+            expected = sep.join(['a', 'b', 'c', 'd', 'e'])
+
+            def check_raw_path():
+                b.wait()
+                self.assertEqual(path._raw_path, expected)
+
+            threads = [threading.Thread(target=check_raw_path) for _ in range(NUM_THREADS)]
+            with threading_helper.start_threads(threads):
+                pass
 
 
 class PurePosixPathTest(PurePathTest):

--- a/Misc/NEWS.d/next/Library/2025-09-17-12-07-21.gh-issue-139001.O6tseN.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-17-12-07-21.gh-issue-139001.O6tseN.rst
@@ -1,0 +1,2 @@
+Fix race condition in :class:`pathlib.Path` on the internal ``_raw_paths``
+field.


### PR DESCRIPTION
Don't cache the joined path in `_raw_path` because the caching isn't thread safe.


<!-- gh-issue-number: gh-139001 -->
* Issue: gh-139001
<!-- /gh-issue-number -->
