### PR TITLE
gh-139065: Fix trailing space before long word in textwrap

### DIFF
--- a/Lib/test/test_textwrap.py
+++ b/Lib/test/test_textwrap.py
@@ -605,7 +605,7 @@ How *do* you spell that odd word, anyways?
         # bug 1146.  Prevent a long word to be wrongly wrapped when the
         # preceding word is exactly one character shorter than the width
         self.check_wrap(self.text, 12,
-                        ['Did you say ',
+                        ['Did you say',
                          '"supercalifr',
                          'agilisticexp',
                          'ialidocious?',
@@ -633,7 +633,7 @@ How *do* you spell that odd word, anyways?
 
     def test_max_lines_long(self):
         self.check_wrap(self.text, 12,
-                        ['Did you say ',
+                        ['Did you say',
                          '"supercalifr',
                          'agilisticexp',
                          '[...]'],

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -211,7 +211,7 @@ class TextWrapper:
 
         # If we're allowed to break long words, then do so: put as much
         # of the next chunk onto the current line as will fit.
-        if self.break_long_words:
+        if self.break_long_words and space_left > 0:
             end = space_left
             chunk = reversed_chunks[-1]
             if self.break_on_hyphens and len(chunk) > space_left:

--- a/Misc/NEWS.d/next/Library/2025-09-17-19-08-34.gh-issue-139065.Hu8fM5.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-17-19-08-34.gh-issue-139065.Hu8fM5.rst
@@ -1,0 +1,2 @@
+Fix trailing space before a wrapped long word if the line length is exactly
+*width* in :mod:`textwrap`.


### PR DESCRIPTION
Fix trailing space before a wrapped long word if the line length with a space is exactly "width".


<!-- gh-issue-number: gh-139065 -->
* Issue: gh-139065
<!-- /gh-issue-number -->
