### PR TITLE
gh-139076: Fix regression in pydoc not showing extension functions

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -884,6 +884,7 @@ class HTMLDoc(Doc):
         for key, value in inspect.getmembers(object, inspect.isroutine):
             # if __all__ exists, believe it.  Otherwise use a heuristic.
             if (all is not None
+                or inspect.isbuiltin(value)
                 or (inspect.getmodule(value) or object) is object):
                 if visiblename(key, all, object):
                     funcs.append((key, value))
@@ -1328,6 +1329,7 @@ location listed above.
         for key, value in inspect.getmembers(object, inspect.isroutine):
             # if __all__ exists, believe it.  Otherwise use a heuristic.
             if (all is not None
+                or inspect.isbuiltin(value)
                 or (inspect.getmodule(value) or object) is object):
                 if visiblename(key, all, object):
                     funcs.append((key, value))

--- a/Lib/test/test_pydoc/pydocfodder.py
+++ b/Lib/test/test_pydoc/pydocfodder.py
@@ -87,6 +87,8 @@ class B(A):
     object_repr = object.__repr__
     get = {}.get  # same name
     dict_get = {}.get
+    from math import sin
+
 
 B.B_classmethod_ref = B.B_classmethod
 
@@ -186,3 +188,4 @@ __repr__ = object.__repr__  # same name
 object_repr = object.__repr__
 get = {}.get  # same name
 dict_get = {}.get
+from math import sin

--- a/Lib/test/test_pydoc/pydocfodder.py
+++ b/Lib/test/test_pydoc/pydocfodder.py
@@ -188,4 +188,4 @@ __repr__ = object.__repr__  # same name
 object_repr = object.__repr__
 get = {}.get  # same name
 dict_get = {}.get
-from math import sin
+from math import sin  # noqa: F401

--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -1951,9 +1951,11 @@ class PydocFodderTest(unittest.TestCase):
         if not support.MISSING_C_DOCSTRINGS:
             self.assertIn(' |  get(key, default=None, /) method of builtins.dict instance', lines)
             self.assertIn(' |  dict_get = get(key, default=None, /) method of builtins.dict instance', lines)
+            self.assertIn(' |  sin(x, /)', lines)
         else:
             self.assertIn(' |  get(...) method of builtins.dict instance', lines)
             self.assertIn(' |  dict_get = get(...) method of builtins.dict instance', lines)
+            self.assertIn(' |  sin(...)', lines)
 
         lines = self.getsection(result, f' |  Class methods {where}:', ' |  ' + '-'*70)
         self.assertIn(' |  B_classmethod(x)', lines)
@@ -2039,6 +2041,11 @@ class PydocFodderTest(unittest.TestCase):
             self.assertIn('    __repr__(...) unbound builtins.object method', lines)
             self.assertIn('    object_repr = __repr__(...) unbound builtins.object method', lines)
 
+        # builtin functions
+        if not support.MISSING_C_DOCSTRINGS:
+            self.assertIn('    sin(x, /)', lines)
+        else:
+            self.assertIn('    sin(...)', lines)
 
     def test_html_doc_routines_in_module(self):
         doc = pydoc.HTMLDoc()
@@ -2078,6 +2085,12 @@ class PydocFodderTest(unittest.TestCase):
             self.assertIn(' list_count = count(self, object, /) unbound builtins.list method', lines)
             self.assertIn(' __repr__(...) unbound builtins.object method', lines)
             self.assertIn(' object_repr = __repr__(...) unbound builtins.object method', lines)
+
+        # builtin functions
+        if not support.MISSING_C_DOCSTRINGS:
+            self.assertIn(' sin(x, /)', lines)
+        else:
+            self.assertIn(' sin(...)', lines)
 
 
 @unittest.skipIf(

--- a/Misc/NEWS.d/next/Library/2025-09-17-21-54-53.gh-issue-139076.2eX9lG.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-17-21-54-53.gh-issue-139076.2eX9lG.rst
@@ -1,0 +1,3 @@
+Fix a bug in the :mod:`pydoc` module that was hiding functions in a Python
+module if they were implemented in an extension module and the module did
+not have ``__all__``.


### PR DESCRIPTION
Fix a bug in the pydoc module that was hiding functions in a Python module if they were implemented in an extension module and the module did not have __all__.


<!-- gh-issue-number: gh-139076 -->
* Issue: gh-139076
<!-- /gh-issue-number -->
