### PR TITLE
Remove unmatched closing parenthesis

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -747,7 +747,7 @@ APIs:
    Return ``0`` on success, ``-1`` on error with an exception set.
 
    This function checks that *unicode* is a Unicode object, that the index is
-   not out of bounds, and that the object's reference count is one).
+   not out of bounds, and that the object's reference count is one.
    See :c:func:`PyUnicode_WRITE` for a version that skips these checks,
    making them your responsibility.
 


### PR DESCRIPTION
This was introduced in https://github.com/python/cpython/commit/e21863ce78b17ab9fc98df08681d89e57c275a60, and it seems the intention was to remove the parentheses.

Error spotted by NyaPuma from pt_PT translation team.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139082.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->