### PR TITLE
Revert gh-139075.  The sumprod fix needs more work.

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1485,9 +1485,7 @@ class MathTests(unittest.TestCase):
 
         # Error cases that arose during development
         args = ((-5, -5, 10), (1.5, 4611686018427387904, 2305843009213693952))
-        self.assertEqual(sumprod(*args), -7.5)
-        self.assertEqual(sumprod([-0.01, 1, -1, 0.01], [1, 1, 1, 1]), 0.0)
-        self.assertEqual(sumprod([1, 1, 1, 1], [-0.01, 1, -1, 0.01], ), 0.0)
+        self.assertEqual(sumprod(*args), 0.0)
 
     @requires_IEEE_754
     @unittest.skipIf(HAVE_DOUBLE_ROUNDING,

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-17-13-21-26.gh-issue-139074.dVZO5F.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-17-13-21-26.gh-issue-139074.dVZO5F.rst
@@ -1,2 +1,0 @@
-Fixed a missing case in :func:`math.sumprod` where a low precision path was
-taken when an int/int input pair followed a float input.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2937,10 +2937,24 @@ math_sumprod_impl(PyObject *module, PyObject *p, PyObject *q)
 
             if (!finished) {
                 double flt_p, flt_q;
-
-                if (PyFloat_CheckExact(p_i)) {
+                bool p_type_float = PyFloat_CheckExact(p_i);
+                bool q_type_float = PyFloat_CheckExact(q_i);
+                if (p_type_float && q_type_float) {
                     flt_p = PyFloat_AS_DOUBLE(p_i);
-                } else if (PyLong_CheckExact(p_i) || PyBool_Check(p_i)) {
+                    flt_q = PyFloat_AS_DOUBLE(q_i);
+                } else if (p_type_float && (PyLong_CheckExact(q_i) || PyBool_Check(q_i))) {
+                    /* We care about float/int pairs and int/float pairs because
+                       they arise naturally in several use cases such as price
+                       times quantity, measurements with integer weights, or
+                       data selected by a vector of bools. */
+                    flt_p = PyFloat_AS_DOUBLE(p_i);
+                    flt_q = PyLong_AsDouble(q_i);
+                    if (flt_q == -1.0 && PyErr_Occurred()) {
+                        PyErr_Clear();
+                        goto finalize_flt_path;
+                    }
+                } else if (q_type_float && (PyLong_CheckExact(p_i) || PyBool_Check(p_i))) {
+                    flt_q = PyFloat_AS_DOUBLE(q_i);
                     flt_p = PyLong_AsDouble(p_i);
                     if (flt_p == -1.0 && PyErr_Occurred()) {
                         PyErr_Clear();
@@ -2949,19 +2963,6 @@ math_sumprod_impl(PyObject *module, PyObject *p, PyObject *q)
                 } else {
                     goto finalize_flt_path;
                 }
-
-                if (PyFloat_CheckExact(q_i)) {
-                    flt_q = PyFloat_AS_DOUBLE(q_i);
-                } else if (PyLong_CheckExact(q_i) || PyBool_Check(q_i)) {
-                    flt_q = PyLong_AsDouble(q_i);
-                    if (flt_q == -1.0 && PyErr_Occurred()) {
-                        PyErr_Clear();
-                        goto finalize_flt_path;
-                    }
-                } else {
-                    goto finalize_flt_path;
-                }
-
                 TripleLength new_flt_total = tl_fma(flt_p, flt_q, flt_total);
                 if (isfinite(new_flt_total.hi)) {
                     flt_total = new_flt_total;


### PR DESCRIPTION
Getting many buildbot failures due a single case:

```python
>>> from math import sumprod
>>> args = ((-5,), (2305843009213693952,))
>>> sumprod(*args)
-1.152921504606847e+19
```

That should have been an integer result, not a float.


<!-- gh-issue-number: gh-139074 -->
* Issue: gh-139074
<!-- /gh-issue-number -->
