### PR TITLE
gh-135729: Store reference to globals in `Interpreter._decref`

### DIFF
--- a/Lib/concurrent/interpreters/__init__.py
+++ b/Lib/concurrent/interpreters/__init__.py
@@ -149,12 +149,14 @@ class Interpreter:
     def __reduce__(self):
         return (type(self), (self._id,))
 
-    def _decref(self):
+    # gh-135729: Globals might be destroyed by the time this is called, so we
+    # need to keep references ourself
+    def _decref(self, InterpreterNotFoundError=InterpreterNotFoundError, _interp_decref=_interpreters.decref):
         if not self._ownsref:
             return
         self._ownsref = False
         try:
-            _interpreters.decref(self._id)
+            _interp_decref(self._id)
         except InterpreterNotFoundError:
             pass
 

--- a/Lib/concurrent/interpreters/__init__.py
+++ b/Lib/concurrent/interpreters/__init__.py
@@ -151,7 +151,10 @@ class Interpreter:
 
     # gh-135729: Globals might be destroyed by the time this is called, so we
     # need to keep references ourself
-    def _decref(self, InterpreterNotFoundError=InterpreterNotFoundError, _interp_decref=_interpreters.decref):
+    def _decref(self, *,
+                InterpreterNotFoundError=InterpreterNotFoundError,
+                _interp_decref=_interpreters.decref,
+                ):
         if not self._ownsref:
             return
         self._ownsref = False

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -419,6 +419,22 @@ class InterpreterObjectTests(TestBase):
                 unpickled = pickle.loads(data)
                 self.assertEqual(unpickled, interp)
 
+    @support.requires_subprocess()
+    @force_not_colorized
+    def test_cleanup_in_repl(self):
+        # GH-135729: Using a subinterpreter in the REPL would lead to an unraisable
+        # exception during finalization
+        repl = script_helper.spawn_python("-i")
+        script = b"""if True:
+        from concurrent import interpreters
+        interpreters.create()
+        exit()"""
+        stdout, stderr = repl.communicate(script)
+        self.assertIsNone(stderr)
+        self.assertIn(b"remaining subinterpreters", stdout)
+        self.assertNotIn(b"Traceback", stdout)
+
+
 
 class TestInterpreterIsRunning(TestBase):
 

--- a/Misc/NEWS.d/next/Library/2025-09-18-05-32-18.gh-issue-135729.8AmMza.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-18-05-32-18.gh-issue-135729.8AmMza.rst
@@ -1,0 +1,2 @@
+Fix unraisable exception during finalization when using
+:mod:`concurrent.interpreters` in the REPL.


### PR DESCRIPTION


<!-- gh-issue-number: gh-135729 -->
* Issue: gh-135729
<!-- /gh-issue-number -->
