### PR TITLE
gh-139105: Fix the EOF key shows on Windows for sqlite3 .help

### DIFF
--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -15,6 +15,9 @@ from _colorize import get_theme, theme_no_color
 from ._completer import completer
 
 
+EOF_KEY = "CTRL-Z" if sys.platform == "win32" else "CTRL-D"
+
+
 def execute(c, sql, suppress_errors=True, theme=theme_no_color):
     """Helper that wraps execution of SQL code.
 
@@ -39,13 +42,6 @@ def execute(c, sql, suppress_errors=True, theme=theme_no_color):
         )
         if not suppress_errors:
             sys.exit(1)
-
-
-def _eof_key():
-    if sys.platform == "win32" and "idlelib.run" not in sys.modules:
-        return "CTRL-Z"
-    else:
-        return "CTRL-D"
 
 
 class SqliteInteractiveConsole(InteractiveConsole):
@@ -76,7 +72,7 @@ class SqliteInteractiveConsole(InteractiveConsole):
                     print(f"Enter SQL code or one of the below commands, and press enter.\n\n"
                           f"{t.builtin}.version{t.reset}    Print underlying SQLite library version\n"
                           f"{t.builtin}.help{t.reset}       Print this help message\n"
-                          f"{t.builtin}.quit{t.reset}       Exit the CLI, equivalent to {_eof_key()}\n")
+                          f"{t.builtin}.quit{t.reset}       Exit the CLI, equivalent to {EOF_KEY}\n")
                 case "quit":
                     sys.exit(0)
                 case "":
@@ -129,7 +125,7 @@ def main(*args):
         Connected to {db_name}
 
         Each command will be run using execute() on the cursor.
-        Type ".help" for more information; type ".quit" or {_eof_key()} to quit.
+        Type ".help" for more information; type ".quit" or {EOF_KEY} to quit.
     """).strip()
 
     theme = get_theme()

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -41,6 +41,13 @@ def execute(c, sql, suppress_errors=True, theme=theme_no_color):
             sys.exit(1)
 
 
+def _eof_key():
+    if sys.platform == "win32" and "idlelib.run" not in sys.modules:
+        return "CTRL-Z"
+    else:
+        return "CTRL-D"
+
+
 class SqliteInteractiveConsole(InteractiveConsole):
     """A simple SQLite REPL."""
 
@@ -69,7 +76,7 @@ class SqliteInteractiveConsole(InteractiveConsole):
                     print(f"Enter SQL code or one of the below commands, and press enter.\n\n"
                           f"{t.builtin}.version{t.reset}    Print underlying SQLite library version\n"
                           f"{t.builtin}.help{t.reset}       Print this help message\n"
-                          f"{t.builtin}.quit{t.reset}       Exit the CLI, equivalent to CTRL-D\n")
+                          f"{t.builtin}.quit{t.reset}       Exit the CLI, equivalent to {_eof_key()}\n")
                 case "quit":
                     sys.exit(0)
                 case "":
@@ -117,16 +124,12 @@ def main(*args):
         db_name = repr(args.filename)
 
     # Prepare REPL banner and prompts.
-    if sys.platform == "win32" and "idlelib.run" not in sys.modules:
-        eofkey = "CTRL-Z"
-    else:
-        eofkey = "CTRL-D"
     banner = dedent(f"""
         sqlite3 shell, running on SQLite version {sqlite3.sqlite_version}
         Connected to {db_name}
 
         Each command will be run using execute() on the cursor.
-        Type ".help" for more information; type ".quit" or {eofkey} to quit.
+        Type ".help" for more information; type ".quit" or {_eof_key()} to quit.
     """).strip()
 
     theme = get_theme()

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -109,6 +109,34 @@ class InteractiveSession(unittest.TestCase):
         self.assertEqual(out.count(self.PS1), 1)
         self.assertEqual(out.count(self.PS2), 0)
 
+    @unittest.skipUnless(sys.platform == "win32", "Windows EOF is CTRL-Z")
+    def test_interact_banner_win(self):
+        _, err = self.run_cli()
+        self.assertIn('type ".quit" or CTRL-Z to quit', err)
+
+    @unittest.skipUnless(sys.platform != "win32", "Non-Windows EOF is CTRL-D")
+    def test_interact_banner_non_win(self):
+        _, err = self.run_cli()
+        self.assertIn('type ".quit" or CTRL-D to quit', err)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows EOF is CTRL-Z")
+    def test_interact_help_eof_win(self):
+        out, err = self.run_cli(commands=(".help",))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertIn("Exit the CLI, equivalent to CTRL-Z", out)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 2)
+        self.assertEqual(out.count(self.PS2), 0)
+
+    @unittest.skipUnless(sys.platform != "win32", "Non-Windows EOF is CTRL-D")
+    def test_interact_help_eof_non_win(self):
+        out, err = self.run_cli(commands=(".help",))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertIn("Exit the CLI, equivalent to CTRL-D", out)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 2)
+        self.assertEqual(out.count(self.PS2), 0)
+
     def test_interact_quit(self):
         out, err = self.run_cli(commands=(".quit",))
         self.assertIn(self.MEMORY_DB_MSG, err)

--- a/Misc/NEWS.d/next/Library/2025-09-18-18-03-32.gh-issue-139105.1QQ_W4.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-18-18-03-32.gh-issue-139105.1QQ_W4.rst
@@ -1,1 +1,1 @@
-Fix the EOF key shows in sqlite3 `.help` command on Windows.
+Fix the EOF key shows in sqlite3 ``.help`` command on Windows.

--- a/Misc/NEWS.d/next/Library/2025-09-18-18-03-32.gh-issue-139105.1QQ_W4.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-18-18-03-32.gh-issue-139105.1QQ_W4.rst
@@ -1,1 +1,1 @@
-Fix the EOF key shows in sqlite3 ``.help`` command on Windows.
+Correct the EOF key shown in the :mod:`sqlite3` CLI ``.help`` text on Windows.

--- a/Misc/NEWS.d/next/Library/2025-09-18-18-03-32.gh-issue-139105.1QQ_W4.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-18-18-03-32.gh-issue-139105.1QQ_W4.rst
@@ -1,0 +1,1 @@
+Fix the EOF key shows in sqlite3 `.help` command on Windows.


### PR DESCRIPTION
This fixed the sqlite3 help message on Windows. Now it shows the correct EOF key.

- Windows: CTRL-Z
- Others: CTRL-D

<!-- gh-issue-number: gh-139105 -->
* Issue: gh-139105
<!-- /gh-issue-number -->
