### PR TITLE
gh-138970: Adjust tests for pegen rule flags

### DIFF
--- a/Lib/test/test_peg_generator/test_pegen.py
+++ b/Lib/test/test_peg_generator/test_pegen.py
@@ -1131,24 +1131,28 @@ class TestGrammarVisualizer(unittest.TestCase):
 
         # Test memo-only rule
         simple_rule = rules['simple_rule']
-        self.assertTrue(simple_rule.memo, "simple_rule should have memo=True")
+        self.assertTrue('memo' in simple_rule.flags,
+                        "simple_rule should have memo")
         self.assertEqual(simple_rule.flags, frozenset(['memo']),
                         f"simple_rule flags should be {'memo'}, got {simple_rule.flags}")
 
         # Test multi-flag rule
         multi_flag_rule = rules['multi_flag_rule']
-        self.assertTrue(multi_flag_rule.memo, "multi_flag_rule should have memo=True")
+        self.assertTrue('memo' in simple_rule.flags,
+                        "multi_flag_rule should have memo=True")
         self.assertEqual(multi_flag_rule.flags, frozenset({'memo', 'custom', 'test'}),
                         f"multi_flag_rule flags should contain memo, custom, test, got {multi_flag_rule.flags}")
 
         # Test single custom flag rule
         single_custom_rule = rules['single_custom_flag']
-        self.assertFalse(single_custom_rule.memo, "single_custom_flag should have memo=False")
+        self.assertFalse('memo' not in simple_rule.flags,
+                         "single_custom_flag should not have memo")
         self.assertEqual(single_custom_rule.flags, frozenset(['custom']),
                         f"single_custom_flag flags should be {'custom'}, got {single_custom_rule.flags}")
 
         # Test no flags rule
         no_flags_rule = rules['no_flags_rule']
-        self.assertFalse(no_flags_rule.memo, "no_flags_rule should have memo=False")
-        self.assertEqual(no_flags_rule.flags, [],
+        self.assertFalse('memo' not in simple_rule.flags,
+                         "no_flags_rule should have memo=False")
+        self.assertEqual(no_flags_rule.flags, frozenset(),
                         f"no_flags_rule flags should be the empty set, got {no_flags_rule.flags}")

--- a/Lib/test/test_peg_generator/test_pegen.py
+++ b/Lib/test/test_peg_generator/test_pegen.py
@@ -1139,7 +1139,7 @@ class TestGrammarVisualizer(unittest.TestCase):
         # Test multi-flag rule
         multi_flag_rule = rules['multi_flag_rule']
         self.assertTrue('memo' in simple_rule.flags,
-                        "multi_flag_rule should have memo=True")
+                        "multi_flag_rule should have memo")
         self.assertEqual(multi_flag_rule.flags, frozenset({'memo', 'custom', 'test'}),
                         f"multi_flag_rule flags should contain memo, custom, test, got {multi_flag_rule.flags}")
 
@@ -1153,6 +1153,6 @@ class TestGrammarVisualizer(unittest.TestCase):
         # Test no flags rule
         no_flags_rule = rules['no_flags_rule']
         self.assertFalse('memo' not in simple_rule.flags,
-                         "no_flags_rule should have memo=False")
+                         "no_flags_rule should not have memo")
         self.assertEqual(no_flags_rule.flags, frozenset(),
                         f"no_flags_rule flags should be the empty set, got {no_flags_rule.flags}")


### PR DESCRIPTION
#138971 turned `memo` into a flag, it's no longer an attribute.
Also, flags are in a frozenset.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138970 -->
* Issue: gh-138970
<!-- /gh-issue-number -->
