### PR TITLE
gh-118803: Improve documentation around `ByteString` deprecation

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.17.rst
+++ b/Doc/deprecations/pending-removal-in-3.17.rst
@@ -9,14 +9,27 @@ Pending removal in Python 3.17
     3.17. Users should use documented introspection helpers like :func:`typing.get_origin`
     and :func:`typing.get_args` instead of relying on private implementation details.
   - :class:`typing.ByteString`, deprecated since Python 3.9, is scheduled for removal in
-    Python 3.17. Prefer :class:`~collections.abc.Sequence` or
-    :class:`~collections.abc.Buffer`. For use in type annotations, prefer a union, like
-    ``bytes | bytearray``, or :class:`collections.abc.Buffer`.
+    Python 3.17.
+
+   ``ByteString`` was originally intended to be an abstract type that would serve as a
+    supertype of both :class:`bytes` and :class:`bytearray`, but its semantics were never
+    clearly specified, and it was never understood properly by type checkers. See
+    :pep:`PEP 688 <688#current-options>` for more details.
+
+    Prefer :class:`~collections.abc.Sequence` or :class:`~collections.abc.Buffer`. For
+    use in type annotations, prefer a union, like ``bytes | bytearray``, or
+    :class:`collections.abc.Buffer`.
     (Contributed by Shantanu Jain in :gh:`91896`.)
 
 * :mod:`collections.abc`:
 
-  - :class:`collections.abc.ByteString` is scheduled for removal in Python 3.17. Prefer
-    :class:`~collections.abc.Sequence` or :class:`~collections.abc.Buffer`. For use in
-    type annotations, prefer a union, like ``bytes | bytearray``, or
+  - :class:`collections.abc.ByteString` is scheduled for removal in Python 3.17.
+
+    ``ByteString`` was originally intended to be an abstract type that would serve as a
+    supertype of both :class:`bytes` and :class:`bytearray`, but its semantics were never
+    clearly specified, and it was never understood properly by type checkers. See
+    :pep:`PEP 688 <688#current-options>` for more details.
+
+    Prefer :class:`~collections.abc.Sequence` or :class:`~collections.abc.Buffer`. For
+    use in type annotations, prefer a union, like ``bytes | bytearray``, or
     :class:`collections.abc.Buffer`. (Contributed by Shantanu Jain in :gh:`91896`.)

--- a/Doc/deprecations/pending-removal-in-3.17.rst
+++ b/Doc/deprecations/pending-removal-in-3.17.rst
@@ -7,8 +7,8 @@ Pending removal in Python 3.17
 
     Use ``isinstance(obj, collections.abc.Buffer)`` to test if ``obj``
     implements the :ref:`buffer protocol <bufferobjects>` at runtime. For use
-    in type annotations, either use :class:`Buffer` or a union that explicitly
-    specifies the types your code supports (e.g.,
+    in type annotations, either use :class:`~collections.abc.Buffer` or a union
+    that explicitly specifies the types your code supports (e.g.,
     ``bytes | bytearray | memoryview``).
 
     :class:`!ByteString` was originally intended to be an abstract class that

--- a/Doc/deprecations/pending-removal-in-3.17.rst
+++ b/Doc/deprecations/pending-removal-in-3.17.rst
@@ -5,14 +5,23 @@ Pending removal in Python 3.17
 
   - :class:`collections.abc.ByteString` is scheduled for removal in Python 3.17.
 
-    ``ByteString`` was originally intended to be an abstract type that would serve as a
-    supertype of both :class:`bytes` and :class:`bytearray`, but its semantics were never
-    clearly specified, and it was never understood properly by type checkers. See
-    :pep:`PEP 688 <688#current-options>` for more details.
+    Use ``isinstance(obj, collections.abc.Buffer)`` to test if ``obj``
+    implements the :ref:`buffer protocol <bufferobjects>` at runtime. For use
+    in type annotations, either use :class:`Buffer` or a union that explicitly
+    specifies the types your code supports (e.g.,
+    ``bytes | bytearray | memoryview``).
 
-    Prefer :class:`~collections.abc.Sequence` or :class:`~collections.abc.Buffer`. For
-    use in type annotations, prefer a union, like ``bytes | bytearray``, or
-    :class:`collections.abc.Buffer`. (Contributed by Shantanu Jain in :gh:`91896`.)
+    :class:`!ByteString` was originally intended to be an abstract class that
+    would serve as a supertype of both :class:`bytes` and :class:`bytearray`.
+    However, since the ABC never had any methods, knowing that an object was an
+    instance of :class:`!ByteString` never actually told you anything useful
+    about the object. Other common buffer types such as :class:`memoryview`
+    were also never understood as subtypes of :class:`!ByteString` (either at
+    runtime or by static type checkers).
+
+    See :pep:`PEP 688 <688#current-options>` for more details.
+    (Contributed by Shantanu Jain in :gh:`91896`.)
+
 
 * :mod:`typing`:
 
@@ -24,12 +33,19 @@ Pending removal in Python 3.17
   - :class:`typing.ByteString`, deprecated since Python 3.9, is scheduled for removal in
     Python 3.17.
 
-   ``ByteString`` was originally intended to be an abstract type that would serve as a
-    supertype of both :class:`bytes` and :class:`bytearray`, but its semantics were never
-    clearly specified, and it was never understood properly by type checkers. See
-    :pep:`PEP 688 <688#current-options>` for more details.
+    Use ``isinstance(obj, collections.abc.Buffer)`` to test if ``obj``
+    implements the :ref:`buffer protocol <bufferobjects>` at runtime. For use
+    in type annotations, either use :class:`~collections.abc.Buffer` or a union
+    that explicitly specifies the types your code supports (e.g.,
+    ``bytes | bytearray | memoryview``).
 
-    Prefer :class:`~collections.abc.Sequence` or :class:`~collections.abc.Buffer`. For
-    use in type annotations, prefer a union, like ``bytes | bytearray``, or
-    :class:`collections.abc.Buffer`.
+    :class:`!ByteString` was originally intended to be an abstract class that
+    would serve as a supertype of both :class:`bytes` and :class:`bytearray`.
+    However, since the ABC never had any methods, knowing that an object was an
+    instance of :class:`!ByteString` never actually told you anything useful
+    about the object. Other common buffer types such as :class:`memoryview`
+    were also never understood as subtypes of :class:`!ByteString` (either at
+    runtime or by static type checkers).
+
+    See :pep:`PEP 688 <688#current-options>` for more details.
     (Contributed by Shantanu Jain in :gh:`91896`.)

--- a/Doc/deprecations/pending-removal-in-3.17.rst
+++ b/Doc/deprecations/pending-removal-in-3.17.rst
@@ -1,6 +1,19 @@
 Pending removal in Python 3.17
 ------------------------------
 
+* :mod:`collections.abc`:
+
+  - :class:`collections.abc.ByteString` is scheduled for removal in Python 3.17.
+
+    ``ByteString`` was originally intended to be an abstract type that would serve as a
+    supertype of both :class:`bytes` and :class:`bytearray`, but its semantics were never
+    clearly specified, and it was never understood properly by type checkers. See
+    :pep:`PEP 688 <688#current-options>` for more details.
+
+    Prefer :class:`~collections.abc.Sequence` or :class:`~collections.abc.Buffer`. For
+    use in type annotations, prefer a union, like ``bytes | bytearray``, or
+    :class:`collections.abc.Buffer`. (Contributed by Shantanu Jain in :gh:`91896`.)
+
 * :mod:`typing`:
 
   - Before Python 3.14, old-style unions were implemented using the private class
@@ -20,16 +33,3 @@ Pending removal in Python 3.17
     use in type annotations, prefer a union, like ``bytes | bytearray``, or
     :class:`collections.abc.Buffer`.
     (Contributed by Shantanu Jain in :gh:`91896`.)
-
-* :mod:`collections.abc`:
-
-  - :class:`collections.abc.ByteString` is scheduled for removal in Python 3.17.
-
-    ``ByteString`` was originally intended to be an abstract type that would serve as a
-    supertype of both :class:`bytes` and :class:`bytearray`, but its semantics were never
-    clearly specified, and it was never understood properly by type checkers. See
-    :pep:`PEP 688 <688#current-options>` for more details.
-
-    Prefer :class:`~collections.abc.Sequence` or :class:`~collections.abc.Buffer`. For
-    use in type annotations, prefer a union, like ``bytes | bytearray``, or
-    :class:`collections.abc.Buffer`. (Contributed by Shantanu Jain in :gh:`91896`.)

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -292,15 +292,21 @@ Collections Abstract Base Classes -- Detailed Descriptions
    .. deprecated-removed:: 3.12 3.17
       The :class:`ByteString` ABC has been deprecated.
 
-      ``ByteString`` was originally intended to be an abstract type that would
-      serve as a supertype of both :class:`bytes` and :class:`bytearray`, but
-      its semantics were never clearly specified, and it was never understood
-      properly by type checkers. See :pep:`PEP 688 <688#current-options>` for
-      more details.
+      Use ``isinstance(obj, collections.abc.Buffer)`` to test if ``obj``
+      implements the :ref:`buffer protocol <bufferobjects>` at runtime. For use
+      in type annotations, either use :class:`Buffer` or a union that
+      explicitly specifies the types your code supports (e.g.,
+      ``bytes | bytearray | memoryview``).
 
-      For use in type annotations, prefer a union, like ``bytes | bytearray``, or
-      :class:`collections.abc.Buffer`.
-      For use as an ABC, prefer :class:`Sequence` or :class:`collections.abc.Buffer`.
+      :class:`!ByteString` was originally intended to be an abstract class that
+      would serve as a supertype of both :class:`bytes` and :class:`bytearray`.
+      However, since the ABC never had any methods, knowing that an object was
+      an instance of :class:`!ByteString` never actually told you anything
+      useful about the object. Other common buffer types such as
+      :class:`memoryview` were also never understood as subtypes of
+      :class:`!ByteString` (either at runtime or by static type checkers).
+
+      See :pep:`PEP 688 <688#current-options>` for more details.
 
 .. class:: Set
            MutableSet

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -291,6 +291,13 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    .. deprecated-removed:: 3.12 3.17
       The :class:`ByteString` ABC has been deprecated.
+
+      ``ByteString`` was originally intended to be an abstract type that would
+      serve as a supertype of both :class:`bytes` and :class:`bytearray`, but
+      its semantics were never clearly specified, and it was never understood
+      properly by type checkers. See :pep:`PEP 688 <688#current-options>` for
+      more details.
+
       For use in type annotations, prefer a union, like ``bytes | bytearray``, or
       :class:`collections.abc.Buffer`.
       For use as an ABC, prefer :class:`Sequence` or :class:`collections.abc.Buffer`.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3792,14 +3792,23 @@ Aliases to container ABCs in :mod:`collections.abc`
 
    Deprecated alias to :class:`collections.abc.ByteString`.
 
-   ``ByteString`` was originally intended to be an abstract type that would
-   serve as a supertype of both :class:`bytes` and :class:`bytearray`. However,
-   its semantics were never clearly specified, and it was never understood
-   properly by type checkers. See :pep:`PEP 688 <688#current-options>` for more
-   details.
+   Use ``isinstance(obj, collections.abc.Buffer)`` to test if ``obj``
+   implements the :ref:`buffer protocol <bufferobjects>` at runtime. For use in
+   type annotations, either use :class:`~collections.abc.Buffer` or a union
+   that explicitly specifies the types your code supports (e.g.,
+   ``bytes | bytearray | memoryview``).
+
+   :class:`!ByteString` was originally intended to be an abstract class that
+   would serve as a supertype of both :class:`bytes` and :class:`bytearray`.
+   However, since the ABC never had any methods, knowing that an object was an
+   instance of :class:`!ByteString` never actually told you anything useful
+   about the object. Other common buffer types such as :class:`memoryview` were
+   also never understood as subtypes of :class:`!ByteString` (either at runtime
+   or by static type checkers).
+
+   See :pep:`PEP 688 <688#current-options>` for more details.
 
    .. deprecated-removed:: 3.9 3.17
-      Prefer :class:`collections.abc.Buffer`, or a union like ``bytes | bytearray | memoryview``.
 
 .. class:: Collection(Sized, Iterable[T_co], Container[T_co])
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3790,8 +3790,13 @@ Aliases to container ABCs in :mod:`collections.abc`
 
 .. class:: ByteString(Sequence[int])
 
-   This type represents the types :class:`bytes`, :class:`bytearray`,
-   and :class:`memoryview` of byte sequences.
+   Deprecated alias to :class:`collections.abc.ByteString`.
+
+   ``ByteString`` was originally intended to be an abstract type that would
+   serve as a supertype of both :class:`bytes` and :class:`bytearray`. However,
+   its semantics were never clearly specified, and it was never understood
+   properly by type checkers. See :pep:`PEP 688 <688#current-options>` for more
+   details.
 
    .. deprecated-removed:: 3.9 3.17
       Prefer :class:`collections.abc.Buffer`, or a union like ``bytes | bytearray | memoryview``.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1192,6 +1192,12 @@ Deprecated
   (Contributed by Prince Roshan in :gh:`103636`.)
 
 * :mod:`collections.abc`: Deprecated :class:`collections.abc.ByteString`.
+
+  ``ByteString`` was originally intended to be an abstract type that would
+  serve as a supertype of both :class:`bytes` and :class:`bytearray`, but its
+  semantics were never clearly specified, and it was never understood properly
+  by type checkers. See :pep:`PEP 688 <688#current-options>` for more details.
+
   Prefer :class:`Sequence` or :class:`collections.abc.Buffer`.
   For use in type annotations, prefer a union, like ``bytes | bytearray``, or :class:`collections.abc.Buffer`.
   (Contributed by Shantanu Jain in :gh:`91896`.)

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1193,13 +1193,21 @@ Deprecated
 
 * :mod:`collections.abc`: Deprecated :class:`collections.abc.ByteString`.
 
-  ``ByteString`` was originally intended to be an abstract type that would
-  serve as a supertype of both :class:`bytes` and :class:`bytearray`, but its
-  semantics were never clearly specified, and it was never understood properly
-  by type checkers. See :pep:`PEP 688 <688#current-options>` for more details.
+  Use ``isinstance(obj, collections.abc.Buffer)`` to test if ``obj`` implements
+  the :ref:`buffer protocol <bufferobjects>` at runtime. For use in type
+  annotations, either use :class:`~collections.abc.Buffer` or a union
+  that explicitly specifies the types your code supports (e.g.,
+  ``bytes | bytearray | memoryview``).
 
-  Prefer :class:`Sequence` or :class:`collections.abc.Buffer`.
-  For use in type annotations, prefer a union, like ``bytes | bytearray``, or :class:`collections.abc.Buffer`.
+  :class:`!ByteString` was originally intended to be an abstract class that
+  would serve as a supertype of both :class:`bytes` and :class:`bytearray`.
+  However, since the ABC never had any methods, knowing that an object was an
+  instance of :class:`!ByteString` never actually told you anything useful
+  about the object. Other common buffer types such as :class:`memoryview` were
+  also never understood as subtypes of :class:`!ByteString` (either at
+  runtime or by static type checkers).
+
+  See :pep:`PEP 688 <688#current-options>` for more details.
   (Contributed by Shantanu Jain in :gh:`91896`.)
 
 * :mod:`datetime`: :class:`datetime.datetime`'s :meth:`~datetime.datetime.utcnow` and

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -1082,9 +1082,12 @@ class _DeprecateByteStringMeta(ABCMeta):
         return super().__instancecheck__(instance)
 
 class ByteString(Sequence, metaclass=_DeprecateByteStringMeta):
-    """This unifies bytes and bytearray.
+    """Deprecated ABC serving as a common supertype of ``bytes`` and ``bytearray``.
 
-    XXX Should add all their methods.
+    This ABC is scheduled for removal in Python 3.17.
+    For use in type annotations, prefer a union, like ``bytes | bytearray``, or
+    ``collections.abc.Buffer``. For use as an ABC, prefer ``Sequence`` or
+    ``collections.abc.Buffer``.
     """
 
     __slots__ = ()

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -1085,9 +1085,10 @@ class ByteString(Sequence, metaclass=_DeprecateByteStringMeta):
     """Deprecated ABC serving as a common supertype of ``bytes`` and ``bytearray``.
 
     This ABC is scheduled for removal in Python 3.17.
-    For use in type annotations, prefer a union, like ``bytes | bytearray``, or
-    ``collections.abc.Buffer``. For use as an ABC, prefer ``Sequence`` or
-    ``collections.abc.Buffer``.
+    Use ``isinstance(obj, collections.abc.Buffer)`` to test if ``obj``
+    implements the buffer protocol at runtime. For use in type annotations,
+    either use ``Buffer`` or a union that explicitly specifies the types your
+    code supports (e.g., ``bytes | bytearray | memoryview``).
     """
 
     __slots__ = ()


### PR DESCRIPTION
State more clearly why the ABC is scheduled for removal. State more clearly what the different options are that users should prefer instead.


<!-- gh-issue-number: gh-118803 -->
* Issue: gh-118803
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139115.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->