### PR TITLE
Document `Py_AddPendingCall()` change with subinterpreters in 3.12

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1834,6 +1834,10 @@ pointer and a void pointer argument.
       called from the main interpreter. Each subinterpreter now has its own
       list of scheduled calls.
 
+   .. versionchanged:: 3.12
+      This function now always schedules *func* to be run in the main
+      interpreter.
+
 .. _profiling:
 
 Profiling and Tracing


### PR DESCRIPTION
Noticed while working on GH-136004. Prior to 3.9, `Py_AddPendingCall()` would always run pending calls in the main interpreter, but then each interpreter got their own ceval state and it scheduled for any interpreter. In GH-104813, this was undone, so `Py_AddPendingCall()` would always schedule for the main interpreter.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139117.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->