### PR TITLE
gh-136003: Skip non-daemon threads when exceptions occur during finalization

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -2084,6 +2084,7 @@ class ThreadingExceptionTests(BaseTestCase):
         self.assertEqual(err, b"")
 
     @requires_subprocess()
+    @unittest.skipIf(os.name == 'nt', "signals don't work well on windows")
     def test_keyboard_interrupt_during_threading_shutdown(self):
         import subprocess
         source = f"""

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -6,7 +6,7 @@ import test.support
 from test.support import threading_helper, requires_subprocess, requires_gil_enabled
 from test.support import verbose, cpython_only, os_helper
 from test.support.import_helper import ensure_lazy_imports, import_module
-from test.support.script_helper import assert_python_ok, assert_python_failure
+from test.support.script_helper import assert_python_ok, assert_python_failure, spawn_python
 from test.support import force_not_colorized
 
 import random
@@ -2082,6 +2082,32 @@ class ThreadingExceptionTests(BaseTestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(out, b"")
         self.assertEqual(err, b"")
+
+    @requires_subprocess()
+    def test_keyboard_interrupt_during_threading_shutdown(self):
+        import subprocess
+        source = f"""
+        from threading import Thread
+        import time
+        import os
+
+
+        def test():
+            print('a', flush=True, end='')
+            time.sleep(10)
+
+
+        for _ in range(3):
+            Thread(target=test).start()
+        """
+
+        with spawn_python("-c", source, stderr=subprocess.PIPE) as proc:
+            self.assertEqual(proc.stdout.read(3), b'aaa')
+            proc.send_signal(signal.SIGINT)
+            proc.stderr.flush()
+            error = proc.stderr.read()
+            self.assertIn(b"KeyboardInterrupt", error)
+            self.assertIn(b"threading shutdown", error)
 
 
 class ThreadRunFail(threading.Thread):

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -2107,7 +2107,6 @@ class ThreadingExceptionTests(BaseTestCase):
             proc.stderr.flush()
             error = proc.stderr.read()
             self.assertIn(b"KeyboardInterrupt", error)
-            self.assertIn(b"threading shutdown", error)
 
 
 class ThreadRunFail(threading.Thread):

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -2429,10 +2429,8 @@ thread_shutdown(PyObject *self, PyObject *args)
         // Wait for the thread to finish. If we're interrupted, such
         // as by a ctrl-c we print the error and exit early.
         if (ThreadHandle_join(handle, -1) < 0) {
-            PyErr_FormatUnraisable("Exception ignored while joining a thread "
-                                   "in _thread._shutdown()");
             ThreadHandle_decref(handle);
-            Py_RETURN_NONE;
+            return NULL;
         }
 
         ThreadHandle_decref(handle);


### PR DESCRIPTION
During finalization, we need to mark all non-daemon threads as daemon to quickly shut down threads when sending CTRL^C to the process. This was a minor regression from GH-136004.

<!-- gh-issue-number: gh-136003 -->
* Issue: gh-136003
<!-- /gh-issue-number -->
