### PR TITLE
gh-125318: Prevent segfaults when zoneinfo is used with "false friends"

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-09-18-16-40-18.gh-issue-125318.JzZysW.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-18-16-40-18.gh-issue-125318.JzZysW.rst
@@ -1,0 +1,3 @@
+Fixes a segmentation fault that would happen if :class:`zoneinfo.ZoneInfo`
+were used with certain non-:class:`datetime.datetime` classes. Patch by Paul
+Ganssle


### PR DESCRIPTION
Fixes #125318.

I think this can be backported to bugfix branches, since it just prevents segfaults. It might make things slower in some situations for people who have "false friend" classes that happen to have the same memory layout as `datetime` but that is not really a supported mode of operation anyway, we're really just fixing this because you shouldn't be able to crash the interpreter from pure Python code.

<!-- gh-issue-number: gh-125318 -->
* Issue: gh-125318
<!-- /gh-issue-number -->
