### PR TITLE
gh-139134: Fix pathlib.Path.copy() Windows privilege errors with copyfile2 fallback

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -27,10 +27,6 @@ try:
     import grp
 except ImportError:
     grp = None
-try:
-    import _winapi
-except ImportError:
-    _winapi = None
 
 from pathlib._os import (
     vfsopen, vfspath,
@@ -1393,7 +1389,8 @@ class Path(PurePath):
             try:
                 copyfile2(source_path, str(self))
             except OSError as exc:
-                if hasattr(exc, "winerror") and exc.winerror in (5, 1314):
+                # On Windows, OSError from file operations is guaranteed to have winerror attribute
+                if exc.winerror in (5, 1314):
                     # ERROR_ACCESS_DENIED (5) or ERROR_PRIVILEGE_NOT_HELD (1314)
                     self._copy_from_file_fallback(source, preserve_metadata)
                     return

--- a/Misc/NEWS.d/next/Library/2025-09-18-16-31-45.gh-issue-139135.hL3fZ2.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-18-16-31-45.gh-issue-139135.hL3fZ2.rst
@@ -1,1 +1,1 @@
-Fix ``pathlib.Path.copy()`` failing on Windows when copying files that require elevated privileges (e.g., hidden or system files) by adding a fallback mechanism when ``copyfile2`` encounters privilege-related errors.
+Fix :meth:`pathlib.Path.copy` failing on Windows when copying files that require elevated privileges (e.g., hidden or system files) by adding a fallback mechanism when ``CopyFile2()`` encounters privilege-related errors.

--- a/Misc/NEWS.d/next/Library/2025-09-18-16-31-45.gh-issue-139135.hL3fZ2.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-18-16-31-45.gh-issue-139135.hL3fZ2.rst
@@ -1,0 +1,1 @@
+Fix ``pathlib.Path.copy()`` failing on Windows when copying files that require elevated privileges (e.g., hidden or system files) by adding a fallback mechanism when ``copyfile2`` encounters privilege-related errors.


### PR DESCRIPTION
<!-- gh-issue-number: gh-139134 -->
* Issue: gh-139134
<!-- /gh-issue-number -->
