### PR TITLE
Fix the reference to unicode specification

### DIFF
--- a/Doc/library/unicodedata.rst
+++ b/Doc/library/unicodedata.rst
@@ -123,7 +123,7 @@ following functions:
    Returns the canonical combining class assigned to the character *chr*
    as integer. Returns ``0`` if no combining class is defined.
    See the `Canonical Combining Class Values section of the Unicode Character
-   Database <www.unicode.org/reports/tr44/#Canonical_Combining_Class_Values>`_
+   Database <https://www.unicode.org/reports/tr44/#Canonical_Combining_Class_Values>`_
    for more information.
 
 


### PR DESCRIPTION
This has been found by linkchecker we run in Fedora during the Python documentation build:

```
Result     Error: URLError: <urlopen error [Errno 2] No such file or directory: '/builddir/build/BUILD/python3-docs-3.14.0_rc3-build/Python-3.14.0rc3/Doc/build/html/library/www.unicode.org/reports/tr44/tr44-34.html'>
```

Introduced in https://github.com/python/cpython/pull/138346, most probably a typo.
Based on linked PRs in https://github.com/python/cpython/issues/54874 the fix should also be backported to 3.14 and 3.13 branches.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139138.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->