### PR TITLE
gh-139436: Remove link to the PDF downloads

### DIFF
--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -41,11 +41,6 @@ Python in one of various formats, follow one of links in this table.{% endtrans 
     <th>{% trans %}Packed as .tar.bz2{% endtrans %}</th>
   </tr>
   <tr>
-    <td>{% trans %}PDF{% endtrans %}</td>
-    <td>{% trans download_size="17" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-pdf-a4.zip">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
-    <td>{% trans download_size="17" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-pdf-a4.tar.bz2">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
-  </tr>
-  <tr>
     <td>{% trans %}HTML{% endtrans %}</td>
     <td>{% trans download_size="13" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-html.zip">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
     <td>{% trans download_size="8" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-html.tar.bz2">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
@@ -68,6 +63,13 @@ Python in one of various formats, follow one of links in this table.{% endtrans 
 </table>
 
 <p>{% trans %}These archives contain all the content in the documentation.{% endtrans %}</p>
+
+<p>{% trans %}
+We no longer provide pre-built PDFs of the documentation.
+To build a PDF archive, follow the instructions in the
+<a href="https://devguide.python.org/documentation/start-documenting/#building-the-documentation">Developer's Guide</a>
+and run <code>make dist-pdf</code> in the <code>Doc/</code> directory of a copy of the CPython repository.
+{% endtrans %}</p>
 
 
 <h2>{% trans %}Unpacking{% endtrans %}</h2>


### PR DESCRIPTION
Following https://discuss.python.org/t/101343/45

This is the first step, no longer advertising the links.

A


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139142.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-139436 -->
* Issue: gh-139436
<!-- /gh-issue-number -->
