### PR TITLE
gh-112729: Correctly fail when the process is out of memory during interpreter creation

### DIFF
--- a/Lib/test/test_interpreters/test_stress.py
+++ b/Lib/test/test_interpreters/test_stress.py
@@ -7,6 +7,7 @@ from test.support import threading_helper
 # Raise SkipTest if subinterpreters not supported.
 import_helper.import_module('_interpreters')
 from concurrent import interpreters
+from concurrent.interpreters import InterpreterError
 from .utils import TestBase
 
 
@@ -74,12 +75,13 @@ class StressTests(TestBase):
             start.set()
         support.gc_collect()
 
-    def create_interpreter_no_memory(self):
+    def test_create_interpreter_no_memory(self):
+        import _interpreters
         _testcapi = import_helper.import_module("_testcapi")
 
-        with self.assertRaises(MemoryError):
+        with self.assertRaises(InterpreterError):
             _testcapi.set_nomemory(0, 1)
-            interpreters.create()
+            _interpreters.create()
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_interpreters/test_stress.py
+++ b/Lib/test/test_interpreters/test_stress.py
@@ -74,6 +74,13 @@ class StressTests(TestBase):
             start.set()
         support.gc_collect()
 
+    def create_interpreter_no_memory(self):
+        _testcapi = import_helper.import_module("_testcapi")
+
+        with self.assertRaises(MemoryError):
+            _testcapi.set_nomemory(0, 1)
+            interpreters.create()
+
 
 if __name__ == '__main__':
     # Test needs to be a package, so we can do relative imports.

--- a/Misc/NEWS.d/next/Library/2025-09-19-09-36-42.gh-issue-112729.mmty0_.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-19-09-36-42.gh-issue-112729.mmty0_.rst
@@ -1,0 +1,2 @@
+Fix crash when calling :func:`concurrent.interpreters.create` when the
+process is out of memory.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2411,17 +2411,16 @@ new_interpreter(PyThreadState **tstate_p,
        interpreters: disable PyGILState_Check(). */
     runtime->gilstate.check_enabled = 0;
 
-    PyInterpreterState *interp = PyInterpreterState_New();
-    if (interp == NULL) {
-        *tstate_p = NULL;
-        return _PyStatus_OK();
-    }
-    _PyInterpreterState_SetWhence(interp, whence);
-    interp->_ready = 1;
-
     // XXX Might new_interpreter() have been called without the GIL held?
     PyThreadState *save_tstate = _PyThreadState_GET();
     PyThreadState *tstate = NULL;
+    PyInterpreterState *interp;
+    status = _PyInterpreterState_New(save_tstate, &interp);
+    if (interp == NULL) {
+        goto error;
+    }
+    _PyInterpreterState_SetWhence(interp, whence);
+    interp->_ready = 1;
 
     /* From this point until the init_interp_create_gil() call,
        we must not do anything that requires that the GIL be held
@@ -2498,7 +2497,7 @@ error:
     *tstate_p = NULL;
     if (tstate != NULL) {
         Py_EndInterpreter(tstate);
-    } else {
+    } else if (interp != NULL) {
         PyInterpreterState_Delete(interp);
     }
     if (save_tstate != NULL) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-112729 -->
* Issue: gh-112729
<!-- /gh-issue-number -->
