### PR TITLE
[3.13] gh-112729: Correctly fail when the process is out of memory during interpreter creation (GH-139164)

### DIFF
--- a/Lib/test/test_interpreters/test_stress.py
+++ b/Lib/test/test_interpreters/test_stress.py
@@ -7,6 +7,7 @@ from test.support import threading_helper
 # Raise SkipTest if subinterpreters not supported.
 import_helper.import_module('_interpreters')
 from test.support import interpreters
+from test.support.interpreters import InterpreterError
 from .utils import TestBase
 
 
@@ -73,6 +74,14 @@ class StressTests(TestBase):
         with threading_helper.start_threads(threads):
             start.set()
         support.gc_collect()
+
+    def test_create_interpreter_no_memory(self):
+        import _interpreters
+        _testcapi = import_helper.import_module("_testcapi")
+
+        with self.assertRaises(InterpreterError):
+            _testcapi.set_nomemory(0, 1)
+            _interpreters.create()
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2025-09-19-09-36-42.gh-issue-112729.mmty0_.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-19-09-36-42.gh-issue-112729.mmty0_.rst
@@ -1,0 +1,2 @@
+Fix crash when calling :func:`concurrent.interpreters.create` when the
+process is out of memory.

--- a/Misc/NEWS.d/next/Library/2025-09-19-09-36-42.gh-issue-112729.mmty0_.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-19-09-36-42.gh-issue-112729.mmty0_.rst
@@ -1,2 +1,2 @@
-Fix crash when calling :func:`concurrent.interpreters.create` when the
+Fix crash when calling ``_interpreters.create`` when the
 process is out of memory.


### PR DESCRIPTION
(cherry picked from commit d06113c7a7cac76a28847702685e601b79f71bf8)

<!-- gh-issue-number: gh-112729 -->
* Issue: gh-112729
<!-- /gh-issue-number -->
