### PR TITLE
[3.13] gh-118803: Fixup a few references in the 3.13 branch to the intended removal date for `ByteString`

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.14.rst
+++ b/Doc/deprecations/pending-removal-in-3.14.rst
@@ -38,12 +38,6 @@ Pending Removal in Python 3.14
     is no current event loop set and it decides to create one.
     (Contributed by Serhiy Storchaka and Guido van Rossum in :gh:`100160`.)
 
-* :mod:`collections.abc`: Deprecated :class:`~collections.abc.ByteString`.
-  Prefer :class:`!Sequence` or :class:`~collections.abc.Buffer`.
-  For use in typing, prefer a union, like ``bytes | bytearray``,
-  or :class:`collections.abc.Buffer`.
-  (Contributed by Shantanu Jain in :gh:`91896`.)
-
 * :mod:`email`: Deprecated the *isdst* parameter in :func:`email.utils.localtime`.
   (Contributed by Alan Williams in :gh:`72346`.)
 
@@ -95,9 +89,6 @@ Pending Removal in Python 3.14
   * :meth:`~sqlite3.Cursor.execute` and :meth:`~sqlite3.Cursor.executemany`
     if :ref:`named placeholders <sqlite3-placeholders>` are used and
     *parameters* is a sequence instead of a :class:`dict`.
-
-* :mod:`typing`: :class:`~typing.ByteString`, deprecated since Python 3.9,
-  now causes a :exc:`DeprecationWarning` to be emitted when it is used.
 
 * :mod:`urllib`:
   :class:`!urllib.parse.Quoter` is deprecated: it was not intended to be a

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3953,7 +3953,7 @@ convenience. This is subject to change, and not all deprecations are listed.
      - :pep:`585`
    * - :class:`typing.ByteString`
      - 3.9
-     - 3.14
+     - 3.17
      - :gh:`91896`
    * - :data:`typing.Text`
      - 3.11

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -1083,7 +1083,7 @@ class _DeprecateByteStringMeta(ABCMeta):
 
             warnings._deprecated(
                 "collections.abc.ByteString",
-                remove=(3, 14),
+                remove=(3, 17),
             )
         return super().__new__(cls, name, bases, namespace, **kwargs)
 
@@ -1092,7 +1092,7 @@ class _DeprecateByteStringMeta(ABCMeta):
 
         warnings._deprecated(
             "collections.abc.ByteString",
-            remove=(3, 14),
+            remove=(3, 17),
         )
         return super().__instancecheck__(instance)
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2843,7 +2843,7 @@ MutableMapping = _alias(collections.abc.MutableMapping, 2)
 Sequence = _alias(collections.abc.Sequence, 1)
 MutableSequence = _alias(collections.abc.MutableSequence, 1)
 ByteString = _DeprecatedGenericAlias(
-    collections.abc.ByteString, 0, removal_version=(3, 14)  # Not generic.
+    collections.abc.ByteString, 0, removal_version=(3, 17)  # Not generic.
 )
 # Tuple accepts variable number of parameters.
 Tuple = _TupleType(tuple, -1, inst=False, name='Tuple')


### PR DESCRIPTION
We received a report on the docs@python.org mailing list that there were some lingering references in the 3.13 branch to `ByteString` being removed in 3.14, which was causing some confusion

<!-- gh-issue-number: gh-118803 -->
* Issue: gh-118803
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139171.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->