### PR TITLE
gh-133560: Clarified `parser.md` doc for pegen parser issue in using the existing `Grammar/python.gram` file.

### DIFF
--- a/InternalDocs/parser.md
+++ b/InternalDocs/parser.md
@@ -819,6 +819,12 @@ directory on the CPython repository and manually call the parser generator by ex
 $ python -m pegen python <PATH TO YOUR GRAMMAR FILE>
 ```
 
+> [!CAUTION]
+> This grammar file has to be specific to Python and does not work with the existing
+> C language based`Grammar/python.gram` file.
+> See [#133560](https://github.com/python/cpython/issues/133560) 
+> and [#96424](https://github.com/python/cpython/issues/96424) for more information.
+
 This will generate a file called `parse.py` in the same directory that you
 can use to parse some input:
 
@@ -828,10 +834,6 @@ $ python parse.py file_with_source_code_to_test.py
 
 As the generated `parse.py` file is just Python code, you can modify it
 and add breakpoints to debug or better understand some complex situations.
-
-However, this does not work with the existing `Grammar/python.gram` file.
-See [#133560](https://github.com/python/cpython/issues/133560) 
-and [#96424](https://github.com/python/cpython/issues/96424) for more information.
 
 
 Verbose mode

--- a/InternalDocs/parser.md
+++ b/InternalDocs/parser.md
@@ -829,6 +829,10 @@ $ python parse.py file_with_source_code_to_test.py
 As the generated `parse.py` file is just Python code, you can modify it
 and add breakpoints to debug or better understand some complex situations.
 
+However, this does not work with the existing `Grammar/python.gram` file.
+See [#133560](https://github.com/python/cpython/issues/133560) 
+and [#96424](https://github.com/python/cpython/issues/96424) for more information.
+
 
 Verbose mode
 ------------

--- a/InternalDocs/parser.md
+++ b/InternalDocs/parser.md
@@ -821,7 +821,7 @@ $ python -m pegen python <PATH TO YOUR GRAMMAR FILE>
 
 > [!CAUTION]
 > This grammar file has to be specific to Python and does not work with the existing
-> C language based`Grammar/python.gram` file.
+> C language based `Grammar/python.gram` file.
 > See [#133560](https://github.com/python/cpython/issues/133560) 
 > and [#96424](https://github.com/python/cpython/issues/96424) for more information.
 

--- a/InternalDocs/parser.md
+++ b/InternalDocs/parser.md
@@ -820,8 +820,9 @@ $ python -m pegen python <PATH TO YOUR GRAMMAR FILE>
 ```
 
 > [!CAUTION]
-> This grammar file has to be specific to Python and does not work with the existing
-> C language based `Grammar/python.gram` file.
+> Python's grammar (the `Grammar/python.gram` file) is written for the
+> C backend. To experiment, you will need to write a grammar
+> without C-specific parts like actions and the trailer.
 > See [#133560](https://github.com/python/cpython/issues/133560) 
 > and [#96424](https://github.com/python/cpython/issues/96424) for more information.
 


### PR DESCRIPTION
Documentation only change.  Credit goes to @sobolevn and @alexprengere.

Added some clarifying notes to documentation of [InternalDocs/parser.md](https://github.com/python/cpython/tree/main/InternalDocs).

See https://github.com/python/cpython/issues/133560 and https://github.com/python/cpython/issues/96424 for more information.

<!-- gh-issue-number: gh-133560 -->
* Issue: gh-133560
<!-- /gh-issue-number -->
