### PR TITLE
gh-139181: Allow translation of html_short_title in docs config

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -447,8 +447,8 @@ latex_appendices = ['glossary', 'about', 'license', 'copyright']
 # Options for Epub output
 # -----------------------
 
-epub_author = _('Python Documentation Authors',)
-epub_publisher = _('Python Software Foundation',)
+epub_author = _('Python Documentation Authors')
+epub_publisher = _('Python Software Foundation')
 epub_exclude_files = ('index.xhtml', 'download.xhtml')
 
 # index pages are not valid xhtml

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -17,6 +17,7 @@ sys.path.append(os.path.abspath('includes'))
 
 # Python specific content from Doc/Tools/extensions/pyspecific.py
 from pyspecific import SOURCE_URI
+from sphinx.locale import _
 
 # General configuration
 # ---------------------
@@ -299,7 +300,7 @@ if any('htmlhelp' in arg for arg in sys.argv):
     print("It may be removed in the future\n")
 
 # Short title used e.g. for <title> HTML tags.
-html_short_title = f'{release} Documentation'
+html_short_title = _(f'{release} Documentation')
 
 # Deployment preview information
 # (See .readthedocs.yml and https://docs.readthedocs.io/en/stable/reference/environment-variables.html)

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -300,7 +300,7 @@ if any('htmlhelp' in arg for arg in sys.argv):
     print("It may be removed in the future\n")
 
 # Short title used e.g. for <title> HTML tags.
-html_short_title = _(f'{release} Documentation')
+html_short_title = _('%(release)s Documentation') % {'release': release}
 
 # Deployment preview information
 # (See .readthedocs.yml and https://docs.readthedocs.io/en/stable/reference/environment-variables.html)
@@ -447,8 +447,8 @@ latex_appendices = ['glossary', 'about', 'license', 'copyright']
 # Options for Epub output
 # -----------------------
 
-epub_author = 'Python Documentation Authors'
-epub_publisher = 'Python Software Foundation'
+epub_author = _('Python Documentation Authors',)
+epub_publisher = _('Python Software Foundation',)
 epub_exclude_files = ('index.xhtml', 'download.xhtml')
 
 # index pages are not valid xhtml


### PR DESCRIPTION
#139181 
This PR wraps the `html_short_title` string in conf.py with the `Sphinx translation function _().`

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou !

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139195.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->