### PR TITLE
`Doc/library/os.rst`: Remove spurious parenthesis

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2027,7 +2027,7 @@ features:
   on should be relative; path will then be relative to that directory.  If the
   path is absolute, *dir_fd* is ignored.  (For POSIX systems, Python will call
   the variant of the function with an ``at`` suffix and possibly prefixed with
-  ``f`` (e.g. call ``faccessat`` instead of ``access``).
+  ``f`` (e.g. call ``faccessat`` instead of ``access``).)
 
   You can check whether or not *dir_fd* is supported for a particular function
   on your platform using :data:`os.supports_dir_fd`.  If it's unavailable,

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2009,8 +2009,8 @@ features:
   must be a string specifying a file path.  However, some functions now
   alternatively accept an open file descriptor for their *path* argument.
   The function will then operate on the file referred to by the descriptor.
-  (For POSIX systems, Python will call the variant of the function prefixed
-  with ``f`` (e.g. call ``fchdir`` instead of ``chdir``).)
+  For POSIX systems, Python will call the variant of the function prefixed
+  with ``f`` (e.g. call ``fchdir`` instead of ``chdir``).
 
   You can check whether or not *path* can be specified as a file descriptor
   for a particular function on your platform using :data:`os.supports_fd`.
@@ -2025,9 +2025,9 @@ features:
 * **paths relative to directory descriptors:** If *dir_fd* is not ``None``, it
   should be a file descriptor referring to a directory, and the path to operate
   on should be relative; path will then be relative to that directory.  If the
-  path is absolute, *dir_fd* is ignored.  (For POSIX systems, Python will call
+  path is absolute, *dir_fd* is ignored.  For POSIX systems, Python will call
   the variant of the function with an ``at`` suffix and possibly prefixed with
-  ``f`` (e.g. call ``faccessat`` instead of ``access``).)
+  ``f`` (e.g. call ``faccessat`` instead of ``access``).
 
   You can check whether or not *dir_fd* is supported for a particular function
   on your platform using :data:`os.supports_dir_fd`.  If it's unavailable,
@@ -2038,8 +2038,8 @@ features:
 * **not following symlinks:** If *follow_symlinks* is
   ``False``, and the last element of the path to operate on is a symbolic link,
   the function will operate on the symbolic link itself rather than the file
-  pointed to by the link.  (For POSIX systems, Python will call the ``l...``
-  variant of the function.)
+  pointed to by the link.  For POSIX systems, Python will call the ``l...``
+  variant of the function.
 
   You can check whether or not *follow_symlinks* is supported for a particular
   function on your platform using :data:`os.supports_follow_symlinks`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Found by André Moreira on Transifex.

As is done above:
https://github.com/python/cpython/blob/e101f907dc827e3dc0bd3b08e4a0897d4a467430/Doc/library/os.rst?plain=1#L2021

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139205.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->