### PR TITLE
gh-139210: Fix use-after-free in _elementtree_XMLParser__setevents_impl

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1749,6 +1749,8 @@ class XMLPullParserTest(unittest.TestCase):
     def test_unknown_event(self):
         with self.assertRaises(ValueError):
             ET.XMLPullParser(events=('start', 'end', 'bogus'))
+        with self.assertRaisesRegex(ValueError, "unknown event 'bogus'"):
+            ET.XMLPullParser(events=(x.decode() for x in (b'start', b'end', b'bogus')))
 
     @unittest.skipIf(pyexpat.version_info < (2, 6, 0),
                      f'Expat {pyexpat.version_info} does not '

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-21-15-58-57.gh-issue-139210.HGbMvz.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-21-15-58-57.gh-issue-139210.HGbMvz.rst
@@ -1,0 +1,1 @@
+Fix use after free when handling unicode characters in ``xml.etree.ElementTree.iterparse``. Patch by Ken Jin.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-21-15-58-57.gh-issue-139210.HGbMvz.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-21-15-58-57.gh-issue-139210.HGbMvz.rst
@@ -1,1 +1,1 @@
-Fix use after free when handling unicode characters in ``xml.etree.ElementTree.iterparse``. Patch by Ken Jin.
+Fix use-after-free when reporting unknown event in :func:`xml.etree.ElementTree.iterparse`. Patch by Ken Jin.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -4214,8 +4214,8 @@ _elementtree_XMLParser__setevents_impl(XMLParserObject *self,
                 (XML_ProcessingInstructionHandler) expat_pi_handler
                 );
         } else {
-            Py_DECREF(events_seq);
             PyErr_Format(PyExc_ValueError, "unknown event '%s'", event_name);
+            Py_DECREF(events_seq);
             return NULL;
         }
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139210 -->
* Issue: gh-139210
<!-- /gh-issue-number -->
