### PR TITLE
gh-126016: Fix flaky test by allowing the SIGINT return code

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -459,7 +459,12 @@ class InterpreterObjectTests(TestBase):
             error = proc.stderr.read()
             self.assertIn(b"KeyboardInterrupt", error)
             retcode = proc.wait()
-            self.assertEqual(retcode, 0)
+            # Sometimes we send the SIGINT after the subthread yields the GIL to
+            # the main thread, which results in the main thread getting the
+            # KeyboardInterrupt before finalization is reached. There's not
+            # any great way to protect against that, so we just allow a -2
+            # return code as well.
+            self.assertIn(retcode, (0, -signal.SIGINT))
 
 
 class TestInterpreterIsRunning(TestBase):


### PR DESCRIPTION
In GH-139158, I added a test that sent `KeyboardInterrupt` to the main thread so it would interrupt `_Py_Finalize` and shut down. There was a subtle race condition there:

1. The main thread starts the subthread by calling `_thread._start_joinable_thread`.
2. The thread is physically created before `_start_joinable_thread` finishes from Python's perspective, so it begins execution.
3. The subthread prints out `a`, signaling to the parent process that it is ready and may send the interrupt signal.
4. The subthread yields the GIL anywhere after this point.
5. The main thread acquires the GIL, and then finishes executing `_start_joinable_thread`.
6. The parent process sends the `KeyboardInterrupt` before `_Py_Finalize` is reached. Python returns -2, which fails the test.

The simplest way to fix this is by allowing a return code of -2 (`-SIGINT`) in addition to 0.

<!-- gh-issue-number: gh-126016 -->
* Issue: gh-126016
<!-- /gh-issue-number -->
