### PR TITLE
gh-139231: Fix estimation of available stack size for recursion limit on macOS

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -451,6 +451,13 @@ _Py_InitializeRecursionLimits(PyThreadState *tstate)
     SetThreadStackGuarantee(&guarantee);
     _tstate->c_stack_hard_limit = ((uintptr_t)low) + guarantee + _PyOS_STACK_MARGIN_BYTES;
     _tstate->c_stack_soft_limit = _tstate->c_stack_hard_limit + _PyOS_STACK_MARGIN_BYTES;
+#elif defined(__APPLE__)
+    pthread_t this_thread = pthread_self();
+    void *stack_addr = pthread_get_stackaddr_np(this_thread); // top of the stack
+    size_t stack_size = pthread_get_stacksize_np(this_thread);
+    _tstate->c_stack_top = (uintptr_t)stack_addr;
+    _tstate->c_stack_hard_limit = _tstate->c_stack_top - stack_size;
+    _tstate->c_stack_soft_limit = _tstate->c_stack_hard_limit + _PyOS_STACK_MARGIN_BYTES;
 #else
     uintptr_t here_addr = _Py_get_machine_stack_pointer();
 /// XXX musl supports HAVE_PTHRED_GETATTR_NP, but the resulting stack size


### PR DESCRIPTION
On macOS, use `pthread_get_stackaddr_np()` and `pthread_get_stacksize_np()` to determine the stack address and size (used by code handling the recursion limit), rather than falling back to conservative hard-coded default of 4 MB.

Fixes #139231; the output of reproducer script is now:

``` 
Stack address: 6089916416 = 0x16AFCC000
Stack size: 16777216 = 16384.0 kB = 16.0 MB
Stack pointer: 0x16AFCA140, depth: 7.69 kB
Testing Recursion Limit
Initial limit: 1000
Recursion level: 1, stack pointer: 0x16AFC9870, depth: 9.89 kB
Recursion level: 2, stack pointer: 0x16AFC8FA0, depth: 12.09 kB
...
Recursion level: 7586, stack pointer: 0x169FD0BA0, depth: 16365.09 kB
Recursion level: 7587, stack pointer: 0x169FD0300, depth: 16367.25 kB
Recursion Limit ok (reached level 7588)
```

(i.e., stack is fully utilized, as expected).

<!-- gh-issue-number: gh-139231 -->
* Issue: gh-139231
<!-- /gh-issue-number -->
