### PR TITLE
gh-139246: zero-width word paste can be wrong in default repl

### DIFF
--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -63,6 +63,9 @@ class ColorSpan(NamedTuple):
 def str_width(c: str) -> int:
     if ord(c) < 128:
         return 1
+    # gh-139246 for zero-width joiner and combining characters
+    if unicodedata.combining(c) or unicodedata.category(c) == "Cf":
+        return 0
     w = unicodedata.east_asian_width(c)
     if w in ("N", "Na", "H", "A"):
         return 1

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -64,9 +64,9 @@ def str_width(c: str) -> int:
     if ord(c) < 128:
         return 1
     # gh-139246 for zero-width joiner and combining characters
-    category = unicodedata.category(c)
     if unicodedata.combining(c):
         return 0
+    category = unicodedata.category(c)
     if category == "Cf" and c != "\u00ad":
         return 0
     if "\u2028" <= c <= "\u2029":

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -64,7 +64,12 @@ def str_width(c: str) -> int:
     if ord(c) < 128:
         return 1
     # gh-139246 for zero-width joiner and combining characters
-    if unicodedata.combining(c) or unicodedata.category(c) == "Cf":
+    category = unicodedata.category(c)
+    if unicodedata.combining(c):
+        return 0
+    if category == "Cf" and c != "\u00ad":
+        return 0
+    if "\u2028" <= c <= "\u2029":
         return 0
     w = unicodedata.east_asian_width(c)
     if w in ("N", "Na", "H", "A"):

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -69,8 +69,6 @@ def str_width(c: str) -> int:
     category = unicodedata.category(c)
     if category == "Cf" and c != "\u00ad":
         return 0
-    if "\u2028" <= c <= "\u2029":
-        return 0
     w = unicodedata.east_asian_width(c)
     if w in ("N", "Na", "H", "A"):
         return 1

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -5,9 +5,27 @@ from _pyrepl.utils import str_width, wlen, prev_next_window, gen_colors
 
 class TestUtils(TestCase):
     def test_str_width(self):
-        characters = ['a', '1', '_', '!', '\x1a', '\u263A', '\uffb9']
+        characters = [
+            'a',
+            '1',
+            '_',
+            '!',
+            '\x1a',
+            '\u263A',
+            '\uffb9',
+            '\N{LATIN SMALL LETTER E WITH ACUTE}',  # é
+            '\N{LATIN SMALL LETTER E WITH CEDILLA}', # ȩ
+        ]
         for c in characters:
             self.assertEqual(str_width(c), 1)
+
+        zero_width_characters = [
+            '\N{COMBINING ACUTE ACCENT}',
+            '\N{ZERO WIDTH JOINER}',
+        ]
+        for c in zero_width_characters:
+            with self.subTest(character=c):
+                self.assertEqual(str_width(c), 0)
 
         characters = [chr(99989), chr(99999)]
         for c in characters:
@@ -25,6 +43,8 @@ class TestUtils(TestCase):
 
         self.assertEqual(wlen('hello'), 5)
         self.assertEqual(wlen('hello' + '\x1a'), 7)
+        self.assertEqual(wlen('e\N{COMBINING ACUTE ACCENT}'), 1)
+        self.assertEqual(wlen('a\N{ZERO WIDTH JOINER}b'), 2)
 
     def test_prev_next_window(self):
         def gen_normal():

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -15,6 +15,7 @@ class TestUtils(TestCase):
             '\uffb9',
             '\N{LATIN SMALL LETTER E WITH ACUTE}',  # é
             '\N{LATIN SMALL LETTER E WITH CEDILLA}', # ȩ
+            '\u00ad',
         ]
         for c in characters:
             self.assertEqual(str_width(c), 1)
@@ -22,6 +23,8 @@ class TestUtils(TestCase):
         zero_width_characters = [
             '\N{COMBINING ACUTE ACCENT}',
             '\N{ZERO WIDTH JOINER}',
+            '\u2028',
+            '\u2029',
         ]
         for c in zero_width_characters:
             with self.subTest(character=c):

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -23,8 +23,6 @@ class TestUtils(TestCase):
         zero_width_characters = [
             '\N{COMBINING ACUTE ACCENT}',
             '\N{ZERO WIDTH JOINER}',
-            '\u2028',
-            '\u2029',
         ]
         for c in zero_width_characters:
             with self.subTest(character=c):

--- a/Misc/NEWS.d/next/Library/2025-09-23-09-46-46.gh-issue-139246.pzfM-w.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-23-09-46-46.gh-issue-139246.pzfM-w.rst
@@ -1,0 +1,1 @@
+fix: paste zero-width in default repl width is wrong.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139246 -->
* Issue: gh-139246
<!-- /gh-issue-number -->
