### PR TITLE
gh-139257: Support docutils >= 0.22

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -25,11 +25,21 @@ from sphinx.util.docutils import SphinxDirective
 SOURCE_URI = 'https://github.com/python/cpython/tree/main/%s'
 
 # monkey-patch reST parser to disable alphabetic and roman enumerated lists
+def _disable_alphabetic_and_roman(text):
+    try:
+        # docutils >= 0.22
+        from docutils.parsers.rst.states import InvalidRomanNumeralError
+        raise InvalidRomanNumeralError(text)
+    except ImportError:
+        # docutils < 0.22
+        return None
+
+
 from docutils.parsers.rst.states import Body
 Body.enum.converters['loweralpha'] = \
     Body.enum.converters['upperalpha'] = \
     Body.enum.converters['lowerroman'] = \
-    Body.enum.converters['upperroman'] = lambda x: None
+    Body.enum.converters['upperroman'] = _disable_alphabetic_and_roman
 
 
 class PyAwaitableMixin(object):

--- a/Misc/NEWS.d/next/Documentation/2025-09-23-10-29-31.gh-issue-139257.zze4rw.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-09-23-10-29-31.gh-issue-139257.zze4rw.rst
@@ -1,0 +1,1 @@
+Support docutils >= 0.22 for documentation generation.


### PR DESCRIPTION
This change fix the doc generation with newer docutils keeping the monkey-patch to to disable alphabetic and roman enumerated lists.

Fix https://github.com/python/cpython/issues/139257

<!-- gh-issue-number: gh-139257 -->
* Issue: gh-139257
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139258.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->