### PR TITLE
gh-136744: Remove a redundant test skip

### DIFF
--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -1299,7 +1299,6 @@ class PydocImportTest(PydocBaseTest):
         self.assertEqual(out.getvalue(), '')
         self.assertEqual(err.getvalue(), '')
 
-    @os_helper.skip_unless_working_chmod
     def test_apropos_empty_doc(self):
         pkgdir = os.path.join(TESTFN, 'walkpkg')
         os.mkdir(pkgdir)


### PR DESCRIPTION
After #136746 was merged, @zware noticed that the skip on the simplified test was now redundant. This removes the redundant test skip.

<!-- gh-issue-number: gh-136744 -->
* Issue: gh-136744
<!-- /gh-issue-number -->
