### PR TITLE
[3.13] gh-138860: Lazy import rlcompleter in pdb to avoid deadlock in…

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -90,7 +90,6 @@ import linecache
 import _colorize
 
 from contextlib import contextmanager
-from rlcompleter import Completer
 from types import CodeType
 
 
@@ -332,6 +331,15 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             readline.set_completer_delims(' \t\n`@#%^&*()=+[{]}\\|;:\'",<>?')
         except ImportError:
             pass
+
+        # GH-138860
+        # We need to lazy-import rlcompleter to avoid deadlock
+        # We cannot import it during self.complete* methods because importing
+        # rlcompleter for the first time will overwrite readline's completer
+        # So we import it here and save the Completer class
+        from rlcompleter import Completer
+        self.RlCompleter = Completer
+
         self.allow_kbdint = False
         self.nosigint = nosigint
         # Consider these characters as part of the command so when the users type
@@ -986,10 +994,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             conv_vars = self.curframe.f_globals.get('__pdb_convenience_variables', {})
             return [f"${name}" for name in conv_vars if name.startswith(text[1:])]
 
-        # Use rlcompleter to do the completion
         state = 0
         matches = []
-        completer = Completer(self.curframe.f_globals | self.curframe_locals)
+        completer = self.RlCompleter(self.curframe.f_globals | self.curframe.f_locals)
         while (match := completer.complete(text, state)) is not None:
             matches.append(match)
             state += 1

--- a/Misc/NEWS.d/next/Library/2025-09-20-17-50-31.gh-issue-138860.Y9JXap.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-20-17-50-31.gh-issue-138860.Y9JXap.rst
@@ -1,0 +1,1 @@
+Lazy import :mod:`rlcompleter` in :mod:`pdb` to avoid deadlock in subprocess.


### PR DESCRIPTION
… subprocess (GH-139185)

(cherry picked from commit c8624cd36746b17d8f991cde63705e9419e940de)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138860 -->
* Issue: gh-138860
<!-- /gh-issue-number -->
