### PR TITLE
[3.14] Fix the reference to unicode specification (#139138)

### DIFF
--- a/Doc/library/unicodedata.rst
+++ b/Doc/library/unicodedata.rst
@@ -123,7 +123,7 @@ following functions:
    Returns the canonical combining class assigned to the character *chr*
    as integer. Returns ``0`` if no combining class is defined.
    See the `Canonical Combining Class Values section of the Unicode Character
-   Database <www.unicode.org/reports/tr44/tr44-34.html#Canonical_Combining_Class_Values>`_
+   Database <https://www.unicode.org/reports/tr44/tr44-34.html#Canonical_Combining_Class_Values>`_
    for more information.
 
 


### PR DESCRIPTION
(cherry picked from commit b36dee855dd61f6ac37208866c3c4c21429a587a)

A backport to 3.14

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139286.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->