### PR TITLE
gh-139283: correctly handle `size` limit in `cursor.fetchmany()`

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1611,6 +1611,9 @@ Cursor objects
       If the *size* parameter is used, then it is best for it to retain the same
       value from one :meth:`fetchmany` call to the next.
 
+      .. versionchanged:: next
+         Reject negative *size* values by rasing :exc:`ValueError`.
+
    .. method:: fetchall()
 
       Return all (remaining) rows of a query result as a :class:`list`.
@@ -1637,6 +1640,9 @@ Cursor objects
 
       Read/write attribute that controls the number of rows returned by :meth:`fetchmany`.
       The default value is 1 which means a single row would be fetched per call.
+
+      .. versionchanged:: next
+         Reject negative values by rasing :exc:`ValueError`.
 
    .. attribute:: connection
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1612,7 +1612,7 @@ Cursor objects
       value from one :meth:`fetchmany` call to the next.
 
       .. versionchanged:: next
-         Reject negative *size* values by rasing :exc:`ValueError`.
+         Negative *size* values are rejected by raising :exc:`ValueError`.
 
    .. method:: fetchall()
 
@@ -1642,7 +1642,7 @@ Cursor objects
       The default value is 1 which means a single row would be fetched per call.
 
       .. versionchanged:: next
-         Reject negative values by rasing :exc:`ValueError`.
+         Negative values are rejected by raising :exc:`ValueError`.
 
    .. attribute:: connection
 

--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -21,6 +21,7 @@
 # 3. This notice may not be removed or altered from any source distribution.
 
 import contextlib
+import functools
 import os
 import sqlite3 as sqlite
 import subprocess
@@ -1060,7 +1061,7 @@ class CursorTests(unittest.TestCase):
         # now set to 2
         self.cu.arraysize = 2
 
-        # now make the query return 3 rows
+        # now make the query return 2 rows from a table of 3 rows
         self.cu.execute("delete from test")
         self.cu.execute("insert into test(name) values ('A')")
         self.cu.execute("insert into test(name) values ('B')")
@@ -1070,12 +1071,49 @@ class CursorTests(unittest.TestCase):
 
         self.assertEqual(len(res), 2)
 
+    def test_invalid_array_size(self):
+        UINT32_MAX = (1 << 32) - 1
+        setter = functools.partial(setattr, self.cu, 'arraysize')
+
+        self.assertRaises(TypeError, setter, 1.0)
+        self.assertRaises(ValueError, setter, -3)
+        self.assertRaises(OverflowError, setter, UINT32_MAX + 1)
+
     def test_fetchmany(self):
+        # no active SQL statement
+        res = self.cu.fetchmany()
+        self.assertEqual(res, [])
+        res = self.cu.fetchmany(1000)
+        self.assertEqual(res, [])
+
+        # test default parameter
+        self.cu.execute("select name from test")
+        res = self.cu.fetchmany()
+        self.assertEqual(len(res), 1)
+
+        # test when the number of requested rows exceeds the actual count
         self.cu.execute("select name from test")
         res = self.cu.fetchmany(100)
         self.assertEqual(len(res), 1)
         res = self.cu.fetchmany(100)
         self.assertEqual(res, [])
+
+        # test when size = 0
+        self.cu.execute("select name from test")
+        res = self.cu.fetchmany(0)
+        self.assertEqual(res, [])
+        res = self.cu.fetchmany(100)
+        self.assertEqual(len(res), 1)
+        res = self.cu.fetchmany(100)
+        self.assertEqual(res, [])
+
+    def test_invalid_fetchmany(self):
+        UINT32_MAX = (1 << 32) - 1
+        fetchmany = self.cu.fetchmany
+
+        self.assertRaises(TypeError, fetchmany, 1.0)
+        self.assertRaises(ValueError, fetchmany, -3)
+        self.assertRaises(OverflowError, fetchmany, UINT32_MAX + 1)
 
     def test_fetchmany_kw_arg(self):
         """Checks if fetchmany works with keyword arguments"""

--- a/Misc/NEWS.d/next/Security/2025-09-24-13-39-56.gh-issue-139283.jODz_q.rst
+++ b/Misc/NEWS.d/next/Security/2025-09-24-13-39-56.gh-issue-139283.jODz_q.rst
@@ -1,0 +1,4 @@
+:mod:`sqlite3`: correctly handle maximum number of rows to fetch in
+:meth:`Cursor.fetchmany <sqlite3.Cursor.fetchmany>` and reject negative
+values for :attr:`Cursor.arraysize <sqlite3.Cursor.arraysize>`. Patch by
+Bénédikt Tran.

--- a/Modules/_sqlite/clinic/cursor.c.h
+++ b/Modules/_sqlite/clinic/cursor.c.h
@@ -6,6 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
+#include "pycore_long.h"          // _PyLong_UInt32_Converter()
 #include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 static int
@@ -181,7 +182,7 @@ PyDoc_STRVAR(pysqlite_cursor_fetchmany__doc__,
     {"fetchmany", _PyCFunction_CAST(pysqlite_cursor_fetchmany), METH_FASTCALL|METH_KEYWORDS, pysqlite_cursor_fetchmany__doc__},
 
 static PyObject *
-pysqlite_cursor_fetchmany_impl(pysqlite_Cursor *self, int maxrows);
+pysqlite_cursor_fetchmany_impl(pysqlite_Cursor *self, uint32_t maxrows);
 
 static PyObject *
 pysqlite_cursor_fetchmany(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -216,7 +217,7 @@ pysqlite_cursor_fetchmany(PyObject *self, PyObject *const *args, Py_ssize_t narg
     #undef KWTUPLE
     PyObject *argsbuf[1];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
-    int maxrows = ((pysqlite_Cursor *)self)->arraysize;
+    uint32_t maxrows = ((pysqlite_Cursor *)self)->arraysize;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 0, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -226,8 +227,7 @@ pysqlite_cursor_fetchmany(PyObject *self, PyObject *const *args, Py_ssize_t narg
     if (!noptargs) {
         goto skip_optional_pos;
     }
-    maxrows = PyLong_AsInt(args[0]);
-    if (maxrows == -1 && PyErr_Occurred()) {
+    if (!_PyLong_UInt32_Converter(args[0], &maxrows)) {
         goto exit;
     }
 skip_optional_pos:
@@ -329,4 +329,46 @@ pysqlite_cursor_close(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return pysqlite_cursor_close_impl((pysqlite_Cursor *)self);
 }
-/*[clinic end generated code: output=d05c7cbbc8bcab26 input=a9049054013a1b77]*/
+
+#if !defined(_sqlite3_Cursor_arraysize_DOCSTR)
+#  define _sqlite3_Cursor_arraysize_DOCSTR NULL
+#endif
+#if defined(_SQLITE3_CURSOR_ARRAYSIZE_GETSETDEF)
+#  undef _SQLITE3_CURSOR_ARRAYSIZE_GETSETDEF
+#  define _SQLITE3_CURSOR_ARRAYSIZE_GETSETDEF {"arraysize", (getter)_sqlite3_Cursor_arraysize_get, (setter)_sqlite3_Cursor_arraysize_set, _sqlite3_Cursor_arraysize_DOCSTR},
+#else
+#  define _SQLITE3_CURSOR_ARRAYSIZE_GETSETDEF {"arraysize", (getter)_sqlite3_Cursor_arraysize_get, NULL, _sqlite3_Cursor_arraysize_DOCSTR},
+#endif
+
+static PyObject *
+_sqlite3_Cursor_arraysize_get_impl(pysqlite_Cursor *self);
+
+static PyObject *
+_sqlite3_Cursor_arraysize_get(PyObject *self, void *Py_UNUSED(context))
+{
+    return _sqlite3_Cursor_arraysize_get_impl((pysqlite_Cursor *)self);
+}
+
+#if !defined(_sqlite3_Cursor_arraysize_DOCSTR)
+#  define _sqlite3_Cursor_arraysize_DOCSTR NULL
+#endif
+#if defined(_SQLITE3_CURSOR_ARRAYSIZE_GETSETDEF)
+#  undef _SQLITE3_CURSOR_ARRAYSIZE_GETSETDEF
+#  define _SQLITE3_CURSOR_ARRAYSIZE_GETSETDEF {"arraysize", (getter)_sqlite3_Cursor_arraysize_get, (setter)_sqlite3_Cursor_arraysize_set, _sqlite3_Cursor_arraysize_DOCSTR},
+#else
+#  define _SQLITE3_CURSOR_ARRAYSIZE_GETSETDEF {"arraysize", NULL, (setter)_sqlite3_Cursor_arraysize_set, NULL},
+#endif
+
+static int
+_sqlite3_Cursor_arraysize_set_impl(pysqlite_Cursor *self, PyObject *value);
+
+static int
+_sqlite3_Cursor_arraysize_set(PyObject *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    return_value = _sqlite3_Cursor_arraysize_set_impl((pysqlite_Cursor *)self, value);
+
+    return return_value;
+}
+/*[clinic end generated code: output=a0e3ebba9e4d0ece input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/cursor.c.h
+++ b/Modules/_sqlite/clinic/cursor.c.h
@@ -6,6 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
+#include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
 #include "pycore_long.h"          // _PyLong_UInt32_Converter()
 #include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
@@ -346,7 +347,13 @@ _sqlite3_Cursor_arraysize_get_impl(pysqlite_Cursor *self);
 static PyObject *
 _sqlite3_Cursor_arraysize_get(PyObject *self, void *Py_UNUSED(context))
 {
-    return _sqlite3_Cursor_arraysize_get_impl((pysqlite_Cursor *)self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _sqlite3_Cursor_arraysize_get_impl((pysqlite_Cursor *)self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 #if !defined(_sqlite3_Cursor_arraysize_DOCSTR)
@@ -367,8 +374,10 @@ _sqlite3_Cursor_arraysize_set(PyObject *self, PyObject *value, void *Py_UNUSED(c
 {
     int return_value;
 
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _sqlite3_Cursor_arraysize_set_impl((pysqlite_Cursor *)self, value);
+    Py_END_CRITICAL_SECTION();
 
     return return_value;
 }
-/*[clinic end generated code: output=a0e3ebba9e4d0ece input=a9049054013a1b77]*/
+/*[clinic end generated code: output=481f794ea87df34a input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/cursor.c.h
+++ b/Modules/_sqlite/clinic/cursor.c.h
@@ -6,7 +6,6 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
-#include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
 #include "pycore_long.h"          // _PyLong_UInt32_Converter()
 #include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
@@ -347,13 +346,7 @@ _sqlite3_Cursor_arraysize_get_impl(pysqlite_Cursor *self);
 static PyObject *
 _sqlite3_Cursor_arraysize_get(PyObject *self, void *Py_UNUSED(context))
 {
-    PyObject *return_value = NULL;
-
-    Py_BEGIN_CRITICAL_SECTION(self);
-    return_value = _sqlite3_Cursor_arraysize_get_impl((pysqlite_Cursor *)self);
-    Py_END_CRITICAL_SECTION();
-
-    return return_value;
+    return _sqlite3_Cursor_arraysize_get_impl((pysqlite_Cursor *)self);
 }
 
 #if !defined(_sqlite3_Cursor_arraysize_DOCSTR)
@@ -374,10 +367,8 @@ _sqlite3_Cursor_arraysize_set(PyObject *self, PyObject *value, void *Py_UNUSED(c
 {
     int return_value;
 
-    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _sqlite3_Cursor_arraysize_set_impl((pysqlite_Cursor *)self, value);
-    Py_END_CRITICAL_SECTION();
 
     return return_value;
 }
-/*[clinic end generated code: output=481f794ea87df34a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a0e3ebba9e4d0ece input=a9049054013a1b77]*/

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -1298,27 +1298,25 @@ pysqlite_cursor_close_impl(pysqlite_Cursor *self)
 }
 
 /*[clinic input]
-@critical_section
 @getter
 _sqlite3.Cursor.arraysize
 [clinic start generated code]*/
 
 static PyObject *
 _sqlite3_Cursor_arraysize_get_impl(pysqlite_Cursor *self)
-/*[clinic end generated code: output=e0919d97175e6c50 input=e0e184c319955cbc]*/
+/*[clinic end generated code: output=e0919d97175e6c50 input=3278f8d3ecbd90e3]*/
 {
     return PyLong_FromUInt32(self->arraysize);
 }
 
 /*[clinic input]
-@critical_section
 @setter
 _sqlite3.Cursor.arraysize
 [clinic start generated code]*/
 
 static int
 _sqlite3_Cursor_arraysize_set_impl(pysqlite_Cursor *self, PyObject *value)
-/*[clinic end generated code: output=af59a6b09f8cce6e input=9bb20fe894cda495]*/
+/*[clinic end generated code: output=af59a6b09f8cce6e input=ace48cb114e26060]*/
 {
     return PyLong_AsUInt32(value, &self->arraysize);
 }

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -1298,25 +1298,27 @@ pysqlite_cursor_close_impl(pysqlite_Cursor *self)
 }
 
 /*[clinic input]
+@critical_section
 @getter
 _sqlite3.Cursor.arraysize
 [clinic start generated code]*/
 
 static PyObject *
 _sqlite3_Cursor_arraysize_get_impl(pysqlite_Cursor *self)
-/*[clinic end generated code: output=e0919d97175e6c50 input=3278f8d3ecbd90e3]*/
+/*[clinic end generated code: output=e0919d97175e6c50 input=e0e184c319955cbc]*/
 {
     return PyLong_FromUInt32(self->arraysize);
 }
 
 /*[clinic input]
+@critical_section
 @setter
 _sqlite3.Cursor.arraysize
 [clinic start generated code]*/
 
 static int
 _sqlite3_Cursor_arraysize_set_impl(pysqlite_Cursor *self, PyObject *value)
-/*[clinic end generated code: output=af59a6b09f8cce6e input=ace48cb114e26060]*/
+/*[clinic end generated code: output=af59a6b09f8cce6e input=9bb20fe894cda495]*/
 {
     return PyLong_AsUInt32(value, &self->arraysize);
 }

--- a/Modules/_sqlite/cursor.h
+++ b/Modules/_sqlite/cursor.h
@@ -35,7 +35,7 @@ typedef struct
     pysqlite_Connection* connection;
     PyObject* description;
     PyObject* row_cast_map;
-    int arraysize;
+    uint32_t arraysize;
     PyObject* lastrowid;
     long rowcount;
     PyObject* row_factory;


### PR DESCRIPTION
Using the legacy PyMemerDef API is problematic for writable fields:

- If the field is tagged as `Py_T_UINT` or any other unsigned type, using `obj.attr = -1` does *NOT* raise a ValueError for legacy purposes (part of the very large commit 89f507fe8c497b3f70fdcecce8bc240f9af2bbe2).
- Instead, I'm using plain getter/setters functions so that the "batch" size for each fetchmany() is stored as an `uint32_t` instead. Previously it was stored as an `int`.
- To prevent possible counting overflows, I'm restricting *maxrows* in `fetchmany()` to be a `uint32_t` which I can decrement instead of having an additional counter.
- I don't think we'll ever need more than 2^32 rows per fetchmany() call.


<!-- gh-issue-number: gh-139283 -->
* Issue: gh-139283
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139296.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->