### PR TITLE
gh-138489: Add missing `build-details.json` step for building wasm

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -804,7 +804,7 @@ build_wasm: check-clean-src $(BUILDPYTHON) platform sharedmods \
 		python-config checksharedmods build-details.json
 
 .PHONY: build_emscripten
-build_emscripten: build_wasm build-details.json web_example web_example_pyrepl_jspi
+build_emscripten: build_wasm web_example web_example_pyrepl_jspi
 
 # Check that the source is clean when building out of source.
 .PHONY: check-clean-src

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -801,10 +801,10 @@ build_all:	check-clean-src check-app-store-compliance $(BUILDPYTHON) platform sh
 
 .PHONY: build_wasm
 build_wasm: check-clean-src $(BUILDPYTHON) platform sharedmods \
-		python-config checksharedmods
+		python-config checksharedmods build-details.json
 
 .PHONY: build_emscripten
-build_emscripten: build_wasm web_example web_example_pyrepl_jspi
+build_emscripten: build_wasm build-details.json web_example web_example_pyrepl_jspi
 
 # Check that the source is clean when building out of source.
 .PHONY: check-clean-src

--- a/Misc/NEWS.d/next/Build/2025-09-24-13-59-26.gh-issue-138489.1AcuZM.rst
+++ b/Misc/NEWS.d/next/Build/2025-09-24-13-59-26.gh-issue-138489.1AcuZM.rst
@@ -1,0 +1,6 @@
+When cross-compiling for WASI by ``build_wasm`` or ``build_emscripten``, the
+``build-details.json`` step is now included in the build process, just like
+with native builds.
+
+This fixes the ``libinstall`` task which requires the ``build-details.json``
+file during the process.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Hello, this PR just adds a missing `build-details.json` build step on WASM ecosystems (e.g. `WASI`).

When cross-compiling for WASI by `build_wasm` or `build_emscripten`, the `build-details.json` step is now included in the build process, just like with native builds.

This fixes the `libinstall` task which requires the `build-details.json` file during the process.

<!-- gh-issue-number: gh-138489 -->
* Issue: gh-138489
<!-- /gh-issue-number -->
