### PR TITLE
gh-115119: Defer `--with-system-libmpdec` removal to 3.16

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -869,9 +869,9 @@ Libraries options
    .. versionchanged:: 3.13
       Default to using the installed ``mpdecimal`` library.
 
-   .. deprecated-removed:: 3.13 3.15
+   .. deprecated-removed:: 3.13 3.16
       A copy of the ``mpdecimal`` library sources will no longer be distributed
-      with Python 3.15.
+      with Python 3.16.
 
    .. seealso:: :option:`LIBMPDEC_CFLAGS` and :option:`LIBMPDEC_LIBS`.
 


### PR DESCRIPTION
Based on https://github.com/python/cpython/issues/115119 I understand that `--with-system-libmpdec` will not be removed in 3.15

I prologed the deprecation message.

<!-- gh-issue-number: gh-115119 -->
* Issue: gh-115119
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139318.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->