### PR TITLE
gh-139330: Check expat version/checksum in SBOM with refresh.sh

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2025-09-25-10-31-02.gh-issue-139330.5WWkY0.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-09-25-10-31-02.gh-issue-139330.5WWkY0.rst
@@ -1,0 +1,3 @@
+SBOM generation tool didn't cross-check the version and checksum values
+against the ``Modules/expat/refresh.sh`` script, leading to the values
+becoming out-of-date during routine updates.

--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -1730,14 +1730,14 @@
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "17aa6cfc5c4c219c09287abfc10bc13f0c06f30bb654b28bfe6f567ca646eb79"
+          "checksumValue": "13d42a125897329bfeecab899cb9b5a3ec8c26072994b5cd4c41f28241f5bce7"
         }
       ],
-      "downloadLocation": "https://github.com/libexpat/libexpat/releases/download/R_2_6_3/expat-2.6.3.tar.gz",
+      "downloadLocation": "https://github.com/libexpat/libexpat/releases/download/R_2_7_2/expat-2.7.2.tar.gz",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:libexpat_project:libexpat:2.6.3:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:libexpat_project:libexpat:2.7.2:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
@@ -1745,7 +1745,7 @@
       "name": "expat",
       "originator": "Organization: Expat development team",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "2.6.3"
+      "versionInfo": "2.7.2"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-hacl-star",

--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -242,14 +242,14 @@ def check_sbom_packages(sbom_data: dict[str, typing.Any]) -> None:
             )
 
         # libexpat specifies its expected rev in a refresh script.
-        if package["name"] == "libexpat":
+        if package["name"] == "expat":
             libexpat_refresh_sh = (CPYTHON_ROOT_DIR / "Modules/expat/refresh.sh").read_text()
             libexpat_expected_version_match = re.search(
                 r"expected_libexpat_version=\"([0-9]+\.[0-9]+\.[0-9]+)\"",
                 libexpat_refresh_sh
             )
             libexpat_expected_sha256_match = re.search(
-                r"expected_libexpat_sha256=\"[a-f0-9]{40}\"",
+                r"expected_libexpat_sha256=\"([a-f0-9]{64})\"",
                 libexpat_refresh_sh
             )
             libexpat_expected_version = libexpat_expected_version_match and libexpat_expected_version_match.group(1)


### PR DESCRIPTION
Will need to be backported to all SBOM branches.

<!-- gh-issue-number: gh-139330 -->
* Issue: gh-139330
<!-- /gh-issue-number -->
