### PR TITLE
[3.13] Remove accidental text in What’s New

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2850,7 +2850,7 @@ tarfile
 -------
 
 * :func:`~tarfile.data_filter` now normalizes symbolic link targets in order to
-  avoid path traversal attacks.Add commentMore actions
+  avoid path traversal attacks.
   (Contributed by Petr Viktorin in :gh:`127987` and :cve:`2025-4138`.)
 * :func:`~tarfile.TarFile.extractall` now skips fixing up directory attributes
   when a directory was removed or replaced by another kind of file.


### PR DESCRIPTION
Issue introduced in https://github.com/python/cpython/commit/aa9eb5f757ceff461e6e996f12c89e5d9b583b01. This applies only to 3.13, not to newer versions.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139343.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->