### PR TITLE
gh-90949: amend GH-139234 in prevision of future mitigation API

### DIFF
--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -281,8 +281,8 @@ common XML vulnerabilities.
    .. note::
 
       The maximum amplification factor is only considered if the threshold
-      that can be adjusted :meth:`.SetAllocTrackerActivationThreshold` is
-      exceeded.
+      that can be adjusted by :meth:`.SetAllocTrackerActivationThreshold`
+      is exceeded.
 
    .. versionadded:: next
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -556,8 +556,8 @@ unittest
 xml.parsers.expat
 -----------------
 
-* Add :func:`~xml.parsers.expat.xmlparser.SetAllocTrackerActivationThreshold`
-  and :func:`~xml.parsers.expat.xmlparser.SetAllocTrackerMaximumAmplification`
+* Add :meth:`~xml.parsers.expat.xmlparser.SetAllocTrackerActivationThreshold`
+  and :meth:`~xml.parsers.expat.xmlparser.SetAllocTrackerMaximumAmplification`
   to :ref:`xmlparser <xmlparser-objects>` objects to prevent use of
   disproportional amounts of dynamic memory from within an Expat parser.
   (Contributed by Bénédikt Tran in :gh:`90949`.)

--- a/Misc/NEWS.d/next/Library/2025-09-22-14-40-11.gh-issue-90949.UM35nb.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-22-14-40-11.gh-issue-90949.UM35nb.rst
@@ -1,5 +1,5 @@
-Add :func:`~xml.parsers.expat.xmlparser.SetAllocTrackerActivationThreshold`
-and :func:`~xml.parsers.expat.xmlparser.SetAllocTrackerMaximumAmplification`
+Add :meth:`~xml.parsers.expat.xmlparser.SetAllocTrackerActivationThreshold`
+and :meth:`~xml.parsers.expat.xmlparser.SetAllocTrackerMaximumAmplification`
 to :ref:`xmlparser <xmlparser-objects>` objects to prevent use of
 disproportional amounts of dynamic memory from within an Expat parser.
 Patch by Bénédikt Tran.

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1208,7 +1208,7 @@ set_maximum_amplification(xmlparseobject *self,
     pyexpat_state *state = PyType_GetModuleState(cls);
     // Note: Expat has no API to determine whether a parser is a root parser,
     // and since the Expat functions for defining the various maximum allowed
-    // amplifcation factors fail when a bad parser or a out-of-range factor
+    // amplifcation factors fail when a bad parser or an out-of-range factor
     // is given without specifying which check failed, we check whether the
     // factor is out-of-range to improve the error message. See also gh-90949.
     const char *message = (isnan(max_factor) || max_factor < 1.0f)


### PR DESCRIPTION
There were some typos that slipped under both @hartwork's and my radar and some functions that could be made more generic and used by the next PR.


<!-- gh-issue-number: gh-90949 -->
* Issue: gh-90949
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139366.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->