### PR TITLE
More intuitive alternative for providing empty string to with_suffix

### DIFF
--- a/Lib/pathlib/types.py
+++ b/Lib/pathlib/types.py
@@ -183,6 +183,12 @@ class _JoinablePath(ABC):
         else:
             return self.with_name(stem + suffix)
 
+    def without_suffix(self):
+        """Return a new path without the file suffix.  Readable alternative 
+        for providing empty string to with_suffix.
+        """
+        return self.with_suffix('')
+    
     @property
     def parts(self):
         """An object providing sequence-like access to the


### PR DESCRIPTION
Admittedly trivial but useful attribute I'd argue.