### PR TITLE
gh-139374: colorize `timeit` error traceback

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -528,6 +528,14 @@ tarfile
   (Contributed by Christoph Walcher in :gh:`57911`.)
 
 
+timeit
+------
+
+* Error tracebacks are now colourised by default. This can be controlled by
+  :ref:`environment variables <using-on-controlling-color>`.
+  (Contributed by Yi Hong in :gh:`139374`.)
+
+
 types
 ------
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -531,8 +531,8 @@ tarfile
 timeit
 ------
 
-* The command-line interface now colorize error tracebacks
-  by default. This can be controlled by
+* The command-line interface now colorizes error tracebacks
+  by default. This can be controlled with
   :ref:`environment variables <using-on-controlling-color>`.
   (Contributed by Yi Hong in :gh:`139374`.)
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -531,7 +531,8 @@ tarfile
 timeit
 ------
 
-* Error tracebacks are now colourised by default. This can be controlled by
+* The command-line interface now colorize error tracebacks
+  by default. This can be controlled by
   :ref:`environment variables <using-on-controlling-color>`.
   (Contributed by Yi Hong in :gh:`139374`.)
 

--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -4,8 +4,9 @@ import sys
 import io
 from textwrap import dedent
 
-from test.support import captured_stdout, force_not_colorized
-from test.support import captured_stderr
+from test.support import (
+    captured_stdout, captured_stderr, force_not_colorized,
+)
 
 # timeit's default number of iterations.
 DEFAULT_NUMBER = 1000000

--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -4,7 +4,7 @@ import sys
 import io
 from textwrap import dedent
 
-from test.support import captured_stdout
+from test.support import captured_stdout, force_not_colorized
 from test.support import captured_stderr
 
 # timeit's default number of iterations.
@@ -219,16 +219,12 @@ class TestTimeit(unittest.TestCase):
                 timer=FakeTimer())
         self.assertEqual(delta_times, DEFAULT_REPEAT * [0.0])
 
+    @force_not_colorized
     def assert_exc_string(self, exc_string, expected_exc_name):
         exc_lines = exc_string.splitlines()
         self.assertGreater(len(exc_lines), 2)
         self.assertStartsWith(exc_lines[0], 'Traceback')
-        # Remove ANSI color codes from the last line before checking
-        import re
-        last_line = exc_lines[-1]
-        # Remove ANSI escape sequences
-        clean_last_line = re.sub(r'\x1b\[[0-9;]*m', '', last_line)
-        self.assertStartsWith(clean_last_line, expected_exc_name)
+        self.assertStartsWith(exc_lines[-1], expected_exc_name)
 
     def test_print_exc(self):
         s = io.StringIO()

--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -223,7 +223,12 @@ class TestTimeit(unittest.TestCase):
         exc_lines = exc_string.splitlines()
         self.assertGreater(len(exc_lines), 2)
         self.assertStartsWith(exc_lines[0], 'Traceback')
-        self.assertStartsWith(exc_lines[-1], expected_exc_name)
+        # Remove ANSI color codes from the last line before checking
+        import re
+        last_line = exc_lines[-1]
+        # Remove ANSI escape sequences
+        clean_last_line = re.sub(r'\x1b\[[0-9;]*m', '', last_line)
+        self.assertStartsWith(clean_last_line, expected_exc_name)
 
     def test_print_exc(self):
         s = io.StringIO()

--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -225,7 +225,6 @@ class TestTimeit(unittest.TestCase):
         self.assertStartsWith(exc_lines[0], 'Traceback')
         self.assertStartsWith(exc_lines[-1], expected_exc_name)
 
-    @force_not_colorized
     def test_print_exc(self):
         s = io.StringIO()
         t = timeit.Timer("1/0")

--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -219,13 +219,13 @@ class TestTimeit(unittest.TestCase):
                 timer=FakeTimer())
         self.assertEqual(delta_times, DEFAULT_REPEAT * [0.0])
 
-    @force_not_colorized
     def assert_exc_string(self, exc_string, expected_exc_name):
         exc_lines = exc_string.splitlines()
         self.assertGreater(len(exc_lines), 2)
         self.assertStartsWith(exc_lines[0], 'Traceback')
         self.assertStartsWith(exc_lines[-1], expected_exc_name)
 
+    @force_not_colorized
     def test_print_exc(self):
         s = io.StringIO()
         t = timeit.Timer("1/0")
@@ -352,11 +352,13 @@ class TestTimeit(unittest.TestCase):
         self.assertEqual(error_stringio.getvalue(),
                     "Unrecognized unit. Please select nsec, usec, msec, or sec.\n")
 
+    @force_not_colorized
     def test_main_exception(self):
         with captured_stderr() as error_stringio:
             s = self.run_main(switches=['1/0'])
         self.assert_exc_string(error_stringio.getvalue(), 'ZeroDivisionError')
 
+    @force_not_colorized
     def test_main_exception_fixed_reps(self):
         with captured_stderr() as error_stringio:
             s = self.run_main(switches=['-n1', '1/0'])

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -150,7 +150,7 @@ class Timer:
         The optional file argument directs where the traceback is
         sent; it defaults to sys.stderr.
         """
-        import linecache, traceback
+        import linecache, traceback, _colorize, sys
         if self.src is not None:
             linecache.cache[dummy_src_name] = (len(self.src),
                                                None,
@@ -158,7 +158,8 @@ class Timer:
                                                dummy_src_name)
         # else the source is already stored somewhere else
 
-        traceback.print_exc(file=file)
+        traceback.print_exception(sys.exception(), file=file,
+                                 colorize=_colorize.can_colorize(file=file))
 
     def timeit(self, number=default_number):
         """Time 'number' executions of the main statement.

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -263,10 +263,10 @@ def main(args=None, *, _wrap_timer=None):
     is not None, it must be a callable that accepts a timer function
     and returns another timer function (used for unit testing).
     """
+    import getopt
     if args is None:
         args = sys.argv[1:]
     import _colorize
-    import getopt
     colorize = _colorize.can_colorize()
 
     try:

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -267,6 +267,8 @@ def main(args=None, *, _wrap_timer=None):
         args = sys.argv[1:]
     import getopt
     import _colorize
+    colorize_errors = _colorize.can_colorize()
+
     try:
         opts, args = getopt.getopt(args, "n:u:s:r:pvh",
                                    ["number=", "setup=", "repeat=",

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -335,8 +335,7 @@ def main(args=None, *, _wrap_timer=None):
         try:
             number, _ = t.autorange(callback)
         except:
-            colorize = _colorize.can_colorize()
-            t.print_exc(colorize=colorize)
+            t.print_exc(colorize=colorize_errors)
             return 1
 
         if verbose:
@@ -345,8 +344,7 @@ def main(args=None, *, _wrap_timer=None):
     try:
         raw_timings = t.repeat(repeat, number)
     except:
-        colorize = _colorize.can_colorize()
-        t.print_exc(colorize=colorize)
+        t.print_exc(colorize=colorize_errors)
         return 1
 
     def format_time(dt):

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -149,8 +149,13 @@ class Timer:
 
         The optional file argument directs where the traceback is
         sent; it defaults to sys.stderr.
+
+        The optional colorize keyword argument controls whether the
+        traceback is colorized; it defaults to False for programmatic
+        usage. When used from the command line, this is automatically
+        set based on terminal capabilities.
         """
-        import _colorize, linecache, traceback, sys
+        import linecache, traceback, sys
         if self.src is not None:
             linecache.cache[dummy_src_name] = (len(self.src),
                                                None,
@@ -158,8 +163,7 @@ class Timer:
                                                dummy_src_name)
         # else the source is already stored somewhere else
 
-        if 'colorize' not in kwargs:
-            kwargs['colorize'] = _colorize.can_colorize(file=file)
+        kwargs['colorize'] = kwargs.get('colorize', False)
 
         traceback.print_exc(file=file, **kwargs)
 
@@ -263,6 +267,7 @@ def main(args=None, *, _wrap_timer=None):
     if args is None:
         args = sys.argv[1:]
     import getopt
+    import _colorize
     try:
         opts, args = getopt.getopt(args, "n:u:s:r:pvh",
                                    ["number=", "setup=", "repeat=",
@@ -329,7 +334,8 @@ def main(args=None, *, _wrap_timer=None):
         try:
             number, _ = t.autorange(callback)
         except:
-            t.print_exc()
+            colorize = _colorize.can_colorize()
+            t.print_exc(colorize=colorize)
             return 1
 
         if verbose:
@@ -338,7 +344,8 @@ def main(args=None, *, _wrap_timer=None):
     try:
         raw_timings = t.repeat(repeat, number)
     except:
-        t.print_exc()
+        colorize = _colorize.can_colorize()
+        t.print_exc(colorize=colorize)
         return 1
 
     def format_time(dt):

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -133,7 +133,7 @@ class Timer:
         exec(code, global_ns, local_ns)
         self.inner = local_ns["inner"]
 
-    def print_exc(self, file=None):
+    def print_exc(self, file=None, **kwargs):
         """Helper to print a traceback from the timed code.
 
         Typical use:
@@ -158,8 +158,10 @@ class Timer:
                                                dummy_src_name)
         # else the source is already stored somewhere else
 
-        traceback.print_exception(sys.exception(), file=file,
-                                 colorize=_colorize.can_colorize(file=file))
+        if 'colorize' not in kwargs:
+            kwargs['colorize'] = _colorize.can_colorize(file=file)
+
+        traceback.print_exc(file=file, **kwargs)
 
     def timeit(self, number=default_number):
         """Time 'number' executions of the main statement.

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -265,9 +265,9 @@ def main(args=None, *, _wrap_timer=None):
     """
     if args is None:
         args = sys.argv[1:]
-    import getopt
     import _colorize
-    colorize_errors = _colorize.can_colorize()
+    import getopt
+    colorize = _colorize.can_colorize()
 
     try:
         opts, args = getopt.getopt(args, "n:u:s:r:pvh",
@@ -335,7 +335,7 @@ def main(args=None, *, _wrap_timer=None):
         try:
             number, _ = t.autorange(callback)
         except:
-            t.print_exc(colorize=colorize_errors)
+            t.print_exc(colorize=colorize)
             return 1
 
         if verbose:
@@ -344,7 +344,7 @@ def main(args=None, *, _wrap_timer=None):
     try:
         raw_timings = t.repeat(repeat, number)
     except:
-        t.print_exc(colorize=colorize_errors)
+        t.print_exc(colorize=colorize)
         return 1
 
     def format_time(dt):

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -155,7 +155,7 @@ class Timer:
         usage. When used from the command line, this is automatically
         set based on terminal capabilities.
         """
-        import linecache, traceback, sys
+        import linecache, traceback
         if self.src is not None:
             linecache.cache[dummy_src_name] = (len(self.src),
                                                None,

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -164,7 +164,6 @@ class Timer:
         # else the source is already stored somewhere else
 
         kwargs['colorize'] = kwargs.get('colorize', False)
-
         traceback.print_exc(file=file, **kwargs)
 
     def timeit(self, number=default_number):

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -150,7 +150,7 @@ class Timer:
         The optional file argument directs where the traceback is
         sent; it defaults to sys.stderr.
         """
-        import linecache, traceback, _colorize, sys
+        import _colorize, linecache, traceback, sys
         if self.src is not None:
             linecache.cache[dummy_src_name] = (len(self.src),
                                                None,

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -206,9 +206,9 @@ def _safe_string(value, what, func=str):
 
 # --
 
-def print_exc(limit=None, file=None, chain=True):
+def print_exc(limit=None, file=None, chain=True, **kwargs):
     """Shorthand for 'print_exception(sys.exception(), limit=limit, file=file, chain=chain)'."""
-    print_exception(sys.exception(), limit=limit, file=file, chain=chain)
+    print_exception(sys.exception(), limit=limit, file=file, chain=chain, **kwargs)
 
 def format_exc(limit=None, chain=True):
     """Like print_exc() but return a string."""

--- a/Misc/NEWS.d/next/Library/2025-09-27-08-26-31.gh-issue-139374.hfh-dl.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-27-08-26-31.gh-issue-139374.hfh-dl.rst
@@ -1,1 +1,1 @@
-Make timeit error traceback can with corlor
+:mod:`timeit`: colorize error tracebacks.

--- a/Misc/NEWS.d/next/Library/2025-09-27-08-26-31.gh-issue-139374.hfh-dl.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-27-08-26-31.gh-issue-139374.hfh-dl.rst
@@ -1,1 +1,1 @@
-:mod:`timeit`: colorize error tracebacks.
+:mod:`timeit`: Add color to error tracebacks.

--- a/Misc/NEWS.d/next/Library/2025-09-27-08-26-31.gh-issue-139374.hfh-dl.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-27-08-26-31.gh-issue-139374.hfh-dl.rst
@@ -1,0 +1,1 @@
+Make timeit error traceback can with corlor


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

after this patch 
<img width="1552" height="513" alt="image" src="https://github.com/user-attachments/assets/ece85e57-e162-4798-bf82-095c9a99c17e" />



<!-- gh-issue-number: gh-139374 -->
* Issue: gh-139374
<!-- /gh-issue-number -->
