### PR TITLE
gh-139352: prevent altering `PYTHON_HISTORY` file when running REPL tests

### DIFF
--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -429,6 +429,7 @@ class _ReadlineWrapper:
 
     @staticmethod
     def _analyze_history_file(filename: str | IO[bytes]) -> tuple[bool, str]:
+        is_editline = False
         if isinstance(filename, str):
             if not os.path.exists(filename):
                 return False, "utf-8"

--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -434,7 +434,6 @@ class _ReadlineWrapper:
                 return False
             with open(filename, "rb") as f:
                 return f.readline().startswith(_EDITLINE_BYTES_MARKER)
-            return False
         return filename.readline().startswith(_EDITLINE_BYTES_MARKER)
 
     def read_history_file(self, filename: str = gethistoryfile()) -> None:

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -163,11 +163,10 @@ class Regrtest:
 
         history_file = os.path.join(os.path.expanduser('~'), '.python_history')
         self.__history_file = history_file
+        self.__history_stat: tuple[int, int] | None = None
         if os.path.exists(history_file):
             st = os.stat(history_file)
             self.__history_stat = (stat.S_IFMT(st.st_mode), st.st_size)
-        else:
-            self.__history_stat = None
 
     def log(self, line: str = '') -> None:
         self.logger.log(line)

--- a/Lib/test/support/script_helper.py
+++ b/Lib/test/support/script_helper.py
@@ -330,10 +330,10 @@ def run_test_script(script):
 
 _site_gethistoryfile = site.gethistoryfile
 def _gethistoryfile():
-    """Patch site.gethistoryfile() to ignore -I for PYTHON_HISTORY.
+    """Patch site.gethistoryfile() to ignore -I/-E for PYTHON_HISTORY.
 
-    The -I option is necessary for test_no_memory() but using it
-    forbids using a custom PYTHON_HISTORY.
+    Some tests (e.g, test_repl.test_no_memory) require -I/-E,
+    but those options forbid using a custom PYTHON_HISTORY.
     """
     history = os.environ.get("PYTHON_HISTORY")
     return history or os.path.join(os.path.expanduser('~'), '.python_history')
@@ -351,16 +351,22 @@ def _file_signature(file):
 class EnsureSafeUserHistory(unittest.TestCase):
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.__history_file = cls.__history_stat = None
-        history_file = _site_gethistoryfile()
+    def __history_setup_check(cls):
+        # Ensure that the system-wide history file is not altered by tests.
+        history_file = os.path.join(os.path.expanduser('~'), '.python_history')
+        cls.__history_file = history_file
         if os.path.exists(history_file):
-            cls.__history_file = history_file
             cls.__history_stat = _file_signature(history_file)
+        else:
+            cls.__history_stat = None
 
-    def tearDown(self):
-        if self.__history_file is not None:
+    def __history_teardown_check(self):
+        if self.__history_stat is None:
+            self.assertFalse(
+                os.path.exists(self.__history_file),
+                f"PYTHON_HISTORY file ({self.__history_file!r}) was created"
+            )
+        else:
             self.assertTrue(
                 os.path.exists(self.__history_file),
                 f"PYTHON_HISTORY file ({self.__history_file!r}) was deleted"
@@ -370,4 +376,12 @@ class EnsureSafeUserHistory(unittest.TestCase):
                 _file_signature(self.__history_file),
                 f"PYTHON_HISTORY file ({self.__history_file!r}) was altered"
             )
+
+    @classmethod
+    def setUpClass(cls):
+        cls.__history_setup_check()
+        super().setUpClass()
+
+    def tearDown(self):
         super().tearDown()
+        self.__history_teardown_check()

--- a/Lib/test/support/script_helper.py
+++ b/Lib/test/support/script_helper.py
@@ -352,6 +352,7 @@ class EnsureSafeUserHistory(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.__history_file = cls.__history_stat = None
         history_file = _site_gethistoryfile()
         if os.path.exists(history_file):
@@ -359,15 +360,14 @@ class EnsureSafeUserHistory(unittest.TestCase):
             cls.__history_stat = _file_signature(history_file)
 
     def tearDown(self):
+        if self.__history_file is not None:
+            self.assertTrue(
+                os.path.exists(self.__history_file),
+                f"PYTHON_HISTORY file ({self.__history_file!r}) was deleted"
+            )
+            self.assertEqual(
+                self.__history_stat,
+                _file_signature(self.__history_file),
+                f"PYTHON_HISTORY file ({self.__history_file!r}) was altered"
+            )
         super().tearDown()
-        if self.__history_file is None:
-            return
-        self.assertTrue(
-            os.path.exists(self.__history_file),
-            f"PYTHON_HISTORY file ({self.__history_file!r}) was deleted"
-        )
-        self.assertEqual(
-            self.__history_stat,
-            _file_signature(self.__history_file),
-            f"PYTHON_HISTORY file ({self.__history_file!r}) was altered"
-        )

--- a/Lib/test/support/script_helper.py
+++ b/Lib/test/support/script_helper.py
@@ -352,12 +352,11 @@ class EnsureSafeUserHistory(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if history_file := _site_gethistoryfile():
-            if os.path.exists(history_file):
-                cls.__history_file = history_file
-                cls.__history_stat = _file_signature(history_file)
-        else:
-            cls.__history_file = cls.__history_stat = None
+        cls.__history_file = cls.__history_stat = None
+        history_file = _site_gethistoryfile()
+        if os.path.exists(history_file):
+            cls.__history_file = history_file
+            cls.__history_stat = _file_signature(history_file)
 
     def tearDown(self):
         super().tearDown()

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -17,7 +17,9 @@ from test import support
 from test.support import import_helper, is_apple, os_helper
 from test.support.script_helper import (
     make_pkg, make_script, make_zip_pkg, make_zip_script,
-    assert_python_ok, assert_python_failure, spawn_python, kill_python)
+    assert_python_ok, assert_python_failure, spawn_python, kill_python,
+    patch_gethistoryfile, EnsureSafeUserHistory
+)
 
 verbose = support.verbose
 
@@ -90,7 +92,8 @@ def _make_test_zip_pkg(zip_dir, zip_basename, pkg_name, script_basename,
 
 
 @support.force_not_colorized_test_class
-class CmdLineTest(unittest.TestCase):
+@patch_gethistoryfile()
+class CmdLineTest(EnsureSafeUserHistory, unittest.TestCase):
     def _check_output(self, script_name, exit_code, data,
                              expected_file, expected_argv0,
                              expected_path0, expected_package,

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -16,6 +16,7 @@ from test.support import force_not_colorized, make_clean_env, Py_DEBUG
 from test.support import has_subprocess_support, SHORT_TIMEOUT, STDLIB_DIR
 from test.support.import_helper import import_module
 from test.support.os_helper import EnvironmentVarGuard, unlink
+from test.support.script_helper import EnsureSafeUserHistory
 
 from .support import (
     FakeConsole,
@@ -45,7 +46,7 @@ except ImportError:
     pty = None
 
 
-class ReplTestCase(TestCase):
+class ReplTestCase(EnsureSafeUserHistory, TestCase):
     def setUp(self):
         if not has_subprocess_support:
             raise SkipTest("test module requires subprocess")
@@ -97,10 +98,11 @@ class ReplTestCase(TestCase):
             env["PYTHON_HISTORY"] = os.path.join(cwd, ".regrtest_history")
         if cmdline_args is not None:
             if "PYTHON_HISTORY" in env:
-                self.assertNotIn(
-                    "-I", cmdline_args,
-                    "PYTHON_HISTORY will be ignored by -I"
-                )
+                for bad_option in ('-I', '-E'):
+                    self.assertNotIn(
+                        bad_option, cmdline_args,
+                        f"PYTHON_HISTORY will be ignored by {bad_option}"
+                    )
             cmd.extend(cmdline_args)
 
         try:

--- a/Misc/NEWS.d/next/Tests/2025-09-27-12-02-49.gh-issue-139352.dblQRA.rst
+++ b/Misc/NEWS.d/next/Tests/2025-09-27-12-02-49.gh-issue-139352.dblQRA.rst
@@ -1,0 +1,2 @@
+Prevent altering the content of the :envvar:`PYTHON_HISTORY` file after
+running REPL tests. Patch by Bénédikt Tran.


### PR DESCRIPTION
The issue with the tests is that those that don't specify an environment actually use `-I` and the current environment. Even if the latter is modified with a different `PYTHON_HISTORY`, because of `-I`, it will be ignored by `gethistoryfile()`.

I decided that it was cleaner to assume that `None` environment means "use a *copy* of the current one" and that the it shouldn't be possible to specify `-I` at the same time if we internally add `PYTHON_HISTORY` ourselves.

I believe that we need a better mechanism, but for now, I want to prevent the test suite to overwrite `~/.python_history` (this could be especially annoying for those who actually want to install python system-wide; alternatively, we could make sure to restore the history file at the end of the test).

<!-- gh-issue-number: gh-139352 -->
* Issue: gh-139352
<!-- /gh-issue-number -->
