### PR TITLE
gh-125895: Docs: fix 404 page prefix configuration

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -548,6 +548,11 @@ extlinks_detect_hardcoded_links = True
 refcount_file = 'data/refcounts.dat'
 stable_abi_file = 'data/stable_abi.dat'
 
+# Options for notfound.extension
+# ------------------------------
+if not os.getenv("READTHEDOCS"):  # RTD uses different URLs patterns
+    notfound_urls_prefix = '/3/'
+
 # Options for sphinxext-opengraph
 # -------------------------------
 


### PR DESCRIPTION
The default is `/en/latest/`. Our docs use `/3/` for latest stable version documentation build. That way links and resources URLs will be correct in the generated 404 page, in the docs.python.org subdomain.

Closes #125895 if followed-up by nginx's (https://nginx.org/en/docs/http/ngx_http_core_module.html#error_page) directive config.

(This change doesn't require a news entry.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125895 -->
* Issue: gh-125895
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139386.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->