### PR TITLE
[3.14] Link to 3.14 GC design docs

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -140,7 +140,7 @@ The :mod:`gc` module provides the following functions:
 
    *threshold2* is ignored.
 
-   See `Garbage collector design <https://devguide.python.org/garbage_collector>`_ for more information.
+   See `Garbage collector design <https://github.com/python/cpython/blob/3.14/InternalDocs/garbage_collector.md>`_ for more information.
 
    .. versionchanged:: 3.14
       *threshold2* is ignored


### PR DESCRIPTION
The devguide link is half dead and forwards users to the CPython internal docs on main. So let's just link directly to the CPython internal docs on 3.14

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139387.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->