### PR TITLE
gh-139391: properly handle `signal.signal()` in `UnixConsole` when called from a non-main thread

### DIFF
--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -28,7 +28,6 @@ import select
 import signal
 import struct
 import termios
-import threading
 import time
 import types
 import platform

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -397,6 +397,7 @@ class UnixConsole(Console):
                 # We can silence the ValueError if signal.signal() raised it
                 # from a non-main thread on a non-Windows platform. Otherwise,
                 # we need to re-raise it as its cause could be different.
+                import threading
                 if threading.current_thread() is threading.main_thread():
                     raise e
             del self.old_sigwinch

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -399,7 +399,7 @@ class UnixConsole(Console):
                     # from a non-main thread on a non-Windows platform. Otherwise,
                     # we need to re-raise it as its cause could be different.
                     if threading.current_thread() is threading.main_thread():
-                            raise e
+                        raise e
             del self.old_sigwinch
 
     def push_char(self, char: int | bytes) -> None:

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -391,15 +391,14 @@ class UnixConsole(Console):
             os.write(self.output_fd, b"\033[?7h")
 
         if hasattr(self, "old_sigwinch"):
-            if os.name != 'nt':
-                try:
-                    signal.signal(signal.SIGWINCH, self.old_sigwinch)
-                except ValueError as e:
-                    # We can silence the ValueError if signal.signal() raised it
-                    # from a non-main thread on a non-Windows platform. Otherwise,
-                    # we need to re-raise it as its cause could be different.
-                    if threading.current_thread() is threading.main_thread():
-                        raise e
+            try:
+                signal.signal(signal.SIGWINCH, self.old_sigwinch)
+            except ValueError as e:
+                # We can silence the ValueError if signal.signal() raised it
+                # from a non-main thread on a non-Windows platform. Otherwise,
+                # we need to re-raise it as its cause could be different.
+                if threading.current_thread() is threading.main_thread():
+                    raise e
             del self.old_sigwinch
 
     def push_char(self, char: int | bytes) -> None:

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -393,9 +393,6 @@ class UnixConsole(Console):
             try:
                 signal.signal(signal.SIGWINCH, self.old_sigwinch)
             except ValueError as e:
-                # We can silence the ValueError if signal.signal() raised it
-                # from a non-main thread on a non-Windows platform. Otherwise,
-                # we need to re-raise it as its cause could be different.
                 import threading
                 if threading.current_thread() is threading.main_thread():
                     raise e

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -326,14 +326,14 @@ class TestConsole(TestCase):
         def thread_target():
             try:
                 console.restore()
-            except ValueError as e:
-                if "signal only works in main thread" in str(e):
-                    exception_caught.append(e)
+            except Exception as e:
+                exception_caught.append(e)
         thread = threading.Thread(target=thread_target)
         thread.start()
         thread.join()
+        # gh-139391: should not raise any exception when called from non-main thread
         self.assertEqual(len(exception_caught), 0,
-                        "restore() should not raise ValueError in non-main thread")
+                        "restore() should not raise any exception in non-main thread")
 
 
 @unittest.skipIf(sys.platform == "win32", "No Unix console on Windows")

--- a/Misc/NEWS.d/next/Library/2025-09-28-16-34-11.gh-issue-139391.nRFnmx.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-28-16-34-11.gh-issue-139391.nRFnmx.rst
@@ -1,0 +1,2 @@
+Fix crash in PyREPL asyncio mode when using Ctrl+Z (suspend) followed by
+``fg`` (resume).

--- a/Misc/NEWS.d/next/Library/2025-09-28-16-34-11.gh-issue-139391.nRFnmx.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-28-16-34-11.gh-issue-139391.nRFnmx.rst
@@ -1,2 +1,3 @@
-Fix crash in PyREPL asyncio mode when using Ctrl+Z (suspend) followed by
-``fg`` (resume).
+Fix an issue when, on non-Windows platforms, it was not possible to
+gracefully exit a ``python -m asyncio`` process suspended by Ctrl+Z
+and later resumed by :manpage:`fg` other than with :manpage:`kill`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

after this patch it goes normal with ctrl+z and fg


<!-- gh-issue-number: gh-139391 -->
* Issue: gh-139391
<!-- /gh-issue-number -->
