### PR TITLE
gh-139393:  fix `_CALL_LEN` JIT tests for tuples

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -15,7 +15,7 @@ from test.support import (script_helper, requires_specialization,
 
 _testinternalcapi = import_helper.import_module("_testinternalcapi")
 
-from _testinternalcapi import TIER2_THRESHOLD
+from _testinternalcapi import _PY_NSMALLPOSINTS, TIER2_THRESHOLD
 
 #For test of issue 136154
 GLOBAL_136154 = 42
@@ -2093,6 +2093,10 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertNotIn("_GUARD_TOS_INT", uops)
 
     def test_call_len_known_length_small_int(self):
+        # Make sure that len(t) is optimized for a tuple of length 5.
+        # See https://github.com/python/cpython/issues/139393.
+        self.assertGreater(_PY_NSMALLPOSINTS, 5)
+
         def testfunc(n):
             x = 0
             for _ in range(n):
@@ -2113,13 +2117,17 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertNotIn("_POP_TOP_LOAD_CONST_INLINE_BORROW", uops)
 
     def test_call_len_known_length(self):
+        # Make sure that len(t) is optimized for a tuple of length 2048.
+        # See https://github.com/python/cpython/issues/139393.
+        self.assertLess(_PY_NSMALLPOSINTS, 2048)
+
         def testfunc(n):
             class C:
-                t = tuple(range(300))
+                t = tuple(range(2048))
 
             x = 0
             for _ in range(n):
-                if len(C.t) == 300:  # comparison + guard removed
+                if len(C.t) == 2048:  # comparison + guard removed
                     x += 1
             return x
 

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -2117,7 +2117,7 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertNotIn("_POP_TOP_LOAD_CONST_INLINE_BORROW", uops)
 
     def test_call_len_known_length(self):
-        # Make sure that len(t) is optimized for a tuple of length 2048.
+        # Make sure that len(t) is not optimized for a tuple of length 2048.
         # See https://github.com/python/cpython/issues/139393.
         self.assertLess(_PY_NSMALLPOSINTS, 2048)
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -34,7 +34,7 @@
 #include "pycore_pyerrors.h"      // _PyErr_ChainExceptions1()
 #include "pycore_pylifecycle.h"   // _PyInterpreterConfig_InitFromDict()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "pycore_runtime_structs.h" // _PY_NSMALLPOSINTS, _PY_NSMALLNEGINTS
+#include "pycore_runtime_structs.h" // _PY_NSMALLPOSINTS
 #include "pycore_unicodeobject.h" // _PyUnicode_TransformDecimalAndSpaceToASCII()
 
 #include "clinic/_testinternalcapi.c.h"
@@ -2578,10 +2578,6 @@ module_exec(PyObject *module)
     }
 
     if (PyModule_AddIntMacro(module, _PY_NSMALLPOSINTS) < 0) {
-        return 1;
-    }
-
-    if (PyModule_AddIntMacro(module, _PY_NSMALLNEGINTS) < 0) {
         return 1;
     }
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -34,6 +34,7 @@
 #include "pycore_pyerrors.h"      // _PyErr_ChainExceptions1()
 #include "pycore_pylifecycle.h"   // _PyInterpreterConfig_InitFromDict()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
+#include "pycore_runtime_structs.h" // _PY_NSMALLPOSINTS, _PY_NSMALLNEGINTS
 #include "pycore_unicodeobject.h" // _PyUnicode_TransformDecimalAndSpaceToASCII()
 
 #include "clinic/_testinternalcapi.c.h"
@@ -2573,6 +2574,14 @@ module_exec(PyObject *module)
 
     if (PyModule_Add(module, "SHARED_KEYS_MAX_SIZE",
                         PyLong_FromLong(SHARED_KEYS_MAX_SIZE)) < 0) {
+        return 1;
+    }
+
+    if (PyModule_AddIntMacro(module, _PY_NSMALLPOSINTS) < 0) {
+        return 1;
+    }
+
+    if (PyModule_AddIntMacro(module, _PY_NSMALLNEGINTS) < 0) {
         return 1;
     }
 


### PR DESCRIPTION
This fixes a regression introduced in 7ce25edb8f41e527ed479bf61ef36dc9841b4ac5 when `_PY_NSMALLPOSINTS` was changed from 257 to 1025.

<!-- gh-issue-number: gh-139393 -->
* Issue: gh-139393
<!-- /gh-issue-number -->
