### PR TITLE
gh-99453: improve entries validation of Netscape/Mozilla cookie files

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -2039,7 +2039,10 @@ class MozillaCookieJar(FileCookieJar):
 
                 fields = line.split("\t")
                 if len(fields) != 7:
-                    raise LoadError("invalid fields in Netscape format cookies file %r: %r" % (filename, line))
+                    raise LoadError(
+                        "invalid fields in Netscape format cookies file %r: %r"
+                        % (filename, line)
+                    )
                 domain, domain_specified, path, secure, expires, name, value = fields
                 secure = (secure == "TRUE")
                 domain_specified = (domain_specified == "TRUE")

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -2037,8 +2037,10 @@ class MozillaCookieJar(FileCookieJar):
                     line.strip() == ""):
                     continue
 
-                domain, domain_specified, path, secure, expires, name, value = \
-                        line.split("\t")
+                fields = line.split("\t")
+                if len(fields) != 7:
+                    raise LoadError("invalid fields in Netscape format cookies file %r: %r" % (filename, line))
+                domain, domain_specified, path, secure, expires, name, value = fields
                 secure = (secure == "TRUE")
                 domain_specified = (domain_specified == "TRUE")
                 if name == "":

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -2036,6 +2036,5 @@ class LWPCookieTests(unittest.TestCase):
             os_helper.unlink(filename)
     
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -2023,6 +2023,19 @@ class LWPCookieTests(unittest.TestCase):
             # we didn't have session cookies in the first place
         self.assertNotEqual(counter["session_before"], 0)
 
+    def test_mozilla_cookiejar_loaderror_on_malformed_file(self):
+        # Malformed cookie file should raise LoadError
+        filename = os_helper.TESTFN
+        with open(filename, "w") as f:
+            f.write("# Netscape HTTP Cookie File\ninvalid_line\n")
+        jar = MozillaCookieJar(filename)
+        try:
+            with self.assertRaisesRegex(LoadError, "invalid fields in Netscape format cookies file"):
+                jar.load()
+        finally:
+            os_helper.unlink(filename)
+    
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -2027,13 +2027,12 @@ class LWPCookieTests(unittest.TestCase):
         # Malformed cookie file should raise LoadError
         filename = os_helper.TESTFN
         with open(filename, "w") as f:
-            f.write("# Netscape HTTP Cookie File\ninvalid_line\n")
+            f.write("# Netscape HTTP Cookie File\n")
+            f.write("malformed line\n")
+        self.addCleanup(os_helper.unlink, filename)
         jar = MozillaCookieJar(filename)
-        try:
-            with self.assertRaisesRegex(LoadError, "invalid fields in Netscape format cookies file"):
-                jar.load()
-        finally:
-            os_helper.unlink(filename)
+        err = "invalid fields in Netscape format cookies file"
+        self.assertRaisesRegex(LoadError, err, jar.load)
     
 
 if __name__ == "__main__":

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -2033,7 +2033,7 @@ class LWPCookieTests(unittest.TestCase):
         jar = MozillaCookieJar(filename)
         err = "invalid fields in Netscape format cookies file"
         self.assertRaisesRegex(LoadError, err, jar.load)
-    
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -29,7 +29,7 @@ Anjani Agrawal
 Pablo S. Blum de Aguiar
 Jim Ahlstrom
 Farhan Ahmad
-Matthew Ahrensq
+Matthew Ahrens
 Nir Aides
 Akira
 Ege Akman

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1534,11 +1534,11 @@ Kirill (python273) R.
 Abhilash Raj
 Shorya Raj
 Ajith Ramachandran
-Paul Ramshaw
 Dhushyanth Ramasamy
 Ashwin Ramaswami
 Jeff Ramnani
 Grant Ramsay
+Paul Ramshaw
 Bayard Randel
 Varpu Rantala
 Brodie Rao

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -29,7 +29,7 @@ Anjani Agrawal
 Pablo S. Blum de Aguiar
 Jim Ahlstrom
 Farhan Ahmad
-Matthew Ahrens
+Matthew Ahrensq
 Nir Aides
 Akira
 Ege Akman
@@ -1534,6 +1534,7 @@ Kirill (python273) R.
 Abhilash Raj
 Shorya Raj
 Ajith Ramachandran
+Paul Ramshaw
 Dhushyanth Ramasamy
 Ashwin Ramaswami
 Jeff Ramnani

--- a/Misc/NEWS.d/next/Library/2025-09-28-12-52-40.gh-issue-99453.qJBIf-.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-28-12-52-40.gh-issue-99453.qJBIf-.rst
@@ -1,0 +1,2 @@
+**http.cookiejar**: Netscape/Mozilla cookie files with malformed lines now
+raise :exc:`LoadError` instead of an uncaught :exc:`ValueError`.

--- a/Misc/NEWS.d/next/Library/2025-09-28-12-52-40.gh-issue-99453.qJBIf-.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-28-12-52-40.gh-issue-99453.qJBIf-.rst
@@ -1,2 +1,2 @@
 **http.cookiejar**: Netscape/Mozilla cookie files with malformed lines now
-raise :exc:`LoadError` instead of an uncaught :exc:`ValueError`.
+raise LoadError instead of an uncaught ValueError.

--- a/Misc/NEWS.d/next/Library/2025-09-28-12-52-40.gh-issue-99453.qJBIf-.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-28-12-52-40.gh-issue-99453.qJBIf-.rst
@@ -1,2 +1,4 @@
-**http.cookiejar**: Netscape/Mozilla cookie files with malformed lines now
-raise LoadError instead of an uncaught ValueError.
+:mod:`http.cookiejar`: loading malformed Netscape/Mozilla cookie files
+by :meth:`MozillaCookieJar.load <http.cookiejar.FileCookieJar.load>`
+now raise a :exc:`~http.cookiejar.LoadError` instead of an uncaught
+:exc:`ValueError`.


### PR DESCRIPTION
Fixes gh-99453.

Malformed Netscape/Mozilla cookie lines previously raised a ValueError and triggered an "http.cookiejar bug!" warning. This change validates that cookie lines contain 7 fields and raises LoadError for malformed lines.