### PR TITLE
gh-139424: microoptimize _collections_abc._check_methods

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -106,11 +106,11 @@ del _ag
 ### ONE-TRICK PONIES ###
 
 def _check_methods(C, *methods):
-    mro = C.__mro__
+    mro_dicts = [B.__dict__ for B in C.__mro__]
     for method in methods:
-        for B in mro:
-            if method in B.__dict__:
-                if B.__dict__[method] is None:
+        for base_dict in mro_dicts:
+            if method in base_dict:
+                if base_dict[method] is None:
                     return NotImplemented
                 break
         else:


### PR DESCRIPTION
We can reduce the number of attribute lookups requried here. 

I also think we can speed it up a little bit more if we make `methods` arg a packed tuple instead of an unpacked one since we can bypass the additional tuple creation at the time of each call

Seeking input on that before I implement the same, I'm not 100% certain this internal function is safe to change.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139424 -->
* Issue: gh-139424
<!-- /gh-issue-number -->
