### PR TITLE
GH-123299: Copyedit 3.14 What's New: CPython bytecode changes

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1102,11 +1102,6 @@ iterations of the loop.
    Pushes ``co_consts[consti]`` onto the stack.
 
 
-.. opcode:: LOAD_CONST_IMMORTAL (consti)
-
-   Works as :opcode:`LOAD_CONST`, but is more efficient for immortal objects.
-
-
 .. opcode:: LOAD_SMALL_INT (i)
 
    Pushes the integer ``i`` onto the stack.
@@ -1968,14 +1963,20 @@ but are replaced by real opcodes or removed before bytecode is generated.
    Marks the end of the code block associated with the last ``SETUP_FINALLY``,
    ``SETUP_CLEANUP`` or ``SETUP_WITH``.
 
+
+.. opcode:: LOAD_CONST_IMMORTAL (consti)
+
+   Works as :opcode:`LOAD_CONST`, but is more efficient for immortal objects.
+
+
 .. opcode:: JUMP
-.. opcode:: JUMP_NO_INTERRUPT
+            JUMP_NO_INTERRUPT
 
    Undirected relative jump instructions which are replaced by their
    directed (forward/backward) counterparts by the assembler.
 
 .. opcode:: JUMP_IF_TRUE
-.. opcode:: JUMP_IF_FALSE
+            JUMP_IF_FALSE
 
    Conditional jumps which do not impact the stack. Replaced by the sequence
    ``COPY 1``, ``TO_BOOL``, ``POP_JUMP_IF_TRUE/FALSE``.
@@ -1989,12 +1990,6 @@ but are replaced by real opcodes or removed before bytecode is generated.
 
    .. versionchanged:: 3.13
       This opcode is now a pseudo-instruction.
-
-
-.. opcode:: LOAD_METHOD
-
-   Optimized unbound method lookup. Emitted as a ``LOAD_ATTR`` opcode
-   with a flag set in the arg.
 
 
 .. _opcode_collections:

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1964,11 +1964,6 @@ but are replaced by real opcodes or removed before bytecode is generated.
    ``SETUP_CLEANUP`` or ``SETUP_WITH``.
 
 
-.. opcode:: LOAD_CONST_IMMORTAL (consti)
-
-   Works as :opcode:`LOAD_CONST`, but is more efficient for immortal objects.
-
-
 .. opcode:: JUMP
             JUMP_NO_INTERRUPT
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1642,7 +1642,7 @@ iterations of the loop.
 
    Pushes a ``NULL`` to the stack.
    Used in the call sequence to match the ``NULL`` pushed by
-   :opcode:`LOAD_METHOD` for non-method calls.
+   :opcode:`!LOAD_METHOD` for non-method calls.
 
    .. versionadded:: 3.11
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2800,8 +2800,78 @@ Deprecated
 CPython bytecode changes
 ========================
 
-* Replaced the opcode ``BINARY_SUBSCR`` by :opcode:`BINARY_OP` with oparg ``NB_SUBSCR``.
+* Replaced the opcode :opcode:`!BINARY_SUBSCR` by :opcode:`BINARY_OP`
+  with oparg ``NB_SUBSCR``.
   (Contributed by Irit Katriel in :gh:`100239`.)
+
+* Add the :opcode:`BUILD_INTERPOLATION` & :opcode:`BUILD_TEMPLATE`
+  opcodes to construct new :class:`~string.templatelib.Interpolation`
+  and :class:`~string.templatelib.Template` instances, respectively.
+  (Contributed by Lysandros Nikolaou and others in :gh:`132661`;
+  see also :ref:`PEP 750: Template strings <whatsnew314-pep750>`).
+
+* Remove the :opcode:`!BUILD_CONST_KEY_MAP` opcode.
+  Use :opcode:`BUILD_MAP` instead.
+  (Contributed by Mark Shannon in :gh:`122160`.)
+
+* Replace the :opcode:`!LOAD_ASSERTION_ERROR` opcode with
+  :opcode:`LOAD_COMMON_CONSTANT` and add support for loading
+  :exc:`NotImplementedError`.
+
+* Add the :opcode:`LOAD_FAST_BORROW` & :opcode:`LOAD_FAST_BORROW_LOAD_FAST_BORROW`
+  opcodes to reduce reference counting overhead when the interpreter can prove
+  that the reference in the frame outlives the reference loaded onto the stack.
+  (Contributed by Matt Page in :gh:`130704`.)
+
+* Add the :opcode:`LOAD_SMALL_INT`  opcode, which pushes a small integer
+  equal to the ``oparg`` to the stack.
+  The :opcode:`!RETURN_CONST` opcode is removed as it is no longer used.
+  (Contributed by Mark Shannon in :gh:`125837`.)
+
+* Add the new :opcode:`LOAD_SPECIAL` instruction.
+  Generate code for :keyword:`with` and :keyword:`async with` statements
+  using the new instruction.
+  Removed the :opcode:`!BEFORE_WITH` and :opcode:`!BEFORE_ASYNC_WITH` instructions.
+  (Contributed by Mark Shannon in :gh:`120507`.)
+
+* Add the :opcode:`POP_ITER` opcode to support 'virtual' iterators.
+  (Contributed by Mark Shannon in :gh:`132554`.)
+
+Pseudo-instructions
+-------------------
+
+* Add the :opcode:`!ANNOTATIONS_PLACEHOLDER` pseudo instruction
+  to support partially executed module-level annotations with
+  :ref:`deferred evaluation of annotations <whatsnew314-pep649>`.
+  (Contributed by Jelle Zijlstra in :gh:`130907`.)
+
+* Add the :opcode:`BINARY_OP_EXTEND` pseudo instruction,
+  which executes a pair of functions (guard and specialization functions)
+  accessed from the inline cache.
+  (Contributed by Irit Katriel in :gh:`100239`.)
+
+* Add three specialisations for :opcode:`CALL_KW`;
+  :opcode:`!CALL_KW_PY` for calls to Python functions,
+  :opcode:`!CALL_KW_BOUND_METHOD` for calls to bound methods, and
+  :opcode:`!CALL_KW_NON_PY` for all other calls.
+  (Contributed by Mark Shannon in :gh:`118093`.)
+
+* Add the :opcode:`JUMP_IF_TRUE` and :opcode:`JUMP_IF_FALSE` pseudo instructions,
+  conditional jumps which do not impact the stack.
+  Replaced by the sequence ``COPY 1``, ``TO_BOOL``, ``POP_JUMP_IF_TRUE/FALSE``.
+  (Contributed by Irit Katriel in :gh:`124285`.)
+
+* Add the :opcode:`LOAD_CONST_MORTAL` pseudo instruction.
+  (Contributed by Mark Shannon in :gh:`128685`.)
+
+* Add the :opcode:`LOAD_CONST_IMMORTAL` pseudo instruction,
+  which does the same as :opcode:`!LOAD_CONST`, but is more efficient
+  for immortal objects.
+  (Contributed by Mark Shannon in :gh:`125837`.)
+
+* Add the :opcode:`NOT_TAKEN` pseudo instruction, used by :mod:`sys.monitoring`
+  to record branch events (i.e. :monitoring-event:`BRANCH_LEFT`).
+  (Contributed by Mark Shannon in :gh:`122548`.)
 
 
 C API changes

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2800,8 +2800,8 @@ Deprecated
 CPython bytecode changes
 ========================
 
-* Replaced the opcode :opcode:`!BINARY_SUBSCR` by :opcode:`BINARY_OP`
-  with oparg ``NB_SUBSCR``.
+* Replaced the opcode :opcode:`!BINARY_SUBSCR` by the :opcode:`BINARY_OP`
+  opcode with the ``NB_SUBSCR`` oparg.
   (Contributed by Irit Katriel in :gh:`100239`.)
 
 * Add the :opcode:`BUILD_INTERPOLATION` & :opcode:`BUILD_TEMPLATE`

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2870,7 +2870,7 @@ Pseudo-instructions
   (Contributed by Mark Shannon in :gh:`125837`.)
 
 * Add the :opcode:`NOT_TAKEN` pseudo instruction, used by :mod:`sys.monitoring`
-  to record branch events (i.e. :monitoring-event:`BRANCH_LEFT`).
+  to record branch events (such as :monitoring-event:`BRANCH_LEFT`).
   (Contributed by Mark Shannon in :gh:`122548`.)
 
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2864,7 +2864,7 @@ Pseudo-instructions
 * Add the :opcode:`LOAD_CONST_MORTAL` pseudo instruction.
   (Contributed by Mark Shannon in :gh:`128685`.)
 
-* Add the :opcode:`LOAD_CONST_IMMORTAL` pseudo instruction,
+* Add the :opcode:`!LOAD_CONST_IMMORTAL` pseudo instruction,
   which does the same as :opcode:`!LOAD_CONST`, but is more efficient
   for immortal objects.
   (Contributed by Mark Shannon in :gh:`125837`.)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2845,7 +2845,7 @@ Pseudo-instructions
   :ref:`deferred evaluation of annotations <whatsnew314-pep649>`.
   (Contributed by Jelle Zijlstra in :gh:`130907`.)
 
-* Add the :opcode:`BINARY_OP_EXTEND` pseudo instruction,
+* Add the :opcode:`!BINARY_OP_EXTEND` pseudo instruction,
   which executes a pair of functions (guard and specialization functions)
   accessed from the inline cache.
   (Contributed by Irit Katriel in :gh:`100239`.)
@@ -2861,7 +2861,7 @@ Pseudo-instructions
   Replaced by the sequence ``COPY 1``, ``TO_BOOL``, ``POP_JUMP_IF_TRUE/FALSE``.
   (Contributed by Irit Katriel in :gh:`124285`.)
 
-* Add the :opcode:`LOAD_CONST_MORTAL` pseudo instruction.
+* Add the :opcode:`!LOAD_CONST_MORTAL` pseudo instruction.
   (Contributed by Mark Shannon in :gh:`128685`.)
 
 * Add the :opcode:`!LOAD_CONST_IMMORTAL` pseudo instruction,

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2804,7 +2804,7 @@ CPython bytecode changes
   opcode with the ``NB_SUBSCR`` oparg.
   (Contributed by Irit Katriel in :gh:`100239`.)
 
-* Add the :opcode:`BUILD_INTERPOLATION` & :opcode:`BUILD_TEMPLATE`
+* Add the :opcode:`BUILD_INTERPOLATION` and :opcode:`BUILD_TEMPLATE`
   opcodes to construct new :class:`~string.templatelib.Interpolation`
   and :class:`~string.templatelib.Template` instances, respectively.
   (Contributed by Lysandros Nikolaou and others in :gh:`132661`;
@@ -2818,12 +2818,12 @@ CPython bytecode changes
   :opcode:`LOAD_COMMON_CONSTANT` and add support for loading
   :exc:`NotImplementedError`.
 
-* Add the :opcode:`LOAD_FAST_BORROW` & :opcode:`LOAD_FAST_BORROW_LOAD_FAST_BORROW`
+* Add the :opcode:`LOAD_FAST_BORROW` and :opcode:`LOAD_FAST_BORROW_LOAD_FAST_BORROW`
   opcodes to reduce reference counting overhead when the interpreter can prove
   that the reference in the frame outlives the reference loaded onto the stack.
   (Contributed by Matt Page in :gh:`130704`.)
 
-* Add the :opcode:`LOAD_SMALL_INT`  opcode, which pushes a small integer
+* Add the :opcode:`LOAD_SMALL_INT` opcode, which pushes a small integer
   equal to the ``oparg`` to the stack.
   The :opcode:`!RETURN_CONST` opcode is removed as it is no longer used.
   (Contributed by Mark Shannon in :gh:`125837`.)
@@ -2850,7 +2850,7 @@ Pseudo-instructions
   accessed from the inline cache.
   (Contributed by Irit Katriel in :gh:`100239`.)
 
-* Add three specialisations for :opcode:`CALL_KW`;
+* Add three specializations for :opcode:`CALL_KW`;
   :opcode:`!CALL_KW_PY` for calls to Python functions,
   :opcode:`!CALL_KW_BOUND_METHOD` for calls to bound methods, and
   :opcode:`!CALL_KW_NON_PY` for all other calls.

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2483,7 +2483,7 @@ avoiding possible problems use new functions :c:func:`PySlice_Unpack` and
 CPython bytecode changes
 ------------------------
 
-There are two new opcodes: :opcode:`LOAD_METHOD` and :opcode:`!CALL_METHOD`.
+There are two new opcodes: :opcode:`!LOAD_METHOD` and :opcode:`!CALL_METHOD`.
 (Contributed by Yury Selivanov and INADA Naoki in :issue:`26110`.)
 
 The :opcode:`!STORE_ANNOTATION` opcode has been removed.

--- a/Misc/NEWS.d/3.14.0a2.rst
+++ b/Misc/NEWS.d/3.14.0a2.rst
@@ -1400,7 +1400,7 @@ The :class:`memoryview` type now supports subscription, making it a
 .. nonce: KlCdgD
 .. section: Core and Builtins
 
-Adds :opcode:`LOAD_SMALL_INT` and :opcode:`LOAD_CONST_IMMORTAL`
+Adds :opcode:`LOAD_SMALL_INT` and :opcode:`!LOAD_CONST_IMMORTAL`
 instructions. ``LOAD_SMALL_INT`` pushes a small integer equal to the
 ``oparg`` to the stack. ``LOAD_CONST_IMMORTAL`` does the same as
 ``LOAD_CONST`` but is more efficient for immortal objects. Removes


### PR DESCRIPTION
References are a bit wonky as bytecodes change so frequently. I hope to work with Mark et al on autogenerated bytecode documentation so that this is an easier process for 3.15, it has been somewhat challenging for this cycle!

A

<!-- gh-issue-number: gh-123299 -->
* Issue: gh-123299
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139402.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->