### PR TITLE
gh-139400: Make sure that parent parsers outlive their subparsers in `pyexpat`

### DIFF
--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -773,7 +773,7 @@ class ForeignDTDTests(unittest.TestCase):
 
 class ParentParserLifetimeTest(unittest.TestCase):
     """
-    Subparser make use of the parent XML_Parser inside of Expat.
+    Subparsers make use of their parent XML_Parser inside of Expat.
     As a result, parent parsers need to outlive subparsers.
     Regression test for issue 139400
     """

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -779,13 +779,38 @@ class ParentParserLifetimeTest(unittest.TestCase):
     See https://github.com/python/cpython/issues/139400.
     """
 
-    def test_parent_parser_outlives_its_subparsers(self):
+    def test_parent_parser_outlives_its_subparsers__single(self):
         parser = expat.ParserCreate()
         subparser = parser.ExternalEntityParserCreate(None)
 
         # Now try to cause garbage collection of the parent parser
         # while it's still being referenced by a related subparser
         del parser
+
+    def test_parent_parser_outlives_its_subparsers__multiple(self):
+        parser = expat.ParserCreate()
+        subparser_one = parser.ExternalEntityParserCreate(None)
+        subparser_two = parser.ExternalEntityParserCreate(None)
+
+        # Now try to cause garbage collection of the parent parser
+        # while it's still being referenced by a related subparser
+        del parser
+
+    def test_parent_parser_outlives_its_subparsers__chain(self):
+        parser = expat.ParserCreate()
+        subparser = parser.ExternalEntityParserCreate(None)
+        subsubparser = subparser.ExternalEntityParserCreate(None)
+
+        # Now try to cause garbage collection of the parent parsers
+        # while they are still being referenced by a related subparser
+        del parser
+        del subparser
+
+    def test_cycle(self):
+        parser = expat.ParserCreate()
+        subparser = parser.ExternalEntityParserCreate(None)
+        parser.StartElementHandler = lambda _1, _2: subparser
+        parser.Parse('<doc/>', True)
 
 
 class ReparseDeferralTest(unittest.TestCase):

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -778,6 +778,7 @@ class ParentParserLifetimeTest(unittest.TestCase):
 
     See https://github.com/python/cpython/issues/139400.
     """
+
     def test_parent_parser_outlives_its_subparsers(self):
         parser = expat.ParserCreate()
         subparser = parser.ExternalEntityParserCreate(None)

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -784,7 +784,7 @@ class ParentParserLifetimeTest(unittest.TestCase):
         subparser = parser.ExternalEntityParserCreate(None)
 
         # Now try to cause garbage collection of the parent parser
-        # while it's still being referenced by a related subparser
+        # while it's still being referenced by a related subparser.
         del parser
 
     def test_parent_parser_outlives_its_subparsers__multiple(self):
@@ -793,7 +793,7 @@ class ParentParserLifetimeTest(unittest.TestCase):
         subparser_two = parser.ExternalEntityParserCreate(None)
 
         # Now try to cause garbage collection of the parent parser
-        # while it's still being referenced by a related subparser
+        # while it's still being referenced by a related subparser.
         del parser
 
     def test_parent_parser_outlives_its_subparsers__chain(self):
@@ -802,7 +802,7 @@ class ParentParserLifetimeTest(unittest.TestCase):
         subsubparser = subparser.ExternalEntityParserCreate(None)
 
         # Now try to cause garbage collection of the parent parsers
-        # while they are still being referenced by a related subparser
+        # while they are still being referenced by a related subparser.
         del parser
         del subparser
 

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -3,7 +3,6 @@
 
 import abc
 import functools
-import gc
 import os
 import re
 import sys

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -775,7 +775,8 @@ class ParentParserLifetimeTest(unittest.TestCase):
     """
     Subparsers make use of their parent XML_Parser inside of Expat.
     As a result, parent parsers need to outlive subparsers.
-    Regression test for issue 139400
+
+    See https://github.com/python/cpython/issues/139400.
     """
     def test_parent_parser_outlives_its_subparsers(self):
         parser = expat.ParserCreate()

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -807,22 +807,6 @@ class ParentParserLifetimeTest(unittest.TestCase):
         del parser
         del subparser
 
-    def test_cycle(self):
-        parser = expat.ParserCreate()
-        subparser = parser.ExternalEntityParserCreate(None)
-
-        # This hacks a cycle onto it; note that parsing now would not work.
-        parser.CharacterDataHandler = subparser
-
-        # This self-tests that the cycle is real.
-        self.assertIn(parser, gc.get_referents(subparser))
-        self.assertIn(subparser, gc.get_referents(parser))
-
-        # Now try to cause garbage collection of the parent parsers
-        # while they are still being referenced by a related subparser.
-        del parser
-        del subparser
-
 
 class ReparseDeferralTest(unittest.TestCase):
     def test_getter_setter_round_trip(self):

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -771,6 +771,21 @@ class ForeignDTDTests(unittest.TestCase):
         self.assertEqual(handler_call_args, [("bar", "baz")])
 
 
+class ParentParserLifetimeTest(unittest.TestCase):
+    """
+    Subparser make use of the parent XML_Parser inside of Expat.
+    As a result, parent parsers need to outlive subparsers.
+    Regression test for issue 139400
+    """
+    def test_parent_parser_outlives_its_subparsers(self):
+        parser = expat.ParserCreate()
+        subparser = parser.ExternalEntityParserCreate(None)
+
+        # Now try to cause garbage collection of the parent parser
+        # while it's still being referenced by a related subparser
+        del parser
+
+
 class ReparseDeferralTest(unittest.TestCase):
     def test_getter_setter_round_trip(self):
         parser = expat.ParserCreate()

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -811,10 +811,10 @@ class ParentParserLifetimeTest(unittest.TestCase):
         parser = expat.ParserCreate()
         subparser = parser.ExternalEntityParserCreate(None)
 
-        # Hack a cycle onto it; note that parsing now would not work.
+        # This hacks a cycle onto it; note that parsing now would not work.
         parser.CharacterDataHandler = subparser
 
-        # Self-test that the cycle is real
+        # This self-tests that the cycle is real.
         self.assertIn(parser, gc.get_referents(subparser))
         self.assertIn(subparser, gc.get_referents(parser))
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-29-00-01-28.gh-issue-139400.X2T-jO.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-29-00-01-28.gh-issue-139400.X2T-jO.rst
@@ -1,3 +1,4 @@
-Make sure that parent Expat parsers are only garbage-collected once they are
-no longer being referenced by subparsers.
-(Bugfix contributed by Sebastian Pipping)
+:mod:`xml.parsers.expat`: Make sure that parent Expat parsers are only
+garbage-collected once they are no longer referenced by subparsers created
+by :meth:`~xml.parsers.expat.xmlparser.ExternalEntityParserCreate`.
+Patch by Sebastian Pipping.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-29-00-01-28.gh-issue-139400.X2T-jO.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-29-00-01-28.gh-issue-139400.X2T-jO.rst
@@ -1,0 +1,3 @@
+Make sure that parent Expat parsers are only garbage-collected once they are
+no longer being referenced by subparsers.
+(Bugfix contributed by Sebastian Pipping)

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1549,9 +1549,7 @@ xmlparse_dealloc(PyObject *op)
         XML_ParserFree(self->itself);
     }
     self->itself = NULL;
-    if (self->parent != NULL) {
-        Py_CLEAR(self->parent);
-    }
+    Py_CLEAR(self->parent);
 
     if (self->handlers != NULL) {
         PyMem_Free(self->handlers);

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -76,7 +76,15 @@ typedef struct {
     PyObject_HEAD
 
     XML_Parser itself;
-    PyObject *parent;           /* Parent xmlparseobject (for ref counting) */
+    /*
+     * Strong reference to a parent `xmlparseobject` if this parser
+     * is a child parser. Set to NULL if this parser is a root parser.
+     * This is needed to keep the parent parser alive as long as it has
+     * at least one child parser.
+     *
+     * See https://github.com/python/cpython/issues/139400 for details.
+     */
+    PyObject *parent;
     int ordered_attributes;     /* Return attributes as a list. */
     int specified_attributes;   /* Report only specified attributes. */
     int in_callback;            /* Is a callback active? */

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -76,7 +76,7 @@ typedef struct xmlparseobject {
     PyObject_HEAD
 
     XML_Parser itself;
-    struct xmlparseobject * parent;
+    struct xmlparseobject *parent;
     int ordered_attributes;     /* Return attributes as a list. */
     int specified_attributes;   /* Report only specified attributes. */
     int in_callback;            /* Is a callback active? */

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1545,6 +1545,11 @@ xmlparse_clear(PyObject *op)
     xmlparseobject *self = xmlparseobject_CAST(op);
     clear_handlers(self, 0);
     Py_CLEAR(self->intern);
+    // NOTE: We cannot call Py_CLEAR(self->parent) prior to calling
+    //       XML_ParserFree(self->itself) or a subparser (created via
+    //       XML_ExternalEntityParserCreate could lose its parent XML_Parser
+    //       while still making use of it internally.
+    //       https://github.com/python/cpython/issues/139400
     return 0;
 }
 

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1526,6 +1526,7 @@ xmlparse_traverse(PyObject *op, visitproc visit, void *arg)
     for (size_t i = 0; handler_info[i].name != NULL; i++) {
         Py_VISIT(self->handlers[i]);
     }
+    Py_VISIT(self->parent);
     Py_VISIT(Py_TYPE(op));
     return 0;
 }

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -72,11 +72,11 @@ pyexpat_get_state(PyObject *module)
 
 /* Declarations for objects of type xmlparser */
 
-typedef struct xmlparseobject {
+typedef struct {
     PyObject_HEAD
 
     XML_Parser itself;
-    struct xmlparseobject *parent;
+    PyObject *parent;           /* Parent xmlparseobject (for ref counting) */
     int ordered_attributes;     /* Return attributes as a list. */
     int specified_attributes;   /* Report only specified attributes. */
     int in_callback;            /* Is a callback active? */
@@ -1080,7 +1080,7 @@ pyexpat_xmlparser_ExternalEntityParserCreate_impl(xmlparseobject *self,
     new_parser->ns_prefixes = self->ns_prefixes;
     new_parser->itself = XML_ExternalEntityParserCreate(self->itself, context,
                                                         encoding);
-    new_parser->parent = self;
+    new_parser->parent = (PyObject *)self;
     new_parser->handlers = 0;
     new_parser->intern = Py_XNewRef(self->intern);
 

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -72,11 +72,11 @@ pyexpat_get_state(PyObject *module)
 
 /* Declarations for objects of type xmlparser */
 
-typedef struct xmlparseobject_ {
+typedef struct xmlparseobject {
     PyObject_HEAD
 
     XML_Parser itself;
-    struct xmlparseobject_ * parent;
+    struct xmlparseobject * parent;
     int ordered_attributes;     /* Return attributes as a list. */
     int specified_attributes;   /* Report only specified attributes. */
     int in_callback;            /* Is a callback active? */

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1546,9 +1546,8 @@ xmlparse_clear(PyObject *op)
     clear_handlers(self, 0);
     Py_CLEAR(self->intern);
     // NOTE: We cannot call Py_CLEAR(self->parent) prior to calling
-    //       XML_ParserFree(self->itself) or a subparser (created via
-    //       XML_ExternalEntityParserCreate could lose its parent XML_Parser
-    //       while still making use of it internally.
+    //       XML_ParserFree(self->itself), or a subparser could lose its parent
+    //       XML_Parser while still making use of it internally.
     //       https://github.com/python/cpython/issues/139400
     return 0;
 }

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1550,8 +1550,7 @@ xmlparse_dealloc(PyObject *op)
     }
     self->itself = NULL;
     if (self->parent != NULL) {
-        Py_DECREF(self->parent);
-        self->parent = NULL;
+        Py_CLEAR(self->parent);
     }
 
     if (self->handlers != NULL) {


### PR DESCRIPTION
CC @picnixz 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139400 -->
* Issue: gh-139400
<!-- /gh-issue-number -->
