### PR TITLE
GH-139416: Fix portability of sendfile(2) support detection for Lustre filesystems

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -218,14 +218,15 @@ def _fastcopy_sendfile(fsrc, fdst):
                 # ENODATA.
                 _USE_CP_SENDFILE = False
 
+                # 'infd' and 'outfd' are assumed to be seekable, as
+                # they are checked to be "regular" files.
                 dstpos = os.lseek(outfd, 0, os.SEEK_CUR)
                 if dstpos > 0:
                     # Some data has already been written but we use
                     # sendfile in a mode that does not update the
                     # input fd position when reading. Hence seek the
                     # input fd to the correct position before falling
-                    # back on POSIX read/write method. Since sendfile
-                    # requires mmapable infd, it should also be seekable
+                    # back on POSIX read/write method. 
                     os.lseek(infd, dstpos, os.SEEK_SET)
 
                 raise _GiveupOnFastCopy(err)

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -213,6 +213,12 @@ def _fastcopy_sendfile(fsrc, fdst):
                 _USE_CP_SENDFILE = False
                 raise _GiveupOnFastCopy(err)
 
+            if err.errno == errno.ENODATA:
+                # In rare cases sendfile() on Linux Lsture call
+                # returns ENODATA.
+                _USE_CP_SENDFILE = False
+                raise _GiveupOnFastCopy(err)
+
             if err.errno == errno.ENOSPC:  # filesystem is full
                 raise err from None
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -223,7 +223,7 @@ def _fastcopy_sendfile(fsrc, fdst):
                     # input fd to the correct position before falling
                     # back on POSIX read/write method
                     os.lseek(infd, dstpos, os.SEEK_SET)
-                    
+
                 raise _GiveupOnFastCopy(err)
 
             if err.errno == errno.ENOSPC:  # filesystem is full

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -206,16 +206,12 @@ def _fastcopy_sendfile(fsrc, fdst):
             err.filename = fsrc.name
             err.filename2 = fdst.name
 
-            if err.errno == errno.ENOTSOCK:
-                # sendfile() on this platform (probably Linux < 2.6.33)
-                # does not support copies between regular files (only
-                # sockets).
-                _USE_CP_SENDFILE = False
-                raise _GiveupOnFastCopy(err)
-
-            if err.errno == errno.ENODATA:
-                # In rare cases sendfile() on Linux Lsture call
-                # returns ENODATA.
+            if err.errno in (errno.ENOTSOCK, errno.ENODATA):
+                # ENOTSOCK: sendfile() on this platform (probably
+                # Linux < 2.6.33) does not support copies between
+                # regular files (only sockets).
+                # ENODATA: In rare cases sendfile() on Linux Lustre call
+                # returns ENODATA
                 _USE_CP_SENDFILE = False
                 raise _GiveupOnFastCopy(err)
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -224,7 +224,8 @@ def _fastcopy_sendfile(fsrc, fdst):
                     # sendfile in a mode that does not update the
                     # input fd position when reading. Hence seek the
                     # input fd to the correct position before falling
-                    # back on POSIX read/write method
+                    # back on POSIX read/write method. Since sendfile
+                    # requires mmapable infd, it should also be seekable
                     os.lseek(infd, dstpos, os.SEEK_SET)
 
                 raise _GiveupOnFastCopy(err)

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -207,9 +207,9 @@ def _fastcopy_sendfile(fsrc, fdst):
             err.filename2 = fdst.name
 
             if err.errno == errno.ENOTSOCK:
-                # ENOTSOCK: sendfile() on this platform (probably
-                # Linux < 2.6.33) does not support copies between
-                # regular files (only sockets).
+                # sendfile() on this platform (probably Linux < 2.6.33)
+                # does not support copies between regular files (only
+                # sockets).
                 _USE_CP_SENDFILE = False
                 raise _GiveupOnFastCopy(err)
 
@@ -227,7 +227,7 @@ def _fastcopy_sendfile(fsrc, fdst):
                     # back on POSIX read/write method
                     os.lseek(infd, dstpos, os.SEEK_SET)
 
-                raise _GiveupOnFastCopy(err)            
+                raise _GiveupOnFastCopy(err)
 
             if err.errno == errno.ENOSPC:  # filesystem is full
                 raise err from None

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -226,7 +226,7 @@ def _fastcopy_sendfile(fsrc, fdst):
                     # sendfile in a mode that does not update the
                     # input fd position when reading. Hence seek the
                     # input fd to the correct position before falling
-                    # back on POSIX read/write method. 
+                    # back on POSIX read/write method.
                     os.lseek(infd, dstpos, os.SEEK_SET)
 
                 raise _GiveupOnFastCopy(err)

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -210,8 +210,9 @@ def _fastcopy_sendfile(fsrc, fdst):
                 # ENOTSOCK: sendfile() on this platform (probably
                 # Linux < 2.6.33) does not support copies between
                 # regular files (only sockets).
-                # ENODATA: In rare cases sendfile() on Linux Lustre call
-                # returns ENODATA
+                #
+                # ENODATA: In rare cases, sendfile() on Linux Lustre
+                # returns ENODATA.
                 _USE_CP_SENDFILE = False
                 raise _GiveupOnFastCopy(err)
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -206,13 +206,16 @@ def _fastcopy_sendfile(fsrc, fdst):
             err.filename = fsrc.name
             err.filename2 = fdst.name
 
-            if err.errno in (errno.ENOTSOCK, errno.ENODATA):
+            if err.errno == errno.ENOTSOCK:
                 # ENOTSOCK: sendfile() on this platform (probably
                 # Linux < 2.6.33) does not support copies between
                 # regular files (only sockets).
-                #
-                # ENODATA: In rare cases, sendfile() on Linux Lustre
-                # returns ENODATA.
+                _USE_CP_SENDFILE = False
+                raise _GiveupOnFastCopy(err)
+
+            if err.errno == errno.ENODATA:
+                # In rare cases, sendfile() on Linux Lustre returns
+                # ENODATA.
                 _USE_CP_SENDFILE = False
 
                 dstpos = os.lseek(outfd, 0, os.SEEK_CUR)
@@ -224,7 +227,7 @@ def _fastcopy_sendfile(fsrc, fdst):
                     # back on POSIX read/write method
                     os.lseek(infd, dstpos, os.SEEK_SET)
 
-                raise _GiveupOnFastCopy(err)
+                raise _GiveupOnFastCopy(err)            
 
             if err.errno == errno.ENOSPC:  # filesystem is full
                 raise err from None

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -214,6 +214,16 @@ def _fastcopy_sendfile(fsrc, fdst):
                 # ENODATA: In rare cases, sendfile() on Linux Lustre
                 # returns ENODATA.
                 _USE_CP_SENDFILE = False
+
+                dstpos = os.lseek(outfd, 0, os.SEEK_CUR)
+                if dstpos > 0:
+                    # Some data has already been written but we use
+                    # sendfile in a mode that does not update the
+                    # input fd position when reading. Hence seek the
+                    # input fd to the correct position before falling
+                    # back on POSIX read/write method
+                    os.lseek(infd, dstpos, os.SEEK_SET)
+                    
                 raise _GiveupOnFastCopy(err)
 
             if err.errno == errno.ENOSPC:  # filesystem is full

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -3399,8 +3399,6 @@ class TestZeroCopySendfile(_ZeroCopyFileLinuxTest, unittest.TestCase):
         shutil._USE_CP_SENDFILE = True
         assert flag
         self.assertEqual(read_file(TESTFN2, binary=True), self.FILEDATA)
-        
-            
 
 @unittest.skipUnless(shutil._USE_CP_COPY_FILE_RANGE, "os.copy_file_range() not supported")
 class TestZeroCopyCopyFileRange(_ZeroCopyFileLinuxTest, unittest.TestCase):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -3371,11 +3371,10 @@ class TestZeroCopySendfile(_ZeroCopyFileLinuxTest, unittest.TestCase):
         # traditional POSIX while preserving the position of where we
         # got to in writing
         def syscall(*args, **kwargs):
-            if not flag:
-                flag.append(None)
-                return orig_syscall(*args, **kwargs)
-            else:
+            if flag:
                 raise OSError(errno.ENODATA, "yo")
+            flag.append(None) 
+            return eval(self.PATCHPOINT)(*args, **kwargs)
 
         flag = []
         orig_syscall = eval(self.PATCHPOINT)

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -3373,7 +3373,7 @@ class TestZeroCopySendfile(_ZeroCopyFileLinuxTest, unittest.TestCase):
         def syscall(*args, **kwargs):
             if flag:
                 raise OSError(errno.ENODATA, "yo")
-            flag.append(None) 
+            flag.append(None)
             return eval(self.PATCHPOINT)(*args, **kwargs)
 
         flag = []

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -3390,7 +3390,7 @@ class TestZeroCopySendfile(_ZeroCopyFileLinuxTest, unittest.TestCase):
                         self.zerocopy_fun(src, dst)
 
             # Reset flag so that second syscall fails again
-            flag = []
+            flag.clear()
             with unittest.mock.patch(self.PATCHPOINT, create=True,
                                      side_effect=syscall) as m2:
                 shutil._USE_CP_SENDFILE = True

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -3392,7 +3392,7 @@ class TestZeroCopySendfile(_ZeroCopyFileLinuxTest, unittest.TestCase):
             # Reset flag so that second syscall fails again
             flag = []
             with unittest.mock.patch(self.PATCHPOINT, create=True,
-                                     side_effect=syscall) as m2:                        
+                                     side_effect=syscall) as m2:
                 shutil._USE_CP_SENDFILE = True
                 shutil.copyfile(TESTFN, TESTFN2)
                 assert m2.called

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -3395,7 +3395,7 @@ class TestZeroCopySendfile(_ZeroCopyFileLinuxTest, unittest.TestCase):
                                      side_effect=syscall) as m2:
                 shutil._USE_CP_SENDFILE = True
                 shutil.copyfile(TESTFN, TESTFN2)
-                assert m2.called
+                m2.assert_called()
         shutil._USE_CP_SENDFILE = True
         assert flag
         self.assertEqual(read_file(TESTFN2, binary=True), self.FILEDATA)

--- a/Misc/NEWS.d/next/Library/2025-09-29-14-30-00.gh-issue-139416.bnzz33.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-29-14-30-00.gh-issue-139416.bnzz33.rst
@@ -1,0 +1,3 @@
+:func:`shutil.copyfile`: Detect problem seen on Lustre filesystems
+giving "Errno 61" due to the sendfile(2) optimised implementation and
+fall back to the Posix standard read/write implementation.


### PR DESCRIPTION
On rare occasions shutil.copyfile fails when source file is on AWS Lustre implementation because the sendfile(2) syscall returns ENODATA. This patch works around this by disabling the sendfile(2) implementation in the same way as if sendfile(2) was not available. 


<!-- gh-issue-number: gh-139416 -->
* Issue: gh-139416
<!-- /gh-issue-number -->
