### PR TITLE
gh-139398: Make dir(Enum) include public _sunder_ helpers for REPL completions

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -773,31 +773,37 @@ class EnumType(type):
         super().__delattr__(attr)
 
     def __dir__(cls):
-    interesting = set([
-        '__class__', '__contains__', '__doc__', '__getitem__',
-        '__iter__', '__len__', '__members__', '__module__',
-        '__name__', '__qualname__',
-    ] + cls._member_names_)
+        interesting = set([
+                '__class__', '__contains__', '__doc__', '__getitem__',
+                '__iter__', '__len__', '__members__', '__module__',
+                '__name__', '__qualname__',
+                ]
+                + cls._member_names_
+                )
 
-    if cls._new_member_ is not object.__new__:
-        interesting.add('__new__')
-    if cls.__init_subclass__ is not object.__init_subclass__:
-        interesting.add('__init_subclass__')
+        if cls._new_member_ is not object.__new__:
+            interesting.add('__new__')
+        if cls.__init_subclass__ is not object.__init_subclass__:
+            interesting.add('__init_subclass__')
 
-    # SGP: Include documented public _sunder_ helpers defined on the Enum class.
-    # SGP: This makes them discoverable via dir(Enum) so rlcompleter can surface
-    # SGP: them in REPL completions. (rlcompleter drives dotted-name completion
-    # SGP: from dir(); _add_alias_/_add_value_alias_ are supported _sunder_ APIs.)
-    for _n in ("_add_alias_", "_add_value_alias_"):
-        if _n in cls.__dict__:
-            interesting.add(_n)
+        # SGP: Include documented public _sunder_ helpers defined on the Enum class.
+        # SGP: This makes them discoverable via dir(Enum) so rlcompleter can surface
+        # SGP: them in REPL completions. (rlcompleter drives dotted-name completion
+        # SGP: from dir(); _add_alias_/_add_value_alias_ are supported _sunder_ APIs.)
+        for _n in ("_add_alias_", "_add_value_alias_"):
+            if _n in cls.__dict__:
+                interesting.add(_n)
 
-    if cls._member_type_ is object:
-        return sorted(interesting)
-    else:
-        # return whatever mixed-in data type has
-        # SGP: union the mixin's dir() with 'interesting'
-        return sorted(set(dir(cls._member_type_)) | interesting)
+        if cls._member_type_ is object:
+            return sorted(interesting)
+        else:
+            # return whatever mixed-in data type has
+            # SGP: union the mixin's dir() with 'interesting'
+            return sorted(set(dir(cls._member_type_)) | interesting)
+    
+    
+
+    
 
     def __getitem__(cls, name):
         """

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -773,37 +773,31 @@ class EnumType(type):
         super().__delattr__(attr)
 
     def __dir__(cls):
-        interesting = set([
-                '__class__', '__contains__', '__doc__', '__getitem__',
-                '__iter__', '__len__', '__members__', '__module__',
-                '__name__', '__qualname__',
-                ]
-                + cls._member_names_
-                )
+    interesting = set([
+        '__class__', '__contains__', '__doc__', '__getitem__',
+        '__iter__', '__len__', '__members__', '__module__',
+        '__name__', '__qualname__',
+    ] + cls._member_names_)
 
-        if cls._new_member_ is not object.__new__:
-            interesting.add('__new__')
-        if cls.__init_subclass__ is not object.__init_subclass__:
-            interesting.add('__init_subclass__')
+    if cls._new_member_ is not object.__new__:
+        interesting.add('__new__')
+    if cls.__init_subclass__ is not object.__init_subclass__:
+        interesting.add('__init_subclass__')
 
-        # SGP: Include documented public _sunder_ helpers defined on the Enum class.
-        # SGP: This makes them discoverable via dir(Enum) so rlcompleter can surface
-        # SGP: them in REPL completions. (rlcompleter drives dotted-name completion
-        # SGP: from dir(); _add_alias_/_add_value_alias_ are supported _sunder_ APIs.)
-        for _n in ("_add_alias_", "_add_value_alias_"):
-            if _n in cls.__dict__:
-                interesting.add(_n)
+    # SGP: Include documented public _sunder_ helpers defined on the Enum class.
+    # SGP: This makes them discoverable via dir(Enum) so rlcompleter can surface
+    # SGP: them in REPL completions. (rlcompleter drives dotted-name completion
+    # SGP: from dir(); _add_alias_/_add_value_alias_ are supported _sunder_ APIs.)
+    for _n in ("_add_alias_", "_add_value_alias_"):
+        if _n in cls.__dict__:
+            interesting.add(_n)
 
-        if cls._member_type_ is object:
-            return sorted(interesting)
-        else:
-            # return whatever mixed-in data type has
-            # SGP: union the mixin's dir() with 'interesting'
-            return sorted(set(dir(cls._member_type_)) | interesting)
-    
-    
-
-    
+    if cls._member_type_ is object:
+        return sorted(interesting)
+    else:
+        # return whatever mixed-in data type has
+        # SGP: union the mixin's dir() with 'interesting'
+        return sorted(set(dir(cls._member_type_)) | interesting)
 
     def __getitem__(cls, name):
         """

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -773,22 +773,31 @@ class EnumType(type):
         super().__delattr__(attr)
 
     def __dir__(cls):
-        interesting = set([
-                '__class__', '__contains__', '__doc__', '__getitem__',
-                '__iter__', '__len__', '__members__', '__module__',
-                '__name__', '__qualname__',
-                ]
-                + cls._member_names_
-                )
-        if cls._new_member_ is not object.__new__:
-            interesting.add('__new__')
-        if cls.__init_subclass__ is not object.__init_subclass__:
-            interesting.add('__init_subclass__')
-        if cls._member_type_ is object:
-            return sorted(interesting)
-        else:
-            # return whatever mixed-in data type has
-            return sorted(set(dir(cls._member_type_)) | interesting)
+    interesting = set([
+        '__class__', '__contains__', '__doc__', '__getitem__',
+        '__iter__', '__len__', '__members__', '__module__',
+        '__name__', '__qualname__',
+    ] + cls._member_names_)
+
+    if cls._new_member_ is not object.__new__:
+        interesting.add('__new__')
+    if cls.__init_subclass__ is not object.__init_subclass__:
+        interesting.add('__init_subclass__')
+
+    # SGP: Include documented public _sunder_ helpers defined on the Enum class.
+    # SGP: This makes them discoverable via dir(Enum) so rlcompleter can surface
+    # SGP: them in REPL completions. (rlcompleter drives dotted-name completion
+    # SGP: from dir(); _add_alias_/_add_value_alias_ are supported _sunder_ APIs.)
+    for _n in ("_add_alias_", "_add_value_alias_"):
+        if _n in cls.__dict__:
+            interesting.add(_n)
+
+    if cls._member_type_ is object:
+        return sorted(interesting)
+    else:
+        # return whatever mixed-in data type has
+        # SGP: union the mixin's dir() with 'interesting'
+        return sorted(set(dir(cls._member_type_)) | interesting)
 
     def __getitem__(cls, name):
         """

--- a/Misc/NEWS.d/next/Library/2025-09-29-14-39-34.gh-issue-139398.tbFBKV.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-29-14-39-34.gh-issue-139398.tbFBKV.rst
@@ -1,0 +1,1 @@
+dir(Enum) now includes public _sunder_ helpers (_add_alias_, _add_value_alias_) for better REPL completion. (gh-139398)


### PR DESCRIPTION
…for REPL completions (gh-139398)

- I guess this enhances EnumType.__dir__ to include documented public _sunder_ helpers (_add_alias_, _add_value_alias_) if present on the Enum class
- I think this could enabrle rlcompleter and the REPL show completions for these supported helpers and matching the intent of the enum API docs...
- Normally I think no change to other (private or internal) _sunder_ names
- Fixes: gh-139398

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
