### PR TITLE
[3.11] gh-139436: Remove link to the PDF downloads (GH-139142)

### DIFF
--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -20,14 +20,6 @@ Python in one of various formats, follow one of links in this table.</p>
 
 <table class="docutils">
   <tr><th>Format</th><th>Packed as .zip</th><th>Packed as .tar.bz2</th></tr>
-  <tr><td>PDF (US-Letter paper size)</td>
-    <td><a href="{{ dlbase }}/python-{{ release }}-docs-pdf-letter.zip">Download</a> (ca. 13 MiB)</td>
-    <td><a href="{{ dlbase }}/python-{{ release }}-docs-pdf-letter.tar.bz2">Download</a> (ca. 13 MiB)</td>
-  </tr>
-  <tr><td>PDF (A4 paper size)</td>
-    <td><a href="{{ dlbase }}/python-{{ release }}-docs-pdf-a4.zip">Download</a> (ca. 13 MiB)</td>
-    <td><a href="{{ dlbase }}/python-{{ release }}-docs-pdf-a4.tar.bz2">Download</a> (ca. 13 MiB)</td>
-  </tr>
   <tr><td>HTML</td>
     <td><a href="{{ dlbase }}/python-{{ release }}-docs-html.zip">Download</a> (ca. 9 MiB)</td>
     <td><a href="{{ dlbase }}/python-{{ release }}-docs-html.tar.bz2">Download</a> (ca. 6 MiB)</td>
@@ -43,6 +35,13 @@ Python in one of various formats, follow one of links in this table.</p>
 </table>
 
 <p>These archives contain all the content in the documentation.</p>
+
+<p>{% trans %}
+We no longer provide pre-built PDFs of the documentation.
+To build a PDF archive, follow the instructions in the
+<a href="https://devguide.python.org/documentation/start-documenting/#building-the-documentation">Developer's Guide</a>
+and run <code>make dist-pdf</code> in the <code>Doc/</code> directory of a copy of the CPython repository.
+{% endtrans %}</p>
 
 
 <h2>Unpacking</h2>

--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -36,12 +36,17 @@ Python in one of various formats, follow one of links in this table.</p>
 
 <p>These archives contain all the content in the documentation.</p>
 
-<p>{% trans %}
-We no longer provide pre-built PDFs of the documentation.
+<p>
+We no longer provide updates to the pre-built PDFs of the documentation.
+The previously-built archives are still available and may be of use:
+<a href="{{ dlbase }}/python-{{ release }}-docs-pdf-a4.zip">A4 PDF (.zip archive)</a>;
+<a href="{{ dlbase }}/python-{{ release }}-docs-pdf-a4.tar.bz2">A4 PDF (.tar.bz2 archive)</a>;
+<a href="{{ dlbase }}/python-{{ release }}-docs-pdf-letter.zip">US-Letter PDF (.zip archive)</a>;
+<a href="{{ dlbase }}/python-{{ release }}-docs-pdf-letter.tar.bz2">US-Letter PDF (.tar.bz2 archive)</a>.
 To build a PDF archive, follow the instructions in the
 <a href="https://devguide.python.org/documentation/start-documenting/#building-the-documentation">Developer's Guide</a>
 and run <code>make dist-pdf</code> in the <code>Doc/</code> directory of a copy of the CPython repository.
-{% endtrans %}</p>
+</p>
 
 
 <h2>Unpacking</h2>


### PR DESCRIPTION
(cherry picked from commit 6b5f156)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139430.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-139436 -->
* Issue: gh-139436
<!-- /gh-issue-number -->
