### PR TITLE
gh-139436: Remove ``dist-pdf`` from the docsbuild-scripts rebuild target

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -184,7 +184,7 @@ venv:
 	fi
 
 .PHONY: dist-no-html
-dist-no-html: dist-text dist-pdf dist-epub dist-texinfo
+dist-no-html: dist-text dist-epub dist-texinfo
 
 .PHONY: dist
 dist:


### PR DESCRIPTION
This is waiting on the backports for 3.12/3.13 for the docs changes.

A

<!-- gh-issue-number: gh-139436 -->
* Issue: gh-139436
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139437.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->