### PR TITLE
gh-139116: Skip test_tracemalloc_track_race under ASAN

### DIFF
--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -1115,7 +1115,9 @@ class TestCAPI(unittest.TestCase):
     @threading_helper.requires_working_threading()
     # gh-128679: Test crash on a debug build (especially on FreeBSD).
     @unittest.skipIf(support.Py_DEBUG, 'need release build')
-    @support.skip_if_sanitizer('gh-131566: race when setting allocator', thread=True)
+    @support.skip_if_sanitizer(
+        'gh-131566, gh-139116: race when setting allocator/tracer',
+        thread=True, address=True)
     def test_tracemalloc_track_race(self):
         # gh-128679: Test fix for tracemalloc.stop() race condition
         _testcapi.tracemalloc_track_race()


### PR DESCRIPTION
This should make the buildbot green so it can detect *unknown* failures.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139116 -->
* Issue: gh-139116
<!-- /gh-issue-number -->
