### PR TITLE
gh-139116: tracemalloc: Detach thread state when acquiring tables_lock

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-30-14-57-19.gh-issue-139116.nlVf40.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-30-14-57-19.gh-issue-139116.nlVf40.rst
@@ -1,0 +1,2 @@
+Prevent a deadlock when multiple threads start, stop and use tracemalloc
+simultaneously.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-09-30-14-57-19.gh-issue-139116.nlVf40.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-09-30-14-57-19.gh-issue-139116.nlVf40.rst
@@ -1,2 +1,2 @@
-Prevent a deadlock when multiple threads start, stop and use tracemalloc
+Prevent a deadlock when multiple threads start, stop and use :mod:`tracemalloc`
 simultaneously.

--- a/Python/tracemalloc.c
+++ b/Python/tracemalloc.c
@@ -36,7 +36,7 @@ static int _PyTraceMalloc_TraceRef(PyObject *op, PyRefTracerEvent event,
    the GIL held from PyMem_RawFree(). It cannot acquire the lock because it
    would introduce a deadlock in _PyThreadState_DeleteCurrent(). */
 #define tables_lock _PyRuntime.tracemalloc.tables_lock
-#define TABLES_LOCK() PyMutex_LockFlags(&tables_lock, _PY_LOCK_DETACH)
+#define TABLES_LOCK() PyMutex_Lock(&tables_lock)
 #define TABLES_UNLOCK() PyMutex_Unlock(&tables_lock)
 
 

--- a/Python/tracemalloc.c
+++ b/Python/tracemalloc.c
@@ -36,7 +36,7 @@ static int _PyTraceMalloc_TraceRef(PyObject *op, PyRefTracerEvent event,
    the GIL held from PyMem_RawFree(). It cannot acquire the lock because it
    would introduce a deadlock in _PyThreadState_DeleteCurrent(). */
 #define tables_lock _PyRuntime.tracemalloc.tables_lock
-#define TABLES_LOCK() PyMutex_LockFlags(&tables_lock, _Py_LOCK_DONT_DETACH)
+#define TABLES_LOCK() PyMutex_LockFlags(&tables_lock, _PY_LOCK_DETACH)
 #define TABLES_UNLOCK() PyMutex_Unlock(&tables_lock)
 
 


### PR DESCRIPTION
This prevents a deadlock when:

- One thread is in `_PyTraceMalloc_Stop`, with `TABLES_LOCK` held, calling `PyRefTracer_SetTracer` which wants to stop the world
- Another is thread in `PyTraceMalloc_Track`, just attached thread state, waiting for `TABLES_LOCK`

Detaching the thread state while waiting for `TABLES_LOCK` allows `PyRefTracer_SetTracer` to stop the world.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139116 -->
* Issue: gh-139116
<!-- /gh-issue-number -->
