### PR TITLE
improve isolation of test_pending_call_creates_thread_subinterpreter

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1995,7 +1995,7 @@ class SubinterpreterTest(unittest.TestCase):
 
         def output():
             time.sleep(1)
-            print("x")
+            print("x", end="")
 
         def callback():
             threading.Thread(target=output).start()
@@ -2016,7 +2016,7 @@ class SubinterpreterTest(unittest.TestCase):
         """
         rc, out, err = assert_python_ok('-c', source)
         self.assertEqual(rc, 0)
-        self.assertEqual(out, b"x\n")
+        self.assertEqual(out, b"x")
         self.assertEqual(err, b"")
 
 

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1981,7 +1981,6 @@ class SubinterpreterTest(unittest.TestCase):
         self.assertEqual(main_attr_id, subinterp_attr_id)
 
     @threading_helper.requires_working_threading()
-    @unittest.skipUnless(hasattr(os, "pipe"), "requires os.pipe()")
     @requires_subinterpreters
     def test_pending_call_creates_thread_subinterpreter(self):
         # For better isolation, run the entire test in a different subprocess.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


For better isolation from the current runtime, run the test in a separate subprocess similarly to `test_pending_call_creates_thread`.