### PR TITLE
gh-139322: Remove redundant `test_os.Win32ErrorTests`

### DIFF
--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -4123,9 +4123,14 @@ class OSErrorTests(unittest.TestCase):
 
     def test_mkdir(self):
         filename = os_helper.TESTFN
+        subdir = os.path.join(filename, 'subdir')
+        self.assertRaises(FileNotFoundError, os.mkdir, subdir)
+
         self.addCleanup(os_helper.unlink, filename)
         create_file(filename)
         self.assertRaises(FileExistsError, os.mkdir, filename)
+
+        self.assertRaises(NotADirectoryError, os.mkdir, subdir)
 
 
 class CPUCountTests(unittest.TestCase):

--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -4080,6 +4080,7 @@ class OSErrorTests(unittest.TestCase):
             (self.filenames, os.listdir,),
             (self.filenames, os.rename, "dst"),
             (self.filenames, os.replace, "dst"),
+            (self.filenames, os.utime, None),
         ]
         if os_helper.can_chmod():
             funcs.append((self.filenames, os.chmod, 0o777))
@@ -4119,6 +4120,13 @@ class OSErrorTests(unittest.TestCase):
                     pass
                 else:
                     self.fail(f"No exception thrown by {func}")
+
+    def test_mkdir(self):
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
+        create_file(filename)
+        self.assertRaises(OSError, os.mkdir, filename)
+
 
 class CPUCountTests(unittest.TestCase):
     def check_cpu_count(self, cpus):

--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -4125,7 +4125,7 @@ class OSErrorTests(unittest.TestCase):
         filename = os_helper.TESTFN
         self.addCleanup(os_helper.unlink, filename)
         create_file(filename)
-        self.assertRaises(OSError, os.mkdir, filename)
+        self.assertRaises(FileExistsError, os.mkdir, filename)
 
 
 class CPUCountTests(unittest.TestCase):

--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -4130,7 +4130,8 @@ class OSErrorTests(unittest.TestCase):
         create_file(filename)
         self.assertRaises(FileExistsError, os.mkdir, filename)
 
-        self.assertRaises(NotADirectoryError, os.mkdir, subdir)
+        self.assertRaises((NotADirectoryError, FileNotFoundError),
+                          os.mkdir, subdir)
 
 
 class CPUCountTests(unittest.TestCase):

--- a/Lib/test/test_os/test_windows.py
+++ b/Lib/test/test_os/test_windows.py
@@ -21,41 +21,6 @@ from test.support import os_helper
 from .utils import create_file
 
 
-class Win32ErrorTests(unittest.TestCase):
-    def setUp(self):
-        try:
-            os.stat(os_helper.TESTFN)
-        except FileNotFoundError:
-            exists = False
-        except OSError as exc:
-            exists = True
-            self.fail("file %s must not exist; os.stat failed with %s"
-                      % (os_helper.TESTFN, exc))
-        else:
-            self.fail("file %s must not exist" % os_helper.TESTFN)
-
-    def test_rename(self):
-        self.assertRaises(OSError, os.rename, os_helper.TESTFN, os_helper.TESTFN+".bak")
-
-    def test_remove(self):
-        self.assertRaises(OSError, os.remove, os_helper.TESTFN)
-
-    def test_chdir(self):
-        self.assertRaises(OSError, os.chdir, os_helper.TESTFN)
-
-    def test_mkdir(self):
-        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
-
-        with open(os_helper.TESTFN, "x") as f:
-            self.assertRaises(OSError, os.mkdir, os_helper.TESTFN)
-
-    def test_utime(self):
-        self.assertRaises(OSError, os.utime, os_helper.TESTFN, None)
-
-    def test_chmod(self):
-        self.assertRaises(OSError, os.chmod, os_helper.TESTFN, 0)
-
-
 class Win32KillTests(unittest.TestCase):
     def _kill(self, sig):
         # Start sys.executable as a subprocess and communicate from the


### PR DESCRIPTION
test_os OSErrorTests already covers the OSError class and is more complete than Win32ErrorTests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139322 -->
* Issue: gh-139322
<!-- /gh-issue-number -->
