### PR TITLE
gh-135953: Add GIL contention markers to sampling profiler Gecko format

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -113,6 +113,9 @@ struct _ts {
     /* Currently holds the GIL. Must be its own field to avoid data races */
     int holds_gil;
 
+    /* Currently requesting the GIL */
+    int gil_requested;
+
     int _whence;
 
     /* Thread state (_Py_THREAD_ATTACHED, _Py_THREAD_DETACHED, _Py_THREAD_SUSPENDED).

--- a/Include/internal/pycore_debug_offsets.h
+++ b/Include/internal/pycore_debug_offsets.h
@@ -106,6 +106,8 @@ typedef struct _Py_DebugOffsets {
         uint64_t native_thread_id;
         uint64_t datastack_chunk;
         uint64_t status;
+        uint64_t holds_gil;
+        uint64_t gil_requested;
     } thread_state;
 
     // InterpreterFrame offset;
@@ -273,6 +275,8 @@ typedef struct _Py_DebugOffsets {
         .native_thread_id = offsetof(PyThreadState, native_thread_id), \
         .datastack_chunk = offsetof(PyThreadState, datastack_chunk), \
         .status = offsetof(PyThreadState, _status), \
+        .holds_gil = offsetof(PyThreadState, holds_gil), \
+        .gil_requested = offsetof(PyThreadState, gil_requested), \
     }, \
     .interpreter_frame = { \
         .size = sizeof(_PyInterpreterFrame), \

--- a/Lib/profiling/sampling/collector.py
+++ b/Lib/profiling/sampling/collector.py
@@ -1,17 +1,13 @@
 from abc import ABC, abstractmethod
 
-# Enums are slow
-THREAD_STATE_RUNNING = 0
-THREAD_STATE_IDLE = 1
-THREAD_STATE_GIL_WAIT = 2
-THREAD_STATE_UNKNOWN = 3
-
-STATUS = {
-    THREAD_STATE_RUNNING: "running",
-    THREAD_STATE_IDLE: "idle",
-    THREAD_STATE_GIL_WAIT: "gil_wait",
-    THREAD_STATE_UNKNOWN: "unknown",
-}
+# Thread status flags
+try:
+    from _remote_debugging import THREAD_STATUS_HAS_GIL, THREAD_STATUS_ON_CPU, THREAD_STATUS_UNKNOWN
+except ImportError:
+    # Fallback for tests or when module is not available
+    THREAD_STATUS_HAS_GIL = (1 << 0)
+    THREAD_STATUS_ON_CPU = (1 << 1)
+    THREAD_STATUS_UNKNOWN = (1 << 2)
 
 class Collector(ABC):
     @abstractmethod
@@ -26,8 +22,14 @@ class Collector(ABC):
         """Iterate over all frame stacks from all interpreters and threads."""
         for interpreter_info in stack_frames:
             for thread_info in interpreter_info.threads:
-                if skip_idle and thread_info.status != THREAD_STATE_RUNNING:
-                    continue
+                # skip_idle now means: skip if thread is not actively running
+                # A thread is "active" if it has the GIL OR is on CPU
+                if skip_idle:
+                    status_flags = thread_info.status
+                    has_gil = bool(status_flags & THREAD_STATUS_HAS_GIL)
+                    on_cpu = bool(status_flags & THREAD_STATUS_ON_CPU)
+                    if not (has_gil or on_cpu):
+                        continue
                 frames = thread_info.frame_info
                 if frames:
                     yield frames, thread_info.thread_id

--- a/Lib/profiling/sampling/collector.py
+++ b/Lib/profiling/sampling/collector.py
@@ -2,12 +2,13 @@ from abc import ABC, abstractmethod
 
 # Thread status flags
 try:
-    from _remote_debugging import THREAD_STATUS_HAS_GIL, THREAD_STATUS_ON_CPU, THREAD_STATUS_UNKNOWN
+    from _remote_debugging import THREAD_STATUS_HAS_GIL, THREAD_STATUS_ON_CPU, THREAD_STATUS_UNKNOWN, THREAD_STATUS_GIL_REQUESTED
 except ImportError:
     # Fallback for tests or when module is not available
     THREAD_STATUS_HAS_GIL = (1 << 0)
     THREAD_STATUS_ON_CPU = (1 << 1)
     THREAD_STATUS_UNKNOWN = (1 << 2)
+    THREAD_STATUS_GIL_REQUESTED = (1 << 3)
 
 class Collector(ABC):
     @abstractmethod

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -21,6 +21,7 @@ _FREE_THREADED_BUILD = sysconfig.get_config_var("Py_GIL_DISABLED") is not None
 PROFILING_MODE_WALL = 0
 PROFILING_MODE_CPU = 1
 PROFILING_MODE_GIL = 2
+PROFILING_MODE_ALL = 3  # Combines GIL + CPU checks
 
 
 def _parse_mode(mode_string):
@@ -136,18 +137,20 @@ def _run_with_sync(original_cmd):
 
 
 class SampleProfiler:
-    def __init__(self, pid, sample_interval_usec, all_threads, *, mode=PROFILING_MODE_WALL):
+    def __init__(self, pid, sample_interval_usec, all_threads, *, mode=PROFILING_MODE_WALL, skip_non_matching_threads=True):
         self.pid = pid
         self.sample_interval_usec = sample_interval_usec
         self.all_threads = all_threads
         if _FREE_THREADED_BUILD:
             self.unwinder = _remote_debugging.RemoteUnwinder(
-                self.pid, all_threads=self.all_threads, mode=mode
+                self.pid, all_threads=self.all_threads, mode=mode,
+                skip_non_matching_threads=skip_non_matching_threads
             )
         else:
             only_active_threads = bool(self.all_threads)
             self.unwinder = _remote_debugging.RemoteUnwinder(
-                self.pid, only_active_thread=only_active_threads, mode=mode
+                self.pid, only_active_thread=only_active_threads, mode=mode,
+                skip_non_matching_threads=skip_non_matching_threads
             )
         # Track sample intervals and total sample count
         self.sample_intervals = deque(maxlen=100)
@@ -614,13 +617,20 @@ def sample(
     realtime_stats=False,
     mode=PROFILING_MODE_WALL,
 ):
+    # PROFILING_MODE_ALL implies no skipping at all
+    if mode == PROFILING_MODE_ALL:
+        skip_non_matching_threads = False
+        skip_idle = False
+    else:
+        # Determine skip settings based on output format and mode
+        skip_non_matching_threads = output_format != "gecko"
+        skip_idle = mode != PROFILING_MODE_WALL
+
     profiler = SampleProfiler(
-        pid, sample_interval_usec, all_threads=all_threads, mode=mode
+        pid, sample_interval_usec, all_threads=all_threads, mode=mode,
+        skip_non_matching_threads=skip_non_matching_threads
     )
     profiler.realtime_stats = realtime_stats
-
-    # Determine skip_idle for collector compatibility
-    skip_idle = mode != PROFILING_MODE_WALL
 
     collector = None
     match output_format:
@@ -633,7 +643,8 @@ def sample(
             collector = FlamegraphCollector(skip_idle=skip_idle)
             filename = filename or f"flamegraph.{pid}.html"
         case "gecko":
-            collector = GeckoCollector(skip_idle=skip_idle)
+            # Gecko format never skips idle threads to show full thread states
+            collector = GeckoCollector(skip_idle=False)
             filename = filename or f"gecko.{pid}.json"
         case _:
             raise ValueError(f"Invalid output format: {output_format}")
@@ -877,6 +888,10 @@ def main():
     if args.format in ("collapsed", "gecko"):
         _validate_collapsed_format_args(args, parser)
 
+    # Validate that --mode is not used with --gecko
+    if args.format == "gecko" and args.mode != "wall":
+        parser.error("--mode option is incompatible with --gecko format. Gecko format automatically uses ALL mode (GIL + CPU analysis).")
+
     sort_value = args.sort if args.sort is not None else 2
 
     if args.module is not None and not args.module:
@@ -895,7 +910,11 @@ def main():
     elif target_count > 1:
         parser.error("only one target type can be specified: -p/--pid, -m/--module, or script")
 
-    mode = _parse_mode(args.mode)
+    # Use PROFILING_MODE_ALL for gecko format, otherwise parse user's choice
+    if args.format == "gecko":
+        mode = PROFILING_MODE_ALL
+    else:
+        mode = _parse_mode(args.mode)
 
     if args.pid:
         sample(

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -23,6 +23,12 @@ import subprocess
 PROFILING_MODE_WALL = 0
 PROFILING_MODE_CPU = 1
 PROFILING_MODE_GIL = 2
+PROFILING_MODE_ALL = 3
+
+# Thread status flags
+THREAD_STATUS_HAS_GIL = (1 << 0)
+THREAD_STATUS_ON_CPU = (1 << 1)
+THREAD_STATUS_UNKNOWN = (1 << 2)
 
 try:
     from concurrent import interpreters
@@ -1763,11 +1769,14 @@ class TestDetectionOfThreadStatus(unittest.TestCase):
                             for thread_info in interpreter_info.threads:
                                 statuses[thread_info.thread_id] = thread_info.status
 
-                        # Check if sleeper thread is idle and busy thread is running
+                        # Check if sleeper thread is off CPU and busy thread is on CPU
+                        # In the new flags system:
+                        # - sleeper should NOT have ON_CPU flag (off CPU)
+                        # - busy should have ON_CPU flag
                         if (sleeper_tid in statuses and
                             busy_tid in statuses and
-                            statuses[sleeper_tid] == 1 and
-                            statuses[busy_tid] == 0):
+                            not (statuses[sleeper_tid] & THREAD_STATUS_ON_CPU) and
+                            (statuses[busy_tid] & THREAD_STATUS_ON_CPU)):
                             break
                         time.sleep(0.5)  # Give a bit of time to let threads settle
                 except PermissionError:
@@ -1779,8 +1788,8 @@ class TestDetectionOfThreadStatus(unittest.TestCase):
                 self.assertIsNotNone(busy_tid, "Busy thread id not received")
                 self.assertIn(sleeper_tid, statuses, "Sleeper tid not found in sampled threads")
                 self.assertIn(busy_tid, statuses, "Busy tid not found in sampled threads")
-                self.assertEqual(statuses[sleeper_tid], 1, "Sleeper thread should be idle (1)")
-                self.assertEqual(statuses[busy_tid], 0, "Busy thread should be running (0)")
+                self.assertFalse(statuses[sleeper_tid] & THREAD_STATUS_ON_CPU, "Sleeper thread should be off CPU")
+                self.assertTrue(statuses[busy_tid] & THREAD_STATUS_ON_CPU, "Busy thread should be on CPU")
 
             finally:
                 if client_socket is not None:
@@ -1875,11 +1884,14 @@ class TestDetectionOfThreadStatus(unittest.TestCase):
                             for thread_info in interpreter_info.threads:
                                 statuses[thread_info.thread_id] = thread_info.status
 
-                        # Check if sleeper thread is idle (status 2 for GIL mode) and busy thread is running
+                        # Check if sleeper thread doesn't have GIL and busy thread has GIL
+                        # In the new flags system:
+                        # - sleeper should NOT have HAS_GIL flag (waiting for GIL)
+                        # - busy should have HAS_GIL flag
                         if (sleeper_tid in statuses and
                             busy_tid in statuses and
-                            statuses[sleeper_tid] == 2 and
-                            statuses[busy_tid] == 0):
+                            not (statuses[sleeper_tid] & THREAD_STATUS_HAS_GIL) and
+                            (statuses[busy_tid] & THREAD_STATUS_HAS_GIL)):
                             break
                         time.sleep(0.5)  # Give a bit of time to let threads settle
                 except PermissionError:
@@ -1891,8 +1903,8 @@ class TestDetectionOfThreadStatus(unittest.TestCase):
                 self.assertIsNotNone(busy_tid, "Busy thread id not received")
                 self.assertIn(sleeper_tid, statuses, "Sleeper tid not found in sampled threads")
                 self.assertIn(busy_tid, statuses, "Busy tid not found in sampled threads")
-                self.assertEqual(statuses[sleeper_tid], 2, "Sleeper thread should be idle (1)")
-                self.assertEqual(statuses[busy_tid], 0, "Busy thread should be running (0)")
+                self.assertFalse(statuses[sleeper_tid] & THREAD_STATUS_HAS_GIL, "Sleeper thread should not have GIL")
+                self.assertTrue(statuses[busy_tid] & THREAD_STATUS_HAS_GIL, "Busy thread should have GIL")
 
             finally:
                 if client_socket is not None:
@@ -1900,6 +1912,128 @@ class TestDetectionOfThreadStatus(unittest.TestCase):
                 p.terminate()
                 p.wait(timeout=SHORT_TIMEOUT)
 
+    @unittest.skipIf(
+        sys.platform not in ("linux", "darwin", "win32"),
+        "Test only runs on supported platforms (Linux, macOS, or Windows)",
+    )
+    @unittest.skipIf(sys.platform == "android", "Android raises Linux-specific exception")
+    def test_thread_status_all_mode_detection(self):
+        port = find_unused_port()
+        script = textwrap.dedent(
+            f"""\
+            import socket
+            import threading
+            import time
+            import sys
+
+            def sleeper_thread():
+                conn = socket.create_connection(("localhost", {port}))
+                conn.sendall(b"sleeper:" + str(threading.get_native_id()).encode())
+                while True:
+                    time.sleep(1)
+
+            def busy_thread():
+                conn = socket.create_connection(("localhost", {port}))
+                conn.sendall(b"busy:" + str(threading.get_native_id()).encode())
+                while True:
+                    sum(range(100000))
+
+            t1 = threading.Thread(target=sleeper_thread)
+            t2 = threading.Thread(target=busy_thread)
+            t1.start()
+            t2.start()
+            t1.join()
+            t2.join()
+            """
+        )
+
+        with os_helper.temp_dir() as tmp_dir:
+            script_file = make_script(tmp_dir, "script", script)
+            server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            server_socket.bind(("localhost", port))
+            server_socket.listen(2)
+            server_socket.settimeout(SHORT_TIMEOUT)
+
+            p = subprocess.Popen(
+                [sys.executable, script_file],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            client_sockets = []
+            try:
+                sleeper_tid = None
+                busy_tid = None
+
+                # Receive thread IDs from the child process
+                for _ in range(2):
+                    client_socket, _ = server_socket.accept()
+                    client_sockets.append(client_socket)
+                    line = client_socket.recv(1024)
+                    if line:
+                        if line.startswith(b"sleeper:"):
+                            try:
+                                sleeper_tid = int(line.split(b":")[-1])
+                            except Exception:
+                                pass
+                        elif line.startswith(b"busy:"):
+                            try:
+                                busy_tid = int(line.split(b":")[-1])
+                            except Exception:
+                                pass
+
+                server_socket.close()
+
+                attempts = 10
+                statuses = {}
+                try:
+                    unwinder = RemoteUnwinder(p.pid, all_threads=True, mode=PROFILING_MODE_ALL,
+                                                skip_non_matching_threads=False)
+                    for _ in range(attempts):
+                        traces = unwinder.get_stack_trace()
+                        # Find threads and their statuses
+                        statuses = {}
+                        for interpreter_info in traces:
+                            for thread_info in interpreter_info.threads:
+                                statuses[thread_info.thread_id] = thread_info.status
+
+                        # Check ALL mode provides both GIL and CPU info
+                        # - sleeper should NOT have ON_CPU and NOT have HAS_GIL
+                        # - busy should have ON_CPU and have HAS_GIL
+                        if (sleeper_tid in statuses and
+                            busy_tid in statuses and
+                            not (statuses[sleeper_tid] & THREAD_STATUS_ON_CPU) and
+                            not (statuses[sleeper_tid] & THREAD_STATUS_HAS_GIL) and
+                            (statuses[busy_tid] & THREAD_STATUS_ON_CPU) and
+                            (statuses[busy_tid] & THREAD_STATUS_HAS_GIL)):
+                            break
+                        time.sleep(0.5)
+                except PermissionError:
+                    self.skipTest(
+                        "Insufficient permissions to read the stack trace"
+                    )
+
+                self.assertIsNotNone(sleeper_tid, "Sleeper thread id not received")
+                self.assertIsNotNone(busy_tid, "Busy thread id not received")
+                self.assertIn(sleeper_tid, statuses, "Sleeper tid not found in sampled threads")
+                self.assertIn(busy_tid, statuses, "Busy tid not found in sampled threads")
+
+                # Sleeper thread: off CPU, no GIL
+                self.assertFalse(statuses[sleeper_tid] & THREAD_STATUS_ON_CPU, "Sleeper should be off CPU")
+                self.assertFalse(statuses[sleeper_tid] & THREAD_STATUS_HAS_GIL, "Sleeper should not have GIL")
+
+                # Busy thread: on CPU, has GIL
+                self.assertTrue(statuses[busy_tid] & THREAD_STATUS_ON_CPU, "Busy should be on CPU")
+                self.assertTrue(statuses[busy_tid] & THREAD_STATUS_HAS_GIL, "Busy should have GIL")
+
+            finally:
+                for client_socket in client_sockets:
+                    client_socket.close()
+                p.terminate()
+                p.wait(timeout=SHORT_TIMEOUT)
+                p.stdout.close()
+                p.stderr.close()
 
 
 if __name__ == "__main__":

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -207,6 +207,7 @@ drop_gil_impl(PyThreadState *tstate, struct _gil_runtime_state *gil)
     _Py_atomic_store_int_relaxed(&gil->locked, 0);
     if (tstate != NULL) {
         tstate->holds_gil = 0;
+        tstate->gil_requested = 0;
     }
     COND_SIGNAL(gil->cond);
     MUTEX_UNLOCK(gil->mutex);
@@ -320,6 +321,8 @@ take_gil(PyThreadState *tstate)
 
     MUTEX_LOCK(gil->mutex);
 
+    tstate->gil_requested = 1;
+
     int drop_requested = 0;
     while (_Py_atomic_load_int_relaxed(&gil->locked)) {
         unsigned long saved_switchnum = gil->switch_number;
@@ -407,6 +410,7 @@ take_gil(PyThreadState *tstate)
     }
     assert(_PyThreadState_CheckConsistency(tstate));
 
+    tstate->gil_requested = 0;
     tstate->holds_gil = 1;
     _Py_unset_eval_breaker_bit(tstate, _PY_GIL_DROP_REQUEST_BIT);
     update_eval_breaker_for_thread(interp, tstate);


### PR DESCRIPTION
This commit enhances the Gecko format reporter in the sampling profiler
to include markers for GIL acquisition events. The implementation adds:

- GIL contention tracking in pystate and ceval_gil
- New marker types in the Gecko collector for GIL wait events
- External inspection support for reading GIL state
- Sample collection of GIL acquisition times and thread states

The markers provide visibility into GIL contention patterns, showing
when threads are waiting to acquire the GIL and how long they wait.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135953 -->
* Issue: gh-135953
<!-- /gh-issue-number -->
