### PR TITLE
gh-139452: Clarify redirect_stdout, stderr behavior

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -356,6 +356,12 @@ Functions and classes provided:
         with redirect_stdout(sys.stderr):
             help(pow)
 
+   To discard or suppress the output of :func:`help` without collecting the data::
+
+        with open(os.devnull, 'w') as devnull:
+            with redirect_stdout(devnull):
+                help(pow)
+
    Note that the global side effect on :data:`sys.stdout` means that this
    context manager is not suitable for use in library code and most threaded
    applications. It also has no effect on the output of subprocesses.

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -327,10 +327,12 @@ Functions and classes provided:
 .. function:: redirect_stdout(new_target)
 
    Context manager for temporarily redirecting :data:`sys.stdout` to
-   another file or file-like object.
+   another :term:`file object`.
 
    This tool adds flexibility to existing functions or classes whose output
-   is hardwired to stdout.
+   is hardwired to :data:`sys.stdout`. This does not modify underlying file
+   objects or file descriptors. It sets the global :data:`sys.stdout` to the
+   provided value and at context exit sets it to the previous value.
 
    For example, the output of :func:`help` normally is sent to *sys.stdout*.
    You can capture that output in a string by redirecting the output to an
@@ -366,8 +368,9 @@ Functions and classes provided:
 
 .. function:: redirect_stderr(new_target)
 
-   Similar to :func:`~contextlib.redirect_stdout` but redirecting
-   :data:`sys.stderr` to another file or file-like object.
+   Similar to :func:`~contextlib.redirect_stdout` but redirecting the global
+   :data:`sys.stderr` to another value, typically a :term:`file object`
+   returned from :func:`open`.
 
    This context manager is :ref:`reentrant <reentrant-cms>`.
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -375,8 +375,7 @@ Functions and classes provided:
 .. function:: redirect_stderr(new_target)
 
    Similar to :func:`~contextlib.redirect_stdout` but redirecting the global
-   :data:`sys.stderr` to another value, typically a :term:`file object`
-   returned from :func:`open`.
+   :data:`sys.stderr` to another value, typically a :term:`file object`.
 
    This context manager is :ref:`reentrant <reentrant-cms>`.
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -330,9 +330,7 @@ Functions and classes provided:
    another :term:`file object`.
 
    This tool adds flexibility to existing functions or classes whose output
-   is hardwired to :data:`sys.stdout`. This does not modify underlying file
-   objects or file descriptors. It sets the global :data:`sys.stdout` to the
-   provided value and at context exit sets it to the previous value.
+   is hardwired to :data:`sys.stdout`.
 
    For example, the output of :func:`help` normally is sent to *sys.stdout*.
    You can capture that output in a string by redirecting the output to an
@@ -356,12 +354,6 @@ Functions and classes provided:
         with redirect_stdout(sys.stderr):
             help(pow)
 
-   To discard or suppress the output of :func:`help` without collecting the data::
-
-        with open(os.devnull, 'w') as devnull:
-            with redirect_stdout(devnull):
-                help(pow)
-
    Note that the global side effect on :data:`sys.stdout` means that this
    context manager is not suitable for use in library code and most threaded
    applications. It also has no effect on the output of subprocesses.
@@ -375,7 +367,7 @@ Functions and classes provided:
 .. function:: redirect_stderr(new_target)
 
    Similar to :func:`~contextlib.redirect_stdout` but redirecting the global
-   :data:`sys.stderr` to another value, typically a :term:`file object`.
+   :data:`sys.stderr` to another :term:`file object`.
 
    This context manager is :ref:`reentrant <reentrant-cms>`.
 


### PR DESCRIPTION
These don't "redirect" like a terminal where typically the file pointed to by fd 1 and 2 are made the "same" (ex. by `dup2` the given fd into that specific fd number). Rather, these context managers set the respective globals to the provided value. In most cases that should be a "file object".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139452 -->
* Issue: gh-139452
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139490.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->