### PR TITLE
gh-139495: Fix `hashlib.file_digest()` versionchanged description of `BlockingIOError`

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -310,7 +310,7 @@ a file or file-like object.
    .. versionadded:: 3.11
 
    .. versionchanged:: 3.14
-      Now raises a :exc:`BlockingIOError` if the file is opened in blocking
+      Now raises a :exc:`BlockingIOError` if the file is opened in non-blocking
       mode. Previously, spurious null bytes were added to the digest.
 
 

--- a/Misc/NEWS.d/next/Documentation/2025-10-02-11-51-34.gh-issue-139495.y4Orqf.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-10-02-11-51-34.gh-issue-139495.y4Orqf.rst
@@ -1,2 +1,2 @@
-Fix :func:`hashlib.file_digest()` versionchanged description of
+Fix :func:`hashlib.file_digest` versionchanged description of
 :exc:`BlockingIOError`

--- a/Misc/NEWS.d/next/Documentation/2025-10-02-11-51-34.gh-issue-139495.y4Orqf.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-10-02-11-51-34.gh-issue-139495.y4Orqf.rst
@@ -1,2 +1,0 @@
-Fix :func:`hashlib.file_digest` versionchanged description of
-:exc:`BlockingIOError`

--- a/Misc/NEWS.d/next/Documentation/2025-10-02-11-51-34.gh-issue-139495.y4Orqf.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-10-02-11-51-34.gh-issue-139495.y4Orqf.rst
@@ -1,0 +1,2 @@
+Fix :func:`hashlib.file_digest()` versionchanged description of
+:exc:`BlockingIOError`


### PR DESCRIPTION
The sentence was missing a negation and contradicted the other two descriptions in the same commit. I believe existing code behaviour is correct.

refs #122179, fixes #139495


<!-- gh-issue-number: gh-139495 -->
* Issue: gh-139495
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139496.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->