### PR TITLE
gh-89745: Remove test_embed.test_init_read_set()

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1232,21 +1232,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         self.check_all_configs("test_init_dont_configure_locale", {}, preconfig,
                                api=API_PYTHON)
 
-    @unittest.skip('as of 3.11 this test no longer works because '
-                   'path calculations do not occur on read')
-    def test_init_read_set(self):
-        config = {
-            'program_name': './init_read_set',
-            'executable': 'my_executable',
-            'base_executable': 'my_executable',
-        }
-        def modify_path(path):
-            path.insert(1, "test_path_insert1")
-            path.append("test_path_append")
-        self.check_all_configs("test_init_read_set", config,
-                               api=API_PYTHON,
-                               modify_path_cb=modify_path)
-
     def test_init_sys_add(self):
         config = {
             'faulthandler': 1,

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1506,44 +1506,6 @@ static int test_audit_run_stdin(void)
     return run_audit_run_test(Py_ARRAY_LENGTH(argv), argv, &test);
 }
 
-static int test_init_read_set(void)
-{
-    PyStatus status;
-    PyConfig config;
-    PyConfig_InitPythonConfig(&config);
-
-    config_set_string(&config, &config.program_name, L"./init_read_set");
-
-    status = PyConfig_Read(&config);
-    if (PyStatus_Exception(status)) {
-        goto fail;
-    }
-
-    status = PyWideStringList_Insert(&config.module_search_paths,
-                                     1, L"test_path_insert1");
-    if (PyStatus_Exception(status)) {
-        goto fail;
-    }
-
-    status = PyWideStringList_Append(&config.module_search_paths,
-                                     L"test_path_append");
-    if (PyStatus_Exception(status)) {
-        goto fail;
-    }
-
-    /* override executable computed by PyConfig_Read() */
-    config_set_string(&config, &config.executable, L"my_executable");
-    init_from_config_clear(&config);
-
-    dump_config();
-    Py_Finalize();
-    return 0;
-
-fail:
-    PyConfig_Clear(&config);
-    Py_ExitStatusException(status);
-}
-
 
 static int test_init_sys_add(void)
 {
@@ -2398,7 +2360,6 @@ static struct TestCase TestCases[] = {
     {"test_preinit_isolated2", test_preinit_isolated2},
     {"test_preinit_parse_argv", test_preinit_parse_argv},
     {"test_preinit_dont_parse_argv", test_preinit_dont_parse_argv},
-    {"test_init_read_set", test_init_read_set},
     {"test_init_run_main", test_init_run_main},
     {"test_init_sys_add", test_init_sys_add},
     {"test_init_setpath", test_init_setpath},


### PR DESCRIPTION
Since Python 3.11, it's no longer possible to call PyConfig_Read() to get the path configuration, and then modify the path configuration.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-89745 -->
* Issue: gh-89745
<!-- /gh-issue-number -->
