### PR TITLE
gh-77476: Remove urllib HTTP test

### DIFF
--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -218,27 +218,6 @@ class OtherNetworkTests(unittest.TestCase):
             opener.open(request)
             self.assertEqual(request.get_header('User-agent'),'Test-Agent')
 
-    @unittest.skip('XXX: http://www.imdb.com is gone')
-    def test_sites_no_connection_close(self):
-        # Some sites do not send Connection: close header.
-        # Verify that those work properly. (#issue12576)
-
-        URL = 'http://www.imdb.com' # mangles Connection:close
-
-        with socket_helper.transient_internet(URL):
-            try:
-                with urllib.request.urlopen(URL) as res:
-                    pass
-            except ValueError:
-                self.fail("urlopen failed for site not sending \
-                           Connection:close")
-            else:
-                self.assertTrue(res)
-
-            req = urllib.request.urlopen(URL)
-            res = req.read()
-            self.assertTrue(res)
-
     def _test_urls(self, urls, handlers, retry=True):
         import time
         import logging


### PR DESCRIPTION
Remove test_sites_no_connection_close() which is skipped since 2018 (commit 36d56ea826caffbeac0fc0c6d90248b80516e33c).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-77476 -->
* Issue: gh-77476
<!-- /gh-issue-number -->
