### PR TITLE
[3.13] gh-135329: Use longer timeout in pyrepl test_repl_eio() (#139503)

### DIFF
--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import unittest
 from functools import partial
+from test import support
 from test.support import os_helper
 from test.support import script_helper
 
@@ -384,7 +385,8 @@ class TestUnixConsoleEIOHandling(TestCase):
             self.fail("Child process failed to start properly")
 
         os.kill(proc.pid, signal.SIGUSR1)
-        _, err = proc.communicate(timeout=5)  # sleep for pty to settle
+        # sleep for pty to settle
+        _, err = proc.communicate(timeout=support.SHORT_TIMEOUT)
         self.assertEqual(
             proc.returncode,
             1,


### PR DESCRIPTION
Replace hardcoded 5 seconds with support.SHORT_TIMEOUT.

Fix the following error on slow CI such as GitHub Action UBSan:

test test_pyrepl failed -- Traceback (most recent call last):
  File "Lib/test/test_pyrepl/test_unix_console.py", line 362, in test_repl_eio
    _, err = proc.communicate(timeout=5)  # sleep for pty to settle
             ~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "Lib/subprocess.py", line 1219, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
                     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Lib/subprocess.py", line 2126, in _communicate
    self._check_timeout(endtime, orig_timeout, stdout, stderr)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Lib/subprocess.py", line 1266, in _check_timeout
    raise TimeoutExpired(
    ...<2 lines>...
            stderr=b''.join(stderr_seq) if stderr_seq else None)
subprocess.TimeoutExpired: Command '[...]' timed out after 5 seconds

(cherry picked from commit c985822d86892cd0a978e6e63945be3c0e59217c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135329 -->
* Issue: gh-135329
<!-- /gh-issue-number -->
