### PR TITLE
gh-70765: avoid waiting for HTTP headers when parsing HTTP/0.9 requests

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -370,27 +370,28 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
         if self.path.startswith('//'):
             self.path = '/' + self.path.lstrip('/')  # Reduce to a single /
 
-        # Examine the headers and look for a Connection directive.
         # For HTTP/0.9, headers are not expected at all.
         if is_http_0_9:
             self.headers = {}
-        else:
-            try:
-                self.headers = http.client.parse_headers(self.rfile,
-                                                         _class=self.MessageClass)
-            except http.client.LineTooLong as err:
-                self.send_error(
-                    HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
-                    "Line too long",
-                    str(err))
-                return False
-            except http.client.HTTPException as err:
-                self.send_error(
-                    HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
-                    "Too many headers",
-                    str(err)
-                )
-                return False
+            return True
+
+        # Examine the headers and look for a Connection directive.
+        try:
+            self.headers = http.client.parse_headers(self.rfile,
+                                                     _class=self.MessageClass)
+        except http.client.LineTooLong as err:
+            self.send_error(
+                HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
+                "Line too long",
+                str(err))
+            return False
+        except http.client.HTTPException as err:
+            self.send_error(
+                HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
+                "Too many headers",
+                str(err)
+            )
+            return False
 
         conntype = self.headers.get('Connection', "")
         if conntype.lower() == 'close':

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -362,6 +362,26 @@ class BaseHTTPServerTestCase(BaseTestCase):
             self.assertEqual(b'', data)
 
 
+class HTTP09ServerTestCase(BaseTestCase):
+
+    class request_handler(NoLogRequestHandler, BaseHTTPRequestHandler):
+        """Request handler for HTTP/0.9 server."""
+
+        def do_GET(self):
+            self.wfile.write(f'OK: here is {self.path}\r\n'.encode())
+
+    def setUp(self):
+        super().setUp()
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock = self.enterContext(self.sock)
+        self.sock.connect((self.HOST, self.PORT))
+
+    def test_http_0_9_server(self):
+        self.sock.send(b'GET /index.html\r\n')
+        res = self.sock.recv(1024)
+        self.assertEqual(res, b"OK: here is /index.html\r\n")
+
+
 def certdata_file(*path):
     return os.path.join(os.path.dirname(__file__), "certdata", *path)
 

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -376,10 +376,27 @@ class HTTP09ServerTestCase(BaseTestCase):
         self.sock = self.enterContext(self.sock)
         self.sock.connect((self.HOST, self.PORT))
 
-    def test_http_0_9_server(self):
+    def test_simple_get(self):
         self.sock.send(b'GET /index.html\r\n')
         res = self.sock.recv(1024)
         self.assertEqual(res, b"OK: here is /index.html\r\n")
+
+    def test_invalid_request(self):
+        self.sock.send(b'POST /index.html\r\n')
+        res = self.sock.recv(1024)
+        self.assertIn(b"Bad HTTP/0.9 request type ('POST')", res)
+
+    def test_single_request(self):
+        self.sock.send(b'GET /foo.html\r\n')
+        res = self.sock.recv(1024)
+        self.assertEqual(res, b"OK: here is /foo.html\r\n")
+
+        self.sock.send(b'GET /bar.html\r\n')
+        res = self.sock.recv(1024)
+        # The server will not parse more input as it closed the connection.
+        # Note that the socket connection itself is still opened since the
+        # client is responsible for also closing it on their side.
+        self.assertEqual(res, b'')
 
 
 def certdata_file(*path):

--- a/Misc/NEWS.d/next/Library/2025-10-02-17-40-10.gh-issue-70765.zVlLZn.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-02-17-40-10.gh-issue-70765.zVlLZn.rst
@@ -1,0 +1,5 @@
+:mod:`http.server`: fix default handling of HTTP/0.9 requests in
+:class:`~http.server.BaseHTTPRequestHandler`. Previously,
+:meth:`!BaseHTTPRequestHandler.parse_request`` incorrectly
+waited for headers in the request although those are not
+supported in HTTP/0.9. Patch by Bénédikt Tran.


### PR DESCRIPTION
@Carmina16 with this patch, the handler should be correct. The tests did not catch this regression because we use a shortcut for sending requests and `parse_request` is never called because of that.

<!-- gh-issue-number: gh-70765 -->
* Issue: gh-70765
<!-- /gh-issue-number -->
