### PR TITLE
gh-139458: Fix Interpreter Methods For the Main Interpreter

### DIFF
--- a/Doc/library/concurrent.interpreters.rst
+++ b/Doc/library/concurrent.interpreters.rst
@@ -243,6 +243,16 @@ Interpreter objects
    Generally, :class:`Interpreter` shouldn't be called directly.
    Instead, use :func:`create` or one of the other module functions.
 
+   In addition to interpreters created by this module (via
+   :func:`create`), an :class:`!Interpreter` object may wrap
+   interpreters not created by the module.  Some methods fail for such
+   interpreters, as noted below for each such method.
+
+   An interpreter may be marked as currently executing code in its
+   :mod:`!__main__` module.  See :meth:`~Interpreter.is_running`.
+   Some methods of a running :class:`!interpreter` fail, as noted
+   below for each such method.
+
    .. attribute:: id
 
       (read-only)
@@ -271,20 +281,32 @@ Interpreter objects
       Some objects are actually shared and some are copied efficiently,
       but most are copied via :mod:`pickle`.  See :ref:`interp-object-sharing`.
 
+      This method fails for unsupported modules.
+      It also fails for running modules.
+
    .. method:: exec(code, /, dedent=True)
 
       Run the given source code in the interpreter (in the current thread).
+
+      This method fails for unsupported modules.
+      It also fails for running modules.
 
    .. method:: call(callable, /, *args, **kwargs)
 
       Return the result of calling running the given function in the
       interpreter (in the current thread).
 
+      This method fails for unsupported modules.
+      It also fails for running modules.
+
    .. _interp-call-in-thread:
 
    .. method:: call_in_thread(callable, /, *args, **kwargs)
 
       Run the given function in the interpreter (in a new thread).
+
+      This method fails for unsupported modules.
+      It also fails for running modules.
 
 Exceptions
 ^^^^^^^^^^

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -717,18 +717,18 @@ class TestInterpreterClose(TestBase):
         with self.subTest('running __main__ (from self)'):
             with self.interpreter_from_capi() as interpid:
                 with self.assertRaisesRegex(ExecutionFailed,
-                                            'InterpreterError.*unrecognized'):
+                                            'InterpreterError.*not supported'):
                     self.run_from_capi(interpid, script, main=True)
 
         with self.subTest('running, but not __main__ (from self)'):
             with self.assertRaisesRegex(ExecutionFailed,
-                                        'InterpreterError.*unrecognized'):
+                                        'InterpreterError.*not supported'):
                 self.run_temp_from_capi(script)
 
         with self.subTest('running __main__ (from other)'):
             with self.interpreter_obj_from_capi() as (interp, interpid):
                 with self.running_from_capi(interpid, main=True):
-                    with self.assertRaisesRegex(InterpreterError, 'unrecognized'):
+                    with self.assertRaisesRegex(InterpreterError, 'not supported'):
                         interp.close()
                     # Make sure it wssn't closed.
                     self.assertTrue(
@@ -741,7 +741,7 @@ class TestInterpreterClose(TestBase):
         with self.subTest('running, but not __main__ (from other)'):
             with self.interpreter_obj_from_capi() as (interp, interpid):
                 with self.running_from_capi(interpid, main=False):
-                    with self.assertRaisesRegex(InterpreterError, 'unrecognized'):
+                    with self.assertRaisesRegex(InterpreterError, 'not supported'):
                         interp.close()
                     # Make sure it wssn't closed.
                     self.assertTrue(
@@ -749,7 +749,7 @@ class TestInterpreterClose(TestBase):
 
         with self.subTest('not running (from other)'):
             with self.interpreter_obj_from_capi() as (interp, interpid):
-                with self.assertRaisesRegex(InterpreterError, 'unrecognized'):
+                with self.assertRaisesRegex(InterpreterError, 'not supported'):
                     interp.close()
                 self.assertTrue(
                     self.interp_exists(interpid))
@@ -920,7 +920,7 @@ class TestInterpreterPrepareMain(TestBase):
     @requires_test_modules
     def test_created_with_capi(self):
         with self.interpreter_obj_from_capi() as (interp, interpid):
-            with self.assertRaisesRegex(InterpreterError, 'unrecognized'):
+            with self.assertRaisesRegex(InterpreterError, 'not supported'):
                 interp.prepare_main({'spam': True})
             with self.assertRaisesRegex(ExecutionFailed, 'NameError'):
                 self.run_from_capi(interpid, 'assert spam is True')
@@ -1098,7 +1098,7 @@ class TestInterpreterExec(TestBase):
 
     def test_created_with_capi(self):
         with self.interpreter_obj_from_capi() as (interp, _):
-            with self.assertRaisesRegex(InterpreterError, 'unrecognized'):
+            with self.assertRaisesRegex(InterpreterError, 'not supported'):
                 interp.exec('raise Exception("it worked!")')
 
     def test_list_comprehension(self):
@@ -2271,7 +2271,7 @@ class LowLevelTests(TestBase):
 
         with self.subTest('from C-API'):
             interpid = _testinternalcapi.create_interpreter()
-            with self.assertRaisesRegex(InterpreterError, 'unrecognized'):
+            with self.assertRaisesRegex(InterpreterError, 'not supported'):
                 _interpreters.destroy(interpid, restrict=True)
             self.assertTrue(
                 self.interp_exists(interpid))
@@ -2315,7 +2315,7 @@ class LowLevelTests(TestBase):
         with self.subTest('from C-API'):
             orig = _interpreters.new_config('isolated')
             with self.interpreter_from_capi(orig) as interpid:
-                with self.assertRaisesRegex(InterpreterError, 'unrecognized'):
+                with self.assertRaisesRegex(InterpreterError, 'not supported'):
                     _interpreters.get_config(interpid, restrict=True)
                 config = _interpreters.get_config(interpid)
             self.assert_ns_equal(config, orig)
@@ -2376,7 +2376,7 @@ class LowLevelTests(TestBase):
 
     def test_is_running(self):
         def check(interpid, expected):
-            with self.assertRaisesRegex(InterpreterError, 'unrecognized'):
+            with self.assertRaisesRegex(InterpreterError, 'not supported'):
                 _interpreters.is_running(interpid, restrict=True)
             running = _interpreters.is_running(interpid)
             self.assertIs(running, expected)
@@ -2442,7 +2442,7 @@ class LowLevelTests(TestBase):
 
         with self.subTest('from C-API'):
             with self.interpreter_from_capi() as interpid:
-                with self.assertRaisesRegex(InterpreterError, 'unrecognized'):
+                with self.assertRaisesRegex(InterpreterError, 'not supported'):
                     _interpreters.exec(interpid, 'raise Exception("it worked!")',
                                        restrict=True)
                 exc = _interpreters.exec(interpid, 'raise Exception("it worked!")')
@@ -2521,7 +2521,7 @@ class LowLevelTests(TestBase):
 
         with self.subTest('from C-API'):
             with self.interpreter_from_capi() as interpid:
-                with self.assertRaisesRegex(InterpreterError, 'unrecognized'):
+                with self.assertRaisesRegex(InterpreterError, 'not supported'):
                     _interpreters.set___main___attrs(interpid, {'spam': True},
                                                      restrict=True)
                 _interpreters.set___main___attrs(interpid, {'spam': True})

--- a/Misc/NEWS.d/next/Library/2025-10-02-12-52-51.gh-issue-139458.HGegAs.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-02-12-52-51.gh-issue-139458.HGegAs.rst
@@ -1,0 +1,2 @@
+Errors and documentation are clearer now relative to interpreters not
+created by the :mod:`~concurrent.interpreters` module.

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -775,11 +775,11 @@ resolve_interp(PyObject *idobj, int restricted, int reqready, const char *op)
     if (restricted && get_whence(interp) != _PyInterpreterState_WHENCE_STDLIB) {
         if (idobj == NULL) {
             PyErr_Format(PyExc_InterpreterError,
-                         "cannot %s unrecognized current interpreter", op);
+                         "cannot %s current interpreter (not supported)", op);
         }
         else {
             PyErr_Format(PyExc_InterpreterError,
-                         "cannot %s unrecognized interpreter %R", op, idobj);
+                         "cannot %s interpreter %R (not supported)", op, idobj);
         }
         return NULL;
     }

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -755,6 +755,11 @@ resolve_interp(PyObject *idobj, int restricted, int reqready, const char *op)
         }
     }
 
+    if (_Py_IsMainInterpreter(interp)) {
+        assert(_PyInterpreterState_IsReady(interp));
+        return interp;
+    }
+
     if (reqready && !_PyInterpreterState_IsReady(interp)) {
         if (idobj == NULL) {
             PyErr_Format(PyExc_InterpreterError,


### PR DESCRIPTION
Some methods of `concurrent.interpreters.Interpreter` were not working for the object representing the main interpreter (ID 0).  The relevant code was identifying an interpreter not created by the `interpreters` module as "unrecognized".  However, the error message was a bit confusing since it did not distinguish between "not supported" and "doesn't exist".

This is addressed here for the main interpreter by special-casing it.  The relevant methods now fail with a clearer message along the lines of "already running main".  For other interpreters (e.g. created via C-API), the message is now clearer as well.

<!-- gh-issue-number: gh-139458 -->
* Issue: gh-139458
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139521.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->