### PR TITLE
gh-118767: remove bool(NotImplemented) from pending-removal document

### DIFF
--- a/Doc/deprecations/pending-removal-in-future.rst
+++ b/Doc/deprecations/pending-removal-in-future.rst
@@ -15,7 +15,6 @@ although there is currently no date scheduled for their removal.
 
 * :mod:`builtins`:
 
-  * ``bool(NotImplemented)``.
   * Generators: ``throw(type, exc, tb)`` and ``athrow(type, exc, tb)``
     signature is deprecated: use ``throw(exc)`` and ``athrow(exc)`` instead,
     the single argument signature.


### PR DESCRIPTION
`bool(NotImplemented)` raises a TypeError in 3.14, so should no longer be listed under “Pending removal in future versions”. This is some minor cleanup for gh-118767 and associated PRs.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139526.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->