### PR TITLE
[3.13] gh-139495: Fix `hashlib.file_digest()` versionchanged description of `BlockingIOError` (GH-139496)

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -303,7 +303,7 @@ a file or file-like object.
    .. versionadded:: 3.11
 
    .. versionchanged:: 3.13.4
-      Now raises a :exc:`BlockingIOError` if the file is opened in blocking
+      Now raises a :exc:`BlockingIOError` if the file is opened in non-blocking
       mode. Previously, spurious null bytes were added to the digest.
 
 


### PR DESCRIPTION


* Fix `hashlib.file_digest()` versionchanged description of `BlockingIOError`

The sentence was missing a negation and contradicted the other two descriptions in the same commit. I believe code behaviour is correct.

* fixup! Fix `hashlib.file_digest()` versionchanged description of `BlockingIOError`

* Remove unncessary NEWS.d entry (cherry picked from commit fb114cf49742a3679d56aa4ac3f341839c641221)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139495 -->
* Issue: gh-139495
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139528.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->