### PR TITLE
gh-86354: Fix child processes not reusing forkserver created by parent

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1002,6 +1002,42 @@ class _TestProcess(BaseTestCase):
         proc.start()
         proc.join()
 
+    @classmethod
+    def _create_child_and_get_ppid(cls, queue, remaining):
+        queue.put(os.getppid())
+        remaining -= 1
+        if remaining > 0:
+            proc = cls.Process(target=cls._create_child_and_get_ppid, args=(queue, remaining))
+            proc.start()
+            proc.join()
+
+
+    def test_forkserver_reuse(self):
+        # existing forkserver spawned by parent should be reused by children
+        if self.TYPE == "threads":
+            self.skipTest(f"test not appropriate for {self.TYPE}")
+        if multiprocessing.get_start_method() != "forkserver":
+            self.skipTest("forkserver start method specific")
+
+        forkserver = multiprocessing.forkserver._forkserver
+        forkserver.ensure_running()
+        self.assertTrue(forkserver._forkserver_pid)
+        forkserver_pid = forkserver._forkserver_pid
+
+        # start children recursively
+        ppid_queue = self.Queue()
+        proc = self.Process(target=self._create_child_and_get_ppid, args=(ppid_queue, 3))
+        proc.start()
+        proc.join()
+        for i in range(3):
+            # all descendants should have the same ppid (forkserver)
+            ppid = ppid_queue.get()
+            assert ppid == forkserver_pid
+
+        # forkserver should live after descendants ends
+        forkserver.ensure_running()
+        assert forkserver._forkserver_pid == forkserver_pid
+
 #
 #
 #

--- a/Misc/NEWS.d/next/Library/2025-10-02-23-05-42.gh-issue-86354.0RGEbU.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-02-23-05-42.gh-issue-86354.0RGEbU.rst
@@ -1,0 +1,1 @@
+Fix child processes not reusing forkserver created by parent


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This fixes issue #86354 that a child process does not reuse the forkserver process started by its parent. Currently, each child process creates its own forkserver for its own child processes:

```python
import multiprocessing as mp
import os

mp.set_start_method("forkserver", force=True)


def child(remaining):
    print(f"PID: {os.getpid()}, PPID: {os.getppid()}")
    remaining -= 1
    if remaining > 0:
        proc = mp.Process(target=child, args=(remaining,))
        proc.start()
        proc.join()


def main():
    proc = mp.Process(target=child, args=(5,))
    proc.start()
    proc.join()


if __name__ == '__main__':
    main()

```

```
PID: 60016, PPID: 60015
PID: 60018, PPID: 60017
PID: 60020, PPID: 60019
PID: 60022, PPID: 60021
PID: 60024, PPID: 60023
```

With this patch, all the descendants reuse the forkserver spawned by the main process, reducing the overhead when the process tree is deep:

```
PID: 60054, PPID: 60053
PID: 60055, PPID: 60053
PID: 60056, PPID: 60053
PID: 60057, PPID: 60053
PID: 60058, PPID: 60053
```

The new behavior matches the comment in `forkserver.py`:

https://github.com/python/cpython/blob/fd7dac0430c3773b90a1fb73f7a29ecc6199fdc0/Lib/multiprocessing/forkserver.py#L123-L129


<!-- gh-issue-number: gh-86354 -->
* Issue: gh-86354
<!-- /gh-issue-number -->
