### PR TITLE
gh-133210: Fix `test_types` with `--without-doc-strings`

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -714,7 +714,10 @@ class TypesTests(unittest.TestCase):
 
     def test_frame_locals_proxy_type(self):
         self.assertIsInstance(types.FrameLocalsProxyType, type)
-        self.assertIsInstance(types.FrameLocalsProxyType.__doc__, str)
+        if MISSING_C_DOCSTRINGS:
+            self.assertIsNone(types.FrameLocalsProxyType.__doc__)
+        else:
+            self.assertIsInstance(types.FrameLocalsProxyType.__doc__, str)
         self.assertEqual(types.FrameLocalsProxyType.__module__, 'builtins')
         self.assertEqual(types.FrameLocalsProxyType.__name__, 'FrameLocalsProxy')
 


### PR DESCRIPTION
When compiled with `--without-doc-strings`:

```
» ./python.exe -m test test_types
Using random seed: 2821981553
0:00:00 load avg: 10.13 Run 1 test sequentially in a single process
0:00:00 load avg: 10.13 [1/1] test_types
test test_types failed -- Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython/Lib/test/test_types.py", line 717, in test_frame_locals_proxy_type
    self.assertIsInstance(types.FrameLocalsProxyType.__doc__, str)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: None is not an instance of <class 'str'>

0:00:00 load avg: 10.13 [1/1/1] test_types failed (1 failure)
```

<!-- gh-issue-number: gh-133210 -->
* Issue: gh-133210
<!-- /gh-issue-number -->
