### PR TITLE
gh-139482: Improve performance of os.environ.clear()

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -732,6 +732,14 @@ class _Environ(MutableMapping):
         for key in keys:
             yield self.decodekey(key)
 
+    def clear(self):
+        # linear complexity removal of keys, see gh-139482
+        for key in list(self):
+            try:
+                del self[key]
+            except KeyError:
+                pass
+
     def __len__(self):
         return len(self._data)
 


### PR DESCRIPTION
Implementation based on a suggestion from @gukoff.

When the `environ` is mutated during the execution of `os.environ.clear()` (via another thread, or via destructors of the keys removed), the result can be a non-empty environment after the `clear()`. This is also the case for the current implementation, so this seems acceptable. The exact results can be different, but this seems unavoidable (in particular in the case of threads).
A variation could be to add `super().clear()` at the end of the definition of `clear()` (this would not impact performance complexity)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139482 -->
* Issue: gh-139482
<!-- /gh-issue-number -->
