### PR TITLE
gh-139476: Optimize `range[:]` slice

### DIFF
--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -584,6 +584,14 @@ class RangeTest(unittest.TestCase):
             check(0, -1)
             check(-1, -3, -1)
 
+        for test in (range(5), range(0), range(1, 10, 2), range(10, 0, -1)):
+            with self.subTest(test=test):
+                self.assertIs(test, test[:])
+
+                if len(test) > 1:
+                    self.assertIsNot(test, test[1:])
+                    self.assertIsNot(test, test[:-1])
+
     def test_contains(self):
         r = range(10)
         self.assertIn(0, r)

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -584,11 +584,14 @@ class RangeTest(unittest.TestCase):
             check(0, -1)
             check(-1, -3, -1)
 
-        for test in (range(5), range(0), range(1, 10, 2), range(10, 0, -1)):
+        for test in (range(5), range(0), range(1, 10, 2), range(10, 0, -1), range(-1, 200, 1)):
             with self.subTest(test=test):
                 self.assertIs(test, test[:])
+                self.assertIs(test, test[:len(test):])
+                self.assertIs(test, test[0:len(test):1])
 
                 if len(test) > 1:
+                    self.assertIsNot(test, test[1:len(test):2])
                     self.assertIsNot(test, test[1:])
                     self.assertIsNot(test, test[:-1])
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-04-14-06-40.gh-issue-139476.02iIfn.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-04-14-06-40.gh-issue-139476.02iIfn.rst
@@ -1,2 +1,2 @@
-:func:`range` slicing with ``[:]`` no longer creates a copy, it now returns
-the same object, consistent with :func:`copy.copy`.
+:func:`range` slicing with ``[:]`` and ``[:len(r):]`` no longer creates a copy,
+it now returns the same object, consistent with :func:`copy.copy`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-04-14-06-40.gh-issue-139476.02iIfn.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-04-14-06-40.gh-issue-139476.02iIfn.rst
@@ -1,0 +1,2 @@
+:func:`range` slicing with ``[:]`` no longer creates a copy, it now returns
+the same object, consistent with :func:`copy.copy`.

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -409,13 +409,16 @@ compute_slice(rangeobject *r, PyObject *_slice)
     PyObject *substart = NULL, *substop = NULL, *substep = NULL;
     int error;
 
-    if (slice->start == Py_None && slice->stop == Py_None && slice->step == Py_None) {
-        return Py_NewRef(r);
-    }
-
     error = _PySlice_GetLongIndices(slice, r->length, &start, &stop, &step);
     if (error == -1)
         return NULL;
+
+    if (start == _PyLong_GetZero()
+        && step == _PyLong_GetOne()
+        && (slice->stop == Py_None || PyObject_RichCompareBool(stop, r->length, Py_EQ) == 1))
+    {
+        return Py_NewRef(r);
+    }
 
     substep = PyNumber_Multiply(r->step, step);
     if (substep == NULL) goto fail;

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -409,6 +409,10 @@ compute_slice(rangeobject *r, PyObject *_slice)
     PyObject *substart = NULL, *substop = NULL, *substep = NULL;
     int error;
 
+    if (slice->start == Py_None && slice->stop == Py_None && slice->step == Py_None) {
+        return Py_NewRef(r);
+    }
+
     error = _PySlice_GetLongIndices(slice, r->length, &start, &stop, &step);
     if (error == -1)
         return NULL;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

<details>
Benchmark script

```
import timeit

def bench(code, setup="r=range(1000)", n=500000):
    time = timeit.timeit(code, setup=setup, number=n)
    print(f"{code}: {time/n*1000000:.2f} us/op")

bench("r[:]")
bench("r[1:]")
bench("r[:-1]")
bench("r[1:10]")
bench("r[::2]")
bench("r[1:50:3]")
```

</details>

Quick little patch. Optimises the `r[:]` case nicely (~5x), with negligible impact on other cases (I assume it is just noise):

| Case | Current (us) | PR (us) |
|--------|--------|--------|
| `r[:]` | 0.11 | 0.02 |
| `r[1:]` | 0.13 | 0.13 |
| `r[:-1]` | 0.18 | 0.19 |
| `r[1:10]` | 0.15 | 0.14 |
| `r[::2]` | 0.13 | 0.13 | 
| `r[1:50:3]` | 0.16 | 0.16 | 

I agree with Benedikt optimising this in general has little benefit, though I think one special case is acceptable. To cover all cases, it would require comparing the objects, resulting in a ~4x performance penalty and or some convoluted code. 

<!-- gh-issue-number: gh-139476 -->
* Issue: gh-139476
<!-- /gh-issue-number -->
