### PR TITLE
gh-90949: Fix an "unused function" compiler warning introduced in GH-139234

### DIFF
--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -198,12 +198,14 @@ set_error(pyexpat_state *state, xmlparseobject *self, enum XML_Error code)
     return NULL;
 }
 
+#if XML_COMBINED_VERSION >= 20400
 static PyObject *
 set_invalid_arg(pyexpat_state *state, xmlparseobject *self, const char *errmsg)
 {
     SET_XML_ERROR(state, self, XML_ERROR_INVALID_ARGUMENT, errmsg);
     return NULL;
 }
+#endif
 
 #undef SET_XML_ERROR
 


### PR DESCRIPTION
Adds on top of #139368 to fix a compiler warning that did not exist prior to the work on #90949.

CC @picnixz

<!-- gh-issue-number: gh-90949 -->
* Issue: gh-90949
<!-- /gh-issue-number -->
