### PR TITLE
[Docs] Add missing note about Required/NotRequired in get_type_hints()

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3341,7 +3341,7 @@ Introspection helpers
      earlier in the :term:`method resolution order` always take precedence over
      annotations on classes appearing later in the method resolution order.
    * The function recursively replaces all occurrences of
-     ``Annotated[T, ...]``, ``Required[T]`` and ``NotRequired[T]``
+     ``Annotated[T, ...]``, ``Required[T]``, ``NotRequired[T]``, and ``ReadOnly[T]``
      with ``T``, unless *include_extras* is set to ``True`` (see
      :class:`Annotated` for more information).
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3341,7 +3341,7 @@ Introspection helpers
      earlier in the :term:`method resolution order` always take precedence over
      annotations on classes appearing later in the method resolution order.
    * The function recursively replaces all occurrences of
-     ``Annotated[T, ...]``/``Required[T]``/``NotRequired[T]``
+     ``Annotated[T, ...]``, ``Required[T]`` and ``NotRequired[T]``
      with ``T``, unless *include_extras* is set to ``True`` (see
      :class:`Annotated` for more information).
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3340,7 +3340,8 @@ Introspection helpers
      ``__annotations__`` dictionaries. Annotations on classes appearing
      earlier in the :term:`method resolution order` always take precedence over
      annotations on classes appearing later in the method resolution order.
-   * The function recursively replaces all occurrences of ``Annotated[T, ...]``
+   * The function recursively replaces all occurrences of
+     ``Annotated[T, ...]``/``Required[T]``/``NotRequired[T]``
      with ``T``, unless *include_extras* is set to ``True`` (see
      :class:`Annotated` for more information).
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139565.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->