### PR TITLE
gracefully update the behavior of the buffering argument to open to support buffered text streams too

### DIFF
--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -426,10 +426,11 @@ _io_open_impl(PyObject *module, PyObject *file, const char *mode,
 
     /* wraps into a TextIOWrapper */
     wrapper = PyObject_CallFunction((PyObject *)state->PyTextIOWrapper_Type,
-                                    "OsssO",
+                                    "OsssOO",
                                     buffer,
                                     encoding, errors, newline,
-                                    line_buffering ? Py_True : Py_False);
+                                    line_buffering ? Py_True : Py_False,
+                                    (buffering && !line_buffering) ? Py_True : Py_False);
     if (wrapper == NULL)
         goto error;
     result = wrapper;


### PR DESCRIPTION
# Problem
Mansoor Ahmed wrote one of the best bug reports I've ever seen in my entire life at https://bugs.python.org/issue30718, regarding how the `buffering` argument to the standard builtin `open()` i/o method is unusable for text buffers as a result of double-buffering. @slateny then followed up to modify the documentation in #32351.

This began because I didn't understand the current language used to refer to double buffering, and after having dived into it a bit I have come to agree with Mansoor that there is no useful way to apply the double buffering that results when specifying a positive number greater than 1 for a text stream.

# Solution
Since this issue was first raised, there have been a few changes to the C-level API of `TextIOWrapper` objects. In particular, they now support specifying the `write_through` option directly in the constructor. I believe this fixes a very uncharacteristic "sharp edge" that users can run into working with python.

I spent some more time advancing the documentation and included the code sample @izbyshev provided way back in 2017, as I thought it made the operations happening in C code make much more sense.

I believe however that the list layout I chose which uses asterisks is not quite right and may break the docs. I'm not fully sure because I found the docs extremely difficult to generate and am working on fixing that separately.

Thank you for your time. I hope to work further with CPython in the future.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139566.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->