### PR TITLE
gh-101100: Fix reference warnings in `c-api/init.rst` documenting `PyGILState_STATE`

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1113,7 +1113,7 @@ code, or when embedding the Python interpreter:
    This function is safe to call without an :term:`attached thread state`; it
    will simply return ``NULL`` indicating that there was no prior thread state.
 
-   .. seealso:
+   .. seealso::
       :c:func:`PyEval_ReleaseThread`
 
    .. note::
@@ -1123,6 +1123,12 @@ code, or when embedding the Python interpreter:
 
 The following functions use thread-local storage, and are not compatible
 with sub-interpreters:
+
+.. c:type:: PyGILState_STATE
+
+   A handle to the thread state when :c:func:`PyGILState_Ensure` was
+   called, and must be passed to :c:func:`PyGILState_Release` to ensure Python
+   is left in the same state.
 
 .. c:function:: PyGILState_STATE PyGILState_Ensure()
 
@@ -1179,7 +1185,7 @@ with sub-interpreters:
       Prefer :c:func:`PyThreadState_Get` or :c:func:`PyThreadState_GetUnchecked`
       for most cases.
 
-   .. seealso: :c:func:`PyThreadState_Get``
+   .. seealso:: :c:func:`PyThreadState_Get``
 
 .. c:function:: int PyGILState_Check()
 
@@ -1278,11 +1284,11 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    must be :term:`attached <attached thread state>`
 
    .. versionchanged:: 3.9
-      This function now calls the :c:member:`PyThreadState.on_delete` callback.
+      This function now calls the :c:member:`!PyThreadState.on_delete` callback.
       Previously, that happened in :c:func:`PyThreadState_Delete`.
 
    .. versionchanged:: 3.13
-      The :c:member:`PyThreadState.on_delete` callback was removed.
+      The :c:member:`!PyThreadState.on_delete` callback was removed.
 
 
 .. c:function:: void PyThreadState_Delete(PyThreadState *tstate)

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1187,7 +1187,8 @@ with sub-interpreters:
    made on the main thread.  This is mainly a helper/diagnostic function.
 
    .. note::
-      This function does not account for :term:`thread states <thread state>` created
+      This function may return non-``NULL`` even when the :term:`thread state`
+      is detached.
       by something other than :c:func:`PyGILState_Ensure` (such as :c:func:`PyThreadState_New`).
       Prefer :c:func:`PyThreadState_Get` or :c:func:`PyThreadState_GetUnchecked`
       for most cases.

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1126,9 +1126,16 @@ with sub-interpreters:
 
 .. c:type:: PyGILState_STATE
 
-   A handle to the thread state when :c:func:`PyGILState_Ensure` was
-   called, and must be passed to :c:func:`PyGILState_Release` to ensure Python
-   is left in the same state.
+   The type of the value returned by :c:func:`PyGILState_Ensure` and passed to
+   :c:func:`PyGILState_Release`.
+
+   .. c:enumerator:: PyGILState_LOCKED
+
+      The GIL was already held when :c:func:`PyGILState_Ensure` was called.
+
+   .. c:enumerator:: PyGILState_UNLOCKED
+
+      The GIL was not held when :c:func:`PyGILState_Ensure` was called.
 
 .. c:function:: PyGILState_STATE PyGILState_Ensure()
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1189,7 +1189,6 @@ with sub-interpreters:
    .. note::
       This function may return non-``NULL`` even when the :term:`thread state`
       is detached.
-      by something other than :c:func:`PyGILState_Ensure` (such as :c:func:`PyThreadState_New`).
       Prefer :c:func:`PyThreadState_Get` or :c:func:`PyThreadState_GetUnchecked`
       for most cases.
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1192,7 +1192,7 @@ with sub-interpreters:
       Prefer :c:func:`PyThreadState_Get` or :c:func:`PyThreadState_GetUnchecked`
       for most cases.
 
-   .. seealso:: :c:func:`PyThreadState_Get``
+   .. seealso:: :c:func:`PyThreadState_Get`
 
 .. c:function:: int PyGILState_Check()
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -4,7 +4,6 @@
 
 Doc/c-api/descriptor.rst
 Doc/c-api/float.rst
-Doc/c-api/init.rst
 Doc/c-api/init_config.rst
 Doc/c-api/intro.rst
 Doc/c-api/module.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
`PyGILState_STATE`: If we don't want to document, I can add it to the ignore list.
I also fixed two `.. seealso::` blocks I noticed.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139572.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->