### PR TITLE
Replace ambiguous word "pound" by "hash" in `difflib` docs

### DIFF
--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -229,12 +229,13 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
    (or ``None``):
 
    *linejunk*: A function that accepts a single string argument, and returns
-   true if the string is junk, or false if not. The default is ``None``. There
-   is also a module-level function :func:`IS_LINE_JUNK`, which filters out lines
-   without visible characters, except for at most one pound character (``'#'``)
-   -- however the underlying :class:`SequenceMatcher` class does a dynamic
-   analysis of which lines are so frequent as to constitute noise, and this
-   usually works better than using this function.
+    true if the string is junk, or false if not. The default is ``None``. There
+    is also a module-level function :func:`IS_LINE_JUNK`, which filters out
+    lines without visible characters, or containing one occurrence of the
+    pound, or hash symbol (``'#'``) -- however the underlying
+    :class:`SequenceMatcher` class does a dynamic analysis of which lines are
+    so frequent as to constitute noise, and this usually works better than
+    using this function.
 
    *charjunk*: A function that accepts a character (a string of length 1), and
    returns if the character is junk, or false if not. The default is module-level

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -229,13 +229,12 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
    (or ``None``):
 
    *linejunk*: A function that accepts a single string argument, and returns
-    true if the string is junk, or false if not. The default is ``None``. There
-    is also a module-level function :func:`IS_LINE_JUNK`, which filters out
-    lines without visible characters, or containing one occurrence of the
-    pound, or hash symbol (``'#'``) -- however the underlying
-    :class:`SequenceMatcher` class does a dynamic analysis of which lines are
-    so frequent as to constitute noise, and this usually works better than
-    using this function.
+   true if the string is junk, or false if not. The default is ``None``. There
+   is also a module-level function :func:`IS_LINE_JUNK`, which filters out lines
+   without visible characters, except for at most one hash character (``'#'``)
+   -- however the underlying :class:`SequenceMatcher` class does a dynamic
+   analysis of which lines are so frequent as to constitute noise, and this
+   usually works better than using this function.
 
    *charjunk*: A function that accepts a character (a string of length 1), and
    returns if the character is junk, or false if not. The default is module-level


### PR DESCRIPTION
This clears up what is meant by `IS_LINE_JUNK` and explains refers to `#` as "the pound or hash symbol", rather than just "the pound symbol", which could mean £.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139601.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->