### PR TITLE
gh-127330: Comment correction in _ssl.c

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -148,7 +148,7 @@ static void _PySSLFixErrno(void) {
 #endif
 
 /* Include generated data (error codes) */
-/* See make_ssl_data.h for notes on adding a new version. */
+/* See Tools/ssl/make_ssl_data.py for notes on adding a new version. */
 #if (OPENSSL_VERSION_NUMBER >= 0x30401000L)
 #include "_ssl_data_35.h"
 #elif (OPENSSL_VERSION_NUMBER >= 0x30100000L)


### PR DESCRIPTION
Really trivial issue, mostly the ".h" -> ".py" bit, but properly referencing the location is a trivial improvement I think.

(Apologies for the incorrect title format. I can't actually find an issue. I did this all through the github web interface. Maybe the issue hasn't yet been created. 🤷🏻


<!-- gh-issue-number: gh-127330 -->
* Issue: gh-127330
<!-- /gh-issue-number -->
