### PR TITLE
gh-133951: Fix purelib packages not found in test_peg_generator TestCParser

### DIFF
--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -100,11 +100,15 @@ class TestCParser(unittest.TestCase):
 
         with contextlib.ExitStack() as stack:
             python_exe = stack.enter_context(support.setup_venv_with_pip_setuptools("venv"))
-            sitepackages = subprocess.check_output(
+            platlib_path = subprocess.check_output(
                 [python_exe, "-c", "import sysconfig; print(sysconfig.get_path('platlib'))"],
                 text=True,
             ).strip()
-            stack.enter_context(import_helper.DirsOnSysPath(sitepackages))
+            purelib_path = subprocess.check_output(
+                [python_exe, "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"],
+                text=True,
+            ).strip()
+            stack.enter_context(import_helper.DirsOnSysPath(platlib_path, purelib_path))
             cls.addClassCleanup(stack.pop_all().close)
 
     @support.requires_venv_with_pip()


### PR DESCRIPTION
Previous import context created in `TestCParser.setUpClass()` only includes platlib path. This pr also adds purelib path to fix failing `test_peg_generator` on some platform after #137139 .

<!-- gh-issue-number: gh-139604 -->
* Issue: gh-139604
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-133951 -->
* Issue: gh-133951
<!-- /gh-issue-number -->
