### PR TITLE
gh-70765: fix an HTTP/0.9 flaky test post GH-139514

### DIFF
--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -391,12 +391,14 @@ class HTTP09ServerTestCase(BaseTestCase):
         res = self.sock.recv(1024)
         self.assertEqual(res, b"OK: here is /foo.html\r\n")
 
-        self.sock.send(b'GET /bar.html\r\n')
-        res = self.sock.recv(1024)
-        # The server will not parse more input as it closed the connection.
-        # Note that the socket connection itself is still opened since the
-        # client is responsible for also closing it on their side.
-        self.assertEqual(res, b'')
+        # Ignore errors if the connection is already closed,
+        # as this is the expected behavior of HTTP/0.9.
+        with contextlib.suppress(OSError):
+            self.sock.send(b'GET /bar.html\r\n')
+        with contextlib.suppress(OSError):
+            res = self.sock.recv(1024)
+            # The server should not process our request.
+            self.assertEqual(res, b'')
 
 
 def certdata_file(*path):

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -395,7 +395,6 @@ class HTTP09ServerTestCase(BaseTestCase):
         # as this is the expected behavior of HTTP/0.9.
         with contextlib.suppress(OSError):
             self.sock.send(b'GET /bar.html\r\n')
-        with contextlib.suppress(OSError):
             res = self.sock.recv(1024)
             # The server should not process our request.
             self.assertEqual(res, b'')


### PR DESCRIPTION
This fixes a flaky test on macOS (failure was observed in the backport to 3.13 and on https://github.com/python/cpython/pull/139607). I don't really know why the connection is reset on macOS while it's not on my Linux but the end result for HTTP/0.9 should be that the server neither replies or sends an empty content.

<!-- gh-issue-number: gh-70765 -->
* Issue: gh-70765
<!-- /gh-issue-number -->
