### PR TITLE
gh-139620: fix argument name of `load_module` in `importlib` docs

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1041,7 +1041,7 @@ find and load modules.
 
       Concrete implementation of :meth:`importlib.abc.SourceLoader.set_data`.
 
-   .. method:: load_module(name=None)
+   .. method:: load_module(fullname=None)
 
       Concrete implementation of :meth:`importlib.abc.Loader.load_module` where
       specifying the name of the module to load is optional.
@@ -1084,7 +1084,7 @@ find and load modules.
       Returns ``None`` as bytecode files have no source when this loader is
       used.
 
-   .. method:: load_module(name=None)
+   .. method:: load_module(fullname=None)
 
    Concrete implementation of :meth:`importlib.abc.Loader.load_module` where
    specifying the name of the module to load is optional.


### PR DESCRIPTION
The correct arugment is `fullname` instead of `name`.


<!-- gh-issue-number: gh-139620 -->
* Issue: gh-139620
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139621.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->