### PR TITLE
GH-123299: Announce final release in What's New in Python 3.14

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -60,7 +60,7 @@ Summary -- Release Highlights
 .. This section singles out the most important changes in Python 3.13.
    Brevity is key.
 
-Python 3.13 is the latest stable release of the Python programming
+Python 3.13 is a stable release of the Python programming
 language, with a mix of changes to the language, the implementation
 and the standard library.
 The biggest changes include a new `interactive interpreter

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -3070,7 +3070,7 @@ Deprecated C APIs
 
 .. _whatsnew314-build-changes:
 
-Build Changes
+Build changes
 =============
 
 * :pep:`776`: Emscripten is now an officially supported platform at

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -46,7 +46,7 @@
    when researching a change.
 
 This article explains the new features in Python 3.14, compared to 3.13.
-Python 3.14 will be released on 7 October 2025.
+Python 3.14 was released on 7 October 2025.
 For full details, see the :ref:`changelog <changelog>`.
 
 .. seealso::
@@ -60,7 +60,7 @@ Summary -- Release highlights
 .. This section singles out the most important changes in Python 3.14.
    Brevity is key.
 
-Python 3.14 will be the latest stable release of the Python programming
+Python 3.14 is the latest stable release of the Python programming
 language, with a mix of changes to the language, the implementation,
 and the standard library.
 The biggest changes include :ref:`template string literals


### PR DESCRIPTION
Hugo -- this should (actually) be the final *What's New in Python 3.14* PR ahead of 3.14.0 final -- please close if you'll address it yourself, but as with last year I thought it was worth opening a PR as the commit needs to go into both 3.15 and 3.14.

I've also updated the text for *What's New in Python 3.13* as it will no longer be the latest stable release.

A

<!-- gh-issue-number: gh-123299 -->
* Issue: gh-123299
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139631.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->