### PR TITLE
gh-138044: Fix `importlib.resources.files` deprecation docs

### DIFF
--- a/Doc/library/importlib.resources.rst
+++ b/Doc/library/importlib.resources.rst
@@ -72,8 +72,12 @@ for example, a package and its resources can be imported from a zip file using
 
     .. versionadded:: 3.9
 
-    .. deprecated-removed:: 3.12 3.15
-       *package* parameter was renamed to *anchor*. *anchor* can now be a
+    .. versionchanged:: 3.12
+      *package* parameter was renamed to *anchor*.
+      *package* was still accepted, but deprecated.
+
+    .. versionchanged:: 3.15
+       *package* parameter was fully removed. *anchor* can now be a
        non-package module and if omitted will default to the caller's module.
        *package* is no longer accepted since Python 3.15. Consider passing the
        anchor positionally or using ``importlib_resources >= 5.10`` for a

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -696,6 +696,14 @@ http.server
   (Contributed by Bénédikt Tran in :gh:`133810`.)
 
 
+importlib.resources
+-------------------
+
+* Removed deprecated ``package`` parameter
+  from :func:`importlib.resources.files` function.
+  (Contributed by Semyon Moroz in :gh:`138044`)
+
+
 pathlib
 -------
 


### PR DESCRIPTION
`.. deprecated-removed::` can't be left in the docs if the right version is the current one.
Docs build will start to fail when `.. deprecated-removed:: ... 3.15` is left.

Also, `whatsnew` is updated, we need to add all removals there.
 
CC @donBarbos 

<!-- gh-issue-number: gh-138044 -->
* Issue: gh-138044
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139632.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->