### PR TITLE
gh-139633: Run `netrc` file permission check only once per parse

### DIFF
--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -156,9 +156,9 @@ class netrc:
         if _can_security_check() and default_netrc:
             for entry in self.hosts.values():
                 if entry[0] != "anonymous":
-                    # Raises on security issue
+                    # Raises on security issue; once passed once can exit.
                     self._security_check(fp)
-                    break
+                    return
 
     def _security_check(self, fp):
         prop = os.fstat(fp.fileno())

--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -152,23 +152,28 @@ class netrc:
                 else:
                     raise NetrcParseError("bad follower token %r" % tt,
                                           file, lexer.lineno)
-            self._security_check(fp, default_netrc, self.hosts[entryname][0])
 
-    def _security_check(self, fp, default_netrc, login):
-        if _can_security_check() and default_netrc and login != "anonymous":
-            prop = os.fstat(fp.fileno())
-            current_user_id = os.getuid()
-            if prop.st_uid != current_user_id:
-                fowner = _getpwuid(prop.st_uid)
-                user = _getpwuid(current_user_id)
-                raise NetrcParseError(
-                    f"~/.netrc file owner ({fowner}) does not match"
-                    f" current user ({user})")
-            if (prop.st_mode & (stat.S_IRWXG | stat.S_IRWXO)):
-                raise NetrcParseError(
-                    "~/.netrc access too permissive: access"
-                    " permissions must restrict access to only"
-                    " the owner")
+        if _can_security_check() and default_netrc:
+            for entry in self.hosts.values():
+                if entry[0] != "anonymous":
+                    # Raises on security issue
+                    self._security_check(fp)
+                    break
+
+    def _security_check(self, fp):
+        prop = os.fstat(fp.fileno())
+        current_user_id = os.getuid()
+        if prop.st_uid != current_user_id:
+            fowner = _getpwuid(prop.st_uid)
+            user = _getpwuid(current_user_id)
+            raise NetrcParseError(
+                f"~/.netrc file owner ({fowner}) does not match"
+                f" current user ({user})")
+        if (prop.st_mode & (stat.S_IRWXG | stat.S_IRWXO)):
+            raise NetrcParseError(
+                "~/.netrc access too permissive: access"
+                " permissions must restrict access to only"
+                " the owner")
 
     def authenticators(self, host):
         """Return a (user, account, password) tuple for given host."""

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -1,6 +1,9 @@
 import netrc, os, unittest, sys, textwrap
+from pathlib import Path
 from test import support
 from test.support import os_helper
+from unittest.mock import Mock
+
 
 temp_filename = os_helper.TESTFN
 
@@ -308,6 +311,29 @@ class NetrcTestCase(unittest.TestCase):
             os.chmod(fn, 0o622)
             self.assertEqual(nrc.hosts['foo.domain.com'],
                              ('anonymous', '', 'pass'))
+
+    @unittest.skipUnless(os.name == 'posix', 'POSIX only test')
+    @unittest.skipUnless(hasattr(os, 'getuid'), "os.getuid is required")
+    @os_helper.skip_unless_working_chmod
+    def test_security_only_once(self):
+        # Make sure security check is only run once per parse when multiple
+        # entries are found.
+        check_called = netrc.netrc._security_check = Mock(return_value=True)
+
+        # Parse a default netrc with more than one password line.
+        with os_helper.temp_dir() as tmp_dir:
+            netrc_path = Path(tmp_dir) / '.netrc'
+            netrc_path.write_text("""\
+            machine foo.domain.com login bar password pass
+            machine bar.domain.com login foo password pass
+            """)
+            netrc_path.chmod(0o600)
+            with os_helper.EnvironmentVarGuard() as environ:
+                environ.set('HOME', tmp_dir)
+                netrc.netrc()
+
+        check_called.assert_called_once()
+        del check_called
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2025-10-05-15-38-02.gh-issue-139633.l3P839.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-05-15-38-02.gh-issue-139633.l3P839.rst
@@ -1,0 +1,2 @@
+The :mod:`netrc` security check is now run once per parse rather than once
+per entry.


### PR DESCRIPTION
Change the `.netrc` security check to be run once per parse of the default file rather than once per line inside the file.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139633 -->
* Issue: gh-139633
<!-- /gh-issue-number -->
