### PR TITLE
gh-139588: Add sphinx.ext.imgconvert to support SVG on Latex

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',
+    'sphinx.ext.imgconverter',
 ]
 
 # Skip if downstream redistributors haven't installed them


### PR DESCRIPTION
gh-139588: Add [sphinx.ext.imgconvert](https://www.sphinx-doc.org/en/master/usage/extensions/imgconverter.html#module-sphinx.ext.imgconverter) to support SVG on Latex

It converts the SVG to PNG for LaTeX, but keeps SVG for HTML.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139635.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->