### PR TITLE
gh-88046: remove impossible conditional import for `_ssl.RAND_egd`

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -354,9 +354,8 @@ Random generation
 .. function:: RAND_status()
 
    Return ``True`` if the SSL pseudo-random number generator has been seeded
-   with 'enough' randomness, and ``False`` otherwise.  You can use
-   :func:`ssl.RAND_egd` and :func:`ssl.RAND_add` to increase the randomness of
-   the pseudo-random number generator.
+   with 'enough' randomness, and ``False`` otherwise.  Use :func:`ssl.RAND_add`
+   to increase the randomness of the pseudo-random number generator.
 
 .. function:: RAND_add(bytes, entropy, /)
 

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -110,11 +110,6 @@ from _ssl import (
     )
 from _ssl import txt2obj as _txt2obj, nid2obj as _nid2obj
 from _ssl import RAND_status, RAND_add, RAND_bytes
-try:
-    from _ssl import RAND_egd
-except ImportError:
-    # RAND_egd is not supported on some platforms
-    pass
 from _ssl import get_sigalgs
 
 


### PR DESCRIPTION
`_ssl.RAND_egd` is not supported by OpenSSL 1.1.1 and later, and it's no more present in our code base (it was removed in b8d0fa035d74ae6ae00794c9af636b427c5dc650). However we still have a conditional import for this one, but it will always silently fail.

<!-- gh-issue-number: gh-88046 -->
* Issue: gh-88046
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139648.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->