### PR TITLE
PEP 765: What's New warnings filter suggestions

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -939,13 +939,13 @@ This change is specified in :pep:`765`.
 
 In situations where this change is inconvenient (such as those where the
 warnings are redundant due to code linting), the :ref:`warning filter
-<warning-filter>` can be used to turn off all syntax warnings, by using the
-``ignore::SyntaxWarning`` filter. This can be specified in combination
+<warning-filter>` can be used to turn off all syntax warnings by adding
+``ignore::SyntaxWarning`` as a filter. This can be specified in combination
 with a filter that converts other warnings to errors (for example, passing
 ``-Werror -Wignore::SyntaxWarning`` as CLI options, or setting
 ``PYTHONWARNINGS=error,ignore::SyntaxWarning``).
 
-Note that applying such a filter at runtime, using the :mod:`warnings` module
+Note that applying such a filter at runtime using the :mod:`warnings` module
 will only suppress the warning in code that is compiled *after* the filter is
 adjusted. Code that is compiled prior to the filter adjustment (for example,
 when a module is imported) will still emit the syntax warning.

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -937,18 +937,18 @@ The compiler now emits a :exc:`SyntaxWarning` when a :keyword:`return`,
 leaving a :keyword:`finally` block.
 This change is specified in :pep:`765`.
 
-For use cases where this change is inconvenient (such as those where the
-warnings are redundant due to code linting), syntax warnings specifically
-may be switched off via the :ref:`warning filter <warning-filter>`, using the
-clause ``ignore::SyntaxWarning``. This can also be specified in combination
+In situations where this change is inconvenient (such as those where the
+warnings are redundant due to code linting), the :ref:`warning filter
+<warning-filter>` can be used to turn off all syntax warnings, by using the
+``ignore::SyntaxWarning`` filter. This can be specified in combination
 with a filter that converts other warnings to errors (for example, passing
 ``-Werror -Wignore::SyntaxWarning`` as CLI options, or setting
 ``PYTHONWARNINGS=error,ignore::SyntaxWarning``).
 
-Note that applying such a filter at runtime (rather than via the interpreter's
-startup configuration) will only suppress the warning in code that is compiled
-*after* the filter is adjusted. Code that is compiled prior to the filter
-adjustment (for example, when a module is imported) will still emit the warning.
+Note that applying such a filter at runtime, using the :mod:`warnings` module
+will only suppress the warning in code that is compiled *after* the filter is
+adjusted. Code that is compiled prior to the filter adjustment (for example,
+when a module is imported) will still emit the syntax warning.
 
 (Contributed by Irit Katriel in :gh:`130080`.)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -937,6 +937,19 @@ The compiler now emits a :exc:`SyntaxWarning` when a :keyword:`return`,
 leaving a :keyword:`finally` block.
 This change is specified in :pep:`765`.
 
+For use cases where this change is inconvenient (such as those where the
+warnings are redundant due to code linting), syntax warnings specifically
+may be switched off via the :ref:`warning filter <warning-filter>`, using the
+clause ``ignore::SyntaxWarning``. This can also be specified in combination
+with a filter that converts other warnings to errors (for example, passing
+``-Werror -Wignore::SyntaxWarning`` as CLI options, or setting
+``PYTHONWARNINGS=error,ignore::SyntaxWarning``).
+
+Note that applying such a filter at runtime (rather than via the interpreter's
+startup configuration) will only suppress the warning in code that is compiled
+*after* the filter is adjusted. Code that is compiled prior to the filter
+adjustment (for example, when a module is imported) will still emit the warning.
+
 (Contributed by Irit Katriel in :gh:`130080`.)
 
 


### PR DESCRIPTION
For CI use cases where static code analysis is in use, emitting syntax warnings is essentially redundant.

Accordingly, there's no harm in suggesting that folks turn them off to avoid poor interactions between PEP 765 and treating warnings as errors.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139658.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->