### PR TITLE
gh-139653: If platform API doesn't give the current stack, use generic fallback

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -369,7 +369,8 @@ _Py_EnterRecursiveCallUnchecked(PyThreadState *tstate)
 #if defined(__s390x__)
 #  define Py_C_STACK_SIZE 320000
 #elif defined(_WIN32)
-   // Don't define Py_C_STACK_SIZE, ask the O/S
+   // Normally unused; we ask the O/S
+#  define Py_C_STACK_SIZE 4000000
 #elif defined(__ANDROID__)
 #  define Py_C_STACK_SIZE 1200000
 #elif defined(__sparc__)


### PR DESCRIPTION
Fall back to `_Py_get_machine_stack_pointer` if platform-specific API doesn't give us a stack that we're currently in. This might happen if some bespoke stack switching mechanism is in use.

With this, gh-139653 should be solved if the user calls `_Py_InitializeRecursionLimits` after each `jump_fcontext`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
