### PR TITLE
[3.13] gh-118767: remove bool(NotImplemented) from pending-removal document (GH-139526)

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.14.rst
+++ b/Doc/deprecations/pending-removal-in-3.14.rst
@@ -38,6 +38,10 @@ Pending Removal in Python 3.14
     is no current event loop set and it decides to create one.
     (Contributed by Serhiy Storchaka and Guido van Rossum in :gh:`100160`.)
 
+* :mod:`builtins`: ``bool(NotImplemented)`` now emits a :exc:`DeprecationWarning`
+  and will raise a :exc:`TypeError` in Python 3.14.
+  (Contributed by Jelle Zijlstra in :gh:`118767`.)
+
 * :mod:`email`: Deprecated the *isdst* parameter in :func:`email.utils.localtime`.
   (Contributed by Alan Williams in :gh:`72346`.)
 

--- a/Doc/deprecations/pending-removal-in-future.rst
+++ b/Doc/deprecations/pending-removal-in-future.rst
@@ -9,7 +9,6 @@ although there is currently no date scheduled for their removal.
 
 * :mod:`builtins`:
 
-  * ``bool(NotImplemented)``.
   * Generators: ``throw(type, exc, tb)`` and ``athrow(type, exc, tb)``
     signature is deprecated: use ``throw(exc)`` and ``athrow(exc)`` instead,
     the single argument signature.


### PR DESCRIPTION
As [suggested](https://github.com/python/cpython/pull/139526#issuecomment-3369043100) by @hugovk in gh-139526, this updates the Python 3.13 docs to document that `bool(NotImplemented)` will be removed in 3.14. Previously, it was listed in the “Pending Removal in Future Versions” section, which says “there is currently no [removal] date scheduled”.

If you feel it’s helpful, this PR could also be backported to 3.12. (Backporting to even earlier versions would be more effort since the deprecation docs were restructured in gh-122085; so that’s probably not worth it.)

<!-- gh-issue-number: gh-118767 -->
* Issue: gh-118767
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139677.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->