### PR TITLE
gh-124111: Update macOS installer to use Tcl/Tk 8.6.17.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -264,10 +264,10 @@ def library_recipes():
             tk_patches = ['backport_gh71383_fix.patch', 'tk868_on_10_8_10_9.patch', 'backport_gh110950_fix.patch']
 
         else:
-            tcl_tk_ver='8.6.16'
-            tcl_checksum='91cb8fa61771c63c262efb553059b7c7ad6757afa5857af6265e4b0bdc2a14a5'
+            tcl_tk_ver='8.6.17'
+            tcl_checksum='a3903371efcce8a405c5c245d029e9f6850258a60fa3761c4d58995610949b31'
 
-            tk_checksum='be9f94d3575d4b3099d84bc3c10de8994df2d7aa405208173c709cc404a7e5fe'
+            tk_checksum='e4982df6f969c08bf9dd858a6891059b4a3f50dc6c87c10abadbbe2fc4838946'
             tk_patches = []
 
 

--- a/Misc/NEWS.d/next/macOS/2025-10-06-23-56-36.gh-issue-124111.KOlBvs.rst
+++ b/Misc/NEWS.d/next/macOS/2025-10-06-23-56-36.gh-issue-124111.KOlBvs.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use Tcl/Tk 8.6.17.


### PR DESCRIPTION


<!-- gh-issue-number: gh-124111 -->
* Issue: gh-124111
<!-- /gh-issue-number -->
