### PR TITLE
gh-139688: make _last_pdb_instance to None when pdb do_quit for remote debug

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2008,6 +2008,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                     return
 
         self._user_requested_quit = True
+        # gh-139688 set _last_pdb_instance to None for remote debugging.
+        Pdb._last_pdb_instance = None
         self.set_quit()
         return 1
 

--- a/Misc/NEWS.d/next/Library/2025-10-07-18-02-53.gh-issue-139688.4ZVVQP.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-07-18-02-53.gh-issue-139688.4ZVVQP.rst
@@ -1,0 +1,1 @@
+Fix: Make ``Pdb._last_pdb_instance`` to None when ``pdb`` do_quite


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Pdb._last_pdb_instance obj still exists when do_quit in repl so remote pdb can not exec in it

<!-- gh-issue-number: gh-139688 -->
* Issue: gh-139688
<!-- /gh-issue-number -->
