### PR TITLE
gh-139721: Add ignore_module/unignore_module commands to pdb

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -438,10 +438,16 @@ can be overridden by the local file.
    Move the current frame *count* (default one) levels down in the stack trace
    (to a newer frame).
 
+   Frames from ignored modules will be skipped. Use :pdbcmd:`ignore_module` to
+   ignore modules and :pdbcmd:`unignore_module` to stop ignoring them.
+
 .. pdbcommand:: u(p) [count]
 
    Move the current frame *count* (default one) levels up in the stack trace (to
    an older frame).
+
+   Frames from ignored modules will be skipped. Use :pdbcmd:`ignore_module` to
+   ignore modules and :pdbcmd:`unignore_module` to stop ignoring them.
 
 .. pdbcommand:: b(reak) [([filename:]lineno | function) [, condition]]
 
@@ -717,6 +723,47 @@ can be overridden by the local file.
    .. versionchanged:: 3.13
       :pdbcmd:`interact` directs its output to the debugger's
       output channel rather than :data:`sys.stderr`.
+
+.. pdbcommand:: ignore_module [module_name]
+
+   Add a module to the list of modules to skip when stepping, continuing, or
+   navigating frames. When a module is ignored, the debugger will automatically
+   skip over frames from that module during :pdbcmd:`step`, :pdbcmd:`next`,
+   :pdbcmd:`continue`, :pdbcmd:`up`, and :pdbcmd:`down` commands.
+
+   Supports wildcard patterns using glob-style matching (via :mod:`fnmatch`).
+
+   Without *module_name*, list the currently ignored modules.
+
+   Examples::
+
+      (Pdb) ignore_module threading      # Skip threading module frames
+      (Pdb) ignore_module asyncio.*      # Skip all asyncio submodules
+      (Pdb) ignore_module *.tests        # Skip all test modules
+      (Pdb) ignore_module                # List currently ignored modules
+
+   Common use cases:
+
+   - Skip framework code (``django.*``, ``flask.*``, ``asyncio.*``)
+   - Skip standard library modules (``threading``, ``multiprocessing``, ``logging.*``)
+   - Skip test framework internals (``*pytest*``, ``unittest.*``)
+
+   .. versionadded:: 3.15
+
+.. pdbcommand:: unignore_module [module_name]
+
+   Remove a module from the list of modules to skip when stepping or navigating
+   frames. This will allow the debugger to step into frames from the specified
+   module again.
+
+   Without *module_name*, list the currently ignored modules.
+
+   Example::
+
+      (Pdb) unignore_module threading    # Stop ignoring threading module frames
+      (Pdb) unignore_module asyncio.*    # Remove the asyncio.* pattern
+
+   .. versionadded:: 3.15
 
 .. _debugger-aliases:
 

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -72,7 +72,7 @@ def parse_opcode_signature(env, sig, signode):
 
 # Support for documenting pdb commands
 
-pdbcmd_sig_re = re.compile(r'([a-z()!]+)\s*(.*)')
+pdbcmd_sig_re = re.compile(r'([a-z()!_]+)\s*(.*)')
 
 # later...
 # pdbargs_tokens_re = re.compile(r'''[a-zA-Z]+  |  # identifiers

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -521,6 +521,13 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     # Override Bdb methods
 
+    def stop_here(self, frame):
+        """Override bdb's stop_here to add message when skipping ignored modules."""
+        if self.skip and self.is_skipped_module(frame.f_globals.get('__name__', '')):
+            self.message('[... skipped 1 ignored module(s)]')
+            return False
+        return super().stop_here(frame)
+
     def user_call(self, frame, argument_list):
         """This method is called when there is the remote possibility
         that we ever need to stop in this function."""

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1811,6 +1811,7 @@ def test_pdb_skip_modules():
     > <doctest test.test_pdb.test_pdb_skip_modules[0]>(4)skip_module()
     -> string.capwords('FOO')
     (Pdb) step
+    [... skipped 1 ignored module(s)]
     --Return--
     > <doctest test.test_pdb.test_pdb_skip_modules[0]>(4)skip_module()->None
     -> string.capwords('FOO')
@@ -1884,6 +1885,7 @@ def test_pdb_skip_modules_with_callback():
     > <doctest test.test_pdb.test_pdb_skip_modules_with_callback[0]>(5)skip_module()
     -> mod.foo_pony(callback)
     (Pdb) step
+    [... skipped 1 ignored module(s)]
     --Call--
     > <doctest test.test_pdb.test_pdb_skip_modules_with_callback[0]>(2)callback()
     -> def callback():
@@ -1895,6 +1897,7 @@ def test_pdb_skip_modules_with_callback():
     > <doctest test.test_pdb.test_pdb_skip_modules_with_callback[0]>(3)callback()->None
     -> return None
     (Pdb) step
+    [... skipped 1 ignored module(s)]
     --Return--
     > <doctest test.test_pdb.test_pdb_skip_modules_with_callback[0]>(5)skip_module()->None
     -> mod.foo_pony(callback)
@@ -5131,6 +5134,56 @@ def test_ignore_module_navigation():
     'back at inner_func'
     (Pdb) continue
     'done'
+    """
+
+
+def test_ignore_module_stepping():
+    """Test that ignore_module works with step/next commands.
+
+    >>> def test_stepping():
+    ...     x = 1
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     result = ignore_test_middle.middle_func(lambda: x + 1)
+    ...     y = result + 1
+    ...     return y
+
+    Test step command with ignored modules - should skip into ignored module
+    but show skip message:
+
+    >>> with PdbTestInput([  # doctest: +ELLIPSIS
+    ...     'ignore_module ignore_test_middle',
+    ...     'step',  # Step to the function call
+    ...     'step',  # Step into call - should skip middle_func
+    ...     'return',  # Return from lambda
+    ...     'step',  # Step to next line
+    ...     'p y',
+    ...     'continue',
+    ... ]):
+    ...     test_stepping()
+    > <doctest test.test_pdb.test_ignore_module_stepping[0]>(3)test_stepping()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) ignore_module ignore_test_middle
+    Ignoring module: ignore_test_middle
+    (Pdb) step
+    > <doctest test.test_pdb.test_ignore_module_stepping[0]>(4)test_stepping()
+    -> result = ignore_test_middle.middle_func(lambda: x + 1)
+    (Pdb) step
+    [... skipped 1 ignored module(s)]
+    --Call--
+    > <doctest test.test_pdb.test_ignore_module_stepping[0]>(4)<lambda>()
+    -> result = ignore_test_middle.middle_func(lambda: x + 1)
+    (Pdb) return
+    --Return--
+    > <doctest test.test_pdb.test_ignore_module_stepping[0]>(4)<lambda>()->2
+    -> result = ignore_test_middle.middle_func(lambda: x + 1)
+    (Pdb) step
+    [... skipped 1 ignored module(s)]
+    > <doctest test.test_pdb.test_ignore_module_stepping[0]>(5)test_stepping()
+    -> y = result + 1
+    (Pdb) p y
+    *** NameError: name 'y' is not defined
+    (Pdb) continue
+    3
     """
 
 

--- a/Misc/NEWS.d/next/Library/2025-10-07-20-44-37.gh-issue-139721.N4dpE8.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-07-20-44-37.gh-issue-139721.N4dpE8.rst
@@ -1,0 +1,5 @@
+Add ``ignore_module`` and ``unignore_module`` commands to :mod:`pdb` to
+allow skipping frames from specified modules during debugging. When a module
+is ignored, the debugger will automatically skip over its frames during
+step, next, continue, up, and down commands. Supports wildcard patterns via
+:mod:`fnmatch` for ignoring submodules.


### PR DESCRIPTION
Add two new commands to pdb for skipping frames from specified modules:
- ignore_module [module_name]: Add modules to skip during debugging
- unignore_module [module_name]: Remove modules from skip list

When a module is ignored, the debugger automatically skips over its frames during step, next, continue, up, and down commands. Supports wildcard patterns via fnmatch for flexible module matching.

This feature improves debugging productivity when working with frameworks by allowing developers to hide framework-internal frames and focus on application code.

Issue: https://github.com/python/cpython/issues/139721

<!-- gh-issue-number: gh-139721 -->
* Issue: gh-139721
<!-- /gh-issue-number -->
