### PR TITLE
gh-139743: avoid import-time print in test_sqlite3 that leaks into help('modules')

### DIFF
--- a/Lib/test/test_sqlite3/__init__.py
+++ b/Lib/test/test_sqlite3/__init__.py
@@ -8,8 +8,7 @@ import sqlite3
 
 # Implement the unittest "load tests" protocol.
 def load_tests(*args):
+    if verbose:
+        print(f"test_sqlite3: testing with SQLite version {sqlite3.sqlite_version}")
     pkg_dir = os.path.dirname(__file__)
     return load_package_tests(pkg_dir, *args)
-
-if verbose:
-    print(f"test_sqlite3: testing with SQLite version {sqlite3.sqlite_version}")


### PR DESCRIPTION
Fixes gh-139743: importing test_sqlite3 printed the SQLite version banner, which leaked into help('modules'). Move the print under load_tests (still under verbose) so it only appears when tests actually run.

Credit: thanks to @yihong0618 for identifying the cause and approach.

(No NEWS — tests-only.)