### PR TITLE
gh-90949: Recommend `hasattr` with Expat security methods

### DIFF
--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -225,10 +225,10 @@ XMLParser Objects
 
    .. note::
 
-      :meth:`SetReparseDeferralEnabled`
+      :meth:`!SetReparseDeferralEnabled`
       has been backported to some prior releases of CPython as a security fix.
       Check for availability of
-      :meth:`SetReparseDeferralEnabled`
+      :meth:`!SetReparseDeferralEnabled`
       using :func:`hasattr` if used in code running across a variety of Python
       versions.
 
@@ -268,10 +268,10 @@ against some common XML vulnerabilities.
 
    .. note::
 
-      :meth:`SetBillionLaughsAttackProtectionActivationThreshold`
+      :meth:`!SetBillionLaughsAttackProtectionActivationThreshold`
       has been backported to some prior releases of CPython as a security fix.
       Check for availability of
-      :meth:`SetBillionLaughsAttackProtectionActivationThreshold`
+      :meth:`!SetBillionLaughsAttackProtectionActivationThreshold`
       using :func:`hasattr` if used in code running across a variety of Python
       versions.
 
@@ -309,10 +309,10 @@ against some common XML vulnerabilities.
 
    .. note::
 
-      :meth:`SetBillionLaughsAttackProtectionMaximumAmplification`
+      :meth:`!SetBillionLaughsAttackProtectionMaximumAmplification`
       has been backported to some prior releases of CPython as a security fix.
       Check for availability of
-      :meth:`SetBillionLaughsAttackProtectionMaximumAmplification`
+      :meth:`!SetBillionLaughsAttackProtectionMaximumAmplification`
       using :func:`hasattr` if used in code running across a variety of Python
       versions.
 
@@ -333,10 +333,10 @@ against some common XML vulnerabilities.
 
    .. note::
 
-      :meth:`SetAllocTrackerActivationThreshold`
+      :meth:`!SetAllocTrackerActivationThreshold`
       has been backported to some prior releases of CPython as a security fix.
       Check for availability of
-      :meth:`SetAllocTrackerActivationThreshold`
+      :meth:`!SetAllocTrackerActivationThreshold`
       using :func:`hasattr` if used in code running across a variety of Python
       versions.
 
@@ -373,10 +373,10 @@ against some common XML vulnerabilities.
 
    .. note::
 
-      :meth:`SetAllocTrackerMaximumAmplification`
+      :meth:`!SetAllocTrackerMaximumAmplification`
       has been backported to some prior releases of CPython as a security fix.
       Check for availability of
-      :meth:`SetAllocTrackerMaximumAmplification`
+      :meth:`!SetAllocTrackerMaximumAmplification`
       using :func:`hasattr` if used in code running across a variety of Python
       versions.
 

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -225,10 +225,8 @@ XMLParser Objects
 
    :meth:`!SetReparseDeferralEnabled`
    has been backported to some prior releases of CPython as a security fix.
-   Check for availability of
-   :meth:`!SetReparseDeferralEnabled`
-   using :func:`hasattr` if used in code running across a variety of Python
-   versions.
+   Check for availability using :func:`hasattr` if used in code running
+   across a variety of Python versions.
 
    .. versionadded:: 3.13
 
@@ -261,10 +259,8 @@ against some common XML vulnerabilities.
 
    :meth:`!SetBillionLaughsAttackProtectionActivationThreshold`
    has been backported to some prior releases of CPython as a security fix.
-   Check for availability of
-   :meth:`!SetBillionLaughsAttackProtectionActivationThreshold`
-   using :func:`hasattr` if used in code running across a variety of Python
-   versions.
+   Check for availability using :func:`hasattr` if used in code running
+   across a variety of Python versions.
 
    .. note::
 
@@ -299,10 +295,8 @@ against some common XML vulnerabilities.
 
    :meth:`!SetBillionLaughsAttackProtectionMaximumAmplification`
    has been backported to some prior releases of CPython as a security fix.
-   Check for availability of
-   :meth:`!SetBillionLaughsAttackProtectionMaximumAmplification`
-   using :func:`hasattr` if used in code running across a variety of Python
-   versions.
+   Check for availability using :func:`hasattr` if used in code running
+   across a variety of Python versions.
 
    .. note::
 
@@ -327,10 +321,8 @@ against some common XML vulnerabilities.
 
    :meth:`!SetAllocTrackerActivationThreshold`
    has been backported to some prior releases of CPython as a security fix.
-   Check for availability of
-   :meth:`!SetAllocTrackerActivationThreshold`
-   using :func:`hasattr` if used in code running across a variety of Python
-   versions.
+   Check for availability using :func:`hasattr` if used in code running
+   across a variety of Python versions.
 
    .. versionadded:: next
 
@@ -359,10 +351,8 @@ against some common XML vulnerabilities.
 
    :meth:`!SetAllocTrackerMaximumAmplification`
    has been backported to some prior releases of CPython as a security fix.
-   Check for availability of
-   :meth:`!SetAllocTrackerMaximumAmplification`
-   using :func:`hasattr` if used in code running across a variety of Python
-   versions.
+   Check for availability using :func:`hasattr` if used in code running
+   across a variety of Python versions.
 
    .. note::
 

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -223,7 +223,7 @@ XMLParser Objects
    Calling ``SetReparseDeferralEnabled(True)`` allows re-enabling reparse
    deferral.
 
-   Note that :meth:`!SetReparseDeferralEnabled`
+   :meth:`!SetReparseDeferralEnabled`
    has been backported to some prior releases of CPython as a security fix.
    Check for availability of
    :meth:`!SetReparseDeferralEnabled`
@@ -259,7 +259,7 @@ against some common XML vulnerabilities.
    The corresponding :attr:`~ExpatError.lineno` and :attr:`~ExpatError.offset`
    should not be used as they may have no special meaning.
 
-   Note that  :meth:`!SetBillionLaughsAttackProtectionActivationThreshold`
+   :meth:`!SetBillionLaughsAttackProtectionActivationThreshold`
    has been backported to some prior releases of CPython as a security fix.
    Check for availability of
    :meth:`!SetBillionLaughsAttackProtectionActivationThreshold`
@@ -297,7 +297,7 @@ against some common XML vulnerabilities.
    The corresponding :attr:`~ExpatError.lineno` and :attr:`~ExpatError.offset`
    should not be used as they may have no special meaning.
 
-   Note that :meth:`!SetBillionLaughsAttackProtectionMaximumAmplification`
+   :meth:`!SetBillionLaughsAttackProtectionMaximumAmplification`
    has been backported to some prior releases of CPython as a security fix.
    Check for availability of
    :meth:`!SetBillionLaughsAttackProtectionMaximumAmplification`
@@ -325,7 +325,7 @@ against some common XML vulnerabilities.
    The corresponding :attr:`~ExpatError.lineno` and :attr:`~ExpatError.offset`
    should not be used as they may have no special meaning.
 
-   Note that :meth:`!SetAllocTrackerActivationThreshold`
+   :meth:`!SetAllocTrackerActivationThreshold`
    has been backported to some prior releases of CPython as a security fix.
    Check for availability of
    :meth:`!SetAllocTrackerActivationThreshold`
@@ -357,7 +357,7 @@ against some common XML vulnerabilities.
    The corresponding :attr:`~ExpatError.lineno` and :attr:`~ExpatError.offset`
    should not be used as they may have no special meaning.
 
-   Note that :meth:`!SetAllocTrackerMaximumAmplification`
+   :meth:`!SetAllocTrackerMaximumAmplification`
    has been backported to some prior releases of CPython as a security fix.
    Check for availability of
    :meth:`!SetAllocTrackerMaximumAmplification`

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -262,6 +262,15 @@ against some common XML vulnerabilities.
       Activation thresholds below 4 MiB are known to break support for DITA 1.3
       payload and are hence not recommended.
 
+   .. note::
+
+      :meth:`SetBillionLaughsAttackProtectionActivationThreshold`
+      has been backported to some prior releases of CPython as a security fix.
+      Check for availability of
+      :meth:`SetBillionLaughsAttackProtectionActivationThreshold`
+      using :func:`hasattr` if used in code running across a variety of Python
+      versions.
+
    .. versionadded:: next
 
 .. method:: xmlparser.SetBillionLaughsAttackProtectionMaximumAmplification(max_factor, /)
@@ -294,6 +303,15 @@ against some common XML vulnerabilities.
       that can be adjusted by :meth:`.SetBillionLaughsAttackProtectionActivationThreshold`
       is exceeded.
 
+   .. note::
+
+      :meth:`SetBillionLaughsAttackProtectionMaximumAmplification`
+      has been backported to some prior releases of CPython as a security fix.
+      Check for availability of
+      :meth:`SetBillionLaughsAttackProtectionMaximumAmplification`
+      using :func:`hasattr` if used in code running across a variety of Python
+      versions.
+
    .. versionadded:: next
 
 .. method:: xmlparser.SetAllocTrackerActivationThreshold(threshold, /)
@@ -308,6 +326,15 @@ against some common XML vulnerabilities.
    |xml-non-root-parser| parser.
    The corresponding :attr:`~ExpatError.lineno` and :attr:`~ExpatError.offset`
    should not be used as they may have no special meaning.
+
+   .. note::
+
+      :meth:`SetAllocTrackerActivationThreshold`
+      has been backported to some prior releases of CPython as a security fix.
+      Check for availability of
+      :meth:`SetAllocTrackerActivationThreshold`
+      using :func:`hasattr` if used in code running across a variety of Python
+      versions.
 
    .. versionadded:: next
 
@@ -339,6 +366,15 @@ against some common XML vulnerabilities.
       The maximum amplification factor is only considered if the threshold
       that can be adjusted by :meth:`.SetAllocTrackerActivationThreshold`
       is exceeded.
+
+   .. note::
+
+      :meth:`SetAllocTrackerMaximumAmplification`
+      has been backported to some prior releases of CPython as a security fix.
+      Check for availability of
+      :meth:`SetAllocTrackerMaximumAmplification`
+      using :func:`hasattr` if used in code running across a variety of Python
+      versions.
 
    .. versionadded:: next
 

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -271,7 +271,6 @@ against some common XML vulnerabilities.
       Activation thresholds below 4 MiB are known to break support for DITA 1.3
       payload and are hence not recommended.
 
-
    .. versionadded:: next
 
 .. method:: xmlparser.SetBillionLaughsAttackProtectionMaximumAmplification(max_factor, /)

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -223,10 +223,14 @@ XMLParser Objects
    Calling ``SetReparseDeferralEnabled(True)`` allows re-enabling reparse
    deferral.
 
-   Note that :meth:`SetReparseDeferralEnabled` has been backported to some
-   prior releases of CPython as a security fix.  Check for availability of
-   :meth:`SetReparseDeferralEnabled` using :func:`hasattr` if used in code
-   running across a variety of Python versions.
+   .. note::
+
+      :meth:`SetReparseDeferralEnabled`
+      has been backported to some prior releases of CPython as a security fix.
+      Check for availability of
+      :meth:`SetReparseDeferralEnabled`
+      using :func:`hasattr` if used in code running across a variety of Python
+      versions.
 
    .. versionadded:: 3.13
 

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -223,14 +223,12 @@ XMLParser Objects
    Calling ``SetReparseDeferralEnabled(True)`` allows re-enabling reparse
    deferral.
 
-   .. note::
-
-      :meth:`!SetReparseDeferralEnabled`
-      has been backported to some prior releases of CPython as a security fix.
-      Check for availability of
-      :meth:`!SetReparseDeferralEnabled`
-      using :func:`hasattr` if used in code running across a variety of Python
-      versions.
+   Note that :meth:`!SetReparseDeferralEnabled`
+   has been backported to some prior releases of CPython as a security fix.
+   Check for availability of
+   :meth:`!SetReparseDeferralEnabled`
+   using :func:`hasattr` if used in code running across a variety of Python
+   versions.
 
    .. versionadded:: 3.13
 
@@ -261,19 +259,18 @@ against some common XML vulnerabilities.
    The corresponding :attr:`~ExpatError.lineno` and :attr:`~ExpatError.offset`
    should not be used as they may have no special meaning.
 
+   Note that  :meth:`!SetBillionLaughsAttackProtectionActivationThreshold`
+   has been backported to some prior releases of CPython as a security fix.
+   Check for availability of
+   :meth:`!SetBillionLaughsAttackProtectionActivationThreshold`
+   using :func:`hasattr` if used in code running across a variety of Python
+   versions.
+
    .. note::
 
       Activation thresholds below 4 MiB are known to break support for DITA 1.3
       payload and are hence not recommended.
 
-   .. note::
-
-      :meth:`!SetBillionLaughsAttackProtectionActivationThreshold`
-      has been backported to some prior releases of CPython as a security fix.
-      Check for availability of
-      :meth:`!SetBillionLaughsAttackProtectionActivationThreshold`
-      using :func:`hasattr` if used in code running across a variety of Python
-      versions.
 
    .. versionadded:: next
 
@@ -301,20 +298,18 @@ against some common XML vulnerabilities.
    The corresponding :attr:`~ExpatError.lineno` and :attr:`~ExpatError.offset`
    should not be used as they may have no special meaning.
 
+   Note that :meth:`!SetBillionLaughsAttackProtectionMaximumAmplification`
+   has been backported to some prior releases of CPython as a security fix.
+   Check for availability of
+   :meth:`!SetBillionLaughsAttackProtectionMaximumAmplification`
+   using :func:`hasattr` if used in code running across a variety of Python
+   versions.
+
    .. note::
 
       The maximum amplification factor is only considered if the threshold
       that can be adjusted by :meth:`.SetBillionLaughsAttackProtectionActivationThreshold`
       is exceeded.
-
-   .. note::
-
-      :meth:`!SetBillionLaughsAttackProtectionMaximumAmplification`
-      has been backported to some prior releases of CPython as a security fix.
-      Check for availability of
-      :meth:`!SetBillionLaughsAttackProtectionMaximumAmplification`
-      using :func:`hasattr` if used in code running across a variety of Python
-      versions.
 
    .. versionadded:: next
 
@@ -331,14 +326,12 @@ against some common XML vulnerabilities.
    The corresponding :attr:`~ExpatError.lineno` and :attr:`~ExpatError.offset`
    should not be used as they may have no special meaning.
 
-   .. note::
-
-      :meth:`!SetAllocTrackerActivationThreshold`
-      has been backported to some prior releases of CPython as a security fix.
-      Check for availability of
-      :meth:`!SetAllocTrackerActivationThreshold`
-      using :func:`hasattr` if used in code running across a variety of Python
-      versions.
+   Note that :meth:`!SetAllocTrackerActivationThreshold`
+   has been backported to some prior releases of CPython as a security fix.
+   Check for availability of
+   :meth:`!SetAllocTrackerActivationThreshold`
+   using :func:`hasattr` if used in code running across a variety of Python
+   versions.
 
    .. versionadded:: next
 
@@ -365,20 +358,18 @@ against some common XML vulnerabilities.
    The corresponding :attr:`~ExpatError.lineno` and :attr:`~ExpatError.offset`
    should not be used as they may have no special meaning.
 
+   Note that :meth:`!SetAllocTrackerMaximumAmplification`
+   has been backported to some prior releases of CPython as a security fix.
+   Check for availability of
+   :meth:`!SetAllocTrackerMaximumAmplification`
+   using :func:`hasattr` if used in code running across a variety of Python
+   versions.
+
    .. note::
 
       The maximum amplification factor is only considered if the threshold
       that can be adjusted by :meth:`.SetAllocTrackerActivationThreshold`
       is exceeded.
-
-   .. note::
-
-      :meth:`!SetAllocTrackerMaximumAmplification`
-      has been backported to some prior releases of CPython as a security fix.
-      Check for availability of
-      :meth:`!SetAllocTrackerMaximumAmplification`
-      using :func:`hasattr` if used in code running across a variety of Python
-      versions.
 
    .. versionadded:: next
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1398,7 +1398,7 @@ XMLParser Objects
       Disabling reparse deferral has security consequences; please see
       :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
 
-      Note that :meth:`!flush`
+      :meth:`!flush`
       has been backported to some prior releases of CPython as a security fix.
       Check for availability of
       :meth:`!flush`
@@ -1478,7 +1478,7 @@ XMLPullParser Objects
       Disabling reparse deferral has security consequences; please see
       :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
 
-      Note that :meth:`!flush`
+      :meth:`!flush`
       has been backported to some prior releases of CPython as a security fix.
       Check for availability of
       :meth:`!flush`

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1400,10 +1400,12 @@ XMLParser Objects
 
       .. note::
 
-      :meth:`flush` has been backported to some prior releases of
-      CPython as a security fix.  Check for availability of :meth:`flush`
-      using :func:`hasattr` if used in code running across a variety of Python
-      versions.
+         :meth:`flush`
+         has been backported to some prior releases of CPython as a security
+         fix. Check for availability of
+         :meth:`flush`
+         using :func:`hasattr` if used in code running across a variety of
+         Python versions.
 
       .. versionadded:: 3.13
 
@@ -1480,10 +1482,12 @@ XMLPullParser Objects
 
       .. note::
 
-      :meth:`flush` has been backported to some prior releases of
-      CPython as a security fix.  Check for availability of :meth:`flush`
-      using :func:`hasattr` if used in code running across a variety of Python
-      versions.
+         :meth:`flush`
+         has been backported to some prior releases of CPython as a security
+         fix. Check for availability of
+         :meth:`flush`
+         using :func:`hasattr` if used in code running across a variety of
+         Python versions.
 
       .. versionadded:: 3.13
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1400,10 +1400,8 @@ XMLParser Objects
 
       :meth:`!flush`
       has been backported to some prior releases of CPython as a security fix.
-      Check for availability of
-      :meth:`!flush`
-      using :func:`hasattr` if used in code running across a variety of Python
-      versions.
+      Check for availability using :func:`hasattr` if used in code running
+      across a variety of Python versions.
 
       .. versionadded:: 3.13
 
@@ -1480,10 +1478,8 @@ XMLPullParser Objects
 
       :meth:`!flush`
       has been backported to some prior releases of CPython as a security fix.
-      Check for availability of
-      :meth:`!flush`
-      using :func:`hasattr` if used in code running across a variety of Python
-      versions.
+      Check for availability using :func:`hasattr` if used in code running
+      across a variety of Python versions.
 
       .. versionadded:: 3.13
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1398,14 +1398,12 @@ XMLParser Objects
       Disabling reparse deferral has security consequences; please see
       :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
 
-      .. note::
-
-         :meth:`!flush`
-         has been backported to some prior releases of CPython as a security
-         fix. Check for availability of
-         :meth:`!flush`
-         using :func:`hasattr` if used in code running across a variety of
-         Python versions.
+      Note that :meth:`!flush`
+      has been backported to some prior releases of CPython as a security fix.
+      Check for availability of
+      :meth:`!flush`
+      using :func:`hasattr` if used in code running across a variety of Python
+      versions.
 
       .. versionadded:: 3.13
 
@@ -1480,14 +1478,12 @@ XMLPullParser Objects
       Disabling reparse deferral has security consequences; please see
       :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
 
-      .. note::
-
-         :meth:`!flush`
-         has been backported to some prior releases of CPython as a security
-         fix. Check for availability of
-         :meth:`!flush`
-         using :func:`hasattr` if used in code running across a variety of
-         Python versions.
+      Note that :meth:`!flush`
+      has been backported to some prior releases of CPython as a security fix.
+      Check for availability of
+      :meth:`!flush`
+      using :func:`hasattr` if used in code running across a variety of Python
+      versions.
 
       .. versionadded:: 3.13
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1400,10 +1400,10 @@ XMLParser Objects
 
       .. note::
 
-         :meth:`flush`
+         :meth:`!flush`
          has been backported to some prior releases of CPython as a security
          fix. Check for availability of
-         :meth:`flush`
+         :meth:`!flush`
          using :func:`hasattr` if used in code running across a variety of
          Python versions.
 
@@ -1482,10 +1482,10 @@ XMLPullParser Objects
 
       .. note::
 
-         :meth:`flush`
+         :meth:`!flush`
          has been backported to some prior releases of CPython as a security
          fix. Check for availability of
-         :meth:`flush`
+         :meth:`!flush`
          using :func:`hasattr` if used in code running across a variety of
          Python versions.
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1398,7 +1398,9 @@ XMLParser Objects
       Disabling reparse deferral has security consequences; please see
       :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
 
-      Note that :meth:`flush` has been backported to some prior releases of
+      .. note::
+
+      :meth:`flush` has been backported to some prior releases of
       CPython as a security fix.  Check for availability of :meth:`flush`
       using :func:`hasattr` if used in code running across a variety of Python
       versions.
@@ -1476,7 +1478,9 @@ XMLPullParser Objects
       Disabling reparse deferral has security consequences; please see
       :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
 
-      Note that :meth:`flush` has been backported to some prior releases of
+      .. note::
+
+      :meth:`flush` has been backported to some prior releases of
       CPython as a security fix.  Check for availability of :meth:`flush`
       using :func:`hasattr` if used in code running across a variety of Python
       versions.


### PR DESCRIPTION
Same idea (and approach) as #116278.

CC @picnixz 

<!-- gh-issue-number: gh-90949 -->
* Issue: gh-90949
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139800.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->