### PR TITLE
gh-139821: Make ``tarfile.open`` correctly forward keyword arguments for zstd in stream mode.

### DIFF
--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -137,6 +137,9 @@ Some facts and figures:
    a Zstandard dictionary used to improve compression of smaller amounts of
    data.
 
+   For modes ``'r:zst'`` and ``'r|zst'``, :func:`tarfile.open` accepts the keyword
+   arguments *options* and *zstd_dict* as well.
+
    For special purposes, there is a second format for *mode*:
    ``'filemode|[compression]'``.  :func:`tarfile.open` will return a :class:`TarFile`
    object that processes its data as a stream of blocks.  No random seeking will

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -372,7 +372,7 @@ class _Stream:
                     self.exception = zlib.error
                     self._init_read_gz()
                 else:
-                    self._init_write_gz(kwargs["compresslevel"])
+                    self._init_write_gz(kwargs.get("compresslevel"))
 
             elif comptype == "bz2":
                 try:
@@ -384,7 +384,7 @@ class _Stream:
                     self.cmp = bz2.BZ2Decompressor()
                     self.exception = OSError
                 else:
-                    self.cmp = bz2.BZ2Compressor(kwargs["compresslevel"])
+                    self.cmp = bz2.BZ2Compressor(kwargs.get("compresslevel"))
 
             elif comptype == "xz":
                 try:
@@ -396,7 +396,7 @@ class _Stream:
                     self.cmp = lzma.LZMADecompressor()
                     self.exception = lzma.LZMAError
                 else:
-                    self.cmp = lzma.LZMACompressor(preset=kwargs["preset"])
+                    self.cmp = lzma.LZMACompressor(preset=kwargs.get("preset"))
             elif comptype == "zst":
                 try:
                     from compression import zstd
@@ -404,13 +404,13 @@ class _Stream:
                     raise CompressionError("compression.zstd module is not available") from None
                 if mode == "r":
                     self.dbuf = b""
-                    self.cmp = zstd.ZstdDecompressor(kwargs["zstd_dict"],
-                            kwargs["options"])
+                    self.cmp = zstd.ZstdDecompressor(kwargs.get("zstd_dict"),
+                            kwargs.get("options"))
                     self.exception = zstd.ZstdError
                 else:
-                    self.cmp = zstd.ZstdCompressor(kwargs["level"],
-                                                   kwargs["options"],
-                                                   kwargs["zstd_dict"])
+                    self.cmp = zstd.ZstdCompressor(kwargs.get("level"),
+                                                   kwargs.get("options"),
+                                                   kwargs.get("zstd_dict"))
             elif comptype != "tar":
                 raise CompressionError("unknown compression type %r" % comptype)
 

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1933,7 +1933,7 @@ class TarFile(object):
                 for arg in ("level", "options", "zstd_dict"):
                     if arg in kwargs:
                         raise ValueError(
-                            f"{arg} is only valid for w:zst, x:zst and w|zst modes"
+                            f"{arg} is only valid for zstd compression"
                         )
 
             compresslevel = kwargs.pop("compresslevel", 6)

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -396,7 +396,7 @@ class _Stream:
                     self.cmp = lzma.LZMADecompressor()
                     self.exception = lzma.LZMAError
                 else:
-                    self.cmp = lzma.LZMACompressor(kwargs["preset"])
+                    self.cmp = lzma.LZMACompressor(preset=kwargs["preset"])
             elif comptype == "zst":
                 try:
                     from compression import zstd

--- a/Misc/NEWS.d/next/Library/2025-10-09-05-42-07.gh-issue-139821.cHM3qC.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-09-05-42-07.gh-issue-139821.cHM3qC.rst
@@ -1,0 +1,1 @@
+Make ``tarfile.open`` correctly forward keyword arguments for zstd in stream mode.


### PR DESCRIPTION


<!-- gh-issue-number: gh-139821 -->
* Issue: gh-139821
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139822.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->