### PR TITLE
[3.13] gh-101100: Fix reference warnings in `c-api/init.rst` document…

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1225,8 +1225,22 @@ code, or when embedding the Python interpreter:
    The :term:`GIL` does not need to be held, but will be held upon returning
    if *tstate* is non-``NULL``.
 
+
 The following functions use thread-local storage, and are not compatible
 with sub-interpreters:
+
+.. c:type:: PyGILState_STATE
+
+   The type of the value returned by :c:func:`PyGILState_Ensure` and passed to
+   :c:func:`PyGILState_Release`.
+
+   .. c:enumerator:: PyGILState_LOCKED
+
+      The GIL was already held when :c:func:`PyGILState_Ensure` was called.
+
+   .. c:enumerator:: PyGILState_UNLOCKED
+
+      The GIL was not held when :c:func:`PyGILState_Ensure` was called.
 
 .. c:function:: PyGILState_STATE PyGILState_Ensure()
 
@@ -1372,11 +1386,11 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    must be held.
 
    .. versionchanged:: 3.9
-      This function now calls the :c:member:`PyThreadState.on_delete` callback.
+      This function now calls the :c:member:`!PyThreadState.on_delete` callback.
       Previously, that happened in :c:func:`PyThreadState_Delete`.
 
    .. versionchanged:: 3.13
-      The :c:member:`PyThreadState.on_delete` callback was removed.
+      The :c:member:`!PyThreadState.on_delete` callback was removed.
 
 
 .. c:function:: void PyThreadState_Delete(PyThreadState *tstate)

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1225,7 +1225,6 @@ code, or when embedding the Python interpreter:
    The :term:`GIL` does not need to be held, but will be held upon returning
    if *tstate* is non-``NULL``.
 
-
 The following functions use thread-local storage, and are not compatible
 with sub-interpreters:
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1094,7 +1094,7 @@ acquire the :term:`GIL`.
 If any thread, other than the finalization thread, attempts to acquire the GIL
 during finalization, either explicitly via :c:func:`PyGILState_Ensure`,
 :c:macro:`Py_END_ALLOW_THREADS`, :c:func:`PyEval_AcquireThread`, or
-:c:func:`PyEval_AcquireLock`, or implicitly when the interpreter attempts to
+:c:func:`!PyEval_AcquireLock`, or implicitly when the interpreter attempts to
 reacquire it after having yielded it, the thread enters **a permanently blocked
 state** where it remains until the program exits.  In most cases this is
 harmless, but this can result in deadlock if a later stage of finalization

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -4,7 +4,6 @@
 
 Doc/c-api/descriptor.rst
 Doc/c-api/float.rst
-Doc/c-api/init.rst
 Doc/c-api/init_config.rst
 Doc/c-api/intro.rst
 Doc/c-api/module.rst


### PR DESCRIPTION
…ing `PyGILState_STATE` (GH-139572)

(cherry picked from commit d2deb8fdef1ac5e54564448677cdb1522f1b776d)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139833.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->