### PR TITLE
gh-101100: Document `zlib` public constants to fix reference warnings

### DIFF
--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -350,7 +350,7 @@ behavior:
 
 .. data:: MAX_WBITS
 
-   The maximum window buffer size.
+   The maximum window buffer size (power of 2).
 
 
 .. data:: DEF_MEM_LEVEL

--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -350,7 +350,9 @@ behavior:
 
 .. data:: MAX_WBITS
 
-   The maximum window buffer size (power of 2).
+   The maximum window size, expressed as a power of 2.
+   For example, if :const:`!MAX_WBITS` is ``15`` it results in a window size
+   of ``32 KiB``.
 
 
 .. data:: DEF_MEM_LEVEL

--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -367,6 +367,8 @@ behavior:
 
    Compression level ``0``.
 
+   .. versionadded:: 3.6
+
 
 .. data:: Z_BEST_SPEED
 
@@ -380,7 +382,7 @@ behavior:
 
 .. data:: Z_DEFAULT_COMPRESSION
 
-   Default compression level ``-1``.
+   Default compression level (``-1``).
 
 
 .. data:: Z_DEFAULT_STRATEGY
@@ -405,6 +407,8 @@ behavior:
    This constant is only available if Python was compiled with zlib
    1.2.0.1 or greater.
 
+   .. versionadded:: 3.6
+
 
 .. data:: Z_FIXED
 
@@ -413,10 +417,14 @@ behavior:
    This constant is only available if Python was compiled with zlib
    1.2.2.2 or greater.
 
+   .. versionadded:: 3.6
+
 
 .. data:: Z_NO_FLUSH
 
    Flush mode ``0``. No special flushing behavior.
+
+   .. versionadded:: 3.6
 
 
 .. data:: Z_PARTIAL_FLUSH
@@ -446,6 +454,8 @@ behavior:
    This constant is only available if Python was compiled with zlib
    1.2.2.2 or greater.
 
+   .. versionadded:: 3.6
+
 
 .. data:: Z_TREES
 
@@ -454,6 +464,8 @@ behavior:
 
    This constant is only available if Python was compiled with zlib
    1.2.3.4 or greater.
+
+   .. versionadded:: 3.6
 
 
 Information about the version of the zlib library in use is available through

--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -11,8 +11,8 @@ For applications that require data compression, the functions in this module
 allow compression and decompression, using the zlib library. The zlib library
 has its own home page at https://www.zlib.net.   There are known
 incompatibilities between the Python module and versions of the zlib library
-earlier than 1.1.3; 1.1.3 has a `security vulnerability <https://zlib.net/zlib_faq.html#faq33>`_,
-so we recommend using 1.1.4 or later.
+earlier than 1.1.3; 1.1.3 has a `security vulnerability <https://zlib.net/zlib_faq.html#faq33>`_, so we recommend using
+1.1.4 or later.
 
 zlib's functions have many options and often need to be used in a particular
 order.  This documentation doesn't attempt to cover all of the permutations;

--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -11,12 +11,12 @@ For applications that require data compression, the functions in this module
 allow compression and decompression, using the zlib library. The zlib library
 has its own home page at https://www.zlib.net.   There are known
 incompatibilities between the Python module and versions of the zlib library
-earlier than 1.1.3; 1.1.3 has a `security vulnerability <https://zlib.net/zlib_faq.html#faq33>`_, so we recommend using
-1.1.4 or later.
+earlier than 1.1.3; 1.1.3 has a `security vulnerability <https://zlib.net/zlib_faq.html#faq33>`_,
+so we recommend using 1.1.4 or later.
 
 zlib's functions have many options and often need to be used in a particular
 order.  This documentation doesn't attempt to cover all of the permutations;
-consult the zlib manual at http://www.zlib.net/manual.html for authoritative
+consult the `zlib manual <https://www.zlib.net/manual.html>`_ for authoritative
 information.
 
 For reading and writing ``.gz`` files see the :mod:`gzip` module.
@@ -340,6 +340,122 @@ Decompression objects support the following methods and attributes:
    objects.
 
 
+The following constants are available to configure compression and decompression
+behavior:
+
+.. data:: DEFLATED
+
+   The deflate compression method.
+
+
+.. data:: MAX_WBITS
+
+   The maximum window buffer size.
+
+
+.. data:: DEF_MEM_LEVEL
+
+   The default memory level for compression objects.
+
+
+.. data:: DEF_BUF_SIZE
+
+   The default buffer size for decompression operations.
+
+
+.. data:: Z_NO_COMPRESSION
+
+   Compression level ``0``.
+
+
+.. data:: Z_BEST_SPEED
+
+   Compression level ``1``.
+
+
+.. data:: Z_BEST_COMPRESSION
+
+   Compression level ``9``.
+
+
+.. data:: Z_DEFAULT_COMPRESSION
+
+   Default compression level ``-1``.
+
+
+.. data:: Z_DEFAULT_STRATEGY
+
+   Default compression strategy, for normal data.
+
+
+.. data:: Z_FILTERED
+
+   Compression strategy for data produced by a filter (or predictor).
+
+
+.. data:: Z_HUFFMAN_ONLY
+
+   Compression strategy that forces Huffman coding only.
+
+
+.. data:: Z_RLE
+
+   Compression strategy that limits match distances to one (run-length encoding).
+
+   This constant is only available if Python was compiled with zlib
+   1.2.0.1 or greater.
+
+
+.. data:: Z_FIXED
+
+   Compression strategy that prevents the use of dynamic Huffman codes.
+
+   This constant is only available if Python was compiled with zlib
+   1.2.2.2 or greater.
+
+
+.. data:: Z_NO_FLUSH
+
+   Flush mode ``0``. No special flushing behavior.
+
+
+.. data:: Z_PARTIAL_FLUSH
+
+   Flush mode ``1``. Flush as much output as possible.
+
+
+.. data:: Z_SYNC_FLUSH
+
+   Flush mode ``2``. All output is flushed and the output is aligned to a byte boundary.
+
+
+.. data:: Z_FULL_FLUSH
+
+   Flush mode ``3``. All output is flushed and the compression state is reset.
+
+
+.. data:: Z_FINISH
+
+   Flush mode ``4``. All pending input is processed, no more input is expected.
+
+
+.. data:: Z_BLOCK
+
+   Flush mode ``5``. A deflate block is completed and emitted.
+
+   This constant is only available if Python was compiled with zlib
+   1.2.2.2 or greater.
+
+
+.. data:: Z_TREES
+
+   Flush mode ``6``, for inflate operations. Instructs inflate to return when
+   it gets to the next deflate block boundary.
+
+   This constant is only available if Python was compiled with zlib
+   1.2.3.4 or greater.
+
+
 Information about the version of the zlib library in use is available through
 the following constants:
 
@@ -375,10 +491,10 @@ the following constants:
    Module :mod:`gzip`
       Reading and writing :program:`gzip`\ -format files.
 
-   http://www.zlib.net
+   https://www.zlib.net
       The zlib library home page.
 
-   http://www.zlib.net/manual.html
+   https://www.zlib.net/manual.html
       The zlib manual explains  the semantics and usage of the library's many
       functions.
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -51,7 +51,6 @@ Doc/library/xml.sax.reader.rst
 Doc/library/xml.sax.rst
 Doc/library/xmlrpc.client.rst
 Doc/library/xmlrpc.server.rst
-Doc/library/zlib.rst
 Doc/whatsnew/2.4.rst
 Doc/whatsnew/2.5.rst
 Doc/whatsnew/2.6.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Also included, converting links to `https` and wrapping a long line.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139835.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->