### PR TITLE
gh-139783: Fix inspect.getsourcelines() for the case when a decorator is followed by a comment or an empty line

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1065,7 +1065,9 @@ class BlockFinder:
 
     def tokeneater(self, type, token, srowcol, erowcol, line):
         if not self.started and not self.indecorator:
-            if type == tokenize.INDENT or token == "async":
+            if type in (tokenize.INDENT, tokenize.COMMENT, tokenize.NL):
+                pass
+            elif token == "async":
                 pass
             # skip any decorators
             elif token == "@":

--- a/Lib/test/test_inspect/inspect_fodder2.py
+++ b/Lib/test/test_inspect/inspect_fodder2.py
@@ -388,4 +388,16 @@ def func383():
     )
     return ge385
 
+# line 391
+@decorator
+# comment
+def func394():
+    return 395
+
+# line 397
+@decorator
+
+def func400():
+    return 401
+
 pass # end of file

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -1223,6 +1223,10 @@ class TestBuggyCases(GetSourceBase):
         self.assertSourceEqual(next(mod2.ge377), 377, 380)
         self.assertSourceEqual(next(mod2.func383()), 385, 388)
 
+    def test_comment_or_empty_line_after_decorator(self):
+        self.assertSourceEqual(mod2.func394, 392, 395)
+        self.assertSourceEqual(mod2.func400, 398, 401)
+
 
 class TestNoEOL(GetSourceBase):
     def setUp(self):

--- a/Misc/NEWS.d/next/Library/2025-10-09-13-48-28.gh-issue-139783.__NUgo.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-09-13-48-28.gh-issue-139783.__NUgo.rst
@@ -1,0 +1,2 @@
+Fix :func:`inspect.getsourcelines` for the case when a decorator is followed
+by a comment or an empty line.


### PR DESCRIPTION


<!-- gh-issue-number: gh-139783 -->
* Issue: gh-139783
<!-- /gh-issue-number -->
