### PR TITLE
gh-139843: Document `signal.SIGQUIT` to fix Sphinx references

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -243,7 +243,7 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
-.. data:: SIGQUIT 
+.. data:: SIGQUIT
 
    Terminal quit signal.
 

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -205,6 +205,12 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
+.. data:: SIGQUIT
+
+   Terminal quit signal.
+
+   .. availability:: Unix.
+
 .. data:: SIGSEGV
 
    Segmentation fault: invalid memory reference.
@@ -240,12 +246,6 @@ The variables defined in the :mod:`signal` module are:
 .. data:: SIGWINCH
 
    Window resize signal.
-
-   .. availability:: Unix.
-
-.. data:: SIGQUIT
-
-   Terminal quit signal.
 
    .. availability:: Unix.
 

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -243,6 +243,12 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
+.. data:: SIGQUIT 
+
+   Terminal quit signal.
+
+   .. availability:: Unix.
+
 .. data:: SIG*
 
    All the signal numbers are defined symbolically.  For example, the hangup signal


### PR DESCRIPTION
I'm not that sure about whether I should reference to #101100 or #139843 . Please fix it if I'm wrong, TiA.

<!-- gh-issue-number: gh-139843 -->
* Issue: gh-139843
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139844.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->