### PR TITLE
gh-139845: do not print twice in default asyncio REPL

### DIFF
--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -74,7 +74,6 @@ class AsyncIOInteractiveConsole(InteractiveColoredConsole):
             return
         except BaseException:
             if keyboard_interrupted:
-                # (pyrepl already handles and prints it)
                 if not CAN_USE_PYREPL:
                     self.write("\nKeyboardInterrupt\n")
             else:

--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -74,7 +74,9 @@ class AsyncIOInteractiveConsole(InteractiveColoredConsole):
             return
         except BaseException:
             if keyboard_interrupted:
-                self.write("\nKeyboardInterrupt\n")
+                # (pyrepl already handles and prints it)
+                if not CAN_USE_PYREPL:
+                    self.write("\nKeyboardInterrupt\n")
             else:
                 self.showtraceback()
             return self.STATEMENT_FAILED

--- a/Misc/NEWS.d/next/Library/2025-10-09-21-37-20.gh-issue-139845.dzx5UP.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-09-21-37-20.gh-issue-139845.dzx5UP.rst
@@ -1,1 +1,1 @@
-Fix: do not print KeyboardInterrupt twice in default asyncio REPL.
+Fix to not print KeyboardInterrupt twice in default asyncio REPL.

--- a/Misc/NEWS.d/next/Library/2025-10-09-21-37-20.gh-issue-139845.dzx5UP.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-09-21-37-20.gh-issue-139845.dzx5UP.rst
@@ -1,0 +1,1 @@
+Fix: do not print KeyboardInterrupt twice in default asyncio REPL.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The reason is that we already print `nKeyboardInterrupt\n` in `_pyrepl` 


<!-- gh-issue-number: gh-139845 -->
* Issue: gh-139845
<!-- /gh-issue-number -->
