### PR TITLE
[3.13] gh-139391: properly handle `signal.signal()` in `UnixConsole` when called from a non-main thread (GH-139392)

### DIFF
--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -397,7 +397,12 @@ class UnixConsole(Console):
             os.write(self.output_fd, b"\033[?7h")
 
         if hasattr(self, "old_sigwinch"):
-            signal.signal(signal.SIGWINCH, self.old_sigwinch)
+            try:
+                signal.signal(signal.SIGWINCH, self.old_sigwinch)
+            except ValueError as e:
+                import threading
+                if threading.current_thread() is threading.main_thread():
+                    raise e
             del self.old_sigwinch
 
     def push_char(self, char: int | bytes) -> None:

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -4,11 +4,12 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 import unittest
 from functools import partial
 from test import support
 from test.support import os_helper
-from test.support import script_helper
+from test.support import script_helper, threading_helper
 
 from unittest import TestCase
 from unittest.mock import MagicMock, call, patch, ANY, Mock
@@ -342,6 +343,17 @@ class TestConsole(TestCase):
             os.environ = []
             console.prepare()  # needed to call restore()
             console.restore()  # this should succeed
+
+    @threading_helper.reap_threads
+    @threading_helper.requires_working_threading()
+    def test_restore_in_thread(self, _os_write):
+        # gh-139391: ensure that console.restore() silently suppresses
+        # exceptions when calling signal.signal() from a non-main thread.
+        console = unix_console([])
+        console.old_sigwinch = signal.SIG_DFL
+        thread = threading.Thread(target=console.restore)
+        thread.start()
+        thread.join()  # this should not raise
 
 
 @unittest.skipIf(sys.platform == "win32", "No Unix console on Windows")

--- a/Misc/NEWS.d/next/Library/2025-09-28-16-34-11.gh-issue-139391.nRFnmx.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-28-16-34-11.gh-issue-139391.nRFnmx.rst
@@ -1,0 +1,3 @@
+Fix an issue when, on non-Windows platforms, it was not possible to
+gracefully exit a ``python -m asyncio`` process suspended by Ctrl+Z
+and later resumed by :manpage:`fg` other than with :manpage:`kill`.


### PR DESCRIPTION
(cherry picked from commit b8c8b8f1d30767e5358ffa93d41e6e27ca60570d)


<!-- gh-issue-number: gh-139391 -->
* Issue: gh-139391
<!-- /gh-issue-number -->
