### PR TITLE
gh-139842: Clarify `__module__` description in typing.rst

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2269,7 +2269,7 @@ without the dedicated syntax, as documented below.
 
    .. attribute:: __module__
 
-      The module in which the type alias was defined::
+      The name of the module in which the type alias was defined::
 
          >>> type Alias = int
          >>> Alias.__module__
@@ -2449,7 +2449,7 @@ types.
 
    .. attribute:: __module__
 
-      The module in which the new type is defined.
+      The name of the module in which the new type is defined.
 
    .. attribute:: __name__
 


### PR DESCRIPTION
The `__module__` attribute must be a string or `None`, not an actual module instance. Make it clear in the `__module__` attribute description, and consistent with other occurrences throughout the docs.

Fixes https://github.com/python/cpython/issues/139842.


<!-- gh-issue-number: gh-139842 -->
* Issue: gh-139842
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139863.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->