### PR TITLE
gh-53509: Move _PyObject_ASSERT() to the internal C API

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -380,55 +380,6 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
 #endif
 
 
-/* Define a pair of assertion macros:
-   _PyObject_ASSERT_FROM(), _PyObject_ASSERT_WITH_MSG() and _PyObject_ASSERT().
-
-   These work like the regular C assert(), in that they will abort the
-   process with a message on stderr if the given condition fails to hold,
-   but compile away to nothing if NDEBUG is defined.
-
-   However, before aborting, Python will also try to call _PyObject_Dump() on
-   the given object.  This may be of use when investigating bugs in which a
-   particular object is corrupt (e.g. buggy a tp_visit method in an extension
-   module breaking the garbage collector), to help locate the broken objects.
-
-   The WITH_MSG variant allows you to supply an additional message that Python
-   will attempt to print to stderr, after the object dump. */
-#ifdef NDEBUG
-   /* No debugging: compile away the assertions: */
-#  define _PyObject_ASSERT_FROM(obj, expr, msg, filename, lineno, func) \
-    ((void)0)
-#else
-   /* With debugging: generate checks: */
-#  define _PyObject_ASSERT_FROM(obj, expr, msg, filename, lineno, func) \
-    ((expr) \
-      ? (void)(0) \
-      : _PyObject_AssertFailed((obj), Py_STRINGIFY(expr), \
-                               (msg), (filename), (lineno), (func)))
-#endif
-
-#define _PyObject_ASSERT_WITH_MSG(obj, expr, msg) \
-    _PyObject_ASSERT_FROM((obj), expr, (msg), __FILE__, __LINE__, __func__)
-#define _PyObject_ASSERT(obj, expr) \
-    _PyObject_ASSERT_WITH_MSG((obj), expr, NULL)
-
-#define _PyObject_ASSERT_FAILED_MSG(obj, msg) \
-    _PyObject_AssertFailed((obj), NULL, (msg), __FILE__, __LINE__, __func__)
-
-/* Declare and define _PyObject_AssertFailed() even when NDEBUG is defined,
-   to avoid causing compiler/linker errors when building extensions without
-   NDEBUG against a Python built with NDEBUG defined.
-
-   msg, expr and function can be NULL. */
-PyAPI_FUNC(void) _Py_NO_RETURN _PyObject_AssertFailed(
-    PyObject *obj,
-    const char *expr,
-    const char *msg,
-    const char *file,
-    int line,
-    const char *function);
-
-
 PyAPI_FUNC(void) _PyTrash_thread_deposit_object(PyThreadState *tstate, PyObject *op);
 PyAPI_FUNC(void) _PyTrash_thread_destroy_chain(PyThreadState *tstate);
 

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -11,6 +11,7 @@ extern "C" {
 #include "pycore_interp_structs.h" // PyGC_Head
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
 #include "pycore_typedefs.h"      // _PyInterpreterFrame
+#include "pycore_utils.h"         // _PyObject_ASSERT_FROM()
 
 
 /* Get an object's GC head */

--- a/Include/internal/pycore_utils.h
+++ b/Include/internal/pycore_utils.h
@@ -1,0 +1,62 @@
+#ifndef Py_INTERNAL_UTILS_H
+#define Py_INTERNAL_UTILS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+/* Define a pair of assertion macros:
+ * _PyObject_ASSERT_FROM(), _PyObject_ASSERT_WITH_MSG() and _PyObject_ASSERT().
+ *
+ * These work like the regular C assert(), in that they will abort the
+ * process with a message on stderr if the given condition fails to hold,
+ * but compile away to nothing if NDEBUG is defined.
+ *
+ * However, before aborting, Python will also try to call _PyObject_Dump() on
+ * the given object.  This may be of use when investigating bugs in which a
+ * particular object is corrupt (e.g. buggy a tp_visit method in an extension
+ * module breaking the garbage collector), to help locate the broken objects.
+ *
+ * The WITH_MSG variant allows you to supply an additional message that Python
+ * will attempt to print to stderr, after the object dump. */
+#ifdef NDEBUG
+   /* No debugging: compile away the assertions: */
+#  define _PyObject_ASSERT_FROM(obj, expr, msg, filename, lineno, func) \
+    ((void)0)
+#else
+   /* With debugging: generate checks: */
+#  define _PyObject_ASSERT_FROM(obj, expr, msg, filename, lineno, func) \
+    ((expr) \
+      ? (void)(0) \
+      : _PyObject_AssertFailed((obj), Py_STRINGIFY(expr), \
+                               (msg), (filename), (lineno), (func)))
+#endif
+
+#define _PyObject_ASSERT_WITH_MSG(obj, expr, msg) \
+    _PyObject_ASSERT_FROM((obj), expr, (msg), __FILE__, __LINE__, __func__)
+#define _PyObject_ASSERT(obj, expr) \
+    _PyObject_ASSERT_WITH_MSG((obj), expr, NULL)
+
+#define _PyObject_ASSERT_FAILED_MSG(obj, msg) \
+    _PyObject_AssertFailed((obj), NULL, (msg), __FILE__, __LINE__, __func__)
+
+/* Declare and define _PyObject_AssertFailed() even when NDEBUG is defined,
+   to avoid causing compiler/linker errors when building extensions without
+   NDEBUG against a Python built with NDEBUG defined.
+
+   msg, expr and function can be NULL. */
+PyAPI_FUNC(void) _Py_NO_RETURN _PyObject_AssertFailed(
+    PyObject *obj,
+    const char *expr,
+    const char *msg,
+    const char *file,
+    int line,
+    const char *function);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_UTILS_H */

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1439,6 +1439,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_uop.h \
 		$(srcdir)/Include/internal/pycore_uop_ids.h \
 		$(srcdir)/Include/internal/pycore_uop_metadata.h \
+		$(srcdir)/Include/internal/pycore_utils.h \
 		$(srcdir)/Include/internal/pycore_warnings.h \
 		$(srcdir)/Include/internal/pycore_weakref.h \
 		$(DTRACE_HEADERS) \

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -331,6 +331,7 @@
     <ClInclude Include="..\Include\internal\pycore_unicodeobject.h" />
     <ClInclude Include="..\Include\internal\pycore_unicodeobject_generated.h" />
     <ClInclude Include="..\Include\internal\pycore_uniqueid.h" />
+    <ClInclude Include="..\Include\internal\pycore_utils.h" />
     <ClInclude Include="..\Include\internal\pycore_warnings.h" />
     <ClInclude Include="..\Include\internal\pycore_weakref.h" />
     <ClInclude Include="..\Include\intrcheck.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -534,6 +534,9 @@
     <ClInclude Include="..\Include\internal\pycore_unicodeobject_generated.h">
       <Filter>Include\internal</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_utils.h">
+      <Filter>Include\internal</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_warnings.h">
       <Filter>Include\internal</Filter>
     </ClInclude>


### PR DESCRIPTION
Add pycore_utils.h internal header file. Move the following APIs to pycore_utils.h:

* _PyObject_ASSERT() macro
* _PyObject_ASSERT_FAILED_MSG() macro
* _PyObject_ASSERT_FROM() macro
* _PyObject_ASSERT_WITH_MSG() macro
* _PyObject_AssertFailed() function

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-53509 -->
* Issue: gh-53509
<!-- /gh-issue-number -->
