### PR TITLE
gh-139875: Make `code.interact` Match REPL Behavior on ctrl+d in Multiline Entry

### DIFF
--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -168,8 +168,8 @@ class InteractiveSession(unittest.TestCase):
     def test_interact_incomplete_multiline_sql(self):
         out, err = self.run_cli(commands=("SELECT 1",))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertEndsWith(out, self.PS2)
-        self.assertEqual(out.count(self.PS1), 1)
+        self.assertEqual(out.count(self.PS1), 2)
+        self.assertEqual(err.count('SyntaxError'), 1)
         self.assertEqual(out.count(self.PS2), 1)
 
     def test_interact_valid_multiline_sql(self):

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -168,8 +168,8 @@ class InteractiveSession(unittest.TestCase):
     def test_interact_incomplete_multiline_sql(self):
         out, err = self.run_cli(commands=("SELECT 1",))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertEqual(out.count(self.PS1), 2)
-        self.assertEqual(err.count('SyntaxError'), 1)
+        self.assertEndsWith(out, self.PS2)
+        self.assertEqual(out.count(self.PS1), 1)
         self.assertEqual(out.count(self.PS2), 1)
 
     def test_interact_valid_multiline_sql(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-09-19-37-05.gh-issue-139875.pg95dm.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-09-19-37-05.gh-issue-139875.pg95dm.rst
@@ -1,0 +1,2 @@
+Fix difference in Ctrl+D handling between :func:`code.interact` and the Python
+REPL.  Patch by Adam Hartz


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This patch is an attempt to make `code.interact`'s ctrl+d handling match that of both PyREPL and the Basic REPL, as described in #139875.  Specifically, to be consistent with the REPL, we should execute the existing code rather than exiting when receiving ctrl+d on an empty line in a multiline entry.

<!-- gh-issue-number: gh-139875 -->
* Issue: gh-139875
<!-- /gh-issue-number -->
