### PR TITLE
gh-139878: check logger level when propagating logs

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1728,10 +1728,11 @@ class Logger(Filterer):
         c = self
         found = 0
         while c:
-            for hdlr in c.handlers:
-                found = found + 1
-                if record.levelno >= hdlr.level:
-                    hdlr.handle(record)
+            if record.levelno >= c.level:
+                for hdlr in c.handlers:
+                    found = found + 1
+                    if record.levelno >= hdlr.level:
+                        hdlr.handle(record)
             if not c.propagate:
                 c = None    #break out
             else:

--- a/Misc/NEWS.d/next/Library/2025-10-10-02-40-29.gh-issue-139878.0hVfBS.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-10-02-40-29.gh-issue-139878.0hVfBS.rst
@@ -1,0 +1,1 @@
+In addition to checking the handler level, also verify the logger level when propagating log message.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
### Linked issue:

- gh-139878

### Changes

I will continue to add news and tests once this bug is acknowledged