### PR TITLE
gh-139843: Document signals (SIGSTOP, SIGVTALRM, SIGPROF) to fix sphinx references

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -215,6 +215,10 @@ The variables defined in the :mod:`signal` module are:
 
    Segmentation fault: invalid memory reference.
 
+.. data:: SIGSTOP
+
+   Stop executing (cannot be caught or ignored).
+
 .. data:: SIGSTKFLT
 
    Stack fault on coprocessor. The Linux kernel does not raise this signal: it
@@ -240,6 +244,18 @@ The variables defined in the :mod:`signal` module are:
 .. data:: SIGUSR2
 
    User-defined signal 2.
+
+   .. availability:: Unix.
+
+.. data:: SIGPROF
+
+   Profiling timer expired.
+
+   .. availability:: Unix.
+
+.. data:: SIGVTALRM
+
+   Virtual timer expired.
 
    .. availability:: Unix.
 

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -205,6 +205,12 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
+.. data:: SIGPROF
+
+   Profiling timer expired.
+
+   .. availability:: Unix.
+
 .. data:: SIGQUIT
 
    Terminal quit signal.
@@ -244,12 +250,6 @@ The variables defined in the :mod:`signal` module are:
 .. data:: SIGUSR2
 
    User-defined signal 2.
-
-   .. availability:: Unix.
-
-.. data:: SIGPROF
-
-   Profiling timer expired.
 
    .. availability:: Unix.
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-139895 -->
* Issue: gh-139895
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139896.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-139843 -->
* Issue: gh-139843
<!-- /gh-issue-number -->
