### PR TITLE
gh-138050: move cold invalidation to `Tools/jit/trampoline.c`

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5362,10 +5362,6 @@ dummy_func(
 
         tier2 op(_MAKE_WARM, (--)) {
             current_executor->vm_data.warm = true;
-            // It's okay if this ends up going negative.
-            if (--tstate->interp->trace_run_counter == 0) {
-                _Py_set_eval_breaker_bit(tstate, _PY_EVAL_JIT_INVALIDATE_COLD_BIT);
-            }
         }
 
         tier2 op(_FATAL_ERROR, (--)) {

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -7409,9 +7409,6 @@
 
         case _MAKE_WARM: {
             current_executor->vm_data.warm = true;
-            if (--tstate->interp->trace_run_counter == 0) {
-                _Py_set_eval_breaker_bit(tstate, _PY_EVAL_JIT_INVALIDATE_COLD_BIT);
-            }
             break;
         }
 

--- a/Tools/jit/trampoline.c
+++ b/Tools/jit/trampoline.c
@@ -12,5 +12,8 @@ _JIT_ENTRY(
 ) {
     typedef DECLARE_TARGET((*jit_func));
     jit_func jitted = (jit_func)exec->jit_code;
+    if (--tstate->interp->trace_run_counter == 0) {
+        _Py_set_eval_breaker_bit(tstate, _PY_EVAL_JIT_INVALIDATE_COLD_BIT);
+    }
     return jitted(frame, stack_pointer, tstate);
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

I'm not sure is this the right place to put this. Currently experimenting and figuring out flow of the JIT. 

p.s. this is a draft
p.s.s. I have an idea to make some kind of hooks for jit using `_JIT_ENTRY` to not pollute body of trampoline function and keep it readable


<!-- gh-issue-number: gh-138050 -->
* Issue: gh-138050
<!-- /gh-issue-number -->
