### PR TITLE
gh-133059: fix `Tools/build/deepfreeze.py` nsmallposints

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -16,6 +16,7 @@ on:
       - "Tools/build/check_extension_modules.py"
       - "Tools/build/check_warnings.py"
       - "Tools/build/compute-changes.py"
+      - "Tools/build/consts_getter.py"
       - "Tools/build/deepfreeze.py"
       - "Tools/build/generate-build-details.py"
       - "Tools/build/generate_sbom.py"

--- a/Tools/build/consts_getter.py
+++ b/Tools/build/consts_getter.py
@@ -1,0 +1,22 @@
+import os
+
+SCRIPT_NAME = 'Tools/build/consts_getter.py'
+__file__ = os.path.abspath(__file__)
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+INTERNAL = os.path.join(ROOT, 'Include', 'internal')
+
+def get_nsmallnegints_and_nsmallposints():
+    nsmallposints = None
+    nsmallnegints = None
+    with open(os.path.join(INTERNAL, 'pycore_runtime_structs.h')) as infile:
+        for line in infile:
+            if line.startswith('#define _PY_NSMALLPOSINTS'):
+                nsmallposints = int(line.split()[-1])
+            elif line.startswith('#define _PY_NSMALLNEGINTS'):
+                nsmallnegints = int(line.split()[-1])
+                break
+        else:
+            raise NotImplementedError
+    assert nsmallposints
+    assert nsmallnegints
+    return nsmallnegints, nsmallposints

--- a/Tools/build/consts_getter.py
+++ b/Tools/build/consts_getter.py
@@ -1,7 +1,7 @@
-import os
+from pathlib import Path
 
-ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-INTERNAL = os.path.join(ROOT, 'Include', 'internal')
+ROOT = Path(__file__).resolve().parents[2]
+INTERNAL = ROOT / "Include" / "internal"
 
 def get_nsmallnegints_and_nsmallposints() -> tuple[int, int]:
     nsmallposints = None

--- a/Tools/build/consts_getter.py
+++ b/Tools/build/consts_getter.py
@@ -1,8 +1,6 @@
 import os
 
-SCRIPT_NAME = 'Tools/build/consts_getter.py'
-__file__ = os.path.abspath(__file__)
-ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 INTERNAL = os.path.join(ROOT, 'Include', 'internal')
 
 def get_nsmallnegints_and_nsmallposints() -> tuple[int, int]:

--- a/Tools/build/consts_getter.py
+++ b/Tools/build/consts_getter.py
@@ -6,11 +6,11 @@ INTERNAL = ROOT / "Include" / "internal"
 def get_nsmallnegints_and_nsmallposints() -> tuple[int, int]:
     nsmallposints = None
     nsmallnegints = None
-    with open(os.path.join(INTERNAL, 'pycore_runtime_structs.h')) as infile:
+    with open(INTERNAL / "pycore_runtime_structs.h") as infile:
         for line in infile:
-            if line.startswith('#define _PY_NSMALLPOSINTS'):
+            if line.startswith("#define _PY_NSMALLPOSINTS"):
                 nsmallposints = int(line.split()[-1])
-            elif line.startswith('#define _PY_NSMALLNEGINTS'):
+            elif line.startswith("#define _PY_NSMALLNEGINTS"):
                 nsmallnegints = int(line.split()[-1])
                 break
         else:

--- a/Tools/build/consts_getter.py
+++ b/Tools/build/consts_getter.py
@@ -5,7 +5,7 @@ __file__ = os.path.abspath(__file__)
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 INTERNAL = os.path.join(ROOT, 'Include', 'internal')
 
-def get_nsmallnegints_and_nsmallposints():
+def get_nsmallnegints_and_nsmallposints() -> tuple[int, int]:
     nsmallposints = None
     nsmallnegints = None
     with open(os.path.join(INTERNAL, 'pycore_runtime_structs.h')) as infile:

--- a/Tools/build/deepfreeze.py
+++ b/Tools/build/deepfreeze.py
@@ -17,6 +17,7 @@ import re
 import time
 import types
 
+import consts_getter
 import umarshal
 
 TYPE_CHECKING = False
@@ -362,7 +363,9 @@ class Printer:
                 self.write(f".ob_digit = {{ {ds} }},")
 
     def generate_int(self, name: str, i: int) -> str:
-        if -5 <= i <= 256:
+        nsmallnegints, nsmallposints = consts_getter.get_nsmallnegints_and_nsmallposints()
+
+        if -nsmallnegints <= i <= nsmallposints:
             return f"(PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS + {i}]"
         if i >= 0:
             name = f"const_int_{i}"

--- a/Tools/build/generate_global_objects.py
+++ b/Tools/build/generate_global_objects.py
@@ -3,6 +3,8 @@ import io
 import os.path
 import re
 
+import consts_getter
+
 SCRIPT_NAME = 'Tools/build/generate_global_objects.py'
 __file__ = os.path.abspath(__file__)
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -274,20 +276,7 @@ def generate_global_strings(identifiers, strings):
 
 
 def generate_runtime_init(identifiers, strings):
-    # First get some info from the declarations.
-    nsmallposints = None
-    nsmallnegints = None
-    with open(os.path.join(INTERNAL, 'pycore_runtime_structs.h')) as infile:
-        for line in infile:
-            if line.startswith('#define _PY_NSMALLPOSINTS'):
-                nsmallposints = int(line.split()[-1])
-            elif line.startswith('#define _PY_NSMALLNEGINTS'):
-                nsmallnegints = int(line.split()[-1])
-                break
-        else:
-            raise NotImplementedError
-    assert nsmallposints
-    assert nsmallnegints
+    nsmallnegints, nsmallposints = consts_getter.get_nsmallnegints_and_nsmallposints()
 
     # Then target the runtime initializer.
     filename = os.path.join(INTERNAL, 'pycore_runtime_init_generated.h')

--- a/Tools/build/mypy.ini
+++ b/Tools/build/mypy.ini
@@ -6,6 +6,7 @@ files =
     Tools/build/check_extension_modules.py,
     Tools/build/check_warnings.py,
     Tools/build/compute-changes.py,
+    Tools/build/consts_getter.py,
     Tools/build/deepfreeze.py,
     Tools/build/generate-build-details.py,
     Tools/build/generate_sbom.py,


### PR DESCRIPTION
In `Tools/build/deepfreeze.py` nsmallposints was still 256. 

Although `deepfreeze` is no longer used (#116919), this script still needs to be kept and be actual until it is completely removed.

This PR steals the parser of those numbers from `Tools/build/generate_global_objects.py` and puts it in a new script, so getting constants can be unified.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133059 -->
* Issue: gh-133059
<!-- /gh-issue-number -->
