### PR TITLE
[3.14] gh-139894: fix incorrect sharing of current task while forking in `asyncio` (GH-139897)

### DIFF
--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -15,7 +15,7 @@ import unittest
 from unittest import mock
 
 from test import support
-from test.support import os_helper
+from test.support import os_helper, warnings_helper
 from test.support import socket_helper
 from test.support import wait_process
 from test.support import hashlib_helper
@@ -1180,11 +1180,46 @@ class TestFunctional(unittest.TestCase):
 
 
 @support.requires_fork()
-class TestFork(unittest.IsolatedAsyncioTestCase):
+class TestFork(unittest.TestCase):
 
-    async def test_fork_not_share_event_loop(self):
+    def test_fork_not_share_current_task(self):
+        loop = object()
+        task = object()
+        asyncio._set_running_loop(loop)
+        self.addCleanup(asyncio._set_running_loop, None)
+        asyncio.tasks._enter_task(loop, task)
+        self.addCleanup(asyncio.tasks._leave_task, loop, task)
+        self.assertIs(asyncio.current_task(), task)
+        r, w = os.pipe()
+        self.addCleanup(os.close, r)
+        self.addCleanup(os.close, w)
+        pid = os.fork()
+        if pid == 0:
+            # child
+            try:
+                asyncio._set_running_loop(loop)
+                current_task = asyncio.current_task()
+                if current_task is None:
+                    os.write(w, b'NO TASK')
+                else:
+                    os.write(w, b'TASK:' + str(id(current_task)).encode())
+            except BaseException as e:
+                os.write(w, b'ERROR:' + ascii(e).encode())
+            finally:
+                asyncio._set_running_loop(None)
+                os._exit(0)
+        else:
+            # parent
+            result = os.read(r, 100)
+            self.assertEqual(result, b'NO TASK')
+            wait_process(pid, exitcode=0)
+
+    def test_fork_not_share_event_loop(self):
         # The forked process should not share the event loop with the parent
-        loop = asyncio.get_running_loop()
+        loop = object()
+        asyncio._set_running_loop(loop)
+        self.assertIs(asyncio.get_running_loop(), loop)
+        self.addCleanup(asyncio._set_running_loop, None)
         r, w = os.pipe()
         self.addCleanup(os.close, r)
         self.addCleanup(os.close, w)

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -15,7 +15,7 @@ import unittest
 from unittest import mock
 
 from test import support
-from test.support import os_helper, warnings_helper
+from test.support import os_helper
 from test.support import socket_helper
 from test.support import wait_process
 from test.support import hashlib_helper

--- a/Misc/NEWS.d/next/Library/2025-10-10-11-22-50.gh-issue-139894.ECAXqj.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-10-11-22-50.gh-issue-139894.ECAXqj.rst
@@ -1,0 +1,1 @@
+Fix incorrect sharing of current task with the child process while forking in :mod:`asyncio`. Patch by Kumar Aditya.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -689,6 +689,14 @@ reset_remotedebug_data(PyThreadState *tstate)
            _Py_MAX_SCRIPT_PATH_SIZE);
 }
 
+static void
+reset_asyncio_state(_PyThreadStateImpl *tstate)
+{
+    llist_init(&tstate->asyncio_tasks_head);
+    tstate->asyncio_running_loop = NULL;
+    tstate->asyncio_running_task = NULL;
+}
+
 
 void
 PyOS_AfterFork_Child(void)
@@ -724,6 +732,8 @@ PyOS_AfterFork_Child(void)
     }
 
     reset_remotedebug_data(tstate);
+
+    reset_asyncio_state((_PyThreadStateImpl *)tstate);
 
     // Remove the dead thread states. We "start the world" once we are the only
     // thread state left to undo the stop the world call in `PyOS_BeforeFork`.


### PR DESCRIPTION


Fix incorrect sharing of current task with the forked child process by clearing thread state's current task and current loop in `PyOS_AfterFork_Child`. (cherry picked from commit b881df47ff1adca515d1de04f689160ddae72142)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139894 -->
* Issue: gh-139894
<!-- /gh-issue-number -->
