### PR TITLE
gh-139924: Add PyFunction_PYFUNC_EVENT_MODIFY_QUALNAME event for function watchers

### DIFF
--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -175,6 +175,9 @@ There are a few functions specific to Python functions.
 
    .. versionadded:: 3.12
 
+    - ``PyFunction_PYFUNC_EVENT_MODIFY_QUALNAME``
+
+   .. versionadded:: 3.15
 
 .. c:type:: int (*PyFunction_WatchCallback)(PyFunction_WatchEvent event, PyFunctionObject *func, PyObject *new_value)
 

--- a/Include/cpython/funcobject.h
+++ b/Include/cpython/funcobject.h
@@ -134,7 +134,8 @@ PyAPI_FUNC(PyObject *) PyStaticMethod_New(PyObject *);
     V(DESTROY)                   \
     V(MODIFY_CODE)               \
     V(MODIFY_DEFAULTS)           \
-    V(MODIFY_KWDEFAULTS)
+    V(MODIFY_KWDEFAULTS)         \
+    V(MODIFY_QUALNAME)
 
 typedef enum {
     #define PY_DEF_EVENT(EVENT) PyFunction_EVENT_##EVENT,

--- a/Lib/test/test_capi/test_watchers.py
+++ b/Lib/test/test_capi/test_watchers.py
@@ -514,6 +514,10 @@ class TestFuncWatchers(unittest.TestCase):
             _testcapi.set_func_kwdefaults_via_capi(myfunc, new_kwdefaults)
             self.assertIn((_testcapi.PYFUNC_EVENT_MODIFY_KWDEFAULTS, myfunc, new_kwdefaults), events)
 
+            new_qualname = "foo.bar"
+            myfunc.__qualname__ = new_qualname
+            self.assertIn((_testcapi.PYFUNC_EVENT_MODIFY_QUALNAME, myfunc, new_qualname), events)
+
             # Clear events reference to func
             events = []
             del myfunc

--- a/Misc/NEWS.d/next/C_API/2025-10-10-20-59-07.gh-issue-139924.ALByCb.rst
+++ b/Misc/NEWS.d/next/C_API/2025-10-10-20-59-07.gh-issue-139924.ALByCb.rst
@@ -1,0 +1,1 @@
+Function watchers can now receive a PyFunction_PYFUNC_EVENT_MODIFY_QUALNAME event when a watched functions qualname is changed.

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -62,6 +62,7 @@ handle_func_event(PyFunction_WatchEvent event, PyFunctionObject *func,
         case PyFunction_EVENT_MODIFY_CODE:
         case PyFunction_EVENT_MODIFY_DEFAULTS:
         case PyFunction_EVENT_MODIFY_KWDEFAULTS:
+        case PyFunction_EVENT_MODIFY_QUALNAME:
             RARE_EVENT_INTERP_INC(interp, func_modification);
             break;
         default:
@@ -747,6 +748,7 @@ func_set_qualname(PyObject *self, PyObject *value, void *Py_UNUSED(ignored))
                         "__qualname__ must be set to a string object");
         return -1;
     }
+    handle_func_event(PyFunction_EVENT_MODIFY_QUALNAME, (PyFunctionObject *) op, value);
     Py_XSETREF(op->func_qualname, Py_NewRef(value));
     return 0;
 }


### PR DESCRIPTION
Functions can be watched and most mutable values have events. PyFunction_PYFUNC_EVENT_MODIFY_QUALNAME is missing though.

<!-- gh-issue-number: gh-139924 -->
* Issue: gh-139924
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139925.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->