### PR TITLE
gh-101100: fix sphinx warnings in `library/signal.rst`

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -270,7 +270,7 @@ The variables defined in the :mod:`signal` module are:
    All the signal numbers are defined symbolically.  For example, the hangup signal
    is defined as :const:`signal.SIGHUP`; the variable names are identical to the
    names used in C programs, as found in ``<signal.h>``.  The Unix man page for
-   ':c:func:`!signal`' lists the existing signals (on some systems this is
+   '``signal``' lists the existing signals (on some systems this is
    :manpage:`signal(2)`, on others the list is in :manpage:`signal(7)`). Note that
    not all systems define the same set of signal names; only those names defined by
    the system are defined by this module.
@@ -666,7 +666,7 @@ The :mod:`signal` module defines the following functions:
    *sigset*.
 
    The return value is an object representing the data contained in the
-   :c:type:`siginfo_t` structure, namely: ``si_signo``, ``si_code``,
+   ``siginfo_t`` structure, namely: ``si_signo``, ``si_code``,
    ``si_errno``, ``si_pid``, ``si_uid``, ``si_status``, ``si_band``.
 
    .. availability:: Unix.

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -205,12 +205,6 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
-.. data:: SIGPROF
-
-   Profiling timer expired.
-
-   .. availability:: Unix.
-
 .. data:: SIGQUIT
 
    Terminal quit signal.
@@ -253,6 +247,12 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
+.. data:: SIGPROF
+
+   Profiling timer expired.
+
+   .. availability:: Unix.
+
 .. data:: SIGVTALRM
 
    Virtual timer expired.
@@ -270,7 +270,7 @@ The variables defined in the :mod:`signal` module are:
    All the signal numbers are defined symbolically.  For example, the hangup signal
    is defined as :const:`signal.SIGHUP`; the variable names are identical to the
    names used in C programs, as found in ``<signal.h>``.  The Unix man page for
-   ':c:func:`signal`' lists the existing signals (on some systems this is
+   ':c:func:`!signal`' lists the existing signals (on some systems this is
    :manpage:`signal(2)`, on others the list is in :manpage:`signal(7)`). Note that
    not all systems define the same set of signal names; only those names defined by
    the system are defined by this module.
@@ -666,9 +666,9 @@ The :mod:`signal` module defines the following functions:
    *sigset*.
 
    The return value is an object representing the data contained in the
-   :c:type:`siginfo_t` structure, namely: :attr:`si_signo`, :attr:`si_code`,
-   :attr:`si_errno`, :attr:`si_pid`, :attr:`si_uid`, :attr:`si_status`,
-   :attr:`si_band`.
+   :c:type:`siginfo_t` structure, namely: :attr:`!si_signo`, :attr:`!si_code`,
+   :attr:`!si_errno`, :attr:`!si_pid`, :attr:`!si_uid`, :attr:`!si_status`,
+   :attr:`!si_band`.
 
    .. availability:: Unix.
 

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -666,9 +666,8 @@ The :mod:`signal` module defines the following functions:
    *sigset*.
 
    The return value is an object representing the data contained in the
-   :c:type:`siginfo_t` structure, namely: :attr:`!si_signo`, :attr:`!si_code`,
-   :attr:`!si_errno`, :attr:`!si_pid`, :attr:`!si_uid`, :attr:`!si_status`,
-   :attr:`!si_band`.
+   :c:type:`siginfo_t` structure, namely: ``si_signo``, ``si_code``,
+   ``si_errno``, ``si_pid``, ``si_uid``, ``si_status``, ``si_band``.
 
    .. availability:: Unix.
 

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -205,6 +205,12 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
+.. data:: SIGPROF
+
+   Profiling timer expired.
+
+   .. availability:: Unix.
+
 .. data:: SIGQUIT
 
    Terminal quit signal.
@@ -244,12 +250,6 @@ The variables defined in the :mod:`signal` module are:
 .. data:: SIGUSR2
 
    User-defined signal 2.
-
-   .. availability:: Unix.
-
-.. data:: SIGPROF
-
-   Profiling timer expired.
 
    .. availability:: Unix.
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -29,7 +29,6 @@ Doc/library/profile.rst
 Doc/library/pyexpat.rst
 Doc/library/resource.rst
 Doc/library/select.rst
-Doc/library/signal.rst
 Doc/library/smtplib.rst
 Doc/library/socket.rst
 Doc/library/ssl.rst


### PR DESCRIPTION
```
signal.rst:270: WARNING: c:func reference target not found: signal [ref.func]
signal.rst:668: WARNING: py:attr reference target not found: si_signo [ref.attr]
signal.rst:668: WARNING: py:attr reference target not found: si_code [ref.attr]
signal.rst:668: WARNING: py:attr reference target not found: si_errno [ref.attr]
signal.rst:668: WARNING: py:attr reference target not found: si_pid [ref.attr]
signal.rst:668: WARNING: py:attr reference target not found: si_uid [ref.attr]
signal.rst:668: WARNING: py:attr reference target not found: si_status [ref.attr]
signal.rst:668: WARNING: py:attr reference target not found: si_band [ref.attr]
```

- The c:func referrence in line 270 was suppressed
- In line 668, the py:attr references were namely the attr of `siginfo_t` structure. In library `os` we also mentioned this structure in function [`waitid`](https://docs.python.org/3/library/os.html#os.waitid):

```
   The return value is an object representing the data contained in the
   :c:type:`siginfo_t` structure with the following attributes:

   * :attr:`!si_pid` (process ID)
   * :attr:`!si_uid` (real user ID of the child)
   * :attr:`!si_signo` (always :const:`~signal.SIGCHLD`)
   * :attr:`!si_status` (the exit status or signal number, depending on :attr:`!si_code`)
   * :attr:`!si_code` (see :data:`CLD_EXITED` for possible values)
```

So I just suppress all of them, similar to how we did in `os.rst` 


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139930.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->