### PR TITLE
gh-131178: Add tests for `sysconfig` command-line interface

### DIFF
--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -770,6 +770,7 @@ class MakefileTests(unittest.TestCase):
             print("var8=$$(var3)", file=makefile)
             print("var9=$(var10)(var3)", file=makefile)
             print("var10=$$", file=makefile)
+            print("var11=$${ORIGIN}${var5}", file=makefile)
         vars = _parse_makefile(TESTFN)
         self.assertEqual(vars, {
             'var1': 'ab42',
@@ -782,6 +783,7 @@ class MakefileTests(unittest.TestCase):
             'var8': '$(var3)',
             'var9': '$(var3)',
             'var10': '$',
+            'var11': '${ORIGIN}dollar$5',
         })
 
     def _test_parse_makefile_recursion(self):

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -878,6 +878,7 @@ class DeprecationTests(unittest.TestCase):
         ):
             sysconfig.is_python_build('foo')
 
+
 class CommandLineTests(unittest.TestCase):
     def test_config_output(self):
         output = subprocess.run(
@@ -900,5 +901,7 @@ Paths:
 Variables: 
 {vars}'''
         self.assertTrue(output.stdout == mock_result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -889,7 +889,7 @@ class CommandLineTests(unittest.TestCase):
             text=True,
             check=True
         )
-        paths, vars = '', ''
+        paths, vars = 'Paths: \n', 'Variables: \n'
         for key, value in sorted(get_paths().items()):
             paths += f'\t{key} = "{value}"\n'
         for key, value in sorted(get_config_vars().items()):
@@ -898,9 +898,7 @@ class CommandLineTests(unittest.TestCase):
 Python version: "{get_python_version()}"
 Current installation scheme: "{get_default_scheme()}"
 
-Paths: 
 {paths}
-Variables: 
 {vars}'''
         self.assertTrue(output.stdout == mock_result)
 

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -27,7 +27,7 @@ import sysconfig
 from sysconfig import (get_paths, get_platform, get_config_vars,
                        get_path, get_path_names, _INSTALL_SCHEMES,
                        get_default_scheme, get_scheme_names, get_config_var,
-                       _expand_vars, _get_preferred_schemes, get_python_version,
+                       _expand_vars, _get_preferred_schemes,
                        is_python_build, _PROJECT_BASE)
 from sysconfig.__main__ import _main, _parse_makefile, _get_pybuilddir, _get_json_data_name
 import _imp

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -889,18 +889,8 @@ class CommandLineTests(unittest.TestCase):
             text=True,
             check=True
         )
-        paths, vars = 'Paths: \n', 'Variables: \n'
-        for key, value in sorted(get_paths().items()):
-            paths += f'\t{key} = "{value}"\n'
-        for key, value in sorted(get_config_vars().items()):
-            vars += f'\t{key} = "{value}"\n'
-        mock_result = f'''Platform: "{get_platform()}"
-Python version: "{get_python_version()}"
-Current installation scheme: "{get_default_scheme()}"
-
-{paths}
-{vars}'''
-        self.assertTrue(output.stdout == mock_result)
+        self.assertTrue(output.returncode == 0)
+        self.assertTrue(output.stdout.startswith("Platform: "))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As [doc](https://docs.python.org/dev/library/sysconfig.html#sysconfig-cli) points out, we can use `sysconfig` lib directly as a script to obtain configs.

<img width="1296" height="939" alt="image" src="https://github.com/user-attachments/assets/6ccd8a63-9553-4b6f-af1f-64954b5560fe" />

This PR add tests for this feature.

PS: I notice that the CLI actually has a `--generare-posix-vars` attribute that is undocumented. I don't think we need to add test for that (maybe this is an internal function or what. If not I think we can add document for this later)

```python
def _main():
    """Display all information sysconfig detains."""
    if '--generate-posix-vars' in sys.argv:
        _generate_posix_vars()
        return
    print(f'Platform: "{get_platform()}"')
    print(f'Python version: "{get_python_version()}"')
    print(f'Current installation scheme: "{get_default_scheme()}"')
    print()
    _print_dict('Paths', get_paths())
    print()
    _print_dict('Variables', get_config_vars())
```


<!-- gh-issue-number: gh-131178 -->
* Issue: gh-131178
<!-- /gh-issue-number -->
