### PR TITLE
gh-133423: Avoid ref cycle among MagicMock and its magic methods

### DIFF
--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -2426,5 +2426,25 @@ class MockTest(unittest.TestCase):
         for m in (mock.method, mock.class_method, mock.static_method):
             self.assertIsInstance(m, AsyncMock)
 
+    def test_mock_no_reference_cycle(self):
+        obj = Something()
+        ref = sys.getrefcount(obj)
+        mock = MagicMock()
+        mock.mocked_list = [obj]
+        del mock
+        ref2 = sys.getrefcount(obj)
+        self.assertEqual(ref, ref2)
+
+    def test_mock_patch_no_reference_cycle(self):
+        class Foo():
+            one = 'one'
+
+        obj = Something()
+        ref = sys.getrefcount(obj)
+        with mock.patch.object(Foo, 'one', return_value=3):
+            Foo.one(obj)
+        ref2 = sys.getrefcount(obj)
+        self.assertEqual(ref, ref2)
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -39,6 +39,7 @@ from types import CodeType, ModuleType, MethodType
 from unittest.util import safe_repr
 from functools import wraps, partial
 from threading import RLock
+import weakref
 
 
 class InvalidSpecError(Exception):
@@ -2195,7 +2196,7 @@ class MagicMixin(Base):
 
         _type = type(self)
         for entry in these_magics:
-            setattr(_type, entry, MagicProxy(entry, self))
+            setattr(_type, entry, MagicProxy(entry, weakref.ref(self)))
 
 
 
@@ -2255,7 +2256,7 @@ class MagicProxy(Base):
 
     def create_mock(self):
         entry = self.name
-        parent = self.parent
+        parent = self.parent()  # self.parent is a weakref to the parent
         m = parent._get_child_mock(name=entry, _new_name=entry,
                                    _new_parent=parent)
         setattr(parent, entry, m)


### PR DESCRIPTION

The following tests pass:
```
./python -m test -v test_unittest
```

<!-- gh-issue-number: gh-133423 -->
* Issue: gh-133423
<!-- /gh-issue-number -->
