### PR TITLE
gh-139938: Fewer assignments in html.escape

### DIFF
--- a/Lib/html/__init__.py
+++ b/Lib/html/__init__.py
@@ -16,12 +16,13 @@ def escape(s, quote=True):
     characters, both double quote (") and single quote (') characters are also
     translated.
     """
-    s = s.replace("&", "&amp;") # Must be done first!
-    s = s.replace("<", "&lt;")
-    s = s.replace(">", "&gt;")
+    s = (
+        s.replace("&", "&amp;") # Must be done first!
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
     if quote:
-        s = s.replace('"', "&quot;")
-        s = s.replace('\'', "&#x27;")
+        return s.replace('"', "&quot;").replace('\'', "&#x27;")
     return s
 
 


### PR DESCRIPTION
On my machine, the benchmarking code below shows approximately a 1.2x speedup in the default case of `escape(s, quote=True)`. The `quote=False` case remains more or less unchanged on my machine. The underlying logic in the function should be unaltered.

Here's the code I ran to benchmark:
```python
import time, dis

def escape_old(s, quote=True):
    """
    Replace special characters "&", "<" and ">" to HTML-safe sequences.
    If the optional flag quote is true (the default), the quotation mark
    characters, both double quote (") and single quote (') characters are also
    translated.
    """
    s = s.replace("&", "&amp;") # Must be done first!
    s = s.replace("<", "&lt;")
    s = s.replace(">", "&gt;")
    if quote:
        s = s.replace('"', "&quot;")
        s = s.replace('\'', "&#x27;")
    return s

# identical to the code in the commit
def escape(s, quote=True):
    """
    Replace special characters "&", "<" and ">" to HTML-safe sequences.
    If the optional flag quote is true (the default), the quotation mark
    characters, both double quote (") and single quote (') characters are also
    translated.
    """
    s = (
        s.replace("&", "&amp;") # Must be done first!
        .replace("<", "&lt;")
        .replace(">", "&gt;")
    )
    if quote:
        return s.replace('"', "&quot;").replace('\'', "&#x27;")
    return s

test_html_strings = [
    "Hello, world!",
    "1234567890",
    "Simple text with spaces",

    "Hello, &world!",
    "12345<67890",
    "Simple text with spaces&",

    "<b>bold</b>",
    "<i>italic</i>",
    "<u>underline</u>",
    "<p>paragraph</p>",
    "<div>content</div>",

    "<div><script>alert('x')</script></div>",
    "<a href='https://example.com'>link</a>",
    "<img src='x' onerror='alert(1)'>",
    "<b><i>nested</i> bold</b>",
]


for quote in True, False:
    for fn in escape_old, escape:
        start = time.time()
        for _ in range(10000):
            for s in test_html_strings:
                escape(s, quote)
        end  = time.time()
        print(fn.__name__, f"quote={quote}")
        print(end - start)


# uncomment to compare bytecode
# print(dis.dis(escape_old))
#
# print(dis.dis(escape))
```

The output on my mac is as follows:
<img width="183" height="150" alt="Screenshot 2025-10-10 at 11 17 54 PM" src="https://github.com/user-attachments/assets/b13c42f7-cd0b-46ba-84be-674b93956dc5" />

The disassembled bytecode after the change is 6 instructions shorter.


<!-- gh-issue-number: gh-139938 -->
* Issue: gh-139938
<!-- /gh-issue-number -->
