### PR TITLE
Fix typo in 3.14 release notes

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -532,7 +532,7 @@ Improved error messages
 
   .. code-block:: pycon
 
-     >>> whille True:
+     >>> while True:
      ...     pass
      Traceback (most recent call last):
        File "<stdin>", line 1


### PR DESCRIPTION
Fixes a typo in the 3.14 release notes: `whille` ->  `while`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139942.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->