### PR TITLE
gh-139929: fix incorrect OpenSSL version-based guard in `_ssl.c`

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -937,7 +937,7 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
     }
 
     /* bpo43522 and OpenSSL < 1.1.1l: copy hostflags manually */
-#if OPENSSL_VERSION < 0x101010cf
+#if OPENSSL_VERSION_NUMBER < 0x101010cf
     X509_VERIFY_PARAM *ssl_verification_params = SSL_get0_param(self->ssl);
     X509_VERIFY_PARAM *ssl_ctx_verification_params = SSL_CTX_get0_param(ctx);
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139929 -->
* Issue: gh-139929
<!-- /gh-issue-number -->
