### PR TITLE
Remove redundant `sys.exit(2)` call in `pdb` CLI

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -3597,7 +3597,6 @@ def main():
         invalid_args = list(itertools.takewhile(lambda a: a.startswith('-'), args))
         if invalid_args:
             parser.error(f"unrecognized arguments: {' '.join(invalid_args)}")
-            sys.exit(2)
 
     if opts.module:
         file = opts.module


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Remove a `sys.exit()` call that will never be run because `parser.error()` exits internally.

I am not sure if this needs to link to an issue, i would be happy to create one if needed.
