### PR TITLE
gh-139905: better error msg when subclassing `GenericAlias` without calling `__init_subclass__`

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -203,6 +203,20 @@ class BaseTest(unittest.TestCase):
         self.assertEqual(C.__bases__, (list,))
         self.assertEqual(C.__class__, type)
 
+        class Foo:
+            def __init_subclass__(cls) -> None:
+                pass
+
+        class Bar:
+            def __init_subclass__(cls) -> None:
+                super().__init_subclass__()
+
+        class FooSub[T](Foo): pass
+        class BarSub[T](Bar): pass
+        with self.assertRaisesRegex(RuntimeError, '__parameters__'):
+            _ = FooSub[int]
+        _ = BarSub[int]
+
     def test_class_methods(self):
         t = dict[int, None]
         self.assertEqual(dict.fromkeys(range(2)), {0: None, 1: None})  # This works

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1158,6 +1158,9 @@ def _generic_class_getitem(cls, args):
                 f"Parameters to {cls.__name__}[...] must all be unique")
     else:
         # Subscripting a regular Generic subclass.
+        if not hasattr(cls, "__parameters__"):
+            raise RuntimeError(f"{cls.__name__} has no __parameters__, "
+                               f"you may forget to call super().__init_subclass__()")
         for param in cls.__parameters__:
             prepare = getattr(param, '__typing_prepare_subst__', None)
             if prepare is not None:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-11-17-53-24.gh-issue-139905.qCm4jW.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-11-17-53-24.gh-issue-139905.qCm4jW.rst
@@ -1,0 +1,2 @@
+Print better error message when subclassing `GenericAlias` without calling
+``super().__init_subclass__``.


### PR DESCRIPTION
ditto

<!-- gh-issue-number: gh-139905 -->
* Issue: gh-139905
<!-- /gh-issue-number -->
