### PR TITLE
gh-139540: Fix executor deallocation crash when JIT compilation fails

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-11-16-14-36.gh-issue-139549.9BGTLP.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-11-16-14-36.gh-issue-139549.9BGTLP.rst
@@ -1,0 +1,1 @@
+Fix a memory leak of a JIT executor that occurred when JIT compilation failed.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-11-16-14-36.gh-issue-139549.9BGTLP.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-11-16-14-36.gh-issue-139549.9BGTLP.rst
@@ -1,1 +1,9 @@
-Fix a memory leak of a JIT executor that occurred when JIT compilation failed.
+Fix memory leak in JIT executor on compilation failure
+
+The executor object passed to the TIER1_TO_TIER2 macro was not
+decremented if the Tier 2 code returned with an exception set but
+without a fatal error (i.e., not returning NULL).
+
+This change moves the Py_DECREF call inside the TIER1_TO_TIER2
+macro to ensure the executor's reference count is always decremented
+after its execution, regardless of the outcome.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2972,6 +2972,7 @@ dummy_func(
                     assert(tstate->current_executor == NULL);
                     assert(executor != tstate->interp->cold_executor);
                     tstate->jit_exit = NULL;
+                    tstate->current_executor = (PyObject *)executor;
                     TIER1_TO_TIER2(executor);
                 }
             }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1146,6 +1146,11 @@ early_exit:
     assert(frame->owner == FRAME_OWNED_BY_INTERPRETER);
     /* Restore previous frame and exit */
     tstate->current_frame = frame->previous;
+#ifdef _Py_TIER2
+    if (tstate->current_executor != NULL) {
+        tstate->current_executor = NULL;
+   }
+#endif
     return NULL;
 }
 #ifdef _Py_TIER2

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -351,12 +351,12 @@ _PyFrame_SetStackPointer(frame, stack_pointer)
 
 /* Tier-switching macros. */
 
-#define TIER1_TO_TIER2(EXECUTOR)                        \
+#define TIER1_TO_TIER2(EXECUTOR) \
 do {                                                   \
-    OPT_STAT_INC(traces_executed);                     \
     next_instr = _Py_jit_entry((EXECUTOR), frame, stack_pointer, tstate); \
     frame = tstate->current_frame;                     \
     stack_pointer = _PyFrame_GetStackPointer(frame);   \
+    Py_DECREF(EXECUTOR);                               \
     if (next_instr == NULL) {                          \
         next_instr = frame->instr_ptr;                 \
         JUMP_TO_LABEL(error);                          \
@@ -413,4 +413,3 @@ check_periodics(PyThreadState *tstate) {
     }
     return 0;
 }
-

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -7668,7 +7668,13 @@
                         assert(tstate->current_executor == NULL);
                         assert(executor != tstate->interp->cold_executor);
                         tstate->jit_exit = NULL;
+                        tstate->current_executor = (PyObject *)executor;
+                        _PyFrame_SetStackPointer(frame, stack_pointer);
+                        stack_pointer = _PyFrame_GetStackPointer(frame);
                         TIER1_TO_TIER2(executor);
+                        _PyFrame_SetStackPointer(frame, stack_pointer);
+                        Py_DECREF(executor);
+                        stack_pointer = _PyFrame_GetStackPointer(frame);
                     }
                 }
                 else {

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1202,6 +1202,7 @@ make_executor_from_uops(_PyUOpInstruction *buffer, int length, const _PyBloomFil
     if (executor == NULL) {
         return NULL;
     }
+    _PyObject_GC_TRACK(executor);
 
     /* Initialize exits */
     _PyExecutorObject *cold = _PyExecutor_GetColdExecutor();
@@ -1246,7 +1247,6 @@ make_executor_from_uops(_PyUOpInstruction *buffer, int length, const _PyBloomFil
     }
     sanity_check(executor);
 #endif
-    _PyObject_GC_TRACK(executor);
 #ifdef _Py_JIT
     executor->jit_code = NULL;
     executor->jit_size = 0;
@@ -1507,6 +1507,7 @@ _PyExecutor_GetColdExecutor(void)
     if (cold == NULL) {
         Py_FatalError("Cannot allocate core JIT code");
     }
+    _PyObject_GC_TRACK(cold);
     ((_PyUOpInstruction *)cold->trace)->opcode = _COLD_EXIT;
 #ifdef _Py_JIT
     cold->jit_code = NULL;

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1246,6 +1246,7 @@ make_executor_from_uops(_PyUOpInstruction *buffer, int length, const _PyBloomFil
     }
     sanity_check(executor);
 #endif
+    _PyObject_GC_TRACK(executor);
 #ifdef _Py_JIT
     executor->jit_code = NULL;
     executor->jit_size = 0;
@@ -1257,7 +1258,6 @@ make_executor_from_uops(_PyUOpInstruction *buffer, int length, const _PyBloomFil
         return NULL;
     }
 #endif
-    _PyObject_GC_TRACK(executor);
     return executor;
 }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1717,6 +1717,9 @@ PyThreadState_Clear(PyThreadState *tstate)
     Py_CLEAR(tstate->async_gen_finalizer);
 
     Py_CLEAR(tstate->context);
+#ifdef _Py_TIER2
+    Py_CLEAR(tstate->current_executor);
+#endif
 
 #ifdef Py_GIL_DISABLED
     // Each thread should clear own freelists in free-threading builds.


### PR DESCRIPTION
There is a memory leak in make_executor_from_uops (Python/optimizer.c) when JIT compilation fails. The executor object is created via _PyObject_GC_NewVar but _PyObject_GC_TRACK is called after the JIT compilation attempt. If _PyJIT_Compile fails and returns an error, the code calls Py_DECREF(executor) before the object has been tracked by the garbage collector.


<!-- gh-issue-number: gh-139540 -->
* Issue: gh-139540
<!-- /gh-issue-number -->
