### PR TITLE
gh-139935: do not skip test on real errors in `os.getlogin`

### DIFF
--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -3204,13 +3204,7 @@ class LoginTests(unittest.TestCase):
             user_name = os.getlogin()
         except OSError as exc:
             # See https://man7.org/linux/man-pages/man3/getlogin.3.html#ERRORS.
-            allowed_errors = (
-                # defined by POSIX
-                errno.EMFILE, errno.ENFILE, errno.ENXIO, errno.ERANGE,
-                # defined by Linux/glibc
-                errno.ENOENT, errno.ENOMEM, errno.ENOTTY,
-            )
-            if exc.errno in allowed_errors:
+            if exc.errno in (errno.ENXIO, errno.ENOENT, errno.ENOTTY):
                 self.skipTest(str(exc))
             else:
                 raise


### PR DESCRIPTION
This amends a PR I just merged. This is my fault here as I incorrectly assumed that all those errors were non-fatal.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139935 -->
* Issue: gh-139935
<!-- /gh-issue-number -->
