### PR TITLE
gh-131885: Update location of positional-only parameter indicator for `eval` and `exec`  in the documentation

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -575,7 +575,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. _func-eval:
 
-.. function:: eval(source, /, globals=None, locals=None)
+.. function:: eval(source, globals=None, locals=None, /)
 
    :param source:
       A Python expression.
@@ -651,7 +651,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. index:: pair: built-in function; exec
 
-.. function:: exec(source, /, globals=None, locals=None, *, closure=None)
+.. function:: exec(source, globals=None, locals=None, /, *, closure=None)
 
    .. warning::
 


### PR DESCRIPTION
Fix incorrect location of positional-only parameter indicator for `eval` and `exec` in the documentation

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139978.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-131885 -->
* Issue: gh-131885
<!-- /gh-issue-number -->
