### PR TITLE
GH-139979: Add @force_not_colorized_test_class to TestOptionalHelpVersionActions

### DIFF
--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5831,6 +5831,7 @@ class TestConflictHandling(TestCase):
 # Help and Version option tests
 # =============================
 
+@force_not_colorized_test_class
 class TestOptionalsHelpVersionActions(TestCase):
     """Test the help and version actions"""
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The `TestOptionalsHelpVersionActions` test class is missing the  `@force_not_colorized_test_class decorator`, causing test failures when running in terminals with TERM set and stdout as a TTY, as the tests expect plain text output.

I think this was missed in https://github.com/python/cpython/pull/136809



<!-- gh-issue-number: gh-139979 -->
* Issue: gh-139979
<!-- /gh-issue-number -->
