### PR TITLE
gh-139027: readline doesn't degrade gracefully when tcsetattr() fails.

### DIFF
--- a/Misc/NEWS.d/next/macOS/2025-10-12-16-27-01.gh-issue-139027.Rntwlp.rst
+++ b/Misc/NEWS.d/next/macOS/2025-10-12-16-27-01.gh-issue-139027.Rntwlp.rst
@@ -1,0 +1,1 @@
+Fix: Basic REPL hangs when ioctls can't be written to TTY.

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -17,6 +17,8 @@
 #include <signal.h>               // SIGWINCH
 #include <stdlib.h>               // free()
 #include <string.h>               // strdup()
+#include <termios.h>              // termios, tcgetattr(), tcsetattr()
+#include <unistd.h>               // isatty(), STDIN_FILENO
 #ifdef HAVE_SYS_SELECT_H
 #  include <sys/select.h>         // select()
 #endif
@@ -1645,6 +1647,20 @@ PyInit_readline(void)
     if (mod_state == NULL){
         goto error;
     }
+
+    // gh-139027: If tcsetattr fails do not initialize readline and err it
+    if (isatty(STDIN_FILENO)) {
+        struct termios original_tty;
+        if (tcgetattr(STDIN_FILENO, &original_tty) == 0) {
+            struct termios test_tty = original_tty;
+            if (tcsetattr(STDIN_FILENO, TCSANOW, &test_tty) != 0) {
+                PyErr_SetString(PyExc_OSError,
+                    "termios failure (Operation not permitted)");
+                goto error;
+            }
+        }
+    }
+
     PyOS_ReadlineFunctionPointer = call_readline;
     if (setup_readline(mod_state) < 0) {
         PyErr_NoMemory();


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

after this fix
<img width="1704" height="566" alt="image" src="https://github.com/user-attachments/assets/c26aa051-fa7b-44c6-b9d1-e936b48d4682" />


<!-- gh-issue-number: gh-139027 -->
* Issue: gh-139027
<!-- /gh-issue-number -->
