### PR TITLE
gh-139988: fix a leak when failing to create a Union type

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-12-11-00-06.gh-issue-139988.4wi51t.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-12-11-00-06.gh-issue-139988.4wi51t.rst
@@ -1,0 +1,2 @@
+Fix a memory leak when failing to create a :class:`~typing.Union` type.
+Patch by Bénédikt Tran.

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -474,11 +474,13 @@ _Py_union_from_tuple(PyObject *args)
     }
     if (PyTuple_CheckExact(args)) {
         if (!unionbuilder_add_tuple(&ub, args)) {
+            unionbuilder_finalize(&ub);
             return NULL;
         }
     }
     else {
         if (!unionbuilder_add_single(&ub, args)) {
+            unionbuilder_finalize(&ub);
             return NULL;
         }
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139988 -->
* Issue: gh-139988
<!-- /gh-issue-number -->
