### PR TITLE
gh-101100: Fix sphinx warnings in `library/smtplib.rst`

### DIFF
--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -575,7 +575,6 @@ here.  For details, consult the module code.
    see :meth:`ehlo`.
 .. _smtp-example:
 
-
 SMTP Example
 ------------
 

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -552,6 +552,8 @@ Low-level methods corresponding to the standard SMTP/ESMTP commands ``HELP``,
 Normally these do not need to be called directly, so they are not documented
 here.  For details, consult the module code.
 
+Additionally, an SMTP instance has the following attributes:
+
 
 .. attribute:: SMTP.helo_resp
 

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -223,28 +223,6 @@ SMTP Objects
 
 An :class:`SMTP` instance has the following methods and attributes:
 
-.. attribute:: SMTP.helo_resp
-
-   The response to the ``HELO`` command, see :meth:`helo`.
-
-
-.. attribute:: SMTP.ehlo_resp
-
-   The response to the ``EHLO`` command, see :meth:`ehlo`.
-
-
-.. attribute:: SMTP.does_esmtp
-
-   A boolean value indicating whether the server supports ESMTP, see
-   :meth:`ehlo`.
-
-
-.. attribute:: SMTP.esmtp_features
-
-   A dictionary of the names of SMTP service extensions supported by the server,
-   see :meth:`ehlo`.
-
-
 .. method:: SMTP.set_debuglevel(level)
 
    Set the debug output level.  A value of 1 or ``True`` for *level* results in
@@ -500,7 +478,6 @@ An :class:`SMTP` instance has the following methods and attributes:
    :exc:`SMTPRecipientsRefused`
       All recipients were refused.  Nobody got the mail.
 
-
    :exc:`SMTPHeloError`
       The server didn't reply properly to the ``HELO`` greeting.
 
@@ -576,7 +553,28 @@ Normally these do not need to be called directly, so they are not documented
 here.  For details, consult the module code.
 
 
+.. attribute:: SMTP.helo_resp
+
+   The response to the ``HELO`` command, see :meth:`helo`.
+
+
+.. attribute:: SMTP.ehlo_resp
+
+   The response to the ``EHLO`` command, see :meth:`ehlo`.
+
+
+.. attribute:: SMTP.does_esmtp
+
+   A boolean value indicating whether the server supports ESMTP, see
+   :meth:`ehlo`.
+
+
+.. attribute:: SMTP.esmtp_features
+
+   A dictionary of the names of SMTP service extensions supported by the server,
+   see :meth:`ehlo`.
 .. _smtp-example:
+
 
 SMTP Example
 ------------

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -171,9 +171,9 @@ A nice selection of exceptions is defined as well:
 
    .. attribute:: recipients
 
-      The errors for each recipient are accessible through this
-      attribute, which is a dictionary of exactly thesame sort as
-      :meth:`SMTP.sendmail` returns.
+      A dictionary of exactly the same sort as returned
+      by :meth:`SMTP.sendmail` containing the errors for
+      each recipient.
 
 
 .. exception:: SMTPDataError

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -148,7 +148,7 @@ A nice selection of exceptions is defined as well:
 
    Base class for all exceptions that include an SMTP error code. These exceptions
    are generated in some instances when the SMTP server returns an error code.
-   
+
    .. attribute:: smtp_code
 
       The error code.
@@ -229,8 +229,9 @@ An :class:`SMTP` instance has the following methods and attributes:
 
 
 .. attribute:: SMTP.ehlo_resp
-   
+
    The response to the ``EHLO`` command, see :meth:`ehlo`.
+
 
 .. attribute:: SMTP.does_esmtp
 

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -80,8 +80,8 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
 
    An :class:`SMTP_SSL` instance behaves exactly the same as instances of
    :class:`SMTP`. :class:`SMTP_SSL` should be used for situations where SSL is
-   required from the beginning of the connection and using :meth:`starttls` is
-   not appropriate. If *host* is not specified, the local host is used. If
+   required from the beginning of the connection and using :meth:`~SMTP.starttls`
+   is not appropriate. If *host* is not specified, the local host is used. If
    *port* is zero, the standard SMTP-over-SSL port (465) is used.  The optional
    arguments *local_hostname*, *timeout* and *source_address* have the same
    meaning as they do in the :class:`SMTP` class.  *context*, also optional,
@@ -112,7 +112,7 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
 
    The LMTP protocol, which is very similar to ESMTP, is heavily based on the
    standard SMTP client. It's common to use Unix sockets for LMTP, so our
-   :meth:`connect` method must support that as well as a regular host:port
+   :meth:`~SMTP.connect` method must support that as well as a regular host:port
    server. The optional arguments *local_hostname* and *source_address* have the
    same meaning as they do in the :class:`SMTP` class. To specify a Unix
    socket, you must use an absolute path for *host*, starting with a '/'.
@@ -147,9 +147,15 @@ A nice selection of exceptions is defined as well:
 .. exception:: SMTPResponseException
 
    Base class for all exceptions that include an SMTP error code. These exceptions
-   are generated in some instances when the SMTP server returns an error code.  The
-   error code is stored in the :attr:`smtp_code` attribute of the error, and the
-   :attr:`smtp_error` attribute is set to the error message.
+   are generated in some instances when the SMTP server returns an error code.
+   
+   .. attribute:: smtp_code
+
+      The error code.
+
+   .. attribute:: smtp_error
+
+      The error message.
 
 
 .. exception:: SMTPSenderRefused
@@ -161,9 +167,13 @@ A nice selection of exceptions is defined as well:
 
 .. exception:: SMTPRecipientsRefused
 
-   All recipient addresses refused.  The errors for each recipient are accessible
-   through the attribute :attr:`recipients`, which is a dictionary of exactly the
-   same sort as :meth:`SMTP.sendmail` returns.
+   All recipient addresses refused.
+
+   .. attribute:: recipients
+
+      The errors for each recipient are accessible through this
+      attribute, which is a dictionary of exactly thesame sort as
+      :meth:`SMTP.sendmail` returns.
 
 
 .. exception:: SMTPDataError
@@ -211,7 +221,27 @@ A nice selection of exceptions is defined as well:
 SMTP Objects
 ------------
 
-An :class:`SMTP` instance has the following methods:
+An :class:`SMTP` instance has the following methods and attributes:
+
+.. attribute:: SMTP.helo_resp
+
+   The response to the ``HELO`` command, see :meth:`helo`.
+
+
+.. attribute:: SMTP.ehlo_resp
+   
+   The response to the ``EHLO`` command, see :meth:`ehlo`.
+
+.. attribute:: SMTP.does_esmtp
+
+   A boolean value indicating whether the server supports ESMTP, see
+   :meth:`ehlo`.
+
+
+.. attribute:: SMTP.esmtp_features
+
+   A dictionary of the names of SMTP service extensions supported by the server,
+   see :meth:`ehlo`.
 
 
 .. method:: SMTP.set_debuglevel(level)
@@ -417,7 +447,7 @@ An :class:`SMTP` instance has the following methods:
 
    .. versionchanged:: 3.4
       The method now supports hostname check with
-      :attr:`SSLContext.check_hostname` and *Server Name Indicator* (see
+      :attr:`ssl.SSLContext.check_hostname` and *Server Name Indicator* (see
       :const:`~ssl.HAS_SNI`).
 
    .. versionchanged:: 3.5
@@ -435,7 +465,7 @@ An :class:`SMTP` instance has the following methods:
    ESMTP options (such as ``DSN`` commands) that should be used with all ``RCPT``
    commands can be passed as *rcpt_options*.  (If you need to use different ESMTP
    options to different recipients you have to use the low-level methods such as
-   :meth:`mail`, :meth:`rcpt` and :meth:`data` to send the message.)
+   :meth:`!mail`, :meth:`!rcpt` and :meth:`!data` to send the message.)
 
    .. note::
 
@@ -467,10 +497,12 @@ An :class:`SMTP` instance has the following methods:
    This method may raise the following exceptions:
 
    :exc:`SMTPRecipientsRefused`
-      All recipients were refused.  Nobody got the mail.  The :attr:`recipients`
-      attribute of the exception object is a dictionary with information about the
-      refused recipients (like the one returned when at least one recipient was
-      accepted).
+      All recipients were refused.  Nobody got the mail.
+
+      .. attribute:: recipients
+
+      A dictionary with information about the refused recipients
+      (like the one returned when at least one recipient was accepted).
 
    :exc:`SMTPHeloError`
       The server didn't reply properly to the ``HELO`` greeting.

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -573,6 +573,8 @@ here.  For details, consult the module code.
 
    A dictionary of the names of SMTP service extensions supported by the server,
    see :meth:`ehlo`.
+
+
 .. _smtp-example:
 
 SMTP Example

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -500,10 +500,6 @@ An :class:`SMTP` instance has the following methods and attributes:
    :exc:`SMTPRecipientsRefused`
       All recipients were refused.  Nobody got the mail.
 
-      .. attribute:: recipients
-
-      A dictionary with information about the refused recipients
-      (like the one returned when at least one recipient was accepted).
 
    :exc:`SMTPHeloError`
       The server didn't reply properly to the ``HELO`` greeting.

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -221,7 +221,7 @@ A nice selection of exceptions is defined as well:
 SMTP Objects
 ------------
 
-An :class:`SMTP` instance has the following methods and attributes:
+An :class:`SMTP` instance has the following methods:
 
 .. method:: SMTP.set_debuglevel(level)
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -29,7 +29,6 @@ Doc/library/profile.rst
 Doc/library/pyexpat.rst
 Doc/library/resource.rst
 Doc/library/select.rst
-Doc/library/smtplib.rst
 Doc/library/socket.rst
 Doc/library/ssl.rst
 Doc/library/stdtypes.rst


### PR DESCRIPTION
```
smtplib.rst:81: WARNING: py:meth reference target not found: starttls [ref.meth]
smtplib.rst:113: WARNING: py:meth reference target not found: connect [ref.meth]
smtplib.rst:149: WARNING: py:attr reference target not found: smtp_code [ref.attr]
smtplib.rst:149: WARNING: py:attr reference target not found: smtp_error [ref.attr]
smtplib.rst:164: WARNING: py:attr reference target not found: recipients [ref.attr]
smtplib.rst:258: WARNING: py:attr reference target not found: helo_resp [ref.attr]
smtplib.rst:269: WARNING: py:attr reference target not found: ehlo_resp [ref.attr]
smtplib.rst:269: WARNING: py:attr reference target not found: does_esmtp [ref.attr]
smtplib.rst:269: WARNING: py:attr reference target not found: esmtp_features [ref.attr]
smtplib.rst:350: WARNING: py:attr reference target not found: esmtp_features [ref.attr]
smtplib.rst:419: WARNING: py:attr reference target not found: SSLContext.check_hostname [ref.attr]
smtplib.rst:431: WARNING: py:meth reference target not found: mail [ref.meth]
smtplib.rst:431: WARNING: py:meth reference target not found: rcpt [ref.meth]
smtplib.rst:431: WARNING: py:meth reference target not found: data [ref.meth]
smtplib.rst:470: WARNING: py:attr reference target not found: recipients [ref.attr]
```

- line 81. The method `starttls` is referring to `SMTP.starttls` (Because using this is inappropriate so we use `SMTP_SSL`)
- line 113. Same as line 81. I change this to `~SMTP.connect` (Not sure. Maybe we can suppress this?)
- line 149. I document the attribute of the Exception to fix this:
```
.. attribute:: smtp_code

  The error code.

.. attribute:: smtp_error

  The error message.

```
- line 164. Same as line 149, I document the attribute:
```
.. attribute:: recipients

  The errors for each recipient are accessible through this
  attribute, which is a dictionary of exactly thesame sort as
  :meth:`SMTP.sendmail` returns.
```
- line 258,269,350. Those are undocumented attributes of object `SMTP`, also I write an index on the beginning of the document of this object:
```
.. attribute:: SMTP.helo_resp

   The response to the ``HELO`` command, see :meth:`helo`.


.. attribute:: SMTP.ehlo_resp
   
   The response to the ``EHLO`` command, see :meth:`ehlo`.


.. attribute:: SMTP.does_esmtp

   A boolean value indicating whether the server supports ESMTP, see
   :meth:`ehlo`.


.. attribute:: SMTP.esmtp_features

   A dictionary of the names of SMTP service extensions supported by the server,
   see :meth:`ehlo`.
```
Now the reference points to this attribute index.
- line 419. The `SSLContext.check_hostname` is actually referring to [`ssl.SSLContext.check_hostname`](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname), I change this to `ssl.SSLContext.check_hostname`
- line 431. They are undocumented low-level python-apis, I suppressed them all.
- line 470. ~I also create a index for this attibute:~ This is already documented in the fix of line 164.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139991.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->