### PR TITLE
Using Python on Windows: Free-threaded is supported from 3.14

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -729,14 +729,9 @@ directory containing the configuration file that specified them.
 Installing free-threaded binaries
 ---------------------------------
 
-.. versionadded:: 3.13 (Experimental)
+.. versionadded:: 3.13
 
-.. note::
-
-   Everything described in this section is considered experimental,
-   and should be expected to change in future releases.
-
-Pre-built distributions of the experimental free-threaded build are available
+Pre-built distributions of the free-threaded build are available
 by installing tags with the ``t`` suffix.
 
 .. code::
@@ -989,12 +984,7 @@ for the 64-bit version, `www.nuget.org/packages/pythonx86
 Free-threaded packages
 ----------------------
 
-.. versionadded:: 3.13 (Experimental)
-
-.. note::
-
-   Everything described in this section is considered experimental,
-   and should be expected to change in future releases.
+.. versionadded:: 3.13
 
 Packages containing free-threaded binaries are named
 `python-freethreaded <https://www.nuget.org/packages/python-freethreaded>`_
@@ -1548,12 +1538,7 @@ settings and replace any that have been removed or modified.
 Installing free-threaded binaries
 ---------------------------------
 
-.. versionadded:: 3.13 (Experimental)
-
-.. note::
-
-   Everything described in this section is considered experimental,
-   and should be expected to change in future releases.
+.. versionadded:: 3.13
 
 To install pre-built binaries with free-threading enabled (see :pep:`703`), you
 should select "Customize installation". The second page of options includes the

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -60,7 +60,7 @@ packages.
 .. _windows-path-mod:
 .. _launcher:
 
-Python Install Manager
+Python install manager
 ======================
 
 Installation
@@ -103,7 +103,7 @@ Windows Server 2019, please see :ref:`pymanager-advancedinstall` below for more
 information.
 
 
-Basic Use
+Basic use
 ---------
 
 The recommended command for launching Python is ``python``, which will either
@@ -193,7 +193,7 @@ installed if automatic installation is configured (most likely by setting
 ``pymanager exec`` forms of the command were used.
 
 
-Command Help
+Command help
 ------------
 
 The ``py help`` command will display the full list of supported commands, along
@@ -218,7 +218,7 @@ override multiple settings at once. See :ref:`pymanager-config` below for more
 information about these files.
 
 
-Listing Runtimes
+Listing runtimes
 ----------------
 
 .. code::
@@ -259,7 +259,7 @@ For compatibility with the old launcher, the ``--list``, ``--list-paths``,
 additional options, and will produce legacy formatted output.
 
 
-Installing Runtimes
+Installing runtimes
 -------------------
 
 .. code::
@@ -298,7 +298,7 @@ useful for embedding runtimes into larger applications.
 
 .. _pymanager-offline:
 
-Offline Installs
+Offline installs
 ----------------
 
 To perform offline installs of Python, you will need to first create an offline
@@ -330,7 +330,7 @@ In this way, Python runtimes can be installed and managed on a machine without
 access to the internet.
 
 
-Uninstalling Runtimes
+Uninstalling runtimes
 ---------------------
 
 .. code::
@@ -541,7 +541,7 @@ configuration option.
 
 .. _pymanager-advancedinstall:
 
-Advanced Installation
+Advanced installation
 ---------------------
 
 For situations where an MSIX cannot be installed, such as some older
@@ -635,7 +635,7 @@ the Store package in this way.
 
 .. _pymanager-admin-config:
 
-Administrative Configuration
+Administrative configuration
 ----------------------------
 
 There are a number of options that may be useful for administrators to override
@@ -726,7 +726,7 @@ directory containing the configuration file that specified them.
 
 .. _install-freethreaded-windows:
 
-Installing Free-threaded Binaries
+Installing free-threaded binaries
 ---------------------------------
 
 .. versionadded:: 3.13 (Experimental)
@@ -885,7 +885,7 @@ versions before providing updates to users.
 
 The two recommended use cases for this distribution are described below.
 
-Python Application
+Python application
 ------------------
 
 An application written in Python does not necessarily require users to be aware
@@ -1046,7 +1046,7 @@ please install Python 3.12.
 
 .. _max-path:
 
-Removing the MAX_PATH Limitation
+Removing the MAX_PATH limitation
 ================================
 
 Windows historically has limited path lengths to 260 characters. This meant that
@@ -1332,7 +1332,7 @@ installation". In this case:
 * Shortcuts are available for all users
 
 
-Removing the MAX_PATH Limitation
+Removing the MAX_PATH limitation
 --------------------------------
 
 Windows historically has limited path lengths to 260 characters. This meant that
@@ -1355,7 +1355,7 @@ After changing the above option, no further configuration is required.
 
 .. _install-quiet-option:
 
-Installing Without UI
+Installing without UI
 ---------------------
 
 All of the options available in the installer UI can also be specified from the
@@ -1504,7 +1504,7 @@ example file sets the same options as the previous example:
 
 .. _install-layout-option:
 
-Installing Without Downloading
+Installing without downloading
 ------------------------------
 
 As some features of Python are not included in the initial installer download,
@@ -1545,7 +1545,7 @@ settings and replace any that have been removed or modified.
 :ref:`launcher`, which has its own entry in Programs and Features.
 
 
-Installing Free-threaded Binaries
+Installing free-threaded binaries
 ---------------------------------
 
 .. versionadded:: 3.13 (Experimental)
@@ -1585,7 +1585,7 @@ builds.
 Free-threaded binaries are also available :ref:`on nuget.org <windows-nuget>`.
 
 
-Python Launcher for Windows (Deprecated)
+Python launcher for Windows (deprecated)
 ========================================
 
 .. deprecated:: 3.14
@@ -1737,7 +1737,7 @@ have the script specify the version which should be used.
 The key benefit of this is that a single launcher can support multiple Python
 versions at the same time depending on the contents of the first line.
 
-Shebang Lines
+Shebang lines
 -------------
 
 If the first line of a script file starts with ``#!``, it is known as a
@@ -1949,7 +1949,7 @@ should allow you to see what versions of Python were located, why a
 particular version was chosen and the exact command-line used to execute the
 target Python. It is primarily intended for testing and debugging.
 
-Dry Run
+Dry run
 -------
 
 If an environment variable :envvar:`!PYLAUNCHER_DRYRUN` is set (to any value),


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Similar to https://github.com/python/cpython/pull/135591 which removed "experimental" from "Using Python on macOS" for 3.14+, do the same for "Using Python on Windows".

Compare macOS:

* 3.13: https://docs.python.org/3.13/using/mac.html#install-freethreaded-macos
* 3.14: https://docs.python.org/3.14/using/mac.html#install-freethreaded-macos

Also consistently use sentence case for headers:

https://devguide.python.org/documentation/style-guide/#capitalization

cc @zooba 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--139992.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->