### PR TITLE
gh-140001: Remove obsolete TCL_WIN_SOCKET macro (from Tcl 7.x) from _tkinter.c

### DIFF
--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -82,33 +82,10 @@ typedef int Tcl_Size;
 
 #ifdef HAVE_CREATEFILEHANDLER
 
-/* This bit is to ensure that TCL_UNIX_FD is defined and doesn't interfere
-   with the proper calculation of FHANDLETYPE == TCL_UNIX_FD below. */
-#ifndef TCL_UNIX_FD
-#  ifdef TCL_WIN_SOCKET
-#    define TCL_UNIX_FD (! TCL_WIN_SOCKET)
-#  else
-#    define TCL_UNIX_FD 1
-#  endif
-#endif
-
-/* Tcl_CreateFileHandler() changed several times; these macros deal with the
-   messiness.  In Tcl 8.0 and later, it is not available on Windows (and on
-   Unix, only because Jack added it back); when available on Windows, it only
-   applies to sockets. */
-
-#ifdef MS_WINDOWS
-#define FHANDLETYPE TCL_WIN_SOCKET
-#else
-#define FHANDLETYPE TCL_UNIX_FD
-#endif
-
 /* If Tcl can wait for a Unix file descriptor, define the EventHook() routine
    which uses this to handle Tcl events while the user is typing commands. */
 
-#if FHANDLETYPE == TCL_UNIX_FD
 #define WAIT_FOR_STDIN
-#endif
 
 #endif /* HAVE_CREATEFILEHANDLER */
 


### PR DESCRIPTION
The macro `TCL_WIN_SOCKET` used in `Modules/_tkinter.c` is a Tcl 7.x legacy macro that is no longer defined in Tcl ≥ 8.0.
As Python now requires Tcl 8.5.12, the code path is now unreachable, and can safely be removed.

The macro `FHANDLETYPE` defined in `Modules/_tkinter.c` then always evaluates to `TCL_UNIX_FD`, and can also be removed.

<!-- gh-issue-number: gh-140001 -->
* Issue: gh-140001
<!-- /gh-issue-number -->
