### PR TITLE
gh-140009: Improve performance of list_extend_dictitems by using PyTuple_FromArray

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-12-18-54-06.gh-issue-140009.-MbFh_.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-12-18-54-06.gh-issue-140009.-MbFh_.rst
@@ -1,0 +1,1 @@
+Improve performance of list extension by dictionary items.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1382,9 +1382,9 @@ list_extend_dictitems(PyListObject *self, PyDictObject *dict)
     PyObject **dest = self->ob_item + m;
     Py_ssize_t pos = 0;
     Py_ssize_t i = 0;
-    PyObject *key, *value;
-    while (_PyDict_Next((PyObject *)dict, &pos, &key, &value, NULL)) {
-        PyObject *item = PyTuple_Pack(2, key, value);
+    PyObject *key_value[2];
+    while (_PyDict_Next((PyObject *)dict, &pos, &key_value[0], &key_value[1], NULL)) {
+        PyObject *item = PyTuple_FromArray(key_value, 2);
         if (item == NULL) {
             Py_SET_SIZE(self, m + i);
             return -1;


### PR DESCRIPTION
Benchmark:
```
import pyperf
runner = pyperf.Runner()

setup="""
d = {ii: ii+1 for ii in range(200)}
dct_items = d.items()
"""
runner.timeit(name="extend list with dict keys", stmt="l = []; l += d", setup=setup)
runner.timeit(name="extend list with dict items", stmt="l = []; l += dct_items", setup=setup)
```
Results:
```
extend list with dict items: Mean +- std dev: [main] 3.78 us +- 0.07 us -> [pr] 3.17 us +- 0.03 us: 1.19x faster

Benchmark hidden because not significant (1): extend list with dict keys

Geometric mean: 1.09x faster
```
The benchmark is 19% faster (`extend list with dict keys` is a control benchmark).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140009 -->
* Issue: gh-140009
<!-- /gh-issue-number -->
