### PR TITLE
gh-136655: ensure cancelled futures are notified on process pool shutdown

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -518,7 +518,9 @@ class _ExecutorManagerThread(threading.Thread):
                 # to only have futures that are currently running.
                 new_pending_work_items = {}
                 for work_id, work_item in self.pending_work_items.items():
-                    if not work_item.future.cancel():
+                    if work_item.future.cancel():
+                        work_item.future.set_running_or_notify_cancel()
+                    else:
                         new_pending_work_items[work_id] = work_item
                 self.pending_work_items = new_pending_work_items
                 # Drain work_ids_queue since we no longer need to

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -519,6 +519,7 @@ class _ExecutorManagerThread(threading.Thread):
                 new_pending_work_items = {}
                 for work_id, work_item in self.pending_work_items.items():
                     if work_item.future.cancel():
+                        # gh-136655: ensure cancelled futures are notified
                         work_item.future.set_running_or_notify_cancel()
                     else:
                         new_pending_work_items[work_id] = work_item

--- a/Lib/test/test_concurrent_futures/executor.py
+++ b/Lib/test/test_concurrent_futures/executor.py
@@ -256,7 +256,7 @@ class ExecutorTest:
 
         # gh-136655: ensure cancelled futures are notified
         count = self.worker_count * 2
-        barrier = self.create_barrier(self.worker_count + 1)
+        barrier = self.create_barrier(self.worker_count + 1, timeout=1)
         with self.executor as exec:
             fs = [exec.submit(blocking_raiser,
                               barrier if index < self.worker_count else None)
@@ -277,5 +277,5 @@ class ExecutorTest:
 
 def blocking_raiser(barrier=None):
     if barrier is not None:
-        barrier.wait(1)
+        barrier.wait()
     raise FalseyBoolException()

--- a/Lib/test/test_concurrent_futures/executor.py
+++ b/Lib/test/test_concurrent_futures/executor.py
@@ -247,3 +247,35 @@ class ExecutorTest:
         msg = 'lenlen'
         with self.assertRaisesRegex(FalseyLenException, msg):
             self.executor.submit(raiser, FalseyLenException, msg).result()
+
+    def test_shutdown_notifies_cancelled_futures(self):
+
+        # TODO: remove when gh-109934 is fixed
+        if self.executor_type is futures.ThreadPoolExecutor:
+            self.skipTest("gh-109934: skipping thread pool executor")
+
+        # gh-136655: ensure cancelled futures are notified
+        count = self.worker_count * 2
+        barrier = self.create_barrier(self.worker_count + 1)
+        with self.executor as exec:
+            fs = [exec.submit(blocking_raiser,
+                              barrier if index < self.worker_count else None)
+                  for index in range(count)]
+
+            exec.shutdown(wait=False, cancel_futures=True)
+            try:
+                barrier.wait()
+            except threading.BrokenBarrierError:
+                pass
+
+            for future in fs:
+                self.assertRaises(
+                    (FalseyBoolException, futures.CancelledError, threading.BrokenBarrierError),
+                    future.result)
+
+            self.assertIn('CANCELLED_AND_NOTIFIED', [f._state for f in fs])
+
+def blocking_raiser(barrier=None):
+    if barrier is not None:
+        barrier.wait(1)
+    raise FalseyBoolException()

--- a/Lib/test/test_concurrent_futures/executor.py
+++ b/Lib/test/test_concurrent_futures/executor.py
@@ -248,6 +248,7 @@ class ExecutorTest:
         with self.assertRaisesRegex(FalseyLenException, msg):
             self.executor.submit(raiser, FalseyLenException, msg).result()
 
+    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_shutdown_notifies_cancelled_futures(self):
 
         # TODO: remove when gh-109934 is fixed

--- a/Lib/test/test_concurrent_futures/executor.py
+++ b/Lib/test/test_concurrent_futures/executor.py
@@ -260,7 +260,8 @@ class ExecutorTest:
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_shutdown_notifies_cancelled_futures(self):
-        self.assertGreater(self.worker_count, 1)
+        if self.worker_count < 2:
+            self.skipTest("test requires more than one worker")
 
         # TODO: remove when gh-109934 is fixed
         if self.executor_type is futures.ThreadPoolExecutor:

--- a/Lib/test/test_concurrent_futures/util.py
+++ b/Lib/test/test_concurrent_futures/util.py
@@ -80,6 +80,9 @@ class ExecutorMixin:
 class ThreadPoolMixin(ExecutorMixin):
     executor_type = futures.ThreadPoolExecutor
 
+    def create_barrier(self, count):
+        return threading.Barrier(count)
+
     def create_event(self):
         return threading.Event()
 
@@ -87,6 +90,9 @@ class ThreadPoolMixin(ExecutorMixin):
 @support.skip_if_sanitizer("gh-129824: data races in InterpreterPool tests", thread=True)
 class InterpreterPoolMixin(ExecutorMixin):
     executor_type = futures.InterpreterPoolExecutor
+
+    def create_barrier(self, count):
+        self.skipTest("InterpreterPoolExecutor doesn't support barriers")
 
     def create_event(self):
         self.skipTest("InterpreterPoolExecutor doesn't support events")
@@ -107,6 +113,9 @@ class ProcessPoolForkMixin(ExecutorMixin):
             self.skipTest("TSAN doesn't support threads after fork")
         return super().get_context()
 
+    def create_barrier(self, count):
+        return self.manager.Barrier(count)
+
     def create_event(self):
         return self.manager.Event()
 
@@ -121,6 +130,9 @@ class ProcessPoolSpawnMixin(ExecutorMixin):
         except NotImplementedError:
             self.skipTest("ProcessPoolExecutor unavailable on this system")
         return super().get_context()
+
+    def create_barrier(self, count):
+        return self.manager.Barrier(count)
 
     def create_event(self):
         return self.manager.Event()
@@ -140,6 +152,9 @@ class ProcessPoolForkserverMixin(ExecutorMixin):
         if support.check_sanitizer(thread=True):
             self.skipTest("TSAN doesn't support threads after fork")
         return super().get_context()
+
+    def create_barrier(self, count):
+        return self.manager.Barrier(count)
 
     def create_event(self):
         return self.manager.Event()

--- a/Lib/test/test_concurrent_futures/util.py
+++ b/Lib/test/test_concurrent_futures/util.py
@@ -80,8 +80,8 @@ class ExecutorMixin:
 class ThreadPoolMixin(ExecutorMixin):
     executor_type = futures.ThreadPoolExecutor
 
-    def create_barrier(self, count):
-        return threading.Barrier(count)
+    def create_barrier(self, count, **kwargs):
+        return threading.Barrier(count, **kwargs)
 
     def create_event(self):
         return threading.Event()
@@ -91,7 +91,7 @@ class ThreadPoolMixin(ExecutorMixin):
 class InterpreterPoolMixin(ExecutorMixin):
     executor_type = futures.InterpreterPoolExecutor
 
-    def create_barrier(self, count):
+    def create_barrier(self, count, **kwargs):
         self.skipTest("InterpreterPoolExecutor doesn't support barriers")
 
     def create_event(self):
@@ -113,8 +113,8 @@ class ProcessPoolForkMixin(ExecutorMixin):
             self.skipTest("TSAN doesn't support threads after fork")
         return super().get_context()
 
-    def create_barrier(self, count):
-        return self.manager.Barrier(count)
+    def create_barrier(self, count, **kwargs):
+        return self.manager.Barrier(count, **kwargs)
 
     def create_event(self):
         return self.manager.Event()
@@ -131,8 +131,8 @@ class ProcessPoolSpawnMixin(ExecutorMixin):
             self.skipTest("ProcessPoolExecutor unavailable on this system")
         return super().get_context()
 
-    def create_barrier(self, count):
-        return self.manager.Barrier(count)
+    def create_barrier(self, count, **kwargs):
+        return self.manager.Barrier(count, **kwargs)
 
     def create_event(self):
         return self.manager.Event()
@@ -153,8 +153,8 @@ class ProcessPoolForkserverMixin(ExecutorMixin):
             self.skipTest("TSAN doesn't support threads after fork")
         return super().get_context()
 
-    def create_barrier(self, count):
-        return self.manager.Barrier(count)
+    def create_barrier(self, count, **kwargs):
+        return self.manager.Barrier(count, **kwargs)
 
     def create_event(self):
         return self.manager.Event()

--- a/Misc/NEWS.d/next/Library/2025-10-13-13-05-15.gh-issue-136655.R8fBtC.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-13-13-05-15.gh-issue-136655.R8fBtC.rst
@@ -1,0 +1,2 @@
++Ensure :class:`concurrent.futures.ProcessPoolExecutor` notifies any futures
+it cancels on shutdown.


### PR DESCRIPTION
At present when a process pool executor shuts down it is cancelling pending work items, but failing to notify any waiting threads. Fix this.

See also gh-109934, which is a similar bug in the thread pool executor.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136655 -->
* Issue: gh-136655
<!-- /gh-issue-number -->
