### PR TITLE
gh-131189: Remove `curses` mention from `PYTHON_BASIC_REPL` docs

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -1277,9 +1277,8 @@ conflict.
 .. envvar:: PYTHON_BASIC_REPL
 
    If this variable is set to any value, the interpreter will not attempt to
-   load the Python-based :term:`REPL` that requires :mod:`curses` and
-   :mod:`readline`, and will instead use the traditional parser-based
-   :term:`REPL`.
+   load the Python-based :term:`REPL` that requires :mod:`readline`, and will
+   instead use the traditional parser-based :term:`REPL`.
 
    .. versionadded:: 3.13
 


### PR DESCRIPTION
Since gh-135621, the curses lib is no longer needed to run the new REPL!

Do not backport to 3.13.

<!-- gh-issue-number: gh-131189 -->
* Issue: gh-131189
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140022.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->