### PR TITLE
gh-101100: Fix sphinx warnings in `library/resource.rst`

### DIFF
--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -141,7 +141,7 @@ platform.
 .. data:: RLIMIT_CPU
 
    The maximum amount of processor time (in seconds) that a process can use. If
-   this limit is exceeded, a :const:`SIGXCPU` signal is sent to the process. (See
+   this limit is exceeded, a :const:`~signal.SIGXCPU` signal is sent to the process. (See
    the :mod:`signal` module documentation for information about how to catch this
    signal and do something useful, e.g. flush open files to disk.)
 
@@ -363,47 +363,47 @@ These functions are used to retrieve resource usage information:
    For backward compatibility, the return value is also accessible as a tuple of 16
    elements.
 
-   The fields :attr:`ru_utime` and :attr:`ru_stime` of the return value are
+   The fields :attr:`!ru_utime` and :attr:`!ru_stime` of the return value are
    floating-point values representing the amount of time spent executing in user
    mode and the amount of time spent executing in system mode, respectively. The
    remaining values are integers. Consult the :manpage:`getrusage(2)` man page for
    detailed information about these values. A brief summary is presented here:
 
-   +--------+---------------------+---------------------------------------+
-   | Index  | Field               | Resource                              |
-   +========+=====================+=======================================+
-   | ``0``  | :attr:`ru_utime`    | time in user mode (float seconds)     |
-   +--------+---------------------+---------------------------------------+
-   | ``1``  | :attr:`ru_stime`    | time in system mode (float seconds)   |
-   +--------+---------------------+---------------------------------------+
-   | ``2``  | :attr:`ru_maxrss`   | maximum resident set size             |
-   +--------+---------------------+---------------------------------------+
-   | ``3``  | :attr:`ru_ixrss`    | shared memory size                    |
-   +--------+---------------------+---------------------------------------+
-   | ``4``  | :attr:`ru_idrss`    | unshared memory size                  |
-   +--------+---------------------+---------------------------------------+
-   | ``5``  | :attr:`ru_isrss`    | unshared stack size                   |
-   +--------+---------------------+---------------------------------------+
-   | ``6``  | :attr:`ru_minflt`   | page faults not requiring I/O         |
-   +--------+---------------------+---------------------------------------+
-   | ``7``  | :attr:`ru_majflt`   | page faults requiring I/O             |
-   +--------+---------------------+---------------------------------------+
-   | ``8``  | :attr:`ru_nswap`    | number of swap outs                   |
-   +--------+---------------------+---------------------------------------+
-   | ``9``  | :attr:`ru_inblock`  | block input operations                |
-   +--------+---------------------+---------------------------------------+
-   | ``10`` | :attr:`ru_oublock`  | block output operations               |
-   +--------+---------------------+---------------------------------------+
-   | ``11`` | :attr:`ru_msgsnd`   | messages sent                         |
-   +--------+---------------------+---------------------------------------+
-   | ``12`` | :attr:`ru_msgrcv`   | messages received                     |
-   +--------+---------------------+---------------------------------------+
-   | ``13`` | :attr:`ru_nsignals` | signals received                      |
-   +--------+---------------------+---------------------------------------+
-   | ``14`` | :attr:`ru_nvcsw`    | voluntary context switches            |
-   +--------+---------------------+---------------------------------------+
-   | ``15`` | :attr:`ru_nivcsw`   | involuntary context switches          |
-   +--------+---------------------+---------------------------------------+
+   +--------+----------------------+---------------------------------------+
+   | Index  | Field                | Resource                              |
+   +========+======================+=======================================+
+   | ``0``  | :attr:`!ru_utime`    | time in user mode (float seconds)     |
+   +--------+----------------------+---------------------------------------+
+   | ``1``  | :attr:`!ru_stime`    | time in system mode (float seconds)   |
+   +--------+----------------------+---------------------------------------+
+   | ``2``  | :attr:`!ru_maxrss`   | maximum resident set size             |
+   +--------+----------------------+---------------------------------------+
+   | ``3``  | :attr:`!ru_ixrss`    | shared memory size                    |
+   +--------+----------------------+---------------------------------------+
+   | ``4``  | :attr:`!ru_idrss`    | unshared memory size                  |
+   +--------+----------------------+---------------------------------------+
+   | ``5``  | :attr:`!ru_isrss`    | unshared stack size                   |
+   +--------+----------------------+---------------------------------------+
+   | ``6``  | :attr:`!ru_minflt`   | page faults not requiring I/O         |
+   +--------+----------------------+---------------------------------------+
+   | ``7``  | :attr:`!ru_majflt`   | page faults requiring I/O             |
+   +--------+----------------------+---------------------------------------+
+   | ``8``  | :attr:`!ru_nswap`    | number of swap outs                   |
+   +--------+----------------------+---------------------------------------+
+   | ``9``  | :attr:`!ru_inblock`  | block input operations                |
+   +--------+----------------------+---------------------------------------+
+   | ``10`` | :attr:`!ru_oublock`  | block output operations               |
+   +--------+----------------------+---------------------------------------+
+   | ``11`` | :attr:`!ru_msgsnd`   | messages sent                         |
+   +--------+----------------------+---------------------------------------+
+   | ``12`` | :attr:`!ru_msgrcv`   | messages received                     |
+   +--------+----------------------+---------------------------------------+
+   | ``13`` | :attr:`!ru_nsignals` | signals received                      |
+   +--------+----------------------+---------------------------------------+
+   | ``14`` | :attr:`!ru_nvcsw`    | voluntary context switches            |
+   +--------+----------------------+---------------------------------------+
+   | ``15`` | :attr:`!ru_nivcsw`   | involuntary context switches          |
+   +--------+----------------------+---------------------------------------+
 
    This function will raise a :exc:`ValueError` if an invalid *who* parameter is
    specified. It may also raise :exc:`error` exception in unusual circumstances.

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -205,12 +205,6 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
-.. data:: SIGPROF
-
-   Profiling timer expired.
-
-   .. availability:: Unix.
-
 .. data:: SIGQUIT
 
    Terminal quit signal.
@@ -253,6 +247,12 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
+.. data:: SIGPROF
+
+   Profiling timer expired.
+
+   .. availability:: Unix.
+
 .. data:: SIGVTALRM
 
    Virtual timer expired.
@@ -265,12 +265,18 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
+.. data:: SIGXCPU
+
+   CPU time limit exceeded.
+
+   .. availability:: Unix.
+
 .. data:: SIG*
 
    All the signal numbers are defined symbolically.  For example, the hangup signal
    is defined as :const:`signal.SIGHUP`; the variable names are identical to the
    names used in C programs, as found in ``<signal.h>``.  The Unix man page for
-   '``signal``' lists the existing signals (on some systems this is
+   ':c:func:`!signal`' lists the existing signals (on some systems this is
    :manpage:`signal(2)`, on others the list is in :manpage:`signal(7)`). Note that
    not all systems define the same set of signal names; only those names defined by
    the system are defined by this module.
@@ -666,8 +672,9 @@ The :mod:`signal` module defines the following functions:
    *sigset*.
 
    The return value is an object representing the data contained in the
-   ``siginfo_t`` structure, namely: ``si_signo``, ``si_code``,
-   ``si_errno``, ``si_pid``, ``si_uid``, ``si_status``, ``si_band``.
+   :c:type:`siginfo_t` structure, namely: :attr:`!si_signo`, :attr:`!si_code`,
+   :attr:`!si_errno`, :attr:`!si_pid`, :attr:`!si_uid`, :attr:`!si_status`,
+   :attr:`!si_band`.
 
    .. availability:: Unix.
 

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -205,6 +205,12 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
+.. data:: SIGPROF
+
+   Profiling timer expired.
+
+   .. availability:: Unix.
+
 .. data:: SIGQUIT
 
    Terminal quit signal.
@@ -247,12 +253,6 @@ The variables defined in the :mod:`signal` module are:
 
    .. availability:: Unix.
 
-.. data:: SIGPROF
-
-   Profiling timer expired.
-
-   .. availability:: Unix.
-
 .. data:: SIGVTALRM
 
    Virtual timer expired.
@@ -276,7 +276,7 @@ The variables defined in the :mod:`signal` module are:
    All the signal numbers are defined symbolically.  For example, the hangup signal
    is defined as :const:`signal.SIGHUP`; the variable names are identical to the
    names used in C programs, as found in ``<signal.h>``.  The Unix man page for
-   ':c:func:``signal``' lists the existing signals (on some systems this is
+   '``signal``' lists the existing signals (on some systems this is
    :manpage:`signal(2)`, on others the list is in :manpage:`signal(7)`). Note that
    not all systems define the same set of signal names; only those names defined by
    the system are defined by this module.

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -276,7 +276,7 @@ The variables defined in the :mod:`signal` module are:
    All the signal numbers are defined symbolically.  For example, the hangup signal
    is defined as :const:`signal.SIGHUP`; the variable names are identical to the
    names used in C programs, as found in ``<signal.h>``.  The Unix man page for
-   ':c:func:`!signal`' lists the existing signals (on some systems this is
+   ':c:func:``signal``' lists the existing signals (on some systems this is
    :manpage:`signal(2)`, on others the list is in :manpage:`signal(7)`). Note that
    not all systems define the same set of signal names; only those names defined by
    the system are defined by this module.
@@ -672,9 +672,8 @@ The :mod:`signal` module defines the following functions:
    *sigset*.
 
    The return value is an object representing the data contained in the
-   :c:type:`siginfo_t` structure, namely: :attr:`!si_signo`, :attr:`!si_code`,
-   :attr:`!si_errno`, :attr:`!si_pid`, :attr:`!si_uid`, :attr:`!si_status`,
-   :attr:`!si_band`.
+   ``siginfo_t`` structure, namely: ``si_signo``, ``si_code``,
+   ``si_errno``, ``si_pid``, ``si_uid``, ``si_status``, ``si_band``.
 
    .. availability:: Unix.
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -27,7 +27,6 @@ Doc/library/os.rst
 Doc/library/pickletools.rst
 Doc/library/profile.rst
 Doc/library/pyexpat.rst
-Doc/library/resource.rst
 Doc/library/select.rst
 Doc/library/smtplib.rst
 Doc/library/socket.rst


### PR DESCRIPTION
```
resource.rst:143: WARNING: py:const reference target not found: SIGXCPU [ref.const]
resource.rst:366: WARNING: py:attr reference target not found: ru_utime [ref.attr]
resource.rst:366: WARNING: py:attr reference target not found: ru_stime [ref.attr]
resource.rst:376: WARNING: py:attr reference target not found: ru_utime [ref.attr]
resource.rst:378: WARNING: py:attr reference target not found: ru_stime [ref.attr]
resource.rst:380: WARNING: py:attr reference target not found: ru_maxrss [ref.attr]
resource.rst:382: WARNING: py:attr reference target not found: ru_ixrss [ref.attr]
resource.rst:384: WARNING: py:attr reference target not found: ru_idrss [ref.attr]
resource.rst:386: WARNING: py:attr reference target not found: ru_isrss [ref.attr]
resource.rst:388: WARNING: py:attr reference target not found: ru_minflt [ref.attr]
resource.rst:390: WARNING: py:attr reference target not found: ru_majflt [ref.attr]
resource.rst:392: WARNING: py:attr reference target not found: ru_nswap [ref.attr]
resource.rst:394: WARNING: py:attr reference target not found: ru_inblock [ref.attr]
resource.rst:396: WARNING: py:attr reference target not found: ru_oublock [ref.attr]
resource.rst:398: WARNING: py:attr reference target not found: ru_msgsnd [ref.attr]
resource.rst:400: WARNING: py:attr reference target not found: ru_msgrcv [ref.attr]
resource.rst:402: WARNING: py:attr reference target not found: ru_nsignals [ref.attr]
resource.rst:404: WARNING: py:attr reference target not found: ru_nvcsw [ref.attr]
resource.rst:406: WARNING: py:attr reference target not found: ru_nivcsw [ref.attr]
```
- line 143. I document this in `library/signal.rst`
```
.. data:: SIGXCPU

   CPU time limit exceeded.

   .. availability:: Unix.
```
description and order copied from https://pubs.opengroup.org/onlinepubs/009695399/basedefs/signal.h.html

- others. They are a chart indicating attributes (served as an index) so I suppressed them 

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140023.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->