### PR TITLE
Slightly improve error message when given incorrect module path

### DIFF
--- a/Lib/runpy.py
+++ b/Lib/runpy.py
@@ -135,7 +135,7 @@ def _get_module_details(mod_name, error=ImportError):
         # pkgutil previously raised ImportError
         msg = "Error while finding module specification for {!r} ({}: {})"
         if mod_name.endswith(".py"):
-            msg += (f". Try using '{mod_name[:-3]}' instead of "
+            msg += (f". Try using '{mod_name[:-3].replace('/', '.')}' instead of "
                     f"'{mod_name}' as the module name.")
         raise error(msg.format(mod_name, type(ex).__name__, ex)) from ex
     if spec is None:


### PR DESCRIPTION
# Improve error message when given incorrect module path

Currently, python returns a helpful error message when users accidentally try to run `python -m` and include a '.py' ending in the path. 
```
user@machine:~$ python3 -m path.to.file.py
>>> Error while finding module specification for 'path.to.file.py' 
(ModuleNotFoundError: No module named 'path'). 
Try using 'path.to.file' instead of 'path.to.file.py' as the module name.
```


However, a more common scenario for inexperienced users would be using the path to the file directly:
```
user@machine:~$ python3 -m path/to/file.py
>>> Error while finding module specification for 'path/to/file.py' 
(ModuleNotFoundError: No module named 'path/to/file'). 
Try using 'path/to/file' instead of 'path/to/file.py' as the module name.
```

This PR changes the error message to the more helpful:
```
user@machine:~$ python3 -m path/to/file.py
>>> Error while finding module specification for 'path/to/file.py' 
(ModuleNotFoundError: No module named 'path/to/file'). 
Try using 'path.to.file' instead of 'path/to/file.py' as the module name.
```

