### PR TITLE
GH-140058: Clear key and value if PyTuple_New fails in dictiter_iternextitem

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5719,8 +5719,11 @@ dictiter_iternextitem(PyObject *self)
         }
         else {
             result = PyTuple_New(2);
-            if (result == NULL)
+            if (result == NULL) {
+                Py_DECREF(key);
+                Py_DECREF(value);
                 return NULL;
+            }
             PyTuple_SET_ITEM(result, 0, key);
             PyTuple_SET_ITEM(result, 1, value);
         }


### PR DESCRIPTION
Following code should decref `key` and `value` if `PyTuple_New` fails:
https://github.com/python/cpython/blob/6481539a6d9692ddf13ab01baad1bc9133409413/Objects/dictobject.c#L5720-L5726

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140058 -->
* Issue: gh-140058
<!-- /gh-issue-number -->
