### PR TITLE
Link to data model docs in slice's glossary/built-in doc entry

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1275,6 +1275,8 @@ Glossary
       when several are given, such as in ``variable_name[1:3:5]``.  The bracket
       (subscript) notation uses :class:`slice` objects internally.
 
+      See also :ref:`slice-objects`.
+
    soft deprecated
       A soft deprecated API should not be used in new code,
       but it is safe for already existing code to use it.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1827,6 +1827,8 @@ are always available.  They are listed here in alphabetical order.
    :func:`itertools.islice` for an alternate version that returns an
    :term:`iterator`.
 
+   See also :ref:`slice-objects`.
+
    .. versionchanged:: 3.12
       Slice objects are now :term:`hashable` (provided :attr:`~slice.start`,
       :attr:`~slice.stop`, and :attr:`~slice.step` are hashable).

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5978,7 +5978,7 @@ Internal Objects
 
 See :ref:`types` for this information.  It describes
 :ref:`stack frame objects <frame-objects>`,
-:ref:`traceback objects <traceback-objects>`, and slice objects.
+:ref:`traceback objects <traceback-objects>`, and :ref:`slice objects <slice-objects>`.
 
 
 .. _specialattrs:


### PR DESCRIPTION
#### Story time!
With the way the documentation is currently organised, I expect to find information about built-in functions/types on the Built-in Functions page.
Sure enough, `slice()` is on that list, and it starts as follows: "Returns a :term:\`slice\` object".
Since I needed more information than was already provided, I clicked on the `slice` link, which directed me to the glossary. Information there, however, still did not include the more detailed information that I was looking for. The glossary entry has a `` :class:`slice` `` link, but that just links back to Built-in Functions.

So, that's how this PR came about - I eventually found that `slice` is listed in the Built-in Types document and links to "The standard type hierarchy" part of the Data model docs, where I found the remaining pieces of information. I think it makes sense to add "See also" links to the function and *probably* glossary as well. This is similar to how `staticmethod` documentation in "Built-in Functions" links to "The standard type hierarchy" section.

*I guess*, it's not ideal that the `slice` documentation is spread across "Built-in Functions" (where the `start`, `stop`, and `step` attributes are listed with `.. attribute::`, though not really documented) and "Data model" (where the `slice.indices` method is documented + aforementioned attributes are better documented *and `:ref:`ed*) *but* I wanted to at least make it easy to find the information through links.

I did not make an issue since this seems like a trivial docs enhancement, but please let me know if I should do so.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140070.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->