### PR TITLE
gh-124111: Update macOS installer to use Tcl/Tk 9.0.2.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -264,10 +264,10 @@ def library_recipes():
             tk_patches = ['backport_gh71383_fix.patch', 'tk868_on_10_8_10_9.patch', 'backport_gh110950_fix.patch']
 
         else:
-            tcl_tk_ver='8.6.17'
-            tcl_checksum='a3903371efcce8a405c5c245d029e9f6850258a60fa3761c4d58995610949b31'
+            tcl_tk_ver='9.0.2'
+            tcl_checksum='e074c6a8d9ba2cddf914ba97b6677a552d7a52a3ca102924389a05ccb249b520'
 
-            tk_checksum='e4982df6f969c08bf9dd858a6891059b4a3f50dc6c87c10abadbbe2fc4838946'
+            tk_checksum='76fb852b2f167592fe8b41aa6549ce4e486dbf3b259a269646600e3894517c76'
             tk_patches = []
 
 

--- a/Misc/NEWS.d/next/macOS/2025-10-06-23-56-36.gh-issue-124111.KOlBvs.rst
+++ b/Misc/NEWS.d/next/macOS/2025-10-06-23-56-36.gh-issue-124111.KOlBvs.rst
@@ -1,1 +1,0 @@
-Update macOS installer to use Tcl/Tk 8.6.17.

--- a/Misc/NEWS.d/next/macOS/2025-10-14-00-08-16.gh-issue-124111.7-j-DQ.rst
+++ b/Misc/NEWS.d/next/macOS/2025-10-14-00-08-16.gh-issue-124111.7-j-DQ.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use Tcl/Tk 9.0.2.


### PR DESCRIPTION


<!-- gh-issue-number: gh-124111 -->
* Issue: gh-124111
<!-- /gh-issue-number -->
