### PR TITLE
gh-140025: fix queue.SimpleQueue.__sizeof__() computation

### DIFF
--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -1066,13 +1066,13 @@ class PySimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
         # Test that SimpleQueue uses object identity, not value equality
         q1 = self.type2test()
         q2 = self.type2test()
-        
+
         # Different instances should not be equal
         self.assertNotEqual(q1, q2)
-        
+
         # Same instance should be equal to itself
         self.assertEqual(q1, q1)
-        
+
         # Even with same content, instances should not be equal
         q1.put('test')
         q2.put('test')
@@ -1096,13 +1096,13 @@ class CSimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
         # Test that SimpleQueue uses object identity, not value equality
         q1 = self.type2test()
         q2 = self.type2test()
-        
+
         # Different instances should not be equal
         self.assertNotEqual(q1, q2)
-        
+
         # Same instance should be equal to itself
         self.assertEqual(q1, q1)
-        
+
         # Even with same content, instances should not be equal
         q1.put('test')
         q2.put('test')

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -1039,7 +1039,7 @@ class PySimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
         self.assertGreater(large_size, 0)
 
     def test_is_default(self):
-        self.assertIsNot(self.type2test, self.queue.SimpleQueue)
+        self.assertIs(self.type2test, self.queue.SimpleQueue)
         self.assertIs(self.type2test, self.queue._PySimpleQueue)
 
 

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -1038,10 +1038,6 @@ class PySimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
         large_size = large_q.__sizeof__()
         self.assertGreater(large_size, 0)
 
-    def test_is_default(self):
-        self.assertIs(self.type2test, self.queue.SimpleQueue)
-        self.assertIs(self.type2test, self.queue._PySimpleQueue)
-
 
 @need_c_queue
 class CSimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -1010,18 +1010,11 @@ class BaseSimpleQueueTest:
             self.assertIsNone(wr())
 
     def test_sizeof(self):
-        # Test that __sizeof__() accounts for underlying data structure
         q = self.q
 
-        # Get the size of an empty queue
         empty_size = q.__sizeof__()
         self.assertGreater(empty_size, 0, "Empty queue should have non-zero size")
 
-        # Size should include basic object structure
-        # For C implementation, this includes the ring buffer array
-        # For Python implementation, this includes the underlying deque
-
-        # Add items within initial capacity (if applicable)
         for i in range(8):
             q.put(object())
 
@@ -1034,8 +1027,7 @@ class BaseSimpleQueueTest:
         q.put(object())  # Now 9 items
 
         size_after_9 = q.__sizeof__()
-        self.assertGreaterEqual(size_after_9, size_after_8,
-                               "Size should not decrease when adding items")
+        self.assertGreaterEqual(size_after_9, size_after_8)
 
         # Test with a larger number of items
         large_q = self.type2test()
@@ -1070,6 +1062,22 @@ class PySimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
         self.type2test = self.queue._PySimpleQueue
         super().setUp()
 
+    def test_equality(self):
+        # Test that SimpleQueue uses object identity, not value equality
+        q1 = self.type2test()
+        q2 = self.type2test()
+        
+        # Different instances should not be equal
+        self.assertNotEqual(q1, q2)
+        
+        # Same instance should be equal to itself
+        self.assertEqual(q1, q1)
+        
+        # Even with same content, instances should not be equal
+        q1.put('test')
+        q2.put('test')
+        self.assertNotEqual(q1, q2)
+
 
 @need_c_queue
 class CSimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
@@ -1083,6 +1091,22 @@ class CSimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
     def test_is_default(self):
         self.assertIs(self.type2test, self.queue.SimpleQueue)
         self.assertIs(self.type2test, self.queue.SimpleQueue)
+
+    def test_equality(self):
+        # Test that SimpleQueue uses object identity, not value equality
+        q1 = self.type2test()
+        q2 = self.type2test()
+        
+        # Different instances should not be equal
+        self.assertNotEqual(q1, q2)
+        
+        # Same instance should be equal to itself
+        self.assertEqual(q1, q1)
+        
+        # Even with same content, instances should not be equal
+        q1.put('test')
+        q2.put('test')
+        self.assertNotEqual(q1, q2)
 
     def test_reentrancy(self):
         # bpo-14976: put() may be called reentrantly in an asynchronous

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -1019,7 +1019,7 @@ class BaseSimpleQueueTest:
 
         # Size should include basic object structure
         # For C implementation, this includes the ring buffer array
-        # For Python implementation, this includes the underlying list
+        # For Python implementation, this includes the underlying deque
 
         # Add items within initial capacity (if applicable)
         # For C SimpleQueue, initial capacity is 8 items
@@ -1059,8 +1059,8 @@ class BaseSimpleQueueTest:
                               "Large C SimpleQueue should be at least 2x size of empty queue")
         else:
             # This is the Python implementation
-            # The Python implementation doesn't properly implement __sizeof__
-            # but we can at least verify it returns a positive number
+            # The Python implementation doesn't override __sizeof__
+            # so it only accounts for the object itself, not the underlying deque
             self.assertGreater(large_size, 0, "Python SimpleQueue should have positive size")
 
 

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -1,6 +1,5 @@
 # Some simple queue module tests, plus some failure conditions
 # to ensure the Queue locks remain stable.
-import itertools
 import random
 import threading
 import time
@@ -1019,23 +1018,23 @@ class PySimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
 
     def test_sizeof(self):
         q = self.type2test()
-        
+
         empty_size = q.__sizeof__()
         self.assertGreater(empty_size, 0)
-        
+
         for i in range(8):
             q.put(object())
-        
+
         size_after_8 = q.__sizeof__()
-        
+
         q.put(object())  # Now 9 items
         size_after_9 = q.__sizeof__()
         self.assertGreaterEqual(size_after_9, size_after_8)
-        
+
         large_q = self.type2test()
         for i in range(1000):
             large_q.put(object())
-        
+
         large_size = large_q.__sizeof__()
         self.assertGreater(large_size, 0)
 
@@ -1055,27 +1054,27 @@ class CSimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
 
     def test_sizeof(self):
         q = self.type2test()
-        
+
         empty_size = q.__sizeof__()
         self.assertGreater(empty_size, 0)
-        
+
         for i in range(8):
             q.put(object())
-        
+
         size_after_8 = q.__sizeof__()
 
         q.put(object())  # Now 9 items - should trigger ring buffer growth
         size_after_9 = q.__sizeof__()
         self.assertGreater(size_after_9, size_after_8)
-        
+
         large_q = self.type2test()
         for i in range(1000):
             large_q.put(object())
-        
+
         large_size = large_q.__sizeof__()
-        
+
         self.assertGreater(large_size, empty_size)
-        
+
         self.assertGreater(large_size, empty_size * 2)
 
 

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -1017,13 +1017,6 @@ class PySimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
         self.type2test = self.queue._PySimpleQueue
         super().setUp()
 
-    def test_pysimplequeue_sizeof_constant(self):
-        q = self.type2test()
-        size0 = q.__sizeof__()
-        for _ in range(1000):
-            q.put(object())
-        self.assertEqual(q.__sizeof__(), size0)
-
 
 @need_c_queue
 class CSimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -1022,14 +1022,13 @@ class BaseSimpleQueueTest:
         # For Python implementation, this includes the underlying deque
 
         # Add items within initial capacity (if applicable)
-        # For C SimpleQueue, initial capacity is 8 items
         for i in range(8):
             q.put(object())
 
         size_after_8 = q.__sizeof__()
         # Size may or may not change depending on implementation
         # C implementation: no change (still within initial ring buffer capacity)
-        # Python implementation: may change (list growth)
+        # Python implementation: may change (deque growth, but __sizeof__ may not reflect it)
 
         # Add one more item to potentially trigger growth
         q.put(object())  # Now 9 items
@@ -1046,8 +1045,8 @@ class BaseSimpleQueueTest:
         large_size = large_q.__sizeof__()
 
         # For C implementation, size should grow with capacity
-        # For Python implementation, __sizeof__ may not account for underlying list
-        # (this is a known limitation of the Python implementation)
+        # For Python implementation, __sizeof__ will not account for underlying deque
+        # (this is documented behavior on CPython; PyPy doesn't support __sizeof__ at all)
         if self.__class__.__name__ == 'CSimpleQueueTest':
             # This is the C implementation
             self.assertGreater(large_size, empty_size,

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -1010,8 +1010,6 @@ class BaseSimpleQueueTest:
             self.assertIsNone(wr())
 
 
-
-
 class PySimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
 
     queue = py_queue
@@ -1030,7 +1028,7 @@ class PySimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
         
         size_after_8 = q.__sizeof__()
         
-        q.put(object())
+        q.put(object())  # Now 9 items
         size_after_9 = q.__sizeof__()
         self.assertGreaterEqual(size_after_9, size_after_8)
         
@@ -1041,6 +1039,9 @@ class PySimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
         large_size = large_q.__sizeof__()
         self.assertGreater(large_size, 0)
 
+    def test_is_default(self):
+        self.assertIsNot(self.type2test, self.queue.SimpleQueue)
+        self.assertIs(self.type2test, self.queue._PySimpleQueue)
 
 
 @need_c_queue
@@ -1056,16 +1057,16 @@ class CSimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
         q = self.type2test()
         
         empty_size = q.__sizeof__()
-        self.assertGreater(empty_size, 0, "Empty C SimpleQueue should have non-zero size")
+        self.assertGreater(empty_size, 0)
         
         for i in range(8):
             q.put(object())
         
         size_after_8 = q.__sizeof__()
 
-        q.put(object()) 
+        q.put(object())  # Now 9 items - should trigger ring buffer growth
         size_after_9 = q.__sizeof__()
-        self.assertGreaterEqual(size_after_9, size_after_8)
+        self.assertGreater(size_after_9, size_after_8)
         
         large_q = self.type2test()
         for i in range(1000):

--- a/Misc/NEWS.d/next/Library/2025-10-14-14-07-08.gh-issue-140025.zQ_Fhe.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-14-14-07-08.gh-issue-140025.zQ_Fhe.rst
@@ -1,1 +1,1 @@
-fix ``queue.SimpleQueue.__sizeof__()`` computation
+Fix ``queue.SimpleQueue.__sizeof__()`` computation

--- a/Misc/NEWS.d/next/Library/2025-10-14-14-07-08.gh-issue-140025.zQ_Fhe.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-14-14-07-08.gh-issue-140025.zQ_Fhe.rst
@@ -1,1 +1,1 @@
-fix queue.SimpleQueue.__sizeof__() computation
+fix ``queue.SimpleQueue.__sizeof__()`` computation

--- a/Misc/NEWS.d/next/Library/2025-10-14-14-07-08.gh-issue-140025.zQ_Fhe.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-14-14-07-08.gh-issue-140025.zQ_Fhe.rst
@@ -1,0 +1,1 @@
+fix queue.SimpleQueue.__sizeof__() computation

--- a/Misc/NEWS.d/next/Library/2025-10-14-14-07-08.gh-issue-140025.zQ_Fhe.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-14-14-07-08.gh-issue-140025.zQ_Fhe.rst
@@ -1,1 +1,1 @@
-Fix ``queue.SimpleQueue.__sizeof__()`` computation
+Fix ``queue.SimpleQueue.__sizeof__()`` computation.

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -500,6 +500,24 @@ _queue_SimpleQueue_qsize_impl(simplequeueobject *self)
     return RingBuf_Len(&self->buf);
 }
 
+/*[clinic input]
+_queue.SimpleQueue.__sizeof__ -> Py_ssize_t
+
+Return size of queue in bytes, including underlying data structure.
+[clinic start generated code]*/
+
+static Py_ssize_t
+_queue_SimpleQueue___sizeof___impl(simplequeueobject *self)
+/*[clinic end generated code: output=58ce4e3bbc078fd4 input=7b9d000cdcb71b7d]*/
+{
+    Py_ssize_t size = Py_TYPE(self)->tp_basicsize;
+    // Add size of the ring buffer items array
+    size += self->buf.items_cap * sizeof(PyObject *);
+    return size;
+}
+
+
+
 static int
 queue_traverse(PyObject *m, visitproc visit, void *arg)
 {
@@ -534,6 +552,7 @@ static PyMethodDef simplequeue_methods[] = {
     _QUEUE_SIMPLEQUEUE_PUT_METHODDEF
     _QUEUE_SIMPLEQUEUE_PUT_NOWAIT_METHODDEF
     _QUEUE_SIMPLEQUEUE_QSIZE_METHODDEF
+    _QUEUE_SIMPLEQUEUE___SIZEOF___METHODDEF
     {"__class_getitem__",    Py_GenericAlias,
     METH_O|METH_CLASS,       PyDoc_STR("See PEP 585")},
     {NULL,           NULL}              /* sentinel */

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -516,8 +516,6 @@ _queue_SimpleQueue___sizeof___impl(simplequeueobject *self)
     return size;
 }
 
-
-
 static int
 queue_traverse(PyObject *m, visitproc visit, void *arg)
 {

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -501,6 +501,7 @@ _queue_SimpleQueue_qsize_impl(simplequeueobject *self)
 }
 
 /*[clinic input]
+@critical_section
 _queue.SimpleQueue.__sizeof__ -> Py_ssize_t
 
 Return size of queue in bytes, including underlying data structure.

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -502,13 +502,11 @@ _queue_SimpleQueue_qsize_impl(simplequeueobject *self)
 
 /*[clinic input]
 _queue.SimpleQueue.__sizeof__ -> Py_ssize_t
-
-Return size of queue in bytes, including underlying data structure.
 [clinic start generated code]*/
 
 static Py_ssize_t
 _queue_SimpleQueue___sizeof___impl(simplequeueobject *self)
-/*[clinic end generated code: output=58ce4e3bbc078fd4 input=7b9d000cdcb71b7d]*/
+/*[clinic end generated code: output=58ce4e3bbc078fd4 input=6661f95bc010c7c5]*/
 {
     Py_ssize_t size = Py_TYPE(self)->tp_basicsize;
     size += self->buf.items_cap * sizeof(PyObject *);

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -501,7 +501,6 @@ _queue_SimpleQueue_qsize_impl(simplequeueobject *self)
 }
 
 /*[clinic input]
-@critical_section
 _queue.SimpleQueue.__sizeof__ -> Py_ssize_t
 
 Return size of queue in bytes, including underlying data structure.
@@ -512,7 +511,6 @@ _queue_SimpleQueue___sizeof___impl(simplequeueobject *self)
 /*[clinic end generated code: output=58ce4e3bbc078fd4 input=7b9d000cdcb71b7d]*/
 {
     Py_ssize_t size = Py_TYPE(self)->tp_basicsize;
-    // Add size of the ring buffer items array
     size += self->buf.items_cap * sizeof(PyObject *);
     return size;
 }

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -509,7 +509,7 @@ static Py_ssize_t
 _queue_SimpleQueue___sizeof___impl(simplequeueobject *self)
 /*[clinic end generated code: output=58ce4e3bbc078fd4 input=40a793cdf1c78c30]*/
 {
-    Py_ssize_t size = Py_TYPE(self)->tp_basicsize;
+    Py_ssize_t size = _PyObject_SIZE(Py_TYPE(self));
     size += self->buf.items_cap * sizeof(PyObject *);
     return size;
 }

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -501,12 +501,13 @@ _queue_SimpleQueue_qsize_impl(simplequeueobject *self)
 }
 
 /*[clinic input]
+@critical_section
 _queue.SimpleQueue.__sizeof__ -> Py_ssize_t
 [clinic start generated code]*/
 
 static Py_ssize_t
 _queue_SimpleQueue___sizeof___impl(simplequeueobject *self)
-/*[clinic end generated code: output=58ce4e3bbc078fd4 input=6661f95bc010c7c5]*/
+/*[clinic end generated code: output=58ce4e3bbc078fd4 input=40a793cdf1c78c30]*/
 {
     Py_ssize_t size = Py_TYPE(self)->tp_basicsize;
     size += self->buf.items_cap * sizeof(PyObject *);

--- a/Modules/clinic/_queuemodule.c.h
+++ b/Modules/clinic/_queuemodule.c.h
@@ -358,4 +358,32 @@ _queue_SimpleQueue_qsize(PyObject *self, PyObject *Py_UNUSED(ignored))
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=1d3efe9df89997cf input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(_queue_SimpleQueue___sizeof____doc__,
+"__sizeof__($self, /)\n"
+"--\n"
+"\n"
+"Return size of queue in bytes, including underlying data structure.");
+
+#define _QUEUE_SIMPLEQUEUE___SIZEOF___METHODDEF    \
+    {"__sizeof__", (PyCFunction)_queue_SimpleQueue___sizeof__, METH_NOARGS, _queue_SimpleQueue___sizeof____doc__},
+
+static Py_ssize_t
+_queue_SimpleQueue___sizeof___impl(simplequeueobject *self);
+
+static PyObject *
+_queue_SimpleQueue___sizeof__(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    PyObject *return_value = NULL;
+    Py_ssize_t _return_value;
+
+    _return_value = _queue_SimpleQueue___sizeof___impl((simplequeueobject *)self);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromSsize_t(_return_value);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=dc7b32ca422336a2 input=a9049054013a1b77]*/

--- a/Modules/clinic/_queuemodule.c.h
+++ b/Modules/clinic/_queuemodule.c.h
@@ -362,8 +362,7 @@ exit:
 PyDoc_STRVAR(_queue_SimpleQueue___sizeof____doc__,
 "__sizeof__($self, /)\n"
 "--\n"
-"\n"
-"Return size of queue in bytes, including underlying data structure.");
+"\n");
 
 #define _QUEUE_SIMPLEQUEUE___SIZEOF___METHODDEF    \
     {"__sizeof__", (PyCFunction)_queue_SimpleQueue___sizeof__, METH_NOARGS, _queue_SimpleQueue___sizeof____doc__},
@@ -386,4 +385,4 @@ _queue_SimpleQueue___sizeof__(PyObject *self, PyObject *Py_UNUSED(ignored))
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=dc7b32ca422336a2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=64f86d4983c06225 input=a9049054013a1b77]*/

--- a/Modules/clinic/_queuemodule.c.h
+++ b/Modules/clinic/_queuemodule.c.h
@@ -376,7 +376,9 @@ _queue_SimpleQueue___sizeof__(PyObject *self, PyObject *Py_UNUSED(ignored))
     PyObject *return_value = NULL;
     Py_ssize_t _return_value;
 
+    Py_BEGIN_CRITICAL_SECTION(self);
     _return_value = _queue_SimpleQueue___sizeof___impl((simplequeueobject *)self);
+    Py_END_CRITICAL_SECTION();
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -385,4 +387,4 @@ _queue_SimpleQueue___sizeof__(PyObject *self, PyObject *Py_UNUSED(ignored))
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=64f86d4983c06225 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a27a14c5f640799e input=a9049054013a1b77]*/


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

gh-140025 queue.SimpleQueue.__sizeof__() ignores the underlying data structure
