### PR TITLE
gh-140080: Fix atexit with low memory

### DIFF
--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -202,7 +202,6 @@ class SubinterpreterTest(unittest.TestCase):
 
         def callback():
             print("hello")
-            pass
 
         atexit.register(callback)
         # Simulate low memory condition
@@ -212,10 +211,13 @@ class SubinterpreterTest(unittest.TestCase):
             with script_helper.spawn_python('-c', user_input,
                                            stderr=subprocess.PIPE) as p:
                 p.wait()
-                output = p.stdout.read()
+                stdout = p.stdout.read()
+                stderr = p.stderr.read()
 
         self.assertIn(p.returncode, (0, 1))
-        self.assertNotIn(b"hello", output)
+        self.assertNotIn(b"hello", stdout)
+        # MemoryError should appear in stderr
+        self.assertIn(b"MemoryError", stderr)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -216,7 +216,7 @@ class SubinterpreterTest(unittest.TestCase):
         try:
             with SuppressCrashReport():
                 with script_helper.spawn_python(script,
-                                               stderr=subprocess.PIPE) as proc:
+                                                stderr=subprocess.PIPE) as proc:
                     proc.wait()
                     stdout = proc.stdout.read()
                     stderr = proc.stderr.read()

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -1,11 +1,11 @@
 import atexit
 import os
 import subprocess
-import tempfile
 import textwrap
 import unittest
 from test import support
 from test.support import SuppressCrashReport, script_helper
+from test.support import os_helper
 from test.support import threading_helper
 
 class GeneralTest(unittest.TestCase):
@@ -209,11 +209,8 @@ class SubinterpreterTest(unittest.TestCase):
             _testcapi.set_nomemory(0)
         """)
 
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.py') as f:
-            f.write(code)
-            f.flush()
-            script = f.name
-
+        with os_helper.temp_dir() as temp_dir:
+            script = script_helper.make_script(temp_dir, 'test_atexit_script', code)
             with SuppressCrashReport():
                 with script_helper.spawn_python(script,
                                                 stderr=subprocess.PIPE) as proc:

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -209,19 +209,17 @@ class SubinterpreterTest(unittest.TestCase):
         _testcapi.set_nomemory(0)
         """)
 
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.py') as f:
             f.write(code)
+            f.flush()
             script = f.name
 
-        try:
             with SuppressCrashReport():
                 with script_helper.spawn_python(script,
                                                 stderr=subprocess.PIPE) as proc:
                     proc.wait()
                     stdout = proc.stdout.read()
                     stderr = proc.stderr.read()
-        finally:
-            os.unlink(script)
 
         self.assertIn(proc.returncode, (0, 1))
         self.assertNotIn(b"hello", stdout)

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -201,6 +201,7 @@ class SubinterpreterTest(unittest.TestCase):
         import _testcapi
 
         def callback():
+            print("hello")
             pass
 
         atexit.register(callback)
@@ -211,9 +212,10 @@ class SubinterpreterTest(unittest.TestCase):
             with script_helper.spawn_python('-c', user_input,
                                            stderr=subprocess.PIPE) as p:
                 p.wait()
-                p.stdout.read()
+                output = p.stdout.read()
 
         self.assertIn(p.returncode, (0, 1))
+        self.assertNotIn(b"hello", output)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -195,6 +195,7 @@ class SubinterpreterTest(unittest.TestCase):
     # Python built with Py_TRACE_REFS fail with a fatal error in
     # _PyRefchain_Trace() on memory allocation error.
     @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
+    @support.requires_subprocess()
     def test_atexit_with_low_memory(self):
         # gh-140080: Test that setting low memory after registering an atexit
         # callback doesn't cause an infinite loop during finalization.
@@ -226,7 +227,6 @@ class SubinterpreterTest(unittest.TestCase):
 
         self.assertIn(proc.returncode, (0, 1))
         self.assertNotIn(b"hello", proc.stdout)
-        # MemoryError should appear in stderr
         self.assertIn(b"MemoryError", proc.stderr)
 
 

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -198,15 +198,15 @@ class SubinterpreterTest(unittest.TestCase):
         # gh-140080: Test that setting low memory after registering an atexit
         # callback doesn't cause an infinite loop during finalization.
         code = textwrap.dedent("""
-        import atexit
-        import _testcapi
+            import atexit
+            import _testcapi
 
-        def callback():
-            print("hello")
+            def callback():
+                print("hello")
 
-        atexit.register(callback)
-        # Simulate low memory condition
-        _testcapi.set_nomemory(0)
+            atexit.register(callback)
+            # Simulate low memory condition
+            _testcapi.set_nomemory(0)
         """)
 
         with tempfile.NamedTemporaryFile(mode='w', suffix='.py') as f:

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -1,6 +1,8 @@
 import atexit
 import os
 import subprocess
+import sys
+import tempfile
 import textwrap
 import unittest
 from test import support
@@ -196,7 +198,7 @@ class SubinterpreterTest(unittest.TestCase):
     def test_atexit_with_low_memory(self):
         # gh-140080: Test that setting low memory after registering an atexit
         # callback doesn't cause an infinite loop during finalization.
-        user_input = textwrap.dedent("""
+        code = textwrap.dedent("""
         import atexit
         import _testcapi
 
@@ -207,17 +209,25 @@ class SubinterpreterTest(unittest.TestCase):
         # Simulate low memory condition
         _testcapi.set_nomemory(0)
         """)
-        with SuppressCrashReport():
-            with script_helper.spawn_python('-c', user_input,
-                                           stderr=subprocess.PIPE) as p:
-                p.wait()
-                stdout = p.stdout.read()
-                stderr = p.stderr.read()
 
-        self.assertIn(p.returncode, (0, 1))
-        self.assertNotIn(b"hello", stdout)
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+            f.write(code)
+            script = f.name
+
+        try:
+            with SuppressCrashReport():
+                proc = subprocess.run(
+                    [sys.executable, script],
+                    capture_output=True,
+                    timeout=10
+                )
+        finally:
+            os.unlink(script)
+
+        self.assertIn(proc.returncode, (0, 1))
+        self.assertNotIn(b"hello", proc.stdout)
         # MemoryError should appear in stderr
-        self.assertIn(b"MemoryError", stderr)
+        self.assertIn(b"MemoryError", proc.stderr)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -342,7 +342,6 @@ class ExceptionTests(unittest.TestCase):
         with self.assertRaisesRegex(OverflowError, "Parser column offset overflow"):
             compile(src, '<fragment>', 'exec')
 
-
     @cpython_only
     def testSettingException(self):
         # test that setting an exception at the C level works even if the

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -342,31 +342,6 @@ class ExceptionTests(unittest.TestCase):
         with self.assertRaisesRegex(OverflowError, "Parser column offset overflow"):
             compile(src, '<fragment>', 'exec')
 
-    @cpython_only
-    # Python built with Py_TRACE_REFS fail with a fatal error in
-    # _PyRefchain_Trace() on memory allocation error.
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
-    def test_atexit_with_low_memory(self):
-        # gh-140080: Test that setting low memory after registering an atexit
-        # callback doesn't cause an infinite loop during finalization.
-        user_input = dedent("""
-        import atexit
-        import _testcapi
-
-        def callback():
-            pass
-
-        atexit.register(callback)
-        # Simulate low memory condition
-        _testcapi.set_nomemory(0)
-        """)
-        with SuppressCrashReport():
-            with script_helper.spawn_python('-c', user_input) as p:
-                p.wait()
-                output = p.stdout.read()
-
-        # The key point is that the process should exit (not hang)
-        self.assertIn(p.returncode, (0, 1))
 
     @cpython_only
     def testSettingException(self):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -343,6 +343,32 @@ class ExceptionTests(unittest.TestCase):
             compile(src, '<fragment>', 'exec')
 
     @cpython_only
+    # Python built with Py_TRACE_REFS fail with a fatal error in
+    # _PyRefchain_Trace() on memory allocation error.
+    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
+    def test_atexit_with_low_memory(self):
+        # gh-140080: Test that setting low memory after registering an atexit
+        # callback doesn't cause an infinite loop during finalization.
+        user_input = dedent("""
+        import atexit
+        import _testcapi
+
+        def callback():
+            pass
+
+        atexit.register(callback)
+        # Simulate low memory condition
+        _testcapi.set_nomemory(0)
+        """)
+        with SuppressCrashReport():
+            with script_helper.spawn_python('-c', user_input) as p:
+                p.wait()
+                output = p.stdout.read()
+
+        # The key point is that the process should exit (not hang)
+        self.assertIn(p.returncode, (0, 1))
+
+    @cpython_only
     def testSettingException(self):
         # test that setting an exception at the C level works even if the
         # exception object can't be constructed.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-14-20-18-31.gh-issue-140080.8ROjxW.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-14-20-18-31.gh-issue-140080.8ROjxW.rst
@@ -1,0 +1,2 @@
+Fix: ``atexit_callfuncs`` need to atexit_cleanup the state when copy is NULL
+to avoid the low memory error then recursive error.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-14-20-18-31.gh-issue-140080.8ROjxW.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-14-20-18-31.gh-issue-140080.8ROjxW.rst
@@ -1,2 +1,1 @@
-Fix: ``atexit_callfuncs`` need to atexit_cleanup the state when copy is NULL
-to avoid the low memory error then recursive error.
+Fix hang during finalization when attempting to call :mod:`atexit` handlers under no memory.

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -112,6 +112,8 @@ atexit_callfuncs(struct atexit_state *state)
     {
         PyErr_FormatUnraisable("Exception ignored while "
                                "copying atexit callbacks");
+        // gh-140080: need to cleanup
+        atexit_cleanup(state);
         return;
     }
 

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -112,7 +112,6 @@ atexit_callfuncs(struct atexit_state *state)
     {
         PyErr_FormatUnraisable("Exception ignored while "
                                "copying atexit callbacks");
-        // gh-140080: need to cleanup to prevent recursive when low memory
         atexit_cleanup(state);
         return;
     }

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -112,7 +112,7 @@ atexit_callfuncs(struct atexit_state *state)
     {
         PyErr_FormatUnraisable("Exception ignored while "
                                "copying atexit callbacks");
-        // gh-140080: need to cleanup
+        // gh-140080: need to cleanup to prevent recursive when low memory
         atexit_cleanup(state);
         return;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

fix the error that's forget the cleanup

cc @ZeroIntensity  @picnixz and it also turns out its not the _testcapi_setnomemroy(0) issue.

seems the news can skip?

after this patch no hang anymore

<img width="2704" height="629" alt="image" src="https://github.com/user-attachments/assets/959b9bf3-04be-4282-8f85-43c7bc65aa68" />



<!-- gh-issue-number: gh-140080 -->
* Issue: gh-140080
<!-- /gh-issue-number -->
