### PR TITLE
gh-101100: Fix sphinx warnings in `library/unittest.rst`

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -438,7 +438,7 @@ run whether the test method succeeded or not.
 Such a working environment for the testing code is called a
 :dfn:`test fixture`.  A new TestCase instance is created as a unique
 test fixture used to execute each individual test method.  Thus
-:meth:`~TestCase.setUp`, :meth:`~TestCase.tearDown`, and :meth:`~TestCase.__init__`
+:meth:`~TestCase.setUp`, :meth:`~TestCase.tearDown`, and :meth:`!TestCase.__init__`
 will be called once per test.
 
 It is recommended that you use TestCase implementations to group tests together
@@ -518,7 +518,7 @@ set-up and tear-down methods::
    subclasses will make future test refactorings infinitely easier.
 
 In some cases, the existing tests may have been written using the :mod:`doctest`
-module.  If so, :mod:`doctest` provides a :class:`DocTestSuite` class that can
+module.  If so, :mod:`doctest` provides a :class:`~doctest.DocTestSuite` class that can
 automatically build :class:`unittest.TestSuite` instances from the existing
 :mod:`doctest`\ -based tests.
 
@@ -1023,7 +1023,7 @@ Test cases
       additional keyword argument *msg*.
 
       The context manager will store the caught exception object in its
-      :attr:`exception` attribute.  This can be useful if the intention
+      :attr:`!exception` attribute.  This can be useful if the intention
       is to perform additional checks on the exception raised::
 
          with self.assertRaises(SomeException) as cm:
@@ -1036,7 +1036,7 @@ Test cases
          Added the ability to use :meth:`assertRaises` as a context manager.
 
       .. versionchanged:: 3.2
-         Added the :attr:`exception` attribute.
+         Added the :attr:`!exception` attribute.
 
       .. versionchanged:: 3.3
          Added the *msg* keyword argument when used as a context manager.
@@ -1089,8 +1089,8 @@ Test cases
       additional keyword argument *msg*.
 
       The context manager will store the caught warning object in its
-      :attr:`warning` attribute, and the source line which triggered the
-      warnings in the :attr:`filename` and :attr:`lineno` attributes.
+      :attr:`!warning` attribute, and the source line which triggered the
+      warnings in the :attr:`!filename` and :attr:`!lineno` attributes.
       This can be useful if the intention is to perform additional checks
       on the warning caught::
 
@@ -1437,7 +1437,7 @@ Test cases
       that lists the differences between the sets.  This method is used by
       default when comparing sets or frozensets with :meth:`assertEqual`.
 
-      Fails if either of *first* or *second* does not have a :meth:`set.difference`
+      Fails if either of *first* or *second* does not have a :meth:`frozenset.difference`
       method.
 
       .. versionadded:: 3.1
@@ -1645,7 +1645,7 @@ Test cases
    .. method:: asyncSetUp()
       :async:
 
-      Method called to prepare the test fixture. This is called after :meth:`setUp`.
+      Method called to prepare the test fixture. This is called after :meth:`TestCase.setUp`.
       This is called immediately before calling the test method; other than
       :exc:`AssertionError` or :exc:`SkipTest`, any exception raised by this method
       will be considered an error rather than a test failure. The default implementation
@@ -1655,7 +1655,7 @@ Test cases
       :async:
 
       Method called immediately after the test method has been called and the
-      result recorded.  This is called before :meth:`tearDown`. This is called even if
+      result recorded.  This is called before :meth:`TestCase.tearDown`. This is called even if
       the test method raised an exception, so the implementation in subclasses may need
       to be particularly careful about checking internal state.  Any exception, other than
       :exc:`AssertionError` or :exc:`SkipTest`, raised by this method will be
@@ -1684,7 +1684,7 @@ Test cases
       Sets up a new event loop to run the test, collecting the result into
       the :class:`TestResult` object passed as *result*.  If *result* is
       omitted or ``None``, a temporary result object is created (by calling
-      the :meth:`defaultTestResult` method) and used. The result object is
+      the :meth:`TestCase.defaultTestResult` method) and used. The result object is
       returned to :meth:`run`'s caller. At the end of the test all the tasks
       in the event loop are cancelled.
 
@@ -1805,7 +1805,7 @@ Grouping tests
       returned by repeated iterations before :meth:`TestSuite.run` must be the
       same for each call iteration. After :meth:`TestSuite.run`, callers should
       not rely on the tests returned by this method unless the caller uses a
-      subclass that overrides :meth:`TestSuite._removeTestAtIndex` to preserve
+      subclass that overrides :meth:`!TestSuite._removeTestAtIndex` to preserve
       test references.
 
       .. versionchanged:: 3.2
@@ -1816,10 +1816,10 @@ Grouping tests
       .. versionchanged:: 3.4
          In earlier versions the :class:`TestSuite` held references to each
          :class:`TestCase` after :meth:`TestSuite.run`. Subclasses can restore
-         that behavior by overriding :meth:`TestSuite._removeTestAtIndex`.
+         that behavior by overriding :meth:`!TestSuite._removeTestAtIndex`.
 
    In the typical usage of a :class:`TestSuite` object, the :meth:`run` method
-   is invoked by a :class:`TestRunner` rather than by the end-user test harness.
+   is invoked by a :class:`!TestRunner` rather than by the end-user test harness.
 
 
 Loading and running tests
@@ -1853,12 +1853,12 @@ Loading and running tests
    .. method:: loadTestsFromTestCase(testCaseClass)
 
       Return a suite of all test cases contained in the :class:`TestCase`\ -derived
-      :class:`testCaseClass`.
+      :class:`!testCaseClass`.
 
       A test case instance is created for each method named by
       :meth:`getTestCaseNames`. By default these are the method names
       beginning with ``test``. If :meth:`getTestCaseNames` returns no
-      methods, but the :meth:`runTest` method is implemented, a single test
+      methods, but the :meth:`!runTest` method is implemented, a single test
       case is created for that method instead.
 
 
@@ -1905,13 +1905,13 @@ Loading and running tests
       case class will be picked up as "a test method within a test case class",
       rather than "a callable object".
 
-      For example, if you have a module :mod:`SampleTests` containing a
-      :class:`TestCase`\ -derived class :class:`SampleTestCase` with three test
-      methods (:meth:`test_one`, :meth:`test_two`, and :meth:`test_three`), the
+      For example, if you have a module :mod:`!SampleTests` containing a
+      :class:`TestCase`\ -derived class :class:`!SampleTestCase` with three test
+      methods (:meth:`!test_one`, :meth:`!test_two`, and :meth:`!test_three`), the
       specifier ``'SampleTests.SampleTestCase'`` would cause this method to
       return a suite which will run all three test methods. Using the specifier
       ``'SampleTests.SampleTestCase.test_two'`` would cause it to return a test
-      suite which will run only the :meth:`test_two` test method. The specifier
+      suite which will run only the :meth:`!test_two` test method. The specifier
       can refer to modules and packages which have not been imported; they will
       be imported as a side-effect.
 
@@ -2058,7 +2058,7 @@ Loading and running tests
    Testing frameworks built on top of :mod:`unittest` may want access to the
    :class:`TestResult` object generated by running a set of tests for reporting
    purposes; a :class:`TestResult` instance is returned by the
-   :meth:`TestRunner.run` method for this purpose.
+   :meth:`!TestRunner.run` method for this purpose.
 
    :class:`TestResult` instances have the following attributes that will be of
    interest when inspecting the results of running a set of tests:
@@ -2144,12 +2144,12 @@ Loading and running tests
 
       This method can be called to signal that the set of tests being run should
       be aborted by setting the :attr:`shouldStop` attribute to ``True``.
-      :class:`TestRunner` objects should respect this flag and return without
+      :class:`!TestRunner` objects should respect this flag and return without
       running any additional tests.
 
       For example, this feature is used by the :class:`TextTestRunner` class to
       stop the test framework when the user signals an interrupt from the
-      keyboard.  Interactive tools which provide :class:`TestRunner`
+      keyboard.  Interactive tools which provide :class:`!TestRunner`
       implementations can use this in a similar manner.
 
    The following methods of the :class:`TestResult` class are used to maintain
@@ -2469,9 +2469,9 @@ Class and Module Fixtures
 -------------------------
 
 Class and module level fixtures are implemented in :class:`TestSuite`. When
-the test suite encounters a test from a new class then :meth:`tearDownClass`
-from the previous class (if there is one) is called, followed by
-:meth:`setUpClass` from the new class.
+the test suite encounters a test from a new class then
+:meth:`~TestCase.tearDownClass` from the previous class (if there is one)
+is called, followed by :meth:`~TestCase.setUpClass` from the new class.
 
 Similarly if a test is from a different module from the previous test then
 ``tearDownModule`` from the previous module is run, followed by

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1437,7 +1437,7 @@ Test cases
       that lists the differences between the sets.  This method is used by
       default when comparing sets or frozensets with :meth:`assertEqual`.
 
-      Fails if either of *first* or *second* does not have a :meth:`frozenset.difference`
+      Fails if either of *first* or *second* does not have a :meth:`~frozenset.difference`
       method.
 
       .. versionadded:: 3.1
@@ -1655,7 +1655,7 @@ Test cases
       :async:
 
       Method called immediately after the test method has been called and the
-      result recorded.  This is called before :meth:`TestCase.tearDown`. This is called even if
+      result recorded.  This is called before :meth:`~TestCase.tearDown`. This is called even if
       the test method raised an exception, so the implementation in subclasses may need
       to be particularly careful about checking internal state.  Any exception, other than
       :exc:`AssertionError` or :exc:`SkipTest`, raised by this method will be
@@ -1684,7 +1684,7 @@ Test cases
       Sets up a new event loop to run the test, collecting the result into
       the :class:`TestResult` object passed as *result*.  If *result* is
       omitted or ``None``, a temporary result object is created (by calling
-      the :meth:`TestCase.defaultTestResult` method) and used. The result object is
+      the :meth:`~TestCase.defaultTestResult` method) and used. The result object is
       returned to :meth:`run`'s caller. At the end of the test all the tasks
       in the event loop are cancelled.
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -38,7 +38,6 @@ Doc/library/tkinter.rst
 Doc/library/tkinter.scrolledtext.rst
 Doc/library/tkinter.ttk.rst
 Doc/library/unittest.mock.rst
-Doc/library/unittest.rst
 Doc/library/urllib.parse.rst
 Doc/library/urllib.request.rst
 Doc/library/wsgiref.rst


### PR DESCRIPTION
```
unittest.rst:438: WARNING: py:meth reference target not found: TestCase.__init__ [ref.meth]
unittest.rst:520: WARNING: py:class reference target not found: DocTestSuite [ref.class]
unittest.rst:1025: WARNING: py:attr reference target not found: exception [ref.attr]
unittest.rst:1039: WARNING: py:attr reference target not found: exception [ref.attr]
unittest.rst:1091: WARNING: py:attr reference target not found: warning [ref.attr]
unittest.rst:1091: WARNING: py:attr reference target not found: filename [ref.attr]
unittest.rst:1091: WARNING: py:attr reference target not found: lineno [ref.attr]
unittest.rst:1440: WARNING: py:meth reference target not found: set.difference [ref.meth]
unittest.rst:1648: WARNING: py:meth reference target not found: setUp [ref.meth]
unittest.rst:1657: WARNING: py:meth reference target not found: tearDown [ref.meth]
unittest.rst:1684: WARNING: py:meth reference target not found: defaultTestResult [ref.meth]
unittest.rst:1801: WARNING: py:meth reference target not found: TestSuite._removeTestAtIndex [ref.meth]
unittest.rst:1817: WARNING: py:meth reference target not found: TestSuite._removeTestAtIndex [ref.meth]
unittest.rst:1821: WARNING: py:class reference target not found: TestRunner [ref.class]
unittest.rst:1855: WARNING: py:class reference target not found: testCaseClass [ref.class]
unittest.rst:1858: WARNING: py:meth reference target not found: runTest [ref.meth]
unittest.rst:1908: WARNING: py:mod reference target not found: SampleTests [ref.mod]
unittest.rst:1908: WARNING: py:class reference target not found: SampleTestCase [ref.class]
unittest.rst:1908: WARNING: py:meth reference target not found: test_one [ref.meth]
unittest.rst:1908: WARNING: py:meth reference target not found: test_two [ref.meth]
unittest.rst:1908: WARNING: py:meth reference target not found: test_three [ref.meth]
unittest.rst:1908: WARNING: py:meth reference target not found: test_two [ref.meth]
unittest.rst:2058: WARNING: py:meth reference target not found: TestRunner.run [ref.meth]
unittest.rst:2145: WARNING: py:class reference target not found: TestRunner [ref.class]
unittest.rst:2150: WARNING: py:class reference target not found: TestRunner [ref.class]
unittest.rst:2471: WARNING: py:meth reference target not found: tearDownClass [ref.meth]
unittest.rst:2471: WARNING: py:meth reference target not found: setUpClass [ref.meth]
```

- Line 438: `~TestCase.__init__` is undocumented to-be-implemented function
- line 520: `DocTestSuite` is referring to [`doctest.DocTestSuite`](https://docs.python.org/3/library/doctest.html#doctest.DocTestSuite)
- line 1025: `exception` is an undocumented attribute of the returned context manager.
- Line 1039: same as line 1026
- Line 1091: same. They areundocumented attributes of the returned context manager.
- Line 1440: the builtin-method `set.difference()` is document with `frozenset.difference` together with the reference of `frozenset.difference`, see [here](https://docs.python.org/3/library/stdtypes.html#frozenset.difference)
- Line 1648, 1657, 1684: the method is inherented from `TestCase`
- Line 1801, 1817: Undocumented method of `TestSuite`, fine to leave it undocumented.
- Line 1821: The most common implementation of `TestRunner` is [`unittest.TextTestRunner`](https://docs.python.org/3/library/unittest.html#unittest.TextTestRunner). But here it is referring to all TestRunners that include certain methods. So suppressed as undocument class.
- Line 1855: `testCaseClass` is undocumented derived class from `TestCase`
- Line 1908: Sample tests. Not sure whether it is correct for this to be turned to inline-codeblock or suppressed links.
- Line 2058, 2145, 2150: Same as line 1821.
- Line 2471: They are to-be-implemented methods but documented in `TestCase`. So referring to `TestCase`.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140109.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->