### PR TITLE
[3.13] gh-139640: Fix swallowing syntax warnings in different modules (GH-139755)

### DIFF
--- a/Include/cpython/warnings.h
+++ b/Include/cpython/warnings.h
@@ -18,9 +18,3 @@ PyAPI_FUNC(int) PyErr_WarnExplicitFormat(
 
 // DEPRECATED: Use PyErr_WarnEx() instead.
 #define PyErr_Warn(category, msg) PyErr_WarnEx((category), (msg), 1)
-
-int _PyErr_WarnExplicitObjectWithContext(
-    PyObject *category,
-    PyObject *message,
-    PyObject *filename,
-    int lineno);

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1528,22 +1528,21 @@ class TestSpecifics(unittest.TestCase):
             [[]]
 
     def test_compile_warnings(self):
-        # See gh-131927
-        # Compile warnings originating from the same file and
-        # line are now only emitted once.
+        # Each invocation of compile() emits compiler warnings, even if they
+        # have the same message and line number.
+        source = textwrap.dedent(r"""
+            # tokenizer
+            1or 0  # line 3
+            # code generator
+            1 is 1  # line 5
+        """)
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("default")
-            compile('1 is 1', '<stdin>', 'eval')
-            compile('1 is 1', '<stdin>', 'eval')
+            for i in range(2):
+                # Even if compile() is at the same line.
+                compile(source, '<stdin>', 'exec')
 
-        self.assertEqual(len(caught), 1)
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            compile('1 is 1', '<stdin>', 'eval')
-            compile('1 is 1', '<stdin>', 'eval')
-
-        self.assertEqual(len(caught), 2)
+        self.assertEqual([wm.lineno for wm in caught], [3, 5] * 2)
 
     def test_compile_warning_in_finally(self):
         # Ensure that warnings inside finally blocks are
@@ -1554,16 +1553,47 @@ class TestSpecifics(unittest.TestCase):
             try:
                 pass
             finally:
-                1 is 1
+                1 is 1  # line 5
+                try:
+                    pass
+                finally: # nested
+                    1 is 1  # line 9
         """)
 
         with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("default")
+            warnings.simplefilter("always")
             compile(source, '<stdin>', 'exec')
 
-        self.assertEqual(len(caught), 1)
-        self.assertEqual(caught[0].category, SyntaxWarning)
-        self.assertIn("\"is\" with 'int' literal", str(caught[0].message))
+        self.assertEqual(sorted(wm.lineno for wm in caught), [5, 9])
+        for wm in caught:
+            self.assertEqual(wm.category, SyntaxWarning)
+            self.assertIn("\"is\" with 'int' literal", str(wm.message))
+
+        # Other code path is used for "try" with "except*".
+        source = textwrap.dedent("""
+            try:
+                pass
+            except *Exception:
+                pass
+            finally:
+                1 is 1  # line 7
+                try:
+                    pass
+                except *Exception:
+                    pass
+                finally: # nested
+                    1 is 1  # line 13
+        """)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            compile(source, '<stdin>', 'exec')
+
+        self.assertEqual(sorted(wm.lineno for wm in caught), [7, 13])
+        for wm in caught:
+            self.assertEqual(wm.category, SyntaxWarning)
+            self.assertIn("\"is\" with 'int' literal", str(wm.message))
+
 
 @requires_debug_ranges()
 class TestSourcePositions(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2025-10-06-10-03-37.gh-issue-139640.gY5oTb.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-10-06-10-03-37.gh-issue-139640.gY5oTb.rst
@@ -1,0 +1,3 @@
+Fix swallowing some syntax warnings in different modules if they
+accidentally have the same message and are emitted from the same line.
+Fix duplicated warnings in the ``finally`` block.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1317,28 +1317,6 @@ PyErr_WarnExplicitObject(PyObject *category, PyObject *message,
     return 0;
 }
 
-/* Like PyErr_WarnExplicitObject, but automatically sets up context */
-int
-_PyErr_WarnExplicitObjectWithContext(PyObject *category, PyObject *message,
-                                     PyObject *filename, int lineno)
-{
-    PyObject *unused_filename, *module, *registry;
-    int unused_lineno;
-    int stack_level = 1;
-
-    if (!setup_context(stack_level, NULL, &unused_filename, &unused_lineno,
-                       &module, &registry)) {
-        return -1;
-    }
-
-    int rc = PyErr_WarnExplicitObject(category, message, filename, lineno,
-                                      module, registry);
-    Py_DECREF(unused_filename);
-    Py_DECREF(registry);
-    Py_DECREF(module);
-    return rc;
-}
-
 int
 PyErr_WarnExplicit(PyObject *category, const char *text,
                    const char *filename_str, int lineno,


### PR DESCRIPTION
Revert GH-131993.

Fix swallowing some syntax warnings in different modules if they accidentally have the same message and are emitted from the same line.

Fix duplicated warnings in the "finally" block.

(cherry picked from commit 279db6bede30be3a1b86803585eb4404d27800da)


<!-- gh-issue-number: gh-139640 -->
* Issue: gh-139640
<!-- /gh-issue-number -->
