### PR TITLE
gh-139888: Add PyTupleWriter C API (stack flavor)

### DIFF
--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -142,6 +142,83 @@ Tuple Objects
    ``*p`` is destroyed.  On failure, returns ``-1`` and sets ``*p`` to ``NULL``, and
    raises :exc:`MemoryError` or :exc:`SystemError`.
 
+   .. deprecated:: 3.15
+      Use the :ref:`PyTupleWriter API <pytuplewriter>` instead.
+
+
+.. _pytuplewriter:
+
+PyTupleWriter
+-------------
+
+The :c:type:`PyTupleWriter` API can be used to create a Python :class:`tuple`
+object.
+
+.. versionadded:: next
+
+.. c:type:: PyTupleWriter
+
+   A tuple writer instance.
+
+   The API is **not thread safe**: a writer should only be used by a single
+   thread at the same time.
+
+   The instance must be destroyed by :c:func:`PyTupleWriter_Finish` on
+   success, or :c:func:`PyTupleWriter_Discard` on error.
+
+
+.. c:function:: int PyTupleWriter_Init(PyTupleWriter *writer, Py_ssize_t size)
+
+   Initialize a :c:type:`PyTupleWriter` to add *size* items.
+
+   If *size* is greater than zero, preallocate *size* items. The caller is
+   responsible to add *size* items using :c:func:`PyTupleWriter_Add`.
+
+   On success, return ``0``.
+   On error, set an exception and return ``-1``.
+
+   *size* must be positive or zero.
+
+
+.. c:function:: PyObject* PyTupleWriter_Finish(PyTupleWriter *writer)
+
+   Finish a :c:type:`PyTupleWriter` created by
+   :c:func:`PyTupleWriter_Init`.
+
+   On success, return a Python :class:`tuple` object.
+   On error, set an exception and return ``NULL``.
+
+   The writer instance is invalid after the call in any case.
+   No API can be called on the writer after :c:func:`PyTupleWriter_Finish`.
+
+.. c:function:: void PyTupleWriter_Discard(PyTupleWriter *writer)
+
+   Discard a :c:type:`PyTupleWriter` created by :c:func:`PyTupleWriter_Init`.
+
+   Do nothing if *writer* is ``NULL``.
+
+   The writer instance is invalid after the call.
+   No API can be called on the writer after :c:func:`PyTupleWriter_Discard`.
+
+.. c:function:: int PyTupleWriter_Add(PyTupleWriter *writer, PyObject *item)
+
+   Add an item to *writer*.
+
+   * On success, return ``0``.
+   * If *item* is ``NULL`` with an exception set, return ``-1``.
+   * On error, set an exception and return ``-1``.
+
+.. c:function:: int PyTupleWriter_AddSteal(PyTupleWriter *writer, PyObject *item)
+
+   Similar to :c:func:`PyTupleWriter_Add`, but take the ownership of *item*.
+
+.. c:function:: int PyTupleWriter_AddArray(PyTupleWriter *writer, PyObject *const *array, Py_ssize_t size)
+
+   Add items from an array to *writer*.
+
+   On success, return ``0``.
+   On error, set an exception and return ``-1``.
+
 
 .. _struct-sequence-objects:
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -887,6 +887,17 @@ New features
 * Add :c:func:`PyTuple_FromArray` to create a :class:`tuple` from an array.
   (Contributed by Victor Stinner in :gh:`111489`.)
 
+* Add a :ref:`PyTupleWriter API <pytuplewriter>` to create :class:`tuple`:
+
+  * :c:func:`PyTupleWriter_Init`
+  * :c:func:`PyTupleWriter_Add`
+  * :c:func:`PyTupleWriter_AddSteal`
+  * :c:func:`PyTupleWriter_AddArray`
+  * :c:func:`PyTupleWriter_Finish`
+  * :c:func:`PyTupleWriter_Discard`
+
+  (Contributed by Victor Stinner in :gh:`139888`.)
+
 
 Porting to Python 3.15
 ----------------------
@@ -1017,6 +1028,9 @@ Deprecated C APIs
   since 3.15 and will be removed in 3.17.
   (Contributed by Nikita Sobolev in :gh:`136355`.)
 
+* Deprecate the :c:func:`_PyTuple_Resize` function:
+  use the new :ref:`PyTupleWriter API <pytuplewriter>` instead.
+  (Contributed by Victor Stinner in :gh:`139888`.)
 
 .. Add C API deprecations above alphabetically, not here at the end.
 

--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -43,7 +43,7 @@ PyAPI_FUNC(PyObject*) PyTuple_FromArray(
     PyObject *const *array,
     Py_ssize_t size);
 
-// --- Public PyUnicodeWriter API --------------------------------------------
+// --- Public PyTupleWriter API --------------------------------------------
 
 typedef struct PyTupleWriter {
     char _reserved[sizeof(Py_uintptr_t) * 20];

--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -12,7 +12,7 @@ typedef struct {
     PyObject *ob_item[1];
 } PyTupleObject;
 
-PyAPI_FUNC(int) _PyTuple_Resize(PyObject **, Py_ssize_t);
+_Py_DEPRECATED_EXTERNALLY(3.15) PyAPI_FUNC(int) _PyTuple_Resize(PyObject **, Py_ssize_t);
 
 /* Cast argument to PyTupleObject* type. */
 #define _PyTuple_CAST(op) \
@@ -42,3 +42,23 @@ PyTuple_SET_ITEM(PyObject *op, Py_ssize_t index, PyObject *value) {
 PyAPI_FUNC(PyObject*) PyTuple_FromArray(
     PyObject *const *array,
     Py_ssize_t size);
+
+// --- Public PyUnicodeWriter API --------------------------------------------
+
+typedef struct PyTupleWriter {
+    char _reserved[sizeof(Py_uintptr_t) * 20];
+} PyTupleWriter;
+
+PyAPI_FUNC(int) PyTupleWriter_Init(PyTupleWriter *writer, Py_ssize_t size);
+PyAPI_FUNC(int) PyTupleWriter_Add(
+    PyTupleWriter *writer,
+    PyObject *item);
+PyAPI_FUNC(int) PyTupleWriter_AddSteal(
+    PyTupleWriter *writer,
+    PyObject *item);
+PyAPI_FUNC(int) PyTupleWriter_AddArray(
+    PyTupleWriter *writer,
+    PyObject *const *array,
+    Py_ssize_t size);
+PyAPI_FUNC(PyObject*) PyTupleWriter_Finish(PyTupleWriter *writer);
+PyAPI_FUNC(void) PyTupleWriter_Discard(PyTupleWriter *writer);

--- a/Include/internal/pycore_tuple.h
+++ b/Include/internal/pycore_tuple.h
@@ -68,6 +68,10 @@ _PyTuple_Recycle(PyObject *op)
 #endif
 #define _PyTuple_HASH_EMPTY (_PyTuple_HASH_XXPRIME_5 + (_PyTuple_HASH_XXPRIME_5 ^ 3527539UL))
 
+extern PyObject** _PyTupleWriter_GetItems(
+    PyTupleWriter *writer,
+    Py_ssize_t *size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/C_API/2025-10-10-09-54-28.gh-issue-139888.Z4Px61.rst
+++ b/Misc/NEWS.d/next/C_API/2025-10-10-09-54-28.gh-issue-139888.Z4Px61.rst
@@ -1,0 +1,10 @@
+Add a :ref:`PyTupleWriter API <pytuplewriter>` to create :class:`tuple`:
+
+* :c:func:`PyTupleWriter_Init`
+* :c:func:`PyTupleWriter_Add`
+* :c:func:`PyTupleWriter_AddSteal`
+* :c:func:`PyTupleWriter_AddArray`
+* :c:func:`PyTupleWriter_Finish`
+* :c:func:`PyTupleWriter_Discard`
+
+Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C_API/2025-10-10-09-58-57.gh-issue-139888.xCfJ3L.rst
+++ b/Misc/NEWS.d/next/C_API/2025-10-10-09-58-57.gh-issue-139888.xCfJ3L.rst
@@ -1,0 +1,2 @@
+Deprecate the :c:func:`_PyTuple_Resize` function: use the :ref:`PyTupleWriter
+API <pytuplewriter>` instead.


### PR DESCRIPTION
* Add _PyTuple_NewNoTrack() and _PyTuple_ResizeNoTrack() helper functions.
* Modify PySequence_Tuple() to use PyTupleWriter API.
* Soft deprecate _PyTuple_Resize().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139888 -->
* Issue: gh-139888
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140129.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->