### PR TITLE
gh-140126: Fix compile error if --with-assertions is enabled.

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -81,7 +81,7 @@ class object "PyObject *" "&PyBaseObject_Type"
 
 #define END_TYPE_DICT_LOCK() Py_END_CRITICAL_SECTION2()
 
-#ifdef Py_DEBUG
+#ifndef NDEBUG
 // Return true if the world is currently stopped.
 static bool
 types_world_is_stopped(void)


### PR DESCRIPTION
The `types_world_is_stopped()` function needs to be defined if NDEBUG is not defined.

<!-- gh-issue-number: gh-140126 -->
* Issue: gh-140126
<!-- /gh-issue-number -->
