### PR TITLE
gh-129559: Remove extra `.` in bytearray.resize AC

### DIFF
--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -1469,14 +1469,14 @@ bytearray_removesuffix_impl(PyByteArrayObject *self, Py_buffer *suffix)
 /*[clinic input]
 bytearray.resize
     size: Py_ssize_t
-        New size to resize to..
+        New size to resize to.
     /
 Resize the internal buffer of bytearray to len.
 [clinic start generated code]*/
 
 static PyObject *
 bytearray_resize_impl(PyByteArrayObject *self, Py_ssize_t size)
-/*[clinic end generated code: output=f73524922990b2d9 input=75fd4d17c4aa47d3]*/
+/*[clinic end generated code: output=f73524922990b2d9 input=6c9a260ca7f72071]*/
 {
     Py_ssize_t start_size = PyByteArray_GET_SIZE(self);
     int result = PyByteArray_Resize((PyObject *)self, size);

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -599,7 +599,7 @@ PyDoc_STRVAR(bytearray_resize__doc__,
 "Resize the internal buffer of bytearray to len.\n"
 "\n"
 "  size\n"
-"    New size to resize to..");
+"    New size to resize to.");
 
 #define BYTEARRAY_RESIZE_METHODDEF    \
     {"resize", (PyCFunction)bytearray_resize, METH_O, bytearray_resize__doc__},
@@ -1796,4 +1796,4 @@ bytearray_sizeof(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl((PyByteArrayObject *)self);
 }
-/*[clinic end generated code: output=be6d28193bc96a2c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fdfe41139c91e409 input=a9049054013a1b77]*/


### PR DESCRIPTION
Oops. Not sure if it's worth backporting to 3.14 where this feature first shipped. 

---
I think "skip news" since minor typo fix

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129559 -->
* Issue: gh-129559
<!-- /gh-issue-number -->
