### PR TITLE
gh-140135: use `PyBytesWriter` in `io.RawIOBase.readall`; 3.98x faster

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-10-15-02-26-50.gh-issue-140135.54JYfM.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-15-02-26-50.gh-issue-140135.54JYfM.rst
@@ -1,0 +1,2 @@
+Speed up :meth:`io.RawIOBase.readall` by using PyBytesWriter API (about 4x
+faster)

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -963,7 +963,6 @@ _io__RawIOBase_readall_impl(PyObject *self)
 /*[clinic end generated code: output=1987b9ce929425a0 input=688874141213622a]*/
 {
     PyBytesWriter *writer = PyBytesWriter_Create(0);
-
     if (writer == NULL) {
         return NULL;
     }

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -962,11 +962,10 @@ static PyObject *
 _io__RawIOBase_readall_impl(PyObject *self)
 /*[clinic end generated code: output=1987b9ce929425a0 input=688874141213622a]*/
 {
-    int r;
-    PyObject *chunks = PyList_New(0);
+    PyBytesWriter *writer = PyBytesWriter_Create(0);
     PyObject *result;
 
-    if (chunks == NULL)
+    if (writer == NULL)
         return NULL;
 
     while (1) {
@@ -978,21 +977,21 @@ _io__RawIOBase_readall_impl(PyObject *self)
             if (_PyIO_trap_eintr()) {
                 continue;
             }
-            Py_DECREF(chunks);
+            PyBytesWriter_Discard(writer);
             return NULL;
         }
         if (data == Py_None) {
-            if (PyList_GET_SIZE(chunks) == 0) {
-                Py_DECREF(chunks);
+            if (PyBytesWriter_GetSize(writer) == 0) {
+                PyBytesWriter_Discard(writer);
                 return data;
             }
             Py_DECREF(data);
             break;
         }
         if (!PyBytes_Check(data)) {
-            Py_DECREF(chunks);
             Py_DECREF(data);
             PyErr_SetString(PyExc_TypeError, "read() should return bytes");
+            PyBytesWriter_Discard(writer);
             return NULL;
         }
         if (PyBytes_GET_SIZE(data) == 0) {
@@ -1000,16 +999,16 @@ _io__RawIOBase_readall_impl(PyObject *self)
             Py_DECREF(data);
             break;
         }
-        r = PyList_Append(chunks, data);
-        Py_DECREF(data);
-        if (r < 0) {
-            Py_DECREF(chunks);
+        if (PyBytesWriter_WriteBytes(writer,
+                                     PyBytes_AS_STRING(data),
+                                     PyBytes_GET_SIZE(data)) < 0) {
+            Py_DECREF(data);
+            PyBytesWriter_Discard(writer);
             return NULL;
         }
+        Py_DECREF(data);
     }
-    result = PyBytes_Join((PyObject *)&_Py_SINGLETON(bytes_empty), chunks);
-    Py_DECREF(chunks);
-    return result;
+    return PyBytesWriter_Finish(writer);
 }
 
 static PyObject *

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -964,8 +964,9 @@ _io__RawIOBase_readall_impl(PyObject *self)
 {
     PyBytesWriter *writer = PyBytesWriter_Create(0);
 
-    if (writer == NULL)
+    if (writer == NULL) {
         return NULL;
+    }
 
     while (1) {
         PyObject *data = _PyObject_CallMethod(self, &_Py_ID(read),

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -963,7 +963,6 @@ _io__RawIOBase_readall_impl(PyObject *self)
 /*[clinic end generated code: output=1987b9ce929425a0 input=688874141213622a]*/
 {
     PyBytesWriter *writer = PyBytesWriter_Create(0);
-    PyObject *result;
 
     if (writer == NULL)
         return NULL;


### PR DESCRIPTION
The issue #140135 provides more details.

# <a name="benchmark"></a>Benchmark

<details>
<summary>The script:</summary>

```python
import io
import pyperf

CHUNK_SIZE = 4096
SIZES = [1, 4, 8, 16, 32, 64, 128]


class ChunkedRaw(io.RawIOBase):
    def __init__(self, data, chunk_size):
        self._buf = memoryview(data)
        self._pos = 0
        self._chunk_size = chunk_size

    def readable(self):
        return True

    def read(self, n: int = -1):
        if self._pos >= len(self._buf):
            return b""

        to_read = (
            self._chunk_size
            if (n is None or n < 0)
            else min(n, self._chunk_size)
        )

        end = min(self._pos + to_read, len(self._buf))
        out = bytes(self._buf[self._pos : end])
        self._pos = end

        return out


def generate_bytes(total):
    block = b"abcdefghijklmnopqrstuvwxyz0123456789" * 128
    return (block * (total // len(block) + 1))[:total]


def _bench_readall(data, chunk_size):
    r = ChunkedRaw(data, chunk_size)
    out = r.readall()
    if len(out) != len(data):
        raise RuntimeError("what is going on...???")


def main():
    runner = pyperf.Runner()
    for size_mib in SIZES:
        total_bytes = size_mib * 1024 * 1024
        data = generate_bytes(total_bytes)
        name = f"rawiobase_readall_{size_mib}MB_chunk{CHUNK_SIZE}"
        runner.bench_func(name, _bench_readall, data, CHUNK_SIZE)


if __name__ == "__main__":
    main()
```
</details>

The results (with `--rigorous`):

| Benchmark                         | main    | pybytes-iobase-readall |
|-----------------------------------|:-------:|:----------------------:|
| rawiobase_readall_1MB_chunk4096   | 673 us  | 111 us: 6.04x faster   |
| rawiobase_readall_4MB_chunk4096   | 2.49 ms | 434 us: 5.74x faster   |
| rawiobase_readall_8MB_chunk4096   | 5.21 ms | 907 us: 5.75x faster   |
| rawiobase_readall_16MB_chunk4096  | 12.1 ms | 2.45 ms: 4.95x faster  |
| rawiobase_readall_32MB_chunk4096  | 25.1 ms | 10.2 ms: 2.45x faster  |
| rawiobase_readall_64MB_chunk4096  | 51.0 ms | 20.4 ms: 2.50x faster  |
| rawiobase_readall_128MB_chunk4096 | 101 ms  | 38.9 ms: 2.60x faster  |
| Geometric mean                    | (ref)   | 3.98x faster           |

The environment:

```
% ./python -c "import sysconfig; print(sysconfig.get_config_var('CONFIG_ARGS'))"
'--enable-optimizations' '--with-lto'
```

`sudo ./python -m pyperf system tune` ensured.

<!-- gh-issue-number: gh-140135 -->
* Issue: gh-140135
<!-- /gh-issue-number -->
