### PR TITLE
Revert "gh-140067: Fix memory leak in sub-interpreter creation  (#140111)"

### DIFF
--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -769,6 +769,12 @@ struct _is {
      * and should be placed at the beginning. */
     struct _ceval_state ceval;
 
+    /* This structure is carefully allocated so that it's correctly aligned
+     * to avoid undefined behaviors during LOAD and STORE. The '_malloced'
+     * field stores the allocated pointer address that will later be freed.
+     */
+    void *_malloced;
+
     PyInterpreterState *next;
 
     int64_t id;

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-14-17-07-37.gh-issue-140067.ID2gOm.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-14-17-07-37.gh-issue-140067.ID2gOm.rst
@@ -1,1 +1,0 @@
-Fix memory leak in sub-interpreter creation.


### PR DESCRIPTION
This reverts commit 59547a251f7069dc6e08cb6082dd21872671e381, which broke the TSan CI.

<!-- gh-issue-number: gh-140067 -->
* Issue: gh-140067
<!-- /gh-issue-number -->
