### PR TITLE
gh-83714: Disable os.statx_result.stx_atomic_write_unit_max_opt

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -3366,10 +3366,12 @@ static PyMemberDef pystatx_result_members[] = {
         "minimum size for direct I/O with torn-write protection"),
     MM(stx_atomic_write_unit_max, Py_T_UINT, atomic_write_unit_max,
         "maximum size for direct I/O with torn-write protection"),
-    MM(stx_atomic_write_unit_max_opt, Py_T_UINT, atomic_write_unit_max_opt,
-        "maximum optimized size for direct I/O with torn-write protection"),
     MM(stx_atomic_write_segments_max, Py_T_UINT, atomic_write_segments_max,
         "maximum iovecs for direct I/O with torn-write protection"),
+#endif
+#if 0
+    MM(stx_atomic_write_unit_max_opt, Py_T_UINT, atomic_write_unit_max_opt,
+        "maximum optimized size for direct I/O with torn-write protection"),
 #endif
 #ifdef STATX_DIO_READ_ALIGN
     MM(stx_dio_read_offset_align, Py_T_UINT, dio_read_offset_align,


### PR DESCRIPTION
Fix building on Centos 9 x86-64 buildbot.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-83714 -->
* Issue: gh-83714
<!-- /gh-issue-number -->
