### PR TITLE
Correct usage of "positive numbers" in FAQ section "What’s a negative index?".

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1176,12 +1176,11 @@ is a list, it makes a copy just like ``seq[:]`` would.
 What's a negative index?
 ------------------------
 
-Python sequences are indexed with positive numbers and negative numbers.  For
-positive numbers 0 is the first index 1 is the second index and so forth.  For
-negative indices -1 is the last index and -2 is the penultimate (next to last)
-index and so forth.  Think of ``seq[-n]`` as the same as ``seq[len(seq)-n]``.
+Python sequences are indexed with signed numbers (0, positive numbers and negative numbers). For example, 0 is the 1st index and for positive indices, 1 is the 2nd index, 2 is the 3rd index and so forth. For
+negative indices, -1 is the last index, -2 is the penultimate (next to last)
+index and so forth. Think of ``seq[-n]`` as the same as ``seq[len(seq)-n]``.
 
-Using negative indices can be very convenient.  For example ``S[:-1]`` is all of
+Using negative indices can be very convenient. For example ``S[:-1]`` is all of
 the string except for its last character, which is useful for removing the
 trailing newline from a string.
 

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1176,7 +1176,7 @@ is a list, it makes a copy just like ``seq[:]`` would.
 What's a negative index?
 ------------------------
 
-Python sequences are indexed with signed numbers (0, positive numbers and negative numbers). For example, 0 is the 1st index and for positive indices, 1 is the 2nd index, 2 is the 3rd index and so forth. For
+Python sequences are indexed with signed numbers (zero, positive numbers and negative numbers). For example, 0 is the 1st index and for positive indices, 1 is the 2nd index, 2 is the 3rd index and so forth. For
 negative indices, -1 is the last index, -2 is the penultimate (next to last)
 index and so forth. Think of ``seq[-n]`` as the same as ``seq[len(seq)-n]``.
 


### PR DESCRIPTION
I corrected the meaning of the words **positive numbers** used in the section [What’s a negative index?](https://docs.python.org/3/faq/programming.html#what-s-a-negative-index).

In the original explanation, the words **positive numbers** are used to cover the numbers greater than or equal to zero but actually, **zero** is neither a positive number nor negative number. **Positive numbers** are only the numbers greater than zero.

So as the main change, I added the words **signed numbers** to cover 3 types of numbers **zero**, **positive numbers** and **negative numbers** in the section [What’s a negative index?](https://docs.python.org/3/faq/programming.html#what-s-a-negative-index). 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140176.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->