### PR TITLE
gh-139817: typing docs: Fix indentation of `.. versionadded::` note for `TypeAliasType.__qualname__`

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2279,7 +2279,7 @@ without the dedicated syntax, as documented below.
         >>> Class.Alias.__qualname__
         'Class.Alias'
 
-   .. versionadded:: 3.15
+      .. versionadded:: 3.15
 
    .. attribute:: __module__
 


### PR DESCRIPTION
`TypeAliasType.__qualname__` was added in 3.15, not `TypeAliasType`


<!-- gh-issue-number: gh-139817 -->
* Issue: gh-139817
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140177.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->