### PR TITLE
gh-140041: Fix import of `ctypes` on Android and Cygwin when ABI flags are present

### DIFF
--- a/Android/testbed/app/build.gradle.kts
+++ b/Android/testbed/app/build.gradle.kts
@@ -47,7 +47,7 @@ for ((i, prefix) in prefixes.withIndex()) {
     val libDir = file("$prefix/lib")
     val version = run {
         for (filename in libDir.list()!!) {
-            """python(\d+\.\d+)""".toRegex().matchEntire(filename)?.let {
+            """python(\d+\.\d+[a-z]*)""".toRegex().matchEntire(filename)?.let {
                 return@run it.groupValues[1]
             }
         }
@@ -64,7 +64,7 @@ for ((i, prefix) in prefixes.withIndex()) {
     val libPythonDir = file("$libDir/python$pythonVersion")
     val triplet = run {
         for (filename in libPythonDir.list()!!) {
-            """_sysconfigdata__android_(.+).py""".toRegex().matchEntire(filename)?.let {
+            """_sysconfigdata_[a-z]*_android_(.+).py""".toRegex().matchEntire(filename)?.let {
                 return@run it.groupValues[1]
             }
         }

--- a/Android/testbed/app/build.gradle.kts
+++ b/Android/testbed/app/build.gradle.kts
@@ -64,9 +64,10 @@ for ((i, prefix) in prefixes.withIndex()) {
     val libPythonDir = file("$libDir/python$pythonVersion")
     val triplet = run {
         for (filename in libPythonDir.list()!!) {
-            """_sysconfigdata_[a-z]*_android_(.+).py""".toRegex().matchEntire(filename)?.let {
-                return@run it.groupValues[1]
-            }
+            """_sysconfigdata_[a-z]*_android_(.+).py""".toRegex()
+                .matchEntire(filename)?.let {
+                    return@run it.groupValues[1]
+                }
         }
         throw GradleException("Failed to find Python triplet in $libPythonDir")
     }

--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -1,6 +1,8 @@
 """create and manipulate C data types in Python"""
 
-import os as _os, sys as _sys
+import os as _os
+import sys as _sys
+import sysconfig as _sysconfig
 import types as _types
 
 __version__ = "1.1.0"
@@ -550,10 +552,9 @@ pydll = LibraryLoader(PyDLL)
 
 if _os.name == "nt":
     pythonapi = PyDLL("python dll", None, _sys.dllhandle)
-elif _sys.platform == "android":
-    pythonapi = PyDLL("libpython%d.%d.so" % _sys.version_info[:2])
-elif _sys.platform == "cygwin":
-    pythonapi = PyDLL("libpython%d.%d.dll" % _sys.version_info[:2])
+elif _sys.platform in ["android", "cygwin"]:
+    # These are Unix-like platforms which use a dynamically-linked libpython.
+    pythonapi = PyDLL(_sysconfig.get_config_var("LDLIBRARY"))
 else:
     pythonapi = PyDLL(None)
 

--- a/Misc/NEWS.d/next/Library/2025-10-15-21-42-13.gh-issue-140041._Fka2j.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-15-21-42-13.gh-issue-140041._Fka2j.rst
@@ -1,0 +1,1 @@
+Fix import of :mod:`ctypes` on Android and Cygwin when ABI flags are present.


### PR DESCRIPTION

<!-- gh-issue-number: gh-140041 -->
* Fixes gh-140041
<!-- /gh-issue-number -->
