### PR TITLE
gh-83714: Check for struct statx.stx_atomic_write_unit_max_opt in configure

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3496,7 +3496,7 @@ features:
       Maximum optimized size for direct I/O with torn-write protection.
 
       .. availability:: Linux >= 4.11 with glibc >= 2.28 and build-time kernel
-         userspace API headers >= 6.11.
+         userspace API headers >= 6.16.
 
    .. attribute:: stx_atomic_write_segments_max
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -3369,7 +3369,7 @@ static PyMemberDef pystatx_result_members[] = {
     MM(stx_atomic_write_segments_max, Py_T_UINT, atomic_write_segments_max,
         "maximum iovecs for direct I/O with torn-write protection"),
 #endif
-#if 0
+#ifdef HAVE_STRUCT_STATX_STX_ATOMIC_WRITE_UNIT_MAX_OPT
     MM(stx_atomic_write_unit_max_opt, Py_T_UINT, atomic_write_unit_max_opt,
         "maximum optimized size for direct I/O with torn-write protection"),
 #endif

--- a/configure
+++ b/configure
@@ -25133,6 +25133,21 @@ printf "%s\n" "#define HAVE_SIGINFO_T_SI_BAND 1" >>confdefs.h
 fi
 
 
+if test "$ac_cv_func_statx" = yes; then
+  # stx_atomic_write_unit_max_opt was added in Linux 6.16, but is controlled by
+  # the STATX_WRITE_ATOMIC mask bit added in Linux 6.11, so having the mask bit
+  # doesn't imply having the member.
+  ac_fn_c_check_member "$LINENO" "struct statx" "stx_atomic_write_unit_max_opt" "ac_cv_member_struct_statx_stx_atomic_write_unit_max_opt" "$ac_includes_default"
+if test "x$ac_cv_member_struct_statx_stx_atomic_write_unit_max_opt" = xyes
+then :
+
+printf "%s\n" "#define HAVE_STRUCT_STATX_STX_ATOMIC_WRITE_UNIT_MAX_OPT 1" >>confdefs.h
+
+
+fi
+
+fi
+
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for time.h that defines altzone" >&5
 printf %s "checking for time.h that defines altzone... " >&6; }
 if test ${ac_cv_header_time_altzone+y}

--- a/configure.ac
+++ b/configure.ac
@@ -5819,6 +5819,13 @@ AC_CHECK_MEMBERS([struct passwd.pw_gecos, struct passwd.pw_passwd], [], [], [[
 # Issue #21085: In Cygwin, siginfo_t does not have si_band field.
 AC_CHECK_MEMBERS([siginfo_t.si_band], [], [], [[@%:@include <signal.h>]])
 
+if test "$ac_cv_func_statx" = yes; then
+  # stx_atomic_write_unit_max_opt was added in Linux 6.16, but is controlled by
+  # the STATX_WRITE_ATOMIC mask bit added in Linux 6.11, so having the mask bit
+  # doesn't imply having the member.
+  AC_CHECK_MEMBERS([struct statx.stx_atomic_write_unit_max_opt])
+fi
+
 AC_CACHE_CHECK([for time.h that defines altzone], [ac_cv_header_time_altzone], [
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <time.h>]], [[return altzone;]])],
     [ac_cv_header_time_altzone=yes],

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1330,6 +1330,10 @@
 /* Define to 1 if 'pw_passwd' is a member of 'struct passwd'. */
 #undef HAVE_STRUCT_PASSWD_PW_PASSWD
 
+/* Define to 1 if 'stx_atomic_write_unit_max_opt' is a member of 'struct
+   statx'. */
+#undef HAVE_STRUCT_STATX_STX_ATOMIC_WRITE_UNIT_MAX_OPT
+
 /* Define to 1 if 'st_birthtime' is a member of 'struct stat'. */
 #undef HAVE_STRUCT_STAT_ST_BIRTHTIME
 


### PR DESCRIPTION
[stx_atomic_write_unit_max_opt was added in Linux 6.16](https://github.com/torvalds/linux/commit/5d894321c49e61379189b0ff605f316e39cbd1e9), but is controlled by the STATX_WRITE_ATOMIC mask bit added in Linux 6.11.  That's safe at runtime because all kernels clear the reserved space in struct statx and zero is a valid value for stx_atomic_write_unit_max_opt, and it avoids allocating another mask bit, which are a limited resource.  But it also means the kernel headers don't provide a way to check whether stx_atomic_write_unit_max_opt exists, so add a configure check.

I ran `make regen-configure`.  I know very little about autoconf, so please check I didn't mess up.

<!-- gh-issue-number: gh-83714 -->
* Issue: gh-83714
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140185.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->