### PR TITLE
gh-140193: Forward port test_exec_set_nomemory_hang from 3.13

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1920,6 +1920,13 @@ class ExceptionTests(unittest.TestCase):
     @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
     def test_exec_set_nomemory_hang(self):
         import_module("_testcapi")
+        # gh-134163: A MemoryError inside code that was wrapped by a try/except
+        # block would lead to an infinite loop.
+
+        # The frame_lasti needs to be greater than 257 to prevent
+        # PyLong_FromLong() from returning cached integers, which
+        # don't require a memory allocation. Prepend some dummy code
+        # to artificially increase the instruction index.
         warmup_code = "a = list(range(0, 1))\n" * 20
         user_input = warmup_code + dedent("""
             try:

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1927,7 +1927,7 @@ class ExceptionTests(unittest.TestCase):
         # PyLong_FromLong() from returning cached integers, which
         # don't require a memory allocation. Prepend some dummy code
         # to artificially increase the instruction index.
-        warmup_code = "a = list(range(0, 1))\n" * 20
+        warmup_code = "a = list(range(0, 1))\n" * 2000
         user_input = warmup_code + dedent("""
             try:
                 import _testcapi

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1920,7 +1920,6 @@ class ExceptionTests(unittest.TestCase):
     @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
     def test_exec_set_nomemory_hang(self):
         import_module("_testcapi")
-        # gh-134163: chore from branch 3.13
         warmup_code = "a = list(range(0, 1))\n" * 20
         user_input = warmup_code + dedent("""
             try:

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1927,7 +1927,7 @@ class ExceptionTests(unittest.TestCase):
         # PyLong_FromLong() from returning cached integers, which
         # don't require a memory allocation. Prepend some dummy code
         # to artificially increase the instruction index.
-        warmup_code = "a = list(range(0, 1))\n" * 2000
+        warmup_code = "a = list(range(0, 1))\n" * 60
         user_input = warmup_code + dedent("""
             try:
                 import _testcapi


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

as discuss in https://github.com/python/cpython/pull/140103#issuecomment-3401485892

chore the test from branch 3.13 and need backport to 3.14

since main and 3.14 do not have the issue only test(so change the comments)

cc @ZeroIntensity 


<!-- gh-issue-number: gh-140193 -->
* Issue: gh-140193
<!-- /gh-issue-number -->
