### PR TITLE
gh-140120: Refresh HACL*

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-10-15-20-47-04.gh-issue-140120.3gffZq.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-15-20-47-04.gh-issue-140120.3gffZq.rst
@@ -1,0 +1,2 @@
+Fixed a memory leak in :mod:`hmac` when it was using the hacl-star backend.
+Discovered by ``@ashm-dev`` using AddressSanitizer.

--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -1755,11 +1755,11 @@
           "checksumValue": "39f6fd4f2fe98aecc995a2fd980fae0e0835cef6e563ebbf25f69d3d3102bafd"
         }
       ],
-      "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/4ef25b547b377dcef855db4289c6a00580e7221c.zip",
+      "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/8ba599b2f6c9701b3dc961db895b0856a2210f76.zip",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:hacl-star:hacl-star:4ef25b547b377dcef855db4289c6a00580e7221c:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:hacl-star:hacl-star:8ba599b2f6c9701b3dc961db895b0856a2210f76:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
@@ -1767,7 +1767,7 @@
       "name": "hacl-star",
       "originator": "Organization: HACL* Developers",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "4ef25b547b377dcef855db4289c6a00580e7221c"
+      "versionInfo": "8ba599b2f6c9701b3dc961db895b0856a2210f76"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-macholib",

--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -1752,7 +1752,7 @@
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "39f6fd4f2fe98aecc995a2fd980fae0e0835cef6e563ebbf25f69d3d3102bafd"
+          "checksumValue": "61e48893f37cb2280d106cefacf6fb5afe84edf625fec39572d0ee94e1018f26"
         }
       ],
       "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/8ba599b2f6c9701b3dc961db895b0856a2210f76.zip",

--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -300,11 +300,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "de7179fe6970e2b5d281dfed977ed91be635b8d2"
+          "checksumValue": "a57d53c35aa916ce0cd1567c8f10dcea58270321"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "c0ba888d87775c7d7f7d8a08dac7b3988fed81e11bb52396d90f762a8e90a7eb"
+          "checksumValue": "d68209032703137326f9aadd9abac8fe4a5c92d391e2f43b0414fa63087adc6b"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_HMAC.h"
@@ -328,11 +328,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7c66ac004a1dcf3fee0ab9aa62d61972f029de3a"
+          "checksumValue": "4d767388a34e2a2000e0cbd31f06cf36af1ae10d"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "9a7239a01a4ee8defbe3ebd9f0d12c873a1dd8e0659070380b2eab3ab0177333"
+          "checksumValue": "fac493e96af252abcf5705f0ab4eec59c1f3bc8244e105d75a57c43552dd1569"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_Hash_Blake2b.h"
@@ -356,11 +356,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7f273d26942233e5dcdfb4c1a16ff2486b15f899"
+          "checksumValue": "280fd03ee23e13ecf90711d2be8230035d957343"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "dbc0dacc68ed52dbf1b7d6fba2c87870317998bc046e65f6deaaa150625432f8"
+          "checksumValue": "817dcd05d06d804587fce7d8f2f3f42a6fcf6818d2419a3551ef0df70cb7125a"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_Hash_Blake2b_Simd256.h"
@@ -398,11 +398,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2120c8c467aeebcc7c8b9678c15e79648433b91a"
+          "checksumValue": "79f47ab5458d88bce0f210a566aa117ce2125049"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "45735f7fe2dbbad7656d07854e9ec8176ad26c79f90dcc0fec0b9a59a6311ba7"
+          "checksumValue": "5cc96313f8c066f055c2819e473c79aeff086ba91a1449d54aa569127cd8601e"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_Hash_Blake2s.h"
@@ -426,11 +426,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9028e24c9876d9d16b2435ec29240c6b57bfe2a0"
+          "checksumValue": "c98890b6193baa3dbd472cfb67f22aea3dd0d3e1"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "062e3b856acac4f929c1e04b8264a754cad21ca6580215f7094a3f0a04edb912"
+          "checksumValue": "fe3f17bf237166f872ba88c8204333c4f64bdc4bb29c265448581c7bfea4b151"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_Hash_Blake2s_Simd128.h"
@@ -468,11 +468,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e67a9bc18358c57afaeff3a174893ddfdb52dfc6"
+          "checksumValue": "2ed70f612a998ef6c04d62f9487a1b2534e6d76a"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "16e982081f6c2fd03ea751fcc64f5a835c94652841836e231fe562b9e287f4bc"
+          "checksumValue": "a34534ef36bc8428ac1169ca5f4f1c17a0817507ebae388e3dd825d1a331f28d"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_Hash_MD5.h"
@@ -496,11 +496,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f1ca21f1ee8b15ad9ccfbda72165b9d86912166c"
+          "checksumValue": "a3f9bdc9e73f80eb4a586dc180246cfb8267ffc0"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "4b2ad9ea93fdd9c2fdc521fc4e14e02550666c2717a23b85819db2e07ea555f3"
+          "checksumValue": "2d5cae94382f5473cf6d2654760375ff1ee9cebdb8d4506b63ba33f488de1559"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_Hash_SHA1.h"
@@ -524,11 +524,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f38cebeeca40a83aeb2cf5dfce578ffefe176d84"
+          "checksumValue": "68b35d0c573f7301ba4d6919b1680d55675a0d98"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "ee03bf9368d1a3a3c70cfd4e9391b2485466404db4a60bfc5319630cc314b590"
+          "checksumValue": "442d8997d2bcda20ddf628665e2e69945400e1ab3019bc14fc7c8e20db20c320"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_Hash_SHA2.h"
@@ -552,11 +552,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "01717207aef77174e328186d48c27517f6644c15"
+          "checksumValue": "db1008095b64b2f8ee2a4ce72fa7cfc4a622a108"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "620dded172e94cb3f25f9904b44977d91f2cc9573e41b38f19e929d083ae0308"
+          "checksumValue": "961a686186b76a1cd6a64bcfd06afdc8657b1f901bac991166f498ed16f9349a"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_Hash_SHA3.h"
@@ -566,11 +566,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "417e68ac8498cb2f93a06a19003ea1cc3f0f6753"
+          "checksumValue": "eb224e26bc0503a48c88c837e28bbc7a9878ba5c"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "843db4bba78a476d4d53dabe4eed5c9235f490ccc9fdaf19e22af488af858920"
+          "checksumValue": "29fcf948a3715e09cbbd434cebb6105f276236a6e4947d237b7bf06634bf2432"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_Streaming_HMAC.c"
@@ -580,11 +580,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "49523144583a15d96ba1646af02dc292e633bf8f"
+          "checksumValue": "2d6c600024275c780e8313e0a5ab506e025bb4d6"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "78345519bf6789264f6792b809ee97a9ecf7cb5829c674c61e2d99bfdfdc36fc"
+          "checksumValue": "6450aef92f507fb0a8a3086b1d2792e7fca07121580c24fdaedd1b32e9ad0a76"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_Streaming_HMAC.h"
@@ -594,11 +594,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "372448599774a98e5c5d083e91f301ed1c4b822e"
+          "checksumValue": "ed283b95ebb772b05bdf802b70dbb301ece84e91"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "95d8e70ca4bc6aa98f6d2435ceb6410ead299b1f700fae1f5c603ec3f57ea551"
+          "checksumValue": "efc7bd11460744768425aedf4e004d3ad3397a5489752b80044ae785f30b78d4"
         }
       ],
       "fileName": "Modules/_hacl/Hacl_Streaming_Types.h"
@@ -622,11 +622,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "911c97a0f24067635b164fbca49da76055f192cd"
+          "checksumValue": "ae06c415ae7e0e1e85558863f29d1b9013e46e9b"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "972b5111ebada8e11dd60df3119da1af505fd3e0b6c782ead6cab7f1daf134f1"
+          "checksumValue": "69dc2e78411e9b271100eb0d2a2d8dc39dd2348afc26f8b4cfba14c025102c7f"
         }
       ],
       "fileName": "Modules/_hacl/include/krml/FStar_UInt128_Verified.h"
@@ -636,11 +636,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "41ee1e34ede7ef5b24b87d4ca816fd6d9fac8010"
+          "checksumValue": "edefe48ced707327fd6cdf3f18b3ca42dda9a9f7"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "d48ed03e504cb87793a310a9552fb3ba2ebd6fe90127b7d642c8740fba1b9748"
+          "checksumValue": "f01e3f0892935f3f659019875f580445b9ea23482afbe11ffbe7cdbd22dbd4d2"
         }
       ],
       "fileName": "Modules/_hacl/include/krml/FStar_UInt_8_16_32_64.h"
@@ -678,11 +678,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e01d7d493fbaceeedc4b1c6451d8240bcb9c903a"
+          "checksumValue": "7a943fbb8f55729a960f9b426e9ff2794453aca9"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "c2f0a43884771f24d7cb744b79818b160020d2739b2881b2054cfc97fb2e7b4a"
+          "checksumValue": "08bb43ef5626a8450f985da0af345b6658ac8bcc4585f77271decd0e41fc02e0"
         }
       ],
       "fileName": "Modules/_hacl/include/krml/internal/target.h"
@@ -692,11 +692,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3f66313d16891f43b21c1a736081c2c6d46bf370"
+          "checksumValue": "b4e6c5fc5e17864cc2bf452db2688be733d6df72"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "78e9bff9124968108e1699e1c6388e3d4ec9bd72dd8adff49734a69ab380ee5c"
+          "checksumValue": "404691cf9b2269ecc754ceca27bb8f8f029f1c8deaa4d967990dcf5ce08cd016"
         }
       ],
       "fileName": "Modules/_hacl/include/krml/internal/types.h"
@@ -706,11 +706,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e18efc9239a5df0f222b5f7b0a65f72509d7e304"
+          "checksumValue": "8c3e09e00459951e060ad469c1fa31eeb9b6b9cb"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "47dd5a7d21b5302255f9fff28884f65d3056fc3f54471ed62ec85fa1904f8aa5"
+          "checksumValue": "6d1a350ec272c83761f1789611d8f60947a4d69fed3d23d8eee38709a0ad2c0a"
         }
       ],
       "fileName": "Modules/_hacl/include/krml/lowstar_endianness.h"
@@ -720,11 +720,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "aaa656e25a92ba83655e1398a97efa6981f60fc4"
+          "checksumValue": "c9517c43046de129f02da8b74e454bade4872c00"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "a59abc6e9b3019cb18976a15e634f5146bd965fc9babf4ccbf2b531164a34f85"
+          "checksumValue": "96c2a973bc01b1295f7af67c7de3839facfeee36c8848d7d88c62695de98ab21"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_HMAC.h"
@@ -734,11 +734,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0741cb8497309d648428be1e7b5944b1fc167187"
+          "checksumValue": "1c5eeb5d1866acb6bc8b4e5a01a107e3a87f5694"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "f9b923a566d62de047c753637143d439ca1c25221c08352ddc1738ff4a6ac721"
+          "checksumValue": "f262738390f56e8e9692acadecd1434c688075047d788283e1fb45d920ea6956"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_Hash_Blake2b.h"
@@ -748,11 +748,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "878ae284c93824b80b1763e8b3e6be3c410777a8"
+          "checksumValue": "b600c1b5eafc34b29a778186737d8a51e2342d85"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "49df6223f6403daf503a1af1a3d2f943d30b5889fe7ed20299c3df24c1e3853d"
+          "checksumValue": "f22e088ad9c2eb739aefc3685ef3ab1ccaab3c5ef2e5d06cc846ad9f8e3d2669"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_Hash_Blake2b_Simd256.h"
@@ -762,11 +762,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "25552d8cbf8aa345907635b38f284eec9075301e"
+          "checksumValue": "eb618ecc6ca2830066448f5f6d4df84a5c09f0f4"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "a3424cf4c5518654908086bbbf5d465715ec3b23625ef0cadc29492d1f90366c"
+          "checksumValue": "a4728e43deb0a9d8213b8ddcbda68a63bc73a12fb99aad54b7d28b314776a0d4"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_Hash_Blake2s.h"
@@ -776,11 +776,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "54a712fc3ed5a817288351cbac5b7d9afa7e379f"
+          "checksumValue": "5441b6a97cc053c332b29477238d70fa011c74ac"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "c6abae648b8a1e9d5631c0a959620cad1f7e92ce522e07c3416199fe51debef6"
+          "checksumValue": "dad568d256a2ccbbbcdd419fe0543ea7137d8065a713a5f009aa52521c0f7f6a"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_Hash_Blake2s_Simd128.h"
@@ -790,11 +790,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "c15c5f83bbb9f62611c49f0f8f723eaab1a27488"
+          "checksumValue": "7081b58f28568f600d4624dd5bd6f735191e068b"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "95cd5d91c4a9217901d0b3395dcd8881e62e2055d723b532ec5176386a636d22"
+          "checksumValue": "305af1422213ed97e8e5d3d8a9dfee4f21cb2fcd2acf65ee7303ce00b2b4bd2a"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_Hash_MD5.h"
@@ -804,11 +804,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7b8717e3a24e7e16a34b251d0d02da6f68439695"
+          "checksumValue": "b6fb6219cb40d039e789666e34b43461e3b5c82a"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "9473d8bc9506fe0053d7d98c225d4873011329863f1c4a8e93e43fc71bd1f314"
+          "checksumValue": "63c58363ff95e8146d5628dab2da25bc2fd0e8b590fd4823b512c33f843355bb"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_Hash_SHA1.h"
@@ -818,11 +818,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e319c949f5a2dd765be2c8c7ff77bfe52ee6c7da"
+          "checksumValue": "bcc71e702df1070cb0081cb983aec7683e036719"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "75261448e51c3eb1ba441e973b193e23570b167f67743942ee2ee57417491c9f"
+          "checksumValue": "709c6272f77e2368f6cc0bf36527e3b16dd5d5f3dc26a2afdef8238200af8770"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_Hash_SHA2.h"
@@ -832,11 +832,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "dbd92415c31606804102b79d5ba3d1752fe03887"
+          "checksumValue": "e3b5e6add5357760554b032b818992ce9bc211e0"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "5d74a76a0ac3659a1ae1276c3ca55521f09e83d2f0039f5c519a76f8f3c76a8e"
+          "checksumValue": "cf49d536a5663379fb4517018b4b3f8a232f8d4c7ddc7edfd60163d13f98a530"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_Hash_SHA3.h"
@@ -846,11 +846,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ad788265f8e1b078c4d1cb6e90b8c031590e6baf"
+          "checksumValue": "09a0ea364fb073f5f622a763f1351fbf4bac4627"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "d8354a9b75e2470085fa7e538493130e81fa23a804a6a69d34da8fdcc941c038"
+          "checksumValue": "916d54d7217517f0360edea920dc21585fbe6d1c2458eac86826182e12c82ec2"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_Impl_Blake2_Constants.h"
@@ -860,11 +860,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2048f3cd61dbda2df862a2982ebaf24b6815ed51"
+          "checksumValue": "b082645b43f8841db5e9e57c0b9a3825fa7e52f5"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "b0f5a79c98525b0cb1659238e095641328b7da16a94cb57a0793e635d1da3653"
+          "checksumValue": "059cf0d31427abf84c626797a97c140630a1a6ead578005162f46fad46663389"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_Streaming_HMAC.h"
@@ -874,11 +874,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4e6b098e89fd447bd03f47b55208208456b20966"
+          "checksumValue": "1f85ed69e395829b3ac5af9e2d049af7708cb9cb"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "d54d947968ca125978d61fea844711b990f0a18ab0fbca87e41029004d9d04b6"
+          "checksumValue": "76997c7069a347ac78b65d26354a0324d54add4ca7a02e7be36d6d5e1c9702e0"
         }
       ],
       "fileName": "Modules/_hacl/internal/Hacl_Streaming_Types.h"

--- a/Modules/_hacl/Hacl_HMAC.h
+++ b/Modules/_hacl/Hacl_HMAC.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_HMAC_H
-#define __Hacl_HMAC_H
+#ifndef Hacl_HMAC_H
+#define Hacl_HMAC_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -220,5 +220,5 @@ Hacl_HMAC_compute_blake2b_32(
 }
 #endif
 
-#define __Hacl_HMAC_H_DEFINED
-#endif
+#define Hacl_HMAC_H_DEFINED
+#endif /* Hacl_HMAC_H */

--- a/Modules/_hacl/Hacl_Hash_Blake2b.h
+++ b/Modules/_hacl/Hacl_Hash_Blake2b.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_Hash_Blake2b_H
-#define __Hacl_Hash_Blake2b_H
+#ifndef Hacl_Hash_Blake2b_H
+#define Hacl_Hash_Blake2b_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -220,5 +220,5 @@ Hacl_Hash_Blake2b_hash_with_key_and_params(
 }
 #endif
 
-#define __Hacl_Hash_Blake2b_H_DEFINED
-#endif
+#define Hacl_Hash_Blake2b_H_DEFINED
+#endif /* Hacl_Hash_Blake2b_H */

--- a/Modules/_hacl/Hacl_Hash_Blake2b_Simd256.h
+++ b/Modules/_hacl/Hacl_Hash_Blake2b_Simd256.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_Hash_Blake2b_Simd256_H
-#define __Hacl_Hash_Blake2b_Simd256_H
+#ifndef Hacl_Hash_Blake2b_Simd256_H
+#define Hacl_Hash_Blake2b_Simd256_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -206,5 +206,5 @@ Hacl_Hash_Blake2b_Simd256_hash_with_key_and_params(
 }
 #endif
 
-#define __Hacl_Hash_Blake2b_Simd256_H_DEFINED
-#endif
+#define Hacl_Hash_Blake2b_Simd256_H_DEFINED
+#endif /* Hacl_Hash_Blake2b_Simd256_H */

--- a/Modules/_hacl/Hacl_Hash_Blake2s.h
+++ b/Modules/_hacl/Hacl_Hash_Blake2s.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_Hash_Blake2s_H
-#define __Hacl_Hash_Blake2s_H
+#ifndef Hacl_Hash_Blake2s_H
+#define Hacl_Hash_Blake2s_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -198,5 +198,5 @@ Hacl_Hash_Blake2s_hash_with_key_and_params(
 }
 #endif
 
-#define __Hacl_Hash_Blake2s_H_DEFINED
-#endif
+#define Hacl_Hash_Blake2s_H_DEFINED
+#endif /* Hacl_Hash_Blake2s_H */

--- a/Modules/_hacl/Hacl_Hash_Blake2s_Simd128.h
+++ b/Modules/_hacl/Hacl_Hash_Blake2s_Simd128.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_Hash_Blake2s_Simd128_H
-#define __Hacl_Hash_Blake2s_Simd128_H
+#ifndef Hacl_Hash_Blake2s_Simd128_H
+#define Hacl_Hash_Blake2s_Simd128_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -206,5 +206,5 @@ Hacl_Hash_Blake2s_Simd128_hash_with_key_and_params(
 }
 #endif
 
-#define __Hacl_Hash_Blake2s_Simd128_H_DEFINED
-#endif
+#define Hacl_Hash_Blake2s_Simd128_H_DEFINED
+#endif /* Hacl_Hash_Blake2s_Simd128_H */

--- a/Modules/_hacl/Hacl_Hash_MD5.h
+++ b/Modules/_hacl/Hacl_Hash_MD5.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_Hash_MD5_H
-#define __Hacl_Hash_MD5_H
+#ifndef Hacl_Hash_MD5_H
+#define Hacl_Hash_MD5_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -62,5 +62,5 @@ void Hacl_Hash_MD5_hash(uint8_t *output, uint8_t *input, uint32_t input_len);
 }
 #endif
 
-#define __Hacl_Hash_MD5_H_DEFINED
-#endif
+#define Hacl_Hash_MD5_H_DEFINED
+#endif /* Hacl_Hash_MD5_H */

--- a/Modules/_hacl/Hacl_Hash_SHA1.h
+++ b/Modules/_hacl/Hacl_Hash_SHA1.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_Hash_SHA1_H
-#define __Hacl_Hash_SHA1_H
+#ifndef Hacl_Hash_SHA1_H
+#define Hacl_Hash_SHA1_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -62,5 +62,5 @@ void Hacl_Hash_SHA1_hash(uint8_t *output, uint8_t *input, uint32_t input_len);
 }
 #endif
 
-#define __Hacl_Hash_SHA1_H_DEFINED
-#endif
+#define Hacl_Hash_SHA1_H_DEFINED
+#endif /* Hacl_Hash_SHA1_H */

--- a/Modules/_hacl/Hacl_Hash_SHA2.h
+++ b/Modules/_hacl/Hacl_Hash_SHA2.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_Hash_SHA2_H
-#define __Hacl_Hash_SHA2_H
+#ifndef Hacl_Hash_SHA2_H
+#define Hacl_Hash_SHA2_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -199,5 +199,5 @@ void Hacl_Hash_SHA2_hash_384(uint8_t *output, uint8_t *input, uint32_t input_len
 }
 #endif
 
-#define __Hacl_Hash_SHA2_H_DEFINED
-#endif
+#define Hacl_Hash_SHA2_H_DEFINED
+#endif /* Hacl_Hash_SHA2_H */

--- a/Modules/_hacl/Hacl_Hash_SHA3.h
+++ b/Modules/_hacl/Hacl_Hash_SHA3.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_Hash_SHA3_H
-#define __Hacl_Hash_SHA3_H
+#ifndef Hacl_Hash_SHA3_H
+#define Hacl_Hash_SHA3_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -155,5 +155,5 @@ Hacl_Hash_SHA3_shake128_squeeze_nblocks(
 }
 #endif
 
-#define __Hacl_Hash_SHA3_H_DEFINED
-#endif
+#define Hacl_Hash_SHA3_H_DEFINED
+#endif /* Hacl_Hash_SHA3_H */

--- a/Modules/_hacl/Hacl_Streaming_HMAC.c
+++ b/Modules/_hacl/Hacl_Streaming_HMAC.c
@@ -2375,9 +2375,13 @@ Hacl_Streaming_HMAC_digest(
     Hacl_Agile_Hash_state_s *s112 = tmp_block_state1.snd;
     update_multi(s112, prev_len, buf_multi, 0U);
     uint64_t prev_len_last = total_len - (uint64_t)r;
-    Hacl_Agile_Hash_state_s *s11 = tmp_block_state1.snd;
-    update_last(s11, prev_len_last, buf_last, r);
+    Hacl_Agile_Hash_state_s *s113 = tmp_block_state1.snd;
+    update_last(s113, prev_len_last, buf_last, r);
     finish0(tmp_block_state1, output);
+    Hacl_Agile_Hash_state_s *s210 = tmp_block_state1.thd;
+    Hacl_Agile_Hash_state_s *s11 = tmp_block_state1.snd;
+    free_(s11);
+    free_(s210);
     return Hacl_Streaming_Types_Success;
   }
   KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",

--- a/Modules/_hacl/Hacl_Streaming_HMAC.h
+++ b/Modules/_hacl/Hacl_Streaming_HMAC.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_Streaming_HMAC_H
-#define __Hacl_Streaming_HMAC_H
+#ifndef Hacl_Streaming_HMAC_H
+#define Hacl_Streaming_HMAC_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -130,5 +130,5 @@ Hacl_Streaming_HMAC_agile_state
 }
 #endif
 
-#define __Hacl_Streaming_HMAC_H_DEFINED
-#endif
+#define Hacl_Streaming_HMAC_H_DEFINED
+#endif /* Hacl_Streaming_HMAC_H */

--- a/Modules/_hacl/Hacl_Streaming_Types.h
+++ b/Modules/_hacl/Hacl_Streaming_Types.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_Streaming_Types_H
-#define __Hacl_Streaming_Types_H
+#ifndef Hacl_Streaming_Types_H
+#define Hacl_Streaming_Types_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -68,5 +68,5 @@ typedef struct Hacl_Streaming_MD_state_64_s Hacl_Streaming_MD_state_64;
 }
 #endif
 
-#define __Hacl_Streaming_Types_H_DEFINED
-#endif
+#define Hacl_Streaming_Types_H_DEFINED
+#endif /* Hacl_Streaming_Types_H */

--- a/Modules/_hacl/include/krml/FStar_UInt128_Verified.h
+++ b/Modules/_hacl/include/krml/FStar_UInt128_Verified.h
@@ -4,8 +4,8 @@
 */
 
 
-#ifndef __FStar_UInt128_Verified_H
-#define __FStar_UInt128_Verified_H
+#ifndef FStar_UInt128_Verified_H
+#define FStar_UInt128_Verified_H
 
 #include "FStar_UInt_8_16_32_64.h"
 #include <inttypes.h>
@@ -331,5 +331,5 @@ static inline FStar_UInt128_uint128 FStar_UInt128_mul_wide(uint64_t x, uint64_t 
 }
 
 
-#define __FStar_UInt128_Verified_H_DEFINED
-#endif
+#define FStar_UInt128_Verified_H_DEFINED
+#endif /* FStar_UInt128_Verified_H */

--- a/Modules/_hacl/include/krml/FStar_UInt_8_16_32_64.h
+++ b/Modules/_hacl/include/krml/FStar_UInt_8_16_32_64.h
@@ -4,8 +4,8 @@
 */
 
 
-#ifndef __FStar_UInt_8_16_32_64_H
-#define __FStar_UInt_8_16_32_64_H
+#ifndef FStar_UInt_8_16_32_64_H
+#define FStar_UInt_8_16_32_64_H
 
 #include <inttypes.h>
 #include <stdbool.h>
@@ -29,6 +29,8 @@ extern uint64_t FStar_UInt64_uint_to_t(krml_checked_int_t x);
 extern uint64_t FStar_UInt64_zero;
 
 extern uint64_t FStar_UInt64_one;
+
+extern bool FStar_UInt64_ne(uint64_t a, uint64_t b);
 
 extern uint64_t FStar_UInt64_minus(uint64_t a);
 
@@ -80,6 +82,8 @@ extern uint32_t FStar_UInt32_zero;
 
 extern uint32_t FStar_UInt32_one;
 
+extern bool FStar_UInt32_ne(uint32_t a, uint32_t b);
+
 extern uint32_t FStar_UInt32_minus(uint32_t a);
 
 extern uint32_t FStar_UInt32_n_minus_one;
@@ -129,6 +133,8 @@ extern uint16_t FStar_UInt16_uint_to_t(krml_checked_int_t x);
 extern uint16_t FStar_UInt16_zero;
 
 extern uint16_t FStar_UInt16_one;
+
+extern bool FStar_UInt16_ne(uint16_t a, uint16_t b);
 
 extern uint16_t FStar_UInt16_minus(uint16_t a);
 
@@ -180,6 +186,8 @@ extern uint8_t FStar_UInt8_zero;
 
 extern uint8_t FStar_UInt8_one;
 
+extern bool FStar_UInt8_ne(uint8_t a, uint8_t b);
+
 extern uint8_t FStar_UInt8_minus(uint8_t a);
 
 extern uint32_t FStar_UInt8_n_minus_one;
@@ -217,5 +225,5 @@ extern uint8_t FStar_UInt8_of_string(Prims_string uu___);
 typedef uint8_t FStar_UInt8_byte;
 
 
-#define __FStar_UInt_8_16_32_64_H_DEFINED
-#endif
+#define FStar_UInt_8_16_32_64_H_DEFINED
+#endif /* FStar_UInt_8_16_32_64_H */

--- a/Modules/_hacl/include/krml/internal/target.h
+++ b/Modules/_hacl/include/krml/internal/target.h
@@ -1,8 +1,8 @@
 /* Copyright (c) INRIA and Microsoft Corporation. All rights reserved.
    Licensed under the Apache 2.0 and MIT Licenses. */
 
-#ifndef __KRML_TARGET_H
-#define __KRML_TARGET_H
+#ifndef KRML_HEADER_TARGET_H
+#define KRML_HEADER_TARGET_H
 
 #include <assert.h>
 #include <inttypes.h>
@@ -11,6 +11,9 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+typedef float float32_t;
+typedef double float64_t;
 
 /* Since KaRaMeL emits the inline keyword unconditionally, we follow the
  * guidelines at https://gcc.gnu.org/onlinedocs/gcc/Inline.html and make this
@@ -425,4 +428,4 @@ inline static int32_t krml_time(void) {
 #else
 #  define KRML_MAYBE_FOR16(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
 #endif
-#endif
+#endif /* KRML_HEADER_TARGET_H */

--- a/Modules/_hacl/include/krml/internal/types.h
+++ b/Modules/_hacl/include/krml/internal/types.h
@@ -92,7 +92,7 @@ typedef FStar_UInt128_uint128 FStar_UInt128_t, uint128_t;
 
 /* Avoid a circular loop: if this header is included via FStar_UInt8_16_32_64,
  * then don't bring the uint128 definitions into scope. */
-#ifndef __FStar_UInt_8_16_32_64_H
+#ifndef FStar_UInt_8_16_32_64_H
 
 #if !defined(KRML_VERIFIED_UINT128) && defined(IS_MSVC64)
 #include "fstar_uint128_msvc.h"

--- a/Modules/_hacl/include/krml/lowstar_endianness.h
+++ b/Modules/_hacl/include/krml/lowstar_endianness.h
@@ -1,8 +1,8 @@
 /* Copyright (c) INRIA and Microsoft Corporation. All rights reserved.
    Licensed under the Apache 2.0 and MIT Licenses. */
 
-#ifndef __LOWSTAR_ENDIANNESS_H
-#define __LOWSTAR_ENDIANNESS_H
+#ifndef KRML_HEADER_LOWSTAR_ENDIANNESS_H
+#define KRML_HEADER_LOWSTAR_ENDIANNESS_H
 
 #include <string.h>
 #include <inttypes.h>
@@ -228,4 +228,4 @@ inline static void store64(uint8_t *b, uint64_t i) {
 #define load128_be0 load128_be
 #define store128_be0 store128_be
 
-#endif
+#endif /* KRML_HEADER_LOWSTAR_ENDIANNESS_H */

--- a/Modules/_hacl/internal/Hacl_HMAC.h
+++ b/Modules/_hacl/internal/Hacl_HMAC.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_HMAC_H
-#define __internal_Hacl_HMAC_H
+#ifndef internal_Hacl_HMAC_H
+#define internal_Hacl_HMAC_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -48,5 +48,5 @@ K___uint32_t_uint32_t;
 }
 #endif
 
-#define __internal_Hacl_HMAC_H_DEFINED
-#endif
+#define internal_Hacl_HMAC_H_DEFINED
+#endif /* internal_Hacl_HMAC_H */

--- a/Modules/_hacl/internal/Hacl_Hash_Blake2b.h
+++ b/Modules/_hacl/internal/Hacl_Hash_Blake2b.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_Hash_Blake2b_H
-#define __internal_Hacl_Hash_Blake2b_H
+#ifndef internal_Hacl_Hash_Blake2b_H
+#define internal_Hacl_Hash_Blake2b_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -91,5 +91,5 @@ Hacl_Hash_Blake2b_state_t;
 }
 #endif
 
-#define __internal_Hacl_Hash_Blake2b_H_DEFINED
-#endif
+#define internal_Hacl_Hash_Blake2b_H_DEFINED
+#endif /* internal_Hacl_Hash_Blake2b_H */

--- a/Modules/_hacl/internal/Hacl_Hash_Blake2b_Simd256.h
+++ b/Modules/_hacl/internal/Hacl_Hash_Blake2b_Simd256.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_Hash_Blake2b_Simd256_H
-#define __internal_Hacl_Hash_Blake2b_Simd256_H
+#ifndef internal_Hacl_Hash_Blake2b_Simd256_H
+#define internal_Hacl_Hash_Blake2b_Simd256_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -134,5 +134,5 @@ Hacl_Hash_Blake2b_Simd256_state_t;
 }
 #endif
 
-#define __internal_Hacl_Hash_Blake2b_Simd256_H_DEFINED
-#endif
+#define internal_Hacl_Hash_Blake2b_Simd256_H_DEFINED
+#endif /* internal_Hacl_Hash_Blake2b_Simd256_H */

--- a/Modules/_hacl/internal/Hacl_Hash_Blake2s.h
+++ b/Modules/_hacl/internal/Hacl_Hash_Blake2s.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_Hash_Blake2s_H
-#define __internal_Hacl_Hash_Blake2s_H
+#ifndef internal_Hacl_Hash_Blake2s_H
+#define internal_Hacl_Hash_Blake2s_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -90,5 +90,5 @@ Hacl_Hash_Blake2s_state_t;
 }
 #endif
 
-#define __internal_Hacl_Hash_Blake2s_H_DEFINED
-#endif
+#define internal_Hacl_Hash_Blake2s_H_DEFINED
+#endif /* internal_Hacl_Hash_Blake2s_H */

--- a/Modules/_hacl/internal/Hacl_Hash_Blake2s_Simd128.h
+++ b/Modules/_hacl/internal/Hacl_Hash_Blake2s_Simd128.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_Hash_Blake2s_Simd128_H
-#define __internal_Hacl_Hash_Blake2s_Simd128_H
+#ifndef internal_Hacl_Hash_Blake2s_Simd128_H
+#define internal_Hacl_Hash_Blake2s_Simd128_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -134,5 +134,5 @@ Hacl_Hash_Blake2s_Simd128_state_t;
 }
 #endif
 
-#define __internal_Hacl_Hash_Blake2s_Simd128_H_DEFINED
-#endif
+#define internal_Hacl_Hash_Blake2s_Simd128_H_DEFINED
+#endif /* internal_Hacl_Hash_Blake2s_Simd128_H */

--- a/Modules/_hacl/internal/Hacl_Hash_MD5.h
+++ b/Modules/_hacl/internal/Hacl_Hash_MD5.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_Hash_MD5_H
-#define __internal_Hacl_Hash_MD5_H
+#ifndef internal_Hacl_Hash_MD5_H
+#define internal_Hacl_Hash_MD5_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -53,5 +53,5 @@ void Hacl_Hash_MD5_hash_oneshot(uint8_t *output, uint8_t *input, uint32_t input_
 }
 #endif
 
-#define __internal_Hacl_Hash_MD5_H_DEFINED
-#endif
+#define internal_Hacl_Hash_MD5_H_DEFINED
+#endif /* internal_Hacl_Hash_MD5_H */

--- a/Modules/_hacl/internal/Hacl_Hash_SHA1.h
+++ b/Modules/_hacl/internal/Hacl_Hash_SHA1.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_Hash_SHA1_H
-#define __internal_Hacl_Hash_SHA1_H
+#ifndef internal_Hacl_Hash_SHA1_H
+#define internal_Hacl_Hash_SHA1_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -52,5 +52,5 @@ void Hacl_Hash_SHA1_hash_oneshot(uint8_t *output, uint8_t *input, uint32_t input
 }
 #endif
 
-#define __internal_Hacl_Hash_SHA1_H_DEFINED
-#endif
+#define internal_Hacl_Hash_SHA1_H_DEFINED
+#endif /* internal_Hacl_Hash_SHA1_H */

--- a/Modules/_hacl/internal/Hacl_Hash_SHA2.h
+++ b/Modules/_hacl/internal/Hacl_Hash_SHA2.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_Hash_SHA2_H
-#define __internal_Hacl_Hash_SHA2_H
+#ifndef internal_Hacl_Hash_SHA2_H
+#define internal_Hacl_Hash_SHA2_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -161,5 +161,5 @@ void Hacl_Hash_SHA2_sha384_finish(uint64_t *st, uint8_t *h);
 }
 #endif
 
-#define __internal_Hacl_Hash_SHA2_H_DEFINED
-#endif
+#define internal_Hacl_Hash_SHA2_H_DEFINED
+#endif /* internal_Hacl_Hash_SHA2_H */

--- a/Modules/_hacl/internal/Hacl_Hash_SHA3.h
+++ b/Modules/_hacl/internal/Hacl_Hash_SHA3.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_Hash_SHA3_H
-#define __internal_Hacl_Hash_SHA3_H
+#ifndef internal_Hacl_Hash_SHA3_H
+#define internal_Hacl_Hash_SHA3_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -81,5 +81,5 @@ Hacl_Hash_SHA3_state_t;
 }
 #endif
 
-#define __internal_Hacl_Hash_SHA3_H_DEFINED
-#endif
+#define internal_Hacl_Hash_SHA3_H_DEFINED
+#endif /* internal_Hacl_Hash_SHA3_H */

--- a/Modules/_hacl/internal/Hacl_Impl_Blake2_Constants.h
+++ b/Modules/_hacl/internal/Hacl_Impl_Blake2_Constants.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_Impl_Blake2_Constants_H
-#define __internal_Hacl_Impl_Blake2_Constants_H
+#ifndef internal_Hacl_Impl_Blake2_Constants_H
+#define internal_Hacl_Impl_Blake2_Constants_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -69,5 +69,5 @@ Hacl_Hash_Blake2b_ivTable_B[8U] =
 }
 #endif
 
-#define __internal_Hacl_Impl_Blake2_Constants_H_DEFINED
-#endif
+#define internal_Hacl_Impl_Blake2_Constants_H_DEFINED
+#endif /* internal_Hacl_Impl_Blake2_Constants_H */

--- a/Modules/_hacl/internal/Hacl_Streaming_HMAC.h
+++ b/Modules/_hacl/internal/Hacl_Streaming_HMAC.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_Streaming_HMAC_H
-#define __internal_Hacl_Streaming_HMAC_H
+#ifndef internal_Hacl_Streaming_HMAC_H
+#define internal_Hacl_Streaming_HMAC_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -90,5 +90,5 @@ Hacl_Streaming_HMAC_agile_state;
 }
 #endif
 
-#define __internal_Hacl_Streaming_HMAC_H_DEFINED
-#endif
+#define internal_Hacl_Streaming_HMAC_H_DEFINED
+#endif /* internal_Hacl_Streaming_HMAC_H */

--- a/Modules/_hacl/internal/Hacl_Streaming_Types.h
+++ b/Modules/_hacl/internal/Hacl_Streaming_Types.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_Streaming_Types_H
-#define __internal_Hacl_Streaming_Types_H
+#ifndef internal_Hacl_Streaming_Types_H
+#define internal_Hacl_Streaming_Types_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -83,5 +83,5 @@ Hacl_Streaming_MD_state_64;
 }
 #endif
 
-#define __internal_Hacl_Streaming_Types_H_DEFINED
-#endif
+#define internal_Hacl_Streaming_Types_H_DEFINED
+#endif /* internal_Hacl_Streaming_Types_H */

--- a/Modules/_hacl/refresh.sh
+++ b/Modules/_hacl/refresh.sh
@@ -22,7 +22,7 @@ fi
 
 # Update this when updating to a new version after verifying that the changes
 # the update brings in are good.
-expected_hacl_star_rev=4ef25b547b377dcef855db4289c6a00580e7221c
+expected_hacl_star_rev=8ba599b2f6c9701b3dc961db895b0856a2210f76
 
 hacl_dir="$(realpath "$1")"
 cd "$(dirname "$0")"


### PR DESCRIPTION
This pulls an updated version of HACL* that fixes the memory leak reported in #140120, via an upstream fix.

I did not add a NEWS entry because this seems minor. Thank you.

CC @picnixz and @gpshead 

<!-- gh-issue-number: gh-140120 -->
* Issue: gh-140120
<!-- /gh-issue-number -->
