### PR TITLE
gh-101100: Doc: Suppress sphinx warning in descriptor.rst

### DIFF
--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -38,3 +38,8 @@ found in the dictionary of type objects.
 
 
 .. c:function:: PyObject* PyWrapper_New(PyObject *, PyObject *)
+
+
+.. c:struct:: wrapperbase
+
+   A structure defining the basic behavior of a descriptor wrapper.


### PR DESCRIPTION
This PR references the issue in gh-101100 of suppressing the c:identifier reference warning for 'wrapperbase' by marking it as a literal.

The following lines  were added at the end of descriptor.rst:

```
.. c:struct:: wrapperbase

   A structure defining the basic behavior of a descriptor wrapper.

```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140194.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->