### PR TITLE
gh-101525: configure: Add PIE detection logic for BOLT optimizations compatibility

### DIFF
--- a/configure
+++ b/configure
@@ -9138,10 +9138,71 @@ fi
   # These flags are required for bolt to work:
   LDFLAGS_NODIST="$LDFLAGS_NODIST -Wl,--emit-relocs"
 
-  # These flags are required to get good performance from bolt:
-  CFLAGS_NODIST="$CFLAGS_NODIST -fno-pie"
-  # We want to add these no-pie flags to linking executables but not shared libraries:
-  LINKCC="$LINKCC -fno-pie -no-pie"
+  # Detect if PIE is enabled
+  # Compile-time PIE: -fPIE in CFLAGS (defines __PIE__)
+  # Link-time PIE: -pie for link (no __PIE__ defined)
+  # We need to check CFLAGS and LDFLAGS.
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether PIE is enabled by default" >&5
+printf %s "checking whether PIE is enabled by default... " >&6; }
+
+  pie_enabled=no
+
+  # Check for compile-time PIE (-fPIE defines __PIE__/__pie__)
+  # Save original CFLAGS and temporarily add CFLAGS_NODIST to test
+  save_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS $CFLAGS_NODIST"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #if !defined(__PIE__) && !defined(__pie__)
+    #error PIE not enabled
+    #endif
+
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"
+then :
+  pie_enabled=yes
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+  CFLAGS="$save_CFLAGS"
+
+  # Check for link-time PIE (test if linker produces PIE by default)
+  if test "$pie_enabled" = "no"; then
+    save_LDFLAGS="$LDFLAGS"
+    LDFLAGS="$LDFLAGS $LDFLAGS_NODIST"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  if file conftest$EXEEXT 2>/dev/null | grep -q -E 'pie executable|shared object'; then
+         pie_enabled=yes
+       fi
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+    LDFLAGS="$save_LDFLAGS"
+  fi
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $pie_enabled" >&5
+printf "%s\n" "$pie_enabled" >&6; }
+
+  # Only add -fno-pie flags if PIE is not enabled by default.
+  # If PIE is enabled, these flags would conflict with the build system's PIE enforcement.
+  if test "$pie_enabled" = "no"; then
+    # These flags are required to get good performance from bolt:
+    CFLAGS_NODIST="$CFLAGS_NODIST -fno-pie"
+    # We want to add these no-pie flags to linking executables but not shared libraries:
+    LINKCC="$LINKCC -fno-pie -no-pie"
+  fi
 
   if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}llvm-bolt", so it can be a program name with args.
@@ -9398,6 +9459,11 @@ if test -z "${BOLT_COMMON_FLAGS}"
 then
   BOLT_COMMON_FLAGS=" -update-debug-sections -skip-funcs=_PyEval_EvalFrameDefault,sre_ucs1_match/1,sre_ucs2_match/1,sre_ucs4_match/1 "
 
+
+  # Add --relocs flag if PIE is enabled, as BOLT requires it for PIE binaries
+  if test "${pie_enabled:-no}" = "yes"; then
+    BOLT_COMMON_FLAGS="${BOLT_COMMON_FLAGS} --relocs"
+  fi
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -2116,10 +2116,49 @@ if test "$Py_BOLT" = 'true' ; then
   # These flags are required for bolt to work:
   LDFLAGS_NODIST="$LDFLAGS_NODIST -Wl,--emit-relocs"
 
-  # These flags are required to get good performance from bolt:
-  CFLAGS_NODIST="$CFLAGS_NODIST -fno-pie"
-  # We want to add these no-pie flags to linking executables but not shared libraries:
-  LINKCC="$LINKCC -fno-pie -no-pie"
+  # Detect if PIE is enabled
+  # Compile-time PIE: -fPIE in CFLAGS (defines __PIE__)
+  # Link-time PIE: -pie for link (no __PIE__ defined)
+  # We need to check CFLAGS and LDFLAGS.
+  AC_MSG_CHECKING([whether PIE is enabled by default])
+
+  pie_enabled=no
+
+  # Check for compile-time PIE (-fPIE defines __PIE__/__pie__)
+  # Save original CFLAGS and temporarily add CFLAGS_NODIST to test
+  save_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS $CFLAGS_NODIST"
+  AC_PREPROC_IFELSE([AC_LANG_SOURCE([[
+    #if !defined(__PIE__) && !defined(__pie__)
+    #error PIE not enabled
+    #endif
+  ]])],
+  [pie_enabled=yes],
+  [])
+  CFLAGS="$save_CFLAGS"
+
+  # Check for link-time PIE (test if linker produces PIE by default)
+  if test "$pie_enabled" = "no"; then
+    save_LDFLAGS="$LDFLAGS"
+    LDFLAGS="$LDFLAGS $LDFLAGS_NODIST"
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[]],[[]])],
+      [if file conftest$EXEEXT 2>/dev/null | grep -q -E 'pie executable|shared object'; then
+         pie_enabled=yes
+       fi],
+      [])
+    LDFLAGS="$save_LDFLAGS"
+  fi
+
+  AC_MSG_RESULT([$pie_enabled])
+
+  # Only add -fno-pie flags if PIE is not enabled by default.
+  # If PIE is enabled, these flags would conflict with the build system's PIE enforcement.
+  if test "$pie_enabled" = "no"; then
+    # These flags are required to get good performance from bolt:
+    CFLAGS_NODIST="$CFLAGS_NODIST -fno-pie"
+    # We want to add these no-pie flags to linking executables but not shared libraries:
+    LINKCC="$LINKCC -fno-pie -no-pie"
+  fi
   AC_SUBST([LLVM_BOLT])
   AC_PATH_TOOL([LLVM_BOLT], [llvm-bolt], [''], [${llvm_path}])
   if test -n "${LLVM_BOLT}" -a -x "${LLVM_BOLT}"
@@ -2165,6 +2204,11 @@ then
       [-skip-funcs=_PyEval_EvalFrameDefault,sre_ucs1_match/1,sre_ucs2_match/1,sre_ucs4_match/1]
     ")]
   )
+
+  # Add --relocs flag if PIE is enabled, as BOLT requires it for PIE binaries
+  if test "${pie_enabled:-no}" = "yes"; then
+    BOLT_COMMON_FLAGS="${BOLT_COMMON_FLAGS} --relocs"
+  fi
 fi
 
 AC_ARG_VAR(


### PR DESCRIPTION
BOLT requires the --relocs flag if a binary is built as PIE (Position Independent Executable).

Test if a build system enforces PIE during compilation, via the preprocessor macros, or via linkage via creating a test binary.

If so, -fno-pie and -no-pie flags will not be enforced when --enable-bolt is used and --relocs will be added to the BOLT flags.

This resolves the compilation failure when enabling BOLT optimizations in Fedora, where -pie is enforced during linkage and also hidden inside GCC specs.

Tested with both llvm and gcc, static and shared builds, lto combinations and -fPIE,-pie in CFLAGS, LDFLAGS.

Note: This change adds a dependency on `file` for unix when using --enable-bolt. I'm not aware of a better way to test for -pie in the linker flags when it's hidden behind GCC specs, unless I grep for the Fedora specific GCC specs, essentially the `-specs=/usr/lib/rpm/redhat/redhat-hardened-ld` linker flag. `file` is used in configure [here](https://github.com/python/cpython/blob/main/configure.ac#L509) for MacOS builds.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101525 -->
* Issue: gh-101525
<!-- /gh-issue-number -->
