### PR TITLE
gh-140210: Make test_sysconfig.test_parse_makefile_renamed_vars ignore environment variables

### DIFF
--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -20,7 +20,7 @@ from test.support import (
 )
 from test.support.import_helper import import_module
 from test.support.os_helper import (TESTFN, unlink, skip_unless_symlink,
-                                    change_cwd)
+                                    change_cwd, EnvironmentVarGuard)
 from test.support.venv import VirtualEnvironmentMixin
 
 import sysconfig
@@ -807,7 +807,9 @@ class MakefileTests(unittest.TestCase):
             print("PY_LDFLAGS=-lm", file=makefile)
             print("var2=$(LDFLAGS)", file=makefile)
             print("var3=$(CPPFLAGS)", file=makefile)
-        vars = _parse_makefile(TESTFN)
+        with EnvironmentVarGuard() as env:
+            env.clear()
+            vars = _parse_makefile(TESTFN)
         self.assertEqual(vars, {
             'var1': '-Wall',
             'CFLAGS': '-Wall',

--- a/Misc/NEWS.d/next/Tests/2025-10-16-15-08-58.gh-issue-140210.P9vUP8.rst
+++ b/Misc/NEWS.d/next/Tests/2025-10-16-15-08-58.gh-issue-140210.P9vUP8.rst
@@ -1,0 +1,2 @@
+Make ``test_sysconfig.test_parse_makefile_renamed_vars`` less fragile by
+clearing the environment variables before parsing the Makefile.


### PR DESCRIPTION
The test did not expect it could be run with e.g. CFLAGS set to a custom value.

Fixes https://github.com/python/cpython/issues/140210

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140210 -->
* Issue: gh-140210
<!-- /gh-issue-number -->
