### PR TITLE
gh-139707: Better `ModuleNotFoundError` message for missing stdlib modules

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -5049,6 +5049,16 @@ class MiscTest(unittest.TestCase):
                 b"add the site-packages directory to sys.path?"), stderr
         )
 
+    def test_missing_stdlib_package(self):
+        code = """
+            import sys
+            sys.stdlib_module_names |= {'spam'}
+            import spam
+        """
+        _, _, stderr = assert_python_failure('-S', '-c', code)
+
+        self.assertIn(b"Standard library module 'spam' was not found", stderr)
+
 
 class TestColorizedTraceback(unittest.TestCase):
     maxDiff = None

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -5034,7 +5034,8 @@ class MiscTest(unittest.TestCase):
 
         self.assertIn(
             (b"Site initialization is disabled, did you forget to "
-                b"add the site-packages directory to sys.path?"), stderr
+             b"add the site-packages directory to sys.path "
+             b"or to enable your virtual environment?"), stderr
         )
 
         code = """
@@ -5046,7 +5047,8 @@ class MiscTest(unittest.TestCase):
 
         self.assertNotIn(
             (b"Site initialization is disabled, did you forget to "
-                b"add the site-packages directory to sys.path?"), stderr
+             b"add the site-packages directory to sys.path "
+             b"or to enable your virtual environment?"), stderr
         )
 
     def test_missing_stdlib_package(self):

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1109,11 +1109,11 @@ class TracebackException:
                 self._str += f". Did you mean: '{suggestion}'?"
         elif exc_type and issubclass(exc_type, ModuleNotFoundError):
             module_name = getattr(exc_value, "name", None)
-            if sys.flags.no_site and module_name not in sys.stdlib_module_names:
+            if module_name in sys.stdlib_module_names:
+                self._str = f"Standard library module '{module_name}' was not found"
+            elif sys.flags.no_site:
                 self._str += (". Site initialization is disabled, did you forget to "
                     + "add the site-packages directory to sys.path?")
-            elif module_name in sys.stdlib_module_names:
-                self._str = f"Standard library module '{module_name}' was not found"
         elif exc_type and issubclass(exc_type, (NameError, AttributeError)) and \
                 getattr(exc_value, "name", None) is not None:
             wrong_name = getattr(exc_value, "name", None)

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1107,11 +1107,13 @@ class TracebackException:
             suggestion = _compute_suggestion_error(exc_value, exc_traceback, wrong_name)
             if suggestion:
                 self._str += f". Did you mean: '{suggestion}'?"
-        elif exc_type and issubclass(exc_type, ModuleNotFoundError) and \
-                sys.flags.no_site and \
-                getattr(exc_value, "name", None) not in sys.stdlib_module_names:
-            self._str += (". Site initialization is disabled, did you forget to "
-                + "add the site-packages directory to sys.path?")
+        elif exc_type and issubclass(exc_type, ModuleNotFoundError):
+            module_name = getattr(exc_value, "name", None)
+            if sys.flags.no_site and module_name not in sys.stdlib_module_names:
+                self._str += (". Site initialization is disabled, did you forget to "
+                    + "add the site-packages directory to sys.path?")
+            elif module_name in sys.stdlib_module_names:
+                self._str = f"Standard library module '{module_name}' was not found"
         elif exc_type and issubclass(exc_type, (NameError, AttributeError)) and \
                 getattr(exc_value, "name", None) is not None:
             wrong_name = getattr(exc_value, "name", None)

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1113,7 +1113,8 @@ class TracebackException:
                 self._str = f"Standard library module '{module_name}' was not found"
             elif sys.flags.no_site:
                 self._str += (". Site initialization is disabled, did you forget to "
-                    + "add the site-packages directory to sys.path?")
+                    + "add the site-packages directory to sys.path "
+                    + "or to enable your virtual environment?")
         elif exc_type and issubclass(exc_type, (NameError, AttributeError)) and \
                 getattr(exc_value, "name", None) is not None:
             wrong_name = getattr(exc_value, "name", None)

--- a/Misc/NEWS.d/next/Library/2025-10-16-16-10-11.gh-issue-139707.zR6Qtn.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-16-16-10-11.gh-issue-139707.zR6Qtn.rst
@@ -1,0 +1,2 @@
+Improve :exc:`ModuleNotFound` error message when a :term:`standard library`
+module is missing.

--- a/Misc/NEWS.d/next/Library/2025-10-16-16-10-11.gh-issue-139707.zR6Qtn.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-16-16-10-11.gh-issue-139707.zR6Qtn.rst
@@ -1,2 +1,2 @@
-Improve :exc:`ModuleNotFound` error message when a :term:`standard library`
+Improve :exc:`ModuleNotFoundError` error message when a :term:`standard library`
 module is missing.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139707 -->
* Issue: gh-139707
<!-- /gh-issue-number -->
