### PR TITLE
Add documentation for Python install manager's install_dir, global_dir and download_dir

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -460,8 +460,8 @@ customization.
    * - ``install_dir``
      - (none)
      - Specify the root directory that runtimes will be installed into.
-       Previously installed runtimes will not be usable unless moved to the new
-       location.
+       If you change this setting, previously installed runtimes will not be
+       usable unless you move them to the new location.
 
    * - ``global_dir``
      - (none)

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -457,6 +457,25 @@ customization.
      - Specify the default format used by the ``py list`` command.
        By default, ``table``.
 
+   * - ``install_dir``
+     - (none)
+     - Specify the root directory that runtimes will be installed into.
+       Previously installed runtimes will not be usable unless moved to the new
+       location.
+
+   * - ``global_dir``
+     - (none)
+     - Specify the directory where global commands (such as ``python3.14.exe``)
+       are stored.
+       This directory should be added to your :envvar:`PATH` to make the
+       commands available from your terminal.
+
+   * - ``download_dir``
+     - (none)
+     - Specify the directory where downloaded files are stored.
+       This directory is a temporary cache, and can be cleaned up from time to
+       time.
+
 Dotted names should be nested inside JSON objects, for example, ``list.format``
 would be specified as ``{"list": {"format": "table"}}``.
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140223.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->