### PR TITLE
gh-133059: Doc update of preallocated integer range in long.rst

### DIFF
--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -43,7 +43,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    .. impl-detail::
 
       CPython keeps an array of integer objects for all integers
-      between ``-5`` and ``256``.  When you create an int in that range
+      between ``-5`` and ``1024``.  When you create an int in that range
       you actually just get back a reference to the existing object.
 
 


### PR DESCRIPTION
_PY_NSMALLPOSINTS was updated in gh-133160
However, the corresponding documentation has not been amended.

<!-- gh-issue-number: gh-133059 -->
* Issue: gh-133059
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140231.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->