### PR TITLE
gh-140057: Allow daemon threads in subinterpreters

### DIFF
--- a/Lib/concurrent/interpreters/__init__.py
+++ b/Lib/concurrent/interpreters/__init__.py
@@ -62,7 +62,8 @@ class ExecutionFailed(InterpreterError):
 
 def create():
     """Return a new (idle) Python interpreter."""
-    id = _interpreters.create(reqrefs=True)
+    config = _interpreters.new_config('isolated', allow_daemon_threads=True)
+    id = _interpreters.create(config, reqrefs=True)
     return Interpreter(id, _ownsref=True)
 
 

--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -213,6 +213,18 @@ class ProcessPoolExecutorTest(ExecutorTest):
         for i, future in enumerate(futures):
             self.assertEqual(future.result(), mul(i, i))
 
+    def test_subinterpreter(self):
+        from concurrent import interpreters
+        import textwrap
+
+        interp = interpreters.create()
+        interp.exec(textwrap.dedent("""
+            import multiprocessing
+            pool = multiprocessing.Pool()
+            pool.close()
+        """))
+        interp.close()
+
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_python_finalization_error(self):
         # gh-109047: Catch RuntimeError on thread creation

--- a/Misc/NEWS.d/next/Library/2025-10-17-16-20-32.gh-issue-140057.Sb0H3r.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-17-16-20-32.gh-issue-140057.Sb0H3r.rst
@@ -1,0 +1,2 @@
+Subinterpreters are created with ``allow_daemon_threads=True``,
+allowing daemon threads in subinterpreters now.


### PR DESCRIPTION
Allow daemon threads when creating subinterpreters for process pool, as threads are allowed in subinterpreters after #128639.

<!-- gh-issue-number: gh-140057 -->
* Issue: gh-140057
<!-- /gh-issue-number -->
