### PR TITLE
gh-140241: Fix documentation for the registry parameter of warnings.warn_explicit()

### DIFF
--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -480,13 +480,18 @@ Available Functions
 .. function:: warn_explicit(message, category, filename, lineno, module=None, registry=None, module_globals=None, source=None)
 
    This is a low-level interface to the functionality of :func:`warn`, passing in
-   explicitly the message, category, filename and line number, and optionally the
-   module name and the registry (which should be the ``__warningregistry__``
-   dictionary of the module).  The module name defaults to the filename with
-   ``.py`` stripped; if no registry is passed, the warning is never suppressed.
+   explicitly the message, category, filename and line number, and optionally
+   other arguments.
    *message* must be a string and *category* a subclass of :exc:`Warning` or
    *message* may be a :exc:`Warning` instance, in which case *category* will be
    ignored.
+
+   *module*, if supplied, should be the module name.
+   If no module is passed, the filename with ``.py`` stripped is used.
+
+   *registry*, if supplied, should be the ``__warningregistry__`` dictionary
+   of the module.
+   If no registry is passed, each warning is treated as the first occurrence.
 
    *module_globals*, if supplied, should be the global namespace in use by the code
    for which the warning is issued.  (This argument is used to support displaying

--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -491,7 +491,9 @@ Available Functions
 
    *registry*, if supplied, should be the ``__warningregistry__`` dictionary
    of the module.
-   If no registry is passed, each warning is treated as the first occurrence.
+   If no registry is passed, each warning is treated as the first occurrence,
+   that is, filter actions ``"default"``, ``"module"`` and ``"once"`` are
+   handled as ``"always"``.
 
    *module_globals*, if supplied, should be the global namespace in use by the code
    for which the warning is issued.  (This argument is used to support displaying


### PR DESCRIPTION


<!-- gh-issue-number: gh-140241 -->
* Issue: gh-140241
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140242.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->