### PR TITLE
gh-84644: Don't single-dispatch on return types

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -935,7 +935,8 @@ def singledispatch(func):
         return (isinstance(cls, UnionType) and
                 all(isinstance(arg, type) for arg in cls.__args__))
 
-    def _get_type_hints(func):
+    def _get_func_type_hints(func):
+        """Called when type hints are needed to choose the first argument to dispatch on."""
         ann = getattr(func, '__annotate__', None)
         if ann is None:
             raise TypeError(
@@ -977,7 +978,7 @@ def singledispatch(func):
                     f"{cls!r} is not a class or union type."
                 )
             func = cls
-            type_hints = _get_type_hints(func)
+            type_hints = _get_func_type_hints(func)
 
             argname, cls = next(iter(type_hints.items()))
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3182,6 +3182,18 @@ class TestSingleDispatch(unittest.TestCase):
 
         with self.assertRaises(TypeError) as exc:
             @i.register
+            def _(arg) -> str:
+                return "I only have a return type annotation"
+        self.assertStartsWith(str(exc.exception), msg_prefix +
+            "<function TestSingleDispatch.test_invalid_registrations.<locals>._"
+        )
+        self.assertEndsWith(str(exc.exception),
+            ". Use either `@register(some_class)` or plain `@register` on "
+            "a function with annotated parameters."
+        )
+
+        with self.assertRaises(TypeError) as exc:
+            @i.register
             def _(arg: typing.Iterable[str]):
                 # At runtime, dispatching on generics is impossible.
                 # When registering implementations with singledispatch, avoid

--- a/Misc/NEWS.d/next/Library/2025-10-17-15-25-38.gh-issue-84644.eAEJXy.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-17-15-25-38.gh-issue-84644.eAEJXy.rst
@@ -1,0 +1,4 @@
+A :exc:`TypeError` is raised by :py:func:`functools.singledispatch`
+if it is attempted to register function that only annotates its return type.
+
+Contributed by Bartosz Sławecki in :gh:`84644`.


### PR DESCRIPTION
Prior art is https://github.com/python/cpython/pull/19871, but it widened its scope to also fix issue #130827 that hadn't yet been reported back then.

This PR does *not* fix issue #130827.
I'm specifically only trying to close the issue #84644.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-84644 -->
* Issue: gh-84644
<!-- /gh-issue-number -->
