### PR TITLE
gh-140263: Fix data race in test_lock_two_threads

### DIFF
--- a/Modules/_testinternalcapi/test_lock.c
+++ b/Modules/_testinternalcapi/test_lock.c
@@ -91,7 +91,8 @@ test_lock_two_threads(PyObject *self, PyObject *obj)
     } while (v != 3 && iters < 200);
 
     // both the "locked" and the "has parked" bits should be set
-    assert(test_data.m._bits == 3);
+    v = _Py_atomic_load_uint8_relaxed(&test_data.m._bits);
+    assert(v == 3);
 
     PyMutex_Unlock(&test_data.m);
     PyEvent_Wait(&test_data.done);


### PR DESCRIPTION
Clang-20 detects a data race between the unlock and the non-atomic read of the lock state. Use a relaxed load for the assertion to avoid the race.


<!-- gh-issue-number: gh-140263 -->
* Issue: gh-140263
<!-- /gh-issue-number -->
