### PR TITLE
gh-140271: Add <dpiAware> and  <dpiAwareness> in PC/python.manifest

### DIFF
--- a/Misc/NEWS.d/next/Windows/2025-10-21-16-41-14.gh-issue-140271.pnfY7G.rst
+++ b/Misc/NEWS.d/next/Windows/2025-10-21-16-41-14.gh-issue-140271.pnfY7G.rst
@@ -1,0 +1,1 @@
+Make `pylauncher` high DPI aware

--- a/PC/python.manifest
+++ b/PC/python.manifest
@@ -24,6 +24,8 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
     </windowsSettings>
   </application>
   <dependency>


### PR DESCRIPTION
From https://github.com/python/cpython/blob/main/PC/pylauncher.rc, it seem to be the only Windows-based graphical app that comes with the repo, so adjusting the `python.manifest` file will help.


<!-- gh-issue-number: gh-140271 -->
* Issue: gh-140271
<!-- /gh-issue-number -->
