### PR TITLE
GH-137959: fix warning 'visibility' attribute ignored in jit/trampoline.c

### DIFF
--- a/Tools/jit/trampoline.c
+++ b/Tools/jit/trampoline.c
@@ -10,7 +10,6 @@ _Py_CODEUNIT *
 _JIT_ENTRY(
     _PyExecutorObject *exec, _PyInterpreterFrame *frame, _PyStackRef *stack_pointer, PyThreadState *tstate
 ) {
-    typedef DECLARE_TARGET((*jit_func));
-    jit_func jitted = (jit_func)exec->jit_code;
+    jit_func_preserve_none jitted = (jit_func_preserve_none)exec->jit_code;
     return jitted(frame, stack_pointer, tstate);
 }


### PR DESCRIPTION
Since https://github.com/python/cpython/pull/137961 we're getting this warning
```
/home/runner/work/cpython/cpython/Tools/jit/trampoline.c:13:13: warning: 'visibility' attribute ignored [-Wignored-attributes]
   13 |     typedef DECLARE_TARGET((*jit_func));
      |             ^
/home/runner/work/cpython/cpython/Tools/jit/jit.h:11:49: note: expanded from macro 'DECLARE_TARGET'
   11 |     _Py_CODEUNIT *__attribute__((preserve_none, visibility("hidden"))) \
      |                                                 ^
1 warning generated.
```
for all platforms, e.g.
https://github.com/python/cpython/actions/runs/18575809544/job/52961278295?pr=140233
 except i686-pc-windows-msvc, where this warning has to be suppressed
 https://github.com/python/cpython/blob/f937468e7c88c768a28ff4e653da051ffa30d86c/Tools/jit/_targets.py#L583-L587
to silence the many warnings we'd get otherwise, because `preserve_none` is not supported there.

I suggest to use
https://github.com/python/cpython/blob/f937468e7c88c768a28ff4e653da051ffa30d86c/Tools/jit/jit.h#L1-L4

I've verified with a [small Godbolt demo](https://godbolt.org/z/G9vfz57Yq) and by comparing the `emit_trampoline` in the generated `jit_stencils.h` that the generated code remains the same.


<!-- gh-issue-number: gh-137959 -->
* Issue: gh-137959
<!-- /gh-issue-number -->
