### PR TITLE
gh-137568: Ignore startup file in `test_dumb_terminal_exits_cleanly`

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1407,7 +1407,7 @@ class TestDumbTerminal(ReplTestCase):
         env = os.environ.copy()
         env.pop('PYTHON_BASIC_REPL', None)
         # Ignore PYTHONSTARTUP to not pollute the output
-        # with an unrelated traceback. See #137568
+        # with an unrelated traceback. See GH-137568.
         env.pop('PYTHONSTARTUP', None)
         env.update({"TERM": "dumb"})
         output, exit_code = self.run_repl("exit()\n", env=env)

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1406,6 +1406,8 @@ class TestDumbTerminal(ReplTestCase):
     def test_dumb_terminal_exits_cleanly(self):
         env = os.environ.copy()
         env.pop('PYTHON_BASIC_REPL', None)
+        # Ignore PYTHONSTARTUP to not pollute the output
+        # with an unrelated traceback. See #137568
         env.pop('PYTHONSTARTUP', None)
         env.update({"TERM": "dumb"})
         output, exit_code = self.run_repl("exit()\n", env=env)

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1406,6 +1406,7 @@ class TestDumbTerminal(ReplTestCase):
     def test_dumb_terminal_exits_cleanly(self):
         env = os.environ.copy()
         env.pop('PYTHON_BASIC_REPL', None)
+        env.pop('PYTHONSTARTUP', None)
         env.update({"TERM": "dumb"})
         output, exit_code = self.run_repl("exit()\n", env=env)
         self.assertEqual(exit_code, 0)


### PR DESCRIPTION
The test examines tracebacks, but one can occur in a failing startup file and the test shouldn't fail just because of that.

CC @ZeroIntensity (mentorship): `skip news` here. We'll want to backport as well -- let's add `3.13` and `3.14` to the issue.

<!-- gh-issue-number: gh-137568 -->
* Issue: gh-137568
<!-- /gh-issue-number -->
