### PR TITLE
gh-140438: Properly run the asyncio REPL in REPL tests

### DIFF
--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -43,9 +43,9 @@ def spawn_repl(*args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, custom=F
     # default module search path.
     stdin_fname = os.path.join(os.path.dirname(sys.executable), "<stdin>")
     cmd_line = [stdin_fname, '-I']
+    # Don't re-run the built-in REPL from interactive mode
+    # if we're testing a custom REPL (such as the asyncio REPL).
     if not custom:
-        # Don't re-run the built-in REPL from interactive mode
-        # if we're testing a custom REPL (such as the asyncio REPL).
         cmd_line.append('-i')
     cmd_line.extend(args)
 

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -5,6 +5,7 @@ import select
 import subprocess
 import sys
 import unittest
+from functools import partial
 from textwrap import dedent
 from test import support
 from test.support import (
@@ -27,7 +28,7 @@ if not has_subprocess_support:
     raise unittest.SkipTest("test module requires subprocess")
 
 
-def spawn_repl(*args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kw):
+def spawn_repl(*args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, custom=False, **kw):
     """Run the Python REPL with the given arguments.
 
     kw is extra keyword args to pass to subprocess.Popen. Returns a Popen
@@ -41,7 +42,11 @@ def spawn_repl(*args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kw):
     # path may be used by PyConfig_Get("module_search_paths") to build the
     # default module search path.
     stdin_fname = os.path.join(os.path.dirname(sys.executable), "<stdin>")
-    cmd_line = [stdin_fname, '-I', '-i']
+    cmd_line = [stdin_fname, '-I']
+    if not custom:
+        # Don't re-run the built-in REPL from interactive mode
+        # if we're testing a custom REPL (such as the asyncio REPL).
+        cmd_line.append('-i')
     cmd_line.extend(args)
 
     # Set TERM=vt100, for the rationale see the comments in spawn_python() of
@@ -54,6 +59,10 @@ def spawn_repl(*args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kw):
                             stdin=subprocess.PIPE,
                             stdout=stdout, stderr=stderr,
                             **kw)
+
+
+spawn_asyncio_repl = partial(spawn_repl, "-m", "asyncio", custom=True)
+
 
 def run_on_interactive_mode(source):
     """Spawn a new Python interpreter, pass the given
@@ -359,7 +368,7 @@ class TestInteractiveModeSyntaxErrors(unittest.TestCase):
 class TestAsyncioREPL(unittest.TestCase):
     def test_multiple_statements_fail_early(self):
         user_input = "1 / 0; print(f'afterwards: {1+1}')"
-        p = spawn_repl("-m", "asyncio")
+        p = spawn_asyncio_repl()
         p.stdin.write(user_input)
         output = kill_python(p)
         self.assertIn("ZeroDivisionError", output)
@@ -371,7 +380,7 @@ class TestAsyncioREPL(unittest.TestCase):
         var = ContextVar("var", default="failed")
         var.set("ok")
         """)
-        p = spawn_repl("-m", "asyncio")
+        p = spawn_asyncio_repl()
         p.stdin.write(user_input)
         user_input2 = dedent("""
         print(f"toplevel contextvar test: {var.get()}")
@@ -387,7 +396,7 @@ class TestAsyncioREPL(unittest.TestCase):
         from contextvars import ContextVar
         var = ContextVar('var', default='failed')
         """)
-        p = spawn_repl("-m", "asyncio")
+        p = spawn_asyncio_repl()
         p.stdin.write(user_input)
         user_input2 = "async def set_var(): var.set('ok')\n"
         p.stdin.write(user_input2)


### PR DESCRIPTION
Mixing `-i` with `-m asyncio` first spawns the asyncio REPL. After asyncio REPL exits, it spawns the regular Python REPL.

Here we're introducing more idiomatic way to test other custom REPLs in `test_repl` as necessary, without needing a pseudo-terminal.

CC @ZeroIntensity (mentorship): `skip issue`, `skip news`, `needs backport to 3.13`, `needs backport to 3.14`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140438 -->
* Issue: gh-140438
<!-- /gh-issue-number -->
