### PR TITLE
gh-76007: Deprecate `__version__` attribute in `decimal`

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.20.rst
+++ b/Doc/deprecations/pending-removal-in-3.20.rst
@@ -8,7 +8,7 @@ Pending removal in Python 3.20
   - :mod:`argparse`
   - :mod:`csv`
   - :mod:`!ctypes.macholib`
-  - :mod:`decimal` (Use :data:`decimal.SPEC_VERSION` instead)
+  - :mod:`decimal` (use :data:`decimal.SPEC_VERSION` instead)
   - :mod:`imaplib`
   - :mod:`ipaddress`
   - :mod:`json`

--- a/Doc/deprecations/pending-removal-in-3.20.rst
+++ b/Doc/deprecations/pending-removal-in-3.20.rst
@@ -8,6 +8,7 @@ Pending removal in Python 3.20
   - :mod:`argparse`
   - :mod:`csv`
   - :mod:`!ctypes.macholib`
+  - :mod:`decimal` (Use :data:`decimal.SPEC_VERSION` instead)
   - :mod:`ipaddress`
   - :mod:`json`
   - :mod:`logging` (``__date__`` also deprecated)

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -1601,6 +1601,14 @@ are also included in the pure Python version for compatibility.
 
    .. versionadded:: 3.8.3
 
+.. data:: SPEC_VERSION
+
+   The highest version of the General Decimal Arithmetic
+   Specification that this implementation complies with.
+   See https://speleotrove.com/decimal/ for the specification.
+
+   .. versionadded:: next
+
 
 Rounding modes
 --------------

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -1569,7 +1569,16 @@ In addition to the three supplied contexts, new contexts can be created with the
 Constants
 ---------
 
-The constants in this section are only relevant for the C module. They
+.. data:: SPEC_VERSION
+
+   The highest version of the General Decimal Arithmetic
+   Specification that this implementation complies with.
+   See https://speleotrove.com/decimal/decarith.html for the specification.
+
+   .. versionadded:: next
+
+
+The following constants are only relevant for the C module. They
 are also included in the pure Python version for compatibility.
 
 +---------------------------------+---------------------+-------------------------------+
@@ -1600,14 +1609,6 @@ are also included in the pure Python version for compatibility.
    is ``False``.  This is slightly faster in some nested context scenarios.
 
    .. versionadded:: 3.8.3
-
-.. data:: SPEC_VERSION
-
-   The highest version of the General Decimal Arithmetic
-   Specification that this implementation complies with.
-   See https://speleotrove.com/decimal/decarith.html for the specification.
-
-   .. versionadded:: next
 
 
 Rounding modes

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -1605,7 +1605,7 @@ are also included in the pure Python version for compatibility.
 
    The highest version of the General Decimal Arithmetic
    Specification that this implementation complies with.
-   See https://speleotrove.com/decimal/ for the specification.
+   See https://speleotrove.com/decimal/decarith.html for the specification.
 
    .. versionadded:: next
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -825,6 +825,7 @@ New deprecations
     - :mod:`argparse`
     - :mod:`csv`
     - :mod:`!ctypes.macholib`
+    - :mod:`decimal` (Use :data:`decimal.SPEC_VERSION` instead)
     - :mod:`ipaddress`
     - :mod:`json`
     - :mod:`logging` (``__date__`` also deprecated)

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -825,7 +825,7 @@ New deprecations
     - :mod:`argparse`
     - :mod:`csv`
     - :mod:`!ctypes.macholib`
-    - :mod:`decimal` (Use :data:`decimal.SPEC_VERSION` instead)
+    - :mod:`decimal` (use :data:`decimal.SPEC_VERSION` instead)
     - :mod:`imaplib`
     - :mod:`ipaddress`
     - :mod:`json`

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -50,7 +50,7 @@ __all__ = [
     'HAVE_CONTEXTVAR',
 
     # Highest version of the spec this module complies with
-    'SPEC_VERSION'
+    'SPEC_VERSION',
 ]
 
 __xname__ = __name__    # sys.modules lookup (--without-threads)

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -6402,3 +6402,11 @@ _PyHASH_NAN = sys.hash_info.nan
 # _PyHASH_10INV is the inverse of 10 modulo the prime _PyHASH_MODULUS
 _PyHASH_10INV = pow(10, _PyHASH_MODULUS - 2, _PyHASH_MODULUS)
 del sys
+
+def __getattr__(name):
+    if name == "__version__":
+        from warnings import _deprecated
+
+        _deprecated("__version__", remove=(3, 20))
+        return "1.70"  # Do not change
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -47,13 +47,16 @@ __all__ = [
     'HAVE_THREADS',
 
     # C version: compile time choice that enables the coroutine local context
-    'HAVE_CONTEXTVAR'
+    'HAVE_CONTEXTVAR',
+
+    # Highest version of the spec this module complies with
+    'SPEC_VERSION'
 ]
 
 __xname__ = __name__    # sys.modules lookup (--without-threads)
 __name__ = 'decimal'    # For pickling
-__version__ = '1.70'    # Highest version of the spec this complies with
-                        # See http://speleotrove.com/decimal/
+SPEC_VERSION = '1.70'   # Highest version of the spec this complies with
+                        # See https://speleotrove.com/decimal/
 __libmpdec_version__ = "2.4.2" # compatible libmpdec version
 
 import math as _math

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -56,7 +56,7 @@ __all__ = [
 __xname__ = __name__    # sys.modules lookup (--without-threads)
 __name__ = 'decimal'    # For pickling
 SPEC_VERSION = '1.70'   # Highest version of the spec this complies with
-                        # See https://speleotrove.com/decimal/
+                        # See https://speleotrove.com/decimal/decarith.html
 __libmpdec_version__ = "2.4.2" # compatible libmpdec version
 
 import math as _math
@@ -6408,5 +6408,5 @@ def __getattr__(name):
         from warnings import _deprecated
 
         _deprecated("__version__", remove=(3, 20))
-        return "1.70"  # Do not change
+        return SPEC_VERSION
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/decimal.py
+++ b/Lib/decimal.py
@@ -100,10 +100,17 @@ NaN
 
 try:
     from _decimal import *
-    from _decimal import __version__  # noqa: F401
     from _decimal import __libmpdec_version__  # noqa: F401
 except ImportError:
     import _pydecimal
     import sys
     _pydecimal.__doc__ = __doc__
     sys.modules[__name__] = _pydecimal
+
+def __getattr__(name):
+    if name == "__version__":
+        from warnings import _deprecated
+
+        _deprecated("__version__", remove=(3, 20))
+        return "1.70"  # Do not change
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/decimal.py
+++ b/Lib/decimal.py
@@ -97,6 +97,7 @@ NaN
 1
 >>>
 """
+
 try:
     from _decimal import *
     from _decimal import __libmpdec_version__  # noqa: F401

--- a/Lib/decimal.py
+++ b/Lib/decimal.py
@@ -97,20 +97,12 @@ NaN
 1
 >>>
 """
-
 try:
     from _decimal import *
     from _decimal import __libmpdec_version__  # noqa: F401
+    from _decimal import __getattr__  # noqa: F401
 except ImportError:
     import _pydecimal
     import sys
     _pydecimal.__doc__ = __doc__
     sys.modules[__name__] = _pydecimal
-
-def __getattr__(name):
-    if name == "__version__":
-        from warnings import _deprecated
-
-        _deprecated("__version__", remove=(3, 20))
-        return "1.70"  # Do not change
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -4474,7 +4474,7 @@ class CheckAttributes(unittest.TestCase):
         self.assertTrue(C.HAVE_THREADS is True or C.HAVE_THREADS is False)
         self.assertTrue(P.HAVE_THREADS is True or P.HAVE_THREADS is False)
 
-        self.assertEqual(C.__version__, P.__version__)
+        self.assertEqual(C.SPEC_VERSION, P.SPEC_VERSION)
 
         self.assertLessEqual(set(dir(C)), set(dir(P)))
         self.assertEqual([n for n in dir(C) if n[:2] != '__'], sorted(P.__all__))

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -5929,6 +5929,23 @@ class SignatureTest(unittest.TestCase):
         doit('Context')
 
 
+class TestModule:
+    def test_deprecated__version__(self):
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            "'__version__' is deprecated and slated for removal in Python 3.20",
+        ) as cm:
+            getattr(self.decimal, "__version__")
+        self.assertEqual(cm.filename, __file__)
+
+
+@requires_cdecimal
+class CTestModule(TestModule, unittest.TestCase):
+    decimal = C
+class PyTestModule(TestModule, unittest.TestCase):
+    decimal = P
+
+
 def load_tests(loader, tests, pattern):
     if TODO_TESTS is not None:
         # Run only Arithmetic tests

--- a/Misc/NEWS.d/next/Library/2025-10-18-15-20-25.gh-issue-76007.SNUzRq.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-18-15-20-25.gh-issue-76007.SNUzRq.rst
@@ -1,0 +1,2 @@
+:mod:`decimal`: Deprecate ``__version__`` and replace with
+:data:`decimal.SPEC_VERSION`.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -7580,7 +7580,7 @@ decimal_getattr(PyObject *self, PyObject *args)
                          1) < 0) {
             return NULL;
         }
-        return PyUnicode_FromString("1.7");
+        return PyUnicode_FromString("1.70");
     }
 
     PyErr_Format(PyExc_AttributeError, "module 'decimal' has no attribute %R", name);

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -58,6 +58,8 @@
 
 #include "clinic/_decimal.c.h"
 
+#define MPD_SPEC_VERSION "1.70"
+
 /*[clinic input]
 module _decimal
 class _decimal.Decimal "PyObject *" "&dec_spec"
@@ -7580,7 +7582,7 @@ decimal_getattr(PyObject *self, PyObject *args)
                          1) < 0) {
             return NULL;
         }
-        return PyUnicode_FromString("1.70");
+        return PyUnicode_FromString(MPD_SPEC_VERSION);
     }
 
     PyErr_Format(PyExc_AttributeError, "module 'decimal' has no attribute %R", name);
@@ -7914,7 +7916,7 @@ _decimal_exec(PyObject *m)
     }
 
     /* Add specification version number */
-    CHECK_INT(PyModule_AddStringConstant(m, "SPEC_VERSION", "1.70"));
+    CHECK_INT(PyModule_AddStringConstant(m, "SPEC_VERSION", MPD_SPEC_VERSION));
     CHECK_INT(PyModule_AddStringConstant(m, "__libmpdec_version__", mpd_version()));
 
     return 0;

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -7566,12 +7566,35 @@ static PyType_Spec context_spec = {
 };
 
 
+static PyObject *
+decimal_getattr(PyObject *self, PyObject *args)
+{
+    PyObject *name;
+    if (!PyArg_UnpackTuple(args, "__getattr__", 1, 1, &name)) {
+        return NULL;
+    }
+
+    if (PyUnicode_Check(name) && PyUnicode_EqualToUTF8(name, "__version__")) {
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "'__version__' is deprecated and slated for removal in Python 3.20",
+                         1) < 0) {
+            return NULL;
+        }
+        return PyUnicode_FromString("1.7");
+    }
+
+    PyErr_Format(PyExc_AttributeError, "module 'decimal' has no attribute %R", name);
+    return NULL;
+}
+
+
 static PyMethodDef _decimal_methods [] =
 {
   _DECIMAL_GETCONTEXT_METHODDEF
   _DECIMAL_SETCONTEXT_METHODDEF
   _DECIMAL_LOCALCONTEXT_METHODDEF
   _DECIMAL_IEEECONTEXT_METHODDEF
+  {"__getattr__", decimal_getattr, METH_VARARGS, "Module __getattr__"},
   { NULL, NULL, 1, NULL }
 };
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -58,7 +58,8 @@
 
 #include "clinic/_decimal.c.h"
 
-#define MPD_SPEC_VERSION "1.70"
+#define MPD_SPEC_VERSION "1.70"  // Highest version of the spec this complies with
+                                 // See https://speleotrove.com/decimal/decarith.html
 
 /*[clinic input]
 module _decimal

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -7891,7 +7891,7 @@ _decimal_exec(PyObject *m)
     }
 
     /* Add specification version number */
-    CHECK_INT(PyModule_AddStringConstant(m, "__version__", "1.70"));
+    CHECK_INT(PyModule_AddStringConstant(m, "SPEC_VERSION", "1.70"));
     CHECK_INT(PyModule_AddStringConstant(m, "__libmpdec_version__", mpd_version()));
 
     return 0;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
[Per discussion](https://github.com/python/cpython/issues/76007#issuecomment-3272464473) in the issue, provide a `SPEC_VERSION` constant instead. CC @merwok @smontanaro 

<!-- gh-issue-number: gh-76007 -->
* Issue: gh-76007
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140302.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->