### PR TITLE
gh-139951: Test on GC collection disabled if threshold is zero

### DIFF
--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1559,6 +1559,20 @@ class GCTogglingTests(unittest.TestCase):
         finally:
             gc.enable()
 
+    # Ensure that setting *threshold0* to zero disables collection.
+    @gc_threshold(0, 0, 0)
+    def test_threshold_zero(self):
+        junk = []
+        i = 0
+        detector = GC_Detector()
+        while not detector.gc_happened:
+            i += 1
+            if i > 50000:
+                break
+            junk.append([])  # this may eventually trigger gc (if it is enabled)
+
+        self.assertEqual(i, 50001)
+
 
 class PythonFinalizationTests(unittest.TestCase):
     def test_ast_fini(self):

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1560,7 +1560,7 @@ class GCTogglingTests(unittest.TestCase):
             gc.enable()
 
     # Ensure that setting *threshold0* to zero disables collection.
-    @gc_threshold(0, 0, 0)
+    @gc_threshold(0)
     def test_threshold_zero(self):
         junk = []
         i = 0


### PR DESCRIPTION
This PR just adds small test.
I've noticed that there's no such test because CI is green for this PR:
https://github.com/python/cpython/pull/140262, but it has such a flaw.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139951 -->
* Issue: gh-139951
<!-- /gh-issue-number -->
