### PR TITLE
Simplify timedelta.total_seconds implementation

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -784,8 +784,7 @@ class timedelta:
 
     def total_seconds(self):
         """Total seconds in the duration."""
-        return ((self.days * 86400 + self.seconds) * 10**6 +
-                self.microseconds) / 10**6
+        return self.days * 86400 + self.seconds + self.microseconds / 1000000
 
     # Read-only field accessors
     @property


### PR DESCRIPTION
Simplify timedelta.total_seconds implementation:
- slightly improved readability,
- slightly improved consistency (in every other place in this file, 1000000 is used instead of 10**6),
- slightly improved performance (see graphs) for `timedelta > 1 ms`.

Graphs show new implementation is faster for `timedelta > ~250 μs`, however for Python3.15+ it's probably `timedelta > ~1000 μs` since _PY_NSMALLPOSINTS was increased in gh-133059.

I assume it's a trivial change, so I haven't created an issue.
![timedelta_benchmark_50000_100_aarch64](https://github.com/user-attachments/assets/4c8b4771-9a5f-48bb-b0e7-3c0bab827e60)

<img width="4164" height="2349" alt="timedelta_benchmark_50000_100_x86_64" src="https://github.com/user-attachments/assets/f7088ac1-4d3a-4e66-96b2-216adfa2a83e" />
