### PR TITLE
Correct Glossary key function example to use str.casefold instead of str.lower

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -813,7 +813,7 @@ Glossary
       :func:`itertools.groupby`.
 
       There are several ways to create a key function.  For example. the
-      :meth:`str.lower` method can serve as a key function for case insensitive
+      :meth:`str.casefold` method can serve as a key function for case insensitive
       sorts.  Alternatively, a key function can be built from a
       :keyword:`lambda` expression such as ``lambda r: (r[0], r[2])``.  Also,
       :func:`operator.attrgetter`, :func:`operator.itemgetter`, and


### PR DESCRIPTION
The glossary currently states:

“the `str.lower()` method can serve as a key function for case-insensitive sorts.”

I believe this should be updated to use `str.casefold()` instead. `str.casefold()` is recommended for case-insensitive matching in Unicode, and it provides more accurate behavior across languages than `str.lower()`. This also aligns with the "Sorting Techniques" section of the docs, which uses `str.casefold()` as the key function for case-insensitive sorting.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140316.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->