### PR TITLE
gh-140326: disable the relative import in asyncio REPL

### DIFF
--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -191,9 +191,9 @@ if __name__ == '__main__':
     asyncio.set_event_loop(loop)
 
     repl_locals = {'asyncio': asyncio}
-    for key in {'__name__', '__package__',
-                '__loader__', '__spec__',
-                '__builtins__', '__file__'}:
+    for key in {'__name__',
+                '__loader__',
+                '__builtins__'}:
         repl_locals[key] = locals()[key]
 
     console = AsyncIOInteractiveConsole(repl_locals, loop)

--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -213,9 +213,9 @@ if __name__ == '__main__':
     asyncio.set_event_loop(loop)
 
     repl_locals = {'asyncio': asyncio}
-    for key in {'__name__', '__package__',
-                '__loader__', '__spec__',
-                '__builtins__', '__file__'}:
+    for key in {'__name__',
+                '__loader__',
+                '__builtins__'}:
         repl_locals[key] = locals()[key]
 
     console = AsyncIOInteractiveConsole(repl_locals, loop)

--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -212,11 +212,14 @@ if __name__ == '__main__':
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
-    repl_locals = {'asyncio': asyncio}
-    for key in {'__name__',
-                '__loader__',
-                '__builtins__'}:
-        repl_locals[key] = locals()[key]
+    repl_locals = {
+        'asyncio': asyncio,
+        '__name__': __name__,
+        '__package__': None,
+        '__loader__': __loader__,
+        '__spec__': None,
+        '__builtins__': __builtins__,
+    }
 
     console = AsyncIOInteractiveConsole(repl_locals, loop)
 

--- a/Misc/NEWS.d/next/Library/2025-10-19-17-34-07.gh-issue-140326.kZM0pV.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-19-17-34-07.gh-issue-140326.kZM0pV.rst
@@ -1,0 +1,1 @@
+Disable relative import in asyncio repl

--- a/Misc/NEWS.d/next/Library/2025-10-19-17-34-07.gh-issue-140326.kZM0pV.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-19-17-34-07.gh-issue-140326.kZM0pV.rst
@@ -1,1 +1,3 @@
-Disable relative import in asyncio repl
+Fix the :mod:`asyncio` REPL namespace so that relative imports no longer
+resolve against the :mod:`asyncio` package and ``__file__`` is no longer
+set.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Now it only remove some name in locals to disable the relative import in REPL. To change the loader may be too hard.


<!-- gh-issue-number: gh-140326 -->
* Issue: gh-140326
<!-- /gh-issue-number -->
