### PR TITLE
gh-140334: Fix IDLE syntax highlighting after line continuations

### DIFF
--- a/Lib/idlelib/colorizer.py
+++ b/Lib/idlelib/colorizer.py
@@ -17,6 +17,7 @@ def any(name, alternates):
 def make_pat():
     kw = r"\b" + any("KEYWORD", keyword.kwlist) + r"\b"
     match_softkw = (
+        r"(?<!\\\n)" +  # last line doesn't end in slash
         r"^[ \t]*" +  # at beginning of line + possible indentation
         r"(?P<MATCH_SOFTKW>match)\b" +
         r"(?![ \t]*(?:" + "|".join([  # not followed by ...
@@ -27,11 +28,13 @@ def make_pat():
         r"))"
     )
     case_default = (
+        r"(?<!\\\n)" +  # last line doesn't end in slash
         r"^[ \t]*" +  # at beginning of line + possible indentation
         r"(?P<CASE_SOFTKW>case)" +
         r"[ \t]+(?P<CASE_DEFAULT_UNDERSCORE>_\b)"
     )
     case_softkw_and_pattern = (
+        r"(?<!\\\n)" +  # last line doesn't end in slash
         r"^[ \t]*" +  # at beginning of line + possible indentation
         r"(?P<CASE_SOFTKW2>case)\b" +
         r"(?![ \t]*(?:" + "|".join([  # not followed by ...
@@ -45,7 +48,30 @@ def make_pat():
     builtinlist = [str(name) for name in dir(builtins)
                    if not name.startswith('_') and
                    name not in keyword.kwlist]
-    builtin = r"([^.'\"\\#]\b|^)" + any("BUILTIN", builtinlist) + r"\b"
+    builtin = (
+        r"(?<!" +  # make sure there isn't
+            r"\\\n" +  # a slash followed by a newline
+        r")" +
+        r"(?<!" +  # make sure that there also isn't
+            r"|".join([
+                r"\.",  # a dot or
+                r" ",   # a space
+            ]) +
+        r")" +
+        r"(" +  # match any number of
+            r"[ \t]*" +     # spaces/tabs followed by
+            r"(\\\\)*\\" +  # an odd number of slashes followed by
+            r"\n" +         # a newline
+        r")*" +
+        r"(" +  # also match
+            r"|".join([  # either
+                r"[ \t]+",  # indentation or
+                r"\b",      # a word boundary
+            ]) +
+        r")" +
+        any("BUILTIN", builtinlist) +  # followed by a builtin
+        r"\b"  # followed by another word boundary
+    )
     comment = any("COMMENT", [r"#[^\n]*"])
     stringprefix = r"(?i:r|u|f|fr|rf|b|br|rb|t|rt|tr)?"
     sqstring = stringprefix + r"'[^'\\\n]*(\\.[^'\\\n]*)*'?"
@@ -53,11 +79,12 @@ def make_pat():
     sq3string = stringprefix + r"'''[^'\\]*((\\.|'(?!''))[^'\\]*)*(''')?"
     dq3string = stringprefix + r'"""[^"\\]*((\\.|"(?!""))[^"\\]*)*(""")?'
     string = any("STRING", [sq3string, dq3string, sqstring, dqstring])
+    sync = any("SYNC", [r"(?<!\\)\n"])  #  no sync if line ends with slash
     prog = re.compile("|".join([
                                 builtin, comment, string, kw,
                                 match_softkw, case_default,
                                 case_softkw_and_pattern,
-                                any("SYNC", [r"\n"]),
+                                sync,
                                ]),
                       re.DOTALL | re.MULTILINE)
     return prog

--- a/Lib/idlelib/colorizer.py
+++ b/Lib/idlelib/colorizer.py
@@ -21,8 +21,8 @@ def make_pat():
         r"^[ \t]*" +  # at beginning of line + possible indentation
         r"(?P<MATCH_SOFTKW>match)\b" +
         r"(?![ \t]*(?:" + "|".join([  # not followed by ...
-            r"[:,;=^&|@~)\]}]",  # a character which means it can't be a
-                                 # pattern-matching statement
+            r"[.:,;=^&|@~)\]}]",  # a character which means it can't be a
+                                  # pattern-matching statement
             r"\b(?:" + r"|".join(keyword.kwlist) + r")\b",  # a keyword
         ]) +
         r"))"
@@ -39,8 +39,8 @@ def make_pat():
         r"(?P<CASE_SOFTKW2>case)\b" +
         r"(?![ \t]*(?:" + "|".join([  # not followed by ...
             r"_\b",  # a lone underscore
-            r"[:,;=^&|@~)\]}]",  # a character which means it can't be a
-                                 # pattern-matching case
+            r"[.:,;=^&|@~)\]}]",  # a character which means it can't be a
+                                  # pattern-matching case
             r"\b(?:" + r"|".join(keyword.kwlist) + r")\b",  # a keyword
         ]) +
         r"))"

--- a/Lib/idlelib/idle_test/test_colorizer.py
+++ b/Lib/idlelib/idle_test/test_colorizer.py
@@ -52,6 +52,12 @@ source = textwrap.dedent("""\
     '''
     case _:'''
     "match x:"
+    self. \\
+        set
+    f(self, \\
+        set())
+    x = match if match else \\
+            match
     """)
 
 
@@ -404,6 +410,7 @@ class ColorDelegatorTest(unittest.TestCase):
                     ('28.25', ('STRING',)), ('28.38', ('STRING',)),
                     ('30.0', ('STRING',)),
                     ('31.1', ('STRING',)),
+                    ('33.4', ()), ('35.4', ("BUILTIN",)), ('37.8', ()),
                     # SYNC at the end of every line.
                     ('1.55', ('SYNC',)), ('2.50', ('SYNC',)), ('3.34', ('SYNC',)),
                    )
@@ -434,7 +441,11 @@ class ColorDelegatorTest(unittest.TestCase):
         eq(text.tag_nextrange('STRING', '8.12'), ('8.14', '8.17'))
         eq(text.tag_nextrange('STRING', '8.17'), ('8.19', '8.26'))
         eq(text.tag_nextrange('SYNC', '8.0'), ('8.26', '9.0'))
-        eq(text.tag_nextrange('SYNC', '31.0'), ('31.10', '33.0'))
+        eq(text.tag_nextrange('SYNC', '31.0'), ('31.10', '32.0'))
+        eq(text.tag_nextrange('SYNC', '32.0'), ('33.7', '34.0'))
+        eq(text.tag_nextrange('SYNC', '34.0'), ('35.10', '36.0'))
+        eq(text.tag_nextrange('SYNC', '36.0'), ('37.13', '39.0'))
+        eq(text.tag_nextrange('SYNC', '39.0'), ())
 
     def _assert_highlighting(self, source, tag_ranges):
         """Check highlighting of a given piece of code.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1942,6 +1942,7 @@ John Tromp
 Diane Trout
 Jason Trowbridge
 Steven Troxler
+Daniel Tsvetkov
 Brent Tubbs
 Anthony Tuininga
 Erno Tukia

--- a/Misc/NEWS.d/next/IDLE/2025-10-19-18-43-07.gh-issue-140334.3mdyHm.rst
+++ b/Misc/NEWS.d/next/IDLE/2025-10-19-18-43-07.gh-issue-140334.3mdyHm.rst
@@ -1,0 +1,2 @@
+Fixed syntax highlighting in IDLE where slashes at the end of lines aren't
+treated as line continuations

--- a/Misc/NEWS.d/next/IDLE/2025-10-19-18-43-07.gh-issue-140334.3mdyHm.rst
+++ b/Misc/NEWS.d/next/IDLE/2025-10-19-18-43-07.gh-issue-140334.3mdyHm.rst
@@ -1,2 +1,2 @@
-Fixed syntax highlighting in IDLE where slashes at the end of lines aren't
-treated as line continuations
+Fixed syntax highlighting in :mod:`IDLE <idlelib>` where slashes at the end of lines aren't
+treated as line continuations.


### PR DESCRIPTION
### Description
This PR fixes incorrect syntax highlighting in IDLE when a line ends with a backslash (`\`) used for line continuation.

### Previously
Identifiers following a backslash were sometimes misinterpreted as keywords or built-ins instead of variables or attributes.  
For example in:
```python
x = match if match else \
    match
```
The last `match` was coloured like a keyword instead of a variable.

### Summary of changes
* Updated IDLE's syntax highlighting to properly treat backslash line continuations
* Added tests for cases involving identifiers following a line continuation backslash

Fixes gh-140334