### PR TITLE
Fix typo in PyIter_Send docs

### DIFF
--- a/Doc/c-api/iter.rst
+++ b/Doc/c-api/iter.rst
@@ -54,6 +54,6 @@ There are two functions specifically for working with iterators.
 
    - ``PYGEN_RETURN`` if iterator returns. Return value is returned via *presult*.
    - ``PYGEN_NEXT`` if iterator yields. Yielded value is returned via *presult*.
-   - ``PYGEN_ERROR`` if iterator has raised and exception. *presult* is set to ``NULL``.
+   - ``PYGEN_ERROR`` if iterator has raised an exception. *presult* is set to ``NULL``.
 
    .. versionadded:: 3.10


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140336.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->