### PR TITLE
Lib: re-word or remove outdated comments.

### DIFF
--- a/Lib/codecs.py
+++ b/Lib/codecs.py
@@ -83,12 +83,11 @@ BOM64_BE = BOM_UTF32_BE
 class CodecInfo(tuple):
     """Codec details when looking up the codec registry"""
 
-    # Private API to allow Python 3.4 to denylist the known non-Unicode
-    # codecs in the standard library. A more general mechanism to
-    # reliably distinguish test encodings from other codecs will hopefully
-    # be defined for Python 3.5
+    # Private API to allow Python to denylist the known non-Unicode
+    # codecs in the standard library.
     #
-    # See http://bugs.python.org/issue19619
+    # TODO: A more general mechanism to reliably distinguish text encodings
+    # from other codecs. See https://github.com/python/cpython/issues/63818
     _is_text_encoding = True # Assume codecs are text encodings by default
 
     def __new__(cls, encode, decode, streamreader=None, streamwriter=None,

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1446,9 +1446,6 @@ class QueueHandler(logging.Handler):
     with a multiprocessing Queue to centralise logging to file in one process
     (in a multi-process application), so as to avoid file write contention
     between processes.
-
-    This code is new in Python 3.2, but this class can be copy pasted into
-    user code for use with earlier Python versions.
     """
 
     def __init__(self, queue):

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -409,14 +409,6 @@ def collect_readline(info_add):
     copy_attributes(info_add, readline, 'readline.%s', attributes,
                     formatter=format_attr)
 
-    if not hasattr(readline, "_READLINE_LIBRARY_VERSION"):
-        # _READLINE_LIBRARY_VERSION has been added to CPython 3.7
-        doc = getattr(readline, '__doc__', '')
-        if 'libedit readline' in doc:
-            info_add('readline.library', 'libedit readline')
-        elif 'GNU readline' in doc:
-            info_add('readline.library', 'GNU readline')
-
 
 def collect_gdb(info_add):
     import subprocess

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -1811,7 +1811,6 @@ class AsyncGenAsyncioTest(unittest.TestCase):
                 yield i
 
         def make_arange(n):
-            # This syntax is legal starting with Python 3.7
             return (i * 2 async for i in arange(n))
 
         async def run():
@@ -1826,7 +1825,6 @@ class AsyncGenAsyncioTest(unittest.TestCase):
             return n
 
         def make_arange(n):
-            # This syntax is legal starting with Python 3.7
             return (i * 2 for i in range(n) if await wrap(i))
 
         async def run():

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -3073,9 +3073,7 @@ class ContextAPItests:
     def test__clamp(self):
         # In Python 3.2, the private attribute `_clamp` was made
         # public (issue 8540), with the old `_clamp` becoming a
-        # property wrapping `clamp`.  For the duration of Python 3.2
-        # only, the attribute should be gettable/settable via both
-        # `clamp` and `_clamp`; in Python 3.3, `_clamp` should be
+        # property wrapping `clamp`.  In Python 3.3, `_clamp` was
         # removed.
         Context = self.decimal.Context
         c = Context()

--- a/Lib/wsgiref/handlers.py
+++ b/Lib/wsgiref/handlers.py
@@ -84,7 +84,6 @@ def read_environ():
                     v = v.encode(enc, 'replace').decode('iso-8859-1')
 
             # Recover bytes from unicode environ, using surrogate escapes
-            # where available (Python 3.1+).
             else:
                 v = v.encode(enc, esc).decode('iso-8859-1')
 


### PR DESCRIPTION
I searched across the `Lib` directory of CPython and removed or re-worded outdated comments.

For instance, the private `_is_text_encoding` was not in fact removed in Python 3.5 but is still used by the implementation.

The `_clamp` property of Decimal context objects actually was removed in Python 3.3, but a test for its removal (with outdated comment) still only speculated about its eventual removal.