### PR TITLE
[3.13] `zlib.rst`: Link to constants and deduplicate text (GH-140115)

### DIFF
--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -44,21 +44,20 @@ The available exception and functions in this module are:
    .. versionchanged:: 3.0
       The result is always unsigned.
 
-.. function:: compress(data, /, level=-1, wbits=MAX_WBITS)
+.. function:: compress(data, /, level=Z_DEFAULT_COMPRESSION, wbits=MAX_WBITS)
 
    Compresses the bytes in *data*, returning a bytes object containing compressed data.
    *level* is an integer from ``0`` to ``9`` or ``-1`` controlling the level of compression;
-   ``1`` (Z_BEST_SPEED) is fastest and produces the least compression, ``9`` (Z_BEST_COMPRESSION)
-   is slowest and produces the most.  ``0`` (Z_NO_COMPRESSION) is no compression.
-   The default value is ``-1`` (Z_DEFAULT_COMPRESSION).  Z_DEFAULT_COMPRESSION represents a default
-   compromise between speed and compression (currently equivalent to level 6).
+   See :const:`Z_BEST_SPEED` (``1``), :const:`Z_BEST_COMPRESSION` (``9``),
+   :const:`Z_NO_COMPRESSION` (``0``), and the default,
+   :const:`Z_DEFAULT_COMPRESSION` (``-1``) for more information about these values.
 
    .. _compress-wbits:
 
    The *wbits* argument controls the size of the history buffer (or the
    "window size") used when compressing data, and whether a header and
    trailer is included in the output.  It can take several ranges of values,
-   defaulting to ``15`` (MAX_WBITS):
+   defaulting to ``15`` (:const:`MAX_WBITS`):
 
    * +9 to +15: The base-two logarithm of the window size, which
      therefore ranges between 512 and 32768.  Larger values produce
@@ -82,17 +81,15 @@ The available exception and functions in this module are:
       The *wbits* parameter is now available to set window bits and
       compression type.
 
-.. function:: compressobj(level=-1, method=DEFLATED, wbits=MAX_WBITS, memLevel=DEF_MEM_LEVEL, strategy=Z_DEFAULT_STRATEGY[, zdict])
+.. function:: compressobj(level=Z_DEFAULT_COMPRESSION, method=DEFLATED, wbits=MAX_WBITS, memLevel=DEF_MEM_LEVEL, strategy=Z_DEFAULT_STRATEGY[, zdict])
 
    Returns a compression object, to be used for compressing data streams that won't
    fit into memory at once.
 
    *level* is the compression level -- an integer from ``0`` to ``9`` or ``-1``.
-   A value of ``1`` (Z_BEST_SPEED) is fastest and produces the least compression,
-   while a value of ``9`` (Z_BEST_COMPRESSION) is slowest and produces the most.
-   ``0`` (Z_NO_COMPRESSION) is no compression.  The default value is ``-1`` (Z_DEFAULT_COMPRESSION).
-   Z_DEFAULT_COMPRESSION represents a default compromise between speed and compression
-   (currently equivalent to level 6).
+   See :const:`Z_BEST_SPEED` (``1``), :const:`Z_BEST_COMPRESSION` (``9``),
+   :const:`Z_NO_COMPRESSION` (``0``), and the default,
+   :const:`Z_DEFAULT_COMPRESSION` (``-1``) for more information about these values.
 
    *method* is the compression algorithm. Currently, the only supported value is
    :const:`DEFLATED`.
@@ -107,7 +104,7 @@ The available exception and functions in this module are:
 
    *strategy* is used to tune the compression algorithm. Possible values are
    :const:`Z_DEFAULT_STRATEGY`, :const:`Z_FILTERED`, :const:`Z_HUFFMAN_ONLY`,
-   :const:`Z_RLE` (zlib 1.2.0.1) and :const:`Z_FIXED` (zlib 1.2.2.2).
+   :const:`Z_RLE` and :const:`Z_FIXED`.
 
    *zdict* is a predefined compression dictionary. This is a sequence of bytes
    (such as a :class:`bytes` object) containing subsequences that are expected
@@ -221,7 +218,7 @@ Compression objects support the following methods:
    All pending input is processed, and a bytes object containing the remaining compressed
    output is returned.  *mode* can be selected from the constants
    :const:`Z_NO_FLUSH`, :const:`Z_PARTIAL_FLUSH`, :const:`Z_SYNC_FLUSH`,
-   :const:`Z_FULL_FLUSH`, :const:`Z_BLOCK` (zlib 1.2.3.4), or :const:`Z_FINISH`,
+   :const:`Z_FULL_FLUSH`, :const:`Z_BLOCK`, or :const:`Z_FINISH`,
    defaulting to :const:`Z_FINISH`.  Except :const:`Z_FINISH`, all constants
    allow compressing further bytestrings of data, while :const:`Z_FINISH` finishes the
    compressed stream and prevents compressing any more data.  After calling :meth:`flush`
@@ -339,24 +336,25 @@ behavior:
 
 .. data:: Z_NO_COMPRESSION
 
-   Compression level ``0``.
+   Compression level ``0``; no compression.
 
    .. versionadded:: 3.6
 
 
 .. data:: Z_BEST_SPEED
 
-   Compression level ``1``.
+   Compression level ``1``; fastest and produces the least compression.
 
 
 .. data:: Z_BEST_COMPRESSION
 
-   Compression level ``9``.
+   Compression level ``9``; slowest and produces the most compression.
 
 
 .. data:: Z_DEFAULT_COMPRESSION
 
-   Default compression level (``-1``).
+   Default compression level (``-1``); a compromise between speed and
+   compression. Currently equivalent to compression level ``6``.
 
 
 .. data:: Z_DEFAULT_STRATEGY


### PR DESCRIPTION
* Link to compression setting constants from compression functions
* De-duplicate descriptions of the constants (cherry picked from commit 091e8513bb58747ade56a03fccb98e220c7722cc)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140350.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->