### PR TITLE
gh-140358: Bring back elapsed time and unreachable count to gc debug output

### DIFF
--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -814,9 +814,17 @@ class GCTests(unittest.TestCase):
             """
         _, _, err = assert_python_ok("-c", code % "gc.DEBUG_STATS")
         self.assertRegex(err, b"gc: collecting generation [0-9]+")
-        self.assertRegex(err, b"gc: objects in each generation: [0-9]+ [0-9]+ [0-9]+")
-        self.assertRegex(err, b"gc: objects in permanent generation: [0-9]+")
-        self.assertRegex(err, b"gc: done, [0-9]+ unreachable, [0-9]+ uncollectable, [0-9]+.[0-9]+s elapsed")
+        self.assertRegex(
+            err,
+            b"gc: objects in each generation: [0-9]+ [0-9]+ [0-9]+",
+        )
+        self.assertRegex(
+            err, b"gc: objects in permanent generation: [0-9]+"
+        )
+        self.assertRegex(
+            err,
+            b"gc: done, .* unreachable, .* uncollectable, .* elapsed",
+        )
 
         _, _, err = assert_python_ok("-c", code % "0")
         self.assertNotIn(b"elapsed", err)

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -801,6 +801,7 @@ class GCTests(unittest.TestCase):
             rc, out, err = assert_python_ok('-c', code)
             self.assertEqual(out.strip(), b'__del__ called')
 
+    @unittest.skipIf(Py_GIL_DISABLED, "requires GC generations or increments")
     def test_gc_debug_stats(self):
         # Checks that debug information is printed to stderr
         # when DEBUG_STATS is set.

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -812,11 +812,10 @@ class GCTests(unittest.TestCase):
             gc.collect()
             """
         _, _, err = assert_python_ok("-c", code % "gc.DEBUG_STATS")
-        self.assertIn(b"gc: collecting generation", err)
-        self.assertIn(b"gc: objects in each generation:", err)
-        self.assertIn(b"gc: objects in permanent generation:", err)
-        self.assertIn(b"gc: done", err)
-        self.assertIn(b"elapsed", err)
+        self.assertRegex(err, b"gc: collecting generation [0-9]+")
+        self.assertRegex(err, b"gc: objects in each generation: [0-9]+ [0-9]+ [0-9]+")
+        self.assertRegex(err, b"gc: objects in permanent generation: [0-9]+")
+        self.assertRegex(err, b"gc: done, [0-9]+ unreachable, [0-9]+ uncollectable, [0-9]+.[0-9]+s elapsed")
 
         _, _, err = assert_python_ok("-c", code % "0")
         self.assertNotIn(b"elapsed", err)

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -801,6 +801,26 @@ class GCTests(unittest.TestCase):
             rc, out, err = assert_python_ok('-c', code)
             self.assertEqual(out.strip(), b'__del__ called')
 
+    def test_gc_debug_stats(self):
+        # Checks that debug information is printed to stderr
+        # when DEBUG_STATS is set.
+        code = """if 1:
+            import gc
+            gc.set_debug(%s)
+            d = {}
+            d[(1,2)] = 1
+            gc.collect()
+            """
+        _, _, err = assert_python_ok("-c", code % "gc.DEBUG_STATS")
+        self.assertIn(b"gc: collecting generation", err)
+        self.assertIn(b"gc: objects in each generation:", err)
+        self.assertIn(b"gc: objects in permanent generation:", err)
+        self.assertIn(b"gc: done", err)
+        self.assertIn(b"elapsed", err)
+
+        _, _, err = assert_python_ok("-c", code % "0")
+        self.assertNotIn(b"elapsed", err)
+
     def test_global_del_SystemExit(self):
         code = """if 1:
             class ClassWithDel:

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -808,8 +808,6 @@ class GCTests(unittest.TestCase):
         code = """if 1:
             import gc
             gc.set_debug(%s)
-            d = {}
-            d[(1,2)] = 1
             gc.collect()
             """
         _, _, err = assert_python_ok("-c", code % "gc.DEBUG_STATS")

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-20-11-24-36.gh-issue-140358.UQuKdV.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-20-11-24-36.gh-issue-140358.UQuKdV.rst
@@ -1,3 +1,3 @@
 Restore elapsed time and unreachable object count in GC debug output. These
-were inadvertently removed during a refactor of `gc.c`. The debug log now
+were inadvertently removed during a refactor of ``gc.c``. The debug log now
 again reports elapsed collection time and the number of unreachable objects.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-20-11-24-36.gh-issue-140358.UQuKdV.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-20-11-24-36.gh-issue-140358.UQuKdV.rst
@@ -1,3 +1,4 @@
 Restore elapsed time and unreachable object count in GC debug output. These
 were inadvertently removed during a refactor of ``gc.c``. The debug log now
 again reports elapsed collection time and the number of unreachable objects.
+Contributed by Pål Grønås Drange.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-20-11-24-36.gh-issue-140358.UQuKdV.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-20-11-24-36.gh-issue-140358.UQuKdV.rst
@@ -1,0 +1,3 @@
+Restore elapsed time and unreachable object count in GC debug output. These
+were inadvertently removed during a refactor of `gc.c`. The debug log now
+again reports elapsed collection time and the number of unreachable objects.

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -2128,7 +2128,7 @@ _PyGC_Collect(PyThreadState *tstate, int generation, _PyGC_Reason reason)
         double d = PyTime_AsSecondsDouble(endtime - now);
         PySys_WriteStderr(
             "gc: done, %zd unreachable, %zd uncollectable, %.4fs elapsed\n",
-            stats.collected, stats.uncollectable, d
+            stats.collected + stats.collected, stats.uncollectable, d
         );
     }
 

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -2067,8 +2067,11 @@ _PyGC_Collect(PyThreadState *tstate, int generation, _PyGC_Reason reason)
 {
     GCState *gcstate = &tstate->interp->gc;
     assert(tstate->current_frame == NULL || tstate->current_frame->stackpointer != NULL);
+
     PyTime_t now;
-    (void)PyTime_MonotonicRaw(&now);
+    if (gcstate->debug & _PyGC_DEBUG_STATS) {
+        (void)PyTime_MonotonicRaw(&now);
+    }
 
     int expected = 0;
     if (!_Py_atomic_compare_exchange_int(&gcstate->collecting, &expected, 1)) {

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -10,7 +10,6 @@
 #include "pycore_interpframe.h"   // _PyFrame_GetLocalsArray()
 #include "pycore_object_alloc.h"  // _PyObject_MallocWithType()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "pycore_time.h"          // _PyTime_PerfCounterUnchecked()
 #include "pycore_tuple.h"         // _PyTuple_MaybeUntrack()
 #include "pycore_weakref.h"       // _PyWeakref_ClearRef()
 
@@ -2078,7 +2077,7 @@ _PyGC_Collect(PyThreadState *tstate, int generation, _PyGC_Reason reason)
     if (reason != _Py_GC_REASON_SHUTDOWN) {
         invoke_gc_callback(gcstate, "start", generation, &stats);
     }
-    PyTime_t t1 = 0;   /* initialize to prevent a compiler warning */
+    PyTime_t t1;
     if (gcstate->debug & _PyGC_DEBUG_STATS) {
         PySys_WriteStderr("gc: collecting generation %d...\n", generation);
         (void)PyTime_PerfCounterRaw(&t1);
@@ -2120,7 +2119,7 @@ _PyGC_Collect(PyThreadState *tstate, int generation, _PyGC_Reason reason)
     _Py_atomic_store_int(&gcstate->collecting, 0);
 
     if (gcstate->debug & _PyGC_DEBUG_STATS) {
-        PyTime_t t2 = 0;   /* initialize to prevent a compiler warning */
+        PyTime_t t2;
         (void)PyTime_PerfCounterRaw(&t2);
         double d = PyTime_AsSecondsDouble(t2 - t1);
         PySys_WriteStderr(

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1817,7 +1817,6 @@ gc_collect_region(PyThreadState *tstate,
     /* Collect statistics on uncollectable objects found and print
      * debugging information. */
     Py_ssize_t n = 0;
-
     for (gc = GC_NEXT(&finalizers); gc != &finalizers; gc = GC_NEXT(gc)) {
         n++;
         if (gcstate->debug & _PyGC_DEBUG_UNCOLLECTABLE)

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -2126,7 +2126,7 @@ _PyGC_Collect(PyThreadState *tstate, int generation, _PyGC_Reason reason)
         double d = PyTime_AsSecondsDouble(t2 - t1);
         PySys_WriteStderr(
             "gc: done, %zd unreachable, %zd uncollectable, %.4fs elapsed\n",
-            stats.collected + stats.collected, stats.uncollectable, d
+            stats.collected + stats.uncollectable, stats.uncollectable, d
         );
     }
 


### PR DESCRIPTION
Fixes #140358

This code includes `pycore_time.h` in `gc.c` and times the run of `_PyGC_Collect`.  If `_PyGC_DEBUG_STATS`, then we print the total time used:

E.g.

```
gc: done, 0 unreachable, 0 uncollectable, 0.0741s elapsed
```

See also discussion at [elapsed time debugging in gc.c](https://discuss.python.org/t/elapsed-time-debugging-in-gc-c/104396) at discuss.

<!-- gh-issue-number: gh-140358 -->
* Issue: gh-140358
<!-- /gh-issue-number -->
