### PR TITLE
[3.14] gh-63161: Fix test_source_encoding when stderr is StringIO

### DIFF
--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -521,7 +521,7 @@ class FileSourceEncodingTest(AbstractSourceEncodingTest, unittest.TestCase):
             line = src.splitlines()[lineno-1].decode(errors='replace')
             if lineno == 1:
                 line = line.removeprefix('\ufeff')
-            line = line.encode(sys.stderr.encoding, sys.stderr.errors)
+            line = line.encode(sys.__stderr__.encoding, sys.__stderr__.errors)
             self.assertIn(line, err)
 
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-63161 -->
* Issue: gh-63161
<!-- /gh-issue-number -->
