### PR TITLE
gh-140348: Fix using | on unusual objects plus Unions

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2283,6 +2283,15 @@ class UnionTests(BaseTestCase):
         self.assertEqual(Union[Literal[1], Literal[Ints.B], Literal[True]].__args__,
                          (Literal[1], Literal[Ints.B], Literal[True]))
 
+    def test_allow_non_types_in_or(self):
+        # gh-140348: Test that using | with a Union object allows things that are
+        # not allowed by is_unionable().
+        U1 = Union[int, str]
+        self.assertEqual(U1 | float, Union[int, str, float])
+        self.assertEqual(U1 | "float", Union[int, str, "float"])
+        self.assertEqual(float | U1, Union[float, int, str])
+        self.assertEqual("float" | U1, Union["float", int, str])
+
 
 class TupleTests(BaseTestCase):
 

--- a/Misc/NEWS.d/next/Library/2025-10-20-12-33-49.gh-issue-140348.SAKnQZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-20-12-33-49.gh-issue-140348.SAKnQZ.rst
@@ -1,0 +1,3 @@
+Fix regression in Python 3.14.0 where using the ``|`` operator on a
+:class:`typing.Union` object combined with an object that is not a type
+would raise an error.

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -256,13 +256,8 @@ is_unionable(PyObject *obj)
 PyObject *
 _Py_union_type_or(PyObject* self, PyObject* other)
 {
-    if (!is_unionable(self) || !is_unionable(other)) {
-        Py_RETURN_NOTIMPLEMENTED;
-    }
-
     unionbuilder ub;
-    // unchecked because we already checked is_unionable()
-    if (!unionbuilder_init(&ub, false)) {
+    if (!unionbuilder_init(&ub, true)) {
         return NULL;
     }
     if (!unionbuilder_add_single(&ub, self) ||


### PR DESCRIPTION
This restores the 3.13 behavior where `Union[A, B] | ...` was almost always allowed, rejecting only things that `typing._type_check` rejects.

It also necessarily means that something like `int | str | "float"` now works. And if a third-party type implements `__ror__` on union objects and does something other than create a union, it may no longer work.

<!-- gh-issue-number: gh-140348 -->
* Issue: gh-140348
<!-- /gh-issue-number -->
