### PR TITLE
gh-84027: Add whl as an unpack format in shutil

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1358,6 +1358,7 @@ def _unpack_tarfile(filename, extract_dir, *, filter=None):
 _UNPACK_FORMATS = {
     'tar':   (['.tar'], _unpack_tarfile, [], "uncompressed tar file"),
     'zip':   (['.zip'], _unpack_zipfile, [], "ZIP file"),
+    'whl': (['.whl'], _unpack_zipfile, [], "Wheel file"),
 }
 
 if _ZLIB_SUPPORTED:

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2115,12 +2115,13 @@ class TestArchives(BaseTest, unittest.TestCase):
         self.check_unpack_archive_with_converter(format, FakePath, **kwargs)
 
     def check_unpack_archive_with_converter(self, format, converter, **kwargs):
+        make_format = kwargs.pop("make_format", format)
         root_dir, base_dir = self._create_files()
         expected = rlistdir(root_dir)
         expected.remove('outer')
 
         base_name = os.path.join(self.mkdtemp(), 'archive')
-        filename = make_archive(base_name, format, root_dir, base_dir)
+        filename = make_archive(base_name, make_format, root_dir, base_dir)
 
         # let's try to unpack it now
         tmpdir2 = self.mkdtemp()
@@ -2167,6 +2168,12 @@ class TestArchives(BaseTest, unittest.TestCase):
         self.check_unpack_archive('zip')
         with self.assertRaises(TypeError):
             self.check_unpack_archive('zip', filter='data')
+
+    @support.requires_zlib()
+    def test_unpack_archive_whl(self):
+        self.check_unpack_archive('whl', make_format='zip')
+        with self.assertRaises(TypeError):
+            self.check_unpack_archive('whl', filter='data', make_format='zip')
 
     def test_unpack_registry(self):
 

--- a/Misc/NEWS.d/next/Library/2025-10-20-13-08-04.gh-issue-84027.HjBO0B.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-20-13-08-04.gh-issue-84027.HjBO0B.rst
@@ -1,0 +1,1 @@
+:mod:`shutil` now can unpack wheel packages using the ``whl`` format.


### PR DESCRIPTION
Wheels are the most ubiquitous Python package format. Per [the wheel format specification](https://packaging.python.org/en/latest/specifications/binary-distribution-format/), "A wheel is a ZIP-format archive with a specially formatted file name and the .whl extension."

To enable unpacking of wheels for inspection or even installation, we register the format in shutil using shutil._unpack_zipfile to do the actual unpacking.

Also, I would say we should only do this with wheels because they are Python packages. I don't want to set the precedent that we register all zip based formats :)

<!-- gh-issue-number: gh-84027 -->
* Issue: gh-84027
<!-- /gh-issue-number -->
