### PR TITLE
gh-116738: Add critical section to dbm/gdbm context manager

### DIFF
--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -515,8 +515,12 @@ dbm__enter__(PyObject *self, PyObject *Py_UNUSED(dummy))
 static PyObject *
 dbm__exit__(PyObject *self, PyObject *Py_UNUSED(args))
 {
+    PyObject *result;
     dbmobject *dp = dbmobject_CAST(self);
-    return _dbm_dbm_close_impl(dp);
+    Py_BEGIN_CRITICAL_SECTION(self);
+    result = _dbm_dbm_close_impl(dp);
+    Py_END_CRITICAL_SECTION();
+    return result;
 }
 
 static PyMethodDef dbm_methods[] = {

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -690,7 +690,11 @@ gdbm__enter__(PyObject *self, PyObject *args)
 static PyObject *
 gdbm__exit__(PyObject *self, PyObject *args)
 {
-    return _gdbm_gdbm_close_impl((gdbmobject *)self);
+    PyObject *result;
+    Py_BEGIN_CRITICAL_SECTION(self);
+    result = _gdbm_gdbm_close_impl((gdbmobject *)self);
+    Py_END_CRITICAL_SECTION();
+    return result;
 }
 
 static PyMethodDef gdbm_methods[] = {


### PR DESCRIPTION
Add ` Py_{BEGIN,END}_CRITICAL_SECTION()` to the context managers in the `dbm` and `gdbm` modules for the free threading build. Other methods are already covered.

This could be a problem in a rare corner case if a thread outlives the context manager's scope. I created a local test, and TSAN identifies the issue.

```Python
    def test_context_manager(self):
        def worker(db):
            db.close()

        with os_helper.temp_dir() as tmpdirname:
            with gdbm.open(f"{tmpdirname}/gdbm_filename", "c") as db:
                t1 = threading.Thread(target=worker, args=(db,))
                t1.start()

        t1.join()
```

```
WARNING: ThreadSanitizer: data race (pid=1672837)
  Read of size 8 at 0x7f9fdb330e48 by thread T1:
    #0 _gdbm_gdbm_close_impl /home/alper/workspace/tsan/./Modules/_gdbmmodule.c:413:15 (_gdbm.cpython-315td-x86_64-linux-gnu.so+0x2ce1) (BuildId: 42fff9900c3973fef01c9a778b42049ab0110b9f)
    #1 _gdbm_gdbm_close /home/alper/workspace/tsan/./Modules/clinic/_gdbmmodule.c.h:100:20 (_gdbm.cpython-315td-x86_64-linux-gnu.so+0x2ce1)
    #2 method_vectorcall_NOARGS /home/alper/workspace/tsan/Objects/descrobject.c:448:24 (python+0x5c662b) (BuildId: 89128bd333556519224b9af239856b3fcb80f8ab)
...

  Previous write of size 8 at 0x7f9fdb330e48 by main thread:
    #0 _gdbm_gdbm_close_impl /home/alper/workspace/tsan/./Modules/_gdbmmodule.c:416:18 (_gdbm.cpython-315td-x86_64-linux-gnu.so+0x4944) (BuildId: 42fff9900c3973fef01c9a778b42049ab0110b9f)
    #1 gdbm__exit__ /home/alper/workspace/tsan/./Modules/_gdbmmodule.c:693:12 (_gdbm.cpython-315td-x86_64-linux-gnu.so+0x4944)
    #2 method_vectorcall_VARARGS /home/alper/workspace/tsan/Objects/descrobject.c:325:24 (python+0x5c5ef9) (BuildId: 89128bd333556519224b9af239856b3fcb80f8ab)
...

SUMMARY: ThreadSanitizer: data race /home/alper/workspace/tsan/./Modules/_gdbmmodule.c:413:15 in _gdbm_gdbm_close_impl
==================    
```

cc: @mpage @colesbury 

<!-- gh-issue-number: gh-116738 -->
* Issue: gh-116738
<!-- /gh-issue-number -->
