### PR TITLE
gh-140239: Check for statx on Android

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-10-17-11-33-45.gh-issue-140239._k-GgW.rst
+++ b/Misc/NEWS.d/next/Build/2025-10-17-11-33-45.gh-issue-140239._k-GgW.rst
@@ -1,1 +1,1 @@
-Check ``statx`` availability only in Linux platforms
+Check ``statx`` availability only on Linux (including Android).

--- a/configure
+++ b/configure
@@ -20392,16 +20392,21 @@ then :
 fi
 
 
-# Check statx availability in Linux
-if test "$MACHDEP" = "linux"; then
-  ac_fn_c_check_func "$LINENO" "statx" "ac_cv_func_statx"
+# os.statx uses Linux's statx function.  AIX also has a function named statx,
+# but it's unrelated.  Check only on Linux (including Android).
+case $ac_sys_system in #(
+  Linux*) :
+    ac_fn_c_check_func "$LINENO" "statx" "ac_cv_func_statx"
 if test "x$ac_cv_func_statx" = xyes
 then :
   printf "%s\n" "#define HAVE_STATX 1" >>confdefs.h
 
 fi
 
-fi
+ ;; #(
+  *) :
+     ;;
+esac
 
 # Force lchmod off for Linux. Linux disallows changing the mode of symbolic
 # links. Some libc implementations have a stub lchmod implementation that always

--- a/configure.ac
+++ b/configure.ac
@@ -5258,10 +5258,11 @@ AC_CHECK_FUNCS([ \
   wait wait3 wait4 waitid waitpid wcscoll wcsftime wcsxfrm wmemcmp writev \
 ])
 
-# Check statx availability in Linux
-if test "$MACHDEP" = "linux"; then
-  AC_CHECK_FUNCS([statx])
-fi
+# os.statx uses Linux's statx function.  AIX also has a function named statx,
+# but it's unrelated.  Check only on Linux (including Android).
+AS_CASE([$ac_sys_system],
+  [Linux*], [AC_CHECK_FUNCS([statx])]
+)
 
 # Force lchmod off for Linux. Linux disallows changing the mode of symbolic
 # links. Some libc implementations have a stub lchmod implementation that always


### PR DESCRIPTION
#140249 inadvertently disabled checking for `statx` on Android because `MACHDEP` is "android" on Android.  You can verify this by looking at the [logs from the Android runner](https://github.com/python/cpython/actions/runs/18597544861/job/53027626483) from #140249.  This is a cross-compile.  In the "Configure build Python" logs, [`MACHDEP` is `linux`](https://github.com/python/cpython/actions/runs/18597544861/job/53027626483#step:3:19) and [configure checks for `statx`](https://github.com/python/cpython/actions/runs/18597544861/job/53027626483#step:3:535); in the "Configure host Python" logs, [`MACHDEP` is `android`](https://github.com/python/cpython/actions/runs/18597544861/job/53027626483#step:3:1393) and configure doesn't check for `statx` (would be [just after checking for `writev`](https://github.com/python/cpython/actions/runs/18597544861/job/53027626483#step:3:1907)).

Base the check for `statx` on `ac_sys_system` instead, which is `Linux-android` on Android, `Linux` on other Linux distributions, and `AIX` on AIX (which has an incompatible function named statx that prompted #140249).

Before merging:
- ~Please look at the Android build log to make sure both the build and host Python configure check for `statx`.  (The host Python check will result in `no` because the Android CI uses Android API level 24 and `statx` was introduced in Android API level 30.)~  Verified, the [host Python configure checks for `statx`](https://github.com/python/cpython/actions/runs/18673157665/job/53237964056?pr=140395#step:3:1907).
  - People are building for API levels higher than 30, given issue [#123014](https://github.com/python/cpython/issues/123014), so this PR is not theoretical.
- If the Android buildbots still exist and use API level 30 or higher ([#123014](https://github.com/python/cpython/issues/123014) indicates they "will" use 34), please run the Android buildbots to make sure the tests pass.  (I can't do this myself.)

cc @ayappanec as author of #140249
cc @vstinner as reviewer of statx-related PRs
cc @mhsmith as Android buildbot operator and Android maintainer

---

(There's a `"$MACHDEP" != linux` check just below the code this PR changes, which does not exclude Android as may have been intended.  Android introduced `lchmod` in API level 36.  [`lchmod` delegates to `fchmodat` with `AT_SYMLINK_NOFOLLOW`](https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/bionic/lchmod.cpp#35), and [`fchmodat` has code that should work on non-symlinks and give the correct `errno` for symlinks](https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/bionic/fchmodat.cpp), so I think the behavior is acceptable, but we aren't testing it.  That can be a separate issue/PR if it's a problem.)



<!-- gh-issue-number: gh-140239 -->
* Issue: gh-140239
<!-- /gh-issue-number -->
