### PR TITLE
gh-55258: Skip tests of stdout status on mobile platforms

### DIFF
--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -96,6 +96,8 @@ class TestSupport(unittest.TestCase):
                         self.test_get_attribute)
         self.assertRaises(unittest.SkipTest, support.get_attribute, self, "foo")
 
+    @unittest.skipIf(support.is_android or support.is_apple_mobile,
+                     'Mobile platforms redirect stdout to system log')
     def test_get_original_stdout(self):
         if isinstance(sys.stdout, io.StringIO):
             # gh-55258: When --junit-xml is used, stdout is a StringIO:


### PR DESCRIPTION
#139499 re-enabled a test of the support system that checks stdout is unmodified by the testing process.

However, this test isn't helpful on iOS and Android, as both platforms explicitly redirect stdout to the system log so that test output can be observed. 

On mobile platforms, the test consistently fails on the first run; and then passes on re-run. This PR skips the test on Android and iOS to avoid the misleading "warning due to success on re-run".

<!-- gh-issue-number: gh-55258 -->
* Issue: gh-55258
<!-- /gh-issue-number -->
