### PR TITLE
GH-139436: Remove references to downloadable PDF documentation

### DIFF
--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -186,7 +186,7 @@ How do I get documentation on Python?
 -------------------------------------
 
 The standard documentation for the current stable version of Python is available
-at https://docs.python.org/3/.  PDF, plain text, and downloadable HTML versions are
+at https://docs.python.org/3/.  EPUB, plain text, and downloadable HTML versions are
 also available at https://docs.python.org/3/download.html.
 
 The documentation is written in reStructuredText and processed by `the Sphinx

--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,7 @@ Documentation
 updated daily.
 
 It can also be downloaded in many formats for faster access.  The documentation
-is downloadable in HTML, PDF, and reStructuredText formats; the latter version
+is downloadable in HTML, EPUB, and reStructuredText formats; the latter version
 is primarily for documentation authors, translators, and people with special
 formatting requirements.
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-139436 -->
* Issue: gh-139436
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140416.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->