### PR TITLE
GH-139436: Remove PDF and CHM from IDLE HelpSource

### DIFF
--- a/Lib/idlelib/config-main.def
+++ b/Lib/idlelib/config-main.def
@@ -34,9 +34,8 @@
 # relevant settings from the default file.
 #
 # Additional help sources are listed in the [HelpFiles] section below
-# and should be viewable by a web browser (or the Windows Help viewer in
-# the case of .chm files). These sources will be listed on the Help
-# menu.  The pattern, and two examples, are:
+# and should be viewable by a web browser. These sources will be listed
+# on the Help menu.  The pattern, and two examples, are:
 #
 # <sequence_number = menu item;/path/to/help/source>
 # 1 = IDLE;C:/Programs/Python36/Lib/idlelib/help.html

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -35,19 +35,6 @@ from idlelib.help import _get_dochome
 TK_TABWIDTH_DEFAULT = 8
 darwin = sys.platform == 'darwin'
 
-def _sphinx_version():
-    "Format sys.version_info to produce the Sphinx version string used to install the chm docs"
-    major, minor, micro, level, serial = sys.version_info
-    # TODO remove unneeded function since .chm no longer installed
-    release = f'{major}{minor}'
-    release += f'{micro}'
-    if level == 'candidate':
-        release += f'rc{serial}'
-    elif level != 'final':
-        release += f'{level[0]}{serial}'
-    return release
-
-
 class EditorWindow:
     from idlelib.percolator import Percolator
     from idlelib.colorizer import ColorDelegator, color_config

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -289,8 +289,6 @@ class HelpSource(Query):
     def browse_file(self):
         filetypes = [
             ("HTML Files", "*.htm *.html", "TEXT"),
-            ("PDF Files", "*.pdf", "TEXT"),
-            ("Windows Help Files", "*.chm"),
             ("Text Files", "*.txt", "TEXT"),
             ("All Files", "*")]
         path = self.pathvar.get()


### PR DESCRIPTION
cc @terryjreedy

I also removed some other references to CHM, which we no longer support/install.

A

<!-- gh-issue-number: gh-139436 -->
* Issue: gh-139436
<!-- /gh-issue-number -->
