### PR TITLE
gh-140421: Fix perf trampoline on older macOS

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-10-22-14-09-41.gh-issue-140421.2SCWXM.rst
+++ b/Misc/NEWS.d/next/Build/2025-10-22-14-09-41.gh-issue-140421.2SCWXM.rst
@@ -1,0 +1,1 @@
+Fix compilation errors in the perf trampoline on older macOS versions.

--- a/Python/perf_trampoline.c
+++ b/Python/perf_trampoline.c
@@ -145,6 +145,9 @@ any DWARF information available for them).
 #include <unistd.h>               // sysconf()
 #include <sys/time.h>           // gettimeofday()
 
+#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
+#  define MAP_ANONYMOUS MAP_ANON
+#endif
 
 #if defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
 #define PY_HAVE_INVALIDATE_ICACHE

--- a/configure
+++ b/configure
@@ -13836,7 +13836,15 @@ case $PLATFORM_TRIPLET in #(
   aarch64-linux-gnu) :
     perf_trampoline=yes ;; #(
   darwin) :
-    perf_trampoline=yes ;; #(
+    case $host_cpu in #(
+  p*pc*) :
+    perf_trampoline=no ;; #(
+  *) :
+    perf_trampoline=yes
+                 ;; #(
+  *) :
+     ;;
+esac ;; #(
   *) :
     perf_trampoline=no
  ;;

--- a/configure.ac
+++ b/configure.ac
@@ -3704,7 +3704,10 @@ AC_MSG_CHECKING([perf trampoline])
 AS_CASE([$PLATFORM_TRIPLET],
   [x86_64-linux-gnu], [perf_trampoline=yes],
   [aarch64-linux-gnu], [perf_trampoline=yes],
-  [darwin], [perf_trampoline=yes],
+  [darwin], AS_CASE([$host_cpu],
+                [p*pc*], [perf_trampoline=no],
+                [*], [perf_trampoline=yes]
+                ),
   [perf_trampoline=no]
 )
 AC_MSG_RESULT([$perf_trampoline])


### PR DESCRIPTION
* Use `mach_absolute_time(`) when `clock_gettime()` is not available.
* Define `MAP_ANONYMOUS` to `MAP_ANON` if the latter is defined and the former is not. This matches what is done elsewhere in the code base in this situation, e.g. `mmapmodule.c`.
* Don't build perf trampoline on ppc systems, where getting this to work would be a lot more effort.


<!-- gh-issue-number: gh-140421 -->
* Issue: gh-140421
<!-- /gh-issue-number -->
