### PR TITLE
Use ``sphinxext-opengraph`` v0.13.0

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -11,7 +11,7 @@ sphinx~=8.2.0
 
 blurb
 
-sphinxext-opengraph~=0.12.0
+sphinxext-opengraph~=0.13.0
 sphinx-notfound-page~=1.0.0
 
 # The theme used by the documentation is stored separately, so we need


### PR DESCRIPTION
cc @JulienPalard, alternate to and would close #140424.

https://github.com/sphinx-doc/sphinxext-opengraph/compare/v0.12.0...v0.13.0

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140425.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->