### PR TITLE
[3.13] gh-140406: Fix memory leak upon `__hash__` returning a non-integer (GH-140411)

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1094,6 +1094,16 @@ class BuiltinTest(unittest.TestCase):
                 return self
         self.assertEqual(hash(Z(42)), hash(42))
 
+    def test_invalid_hash_typeerror(self):
+        # GH-140406: The returned object from __hash__() would leak if it
+        # wasn't an integer.
+        class A:
+            def __hash__(self):
+                return 1.0
+
+        with self.assertRaises(TypeError):
+            hash(A())
+
     def test_hex(self):
         self.assertEqual(hex(16), '0x10')
         self.assertEqual(hex(-16), '-0x10')

--- a/Misc/NEWS.d/next/Core and Builtins/2025-10-21-06-51-50.gh-issue-140406.0gJs8M.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-10-21-06-51-50.gh-issue-140406.0gJs8M.rst
@@ -1,0 +1,2 @@
+Fix memory leak when an object's :meth:`~object.__hash__` method returns an
+object that isn't an :class:`int`.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -9530,6 +9530,7 @@ slot_tp_hash(PyObject *self)
         return -1;
 
     if (!PyLong_Check(res)) {
+        Py_DECREF(res);
         PyErr_SetString(PyExc_TypeError,
                         "__hash__ method should return an integer");
         return -1;


### PR DESCRIPTION
(cherry picked from commit 71db05a12d9953a96f809d84b4d0d452a464e431)

<!-- gh-issue-number: gh-140406 -->
* Issue: gh-140406
<!-- /gh-issue-number -->
