### PR TITLE
gh-130317: Fix SNaN broken tests on HP PA RISC

### DIFF
--- a/Lib/test/test_capi/test_float.py
+++ b/Lib/test/test_capi/test_float.py
@@ -200,6 +200,7 @@ class CAPIFloatTest(unittest.TestCase):
                     signaling = 0
                     if platform.machine().startswith('parisc'):
                         # HP PA RISC uses 0 for quiet
+                        # https://en.wikipedia.org/wiki/NaN#Encoding
                         signaling = 1
                 quiet = int(not signaling)
                 if size == 8:

--- a/Lib/test/test_capi/test_float.py
+++ b/Lib/test/test_capi/test_float.py
@@ -1,5 +1,6 @@
 import math
 import random
+import platform
 import sys
 import unittest
 import warnings
@@ -197,6 +198,9 @@ class CAPIFloatTest(unittest.TestCase):
                     # PyFloat_Pack/Unpack*() API.  See also gh-130317 and
                     # e.g. https://developercommunity.visualstudio.com/t/155064
                     signaling = 0
+                    if platform.machine().startswith('parisc'):
+                        # HP PA RISC uses 0 for quiet
+                        signaling = 1
                 quiet = int(not signaling)
                 if size == 8:
                     payload = random.randint(signaling, 0x7ffffffffffff)

--- a/Lib/test/test_capi/test_float.py
+++ b/Lib/test/test_capi/test_float.py
@@ -199,7 +199,7 @@ class CAPIFloatTest(unittest.TestCase):
                     # e.g. https://developercommunity.visualstudio.com/t/155064
                     signaling = 0
                     if platform.machine().startswith('parisc'):
-                        # HP PA RISC uses 0 for quiet
+                        # HP PA RISC uses 0 for quiet, see:
                         # https://en.wikipedia.org/wiki/NaN#Encoding
                         signaling = 1
                 quiet = int(not signaling)

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -920,6 +920,7 @@ class UnpackIteratorTest(unittest.TestCase):
         # all exponent bits and the msb of the fraction should all be 1.
         if platform.machine().startswith('parisc'):
             # HP PA RISC uses 0 for quiet
+            # https://en.wikipedia.org/wiki/NaN#Encoding
             expected = 0x7c
         else:
             expected = 0x7e

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -919,7 +919,7 @@ class UnpackIteratorTest(unittest.TestCase):
         # Check that packing produces a bit pattern representing a quiet NaN:
         # all exponent bits and the msb of the fraction should all be 1.
         if platform.machine().startswith('parisc'):
-            # HP PA RISC uses 0 for quiet
+            # HP PA RISC uses 0 for quiet, see:
             # https://en.wikipedia.org/wiki/NaN#Encoding
             expected = 0x7c
         else:

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -5,6 +5,7 @@ import gc
 import math
 import operator
 import unittest
+import platform
 import struct
 import sys
 import weakref
@@ -917,10 +918,16 @@ class UnpackIteratorTest(unittest.TestCase):
 
         # Check that packing produces a bit pattern representing a quiet NaN:
         # all exponent bits and the msb of the fraction should all be 1.
+        if platform.machine().startswith('parisc'):
+            # HP PA RISC uses 0 for quiet
+            expected = 0x7c
+        else:
+            expected = 0x7e
+
         packed = struct.pack('<e', math.nan)
-        self.assertEqual(packed[1] & 0x7e, 0x7e)
+        self.assertEqual(packed[1] & 0x7e, expected)
         packed = struct.pack('<e', -math.nan)
-        self.assertEqual(packed[1] & 0x7e, 0x7e)
+        self.assertEqual(packed[1] & 0x7e, expected)
 
         # Checks for round-to-even behavior
         format_bits_float__rounding_list = [


### PR DESCRIPTION
While looking at #140028 I found some unrelated test regressions in the 3.14 cycle. These seem to all come from #130317. From what I can tell, that made Python more correct than it was before. According to [0] HP PA RISC uses 1 for SNaN and thus a 0 for QNaN.

Update tests to expect this.

[0]: https://grouper.ieee.org/groups/1788/email/msg03272.html

<!-- gh-issue-number: gh-130317 -->
* Issue: gh-130317
<!-- /gh-issue-number -->
