### PR TITLE
Remove incorrect and unused _Py_atomic_store_uint_release() method

### DIFF
--- a/Include/cpython/pyatomic_std.h
+++ b/Include/cpython/pyatomic_std.h
@@ -949,14 +949,6 @@ _Py_atomic_store_ushort_relaxed(unsigned short *obj, unsigned short value)
 }
 
 static inline void
-_Py_atomic_store_uint_release(unsigned int *obj, unsigned int value)
-{
-    _Py_USING_STD;
-    atomic_store_explicit((_Atomic(unsigned int)*)obj, value,
-                          memory_order_relaxed);
-}
-
-static inline void
 _Py_atomic_store_long_relaxed(long *obj, long value)
 {
     _Py_USING_STD;


### PR DESCRIPTION
`_Py_atomic_store_uint_release()` uses `memory_order_relaxed` when it should use `memory_order_release`. This method isn't used anywhere so instead of fixing it we can just delete it.