### PR TITLE
gh-140381: Handle slower machines in test_profiling

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -16,6 +16,7 @@ import sys
 import sysconfig
 import textwrap
 import time
+import timeit
 import types
 import unittest
 import warnings
@@ -2693,6 +2694,9 @@ def exceeds_recursion_limit():
     """For recursion tests, easily exceeds default recursion limit."""
     return 150_000
 
+
+# Is the host running the tests significantly slower than a typical PC?
+is_slow_machine = timeit.timeit("2*2", number=10_000) > 0.0001
 
 # Windows doesn't have os.uname() but it doesn't support s390x.
 is_s390x = hasattr(os, 'uname') and os.uname().machine == 's390x'

--- a/Lib/test/test_profiling/test_sampling_profiler.py
+++ b/Lib/test/test_profiling/test_sampling_profiler.py
@@ -21,11 +21,17 @@ from profiling.sampling.stack_collector import (
 )
 from profiling.sampling.gecko_collector import GeckoCollector
 
+from test.support import (
+    SHORT_TIMEOUT,
+    captured_stderr,
+    captured_stdout,
+    force_not_colorized_test_class,
+    is_emscripten,
+    is_slow_machine,
+    requires_subprocess,
+)
 from test.support.os_helper import unlink
-from test.support import force_not_colorized_test_class, SHORT_TIMEOUT
 from test.support.socket_helper import find_unused_port
-from test.support import requires_subprocess, is_emscripten
-from test.support import captured_stdout, captured_stderr, is_slow_machine
 
 PROCESS_VM_READV_SUPPORTED = False
 

--- a/Lib/test/test_profiling/test_sampling_profiler.py
+++ b/Lib/test/test_profiling/test_sampling_profiler.py
@@ -10,7 +10,6 @@ import socket
 import subprocess
 import sys
 import tempfile
-import timeit
 import unittest
 from collections import namedtuple
 from unittest import mock
@@ -26,11 +25,9 @@ from test.support.os_helper import unlink
 from test.support import force_not_colorized_test_class, SHORT_TIMEOUT
 from test.support.socket_helper import find_unused_port
 from test.support import requires_subprocess, is_emscripten
-from test.support import captured_stdout, captured_stderr
+from test.support import captured_stdout, captured_stderr, is_slow_machine
 
 PROCESS_VM_READV_SUPPORTED = False
-
-SLOW_MACHINE = timeit.timeit("2*2", number=10_000) > 0.0001
 
 try:
     from _remote_debugging import PROCESS_VM_READV_SUPPORTED
@@ -1757,7 +1754,7 @@ if __name__ == "__main__":
 '''
 
     def test_sampling_basic_functionality(self):
-        duration_sec = 10 if SLOW_MACHINE else 2
+        duration_sec = 10 if is_slow_machine else 2
         with (
             test_subprocess(self.test_script) as subproc,
             io.StringIO() as captured_output,
@@ -1908,7 +1905,7 @@ if __name__ == "__main__":
         script_file.flush()
         self.addCleanup(close_and_unlink, script_file)
 
-        duration = 10 if SLOW_MACHINE else 1
+        duration = 10 if is_slow_machine else 1
         test_args = [
             "profiling.sampling.sample", "-d", str(duration), script_file.name
         ]
@@ -1943,7 +1940,7 @@ if __name__ == "__main__":
         with open(module_path, "w") as f:
             f.write(self.test_script)
 
-        duration = 10 if SLOW_MACHINE else 1
+        duration = 10 if is_slow_machine else 1
         test_args = [
             "profiling.sampling.sample",
             "-d", str(duration),


### PR DESCRIPTION
While looking at #140028 I found some test failures that are caused by new tests (from #138122) running too slowly.

This adds an arbitrary heuristic to 10x the sampling run time (to the default value of 10 seconds). Doubling the 1-second duration was sufficient for my HP PA tests, but Fedora reported one of the 2-second durations being too slow for a freethreaded build.

<!-- gh-issue-number: gh-140381 -->
* Issue: gh-140381
<!-- /gh-issue-number -->
