### PR TITLE
gh-140443: Use `fma` in `loghelper` to improve accuracy of log for very large integers

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1921,6 +1921,7 @@ Tim Tisdall
 Jason Tishler
 Christian Tismer
 Jim Tittsler
+Abhishek Tiwari
 Frank J. Tobin
 James Tocknell
 Bennett Todd

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-22-23-26-37.gh-issue-140443.wT5i1A.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-22-23-26-37.gh-issue-140443.wT5i1A.rst
@@ -1,4 +1,4 @@
-The logarithm functions (such as math.log10() and math.log()) may now produce
+The logarithm functions (such as :func:`math.log10` and :func:`math.log`) may now produce
 slightly different results for extremely large integers that cannot be
 converted to floats without overflow. These results are generally more
 accurate, with reduced worst-case error and a tighter overall error

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-22-23-26-37.gh-issue-140443.wT5i1A.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-22-23-26-37.gh-issue-140443.wT5i1A.rst
@@ -1,0 +1,5 @@
+The logarithm functions (such as math.log10() and math.log()) may now produce
+slightly different results for extremely large integers that cannot be
+converted to floats without overflow. These results are generally more
+accurate, with reduced worst-case error and a tighter overall error
+distribution.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2309,7 +2309,7 @@ loghelper(PyObject* arg, double (*func)(double))
             assert(e >= 0);
             assert(!PyErr_Occurred());
             /* Value is ~= x * 2**e, so the log ~= log(x) + log(2) * e. */
-            result = func(x) + func(2.0) * e;
+            result = fma(func(2.0), (double)e, func(x));
         }
         else
             /* Successfully converted x to a double. */


### PR DESCRIPTION


Replaced the expression computing the final result in loghelper with an fma() call:

    result = fma(func(2.0), (double)e, func(x));

This change reduces rounding error and improves the ULP distribution of math.log for very large integer inputs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140443 -->
* Issue: gh-140443
<!-- /gh-issue-number -->
