### PR TITLE
gh-140431: Fix GC crash due to partially initialized coroutines

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-22-17-22-22.gh-issue-140431.m8D_A-.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-22-17-22-22.gh-issue-140431.m8D_A-.rst
@@ -1,0 +1,3 @@
+Fix a crash in Python's :term:`garbage collector <garbage collection>` due to
+partially initialized :term:`coroutine` objects when coroutine origin tracking
+depth is enabled (:func:`sys.set_coroutine_origin_tracking_depth`).

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -932,6 +932,7 @@ make_gen(PyTypeObject *type, PyFunctionObject *func)
     gen->gi_weakreflist = NULL;
     gen->gi_exc_state.exc_value = NULL;
     gen->gi_exc_state.previous_item = NULL;
+    gen->gi_iframe.f_executable = PyStackRef_None;
     assert(func->func_name != NULL);
     gen->gi_name = Py_NewRef(func->func_name);
     assert(func->func_qualname != NULL);


### PR DESCRIPTION
The `make_gen()` function creates and tracks generator/coro objects, but doesn't fully initialize all the fields. At a minimum, we need to initialize all the fields that may be accessed by gen_traverse because the call to `compute_cr_origin()` can trigger a GC.


<!-- gh-issue-number: gh-140431 -->
* Issue: gh-140431
<!-- /gh-issue-number -->
