### PR TITLE
GH-140475: Support WASI SDK 25

### DIFF
--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
-      WASMTIME_VERSION: 22.0.0
-      WASI_SDK_VERSION: 24
+      WASMTIME_VERSION: 38.0.2
+      WASI_SDK_VERSION: 25
       WASI_SDK_PATH: /opt/wasi-sdk
       CROSS_BUILD_PYTHON: cross-build/build
       CROSS_BUILD_WASI: cross-build/wasm32-wasip1

--- a/Misc/NEWS.d/next/Build/2025-10-22-12-44-07.gh-issue-140475.OhzQbR.rst
+++ b/Misc/NEWS.d/next/Build/2025-10-22-12-44-07.gh-issue-140475.OhzQbR.rst
@@ -1,0 +1,1 @@
+Support WASI SDK 25.

--- a/Tools/wasm/wasi/__main__.py
+++ b/Tools/wasm/wasi/__main__.py
@@ -31,7 +31,7 @@ LOCAL_SETUP_MARKER = (
     b"# Required to statically build extension modules."
 )
 
-WASI_SDK_VERSION = 24
+WASI_SDK_VERSION = 25
 
 WASMTIME_VAR_NAME = "WASMTIME"
 WASMTIME_HOST_RUNNER_VAR = f"{{{WASMTIME_VAR_NAME}}}"


### PR DESCRIPTION
As well, bump the version of Wasmtime used in CI.


<!-- gh-issue-number: gh-140475 -->
* Issue: gh-140475
<!-- /gh-issue-number -->
