### PR TITLE
gh-140481: avoid misleading exception in `tk.Tk.__getitem__`

### DIFF
--- a/Lib/test/test_tkinter/widget_tests.py
+++ b/Lib/test/test_tkinter/widget_tests.py
@@ -60,6 +60,8 @@ class AbstractWidgetTest(AbstractTkTest):
         t = widget.configure(name)
         self.assertEqual(len(t), 5)
         self.assertEqual2(t[4], expected, eq=eq)
+        self.assertEqual(name in widget, True)
+        self.assertEqual("invalid-option-tkinter" in widget, False)
 
     def checkInvalidParam(self, widget, name, value, errmsg=None):
         orig = widget[name]

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -1845,9 +1845,17 @@ class Misc:
 
     def cget(self, key):
         """Return the current value of the configuration option."""
-        return self.tk.call(self._w, 'cget', '-' + key)
+        return self.tk.call(self._w, 'cget', f'-{key}')
 
     __getitem__ = cget
+
+    def __contains__(self, option):
+        """Check if the given option exists in this widget"""
+        try:
+            self.cget(option)
+            return True
+        except TclError:
+            return False
 
     def __setitem__(self, key, value):
         self.configure({key: value})
@@ -4322,11 +4330,18 @@ class PhotoImage(Image):
 
     def cget(self, option):
         """Return the value of OPTION."""
-        return self.tk.call(self.name, 'cget', '-' + option)
+        return self.tk.call(self.name, 'cget', f'-{option}')
     # XXX config
 
-    def __getitem__(self, key):
-        return self.tk.call(self.name, 'cget', '-' + key)
+    __getitem__ = cget
+
+    def __contains__(self, option):
+        """Check if the given option exists in this widget"""
+        try:
+            self.cget(option)
+            return True
+        except TclError:
+            return False
 
     def copy(self, *, from_coords=None, zoom=None, subsample=None):
         """Return a new PhotoImage with the same image as this widget.

--- a/Misc/NEWS.d/next/Library/2025-10-22-22-18-12.gh-issue-140481.llKxYZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-22-22-18-12.gh-issue-140481.llKxYZ.rst
@@ -1,0 +1,1 @@
+fixed misleading error and added ``__contain__`` method in ``tkinter.Misc``


### PR DESCRIPTION
### Before
Code like:
```python
import tkinter as tk
root = tk.Tk()
print("background" in root)
```
Would throw a `TypeError: can only concatenate str (not "int") to str`

### Summary of changes
* Fixed the error message when calling `"option" in <tk.Misc>`
* Added `__contain__` method to `tk.Misc` since it already has `__getitem__` and `__setitem__`
* Added tests to prevent regression

### Testing
* Ran `./python -m test test_tkinter -u=gui` locally to make sure the old tests as well as the new ones pass

<!-- gh-issue-number: gh-140481 -->
* Issue: gh-140481
<!-- /gh-issue-number -->
