### PR TITLE
gh-140505: Correct "parameters" to "arguments" in MultiCall doc

### DIFF
--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -472,7 +472,7 @@ remote server into a single request [#]_.
 
    Create an object used to boxcar method calls. *server* is the eventual target of
    the call. Calls can be made to the result object, but they will immediately
-   return ``None``, and only store the call name and parameters in the
+   return ``None``, and only store the call name and arguments in the
    :class:`MultiCall` object. Calling the object itself causes all stored calls to
    be transmitted as a single ``system.multicall`` request. The result of this call
    is a :term:`generator`; iterating over this generator yields the individual

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -203,10 +203,13 @@ grouped under the reserved :attr:`~ServerProxy.system` attribute:
    Because multiple signatures (ie. overloading) is permitted, this method returns
    a list of signatures rather than a singleton.
 
-   Signatures themselves are restricted to the top level parameters expected by a
-   method. For instance if a method expects one array of structs as a argument,
-   and it returns a string, its signature is simply "string, array". If it expects
-   three integers and returns a string, its signature is "string, int, int, int".
+   Note that a signature does not give details of a complex type; it just gives the
+   basic XML-RPC type — array or structure. This applies to both arguments and the
+   return value. For example, if a method expects one array of structs as an argument
+   and returns a string, its signature is simply "string, array". Here, "string" is
+   the return type, and "array" indicates the argument type without showing the structure
+   of its elements. If a method expects three integers and returns an array of strings,
+   its signature is "array, int, int, int".
 
    If no signature is defined for the method, a non-array value is returned. In
    Python this means that the type of the returned  value will be something other

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -15,7 +15,7 @@
 --------------
 
 XML-RPC is a Remote Procedure Call method that uses XML passed via HTTP(S) as a
-transport.  With it, a client can call methods with parameters on a remote
+transport.  With it, a client can call methods with arguments on a remote
 server (the server is named by a URI) and get back structured data.  This module
 supports writing XML-RPC client code; it handles all the details of translating
 between conformable Python objects and XML on the wire.

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -195,7 +195,7 @@ grouped under the reserved :attr:`~ServerProxy.system` attribute:
 
 .. method:: ServerProxy.system.methodSignature(name)
 
-   This method takes one parameter, the name of a method implemented by the XML-RPC
+   This method takes one argument, the name of a method implemented by the XML-RPC
    server. It returns an array of possible signatures for this method. A signature
    is an array of types. The first of these types is the return type of the method,
    the rest are parameters.
@@ -204,7 +204,7 @@ grouped under the reserved :attr:`~ServerProxy.system` attribute:
    a list of signatures rather than a singleton.
 
    Signatures themselves are restricted to the top level parameters expected by a
-   method. For instance if a method expects one array of structs as a parameter,
+   method. For instance if a method expects one array of structs as a argument,
    and it returns a string, its signature is simply "string, array". If it expects
    three integers and returns a string, its signature is "string, int, int, int".
 
@@ -215,7 +215,7 @@ grouped under the reserved :attr:`~ServerProxy.system` attribute:
 
 .. method:: ServerProxy.system.methodHelp(name)
 
-   This method takes one parameter, the name of a method implemented by the XML-RPC
+   This method takes one argument, the name of a method implemented by the XML-RPC
    server.  It returns a documentation string describing the use of that method. If
    no such string is available, an empty string is returned. The documentation
    string may contain HTML markup.


### PR DESCRIPTION

* issue: gh-140505

📚 Documentation preview 📚: https://cpython-previews--140512.org.readthedocs.build/en/140512/library/xmlrpc.client.html#multicall-objects