### PR TITLE
gh-140482: Preserve and restore `stty echo` as a test environment

### DIFF
--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -12,7 +12,7 @@ from .utils import print_warning
 # Import termios to save and restore terminal echo.  This is only available on
 # Unix, and it's fine if the module can't be found.
 try:
-    import termios
+    import termios                                # noqa: F401
 except ModuleNotFoundError:
     pass
 

--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -4,6 +4,7 @@ import os
 import sys
 import threading
 
+from importlib import import_module
 from test import support
 from test.support import os_helper
 
@@ -65,17 +66,23 @@ class saved_test_environment:
                  'shutil_archive_formats', 'shutil_unpack_formats',
                  'asyncio.events._event_loop_policy',
                  'urllib.requests._url_tempfiles', 'urllib.requests._opener',
+                 'stty_echo',
                 )
 
     def get_module(self, name):
         # function for restore() methods
         return sys.modules[name]
 
-    def try_get_module(self, name):
+    def try_get_module(self, name, *, demand=False):
         # function for get() methods
         try:
             return self.get_module(name)
         except KeyError:
+            if demand:
+                try:
+                    return import_module(name)
+                except ModuleNotFoundError:
+                    pass
             raise SkipTestEnvironment
 
     def get_urllib_requests__url_tempfiles(self):
@@ -291,6 +298,25 @@ class saved_test_environment:
     def restore_warnings_showwarning(self, fxn):
         warnings = self.get_module('warnings')
         warnings.showwarning = fxn
+
+    def get_stty_echo(self):
+        termios = self.try_get_module('termios', demand=True)
+        if not os.isatty(fd := sys.__stdin__.fileno()):
+            return None
+        attrs = termios.tcgetattr(fd)
+        lflags = attrs[3]
+        return bool(lflags & termios.ECHO)
+
+    def restore_stty_echo(self, echo):
+        termios = self.get_module('termios')
+        attrs = termios.tcgetattr(fd := sys.__stdin__.fileno())
+        if echo:
+            # Turn echo on.
+            attrs[3] |= termios.ECHO
+        else:
+            # Turn echo off.
+            attrs[3] &= ~termios.ECHO
+        termios.tcsetattr(fd, termios.TCSADRAIN, attrs)
 
     def resource_info(self):
         for name in self.resources:

--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -9,7 +9,7 @@ from test.support import os_helper
 
 from .utils import print_warning
 
-# Import termios to save and restore the tty.  This is only available on
+# Import termios to save and restore terminal echo.  This is only available on
 # Unix, and it's fine if the module can't be found.
 try:
     import termios

--- a/Misc/NEWS.d/next/Tests/2025-10-23-16-39-49.gh-issue-140482.ZMtyeD.rst
+++ b/Misc/NEWS.d/next/Tests/2025-10-23-16-39-49.gh-issue-140482.ZMtyeD.rst
@@ -1,0 +1,1 @@
+Preserve and restore the state of ``stty echo`` as a test environment.

--- a/Misc/NEWS.d/next/Tests/2025-10-23-16-39-49.gh-issue-140482.ZMtyeD.rst
+++ b/Misc/NEWS.d/next/Tests/2025-10-23-16-39-49.gh-issue-140482.ZMtyeD.rst
@@ -1,1 +1,1 @@
-Preserve and restore the state of ``stty echo`` as a test environment.
+Preserve and restore the state of ``stty echo`` as part of the test environment.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The test suite sometimes turns off terminal echo after it completes.  As far as I can tell, it's completely random and probably caused by tests that don't (or can't!) fully clean up after themselves.  After implementing this fix and testing it many times with `make test` and `make quicktest`, I see a common set of tests that it happens in, but no real rhyme or reason.

This patch just saves and restores `termios.ECHO` as a saved test environment and in lots of local testing it works perfectly.  Yeah, it's just an annoyance but as #140480 says, this has been annoying me for many releases.  Thanks to @zware for suggesting a test environment in my abandoned #140482 PR.

I recommend backporting to all active non-security branches as it will help and there should be no risk involved.  One caveat is that I did have to change the signature and semantics of `try_get_module()` because if the requested module is not already imported, `sys.modules[name]` will fail, and since `termios` isn't generally imported, `try_get_module()` would be unhelpful otherwise.  The alternative is to import `termios` at the top of the module so it's always available, but as no other saved test environment seems to do that, and this environment is global rather than tied to a specific test, I thought this was the better approach.  Suggestions welcome.

<!-- gh-issue-number: gh-140482 -->
* Issue: gh-140482
<!-- /gh-issue-number -->
