### PR TITLE
gh-140500: Fix typo on download page

### DIFF
--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -32,7 +32,7 @@
 {% if last_updated %}<p><b>{% trans %}Last updated on: {{ last_updated }}.{% endtrans %}</b></p>{% endif %}
 
 <p>{% trans %}To download an archive containing all the documents for this version of
-Python in one of various formats, follow one of links in this table.{% endtrans %}</p>
+Python in one of various formats, follow one of the links in this table.{% endtrans %}</p>
 
 <table class="docutils">
   <tr>


### PR DESCRIPTION
## Description

Fixed a typo in the download documentation where "follow one of links" should be "follow one of the links".

## Issue

Fixes #140500

## Changes

- Added the missing article "the" before "links" in Doc/tools/templates/download.html (line 35)

This is a minor documentation fix that improves grammar in the download page.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140523.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-140500 -->
* Issue: gh-140500
<!-- /gh-issue-number -->
