### PR TITLE
gh-133956 fix bug where `dataclass` wouldn't detect `ClassVar` fields if `ClassVar` was re-exported from a module other than `typing`

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -809,7 +809,7 @@ def _get_type_from_annotation(annotation, cls):
         return None
 
     # Note: _MODULE_IDENTIFIER_RE guarantees that path is non-empty
-    path = match.group(1).split(".")
+    path = match[1].split(".")
     root = sys.modules.get(cls.__module__)
     for path_item in path:
         root = getattr(root, path_item.strip(), None)

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -762,9 +762,8 @@ def _is_kw_only(a_type, dataclasses):
     return a_type is dataclasses.KW_ONLY
 
 
-def _is_type(annotation, cls, is_type_predicate, *is_type_predicate_args):
-    # Loosely parse a string annotation and pass the result to is_type_predicate,
-    # along with any additional arguments it might require.
+def _get_type_from_annotation(annotation, cls):
+    # Loosely parse a string annotation and return its type.
 
     # We can't perform a full type hint evaluation at the point where @dataclass
     # was invoked because class's module is not fully initialized yet. So we resort
@@ -773,9 +772,6 @@ def _is_type(annotation, cls, is_type_predicate, *is_type_predicate_args):
 
     # - annotation is a string type annotation
     # - cls is the class that this annotation was found in
-    # - is_type_predicate is a function called with (obj, *is_type_predicate_args)
-    #   that determines if obj is of the desired type.
-    # - is_type_predicate_args is additional arguments forwarded to is_type_predicate
 
     # Since this test does not do a local namespace lookup (and
     # instead only a module (global) lookup), there are some things it
@@ -806,25 +802,21 @@ def _is_type(annotation, cls, is_type_predicate, *is_type_predicate_args):
     # https://github.com/python/cpython/issues/77634 for details.
     global _MODULE_IDENTIFIER_RE
     if _MODULE_IDENTIFIER_RE is None:
-        _MODULE_IDENTIFIER_RE = re.compile(r'(?:\s*(\w+)\s*\.)?\s*(\w+)')
+        _MODULE_IDENTIFIER_RE = re.compile(r'^\s*(\w+(?:\s*\.\s*\w+)*)')
 
     match = _MODULE_IDENTIFIER_RE.prefixmatch(annotation)
     if not match:
-        return False
+        return None
 
-    module_name = match.group(1)
-    type_name = match.group(2)
+    # Note: _MODULE_IDENTIFIER_RE guarantees that path is non-empty
+    path = match.group(1).split(".")
+    root = sys.modules.get(cls.__module__)
+    for path_item in path:
+        root = getattr(root, path_item.strip(), None)
+        if root is None:
+            return None
 
-    if not module_name:
-        # No module name, assume the class's module did
-        # "from dataclasses import InitVar".
-        ns = sys.modules.get(cls.__module__)
-    else:
-        # Look up module_name in the class's module.
-        cls_module = sys.modules.get(cls.__module__)
-        ns = cls_module.__dict__.get(module_name)
-
-    return is_type_predicate(getattr(ns, type_name, None), *is_type_predicate_args)
+    return root
 
 
 def _get_field(cls, a_name, a_type, default_kw_only):
@@ -862,6 +854,10 @@ def _get_field(cls, a_name, a_type, default_kw_only):
     # is actually of the correct type.
 
     # For the complete discussion, see https://bugs.python.org/issue33453
+    if isinstance(a_type, str):
+        a_type_annotation = _get_type_from_annotation(a_type, cls)
+    else:
+        a_type_annotation = a_type
 
     # If typing has not been imported, then it's impossible for any
     # annotation to be a ClassVar.  So, only look for ClassVar if
@@ -869,9 +865,7 @@ def _get_field(cls, a_name, a_type, default_kw_only):
     # module).
     typing = sys.modules.get('typing')
     if typing:
-        if (_is_classvar(a_type, typing)
-            or (isinstance(f.type, str)
-                and _is_type(f.type, cls, _is_classvar, typing))):
+        if _is_classvar(a_type_annotation, typing):
             f._field_type = _FIELD_CLASSVAR
 
     # If the type is InitVar, or if it's a matching string annotation,
@@ -880,9 +874,7 @@ def _get_field(cls, a_name, a_type, default_kw_only):
         # The module we're checking against is the module we're
         # currently in (dataclasses.py).
         dataclasses = sys.modules[__name__]
-        if (_is_initvar(a_type, dataclasses)
-            or (isinstance(f.type, str)
-                and _is_type(f.type, cls, _is_initvar, dataclasses))):
+        if _is_initvar(a_type_annotation, dataclasses):
             f._field_type = _FIELD_INITVAR
 
     # Validations for individual fields.  This is delayed until now,
@@ -1053,9 +1045,11 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
     dataclasses = sys.modules[__name__]
     for name, type in cls_annotations.items():
         # See if this is a marker to change the value of kw_only.
-        if (_is_kw_only(type, dataclasses)
-            or (isinstance(type, str)
-                and _is_type(type, cls, _is_kw_only, dataclasses))):
+        if isinstance(type, str):
+            a_type_annotation = _get_type_from_annotation(type, cls)
+        else:
+            a_type_annotation = type
+        if _is_kw_only(a_type_annotation, dataclasses):
             # Switch the default to kw_only=True, and ignore this
             # annotation: it's not a real field.
             if KW_ONLY_seen:

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -831,8 +831,8 @@ def _is_type(annotation, cls, a_module, a_type, is_type_predicate):
         a_type_module = cls_module.__dict__.get(module_name)
         if (
             isinstance(a_type_module, types.ModuleType)
-            # Consider the case when a_type does not belong
-            # to the namespace, e.g. 'dataclasses.ClassVar[int]'
+            # Handle cases when a_type is not defined in
+            # the referenced module, e.g. 'dataclasses.ClassVar[int]'
             and a_type_module.__dict__.get(type_name) is a_type
         ):
             ns = sys.modules.get(a_type.__module__).__dict__

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -811,21 +811,33 @@ def _is_type(annotation, cls, a_module, a_type, is_type_predicate):
         _MODULE_IDENTIFIER_RE = re.compile(r'(?:\s*(\w+)\s*\.)?\s*(\w+)')
 
     match = _MODULE_IDENTIFIER_RE.prefixmatch(annotation)
-    if match:
-        ns = None
-        module_name = match[1]
-        if not module_name:
-            # No module name, assume the class's module did
-            # "from dataclasses import InitVar".
-            ns = sys.modules.get(cls.__module__).__dict__
-        else:
-            # Look up module_name in the class's module.
-            module = sys.modules.get(cls.__module__)
-            if module and module.__dict__.get(module_name) is a_module:
-                ns = sys.modules.get(a_type.__module__).__dict__
-        if ns and is_type_predicate(ns.get(match[2]), a_module):
-            return True
-    return False
+    if not match:
+        return False
+
+    ns = None
+    module_name = match.group(1)
+    type_name = match.group(2)
+
+    if not module_name:
+        # No module name, assume the class's module did
+        # "from dataclasses import InitVar".
+        ns = sys.modules.get(cls.__module__).__dict__
+    else:
+        # Look up module_name in the class's module.
+        cls_module = sys.modules.get(cls.__module__)
+        if not cls_module:
+            return False
+
+        a_type_module = cls_module.__dict__.get(module_name)
+        if (
+            isinstance(a_type_module, types.ModuleType)
+            # Consider the case when a_type does not belong
+            # to the namespace, e.g. 'dataclasses.ClassVar[int]'
+            and a_type_module.__dict__.get(type_name) is a_type
+        ):
+            ns = sys.modules.get(a_type.__module__).__dict__
+
+    return ns and is_type_predicate(ns.get(type_name), a_module)
 
 
 def _get_field(cls, a_name, a_type, default_kw_only):

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -762,22 +762,20 @@ def _is_kw_only(a_type, dataclasses):
     return a_type is dataclasses.KW_ONLY
 
 
-def _is_type(annotation, cls, a_module, a_type, is_type_predicate):
-    # Given a type annotation string, does it refer to a_type in
-    # a_module?  For example, when checking that annotation denotes a
-    # ClassVar, then a_module is typing, and a_type is
-    # typing.ClassVar.
+def _is_type(annotation, cls, is_type_predicate, *is_type_predicate_args):
+    # Loosely parse a string annotation and pass the result to is_type_predicate,
+    # along with any additional arguments it might require.
 
-    # It's possible to look up a_module given a_type, but it involves
-    # looking in sys.modules (again!), and seems like a waste since
-    # the caller already knows a_module.
+    # We can't perform a full type hint evaluation at the point where @dataclass
+    # was invoked because class's module is not fully initialized yet. So we resort
+    # to parsing string annotation using regexp, and extracting a type before
+    # the first square bracket.
 
     # - annotation is a string type annotation
     # - cls is the class that this annotation was found in
-    # - a_module is the module we want to match
-    # - a_type is the type in that module we want to match
-    # - is_type_predicate is a function called with (obj, a_module)
+    # - is_type_predicate is a function called with (obj, *is_type_predicate_args)
     #   that determines if obj is of the desired type.
+    # - is_type_predicate_args is additional arguments forwarded to is_type_predicate
 
     # Since this test does not do a local namespace lookup (and
     # instead only a module (global) lookup), there are some things it
@@ -814,30 +812,19 @@ def _is_type(annotation, cls, a_module, a_type, is_type_predicate):
     if not match:
         return False
 
-    ns = None
     module_name = match.group(1)
     type_name = match.group(2)
 
     if not module_name:
         # No module name, assume the class's module did
         # "from dataclasses import InitVar".
-        ns = sys.modules.get(cls.__module__).__dict__
+        ns = sys.modules.get(cls.__module__)
     else:
         # Look up module_name in the class's module.
         cls_module = sys.modules.get(cls.__module__)
-        if not cls_module:
-            return False
+        ns = cls_module.__dict__.get(module_name)
 
-        a_type_module = cls_module.__dict__.get(module_name)
-        if (
-            isinstance(a_type_module, types.ModuleType)
-            # Handle cases when a_type is not defined in
-            # the referenced module, e.g. 'dataclasses.ClassVar[int]'
-            and a_type_module.__dict__.get(type_name) is a_type
-        ):
-            ns = sys.modules.get(a_type.__module__).__dict__
-
-    return ns and is_type_predicate(ns.get(type_name), a_module)
+    return is_type_predicate(getattr(ns, type_name, None), *is_type_predicate_args)
 
 
 def _get_field(cls, a_name, a_type, default_kw_only):
@@ -884,8 +871,7 @@ def _get_field(cls, a_name, a_type, default_kw_only):
     if typing:
         if (_is_classvar(a_type, typing)
             or (isinstance(f.type, str)
-                and _is_type(f.type, cls, typing, typing.ClassVar,
-                             _is_classvar))):
+                and _is_type(f.type, cls, _is_classvar, typing))):
             f._field_type = _FIELD_CLASSVAR
 
     # If the type is InitVar, or if it's a matching string annotation,
@@ -896,8 +882,7 @@ def _get_field(cls, a_name, a_type, default_kw_only):
         dataclasses = sys.modules[__name__]
         if (_is_initvar(a_type, dataclasses)
             or (isinstance(f.type, str)
-                and _is_type(f.type, cls, dataclasses, dataclasses.InitVar,
-                             _is_initvar))):
+                and _is_type(f.type, cls, _is_initvar, dataclasses))):
             f._field_type = _FIELD_INITVAR
 
     # Validations for individual fields.  This is delayed until now,
@@ -1070,8 +1055,7 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
         # See if this is a marker to change the value of kw_only.
         if (_is_kw_only(type, dataclasses)
             or (isinstance(type, str)
-                and _is_type(type, cls, dataclasses, dataclasses.KW_ONLY,
-                             _is_kw_only))):
+                and _is_type(type, cls, _is_kw_only, dataclasses))):
             # Switch the default to kw_only=True, and ignore this
             # annotation: it's not a real field.
             if KW_ONLY_seen:

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -4643,6 +4643,14 @@ class TestMakeDataclass(unittest.TestCase):
         self.assertEqual(c.x, 10)
         self.assertEqual(c.__custom__, True)
 
+    def test_empty_annotation_string(self):
+        @dataclass
+        class DataclassWithEmptyTypeAnnotation:
+            x: ""
+
+        c = DataclassWithEmptyTypeAnnotation(10)
+        self.assertEqual(c.x, 10)
+
 
 class TestReplace(unittest.TestCase):
     def test(self):

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -4329,10 +4329,14 @@ class TestStringAnnotations(unittest.TestCase):
         from test.test_dataclasses import dataclass_module_1_str
         from test.test_dataclasses import dataclass_module_2
         from test.test_dataclasses import dataclass_module_2_str
+        from test.test_dataclasses import dataclass_module_3
+        from test.test_dataclasses import dataclass_module_3_str
 
-        for m in (dataclass_module_1, dataclass_module_1_str,
-                  dataclass_module_2, dataclass_module_2_str,
-                  ):
+        for m in (
+            dataclass_module_1, dataclass_module_1_str,
+            dataclass_module_2, dataclass_module_2_str,
+            dataclass_module_3, dataclass_module_3_str,
+        ):
             with self.subTest(m=m):
                 # There's a difference in how the ClassVars are
                 # interpreted when using string annotations or

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -4331,11 +4331,14 @@ class TestStringAnnotations(unittest.TestCase):
         from test.test_dataclasses import dataclass_module_2_str
         from test.test_dataclasses import dataclass_module_3
         from test.test_dataclasses import dataclass_module_3_str
+        from test.test_dataclasses import dataclass_module_4
+        from test.test_dataclasses import dataclass_module_4_str
 
         for m in (
             dataclass_module_1, dataclass_module_1_str,
             dataclass_module_2, dataclass_module_2_str,
             dataclass_module_3, dataclass_module_3_str,
+            dataclass_module_4, dataclass_module_4_str,
         ):
             with self.subTest(m=m):
                 # There's a difference in how the ClassVars are

--- a/Lib/test/test_dataclasses/_types_proxy.py
+++ b/Lib/test/test_dataclasses/_types_proxy.py
@@ -1,0 +1,6 @@
+# We need this to test a case when a type
+# is imported via some other package,
+# like ClassVar from typing_extensions instead of typing.
+# https://github.com/python/cpython/issues/133956
+from typing import ClassVar
+from dataclasses import InitVar

--- a/Lib/test/test_dataclasses/_types_proxy.py
+++ b/Lib/test/test_dataclasses/_types_proxy.py
@@ -4,3 +4,5 @@
 # https://github.com/python/cpython/issues/133956
 from typing import ClassVar
 from dataclasses import InitVar
+
+__all__ = ["ClassVar", "InitVar"]

--- a/Lib/test/test_dataclasses/dataclass_module_3.py
+++ b/Lib/test/test_dataclasses/dataclass_module_3.py
@@ -1,0 +1,32 @@
+#from __future__ import annotations
+USING_STRINGS = False
+
+# dataclass_module_3.py and dataclass_module_3_str.py are identical
+# except only the latter uses string annotations.
+
+from dataclasses import dataclass
+import test.test_dataclasses._types_proxy as tp
+
+T_CV2 = tp.ClassVar[int]
+T_CV3 = tp.ClassVar
+
+T_IV2 = tp.InitVar[int]
+T_IV3 = tp.InitVar
+
+@dataclass
+class CV:
+    T_CV4 = tp.ClassVar
+    cv0: tp.ClassVar[int] = 20
+    cv1: tp.ClassVar = 30
+    cv2: T_CV2
+    cv3: T_CV3
+    not_cv4: T_CV4  # When using string annotations, this field is not recognized as a ClassVar.
+
+@dataclass
+class IV:
+    T_IV4 = tp.InitVar
+    iv0: tp.InitVar[int]
+    iv1: tp.InitVar
+    iv2: T_IV2
+    iv3: T_IV3
+    not_iv4: T_IV4  # When using string annotations, this field is not recognized as an InitVar.

--- a/Lib/test/test_dataclasses/dataclass_module_3_str.py
+++ b/Lib/test/test_dataclasses/dataclass_module_3_str.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+USING_STRINGS = True
+
+# dataclass_module_3.py and dataclass_module_2_str.py are identical
+# except only the latter uses string annotations.
+
+from dataclasses import dataclass
+import test.test_dataclasses._types_proxy as tp
+
+T_CV2 = tp.ClassVar[int]
+T_CV3 = tp.ClassVar
+
+T_IV2 = tp.InitVar[int]
+T_IV3 = tp.InitVar
+
+@dataclass
+class CV:
+    T_CV4 = tp.ClassVar
+    cv0: tp.ClassVar[int] = 20
+    cv1: tp.ClassVar = 30
+    cv2: T_CV2
+    cv3: T_CV3
+    not_cv4: T_CV4  # When using string annotations, this field is not recognized as a ClassVar.
+
+@dataclass
+class IV:
+    T_IV4 = tp.InitVar
+    iv0: tp.InitVar[int]
+    iv1: tp.InitVar
+    iv2: T_IV2
+    iv3: T_IV3
+    not_iv4: T_IV4  # When using string annotations, this field is not recognized as an InitVar.

--- a/Lib/test/test_dataclasses/dataclass_module_3_str.py
+++ b/Lib/test/test_dataclasses/dataclass_module_3_str.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 USING_STRINGS = True
 
-# dataclass_module_3.py and dataclass_module_2_str.py are identical
+# dataclass_module_3.py and dataclass_module_3_str.py are identical
 # except only the latter uses string annotations.
 
 from dataclasses import dataclass

--- a/Lib/test/test_dataclasses/dataclass_module_4.py
+++ b/Lib/test/test_dataclasses/dataclass_module_4.py
@@ -9,29 +9,30 @@ import dataclasses
 import typing
 
 class TypingProxy:
-    ClassVar = typing.ClassVar
-    InitVar = dataclasses.InitVar
+    class Nested:
+        ClassVar = typing.ClassVar
+        InitVar = dataclasses.InitVar
 
-T_CV2 = TypingProxy.ClassVar[int]
-T_CV3 = TypingProxy.ClassVar
+T_CV2 = TypingProxy.Nested.ClassVar[int]
+T_CV3 = TypingProxy.Nested.ClassVar
 
-T_IV2 = TypingProxy.InitVar[int]
-T_IV3 = TypingProxy.InitVar
+T_IV2 = TypingProxy.Nested.InitVar[int]
+T_IV3 = TypingProxy.Nested.InitVar
 
 @dataclass
 class CV:
-    T_CV4 = TypingProxy.ClassVar
-    cv0: TypingProxy.ClassVar[int] = 20
-    cv1: TypingProxy.ClassVar = 30
+    T_CV4 = TypingProxy.Nested.ClassVar
+    cv0: TypingProxy.Nested.ClassVar[int] = 20
+    cv1: TypingProxy.Nested.ClassVar = 30
     cv2: T_CV2
     cv3: T_CV3
     not_cv4: T_CV4  # When using string annotations, this field is not recognized as a ClassVar.
 
 @dataclass
 class IV:
-    T_IV4 = TypingProxy.InitVar
-    iv0: TypingProxy.InitVar[int]
-    iv1: TypingProxy.InitVar
+    T_IV4 = TypingProxy.Nested.InitVar
+    iv0: TypingProxy.Nested.InitVar[int]
+    iv1: TypingProxy.Nested.InitVar
     iv2: T_IV2
     iv3: T_IV3
     not_iv4: T_IV4  # When using string annotations, this field is not recognized as an InitVar.

--- a/Lib/test/test_dataclasses/dataclass_module_4.py
+++ b/Lib/test/test_dataclasses/dataclass_module_4.py
@@ -1,0 +1,37 @@
+#from __future__ import annotations
+USING_STRINGS = False
+
+# dataclass_module_4.py and dataclass_module_4_str.py are identical
+# except only the latter uses string annotations.
+
+from dataclasses import dataclass
+import dataclasses
+import typing
+
+class TypingProxy:
+    ClassVar = typing.ClassVar
+    InitVar = dataclasses.InitVar
+
+T_CV2 = TypingProxy.ClassVar[int]
+T_CV3 = TypingProxy.ClassVar
+
+T_IV2 = TypingProxy.InitVar[int]
+T_IV3 = TypingProxy.InitVar
+
+@dataclass
+class CV:
+    T_CV4 = TypingProxy.ClassVar
+    cv0: TypingProxy.ClassVar[int] = 20
+    cv1: TypingProxy.ClassVar = 30
+    cv2: T_CV2
+    cv3: T_CV3
+    not_cv4: T_CV4  # When using string annotations, this field is not recognized as a ClassVar.
+
+@dataclass
+class IV:
+    T_IV4 = TypingProxy.InitVar
+    iv0: TypingProxy.InitVar[int]
+    iv1: TypingProxy.InitVar
+    iv2: T_IV2
+    iv3: T_IV3
+    not_iv4: T_IV4  # When using string annotations, this field is not recognized as an InitVar.

--- a/Lib/test/test_dataclasses/dataclass_module_4_str.py
+++ b/Lib/test/test_dataclasses/dataclass_module_4_str.py
@@ -9,29 +9,30 @@ import dataclasses
 import typing
 
 class TypingProxy:
-    ClassVar = typing.ClassVar
-    InitVar = dataclasses.InitVar
+    class Nested:
+        ClassVar = typing.ClassVar
+        InitVar = dataclasses.InitVar
 
-T_CV2 = TypingProxy.ClassVar[int]
-T_CV3 = TypingProxy.ClassVar
+T_CV2 = TypingProxy.Nested.ClassVar[int]
+T_CV3 = TypingProxy.Nested.ClassVar
 
-T_IV2 = TypingProxy.InitVar[int]
-T_IV3 = TypingProxy.InitVar
+T_IV2 = TypingProxy.Nested.InitVar[int]
+T_IV3 = TypingProxy.Nested.InitVar
 
 @dataclass
 class CV:
-    T_CV4 = TypingProxy.ClassVar
-    cv0: TypingProxy.ClassVar[int] = 20
-    cv1: TypingProxy.ClassVar = 30
+    T_CV4 = TypingProxy.Nested.ClassVar
+    cv0: TypingProxy.Nested.ClassVar[int] = 20
+    cv1: TypingProxy.Nested.ClassVar = 30
     cv2: T_CV2
     cv3: T_CV3
     not_cv4: T_CV4  # When using string annotations, this field is not recognized as a ClassVar.
 
 @dataclass
 class IV:
-    T_IV4 = TypingProxy.InitVar
-    iv0: TypingProxy.InitVar[int]
-    iv1: TypingProxy.InitVar
+    T_IV4 = TypingProxy.Nested.InitVar
+    iv0: TypingProxy.Nested.InitVar[int]
+    iv1: TypingProxy.Nested.InitVar
     iv2: T_IV2
     iv3: T_IV3
     not_iv4: T_IV4  # When using string annotations, this field is not recognized as an InitVar.

--- a/Lib/test/test_dataclasses/dataclass_module_4_str.py
+++ b/Lib/test/test_dataclasses/dataclass_module_4_str.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+USING_STRINGS = True
+
+# dataclass_module_4.py and dataclass_module_4_str.py are identical
+# except only the latter uses string annotations.
+
+from dataclasses import dataclass
+import dataclasses
+import typing
+
+class TypingProxy:
+    ClassVar = typing.ClassVar
+    InitVar = dataclasses.InitVar
+
+T_CV2 = TypingProxy.ClassVar[int]
+T_CV3 = TypingProxy.ClassVar
+
+T_IV2 = TypingProxy.InitVar[int]
+T_IV3 = TypingProxy.InitVar
+
+@dataclass
+class CV:
+    T_CV4 = TypingProxy.ClassVar
+    cv0: TypingProxy.ClassVar[int] = 20
+    cv1: TypingProxy.ClassVar = 30
+    cv2: T_CV2
+    cv3: T_CV3
+    not_cv4: T_CV4  # When using string annotations, this field is not recognized as a ClassVar.
+
+@dataclass
+class IV:
+    T_IV4 = TypingProxy.InitVar
+    iv0: TypingProxy.InitVar[int]
+    iv1: TypingProxy.InitVar
+    iv2: T_IV2
+    iv3: T_IV3
+    not_iv4: T_IV4  # When using string annotations, this field is not recognized as an InitVar.

--- a/Misc/NEWS.d/next/Library/2025-05-16-01-43-58.gh-issue-133956.5kWDYd.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-16-01-43-58.gh-issue-133956.5kWDYd.rst
@@ -1,0 +1,1 @@
+Fix bug where ``ClassVar`` string annotation in :func:`@dataclass <dataclasses.dataclass>` caused incorrect __init__ generation

--- a/Misc/NEWS.d/next/Library/2025-05-16-01-43-58.gh-issue-133956.5kWDYd.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-16-01-43-58.gh-issue-133956.5kWDYd.rst
@@ -1,1 +1,4 @@
-Fix bug where ``ClassVar`` string annotation in :func:`@dataclass <dataclasses.dataclass>` caused incorrect __init__ generation
+Fix bug where :func:`@dataclass <dataclasses.dataclass>`
+wouldn't detect ``ClassVar`` fields
+if ``ClassVar`` was re-exported from a module
+other than :mod:`typing`.


### PR DESCRIPTION
This PR continues work by @dzherb from #134073.

I've simplified the code and removed strict checks from `_is_type`. Supporting arbitrary levels of module nesting turned out to be beneficial for overall code complexity, so I've included it to this PR; I can send it as a separate PR with a separate issue, though.

## Motivation for current implementation

I think we shouldn't assume anything about user-provided type annotations. All we know from annotation `ty.ClassVar` is that there is an object `ty`, and we're getting its attribute `ClassVar`. We shouldn't assume that `ty` is a module, nor that it doesn't implement some custom `__getattr__` logic; instead, we should just do what the annotation tells us to do.


<!-- gh-issue-number: gh-133956 -->
* Issue: gh-133956
<!-- /gh-issue-number -->
