### PR TITLE
gh-140513: Fail to compile if `_Py_TAIL_CALL_INTERP` is set but `preserve_none` and `musttail` do not exist.

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-10-25-08-07-06.gh-issue-140513.6OhLTs.rst
+++ b/Misc/NEWS.d/next/Build/2025-10-25-08-07-06.gh-issue-140513.6OhLTs.rst
@@ -1,2 +1,2 @@
-Ensure that the build fails if ``_Py_TAIL_CALL_INTERP`` is enabled but either
-``preserve_none`` or ``musttail`` is not supported.
+Generate a clear compilation error when ``_Py_TAIL_CALL_INTERP`` is enabled but
+either ``preserve_none`` or ``musttail`` is not supported.

--- a/Misc/NEWS.d/next/Build/2025-10-25-08-07-06.gh-issue-140513.6OhLTs.rst
+++ b/Misc/NEWS.d/next/Build/2025-10-25-08-07-06.gh-issue-140513.6OhLTs.rst
@@ -1,0 +1,2 @@
+Ensure that the build fails if ``_Py_TAIL_CALL_INTERP`` is enabled but either
+``preserve_none`` or ``musttail`` is not supported.

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -78,10 +78,14 @@
 #   define TAIL_CALL_ARGS frame, stack_pointer, tstate, next_instr, instruction_funcptr_table, oparg
 #endif
 
-#if _Py_TAIL_CALL_INTERP && (defined(__clang__) || defined(__GNUC__))
-#    if !_Py__has_attribute(preserve_none) || !_Py__has_attribute(musttail)
-#        error "This compiler does not have support for efficient tail calling."
+#if _Py_TAIL_CALL_INTERP
+#    if defined(__clang__) || defined(__GNUC__)
+#        if !_Py__has_attribute(preserve_none) || !_Py__has_attribute(musttail)
+#            error "This compiler does not have support for efficient tail calling."
+#        endif
 #    endif
+#elif defined(_MSC_VER) && (_MSC_VER < 1950)
+#    error "You need atleast VS 2026 / PlatformToolset v145 for tail calling."
 #endif
 
     // Note: [[clang::musttail]] works for GCC 15, but not __attribute__((musttail)) at the moment.

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -82,7 +82,7 @@
 #   if defined(__clang__) || defined(__GNUC__)
 #       if !_Py__has_attribute(preserve_none) || !_Py__has_attribute(musttail)
 #           error "This compiler does not have support for efficient tail calling."
-#   endif
+#       endif
 #   elif defined(_MSC_VER) && (_MSC_VER < 1950)
 #       error "You need at least VS 2026 / PlatformToolset v145 for tail calling."
 #   endif

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -83,6 +83,7 @@
 #        error "This compiler does not have support for efficient tail calling."
 #    endif
 #endif
+
     // Note: [[clang::musttail]] works for GCC 15, but not __attribute__((musttail)) at the moment.
 #   define Py_MUSTTAIL [[clang::musttail]]
 #   define Py_PRESERVE_NONE_CC __attribute__((preserve_none))

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -83,10 +83,9 @@
 #        if !_Py__has_attribute(preserve_none) || !_Py__has_attribute(musttail)
 #            error "This compiler does not have support for efficient tail calling."
 #        endif
+#    elif defined(_MSC_VER) && (_MSC_VER < 1950)
+#        error "You need atleast VS 2026 / PlatformToolset v145 for tail calling."
 #    endif
-#elif defined(_MSC_VER) && (_MSC_VER < 1950)
-#    error "You need atleast VS 2026 / PlatformToolset v145 for tail calling."
-#endif
 
     // Note: [[clang::musttail]] works for GCC 15, but not __attribute__((musttail)) at the moment.
 #   define Py_MUSTTAIL [[clang::musttail]]

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -79,13 +79,13 @@
 #endif
 
 #if _Py_TAIL_CALL_INTERP
-#    if defined(__clang__) || defined(__GNUC__)
-#        if !_Py__has_attribute(preserve_none) || !_Py__has_attribute(musttail)
-#            error "This compiler does not have support for efficient tail calling."
-#        endif
-#    elif defined(_MSC_VER) && (_MSC_VER < 1950)
-#        error "You need atleast VS 2026 / PlatformToolset v145 for tail calling."
-#    endif
+#   if defined(__clang__) || defined(__GNUC__)
+#       if !_Py__has_attribute(preserve_none) || !_Py__has_attribute(musttail)
+#           error "This compiler does not have support for efficient tail calling."
+#   endif
+#   elif defined(_MSC_VER) && (_MSC_VER < 1950)
+#       error "You need at least VS 2026 / PlatformToolset v145 for tail calling."
+#   endif
 
     // Note: [[clang::musttail]] works for GCC 15, but not __attribute__((musttail)) at the moment.
 #   define Py_MUSTTAIL [[clang::musttail]]

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -78,7 +78,11 @@
 #   define TAIL_CALL_ARGS frame, stack_pointer, tstate, next_instr, instruction_funcptr_table, oparg
 #endif
 
-#if _Py_TAIL_CALL_INTERP
+#if _Py_TAIL_CALL_INTERP && (defined(__clang__) || defined(__GNUC__))
+#    if !_Py__has_attribute(preserve_none) || !!_Py__has_attribute(musttail)
+#        error "This compiler does not have support for efficient tail calling."
+#    endif
+#endif
     // Note: [[clang::musttail]] works for GCC 15, but not __attribute__((musttail)) at the moment.
 #   define Py_MUSTTAIL [[clang::musttail]]
 #   define Py_PRESERVE_NONE_CC __attribute__((preserve_none))

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -79,7 +79,7 @@
 #endif
 
 #if _Py_TAIL_CALL_INTERP && (defined(__clang__) || defined(__GNUC__))
-#    if !_Py__has_attribute(preserve_none) || !!_Py__has_attribute(musttail)
+#    if !_Py__has_attribute(preserve_none) || !_Py__has_attribute(musttail)
 #        error "This compiler does not have support for efficient tail calling."
 #    endif
 #endif


### PR DESCRIPTION


<!-- gh-issue-number: gh-140513 -->
* Issue: gh-140513
<!-- /gh-issue-number -->
