### PR TITLE
gh-140463: Fix typo in xmlrpc.client documentation

### DIFF
--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -524,7 +524,7 @@ Convenience Functions
 
 .. function:: dumps(params, methodname=None, methodresponse=None, encoding=None, allow_none=False)
 
-   Convert *params* into an XML-RPC request. or into a response if *methodresponse*
+   Convert *params* into an XML-RPC request, or into a response if *methodresponse*
    is true. *params* can be either a tuple of arguments or an instance of the
    :exc:`Fault` exception class.  If *methodresponse* is true, only a single value
    can be returned, meaning that *params* must be of length 1. *encoding*, if


### PR DESCRIPTION
<!-- gh-issue-number: gh-140463 -->
* Issue: gh-140463
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140552.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->