### PR TITLE
gh-140551: Fix `dict` crash if `clear` is called at `lookup` stage

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1602,8 +1602,6 @@ class DictTest(unittest.TestCase):
             d.get(key2)
 
     def test_clear_at_lookup(self):
-        d = {}
-
         class X(object):
             def __hash__(self):
                 return 1
@@ -1611,8 +1609,15 @@ class DictTest(unittest.TestCase):
                 nonlocal d
                 d.clear()
 
+        d = {}
         for _ in range(10):
             d[X()] = None
+
+        self.assertEqual(len(d), 1)
+
+        d = {}
+        for _ in range(10):
+            d.setdefault(X(), None)
 
         self.assertEqual(len(d), 1)
 

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1602,7 +1602,7 @@ class DictTest(unittest.TestCase):
             d.get(key2)
 
     def test_clear_at_lookup(self):
-        class X(object):
+        class X:
             def __hash__(self):
                 return 1
             def __eq__(self, other):

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1601,6 +1601,21 @@ class DictTest(unittest.TestCase):
         with self.assertRaises(KeyError):
             d.get(key2)
 
+    def test_clear_at_lookup(self):
+        d = {}
+
+        class X(object):
+            def __hash__(self):
+                return 1
+            def __eq__(self, other):
+                nonlocal d
+                d.clear()
+
+        for _ in range(10):
+            d[X()] = None
+
+        self.assertEqual(len(d), 1)
+
 
 class CAPITest(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-24-20-42-33.gh-issue-140551.-9swrl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-24-20-42-33.gh-issue-140551.-9swrl.rst
@@ -1,2 +1,2 @@
-Fixed crash in :class:`dict` if :meth:`clear` is called at the lookup stage. Patch by
-Mikhail Efimov.
+Fixed crash in :class:`dict` if :meth:`dict.clear` is called at the lookup
+stage. Patch by Mikhail Efimov.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-24-20-42-33.gh-issue-140551.-9swrl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-24-20-42-33.gh-issue-140551.-9swrl.rst
@@ -1,0 +1,2 @@
+Fixed crash in ``dict`` if ``clear`` is called at the lookup stage. Patch by
+Mikhail Efimov.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-24-20-42-33.gh-issue-140551.-9swrl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-24-20-42-33.gh-issue-140551.-9swrl.rst
@@ -1,2 +1,2 @@
 Fixed crash in :class:`dict` if :meth:`dict.clear` is called at the lookup
-stage. Patch by Mikhail Efimov.
+stage. Patch by Mikhail Efimov and Inada Naoki.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-24-20-42-33.gh-issue-140551.-9swrl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-24-20-42-33.gh-issue-140551.-9swrl.rst
@@ -1,2 +1,2 @@
-Fixed crash in ``dict`` if ``clear`` is called at the lookup stage. Patch by
+Fixed crash in :class:`dict` if :meth:`clear` is called at the lookup stage. Patch by
 Mikhail Efimov.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1903,7 +1903,7 @@ insertdict(PyInterpreterState *interp, PyDictObject *mp,
         // insert_combined_dict() will convert from non DICT_KEYS_GENERAL table
         // into DICT_KEYS_GENERAL table if key is not Unicode.
         // We don't convert it before _Py_dict_lookup because non-Unicode key
-        // may change generic table into Unicode/split table.
+        // may change generic table into Unicode table.
         if (insert_combined_dict(interp, mp, hash, key, value) < 0) {
             goto Fail;
         }
@@ -4440,6 +4440,7 @@ dict_setdefault_ref_lock_held(PyObject *d, PyObject *key, PyObject *default_valu
     if (ix == DKIX_EMPTY) {
         value = default_value;
 
+        // See comment to this function in insertdict.
         if (insert_combined_dict(interp, mp, hash, Py_NewRef(key), Py_NewRef(value)) < 0) {
             Py_DECREF(key);
             Py_DECREF(value);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1775,7 +1775,7 @@ static inline int
 insert_combined_dict(PyInterpreterState *interp, PyDictObject *mp,
                      Py_hash_t hash, PyObject *key, PyObject *value)
 {
-    // gh-140551: If dict was cleaned in _Py_dict_lookup,
+    // gh-140551: If dict was cleared in _Py_dict_lookup,
     // we have to resize one more time to force general key kind.
     if (DK_IS_UNICODE(mp->ma_keys) && !PyUnicode_CheckExact(key)) {
         if (insertion_resize(mp, 0) < 0)

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1899,6 +1899,14 @@ insertdict(PyInterpreterState *interp, PyDictObject *mp,
     if (ix == DKIX_ERROR)
         goto Fail;
 
+    // gh-140551: If dict was cleaned in _Py_dict_lookup,
+    // we have to resize one more time to force general key kind.
+    if (DK_IS_UNICODE(mp->ma_keys) && !PyUnicode_CheckExact(key)) {
+        if (insertion_resize(mp, 0) < 0)
+            goto Fail;
+        assert(mp->ma_keys->dk_kind == DICT_KEYS_GENERAL);
+    }
+
     if (ix == DKIX_EMPTY) {
         assert(!_PyDict_HasSplitTable(mp));
         /* Insert into new slot. */


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140551 -->
* Issue: gh-140551
<!-- /gh-issue-number -->
