### PR TITLE
Fix minor typo: 'web site' -> 'website' in tutorial introduction

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -12,7 +12,7 @@
 --------------
 
 The :mod:`http.cookiejar` module defines classes for automatic handling of HTTP
-cookies.  It is useful for accessing web sites that require small pieces of data
+cookies.  It is useful for accessing websites that require small pieces of data
 -- :dfn:`cookies` -- to be set on the client machine by an HTTP response from a
 web server, and then returned to the server in later HTTP requests.
 

--- a/Doc/library/urllib.robotparser.rst
+++ b/Doc/library/urllib.robotparser.rst
@@ -19,7 +19,7 @@
 
 This module provides a single class, :class:`RobotFileParser`, which answers
 questions about whether or not a particular user agent can fetch a URL on the
-web site that published the :file:`robots.txt` file.  For more details on the
+website that published the :file:`robots.txt` file.  For more details on the
 structure of :file:`robots.txt` files, see http://www.robotstxt.org/orig.html.
 
 

--- a/Doc/tutorial/index.rst
+++ b/Doc/tutorial/index.rst
@@ -15,7 +15,7 @@ together with its interpreted nature, make it an ideal language for scripting
 and rapid application development in many areas on most platforms.
 
 The Python interpreter and the extensive standard library are freely available
-in source or binary form for all major platforms from the Python web site,
+in source or binary form for all major platforms from the Python website,
 https://www.python.org/, and may be freely distributed. The same site also
 contains distributions of and pointers to many free third party Python modules,
 programs and tools, and additional documentation.

--- a/Doc/tutorial/whatnow.rst
+++ b/Doc/tutorial/whatnow.rst
@@ -30,7 +30,7 @@ the set are:
 
 More Python resources:
 
-* https://www.python.org:  The major Python web site.  It contains code,
+* https://www.python.org:  The major Python website.  It contains code,
   documentation, and pointers to Python-related pages around the web.
 
 * https://docs.python.org:  Fast access to Python's  documentation.


### PR DESCRIPTION
Fix typo in Python tutorial introduction

Changed "web site" → "website" for consistency with modern style.
 

*This is my first contribution to the Python documentation.*




<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140561.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->