### PR TITLE
Remove unreachable break statements in _ctypes_test.c

### DIFF
--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -989,13 +989,10 @@ EXPORT(RECT) ReturnRect(int i, RECT ar, RECT* br, POINT cp, RECT dr,
     {
     case 0:
         return ar;
-        break;
     case 1:
         return dr;
-        break;
     case 2:
         return gr;
-        break;
 
     }
     return ar;


### PR DESCRIPTION
## Summary
Remove unreachable `break` statements after `return` in switch cases.

## Details
Static analyzers flag these as dead code. The `break` statements on lines 
992, 995, and 998 are never executed since `return` already exits the function.

## Notes
- No functional changes
- No news entry added (trivial cleanup)
- Eliminates static analyzer warnings