### PR TITLE
gh-140593: Fix a memory leak in function `my_ElementDeclHandler` of `pyexpat`

### DIFF
--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -687,7 +687,7 @@ class ChardataBufferTest(unittest.TestCase):
 class ElementDeclHandlerTest(unittest.TestCase):
     def test_trigger_leak(self):
         # Unfixed, this test would leak 32 to 56 bytes of memory.
-        # https://github.com/python/cpython/issues/140593
+        # See https://github.com/python/cpython/issues/140593.
         data = textwrap.dedent('''\
             <!DOCTYPE quotations SYSTEM "quotations.dtd" [
                 <!ELEMENT root ANY>

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -718,6 +718,24 @@ class ErrorMessageTest(unittest.TestCase):
             self.assertEqual(e.code,
                              errors.codes[errors.XML_ERROR_UNCLOSED_TOKEN])
 
+class ElementDeclHandlerCleanUpLeakTest(unittest.TestCase):
+
+    def test_trigger_leak(self):
+        # Unfixed, this test would leak 32 to 56 bytes of memory
+        # https://github.com/python/cpython/issues/140593
+        data = textwrap.dedent('''\
+            <!DOCTYPE quotations SYSTEM "quotations.dtd" [
+                <!ELEMENT root ANY>
+            ]>
+            <root/>
+        ''').encode('UTF-8')
+
+        parser = expat.ParserCreate()
+        parser.NotStandaloneHandler = lambda: 1.234  # arbitrary float
+        parser.ElementDeclHandler = lambda _1, _2: None
+        with self.assertRaises(TypeError):
+            parser.Parse(data, True)
+
 
 class ForeignDTDTests(unittest.TestCase):
     """

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -686,7 +686,8 @@ class ChardataBufferTest(unittest.TestCase):
 
 class ElementDeclHandlerTest(unittest.TestCase):
     def test_trigger_leak(self):
-        # Unfixed, this test would leak 32 to 56 bytes of memory.
+        # Unfixed, this test would leak the memory of the so-called
+        # "content model" in function ``my_ElementDeclHandler`` of pyexpat.
         # See https://github.com/python/cpython/issues/140593.
         data = textwrap.dedent('''\
             <!DOCTYPE quotations SYSTEM "quotations.dtd" [

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -698,8 +698,7 @@ class ElementDeclHandlerTest(unittest.TestCase):
         parser = expat.ParserCreate()
         parser.NotStandaloneHandler = lambda: 1.234  # arbitrary float
         parser.ElementDeclHandler = lambda _1, _2: None
-        with self.assertRaises(TypeError):
-            parser.Parse(data, True)
+        self.assertRaises(TypeError, parser.Parse, data, True)
 
 class MalformedInputTest(unittest.TestCase):
     def test1(self):

--- a/Misc/NEWS.d/next/Library/2025-10-25-21-26-16.gh-issue-140593.OxlLc9.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-25-21-26-16.gh-issue-140593.OxlLc9.rst
@@ -1,0 +1,3 @@
+:mod:`xml.parsers.expat`: Fix a memory leak that could affect users with
+:meth:`~xml.parsers.expat.xmlparser.ElementDeclHandler` set to a custom
+element declaration handler. Patch by Sebastian Pipping.

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -642,7 +642,7 @@ my_ElementDeclHandler(void *userData,
         PyObject *modelobj, *nameobj;
 
         if (PyErr_Occurred())
-            return;
+            goto finally;
 
         if (flush_character_buffer(self) < 0)
             goto finally;


### PR DESCRIPTION
CC @StanFromIreland @YuanchengJiang

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140593 -->
* Issue: gh-140593
<!-- /gh-issue-number -->
