### PR TITLE
gh-140578: Clarify multiprocessing docs to mention ThreadPoolExecutor

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -30,6 +30,8 @@ distributing the input data across processes (data parallelism).  The following
 example demonstrates the common practice of defining such functions in a module
 so that child processes can successfully import that module.  This basic example
 of data parallelism using :class:`~multiprocessing.pool.Pool`, ::
+Note that a similar high-level interface for thread-based parallelism is provided by the :class:`concurrent.futures.ThreadPoolExecutor` class in the :mod:`concurrent.futures` module.
+
 
    from multiprocessing import Pool
 


### PR DESCRIPTION
This pull request fixes issue #140578 by updating the multiprocessing documentation.

It adds a note explaining that a similar high-level interface for thread-based parallelism is available via the :class:`concurrent.futures.ThreadPoolExecutor` in the :mod:`concurrent.futures` module.

This clarification helps prevent confusion for users who might assume no such interface exists.

<!-- gh-issue-number: gh-140578 -->
* Issue: gh-140578
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140604.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->