### PR TITLE
gh-140607: Validate returned byte count in RawIOBase.read

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -617,6 +617,8 @@ class RawIOBase(IOBase):
         n = self.readinto(b)
         if n is None:
             return None
+        if n < 0 or n > len(b):
+            raise ValueError(f"readinto returned '{n}' outside buffer size '{len(b)}'")
         del b[n:]
         return bytes(b)
 

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -618,7 +618,7 @@ class RawIOBase(IOBase):
         if n is None:
             return None
         if n < 0 or n > len(b):
-            raise ValueError(f"readinto returned '{n}' outside buffer size '{len(b)}'")
+            raise ValueError(f"readinto returned {n} outside buffer size {len(b)}")
         del b[n:]
         return bytes(b)
 

--- a/Lib/test/test_io/test_general.py
+++ b/Lib/test/test_io/test_general.py
@@ -603,7 +603,7 @@ class IOTest:
 
         with self.assertRaises(ValueError) as cm:
             Misbehaved(2).read(1)
-        self.assertEqual(str(cm.exception), "readinto returned '2' outside buffer size '1'")
+        self.assertEqual(str(cm.exception), "readinto returned 2 outside buffer size 1")
         for bad_size in (2147483647, sys.maxsize, -1, -1000):
             with self.assertRaises(ValueError):
                 Misbehaved(bad_size).read()

--- a/Lib/test/test_io/test_general.py
+++ b/Lib/test/test_io/test_general.py
@@ -593,9 +593,9 @@ class IOTest:
         self.assertEqual(rawio.read(2), b"")
 
     def test_RawIOBase_read_bounds_checking(self):
-        # Make sure a `.readinto` call which returns a value oustside
+        # Make sure a `.readinto` call which returns a value outside
         # (0, len(buffer)) raises.
-        class Misbehaved(io.RawIOBase):
+        class Misbehaved(self.io.RawIOBase):
             def __init__(self, readinto_return) -> None:
                 self._readinto_return = readinto_return
             def readinto(self, b):
@@ -603,10 +603,10 @@ class IOTest:
 
         with self.assertRaises(ValueError) as cm:
             Misbehaved(2).read(1)
-        self.assertEqual(str(cm.exception), "readinto returned '2' oustside buffer size '1'")
+        self.assertEqual(str(cm.exception), "readinto returned '2' outside buffer size '1'")
         for bad_size in (2147483647, sys.maxsize, -1, -1000):
-          with self.assertRaises(ValueError):
-              Misbehaved(bad_size).read()
+            with self.assertRaises(ValueError):
+                Misbehaved(bad_size).read()
 
     def test_types_have_dict(self):
         test = (

--- a/Lib/test/test_io/test_general.py
+++ b/Lib/test/test_io/test_general.py
@@ -604,10 +604,9 @@ class IOTest:
         with self.assertRaises(ValueError) as cm:
             Misbehaved(2).read(1)
         self.assertEqual(str(cm.exception), "readinto returned '2' oustside buffer size '1'")
-        self.assertRaises(ValueError, Misbehaved(2147483647).read)
-        self.assertRaises(ValueError, Misbehaved(sys.maxsize).read)
-        self.assertRaises(ValueError, Misbehaved(-1).read)
-        self.assertRaises(ValueError, Misbehaved(-1000).read)
+        for bad_size in (2147483647, sys.maxsize, -1, -1000):
+          with self.assertRaises(ValueError):
+              Misbehaved(bad_size).read()
 
     def test_types_have_dict(self):
         test = (

--- a/Misc/NEWS.d/next/Library/2025-10-25-21-04-00.gh-issue-140607.oOZGxS.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-25-21-04-00.gh-issue-140607.oOZGxS.rst
@@ -1,2 +1,2 @@
-Inside :meth:`io.RawIOBase.read` validate that the count of bytes returned by
-:meth:`io.RawIOBase.readinto` is reasonable (inside the provided buffer).
+Inside :meth:`io.RawIOBase.read`, validate that the count of bytes returned by
+:meth:`io.RawIOBase.readinto` is valid (inside the provided buffer).

--- a/Misc/NEWS.d/next/Library/2025-10-25-21-04-00.gh-issue-140607.oOZGxS.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-25-21-04-00.gh-issue-140607.oOZGxS.rst
@@ -1,0 +1,2 @@
+Inside :meth:`io.RawIOBase.read` validate that the count of bytes returned by
+:meth:`io.RawIOBase.readinto` is reasonable (inside the provided buffer).

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -939,14 +939,21 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
         return res;
     }
 
-    n = PyNumber_AsSsize_t(res, PyExc_ValueError);
+    Py_ssize_t bytes_filled = PyNumber_AsSsize_t(res, PyExc_ValueError);
     Py_DECREF(res);
-    if (n == -1 && PyErr_Occurred()) {
+    if (bytes_filled == -1 && PyErr_Occurred()) {
         Py_DECREF(b);
         return NULL;
     }
+    if (bytes_filled < 0 || bytes_filled > n) {
+        Py_DECREF(b);
+        PyErr_Format(PyExc_ValueError,
+                        "readinto returned '%zd' oustside buffer size '%zd'",
+                        bytes_filled, n);
+        return NULL;
+    }
 
-    res = PyBytes_FromStringAndSize(PyByteArray_AsString(b), n);
+    res = PyBytes_FromStringAndSize(PyByteArray_AsString(b), bytes_filled);
     Py_DECREF(b);
     return res;
 }

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -948,7 +948,7 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
     if (bytes_filled < 0 || bytes_filled > n) {
         Py_DECREF(b);
         PyErr_Format(PyExc_ValueError,
-                     "readinto returned '%zd' outside buffer size '%zd'",
+                     "readinto returned %zd outside buffer size %zd",
                      bytes_filled, n);
         return NULL;
     }

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -948,7 +948,7 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
     if (bytes_filled < 0 || bytes_filled > n) {
         Py_DECREF(b);
         PyErr_Format(PyExc_ValueError,
-                     "readinto returned '%zd' oustside buffer size '%zd'",
+                     "readinto returned '%zd' outside buffer size '%zd'",
                      bytes_filled, n);
         return NULL;
     }

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -948,8 +948,8 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
     if (bytes_filled < 0 || bytes_filled > n) {
         Py_DECREF(b);
         PyErr_Format(PyExc_ValueError,
-                        "readinto returned '%zd' oustside buffer size '%zd'",
-                        bytes_filled, n);
+                     "readinto returned '%zd' oustside buffer size '%zd'",
+                     bytes_filled, n);
         return NULL;
     }
 


### PR DESCRIPTION
While `readinto` implementations should return a count of bytes between 0 and the length of the given buffer, they are not required to. Add validation inside `RawIOBase.read` that the returned byte count is reasonable.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140607 -->
* Issue: gh-140607
<!-- /gh-issue-number -->
