### PR TITLE
gh-133346: make `_colorize.Argparse` kw-only constructible

### DIFF
--- a/Lib/_colorize.py
+++ b/Lib/_colorize.py
@@ -155,7 +155,7 @@ class ThemeSection(Mapping[str, str]):
         return iter(self.__dataclass_fields__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Argparse(ThemeSection):
     usage: str = ANSIColors.BOLD_BLUE
     prog: str = ANSIColors.BOLD_MAGENTA


### PR DESCRIPTION
This was an oversight as other themes are kw-only constructible.

<!-- gh-issue-number: gh-133346 -->
* Issue: gh-133346
<!-- /gh-issue-number -->
