### PR TITLE
Minor documentation improvements

### DIFF
--- a/Doc/library/concurrent.interpreters.rst
+++ b/Doc/library/concurrent.interpreters.rst
@@ -29,12 +29,12 @@ Actual concurrency is available separately through
 .. seealso::
 
    :class:`~concurrent.futures.InterpreterPoolExecutor`
-      combines threads with interpreters in a familiar interface.
+      Combines threads with interpreters in a familiar interface.
 
-    .. XXX Add references to the upcoming HOWTO docs in the seealso block.
+   .. XXX Add references to the upcoming HOWTO docs in the seealso block.
 
    :ref:`isolating-extensions-howto`
-       how to update an extension module to support multiple interpreters
+      How to update an extension module to support multiple interpreters.
 
    :pep:`554`
 

--- a/Doc/library/heapq.rst
+++ b/Doc/library/heapq.rst
@@ -58,6 +58,11 @@ functions, respectively.
 The following functions are provided for min-heaps:
 
 
+.. function:: heapify(x)
+
+   Transform list *x* into a min-heap, in-place, in linear time.
+
+
 .. function:: heappush(heap, item)
 
    Push the value *item* onto the *heap*, maintaining the min-heap invariant.
@@ -75,11 +80,6 @@ The following functions are provided for min-heaps:
    Push *item* on the heap, then pop and return the smallest item from the
    *heap*.  The combined action runs more efficiently than :func:`heappush`
    followed by a separate call to :func:`heappop`.
-
-
-.. function:: heapify(x)
-
-   Transform list *x* into a min-heap, in-place, in linear time.
 
 
 .. function:: heapreplace(heap, item)


### PR DESCRIPTION
 - Fixes badly formatted “See also” callout in `concurrent.interpreters` doc page:

Was:

<img width="847" height="342" alt="Screenshot 2025-10-26 at 14 36 37" src="https://github.com/user-attachments/assets/9d32cd21-8248-4086-9a4f-0a45494c8d60" />

Local docs preview:

<img width="847" height="342" alt="Screenshot 2025-10-26 at 14 38 46" src="https://github.com/user-attachments/assets/d74de50a-4586-4934-be07-8a46ace00f0c" />

 - Reorders `heapq` functions for the min-heap so that the order makes more sense **and** matches the order for the max-heap functions.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140626.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->