### PR TITLE
Remove dead stores to 'size' in UTF-8 decoder (unicodeobject.c)

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -5409,7 +5409,6 @@ unicode_decode_utf8(const char *s, Py_ssize_t size,
     if (maxchr <= 255) {
         memcpy(PyUnicode_1BYTE_DATA(u), s, pos);
         s += pos;
-        size -= pos;
         writer.pos = pos;
     }
 
@@ -5457,7 +5456,6 @@ unicode_decode_utf8_writer(_PyUnicodeWriter *writer,
             return 0;
         }
         s += decoded;
-        size -= decoded;
     }
 
     return unicode_decode_utf8_impl(writer, starts, s, end,


### PR DESCRIPTION
## Summary
Remove two dead assignments to size after advancing s in the UTF-8 decoding paths. The decoding logic uses s and end for bounds; size is not read after these points. No functional changes. 

## Details 
Affected functions: unicode_decode_utf8() and unicode_decode_utf8_writer()
After s += pos/decoded, previous code also did size -= pos/decoded, but the remaining input is tracked via s < end and passed to unicode_decode_utf8_impl(..., s, end, ...).
Eliminates dead-store/unused-but-set warnings from static analyzers/compilers.
Behavior and performance are unchanged.
     
## Notes 
* No functional changes
* No news entry (trivial cleanup)
* OK to mark as skip issue / skip news
     