### PR TITLE
gh-140641: Break out of inittab search on match

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -2358,6 +2358,7 @@ create_builtin(PyThreadState *tstate, PyObject *name, PyObject *spec)
     for (struct _inittab *p = INITTAB; p->name != NULL; p++) {
         if (_PyUnicode_EqualToASCIIString(info.name, p->name)) {
             found = p;
+            break;
         }
     }
     if (found == NULL) {


### PR DESCRIPTION
The search loop is needlessly exhaustive.
We can break out of the search loop once we find a match.

<!-- gh-issue-number: gh-140641 -->
* Issue: gh-140641
<!-- /gh-issue-number -->
