### PR TITLE
gh-140650: fix SystemError in io.BufferedWriter.close when closed errors

### DIFF
--- a/Lib/test/test_io/test_bufferedio.py
+++ b/Lib/test/test_io/test_bufferedio.py
@@ -922,6 +922,14 @@ class BufferedWriterTest(CommonBufferedTests):
         self.assertTrue(bufio.closed)
         t.join()
 
+    def test_close_without_closed(self):
+        # gh-140650: check TypeError is raised
+        class MockRawIOWithoutClosed(self.MockRawIO):
+            closed = NotImplemented
+
+        bufio = self.tp(MockRawIOWithoutClosed())
+        self.assertRaises(TypeError, bufio.close)
+
 
 class CBufferedWriterTest(BufferedWriterTest, SizeofTest, CTestCase):
     tp = io.BufferedWriter

--- a/Lib/test/test_io/test_bufferedio.py
+++ b/Lib/test/test_io/test_bufferedio.py
@@ -922,14 +922,6 @@ class BufferedWriterTest(CommonBufferedTests):
         self.assertTrue(bufio.closed)
         t.join()
 
-    def test_close_without_closed(self):
-        # gh-140650: check TypeError is raised
-        class MockRawIOWithoutClosed(self.MockRawIO):
-            closed = NotImplemented
-
-        bufio = self.tp(MockRawIOWithoutClosed())
-        self.assertRaises(TypeError, bufio.close)
-
 
 class CBufferedWriterTest(BufferedWriterTest, SizeofTest, CTestCase):
     tp = io.BufferedWriter
@@ -969,6 +961,14 @@ class CBufferedWriterTest(BufferedWriterTest, SizeofTest, CTestCase):
         # Issue #17275
         with self.assertRaisesRegex(TypeError, "BufferedWriter"):
             self.tp(self.BytesIO(), 1024, 1024, 1024)
+
+    def test_close_without_closed(self):
+        # gh-140650: check TypeError is raised
+        class MockRawIOWithoutClosed(self.MockRawIO):
+            closed = NotImplemented
+
+        bufio = self.tp(MockRawIOWithoutClosed())
+        self.assertRaises(TypeError, bufio.close)
 
 
 class PyBufferedWriterTest(BufferedWriterTest, PyTestCase):

--- a/Lib/test/test_io/test_bufferedio.py
+++ b/Lib/test/test_io/test_bufferedio.py
@@ -962,12 +962,13 @@ class CBufferedWriterTest(BufferedWriterTest, SizeofTest, CTestCase):
         with self.assertRaisesRegex(TypeError, "BufferedWriter"):
             self.tp(self.BytesIO(), 1024, 1024, 1024)
 
-    def test_close_without_closed(self):
+    def test_closed_errors(self):
         # gh-140650: check TypeError is raised
         class MockRawIOWithoutClosed(self.MockRawIO):
             closed = NotImplemented
 
         bufio = self.tp(MockRawIOWithoutClosed())
+        self.assertRaises(TypeError, bufio.write, b"")
         self.assertRaises(TypeError, bufio.close)
 
 

--- a/Lib/test/test_io/test_bufferedio.py
+++ b/Lib/test/test_io/test_bufferedio.py
@@ -969,6 +969,7 @@ class CBufferedWriterTest(BufferedWriterTest, SizeofTest, CTestCase):
 
         bufio = self.tp(MockRawIOWithoutClosed())
         self.assertRaises(TypeError, bufio.write, b"")
+        self.assertRaises(TypeError, bufio.flush)
         self.assertRaises(TypeError, bufio.close)
 
 

--- a/Lib/test/test_io/test_bufferedio.py
+++ b/Lib/test/test_io/test_bufferedio.py
@@ -962,7 +962,7 @@ class CBufferedWriterTest(BufferedWriterTest, SizeofTest, CTestCase):
         with self.assertRaisesRegex(TypeError, "BufferedWriter"):
             self.tp(self.BytesIO(), 1024, 1024, 1024)
 
-    def test_closed_errors(self):
+    def test_non_boolean_closed_attr(self):
         # gh-140650: check TypeError is raised
         class MockRawIOWithoutClosed(self.MockRawIO):
             closed = NotImplemented
@@ -971,6 +971,17 @@ class CBufferedWriterTest(BufferedWriterTest, SizeofTest, CTestCase):
         self.assertRaises(TypeError, bufio.write, b"")
         self.assertRaises(TypeError, bufio.flush)
         self.assertRaises(TypeError, bufio.close)
+
+    def test_closed_attr_raises(self):
+        class MockRawIOClosedRaises(self.MockRawIO):
+            @property
+            def closed(self):
+                raise ValueError("test")
+
+        bufio = self.tp(MockRawIOClosedRaises())
+        self.assertRaisesRegex(ValueError, "test", bufio.write, b"")
+        self.assertRaisesRegex(ValueError, "test", bufio.flush)
+        self.assertRaisesRegex(ValueError, "test", bufio.close)
 
 
 class PyBufferedWriterTest(BufferedWriterTest, PyTestCase):

--- a/Misc/NEWS.d/next/Library/2025-10-27-00-40-49.gh-issue-140650.DYJPJ9.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-27-00-40-49.gh-issue-140650.DYJPJ9.rst
@@ -1,2 +1,2 @@
 Fix an issue where closing :class:`io.BufferedWriter` could crash
-if the closed attribute had the wrong type.
+if the closed attribute raised an exception.

--- a/Misc/NEWS.d/next/Library/2025-10-27-00-40-49.gh-issue-140650.DYJPJ9.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-27-00-40-49.gh-issue-140650.DYJPJ9.rst
@@ -1,2 +1,2 @@
-Fix an issue where :meth:`io.BufferedWriter.close` would crash when "closed"
-was not implemented.
+Fix an issue where closing :class:`io.BufferedWriter` could crash
+if the closed attribute had the wrong type.

--- a/Misc/NEWS.d/next/Library/2025-10-27-00-40-49.gh-issue-140650.DYJPJ9.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-27-00-40-49.gh-issue-140650.DYJPJ9.rst
@@ -1,0 +1,2 @@
+Fix an issue where :meth:`io.BufferedWriter.close` would crash when "closed"
+was not implemented.

--- a/Misc/NEWS.d/next/Library/2025-10-27-00-40-49.gh-issue-140650.DYJPJ9.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-27-00-40-49.gh-issue-140650.DYJPJ9.rst
@@ -1,2 +1,3 @@
-Fix an issue where closing :class:`io.BufferedWriter` could crash
-if the closed attribute raised an exception.
+Fix an issue where closing :class:`io.BufferedWriter` could crash if
+the closed attribute raised an exception on access or could not be
+converted to a boolean.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -362,7 +362,7 @@ _enter_buffered_busy(buffered *self)
     }
 
 #define IS_CLOSED(self) \
-    (!self->buffer || \
+    (!self->buffer ?: \
     (self->fast_closed_checks \
      ? _PyFileIO_closed(self->raw) \
      : buffered_closed(self)))

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -362,7 +362,7 @@ _enter_buffered_busy(buffered *self)
     }
 
 #define IS_CLOSED(self) \
-    (!self->buffer ?: \
+    (!self->buffer ? !self->buffer : \
     (self->fast_closed_checks \
      ? _PyFileIO_closed(self->raw) \
      : buffered_closed(self)))

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -362,7 +362,7 @@ _enter_buffered_busy(buffered *self)
     }
 
 #define IS_CLOSED(self) \
-    (!self->buffer ? !self->buffer : \
+    (!self->buffer || \
     (self->fast_closed_checks \
      ? _PyFileIO_closed(self->raw) \
      : buffered_closed(self)))
@@ -555,10 +555,9 @@ _io__Buffered_close_impl(buffered *self)
     }
     /* gh-138720: Use IS_CLOSED to match flush CHECK_CLOSED. */
     r = IS_CLOSED(self);
-    if (r < 0)
-        goto end;
     if (r > 0) {
-        res = Py_NewRef(Py_None);
+        if (!PyErr_Occurred())
+            res = Py_NewRef(Py_None);
         goto end;
     }
 

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -362,7 +362,7 @@ _enter_buffered_busy(buffered *self)
     }
 
 #define IS_CLOSED(self) \
-    (!self->buffer ? !self->buffer : \
+    (!self->buffer ? 1 : \
     (self->fast_closed_checks \
      ? _PyFileIO_closed(self->raw) \
      : buffered_closed(self)))

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -563,11 +563,10 @@ _io__Buffered_close_impl(buffered *self)
     }
     /* gh-138720: Use IS_CLOSED to match flush CHECK_CLOSED. */
     r = IS_CLOSED(self);
-    if (r < 0) {
+    if (r < 0)
         goto end;
-    }
     if (r > 0) {
-        res = Py_None;
+        res = Py_NewRef(Py_None);
         goto end;
     }
 


### PR DESCRIPTION
Restores the 3.14 behavior of emitting a TypeError. Preservation of the sign helps in the error checking here:
https://github.com/python/cpython/blob/3dab11f888fda34c02734e4468d1acd4c36927fe/Modules/_io/bufferedio.c#L556-L563

db68bfc771e6a85573732e0b579e8f68841c9b5c changed from `buffered_closed` to `IS_CLOSED`.

<!-- gh-issue-number: gh-140650 -->
* Issue: gh-140650
<!-- /gh-issue-number -->
