### PR TITLE
gh-140657: (bug trigger) Add extra no-op tests to test_import.SubinterpImportTests

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2467,6 +2467,30 @@ class SubinterpImportTests(unittest.TestCase):
                         self.check_compatible_here(
                             modname, filename, strict=False, isolated=False)
 
+    def test_extra_A(self):
+        return
+
+    def test_extra_B(self):
+        return
+
+    def test_extra_C(self):
+        return
+
+    def test_extra_D(self):
+        return
+
+    def test_extra_E(self):
+        return
+
+    def test_extra_F(self):
+        return
+
+    def test_extra_G(self):
+        return
+
+    def test_extra_H(self):
+        return
+
     @unittest.skipIf(_testinternalcapi is None, "requires _testinternalcapi")
     def test_python_compat(self):
         module = 'threading'


### PR DESCRIPTION
This... somehow causes a refleak on FreeBSD.
I want to verify on the buildbot.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140657 -->
* Issue: gh-140657
<!-- /gh-issue-number -->
