### PR TITLE
gh-140652: fix can not list_all after _interpchannels.close

### DIFF
--- a/Lib/test/test__interpchannels.py
+++ b/Lib/test/test__interpchannels.py
@@ -1208,6 +1208,20 @@ class ChannelTests(TestBase):
         with self.assertRaises(TypeError):
             _channels.list_interpreters(cid)
 
+    def test_channel_close_and_list_all(self):
+        # gh-140652
+        cid1 = _channels.create(REPLACE)
+        cid2 = _channels.create(REPLACE)
+        cid3 = _channels.create(REPLACE)
+
+        _channels.close(cid1)
+        _channels.close(cid2, force=True)
+
+        all_channels = [cid for cid, _, _ in _channels.list_all()]
+        self.assertNotIn(cid1, all_channels)
+        self.assertNotIn(cid2, all_channels)
+        self.assertIn(cid3, all_channels)
+
 
 class ChannelReleaseTests(TestBase):
 

--- a/Misc/NEWS.d/next/C_API/2025-10-27-16-17-43.gh-issue-140652.h_hnlb.rst
+++ b/Misc/NEWS.d/next/C_API/2025-10-27-16-17-43.gh-issue-140652.h_hnlb.rst
@@ -1,0 +1,1 @@
+Fix: can not ``list_all`` after ``_interpchannels.close(cid)``

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -1645,13 +1645,18 @@ _channels_list_all(_channels *channels, int64_t *count)
         goto done;
     }
     _channelref *ref = channels->head;
-    for (int64_t i=0; ref != NULL; ref = ref->next, i++) {
+    int64_t i = 0;
+    for (; ref != NULL; ref = ref->next) {
+        if (ref->chan == NULL) {
+            continue;
+        }
         ids[i] = (struct channel_id_and_info){
             .id = ref->cid,
             .defaults = ref->chan->defaults,
         };
+        i++;
     }
-    *count = channels->numopen;
+    *count = i;
 
     cids = ids;
 done:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

the count should not be `*count = channels->numopen;` 
because the channel may close after it close the ref->chan will be NULL `ref->chan == NULL` 


<!-- gh-issue-number: gh-140652 -->
* Issue: gh-140652
<!-- /gh-issue-number -->
