### PR TITLE
gh-131196: Improve `uuid.__str__()` performance a little more

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -329,7 +329,7 @@ class UUID:
         raise TypeError('UUID objects are immutable')
 
     def __str__(self):
-        x = self.hex
+        x = self.int.to_bytes(16).hex()
         return f'{x[:8]}-{x[8:12]}-{x[12:16]}-{x[16:20]}-{x[20:]}'
 
     @property

--- a/Misc/NEWS.d/next/Library/2025-10-27-12-16-34.gh-issue-131196.nLpXzf.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-27-12-16-34.gh-issue-131196.nLpXzf.rst
@@ -1,0 +1,1 @@
+Improve performance of :meth:`uuid.UUID.__str__ <object.__str__>`.


### PR DESCRIPTION
This PR follows up on the PR #131197 to further slightly (~2%) improve the performance of `UUID.__str__()` by avoiding trampolining through the `hex` and `bytes` properties.

(Given that stringifying UUIDs is likely a pretty common use case, maybe this would be worth a speedup alternative in `_uuidmodule.c`?)

Here's what a `pytest-benchmark` comparison says (`suuid` being a copy of this `uuid.py` and `suuid_orig` the one from 3416e7c8dc004773d814b6f9ec9562434ed961cd).

| Name (time in ns) | Min | Max | Mean | StdDev | Median | IQR | Outliers | OPS (Mops/s) | Rounds | Iterations |
|---|---|---|---|---|---|---|---|---|---|---|
| test_suuid[suuid] | 370.0099 (1.0) | 442.6828 (1.05) | 401.2448 (1.0) | 20.4759 (2.85) | 398.8881 (1.0) | 20.2299 (1.88) | 3;1 | 2.4922 (1.0) | 10 | 1,355,472 |
| test_suuid[suuid_orig] | 402.7837 (1.09) | 422.9409 (1.0) | 410.2969 (1.02) | 7.1930 (1.0) | 408.5021 (1.02) | 10.7775 (1.0) | 4;0 | 2.4373 (0.98) | 10 | 1,245,293 |


<details><summary>Test code</summary>
```python
import suuid_orig
import suuid
import pytest

@pytest.mark.parametrize("module", [suuid, suuid_orig])
def test_suuid(benchmark, module):
    u = module.uuid4()
    def b():
        assert str(u)
    benchmark(b)
```
</details>


<!-- gh-issue-number: gh-131196 -->
* Issue: gh-131196
<!-- /gh-issue-number -->
