### PR TITLE
gh-131196: Add C implementation of UUID stringification

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -224,6 +224,10 @@ class BaseTestUUID:
                       self.uuid.UUID(urn)]:
                 # Test all conversions and properties of the UUID object.
                 equal(str(u), string)
+                if hasattr(self.uuid, "_c_uuid_str_method"):
+                    # If we have the C accelerator, test both implementations.
+                    equal(self.uuid._py_uuid_str_method(u), string)
+                    equal(self.uuid._c_uuid_str_method(u), string)
                 equal(int(u), integer)
                 equal(u.bytes, bytes)
                 equal(u.bytes_le, bytes_le)

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -635,6 +635,12 @@ try:
     _generate_time_safe = getattr(_uuid, "generate_time_safe", None)
     _has_stable_extractable_node = _uuid.has_stable_extractable_node
     _UuidCreate = getattr(_uuid, "UuidCreate", None)
+    _uuid_int_to_str = getattr(_uuid, "uuid_int_to_str", None)
+    _py_uuid_str_method = UUID.__str__
+    if _uuid_int_to_str is not None:
+        def _c_uuid_str_method(self):
+            return _uuid_int_to_str(self.int)
+        UUID.__str__ = _c_uuid_str_method
 except ImportError:
     _uuid = None
     _generate_time_safe = None

--- a/Misc/NEWS.d/next/Library/2025-10-27-13-17-17.gh-issue-131196.tYkQbd.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-27-13-17-17.gh-issue-131196.tYkQbd.rst
@@ -1,0 +1,2 @@
+Improve performance of :meth:`uuid.UUID.__str__ <object.__str__>` by adding
+a C implementation in _uuidmodule.


### PR DESCRIPTION
This PR follows up on #140663 by, well, following up on my musing about whether there should be an optimized C implementation of UUID stringification.

I tried to tighten the C implementation as much as possible, e.g. by directly writing into an `1BYTE_KIND` PyUnicode object (as e.g. `pystrhex.c` does, which I couldn't use here because of the unique separator situation UUIDs have). I'd appreciate extra eyes on it, though!

The speedup seems pleasant for a fairly small patch – on my machine, some 4.5x:

```
$ ./python.exe -m timeit -s 'import uuid; uuid.UUID.__str__ = uuid._py_uuid_str_method; u = uuid.uuid4()' 'str(u)'
500000 loops, best of 5: 443 nsec per loop
$ ./python.exe -m timeit -s 'import uuid; u = uuid.uuid4()' 'str(u)'
2000000 loops, best of 5: 97.2 nsec per loop
```

<!-- gh-issue-number: gh-131196 -->
* Issue: gh-131196
<!-- /gh-issue-number -->
