### PR TITLE
gh-140634: Fix a reference counting bug in posix.sched_param.__reduce__()

### DIFF
--- a/Lib/test/test_os/test_posix.py
+++ b/Lib/test/test_os/test_posix.py
@@ -1427,6 +1427,14 @@ class PosixTester(unittest.TestCase):
         self.assertNotEqual(newparam, param)
         self.assertEqual(newparam.sched_priority, 0)
 
+    @requires_sched
+    def test_bug_140634(self):
+        sched_priority = float('inf')  # any new reference
+        param = posix.sched_param(sched_priority)
+        param.__reduce__()
+        del sched_priority, param  # should not crash
+        support.gc_collect()  # just to be sure
+
     @unittest.skipUnless(hasattr(posix, "sched_rr_get_interval"), "no function")
     def test_sched_rr_get_interval(self):
         try:

--- a/Misc/NEWS.d/next/Library/2025-10-27-13-49-31.gh-issue-140634.ULng9G.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-27-13-49-31.gh-issue-140634.ULng9G.rst
@@ -1,1 +1,1 @@
-Fix a reference counting bug in :meth:`posix.sched_param.__reduce__`.
+Fix a reference counting bug in :meth:`!os.sched_param.__reduce__`.

--- a/Misc/NEWS.d/next/Library/2025-10-27-13-49-31.gh-issue-140634.ULng9G.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-27-13-49-31.gh-issue-140634.ULng9G.rst
@@ -1,0 +1,1 @@
+Fix a reference counting bug in :meth:`posix.sched_param.__reduce__`.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8724,7 +8724,7 @@ os_sched_param_impl(PyTypeObject *type, PyObject *sched_priority)
 static PyObject *
 os_sched_param_reduce(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
-    return Py_BuildValue("(O(N))", Py_TYPE(self), PyStructSequence_GetItem(self, 0));
+    return Py_BuildValue("(O(O))", Py_TYPE(self), PyStructSequence_GetItem(self, 0));
 }
 
 static PyMethodDef os_sched_param_reduce_method = {


### PR DESCRIPTION


<!-- gh-issue-number: gh-140634 -->
* Issue: gh-140634
<!-- /gh-issue-number -->
