### PR TITLE
Improve clarity in tutorial introduction

### DIFF
--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -49,7 +49,7 @@ primary prompt, ``>>>``.  (It shouldn't take long.)
 Numbers
 -------
 
-The interpreter acts as a simple calculator: you can type an expression at it
+The interpreter acts as a simple calculator: you can type an expression into it
 and it will write the value.  Expression syntax is straightforward: the
 operators ``+``, ``-``, ``*`` and ``/`` can be used to perform
 arithmetic; parentheses (``()``) can be used for grouping.


### PR DESCRIPTION
Fixed typo in tutorial introduction: Changed "at it" to "into it" for better clarity.

The phrase "type an expression at it" reads awkwardly. 
"Type an expression into it" is more natural and clearer for learners.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140669.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->