### PR TITLE
[3.13] gh-140487: Fix Py_RETURN_NOTIMPLEMENTED in limited C API 3.11 (GH-140636)

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -1130,8 +1130,13 @@ PyAPI_DATA(PyObject) _Py_NotImplementedStruct; /* Don't use this directly */
 #  define Py_NotImplemented (&_Py_NotImplementedStruct)
 #endif
 
-/* Macro for returning Py_NotImplemented from a function */
-#define Py_RETURN_NOTIMPLEMENTED return Py_NotImplemented
+/* Macro for returning Py_NotImplemented from a function. Only treat
+ * Py_NotImplemented as immortal in the limited C API 3.12 and newer. */
+#if defined(Py_LIMITED_API) && Py_LIMITED_API+0 < 0x030c0000
+#  define Py_RETURN_NOTIMPLEMENTED return Py_NewRef(Py_NotImplemented)
+#else
+#  define Py_RETURN_NOTIMPLEMENTED return Py_NotImplemented
+#endif
 
 /* Rich comparison opcodes */
 #define Py_LT 0

--- a/Misc/NEWS.d/next/C API/2025-10-26-16-45-06.gh-issue-140487.fGOqss.rst
+++ b/Misc/NEWS.d/next/C API/2025-10-26-16-45-06.gh-issue-140487.fGOqss.rst
@@ -1,0 +1,2 @@
+Fix :c:macro:`Py_RETURN_NOTIMPLEMENTED` in limited C API 3.11 and older:
+don't treat ``Py_NotImplemented`` as immortal. Patch by Victor Stinner.


### PR DESCRIPTION
Py_RETURN_NONE, Py_RETURN_TRUE and Py_RETURN_FALSE have already been fixed by commit 9258f3da9175134d03f2c8c7c7eed223802ad945 (issue gh-134989).

(cherry picked from commit c6364775236e3c634c3393c7f50fece50611245f)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140487 -->
* Issue: gh-140487
<!-- /gh-issue-number -->
