### PR TITLE
gh-140381: Increase slow_fibonacci call frequency in test_profiling

### DIFF
--- a/Lib/test/test_profiling/test_sampling_profiler/test_integration.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_integration.py
@@ -414,8 +414,8 @@ def main_loop():
         if iteration % 3 == 0:
             # Very CPU intensive
             result = cpu_intensive_work()
-        elif iteration % 5 == 0:
-            # Expensive recursive operation
+        elif iteration % 2 == 0:
+            # Expensive recursive operation (increased frequency for slower machines)
             result = slow_fibonacci(12)
         else:
             # Medium operation

--- a/Misc/NEWS.d/next/Tests/2025-10-27-15-53-47.gh-issue-140381.N5o3pa.rst
+++ b/Misc/NEWS.d/next/Tests/2025-10-27-15-53-47.gh-issue-140381.N5o3pa.rst
@@ -1,0 +1,1 @@
+Fix flaky test_profiling tests on i686 and s390x architectures by increasing slow_fibonacci call frequency from every 5th iteration to every 2nd iteration.


### PR DESCRIPTION
Fixes #140381

## Problem
Tests asserting "slow_fibonacci" in test_profiling were flaky on slower architectures (i686/s390x) because the function wasn't called frequently enough for the profiler to reliably capture it.

## Solution
Changed slow_fibonacci to run every 2nd iteration instead of every 5th iteration, increasing its call frequency from 20% to 50% of iterations.

## Testing
This should resolve the flaky test failures on i686/s390x builds.

<!-- gh-issue-number: gh-140381 -->
* Issue: gh-140381
<!-- /gh-issue-number -->
