### PR TITLE
[3.13] gh-140301: Fix memory leak in subinterpreter PyConfig cleanup (GH-140303)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2025-10-18-18-08-36.gh-issue-140301.m-2HxC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-10-18-18-08-36.gh-issue-140301.m-2HxC.rst
@@ -1,0 +1,1 @@
+Fix memory leak of ``PyConfig`` in subinterpreters.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -985,6 +985,8 @@ PyInterpreterState_Delete(PyInterpreterState *interp)
 
     _PyObject_FiniState(interp);
 
+    PyConfig_Clear(&interp->config);
+
     free_interpreter(interp);
 }
 


### PR DESCRIPTION
(cherry picked from commit a615fb49c948902a982c3256899507abcc9f9bc8)

Co-authored-by: Shamil [ashm.tech@proton.me](mailto:ashm.tech@proton.me)
Co-authored-by: Kumar Aditya [kumaraditya@python.org](mailto:kumaraditya@python.org)
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140301 -->
* Issue: gh-140301
<!-- /gh-issue-number -->
