### PR TITLE
gh-140544: Always assume that thread locals are available

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -85,6 +85,21 @@ _Py_ThreadCanHandleSignals(PyInterpreterState *interp)
     return (_Py_IsMainThread() && _Py_IsMainInterpreter(interp));
 }
 
+/* Definition of the _Py_thread_local macro. In reality, this should really be
+ * in pyport.h, but some extensions define Py_BUILD_CORE after including that.
+ * So, instead of breaking things, we just put this here for now. */
+
+#ifdef thread_local
+#  define _Py_thread_local thread_local
+#elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
+#  define _Py_thread_local _Thread_local
+#elif defined(_MSC_VER)  /* AKA NT_THREADS */
+#  define _Py_thread_local __declspec(thread)
+#elif defined(__GNUC__)  /* includes clang */
+#  define _Py_thread_local __thread
+#else
+#  error "no supported thread-local variable storage classifier"
+#endif
 
 /* Variable and static inline functions for in-line access to current thread
    and interpreter state */

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -85,6 +85,7 @@ _Py_ThreadCanHandleSignals(PyInterpreterState *interp)
     return (_Py_IsMainThread() && _Py_IsMainInterpreter(interp));
 }
 
+
 /* Variable and static inline functions for in-line access to current thread
    and interpreter state */
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -85,22 +85,6 @@ _Py_ThreadCanHandleSignals(PyInterpreterState *interp)
     return (_Py_IsMainThread() && _Py_IsMainInterpreter(interp));
 }
 
-/* Definition of the _Py_thread_local macro. In reality, this should really be
- * in pyport.h, but some extensions define Py_BUILD_CORE after including that.
- * So, instead of breaking things, we just put this here for now. */
-
-#ifdef thread_local
-#  define _Py_thread_local thread_local
-#elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
-#  define _Py_thread_local _Thread_local
-#elif defined(_MSC_VER)  /* AKA NT_THREADS */
-#  define _Py_thread_local __declspec(thread)
-#elif defined(__GNUC__)  /* includes clang */
-#  define _Py_thread_local __thread
-#else
-#  error "no supported thread-local variable storage classifier"
-#endif
-
 /* Variable and static inline functions for in-line access to current thread
    and interpreter state */
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -512,17 +512,6 @@ extern "C" {
 #  ifdef Py_BUILD_CORE
 // HAVE_THREAD_LOCAL is just defined here for compatibility's sake
 #    define HAVE_THREAD_LOCAL 1
-#    ifdef thread_local
-#      define _Py_thread_local thread_local
-#    elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
-#      define _Py_thread_local _Thread_local
-#    elif defined(_MSC_VER)  /* AKA NT_THREADS */
-#      define _Py_thread_local __declspec(thread)
-#    elif defined(__GNUC__)  /* includes clang */
-#      define _Py_thread_local __thread
-#    else
-#      error "no supported thread-local variable storage classifier"
-#    endif
 #  endif
 #endif
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -510,9 +510,7 @@ extern "C" {
 
 #ifdef WITH_THREAD
 #  ifdef Py_BUILD_CORE
-#    ifdef HAVE_THREAD_LOCAL
-#      error "HAVE_THREAD_LOCAL is already defined"
-#    endif
+// HAVE_THREAD_LOCAL is just defined here for compatibility's sake
 #    define HAVE_THREAD_LOCAL 1
 #    ifdef thread_local
 #      define _Py_thread_local thread_local
@@ -523,8 +521,7 @@ extern "C" {
 #    elif defined(__GNUC__)  /* includes clang */
 #      define _Py_thread_local __thread
 #    else
-       // fall back to the PyThread_tss_*() API, or ignore.
-#      undef HAVE_THREAD_LOCAL
+#      error "no supported thread-local variable storage classifier"
 #    endif
 #  endif
 #endif

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -511,6 +511,17 @@ extern "C" {
 #ifdef WITH_THREAD
 // HAVE_THREAD_LOCAL is just defined here for compatibility's sake
 #  define HAVE_THREAD_LOCAL 1
+#  ifdef thread_local
+#    define _Py_thread_local thread_local
+#  elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
+#    define _Py_thread_local _Thread_local
+#  elif defined(_MSC_VER)  /* AKA NT_THREADS */
+#    define _Py_thread_local __declspec(thread)
+#  elif defined(__GNUC__)  /* includes clang */
+#    define _Py_thread_local __thread
+#  else
+#    error "no supported thread-local variable storage classifier"
+#  endif
 #endif
 
 #if defined(__ANDROID__) || defined(__VXWORKS__)

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -509,10 +509,8 @@ extern "C" {
 #endif
 
 #ifdef WITH_THREAD
-#  ifdef Py_BUILD_CORE
 // HAVE_THREAD_LOCAL is just defined here for compatibility's sake
-#    define HAVE_THREAD_LOCAL 1
-#  endif
+#  define HAVE_THREAD_LOCAL 1
 #endif
 
 #if defined(__ANDROID__) || defined(__VXWORKS__)

--- a/Python/import.c
+++ b/Python/import.c
@@ -782,18 +782,13 @@ _PyImport_ClearModulesByIndex(PyInterpreterState *interp)
    substitute this (if the name actually matches).
 */
 
-#ifdef HAVE_THREAD_LOCAL
 _Py_thread_local const char *pkgcontext = NULL;
 # undef PKGCONTEXT
 # define PKGCONTEXT pkgcontext
-#endif
 
 const char *
 _PyImport_ResolveNameWithPackageContext(const char *name)
 {
-#ifndef HAVE_THREAD_LOCAL
-    PyMutex_Lock(&EXTENSIONS.mutex);
-#endif
     if (PKGCONTEXT != NULL) {
         const char *p = strrchr(PKGCONTEXT, '.');
         if (p != NULL && strcmp(name, p+1) == 0) {
@@ -801,23 +796,14 @@ _PyImport_ResolveNameWithPackageContext(const char *name)
             PKGCONTEXT = NULL;
         }
     }
-#ifndef HAVE_THREAD_LOCAL
-    PyMutex_Unlock(&EXTENSIONS.mutex);
-#endif
     return name;
 }
 
 const char *
 _PyImport_SwapPackageContext(const char *newcontext)
 {
-#ifndef HAVE_THREAD_LOCAL
-    PyMutex_Lock(&EXTENSIONS.mutex);
-#endif
     const char *oldcontext = PKGCONTEXT;
     PKGCONTEXT = newcontext;
-#ifndef HAVE_THREAD_LOCAL
-    PyMutex_Unlock(&EXTENSIONS.mutex);
-#endif
     return oldcontext;
 }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -67,9 +67,6 @@ to avoid the expense of doing their own locking).
    For each of these functions, the GIL must be held by the current thread.
  */
 
-#ifndef HAVE_THREAD_LOCAL
-#  error "no supported thread-local variable storage classifier"
-#endif
 
 /* The attached thread state for the current thread. */
 _Py_thread_local PyThreadState *_Py_tss_tstate = NULL;


### PR DESCRIPTION
Python has [required thread local support](https://github.com/python/cpython/pull/103324) since 3.12. By assuming that thread locals are always supported, we can improve the performance of third-party extensions by allowing them to access the attached thread and interpreter states directly.

cc @cdce8p

<!-- gh-issue-number: gh-140544 -->
* Issue: gh-140544
<!-- /gh-issue-number -->
