### PR TITLE
gh-140502: fix default REPL does not handle tab right

### DIFF
--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -331,6 +331,7 @@ def disp_str(
             pre_color = theme[colors[0].tag]
 
         if c == "\t":  # gh-140502: handle tabs
+        if c == "\t":  # gh-140502: properly handle tabs when pasting multiline text
             width = 8 - (sum(char_widths) % 8)
             chars.append(" " * width)
             char_widths.append(width)

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -330,7 +330,11 @@ def disp_str(
         if colors and colors[0].span.start == i:  # new color starts now
             pre_color = theme[colors[0].tag]
 
-        if c == "\x1a":  # CTRL-Z on Windows
+        if c == "\t":  # gh-140502: handle tabs
+            width = 8 - (sum(char_widths) % 8)
+            chars.append(" " * width)
+            char_widths.append(width)
+        elif c == "\x1a":  # CTRL-Z on Windows
             chars.append(c)
             char_widths.append(2)
         elif ord(c) < 128:

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -329,9 +329,8 @@ def disp_str(
     for i, c in enumerate(buffer, start_index):
         if colors and colors[0].span.start == i:  # new color starts now
             pre_color = theme[colors[0].tag]
-
-        if c == "\t":  # gh-140502: handle tabs
-        if c == "\t":  # gh-140502: properly handle tabs when pasting multiline text
+        # gh-140502: properly handle tabs when pasting multiline text
+        if c == "\t":
             width = 8 - (sum(char_widths) % 8)
             chars.append(" " * width)
             char_widths.append(width)

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -40,7 +40,6 @@ from _pyrepl.readline import (
 from _pyrepl.utils import disp_str
 from _pyrepl.readline import multiline_input as readline_multiline_input
 
-
 try:
     import pty
 except ImportError:

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -37,7 +37,9 @@ from _pyrepl.readline import (
     ReadlineConfig,
     _ReadlineWrapper,
 )
+from _pyrepl.utils import disp_str
 from _pyrepl.readline import multiline_input as readline_multiline_input
+
 
 try:
     import pty
@@ -1911,3 +1913,19 @@ class TestPyReplCtrlD(TestCase):
         )
         reader, _ = handle_all_events(events)
         self.assertEqual("hello", "".join(reader.buffer))
+
+
+class TestDispStr(TestCase):
+    def test_disp_str_width_calculation(self):
+        test_cases = [
+            ("\tX", [8, 1]),           # column 0 -> 8 spaces
+            ("X\t", [1, 7]),           # column 1 -> 7 spaces to column 8
+            ("ABC\tX", [1, 1, 1, 5, 1]),  # column 3 -> 5 spaces to column 8
+            ("XXXXXXX\t", [1, 1, 1, 1, 1, 1, 1, 1]),  # column 7 -> 1 space
+            ("XXXXXXXX\t", [1, 1, 1, 1, 1, 1, 1, 1, 8]),  # column 8 -> 8 spaces
+            ("中\tX", [2, 6, 1]),      # wide char + tab
+        ]
+        for buffer, expected_widths in test_cases:
+            with self.subTest(buffer=repr(buffer)):
+                _, widths = disp_str(buffer, 0)
+                self.assertEqual(widths, expected_widths)

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1917,12 +1917,12 @@ class TestPyReplCtrlD(TestCase):
 class TestDispStr(TestCase):
     def test_disp_str_width_calculation(self):
         test_cases = [
-            ("\tX", [8, 1]),           # column 0 -> 8 spaces
-            ("X\t", [1, 7]),           # column 1 -> 7 spaces to column 8
-            ("ABC\tX", [1, 1, 1, 5, 1]),  # column 3 -> 5 spaces to column 8
-            ("XXXXXXX\t", [1, 1, 1, 1, 1, 1, 1, 1]),  # column 7 -> 1 space
+            ("\tX", [8, 1]),                              # column 0 -> 8 spaces
+            ("X\t", [1, 7]),                              # column 1 -> 7 spaces
+            ("ABC\tX", [1, 1, 1, 5, 1]),                  # column 3 -> 5 spaces
+            ("XXXXXXX\t", [1, 1, 1, 1, 1, 1, 1, 1]),      # column 7 -> 1 space
             ("XXXXXXXX\t", [1, 1, 1, 1, 1, 1, 1, 1, 8]),  # column 8 -> 8 spaces
-            ("中\tX", [2, 6, 1]),      # wide char + tab
+            ("中\tX", [2, 6, 1]),                         # wide char + tab
         ]
         for buffer, expected_widths in test_cases:
             with self.subTest(buffer=repr(buffer)):

--- a/Misc/NEWS.d/next/Library/2025-10-28-17-15-30.gh-issue-140502.ilUv1f.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-28-17-15-30.gh-issue-140502.ilUv1f.rst
@@ -1,0 +1,1 @@
+Fix: default REPL ``disp_str`` does not handle tab right.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

and found there is no test for `disp_str`
also add a test for it.

after this patch
cc @sergey-miryanov


<img width="1770" height="497" alt="image" src="https://github.com/user-attachments/assets/3f24a525-c140-4b96-807c-fa10946e0556" />
 


<!-- gh-issue-number: gh-140502 -->
* Issue: gh-140502
<!-- /gh-issue-number -->
