### PR TITLE
[3.14] gh-139951: Tests on tuple tracking (GH-140575)

### DIFF
--- a/Lib/test/test_capi/test_tuple.py
+++ b/Lib/test/test_capi/test_tuple.py
@@ -14,6 +14,12 @@ class TupleSubclass(tuple):
 
 
 class CAPITest(unittest.TestCase):
+    def _not_tracked(self, t):
+        self.assertFalse(gc.is_tracked(t), t)
+
+    def _tracked(self, t):
+        self.assertTrue(gc.is_tracked(t), t)
+
     def test_check(self):
         # Test PyTuple_Check()
         check = _testlimitedcapi.tuple_check
@@ -52,15 +58,46 @@ class CAPITest(unittest.TestCase):
         self.assertEqual(tup1, ())
         self.assertEqual(size(tup1), 0)
         self.assertIs(type(tup1), tuple)
+        self._not_tracked(tup1)
+
         tup2 = tuple_new(1)
         self.assertIs(type(tup2), tuple)
         self.assertEqual(size(tup2), 1)
         self.assertIsNot(tup2, tup1)
         self.assertTrue(checknull(tup2, 0))
+        self._tracked(tup2)
 
         self.assertRaises(SystemError, tuple_new, -1)
         self.assertRaises(SystemError, tuple_new, PY_SSIZE_T_MIN)
         self.assertRaises(MemoryError, tuple_new, PY_SSIZE_T_MAX)
+
+    def test_tuple_fromarray(self):
+        # Test PyTuple_FromArray()
+        tuple_fromarray = _testcapi.tuple_fromarray
+
+        tup = tuple([i] for i in range(5))
+        copy = tuple_fromarray(tup)
+        self.assertEqual(copy, tup)
+        self._tracked(copy)
+
+        tup = tuple(42**i for i in range(5))
+        copy = tuple_fromarray(tup)
+        self.assertEqual(copy, tup)
+        self._not_tracked(copy)
+
+        tup = ()
+        copy = tuple_fromarray(tup)
+        self.assertIs(copy, tup)
+
+        copy = tuple_fromarray(NULL, 0)
+        self.assertIs(copy, ())
+
+        with self.assertRaises(SystemError):
+            tuple_fromarray(NULL, -1)
+        with self.assertRaises(SystemError):
+            tuple_fromarray(NULL, PY_SSIZE_T_MIN)
+        with self.assertRaises(MemoryError):
+            tuple_fromarray(NULL, PY_SSIZE_T_MAX)
 
     def test_tuple_pack(self):
         # Test PyTuple_Pack()
@@ -69,6 +106,10 @@ class CAPITest(unittest.TestCase):
         self.assertEqual(pack(0), ())
         self.assertEqual(pack(1, [1]), ([1],))
         self.assertEqual(pack(2, [1], [2]), ([1], [2]))
+
+        self._tracked(pack(1, [1]))
+        self._tracked(pack(2, [1], b'abc'))
+        self._not_tracked(pack(2, 42, b'abc'))
 
         self.assertRaises(SystemError, pack, PY_SSIZE_T_MIN)
         self.assertRaises(SystemError, pack, -1)

--- a/Lib/test/test_capi/test_tuple.py
+++ b/Lib/test/test_capi/test_tuple.py
@@ -71,34 +71,6 @@ class CAPITest(unittest.TestCase):
         self.assertRaises(SystemError, tuple_new, PY_SSIZE_T_MIN)
         self.assertRaises(MemoryError, tuple_new, PY_SSIZE_T_MAX)
 
-    def test_tuple_fromarray(self):
-        # Test PyTuple_FromArray()
-        tuple_fromarray = _testcapi.tuple_fromarray
-
-        tup = tuple([i] for i in range(5))
-        copy = tuple_fromarray(tup)
-        self.assertEqual(copy, tup)
-        self._tracked(copy)
-
-        tup = tuple(42**i for i in range(5))
-        copy = tuple_fromarray(tup)
-        self.assertEqual(copy, tup)
-        self._not_tracked(copy)
-
-        tup = ()
-        copy = tuple_fromarray(tup)
-        self.assertIs(copy, tup)
-
-        copy = tuple_fromarray(NULL, 0)
-        self.assertIs(copy, ())
-
-        with self.assertRaises(SystemError):
-            tuple_fromarray(NULL, -1)
-        with self.assertRaises(SystemError):
-            tuple_fromarray(NULL, PY_SSIZE_T_MIN)
-        with self.assertRaises(MemoryError):
-            tuple_fromarray(NULL, PY_SSIZE_T_MAX)
-
     def test_tuple_pack(self):
         # Test PyTuple_Pack()
         pack = _testlimitedcapi.tuple_pack


### PR DESCRIPTION
There was a little problem in automatic backporting, since `test_tuple_fromarray` was added in this PR: https://github.com/python/cpython/pull/139691.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139951 -->
* Issue: gh-139951
<!-- /gh-issue-number -->
