### PR TITLE
gh-57665: Remove 'response_class' from getresponse docstring.

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1391,8 +1391,7 @@ class HTTPConnection:
         """Get the response from the server.
 
         If the HTTPConnection is in the correct state, returns an
-        instance of HTTPResponse or of whatever object is returned by
-        the response_class variable.
+        instance of HTTPResponse.
 
         If a request has not been sent or if a previous response has
         not be handled, ResponseNotReady is raised.  If the HTTP


### PR DESCRIPTION
This variable is not documented as part of the API in the standard
library documentation; it should be considered as an implementation
detail and as such should not be included in the doc string.

Closes #57665.

<!-- gh-issue-number: gh-57665 -->
* Issue: gh-57665
<!-- /gh-issue-number -->
