### PR TITLE
gh-139588: Docs: PDF/LaTeX: bump max list depth

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -359,6 +359,7 @@ latex_elements = {
     'papersize': 'a4paper',
     # The font size ('10pt', '11pt' or '12pt').
     'pointsize': '10pt',
+    'maxlistdepth': 7,
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -359,7 +359,7 @@ latex_elements = {
     'papersize': 'a4paper',
     # The font size ('10pt', '11pt' or '12pt').
     'pointsize': '10pt',
-    'maxlistdepth': 7,
+    'maxlistdepth': 7,  # for layers in reference/executionmodel.rst#Python Runtime Model, see #gh-139588
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -359,7 +359,7 @@ latex_elements = {
     'papersize': 'a4paper',
     # The font size ('10pt', '11pt' or '12pt').
     'pointsize': '10pt',
-    'maxlistdepth': 7,  # for layers in reference/executionmodel.rst#Python Runtime Model, see #gh-139588
+    'maxlistdepth': '8',  # See https://github.com/python/cpython/issues/139588
 }
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
Prevents LaTeX PDF build error `Too deeply nested`. (Regression from #135945.)

Thanks @jfbu for the [fix suggestion](https://github.com/python/cpython/issues/139588#issuecomment-3448461300).

<img width="930" height="1056" alt="Zrzut ekranu 2025-10-28 o 15 45 51" src="https://github.com/user-attachments/assets/773bedac-edc5-4c5d-98bf-dc5008932f64" />

Better alternative to #140445.

Could it be labeled for backport on 3.13-3.15 please?

<!-- gh-issue-number: gh-139588 -->
* Issue: gh-139588
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140709.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->