### PR TITLE
[3.13] gh-140717: Add `exc_text` to LogRecord attributes table (GH-140718)

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1011,6 +1011,11 @@ the options available to you.
 | exc_info       | You shouldn't need to   | Exception tuple (à la ``sys.exc_info``) or,   |
 |                | format this yourself.   | if no exception has occurred, ``None``.       |
 +----------------+-------------------------+-----------------------------------------------+
+| exc_text       | You shouldn't need to   | Cached formatted exception information. This  |
+|                | format this yourself.   | is set when :meth:`Formatter.formatException` |
+|                |                         | is called, or ``None`` if no exception has    |
+|                |                         | occurred.                                     |
++----------------+-------------------------+-----------------------------------------------+
 | filename       | ``%(filename)s``        | Filename portion of ``pathname``.             |
 +----------------+-------------------------+-----------------------------------------------+
 | funcName       | ``%(funcName)s``        | Name of function containing the logging call. |


### PR DESCRIPTION
Cherry-picks 49d85c8cf6785c6cb4bf31745c30c3f34e65bad1 from #140718

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140719.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->