### PR TITLE
gh-139588: Docs: Convert the execution model "textual" diagram to a visual diagram

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',
+    'sphinx.ext.graphviz',
 ]
 
 # Skip if downstream redistributors haven't installed them
@@ -559,6 +560,10 @@ extlinks = {
     "source": (SOURCE_URI, "%s"),
 }
 extlinks_detect_hardcoded_links = True
+
+# Options for sphinx.ext.graphviz
+# -------------------------------
+graphviz_output_format = 'svg'
 
 # Options for c_annotations extension
 # -----------------------------------

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -412,9 +412,35 @@ its operating system (OS), if there is one.  When a program runs,
 the conceptual layers of how it runs on the host look something
 like this:
 
-   | **host machine**
-   |   **process** (global resources)
-   |     **thread** (runs machine code)
+.. graphviz::
+
+   digraph general_comput_model {
+       graph [
+           bgcolor=white,
+           splines=false,
+           overlap=false,
+           rankdir=TB,
+       ];
+
+       subgraph cluster_host {
+           label="host machine";
+           style=filled;
+           color=lightgrey;
+           penwidth=2;
+           shape=ellipse;
+
+           subgraph cluster_process {
+               label="process\n(global resources)";
+               style=filled;
+               color=white;
+               penwidth=2;
+
+               thread [label="thread\n(runs machine code)",
+                            style=filled, fillcolor=lightgreen];
+
+           }
+       }
+   }
 
 Each process represents a program running on the host.  Think of each
 process itself as the data part of its program.  Think of the process'
@@ -471,12 +497,55 @@ Python Runtime Model
 The same conceptual layers apply to each Python program, with some
 extra data layers specific to Python:
 
-   | **host machine**
-   |   **process** (global resources)
-   |     Python global runtime (*state*)
-   |       Python interpreter (*state*)
-   |         **thread** (runs Python bytecode and "C-API")
-   |           Python thread *state*
+.. graphviz::
+
+   digraph python_exec_model {
+       graph [
+           bgcolor=white,
+           splines=false,
+           overlap=false,
+           rankdir=TB,
+       ];
+
+       subgraph cluster_host {
+           label="host machine";
+           style=filled;
+           color=lightgrey;
+           penwidth=2;
+           shape=ellipse;
+
+           subgraph cluster_process {
+               label="process\n(global resources)";
+               style=filled;
+               color=white;
+               penwidth=2;
+
+               subgraph cluster_runtime {
+                   label="Python global runtime\n(state)";
+                   style=filled;
+                   color=lightyellow;
+                   penwidth=2;
+
+                   subgraph cluster_interpreter {
+                       label="Python interpreter\n(state)";
+                       style=filled;
+                       color=lightblue;
+                       penwidth=2;
+
+                       subgraph cluster_thread {
+                           label="thread\n(runs Python bytecode and C-API)";
+                           style=filled;
+                           color=lightgreen;
+                           penwidth=2;
+
+                           thread_state [label="Python thread state",
+                                style=filled, fillcolor=white];
+                       }
+                   }
+               }
+           }
+       }
+   }
 
 At the conceptual level: when a Python program starts, it looks exactly
 like that diagram, with one of each.  The runtime may grow to include


### PR DESCRIPTION
It prevents LaTeX PDF build error: Too deeply nested. (Regression from #139509.).

Besides, it also makes the diagram richer.

It is an alternative to #140709.


#139588: Docs: Convert the execution model "textual" diagram to a visual diagram


<img width="387" height="421" alt="image" src="https://github.com/user-attachments/assets/70c101db-5f81-4774-a9f0-86e7ff1e5c31" />

<img width="387" height="421" alt="image" src="https://github.com/user-attachments/assets/f5e68221-31d0-43b8-85b8-d3a1d065960a" />




<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140721.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-139588 -->
* Issue: gh-139588
<!-- /gh-issue-number -->
