### PR TITLE
gh-140702: Add test skip for Unix Datagram tests on iOS when on Github Actions

### DIFF
--- a/Apple/iOS/README.md
+++ b/Apple/iOS/README.md
@@ -224,6 +224,17 @@ Once you have a built an XCframework, you can test that framework by running:
 
   $ python Apple test iOS
 
+This test will attempt to find an "SE-class" simulator (i.e., an iPhone SE, or
+iPhone 16e, or similar), and run the test suite on the most recent version of
+iOS that is available. You can specify a simulator using the `--simulator`
+command line argument, providing the name of the simulator (e.g., `--simulator
+'iPhone 16 Pro'`). You can also use this argument to control the OS version used
+for testing; `--simulator 'iPhone 16 Pro,OS=18.2'` would attempt to run the
+tests on an iPhone 16 Pro running iOS 18.2.
+
+If the test runner is executed on GitHub Actions, the `GITHUB_ACTIONS`
+environment variable will be exposed to the iOS process at runtime.
+
 ### Testing a single-architecture framework
 
 The `Apple/testbed` folder that contains an Xcode project that is able to run

--- a/Apple/testbed/TestbedTests/TestbedTests.m
+++ b/Apple/testbed/TestbedTests/TestbedTests.m
@@ -35,6 +35,9 @@
     setenv("NO_COLOR", "1", true);
     setenv("PYTHON_COLORS", "0", true);
 
+    if (getenv("GITHUB_ACTIONS")) {
+        NSLog(@"Running in a GitHub Actions environment");
+    }
     // Arguments to pass into the test suite runner.
     // argv[0] must identify the process; any subsequent arg
     // will be handled as if it were an argument to `python -m test`

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -68,7 +68,7 @@ __all__ = [
     "BrokenIter",
     "in_systemd_nspawn_sync_suppressed",
     "run_no_yield_async_fn", "run_yielding_async_fn", "async_yield",
-    "reset_code",
+    "reset_code", "on_github_actions"
     ]
 
 
@@ -1369,6 +1369,7 @@ def reset_code(f: types.FunctionType) -> types.FunctionType:
     f.__code__ = f.__code__.replace()
     return f
 
+on_github_actions = "GITHUB_ACTIONS" in os.environ
 
 #=======================================================================
 # Check for the presence of docstrings.

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -224,7 +224,7 @@ class SocketServerTest(unittest.TestCase):
 
     @requires_unix_sockets
     @unittest.skipIf(test.support.is_apple_mobile and test.support.on_github_actions,
-                     "Test fails regularly on iOS simulator on Github Actions - See #140702")
+                     "gh-140702: Test fails regularly on iOS simulator on Github Actions")
     def test_UnixDatagramServer(self):
         self.run_server(socketserver.UnixDatagramServer,
                         socketserver.DatagramRequestHandler,
@@ -232,7 +232,7 @@ class SocketServerTest(unittest.TestCase):
 
     @requires_unix_sockets
     @unittest.skipIf(test.support.is_apple_mobile and test.support.on_github_actions,
-                     "Test fails regularly on iOS simulator on Github Actions - See #140702")
+                     "gh-140702: Test fails regularly on iOS simulator on Github Actions")
     def test_ThreadingUnixDatagramServer(self):
         self.run_server(socketserver.ThreadingUnixDatagramServer,
                         socketserver.DatagramRequestHandler,

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -204,15 +204,11 @@ class SocketServerTest(unittest.TestCase):
                             socketserver.StreamRequestHandler,
                             self.stream_examine)
 
-    @unittest.skipIf(test.support.is_apple_mobile and test.support.on_github_actions,
-                     "Test fails regularly on iOS simulator on Github Actions - See #140702")
     def test_UDPServer(self):
         self.run_server(socketserver.UDPServer,
                         socketserver.DatagramRequestHandler,
                         self.dgram_examine)
 
-    @unittest.skipIf(test.support.is_apple_mobile and test.support.on_github_actions,
-                     "Test fails regularly on iOS simulator on Github Actions - See #140702")
     def test_ThreadingUDPServer(self):
         self.run_server(socketserver.ThreadingUDPServer,
                         socketserver.DatagramRequestHandler,
@@ -227,12 +223,16 @@ class SocketServerTest(unittest.TestCase):
                             self.dgram_examine)
 
     @requires_unix_sockets
+    @unittest.skipIf(test.support.is_apple_mobile and test.support.on_github_actions,
+                     "Test fails regularly on iOS simulator on Github Actions - See #140702")
     def test_UnixDatagramServer(self):
         self.run_server(socketserver.UnixDatagramServer,
                         socketserver.DatagramRequestHandler,
                         self.dgram_examine)
 
     @requires_unix_sockets
+    @unittest.skipIf(test.support.is_apple_mobile and test.support.on_github_actions,
+                     "Test fails regularly on iOS simulator on Github Actions - See #140702")
     def test_ThreadingUnixDatagramServer(self):
         self.run_server(socketserver.ThreadingUnixDatagramServer,
                         socketserver.DatagramRequestHandler,

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -224,7 +224,7 @@ class SocketServerTest(unittest.TestCase):
 
     @requires_unix_sockets
     @unittest.skipIf(test.support.is_apple_mobile and test.support.on_github_actions,
-                     "gh-140702: Test fails regularly on iOS simulator on Github Actions")
+                     "gh-140702: Test fails regularly on iOS simulator on GitHub Actions")
     def test_UnixDatagramServer(self):
         self.run_server(socketserver.UnixDatagramServer,
                         socketserver.DatagramRequestHandler,
@@ -232,7 +232,7 @@ class SocketServerTest(unittest.TestCase):
 
     @requires_unix_sockets
     @unittest.skipIf(test.support.is_apple_mobile and test.support.on_github_actions,
-                     "gh-140702: Test fails regularly on iOS simulator on Github Actions")
+                     "gh-140702: Test fails regularly on iOS simulator on GitHub Actions")
     def test_ThreadingUnixDatagramServer(self):
         self.run_server(socketserver.ThreadingUnixDatagramServer,
                         socketserver.DatagramRequestHandler,

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -204,11 +204,15 @@ class SocketServerTest(unittest.TestCase):
                             socketserver.StreamRequestHandler,
                             self.stream_examine)
 
+    @unittest.skipIf(test.support.is_apple_mobile and test.support.on_github_actions,
+                     "Test fails regularly on iOS simulator on Github Actions - See #140702")
     def test_UDPServer(self):
         self.run_server(socketserver.UDPServer,
                         socketserver.DatagramRequestHandler,
                         self.dgram_examine)
 
+    @unittest.skipIf(test.support.is_apple_mobile and test.support.on_github_actions,
+                     "Test fails regularly on iOS simulator on Github Actions - See #140702")
     def test_ThreadingUDPServer(self):
         self.run_server(socketserver.ThreadingUDPServer,
                         socketserver.DatagramRequestHandler,

--- a/Misc/NEWS.d/next/Tools-Demos/2025-10-29-15-20-19.gh-issue-140702.ZXtW8h.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-10-29-15-20-19.gh-issue-140702.ZXtW8h.rst
@@ -1,0 +1,2 @@
+The iOS testbed app will now expose the ``GITHUB_ACTIONS`` environment
+variable to iOS apps being tested.


### PR DESCRIPTION
On GitHub Actions, it appears that the UnixDatagramServer tests are unstable on the iOS simulator.

This test has been running successfully on the buildbot for months; I think I've seen one failure in the last 6 months that [might be the same cause](https://buildbot.python.org/#/builders/1380/builds/4917). 

I can't reproduce the failure locally. But it appears that on GitHub Actions, the test fails regularly. I have spent the day trying to work out why, without a whole lot of success - mostly because it can only be replicated on GitHub Actions. And given the [problems that GitHub have been having with the macOS-15 runners for the last couple of months](https://github.com/actions/runner-images/issues/12777), it doesn't seem out of the question that there may be systemic problems with the platform that will be resolved with time.

This PR skips the 2 affected tests, but only on iOS simulator, when running on GitHub Actions. It exposes the GITHUB_ACTIONS variable to the running iOS app environment to make this possible.

I don't like this fix; but at this point, it seems the pragmatic option. The underlying test will still run on buildbots, and on individual tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140702 -->
* Issue: gh-140702
<!-- /gh-issue-number -->
