### PR TITLE
gh-140458: Clarify `xmlrpc.client` behavior

### DIFF
--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -179,9 +179,9 @@ ServerProxy Objects
 A :class:`ServerProxy` instance has a method corresponding to each remote
 procedure call accepted by the XML-RPC server.  Calling the method performs an
 RPC, dispatched by both name and argument signature (e.g. the same method name
-can be overloaded with multiple argument signatures).  The RPC finishes by
-returning a value, which may be either returned data in a conformant type or a
-:class:`Fault` or :class:`ProtocolError` object indicating an error.
+can be overloaded with multiple argument signatures).  The RPC finishes either
+by returning data in a conformant type or by raising a :class:`Fault` or
+:class:`ProtocolError` exception indicating an error.
 
 Servers that support the XML introspection API support some common methods
 grouped under the reserved :attr:`~ServerProxy.system` attribute:


### PR DESCRIPTION
Fails or ProtocolError are raised as exceptions, not returned.

<!-- gh-issue-number: gh-140458 -->
* Issue: gh-140458
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140759.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->