### PR TITLE
gh-140379: Add reference link to set types in tutorial

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -445,7 +445,7 @@ packing and sequence unpacking.
 Sets
 ====
 
-Python also includes a data type for *sets*.  A set is an unordered collection
+Python also includes a data type for *sets* (see :ref:`types-set`).  A set is an unordered collection
 with no duplicate elements.  Basic uses include membership testing and
 eliminating duplicate entries.  Set objects also support mathematical operations
 like union, intersection, difference, and symmetric difference.


### PR DESCRIPTION
<!--

```
gh-140379: Add reference link to set types in tutorial

This PR adds a reference link in the Sets section of the Data Structures tutorial (line 448) to point to the comprehensive set/frozenset documentation in the standard library reference.

This makes the Sets section consistent with other sections (like Tuples and Sequences) that already include such reference links.

Fixes #140379
```

-->

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140775.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->