### PR TITLE
gh-140790: pdb: Initialize instance variables in Pdb.__init__

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -402,7 +402,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.stack = []
         self.curindex = 0
         self.curframe = None
-        self.currentbp = 0
         self._user_requested_quit = False
 
     def set_trace(self, frame=None, *, commands=None):

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -561,7 +561,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         Returns True if the normal interaction function must be called,
         False otherwise."""
         # self.currentbp is set in bdb in Bdb.break_here if a breakpoint was hit
-        if self.currentbp and \
+        if getattr(self, "currentbp", False) and \
                self.currentbp in self.commands:
             currentbp = self.currentbp
             self.currentbp = 0

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -398,6 +398,13 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
         self._current_task = None
 
+        self.lineno = None
+        self.stack = []
+        self.curindex = 0
+        self.curframe = None
+        self.currentbp = 0
+        self._user_requested_quit = False
+
     def set_trace(self, frame=None, *, commands=None):
         Pdb._last_pdb_instance = self
         if frame is None:
@@ -474,7 +481,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.lineno = None
         self.stack = []
         self.curindex = 0
-        if hasattr(self, 'curframe') and self.curframe:
+        if self.curframe:
             self.curframe.f_globals.pop('__pdb_convenience_variables', None)
         self.curframe = None
         self.tb_lineno.clear()
@@ -555,7 +562,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         Returns True if the normal interaction function must be called,
         False otherwise."""
         # self.currentbp is set in bdb in Bdb.break_here if a breakpoint was hit
-        if getattr(self, "currentbp", False) and \
+        if self.currentbp and \
                self.currentbp in self.commands:
             currentbp = self.currentbp
             self.currentbp = 0
@@ -1493,7 +1500,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         # this method should be callable before starting debugging, so default
         # to "no globals" if there is no current frame
-        frame = getattr(self, 'curframe', None)
+        frame = self.curframe
         if module_globals is None:
             module_globals = frame.f_globals if frame else None
         line = linecache.getline(filename, lineno, module_globals)

--- a/Misc/NEWS.d/next/Library/2025-10-30-12-36-19.gh-issue-140790._3T6-N.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-30-12-36-19.gh-issue-140790._3T6-N.rst
@@ -1,0 +1,1 @@
+Initialize all Pdb's instance variables in ``__init__``,  remove some hasattr/getattr


### PR DESCRIPTION
Initialize lineno, stack, curindex, curframe,
currentbp, and _user_requested_quit attributes in
`Pdb.__init__` instead of at first use. This ensures these attributes are always defined and allows
removal of defensive getattr/hasattr checks
throughout the codebase.

In particular for a custom PDB subclass in
IPython, the need to use a getattr has performance implications, and while we could set it  our `__init__` it was easy to send a more global patch to CPython.

Should fix gh-140790

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
