### PR TITLE
gh-140793: Make `\x7f` handling consistent across JSON

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -16,7 +16,7 @@ except ImportError:
     c_make_encoder = None
 
 ESCAPE = re.compile(r'[\x00-\x1f\\"\b\f\n\r\t]')
-ESCAPE_ASCII = re.compile(r'([\\"]|[^\ -~])')
+ESCAPE_ASCII = re.compile(r'([\\"]|[^\ -\x7f])')
 HAS_UTF8 = re.compile(b'[\x80-\xff]')
 ESCAPE_DCT = {
     '\\': '\\\\',

--- a/Lib/test/test_json/test_encode_basestring_ascii.py
+++ b/Lib/test/test_json/test_encode_basestring_ascii.py
@@ -36,6 +36,15 @@ class TestEncodeBasestringAscii:
         s = self.dumps(dict(items), sort_keys=True)
         self.assertEqual(s, '{"five": 5, "four": 4, "one": 1, "three": 3, "two": 2}')
 
+    def test_ascii_range_consistency(self):
+        encode_basestring = self.json.encoder.encode_basestring
+        encode_basestring_ascii = self.json.encoder.encode_basestring_ascii
+
+        for i in range(0x80):
+            result_basestring = encode_basestring(chr(i))
+            result_ascii = encode_basestring_ascii(chr(i))
+            self.assertEqual(result_basestring, result_ascii)
+
 
 class TestPyEncodeBasestringAscii(TestEncodeBasestringAscii, PyTest): pass
 class TestCEncodeBasestringAscii(TestEncodeBasestringAscii, CTest):

--- a/Misc/NEWS.d/next/Library/2025-10-30-13-24-13.gh-issue-140793.hkt5qr.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-30-13-24-13.gh-issue-140793.hkt5qr.rst
@@ -1,0 +1,2 @@
+:mod:`json`: Fix inconsistency where U+007F was incorrectly escaped by
+:meth:`JSONEncoder.encode` with ``ensure_ascii=True``.

--- a/Misc/NEWS.d/next/Library/2025-10-30-13-24-13.gh-issue-140793.hkt5qr.rst
+++ b/Misc/NEWS.d/next/Library/2025-10-30-13-24-13.gh-issue-140793.hkt5qr.rst
@@ -1,2 +1,2 @@
 :mod:`json`: Fix inconsistency where U+007F was incorrectly escaped by
-:meth:`JSONEncoder.encode` with ``ensure_ascii=True``.
+:meth:`json.JSONEncoder.encode` with ``ensure_ascii=True``.

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -116,7 +116,7 @@ encoder_write_string(PyEncoderObject *s, PyUnicodeWriter *writer, PyObject *obj)
 static PyObject *
 encoder_encode_float(PyEncoderObject *s, PyObject *obj);
 
-#define S_CHAR(c) (c >= ' ' && c <= '~' && c != '\\' && c != '"')
+#define S_CHAR(c) (c >= ' ' && c <= 0x7F && c != '\\' && c != '"')
 #define IS_WHITESPACE(c) (((c) == ' ') || ((c) == '\t') || ((c) == '\n') || ((c) == '\r'))
 
 static Py_ssize_t


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140793 -->
* Issue: gh-140793
<!-- /gh-issue-number -->
