### PR TITLE
gh-140806: add docs for `enum.bin` function

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -1046,7 +1046,7 @@ Utilities and Decorators
    two's-complement, and the leading bit always indicates sign
    (0=positive, 1=negative).
 
-      >>> from enum import enum
+      >>> import enum
       >>> enum.bin(10)
       '0b0 1010'
       >>> enum.bin(~10)   # ~10 is -11

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -156,7 +156,7 @@ Module Contents
    :func:`enum.bin`
 
       Like built-in :func:`bin`, except negative values are represented in
-      two's-complement, and the leading bit always indicates sign
+      two's complement, and the leading bit always indicates sign
       (0=positive, 1=negative).
 
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -157,7 +157,7 @@ Module Contents
 
       Like built-in :func:`bin`, except negative values are represented in
       two's complement, and the leading bit always indicates sign
-      (0=positive, 1=negative).
+      (``0`` implies positive, ``1`` implies negative).
 
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -1044,7 +1044,7 @@ Utilities and Decorators
 
    Like built-in :func:`bin`, except negative values are represented in
    two's-complement, and the leading bit always indicates sign
-   (0=positive, 1=negative).
+   (``0`` implies positive, ``1`` implies negative).
 
       >>> import enum
       >>> enum.bin(10)

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -153,6 +153,12 @@ Module Contents
 
       Return a list of all power-of-two integers contained in a flag.
 
+   :func:`enum.bin`
+
+      Like built-in :func:`bin`, except negative values are represented in
+      two's-complement, and the leading bit always indicates sign
+      (0=positive, 1=negative).
+
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
 .. versionadded:: 3.11  ``StrEnum``, ``EnumCheck``, ``ReprEnum``, ``FlagBoundary``, ``property``, ``member``, ``nonmember``, ``global_enum``, ``show_flag_values``
@@ -1031,6 +1037,20 @@ Utilities and Decorators
 .. function:: show_flag_values(value)
 
    Return a list of all power-of-two integers contained in a flag *value*.
+
+   .. versionadded:: 3.11
+
+.. function:: bin(num, max_bits=None)
+
+   Like built-in :func:`bin`, except negative values are represented in
+   two's-complement, and the leading bit always indicates sign
+   (0=positive, 1=negative).
+
+      >>> from enum import enum
+      >>> enum.bin(10)
+      '0b0 1010'
+      >>> enum.bin(~10)   # ~10 is -11
+      '0b1 0101'
 
    .. versionadded:: 3.11
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -1052,7 +1052,7 @@ Utilities and Decorators
       >>> enum.bin(~10)   # ~10 is -11
       '0b1 0101'
 
-   .. versionadded:: 3.11
+   .. versionadded:: 3.10
 
 ---------------
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -1043,7 +1043,7 @@ Utilities and Decorators
 .. function:: bin(num, max_bits=None)
 
    Like built-in :func:`bin`, except negative values are represented in
-   two's-complement, and the leading bit always indicates sign
+   two's complement, and the leading bit always indicates sign
    (``0`` implies positive, ``1`` implies negative).
 
       >>> import enum

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -138,6 +138,8 @@ are always available.  They are listed here in alphabetical order.
       >>> f'{14:#b}', f'{14:b}'
       ('0b1110', '1110')
 
+   See also :func:`enum.bin` to represent negative values as twos-complement.
+
    See also :func:`format` for more information.
 
 

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -130,7 +130,7 @@ def show_flag_values(value):
 def bin(num, max_bits=None):
     """
     Like built-in bin(), except negative values are represented in
-    twos-compliment, and the leading bit always indicates sign
+    twos-complement, and the leading bit always indicates sign
     (0=positive, 1=negative).
 
     >>> bin(10)
@@ -139,6 +139,7 @@ def bin(num, max_bits=None):
     '0b1 0101'
     """
 
+    num = num.__index__()
     ceiling = 2 ** (num).bit_length()
     if num >= 0:
         s = bltns.bin(num + ceiling).replace('1', '0', 1)

--- a/Misc/NEWS.d/next/Documentation/2025-10-30-19-28-42.gh-issue-140806.RBT9YH.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-10-30-19-28-42.gh-issue-140806.RBT9YH.rst
@@ -1,0 +1,1 @@
+Add documentation for :func:`enum.bin`.


### PR DESCRIPTION
Add documentation for `enum.bin` function. As suggested in https://github.com/python/cpython/pull/140765#pullrequestreview-3400164733, by @ethanfurman.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140806 -->
* Issue: gh-140806
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140807.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->