### PR TITLE
lzma: do not include crc64_table.c and crc32_table.c

### DIFF
--- a/PCbuild/liblzma.vcxproj
+++ b/PCbuild/liblzma.vcxproj
@@ -102,9 +102,7 @@
     <ClCompile Include="$(lzmaDir)src\common\tuklib_physmem.c" />
     <ClCompile Include="$(lzmaDir)src\liblzma\check\check.c" />
     <ClCompile Include="$(lzmaDir)src\liblzma\check\crc32_fast.c" />
-    <ClCompile Include="$(lzmaDir)src\liblzma\check\crc32_table.c" />
     <ClCompile Include="$(lzmaDir)src\liblzma\check\crc64_fast.c" />
-    <ClCompile Include="$(lzmaDir)src\liblzma\check\crc64_table.c" />
     <ClCompile Include="$(lzmaDir)src\liblzma\check\sha256.c" />
     <ClCompile Include="$(lzmaDir)src\liblzma\common\alone_decoder.c" />
     <ClCompile Include="$(lzmaDir)src\liblzma\common\alone_encoder.c" />

--- a/PCbuild/liblzma.vcxproj.filters
+++ b/PCbuild/liblzma.vcxproj.filters
@@ -54,13 +54,7 @@
     <ClCompile Include="$(lzmaDir)src\liblzma\check\crc32_fast.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="$(lzmaDir)src\liblzma\check\crc32_table.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="$(lzmaDir)src\liblzma\check\crc64_fast.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(lzmaDir)src\liblzma\check\crc64_table.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="$(lzmaDir)src\liblzma\delta\delta_common.c">


### PR DESCRIPTION
They were removed upstream in
https://github.com/tukaani-project/xz/commit/85b081f5d4598342b8c155a2c08697fb2adc372c

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
