### PR TITLE
Fix a typo in plistlib

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -471,7 +471,7 @@ class _BinaryPlistParser:
     """
     def __init__(self, dict_type, aware_datetime=False):
         self._dict_type = dict_type
-        self._aware_datime = aware_datetime
+        self._aware_datetime = aware_datetime
 
     def parse(self, fp):
         try:
@@ -565,7 +565,7 @@ class _BinaryPlistParser:
             f = struct.unpack('>d', self._fp.read(8))[0]
             # timestamp 0 of binary plists corresponds to 1/1/2001
             # (year of Mac OS X 10.0), instead of 1/1/1970.
-            if self._aware_datime:
+            if self._aware_datetime:
                 epoch = datetime.datetime(2001, 1, 1, tzinfo=datetime.UTC)
             else:
                 epoch = datetime.datetime(2001, 1, 1)


### PR DESCRIPTION
All variables with the same pattern use the name `_aware_datetime` in this file, so I think `_aware_datime` is probably just a typo rather than a short form. It might be a bit misleading, so we should fix it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
