### PR TITLE
gh-140826: Compare winreg.HKEYType by the internal handle value 

### DIFF
--- a/Doc/library/winreg.rst
+++ b/Doc/library/winreg.rst
@@ -771,9 +771,9 @@ Handle objects provide semantics for :meth:`~object.__bool__` -- thus ::
 will print ``Yes`` if the handle is currently valid (has not been closed or
 detached).
 
-The object also support comparison semantics, so handle objects will compare
-true if they both reference the same underlying Windows handle value. Closed
-handle objects (those with a handle value of zero) always compare equal.
+The object also support equality comparison semantics, so handle objects will
+compare equal if they both reference the same underlying Windows handle value.
+Closed handle objects (those with a handle value of zero) always compare equal.
 
 Handle objects can be converted to an integer (e.g., using the built-in
 :func:`int` function), in which case the underlying Windows handle value is
@@ -818,4 +818,4 @@ integer handle, and also disconnect the Windows handle from the handle object.
 
 .. versionchanged:: next
    Handle objects are now compared by their underlying Windows handle value
-   instead of object identity.
+   instead of object identity for equality comparisons.

--- a/Doc/library/winreg.rst
+++ b/Doc/library/winreg.rst
@@ -772,7 +772,8 @@ will print ``Yes`` if the handle is currently valid (has not been closed or
 detached).
 
 The object also support comparison semantics, so handle objects will compare
-true if they both reference the same underlying Windows handle value.
+true if they both reference the same underlying Windows handle value. Closed
+handle objects (those with a handle value of zero) always compare equal.
 
 Handle objects can be converted to an integer (e.g., using the built-in
 :func:`int` function), in which case the underlying Windows handle value is
@@ -815,3 +816,6 @@ integer handle, and also disconnect the Windows handle from the handle object.
    will automatically close *key* when control leaves the :keyword:`with` block.
 
 
+.. versionchanged:: next
+   Handle objects are now compared by their underlying Windows handle value
+   instead of object identity.

--- a/Lib/test/test_winreg.py
+++ b/Lib/test/test_winreg.py
@@ -220,11 +220,9 @@ class BaseWinregTests(unittest.TestCase):
         self.addCleanup(CloseKey, key3)
 
         self.assertEqual(key1.handle, key2.handle)
-        self.assertEqual(key1, key2)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
-        self.assertNotEqual(key1, key3)
         self.assertTrue(key1 != key3)
         self.assertFalse(key1 == key3)
 

--- a/Lib/test/test_winreg.py
+++ b/Lib/test/test_winreg.py
@@ -209,6 +209,31 @@ class BaseWinregTests(unittest.TestCase):
                        access=KEY_ALL_ACCESS) as okey:
             self.assertTrue(okey.handle != 0)
 
+    def test_hkey_comparison(self):
+        """Test HKEY comparison by handle value rather than object identity."""
+        key1 = OpenKey(HKEY_CURRENT_USER, None)
+        key2 = OpenKey(HKEY_CURRENT_USER, None)
+
+        self.assertEqual(key1.handle, key2.handle)
+        self.assertEqual(key1, key2)
+        self.assertTrue(key1 == key2)
+        self.assertFalse(key1 != key2)
+
+        key3 = OpenKey(HKEY_LOCAL_MACHINE, None)
+        self.assertNotEqual(key1, key3)
+        self.assertTrue(key1 != key3)
+        self.assertFalse(key1 == key3)
+
+        # Closed keys should be equal (all have handle=0)
+        CloseKey(key1)
+        CloseKey(key2)
+        CloseKey(key3)
+
+        self.assertEqual(key1.handle, 0)
+        self.assertEqual(key2.handle, 0)
+        self.assertEqual(key3.handle, 0)
+        self.assertEqual(key2, key3)
+
 
 class LocalWinregTests(BaseWinregTests):
 

--- a/Lib/test/test_winreg.py
+++ b/Lib/test/test_winreg.py
@@ -213,13 +213,17 @@ class BaseWinregTests(unittest.TestCase):
         """Test HKEY comparison by handle value rather than object identity."""
         key1 = OpenKey(HKEY_CURRENT_USER, None)
         key2 = OpenKey(HKEY_CURRENT_USER, None)
+        key3 = OpenKey(HKEY_LOCAL_MACHINE, None)
+
+        self.addCleanup(CloseKey, key1)
+        self.addCleanup(CloseKey, key2)
+        self.addCleanup(CloseKey, key3)
 
         self.assertEqual(key1.handle, key2.handle)
         self.assertEqual(key1, key2)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
-        key3 = OpenKey(HKEY_LOCAL_MACHINE, None)
         self.assertNotEqual(key1, key3)
         self.assertTrue(key1 != key3)
         self.assertFalse(key1 == key3)

--- a/Misc/NEWS.d/next/Library/2025-11-01-00-34-53.gh-issue-140826.JEDd7U.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-01-00-34-53.gh-issue-140826.JEDd7U.rst
@@ -1,0 +1,2 @@
+Now :class:`winreg.PyHKEY` objects are compared by their underlying Windows
+registry handle value instead of their object identity.

--- a/Misc/NEWS.d/next/Library/2025-11-01-00-34-53.gh-issue-140826.JEDd7U.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-01-00-34-53.gh-issue-140826.JEDd7U.rst
@@ -1,2 +1,2 @@
-Now :class:`winreg.HKEYType` objects are compared by their underlying Windows
+Now :class:`!winreg.HKEYType` objects are compared by their underlying Windows
 registry handle value instead of their object identity.

--- a/Misc/NEWS.d/next/Library/2025-11-01-00-34-53.gh-issue-140826.JEDd7U.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-01-00-34-53.gh-issue-140826.JEDd7U.rst
@@ -1,2 +1,2 @@
-Now :class:`winreg.KEYType` objects are compared by their underlying Windows
+Now :class:`winreg.HKEYType` objects are compared by their underlying Windows
 registry handle value instead of their object identity.

--- a/Misc/NEWS.d/next/Library/2025-11-01-00-34-53.gh-issue-140826.JEDd7U.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-01-00-34-53.gh-issue-140826.JEDd7U.rst
@@ -1,2 +1,2 @@
-Now :class:`winreg.PyHKEY` objects are compared by their underlying Windows
+Now :class:`winreg.KEYType` objects are compared by their underlying Windows
 registry handle value instead of their object identity.


### PR DESCRIPTION
This should be merged after https://github.com/python/cpython/pull/140840, as Serhiy suggested in the original issue.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140826 -->
* Issue: gh-140826
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140843.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->