### PR TITLE
gh-140849: Update macOS installer to XZ 5.8.1

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -314,9 +314,9 @@ def library_recipes():
     if PYTHON_3:
         result.extend([
           dict(
-              name="XZ 5.2.3",
-              url="http://tukaani.org/xz/xz-5.2.3.tar.gz",
-              checksum='ef68674fb47a8b8e741b34e429d86e9d',
+              name="XZ 5.8.1",
+              url="https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1.tar.gz",
+              checksum='209cb25608ab0841f68df4d50d0faa22',
               configure_pre=[
                     '--disable-dependency-tracking',
               ]

--- a/Misc/NEWS.d/next/macOS/2025-10-31-09-46-13.gh-issue-140849.OKe0x_.rst
+++ b/Misc/NEWS.d/next/macOS/2025-10-31-09-46-13.gh-issue-140849.OKe0x_.rst
@@ -1,1 +1,1 @@
-Update macOS installer to XZ 5.8.1.
+Update macOS installer to use XZ 5.8.1.

--- a/Misc/NEWS.d/next/macOS/2025-10-31-09-46-13.gh-issue-140849.OKe0x_.rst
+++ b/Misc/NEWS.d/next/macOS/2025-10-31-09-46-13.gh-issue-140849.OKe0x_.rst
@@ -1,0 +1,1 @@
+Update macOS installer to XZ 5.8.1.


### PR DESCRIPTION
The current version of XZ downloaded by the macOS installer, 5.2.3 is no longer supported. This updates the installer to use the latest 5.8.1, which is also the only branch receiving new releases.

Note: I do not have a machine to test this on. Do we have a macOS installer buildbot?

<!-- gh-issue-number: gh-140849 -->
* Issue: gh-140849
<!-- /gh-issue-number -->
