### PR TITLE
gh-140868: Don't rely on undefined left shift behavior in assert

### DIFF
--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -403,7 +403,8 @@ PyStackRef_IsTaggedInt(_PyStackRef i)
 static inline _PyStackRef
 PyStackRef_TagInt(intptr_t i)
 {
-    assert(Py_ARITHMETIC_RIGHT_SHIFT(intptr_t, (i << Py_TAGGED_SHIFT), Py_TAGGED_SHIFT) == i);
+    assert(Py_ARITHMETIC_RIGHT_SHIFT(intptr_t, (intptr_t)(((uintptr_t)i) << Py_TAGGED_SHIFT),
+                                     Py_TAGGED_SHIFT) == i);
     return (_PyStackRef){ .bits = ((((uintptr_t)i) << Py_TAGGED_SHIFT) | Py_INT_TAG) };
 }
 


### PR DESCRIPTION
This assert https://github.com/python/cpython/blob/main/Include/internal/pycore_stackref.h#L406 contains a left shift of a potentially negative value which is undefined behavior. The non-assert line does a uintptr_t cast to avoid the undefined behavior. Replicate that in the assert and then cast the final value back to intptr_t.

<!-- gh-issue-number: gh-140868 -->
* Issue: gh-140868
<!-- /gh-issue-number -->
