### PR TITLE
gh-140873: Add support of non-descriptor callables in functools.singledispatchmethod()

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -672,7 +672,7 @@ The :mod:`functools` module defines the following functions:
    dispatch>` :term:`generic function`.
 
    To define a generic method, decorate it with the ``@singledispatchmethod``
-   decorator. When defining a function using ``@singledispatchmethod``, note
+   decorator. When defining a method using ``@singledispatchmethod``, note
    that the dispatch happens on the type of the first non-*self* or non-*cls*
    argument::
 
@@ -715,6 +715,9 @@ The :mod:`functools` module defines the following functions:
    :deco:`staticmethod`, :deco:`~abc.abstractmethod`, and others.
 
    .. versionadded:: 3.8
+
+   .. versionchanged:: next
+      Added support of non-:term:`descriptor` callables.
 
 
 .. function:: update_wrapper(wrapper, wrapped, assigned=WRAPPER_ASSIGNMENTS, updated=WRAPPER_UPDATES)

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -393,6 +393,14 @@ difflib
   (Contributed by Jiahao Li in :gh:`134580`.)
 
 
+functools
+---------
+
+* :func:`~functools.singledispatchmethod` now supports non-:term:`descriptor`
+  callables.
+  (Contributed by Serhiy Storchaka in :gh:`140873`.)
+
+
 hashlib
 -------
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1083,7 +1083,10 @@ class _singledispatchmethod_get:
                                'singledispatchmethod method')
             raise TypeError(f'{funcname} requires at least '
                             '1 positional argument')
-        return self._dispatch(args[0].__class__).__get__(self._obj, self._cls)(*args, **kwargs)
+        method = self._dispatch(args[0].__class__)
+        if hasattr(method, "__get__"):
+            method = method.__get__(self._obj, self._cls)
+        return method(*args, **kwargs)
 
     def __getattr__(self, name):
         # Resolve these attributes lazily to speed up creation of

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3498,11 +3498,25 @@ class TestSingleDispatch(unittest.TestCase):
             t = functools.singledispatchmethod(Callable('general'))
             t.register(int, Callable('special'))
 
+            @functools.singledispatchmethod
+            def u(self, arg):
+                return 'general', arg
+            u.register(int, Callable('special'))
+
+            v = functools.singledispatchmethod(Callable('general'))
+            @v.register(int)
+            def _(self, arg):
+                return 'special', arg
+
         a = A()
         self.assertEqual(a.t(0), ('special', 0))
         self.assertEqual(a.t(2.5), ('general', 2.5))
         self.assertEqual(A.t(0), ('special', 0))
         self.assertEqual(A.t(2.5), ('general', 2.5))
+        self.assertEqual(a.u(0), ('special', 0))
+        self.assertEqual(a.u(2.5), ('general', 2.5))
+        self.assertEqual(a.v(0), ('special', 0))
+        self.assertEqual(a.v(2.5), ('general', 2.5))
 
 
 class CachedCostItem:

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2785,7 +2785,7 @@ class TestSingleDispatch(unittest.TestCase):
             @functools.singledispatchmethod
             @classmethod
             def go(cls, item, arg):
-                pass
+                return item - arg
 
             @go.register
             @classmethod
@@ -2794,7 +2794,9 @@ class TestSingleDispatch(unittest.TestCase):
 
         s = Slot()
         self.assertEqual(s.go(1, 1), 2)
+        self.assertEqual(s.go(1.5, 1), 0.5)
         self.assertEqual(Slot.go(1, 1), 2)
+        self.assertEqual(Slot.go(1.5, 1), 0.5)
 
     def test_staticmethod_slotted_class(self):
         class A:
@@ -3484,6 +3486,23 @@ class TestSingleDispatch(unittest.TestCase):
                          '(cls, item, arg: int) -> str')
         self.assertEqual(str(Signature.from_callable(A.static_func)),
                          '(item, arg: int) -> str')
+
+    def test_method_non_descriptor(self):
+        class Callable:
+            def __init__(self, value):
+                self.value = value
+            def __call__(self, arg):
+                return self.value, arg
+
+        class A:
+            t = functools.singledispatchmethod(Callable('general'))
+            t.register(int, Callable('special'))
+
+        a = A()
+        self.assertEqual(a.t(0), ('special', 0))
+        self.assertEqual(a.t(2.5), ('general', 2.5))
+        self.assertEqual(A.t(0), ('special', 0))
+        self.assertEqual(A.t(2.5), ('general', 2.5))
 
 
 class CachedCostItem:

--- a/Misc/NEWS.d/next/Library/2025-11-01-14-44-09.gh-issue-140873.kfuc9B.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-01-14-44-09.gh-issue-140873.kfuc9B.rst
@@ -1,0 +1,2 @@
+Add support of non-:term:`descriptor` callables in
+:func:`functools.singledispatchmethod`.


### PR DESCRIPTION


<!-- gh-issue-number: gh-140873 -->
* Issue: gh-140873
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140884.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->