### PR TITLE
[3.14] gh-140104: Revert "Set next_instr properly in the JIT during exceptions (GH-140233) (GH-140687)"

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1972,27 +1972,6 @@ class TestUopsOptimization(unittest.TestCase):
         assert ex is not None
         """))
 
-    def test_next_instr_for_exception_handler_set(self):
-        # gh-140104: We just want the exception to be caught properly.
-        def f():
-            for i in range(TIER2_THRESHOLD + 3):
-                try:
-                    undefined_variable(i)
-                except Exception:
-                    pass
-
-        f()
-
-    def test_next_instr_for_exception_handler_set_lasts_instr(self):
-        # gh-140104: We just want the exception to be caught properly.
-        def f():
-            a_list = []
-            for _ in range(TIER2_THRESHOLD + 3):
-                try:
-                    a_list[""] = 0
-                except Exception:
-                    pass
-
 
 def global_identity(x):
     return x

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-10-16-21-47-00.gh-issue-140104.A8SQIm.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-10-16-21-47-00.gh-issue-140104.A8SQIm.rst
@@ -1,2 +1,0 @@
-Fix a bug with exception handling in the JIT. Patch by Ken Jin. Bug reported
-by Daniel Diniz.

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -368,9 +368,7 @@ do {                                                   \
     frame = tstate->current_frame;                     \
     stack_pointer = _PyFrame_GetStackPointer(frame);   \
     if (next_instr == NULL) {                          \
-        /* gh-140104: The exception handler expects frame->instr_ptr
-            to after this_instr, not this_instr! */    \
-        next_instr = frame->instr_ptr + 1;             \
+        next_instr = frame->instr_ptr;                 \
         JUMP_TO_LABEL(error);                          \
     }                                                  \
     DISPATCH();                                        \


### PR DESCRIPTION
This makes CI green again for JIT on 3.14

<!-- gh-issue-number: gh-140104 -->
* Issue: gh-140104
<!-- /gh-issue-number -->
