### PR TITLE
gh-115634: document ProcessPoolExecutor max_tasks_per_child bug

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -379,6 +379,11 @@ in a REPL or a lambda should not be expected to work.
    default in absence of a *mp_context* parameter. This feature is incompatible
    with the "fork" start method.
 
+   .. note::
+      Bugs have been reported when using the *max_tasks_per_child* feature that
+      can result in the :class:`ProcessPoolExecutor` hanging in some
+      circumstances. Follow its eventual resolution in :gh:`115634`.
+
    .. versionchanged:: 3.3
       When one of the worker processes terminates abruptly, a
       :exc:`~concurrent.futures.process.BrokenProcessPool` error is now raised.


### PR DESCRIPTION
This stems from the user comment in https://github.com/python/cpython/issues/115634#issuecomment-2848046340 - this bug has existed since the feature was introduced in 3.11 and is a footgun that causes occasional hard to debug problems when people do try to use the documented feature.  We should acknowledge it in the docs.

It won't be fixed in older out of bug fix support Python versions and we still don't have it fixed in the latest version.  We can update the docs to note the versions with the bug in whatever versions we do ever manage to fix it in when that happens.

I'll backport this doc update to 3.11 & 3.12 if the release managers want it, but will tweak the wording in those backports to make it clear it will not be fixed in those releases.

<!-- gh-issue-number: gh-115634 -->
* Issue: gh-115634
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140897.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->