### PR TITLE
gh-115634: Fix ProcessPoolExecutor deadlock with max_tasks_per_child

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -386,11 +386,6 @@ in a REPL or a lambda should not be expected to work.
    default in absence of a *mp_context* parameter. This feature is incompatible
    with the "fork" start method.
 
-   .. note::
-      Bugs have been reported when using the *max_tasks_per_child* feature that
-      can result in the :class:`ProcessPoolExecutor` hanging in some
-      circumstances. Follow its eventual resolution in :gh:`115634`.
-
    .. versionchanged:: 3.3
       When one of the worker processes terminates abruptly, a
       :exc:`~concurrent.futures.process.BrokenProcessPool` error is now raised.
@@ -425,6 +420,11 @@ in a REPL or a lambda should not be expected to work.
       :ref:`multiprocessing-start-methods`) changed away from *fork*. If you
       require the *fork* start method for :class:`ProcessPoolExecutor` you must
       explicitly pass ``mp_context=multiprocessing.get_context("fork")``.
+
+   .. versionchanged:: next
+      Fixed a deadlock (:gh:`115634`) where the executor could hang after
+      a worker process exited upon reaching its *max_tasks_per_child*
+      limit while tasks remained queued.
 
    .. method:: terminate_workers()
 

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -360,7 +360,7 @@ class _ExecutorManagerThread(threading.Thread):
                 if executor := self.executor_reference():
                     if process_exited:
                         with self.shutdown_lock:
-                            executor._adjust_process_count()
+                            executor._adjust_process_count(process_died=True)
                     else:
                         executor._idle_worker_semaphore.release()
                     del executor
@@ -754,13 +754,26 @@ class ProcessPoolExecutor(_base.Executor):
             _threads_wakeups[self._executor_manager_thread] = \
                 self._executor_manager_thread_wakeup
 
-    def _adjust_process_count(self):
+    def _adjust_process_count(self, process_died=False):
         # gh-132969: avoid error when state is reset and executor is still running,
         # which will happen when shutdown(wait=False) is called.
         if self._processes is None:
             return
 
-        # if there's an idle process, we don't need to spawn a new one.
+        # gh-115634: When a worker process dies (e.g., due to max_tasks_per_child),
+        # the semaphore may have stale values from completed tasks, causing
+        # acquire() to succeed incorrectly and preventing a replacement worker
+        # from being spawned. To fix this, check process count first when handling
+        # a process death, but check semaphore first for normal task submission
+        # to preserve idle worker reuse.
+        if process_died:
+            # Process death: semaphore might be wrong, check count first
+            process_count = len(self._processes)
+            if process_count < self._max_workers:
+                self._spawn_process()
+                return
+
+        # Normal path: check for idle workers first (preserves idle reuse)
         if self._idle_worker_semaphore.acquire(blocking=False):
             return
 

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -360,7 +360,7 @@ class _ExecutorManagerThread(threading.Thread):
                 if executor := self.executor_reference():
                     if process_exited:
                         with self.shutdown_lock:
-                            executor._adjust_process_count()
+                            executor._replace_dead_worker()
                     else:
                         executor._idle_worker_semaphore.release()
                     del executor
@@ -772,6 +772,30 @@ class ProcessPoolExecutor(_base.Executor):
             _threads_wakeups[self._executor_manager_thread] = \
                 self._executor_manager_thread_wakeup
 
+    def _replace_dead_worker(self):
+        # gh-132969: avoid error when state is reset and executor is still running,
+        # which will happen when shutdown(wait=False) is called.
+        if self._processes is None:
+            return
+
+        # A replacement is pointless when shutting down with nothing left
+        # to run.  Both attributes are read under _shutdown_lock, which
+        # shutdown() holds while setting _shutdown_thread.
+        assert self._shutdown_lock.locked()
+        if self._shutdown_thread and not self._pending_work_items:
+            return
+
+        # gh-115634: A worker exited after reaching max_tasks_per_child and
+        # has been removed from self._processes.  Do not consult
+        # _idle_worker_semaphore here: it counts task completions, not idle
+        # workers, so it can hold a stale token released by the now-dead
+        # worker.  Trusting such a token would leave the pool a worker short,
+        # deadlocking once all workers reach their task limit.  Spawning is
+        # safe from this (manager) thread despite gh-90622 because
+        # max_tasks_per_child is rejected for the "fork" start method.
+        if len(self._processes) < self._max_workers:
+            self._spawn_process()
+
     def _adjust_process_count(self):
         # gh-132969: avoid error when state is reset and executor is still running,
         # which will happen when shutdown(wait=False) is called.
@@ -784,12 +808,12 @@ class ProcessPoolExecutor(_base.Executor):
 
         process_count = len(self._processes)
         if process_count < self._max_workers:
-            # Assertion disabled as this codepath is also used to replace a
-            # worker that unexpectedly dies, even when using the 'fork' start
-            # method. That means there is still a potential deadlock bug. If a
-            # 'fork' mp_context worker dies, we'll be forking a new one when
-            # we know a thread is running (self._executor_manager_thread).
-            #assert self._safe_to_dynamically_spawn_children or not self._executor_manager_thread, 'https://github.com/python/cpython/issues/90622'
+            # gh-90622: spawning a child via fork while another thread is
+            # running can deadlock in the child.  submit() only calls this
+            # method when using a non-fork start method.
+            assert (self._safe_to_dynamically_spawn_children
+                    or not self._executor_manager_thread), (
+                    'https://github.com/python/cpython/issues/90622')
             self._spawn_process()
 
     def _launch_processes(self):

--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -241,6 +241,33 @@ class ProcessPoolExecutorTest(ExecutorTest):
         executor = self.executor_type(1, max_tasks_per_child=3)
         self.assertEqual(executor._mp_context.get_start_method(), "spawn")
 
+    def test_max_tasks_per_child_pending_tasks_gh115634(self):
+        # gh-115634: A worker exiting at its max_tasks_per_child limit left a
+        # stale token in the idle worker semaphore, so no replacement worker
+        # was spawned and the remaining queued tasks deadlocked.  Submit more
+        # tasks than the pool can run at once so a backlog is queued while
+        # workers hit their task limit.
+        context = self.get_context()
+        if context.get_start_method(allow_none=False) == "fork":
+            raise unittest.SkipTest("Incompatible with the fork start method.")
+
+        for max_workers, max_tasks, num_tasks in [(1, 2, 6), (2, 2, 8)]:
+            with self.subTest(max_workers=max_workers, max_tasks=max_tasks):
+                executor = self.executor_type(
+                        max_workers, mp_context=context,
+                        max_tasks_per_child=max_tasks)
+                try:
+                    futures = [executor.submit(mul, i, 2)
+                               for i in range(num_tasks)]
+                    # If the deadlock regresses, the result() calls time out,
+                    # and the shutdown below hangs until the test timeout.
+                    results = [f.result(timeout=support.SHORT_TIMEOUT)
+                               for f in futures]
+                    self.assertEqual(results,
+                                     [i * 2 for i in range(num_tasks)])
+                finally:
+                    executor.shutdown(wait=True, cancel_futures=True)
+
     def test_max_tasks_early_shutdown(self):
         context = self.get_context()
         if context.get_start_method(allow_none=False) == "fork":

--- a/Misc/NEWS.d/next/Library/2025-11-02-05-28-56.gh-issue-115634.JbcNnF.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-02-05-28-56.gh-issue-115634.JbcNnF.rst
@@ -1,0 +1,3 @@
+Fix deadlock in :class:`concurrent.futures.ProcessPoolExecutor` when using
+``max_tasks_per_child``. The executor would hang after a worker process exited
+due to incorrect idle worker accounting. Patch by tabrezm and Tian Gao.

--- a/Misc/NEWS.d/next/Library/2025-11-02-05-28-56.gh-issue-115634.JbcNnF.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-02-05-28-56.gh-issue-115634.JbcNnF.rst
@@ -1,0 +1,5 @@
+Fix a deadlock in :class:`concurrent.futures.ProcessPoolExecutor` when
+using ``max_tasks_per_child``, present since the feature was introduced in
+Python 3.11. The executor stopped scheduling queued tasks after a worker
+process exited upon reaching its task limit. Based on a fix proposed by
+Tabrez Mohammed.


### PR DESCRIPTION
### Summary

Fix a deadlock in `ProcessPoolExecutor` when using `max_tasks_per_child`.
The executor stopped scheduling queued tasks after a worker process exited
upon reaching its task limit.

```python
from concurrent.futures import ProcessPoolExecutor

if __name__ == "__main__":
    with ProcessPoolExecutor(1, max_tasks_per_child=2) as exe:
        futs = [exe.submit(print, i) for i in range(10)]
```

Prints 0 and 1, then hangs forever.

### The bug

The idle worker semaphore counts task completions, not idle workers: a
token is released on every non-final task completion, but only `submit()`
consumes tokens. When a backlog is queued, workers take their next task
directly from the call queue, so a token can outlive the idle period it
was released for -- and outlive the worker itself once the worker exits
at its `max_tasks_per_child` limit. The worker-replacement path then
acquired such a stale token, concluded an idle worker existed, and never
spawned a replacement. With no workers left, the queued tasks deadlocked.

Present since `max_tasks_per_child` was introduced in Python 3.11
(GH-27373). Affects 3.11 through 3.15.0beta3.

### The fix

Worker replacement after a process exit no longer consults the semaphore:
a new `_replace_dead_worker()` spawns a replacement whenever the pool is
below `max_workers`, using `len(self._processes)` as the source of truth.
The `submit()` path is unchanged, preserving on-demand spawning and idle
worker reuse (bpo-39207). This is the semantics suggested by @pitrou in
the GH-115642 review; the approach was proposed and production-tested by
@tabrezm.

Replacement is skipped when the executor is shutting down with no
pending work, so a worker reaching its task limit during shutdown does
not spawn a process that shutdown immediately reaps. The previously
disabled gh-90622 assertion in `_adjust_process_count()` is re-enabled:
with worker replacement split out, that method is reachable only from
`submit()` with a non-fork start method, so the assertion is valid now.

The semaphore still drifts above the true idle count while a backlog
exists. After this change the drift is harmless: it can only briefly
suppress pool growth below `max_workers` (each suppressed spawn drains
one token), never lose a worker. Whether the semaphore should be
redesigned or removed is left as a follow-up (see GH-115642 discussion).

The documentation warning added in GH-140897 is replaced with a
`versionchanged:: next` entry, so each branch's docs will name the
release that fixed it; backports should likewise replace the notes
added by GH-143302 / GH-143303.

---

### Related Issues
- Closes #115634
- Alternative to PR #115642
- May also fix #119592 and #111498 (untested)

### Acknowledgments
- Thanks to @tabrezm for the elegant fix idea and production testing
- Thanks to @gaogaotiantian for the original PR #115642 and extensive analysis
- Thanks to all who reported and helped diagnose this issue

Claude Sonnet 4.5 helped do the original work on this PR last year.  Claude Fable 5 helped tighten it up and validate everything.

<!-- gh-issue-number: gh-115634 -->
* Issue: gh-115634
<!-- /gh-issue-number -->
