### PR TITLE
[3.13] gh-135307: Fix email error when policy max_line_length is set to 0 or None (GH-135367)

### DIFF
--- a/Lib/email/contentmanager.py
+++ b/Lib/email/contentmanager.py
@@ -2,6 +2,7 @@ import binascii
 import email.charset
 import email.message
 import email.errors
+import sys
 from email import quoprimime
 
 class ContentManager:
@@ -142,13 +143,15 @@ def _encode_base64(data, max_line_length):
 
 
 def _encode_text(string, charset, cte, policy):
+    # If max_line_length is 0 or None, there is no limit.
+    maxlen = policy.max_line_length or sys.maxsize
     lines = string.encode(charset).splitlines()
     linesep = policy.linesep.encode('ascii')
     def embedded_body(lines): return linesep.join(lines) + linesep
     def normal_body(lines): return b'\n'.join(lines) + b'\n'
     if cte is None:
         # Use heuristics to decide on the "best" encoding.
-        if max((len(x) for x in lines), default=0) <= policy.max_line_length:
+        if max(map(len, lines), default=0) <= maxlen:
             try:
                 return '7bit', normal_body(lines).decode('ascii')
             except UnicodeDecodeError:
@@ -156,8 +159,7 @@ def _encode_text(string, charset, cte, policy):
             if policy.cte_type == '8bit':
                 return '8bit', normal_body(lines).decode('ascii', 'surrogateescape')
         sniff = embedded_body(lines[:10])
-        sniff_qp = quoprimime.body_encode(sniff.decode('latin-1'),
-                                          policy.max_line_length)
+        sniff_qp = quoprimime.body_encode(sniff.decode('latin-1'), maxlen)
         sniff_base64 = binascii.b2a_base64(sniff)
         # This is a little unfair to qp; it includes lineseps, base64 doesn't.
         if len(sniff_qp) > len(sniff_base64):
@@ -172,9 +174,9 @@ def _encode_text(string, charset, cte, policy):
         data = normal_body(lines).decode('ascii', 'surrogateescape')
     elif cte == 'quoted-printable':
         data = quoprimime.body_encode(normal_body(lines).decode('latin-1'),
-                                      policy.max_line_length)
+                                      maxlen)
     elif cte == 'base64':
-        data = _encode_base64(embedded_body(lines), policy.max_line_length)
+        data = _encode_base64(embedded_body(lines), maxlen)
     else:
         raise ValueError("Unknown content transfer encoding {}".format(cte))
     return cte, data

--- a/Lib/test/test_email/test_message.py
+++ b/Lib/test/test_email/test_message.py
@@ -1030,30 +1030,6 @@ class TestEmailMessage(TestEmailMessageBase, TestEmailBase):
         parsed_body = parsed.get_body().get_content().rstrip('\n')
         self.assertEqual(parsed_body, body)
 
-    def test_invalid_header_names(self):
-        invalid_headers = [
-            ('Invalid Header', 'contains space'),
-            ('Tab\tHeader', 'contains tab'),
-            ('Colon:Header', 'contains colon'),
-            ('', 'Empty name'),
-            (' LeadingSpace', 'starts with space'),
-            ('TrailingSpace ', 'ends with space'),
-            ('Header\x7F', 'Non-ASCII character'),
-            ('Header\x80', 'Extended ASCII'),
-        ]
-        for email_policy in (policy.default, policy.compat32):
-            for setter in (EmailMessage.__setitem__, EmailMessage.add_header):
-                for name, value in invalid_headers:
-                    self.do_test_invalid_header_names(email_policy, setter, name, value)
-
-    def do_test_invalid_header_names(self, policy, setter, name, value):
-        with self.subTest(policy=policy, setter=setter, name=name, value=value):
-            message = EmailMessage(policy=policy)
-            pattern = r'(?i)(?=.*invalid)(?=.*header)(?=.*name)'
-            with self.assertRaisesRegex(ValueError, pattern) as cm:
-                 setter(message, name, value)
-            self.assertIn(f"{name!r}", str(cm.exception))
-
     def test_get_body_malformed(self):
         """test for bpo-42892"""
         msg = textwrap.dedent("""\

--- a/Lib/test/test_email/test_message.py
+++ b/Lib/test/test_email/test_message.py
@@ -1004,6 +1004,56 @@ class TestEmailMessage(TestEmailMessageBase, TestEmailBase):
         parsed_msg = message_from_bytes(m.as_bytes(), policy=policy.default)
         self.assertEqual(parsed_msg['Message-ID'], m['Message-ID'])
 
+    def test_no_wrapping_max_line_length(self):
+        # Test that falsey 'max_line_length' are converted to sys.maxsize.
+        for n in [0, None]:
+            with self.subTest(max_line_length=n):
+                self.do_test_no_wrapping_max_line_length(n)
+
+    def do_test_no_wrapping_max_line_length(self, falsey):
+        self.assertFalse(falsey)
+        pol = policy.default.clone(max_line_length=falsey)
+        subj = "S" * 100
+        body = "B" * 100
+        msg = EmailMessage(policy=pol)
+        msg["From"] = "a@ex.com"
+        msg["To"] = "b@ex.com"
+        msg["Subject"] = subj
+        msg.set_content(body)
+
+        raw = msg.as_bytes()
+        self.assertNotIn(b"=\n", raw,
+                         "Found fold indicator; wrapping not disabled")
+
+        parsed = message_from_bytes(raw, policy=policy.default)
+        self.assertEqual(parsed["Subject"], subj)
+        parsed_body = parsed.get_body().get_content().rstrip('\n')
+        self.assertEqual(parsed_body, body)
+
+    def test_invalid_header_names(self):
+        invalid_headers = [
+            ('Invalid Header', 'contains space'),
+            ('Tab\tHeader', 'contains tab'),
+            ('Colon:Header', 'contains colon'),
+            ('', 'Empty name'),
+            (' LeadingSpace', 'starts with space'),
+            ('TrailingSpace ', 'ends with space'),
+            ('Header\x7F', 'Non-ASCII character'),
+            ('Header\x80', 'Extended ASCII'),
+        ]
+        for email_policy in (policy.default, policy.compat32):
+            for setter in (EmailMessage.__setitem__, EmailMessage.add_header):
+                for name, value in invalid_headers:
+                    self.do_test_invalid_header_names(email_policy, setter, name, value)
+
+    def do_test_invalid_header_names(self, policy, setter, name, value):
+        with self.subTest(policy=policy, setter=setter, name=name, value=value):
+            message = EmailMessage(policy=policy)
+            pattern = r'(?i)(?=.*invalid)(?=.*header)(?=.*name)'
+            with self.assertRaisesRegex(ValueError, pattern) as cm:
+                 setter(message, name, value)
+            self.assertIn(f"{name!r}", str(cm.exception))
+
     def test_get_body_malformed(self):
         """test for bpo-42892"""
         msg = textwrap.dedent("""\

--- a/Misc/NEWS.d/next/Library/2025-06-10-18-02-29.gh-issue-135307.fXGrcK.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-10-18-02-29.gh-issue-135307.fXGrcK.rst
@@ -1,0 +1,2 @@
+:mod:`email`: Fix exception in ``set_content()`` when encoding text
+and max_line_length is set to ``0`` or ``None`` (unlimited).


### PR DESCRIPTION
(cherry picked from commit 6d45cd8dbb07ae020ec07f2c3375dd06e52377f6)

RDM: Like the change made in a earlier PR to the folder, we can/must use 'maxlen' as a stand in for 'unlimited' when computing line lengths when max_line_length is 0 or None; otherwise the computation results in a traceback.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135307 -->
* Issue: gh-135307
<!-- /gh-issue-number -->
