### PR TITLE
gh-78809: Fix urlopen crash using credentials in URL

### DIFF
--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -343,7 +343,8 @@ class Request:
         self.type, rest = _splittype(self._full_url)
         if self.type is None:
             raise ValueError("unknown url type: %r" % self.full_url)
-        self.host, self.selector = _splithost(rest)
+        host, self.selector = _splithost(rest)
+        _, self.host = _splituser(host)
         if self.host:
             self.host = unquote(self.host)
 

--- a/Misc/NEWS.d/next/Library/2025-11-02-19-12-26.gh-issue-140918.O10SPu.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-02-19-12-26.gh-issue-140918.O10SPu.rst
@@ -1,1 +1,1 @@
-This patch introduces a call to :func:`urllib.parse._splituser` in :class:`urllib.request.Request` to correctly clean the hostname by removing any credentials.
+This patch introduces a call to urllib.parse._splituser in :class:`urllib.request.Request` to correctly clean the hostname by removing any credentials.

--- a/Misc/NEWS.d/next/Library/2025-11-02-19-12-26.gh-issue-140918.O10SPu.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-02-19-12-26.gh-issue-140918.O10SPu.rst
@@ -1,0 +1,1 @@
+This patch introduces a call to :func:`urllib.parse._splituser` in :class:`urllib.request.Request` to correctly clean the hostname by removing any credentials.


### PR DESCRIPTION
### **Description**:

This PR addresses a bug in `urllib.request.urlopen` where the host field would incorrectly include credentials (e.g., `user:password@host`). This causes errors when attempting to make requests, such as:

* `InvalidURL: nonnumeric port: 'user:password@host'`
* `socket.gaierror: [Errno -2] Name or service not known`

To fix this issue, I've added a call to `urllib.parse._splituser` which ensures that the `host` field only contains the hostname, without any user information.

---

### **Changes made**:

* Modified `urllib.request.Request._parse` to call `urllib.parse._splituser` after `urllib.parse._splithost` when extracting the host, ensuring credentials are removed before making the request.
* This prevents the error where the credentials were included in the host field, leading to invalid connection attempts.

---

### **Steps to reproduce**:

```python
>>> from urllib.request import urlopen
>>> urlopen("http://test:test@example.com/")
Traceback (most recent call last):
  File "/usr/lib/python3.10/http/client.py", line 890, in _get_hostport
    port = int(host[i+1:])
ValueError: invalid literal for int() with base 10: 'test@example.com'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.10/urllib/request.py", line 519, in open
    response = self._open(req, data)
  File "/usr/lib/python3.10/urllib/request.py", line 536, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/usr/lib/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.10/urllib/request.py", line 1377, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/lib/python3.10/urllib/request.py", line 1317, in do_open
    h = http_class(host, timeout=req.timeout, **http_conn_args)
  File "/usr/lib/python3.10/http/client.py", line 852, in __init__
    (self.host, self.port) = self._get_hostport(host, port)
  File "/usr/lib/python3.10/http/client.py", line 895, in _get_hostport
    raise InvalidURL("nonnumeric port: '%s'" % host[i+1:])
http.client.InvalidURL: nonnumeric port: 'test@example.com'
>>> urlopen("http://test:test@example.com:80/")
Traceback (most recent call last):
  File "/usr/lib/python3.10/urllib/request.py", line 1348, in do_open
    h.request(req.get_method(), req.selector, req.data, headers,
  File "/usr/lib/python3.10/http/client.py", line 1283, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1329, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1278, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1038, in _send_output
    self.send(msg)
  File "/usr/lib/python3.10/http/client.py", line 976, in send
    self.connect()
  File "/usr/lib/python3.10/http/client.py", line 942, in connect
    self.sock = self._create_connection(
  File "/usr/lib/python3.10/socket.py", line 824, in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
  File "/usr/lib/python3.10/socket.py", line 955, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.10/urllib/request.py", line 519, in open
    response = self._open(req, data)
  File "/usr/lib/python3.10/urllib/request.py", line 536, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/usr/lib/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.10/urllib/request.py", line 1377, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/lib/python3.10/urllib/request.py", line 1351, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [Errno -2] Name or service not known>
>>> 
```

---

### **Example**:

Here is an example of how the code is fixed:

```python
>>> from urllib.request import Request
>>> Request("http://test:test@example.com/").host
'example.com'
>>> 
```

This ensures that `req.host` is clean, without any credentials.


<!-- gh-issue-number: gh-140918 -->
* Issue: gh-140918
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-78809 -->
* Issue: gh-78809
<!-- /gh-issue-number -->
