### PR TITLE
gh-140815: Fix faulthandler for invalid/freed frame

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -276,8 +276,9 @@ PyAPI_FUNC(int) _PyLineTable_NextAddressRange(PyCodeAddressRange *range);
 extern int _PyLineTable_PreviousAddressRange(PyCodeAddressRange *range);
 
 // Similar to PyCode_Addr2Line(), but return -1 if the code object is invalid
-// and can be called without an attached tstate.
-// Used by dump_frame() in Python/traceback.c.
+// and can be called without an attached tstate. Used by dump_frame() in
+// Python/traceback.c. The function uses heuristics to detect freed memory,
+// it's not 100% reliable.
 extern int _PyCode_SafeAddr2Line(PyCodeObject *co, int addr);
 
 

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -276,7 +276,7 @@ PyAPI_FUNC(int) _PyLineTable_NextAddressRange(PyCodeAddressRange *range);
 extern int _PyLineTable_PreviousAddressRange(PyCodeAddressRange *range);
 
 // Similar to PyCode_Addr2Line(), but return -1 if the code object is invalid
-// and call be called without an attached tstate.
+// and can be called without an attached tstate.
 // Used by dump_frame() in Python/traceback.c.
 extern int _PyCode_SafeAddr2Line(PyCodeObject *co, int addr);
 

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -274,8 +274,12 @@ extern void _PyLineTable_InitAddressRange(
 /** API for traversing the line number table. */
 PyAPI_FUNC(int) _PyLineTable_NextAddressRange(PyCodeAddressRange *range);
 extern int _PyLineTable_PreviousAddressRange(PyCodeAddressRange *range);
-// This is used in dump_frame() in traceback.c without an attached tstate.
-extern int _PyCode_Addr2LineNoTstate(PyCodeObject *co, int addr);
+
+// Similar to PyCode_Addr2Line(), but return -1 if the code object is invalid
+// and call be called without an attached tstate.
+// Used by dump_frame() in Python/traceback.c.
+extern int _PyCode_SafeAddr2Line(PyCodeObject *co, int addr);
+
 
 /** API for executors */
 extern void _PyCode_Clear_Executors(PyCodeObject *code);

--- a/Include/internal/pycore_interpframe.h
+++ b/Include/internal/pycore_interpframe.h
@@ -26,7 +26,9 @@ static inline PyCodeObject *_PyFrame_GetCode(_PyInterpreterFrame *f) {
 
 // Similar to _PyFrame_GetCode(), but return NULL if the frame is invalid or
 // freed. Used by dump_frame() in Python/traceback.c.
-static inline PyCodeObject* _PyFrame_SafeGetCode(_PyInterpreterFrame *f) {
+static inline PyCodeObject*
+_PyFrame_SafeGetCode(_PyInterpreterFrame *f)
+{
     if (PyStackRef_IsNull(f->f_executable)) {
         return NULL;
     }
@@ -64,22 +66,19 @@ _PyFrame_GetBytecode(_PyInterpreterFrame *f)
 static inline int
 _PyFrame_SafeGetLasti(struct _PyInterpreterFrame *f)
 {
-    // Inline _PyFrame_GetBytecode() but replace _PyFrame_GetCode()
+    // Code based on _PyFrame_GetBytecode() but replace _PyFrame_GetCode()
     // with _PyFrame_SafeGetCode().
-    _Py_CODEUNIT *bytecode;
-#ifdef Py_GIL_DISABLED
     PyCodeObject *co = _PyFrame_SafeGetCode(f);
     if (co == NULL) {
         return -1;
     }
+
+    _Py_CODEUNIT *bytecode;
+#ifdef Py_GIL_DISABLED
     _PyCodeArray *tlbc = _PyCode_GetTLBCArray(co);
     assert(f->tlbc_index >= 0 && f->tlbc_index < tlbc->size);
     bytecode = (_Py_CODEUNIT *)tlbc->entries[f->tlbc_index];
 #else
-    PyCodeObject *co = _PyFrame_SafeGetCode(f);
-    if (co == NULL) {
-        return -1;
-    }
     bytecode = _PyCode_CODE(co);
 #endif
 

--- a/Include/internal/pycore_interpframe.h
+++ b/Include/internal/pycore_interpframe.h
@@ -25,7 +25,8 @@ static inline PyCodeObject *_PyFrame_GetCode(_PyInterpreterFrame *f) {
 }
 
 // Similar to _PyFrame_GetCode(), but return NULL if the frame is invalid or
-// freed. Used by dump_frame() in Python/traceback.c.
+// freed. Used by dump_frame() in Python/traceback.c. The function uses
+// heuristics to detect freed memory, it's not 100% reliable.
 static inline PyCodeObject*
 _PyFrame_SafeGetCode(_PyInterpreterFrame *f)
 {
@@ -66,9 +67,9 @@ _PyFrame_GetBytecode(_PyInterpreterFrame *f)
 #endif
 }
 
-// Similar to PyUnstable_InterpreterFrame_GetLasti(), but return NULL
-// if the frame is invalid or freed.
-// Used by dump_frame() in Python/traceback.c.
+// Similar to PyUnstable_InterpreterFrame_GetLasti(), but return NULL if the
+// frame is invalid or freed. Used by dump_frame() in Python/traceback.c. The
+// function uses heuristics to detect freed memory, it's not 100% reliable.
 static inline int
 _PyFrame_SafeGetLasti(struct _PyInterpreterFrame *f)
 {

--- a/Include/internal/pycore_interpframe.h
+++ b/Include/internal/pycore_interpframe.h
@@ -29,6 +29,12 @@ static inline PyCodeObject *_PyFrame_GetCode(_PyInterpreterFrame *f) {
 static inline PyCodeObject*
 _PyFrame_SafeGetCode(_PyInterpreterFrame *f)
 {
+    // globals and builtins may be NULL on a legit frame, but it's unlikely.
+    // It's more likely that it's a sign of an invalid frame.
+    if (f->f_globals == NULL || f->f_builtins == NULL) {
+        return NULL;
+    }
+
     if (PyStackRef_IsNull(f->f_executable)) {
         return NULL;
     }

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -54,12 +54,12 @@ static inline int _PyMem_IsPtrFreed(const void *ptr)
 {
     uintptr_t value = (uintptr_t)ptr;
 #if SIZEOF_VOID_P == 8
-    return (value == 0
+    return (value < 256  // NULL, 0x1, 0x2, ...
             || value == (uintptr_t)0xCDCDCDCDCDCDCDCD
             || value == (uintptr_t)0xDDDDDDDDDDDDDDDD
             || value == (uintptr_t)0xFDFDFDFDFDFDFDFD);
 #elif SIZEOF_VOID_P == 4
-    return (value == 0
+    return (value < 256
             || value == (uintptr_t)0xCDCDCDCD
             || value == (uintptr_t)0xDDDDDDDD
             || value == (uintptr_t)0xFDFDFDFD);

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -54,15 +54,17 @@ static inline int _PyMem_IsPtrFreed(const void *ptr)
 {
     uintptr_t value = (uintptr_t)ptr;
 #if SIZEOF_VOID_P == 8
-    return (value < 256  // NULL, 0x1, 0x2, ...
+    return (value <= 0xff  // NULL, 0x1, 0x2, ..., 0xff
             || value == (uintptr_t)0xCDCDCDCDCDCDCDCD
             || value == (uintptr_t)0xDDDDDDDDDDDDDDDD
-            || value == (uintptr_t)0xFDFDFDFDFDFDFDFD);
+            || value == (uintptr_t)0xFDFDFDFDFDFDFDFD
+            || value >= (uintptr_t)0xFFFFFFFFFFFFFF00);  // -0xff, ..., -2, -1
 #elif SIZEOF_VOID_P == 4
-    return (value < 256
+    return (value <= 0xff
             || value == (uintptr_t)0xCDCDCDCD
             || value == (uintptr_t)0xDDDDDDDD
-            || value == (uintptr_t)0xFDFDFDFD);
+            || value == (uintptr_t)0xFDFDFDFD
+            || value >= (uintptr_t)0xFFFFFF00);
 #else
 #  error "unknown pointer size"
 #endif

--- a/Misc/NEWS.d/next/Library/2025-11-02-19-23-32.gh-issue-140815.McEG-T.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-02-19-23-32.gh-issue-140815.McEG-T.rst
@@ -1,0 +1,2 @@
+:mod:`faulthandler` now detects if a frame or a code object is invalid or
+freed. Patch by Victor Stinner.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1005,8 +1005,8 @@ failed:
  * source location tracking (co_lines/co_positions)
  ******************/
 
-int
-_PyCode_Addr2LineNoTstate(PyCodeObject *co, int addrq)
+static int
+_PyCode_Addr2Line(PyCodeObject *co, int addrq)
 {
     if (addrq < 0) {
         return co->co_firstlineno;
@@ -1021,11 +1021,28 @@ _PyCode_Addr2LineNoTstate(PyCodeObject *co, int addrq)
 }
 
 int
+_PyCode_SafeAddr2Line(PyCodeObject *co, int addrq)
+{
+    if (addrq < 0) {
+        return co->co_firstlineno;
+    }
+    if (co->_co_monitoring && co->_co_monitoring->lines) {
+        return _Py_Instrumentation_GetLine(co, addrq/sizeof(_Py_CODEUNIT));
+    }
+    if (!(addrq >= 0 && addrq < _PyCode_NBYTES(co))) {
+        return -1;
+    }
+    PyCodeAddressRange bounds;
+    _PyCode_InitAddressRange(co, &bounds);
+    return _PyCode_CheckLineNumber(addrq, &bounds);
+}
+
+int
 PyCode_Addr2Line(PyCodeObject *co, int addrq)
 {
     int lineno;
     Py_BEGIN_CRITICAL_SECTION(co);
-    lineno = _PyCode_Addr2LineNoTstate(co, addrq);
+    lineno = _PyCode_Addr2Line(co, addrq);
     Py_END_CRITICAL_SECTION();
     return lineno;
 }

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -1028,14 +1028,24 @@ _Py_DumpWideString(int fd, wchar_t *str)
 
 /* Write a frame into the file fd: "File "xxx", line xxx in xxx".
 
-   This function is signal safe. */
+   This function is signal safe.
 
-static void
+   Return 0 on success. Return -1 if the frame is invalid. */
+
+static int
 dump_frame(int fd, _PyInterpreterFrame *frame)
 {
-    assert(frame->owner < FRAME_OWNED_BY_INTERPRETER);
+    if (frame->owner == FRAME_OWNED_BY_INTERPRETER) {
+        /* Ignore trampoline frame */
+        return 0;
+    }
 
-    PyCodeObject *code =_PyFrame_GetCode(frame);
+    PyCodeObject *code = _PyFrame_SafeGetCode(frame);
+    if (code == NULL) {
+        return -1;
+    }
+
+    int res = 0;
     PUTS(fd, "  File ");
     if (code->co_filename != NULL
         && PyUnicode_Check(code->co_filename))
@@ -1043,29 +1053,36 @@ dump_frame(int fd, _PyInterpreterFrame *frame)
         PUTS(fd, "\"");
         _Py_DumpASCII(fd, code->co_filename);
         PUTS(fd, "\"");
-    } else {
-        PUTS(fd, "???");
     }
-    int lasti = PyUnstable_InterpreterFrame_GetLasti(frame);
-    int lineno = _PyCode_Addr2LineNoTstate(code, lasti);
+    else {
+        PUTS(fd, "???");
+        res = -1;
+    }
+
     PUTS(fd, ", line ");
+    int lasti = _PyFrame_SafeGetLasti(frame);
+    int lineno = -1;
+    if (0 <= lasti) {
+        lineno = _PyCode_SafeAddr2Line(code, lasti);
+    }
     if (lineno >= 0) {
         _Py_DumpDecimal(fd, (size_t)lineno);
     }
     else {
         PUTS(fd, "???");
+        res = -1;
     }
-    PUTS(fd, " in ");
 
-    if (code->co_name != NULL
-       && PyUnicode_Check(code->co_name)) {
+    PUTS(fd, " in ");
+    if (code->co_name != NULL && PyUnicode_Check(code->co_name)) {
         _Py_DumpASCII(fd, code->co_name);
     }
     else {
         PUTS(fd, "???");
+        res = -1;
     }
-
     PUTS(fd, "\n");
+    return res;
 }
 
 static int
@@ -1108,17 +1125,6 @@ dump_traceback(int fd, PyThreadState *tstate, int write_header)
 
     unsigned int depth = 0;
     while (1) {
-        if (frame->owner == FRAME_OWNED_BY_INTERPRETER) {
-            /* Trampoline frame */
-            frame = frame->previous;
-            if (frame == NULL) {
-                break;
-            }
-
-            /* Can't have more than one shim frame in a row */
-            assert(frame->owner != FRAME_OWNED_BY_INTERPRETER);
-        }
-
         if (MAX_FRAME_DEPTH <= depth) {
             if (MAX_FRAME_DEPTH < depth) {
                 PUTS(fd, "plus ");
@@ -1128,9 +1134,17 @@ dump_traceback(int fd, PyThreadState *tstate, int write_header)
             break;
         }
 
-        dump_frame(fd, frame);
+        if (dump_frame(fd, frame) < 0) {
+            PUTS(fd, "  <invalid frame>\n");
+            break;
+        }
+
         frame = frame->previous;
         if (frame == NULL) {
+            break;
+        }
+        if (_PyMem_IsPtrFreed(frame)) {
+            PUTS(fd, "  <freed frame>\n");
             break;
         }
         depth++;

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -1134,6 +1134,10 @@ dump_traceback(int fd, PyThreadState *tstate, int write_header)
             break;
         }
 
+        if (_PyMem_IsPtrFreed(frame)) {
+            PUTS(fd, "  <freed frame>\n");
+            break;
+        }
         if (dump_frame(fd, frame) < 0) {
             PUTS(fd, "  <invalid frame>\n");
             break;
@@ -1141,10 +1145,6 @@ dump_traceback(int fd, PyThreadState *tstate, int write_header)
 
         frame = frame->previous;
         if (frame == NULL) {
-            break;
-        }
-        if (_PyMem_IsPtrFreed(frame)) {
-            PUTS(fd, "  <freed frame>\n");
             break;
         }
         depth++;

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -1062,7 +1062,7 @@ dump_frame(int fd, _PyInterpreterFrame *frame)
     PUTS(fd, ", line ");
     int lasti = _PyFrame_SafeGetLasti(frame);
     int lineno = -1;
-    if (0 <= lasti) {
+    if (lasti >= 0) {
         lineno = _PyCode_SafeAddr2Line(code, lasti);
     }
     if (lineno >= 0) {


### PR DESCRIPTION
faulthandler now detects if a frame or a code object is invalid or freed.

Add helper functions:

* _PyCode_SafeAddr2Line()
* _PyFrame_SafeGetCode()
* _PyFrame_SafeGetLasti()

_PyMem_IsPtrFreed() now also considers the pointer 0x1 as freed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140815 -->
* Issue: gh-140815
<!-- /gh-issue-number -->
