### PR TITLE
[3.14] gh-140513: Fail to compile if _Py_TAIL_CALL_INTERP is set but preserve_none and musttail do not exist (GH-140548)

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-10-25-08-07-06.gh-issue-140513.6OhLTs.rst
+++ b/Misc/NEWS.d/next/Build/2025-10-25-08-07-06.gh-issue-140513.6OhLTs.rst
@@ -1,0 +1,2 @@
+Generate a clear compilation error when ``_Py_TAIL_CALL_INTERP`` is enabled but
+either ``preserve_none`` or ``musttail`` is not supported.

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -79,6 +79,14 @@
 #endif
 
 #if Py_TAIL_CALL_INTERP
+#   if defined(__clang__) || defined(__GNUC__)
+#       if !_Py__has_attribute(preserve_none) || !_Py__has_attribute(musttail)
+#           error "This compiler does not have support for efficient tail calling."
+#       endif
+#   elif defined(_MSC_VER)
+#       error "Tail calling not supported for MSVC."
+#   endif
+
     // Note: [[clang::musttail]] works for GCC 15, but not __attribute__((musttail)) at the moment.
 #   define Py_MUSTTAIL [[clang::musttail]]
 #   define Py_PRESERVE_NONE_CC __attribute__((preserve_none))


### PR DESCRIPTION
(cherry picked from commit 2f60b8f02fe7cb83dd589d9664460082c13e85ef)


<!-- gh-issue-number: gh-140513 -->
* Issue: gh-140513
<!-- /gh-issue-number -->
