### PR TITLE
Revert "gh-137969: Fix evaluation of `ref.evaluate(format=Format.FORWARDREF)` objects (#138075)"

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -159,12 +159,12 @@ class ForwardRef:
             type_params = getattr(owner, "__type_params__", None)
 
         # Type parameters exist in their own scope, which is logically
-        # between the locals and the globals.
-        type_param_scope = {}
+        # between the locals and the globals. We simulate this by adding
+        # them to the globals.
         if type_params is not None:
+            globals = dict(globals)
             for param in type_params:
-                type_param_scope[param.__name__] = param
-
+                globals[param.__name__] = param
         if self.__extra_names__:
             locals = {**locals, **self.__extra_names__}
 
@@ -172,8 +172,6 @@ class ForwardRef:
         if arg.isidentifier() and not keyword.iskeyword(arg):
             if arg in locals:
                 return locals[arg]
-            elif arg in type_param_scope:
-                return type_param_scope[arg]
             elif arg in globals:
                 return globals[arg]
             elif hasattr(builtins, arg):
@@ -185,7 +183,7 @@ class ForwardRef:
         else:
             code = self.__forward_code__
             try:
-                return eval(code, globals=globals, locals={**type_param_scope, **locals})
+                return eval(code, globals=globals, locals=locals)
             except Exception:
                 if not is_forwardref_format:
                     raise
@@ -193,7 +191,7 @@ class ForwardRef:
             # All variables, in scoping order, should be checked before
             # triggering __missing__ to create a _Stringifier.
             new_locals = _StringifierDict(
-                {**builtins.__dict__, **globals, **type_param_scope, **locals},
+                {**builtins.__dict__, **globals, **locals},
                 globals=globals,
                 owner=owner,
                 is_class=self.__forward_is_class__,

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1911,15 +1911,6 @@ class TestForwardRefClass(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             fr.evaluate()
 
-    def test_re_evaluate_generics(self):
-        global alias
-        class C:
-            x: alias[int]
-
-        evaluated = get_annotations(C, format=Format.FORWARDREF)["x"].evaluate(format=Format.FORWARDREF)
-        alias = list
-        self.assertEqual(evaluated.evaluate(), list[int])
-
 
 class TestAnnotationLib(unittest.TestCase):
     def test__all__(self):

--- a/Misc/NEWS.d/next/Library/2025-08-22-23-50-38.gh-issue-137969.Fkvis3.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-22-23-50-38.gh-issue-137969.Fkvis3.rst
@@ -1,2 +1,0 @@
-Fix :meth:`annotationlib.ForwardRef.evaluate` returning :class:`annotationlib.ForwardRef`
-objects which do not update in new contexts.


### PR DESCRIPTION
This reverts commit 63e01d6bae9ddc9ff35aca2134945670eacef163.

Broke a number of buildbots.

<!-- gh-issue-number: gh-137969 -->
* Issue: gh-137969
<!-- /gh-issue-number -->
