### PR TITLE
gh-140942: Add MIME type for .cjs extension

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -443,6 +443,7 @@ math
 mimetypes
 ---------
 
+* Add ``application/node`` MIME type for ``.cjs`` extension. (Contributed by John Franey in :gh:`140937`.)
 * Add ``application/toml``. (Contributed by Gil Forcada in :gh:`139959`.)
 * Rename ``application/x-texinfo`` to ``application/texinfo``.
   (Contributed by Charlie Lin in :gh:`140165`)

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -681,6 +681,7 @@ def _default_mime_types():
 
     # Please sort these too
     common_types = _common_types_default = {
+        '.cjs' : 'application/node',
         '.rtf' : 'application/rtf',
         '.apk' : 'application/vnd.android.package-archive',
         '.midi': 'audio/midi',

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -486,6 +486,7 @@ def _default_mime_types():
         '.wiz'    : 'application/msword',
         '.nq'     : 'application/n-quads',
         '.nt'     : 'application/n-triples',
+        '.cjs'    : 'application/node',
         '.bin'    : 'application/octet-stream',
         '.a'      : 'application/octet-stream',
         '.dll'    : 'application/octet-stream',
@@ -681,7 +682,6 @@ def _default_mime_types():
 
     # Please sort these too
     common_types = _common_types_default = {
-        '.cjs' : 'application/node',
         '.rtf' : 'application/rtf',
         '.apk' : 'application/vnd.android.package-archive',
         '.midi': 'audio/midi',

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-04-12-18-06.gh-issue-140942.GYns6n.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-04-12-18-06.gh-issue-140942.GYns6n.rst
@@ -1,2 +1,2 @@
-Add .cjs extension to common_types to give CommonJS modules a mimetype of
+Add .cjs to mimetypes to give CommonJS modules a mimetype of
 "application/node"

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-04-12-18-06.gh-issue-140942.GYns6n.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-04-12-18-06.gh-issue-140942.GYns6n.rst
@@ -1,0 +1,2 @@
+Add .cjs extension to common_types to give CommonJS modules a mimetype of
+"application/node"

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-04-12-18-06.gh-issue-140942.GYns6n.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-04-12-18-06.gh-issue-140942.GYns6n.rst
@@ -1,2 +1,2 @@
-Add .cjs to mimetypes to give CommonJS modules a mimetype of
-"application/node"
+Add ``.cjs`` to :mod:`mimetypes` to give CommonJS modules a MIME type of
+``application/node``.


### PR DESCRIPTION
Updates MIME types with `.cjs` type of `application/node` for CommonJS modules. See here for more information: https://www.iana.org/assignments/media-types/application/node

Fixes #140942


<!-- gh-issue-number: gh-140942 -->
* Issue: gh-140942
<!-- /gh-issue-number -->
