### PR TITLE
Docs: Fix typo in socketserver documentation

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -546,7 +546,7 @@ The difference is that the ``readline()`` call in the second handler will call
 first handler had to use a ``recv()`` loop to accumulate data until a
 newline itself.  If it had just used a single ``recv()`` without the loop it
 would just have returned what has been received so far from the client.
-TCP is stream based: data arrives in the order it was sent, but there no
+TCP is stream based: data arrives in the order it was sent, but there is no
 correlation between client ``send()`` or ``sendall()`` calls and the number
 of ``recv()`` calls on the server required to receive it.
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140956.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->