### PR TITLE
gh-140939: Fix memory leak in `_PyBytes_FormatEx` error path

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -802,6 +802,7 @@ class BaseBytesTest:
             with self.assertRaisesRegex(TypeError, msg):
                 operator.mod(format_bytes, value)
 
+    def test_memory_leak_gh_140939(self):
         # gh-140939: MemoryError is raised without leaking
         _testcapi = import_helper.import_module('_testcapi')
         with self.assertRaises(MemoryError):

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -803,10 +803,9 @@ class BaseBytesTest:
                 operator.mod(format_bytes, value)
 
         # gh-140939: MemoryError is raised without leaking
-        for _ in range(100):
-            with self.assertRaises((MemoryError, OverflowError)):
-                b = self.type2test(b'%*b')
-                b % (2**63-1, b'abc')
+        with self.assertRaises((MemoryError, OverflowError)):
+            b = self.type2test(b'%*b')
+            b % (2**63-1, b'abc')
 
     def test_imod(self):
         b = self.type2test(b'hello, %b!')

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -804,7 +804,7 @@ class BaseBytesTest:
 
         # gh-140939: MemoryError is raised without leaking
         for _ in range(100):
-            with self.assertRaises(MemoryError):
+            with self.assertRaises((MemoryError, OverflowError)):
                 b = self.type2test(b'%*b')
                 b % (2**63-1, b'abc')
 

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -803,9 +803,10 @@ class BaseBytesTest:
                 operator.mod(format_bytes, value)
 
         # gh-140939: MemoryError is raised without leaking
-        with self.assertRaises((MemoryError, OverflowError)):
+        _testcapi = import_helper.import_module('_testcapi')
+        with self.assertRaises(MemoryError):
             b = self.type2test(b'%*b')
-            b % (2**63-1, b'abc')
+            b % (_testcapi.PY_SSIZE_T_MAX, b'abc')
 
     def test_imod(self):
         b = self.type2test(b'hello, %b!')

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -802,6 +802,12 @@ class BaseBytesTest:
             with self.assertRaisesRegex(TypeError, msg):
                 operator.mod(format_bytes, value)
 
+        # gh-140939: MemoryError is raised without leaking
+        for _ in range(100):
+            with self.assertRaises(MemoryError):
+                b = self.type2test(b'%*b')
+                b % (2**63-1, b'abc')
+
     def test_imod(self):
         b = self.type2test(b'hello, %b!')
         orig = b

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-03-17-21-38.gh-issue-140939.FVboAw.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-03-17-21-38.gh-issue-140939.FVboAw.rst
@@ -1,0 +1,2 @@
+Fix memory leak when :class:`bytearray` or :class:`bytes` is formated with the
+``%*b`` format with a large width that results in a :exc:`MemoryError`.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -985,6 +985,7 @@ _PyBytes_FormatEx(const char *format, Py_ssize_t format_len,
             if (alloc > 2) {
                 res = PyBytesWriter_GrowAndUpdatePointer(writer, alloc - 2, res);
                 if (res == NULL) {
+                    Py_XDECREF(temp);
                     goto error;
                 }
             }


### PR DESCRIPTION
It is already accounted for in the other path:

https://github.com/python/cpython/blob/b373d3494c587cf27b31f3dff89a8d96f7d29b9d/Objects/bytesobject.c#L1049-L1054

<!-- gh-issue-number: gh-140939 -->
* Issue: gh-140939
<!-- /gh-issue-number -->
