### PR TITLE
[3.13] Fix minor typos and wording in C API docs (GH-140955)

### DIFF
--- a/Doc/c-api/cell.rst
+++ b/Doc/c-api/cell.rst
@@ -7,7 +7,7 @@ Cell Objects
 
 "Cell" objects are used to implement variables referenced by multiple scopes.
 For each such variable, a cell object is created to store the value; the local
-variables of each stack frame that references the value contains a reference to
+variables of each stack frame that references the value contain a reference to
 the cells from outer scopes which also use that variable.  When the value is
 accessed, the value contained in the cell is used instead of the cell object
 itself.  This de-referencing of the cell object requires support from the

--- a/Doc/c-api/datetime.rst
+++ b/Doc/c-api/datetime.rst
@@ -46,7 +46,7 @@ macros.
 
 .. c:var:: PyTypeObject PyDateTime_DeltaType
 
-   This instance of :c:type:`PyTypeObject` represents Python type for
+   This instance of :c:type:`PyTypeObject` represents the Python type for
    the difference between two datetime values;
    it is the same object as :class:`datetime.timedelta` in the Python layer.
 

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -32,7 +32,7 @@ found in the dictionary of type objects.
 
 .. c:function:: int PyDescr_IsData(PyObject *descr)
 
-   Return non-zero if the descriptor objects *descr* describes a data attribute, or
+   Return non-zero if the descriptor object *descr* describes a data attribute, or
    ``0`` if it describes a method.  *descr* must be a descriptor object; there is
    no error checking.
 

--- a/Doc/c-api/mapping.rst
+++ b/Doc/c-api/mapping.rst
@@ -102,7 +102,7 @@ See also :c:func:`PyObject_GetItem`, :c:func:`PyObject_SetItem` and
 
    .. note::
 
-      Exceptions which occur when this calls :meth:`~object.__getitem__`
+      Exceptions which occur when this calls the :meth:`~object.__getitem__`
       method are silently ignored.
       For proper error handling, use :c:func:`PyMapping_HasKeyWithError`,
       :c:func:`PyMapping_GetOptionalItem` or :c:func:`PyObject_GetItem()` instead.
@@ -116,7 +116,7 @@ See also :c:func:`PyObject_GetItem`, :c:func:`PyObject_SetItem` and
 
    .. note::
 
-      Exceptions that occur when this calls :meth:`~object.__getitem__`
+      Exceptions that occur when this calls the :meth:`~object.__getitem__`
       method or while creating the temporary :class:`str`
       object are silently ignored.
       For proper error handling, use :c:func:`PyMapping_HasKeyStringWithError`,

--- a/Doc/c-api/marshal.rst
+++ b/Doc/c-api/marshal.rst
@@ -81,7 +81,7 @@ The following functions allow marshalled values to be read back in.
    assumes that no further objects will be read from the file, allowing it to
    aggressively load file data into memory so that the de-serialization can
    operate from data in memory rather than reading a byte at a time from the
-   file.  Only use these variant if you are certain that you won't be reading
+   file.  Only use this variant if you are certain that you won't be reading
    anything else from the file.
 
    On error, sets the appropriate exception (:exc:`EOFError`, :exc:`ValueError`

--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -102,7 +102,7 @@ All allocating functions belong to one of three different "domains" (see also
 strategies and are optimized for different purposes. The specific details on
 how every domain allocates memory or what internal functions each domain calls
 is considered an implementation detail, but for debugging purposes a simplified
-table can be found at :ref:`here <default-memory-allocators>`.
+table can be found at :ref:`default-memory-allocators`.
 The APIs used to allocate and free a block of memory must be from the same domain.
 For example, :c:func:`PyMem_Free` must be used to free memory allocated using :c:func:`PyMem_Malloc`.
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -103,7 +103,7 @@ Module Objects
    created, or ``NULL`` if the module wasn't created from a definition.
 
    On error, return ``NULL`` with an exception set.
-   Use :c:func:`PyErr_Occurred` to tell this case apart from a mising
+   Use :c:func:`PyErr_Occurred` to tell this case apart from a missing
    :c:type:`!PyModuleDef`.
 
 

--- a/Doc/c-api/monitoring.rst
+++ b/Doc/c-api/monitoring.rst
@@ -131,7 +131,7 @@ Managing the Monitoring State
 -----------------------------
 
 Monitoring states can be managed with the help of monitoring scopes. A scope
-would typically correspond to a python function.
+would typically correspond to a Python function.
 
 .. c:function:: int PyMonitoring_EnterScope(PyMonitoringState *state_array, uint64_t *version, const uint8_t *event_types, Py_ssize_t length)
 

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -73,7 +73,7 @@ Object Protocol
 
    Flag to be used with multiple functions that print the object (like
    :c:func:`PyObject_Print` and :c:func:`PyFile_WriteObject`).
-   If passed, these function would use the :func:`str` of the object
+   If passed, these functions use the :func:`str` of the object
    instead of the :func:`repr`.
 
 

--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -48,7 +48,7 @@ Tuple Objects
 .. c:function:: Py_ssize_t PyTuple_Size(PyObject *p)
 
    Take a pointer to a tuple object, and return the size of that tuple.
-   On error, return ``-1`` and with an exception set.
+   On error, return ``-1`` with an exception set.
 
 
 .. c:function:: Py_ssize_t PyTuple_GET_SIZE(PyObject *p)

--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -140,7 +140,7 @@ the same library that the Python runtime is using.
    interpreter prompt is about to become idle and wait for user input
    from the terminal.  The return value is ignored.  Overriding this
    hook can be used to integrate the interpreter's prompt with other
-   event loops, as done in the :file:`Modules/_tkinter.c` in the
+   event loops, as done in :file:`Modules/_tkinter.c` in the
    Python source code.
 
    .. versionchanged:: 3.12


### PR DESCRIPTION
(cherry picked from commit 3f2b83e9595ff2436a646e6bbd335198c4bc06db)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140967.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->