### PR TITLE
gh-140972: Fix: DynamicClassAttribute drops explicitly provided empty docstrings

### DIFF
--- a/Lib/types.py
+++ b/Lib/types.py
@@ -210,8 +210,10 @@ class DynamicClassAttribute:
         self.fget = fget
         self.fset = fset
         self.fdel = fdel
+        if doc is None and fget is not None:
+            doc = fget.__doc__
         # next two lines make DynamicClassAttribute act the same as property
-        self.__doc__ = doc or fget.__doc__
+        self.__doc__ = doc
         self.overwrite_doc = doc is None
         # support for abstract methods
         self.__isabstractmethod__ = bool(getattr(fget, '__isabstractmethod__', False))


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140972 -->
* Issue: gh-140972
<!-- /gh-issue-number -->
