### PR TITLE
Docs: Clarify Windows version for high-resolution timer

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -407,7 +407,7 @@ Functions
    On Windows, if *secs* is zero, the thread relinquishes the remainder of its
    time slice to any other thread that is ready to run. If there are no other
    threads ready to run, the function returns immediately, and the thread
-   continues execution.  On Windows 10 version 1803, and later the implementation uses
+   continues execution.  On Windows 10 version 1803 and later the implementation uses
    a `high-resolution timer
    <https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createwaitabletimerexw>`_
    which provides resolution of 100 nanoseconds. If *secs* is zero, ``Sleep(0)`` is used.

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -407,9 +407,9 @@ Functions
    On Windows, if *secs* is zero, the thread relinquishes the remainder of its
    time slice to any other thread that is ready to run. If there are no other
    threads ready to run, the function returns immediately, and the thread
-   continues execution.  On Windows 8.1 and newer the implementation uses
+   continues execution.  On Windows 10 version 1803, and later the implementation uses
    a `high-resolution timer
-   <https://learn.microsoft.com/windows-hardware/drivers/kernel/high-resolution-timers>`_
+   <https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createwaitabletimerexw>`_
    which provides resolution of 100 nanoseconds. If *secs* is zero, ``Sleep(0)`` is used.
 
    .. rubric:: Unix implementation


### PR DESCRIPTION
skip issue

the referenced link is for driver but not userland application and we are not using that API, change it to the correct docs and correct the windows version range (which comes from windows's docs)

here is the corresponding code: https://github.com/python/cpython/blob/947bb4642c612b66de7cae815aaf9c570a93882a/Modules/timemodule.c#L2318

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140978.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->