### PR TITLE
gh-140979: Fix off-by-one error in the RE code validator

### DIFF
--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -1946,7 +1946,7 @@ _validate_inner(SRE_CODE *code, SRE_CODE *end, Py_ssize_t groups)
                sre_match() code is robust even if they don't, and the worst
                you can get is nonsensical match results. */
             GET_ARG;
-            if (arg > 2 * (size_t)groups + 1) {
+            if (arg >= 2 * (size_t)groups) {
                 VTRACE(("arg=%d, groups=%d\n", (int)arg, (int)groups));
                 FAIL;
             }


### PR DESCRIPTION
It was too lenient and allowed MARK opcodes with too large value.


<!-- gh-issue-number: gh-140797 -->
* Issue: gh-140797
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-140979 -->
* Issue: gh-140979
<!-- /gh-issue-number -->
