### PR TITLE
[3.14] Omit `Python/perf_jit_trampoline.c` from the `**/*jit*` CODEOWNERS rule (GH-136519)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,7 @@ Modules/Setup*                @erlend-aasland
 **/*genobject*                @markshannon
 **/*hamt*                     @1st1
 **/*jit*                      @brandtbucher @savannahostrowski
+Python/perf_jit_trampoline.c  # Exclude the owners of "**/*jit*", above.
 Objects/set*                  @rhettinger
 Objects/dict*                 @methane @markshannon
 Objects/typevarobject.c       @JelleZijlstra


### PR DESCRIPTION


Omit perf_jit_trampoline from "JIT" codeowners
(cherry picked from commit 56c6f04b8862c20ff6eddc4400f170ad91e55f66)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
