### PR TITLE
gh-140971: Doc: Clarify pathlib.Path("") behavior

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -136,6 +136,14 @@ we also call *flavours*:
       >>> PurePath()
       PurePosixPath('.')
 
+   An empty string in *pathsegments* also refers to the current directory.
+   This means that ``PurePath("")`` is equivalent to ``PurePath(".")``,
+   and consequently ``Path("").exists()`` will always return ``True``. This
+   differs from ``os.path.exists("")``, which returns ``False``.
+
+      >>> PurePath("")
+      PurePosixPath('.')
+
    If a segment is an absolute path, all previous segments are ignored
    (like :func:`os.path.join`)::
 


### PR DESCRIPTION
Fixes #140971
This PR clarifies the behavior of `pathlib.Path("")` in the documentation.

The current behavior, where `pathlib.Path("").exists()` returns `True`, is intentional but
     can be confusing because it differs from `os.path.exists("")`, which returns `False`.



This change adds a note to the `PurePath` constructor documentation to explain that an empty string path segment refers to the current directory. This makes the behavior  explicit to users and helps prevent further confusion.

<!-- gh-issue-number: gh-140971 -->
* Issue: gh-140971
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140993.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->