### PR TITLE
gh-140995: [asyncio] Add high-level API to run functions in subinterpreters

### DIFF
--- a/Lib/asyncio/__init__.py
+++ b/Lib/asyncio/__init__.py
@@ -46,6 +46,7 @@ try:
 except ImportError:
     subinterpreters = None
 else:
+    from .subinterpreters import *
     __all__ = __all__ + subinterpreters.__all__
 
 if sys.platform == 'win32':  # pragma: no cover

--- a/Lib/asyncio/__init__.py
+++ b/Lib/asyncio/__init__.py
@@ -46,7 +46,7 @@ try:
 except ImportError:
     subinterpreters = None
 else:
-    __all__.extend(subinterpreters.__all__)
+    __all__ = __all__ + subinterpreters.__all__
 
 if sys.platform == 'win32':  # pragma: no cover
     from .windows_events import *

--- a/Lib/asyncio/__init__.py
+++ b/Lib/asyncio/__init__.py
@@ -22,7 +22,6 @@ from .taskgroups import *
 from .timeouts import *
 from .threads import *
 from .transports import *
-from .subinterpreters import *
 
 __all__ = (base_events.__all__ +
            coroutines.__all__ +
@@ -40,8 +39,14 @@ __all__ = (base_events.__all__ +
            taskgroups.__all__ +
            threads.__all__ +
            timeouts.__all__ +
-           transports.__all__ +
-           subinterpreters.__all__)
+           transports.__all__ )
+
+try:
+    from . import subinterpreters
+except ImportError:
+    subinterpreters = None
+else:
+    __all__.extend(subinterpreters.__all__)
 
 if sys.platform == 'win32':  # pragma: no cover
     from .windows_events import *

--- a/Lib/asyncio/__init__.py
+++ b/Lib/asyncio/__init__.py
@@ -22,6 +22,7 @@ from .taskgroups import *
 from .timeouts import *
 from .threads import *
 from .transports import *
+from .subinterpreters import *
 
 __all__ = (base_events.__all__ +
            coroutines.__all__ +
@@ -39,7 +40,8 @@ __all__ = (base_events.__all__ +
            taskgroups.__all__ +
            threads.__all__ +
            timeouts.__all__ +
-           transports.__all__)
+           transports.__all__ +
+           subinterpreters.__all__)
 
 if sys.platform == 'win32':  # pragma: no cover
     from .windows_events import *

--- a/Lib/asyncio/subinterpreters.py
+++ b/Lib/asyncio/subinterpreters.py
@@ -1,6 +1,6 @@
 """High-level support for working with subinterpreters in asyncio"""
 
-import os
+import asyncio
 from concurrent.futures.interpreter import InterpreterPoolExecutor
 
 __all__ = "run_in_subinterpreter",
@@ -12,9 +12,7 @@ async def run_in_subinterpreter(func, /, *args, **kwargs):
     Run a Python function in a subinterpreter asynchronously.
 
     This function executes the given callable `func` in a subinterpreter
-    using `InterpreterPoolExecutor`. It chooses the number of 
-    subinterpreters based on the CPU count of the host system, 
-    defaulting to half the available cores if detectable.
+    using `InterpreterPoolExecutor`.
 
     Args:
         func (Callable): The function to run in the subinterpreter.
@@ -23,16 +21,8 @@ async def run_in_subinterpreter(func, /, *args, **kwargs):
 
     Returns:
         Any: The result returned by `func`.
-
-    Raises:
-        RuntimeError: If CPU count cannot be determined and a default 
-        cannot be safely chosen.
     """
     
-    n: int | None = os.cpu_count()
-    worker_count: int | None = None
-    if n:
-        worker_count = max(1, n // 2)  
-    with InterpreterPoolExecutor(max_workers=worker_count) as pool:
-        future = pool.submit(func, *args, **kwargs)
-        return future.result()
+    with InterpreterPoolExecutor() as pool:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(pool, func, *args, **kwargs)

--- a/Lib/asyncio/subinterpreters.py
+++ b/Lib/asyncio/subinterpreters.py
@@ -1,0 +1,38 @@
+"""High-level support for working with subinterpreters in asyncio"""
+
+import os
+from concurrent.futures.interpreter import InterpreterPoolExecutor
+
+__all__ = "run_in_subinterpreter",
+
+
+async def run_in_subinterpreter(func, /, *args, **kwargs):
+    
+    """
+    Run a Python function in a subinterpreter asynchronously.
+
+    This function executes the given callable `func` in a subinterpreter
+    using `InterpreterPoolExecutor`. It chooses the number of 
+    subinterpreters based on the CPU count of the host system, 
+    defaulting to half the available cores if detectable.
+
+    Args:
+        func (Callable): The function to run in the subinterpreter.
+        *args: Positional arguments to pass to `func`.
+        **kwargs: Keyword arguments to pass to `func`.
+
+    Returns:
+        Any: The result returned by `func`.
+
+    Raises:
+        RuntimeError: If CPU count cannot be determined and a default 
+        cannot be safely chosen.
+    """
+    
+    n: int | None = os.cpu_count()
+    worker_count: int | None = None
+    if n:
+        worker_count = max(1, n // 2)  
+    with InterpreterPoolExecutor(max_workers=worker_count) as pool:
+        future = pool.submit(func, *args, **kwargs)
+        return future.result()

--- a/Lib/test/test_asyncio/test_subinterpreters.py
+++ b/Lib/test/test_asyncio/test_subinterpreters.py
@@ -1,11 +1,10 @@
 import asyncio
+import unittest
 
 try:
     from asyncio import run_in_subinterpreter
 except ImportError:
     raise unittest.SkipTest("subinterpreters not supported")
-
-import unittest
 
 def simple_func():
     return 42

--- a/Lib/test/test_asyncio/test_subinterpreters.py
+++ b/Lib/test/test_asyncio/test_subinterpreters.py
@@ -1,5 +1,9 @@
 import asyncio
-from asyncio import run_in_subinterpreter
+
+try:
+    from asyncio import run_in_subinterpreter
+except ImportError:
+    raise unittest.SkipTest("subinterpreters not supported")
 
 import unittest
 

--- a/Lib/test/test_asyncio/test_subinterpreters.py
+++ b/Lib/test/test_asyncio/test_subinterpreters.py
@@ -1,7 +1,7 @@
-from test.test_asyncio import utils as test_utils
-
+import asyncio
 from asyncio import run_in_subinterpreter
 
+import unittest
 
 def simple_func():
     return 42
@@ -12,8 +12,23 @@ def sum_func(a, b):
 def raise_func():
     raise ValueError("Test error")
 
+def large_number():
+    return 10**15 * 10**15
 
-class TestRunInSubinterpreter(test_utils.TestCase):
+def return_objects():
+    return {"a": [1, 2, 3], "b": (4, 5), "c": {"nested": 42}}
+
+def multiply_by_3(x):
+    return x * 3
+
+def multiply_by_2(x):
+    return x * 2
+
+
+class TestRunInSubinterpreter(unittest.IsolatedAsyncioTestCase):
+    
+    async def asyncSetUp(self) -> None:
+        return await super().asyncSetUp()
 
     async def test_basic_return(self):
         """Check that simple function returns correct result."""
@@ -26,7 +41,8 @@ class TestRunInSubinterpreter(test_utils.TestCase):
         self.assertEqual(result, 42)
 
     async def test_exception_propagation(self):
-        """Check that exceptions inside subinterpreter are propagated."""
+        """Check that exceptions inside subinterpreter are propagated.
+        """
         with self.assertRaises(ValueError) as cm:
             await run_in_subinterpreter(raise_func)
         self.assertEqual(str(cm.exception), "Test error")
@@ -35,6 +51,28 @@ class TestRunInSubinterpreter(test_utils.TestCase):
         """Check that multiple sequential calls work."""
         results = []
         for i in range(5):
-            result = await run_in_subinterpreter(lambda x=i: x * 2)
+            result = await run_in_subinterpreter(multiply_by_2, i)
             results.append(result)
         self.assertEqual(results, [0, 2, 4, 6, 8])
+        
+    async def test_parallel_calls(self):
+        """Check that multiple calls can be awaited concurrently."""
+        tasks = [
+            run_in_subinterpreter(multiply_by_3, i)
+            for i in range(5)
+        ]
+        results = await asyncio.gather(*tasks)
+        self.assertEqual(results, [0, 3, 6, 9, 12])
+
+    async def test_complex_objects(self):
+        """Check that function can return complex objects."""
+        result = await run_in_subinterpreter(return_objects)
+        self.assertEqual(
+            result, 
+            {"a": [1, 2, 3], "b": (4, 5), "c": {"nested": 42}}
+        )
+
+    async def test_large_numbers(self):
+        """Check CPU-bound operation with large numbers."""
+        result = await run_in_subinterpreter(large_number)
+        self.assertEqual(result, 10**15 * 10**15)

--- a/Lib/test/test_asyncio/test_subinterpreters.py
+++ b/Lib/test/test_asyncio/test_subinterpreters.py
@@ -1,0 +1,40 @@
+from test.test_asyncio import utils as test_utils
+
+from asyncio import run_in_subinterpreter
+
+
+def simple_func():
+    return 42
+
+def sum_func(a, b):
+    return a + b
+
+def raise_func():
+    raise ValueError("Test error")
+
+
+class TestRunInSubinterpreter(test_utils.TestCase):
+
+    async def test_basic_return(self):
+        """Check that simple function returns correct result."""
+        result = await run_in_subinterpreter(simple_func)
+        self.assertEqual(result, 42)
+
+    async def test_arguments(self):
+        """Check that positional arguments are passed correctly."""
+        result = await run_in_subinterpreter(sum_func, 10, 32)
+        self.assertEqual(result, 42)
+
+    async def test_exception_propagation(self):
+        """Check that exceptions inside subinterpreter are propagated."""
+        with self.assertRaises(ValueError) as cm:
+            await run_in_subinterpreter(raise_func)
+        self.assertEqual(str(cm.exception), "Test error")
+
+    async def test_multiple_calls(self):
+        """Check that multiple sequential calls work."""
+        results = []
+        for i in range(5):
+            result = await run_in_subinterpreter(lambda x=i: x * 2)
+            results.append(result)
+        self.assertEqual(results, [0, 2, 4, 6, 8])


### PR DESCRIPTION
This PR adds a high-level asynchronous API `asyncio.run_in_subinterpreter` for running Python functions
in subinterpreters. It uses InterpreterPoolExecutor internally and chooses the number of subinterpreters
based on the CPU count.

Motivation:
- Enables CPU-bound tasks to run in parallel without being limited by the GIL.
- Provides a lighter alternative to ProcessPoolExecutor.
- Offers asyncio-friendly syntax.

Example usage:

```python
import asyncio
from asyncio import run_in_subinterpreter

def cpu_task(x):
    return x * x

async def main():
    result = await run_in_subinterpreter(cpu_task, 10)
    # or
    result = await asyncio.run_in_subinterpreter(cpu_task, 10)
    print(result)

asyncio.run(main())
```

Tests:
- Added unit tests for return values, argument passing, exception propagation, parallel calls, 
  and complex objects.



<!-- gh-issue-number: gh-140995 -->
* Issue: gh-140995
<!-- /gh-issue-number -->
