### PR TITLE
gh-118516: clarify that subprocess are automatically killed if transport gets garbage collected

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1631,6 +1631,9 @@ async/await code consider using the high-level
    conforms to the :class:`asyncio.SubprocessTransport` base class and
    *protocol* is an object instantiated by the *protocol_factory*.
 
+   If the transport is closed or is garbage collected, the child process
+   is killed if it is still running.
+
 .. method:: loop.subprocess_shell(protocol_factory, cmd, *, \
                stdin=subprocess.PIPE, stdout=subprocess.PIPE, \
                stderr=subprocess.PIPE, **kwargs)
@@ -1653,6 +1656,9 @@ async/await code consider using the high-level
    Returns a pair of ``(transport, protocol)``, where *transport*
    conforms to the :class:`SubprocessTransport` base class and
    *protocol* is an object instantiated by the *protocol_factory*.
+
+   If the transport is closed or is garbage collected, the child process
+   is killed if it is still running.
 
 .. note::
    It is the application's responsibility to ensure that all whitespace

--- a/Doc/library/asyncio-subprocess.rst
+++ b/Doc/library/asyncio-subprocess.rst
@@ -76,6 +76,9 @@ Creating Subprocesses
    See the documentation of :meth:`loop.subprocess_exec` for other
    parameters.
 
+   If the process object is garbage collected while the process is still
+   running, the child process will be killed.
+
    .. versionchanged:: 3.10
       Removed the *loop* parameter.
 
@@ -94,6 +97,9 @@ Creating Subprocesses
 
    See the documentation of :meth:`loop.subprocess_shell` for other
    parameters.
+
+   If the process object is garbage collected while the process is still
+   running, the child process will be killed.
 
    .. important::
 


### PR DESCRIPTION
This documents the asyncio's behavior of killing the subprocess if the transport is closed or gets garbage collected. 
This behaviour is tested at https://github.com/python/cpython/blob/fa9c3eefd475f0647a69bf3f49db8100848fb6a9/Lib/test/test_asyncio/test_subprocess.py#L563

<!-- gh-issue-number: gh-118516 -->
* Issue: gh-118516
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--140997.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->