### PR TITLE
gh-141007: update string module source code link

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -4,7 +4,7 @@
 .. module:: string
    :synopsis: Common string operations.
 
-**Source code:** :source:`Lib/string.py`
+**Source code:** :source:`Lib/string/__init__.py`
 
 --------------
 


### PR DESCRIPTION
In 3.14, implementation file string.py became `__init__.py` (paired with a new `__main__.py`) within a new `string` directory that also contains the `template` directory for the new string.template module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141007 -->
* Issue: gh-141007
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141008.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->