### PR TITLE
Avoid TestNullDlsym hanging on HP-PA

### DIFF
--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -30,8 +30,9 @@ void *foo(void)
 """
 
 
-@unittest.skipUnless(sys.platform.startswith('linux'),
-                     'test requires GNU IFUNC support')
+@unittest.skipIf(not sys.platform.startswith('linux')
+                 or platform.machine().startswith('parisc'),
+                 'test requires GNU IFUNC support')
 @unittest.skipIf(test.support.linked_to_musl(), "Requires glibc")
 class TestNullDlsym(unittest.TestCase):
     """GH-126554: Ensure that we catch NULL dlsym return values


### PR DESCRIPTION
glibc has no support for IFUNC on HP PA RISC yet. Rather than waiting for an "OK" that we'll never get, skip the test.

See: https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/hppa/dl-irel.h;h=770dcb3ea3a6ce232bb11bf59315cfec4c543f93;hb=HEAD