### PR TITLE
gh-134817: Restore accidentally deleted line in documentation.

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -463,6 +463,7 @@ timed intervals.
    .. method:: getFilesToDelete()
 
       Returns a list of filenames which should be deleted as part of rollover. These
+      are the absolute paths of the oldest backup log files written by the handler.
 
    .. method:: shouldRollover(record)
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-134817 -->
* Issue: gh-134817
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141013.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->