### PR TITLE
[3.14] gh-139434: Update selected RFC 2822 references to RFC 5322 (GH-139435)

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -125,7 +125,7 @@ This module provides the following function:
 
    Parse the headers from a file pointer *fp* representing a HTTP
    request/response. The file has to be a :class:`~io.BufferedIOBase` reader
-   (i.e. not text) and must provide a valid :rfc:`2822` style header.
+   (i.e. not text) and must provide a valid :rfc:`5322` style header.
 
    This function returns an instance of :class:`http.client.HTTPMessage`
    that holds the header fields, but no payload

--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -154,7 +154,7 @@ instantiation, of which this module provides three different variants:
       variable. This instance parses and manages the headers in the HTTP
       request. The :func:`~http.client.parse_headers` function from
       :mod:`http.client` is used to parse the headers and it requires that the
-      HTTP request provide a valid :rfc:`2822` style header.
+      HTTP request provide a valid :rfc:`5322` style header.
 
    .. attribute:: rfile
 

--- a/Doc/library/mailbox.rst
+++ b/Doc/library/mailbox.rst
@@ -917,7 +917,7 @@ Supported mailbox formats are Maildir, mbox, MH, Babyl, and MMDF.
    copied; furthermore, any format-specific information is converted insofar as
    possible if *message* is a :class:`!Message` instance. If *message* is a string,
    a byte string,
-   or a file, it should contain an :rfc:`2822`\ -compliant message, which is read
+   or a file, it should contain an :rfc:`5322`\ -compliant message, which is read
    and parsed.  Files should be open in binary mode, but text mode files
    are accepted for backward compatibility.
 

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -570,7 +570,7 @@ Functions
       calculations when the day of the week and the year are specified.
 
    Here is an example, a format for dates compatible with that specified  in the
-   :rfc:`2822` Internet email standard.  [1]_ ::
+   :rfc:`5322` Internet email standard.  [1]_ ::
 
       >>> from time import gmtime, strftime
       >>> strftime("%a, %d %b %Y %H:%M:%S +0000", gmtime())
@@ -1052,4 +1052,5 @@ Timezone Constants
    strict reading of the original 1982 :rfc:`822` standard calls for a two-digit
    year (``%y`` rather than ``%Y``), but practice moved to 4-digit years long before the
    year 2000.  After that, :rfc:`822` became obsolete and the 4-digit year has
-   been first recommended by :rfc:`1123` and then mandated by :rfc:`2822`.
+   been first recommended by :rfc:`1123` and then mandated by :rfc:`2822`,
+   with :rfc:`5322` continuing this requirement.

--- a/Doc/tutorial/stdlib.rst
+++ b/Doc/tutorial/stdlib.rst
@@ -335,7 +335,7 @@ sophisticated and robust capabilities of its larger packages. For example:
   names, no direct knowledge or handling of XML is needed.
 
 * The :mod:`email` package is a library for managing email messages, including
-  MIME and other :rfc:`2822`-based message documents. Unlike :mod:`smtplib` and
+  MIME and other :rfc:`5322`-based message documents. Unlike :mod:`smtplib` and
   :mod:`poplib` which actually send and receive messages, the email package has
   a complete toolset for building or decoding complex message structures
   (including attachments) and for implementing internet encoding and header

--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -146,8 +146,9 @@ def _parsedate_tz(data):
         return None
     # Check for a yy specified in two-digit format, then convert it to the
     # appropriate four-digit format, according to the POSIX standard. RFC 822
-    # calls for a two-digit yy, but RFC 2822 (which obsoletes RFC 822)
-    # mandates a 4-digit yy. For more information, see the documentation for
+    # calls for a two-digit yy, but RFC 2822 (which obsoletes RFC 822) already
+    # mandated a 4-digit yy, and RFC 5322 (which obsoletes RFC 2822) continues
+    # this requirement. For more information, see the documentation for
     # the time module.
     if yy < 100:
         # The year is between 1969 and 1999 (inclusive).
@@ -233,9 +234,11 @@ class AddrlistClass:
         self.CR = '\r\n'
         self.FWS = self.LWS + self.CR
         self.atomends = self.specials + self.LWS + self.CR
-        # Note that RFC 2822 now specifies '.' as obs-phrase, meaning that it
-        # is obsolete syntax.  RFC 2822 requires that we recognize obsolete
-        # syntax, so allow dots in phrases.
+        # Note that RFC 2822 section 4.1 introduced '.' as obs-phrase to handle
+        # existing practice (periods in display names), even though it was not
+        # allowed in RFC 822. RFC 5322 section 4.1 (which obsoletes RFC 2822)
+        # continues this requirement. We must recognize obsolete syntax, so
+        # allow dots in phrases.
         self.phraseends = self.atomends.replace('.', '')
         self.field = field
         self.commentlist = []

--- a/Lib/email/_policybase.py
+++ b/Lib/email/_policybase.py
@@ -380,7 +380,7 @@ class Compat32(Policy):
             h = value
         if h is not None:
             # The Header class interprets a value of None for maxlinelen as the
-            # default value of 78, as recommended by RFC 2822.
+            # default value of 78, as recommended by RFC 5322 section 2.1.1.
             maxlinelen = 0
             if self.max_line_length is not None:
                 maxlinelen = self.max_line_length

--- a/Lib/email/feedparser.py
+++ b/Lib/email/feedparser.py
@@ -32,7 +32,7 @@ NLCRE = re.compile(r'\r\n|\r|\n')
 NLCRE_bol = re.compile(r'(\r\n|\r|\n)')
 NLCRE_eol = re.compile(r'(\r\n|\r|\n)\z')
 NLCRE_crack = re.compile(r'(\r\n|\r|\n)')
-# RFC 2822 $3.6.8 Optional fields.  ftext is %d33-57 / %d59-126, Any character
+# RFC 5322 section 3.6.8 Optional fields.  ftext is %d33-57 / %d59-126, Any character
 # except controls, SP, and ":".
 headerRE = re.compile(r'^(From |[\041-\071\073-\176]*:|[\t ])')
 EMPTYSTRING = ''
@@ -294,7 +294,7 @@ class FeedParser:
             return
         if self._cur.get_content_maintype() == 'message':
             # The message claims to be a message/* type, then what follows is
-            # another RFC 2822 message.
+            # another RFC 5322 message.
             for retval in self._parsegen():
                 if retval is NeedMoreData:
                     yield NeedMoreData

--- a/Lib/email/generator.py
+++ b/Lib/email/generator.py
@@ -50,7 +50,7 @@ class Generator:
         expanded to 8 spaces) than maxheaderlen, the header will split as
         defined in the Header class.  Set maxheaderlen to zero to disable
         header wrapping.  The default is 78, as recommended (but not required)
-        by RFC 2822.
+        by RFC 5322 section 2.1.1.
 
         The policy keyword specifies a policy object that controls a number of
         aspects of the generator's operation.  If no policy is specified,

--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -135,7 +135,7 @@ def _decode_uu(encoded):
 class Message:
     """Basic message object.
 
-    A message object is defined as something that has a bunch of RFC 2822
+    A message object is defined as something that has a bunch of RFC 5322
     headers and a payload.  It may optionally have an envelope header
     (a.k.a. Unix-From or From_ header).  If the message is a container (i.e. a
     multipart or a message/rfc822), then the payload is a list of Message

--- a/Lib/email/parser.py
+++ b/Lib/email/parser.py
@@ -2,7 +2,7 @@
 # Author: Barry Warsaw, Thomas Wouters, Anthony Baxter
 # Contact: email-sig@python.org
 
-"""A parser of RFC 2822 and MIME email messages."""
+"""A parser of RFC 5322 and MIME email messages."""
 
 __all__ = ['Parser', 'HeaderParser', 'BytesParser', 'BytesHeaderParser',
            'FeedParser', 'BytesFeedParser']
@@ -15,13 +15,13 @@ from email._policybase import compat32
 
 class Parser:
     def __init__(self, _class=None, *, policy=compat32):
-        """Parser of RFC 2822 and MIME email messages.
+        """Parser of RFC 5322 and MIME email messages.
 
         Creates an in-memory object tree representing the email message, which
         can then be manipulated and turned over to a Generator to return the
         textual representation of the message.
 
-        The string must be formatted as a block of RFC 2822 headers and header
+        The string must be formatted as a block of RFC 5322 headers and header
         continuation lines, optionally preceded by a 'Unix-from' header.  The
         header block is terminated either by the end of the string or by a
         blank line.
@@ -75,13 +75,13 @@ class HeaderParser(Parser):
 class BytesParser:
 
     def __init__(self, *args, **kw):
-        """Parser of binary RFC 2822 and MIME email messages.
+        """Parser of binary RFC 5322 and MIME email messages.
 
         Creates an in-memory object tree representing the email message, which
         can then be manipulated and turned over to a Generator to return the
         textual representation of the message.
 
-        The input must be formatted as a block of RFC 2822 headers and header
+        The input must be formatted as a block of RFC 5322 headers and header
         continuation lines, optionally preceded by a 'Unix-from' header.  The
         header block is terminated either by the end of the input or by a
         blank line.

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -230,7 +230,7 @@ def _read_headers(fp):
 
 def _parse_header_lines(header_lines, _class=HTTPMessage):
     """
-    Parses only RFC2822 headers from header lines.
+    Parses only RFC 5322 headers from header lines.
 
     email Parser wants to see strings rather than bytes.
     But a TextIOWrapper around self.rfile would buffer too many bytes
@@ -243,7 +243,7 @@ def _parse_header_lines(header_lines, _class=HTTPMessage):
     return email.parser.Parser(_class=_class).parsestr(hstring)
 
 def parse_headers(fp, _class=HTTPMessage):
-    """Parses only RFC2822 headers from a file pointer."""
+    """Parses only RFC 5322 headers from a file pointer."""
 
     headers = _read_headers(fp)
     return _parse_header_lines(headers, _class)

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -917,7 +917,7 @@ class SMTP:
         The arguments are as for sendmail, except that msg is an
         email.message.Message object.  If from_addr is None or to_addrs is
         None, these arguments are taken from the headers of the Message as
-        described in RFC 2822 (a ValueError is raised if there is more than
+        described in RFC 5322 (a ValueError is raised if there is more than
         one set of 'Resent-' headers).  Regardless of the values of from_addr and
         to_addr, any Bcc field (or Resent-Bcc field, when the Message is a
         resent) of the Message object won't be transmitted.  The Message
@@ -931,7 +931,7 @@ class SMTP:
         policy.
 
         """
-        # 'Resent-Date' is a mandatory field if the Message is resent (RFC 2822
+        # 'Resent-Date' is a mandatory field if the Message is resent (RFC 5322
         # Section 3.6.6). In such a case, we use the 'Resent-*' fields.  However,
         # if there is more than one 'Resent-' block there's no way to
         # unambiguously determine which one is the most recent in all cases,
@@ -950,7 +950,7 @@ class SMTP:
         else:
             raise ValueError("message has more than one 'Resent-' header block")
         if from_addr is None:
-            # Prefer the sender field per RFC 2822:3.6.2.
+            # Prefer the sender field per RFC 5322 section 3.6.2.
             from_addr = (msg[header_prefix + 'Sender']
                            if (header_prefix + 'Sender') in msg
                            else msg[header_prefix + 'From'])

--- a/Lib/test/test_email/data/msg_35.txt
+++ b/Lib/test/test_email/data/msg_35.txt
@@ -1,4 +1,4 @@
 From: aperson@dom.ain
 To: bperson@dom.ain
 Subject: here's something interesting
-counter to RFC 2822, there's no separating newline here
+counter to RFC 5322, there's no separating newline here

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -2352,7 +2352,7 @@ From: aperson@dom.ain
 To: bperson@dom.ain
 Subject: here's something interesting
 
-counter to RFC 2822, there's no separating newline here
+counter to RFC 5322, there's no separating newline here
 """)
 
     # test_defect_handling
@@ -2508,49 +2508,49 @@ Re: =?mac-iceland?q?r=8Aksm=9Arg=8Cs?= baz foo bar =?mac-iceland?q?r=8Aksm?=
                         [(b'andr\xe9=zz', 'iso-8859-1')])
 
     def test_rfc2047_rfc2047_1(self):
-        # 1st testcase at end of rfc2047
+        # 1st testcase at end of RFC 2047
         s = '(=?ISO-8859-1?Q?a?=)'
         self.assertEqual(decode_header(s),
             [(b'(', None), (b'a', 'iso-8859-1'), (b')', None)])
 
     def test_rfc2047_rfc2047_2(self):
-        # 2nd testcase at end of rfc2047
+        # 2nd testcase at end of RFC 2047
         s = '(=?ISO-8859-1?Q?a?= b)'
         self.assertEqual(decode_header(s),
             [(b'(', None), (b'a', 'iso-8859-1'), (b' b)', None)])
 
     def test_rfc2047_rfc2047_3(self):
-        # 3rd testcase at end of rfc2047
+        # 3rd testcase at end of RFC 2047
         s = '(=?ISO-8859-1?Q?a?= =?ISO-8859-1?Q?b?=)'
         self.assertEqual(decode_header(s),
             [(b'(', None), (b'ab', 'iso-8859-1'), (b')', None)])
 
     def test_rfc2047_rfc2047_4(self):
-        # 4th testcase at end of rfc2047
+        # 4th testcase at end of RFC 2047
         s = '(=?ISO-8859-1?Q?a?=  =?ISO-8859-1?Q?b?=)'
         self.assertEqual(decode_header(s),
             [(b'(', None), (b'ab', 'iso-8859-1'), (b')', None)])
 
     def test_rfc2047_rfc2047_5a(self):
-        # 5th testcase at end of rfc2047 newline is \r\n
+        # 5th testcase at end of RFC 2047 newline is \r\n
         s = '(=?ISO-8859-1?Q?a?=\r\n    =?ISO-8859-1?Q?b?=)'
         self.assertEqual(decode_header(s),
             [(b'(', None), (b'ab', 'iso-8859-1'), (b')', None)])
 
     def test_rfc2047_rfc2047_5b(self):
-        # 5th testcase at end of rfc2047 newline is \n
+        # 5th testcase at end of RFC 2047 newline is \n
         s = '(=?ISO-8859-1?Q?a?=\n    =?ISO-8859-1?Q?b?=)'
         self.assertEqual(decode_header(s),
             [(b'(', None), (b'ab', 'iso-8859-1'), (b')', None)])
 
     def test_rfc2047_rfc2047_6(self):
-        # 6th testcase at end of rfc2047
+        # 6th testcase at end of RFC 2047
         s = '(=?ISO-8859-1?Q?a_b?=)'
         self.assertEqual(decode_header(s),
             [(b'(', None), (b'a b', 'iso-8859-1'), (b')', None)])
 
     def test_rfc2047_rfc2047_7(self):
-        # 7th testcase at end of rfc2047
+        # 7th testcase at end of RFC 2047
         s = '(=?ISO-8859-1?Q?a?= =?ISO-8859-2?Q?_b?=)'
         self.assertEqual(decode_header(s),
             [(b'(', None), (b'a', 'iso-8859-1'), (b' b', 'iso-8859-2'),
@@ -3252,8 +3252,8 @@ class TestMiscellaneous(TestEmailBase):
         """Test for parsing a date with a two-digit year.
 
         Parsing a date with a two-digit year should return the correct
-        four-digit year. RFC822 allows two-digit years, but RFC2822 (which
-        obsoletes RFC822) requires four-digit years.
+        four-digit year. RFC 822 allows two-digit years, but RFC 5322 (which
+        obsoletes RFC 2822, which obsoletes RFC 822) requires four-digit years.
 
         """
         self.assertEqual(utils.parsedate_tz('25 Feb 03 13:47:26 -0800'),
@@ -3304,7 +3304,7 @@ class TestMiscellaneous(TestEmailBase):
         self.assertEqual(utils.parseaddr(utils.formataddr((a, b))), (a, b))
 
     def test_quotes_unicode_names(self):
-        # issue 1690608.  email.utils.formataddr() should be rfc2047 aware.
+        # issue 1690608.  email.utils.formataddr() should be RFC 2047 aware.
         name = "H\u00e4ns W\u00fcrst"
         addr = 'person@dom.ain'
         utf8_base64 = "=?utf-8?b?SMOkbnMgV8O8cnN0?= <person@dom.ain>"
@@ -3314,7 +3314,7 @@ class TestMiscellaneous(TestEmailBase):
             latin1_quopri)
 
     def test_accepts_any_charset_like_object(self):
-        # issue 1690608.  email.utils.formataddr() should be rfc2047 aware.
+        # issue 1690608.  email.utils.formataddr() should be RFC 2047 aware.
         name = "H\u00e4ns W\u00fcrst"
         addr = 'person@dom.ain'
         utf8_base64 = "=?utf-8?b?SMOkbnMgV8O8cnN0?= <person@dom.ain>"
@@ -3329,7 +3329,7 @@ class TestMiscellaneous(TestEmailBase):
             utf8_base64)
 
     def test_invalid_charset_like_object_raises_error(self):
-        # issue 1690608.  email.utils.formataddr() should be rfc2047 aware.
+        # issue 1690608.  email.utils.formataddr() should be RFC 2047 aware.
         name = "H\u00e4ns W\u00fcrst"
         addr = 'person@dom.ain'
         # An object without a header_encode method:
@@ -3338,7 +3338,7 @@ class TestMiscellaneous(TestEmailBase):
             bad_charset)
 
     def test_unicode_address_raises_error(self):
-        # issue 1690608.  email.utils.formataddr() should be rfc2047 aware.
+        # issue 1690608.  email.utils.formataddr() should be RFC 2047 aware.
         addr = 'pers\u00f6n@dom.in'
         self.assertRaises(UnicodeError, utils.formataddr, (None, addr))
         self.assertRaises(UnicodeError, utils.formataddr, ("Name", addr))
@@ -3359,7 +3359,7 @@ class TestMiscellaneous(TestEmailBase):
         # string containing a quoted backslash, followed by 'example' and two
         # backslashes, followed by another quoted string containing a space and
         # the word 'example'.  parseaddr copies those two backslashes
-        # literally.  Per rfc5322 this is not technically correct since a \ may
+        # literally.  Per RFC 5322 this is not technically correct since a \ may
         # not appear in an address outside of a quoted string.  It is probably
         # a sensible Postel interpretation, though.
         eq = self.assertEqual
@@ -3371,12 +3371,12 @@ class TestMiscellaneous(TestEmailBase):
           ('', '"\\\\"example\\\\" example"@example.com'))
 
     def test_parseaddr_preserves_spaces_in_local_part(self):
-        # issue 9286.  A normal RFC5322 local part should not contain any
+        # issue 9286.  A normal RFC 5322 local part should not contain any
         # folding white space, but legacy local parts can (they are a sequence
         # of atoms, not dotatoms).  On the other hand we strip whitespace from
         # before the @ and around dots, on the assumption that the whitespace
         # around the punctuation is a mistake in what would otherwise be
-        # an RFC5322 local part.  Leading whitespace is, usual, stripped as well.
+        # an RFC 5322 local part.  Leading whitespace is, usual, stripped as well.
         self.assertEqual(('', "merwok wok@xample.com"),
             utils.parseaddr("merwok wok@xample.com"))
         self.assertEqual(('', "merwok  wok@xample.com"),


### PR DESCRIPTION
Update selected RFC 2822 references to RFC 5322

RFC 2822 was obsoleted by RFC 5322 in 2008. This updates references to use the current standard in documentation, docstrings, and comments.

It preserves RFC 2822 references in legacy API components to maintain their historical context.

RFC 822 → RFC 2822 → RFC 5322 progression is explained where relevant.

In some places specific sections of RFC are referenced where it seems helpful.

Scout rule was applied in some places and RFC mentions format was normalized in doc strings and comments.
(cherry picked from commit ce1bb85d286130f44b7e874430b0b12990d61dc1)

<!-- gh-issue-number: gh-139434 -->
* Issue: gh-139434
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141025.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->