### PR TITLE
gh-141004: Document `PyMemoryView_Type`

### DIFF
--- a/Doc/c-api/memoryview.rst
+++ b/Doc/c-api/memoryview.rst
@@ -13,6 +13,11 @@ A :class:`memoryview` object exposes the C level :ref:`buffer interface
 any other object.
 
 
+.. c:var:: PyTypeObject PyMemoryView_Type
+
+   The type object for :class:`memoryview` objects.
+
+
 .. c:function:: PyObject *PyMemoryView_FromObject(PyObject *obj)
 
    Create a memoryview object from an object that provides the buffer interface.

--- a/Doc/c-api/memoryview.rst
+++ b/Doc/c-api/memoryview.rst
@@ -15,7 +15,8 @@ any other object.
 
 .. c:var:: PyTypeObject PyMemoryView_Type
 
-   The type object for :class:`memoryview` objects.
+   This instance of :c:type:`PyTypeObject` represents the Python memoryview
+   type. This is the same object as :class:`memoryview` in the Python layer.
 
 
 .. c:function:: PyObject *PyMemoryView_FromObject(PyObject *obj)


### PR DESCRIPTION
This one should definitely not be soft-deprecated. I'm not a huge fan of the wording, but we use it everywhere else, so I didn't think it was worth the hassle to argue that this one should be different.

<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141034.org.readthedocs.build/en/141034/c-api/memoryview.html#c.PyMemoryView_Type

<!-- readthedocs-preview cpython-previews end -->