### PR TITLE
Remove duplicate content in `Mapping types - dict` documentation

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4986,9 +4986,6 @@ can be used interchangeably to index the same dictionary entry.
       >>> a == b == c == d == e == f
       True
 
-   Providing keyword arguments as in the first example only works for keys that
-   are valid Python identifiers.  Otherwise, any valid keys can be used.
-
    Dictionaries preserve insertion order.  Note that updating a key does not
    affect the order.  Keys added after deletion are inserted at the end. ::
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4968,9 +4968,6 @@ can be used interchangeably to index the same dictionary entry.
    being added is already present, the value from the keyword argument
    replaces the value from the positional argument.
 
-   Providing keyword arguments as in the first example only works for keys that
-   are valid Python identifiers.  Otherwise, any valid keys can be used.
-
    Dictionaries compare equal if and only if they have the same ``(key,
    value)`` pairs (regardless of ordering). Order comparisons ('<', '<=', '>=', '>') raise
    :exc:`TypeError`.  To illustrate dictionary creation and equality,
@@ -4985,6 +4982,9 @@ can be used interchangeably to index the same dictionary entry.
       >>> f = dict({'one': 1, 'three': 3}, two=2)
       >>> a == b == c == d == e == f
       True
+
+   Providing keyword arguments as in the first example only works for keys that
+   are valid Python identifiers.  Otherwise, any valid keys can be used.
 
    Dictionaries preserve insertion order.  Note that updating a key does not
    affect the order.  Keys added after deletion are inserted at the end. ::


### PR DESCRIPTION
https://github.com/python/cpython/blob/1ae900424b3c888d2b2cc97e6ef780717813d658/Doc/library/stdtypes.rst?plain=1#L4971-L4990

The first two sentences in the snippet above are duplicated under the example.

I think it would be better if the second occurrence were removed?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141036.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->