### PR TITLE
gh-76007: remove curses.__version__ doc

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -1349,7 +1349,6 @@ The :mod:`curses` module defines the following data members:
 
 
 .. data:: version
-.. data:: __version__
 
    A bytes object representing the current version of the module.
 


### PR DESCRIPTION
`curses.__version__` hasn't been defined since at least 3.8 It is defined in the c module as `_curses.__version__` and `_curses_panel.__version__` but due to star imports and a lack of `__all__`, is not defined in the public module

This attribute does not exist in any of stable versions 3.10, 3.11, 3.12, 3.13, 3.14

I don't think this needs a news entry, but if it does please let me know.  


<!-- gh-issue-number: gh-76007 -->
* Issue: gh-76007
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141052.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->