### PR TITLE
Fix a compiler warning in _randommodule.c

### DIFF
--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -522,7 +522,7 @@ _random_Random_getrandbits_impl(RandomObject *self, uint64_t k)
         PyErr_NoMemory();
         return NULL;
     }
-    words = (k - 1u) / 32u + 1u;
+    words = (Py_ssize_t)((k - 1u) / 32u + 1u);
     wordarray = (uint32_t *)PyMem_Malloc(words * 4);
     if (wordarray == NULL) {
         PyErr_NoMemory();


### PR DESCRIPTION
The test just before the cast ensures that the cast cannot overflow.

Fix the warning on 32-bit Windows:

    Modules\_randommodule.c(525,28): warning C4244: '=': conversion
    from 'uint64_t' to 'Py_ssize_t', possible loss of data

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
