### PR TITLE
Fix compiler warnings in remote debugging

### DIFF
--- a/Python/remote_debugging.c
+++ b/Python/remote_debugging.c
@@ -19,7 +19,7 @@ cleanup_proc_handle(proc_handle_t *handle) {
 }
 
 static int
-read_memory(proc_handle_t *handle, uint64_t remote_address, size_t len, void* dst)
+read_memory(proc_handle_t *handle, uintptr_t remote_address, size_t len, void* dst)
 {
     return _Py_RemoteDebug_ReadRemoteMemory(handle, remote_address, len, dst);
 }

--- a/Python/remote_debugging.c
+++ b/Python/remote_debugging.c
@@ -235,7 +235,7 @@ send_exec_to_proc_handle(proc_handle_t *handle, int tid, const char *debugger_sc
     int is_remote_debugging_enabled = 0;
     if (0 != read_memory(
             handle,
-            interpreter_state_addr + debug_offsets.debugger_support.remote_debugging_enabled,
+            interpreter_state_addr + (uintptr_t)debug_offsets.debugger_support.remote_debugging_enabled,
             sizeof(int),
             &is_remote_debugging_enabled))
     {
@@ -255,7 +255,7 @@ send_exec_to_proc_handle(proc_handle_t *handle, int tid, const char *debugger_sc
     if (tid != 0) {
         if (0 != read_memory(
                 handle,
-                interpreter_state_addr + debug_offsets.interpreter_state.threads_head,
+                interpreter_state_addr + (uintptr_t)debug_offsets.interpreter_state.threads_head,
                 sizeof(void*),
                 &thread_state_addr))
         {
@@ -264,7 +264,7 @@ send_exec_to_proc_handle(proc_handle_t *handle, int tid, const char *debugger_sc
         while (thread_state_addr != 0) {
             if (0 != read_memory(
                     handle,
-                    thread_state_addr + debug_offsets.thread_state.native_thread_id,
+                    thread_state_addr + (uintptr_t)debug_offsets.thread_state.native_thread_id,
                     sizeof(this_tid),
                     &this_tid))
             {
@@ -277,7 +277,7 @@ send_exec_to_proc_handle(proc_handle_t *handle, int tid, const char *debugger_sc
 
             if (0 != read_memory(
                     handle,
-                    thread_state_addr + debug_offsets.thread_state.next,
+                    thread_state_addr + (uintptr_t)debug_offsets.thread_state.next,
                     sizeof(void*),
                     &thread_state_addr))
             {
@@ -294,7 +294,7 @@ send_exec_to_proc_handle(proc_handle_t *handle, int tid, const char *debugger_sc
     } else {
         if (0 != read_memory(
                 handle,
-                interpreter_state_addr + debug_offsets.interpreter_state.threads_main,
+                interpreter_state_addr + (uintptr_t)debug_offsets.interpreter_state.threads_main,
                 sizeof(void*),
                 &thread_state_addr))
         {
@@ -346,7 +346,7 @@ send_exec_to_proc_handle(proc_handle_t *handle, int tid, const char *debugger_sc
     uintptr_t eval_breaker;
     if (0 != read_memory(
             handle,
-            thread_state_addr + debug_offsets.debugger_support.eval_breaker,
+            thread_state_addr + (uintptr_t)debug_offsets.debugger_support.eval_breaker,
             sizeof(uintptr_t),
             &eval_breaker))
     {


### PR DESCRIPTION
Example of fixed warnings on 32-bit Windows:

    Python\remote_debugging.c(24,53): warning C4244: 'function':
    conversion from 'uint64_t' to 'uintptr_t', possible loss of data

    Modules\_remote_debugging_module.c(789,44): warning C4244:
    'function': conversion from 'uint64_t' to 'size_t', possible loss
    of data

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
