### PR TITLE
gh-141127: Clarify os.symlink() documentation for argument order

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3868,10 +3868,13 @@ features:
 
    .. versionadded:: 3.3
 
+.. function:: symlink(src, dst, target_is_directory=False, *, dir_fd=None)
 
-.. function:: symlink(target, link_name, target_is_directory=False, *, dir_fd=None)
+   Create a symbolic link pointing to *src* named *dst*.
 
-   Create a symbolic link pointing to *target* named *link_name*.
+   The *src* parameter refers to the target of the link (the file or directory being linked to),
+   and *dst* is the name of the link being created.
+   This matches the behavior of the Unix ``ln`` command (``ln TARGET LINK_NAME``).
 
    On Windows, a symlink represents either a file or a directory, and does not
    morph to the target dynamically.  If the target is present, the type of the

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3869,9 +3869,9 @@ features:
    .. versionadded:: 3.3
 
 
-.. function:: symlink(src, dst, target_is_directory=False, *, dir_fd=None)
+.. function:: symlink(target, link_name, target_is_directory=False, *, dir_fd=None)
 
-   Create a symbolic link pointing to *src* named *dst*.
+   Create a symbolic link pointing to *target* named *link_name*.
 
    On Windows, a symlink represents either a file or a directory, and does not
    morph to the target dynamically.  If the target is present, the type of the

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3868,13 +3868,13 @@ features:
 
    .. versionadded:: 3.3
 
+
 .. function:: symlink(src, dst, target_is_directory=False, *, dir_fd=None)
 
    Create a symbolic link pointing to *src* named *dst*.
 
    The *src* parameter refers to the target of the link (the file or directory being linked to),
    and *dst* is the name of the link being created.
-   This matches the behavior of the Unix ``ln`` command (``ln TARGET LINK_NAME``).
 
    On Windows, a symlink represents either a file or a directory, and does not
    morph to the target dynamically.  If the target is present, the type of the


### PR DESCRIPTION
## Summary

This pull request clarifies the documentation for `os.symlink()` to make the argument order unambiguous and consistent with Unix conventions.

### before
```python
os.symlink(src, dst, target_is_directory=False, *, dir_fd=None)
Create a symbolic link pointing to src named dst.
```

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141144.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-141127 -->
* Issue: gh-141127
<!-- /gh-issue-number -->
