### PR TITLE
gh-141150: Don't rely on implicit conversion from void * to pointer in _PyModule…

### DIFF
--- a/Include/internal/pycore_moduleobject.h
+++ b/Include/internal/pycore_moduleobject.h
@@ -53,7 +53,7 @@ static inline PyModuleDef *_PyModule_GetDefOrNull(PyObject *arg) {
 
 static inline PyModuleDef *_PyModule_GetToken(PyObject *arg) {
     PyModuleObject *mod = _PyModule_CAST(arg);
-    return mod->md_token;
+    return (PyModuleDef *)mod->md_token;
 }
 
 static inline void* _PyModule_GetState(PyObject* mod) {


### PR DESCRIPTION
`_PyModule_GetToken` relies upon an implicit conversion from a void* to `PyModuleDef *`. This is totally legal but the explicit cast is a little bit better. FYI we saw this where we include this in Cinder from a C++ file.

<!-- gh-issue-number: gh-141150 -->
* Issue: gh-141150
<!-- /gh-issue-number -->
