### PR TITLE
gh-141141: Make `base64.b85decode` thread safe

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -462,9 +462,12 @@ def b85decode(b):
     # Delay the initialization of tables to not waste memory
     # if the function is never called
     if _b85dec is None:
-        _b85dec = [None] * 256
+        # we don't assign to _b85dec directly to avoid issues when
+        # multiple threads call this function simultaneously
+        _b85dec_tmp = [None] * 256
         for i, c in enumerate(_b85alphabet):
-            _b85dec[c] = i
+            _b85dec_tmp[c] = i
+        _b85dec = _b85dec_tmp
 
     b = _bytes_from_decode_data(b)
     padding = (-len(b)) % 5

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -464,10 +464,10 @@ def b85decode(b):
     if _b85dec is None:
         # we don't assign to _b85dec directly to avoid issues when
         # multiple threads call this function simultaneously
-        _b85dec_tmp = [None] * 256
+        b85dec_tmp = [None] * 256
         for i, c in enumerate(_b85alphabet):
-            _b85dec_tmp[c] = i
-        _b85dec = _b85dec_tmp
+            b85dec_tmp[c] = i
+        _b85dec = b85dec_tmp
 
     b = _bytes_from_decode_data(b)
     padding = (-len(b)) % 5

--- a/Misc/NEWS.d/next/Library/2025-11-06-15-11-50.gh-issue-141141.tgIfgH.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-06-15-11-50.gh-issue-141141.tgIfgH.rst
@@ -1,0 +1,1 @@
+Fix a thread safety issue with :func:`base64.b85decode`. Contributed by Benel Tayar.


### PR DESCRIPTION
Fixes a thread safety issue with `base64.b85decode`


<!-- gh-issue-number: gh-141141 -->
* Issue: gh-141141
<!-- /gh-issue-number -->
