### PR TITLE
gh-141004: Document `Py_GetRecursionLimit` and `Py_SetRecursionLimit`

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -979,6 +979,27 @@ these are the C equivalent to :func:`reprlib.recursive_repr`.
    Ends a :c:func:`Py_ReprEnter`.  Must be called once for each
    invocation of :c:func:`Py_ReprEnter` that returns zero.
 
+.. c:function:: int Py_GetRecursionLimit(void)
+
+   Get the recursion limit for the current interpreter. It can be set by
+   :c:func:`Py_SetRecursionLimit`. The recursion limit prevents the
+   Python interpreter stack from growing infinitely.
+
+   This function cannot fail, and the caller must hold an
+   :term:`attached thread state`.
+
+   .. seealso::
+      :py:func:`sys.getrecursionlimit`
+
+.. c:function:: void Py_SetRecursionLimit(int limit)
+
+   Set the recursion limit for the current interpreter.
+
+   This function cannot fail, and the caller must hold an
+   :term:`attached thread state`.
+
+   .. seealso::
+      :py:func:`sys.setrecursionlimit`
 
 .. _standardexceptions:
 

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -991,7 +991,7 @@ these are the C equivalent to :func:`reprlib.recursive_repr`.
    .. seealso::
       :py:func:`sys.getrecursionlimit`
 
-.. c:function:: void Py_SetRecursionLimit(int limit)
+.. c:function:: void Py_SetRecursionLimit(int new_limit)
 
    Set the recursion limit for the current interpreter.
 

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -981,7 +981,7 @@ these are the C equivalent to :func:`reprlib.recursive_repr`.
 
 .. c:function:: int Py_GetRecursionLimit(void)
 
-   Get the recursion limit for the current interpreter. It can be set by
+   Get the recursion limit for the current interpreter. It can be set with
    :c:func:`Py_SetRecursionLimit`. The recursion limit prevents the
    Python interpreter stack from growing infinitely.
 


### PR DESCRIPTION

<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141151.org.readthedocs.build/en/141151/c-api/exceptions.html#c.Py_GetRecursionLimit

<!-- readthedocs-preview cpython-previews end -->