### PR TITLE
[3.13] gh-140939: Fix memory leak in `_PyBytes_FormatEx` error path (GH-140957)

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -769,6 +769,13 @@ class BaseBytesTest:
             with self.assertRaisesRegex(TypeError, msg):
                 operator.mod(format_bytes, value)
 
+    def test_memory_leak_gh_140939(self):
+        # gh-140939: MemoryError is raised without leaking
+        _testcapi = import_helper.import_module('_testcapi')
+        with self.assertRaises(MemoryError):
+            b = self.type2test(b'%*b')
+            b % (_testcapi.PY_SSIZE_T_MAX, b'abc')
+
     def test_imod(self):
         b = self.type2test(b'hello, %b!')
         orig = b

--- a/Misc/NEWS.d/next/Core and Builtins/2025-11-03-17-21-38.gh-issue-140939.FVboAw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-11-03-17-21-38.gh-issue-140939.FVboAw.rst
@@ -1,0 +1,2 @@
+Fix memory leak when :class:`bytearray` or :class:`bytes` is formated with the
+``%*b`` format with a large width that results in a :exc:`MemoryError`.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -965,8 +965,10 @@ _PyBytes_FormatEx(const char *format, Py_ssize_t format_len,
             /* 2: size preallocated for %s */
             if (alloc > 2) {
                 res = _PyBytesWriter_Prepare(&writer, res, alloc - 2);
-                if (res == NULL)
+                if (res == NULL) {
+                    Py_XDECREF(temp);
                     goto error;
+                }
             }
 #ifndef NDEBUG
             char *before = res;


### PR DESCRIPTION

(cherry picked from commit d6c89a2df2c8b7603125883494e9058a88348f66)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140939 -->
* Issue: gh-140939
<!-- /gh-issue-number -->
