### PR TITLE
Clarify argument/result ownership/validity for PyModule_* functions

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -13,7 +13,7 @@ Module Objects
    .. index:: single: ModuleType (in module types)
 
    This instance of :c:type:`PyTypeObject` represents the Python module type.  This
-   is exposed to Python programs as ``types.ModuleType``.
+   is exposed to Python programs as :py:class:`types.ModuleType`.
 
 
 .. c:function:: int PyModule_Check(PyObject *p)
@@ -71,6 +71,9 @@ Module Objects
    ``PyObject_*`` functions rather than directly manipulate a module's
    :attr:`~object.__dict__`.
 
+   The returned reference is borrowed from the module; it is valid until
+   the module is destroyed.
+
 
 .. c:function:: PyObject* PyModule_GetNameObject(PyObject *module)
 
@@ -89,6 +92,10 @@ Module Objects
 
    Similar to :c:func:`PyModule_GetNameObject` but return the name encoded to
    ``'utf-8'``.
+
+   The returned buffer is only valid until the module is renamed or destroyed.
+   Note that Python code may rename a module by setting its ``__name__``
+   attribute.
 
 .. c:function:: void* PyModule_GetState(PyObject *module)
 
@@ -125,6 +132,9 @@ Module Objects
 
    Similar to :c:func:`PyModule_GetFilenameObject` but return the filename
    encoded to 'utf-8'.
+
+   The returned buffer is only valid until the module's ``__file__`` attribute
+   is reassigned or the module is destroyed.
 
    .. deprecated:: 3.2
       :c:func:`PyModule_GetFilename` raises :exc:`UnicodeEncodeError` on
@@ -670,6 +680,9 @@ or code that creates modules dynamically.
    Some module authors may prefer defining functions in multiple
    :c:type:`PyMethodDef` arrays; in that case they should call this function
    directly.
+
+   The *functions* array must be statically allocated (or otherwise guaranteed
+   to outlive the module object).
 
    .. versionadded:: 3.5
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -94,7 +94,7 @@ Module Objects
    ``'utf-8'``.
 
    The returned buffer is only valid until the module is renamed or destroyed.
-   Note that Python code may rename a module by setting its ``__name__``
+   Note that Python code may rename a module by setting its :py:attr:`~module.__name__`
    attribute.
 
 .. c:function:: void* PyModule_GetState(PyObject *module)
@@ -133,7 +133,7 @@ Module Objects
    Similar to :c:func:`PyModule_GetFilenameObject` but return the filename
    encoded to 'utf-8'.
 
-   The returned buffer is only valid until the module's ``__file__`` attribute
+   The returned buffer is only valid until the module's :py:attr:`~module.__file__` attribute
    is reassigned or the module is destroyed.
 
    .. deprecated:: 3.2


### PR DESCRIPTION
When working on PEP-793 docs, I found some backportable clarifications. (Sure, some clarify that the functions are somewhat dangerous with free-threading...)

Also: Turn a mention of `types.ModuleType` into a link.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141159.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->