### PR TITLE
gh-141174: Improve `annotationlib.call_annotate_function()` test coverage

### DIFF
--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1247,6 +1247,32 @@ class TestCallEvaluateFunction(unittest.TestCase):
             "undefined",
         )
 
+    def test_fake_global_evaluation(self):
+        # This will raise an AttributeError
+        def evaluate_union(format, exc=NotImplementedError):
+            if format == Format.VALUE_WITH_FAKE_GLOBALS:
+                # Return a ForwardRef
+                return builtins.undefined | list[int]
+            raise exc
+
+        self.assertEqual(
+            annotationlib.call_evaluate_function(evaluate_union, Format.FORWARDREF),
+            support.EqualToForwardRef("builtins.undef | list[int]"),
+        )
+
+        # This will raise an AttributeError
+        def evaluate_intermediate(format, exc=NotImplementedError):
+            if format == Format.VALUE_WITH_FAKE_GLOBALS:
+                intermediate = builtins.undefined
+                # Return a literal
+                return intermediate == builtins.defined
+            raise exc
+
+        self.assertIs(
+            annotationlib.call_evaluate_function(evaluate_intermediate, Format.FORWARDREF),
+            False,
+        )
+
 
 class TestCallAnnotateFunction(unittest.TestCase):
     # Tests for user defined annotate functions.

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1257,7 +1257,7 @@ class TestCallEvaluateFunction(unittest.TestCase):
 
         self.assertEqual(
             annotationlib.call_evaluate_function(evaluate_union, Format.FORWARDREF),
-            support.EqualToForwardRef("builtins.undef | list[int]"),
+            support.EqualToForwardRef("builtins.undefined | list[int]"),
         )
 
         # This will raise an AttributeError
@@ -1265,7 +1265,7 @@ class TestCallEvaluateFunction(unittest.TestCase):
             if format == Format.VALUE_WITH_FAKE_GLOBALS:
                 intermediate = builtins.undefined
                 # Return a literal
-                return intermediate == builtins.defined
+                return intermediate is None
             raise exc
 
         self.assertIs(

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1388,6 +1388,23 @@ class TestCallAnnotateFunction(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             annotationlib.call_annotate_function(annotate, Format.STRING)
 
+    def test_unsupported_formats(self):
+        def annotate(format, /):
+            if format == Format.FORWARDREF:
+                return {"x": str}
+            else:
+                raise NotImplementedError(format)
+
+        with self.assertRaises(ValueError):
+            annotationlib.call_annotate_function(annotate, Format.VALUE_WITH_FAKE_GLOBALS)
+
+        with self.assertRaises(RuntimeError):
+            annotationlib.call_annotate_function(annotate, Format.VALUE)
+
+        with self.assertRaises(ValueError):
+            # Some non-Format value
+            annotationlib.call_annotate_function(annotate, 7)
+
     def test_error_from_value_raised(self):
         # Test that the error from format.VALUE is raised
         # if all formats fail


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

All lines in `call_annotate_function()` should now be covered.
This PR includes an added test for `call_evaluate_function()` as this just calls `call_annotate_function()` under the hood and some of its code paths weren't being tested.

<!-- gh-issue-number: gh-141174 -->
* Issue: gh-141174
<!-- /gh-issue-number -->
