### PR TITLE
Update NaNs handling description in `c-api/float.rst`

### DIFF
--- a/Doc/c-api/float.rst
+++ b/Doc/c-api/float.rst
@@ -113,8 +113,8 @@ NaNs (if such things exist on the platform) isn't handled correctly, and
 attempting to unpack a bytes string containing an IEEE INF or NaN will raise an
 exception.
 
-Note that NaNs type may not be preserved on IEEE platforms (silent NaN become
-quiet), for example on x86 systems in 32-bit mode.
+Note that NaNs type may not be preserved on IEEE platforms (signaling NaN become
+quiet NaN), for example on x86 systems in 32-bit mode.
 
 On non-IEEE platforms with more precision, or larger dynamic range, than IEEE
 754 supports, not all values can be packed; on non-IEEE platforms with less


### PR DESCRIPTION
It looks like a typo from #133204, which talks about the sNaN (_signaling_ NaN) and qNaN (quiet NaN).


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141179.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->