### PR TITLE
gh-141004: Document missing frame APIs

### DIFF
--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -29,6 +29,12 @@ See also :ref:`Reflection <reflection>`.
       Previously, this type was only available after including
       ``<frameobject.h>``.
 
+.. c:function:: PyObject *PyFrame_New(PyThreadState *tstate, PyCodeObject *code, PyObject *globals, PyObject *locals)
+
+   Create a new frame object. This function returns a :term:`strong reference`
+   to the new frame object on success; return ``NULL`` with an exception set
+   on failure.
+
 .. c:function:: int PyFrame_Check(PyObject *obj)
 
    Return non-zero if *obj* is a frame object.
@@ -160,6 +166,56 @@ See :pep:`667` for more information.
 .. c:function:: int PyFrameLocalsProxy_Check(PyObject *obj)
 
    Return non-zero if *obj* is a frame :func:`locals` proxy.
+
+
+Legacy Local Variable APIs
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These APIs are :term:`soft deprecated`. As of Python 3.13, they do nothing.
+They exist solely for backwards compatibility.
+
+
+.. c:function:: void PyFrame_LocalsToFast(PyFrameObject *f, int clear)
+
+   This function is :term:`soft deprecated` and does nothing.
+
+   Prior to Python 3.13, this function would copy the :attr:`~frame.f_locals`
+   attribute of *f* to the internal "fast" array of local variables, allowing
+   changes in frame objects to be visible to the interpreter. If *clear* was
+   true, this function would clear exceptions.
+
+   .. versionchanged:: 3.13
+      This function now does nothing.
+
+
+.. c:function:: void PyFrame_FastToLocals(PyFrameObject *f)
+
+   This function is :term:`soft deprecated` and does nothing.
+
+   Prior to Python 3.13, this function would copy the internal "fast" array
+   of local variables (which is used by the interpreter) to the
+   :attr:`~frame.f_locals` attribute of *f*, allowing changes in local
+   variables to be visible to frame objects.
+
+   .. versionchanged:: 3.13
+      This function now does nothing.
+
+
+.. c:function:: int PyFrame_FastToLocalsWithError(PyFrameObject *f)
+
+   This function is :term:`soft deprecated` and does nothing.
+
+   Prior to Python 3.13, this function was similar to
+   :c:func:`PyFrame_FastToLocals`, but would return ``0`` on success, and
+   ``-1`` with an exception set on failure.
+
+   .. versionchanged:: 3.13
+      This function now does nothing.
+
+
+.. seealso::
+   :pep:`667`
+
 
 Internal Frames
 ^^^^^^^^^^^^^^^

--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -182,7 +182,9 @@ They exist solely for backwards compatibility.
    Prior to Python 3.13, this function would copy the :attr:`~frame.f_locals`
    attribute of *f* to the internal "fast" array of local variables, allowing
    changes in frame objects to be visible to the interpreter. If *clear* was
-   true, this function would clear exceptions.
+   changes in frame objects to be visible to the interpreter. If *clear* was
+   true, this function would process variables that were unset in the locals
+   dictionary.
 
    .. versionchanged:: 3.13
       This function now does nothing.

--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -32,8 +32,8 @@ See also :ref:`Reflection <reflection>`.
 .. c:function:: PyObject *PyFrame_New(PyThreadState *tstate, PyCodeObject *code, PyObject *globals, PyObject *locals)
 
    Create a new frame object. This function returns a :term:`strong reference`
-   to the new frame object on success; return ``NULL`` with an exception set
-   on failure.
+   to the new frame object on success, and returns ``NULL`` with an exception
+   set on failure.
 
 .. c:function:: int PyFrame_Check(PyObject *obj)
 

--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -29,7 +29,7 @@ See also :ref:`Reflection <reflection>`.
       Previously, this type was only available after including
       ``<frameobject.h>``.
 
-.. c:function:: PyObject *PyFrame_New(PyThreadState *tstate, PyCodeObject *code, PyObject *globals, PyObject *locals)
+.. c:function:: PyFrameObject *PyFrame_New(PyThreadState *tstate, PyCodeObject *code, PyObject *globals, PyObject *locals)
 
    Create a new frame object. This function returns a :term:`strong reference`
    to the new frame object on success, and returns ``NULL`` with an exception

--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -182,7 +182,6 @@ They exist solely for backwards compatibility.
    Prior to Python 3.13, this function would copy the :attr:`~frame.f_locals`
    attribute of *f* to the internal "fast" array of local variables, allowing
    changes in frame objects to be visible to the interpreter. If *clear* was
-   changes in frame objects to be visible to the interpreter. If *clear* was
    true, this function would process variables that were unset in the locals
    dictionary.
 


### PR DESCRIPTION

<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141189.org.readthedocs.build/en/141189/c-api/frame.html

<!-- readthedocs-preview cpython-previews end -->