### PR TITLE
gh-141169: Clear error before trying again

### DIFF
--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -413,6 +413,8 @@ _PyImport_GetModuleExportHooks(
     if (exportfunc) {
         *modexport = (PyModExportFunction)exportfunc;
         return 2;
+    } else if (PyErr_Occurred()) {
+        PyErr_Clear();
     }
 
     exportfunc = findfuncptr(


### PR DESCRIPTION
Per the issue - we can end up making a call with an error already set when switching from export_prefix to init_prefix - one possible solution is to just clear the error. In this case both calls are failing due to the dlopen failing. I'm not exactly sure how to add a test case for this though.

<!-- gh-issue-number: gh-141169 -->
* Issue: gh-141169
<!-- /gh-issue-number -->
