### PR TITLE
gh-141216 Extend `functools.cached_property` so the user can select the attrname

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1110,14 +1110,34 @@ _NOT_FOUND = object()
 
 class cached_property:
     def __init__(self, func):
+        if callable(func):
+            self.func = func
+            self.attrname = None
+            self.slot = False
+            self.__doc__ = func.__doc__
+            self.__module__ = func.__module__
+        else:
+            self.attrname = func
+            self.slot = True
+            self.func = None
+
+    def __call__(self, func):
+        if self.slot is None:
+            raise TypeError("Can only use one function per 'cached_property'")
+        if not callable(func):
+            raise TypeError(
+                "Can only cache functions as properties, not this", func
+            )
         self.func = func
-        self.attrname = None
         self.__doc__ = func.__doc__
         self.__module__ = func.__module__
+        return self
 
     def __set_name__(self, owner, name):
         if self.attrname is None:
             self.attrname = name
+        elif self.slot:
+            return
         elif name != self.attrname:
             raise TypeError(
                 "Cannot assign the same cached_property to two different names "
@@ -1129,7 +1149,22 @@ class cached_property:
             return self
         if self.attrname is None:
             raise TypeError(
-                "Cannot use cached_property instance without calling __set_name__ on it.")
+                "Cannot use cached_property instance without an attribute name"
+            )
+        if self.slot:
+            val = getattr(instance, self.attrname, _NOT_FOUND)
+            if val is _NOT_FOUND:
+                val = self.func(instance)
+                try:
+                    setattr(instance, self.attrname, val)
+                except AttributeError as err:
+                    msg = (
+                        f"The class {type(instance).__name__!r} does not "
+                        f"have the requested slot, {self.attrname!r}, "
+                        "in its '__slots__' attribute"
+                    )
+                    raise TypeError(msg) from err
+            return val
         try:
             cache = instance.__dict__
         except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1122,7 +1122,7 @@ class cached_property:
             self.func = None
 
     def __call__(self, func):
-        if self.slot is None:
+        if self.attrname is None:
             raise TypeError("Can only use one function per 'cached_property'")
         if not callable(func):
             raise TypeError(

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1157,13 +1157,13 @@ class cached_property:
                 val = self.func(instance)
                 try:
                     setattr(instance, self.attrname, val)
-                except AttributeError as err:
+                except AttributeError:
                     msg = (
                         f"The class {type(instance).__name__!r} does not "
                         f"have the requested slot, {self.attrname!r}, "
                         "in its '__slots__' attribute"
                     )
-                    raise TypeError(msg) from err
+                    raise TypeError(msg) from None
             return val
         try:
             cache = instance.__dict__

--- a/Misc/NEWS.d/next/Library/2025-11-07-22-57-53.gh-issue-141216.aMcICl.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-07-22-57-53.gh-issue-141216.aMcICl.rst
@@ -1,0 +1,3 @@
+Extend `functools.cached_property` so the user can select the attrname
+
+A class with `__slots__`, which ordinarily keeps them empty to minimize memory use, may define some properties as `@cached_property(slot)` to instantiate them only on demand.

--- a/Misc/NEWS.d/next/Library/2025-11-07-22-57-53.gh-issue-141216.aMcICl.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-07-22-57-53.gh-issue-141216.aMcICl.rst
@@ -1,3 +1,3 @@
-Extend `functools.cached_property` so the user can select the attrname
+Extend ``functools.cached_property`` so the user can select the attrname
 
-A class with `__slots__`, which ordinarily keeps them empty to minimize memory use, may define some properties as `@cached_property(slot)` to instantiate them only on demand.
+A class with ``__slots__``, which ordinarily keeps them empty to minimize memory use, may define some properties as ``@cached_property("slot")`` to instantiate them only on demand.


### PR DESCRIPTION
A class with `__slots__`, which ordinarily keeps them empty to minimize memory use, may define some properties as `@cached_property("slot")` to instantiate them only on demand.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141216 -->
* Issue: gh-141216
<!-- /gh-issue-number -->
