### PR TITLE
gh-141218: Fix inaccurate object comparison documentation

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -164,7 +164,7 @@ This table summarizes the comparison operations:
    pair: object; numeric
    pair: objects; comparing
 
-Objects of different types, unless documented otherwise, never compare equal.
+Unless stated otherwise, objects of different types never compare equal.
 The ``==`` operator is always defined but for some object types (for example,
 class objects) is equivalent to :keyword:`is`. The ``<``, ``<=``, ``>`` and ``>=``
 operators are only defined where they make sense; for example, they raise a

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -164,7 +164,7 @@ This table summarizes the comparison operations:
    pair: object; numeric
    pair: objects; comparing
 
-Objects of different types, except different numeric types, never compare equal.
+Objects of different types, unless documented otherwise, never compare equal.
 The ``==`` operator is always defined but for some object types (for example,
 class objects) is equivalent to :keyword:`is`. The ``<``, ``<=``, ``>`` and ``>=``
 operators are only defined where they make sense; for example, they raise a

--- a/Misc/NEWS.d/next/Documentation/2025-11-08-12-00-00.gh-issue-141218.kL3mNx.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-11-08-12-00-00.gh-issue-141218.kL3mNx.rst
@@ -1,0 +1,4 @@
+Fix inaccurate documentation about object comparison. Changed "Objects of different 
+types, except different numeric types, never compare equal" to "Objects of different 
+types, unless documented otherwise, never compare equal" to account for documented 
+exceptions like set/frozenset comparisons.

--- a/Misc/NEWS.d/next/Documentation/2025-11-08-12-00-00.gh-issue-141218.kL3mNx.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-11-08-12-00-00.gh-issue-141218.kL3mNx.rst
@@ -1,4 +1,0 @@
-Fix inaccurate documentation about object comparison. Changed "Objects of different 
-types, except different numeric types, never compare equal" to "Objects of different 
-types, unless documented otherwise, never compare equal" to account for documented 
-exceptions like set/frozenset comparisons.


### PR DESCRIPTION
## Summary

Fixes issue #141218 by correcting inaccurate documentation about object comparison.

**Problem**: The current documentation states "Objects of different types, except different numeric types, never compare equal" which is factually incorrect.

**Counter-example**: 
```python
>>> frozenset([1, 2]) == {1, 2}
True
```

**Solution**: Changed to "Objects of different types, unless documented otherwise, never compare equal" to account for all documented exceptions.

**Documented exceptions include**:
- Numeric types (int, float, complex) - already mentioned  
- set/frozenset comparisons - documented later in same file
- dict subclass comparisons (defaultdict, Counter, OrderedDict)

## Changes

- Updated `Doc/library/stdtypes.rst` line 167
- Added news entry in `Misc/NEWS.d/next/Documentation/`

## Test plan

- [x] Documentation builds successfully with `make html`
- [x] Verified change maintains consistency with existing specific type documentation
- [x] Tested that the issue examples work as described
- [x] Confirmed change is minimal and maintains readability

The fix improves documentation accuracy while maintaining clarity and consistency.

<!-- gh-issue-number: gh-141218 -->
* Issue: gh-141218
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141221.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->