### PR TITLE
gh-141004: correctly document `Py_HASH_*` and `PyHASH_*` as `hash_info` attributes

### DIFF
--- a/Doc/c-api/hash.rst
+++ b/Doc/c-api/hash.rst
@@ -56,6 +56,8 @@ See also the :c:member:`PyTypeObject.tp_hash` member and :ref:`numeric-hash`.
    it is easier to create colliding strings. A cutoff of 7 on 64-bit platforms
    and 5 on 32-bit platforms should provide a decent safety margin.
 
+   This corresponds to the :data:`sys.hash_info.cutoff` constant.
+
    .. versionadded:: 3.4
 
 
@@ -63,6 +65,7 @@ See also the :c:member:`PyTypeObject.tp_hash` member and :ref:`numeric-hash`.
 
    The `Mersenne prime <https://en.wikipedia.org/wiki/Mersenne_prime>`_ ``P = 2**n -1``,
    used for numeric hash scheme.
+
    This corresponds to the :data:`sys.hash_info.modulus` constant.
 
    .. versionadded:: 3.13
@@ -71,7 +74,6 @@ See also the :c:member:`PyTypeObject.tp_hash` member and :ref:`numeric-hash`.
 .. c:macro:: PyHASH_BITS
 
    The exponent ``n`` of ``P`` in :c:macro:`PyHASH_MODULUS`.
-   This corresponds to the :data:`sys.hash_info.hash_bits` constant.
 
    .. versionadded:: 3.13
 
@@ -86,6 +88,7 @@ See also the :c:member:`PyTypeObject.tp_hash` member and :ref:`numeric-hash`.
 .. c:macro:: PyHASH_INF
 
    The hash value returned for a positive infinity.
+
    This corresponds to the :data:`sys.hash_info.inf` constant.
 
    .. versionadded:: 3.13
@@ -94,6 +97,7 @@ See also the :c:member:`PyTypeObject.tp_hash` member and :ref:`numeric-hash`.
 .. c:macro:: PyHASH_IMAG
 
    The multiplier used for the imaginary part of a complex number.
+
    This corresponds to the :data:`sys.hash_info.imag` constant.
 
    .. versionadded:: 3.13
@@ -111,13 +115,19 @@ See also the :c:member:`PyTypeObject.tp_hash` member and :ref:`numeric-hash`.
 
       Hash function name (UTF-8 encoded string).
 
+      This corresponds to the :data:`sys.hash_info.algorithm` constant.
+
    .. c:member:: const int hash_bits
 
       Internal size of the hash value in bits.
 
+      This corresponds to the :data:`sys.hash_info.hash_bits` constant.
+
    .. c:member:: const int seed_bits
 
       Size of seed input in bits.
+
+      This corresponds to the :data:`sys.hash_info.seed_bits` constant.
 
    .. versionadded:: 3.4
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1176,10 +1176,14 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
       The size of the seed key of the hash algorithm
 
+   .. attribute:: hash_info.cutoff
+
+      Cutoff for small string DJBX33A optimization in range ``[1, cutoff)``.
+
    .. versionadded:: 3.2
 
    .. versionchanged:: 3.4
-      Added *algorithm*, *hash_bits* and *seed_bits*
+      Added *algorithm*, *hash_bits*, *seed_bits*, and *cutoff*.
 
 
 .. data:: hexversion


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

My very bad, I incorrectly documented PyHASH_BITS as hash_info.hash_bits, but the former is for numerical schemes while the latter is for strings schemes. I also added a newline before the "This corresponds to ..." and added the link to `cutoff` for `Py_HASH_CUTOFF`.


<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141233.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->