### PR TITLE
gh-140972: Empty docstrings passed to `DynamicClassAttribute` are preserved

### DIFF
--- a/Lib/test/test_dynamicclassattribute.py
+++ b/Lib/test/test_dynamicclassattribute.py
@@ -195,6 +195,17 @@ class PropertyTests(unittest.TestCase):
             Okay2.color
         self.assertEqual(Okay2().color, 'magenta')
 
+    @unittest.skipIf(sys.flags.optimize >= 2,
+                     "Docstrings are omitted with -O2 and above")
+    def test_empty_docstring(self):
+        attr = DynamicClassAttribute(fget=None, fset=None, fdel=None, doc='')
+        self.assertEqual(attr.__doc__, '',)
+        def fget():
+            """fget's docstring"""
+        attr_with_fget = DynamicClassAttribute(fget=fget, doc='')
+        self.assertEqual(attr_with_fget.__doc__, '')
+        attr_no_doc = DynamicClassAttribute(fget=None)
+        self.assertIsNone(attr_no_doc.__doc__)
 
 # Issue 5890: subclasses of DynamicClassAttribute do not preserve method __doc__ strings
 class PropertySub(DynamicClassAttribute):

--- a/Lib/test/test_dynamicclassattribute.py
+++ b/Lib/test/test_dynamicclassattribute.py
@@ -4,6 +4,7 @@
 import abc
 import sys
 import unittest
+from test import support
 from types import DynamicClassAttribute
 
 class PropertyBase(Exception):
@@ -195,8 +196,7 @@ class PropertyTests(unittest.TestCase):
             Okay2.color
         self.assertEqual(Okay2().color, 'magenta')
 
-    @unittest.skipIf(sys.flags.optimize >= 2,
-                     "Docstrings are omitted with -O2 and above")
+    @support.requires_docstrings
     def test_empty_docstring(self):
         attr = DynamicClassAttribute(fget=None, fset=None, fdel=None, doc='')
         self.assertEqual(attr.__doc__, '',)

--- a/Lib/test/test_dynamicclassattribute.py
+++ b/Lib/test/test_dynamicclassattribute.py
@@ -199,7 +199,7 @@ class PropertyTests(unittest.TestCase):
     @support.requires_docstrings
     def test_empty_docstring(self):
         attr = DynamicClassAttribute(fget=None, fset=None, fdel=None, doc='')
-        self.assertEqual(attr.__doc__, '',)
+        self.assertEqual(attr.__doc__, '')
         def fget():
             """fget's docstring"""
         attr_with_fget = DynamicClassAttribute(fget=fget, doc='')

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -211,7 +211,9 @@ class DynamicClassAttribute:
         self.fset = fset
         self.fdel = fdel
         # next two lines make DynamicClassAttribute act the same as property
-        self.__doc__ = doc or fget.__doc__
+        if doc is None and fget is not None:
+            doc = fget.__doc__
+        self.__doc__ = doc
         self.overwrite_doc = doc is None
         # support for abstract methods
         self.__isabstractmethod__ = bool(getattr(fget, '__isabstractmethod__', False))

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -210,11 +210,12 @@ class DynamicClassAttribute:
         self.fget = fget
         self.fset = fset
         self.fdel = fdel
-        # next two lines make DynamicClassAttribute act the same as property
+        overwrite_doc = doc is None
         if doc is None and fget is not None:
             doc = fget.__doc__
+        # next two lines make DynamicClassAttribute act the same as property
         self.__doc__ = doc
-        self.overwrite_doc = doc is None
+        self.overwrite_doc = overwrite_doc
         # support for abstract methods
         self.__isabstractmethod__ = bool(getattr(fget, '__isabstractmethod__', False))
 

--- a/Misc/NEWS.d/next/Library/2025-11-08-21-01-46.gh-issue-140972.v960ZZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-08-21-01-46.gh-issue-140972.v960ZZ.rst
@@ -1,0 +1,3 @@
+Now empty docstrings passed to :class:`DynamicClassAttribute` are preserved
+when ``fget`` is ``None``; previously ``NoneType.__doc__`` was used
+incorrectly.

--- a/Misc/NEWS.d/next/Library/2025-11-08-21-01-46.gh-issue-140972.v960ZZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-08-21-01-46.gh-issue-140972.v960ZZ.rst
@@ -1,3 +1,3 @@
-Now empty docstrings passed to :func:`DynamicClassAttribute` are preserved
-when ``fget`` is ``None``; previously ``NoneType.__doc__`` was used
+Now empty docstrings passed to :func:`types.DynamicClassAttribute` are
+preserved when ``fget`` is ``None``; previously ``NoneType.__doc__`` was used
 incorrectly.

--- a/Misc/NEWS.d/next/Library/2025-11-08-21-01-46.gh-issue-140972.v960ZZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-08-21-01-46.gh-issue-140972.v960ZZ.rst
@@ -1,3 +1,3 @@
-Now empty docstrings passed to :class:`DynamicClassAttribute` are preserved
+Now empty docstrings passed to :func:`DynamicClassAttribute` are preserved
 when ``fget`` is ``None``; previously ``NoneType.__doc__`` was used
 incorrectly.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140972 -->
* Issue: gh-140972
<!-- /gh-issue-number -->
