### PR TITLE
gh-141226: correctly support `Py_HASH_EXTERNAL` for Unix platforms

### DIFF
--- a/Doc/c-api/hash.rst
+++ b/Doc/c-api/hash.rst
@@ -44,6 +44,29 @@ See also the :c:member:`PyTypeObject.tp_hash` member and :ref:`numeric-hash`.
       Add :c:macro:`!Py_HASH_SIPHASH13`.
 
 
+.. c:macro:: Py_HASH_EXTERNAL
+
+   If :c:macro:`Py_HASH_ALGORITHM` is set to that value, the hash function
+   definition ``PyHash_Func`` must be provided by embedders at compile time.
+   For instance, to use SipHash-4-8 for conservative security purposes
+
+   .. code-block:: c
+
+      static Py_hash_t
+      siphash48(const void *src, Py_ssize_t src_sz) { ... }
+
+      PyHash_FuncDef PyHash_Func = {
+         .hash = siphash48,
+         .name = "siphash48",
+         .hash_bits = 64,
+         .seed_bits = 128,
+      };
+
+   .. availability:: Unix
+
+   .. versionadded:: 3.4
+
+
 .. c:macro:: Py_HASH_CUTOFF
 
    Buffers of length in range ``[1, Py_HASH_CUTOFF)`` are hashed using DJBX33A

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -1024,13 +1024,14 @@ Libraries options
 Security Options
 ----------------
 
-.. option:: --with-hash-algorithm=[fnv|siphash13|siphash24]
+.. option:: --with-hash-algorithm=[fnv|siphash13|siphash24|external]
 
    Select hash algorithm for use in ``Python/pyhash.c``:
 
    * ``siphash13`` (default);
    * ``siphash24``;
-   * ``fnv``.
+   * ``fnv``;
+   * ``external``.
 
    .. versionadded:: 3.4
 

--- a/configure
+++ b/configure
@@ -1902,7 +1902,7 @@ Optional Packages:
                           behaviour detector, 'ubsan' (default is no)
   --with-thread-sanitizer enable ThreadSanitizer data race detector, 'tsan'
                           (default is no)
-  --with-hash-algorithm=[fnv|siphash13|siphash24]
+  --with-hash-algorithm=[fnv|siphash13|siphash24|external]
                           select hash algorithm for use in Python/pyhash.c
                           (default is SipHash13)
   --with-tzpath=<list of absolute paths separated by pathsep>
@@ -14934,6 +14934,10 @@ then :
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $withval" >&5
 printf "%s\n" "$withval" >&6; }
 case "$withval" in
+    external)
+        printf "%s\n" "#define Py_HASH_ALGORITHM 0" >>confdefs.h
+
+        ;;
     siphash13)
         printf "%s\n" "#define Py_HASH_ALGORITHM 3" >>confdefs.h
 

--- a/configure.ac
+++ b/configure.ac
@@ -3966,12 +3966,15 @@ dnl quadrigraphs "@<:@" and "@:>@" produce "[" and "]" in the output
 AC_ARG_WITH(
   [hash_algorithm],
   [AS_HELP_STRING(
-    [--with-hash-algorithm=@<:@fnv|siphash13|siphash24@:>@],
+    [--with-hash-algorithm=@<:@fnv|siphash13|siphash24|external@:>@],
     [select hash algorithm for use in Python/pyhash.c (default is SipHash13)]
   )],
 [
 AC_MSG_RESULT([$withval])
 case "$withval" in
+    external)
+        AC_DEFINE([Py_HASH_ALGORITHM], [0])
+        ;;
     siphash13)
         AC_DEFINE([Py_HASH_ALGORITHM], [3])
         ;;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

I will need to test this manually. However, do we have give docs for embedders that would provide custom implementations? It's really "figure how to link your embedded implementation but here's what you need to provide". Is it sufficient? `PyHash_Func` is defined in `pyhash.c`:

```c
#if Py_HASH_ALGORITHM == Py_HASH_EXTERNAL
extern PyHash_FuncDef PyHash_Func;
#else
static PyHash_FuncDef PyHash_Func;
#endif
```

I guess it's sufficient if we use the correct linker flags but I'm not entirely sure whether I should document this as well. It's a really niche thing (and I'm not aware of anyone doing this; everyone uses the default hash functions that is siphash13 and this hash function is used by most programming languages and the Linux kernel so I don't see why someone would need to change this except for performance reasons such as SIMD implementations).

Note that we cannot just remove this feature because it's part of PEP-456. I can write a PEP to officially deprecate it but I don't think it's worth SC's or my time.

cc @encukou @vstinner 

<!-- gh-issue-number: gh-141226 -->
* Issue: gh-141226
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141245.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->