### PR TITLE
gh-141246: Link to correct Windows docs in `time.sleep()` doc

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -407,9 +407,9 @@ Functions
    On Windows, if *secs* is zero, the thread relinquishes the remainder of its
    time slice to any other thread that is ready to run. If there are no other
    threads ready to run, the function returns immediately, and the thread
-   continues execution.  On Windows 8.1 and newer the implementation uses
+   continues execution.  On Windows 10 and newer the implementation uses
    a `high-resolution timer
-   <https://learn.microsoft.com/windows-hardware/drivers/kernel/high-resolution-timers>`_
+   <https://learn.microsoft.com/windows/win32/api/synchapi/nf-synchapi-createwaitabletimerexw#parameters>`_
    which provides resolution of 100 nanoseconds. If *secs* is zero, ``Sleep(0)`` is used.
 
    .. rubric:: Unix implementation

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -409,7 +409,7 @@ Functions
    threads ready to run, the function returns immediately, and the thread
    continues execution.  On Windows 10 and newer the implementation uses
    a `high-resolution timer
-   <https://learn.microsoft.com/windows/win32/api/synchapi/nf-synchapi-createwaitabletimerexw#parameters>`_
+   <https://learn.microsoft.com/windows/win32/api/synchapi/nf-synchapi-createwaitabletimerexw>`_
    which provides resolution of 100 nanoseconds. If *secs* is zero, ``Sleep(0)`` is used.
 
    .. rubric:: Unix implementation


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

In time.sleep documentation, we referred a kernel API available from Windows 8.1, while CPython runs in userspace.

It's replaced to the correct MSDN documentation and the first supported and documented version was Windows 10

<!-- gh-issue-number: gh-141246 -->
* close: gh-141246
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141248.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->