### PR TITLE
gh-141186: Document asyncio Task cancellation propagation behavior

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -1221,8 +1221,8 @@ Task Object
 
    To cancel a running Task use the :meth:`cancel` method.  Calling it
    will cause the Task to throw a :exc:`CancelledError` exception into
-   the wrapped coroutine.  If a coroutine is awaiting on a Future
-   object during cancellation, the Future object will be cancelled.
+   the wrapped coroutine.  If a coroutine is awaiting on a future-like
+   object during cancellation, the awaited object will be cancelled.
 
    :meth:`cancelled` can be used to check if the Task was cancelled.
    The method returns ``True`` if the wrapped coroutine did not
@@ -1410,6 +1410,10 @@ Task Object
       discouraged.  Should the coroutine nevertheless decide to suppress
       the cancellation, it needs to call :meth:`Task.uncancel` in addition
       to catching the exception.
+
+      If the Task being cancelled is currently awaiting on a future-like
+      object, that awaited object will also be cancelled. This cancellation
+      propagates down the entire chain of awaited objects.
 
       .. versionchanged:: 3.9
          Added the *msg* parameter.


### PR DESCRIPTION
Fixes issue #141186 by documenting that cancelling a Task cancels what it's waiting for.

## Problem
The docs said cancelling a coroutine waiting on a Future cancels the Future, but didn't mention this also happens with Tasks. Users didn't know Tasks work the same way.

## Solution
- Added "or Task" to the documentation where it only mentioned Future
- Explained that cancellation goes down the whole chain of waiting tasks
- Mentioned that Tasks inherit from Future so they work the same

## Testing
Ran the exact code from the issue - it works as expected. Tested multiple scenarios to confirm the behavior.

Documentation-only change. No code was modified.

<!-- gh-issue-number: gh-141186 -->
* Issue: gh-141186
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141249.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->