### PR TITLE
gh-141004: Document `PyErr_ProgramTextObject` and `PyErr_ProgramText`

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -344,7 +344,7 @@ For convenience, some of these functions will always return a
 
    Similar to :c:func:`PyErr_ProgramTextObject`, but *filename* is a
    :c:expr:`const char *`, which is decoded with the
-   :term:`filesystem-encoding-and-error-handler`, instead of a
+   :term:`filesystem encoding and error handler`, instead of a
    Python object reference.
 
 

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -331,6 +331,22 @@ For convenience, some of these functions will always return a
    use.
 
 
+.. c:function:: PyObject *PyErr_ProgramTextObject(PyObject *filename, int lineno)
+
+   Get the source line in *filename* at line *lineno*. *filename* should be a
+   Python :class:`str` object.
+
+   On success, this function returns a Python string object with the found line.
+   On failure, this function returns ``NULL`` without an exception set.
+
+
+.. c:function:: PyObject *PyErr_ProgramText(const char *filename, int lineno)
+
+   Similar to :c:func:`PyErr_ProgramTextObject`, but *filename* is a
+   :c:expr:`const char *` UTF-8 encoded string instead of a Python object
+   reference.
+
+
 Issuing warnings
 ================
 

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -343,8 +343,9 @@ For convenience, some of these functions will always return a
 .. c:function:: PyObject *PyErr_ProgramText(const char *filename, int lineno)
 
    Similar to :c:func:`PyErr_ProgramTextObject`, but *filename* is a
-   :c:expr:`const char *` UTF-8 encoded string instead of a Python object
-   reference.
+   :c:expr:`const char *`, which is decoded with the
+   :term:`filesystem-encoding-and-error-handler`, instead of a
+   Python object reference.
 
 
 Issuing warnings


### PR DESCRIPTION

<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141250.org.readthedocs.build/en/141250/c-api/exceptions.html#c.PyErr_ProgramTextObject

<!-- readthedocs-preview cpython-previews end -->