### PR TITLE
gh-141004: Document missing `PyCFunction*` and `PyCMethod*` APIs

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -472,6 +472,24 @@ definition with the same method name.
    .. versionadded:: 3.9
 
 
+.. c:var:: PyTypeObject PyCFunction_Type
+
+   The type object corresponding to Python C function objects. This is
+   available as :class:`types.BuiltinFunctionType` in the Python layer.
+
+
+.. c:function:: int PyCFunction_Check(PyObject *f)
+
+   Return true if *f* is an instance of the :c:type:`PyCFunction_Type` type
+   or a subtype of it. This function always succeeds.
+
+
+.. c:function:: int PyCFunction_CheckExact(PyObject *f)
+
+   This is the same as :c:func:`PyCFunction_Check`, but does not account for
+   subtypes.
+
+
 .. c:function:: PyObject * PyCFunction_NewEx(PyMethodDef *ml, PyObject *self, PyObject *module)
 
    Equivalent to ``PyCMethod_New(ml, self, module, NULL)``.
@@ -480,6 +498,52 @@ definition with the same method name.
 .. c:function:: PyObject * PyCFunction_New(PyMethodDef *ml, PyObject *self)
 
    Equivalent to ``PyCMethod_New(ml, self, NULL, NULL)``.
+
+
+.. c:function:: int PyCFunction_GetFlags(PyObject *func)
+
+   Get the function flags on *func* as they were passed to
+   :c:member:`~PyMethodDef.ml_flags`.
+
+   This function returns the function's flags on success, and ``-1`` with an
+   exception set on failure.
+
+
+.. c:function:: int PyCFunction_GET_FLAGS(PyObject *func)
+
+   This is the same as :c:func:`PyCFunction_GetFlags`, but without error
+   checking.
+
+
+.. c:function:: PyCFunction PyCFunction_GetFunction(PyObject *func)
+
+   Get the function pointer on *func* as it was passed to
+   :c:member:`~PyMethodDef.ml_meth`.
+
+   This function returns the function pointer on success, and ``NULL`` with an
+   exception set on failure.
+
+
+.. c:function:: int PyCFunction_GET_FUNCTION(PyObject *func)
+
+   This is the same as :c:func:`PyCFunction_GetFunction`, but without error
+   checking.
+
+
+.. c:function:: PyObject *PyCFunction_GetSelf(PyObject *func)
+
+   Get the "self" object on *func*. This is the object that would be passed
+   to the first argument of a :c:type:`PyCFunction`. In modules, this is the
+   module object.
+
+   This function returns a :term:`borrowed reference` to the "self" object
+   on success, and ``NULL`` with an exception set on failure.
+
+
+.. c:function:: PyObject *PyCFunction_GET_SELF(PyObject *func)
+
+   This is the same as :c:func:`PyCFunction_GetSelf`, but without error
+   checking.
 
 
 Accessing attributes of extension types

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -521,7 +521,7 @@ definition with the same method name.
 
 .. c:function:: int PyCFunction_GetFlags(PyObject *func)
 
-   Get the function flags on *func* as they were passed to
+   Get the function's flags on *func* as they were passed to
    :c:member:`~PyMethodDef.ml_flags`.
 
    This function returns the function's flags on success, and ``-1`` with an

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -447,6 +447,25 @@ definition with the same method name.
    slot.  This is helpful because calls to PyCFunctions are optimized more
    than wrapper object calls.
 
+
+.. c:var:: PyTypeObject PyCMethod_Type
+
+   The type object corresponding to Python C method objects. This is
+   available as :class:`types.BuiltinMethodType` in the Python layer.
+
+
+.. c:function:: int PyCMethod_Check(PyObject *f)
+
+   Return true if *f* is an instance of the :c:type:`PyCMethod_Type` type
+   or a subtype of it. This function always succeeds.
+
+
+.. c:function:: int PyCMethod_CheckExact(PyObject *f)
+
+   This is the same as :c:func:`PyCMethod_Check`, but does not account for
+   subtypes.
+
+
 .. c:function:: PyObject * PyCMethod_New(PyMethodDef *ml, PyObject *self, PyObject *module, PyTypeObject *cls)
 
    Turn *ml* into a Python :term:`callable` object.

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -549,7 +549,6 @@ definition with the same method name.
    exception set on failure.
 
 
-
 .. c:function:: int PyCFunction_GET_FUNCTION(PyObject *func)
 
    This is the same as :c:func:`PyCFunction_GetFunction`, but without error

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -559,8 +559,9 @@ definition with the same method name.
 .. c:function:: PyObject *PyCFunction_GetSelf(PyObject *func)
 
    Get the "self" object on *func*. This is the object that would be passed
-   to the first argument of a :c:type:`PyCFunction`. In modules, this is the
-   module object.
+   to the first argument of a :c:type:`PyCFunction`. For C function objects
+   created through a :c:type:`PyMethodDef` on a :c:type:`PyModuleDef`, this
+   is the resulting module object.
 
    If *func* is not a C function object, this fails with a
    :class:`SystemError`.

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -524,6 +524,9 @@ definition with the same method name.
    Get the function's flags on *func* as they were passed to
    :c:member:`~PyMethodDef.ml_flags`.
 
+   If *func* is not a C function object, this fails with a
+   :class:`SystemError`.
+
    This function returns the function's flags on success, and ``-1`` with an
    exception set on failure.
 
@@ -531,7 +534,7 @@ definition with the same method name.
 .. c:function:: int PyCFunction_GET_FLAGS(PyObject *func)
 
    This is the same as :c:func:`PyCFunction_GetFlags`, but without error
-   checking.
+   or type checking.
 
 
 .. c:function:: PyCFunction PyCFunction_GetFunction(PyObject *func)
@@ -539,14 +542,18 @@ definition with the same method name.
    Get the function pointer on *func* as it was passed to
    :c:member:`~PyMethodDef.ml_meth`.
 
+   If *func* is not a C function object, this fails with a
+   :class:`SystemError`.
+
    This function returns the function pointer on success, and ``NULL`` with an
    exception set on failure.
+
 
 
 .. c:function:: int PyCFunction_GET_FUNCTION(PyObject *func)
 
    This is the same as :c:func:`PyCFunction_GetFunction`, but without error
-   checking.
+   or type checking.
 
 
 .. c:function:: PyObject *PyCFunction_GetSelf(PyObject *func)
@@ -555,14 +562,17 @@ definition with the same method name.
    to the first argument of a :c:type:`PyCFunction`. In modules, this is the
    module object.
 
+   If *func* is not a C function object, this fails with a
+   :class:`SystemError`.
+
    This function returns a :term:`borrowed reference` to the "self" object
    on success, and ``NULL`` with an exception set on failure.
 
 
 .. c:function:: PyObject *PyCFunction_GET_SELF(PyObject *func)
 
-   This is the same as :c:func:`PyCFunction_GetSelf`, but without error
-   checking.
+   This is the same as :c:func:`PyCFunction_GetSelf`, but without error or
+   type checking.
 
 
 Accessing attributes of extension types

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -454,13 +454,13 @@ definition with the same method name.
    available as :class:`types.BuiltinMethodType` in the Python layer.
 
 
-.. c:function:: int PyCMethod_Check(PyObject *f)
+.. c:function:: int PyCMethod_Check(PyObject *op)
 
-   Return true if *f* is an instance of the :c:type:`PyCMethod_Type` type
+   Return true if *op* is an instance of the :c:type:`PyCMethod_Type` type
    or a subtype of it. This function always succeeds.
 
 
-.. c:function:: int PyCMethod_CheckExact(PyObject *f)
+.. c:function:: int PyCMethod_CheckExact(PyObject *op)
 
    This is the same as :c:func:`PyCMethod_Check`, but does not account for
    subtypes.
@@ -497,13 +497,13 @@ definition with the same method name.
    available as :class:`types.BuiltinFunctionType` in the Python layer.
 
 
-.. c:function:: int PyCFunction_Check(PyObject *f)
+.. c:function:: int PyCFunction_Check(PyObject *op)
 
-   Return true if *f* is an instance of the :c:type:`PyCFunction_Type` type
+   Return true if *op* is an instance of the :c:type:`PyCFunction_Type` type
    or a subtype of it. This function always succeeds.
 
 
-.. c:function:: int PyCFunction_CheckExact(PyObject *f)
+.. c:function:: int PyCFunction_CheckExact(PyObject *op)
 
    This is the same as :c:func:`PyCFunction_Check`, but does not account for
    subtypes.

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -524,8 +524,8 @@ definition with the same method name.
    Get the function's flags on *func* as they were passed to
    :c:member:`~PyMethodDef.ml_flags`.
 
-   If *func* is not a C function object, this fails with a
-   :class:`SystemError`.
+   If *func* is not a C function object, this fails with an exception.
+   *func* must not be ``NULL``.
 
    This function returns the function's flags on success, and ``-1`` with an
    exception set on failure.
@@ -542,8 +542,8 @@ definition with the same method name.
    Get the function pointer on *func* as it was passed to
    :c:member:`~PyMethodDef.ml_meth`.
 
-   If *func* is not a C function object, this fails with a
-   :class:`SystemError`.
+   If *func* is not a C function object, this fails with an exception.
+   *func* must not be ``NULL``.
 
    This function returns the function pointer on success, and ``NULL`` with an
    exception set on failure.
@@ -563,8 +563,8 @@ definition with the same method name.
    created through a :c:type:`PyMethodDef` on a :c:type:`PyModuleDef`, this
    is the resulting module object.
 
-   If *func* is not a C function object, this fails with a
-   :class:`SystemError`.
+   If *func* is not a C function object, this fails with an exception.
+   *func* must not be ``NULL``.
 
    This function returns a :term:`borrowed reference` to the "self" object
    on success, and ``NULL`` with an exception set on failure.


### PR DESCRIPTION

<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141253.org.readthedocs.build/en/141253/c-api/structures.html#implementing-functions-and-methods

<!-- readthedocs-preview cpython-previews end -->