### PR TITLE
GH-116946: Eliminate the need for the GC in the `_thread.lock` and `_thread.RLock`

### DIFF
--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -41,6 +41,7 @@ typedef struct {
 typedef struct {
     PyObject_HEAD
     PyMutex lock;
+    PyObject *weakreflist; /* List of weak references */
 } lockobject;
 
 #define lockobject_CAST(op) ((lockobject *)(op))
@@ -48,6 +49,7 @@ typedef struct {
 typedef struct {
     PyObject_HEAD
     _PyRecursiveMutex lock;
+    PyObject *weakreflist; /* List of weak references */
 } rlockobject;
 
 #define rlockobject_CAST(op)    ((rlockobject *)(op))
@@ -767,7 +769,6 @@ static PyType_Spec ThreadHandle_Type_spec = {
 static void
 lock_dealloc(PyObject *self)
 {
-    PyObject_GC_UnTrack(self);
     PyObject_ClearWeakRefs(self);
     PyTypeObject *tp = Py_TYPE(self);
     tp->tp_free(self);
@@ -999,6 +1000,10 @@ lock_new_impl(PyTypeObject *type)
     return (PyObject *)self;
 }
 
+static PyMemberDef lock_members[] = {
+    {"__weaklistoffset__", Py_T_PYSSIZET, offsetof(lockobject, weakreflist), Py_READONLY},
+    {NULL}
+};
 
 static PyMethodDef lock_methods[] = {
     _THREAD_LOCK_ACQUIRE_LOCK_METHODDEF
@@ -1034,8 +1039,8 @@ static PyType_Slot lock_type_slots[] = {
     {Py_tp_dealloc, lock_dealloc},
     {Py_tp_repr, lock_repr},
     {Py_tp_doc, (void *)lock_doc},
+    {Py_tp_members, lock_members},
     {Py_tp_methods, lock_methods},
-    {Py_tp_traverse, _PyObject_VisitType},
     {Py_tp_new, lock_new},
     {0, 0}
 };
@@ -1043,8 +1048,7 @@ static PyType_Slot lock_type_slots[] = {
 static PyType_Spec lock_type_spec = {
     .name = "_thread.lock",
     .basicsize = sizeof(lockobject),
-    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-              Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_MANAGED_WEAKREF),
+    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE),
     .slots = lock_type_slots,
 };
 
@@ -1059,7 +1063,6 @@ rlock_locked_impl(rlockobject *self)
 static void
 rlock_dealloc(PyObject *self)
 {
-    PyObject_GC_UnTrack(self);
     PyObject_ClearWeakRefs(self);
     PyTypeObject *tp = Py_TYPE(self);
     tp->tp_free(self);
@@ -1319,6 +1322,11 @@ _thread_RLock__at_fork_reinit_impl(rlockobject *self)
 #endif  /* HAVE_FORK */
 
 
+static PyMemberDef rlock_members[] = {
+    {"__weaklistoffset__", Py_T_PYSSIZET, offsetof(rlockobject, weakreflist), Py_READONLY},
+    {NULL}
+};
+
 static PyMethodDef rlock_methods[] = {
     _THREAD_RLOCK_ACQUIRE_METHODDEF
     _THREAD_RLOCK_RELEASE_METHODDEF
@@ -1339,10 +1347,10 @@ static PyMethodDef rlock_methods[] = {
 static PyType_Slot rlock_type_slots[] = {
     {Py_tp_dealloc, rlock_dealloc},
     {Py_tp_repr, rlock_repr},
+    {Py_tp_members, rlock_members},
     {Py_tp_methods, rlock_methods},
     {Py_tp_alloc, PyType_GenericAlloc},
     {Py_tp_new, rlock_new},
-    {Py_tp_traverse, _PyObject_VisitType},
     {0, 0},
 };
 
@@ -1350,7 +1358,7 @@ static PyType_Spec rlock_type_spec = {
     .name = "_thread.RLock",
     .basicsize = sizeof(rlockobject),
     .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-              Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_MANAGED_WEAKREF),
+              Py_TPFLAGS_IMMUTABLETYPE),
     .slots = rlock_type_slots,
 };
 


### PR DESCRIPTION
From https://github.com/python/cpython/issues/116946#issuecomment-3280487211:
> There are a number of heap types which are currently unnecessary gc types like _thread.lock, it would be nice to remove that as it would reduce memory usage and reduce pressure on gc, in case anyone wants to work on it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116946 -->
* Issue: gh-116946
<!-- /gh-issue-number -->
