### PR TITLE
[3.13] gh-140530: fix a reference leak in an error path for `raise exc from cause` (GH-140908)

### DIFF
--- a/Lib/test/test_raise.py
+++ b/Lib/test/test_raise.py
@@ -186,18 +186,14 @@ class TestCause(unittest.TestCase):
             self.fail("No exception raised")
 
     def test_class_cause_nonexception_result(self):
-        class ConstructsNone(BaseException):
-            @classmethod
+        # See https://github.com/python/cpython/issues/140530.
+        class ConstructMortal(BaseException):
             def __new__(*args, **kwargs):
-                return None
-        try:
-            raise IndexError from ConstructsNone
-        except TypeError as e:
-            self.assertIn("should have returned an instance of BaseException", str(e))
-        except IndexError:
-            self.fail("Wrong kind of exception raised")
-        else:
-            self.fail("No exception raised")
+                return ["mortal value"]
+
+        msg = ".*should have returned an instance of BaseException.*"
+        with self.assertRaisesRegex(TypeError, msg):
+            raise IndexError from ConstructMortal
 
     def test_instance_cause(self):
         cause = KeyError()

--- a/Misc/NEWS.d/next/Core and Builtins/2025-11-02-12-47-38.gh-issue-140530.S934bp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-11-02-12-47-38.gh-issue-140530.S934bp.rst
@@ -1,0 +1,2 @@
+Fix a reference leak when ``raise exc from cause`` fails. Patch by Bénédikt
+Tran.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1962,6 +1962,7 @@ do_raise(PyThreadState *tstate, PyObject *exc, PyObject *cause)
                               "calling %R should have returned an instance of "
                               "BaseException, not %R",
                               cause, Py_TYPE(fixed_cause));
+                Py_DECREF(fixed_cause);
                 goto raise_error;
             }
             Py_DECREF(cause);


### PR DESCRIPTION
Fix a reference leak in `raise E from T` when `T` is an exception subtype for which `T.__new__` does not return an exception instance.

(cherry picked from commit 0c77e7c23b5c270a3142105542c56c59b59c52a0)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140530 -->
* Issue: gh-140530
<!-- /gh-issue-number -->
