### PR TITLE
[3.13] gh-141004: Document deprecated aliases for memory allocation (GH-141146)

### DIFF
--- a/Doc/c-api/allocation.rst
+++ b/Doc/c-api/allocation.rst
@@ -58,24 +58,34 @@ Allocating Objects on the Heap
    use :c:func:`PyObject_GC_NewVar` instead.
 
 
-.. c:function:: void PyObject_Del(void *op)
+Deprecated aliases
+^^^^^^^^^^^^^^^^^^
 
-   Releases memory allocated to an object using :c:macro:`PyObject_New` or
-   :c:macro:`PyObject_NewVar`.  This is normally called from the
-   :c:member:`~PyTypeObject.tp_dealloc` handler specified in the object's type.  The fields of
-   the object should not be accessed after this call as the memory is no
-   longer a valid Python object.
+These are :term:`soft deprecated` aliases to existing functions and macros.
+They exist solely for backwards compatibility.
 
 
-.. c:var:: PyObject _Py_NoneStruct
+.. list-table::
+   :widths: auto
+   :header-rows: 1
 
-   Object which is visible in Python as ``None``.  This should only be accessed
-   using the :c:macro:`Py_None` macro, which evaluates to a pointer to this
-   object.
-
-
-.. seealso::
-
-   :ref:`moduleobjects`
-      To allocate and create extension modules.
-
+   * * Deprecated alias
+     * Function
+   * * .. c:macro:: PyObject_NEW(type, typeobj)
+     * :c:macro:`PyObject_New`
+   * * .. c:macro:: PyObject_NEW_VAR(type, typeobj, n)
+     * :c:macro:`PyObject_NewVar`
+   * * .. c:macro:: PyObject_INIT(op, typeobj)
+     * :c:func:`PyObject_Init`
+   * * .. c:macro:: PyObject_INIT_VAR(op, typeobj, n)
+     * :c:func:`PyObject_InitVar`
+   * * .. c:macro:: PyObject_MALLOC(n)
+     * :c:func:`PyObject_Malloc`
+   * * .. c:macro:: PyObject_REALLOC(p, n)
+     * :c:func:`PyObject_Realloc`
+   * * .. c:macro:: PyObject_FREE(p)
+     * :c:func:`PyObject_Free`
+   * * .. c:macro:: PyObject_DEL(p)
+     * :c:func:`PyObject_Free`
+   * * .. c:macro:: PyObject_Del(p)
+     * :c:func:`PyObject_Free`

--- a/Doc/c-api/allocation.rst
+++ b/Doc/c-api/allocation.rst
@@ -58,6 +58,19 @@ Allocating Objects on the Heap
    use :c:func:`PyObject_GC_NewVar` instead.
 
 
+.. c:var:: PyObject _Py_NoneStruct
+
+   Object which is visible in Python as ``None``.  This should only be accessed
+   using the :c:macro:`Py_None` macro, which evaluates to a pointer to this
+   object.
+
+
+.. seealso::
+
+   :ref:`moduleobjects`
+      To allocate and create extension modules.
+
+
 Deprecated aliases
 ^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
(cherry picked from commit 1d738dea6364de004f8cec7c6309d6bbd3b996c7)


<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141289.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->