### PR TITLE
gh-141004: Document `PyClassMethod*` and `PyStaticMethod*` APIs

### DIFF
--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -43,7 +43,6 @@ found in the dictionary of type objects.
 Built-in descriptors
 ^^^^^^^^^^^^^^^^^^^^
 
-
 .. c:var:: PyTypeObject PyClassMethod_Type
 
    The type of class method objects. This is the same object as

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -52,6 +52,7 @@ Built-in descriptors
 .. c:function:: PyObject *PyClassMethod_New(PyObject *callable)
 
    Create a new :class:`classmethod` object wrapping *callable*.
+   *callable* must be a callable object and must not be ``NULL``.
 
    On success, this function returns a :term:`strong reference` to a new class
    method descriptor. On failure, this function returns ``NULL`` with an
@@ -67,6 +68,7 @@ Built-in descriptors
 .. c:function:: PyObject *PyStaticMethod_New(PyObject *callable)
 
    Create a new :class:`staticmethod` object wrapping *callable*.
+   *callable* must be a callable object and must not be ``NULL``.
 
    On success, this function returns a :term:`strong reference` to a new static
    method descriptor. On failure, this function returns ``NULL`` with an

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -38,3 +38,38 @@ found in the dictionary of type objects.
 
 
 .. c:function:: PyObject* PyWrapper_New(PyObject *, PyObject *)
+
+
+Built-in descriptors
+^^^^^^^^^^^^^^^^^^^^
+
+
+.. c:var:: PyTypeObject PyClassMethod_Type
+
+   The type of class method objects. This is the same object as
+   :class:`classmethod` in the Python layer.
+
+
+.. c:function:: PyObject *PyClassMethod_New(PyObject *callable)
+
+   Create a new :class:`classmethod` object wrapping *callable*.
+
+   On success, this function returns a :term:`strong reference` to a new class
+   method descriptor. On failure, this function returns ``NULL`` with an
+   exception set.
+
+
+.. c:var:: PyTypeObject PyStaticMethod_Type
+
+   The type of static method objects. This is the same object as
+   :class:`staticmethod` in the Python layer.
+
+
+.. c:function:: PyObject *PyStaticMethod_New(PyObject *callable)
+
+   Create a new :class:`staticmethod` object wrapping *callable*.
+
+   On success, this function returns a :term:`strong reference` to a new static
+   method descriptor. On failure, this function returns ``NULL`` with an
+   exception set.
+


### PR DESCRIPTION

<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141296.org.readthedocs.build/en/141296/c-api/descriptor.html#built-in-descriptors

<!-- readthedocs-preview cpython-previews end -->