### PR TITLE
gh-140980: document `SET_FUNCTION_ATTRIBUTE` flag for `annotate` function 

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1673,7 +1673,7 @@ iterations of the loop.
    * ``0x02`` a dictionary of keyword-only parameters' default values
    * ``0x04`` a tuple of strings containing parameters' annotations
    * ``0x08`` a tuple containing cells for free variables, making a closure
-   * ``0x10`` the annotate function for the function object
+   * ``0x10`` the :term:`annotate function` for the function object
 
    .. versionadded:: 3.13
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1673,6 +1673,7 @@ iterations of the loop.
    * ``0x02`` a dictionary of keyword-only parameters' default values
    * ``0x04`` a tuple of strings containing parameters' annotations
    * ``0x08`` a tuple containing cells for free variables, making a closure
+   * ``0x10`` the annotate function for the function object
 
    .. versionadded:: 3.13
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1677,6 +1677,9 @@ iterations of the loop.
 
    .. versionadded:: 3.13
 
+   .. versionchanged:: 3.14
+      Added ``0x10`` to indicate the annotate function for the function object.
+
 
 .. opcode:: BUILD_SLICE (argc)
 


### PR DESCRIPTION
Fixes gh-140980

This adds documentation for the `0x10` bit flag (annotate) that was added to 
`SET_FUNCTION_ATTRIBUTE` in #124566. The bit sets the annotate function for 
the function object.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141306.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->