### PR TITLE
gh-140500: Update download.html instructions

### DIFF
--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -32,7 +32,7 @@
 {% if last_updated %}<p><b>{% trans %}Last updated on: {{ last_updated }}.{% endtrans %}</b></p>{% endif %}
 
 <p>{% trans %}To download an archive containing all the documents for this version of
-Python in one of various formats, follow one of links in this table.{% endtrans %}</p>
+Python in one of various formats, follow one of the links in this table.{% endtrans %}</p>
 
 <table class="docutils">
   <tr>

--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -61,7 +61,6 @@
   </tr>
 </table>
 
-<p>{% trans %}+{% endtrans %}</p>
 
 <p>{% trans %}
 We no longer provide pre-built PDFs of the documentation.

--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -61,7 +61,6 @@
   </tr>
 </table>
 
-
 <p>{% trans %}
 We no longer provide pre-built PDFs of the documentation.
 To build a PDF archive, follow the instructions in the
@@ -72,7 +71,6 @@ and run <code>make dist-pdf</code> in the <code>Doc/</code> directory of a copy 
 <p>{% trans %}
 See the <a href="https://docs.python.org/{{ version }}/archives/">directory listing</a>
 for file sizes.{% endtrans %}</p>
-
 
 <h2>{% trans %}Problems{% endtrans %}</h2>
 {% set bugs = pathto('bugs') %}

--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -31,7 +31,7 @@
 
 {% if last_updated %}<p><b>{% trans %}Last updated on: {{ last_updated }}.{% endtrans %}</b></p>{% endif %}
 
-<p>{% trans %}+Download an archive containing all the documentation for this version of Python:{% endtrans %}</p>
+<p>{% trans %}Download an archive containing all the documentation for this version of Python:{% endtrans %}</p>
 
 <table class="docutils">
   <tr>

--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -31,8 +31,7 @@
 
 {% if last_updated %}<p><b>{% trans %}Last updated on: {{ last_updated }}.{% endtrans %}</b></p>{% endif %}
 
-<p>{% trans %}To download an archive containing all the documents for this version of
-Python in one of various formats, follow one of the links in this table.{% endtrans %}</p>
+<p>{% trans %}+Download an archive containing all the documentation for this version of Python:{% endtrans %}</p>
 
 <table class="docutils">
   <tr>
@@ -62,7 +61,7 @@ Python in one of various formats, follow one of the links in this table.{% endtr
   </tr>
 </table>
 
-<p>{% trans %}These archives contain all the content in the documentation.{% endtrans %}</p>
+<p>{% trans %}+{% endtrans %}</p>
 
 <p>{% trans %}
 We no longer provide pre-built PDFs of the documentation.


### PR DESCRIPTION
Missing "the" in the description

Closes #140500

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141320.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-140500 -->
* Issue: gh-140500
<!-- /gh-issue-number -->
