### PR TITLE
gh-62480: De-personalize "Partial mocking" section in `unittest.mock` examples

### DIFF
--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -602,7 +602,7 @@ Partial mocking
 
 For some tests, you may want to mock out a call to :meth:`datetime.date.today`
 to return a known date, but don't want to prevent the code under test from
-creating new date objects. Unfortunately :class:`datetime.date` is written in C, and
+creating new date objects. Unfortunately :class:`datetime.date` is written in C,
 so you cannot just monkey-patch out the static :meth:`datetime.date.today` method.
 
 Instead, you can effectively wrap the date

--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -600,7 +600,7 @@ this list of calls for us::
 Partial mocking
 ~~~~~~~~~~~~~~~
 
-For some tests you may want to mock out a call to :meth:`datetime.date.today`
+For some tests, you may want to mock out a call to :meth:`datetime.date.today`
 to return a known date, but you may not want to prevent the code under test from
 creating new date objects. Unfortunately :class:`datetime.date` is written in C, and
 so you cannot just monkey-patch out the static :meth:`datetime.date.today` method.

--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -606,7 +606,7 @@ creating new date objects. Unfortunately :class:`datetime.date` is written in C,
 so you cannot just monkey-patch out the static :meth:`datetime.date.today` method.
 
 Instead, you can effectively wrap the date
-class with a mock, but passing through calls to the constructor to the real
+class with a mock, while passing through calls to the constructor to the real
 class (and returning real instances).
 
 The :func:`patch decorator <patch>` is used here to

--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -601,7 +601,7 @@ Partial mocking
 ~~~~~~~~~~~~~~~
 
 For some tests, you may want to mock out a call to :meth:`datetime.date.today`
-to return a known date, but you may not want to prevent the code under test from
+to return a known date, but don't want to prevent the code under test from
 creating new date objects. Unfortunately :class:`datetime.date` is written in C, and
 so you cannot just monkey-patch out the static :meth:`datetime.date.today` method.
 

--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -605,7 +605,7 @@ to return a known date, but don't want to prevent the code under test from
 creating new date objects. Unfortunately :class:`datetime.date` is written in C, and
 so you cannot just monkey-patch out the static :meth:`datetime.date.today` method.
 
-A simple way of doing this involves effectively wrapping the date
+Instead, you can effectively wrap the date
 class with a mock, but passing through calls to the constructor to the real
 class (and returning real instances).
 

--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -600,12 +600,12 @@ this list of calls for us::
 Partial mocking
 ~~~~~~~~~~~~~~~
 
-In some tests I wanted to mock out a call to :meth:`datetime.date.today`
-to return a known date, but I didn't want to prevent the code under test from
+For some tests you may want to mock out a call to :meth:`datetime.date.today`
+to return a known date, but you may not want to prevent the code under test from
 creating new date objects. Unfortunately :class:`datetime.date` is written in C, and
-so I couldn't just monkey-patch out the static :meth:`datetime.date.today` method.
+so you cannot just monkey-patch out the static :meth:`datetime.date.today` method.
 
-I found a simple way of doing this that involved effectively wrapping the date
+A simple way of doing this involves effectively wrapping the date
 class with a mock, but passing through calls to the constructor to the real
 class (and returning real instances).
 


### PR DESCRIPTION
Some of the descriptions were addressed in first person, but have now been changed to address the user reading the documentation instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-62480 -->
* Issue: gh-62480
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141321.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->