### PR TITLE
gh-62480: De-personalize "Mocking Unbound Methods" section in `unittest.mock` examples

### DIFF
--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -743,16 +743,15 @@ exception is raised in the setUp then tearDown is not called.
 Mocking Unbound Methods
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Whilst writing tests today I needed to patch an *unbound method* (patching the
-method on the class rather than on the instance). I needed self to be passed
-in as the first argument because I want to make asserts about which objects
-were calling this particular method. The issue is that you can't patch with a
-mock for this, because if you replace an unbound method with a mock it doesn't
-become a bound method when fetched from the instance, and so it doesn't get
-self passed in. The workaround is to patch the unbound method with a real
-function instead. The :func:`patch` decorator makes it so simple to
-patch out methods with a mock that having to create a real function becomes a
-nuisance.
+Sometimes a test needs to patch an *unbound method* which means patching the 
+method on the class rather than on the instance. In order to make asserts 
+about which objects were calling this particular method, you need to pass 
+self as the first argument. The issue is that you can't patch with a mock for
+this, because if you replace an unbound method with a mock it doesn't become 
+a bound method when fetched from the instance, and so it doesn't get self 
+passed in. The workaround is to patch the unbound method with a real function
+instead. The :func:`patch` decorator makes it so simple to patch out methods 
+with a mock that having to create a real function becomes a nuisance.
 
 If you pass ``autospec=True`` to patch then it does the patching with a
 *real* function object. This function object has the same signature as the one
@@ -760,8 +759,8 @@ it is replacing, but delegates to a mock under the hood. You still get your
 mock auto-created in exactly the same way as before. What it means though, is
 that if you use it to patch out an unbound method on a class the mocked
 function will be turned into a bound method if it is fetched from an instance.
-It will have ``self`` passed in as the first argument, which is exactly what I
-wanted:
+It will have ``self`` passed in as the first argument, which is exactly what 
+was needed:
 
     >>> class Foo:
     ...   def foo(self):

--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -743,14 +743,14 @@ exception is raised in the setUp then tearDown is not called.
 Mocking Unbound Methods
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Sometimes a test needs to patch an *unbound method* which means patching the 
-method on the class rather than on the instance. In order to make asserts 
-about which objects were calling this particular method, you need to pass 
-self as the first argument. The issue is that you can't patch with a mock for
+Sometimes a test needs to patch an *unbound method*, which means patching the
+method on the class rather than on the instance. In order to make assertions
+about which objects were calling this particular method, you need to pass
+``self`` as the first argument. The issue is that you can't patch with a mock for
 this, because if you replace an unbound method with a mock it doesn't become 
-a bound method when fetched from the instance, and so it doesn't get self 
+a bound method when fetched from the instance, and so it doesn't get ``self``
 passed in. The workaround is to patch the unbound method with a real function
-instead. The :func:`patch` decorator makes it so simple to patch out methods 
+instead. The :func:`patch` decorator makes it so simple to patch out methods
 with a mock that having to create a real function becomes a nuisance.
 
 If you pass ``autospec=True`` to patch then it does the patching with a
@@ -759,7 +759,7 @@ it is replacing, but delegates to a mock under the hood. You still get your
 mock auto-created in exactly the same way as before. What it means though, is
 that if you use it to patch out an unbound method on a class the mocked
 function will be turned into a bound method if it is fetched from an instance.
-It will have ``self`` passed in as the first argument, which is exactly what 
+It will have ``self`` passed in as the first argument, which is exactly what
 was needed:
 
     >>> class Foo:

--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -747,7 +747,7 @@ Sometimes a test needs to patch an *unbound method*, which means patching the
 method on the class rather than on the instance. In order to make assertions
 about which objects were calling this particular method, you need to pass
 ``self`` as the first argument. The issue is that you can't patch with a mock for
-this, because if you replace an unbound method with a mock it doesn't become 
+this, because if you replace an unbound method with a mock it doesn't become
 a bound method when fetched from the instance, and so it doesn't get ``self``
 passed in. The workaround is to patch the unbound method with a real function
 instead. The :func:`patch` decorator makes it so simple to patch out methods


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Rewrote two first sentenced and the last sentence of Mocking Unbound Methods paragraph to second person.
<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141322.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-62480 -->
* Issue: gh-62480
<!-- /gh-issue-number -->
