### PR TITLE
gh-71136: IDLE: Fix hanging when raise KeyboardInterrupt with debugger open

### DIFF
--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -176,6 +176,7 @@ def main(del_exitfunc=False):
         except KeyboardInterrupt:
             if quitting:
                 exit_now = True
+            rpc.response_queue.put((seq, None))
             continue
         except SystemExit:
             capture_warnings(False)


### PR DESCRIPTION
:wave: This is a rebase of an ancient PR: #1711, I'm trying to shepherd it to closure.

When catch `KeyboardInterrupt`, it should put a dummy msg back to `response_queue` to prevent queue.Empty cause the infinity loop.

https://bugs.python.org/issue26949

Issue: https://github.com/python/cpython/issues/71136

<!-- gh-issue-number: gh-71136 -->
* Issue: gh-71136
<!-- /gh-issue-number -->
