### PR TITLE
gh-141311: Avoid assertion in BytesIO readinto

### DIFF
--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -557,8 +557,8 @@ class PyBytesIOTest(MemoryTestMixin, MemorySeekTestMixin, unittest.TestCase):
         _testcapi = import_module("_testcapi")
 
         memio = self.ioclass()
-        # Seek should allow PY_SSIZE_T_MAX, read should be capped to buffer size.
-        # Past end of buffer read should always return empty bytes (EOF).
+        # Seek allows PY_SSIZE_T_MAX, read handle that.
+        # Past end of buffer read should always return 0 (EOF).
         self.assertEqual(_testcapi.PY_SSIZE_T_MAX,
                          memio.seek(_testcapi.PY_SSIZE_T_MAX))
         buf = bytearray(2)

--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -12,6 +12,7 @@ import _pyio as pyio
 import pickle
 import sys
 import weakref
+from test.support.import_helper import import_module
 
 class IntLike:
     def __init__(self, num):
@@ -551,6 +552,17 @@ class PyBytesIOTest(MemoryTestMixin, MemorySeekTestMixin, unittest.TestCase):
         memio.seek(0)
         memio.seek(1, 1)
         self.assertEqual(memio.read(), buf[1:])
+
+    def test_issue141311(self):
+        _testcapi = import_module("_testcapi")
+
+        memio = self.ioclass()
+        # Seek should allow PY_SSIZE_T_MAX, read should be capped to buffer size.
+        # Past end of buffer read should always return empty bytes (EOF).
+        self.assertEqual(_testcapi.PY_SSIZE_T_MAX,
+                         memio.seek(_testcapi.PY_SSIZE_T_MAX))
+        buf = bytearray(2)
+        self.assertEqual(0, memio.readinto(buf))
 
     def test_unicode(self):
         memio = self.ioclass()

--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -12,7 +12,6 @@ import _pyio as pyio
 import pickle
 import sys
 import weakref
-from test.support.import_helper import import_module
 
 class IntLike:
     def __init__(self, num):
@@ -554,13 +553,10 @@ class PyBytesIOTest(MemoryTestMixin, MemorySeekTestMixin, unittest.TestCase):
         self.assertEqual(memio.read(), buf[1:])
 
     def test_issue141311(self):
-        _testcapi = import_module("_testcapi")
-
         memio = self.ioclass()
-        # Seek allows PY_SSIZE_T_MAX, read handle that.
+        # Seek allows PY_SSIZE_T_MAX, read should handle that.
         # Past end of buffer read should always return 0 (EOF).
-        self.assertEqual(_testcapi.PY_SSIZE_T_MAX,
-                         memio.seek(_testcapi.PY_SSIZE_T_MAX))
+        self.assertEqual(sys.maxsize, memio.seek(sys.maxsize))
         buf = bytearray(2)
         self.assertEqual(0, memio.readinto(buf))
 

--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -54,6 +54,12 @@ class MemorySeekTestMixin:
         self.assertEqual(buf[3:], bytesIo.read())
         self.assertRaises(TypeError, bytesIo.seek, 0.0)
 
+        self.assertEqual(sys.maxsize, bytesIo.seek(sys.maxsize))
+        self.assertEqual(self.EOF, bytesIo.read(4))
+
+        self.assertEqual(sys.maxsize - 2, bytesIo.seek(sys.maxsize - 2))
+        self.assertEqual(self.EOF, bytesIo.read(4))
+
     def testTell(self):
         buf = self.buftype("1234567890")
         bytesIo = self.ioclass(buf)

--- a/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
@@ -1,2 +1,2 @@
-Fix assertion failure in :func:`!io.BytesIO.readinto` and possible out of bounds
-read when position is near :data:`sys.maxsize` in :class:`io.BytesIO`.
+Fix assertion failure in :func:`!io.BytesIO.readinto` and undefined behavior
+arising when read position is above capcity in :class:`io.BytesIO`.

--- a/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
@@ -1,3 +1,2 @@
-Fix assertion failure in :class:`io.BytesIO` implementation of
-:func:`~io.BufferedIOBase.readinto` when the current offset is at the max
-offset and readinto is called.
+Fix assertion failure in :class:`!io.BytesIO.readinto` when the current offset
+is at the max offset and readinto is called.

--- a/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
@@ -1,3 +1,2 @@
-Fix assertion failure in :func:`!io.BytesIO.readinto` and possible
-undefined behavior in :class:`io.BytesIO` when the current position
-is at or near :data:`sys.maxsize`.
+Fix assertion failure in :func:`!io.BytesIO.readinto` and possible out of bounds
+read when position is near :data:`sys.maxsize` in :class:`io.BytesIO`.

--- a/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
@@ -1,0 +1,3 @@
+Fix assertion failure in :class:`io.BytesIO` implementation of
+:func:`~io.BufferedIOBase.readinto` when the current offset is at the max
+offset and readinto is called.

--- a/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
@@ -1,2 +1,3 @@
-Fix assertion failure in :class:`!io.BytesIO.readinto` when the current offset
-is at the max offset and readinto is called.
+Fix assertion failure in :func:`!io.BytesIO.readinto` and possible
+undefined behavior in :class:`io.BytesIO` when the current position
+is at or near :data:`sys.maxsize`.

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -436,7 +436,9 @@ read_bytes_lock_held(bytesio *self, Py_ssize_t size)
         return Py_NewRef(self->buf);
     }
 
-    /* gh-141311: avoid past end of self->buf access */
+    /* gh-141311: Avoid undefined behavior when self->pos (limit PY_SSIZE_T_MAX)
+       is beyond the size of self->buf. Assert above validates size is always in
+       bounds. When self->pos is out of bounds calling code sets size to 0. */
     if (size == 0) {
         return PyBytes_FromStringAndSize(NULL, 0);
     }
@@ -615,7 +617,8 @@ _io_BytesIO_readinto_impl(bytesio *self, Py_buffer *buffer)
     if (len > n) {
         len = n;
         if (len < 0) {
-            /* gh-141311: avoid past end of self->buf access */
+            /* gh-141311: Avoid undefined behavior when self->pos (limit
+               PY_SSIZE_T_MAX) points beyond the size of self->buf. */
             return PyLong_FromSsize_t(0);
         }
     }

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -609,8 +609,9 @@ _io_BytesIO_readinto_impl(bytesio *self, Py_buffer *buffer)
     n = self->string_size - self->pos;
     if (len > n) {
         len = n;
-        if (len < 0)
-            len = 0;
+        if (len < 0) {
+            return PyLong_FromSsize_t(0);
+        }
     }
 
     assert(self->pos + len < PY_SSIZE_T_MAX);


### PR DESCRIPTION
Account for when self->pos is equal to PY_SSIZE_T_MAX. The length of read was correctly set to zero but the asserts assumed self->pos couldn't reach PY_SSIZE_T_MAX. Return early to avoid edge cases.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141311 -->
* Issue: gh-141311
<!-- /gh-issue-number -->
