### PR TITLE
gh-141336: Fix Unicode escape assertion failure in error handler

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-10-17-11-11.gh-issue-141336.Ux3K2g.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-10-17-11-11.gh-issue-141336.Ux3K2g.rst
@@ -1,0 +1,4 @@
+Fix assertion failure in Unicode escape decoding when using custom error
+handlers that return single-character replacements and rewind the input
+position. The bug occurred in debug builds where ``unicode_decode_call_errorhandler_writer()``
+failed to account for replacement text length in buffer capacity calculations.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -4426,8 +4426,14 @@ unicode_decode_call_errorhandler_writer(
     }
 
     replen = PyUnicode_GET_LENGTH(repunicode);
-    if (replen > 1) {
-        writer->min_length += replen - 1;
+    /* Account for the replacement text itself. The caller set
+       writer->min_length to (remaining_input + writer.pos) before
+       invoking the error handler. Since we are about to write the
+       replacement and then continue decoding from the (possibly
+       updated) input position, ensure min_length includes the full
+       replacement length unconditionally. */
+    if (replen > 0) {
+        writer->min_length += replen;
         need_to_grow = 1;
     }
     new_inptr = *input + newpos;


### PR DESCRIPTION
Fixes assertion failure in Unicode escape decoding when using custom error handlers that return single-character replacements and rewind input position.

## Root Cause

The issue occurs in unicode_decode_call_errorhandler_writer() when:
1. Error handler returns a replacement string of length 1 (replen == 1)
2. Error handler rewinds input position (increasing remaining input bytes) 
3. Original code failed to account for replacement length in buffer calculations

This led to assertion failures in debug builds.

## Fix

- Always include full replacement length in writer.min_length calculations
- Change condition from replen > 1 to replen > 0
- Add full replen instead of replen - 1 to maintain buffer invariant

## Testing

- Reproduction case now works without assertion failure
- All codec callback tests pass (43/43) 
- Specific mutating decode handler test passes
- No regressions detected in broader codec tests

Fixes #141336

<!-- gh-issue-number: gh-141336 -->
* Issue: gh-141336
<!-- /gh-issue-number -->
