### PR TITLE
gh-136702: Clear codec caches for refleak tests; use test.support helpers

### DIFF
--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -294,6 +294,25 @@ def clear_caches():
     else:
         importlib_metadata.FastPath.__new__.cache_clear()
 
+    try:
+        encodings = sys.modules['encodings']
+    except KeyError:
+        pass
+    else:
+        encodings._cache.clear()
+
+    try:
+        codecs = sys.modules['codecs']
+    except KeyError:
+        pass
+    else:
+        # There's no direct API to clear the codecs search cache, but
+        # `unregister` clears it implicitly.
+        def noop_search_function(name):
+            return None
+        codecs.register(noop_search_function)
+        codecs.unregister(noop_search_function)
+
 
 def get_build_info():
     # Get most important configure and build options as a list of strings.

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -13,6 +13,7 @@ import warnings
 
 from test import support
 from test.support import os_helper
+from test.support import warnings_helper
 
 try:
     import _testlimitedcapi
@@ -3902,8 +3903,8 @@ class CodecNameNormalizationTest(unittest.TestCase):
         self.assertEqual(normalize('utf...8'), 'utf...8')
 
         # Non-ASCII *encoding* is deprecated.
-        with self.assertWarnsRegex(DeprecationWarning,
-                "Support for non-ascii encoding names will be removed in 3.17"):
+        msg = "Support for non-ascii encoding names will be removed in 3.17"
+        with warnings_helper.check_warnings((msg, DeprecationWarning)):
             self.assertEqual(normalize('utf\xE9\u20AC\U0010ffff-8'), 'utf_8')
 
 

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -41,6 +41,7 @@ from email import utils
 
 from test import support
 from test.support import threading_helper
+from test.support import warnings_helper
 from test.support.os_helper import unlink
 from test.test_email import openfile, TestEmailBase
 
@@ -5738,7 +5739,7 @@ Content-Disposition: inline; filename*=utf-8\udce2\udc80\udc9d''myfile.txt
 
 """
         msg = email.message_from_string(m)
-        with self.assertWarns(DeprecationWarning):
+        with warnings_helper.check_warnings(('', DeprecationWarning)):
             self.assertEqual(msg.get_filename(), 'myfile.txt')
 
     def test_rfc2231_single_tick_in_filename_extended(self):

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -8,6 +8,7 @@ from test.test_email import TestEmailBase, parameterize
 from email import headerregistry
 from email.headerregistry import Address, Group
 from test.support import ALWAYS_EQ
+from test.support import warnings_helper
 
 
 DITTO = object()
@@ -252,7 +253,7 @@ class TestContentTypeHeader(TestHeaderBase):
         if 'utf-8%E2%80%9D' in source and 'ascii' not in source:
             import encodings
             encodings._cache.clear()
-            with self.assertWarns(DeprecationWarning):
+            with warnings_helper.check_warnings(('', DeprecationWarning)):
                 h = self.make_header('Content-Type', source)
         else:
             h = self.make_header('Content-Type', source)


### PR DESCRIPTION
This should fix refleak buildbots.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-136702 -->
* Issue: gh-136702
<!-- /gh-issue-number -->
