### PR TITLE
gh-141343: Fix a grammar error in `functions.rst`

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1859,7 +1859,7 @@ are always available.  They are listed here in alphabetical order.
    the same data with other ordering tools such as :func:`max` that rely
    on a different underlying method.  Implementing all six comparisons
    also helps avoid confusion for mixed type comparisons which can call
-   reflected the :meth:`~object.__gt__` method.
+   the reflected :meth:`~object.__gt__` method.
 
    For sorting examples and a brief sorting tutorial, see :ref:`sortinghowto`.
 


### PR DESCRIPTION
```diff
- reflected the :meth:`~object.__gt__` method.
+ the reflected :meth:`~object.__gt__` method.
```

<!-- gh-issue-number: gh-141343 -->
* Issue: gh-141343
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141348.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->