### PR TITLE
gh-116738: Make csv module thread-safe

### DIFF
--- a/Lib/test/test_free_threading/test_csv.py
+++ b/Lib/test/test_free_threading/test_csv.py
@@ -1,0 +1,50 @@
+import csv
+import io
+import unittest
+
+from test.support import threading_helper
+from test.support.threading_helper import run_concurrently
+
+
+NTHREADS = 10
+
+
+@threading_helper.requires_working_threading()
+class TestCSV(unittest.TestCase):
+    def test_concurrent_reader_next(self):
+        input_rows = [f"{i},{i},{i}" for i in range(50)]
+        input_stream = io.StringIO("\n".join(input_rows))
+        reader = csv.reader(input_stream)
+        output_rows = []
+
+        def read_row():
+            for row in reader:
+                self.assertEqual(len(row), 3)
+                output_rows.append(",".join(row))
+
+        run_concurrently(worker_func=read_row, nthreads=NTHREADS)
+        self.assertSetEqual(set(input_rows), set(output_rows))
+
+    def test_concurrent_writer_writerow(self):
+        output_stream = io.StringIO()
+        writer = csv.writer(output_stream)
+        row_per_thread = 10
+        expected_rows = []
+
+        def write_row():
+            for i in range(row_per_thread):
+                writer.writerow([i, i, i])
+                expected_rows.append(f"{i},{i},{i}")
+
+        run_concurrently(worker_func=write_row, nthreads=NTHREADS)
+
+        # Rewind to the start of the stream and parse the rows
+        output_stream.seek(0)
+        output_rows = [line.strip() for line in output_stream.readlines()]
+
+        self.assertEqual(len(output_rows), NTHREADS * row_per_thread)
+        self.assertListEqual(sorted(output_rows), sorted(expected_rows))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-10-00-14-20.gh-issue-116738.IxliC_.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-10-00-14-20.gh-issue-116738.IxliC_.rst
@@ -1,0 +1,2 @@
+Make csv module thread-safe on the :term:`free threaded <free threading>`
+build.


### PR DESCRIPTION
Added a critical section to protect the states of `ReaderObj` and `WriterObj` in the free-threading build. Without the critical sections, both new free-threading tests were crashing. Also ran the tests with tsan.

cc: @mpage @colesbury

<!-- gh-issue-number: gh-116738 -->
* Issue: gh-116738
<!-- /gh-issue-number -->
