### PR TITLE
gh-85588: Restore the __ne__() method in Set and Mapping

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -594,6 +594,8 @@ class Set(Collection):
             return NotImplemented
         return len(self) == len(other) and self.__le__(other)
 
+    __ne__ = object.__ne__
+
     @classmethod
     def _from_iterable(cls, it):
         '''Construct an instance of the class from any iterable input.
@@ -820,6 +822,8 @@ class Mapping(Collection):
         if not isinstance(other, Mapping):
             return NotImplemented
         return dict(self.items()) == dict(other.items())
+
+    __ne__ = object.__ne__
 
     __reversed__ = None
 

--- a/Misc/NEWS.d/next/Library/2025-11-10-18-38-58.gh-issue-85588.562vvi.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-10-18-38-58.gh-issue-85588.562vvi.rst
@@ -1,0 +1,5 @@
+Restore the :meth:`!__ne__` method (identical to :meth:`object.__ne__`) in
+:class:`collections.abc.Set` and :class:`collections.abc.Mapping` classes.
+This guarantees that the ``!=`` operator is consistent with the ``==``
+operator, even if the :meth:`!__ne__` method was defined in other parent
+class.


### PR DESCRIPTION
Set it to object.__ne__.
This guarantees that the != operator is consistent with the == operator, even if the __ne__ method was defined in other parent class.


<!-- gh-issue-number: gh-85588 -->
* Issue: gh-85588
<!-- /gh-issue-number -->
