### PR TITLE
gh-141004: Document missing generator APIs

### DIFF
--- a/Doc/c-api/gen.rst
+++ b/Doc/c-api/gen.rst
@@ -45,7 +45,7 @@ than explicitly calling :c:func:`PyGen_New` or :c:func:`PyGen_NewWithQualName`.
    A reference to *frame* is stolen by this function.  The *frame* argument
    must not be ``NULL``.
 
-.. c:function:: PyCodeObject *PyGen_GetCode(PyGenObject *gen)
+.. c:function:: PyCodeObject* PyGen_GetCode(PyGenObject *gen)
 
    Return a new :term:`strong reference` to the code object wrapped by *gen*.
    This function always succeeds.

--- a/Doc/c-api/gen.rst
+++ b/Doc/c-api/gen.rst
@@ -44,3 +44,8 @@ than explicitly calling :c:func:`PyGen_New` or :c:func:`PyGen_NewWithQualName`.
    with ``__name__`` and ``__qualname__`` set to *name* and *qualname*.
    A reference to *frame* is stolen by this function.  The *frame* argument
    must not be ``NULL``.
+
+.. c:function:: PyCodeObject *PyGen_GetCode(PyGenObject *gen)
+
+   Return a new :term:`strong reference` to the code object wrapped by *gen*.
+   This function always succeeds.

--- a/Doc/c-api/gen.rst
+++ b/Doc/c-api/gen.rst
@@ -62,6 +62,8 @@ Asynchronous Generator Objects
    The type object corresponding to asynchronous generator objects. This is
    available as :class:`types.AsyncGeneratorType` in the Python layer.
 
+   .. versionadded:: 3.6
+
 .. c:function:: PyObject *PyAsyncGen_New(PyFrameObject *frame, PyObject *name, PyObject *qualname)
 
    Create a new asynchronous generator wrapping *frame*, with ``__name__`` and
@@ -78,3 +80,5 @@ Asynchronous Generator Objects
 
    Return true if *op* is an asynchronous generator object, false otherwise.
    This function always succeeds.
+
+   .. versionadded:: 3.6

--- a/Doc/c-api/gen.rst
+++ b/Doc/c-api/gen.rst
@@ -49,3 +49,32 @@ than explicitly calling :c:func:`PyGen_New` or :c:func:`PyGen_NewWithQualName`.
 
    Return a new :term:`strong reference` to the code object wrapped by *gen*.
    This function always succeeds.
+
+
+Asynchronous Generator Objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. seealso::
+   :pep:`525`
+
+.. c:var:: PyTypeObject PyAsyncGen_Type
+
+   The type object corresponding to asynchronous generator objects. This is
+   available as :class:`types.AsyncGeneratorType` in the Python layer.
+
+.. c:function:: PyObject *PyAsyncGen_New(PyFrameObject *frame, PyObject *name, PyObject *qualname)
+
+   Create a new asynchronous generator wrapping *frame*, with ``__name__`` and
+   ``__qualname__`` set to *name* and *qualname*. *frame* is stolen by this
+   function and must not be ``NULL``.
+
+   On success, this function returns a :term:`strong reference` to the
+   new asynchronous generator. On failure, this function returns ``NULL``
+   with an exception set.
+
+   .. versionadded:: 3.6
+
+.. c:function:: int PyAsyncGen_CheckExact(PyObject *op)
+
+   Return true if *op* is an asynchronous generator object, false otherwise.
+   This function always succeeds.


### PR DESCRIPTION
I didn't do `PyAsyncGenASend_CheckExact` in this one because I think that should just be deprecated.

<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141409.org.readthedocs.build/en/141409/c-api/gen.html#c.PyGen_GetCode

<!-- readthedocs-preview cpython-previews end -->