### PR TITLE
gh-132657: Add regression test for PySet_Contains

### DIFF
--- a/Modules/_testlimitedcapi/set.c
+++ b/Modules/_testlimitedcapi/set.c
@@ -158,7 +158,7 @@ error:
 static PyObject *
 test_set_contains_does_not_convert_unhashable_key(PyObject *self, PyObject *Py_UNUSED(obj))
 {
-    // see documentation of int PySet_Contains in c-api/set.rst
+    // See https://docs.python.org/3/c-api/set.html#c.PySet_Contains
     PyObject *outer_set = PySet_New(NULL);
 
     PyObject *needle = PySet_New(NULL);

--- a/Modules/_testlimitedcapi/set.c
+++ b/Modules/_testlimitedcapi/set.c
@@ -158,22 +158,7 @@ error:
 static PyObject *
 test_set_contains_does_not_convert_unhashable_key(PyObject *self, PyObject *Py_UNUSED(obj))
 {
-    // The documentation of PySet_Contains state:
-    //
-    // int PySet_Contains(PyObject *anyset, PyObject *key)
-    //
-    // Part of the Stable ABI.
-    //
-    // ... Unlike the Python __contains__() method, this function does not
-    // automatically convert unhashable sets [key] into temporary frozensets.
-    // Raise a TypeError if the key is unhashable.
-    //
-    // That is to say {2,3} in {1, 2, frozenset({2,3})}
-    //                ^_ will be converted in a frozenset in Python code.
-    // But not if using PySet_Contains(..., key)
-    //
-    // We test that this behavior is unchanged as this is a stable API.
-
+    // see documentation of int PySet_Contains in c-api/set.rst
     PyObject *outer_set = PySet_New(NULL);
 
     PyObject *needle = PySet_New(NULL);
@@ -189,7 +174,6 @@ test_set_contains_does_not_convert_unhashable_key(PyObject *self, PyObject *Py_U
         return NULL;
     }
 
-    // Add an element to needle to make it {42}
     if (PySet_Add(needle, num) < 0) {
         Py_DECREF(outer_set);
         Py_DECREF(needle);

--- a/Modules/_testlimitedcapi/set.c
+++ b/Modules/_testlimitedcapi/set.c
@@ -155,6 +155,67 @@ error:
     return NULL;
 }
 
+static PyObject *
+test_set_contains_does_not_convert_unhashable_key(PyObject *self, PyObject *Py_UNUSED(obj))
+{
+    // The documentation of PySet_Contains state:
+    //
+    // int PySet_Contains(PyObject *anyset, PyObject *key)
+    //
+    // Part of the Stable ABI.
+    //
+    // ... Unlike the Python __contains__() method, this function does not
+    // automatically convert unhashable sets [key] into temporary frozensets.
+    // Raise a TypeError if the key is unhashable.
+    //
+    // That is to say {2,3} in {1, 2, frozenset({2,3})}
+    //                ^_ will be converted in a frozenset in Python code.
+    // But not if using PySet_Contains(..., key)
+    //
+    // We test that this behavior is unchanged as this is a stable API.
+
+    PyObject *outer_set = PySet_New(NULL);
+
+    PyObject *needle = PySet_New(NULL);
+    if (needle == NULL) {
+        Py_DECREF(outer_set);
+        return NULL;
+    }
+
+    PyObject *num = PyLong_FromLong(42);
+    if (num == NULL) {
+        Py_DECREF(outer_set);
+        Py_DECREF(needle);
+        return NULL;
+    }
+
+    // Add an element to needle to make it {42}
+    if (PySet_Add(needle, num) < 0) {
+        Py_DECREF(outer_set);
+        Py_DECREF(needle);
+        Py_DECREF(num);
+        return NULL;
+    }
+
+    int result = PySet_Contains(outer_set, needle);
+
+    Py_DECREF(num);
+    Py_DECREF(needle);
+    Py_DECREF(outer_set);
+
+    if (result < 0) {
+        if (PyErr_ExceptionMatches(PyExc_TypeError)) {
+            PyErr_Clear();
+            Py_RETURN_NONE;
+        }
+        return NULL;
+    }
+
+    PyErr_SetString(PyExc_AssertionError,
+                    "PySet_Contains should have raised TypeError for unhashable key");
+    return NULL;
+}
+
 static PyMethodDef test_methods[] = {
     {"set_check", set_check, METH_O},
     {"set_checkexact", set_checkexact, METH_O},
@@ -174,6 +235,8 @@ static PyMethodDef test_methods[] = {
     {"set_clear", set_clear, METH_O},
 
     {"test_frozenset_add_in_capi", test_frozenset_add_in_capi, METH_NOARGS},
+    {"test_set_contains_does_not_convert_unhashable_key",
+     test_set_contains_does_not_convert_unhashable_key, METH_NOARGS},
 
     {NULL},
 };


### PR DESCRIPTION
As discussed in gh-141183, the test suite did not
test that `PySet_Contains` does not convert unhashable key into a frozenset.

This commit adds a regression test for this
behavior, to ensure that any behavior change is
caught by the test suite.

-- 

I'm not sure opening a GitHub issue, or having a blurb is necessary as this only adds a test. 

Here is the [link to the comment](https://github.com/python/cpython/pull/141183#issuecomment-3517194781) where @kumaraditya303 suggested for me to send a test as a separate PR.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
