### PR TITLE
gh-141415: Remove unused variables and comment in `_pyrepl.windows_console.py`

### DIFF
--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -249,21 +249,9 @@ class WindowsConsole(Console):
     def __write_changed_line(
         self, y: int, oldline: str, newline: str, px_coord: int
     ) -> None:
-        # this is frustrating; there's no reason to test (say)
-        # self.dch1 inside the loop -- but alternative ways of
-        # structuring this function are equally painful (I'm trying to
-        # avoid writing code generators these days...)
         minlen = min(wlen(oldline), wlen(newline))
         x_pos = 0
         x_coord = 0
-
-        px_pos = 0
-        j = 0
-        for c in oldline:
-            if j >= px_coord:
-                break
-            j += wlen(c)
-            px_pos += 1
 
         # reuse the oldline as much as possible, but stop as soon as we
         # encounter an ESCAPE, because it might be the start of an escape
@@ -358,7 +346,6 @@ class WindowsConsole(Console):
         self.height, self.width = self.getheightwidth()
 
         self.posxy = 0, 0
-        self.__gone_tall = 0
         self.__offset = 0
 
         if self.__vt_support:

--- a/Misc/NEWS.d/next/Library/2025-11-12-00-45-35.gh-issue-141415.I_sVyA.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-12-00-45-35.gh-issue-141415.I_sVyA.rst
@@ -1,0 +1,1 @@
+Remove unused variables and comment in ``_pyrepl.windows_console.py``.

--- a/Misc/NEWS.d/next/Library/2025-11-12-00-45-35.gh-issue-141415.I_sVyA.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-12-00-45-35.gh-issue-141415.I_sVyA.rst
@@ -1,1 +1,0 @@
-Remove unused variables and comment in ``_pyrepl.windows_console.py``.


### PR DESCRIPTION
This removes the unused `px_pos`, `self.__gone_tall` and comment from `_pyrepl.windows_console.py`.

After `px_pos` is removed, [the `px_coord` parameter](https://github.com/python/cpython/blob/main/Lib/_pyrepl/windows_console.py#L250) of `__write_changed_line` also becomes unused, which in turn makes [an access to `self.posxy`](https://github.com/python/cpython/blob/main/Lib/_pyrepl/windows_console.py#L191) unused as well. I didn't remove these two parts as I'm not sure if there are any concerns about changing the function signature of `__write_changed_line()`, 

<!-- gh-issue-number: gh-141415 -->
* Issue: gh-141415
<!-- /gh-issue-number -->
