### PR TITLE
gh-141412: Use reliable target URL for urllib example

### DIFF
--- a/Doc/tutorial/stdlib.rst
+++ b/Doc/tutorial/stdlib.rst
@@ -183,13 +183,13 @@ protocols. Two of the simplest are :mod:`urllib.request` for retrieving data
 from URLs and :mod:`smtplib` for sending mail::
 
    >>> from urllib.request import urlopen
-   >>> with urlopen('http://worldtimeapi.org/api/timezone/etc/UTC.txt') as response:
+   >>> with urlopen('https://docs.python.org/3/') as response:
    ...     for line in response:
    ...         line = line.decode()             # Convert bytes to a str
-   ...         if line.startswith('datetime'):
+   ...         if 'updated' in line:
    ...             print(line.rstrip())         # Remove trailing newline
    ...
-   datetime: 2022-01-01T01:36:47.689215+00:00
+         Last updated on Nov 11, 2025 (20:11 UTC).
 
    >>> import smtplib
    >>> server = smtplib.SMTP('localhost')


### PR DESCRIPTION
The endpoint used for demonstrating reading URLs is no longer stable. This change substitutes a target over which we have more control.

Closes #141412


<!-- gh-issue-number: gh-141412 -->
* Issue: gh-141412
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141428.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->