### PR TITLE
gh-84464: Clarify turtle documentation typo for turtle.circle function

### DIFF
--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -753,7 +753,7 @@ Turtle motion
    is not a full circle, one endpoint of the arc is the current pen
    position.  Draw the arc in counterclockwise direction if *radius* is
    positive, otherwise in clockwise direction.  Finally the direction of the
-   turtle is changed by the amount of *extent*.
+   turtle is changed by the sign of the *extent*.
 
    As the circle is approximated by an inscribed regular polygon, *steps*
    determines the number of steps to use.  If not given, it will be


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
After a past pull request #20928 that had received multiple comments and suggestions, this current pull request addresses  that when reading the turtle.circle() function description, the direction of the turtle(arrow) functionality influence was not stated correctly. By editing the sentence to clearly state that the functionality of the turtle direction was influenced by the extents sign fixes the misunderstanding of the modules functionality.  

<!-- gh-issue-number: gh-84464 -->
* Issue: gh-84464
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141430.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->