### PR TITLE
gh-141442: Add escaping to iOS testbed arguments

### DIFF
--- a/Apple/testbed/__main__.py
+++ b/Apple/testbed/__main__.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -252,7 +253,7 @@ def update_test_plan(testbed_path, platform, args):
         test_plan = json.load(f)
 
     test_plan["defaultOptions"]["commandLineArgumentEntries"] = [
-        {"argument": arg} for arg in args
+        {"argument": shlex.quote(arg)} for arg in args
     ]
 
     with test_plan_path.open("w", encoding="utf-8") as f:

--- a/Misc/NEWS.d/next/Tools-Demos/2025-11-12-12-54-28.gh-issue-141442.50dS3P.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-11-12-12-54-28.gh-issue-141442.50dS3P.rst
@@ -1,0 +1,1 @@
+The iOS testbed now correctly handles test arguments that contain spaces.


### PR DESCRIPTION
Apply shell quoting to arguments used as test arguments in the iOS test runner. 

This is needed because Xcode generates test arguments by a raw concatenation, even though there passed as an array of strings.

<!-- gh-issue-number: gh-141442 -->
* Issue: gh-141442
<!-- /gh-issue-number -->
