### PR TITLE
gh-141388: Fully support non-function callables as annotate functions

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -728,7 +728,7 @@ def call_annotate_function(annotate, format, *, owner=None, _is_evaluate=False):
             annotate, owner, is_class, globals, allow_evaluation=False
         )
         func = types.FunctionType(
-            _get_annotate_attr(annotate, "__code__", None),
+            _get_annotate_attr(annotate, "__code__"),
             globals,
             closure=closure,
             argdefs=_get_annotate_attr(annotate, "__defaults__", None),
@@ -763,7 +763,7 @@ def call_annotate_function(annotate, format, *, owner=None, _is_evaluate=False):
         # Grab and store all the annotate function attributes that we might need to access
         # multiple times as variables, as this could be a bit expensive for non-functions.
         annotate_globals = _get_annotate_attr(annotate, "__globals__", {})
-        annotate_code = _get_annotate_attr(annotate, "__code__", None)
+        annotate_code = _get_annotate_attr(annotate, "__code__")
         annotate_defaults = _get_annotate_attr(annotate, "__defaults__", None)
         annotate_kwdefaults = _get_annotate_attr(annotate, "__kwdefaults__", None)
         namespace = {
@@ -890,7 +890,7 @@ def _stringify_single(anno):
         return repr(anno)
 
 
-def _get_annotate_attr(annotate, attr, default):
+def _get_annotate_attr(annotate, attr, default=_sentinel):
     # Try to get the attr on the annotate function. If it doesn't exist, we might
     # need to look in other places on the object. If all of those fail, we can
     # return the default at the end.
@@ -944,6 +944,8 @@ def _get_annotate_attr(annotate, attr, default):
     ):
         return _get_annotate_attr(annotate.func, attr, default)
 
+    if default is _sentinel:
+        raise TypeError(f"annotate function missing {attr!r} attribute")
     return default
 
 def _direct_call_annotate(func, annotate, *args):

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -854,7 +854,7 @@ def _build_closure(annotate, owner, is_class, stringifier_dict, *, allow_evaluat
     closure = _get_annotate_attr(annotate, "__closure__", None)
     if not closure:
         return None, None
-    freevars = annotate.__code__.co_freevars
+    freevars = _get_annotate_attr(annotate, "__code__", None).co_freevars
     new_closure = []
     cell_dict = {}
     for i, cell in enumerate(closure):

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -728,13 +728,18 @@ def call_annotate_function(annotate, format, *, owner=None, _is_evaluate=False):
             annotate, owner, is_class, globals, allow_evaluation=False
         )
         func = types.FunctionType(
-            annotate.__code__,
+            _get_annotate_attr(annotate, "__code__", None),
             globals,
             closure=closure,
-            argdefs=annotate.__defaults__,
-            kwdefaults=annotate.__kwdefaults__,
+            argdefs=_get_annotate_attr(annotate, "__defaults__", None),
+            kwdefaults=_get_annotate_attr(annotate, "__kwdefaults__", None),
         )
-        annos = func(Format.VALUE_WITH_FAKE_GLOBALS)
+        if isinstance(annotate.__call__, types.MethodType):
+            annos = func(
+                annotate.__call__.__self__, Format.VALUE_WITH_FAKE_GLOBALS
+            )
+        else:
+            annos = func(Format.VALUE_WITH_FAKE_GLOBALS)
         if _is_evaluate:
             return _stringify_single(annos)
         return {

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -905,7 +905,7 @@ def _get_annotate_attr(annotate, attr, default):
         (functools := sys.modules.get("functools", None))
         and isinstance(annotate, functools.partial)
     ):
-        return getattr(annotate.func, attr, default)
+        return _get_annotate_attr(annotate.func, attr, default)
 
     return default
 
@@ -929,6 +929,9 @@ def _direct_call_annotate(func, annotate, format):
         # We could call the function directly, but then we'd have to handle placeholders,
         # and this way should be more robust for future changes.
         if isinstance(annotate, functools.partial):
+            # Partial methods
+            if self := getattr(annotate, "__self__", None):
+                return functools.partial(func, self, *annotate.args, **annotate.keywords)(format)
             return functools.partial(func, *annotate.args, **annotate.keywords)(format)
 
     # If annotate is a cached function, we've now updated the function data, so

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -959,6 +959,7 @@ def _direct_call_annotate(func, annotate, *args):
         inst = annotate.__new__(annotate.__origin__)
         func(inst, *args)
         # Try to set the original class on the instance, if possible.
+        # This is the same logic used in typing for custom generics.
         try:
             inst.__orig_class__ = annotate
         except Exception:

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -896,6 +896,11 @@ def _get_annotate_attr(annotate, attr, default):
             return getattr(call_func, attr, default)
     elif isinstance(annotate, type):
         return getattr(annotate.__init__, attr, default)
+    elif (
+        "functools" in sys.modules
+        and isinstance(annotate, sys.modules["functools"].partial)
+    ):
+        return getattr(annotate.func, attr, default)
 
     return default
 
@@ -911,6 +916,12 @@ def _direct_call_annotate(func, annotate, format):
         inst = annotate.__new__(annotate)
         func(inst, format)
         return inst
+
+    if (
+        "functools" in sys.modules
+        and isinstance(annotate, sys.modules["functools"].partial)
+    ):
+        return func(*annotate.args, format, **annotate.keywords)
 
     return func(format)
 

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -931,15 +931,10 @@ def _direct_call_annotate(func, annotate, format):
         if isinstance(annotate, functools.partial):
             return functools.partial(func, *annotate.args, **annotate.keywords)(format)
 
-        # If annotate is a cached function, re-create it with the new function object.
-        # We want a new, clean, cache, as we've updated the function data, so let's
-        # re-create with the new function and old cache parameters.
-        if isinstance(annotate, functools._lru_cache_wrapper):
-            return functools._lru_cache_wrapper(
-                func, **annotate.cache_parameters(),
-                cache_info_type=(0, 0, 0, annotate.cache_parameters()["maxsize"])
-            )(format)
-
+    # If annotate is a cached function, we've now updated the function data, so
+    # let's not use the old cache. Furthermore, we're about to call the function
+    # and never use it again, so let's not bother trying to cache it.
+    # Or, if it's a normal function or unsupported callable, we should just call it.
     return func(format)
 
 

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1655,7 +1655,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
         def format(format, /, __Format=Format,
                    __NotImplementedError=NotImplementedError):
             if format == __Format.VALUE:
-                return {"x": random.random()}
+                return {"x": random.random(), "y": str}
             else:
                 raise __NotImplementedError(format)
 
@@ -1667,6 +1667,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
         self.assertIsInstance(annotations, dict)
         self.assertIn("x", annotations)
         self.assertIsInstance(annotations["x"], float)
+        self.assertIs(annotations["y"], str)
 
         new_anns = annotationlib.call_annotate_function(format, Format.FORWARDREF)
         self.assertEqual(annotations, new_anns)

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1613,6 +1613,24 @@ class TestCallAnnotateFunction(unittest.TestCase):
 
         self.assertEqual(annotations, {"x": str})
 
+    def test_callable_method_annotate_forwardref_value_fallback(self):
+        # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
+        # supported fall back to Format.VALUE and convert to strings
+        class Annotate:
+            def format(self, format, /, __Format=Format,
+                         __NotImplementedError=NotImplementedError):
+                if format == __Format.VALUE:
+                    return {"x": str}
+                else:
+                    raise __NotImplementedError(format)
+
+        annotations = annotationlib.call_annotate_function(
+            Annotate().format,
+            Format.FORWARDREF,
+        )
+
+        self.assertEqual(annotations, {"x": str})
+
     def test_callable_classmethod_annotate_forwardref_value_fallback(self):
         # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
         # supported fall back to Format.VALUE and convert to strings

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1632,6 +1632,27 @@ class TestCallAnnotateFunction(unittest.TestCase):
 
         self.assertEqual(annotations, {"x": str})
 
+    def test_callable_custom_method_annotate_forwardref_value_fallback(self):
+        # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
+        # supported fall back to Format.VALUE and convert to strings
+        class Annotate(dict):
+            def __init__(inst, self, format, /, __Format=Format,
+                         __NotImplementedError=NotImplementedError):
+                if format == __Format.VALUE:
+                    super().__init__({"x": str})
+                else:
+                    raise __NotImplementedError(format)
+
+        # This wouldn't happen on a normal class, but it's technically legal.
+        custom_method = types.MethodType(Annotate, Annotate(None, Format.VALUE))
+
+        annotations = annotationlib.call_annotate_function(
+            custom_method,
+            Format.FORWARDREF,
+        )
+
+        self.assertEqual(annotations, {"x": str})
+
     def test_callable_classmethod_annotate_forwardref_value_fallback(self):
         # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
         # supported fall back to Format.VALUE and convert to strings

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1618,7 +1618,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
         # supported fall back to Format.VALUE and convert to strings
         class Annotate:
             @classmethod
-            def __call__(cls, format, /, __Format=Format,
+            def format(cls, format, /, __Format=Format,
                          __NotImplementedError=NotImplementedError):
                 if format == __Format.VALUE:
                     return {"x": str}
@@ -1626,7 +1626,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
                     raise __NotImplementedError(format)
 
         annotations = annotationlib.call_annotate_function(
-            Annotate.__call__,
+            Annotate.format,
             Format.FORWARDREF,
         )
 
@@ -1637,7 +1637,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
         # supported fall back to Format.VALUE and convert to strings
         class Annotate:
             @staticmethod
-            def __call__(format, /, __Format=Format,
+            def format(format, /, __Format=Format,
                          __NotImplementedError=NotImplementedError):
                 if format == __Format.VALUE:
                     return {"x": str}
@@ -1645,7 +1645,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
                     raise __NotImplementedError(format)
 
         annotations = annotationlib.call_annotate_function(
-            Annotate.__call__,
+            Annotate.format,
             Format.FORWARDREF,
         )
 

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1648,6 +1648,31 @@ class TestCallAnnotateFunction(unittest.TestCase):
 
         self.assertEqual(annotations, {"x": Format.VALUE * 5 * 6})
 
+    def test_callable_partialmethod_annotate_forwardref_value_fallback(self):
+        # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
+        # supported fall back to Format.VALUE and convert to strings
+        class Annotate:
+            def _internal_format(self, format, second, /, *, third, __Format=Format,
+                       __NotImplementedError=NotImplementedError):
+                if format == __Format.VALUE:
+                    return {"x": format * second * third}
+                else:
+                    raise __NotImplementedError(format)
+
+            format = functools.partialmethod(
+                _internal_format,
+                functools.Placeholder,
+                5,
+                third=6
+            )
+
+        annotations = annotationlib.call_annotate_function(
+            Annotate().format,
+            Format.FORWARDREF,
+        )
+
+        self.assertEqual(annotations, {"x": Format.VALUE * 5 * 6})
+
     def test_callable_cache_annotate_forwardref_value_fallback(self):
         # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
         # supported fall back to Format.VALUE and convert to strings

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1132,6 +1132,26 @@ class TestGetAnnotations(unittest.TestCase):
             {"x": "int"},
         )
 
+    def test_non_function_annotate(self):
+        class AnnotateCallable:
+            def __call__(self, format, /):
+                if format > 2:
+                    raise NotImplementedError
+                return {"x": int}
+
+        class OnlyAnnotate:
+            @property
+            def __annotate__(self):
+                return AnnotateCallable()
+
+        oa = OnlyAnnotate()
+        self.assertEqual(get_annotations(oa, format=Format.VALUE), {"x": int})
+        self.assertEqual(get_annotations(oa, format=Format.FORWARDREF), {"x": int})
+        self.assertEqual(
+            get_annotations(oa, format=Format.STRING),
+            {"x": "int"},
+        )
+
     def test_non_dict_annotate(self):
         class WeirdAnnotate:
             def __annotate__(self, *args, **kwargs):

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1717,6 +1717,28 @@ class TestCallAnnotateFunction(unittest.TestCase):
 
         self.assertEqual(annotations, {"x": int})
 
+    def test_callable_object_custom_call_annotate_forwardref_value_fallback(self):
+        # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
+        # supported fall back to Format.VALUE and convert to strings
+        class AnnotateClass(dict):
+            def __init__(self, format, /, __Format=Format,
+                         __NotImplementedError=NotImplementedError):
+                if format == __Format.VALUE:
+                    super().__init__({"x": int})
+                else:
+                    raise __NotImplementedError(format)
+
+        class Annotate:
+            __call__ = AnnotateClass
+
+        annotations = annotationlib.call_annotate_function(
+            Annotate(),
+            Format.FORWARDREF,
+        )
+
+        self.assertEqual(annotations, {"x": int})
+
+
     def test_callable_generic_class_annotate_forwardref_value_fallback(self):
         # Generics that inherit from builtins become types.GenericAlias objects.
         # This is special-case in annotationlib to ensure the constructor is handled

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1687,6 +1687,25 @@ class TestCallAnnotateFunction(unittest.TestCase):
 
         self.assertEqual(annotations, {"x": int})
 
+    def test_callable_generic_class_annotate_forwardref_value_fallback(self):
+        # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
+        # supported fall back to Format.VALUE and convert to strings
+        class Annotate[T](dict[T]):
+            def __init__(self, format, /, __Format=Format,
+                         __NotImplementedError=NotImplementedError):
+                if format == __Format.VALUE:
+                    super().__init__({"x": int})
+                else:
+                    raise __NotImplementedError(format)
+
+        annotations = annotationlib.call_annotate_function(
+            Annotate[int],
+            Format.FORWARDREF,
+        )
+
+        self.assertEqual(annotations, {"x": int})
+        self.assertEqual(annotations.__orig_class__, Annotate[int])
+
     def test_callable_partial_annotate_forwardref_value_fallback(self):
         # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
         # supported fall back to Format.VALUE and convert to strings

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1613,6 +1613,44 @@ class TestCallAnnotateFunction(unittest.TestCase):
 
         self.assertEqual(annotations, {"x": str})
 
+    def test_callable_classmethod_annotate_forwardref_value_fallback(self):
+        # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
+        # supported fall back to Format.VALUE and convert to strings
+        class Annotate:
+            @classmethod
+            def __call__(cls, format, /, __Format=Format,
+                         __NotImplementedError=NotImplementedError):
+                if format == __Format.VALUE:
+                    return {"x": str}
+                else:
+                    raise __NotImplementedError(format)
+
+        annotations = annotationlib.call_annotate_function(
+            Annotate.__call__,
+            Format.FORWARDREF,
+        )
+
+        self.assertEqual(annotations, {"x": str})
+
+    def test_callable_staticmethod_annotate_forwardref_value_fallback(self):
+        # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
+        # supported fall back to Format.VALUE and convert to strings
+        class Annotate:
+            @staticmethod
+            def __call__(format, /, __Format=Format,
+                         __NotImplementedError=NotImplementedError):
+                if format == __Format.VALUE:
+                    return {"x": str}
+                else:
+                    raise __NotImplementedError(format)
+
+        annotations = annotationlib.call_annotate_function(
+            Annotate.__call__,
+            Format.FORWARDREF,
+        )
+
+        self.assertEqual(annotations, {"x": str})
+
     def test_callable_class_annotate_forwardref_value_fallback(self):
         # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not
         # supported fall back to Format.VALUE and convert to strings

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1514,6 +1514,25 @@ class TestCallAnnotateFunction(unittest.TestCase):
 
         self.assertEqual(annotations, {"x": int})
 
+    def test_callable_class_annotate_forwardref_fakeglobals(self):
+        # If Format.FORWARDREF is not supported, use Format.VALUE_WITH_FAKE_GLOBALS
+        # before falling back to Format.VALUE
+        class Annotate(dict):
+            def __init__(self, format, /, __Format=Format, __NotImplementedError=NotImplementedError):
+                if format == __Format.VALUE:
+                    super().__init__({'x': str})
+                elif format == __Format.VALUE_WITH_FAKE_GLOBALS:
+                    super().__init__({'x': int})
+                else:
+                    raise __NotImplementedError(format)
+
+        annotations = annotationlib.call_annotate_function(
+            Annotate,
+            Format.FORWARDREF
+        )
+
+        self.assertEqual(annotations, {"x": int})
+
     def test_user_annotate_forwardref_value_fallback(self):
         # If Format.FORWARDREF and Format.VALUE_WITH_FAKE_GLOBALS are not supported
         # use Format.VALUE

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1732,7 +1732,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
         # This wouldn't happen on a normal class, but it's technically legal.
         # Ensure that methods (which are special-cased) can wrap class construction
         # (which is also special-cased).
-        custom_method = types.MethodType(Annotate, Annotate(None, Format.VALUE))
+        custom_method = types.MethodType(Annotate, Annotate)
 
         annotations = annotationlib.call_annotate_function(
             custom_method,
@@ -1815,7 +1815,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
         class Annotate[T]:
             def __init__(self, format, /, __Format=Format,
                          __NotImplementedError=NotImplementedError):
-                if format == __Format.VALUE:
+                if format == __Format.VALUE_WITH_FAKE_GLOBALS:
                     self.data = {"x": int}
                 else:
                     raise __NotImplementedError(format)

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1662,12 +1662,20 @@ class TestCallAnnotateFunction(unittest.TestCase):
                 else:
                     raise __NotImplementedError(format)
 
+        # @staticmethod descriptor means that Annotate.format should be a function object.
         annotations = annotationlib.call_annotate_function(
             Annotate.format,
             Format.FORWARDREF,
         )
-
         self.assertEqual(annotations, {"x": str})
+
+        # But if we access the __dict__, the underlying staticmethod object is returned.
+        annotations = annotationlib.call_annotate_function(
+            Annotate.__dict__["format"],
+            Format.FORWARDREF,
+        )
+        self.assertEqual(annotations, {"x": str})
+
 
     def test_callable_class_annotate_forwardref_value_fallback(self):
         # If Format.STRING and Format.VALUE_WITH_FAKE_GLOBALS are not

--- a/Misc/NEWS.d/next/Library/2025-11-18-16-46-58.gh-issue-141388.V5UBkb.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-18-16-46-58.gh-issue-141388.V5UBkb.rst
@@ -1,0 +1,1 @@
+Support arbitrary callables as annotate functions.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

- Any callable can be used as an `__annotate__` function in 3.14, but `annotationlib` will start throwing errors if the format is not implemented.
- This is an initial implementation to support them as first-class citizens included here, mostly in `call_annotate_function()`
- Currently this implementation supports: methods, class/static methods, class instances that are callable, classes and generics themselves, partial, wrapped, singledispatch, and cached functions. 'Builtin' (C) callables can't really be supported because they have no `__code__`, `__globals__`, etc., so a `ForwardRef` or stringification using the current techniques is impossible. Let me know if there are any more callables to implement, some more special-casing will probably be required.
- Initial tests are present but not thorough. It should work for all parts of `annotationlib`, but tests are mostly present on `call_annotate_function()` for now.
- Opening a PR now to seek feedback on the implementation and decide on whether the extra complexity is worth it. If there is interest, I'll add more thorough tests, etc.

<!-- gh-issue-number: gh-141388 -->
* Issue: gh-141388
<!-- /gh-issue-number -->
