### PR TITLE
gh-141444: Doc: update urllib.robotparser example to use python.org robots.txt

### DIFF
--- a/Doc/library/urllib.robotparser.rst
+++ b/Doc/library/urllib.robotparser.rst
@@ -91,16 +91,13 @@ class::
 
    >>> import urllib.robotparser
    >>> rp = urllib.robotparser.RobotFileParser()
-   >>> rp.set_url("http://www.musi-cal.com/robots.txt")
+   >>> rp.set_url("https://www.python.org/robots.txt")
    >>> rp.read()
-   >>> rrate = rp.request_rate("*")
-   >>> rrate.requests
-   3
-   >>> rrate.seconds
-   20
-   >>> rp.crawl_delay("*")
-   6
-   >>> rp.can_fetch("*", "http://www.musi-cal.com/cgi-bin/search?city=San+Francisco")
-   False
-   >>> rp.can_fetch("*", "http://www.musi-cal.com/")
+   >>> print(rp.request_rate("*"))
+   None
+   >>> print(rp.crawl_delay("*"))
+   None
+   >>> rp.can_fetch("*", "https://www.python.org/psf/")
    True
+   >>> rp.can_fetch("*", "https://www.python.org/webstats/")
+   False


### PR DESCRIPTION
* Issue: #141444

Closes: #141444

gh-141444: Updated `Doc/library/urllib.robotparser.rst` to use `https://www.python.org/robots.txt` in the example so it reflects a live robots file. The snippet now shows the expected None values for `request_rate` and `crawl_delay`, and demonstrates `can_fetch()` returning True for an allowed path and False for a disallowed one.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141461.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->