### PR TITLE
gh-141464: a typo in profiling sampling when can not run warning in linux

### DIFF
--- a/Lib/profiling/sampling/__main__.py
+++ b/Lib/profiling/sampling/__main__.py
@@ -15,7 +15,7 @@ Tachyon needs elevated permissions to profile processes. Try one of these soluti
 """
 
 LINUX_PERMISSION_ERROR = """
-🔒 Tachyon was unable to acess process memory. This could be because tachyon
+🔒 Tachyon was unable to access process memory. This could be because tachyon
 has insufficient privileges (the required capability is CAP_SYS_PTRACE).
 Unprivileged processes cannot trace processes that they cannot send signals
 to or those running set-user-ID/set-group-ID programs, for security reasons.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

as diff and can skip the news

others seems right
<img width="1659" height="1141" alt="image" src="https://github.com/user-attachments/assets/89989338-8fa9-4ce5-ba9d-ce05df5790ab" />


<!-- gh-issue-number: gh-141464 -->
* Issue: gh-141464
<!-- /gh-issue-number -->
