### PR TITLE
gh-114203: skip locking if object is already locked by two-mutex critical section 

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-16-25-15.gh-issue-114203.n3tlQO.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-16-25-15.gh-issue-114203.n3tlQO.rst
@@ -1,0 +1,1 @@
+Skip locking if object is already locked by two-mutex critical section.

--- a/Modules/_testinternalcapi/test_critical_sections.c
+++ b/Modules/_testinternalcapi/test_critical_sections.c
@@ -284,10 +284,105 @@ test_critical_sections_gc(PyObject *self, PyObject *Py_UNUSED(args))
 
 #endif
 
+static PyObject *
+test_critical_section1_reacquisition(PyObject *self, PyObject *Py_UNUSED(args))
+{
+    PyObject *a = PyDict_New();
+    assert(a != NULL);
+
+    PyCriticalSection cs1, cs2;
+    // First acquisition of critical section on object locks it
+    PyCriticalSection_Begin(&cs1, a);
+    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
+    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert_nogil(_PyThreadState_GET()->critical_section == (uintptr_t)&cs1);
+    // Attempting to re-acquire critical section on same object which
+    // is already locked by top-most critical section is a no-op.
+    PyCriticalSection_Begin(&cs2, a);
+    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
+    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert_nogil(_PyThreadState_GET()->critical_section == (uintptr_t)&cs1);
+    // Releasing second critical section is a no-op.
+    PyCriticalSection_End(&cs2);
+    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
+    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert_nogil(_PyThreadState_GET()->critical_section == (uintptr_t)&cs1);
+    // Releasing first critical section unlocks the object
+    PyCriticalSection_End(&cs1);
+    assert_nogil(!PyMutex_IsLocked(&a->ob_mutex));
+
+    Py_DECREF(a);
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+test_critical_section2_reacquisition(PyObject *self, PyObject *Py_UNUSED(args))
+{
+    PyObject *a = PyDict_New();
+    assert(a != NULL);
+    PyObject *b = PyDict_New();
+    assert(b != NULL);
+
+    PyCriticalSection2 cs;
+    // First acquisition of critical section on objects locks them
+    PyCriticalSection2_Begin(&cs, a, b);
+    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
+    assert_nogil(PyMutex_IsLocked(&b->ob_mutex));
+    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert_nogil((_PyThreadState_GET()->critical_section &
+                  ~_Py_CRITICAL_SECTION_MASK) == (uintptr_t)&cs);
+
+    // Attempting to re-acquire critical section on either of two
+    // objects already locked by top-most critical section is a no-op.
+
+    // Check re-acquiring on first object
+    PyCriticalSection a_cs;
+    PyCriticalSection_Begin(&a_cs, a);
+    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
+    assert_nogil(PyMutex_IsLocked(&b->ob_mutex));
+    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert_nogil((_PyThreadState_GET()->critical_section &
+                  ~_Py_CRITICAL_SECTION_MASK) == (uintptr_t)&cs);
+    // Releasing critical section on either object is a no-op.
+    PyCriticalSection_End(&a_cs);
+    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
+    assert_nogil(PyMutex_IsLocked(&b->ob_mutex));
+    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert_nogil((_PyThreadState_GET()->critical_section &
+                  ~_Py_CRITICAL_SECTION_MASK) == (uintptr_t)&cs);
+
+    // Check re-acquiring on second object
+    PyCriticalSection b_cs;
+    PyCriticalSection_Begin(&b_cs, b);
+    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
+    assert_nogil(PyMutex_IsLocked(&b->ob_mutex));
+    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert_nogil((_PyThreadState_GET()->critical_section &
+                  ~_Py_CRITICAL_SECTION_MASK) == (uintptr_t)&cs);
+    // Releasing critical section on either object is a no-op.
+    PyCriticalSection_End(&b_cs);
+    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
+    assert_nogil(PyMutex_IsLocked(&b->ob_mutex));
+    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert_nogil((_PyThreadState_GET()->critical_section &
+                  ~_Py_CRITICAL_SECTION_MASK) == (uintptr_t)&cs);
+
+    // Releasing critical section on both objects unlocks them
+    PyCriticalSection2_End(&cs);
+    assert_nogil(!PyMutex_IsLocked(&a->ob_mutex));
+    assert_nogil(!PyMutex_IsLocked(&b->ob_mutex));
+
+    Py_DECREF(a);
+    Py_DECREF(b);
+    Py_RETURN_NONE;
+}
+
 static PyMethodDef test_methods[] = {
     {"test_critical_sections", test_critical_sections, METH_NOARGS},
     {"test_critical_sections_nest", test_critical_sections_nest, METH_NOARGS},
     {"test_critical_sections_suspend", test_critical_sections_suspend, METH_NOARGS},
+    {"test_critical_section1_reacquisition", test_critical_section1_reacquisition, METH_NOARGS},
+    {"test_critical_section2_reacquisition", test_critical_section2_reacquisition, METH_NOARGS},
 #ifdef Py_CAN_START_THREADS
     {"test_critical_sections_threads", test_critical_sections_threads, METH_NOARGS},
     {"test_critical_sections_gc", test_critical_sections_gc, METH_NOARGS},

--- a/Modules/_testinternalcapi/test_critical_sections.c
+++ b/Modules/_testinternalcapi/test_critical_sections.c
@@ -284,6 +284,8 @@ test_critical_sections_gc(PyObject *self, PyObject *Py_UNUSED(args))
 
 #endif
 
+#ifdef Py_GIL_DISABLED
+
 static PyObject *
 test_critical_section1_reacquisition(PyObject *self, PyObject *Py_UNUSED(args))
 {
@@ -377,12 +379,16 @@ test_critical_section2_reacquisition(PyObject *self, PyObject *Py_UNUSED(args))
     Py_RETURN_NONE;
 }
 
+#endif // Py_GIL_DISABLED
+
 static PyMethodDef test_methods[] = {
     {"test_critical_sections", test_critical_sections, METH_NOARGS},
     {"test_critical_sections_nest", test_critical_sections_nest, METH_NOARGS},
     {"test_critical_sections_suspend", test_critical_sections_suspend, METH_NOARGS},
+#ifdef Py_GIL_DISABLED
     {"test_critical_section1_reacquisition", test_critical_section1_reacquisition, METH_NOARGS},
     {"test_critical_section2_reacquisition", test_critical_section2_reacquisition, METH_NOARGS},
+#endif
 #ifdef Py_CAN_START_THREADS
     {"test_critical_sections_threads", test_critical_sections_threads, METH_NOARGS},
     {"test_critical_sections_gc", test_critical_sections_gc, METH_NOARGS},

--- a/Modules/_testinternalcapi/test_critical_sections.c
+++ b/Modules/_testinternalcapi/test_critical_sections.c
@@ -295,23 +295,23 @@ test_critical_section1_reacquisition(PyObject *self, PyObject *Py_UNUSED(args))
     PyCriticalSection cs1, cs2;
     // First acquisition of critical section on object locks it
     PyCriticalSection_Begin(&cs1, a);
-    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
-    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
-    assert_nogil(_PyThreadState_GET()->critical_section == (uintptr_t)&cs1);
+    assert(PyMutex_IsLocked(&a->ob_mutex));
+    assert(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert(_PyThreadState_GET()->critical_section == (uintptr_t)&cs1);
     // Attempting to re-acquire critical section on same object which
     // is already locked by top-most critical section is a no-op.
     PyCriticalSection_Begin(&cs2, a);
-    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
-    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
-    assert_nogil(_PyThreadState_GET()->critical_section == (uintptr_t)&cs1);
+    assert(PyMutex_IsLocked(&a->ob_mutex));
+    assert(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert(_PyThreadState_GET()->critical_section == (uintptr_t)&cs1);
     // Releasing second critical section is a no-op.
     PyCriticalSection_End(&cs2);
-    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
-    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
-    assert_nogil(_PyThreadState_GET()->critical_section == (uintptr_t)&cs1);
+    assert(PyMutex_IsLocked(&a->ob_mutex));
+    assert(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert(_PyThreadState_GET()->critical_section == (uintptr_t)&cs1);
     // Releasing first critical section unlocks the object
     PyCriticalSection_End(&cs1);
-    assert_nogil(!PyMutex_IsLocked(&a->ob_mutex));
+    assert(!PyMutex_IsLocked(&a->ob_mutex));
 
     Py_DECREF(a);
     Py_RETURN_NONE;
@@ -328,10 +328,10 @@ test_critical_section2_reacquisition(PyObject *self, PyObject *Py_UNUSED(args))
     PyCriticalSection2 cs;
     // First acquisition of critical section on objects locks them
     PyCriticalSection2_Begin(&cs, a, b);
-    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
-    assert_nogil(PyMutex_IsLocked(&b->ob_mutex));
-    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
-    assert_nogil((_PyThreadState_GET()->critical_section &
+    assert(PyMutex_IsLocked(&a->ob_mutex));
+    assert(PyMutex_IsLocked(&b->ob_mutex));
+    assert(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert((_PyThreadState_GET()->critical_section &
                   ~_Py_CRITICAL_SECTION_MASK) == (uintptr_t)&cs);
 
     // Attempting to re-acquire critical section on either of two
@@ -340,39 +340,39 @@ test_critical_section2_reacquisition(PyObject *self, PyObject *Py_UNUSED(args))
     // Check re-acquiring on first object
     PyCriticalSection a_cs;
     PyCriticalSection_Begin(&a_cs, a);
-    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
-    assert_nogil(PyMutex_IsLocked(&b->ob_mutex));
-    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
-    assert_nogil((_PyThreadState_GET()->critical_section &
+    assert(PyMutex_IsLocked(&a->ob_mutex));
+    assert(PyMutex_IsLocked(&b->ob_mutex));
+    assert(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert((_PyThreadState_GET()->critical_section &
                   ~_Py_CRITICAL_SECTION_MASK) == (uintptr_t)&cs);
     // Releasing critical section on either object is a no-op.
     PyCriticalSection_End(&a_cs);
-    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
-    assert_nogil(PyMutex_IsLocked(&b->ob_mutex));
-    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
-    assert_nogil((_PyThreadState_GET()->critical_section &
+    assert(PyMutex_IsLocked(&a->ob_mutex));
+    assert(PyMutex_IsLocked(&b->ob_mutex));
+    assert(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert((_PyThreadState_GET()->critical_section &
                   ~_Py_CRITICAL_SECTION_MASK) == (uintptr_t)&cs);
 
     // Check re-acquiring on second object
     PyCriticalSection b_cs;
     PyCriticalSection_Begin(&b_cs, b);
-    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
-    assert_nogil(PyMutex_IsLocked(&b->ob_mutex));
-    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
-    assert_nogil((_PyThreadState_GET()->critical_section &
+    assert(PyMutex_IsLocked(&a->ob_mutex));
+    assert(PyMutex_IsLocked(&b->ob_mutex));
+    assert(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert((_PyThreadState_GET()->critical_section &
                   ~_Py_CRITICAL_SECTION_MASK) == (uintptr_t)&cs);
     // Releasing critical section on either object is a no-op.
     PyCriticalSection_End(&b_cs);
-    assert_nogil(PyMutex_IsLocked(&a->ob_mutex));
-    assert_nogil(PyMutex_IsLocked(&b->ob_mutex));
-    assert_nogil(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
-    assert_nogil((_PyThreadState_GET()->critical_section &
+    assert(PyMutex_IsLocked(&a->ob_mutex));
+    assert(PyMutex_IsLocked(&b->ob_mutex));
+    assert(_PyCriticalSection_IsActive(PyThreadState_GET()->critical_section));
+    assert((_PyThreadState_GET()->critical_section &
                   ~_Py_CRITICAL_SECTION_MASK) == (uintptr_t)&cs);
 
     // Releasing critical section on both objects unlocks them
     PyCriticalSection2_End(&cs);
-    assert_nogil(!PyMutex_IsLocked(&a->ob_mutex));
-    assert_nogil(!PyMutex_IsLocked(&b->ob_mutex));
+    assert(!PyMutex_IsLocked(&a->ob_mutex));
+    assert(!PyMutex_IsLocked(&b->ob_mutex));
 
     Py_DECREF(a);
     Py_DECREF(b);


### PR DESCRIPTION
This fixes the issue outlined in https://gist.github.com/kumaraditya303/05cd1c93577bd7f44f573dad61674842

If the object is currently locked by a two-mutex critical section then locking is skipped. Previously locking was skipped only in case where mutex was the first mutex of the two which is decided by memory address so was nondeterministic. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-114203 -->
* Issue: gh-114203
<!-- /gh-issue-number -->
