### PR TITLE
[3.13] gh-141311: Avoid assertion in BytesIO.readinto() (GH-141333)

### DIFF
--- a/Lib/test/test_memoryio.py
+++ b/Lib/test/test_memoryio.py
@@ -54,6 +54,12 @@ class MemorySeekTestMixin:
         self.assertEqual(buf[3:], bytesIo.read())
         self.assertRaises(TypeError, bytesIo.seek, 0.0)
 
+        self.assertEqual(sys.maxsize, bytesIo.seek(sys.maxsize))
+        self.assertEqual(self.EOF, bytesIo.read(4))
+
+        self.assertEqual(sys.maxsize - 2, bytesIo.seek(sys.maxsize - 2))
+        self.assertEqual(self.EOF, bytesIo.read(4))
+
     def testTell(self):
         buf = self.buftype("1234567890")
         bytesIo = self.ioclass(buf)
@@ -551,6 +557,14 @@ class PyBytesIOTest(MemoryTestMixin, MemorySeekTestMixin, unittest.TestCase):
         memio.seek(0)
         memio.seek(1, 1)
         self.assertEqual(memio.read(), buf[1:])
+
+    def test_issue141311(self):
+        memio = self.ioclass()
+        # Seek allows PY_SSIZE_T_MAX, read should handle that.
+        # Past end of buffer read should always return 0 (EOF).
+        self.assertEqual(sys.maxsize, memio.seek(sys.maxsize))
+        buf = bytearray(2)
+        self.assertEqual(0, memio.readinto(buf))
 
     def test_unicode(self):
         memio = self.ioclass()

--- a/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-09-18-55-13.gh-issue-141311.qZ3swc.rst
@@ -1,0 +1,2 @@
+Fix assertion failure in :func:`!io.BytesIO.readinto` and undefined behavior
+arising when read position is above capcity in :class:`io.BytesIO`.

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -407,6 +407,13 @@ read_bytes(bytesio *self, Py_ssize_t size)
         return Py_NewRef(self->buf);
     }
 
+    /* gh-141311: Avoid undefined behavior when self->pos (limit PY_SSIZE_T_MAX)
+       is beyond the size of self->buf. Assert above validates size is always in
+       bounds. When self->pos is out of bounds calling code sets size to 0. */
+    if (size == 0) {
+        return PyBytes_FromStringAndSize(NULL, 0);
+    }
+
     output = PyBytes_AS_STRING(self->buf) + self->pos;
     self->pos += size;
     return PyBytes_FromStringAndSize(output, size);
@@ -575,13 +582,16 @@ _io_BytesIO_readinto_impl(bytesio *self, Py_buffer *buffer)
     n = self->string_size - self->pos;
     if (len > n) {
         len = n;
-        if (len < 0)
-            len = 0;
+        if (len < 0) {
+            /* gh-141311: Avoid undefined behavior when self->pos (limit
+               PY_SSIZE_T_MAX) points beyond the size of self->buf. */
+            return PyLong_FromSsize_t(0);
+        }
     }
 
-    memcpy(buffer->buf, PyBytes_AS_STRING(self->buf) + self->pos, len);
-    assert(self->pos + len < PY_SSIZE_T_MAX);
+    assert(self->pos + len <= PY_SSIZE_T_MAX);
     assert(len >= 0);
+    memcpy(buffer->buf, PyBytes_AS_STRING(self->buf) + self->pos, len);
     self->pos += len;
 
     return PyLong_FromSsize_t(len);


### PR DESCRIPTION
Fix error in assertion which causes failure if pos is equal to PY_SSIZE_T_MAX. Fix undefined behavior in read() and readinto() if pos is larger that the size of the underlying buffer.
(cherry picked from commit 7d54374f9c7d91e0ef90c4ad84baf10073cf1d8a)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141311 -->
* Issue: gh-141311
<!-- /gh-issue-number -->
