### PR TITLE
gh-137959: Fix `TIER1_TO_TIER2` macro name in JIT InternalDocs

### DIFF
--- a/InternalDocs/jit.md
+++ b/InternalDocs/jit.md
@@ -53,7 +53,7 @@ and an instance of `_PyUOpExecutor_Type` is created to contain it.
 ## The JIT interpreter
 
 After a `JUMP_BACKWARD` instruction invokes the uop optimizer to create a uop
-executor, it transfers control to this executor via the `GOTO_TIER_TWO` macro.
+executor, it transfers control to this executor via the `TIER1_TO_TIER2` macro.
 
 CPython implements two executors. Here we describe the JIT interpreter,
 which is the simpler of them and is therefore useful for debugging and analyzing


### PR DESCRIPTION
It seems that macro `GOTO_TIER_TWO` was renamed to `TIER1_TO_TIER2` in this PR:  https://github.com/python/cpython/pull/137961
But its mention in docs was not changed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-137959 -->
* Issue: gh-137959
<!-- /gh-issue-number -->
