### PR TITLE
gh-140550: Use a bool for the Py_mod_gil value

### DIFF
--- a/Include/internal/pycore_moduleobject.h
+++ b/Include/internal/pycore_moduleobject.h
@@ -30,7 +30,7 @@ typedef struct {
     PyObject *md_name;
     bool md_token_is_def;  /* if true, `md_token` is the PyModuleDef */
 #ifdef Py_GIL_DISABLED
-    void *md_gil;
+    bool md_requires_gil;
 #endif
     Py_ssize_t md_state_size;
     traverseproc md_state_traverse;

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1725,7 +1725,7 @@ class SizeofTest(unittest.TestCase):
         check(int(PyLong_BASE**2), vsize('') + 3*self.longdigit)
         # module
         if support.Py_GIL_DISABLED:
-            md_gil = 'P'
+            md_gil = '?'
         else:
             md_gil = ''
         check(unittest, size('PPPP?' + md_gil + 'NPPPPP'))

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -178,7 +178,7 @@ new_module_notrack(PyTypeObject *mt)
     m->md_name = NULL;
     m->md_token_is_def = false;
 #ifdef Py_GIL_DISABLED
-    m->md_gil = Py_MOD_GIL_USED;
+    m->md_requires_gil = true;
 #endif
     m->md_state_size = 0;
     m->md_state_traverse = NULL;
@@ -361,7 +361,7 @@ _PyModule_CreateInitialized(PyModuleDef* module, int module_api_version)
     m->md_token_is_def = true;
     module_copy_members_from_deflike(m, module);
 #ifdef Py_GIL_DISABLED
-    m->md_gil = Py_MOD_GIL_USED;
+    m->md_requires_gil = true;
 #endif
     return (PyObject*)m;
 }
@@ -380,7 +380,7 @@ module_from_def_and_spec(
     int has_multiple_interpreters_slot = 0;
     void *multiple_interpreters = (void *)0;
     int has_gil_slot = 0;
-    void *gil_slot = Py_MOD_GIL_USED;
+    bool requires_gil = true;
     int has_execution_slots = 0;
     const char *name;
     int ret;
@@ -474,7 +474,7 @@ module_from_def_and_spec(
                        name);
                     goto error;
                 }
-                gil_slot = cur_slot->value;
+                requires_gil = (cur_slot->value != Py_MOD_GIL_NOT_USED);
                 has_gil_slot = 1;
                 break;
             case Py_mod_abi:
@@ -581,9 +581,9 @@ module_from_def_and_spec(
             mod->md_token = token;
         }
 #ifdef Py_GIL_DISABLED
-        mod->md_gil = gil_slot;
+        mod->md_requires_gil = requires_gil;
 #else
-        (void)gil_slot;
+        (void)requires_gil;
 #endif
         mod->md_exec = m_exec;
     } else {
@@ -664,11 +664,12 @@ PyModule_FromSlotsAndSpec(const PyModuleDef_Slot *slots, PyObject *spec)
 int
 PyUnstable_Module_SetGIL(PyObject *module, void *gil)
 {
+    bool requires_gil = (gil != Py_MOD_GIL_NOT_USED);
     if (!PyModule_Check(module)) {
         PyErr_BadInternalCall();
         return -1;
     }
-    ((PyModuleObject *)module)->md_gil = gil;
+    ((PyModuleObject *)module)->md_requires_gil = requires_gil;
     return 0;
 }
 #endif


### PR DESCRIPTION
This needs a single bit, but was stored as a void* in the module struct. This didn't matter due to packing, but now that there's another bool in the struct, we can save a bit of memory by making md_gil a bool.

Variables that changed type are renamed, to detect conflicts.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140550 -->
* Issue: gh-140550
<!-- /gh-issue-number -->
