### PR TITLE
[3.14] gh-140873: Fix the singledispatchmethod documentation

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -672,7 +672,7 @@ The :mod:`functools` module defines the following functions:
    dispatch>` :term:`generic function`.
 
    To define a generic method, decorate it with the ``@singledispatchmethod``
-   decorator. When defining a function using ``@singledispatchmethod``, note
+   decorator. When defining a method using ``@singledispatchmethod``, note
    that the dispatch happens on the type of the first non-*self* or non-*cls*
    argument::
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -995,8 +995,7 @@ def singledispatch(func):
 class singledispatchmethod:
     """Single-dispatch generic method descriptor.
 
-    Supports wrapping existing descriptors and handles non-descriptor
-    callables as instance methods.
+    Supports wrapping existing descriptors.
     """
 
     def __init__(self, func):


### PR DESCRIPTION
It does not support non-descriptor callables yet.


<!-- gh-issue-number: gh-140873 -->
* Issue: gh-140873
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141523.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->