### PR TITLE
GH-141509: Fix warning about remaining subinterpreters

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -432,8 +432,7 @@ class InterpreterObjectTests(TestBase):
         exit()"""
         stdout, stderr = repl.communicate(script)
         self.assertIsNone(stderr)
-        msg = b"remaining subinterpreters; close them with Interpreter.close()"
-        self.assertIn(msg, stdout)
+        self.assertIn(b"Interpreter.close()", stdout)
         self.assertNotIn(b"Traceback", stdout)
 
     @support.requires_subprocess()

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -432,7 +432,8 @@ class InterpreterObjectTests(TestBase):
         exit()"""
         stdout, stderr = repl.communicate(script)
         self.assertIsNone(stderr)
-        self.assertIn(b"remaining subinterpreters", stdout)
+        msg = b"remaining subinterpreters; close them with Interpreter.close()"
+        self.assertIn(msg, stdout)
         self.assertNotIn(b"Traceback", stdout)
 
     @support.requires_subprocess()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
@@ -1,4 +1,2 @@
-Fix warning message about remaining :mod:`subinterpreters
-<concurrent.interpreters>` while finalizing :mod:`"main" interpreter
-<concurrent.interpreters>` and suggest using of ``Interpreter.close``.
+Suggest using :meth:`concurrent.interpreters.Interpreter.close` instead of the private `_interpreters.close` function when warning about remaining subinterpreters.
 Patch by Sergey Miryanov.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
@@ -1,3 +1,3 @@
 Suggest using :meth:`concurrent.interpreters.Interpreter.close` instead of the
-private `_interpreters.destroy` function when warning about remaining subinterpreters.
+private ``_interpreters.destroy`` function when warning about remaining subinterpreters.
 Patch by Sergey Miryanov.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
@@ -1,4 +1,4 @@
 Fix warning message about remaining :mod:`subinterpreters
 <concurrent.interpreters>` while finalizing :mod:`"main" interpreter
-<concurrent.interpreters>` and suggest using of :method:`Interpreter.close`.
+<concurrent.interpreters>` and suggest using of :meth:`Interpreter.close`.
 Patch by Sergey Miryanov.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
@@ -1,4 +1,4 @@
 Fix warning message about remaining :mod:`subinterpreters
 <concurrent.interpreters>` while finalizing :mod:`"main" interpreter
-<concurrent.interpreters>` and suggest using of :meth:`Interpreter.close`.
+<concurrent.interpreters>` and suggest using of ``Interpreter.close``.
 Patch by Sergey Miryanov.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
@@ -1,0 +1,4 @@
+Fix warning message about remaining :mod:`subinterpreters
+<concurrent.interpreters>` while finalizing :mod:`"main" interpreter
+<concurrent.interpreters>` and suggest using of :method:`Interpreter.close`.
+Patch by Sergey Miryanov.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
@@ -1,2 +1,3 @@
-Suggest using :meth:`concurrent.interpreters.Interpreter.close` instead of the private `_interpreters.close` function when warning about remaining subinterpreters.
+Suggest using :meth:`concurrent.interpreters.Interpreter.close` instead of the
+private `_interpreters.destroy` function when warning about remaining subinterpreters.
 Patch by Sergey Miryanov.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2643,7 +2643,7 @@ finalize_subinterpreters(void)
     (void)PyErr_WarnEx(
             PyExc_RuntimeWarning,
             "remaining subinterpreters; "
-            "destroy them with _interpreters.destroy()",
+            "close them with Interpreter.close()",
             0);
 
     /* Swap out the current tstate, which we know must belong


### PR DESCRIPTION
Fix warning - suggest using `Interpreter.close` instead of `_interpeters.destroy`.

@ZeroIntensity Could you please take a look?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141509 -->
* Issue: gh-141509
<!-- /gh-issue-number -->
