### PR TITLE
gh-60107: Remove a copy from RawIOBase.read

### DIFF
--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -2066,6 +2066,7 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(symmetric_difference_update));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(tabsize));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(tag));
+    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(take_bytes));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(target));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(target_is_directory));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(task));

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -789,6 +789,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(symmetric_difference_update)
         STRUCT_FOR_ID(tabsize)
         STRUCT_FOR_ID(tag)
+        STRUCT_FOR_ID(take_bytes)
         STRUCT_FOR_ID(target)
         STRUCT_FOR_ID(target_is_directory)
         STRUCT_FOR_ID(task)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -2064,6 +2064,7 @@ extern "C" {
     INIT_ID(symmetric_difference_update), \
     INIT_ID(tabsize), \
     INIT_ID(tag), \
+    INIT_ID(take_bytes), \
     INIT_ID(target), \
     INIT_ID(target_is_directory), \
     INIT_ID(task), \

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -2944,6 +2944,10 @@ _PyUnicode_InitStaticStrings(PyInterpreterState *interp) {
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));
     assert(PyUnicode_GET_LENGTH(string) != 1);
+    string = &_Py_ID(take_bytes);
+    _PyUnicode_InternStatic(interp, &string);
+    assert(_PyUnicode_CheckConsistency(string, 1));
+    assert(PyUnicode_GET_LENGTH(string) != 1);
     string = &_Py_ID(target);
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));

--- a/Lib/test/test_io/test_general.py
+++ b/Lib/test/test_io/test_general.py
@@ -724,6 +724,26 @@ class IOTest:
         rawio = self.MockRawIOWithoutRead((b"abc", b"d", b"efg"))
         self.assertEqual(rawio.readall(), b"abcdefg")
 
+        # gh-60107: Ensure a "Raw I/O" which keeps a reference to the
+        # mutable memory doesn't allow making a mutable bytes.
+        class RawIOKeepsReference(self.MockRawIOWithoutRead):
+            def __init__(self, *args, **kwargs):
+                self.buf = None
+                super().__init__(*args, **kwargs)
+
+            def readinto(self, buf):
+                # buf is the bytearray so keeping a reference to it doesn't keep
+                # the memory alive; a memoryview does.
+                self.buf = memoryview(buf)
+                buf[0:4] = self._read_stack.pop()
+                return 3
+
+        with self.assertRaises(BufferError):
+            rawio = RawIOKeepsReference([b"1234"])
+            rawio.read(4)
+
+
+
     def test_BufferedIOBase_readinto(self):
         # Exercise the default BufferedIOBase.readinto() and readinto1()
         # implementations (which call read() or read1() internally).

--- a/Lib/test/test_io/test_general.py
+++ b/Lib/test/test_io/test_general.py
@@ -609,6 +609,25 @@ class IOTest:
             with self.assertRaises(ValueError):
                 Misbehaved(bad_size).read()
 
+    def test_RawIOBase_read_gh60107(self):
+        # gh-60107: Ensure a "Raw I/O" which keeps a reference to the
+        # mutable memory doesn't allow making a mutable bytes.
+        class RawIOKeepsReference(self.MockRawIOWithoutRead):
+            def __init__(self, *args, **kwargs):
+                self.buf = None
+                super().__init__(*args, **kwargs)
+
+            def readinto(self, buf):
+                # buf is the bytearray so keeping a reference to it doesn't keep
+                # the memory alive; a memoryview does.
+                self.buf = memoryview(buf)
+                buf[0:4] = self._read_stack.pop()
+                return 3
+
+        with self.assertRaises(BufferError):
+            rawio = RawIOKeepsReference([b"1234"])
+            rawio.read(4)
+
     def test_types_have_dict(self):
         test = (
             self.IOBase(),
@@ -723,26 +742,6 @@ class IOTest:
         self.assertEqual(rawio.read(), b"abcdefg")
         rawio = self.MockRawIOWithoutRead((b"abc", b"d", b"efg"))
         self.assertEqual(rawio.readall(), b"abcdefg")
-
-        # gh-60107: Ensure a "Raw I/O" which keeps a reference to the
-        # mutable memory doesn't allow making a mutable bytes.
-        class RawIOKeepsReference(self.MockRawIOWithoutRead):
-            def __init__(self, *args, **kwargs):
-                self.buf = None
-                super().__init__(*args, **kwargs)
-
-            def readinto(self, buf):
-                # buf is the bytearray so keeping a reference to it doesn't keep
-                # the memory alive; a memoryview does.
-                self.buf = memoryview(buf)
-                buf[0:4] = self._read_stack.pop()
-                return 3
-
-        with self.assertRaises(BufferError):
-            rawio = RawIOKeepsReference([b"1234"])
-            rawio.read(4)
-
-
 
     def test_BufferedIOBase_readinto(self):
         # Exercise the default BufferedIOBase.readinto() and readinto1()

--- a/Misc/NEWS.d/next/Library/2025-11-13-13-11-02.gh-issue-60107.LZq3QF.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-13-13-11-02.gh-issue-60107.LZq3QF.rst
@@ -1,0 +1,2 @@
+Remove a copy from :meth:`io.RawIOBase.read`. If the underlying I/O class
+keeps a reference to the mutable memory raise a :exc:`BufferError`.

--- a/Misc/NEWS.d/next/Library/2025-11-13-13-11-02.gh-issue-60107.LZq3QF.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-13-13-11-02.gh-issue-60107.LZq3QF.rst
@@ -1,2 +1,2 @@
 Remove a copy from :meth:`io.RawIOBase.read`. If the underlying I/O class
-keeps a reference to the mutable memory raise a :exc:`BufferError`.
+keeps a reference to the mutable memory, raise a :exc:`BufferError`.

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -953,7 +953,18 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
         return NULL;
     }
 
-    res = PyBytes_FromStringAndSize(PyByteArray_AsString(b), bytes_filled);
+    res = PyObject_CallMethod(b, "resize", "i", bytes_filled);
+    if (res != Py_None) {
+        Py_DECREF(b);
+        if (res != NULL) {
+            PyErr_Format(PyExc_ValueError,
+                         "resize returned unexpected value %R",
+                        res);
+            Py_DECREF(res);
+        }
+        return res;
+    }
+    res = PyObject_CallMethod(b, "take_bytes", NULL);
     Py_DECREF(b);
     return res;
 }

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -951,7 +951,7 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
     if (PyByteArray_Resize(b, bytes_filled) < 0) {
         goto cleanup;
     }
-    res = _PyObject_CallMethod(b, &_Py_ID(takes_bytes), NULL);
+    res = PyObject_CallMethodNoArgs(b, &_Py_ID(take_bytes));
 
 cleanup:
     Py_DECREF(b);

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -961,6 +961,7 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
                          "resize returned unexpected value %R",
                         res);
             Py_DECREF(res);
+            res = NULL;
         }
         return res;
     }

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -957,7 +957,7 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
         if (res != NULL) {
             PyErr_Format(PyExc_ValueError,
                          "resize returned unexpected value %R",
-                        res);
+                         res);
             Py_DECREF(res);
             res = NULL;
         }

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -949,7 +949,7 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
         goto cleanup;
     }
 
-    res = PyObject_CallMethod(b, "resize", "i", bytes_filled);
+    res = PyObject_CallMethod(b, "resize", "n", bytes_filled);
     if (res != Py_None) {
         if (res != NULL) {
             PyErr_Format(PyExc_ValueError,

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -928,41 +928,40 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
     }
 
     b = PyByteArray_FromStringAndSize(NULL, n);
-    if (b == NULL)
+    if (b == NULL) {
         return NULL;
+    }
 
     res = PyObject_CallMethodObjArgs(self, &_Py_ID(readinto), b, NULL);
     if (res == NULL || res == Py_None) {
-        Py_DECREF(b);
-        return res;
+        goto cleanup;
     }
 
     Py_ssize_t bytes_filled = PyNumber_AsSsize_t(res, PyExc_ValueError);
-    Py_DECREF(res);
+    Py_CLEAR(res);
     if (bytes_filled == -1 && PyErr_Occurred()) {
-        Py_DECREF(b);
-        return NULL;
+        goto cleanup;
     }
     if (bytes_filled < 0 || bytes_filled > n) {
-        Py_DECREF(b);
         PyErr_Format(PyExc_ValueError,
                      "readinto returned %zd outside buffer size %zd",
                      bytes_filled, n);
-        return NULL;
+        goto cleanup;
     }
 
     res = PyObject_CallMethod(b, "resize", "i", bytes_filled);
     if (res != Py_None) {
-        Py_DECREF(b);
         if (res != NULL) {
             PyErr_Format(PyExc_ValueError,
                          "resize returned unexpected value %R",
                          res);
             Py_CLEAR(res);
         }
-        return res;
+        goto cleanup;
     }
     res = PyObject_CallMethod(b, "take_bytes", NULL);
+
+cleanup:
     Py_DECREF(b);
     return res;
 }

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -951,7 +951,7 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
     if (PyByteArray_Resize(b, bytes_filled) < 0) {
         goto cleanup;
     }
-    res = PyObject_CallMethod(b, "take_bytes", NULL);
+    res = _PyObject_CallMethod(b, &_Py_ID(takes_bytes), NULL);
 
 cleanup:
     Py_DECREF(b);

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -927,8 +927,6 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
         return PyObject_CallMethodNoArgs(self, &_Py_ID(readall));
     }
 
-    /* TODO: allocate a bytes object directly instead and manually construct
-       a writable memoryview pointing to it. */
     b = PyByteArray_FromStringAndSize(NULL, n);
     if (b == NULL)
         return NULL;

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -958,8 +958,7 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
             PyErr_Format(PyExc_ValueError,
                          "resize returned unexpected value %R",
                          res);
-            Py_DECREF(res);
-            res = NULL;
+            Py_CLEAR(res);
         }
         return res;
     }

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -948,15 +948,7 @@ _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n)
                      bytes_filled, n);
         goto cleanup;
     }
-
-    res = PyObject_CallMethod(b, "resize", "n", bytes_filled);
-    if (res != Py_None) {
-        if (res != NULL) {
-            PyErr_Format(PyExc_ValueError,
-                         "resize returned unexpected value %R",
-                         res);
-            Py_CLEAR(res);
-        }
+    if (PyByteArray_Resize(b, bytes_filled) < 0) {
         goto cleanup;
     }
     res = PyObject_CallMethod(b, "take_bytes", NULL);


### PR DESCRIPTION
If the underlying I/O class keeps a reference to the memory raise `BufferError`.

Uses gh-139871 to implement. 

-- 
If want to maintain closer compatibility when a `BufferError` occurs can fall back to a copy (copying is as safe as the original code). I have a slight preference to erroring as I think keeping a reference to the memory is uncommon (and probably unintended).

<!-- gh-issue-number: gh-60107 -->
* Issue: gh-60107
<!-- /gh-issue-number -->
