### PR TITLE
gh-129005: Remove copies from _pyio using take_bytes

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -546,7 +546,7 @@ class IOBase(metaclass=abc.ABCMeta):
             res += b
             if res.endswith(b"\n"):
                 break
-        return bytes(res)
+        return res.take_bytes()
 
     def __iter__(self):
         self._checkClosed()
@@ -620,7 +620,7 @@ class RawIOBase(IOBase):
         if n < 0 or n > len(b):
             raise ValueError(f"readinto returned {n} outside buffer size {len(b)}")
         del b[n:]
-        return bytes(b)
+        return b.take_bytes()
 
     def readall(self):
         """Read until EOF, using multiple read() call."""
@@ -628,7 +628,7 @@ class RawIOBase(IOBase):
         while data := self.read(DEFAULT_BUFFER_SIZE):
             res += data
         if res:
-            return bytes(res)
+            return res.take_bytes()
         else:
             # b'' or None
             return data
@@ -1738,7 +1738,7 @@ class FileIO(RawIOBase):
         assert len(result) - bytes_read >= 1, \
             "os.readinto buffer size 0 will result in erroneous EOF / returns 0"
         result.resize(bytes_read)
-        return bytes(result)
+        return result.take_bytes()
 
     def readinto(self, buffer):
         """Same as RawIOBase.readinto()."""

--- a/Lib/test/test_io/test_bufferedio.py
+++ b/Lib/test/test_io/test_bufferedio.py
@@ -1277,7 +1277,8 @@ class BufferedRandomTest(BufferedReaderTest, BufferedWriterTest):
         def _readinto(bufio, n=-1):
             b = bytearray(n if n >= 0 else 9999)
             n = bufio.readinto(b)
-            return bytes(b[:n])
+            b.resize(n)
+            return b.take_bytes()
         self.check_flush_and_read(_readinto)
 
     def test_flush_and_peek(self):

--- a/Lib/test/test_io/test_largefile.py
+++ b/Lib/test/test_io/test_largefile.py
@@ -56,9 +56,7 @@ class TestFileMethods(LargeFileTest):
     (i.e. > 2 GiB) files.
     """
 
-    # _pyio.FileIO.readall() uses a temporary bytearray then casted to bytes,
-    # so memuse=2 is needed
-    @bigmemtest(size=size, memuse=2, dry_run=False)
+    @bigmemtest(size=size, memuse=1, dry_run=False)
     def test_large_read(self, _size):
         # bpo-24658: Test that a read greater than 2GB does not fail.
         with self.open(TESTFN, "rb") as f:
@@ -154,7 +152,7 @@ class TestFileMethods(LargeFileTest):
                 f.seek(pos)
                 self.assertTrue(f.seekable())
 
-    @bigmemtest(size=size, memuse=2, dry_run=False)
+    @bigmemtest(size=size, memuse=1, dry_run=False)
     def test_seek_readall(self, _size):
         # Seek which doesn't change position should readall successfully.
         with self.open(TESTFN, 'rb') as f:


### PR DESCRIPTION
Memory usage now matches that of _io for large files.

```
$ ./python -Wd -I -m test test_io.test_largefile -uall,largefile,walltime -M32G -v
== CPython 3.15.0a1+ (heads/gh129005_take_bytes-dirty:d8b88498ebf, Nov 13 2025, 15:43:51) [Clang 21.1.5 ]
== Linux-6.17.7-arch1-1-x86_64-with-glibc2.42 little-endian
== Python build: debug
== cwd: <build_dir>/build/test_python_worker_116910æ
== CPU count: 32
== encodings: locale=UTF-8 FS=utf-8
== resources: all

Using random seed: 365280675
0:00:00 load avg: 9.60 Run 1 test sequentially in a single process
0:00:00 load avg: 9.60 [1/1] test_io.test_largefile
test_large_read (test.test_io.test_largefile.CLargeFileTest.test_large_read) ... 
 ... expected peak memory use: 2.3G
 ... process data size: 2.3G
ok
test_lseek (test.test_io.test_largefile.CLargeFileTest.test_lseek) ... ok
test_osstat (test.test_io.test_largefile.CLargeFileTest.test_osstat) ... ok
test_seek_read (test.test_io.test_largefile.CLargeFileTest.test_seek_read) ... ok
test_seek_readall (test.test_io.test_largefile.CLargeFileTest.test_seek_readall) ... 
 ... expected peak memory use: 2.3G
 ... process data size: 2.3G
 ... process data size: 2.3G
ok
test_seekable (test.test_io.test_largefile.CLargeFileTest.test_seekable) ... ok
test_truncate (test.test_io.test_largefile.CLargeFileTest.test_truncate) ... ok
test_large_read (test.test_io.test_largefile.PyLargeFileTest.test_large_read) ... 
 ... expected peak memory use: 2.3G
 ... process data size: 2.3G
ok
test_lseek (test.test_io.test_largefile.PyLargeFileTest.test_lseek) ... ok
test_osstat (test.test_io.test_largefile.PyLargeFileTest.test_osstat) ... ok
test_seek_read (test.test_io.test_largefile.PyLargeFileTest.test_seek_read) ... ok
test_seek_readall (test.test_io.test_largefile.PyLargeFileTest.test_seek_readall) ... 
 ... expected peak memory use: 2.3G
 ... process data size: 2.3G
 ... process data size: 2.3G
ok
test_seekable (test.test_io.test_largefile.PyLargeFileTest.test_seekable) ... ok
test_truncate (test.test_io.test_largefile.PyLargeFileTest.test_truncate) ... ok
test_it (test.test_io.test_largefile.TestCopyfile.test_it) ... ok
test_it (test.test_io.test_largefile.TestSocketSendfile.test_it) ... ok

----------------------------------------------------------------------
Ran 16 tests in 6.950s

OK
0:00:06 load avg: 9.72 [1/1] test_io.test_largefile passed

== Tests result: SUCCESS ==

1 test OK.

Total duration: 7.0 sec
Total tests: run=16
Total test files: run=1/1
Result: SUCCESS
```

For reference; this test goes from 8.5sec overall duration on my AMD 64 bit Arch Linux box to 7 seconds.

<!-- gh-issue-number: gh-129005 -->
* Issue: gh-129005
<!-- /gh-issue-number -->
