### PR TITLE
gh-141540: use %r instead of %s in error messages

### DIFF
--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -522,8 +522,7 @@ def _strptime(data_string, format="%a %b %d %H:%M:%S %Y"):
 
     for index, arg in enumerate([data_string, format]):
         if not isinstance(arg, str):
-            msg = "strptime() argument {} must be str, not {}"
-            raise TypeError(msg.format(index, type(arg)))
+            raise TypeError(f"strptime() argument {index} must be str, not {type(arg)}")
 
     global _TimeRE_cache, _regex_cache
     with _cache_lock:
@@ -547,15 +546,14 @@ def _strptime(data_string, format="%a %b %d %H:%M:%S %Y"):
                 del err
                 bad_directive = bad_directive.replace('\\s', '')
                 if not bad_directive:
-                    raise ValueError("stray %% in format '%s'" % format) from None
+                    raise ValueError(f"stray % in format {format!r}") from None
                 bad_directive = bad_directive.replace('\\', '', 1)
-                raise ValueError("'%s' is a bad directive in format '%s'" %
-                                    (bad_directive, format)) from None
+                raise ValueError(
+                    f"{bad_directive!r} is a bad directive in format {format!r}") from None
             _regex_cache[format] = format_regex
     found = format_regex.match(data_string)
     if not found:
-        raise ValueError("time data %r does not match format %r" %
-                         (data_string, format))
+        raise ValueError(f"time data {data_string!r} does not match format {format!r}")
     if len(data_string) != found.end():
         rest = data_string[found.end():]
         # Specific check for '%:z' directive
@@ -565,9 +563,9 @@ def _strptime(data_string, format="%a %b %d %H:%M:%S %Y"):
             and rest[0] != ":"
         ):
             raise ValueError(
-                f"Missing colon in %:z before '{rest}', got '{data_string}'"
+                f"Missing colon in %:z before {rest!r}, got {data_string!r}"
             )
-        raise ValueError("unconverted data remains: %s" % rest)
+        raise ValueError(f"unconverted data remains: {rest!r}")
 
     iso_year = year = None
     month = day = 1


### PR DESCRIPTION
I fixed the original example, then looked for other examples of `'%s'` and `"%s"` in error messages that might want to be replaced with `%r`. This isn't all of them, but it was all the cases where I felt confident I understood the original code, the printed value was a `str`, and this seemed like a sensible suggestion.

I had issues running the tests locally and it's late here, so I'm going to open this PR now and review any CI failures in the morning. 😴 

<!-- gh-issue-number: gh-141540 -->
* Issue: gh-141540
<!-- /gh-issue-number -->
