### PR TITLE
gh-141004: Document missing `PyDateTime*` APIs.

### DIFF
--- a/Doc/c-api/datetime.rst
+++ b/Doc/c-api/datetime.rst
@@ -361,7 +361,7 @@ Macros for the convenience of modules implementing the DB API:
 Internal data
 -------------
 
-The following symbol are exposed by the C API but should be considered
+The following symbols are exposed by the C API but should be considered
 internal-only.
 
 .. c:macro:: PyDateTime_CAPSULE_NAME

--- a/Doc/c-api/datetime.rst
+++ b/Doc/c-api/datetime.rst
@@ -8,10 +8,42 @@ DateTime Objects
 Various date and time objects are supplied by the :mod:`datetime` module.
 Before using any of these functions, the header file :file:`datetime.h` must be
 included in your source (note that this is not included by :file:`Python.h`),
-and the macro :c:macro:`!PyDateTime_IMPORT` must be invoked, usually as part of
+and the macro :c:macro:`PyDateTime_IMPORT` must be invoked, usually as part of
 the module initialisation function.  The macro puts a pointer to a C structure
-into a static variable, :c:data:`!PyDateTimeAPI`, that is used by the following
+into a static variable, :c:data:`PyDateTimeAPI`, that is used by the following
 macros.
+
+.. c:macro:: PyDateTime_IMPORT()
+
+   Import the datetime C API. The macro does not need a semi-colon to be called.
+
+   On success, populate the :c:var:`PyDateTimeAPI` pointer.
+
+   On failure, set :c:var:`PyDateTimeAPI` to ``NULL`` and set an exception.
+   The caller must check if an error occurred via :c:func:`PyErr_Occurred`:
+
+   .. code-block::
+
+      PyDateTime_IMPORT();  // semi-colon is optional but recommended
+      if (PyErr_Occurred()) { /* cleanup */ }
+
+   .. warning::
+
+      This is not compatible with subinterpreters.
+
+.. c:type:: PyDateTime_CAPI
+
+   Structure containing the fields for the datetime C API.
+
+   The fields of this structure are private and subject to change.
+
+   Do not use this directly; prefer ``PyDateTime_*`` APIs instead.
+
+.. c:var:: PyDateTime_CAPI *PyDateTimeAPI
+
+   Dynamically allocated object containing the datetime C API.
+
+   This variable is only available once :c:macro:`PyDateTime_IMPORT` succeeds.
 
 .. c:type:: PyDateTime_Date
 
@@ -325,3 +357,15 @@ Macros for the convenience of modules implementing the DB API:
 
    Create and return a new :class:`datetime.date` object given an argument
    tuple suitable for passing to :meth:`datetime.date.fromtimestamp`.
+
+Internal data
+-------------
+
+The following symbol are exposed by the C API but should be considered
+internal-only.
+
+.. c:macro:: PyDateTime_CAPSULE_NAME
+
+   Name of the datetime capsule to pass to :c:func:`PyCapsule_Import`.
+
+   Internal usage only. Use :c:macro:`PyDateTime_IMPORT` instead.

--- a/Doc/c-api/datetime.rst
+++ b/Doc/c-api/datetime.rst
@@ -358,6 +358,7 @@ Macros for the convenience of modules implementing the DB API:
    Create and return a new :class:`datetime.date` object given an argument
    tuple suitable for passing to :meth:`datetime.date.fromtimestamp`.
 
+
 Internal data
 -------------
 

--- a/Doc/c-api/datetime.rst
+++ b/Doc/c-api/datetime.rst
@@ -24,7 +24,7 @@ macros.
 
    .. code-block::
 
-      PyDateTime_IMPORT();  // semi-colon is optional but recommended
+      PyDateTime_IMPORT;  // semi-colon is optional but recommended
       if (PyErr_Occurred()) { /* cleanup */ }
 
    .. warning::

--- a/Doc/c-api/datetime.rst
+++ b/Doc/c-api/datetime.rst
@@ -15,7 +15,7 @@ macros.
 
 .. c:macro:: PyDateTime_IMPORT()
 
-   Import the datetime C API. The macro does not need a semi-colon to be called.
+   Import the datetime C API.
 
    On success, populate the :c:var:`PyDateTimeAPI` pointer.
 
@@ -24,7 +24,7 @@ macros.
 
    .. code-block::
 
-      PyDateTime_IMPORT;  // semi-colon is optional but recommended
+      PyDateTime_IMPORT;
       if (PyErr_Occurred()) { /* cleanup */ }
 
    .. warning::

--- a/Doc/c-api/datetime.rst
+++ b/Doc/c-api/datetime.rst
@@ -18,7 +18,6 @@ macros.
    Import the datetime C API.
 
    On success, populate the :c:var:`PyDateTimeAPI` pointer.
-
    On failure, set :c:var:`PyDateTimeAPI` to ``NULL`` and set an exception.
    The caller must check if an error occurred via :c:func:`PyErr_Occurred`:
 


### PR DESCRIPTION
I was mostly inspired by Bénédikt's work on the `curses` C API (#141254) for this.

In the future, I think we should completely deprecate `PyDateTimeAPI` and `PyDateTime_IMPORT` because of subinterpreter incompatibility, as well as documenting all the fields on `PyDateTime_CAPI` to make this usable under subinterpreters, but that's a later project.

<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141543.org.readthedocs.build/en/141543/c-api/datetime.html

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-83785 -->
* Issue: gh-83785
<!-- /gh-issue-number -->
