### PR TITLE
gh-131229: Temporarily skip `test_basic_multiple_interpreters_deleted_no_reset`

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -3261,6 +3261,7 @@ class SinglephaseInitTests(unittest.TestCase):
         #  * m_copy was copied from interp2 (was from interp1)
         #  * module's global state was updated, not reset
 
+    @unittest.skipIf(True, "gh-131229: This is suddenly very flaky")
     @no_rerun(reason="rerun not possible; module state is never cleared (see gh-102251)")
     @requires_subinterpreters
     def test_basic_multiple_interpreters_deleted_no_reset(self):

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -3261,7 +3261,7 @@ class SinglephaseInitTests(unittest.TestCase):
         #  * m_copy was copied from interp2 (was from interp1)
         #  * module's global state was updated, not reset
 
-    @unittest.skipIf(True, "gh-131229: This is suddenly very flaky")
+    @unittest.skip("gh-131229: This is suddenly very flaky")
     @no_rerun(reason="rerun not possible; module state is never cleared (see gh-102251)")
     @requires_subinterpreters
     def test_basic_multiple_interpreters_deleted_no_reset(self):


### PR DESCRIPTION
This is a temporary band-aid to unblock CI on other PRs. We should investigate why this broke all of a sudden and if it's an actual bug. But, in the meantime, let's disable this test; several PRs are unable to merge because of it.

<!-- gh-issue-number: gh-131229 -->
* Issue: gh-131229
<!-- /gh-issue-number -->
