### PR TITLE
[3.14] GH-141509: Fix warning about remaining subinterpreters (GH-141528)

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -431,6 +431,7 @@ class InterpreterObjectTests(TestBase):
         exit()"""
         stdout, stderr = repl.communicate(script)
         self.assertIsNone(stderr)
+        self.assertIn(b"Interpreter.close()", stdout)
         self.assertNotIn(b"Traceback", stdout)
 
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-14-00-19-45.gh-issue-141528.VWdax1.rst
@@ -1,0 +1,3 @@
+Suggest using :meth:`concurrent.interpreters.Interpreter.close` instead of the
+private ``_interpreters.destroy`` function when warning about remaining subinterpreters.
+Patch by Sergey Miryanov.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2517,7 +2517,7 @@ finalize_subinterpreters(void)
     (void)PyErr_WarnEx(
             PyExc_RuntimeWarning,
             "remaining subinterpreters; "
-            "destroy them with _interpreters.destroy()",
+            "close them with Interpreter.close()",
             0);
 
     /* Swap out the current tstate, which we know must belong


### PR DESCRIPTION
Fix warning - suggest using `Interpreter.close` instead of `_interpeters.destroy`.

(cherry picked from commit fa245df4a0848c15cf8d907c10fc92819994b866)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141509 -->
* Issue: gh-141509
<!-- /gh-issue-number -->
