### PR TITLE
[3.13] GH-141312: Allow only integers to longrangeiter_setstate state (GH-141317)

### DIFF
--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -470,6 +470,16 @@ class RangeTest(unittest.TestCase):
         it.__setstate__(2**64 - 7)
         self.assertEqual(list(it), [12, 10])
 
+    def test_iterator_invalid_setstate(self):
+        for invalid_value in (1.0, ""):
+            ranges = (('rangeiter', range(10, 100, 2)),
+                      ('longrangeiter', range(10, 2**65, 2)))
+            for rng_name, rng in ranges:
+                with self.subTest(invalid_value=invalid_value, range=rng_name):
+                    it = iter(rng)
+                    with self.assertRaises(TypeError):
+                        it.__setstate__(invalid_value)
+
     def test_odd_bug(self):
         # This used to raise a "SystemError: NULL result without error"
         # because the range validation step was eating the exception

--- a/Misc/NEWS.d/next/Core and Builtins/2025-11-10-23-07-06.gh-issue-141312.H-58GB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-11-10-23-07-06.gh-issue-141312.H-58GB.rst
@@ -1,0 +1,2 @@
+Fix the assertion failure in the ``__setstate__`` method of the range iterator
+when a non-integer argument is passed. Patch by Sergey Miryanov.

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -1014,6 +1014,11 @@ longrangeiter_reduce(longrangeiterobject *r, PyObject *Py_UNUSED(ignored))
 static PyObject *
 longrangeiter_setstate(longrangeiterobject *r, PyObject *state)
 {
+    if (!PyLong_CheckExact(state)) {
+        PyErr_Format(PyExc_TypeError, "state must be an int, not %T", state);
+        return NULL;
+    }
+
     PyObject *zero = _PyLong_GetZero();  // borrowed reference
     int cmp;
 


### PR DESCRIPTION
This fixes an assertion error when the new computed start is not an integer. (cherry picked from commit 10bec7c1eb3ee27f490a067426eef452b15f78f9)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141312 -->
* Issue: gh-141312
<!-- /gh-issue-number -->
