### PR TITLE
gh-139109: JIT _EXIT_TRACE to ENTER_EXECUTOR rather than _DEOPT

### DIFF
--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -362,7 +362,7 @@ PyAPI_FUNC(int) _PyDumpExecutors(FILE *out);
 extern void _Py_ClearExecutorDeletionList(PyInterpreterState *interp);
 #endif
 
-int _PyJit_translate_single_bytecode_to_trace(PyThreadState *tstate, _PyInterpreterFrame *frame, _Py_CODEUNIT *next_instr, bool stop_tracing);
+int _PyJit_translate_single_bytecode_to_trace(PyThreadState *tstate, _PyInterpreterFrame *frame, _Py_CODEUNIT *next_instr, int stop_tracing_opcode);
 
 int
 _PyJit_TryInitializeTracing(PyThreadState *tstate, _PyInterpreterFrame *frame,

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -2655,7 +2655,7 @@ class TestUopsOptimization(unittest.TestCase):
         for executor in all_executors:
             opnames = list(get_opnames(executor))
             # Assert all executors first terminator ends in
-            # _JUMP_TO_TOP or _EXIT_TRACE, not _DEOPT
+            # _EXIT_TRACE or _JUMP_TO_TOP, not _DEOPT
             for idx, op in enumerate(opnames):
                 if op == "_EXIT_TRACE" or op == "_JUMP_TO_TOP":
                     break

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -2648,7 +2648,7 @@ class TestUopsOptimization(unittest.TestCase):
 
         f()
         # Inner loop warms up first.
-        # Outer loop warms up later, linking to the innter one.
+        # Outer loop warms up later, linking to the inner one.
         # Therefore, at least two executors.
         self.assertGreaterEqual(len(get_all_executors(f)), 2)
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5644,7 +5644,7 @@ dummy_func(
             bool stop_tracing = (opcode == WITH_EXCEPT_START ||
                 opcode == RERAISE || opcode == CLEANUP_THROW ||
                 opcode == PUSH_EXC_INFO || opcode == INTERPRETER_EXIT);
-            int full = !_PyJit_translate_single_bytecode_to_trace(tstate, frame, next_instr, stop_tracing);
+            int full = !_PyJit_translate_single_bytecode_to_trace(tstate, frame, next_instr, stop_tracing ? _DEOPT : 0);
             if (full) {
                 LEAVE_TRACING();
                 int err = stop_tracing_and_jit(tstate, frame);
@@ -5684,7 +5684,7 @@ dummy_func(
 #if _Py_TIER2
             assert(IS_JIT_TRACING());
             int opcode = next_instr->op.code;
-            _PyJit_translate_single_bytecode_to_trace(tstate, frame, NULL, true);
+            _PyJit_translate_single_bytecode_to_trace(tstate, frame, NULL, _EXIT_TRACE);
             LEAVE_TRACING();
             int err = stop_tracing_and_jit(tstate, frame);
             ERROR_IF(err < 0);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -12268,7 +12268,7 @@ JUMP_TO_LABEL(error);
                                  opcode == RERAISE || opcode == CLEANUP_THROW ||
                                  opcode == PUSH_EXC_INFO || opcode == INTERPRETER_EXIT);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            int full = !_PyJit_translate_single_bytecode_to_trace(tstate, frame, next_instr, stop_tracing);
+            int full = !_PyJit_translate_single_bytecode_to_trace(tstate, frame, next_instr, stop_tracing ? _DEOPT : 0);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (full) {
                 LEAVE_TRACING();
@@ -12314,7 +12314,7 @@ JUMP_TO_LABEL(error);
             assert(IS_JIT_TRACING());
             int opcode = next_instr->op.code;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            _PyJit_translate_single_bytecode_to_trace(tstate, frame, NULL, true);
+            _PyJit_translate_single_bytecode_to_trace(tstate, frame, NULL, _EXIT_TRACE);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             LEAVE_TRACING();
             _PyFrame_SetStackPointer(frame, stack_pointer);

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -574,7 +574,7 @@ _PyJit_translate_single_bytecode_to_trace(
     PyThreadState *tstate,
     _PyInterpreterFrame *frame,
     _Py_CODEUNIT *next_instr,
-    bool stop_tracing)
+    int stop_tracing_opocde)
 {
 
 #ifdef Py_DEBUG
@@ -637,8 +637,8 @@ _PyJit_translate_single_bytecode_to_trace(
         goto full;
     }
 
-    if (stop_tracing) {
-        ADD_TO_TRACE(_DEOPT, 0, 0, target);
+    if (stop_tracing_opocde != 0) {
+        ADD_TO_TRACE(stop_tracing_opocde, 0, 0, target);
         goto done;
     }
 

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -574,7 +574,7 @@ _PyJit_translate_single_bytecode_to_trace(
     PyThreadState *tstate,
     _PyInterpreterFrame *frame,
     _Py_CODEUNIT *next_instr,
-    int stop_tracing_opocde)
+    int stop_tracing_opcode)
 {
 
 #ifdef Py_DEBUG
@@ -637,8 +637,8 @@ _PyJit_translate_single_bytecode_to_trace(
         goto full;
     }
 
-    if (stop_tracing_opocde != 0) {
-        ADD_TO_TRACE(stop_tracing_opocde, 0, 0, target);
+    if (stop_tracing_opcode != 0) {
+        ADD_TO_TRACE(stop_tracing_opcode, 0, 0, target);
         goto done;
     }
 


### PR DESCRIPTION
This was responsible for the pretty big perf regression in the final benchmarks over the old JIT. It got missed in the flurry of commits and reviews at the end.

<!-- gh-issue-number: gh-139109 -->
* Issue: gh-139109
<!-- /gh-issue-number -->
