### PR TITLE
gh-141579: Fix perf_jit backend in sys.activate_stack_trampoline()

### DIFF
--- a/Lib/test/test_perf_profiler.py
+++ b/Lib/test/test_perf_profiler.py
@@ -238,6 +238,24 @@ class TestPerfTrampoline(unittest.TestCase):
                 """
         assert_python_ok("-c", code, PYTHON_JIT="0")
 
+    def test_sys_api_perf_jit_backend(self):
+        code = """if 1:
+                import sys
+                sys.activate_stack_trampoline("perf_jit")
+                assert sys.is_stack_trampoline_active() is True
+                sys.deactivate_stack_trampoline()
+                assert sys.is_stack_trampoline_active() is False
+                """
+        assert_python_ok("-c", code, PYTHON_JIT="0")
+
+    def test_sys_api_with_existing_perf_jit_trampoline(self):
+        code = """if 1:
+                import sys
+                sys.activate_stack_trampoline("perf_jit")
+                sys.activate_stack_trampoline("perf_jit")
+                """
+        assert_python_ok("-c", code, PYTHON_JIT="0")
+
 
 def is_unwinding_reliable_with_frame_pointers():
     cflags = sysconfig.get_config_var("PY_CORE_CFLAGS")

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-15-01-21-00.gh-issue-141579.aB7cD9.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-15-01-21-00.gh-issue-141579.aB7cD9.rst
@@ -1,0 +1,2 @@
+Fix :func:`sys.activate_stack_trampoline` to properly support the
+``perf_jit`` backend. Patch by Pablo Galindo.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2378,14 +2378,14 @@ sys_activate_stack_trampoline_impl(PyObject *module, const char *backend)
                 return NULL;
             }
         }
-        else if (strcmp(backend, "perf_jit") == 0) {
-            _PyPerf_Callbacks cur_cb;
-            _PyPerfTrampoline_GetCallbacks(&cur_cb);
-            if (cur_cb.write_state != _Py_perfmap_jit_callbacks.write_state) {
-                if (_PyPerfTrampoline_SetCallbacks(&_Py_perfmap_jit_callbacks) < 0 ) {
-                    PyErr_SetString(PyExc_ValueError, "can't activate perf jit trampoline");
-                    return NULL;
-                }
+    }
+    else if (strcmp(backend, "perf_jit") == 0) {
+        _PyPerf_Callbacks cur_cb;
+        _PyPerfTrampoline_GetCallbacks(&cur_cb);
+        if (cur_cb.write_state != _Py_perfmap_jit_callbacks.write_state) {
+            if (_PyPerfTrampoline_SetCallbacks(&_Py_perfmap_jit_callbacks) < 0 ) {
+                PyErr_SetString(PyExc_ValueError, "can't activate perf jit trampoline");
+                return NULL;
             }
         }
     }


### PR DESCRIPTION
The perf_jit backend was unreachable due to incorrect if-else nesting
in the backend selection logic. The else-if checking for "perf_jit"
was nested inside the if statement checking for "perf", making it
impossible to activate the perf_jit trampoline.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141579 -->
* Issue: gh-141579
<!-- /gh-issue-number -->
