### PR TITLE
argparse: avoid redundant early _set_color() call in HelpFormatter.__…

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -175,7 +175,7 @@ class HelpFormatter(object):
             width = shutil.get_terminal_size().columns
             width -= 2
 
-        self._set_color(color)
+        self._color = color
         self._prog = prog
         self._indent_increment = indent_increment
         self._max_help_position = min(max_help_position,


### PR DESCRIPTION
Fixes: python/cpython#141571

The color initialization logic in argparse currently calls `_set_color()`
twice when creating a formatter:

1. HelpFormatter.__init__() calls `_set_color(color)` immediately,
   with `color=True` by default.

2. Later, _get_formatter() calls `_set_color(self.color)` again.

This results in unnecessary repeated environment lookups and duplicate
calls to `_colorize.can_colorize()`, especially when color=False.

This patch removes the early `_set_color(color)` call inside
HelpFormatter.__init__ and replaces it with a simple attribute assignment:

    self._color = color

The actual color initialization continues to happen once in
`_get_formatter()`, maintaining all existing behavior while avoiding
redundant work.


