### PR TITLE
gh-141592: test_perf_profiler: fix race in perf map cleanup using addCleanup

### DIFF
--- a/Lib/test/test_perf_profiler.py
+++ b/Lib/test/test_perf_profiler.py
@@ -35,26 +35,16 @@ if not supports_trampoline_profiling():
 
 
 class TestPerfTrampoline(unittest.TestCase):
-    #
-    # We've removed the buggy setUp and tearDown methods.
-    # They caused race conditions by scanning /tmp for `perf-*.map` files.
-    # Instead, we now use `addCleanup()` inside each test to delete
-    # the *specific* files we know that test created.
-    #
 
     def _cleanup_perf_map(self, pid):
         """
         Helper to safely delete a specific perf map file.
-        We register this with addCleanup() to make sure it runs
-        even if the test assertions fail.
         """
         perf_map = pathlib.Path(f"/tmp/perf-{pid}.map")
         try:
             if perf_map.exists():
                 perf_map.unlink()
         except OSError:
-            # Surpress errors, e.g., file already removed or
-            # another kind of race condition.
             pass
 
     @unittest.skipIf(support.check_bolt_optimized(), "fails on BOLT instrumented binaries")
@@ -75,7 +65,6 @@ class TestPerfTrampoline(unittest.TestCase):
             script = make_script(script_dir, "perftest", code)
             env = {**os.environ, "PYTHON_JIT": "0"}
 
-            # Start the subprocess...
             process = subprocess.Popen(
                 [sys.executable, "-Xperf", script],
                 text=True,
@@ -84,8 +73,6 @@ class TestPerfTrampoline(unittest.TestCase):
                 env=env,
             )
 
-            # ...and immediately register a cleanup task for its PID.
-            # This is guaranteed to run after the test.
             self.addCleanup(self._cleanup_perf_map, process.pid)
 
             with process:
@@ -134,11 +121,9 @@ class TestPerfTrampoline(unittest.TestCase):
                 def foo():
                     pid = os.fork()
                     if pid == 0:
-                        # We're in the child process
                         print(os.getpid())
                         baz_fork()
                     else:
-                        # We're in the parent process
                         _, status = os.waitpid(-1, 0)
                         sys.exit(status)
 
@@ -160,17 +145,13 @@ class TestPerfTrampoline(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 env=env,
             ) as process:
-                # Register cleanup for the PARENT process
                 self.addCleanup(self._cleanup_perf_map, process.pid)
                 stdout, stderr = process.communicate()
 
         self.assertEqual(process.returncode, 0)
         self.assertEqual(stderr, "")
 
-        # The child process printed its PID to stdout
         child_pid = int(stdout.strip())
-
-        # Register cleanup for the CHILD process
         self.addCleanup(self._cleanup_perf_map, child_pid)
 
         perf_file = pathlib.Path(f"/tmp/perf-{process.pid}.map")
@@ -227,7 +208,6 @@ class TestPerfTrampoline(unittest.TestCase):
                     stdout=subprocess.PIPE,
                     env=env,
                 ) as process:
-                    # Register cleanup inside the loop for each process created
                     self.addCleanup(self._cleanup_perf_map, process.pid)
                     stdout, stderr = process.communicate()
 
@@ -301,12 +281,9 @@ def perf_command_works():
     except (subprocess.SubprocessError, OSError):
         return False
 
-    # perf version does not return a version number on Fedora. Use presence
-    # of "perf.data" in help as indicator that it's perf from Linux tools.
     if "perf.data" not in stdout:
         return False
 
-    # Check that we can run a simple perf run
     with temp_dir() as script_dir:
         try:
             output_file = script_dir + "/perf_output.perf"
@@ -338,10 +315,6 @@ def perf_command_works():
 
 
 def run_perf(cwd, *args, use_jit=False, **env_vars):
-    # This helper function runs perf and stores its output files *inside*
-    # the 'cwd' (which is a temp_dir()). This is good! It means
-    # those files (`perf_output.perf`, `jit_output.dump`)
-    # are automatically cleaned up when the temp_dir() context manager exits.
     env = os.environ.copy()
     if env_vars:
         env.update(env_vars)
@@ -392,7 +365,6 @@ def run_perf(cwd, *args, use_jit=False, **env_vars):
         if proc.returncode:
             print(proc.stderr, file=sys.stderr)
             raise ValueError(f"Perf failed with return code {proc.returncode}")
-        # Copy the jit_output_file to the output_file
         os.rename(jit_output_file, output_file)
 
     base_cmd = ("perf", "script")
@@ -468,15 +440,10 @@ class TestPerfProfilerMixin:
     "Unwinding is unreliable with frame pointers",
 )
 class TestPerfProfiler(unittest.TestCase, TestPerfProfilerMixin):
-    #
-    # Just like in TestPerfTrampoline, we remove the racy
-    # setUp/tearDown methods.
-    #
 
     def _cleanup_perf_map(self, pid):
         """
         Helper to safely delete a specific perf map file.
-        We need this for test_pre_fork_compile.
         """
         perf_map = pathlib.Path(f"/tmp/perf-{pid}.map")
         try:
@@ -486,8 +453,6 @@ class TestPerfProfiler(unittest.TestCase, TestPerfProfilerMixin):
             pass
 
     def run_perf(self, script_dir, script, activate_trampoline=True):
-        # The run_perf helper handles its own temp files inside script_dir
-        # so we don't need to add cleanups for it here.
         if activate_trampoline:
             return run_perf(script_dir, sys.executable, "-Xperf", script)
         return run_perf(script_dir, sys.executable, script)
@@ -540,8 +505,6 @@ class TestPerfProfiler(unittest.TestCase, TestPerfProfilerMixin):
                 stdout=subprocess.PIPE,
                 env=env,
             ) as process:
-                # This test also creates map files, so we clean them up
-                # just like in TestPerfTrampoline.
                 self.addCleanup(self._cleanup_perf_map, process.pid)
                 stdout, stderr = process.communicate()
 
@@ -566,8 +529,6 @@ class TestPerfProfiler(unittest.TestCase, TestPerfProfilerMixin):
         self.assertIn(f"py::foo_fork:{script}", child_perf_file_contents)
         self.assertIn(f"py::bar_fork:{script}", child_perf_file_contents)
 
-        # Pre-compiled perf-map entries of a forked process must be
-        # identical in both the parent and child perf-map files.
         perf_file_lines = perf_file_contents.split("\n")
         for line in perf_file_lines:
             if f"py::foo_fork:{script}" in line or f"py::bar_fork:{script}" in line:
@@ -575,12 +536,6 @@ class TestPerfProfiler(unittest.TestCase, TestPerfProfilerMixin):
 
 
 def _is_perf_version_at_least(major, minor):
-    # The output of perf --version looks like "perf version 6.7-3" but
-    # it can also be perf version "perf version 5.15.143", or even include
-    # a commit hash in the version string, like "6.12.9.g242e6068fd5c"
-    #
-    # PermissionError is raised if perf does not exist on the Windows Subsystem
-    # for Linux, see #134987
     try:
         output = subprocess.check_output(["perf", "--version"], text=True)
     except (subprocess.CalledProcessError, FileNotFoundError, PermissionError):
@@ -597,13 +552,6 @@ def _is_perf_version_at_least(major, minor):
     _is_perf_version_at_least(6, 6), "perf command may not work due to a perf bug"
 )
 class TestPerfProfilerWithDwarf(unittest.TestCase, TestPerfProfilerMixin):
-    #
-    # We've removed the racy setUp/tearDown methods from here, too.
-    # The `run_perf` function (with use_jit=True) already creates its
-    # .dump and .so files inside the `temp_dir()`, which gets
-    # cleaned up automatically. The old setUp/tearDown were
-    # trying to clean up /tmp, which was buggy and unreliable.
-    #
 
     def run_perf(self, script_dir, script, activate_trampoline=True):
         if activate_trampoline:
@@ -611,10 +559,6 @@ class TestPerfProfilerWithDwarf(unittest.TestCase, TestPerfProfilerMixin):
                 script_dir, sys.executable, "-Xperf_jit", script, use_jit=True
             )
         return run_perf(script_dir, sys.executable, script, use_jit=True)
-
-    #
-    # No setUp or tearDown needed!
-    #
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The test suite in `Lib/test/test_perf_profiler.py` previously used `setUp`/`tearDown` to scan `/tmp` for `perf-*.map` files and delete any that appeared after the test started.

This creates a **race condition** when tests run in parallel (e.g., `make -j`, CI, `pytest-xdist`): one test deletes map files belonging to another, leading to:
- Flaky test failures
- Leftover files in `/tmp`
- Unreliable CI behavior

### Fix

- **Removed** global `/tmp` scanning in `setUp`/`tearDown`
- **Added** `addCleanup(self._cleanup_perf_map, pid)` for **every subprocess PID**
- Applied consistently across:
  - `TestPerfTrampoline`
  - `TestPerfProfiler`
  - `test_pre_fork_compile`
- `run_perf()` already uses `temp_dir()` → no cleanup needed


### Testing

Verified in **GitHub Codespaces** (Linux, India/IST):

```bash
./configure --with-pydebug
make -j$(nproc)
make test TESTOPTS="-v test_perf_profiler"

All 4 tests passed
No leftover perf-*.map files in /tmp
Safe under parallel execution
```


<!-- gh-issue-number: gh-141592 -->
* Issue: gh-141592
<!-- /gh-issue-number -->
