### PR TITLE
gh-141600: fix musl detection on Void Linux

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -197,7 +197,7 @@ def libc_ver(executable=None, lib='', version='', chunksize=16384):
         | (GLIBC_([0-9.]+))
         | (libc(_\w+)?\.so(?:\.(\d[0-9.]*))?)
         | (musl-([0-9.]+))
-        | (libc.musl(?:-\w+)?.so(?:\.(\d[0-9.]*))?)
+        | ((?:libc\.|ld-)musl(?:-\w+)?.so(?:\.(\d[0-9.]*))?)
         """,
         re.ASCII | re.VERBOSE)
 
@@ -236,7 +236,7 @@ def libc_ver(executable=None, lib='', version='', chunksize=16384):
                 elif V(glibcversion) > V(ver):
                     ver = glibcversion
             elif so:
-                if lib != 'glibc':
+                if lib not in ('glibc', 'musl'):
                     lib = 'libc'
                     if soversion and (not ver or V(soversion) > V(ver)):
                         ver = soversion

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -569,6 +569,8 @@ class PlatformTest(unittest.TestCase):
                 (b'/aports/main/musl/src/musl-1.2.5.7', ('musl', '1.2.5.7')),
                 (b'libc.musl.so.1', ('musl', '1')),
                 (b'libc.musl-x86_64.so.1.2.5', ('musl', '1.2.5')),
+                (b'ld-musl.so.1', ('musl', '1')),
+                (b'ld-musl-x86_64.so.1.2.5', ('musl', '1.2.5')),
                 (b'', ('', '')),
             ):
                 with open(filename, 'wb') as fp:
@@ -589,6 +591,10 @@ class PlatformTest(unittest.TestCase):
                 (b'musl-1.4.1\0musl-2.1.1\0musl-2.0.1\0', ('musl', '2.1.1')),
                 (
                     b'libc.musl-x86_64.so.1.4.1\0libc.musl-x86_64.so.2.1.1\0libc.musl-x86_64.so.2.0.1',
+                    ('musl', '2.1.1'),
+                ),
+                (
+                    b'ld-musl-x86_64.so.1.4.1\0ld-musl-x86_64.so.2.1.1\0ld-musl-x86_64.so.2.0.1',
                     ('musl', '2.1.1'),
                 ),
                 (b'no match here, so defaults are used', ('test', '100.1.0')),

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -798,10 +798,10 @@ class TestSupport(unittest.TestCase):
             self.assertTrue(linked)
         # The value is cached, so make sure it returns the same value again.
         self.assertIs(linked, support.linked_to_musl())
-        # The unlike libc, the musl version is a triple.
+        # The musl version is either triple or just a major version number.
         if linked:
             self.assertIsInstance(linked, tuple)
-            self.assertEqual(3, len(linked))
+            self.assertIn(len(linked), (1, 3))
             for v in linked:
                 self.assertIsInstance(v, int)
 

--- a/Misc/NEWS.d/next/Library/2025-11-15-14-58-12.gh-issue-141600.XY2BXg.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-15-14-58-12.gh-issue-141600.XY2BXg.rst
@@ -1,0 +1,1 @@
+Fix musl version detection on Void Linux.


### PR DESCRIPTION
This patch amends the search patterns in the function `platform.libc_ver` to properly recognize musl on Void Linux. Unlike Alpine, Void does not provide a `libc.musl` symlink that points to the linker, so executables link to a generic (and unversioned) `libc.so`, which is just a symlink to the linker at `ld-musl-${arch}.so.${version}`. By slightly modifying the pattern to accept `ld-musl` in addition to `libc.musl`, the function will pick up the linker encoded in executable rather than the generic C library path.

This patch also prevents a match against `libc.so` from setting the returned library name to `libc` when the library name has already been set to `glibc` or `musl`. Previously, the exclusion only applied when the library name was already set to `glibc`. This change is necessary because the pattern matching will pick up Void's generic `libc.so` *after* it has picked up the `ld-linux` linker path.

Finally, a unit test that relies (via the `linked_to_musl` function) on the version returned by `libc_ver` has been amended to accept a returned version consisting only of a single major number in addition to a complete full (major, minor, patch) triplet. The patterns admit the possibility that only the major version is known, so this must be accommodated.

<!-- gh-issue-number: gh-141600 -->
* Issue: gh-141600
<!-- /gh-issue-number -->
