### PR TITLE
gh-51338: Fix `shlex` to preserve newlines after comments in POSIX mode

### DIFF
--- a/Lib/test/test_shlex.py
+++ b/Lib/test/test_shlex.py
@@ -368,6 +368,15 @@ class ShlexTest(unittest.TestCase):
         with self.assertRaises(AttributeError):
             shlex_instance.punctuation_chars = False
 
+    def testNewlineAfterComment(self):
+        """Test that newline after comment is not consumed (POSIX compliance)"""
+        # When whitespace is customized to exclude newlines, newlines should
+        # be treated as tokens, even when following a comment
+        s = shlex.shlex('a # comment \n b', posix=True)
+        s.whitespace = ' '
+        result = list(s)
+        self.assertEqual(result, ['a', '\n', 'b'])
+
     @cpython_only
     def test_lazy_imports(self):
         import_helper.ensure_lazy_imports('shlex', {'collections', 're', 'os'})

--- a/Misc/NEWS.d/next/Library/2025-11-15-22-30-13.gh-issue-51338.8XI4Hk.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-15-22-30-13.gh-issue-51338.8XI4Hk.rst
@@ -1,0 +1,1 @@
+Fix :mod:`shlex` to preserve newlines after comments in POSIX mode.


### PR DESCRIPTION
According to POSIX standard, newlines are NOT part of comments. Previously, `shlex` incorrectly consumed newlines when skipping comments, causing them to be lost even when excluded from the `whitespace` attribute.

> If the current character is a '#', it and all subsequent characters up to, but excluding, the next \<newline\> shall be discarded as a comment. The \<newline\> that ends the line is not considered part of the comment.

https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_03

<!-- gh-issue-number: gh-51338 -->
* Issue: gh-51338
<!-- /gh-issue-number -->
