### PR TITLE
gh-141571: argparse: avoid redundant early _set_color() call in HelpFormatter.__…

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -174,7 +174,7 @@ class HelpFormatter(object):
             width = shutil.get_terminal_size().columns
             width -= 2
 
-        self._set_color(color)
+        self._color = color 
         self._prog = prog
         self._indent_increment = indent_increment
         self._max_help_position = min(max_help_position,

--- a/Misc/NEWS.d/next/gh-141571.bugfix.rst
+++ b/Misc/NEWS.d/next/gh-141571.bugfix.rst
@@ -1,0 +1,1 @@
+Fix redundant early _set_color() call in argparse.HelpFormatter to avoid double color initialization.


### PR DESCRIPTION
Fixes: python/cpython#141571

argparse currently initializes color twice when constructing a
HelpFormatter:

1. HelpFormatter.__init__() calls _set_color(color) immediately,
   using the default value color=True.
2. Later, argparse._get_formatter() instantiates a new formatter and
   calls formatter._set_color(self.color) again.

The first initialization is redundant and causes duplicate environment
lookups and repeated calls to colorize.can_colorize(), especially when
color=False. The actual color configuration only needs to happen once,
and the correct location is inside _get_formatter(), where formatter
instances are created.

This patch removes the early invocation of _set_color() in
HelpFormatter.__init__ and simply stores the requested color preference:

  ```  self._color = color```

The color initialization continues to happen once in
_get_formatter():

  ```  formatter._set_color(self.color)```

This preserves the existing behavior for all consumers while avoiding
unnecessary work during HelpFormatter construction.


