### PR TITLE
gh-141571: Avoid redundant early _set_color() call in HelpFormatter

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -174,7 +174,7 @@ class HelpFormatter(object):
             width = shutil.get_terminal_size().columns
             width -= 2
 
-        self._set_color(color)
+        self._color = color 
         self._prog = prog
         self._indent_increment = indent_increment
         self._max_help_position = min(max_help_position,

--- a/Misc/NEWS.d/next/Library/2025-11-16-06-33-31.gh-issue-141571.n2n0BX.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-16-06-33-31.gh-issue-141571.n2n0BX.rst
@@ -1,0 +1,1 @@
+Avoid redundant color initialization in argparse.HelpFormatter. Patch by Chilla Kalyan.

--- a/Misc/NEWS.d/next/gh-141571.bugfix.rst
+++ b/Misc/NEWS.d/next/gh-141571.bugfix.rst
@@ -1,0 +1,1 @@
+Fix redundant early _set_color() call in argparse.HelpFormatter to avoid double color initialization.

--- a/Misc/NEWS.d/next/gh-141571.bugfix.rst
+++ b/Misc/NEWS.d/next/gh-141571.bugfix.rst
@@ -1,1 +1,0 @@
-Fix redundant early _set_color() call in argparse.HelpFormatter to avoid double color initialization.


### PR DESCRIPTION
This PR fixes a redundant color initialization in argparse.HelpFormatter.

Currently, ```HelpFormatter.__init__()``` calls ```_set_color(color)``` immediately,
and then``` _get_formatter()``` calls ```_set_color(self.color)``` again.

This results in duplicate environment checks and redundant calls to
```_colorize.can_colorize()```, especially when``` color=False.```

This patch removes the early``` _set_color(color)``` call ```in __init__ ```and instead
stores the value in ```self._color```. The actual color initialization is now
performed only once in ```_get_formatter()```, preserving existing behavior while
avoiding duplicate work.

A NEWS entry for gh-141571 has been added.
