### PR TITLE
gh-139743: avoid print twice verbose version for sqlite tests

### DIFF
--- a/Lib/test/test_sqlite3/__init__.py
+++ b/Lib/test/test_sqlite3/__init__.py
@@ -6,10 +6,14 @@ import_helper.import_module('_sqlite3')
 import os
 import sqlite3
 
+# make sure only print once
+_printed_version = False
+
 # Implement the unittest "load tests" protocol.
 def load_tests(loader, tests, pattern):
-    # Only print on the top-level call
-    if verbose and pattern is None:
+    global _printed_version
+    if verbose and not _printed_version:
         print(f"test_sqlite3: testing with SQLite version {sqlite3.sqlite_version}")
+        _printed_version = True
     pkg_dir = os.path.dirname(__file__)
     return load_package_tests(pkg_dir, loader, tests, pattern)

--- a/Lib/test/test_sqlite3/__init__.py
+++ b/Lib/test/test_sqlite3/__init__.py
@@ -7,8 +7,9 @@ import os
 import sqlite3
 
 # Implement the unittest "load tests" protocol.
-def load_tests(*args):
-    if verbose:
+def load_tests(loader, tests, pattern):
+    # Only print on the top-level call
+    if verbose and pattern is None:
         print(f"test_sqlite3: testing with SQLite version {sqlite3.sqlite_version}")
     pkg_dir = os.path.dirname(__file__)
-    return load_package_tests(pkg_dir, *args)
+    return load_package_tests(pkg_dir, loader, tests, pattern)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

follow #139743 
avoid print twice 

after this patch
```cli
➜  cpython git:(main) ./python.exe -m test test_sqlite3 -v
== CPython 3.15.0a1+ (heads/main:ed73c909f2, Nov 16 2025, 15:29:51) [Clang 17.0.0 (clang-1700.0.13.5)]
== macOS-15.3.2-arm64-arm-64bit-Mach-O little-endian
== Python build: release
== cwd: /Users/yihong/repos/cpython/build/test_python_worker_37275æ
== CPU count: 10
== encodings: locale=UTF-8 FS=utf-8
== resources: all test resources are disabled, use -u option to unskip tests

Using random seed: 643038146
0:00:00 load avg: 1.46 Run 1 test sequentially in a single process
0:00:00 load avg: 1.46 [1/1] test_sqlite3
test_sqlite3: testing with SQLite version 3.43.2
test_bad_source_closed_connection (test.test_sqlite3.test_backup.BackupTests.test_bad_source_closed_connection) ... ok
```


<!-- gh-issue-number: gh-139743 -->
* Issue: gh-139743
<!-- /gh-issue-number -->
