### PR TITLE
gh-69113: Fix doctest to report line numbers for __test__ strings

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-11-16-04-40-06.gh-issue-69113.Xy7Fmn.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-16-04-40-06.gh-issue-69113.Xy7Fmn.rst
@@ -1,0 +1,1 @@
+Fix :mod:`doctest` to correctly report line numbers for doctests in ``__test__`` dictionary when formatted as triple-quoted strings by finding unique lines in the string and matching them in the source file.


### PR DESCRIPTION
Enhanced the `_find_lineno` method in doctest to correctly identify and report line numbers for doctests defined in `__test__` dictionaries when formatted as triple-quoted strings. The implementation finds unique lines in the test string and matches them in the source file to calculate the correct starting line number.

Previously, doctest would report `"line None"` for `__test__` dictionary strings, making it difficult to debug failing tests.

Fixes #69113 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-69113 -->
* Issue: gh-69113
<!-- /gh-issue-number -->
