### PR TITLE
gh-103740: Improve support of __slots__ for variable-length classes

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2630,9 +2630,10 @@ Notes on using *__slots__*:
   descriptor directly from the base class). This renders the meaning of the
   program undefined.  In the future, a check may be added to prevent this.
 
-* :exc:`TypeError` will be raised if nonempty *__slots__* are defined for a
-  class derived from a
-  :c:member:`"variable-length" built-in type <PyTypeObject.tp_itemsize>` such as
+* :exc:`TypeError` will be raised if *__slots__* other than *__dict__* and
+  *__weakref__* are defined for a class derived from a
+  :c:member:`"variable-length" built-in type <PyTypeObject.tp_itemsize>`
+  without the :c:macro:`Py_TPFLAGS_ITEMS_AT_END` flag such as
   :class:`int`, :class:`bytes`, and :class:`tuple`.
 
 * Any non-string :term:`iterable` may be assigned to *__slots__*.
@@ -2655,6 +2656,14 @@ Notes on using *__slots__*:
   created for each
   of the iterator's values. However, the *__slots__* attribute will be an empty
   iterator.
+
+.. versionchanged:: next
+   Allowed defining the *__dict__* and *__weakref__* *__slots__* for any class.
+
+   Allowed defining any *__slots__* for a class derived from :class:`type` or
+   other :c:member:`"variable-length" built-in type <PyTypeObject.tp_itemsize>`
+   with the :c:macro:`Py_TPFLAGS_ITEMS_AT_END` flag.
+
 
 .. _class-customization:
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2632,9 +2632,10 @@ Notes on using *__slots__*:
 
 * :exc:`TypeError` will be raised if *__slots__* other than *__dict__* and
   *__weakref__* are defined for a class derived from a
-  :c:member:`"variable-length" built-in type <PyTypeObject.tp_itemsize>`
-  without the :c:macro:`Py_TPFLAGS_ITEMS_AT_END` flag such as
-  :class:`int`, :class:`bytes`, and :class:`tuple`.
+  :c:member:`"variable-length" built-in type <PyTypeObject.tp_itemsize>`,
+  unless the C type is defined with :c:macro:`Py_TPFLAGS_ITEMS_AT_END`.
+  For example, *__slots__* other than *__dict__* and *__weakref__* cannot
+  be defined on subclasses of :class:`int`, :class:`bytes`, or :class:`tuple`.
 
 * Any non-string :term:`iterable` may be assigned to *__slots__*.
 
@@ -2659,7 +2660,6 @@ Notes on using *__slots__*:
 
 .. versionchanged:: next
    Allowed defining the *__dict__* and *__weakref__* *__slots__* for any class.
-
    Allowed defining any *__slots__* for a class derived from :class:`type` or
    other :c:member:`"variable-length" built-in type <PyTypeObject.tp_itemsize>`
    with the :c:macro:`Py_TPFLAGS_ITEMS_AT_END` flag.

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -394,6 +394,13 @@ Other language changes
   syntax warnings by module name.
   (Contributed by Serhiy Storchaka in :gh:`135801`.)
 
+* Allowed defining the *__dict__* and *__weakref__* :ref:`__slots__ <_slots>`
+  for any class.
+  Allowed defining any *__slots__* for a class derived from :class:`type` or
+  other :c:member:`"variable-length" built-in type <PyTypeObject.tp_itemsize>`
+  with the :c:macro:`Py_TPFLAGS_ITEMS_AT_END` flag.
+  (Contributed by Serhiy Storchaka in :gh:`103740`.)
+
 
 New modules
 ===========

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -394,7 +394,7 @@ Other language changes
   syntax warnings by module name.
   (Contributed by Serhiy Storchaka in :gh:`135801`.)
 
-* Allowed defining the *__dict__* and *__weakref__* :ref:`__slots__ <_slots>`
+* Allowed defining the *__dict__* and *__weakref__* :ref:`__slots__ <slots>`
   for any class.
   Allowed defining any *__slots__* for a class derived from :class:`type` or
   other :c:member:`"variable-length" built-in type <PyTypeObject.tp_itemsize>`

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1320,6 +1320,32 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         with self.assertRaisesRegex(AttributeError, "'X' object has no attribute 'a'"):
             X().a
 
+    def test_slots_before_items(self):
+        class C(type):
+            __slots__ = ['a']
+        x = C('A', (int,), {})
+        self.assertNotHasAttr(x, "a")
+        x.a = 1
+        x.b = 2
+        self.assertEqual(x.a, 1)
+        self.assertEqual(x.b, 2)
+        self.assertNotIn('a', x.__dict__)
+        self.assertIn('b', x.__dict__)
+        del x.a
+        self.assertNotHasAttr(x, "a")
+
+    @unittest.skipIf(_testcapi is None, 'need the _testcapi module')
+    def test_slots_before_items2(self):
+        class D(_testcapi.HeapCCollection):
+            __slots__ = ['a']
+        x = D(1, 2, 3)
+        self.assertNotHasAttr(x, "a")
+        x.a = 42
+        self.assertEqual(x.a, 42)
+        del x.a
+        self.assertNotHasAttr(x, "a")
+        self.assertEqual(list(x), [1, 2, 3])
+
     def test_slots_special(self):
         # Testing __dict__ and __weakref__ in __slots__...
         class D(object):
@@ -1329,18 +1355,17 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         self.assertNotHasAttr(a, "__weakref__")
         a.foo = 42
         self.assertEqual(a.__dict__, {"foo": 42})
+        with self.assertRaises(TypeError):
+            weakref.ref(a)
 
         class W(object):
             __slots__ = ["__weakref__"]
         a = W()
         self.assertHasAttr(a, "__weakref__")
         self.assertNotHasAttr(a, "__dict__")
-        try:
+        with self.assertRaises(AttributeError):
             a.foo = 42
-        except AttributeError:
-            pass
-        else:
-            self.fail("shouldn't be allowed to set a.foo")
+        self.assertIs(weakref.ref(a)(), a)
 
         class C1(W, D):
             __slots__ = []
@@ -1349,6 +1374,7 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         self.assertHasAttr(a, "__weakref__")
         a.foo = 42
         self.assertEqual(a.__dict__, {"foo": 42})
+        self.assertIs(weakref.ref(a)(), a)
 
         class C2(D, W):
             __slots__ = []
@@ -1357,6 +1383,62 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         self.assertHasAttr(a, "__weakref__")
         a.foo = 42
         self.assertEqual(a.__dict__, {"foo": 42})
+        self.assertIs(weakref.ref(a)(), a)
+
+    @unittest.skipIf(_testcapi is None, 'need the _testcapi module')
+    def test_slots_special_before_items(self):
+        class D(_testcapi.HeapCCollection):
+            __slots__ = ["__dict__"]
+        a = D(1, 2, 3)
+        self.assertHasAttr(a, "__dict__")
+        self.assertNotHasAttr(a, "__weakref__")
+        a.foo = 42
+        self.assertEqual(a.__dict__, {"foo": 42})
+        with self.assertRaises(TypeError):
+            weakref.ref(a)
+        del a.__dict__
+        self.assertNotHasAttr(a, "foo")
+        self.assertEqual(a.__dict__, {})
+        self.assertEqual(list(a), [1, 2, 3])
+
+        class W(_testcapi.HeapCCollection):
+            __slots__ = ["__weakref__"]
+        a = W(1, 2, 3)
+        self.assertHasAttr(a, "__weakref__")
+        self.assertNotHasAttr(a, "__dict__")
+        with self.assertRaises(AttributeError):
+            a.foo = 42
+        self.assertIs(weakref.ref(a)(), a)
+
+    @support.subTests(('base', 'arg'), [
+        (tuple, (1, 2, 3)),
+        (int, 9876543210**2),
+        (bytes, b'ab'),
+    ])
+    def test_slots_special_after_items(self, base, arg):
+        class D(base):
+            __slots__ = ["__dict__"]
+        a = D(arg)
+        self.assertHasAttr(a, "__dict__")
+        self.assertNotHasAttr(a, "__weakref__")
+        a.foo = 42
+        self.assertEqual(a.__dict__, {"foo": 42})
+        with self.assertRaises(TypeError):
+            weakref.ref(a)
+        del a.__dict__
+        self.assertNotHasAttr(a, "foo")
+        self.assertEqual(a.__dict__, {})
+        self.assertEqual(a, base(arg))
+
+        class W(base):
+            __slots__ = ["__weakref__"]
+        a = W(arg)
+        self.assertHasAttr(a, "__weakref__")
+        self.assertNotHasAttr(a, "__dict__")
+        with self.assertRaises(AttributeError):
+            a.foo = 42
+        self.assertIs(weakref.ref(a)(), a)
+        self.assertEqual(a, base(arg))
 
     def test_slots_special2(self):
         # Testing __qualname__ and __classcell__ in __slots__

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-16-21-14-48.gh-issue-103740.rXIj5h.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-16-21-14-48.gh-issue-103740.rXIj5h.rst
@@ -1,4 +1,4 @@
-Allowed defining the *__dict__* and *__weakref__* :ref:`__slots__ <_slots>`
+Allowed defining the *__dict__* and *__weakref__* :ref:`__slots__ <slots>`
 for any class. Allowed defining any *__slots__* for a class derived from
 :class:`type` or other :c:member:`"variable-length" built-in type
 <PyTypeObject.tp_itemsize>` with the :c:macro:`Py_TPFLAGS_ITEMS_AT_END`

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-16-21-14-48.gh-issue-103740.rXIj5h.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-16-21-14-48.gh-issue-103740.rXIj5h.rst
@@ -1,0 +1,5 @@
+Allowed defining the *__dict__* and *__weakref__* :ref:`__slots__ <_slots>`
+for any class. Allowed defining any *__slots__* for a class derived from
+:class:`type` or other :c:member:`"variable-length" built-in type
+<PyTypeObject.tp_itemsize>` with the :c:macro:`Py_TPFLAGS_ITEMS_AT_END`
+flag.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4343,14 +4343,6 @@ type_new_slots_bases(type_new_ctx *ctx)
 static int
 type_new_slots_impl(type_new_ctx *ctx, PyObject *dict)
 {
-    /* Are slots allowed? */
-    if (ctx->nslot > 0 && ctx->base->tp_itemsize != 0) {
-        PyErr_Format(PyExc_TypeError,
-                     "nonempty __slots__ not supported for subtype of '%s'",
-                     ctx->base->tp_name);
-        return -1;
-    }
-
     if (type_new_visit_slots(ctx) < 0) {
         return -1;
     }
@@ -4377,14 +4369,13 @@ type_new_slots(type_new_ctx *ctx, PyObject *dict)
     ctx->add_dict = 0;
     ctx->add_weak = 0;
     ctx->may_add_dict = (ctx->base->tp_dictoffset == 0);
-    ctx->may_add_weak = (ctx->base->tp_weaklistoffset == 0
-                         && ctx->base->tp_itemsize == 0);
+    ctx->may_add_weak = (ctx->base->tp_weaklistoffset == 0);
 
     if (ctx->slots == NULL) {
         if (ctx->may_add_dict) {
             ctx->add_dict++;
         }
-        if (ctx->may_add_weak) {
+        if (ctx->may_add_weak && ctx->base->tp_itemsize == 0) {
             ctx->add_weak++;
         }
     }
@@ -4650,6 +4641,14 @@ type_new_descriptors(const type_new_ctx *ctx, PyTypeObject *type, PyObject *dict
     if (et->ht_slots != NULL) {
         PyMemberDef *mp = _PyHeapType_GET_MEMBERS(et);
         Py_ssize_t nslot = PyTuple_GET_SIZE(et->ht_slots);
+        int after_items = (ctx->base->tp_itemsize != 0 &&
+                           !(ctx->base->tp_flags & Py_TPFLAGS_ITEMS_AT_END));
+        if (after_items) {
+            PyErr_Format(PyExc_TypeError,
+                         "nonempty __slots__ not supported for subtype of '%s'",
+                         ctx->base->tp_name);
+            return -1;
+        }
         for (Py_ssize_t i = 0; i < nslot; i++, mp++) {
             mp->name = PyUnicode_AsUTF8(
                 PyTuple_GET_ITEM(et->ht_slots, i));
@@ -4889,8 +4888,14 @@ type_new_init(type_new_ctx *ctx)
     set_tp_dict(type, dict);
 
     PyHeapTypeObject *et = (PyHeapTypeObject*)type;
-    et->ht_slots = ctx->slots;
-    ctx->slots = NULL;
+    if (ctx->slots && PyTuple_GET_SIZE(ctx->slots)) {
+        et->ht_slots = ctx->slots;
+        ctx->slots = NULL;
+    }
+    else {
+        et->ht_slots = NULL;
+        Py_CLEAR(ctx->slots);
+    }
 
     return type;
 


### PR DESCRIPTION
* Allow defining the __dict__ and __weakref__ __slots__ for any class.
* Allow defining any __slots__ for a class derived from the type class or other "variable-length" built-in type with the Py_TPFLAGS_ITEMS_AT_END flag.


<!-- gh-issue-number: gh-103740 -->
* Issue: gh-103740
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141636.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->