### PR TITLE
gh-91242: [cleanup] Remove the unsupported windows CHM help doc build system

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -84,8 +84,7 @@ html: build
 .PHONY: htmlhelp
 htmlhelp: BUILDER = htmlhelp
 htmlhelp: build
-	@echo "Build finished; now you can run HTML Help Workshop with the" \
-	      "build/htmlhelp/pydoc.hhp project file."
+	@echo "Build finished. The HTML Help files are in build/htmlhelp."
 
 .PHONY: latex
 latex: BUILDER = latex

--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -66,13 +66,8 @@ Available make targets are:
   starts a local server, and automatically reloads the page in your browser
   when you make changes to reST files (Unix only).
 
-* "htmlhelp", which builds HTML files and a HTML Help project file usable to
-  convert them into a single Compiled HTML (.chm) file -- these are popular
-  under Microsoft Windows, but very handy on every platform.
-
-  To create the CHM file, you need to run the Microsoft HTML Help Workshop
-  over the generated project (.hhp) file.  The ``make.bat`` script does this for
-  you on Windows.
+* "htmlhelp", which builds HTML files in HTML Help format -- this format
+  is useful on every platform.
 
 * "latex", which builds LaTeX source files as input to ``pdflatex`` to produce
   PDF documents.

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -278,13 +278,6 @@ if os.getenv("READTHEDOCS"):
         '<a href="https://about.readthedocs.com/">Read the Docs</a>'
     )
 
-# Override stylesheet fingerprinting for Windows CHM htmlhelp to fix GH-91207
-# https://github.com/python/cpython/issues/91207
-if any('htmlhelp' in arg for arg in sys.argv):
-    html_style = 'pydoctheme.css'
-    print("\nWARNING: Windows CHM Help is no longer supported.")
-    print("It may be removed in the future\n")
-
 # Short title used e.g. for <title> HTML tags.
 html_short_title = f'{release} Documentation'
 
@@ -326,9 +319,6 @@ html_use_opensearch = 'https://docs.python.org/' + version
 
 # Additional static files.
 html_static_path = ['_static', 'tools/static']
-
-# Output file base name for HTML help builder.
-htmlhelp_basename = 'python' + release.replace('.', '')
 
 # Split the index
 html_split_index = True

--- a/Doc/make.bat
+++ b/Doc/make.bat
@@ -48,23 +48,6 @@ if not defined SPHINXLINT (
     set SPHINXLINT=%PYTHON% -m sphinxlint
 )
 
-if "%1" NEQ "htmlhelp" goto :skiphhcsearch
-if exist "%HTMLHELP%" goto :skiphhcsearch
-
-rem Search for HHC in likely places
-set HTMLHELP=
-where hhc /q && set "HTMLHELP=hhc" && goto :skiphhcsearch
-where /R ..\externals hhc > "%TEMP%\hhc.loc" 2> nul && set /P HTMLHELP= < "%TEMP%\hhc.loc" & del "%TEMP%\hhc.loc"
-if not exist "%HTMLHELP%" where /R "%ProgramFiles(x86)%" hhc > "%TEMP%\hhc.loc" 2> nul && set /P HTMLHELP= < "%TEMP%\hhc.loc" & del "%TEMP%\hhc.loc"
-if not exist "%HTMLHELP%" where /R "%ProgramFiles%" hhc > "%TEMP%\hhc.loc" 2> nul && set /P HTMLHELP= < "%TEMP%\hhc.loc" & del "%TEMP%\hhc.loc"
-if not exist "%HTMLHELP%" (
-    echo.
-    echo.The HTML Help Workshop was not found.  Set the HTMLHELP variable
-    echo.to the path to hhc.exe or download and install it from
-    echo.http://msdn.microsoft.com/en-us/library/ms669985
-    exit /B 1
-)
-:skiphhcsearch
 
 if not defined DISTVERSION for /f "usebackq" %%v in (`%PYTHON% tools/extensions/patchlevel.py`) do set DISTVERSION=%%v
 
@@ -148,12 +131,6 @@ if "%1" EQU "htmlhelp" (
     set SPHINXOPTS=--define html_theme_options.body_max_width=none %SPHINXOPTS%
 )
 cmd /S /C "%SPHINXBUILD% %SPHINXOPTS% --builder %1 --doctree-dir build\doctrees . "%BUILDDIR%\%1" %2 %3 %4 %5 %6 %7 %8 %9"
-
-if "%1" EQU "htmlhelp" (
-    "%HTMLHELP%" "%BUILDDIR%\htmlhelp\python%DISTVERSION:.=%.hhp"
-    rem hhc.exe seems to always exit with code 1, reset to 0 for less than 2
-    if not errorlevel 2 cmd /C exit /b 0
-)
 
 echo.
 if errorlevel 1 (

--- a/Lib/idlelib/config-main.def
+++ b/Lib/idlelib/config-main.def
@@ -34,9 +34,8 @@
 # relevant settings from the default file.
 #
 # Additional help sources are listed in the [HelpFiles] section below
-# and should be viewable by a web browser (or the Windows Help viewer in
-# the case of .chm files). These sources will be listed on the Help
-# menu.  The pattern, and two examples, are:
+# and should be viewable by a web browser. These sources will be listed
+# on the Help menu.  The pattern, and two examples, are:
 #
 # <sequence_number = menu item;/path/to/help/source>
 # 1 = IDLE;C:/Programs/Python36/Lib/idlelib/help.html

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -35,18 +35,6 @@ from idlelib.help import _get_dochome
 TK_TABWIDTH_DEFAULT = 8
 darwin = sys.platform == 'darwin'
 
-def _sphinx_version():
-    "Format sys.version_info to produce the Sphinx version string used to install the chm docs"
-    major, minor, micro, level, serial = sys.version_info
-    # TODO remove unneeded function since .chm no longer installed
-    release = f'{major}{minor}'
-    release += f'{micro}'
-    if level == 'candidate':
-        release += f'rc{serial}'
-    elif level != 'final':
-        release += f'{level[0]}{serial}'
-    return release
-
 
 class EditorWindow:
     from idlelib.percolator import Percolator

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -289,8 +289,6 @@ class HelpSource(Query):
     def browse_file(self):
         filetypes = [
             ("HTML Files", "*.htm *.html", "TEXT"),
-            ("PDF Files", "*.pdf", "TEXT"),
-            ("Windows Help Files", "*.chm"),
             ("Text Files", "*.txt", "TEXT"),
             ("All Files", "*")]
         path = self.pathvar.get()

--- a/PC/layout/main.py
+++ b/PC/layout/main.py
@@ -291,10 +291,6 @@ def get_layout(ns):
                 continue
             yield dest, src
 
-    if ns.include_chm:
-        for dest, src in rglob(ns.doc_build / "htmlhelp", PYTHON_CHM_NAME):
-            yield "Doc/{}".format(dest), src
-
     if ns.include_html_doc:
         for dest, src in rglob(ns.doc_build / "html", "**/*"):
             yield "Doc/html/{}".format(dest), src

--- a/PC/layout/support/appxmanifest.py
+++ b/PC/layout/support/appxmanifest.py
@@ -171,10 +171,6 @@ REGISTRY = {
                 ),
             },
             "Help": {
-                "Main Python Documentation": {
-                    "_condition": lambda ns: ns.include_chm,
-                    "": "[{{AppVPackageRoot}}]\\Doc\\{}".format(PYTHON_CHM_NAME),
-                },
                 "Local Python Documentation": {
                     "_condition": lambda ns: ns.include_html_doc,
                     "": "[{AppVPackageRoot}]\\Doc\\html\\index.html",

--- a/PC/layout/support/constants.py
+++ b/PC/layout/support/constants.py
@@ -77,9 +77,5 @@ PYTHON_STABLE_DLL_NAME = "python{}.dll".format(VER_MAJOR)
 PYTHON_ZIP_NAME = "python{}{}.zip".format(VER_MAJOR, VER_MINOR)
 PYTHON_PTH_NAME = "python{}{}._pth".format(VER_MAJOR, VER_MINOR)
 
-PYTHON_CHM_NAME = "python{}{}{}{}.chm".format(
-    VER_MAJOR, VER_MINOR, VER_MICRO, VER_SUFFIX
-)
-
 FREETHREADED_PYTHON_DLL_NAME = "python{}{}t.dll".format(VER_MAJOR, VER_MINOR)
 FREETHREADED_PYTHON_STABLE_DLL_NAME = "python{}t.dll".format(VER_MAJOR)

--- a/PC/layout/support/options.py
+++ b/PC/layout/support/options.py
@@ -30,7 +30,6 @@ OPTIONS = {
     "appxmanifest": {"help": "an appxmanifest"},
     "props": {"help": "a python.props file"},
     "nuspec": {"help": "a python.nuspec file"},
-    "chm": {"help": "the CHM documentation"},
     "html-doc": {"help": "the HTML documentation"},
     "freethreaded": {"help": "freethreaded binaries", "not-in-all": True},
     "alias": {"help": "aliased python.exe entry-point binaries"},

--- a/PC/layout/support/pymanager.py
+++ b/PC/layout/support/pymanager.py
@@ -219,15 +219,6 @@ def calculate_install_json(ns, *, for_embed=False, for_test=False):
             "Name": f"{DISPLAY_NAME} {VER_DOT} Manuals{DISPLAY_SUFFIX}",
             "Target": r"%PREFIX%Doc\html\index.html",
         })
-    elif ns.include_chm:
-        STD_PEP514[0]["Help"]["Main Python Documentation"] = {
-            "_": rf"%PREFIX%Doc\{PYTHON_CHM_NAME}",
-        }
-        STD_START[0]["Items"].append({
-            "Name": f"{DISPLAY_NAME} {VER_DOT} Manuals{DISPLAY_SUFFIX}",
-            "Target": "%WINDIR%hhc.exe",
-            "Arguments": rf"%PREFIX%Doc\{PYTHON_CHM_NAME}",
-        })
 
     STD_UNINSTALL.append({
         "kind": "uninstall",

--- a/Tools/msi/get_externals.bat
+++ b/Tools/msi/get_externals.bat
@@ -53,7 +53,6 @@ set binaries=
 rem We always use whatever's latest in the repo for these
 set binaries=%binaries%     binutils
 set binaries=%binaries%     gpg
-set binaries=%binaries%     htmlhelp
 set binaries=%binaries%     nuget
 set binaries=%binaries%     redist-1
 set binaries=%binaries%     wix-314

--- a/Tools/msi/msi.props
+++ b/Tools/msi/msi.props
@@ -59,7 +59,6 @@
         <CRTRedist Condition="'$(CRTRedist)' == ''">$(ExternalsDir)\windows-installer\redist-1\$(Platform)</CRTRedist>
         <CRTRedist>$([System.IO.Path]::GetFullPath($(CRTRedist)))</CRTRedist>
         <TclTkLibraryDir Condition="$(TclTkLibraryDir) == ''">$(tcltkDir)lib</TclTkLibraryDir>
-        <DocFilename>python$(MajorVersionNumber)$(MinorVersionNumber)$(MicroVersionNumber)$(ReleaseLevelName).chm</DocFilename>
 
         <InstallerVersion>$(MajorVersionNumber).$(MinorVersionNumber).$(Field3Value).0</InstallerVersion>
     </PropertyGroup>

--- a/Tools/msi/uploadrelease.proj
+++ b/Tools/msi/uploadrelease.proj
@@ -27,9 +27,6 @@
         <File Include="$(OutputPath)\*.exe;$(OutputPath)\*.zip">
             <CopyTo>$(EXETarget)</CopyTo>
         </File>
-        <File Include="$(PySourcePath)Doc\build\htmlhelp\python$(MajorVersionNumber)$(MinorVersionNumber)$(MicroVersionNumber)$(ReleaseLevelName).chm" Condition="$(IncludeDoc)">
-            <CopyTo>$(EXETarget)</CopyTo>
-        </File>
     </ItemGroup>
     
     <Target Name="_ValidateProperties">

--- a/Tools/msi/uploadrelease.ps1
+++ b/Tools/msi/uploadrelease.ps1
@@ -15,8 +15,6 @@
     The subdirectory on the host to copy files to.
 .Parameter tests
     The path to run download tests in.
-.Parameter doc_htmlhelp
-    Optional path besides -build to locate CHM files.
 .Parameter embed
     Optional path besides -build to locate ZIP files.
 .Parameter skipupload
@@ -34,7 +32,6 @@ param(
     [string]$server="python-downloads",
     [string]$target="/srv/www.python.org/ftp/python",
     [string]$tests=${env:TEMP},
-    [string]$doc_htmlhelp=$null,
     [string]$embed=$null,
     [switch]$skipupload,
     [switch]$skippurge,
@@ -79,20 +76,10 @@ if (-not $skipupload) {
     "Upload using $pscp and $plink"
     ""
 
-    if ($doc_htmlhelp) {
-        $chm = gci -EA 0 $doc_htmlhelp\python*.chm, $doc_htmlhelp\python*.chm.asc
-    } else {
-        $chm = gci -EA 0 $build\python*.chm, $build\python*.chm.asc
-    }
-
     $d = "$target/$($p[0])/"
     & $plink -batch $user@$server mkdir $d
     & $plink -batch $user@$server chgrp downloads $d
     & $plink -batch $user@$server chmod o+rx $d
-    if ($chm) {
-        & $pscp -batch $chm.FullName "$user@${server}:$d"
-        if (-not $?) { throw "Failed to upload $chm" }
-    }
 
     $dirs = gci "$build" -Directory
     if ($embed) {
@@ -151,11 +138,7 @@ if (-not $skiptest) {
 if (-not $skiphash) {
     # Display MD5 hash and size of each downloadable file
     pushd $build
-    $files = gci python*.chm, *\*.exe, *\*.zip
-    if ($doc_htmlhelp) {
-        cd $doc_htmlhelp
-        $files = ($files, (gci python*.chm)) | %{ $_ }
-    }
+    $files = gci *\*.exe, *\*.zip
     if ($embed) {
         cd $embed
         $files = ($files, (gci *.zip)) | %{ $_ }


### PR DESCRIPTION
This originally started by having claude look for easy TODOs to tackle and seeing `idlelib.editor._sphinx_version()` as unneeded.  which led to the rabbithole of "what windows chm build stuff is left to cleanup" and finding all of this.

I explicitly asked claude to keep the htmlhelp build target and focus only on removing the CHM support.  As I have no idea who and what may still use the claimed useful on all platforms htmlhelp itself.

But the long dead/deprecated by Microsoft CHM format stuff can still go away?  I need both Windows and Docs folks take on this.  The linked issue kickstarted its deprecation and removal from our installers in 2022, but I also don't touch windows so I'm the wrong one to ask.

🤖 Commits generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-91242 -->
* Issue: gh-91242
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141643.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->