### PR TITLE
gh-141647: attribute breaks __eq__ behaviour of IPv4Network and IPv6Network

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -567,11 +567,10 @@ class _BaseAddress(_IPAddressBase):
         return self._ip
 
     def __eq__(self, other):
-        try:
-            return (self._ip == other._ip
-                    and self.version == other.version)
-        except AttributeError:
+        if not isinstance(other, _BaseAddress):
             return NotImplemented
+        return (self._ip == other._ip
+                and self.version == other.version)
 
     def __lt__(self, other):
         if not isinstance(other, _BaseAddress):
@@ -718,12 +717,11 @@ class _BaseNetwork(_IPAddressBase):
         return False
 
     def __eq__(self, other):
-        try:
-            return (self.version == other.version and
-                    self.network_address == other.network_address and
-                    int(self.netmask) == int(other.netmask))
-        except AttributeError:
+        if not isinstance(other, _BaseNetwork):
             return NotImplemented
+        return (self.version == other.version and
+                self.network_address == other.network_address and
+                int(self.netmask) == int(other.netmask))
 
     def __hash__(self):
         return hash((int(self.network_address), int(self.netmask)))

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -719,9 +719,9 @@ class _BaseNetwork(_IPAddressBase):
     def __eq__(self, other):
         if not isinstance(other, _BaseNetwork):
             return NotImplemented
-        return (self.version == other.version and
-                self.network_address == other.network_address and
-                int(self.netmask) == int(other.netmask))
+        return (self.version == other.version
+                and self.network_address == other.network_address
+                and int(self.netmask) == int(other.netmask))
 
     def __hash__(self):
         return hash((int(self.network_address), int(self.netmask)))

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -1078,16 +1078,6 @@ class ComparisonTests(unittest.TestCase):
         self.assertRaises(TypeError, v6net_scoped.__lt__, v4net)
         self.assertRaises(TypeError, v6net_scoped.__gt__, v4net)
 
-    def test_network_eq_with_faux_object(self):
-        class AlwaysTrue:
-            version = 42
-            def __eq__(self, other):
-                return True
-
-        always_true = AlwaysTrue()
-        self.assertEqual(ipaddress.IPv4Network('43.48.0.0/12'), always_true)
-        self.assertEqual(ipaddress.IPv6Network('::eeff:ae3f:d473/128'), always_true)
-
     def test_address_eq_with_faux_object(self):
         class AlwaysTrue:
             def __init__(self, ip_value):
@@ -1112,6 +1102,16 @@ class ComparisonTests(unittest.TestCase):
         intf6 = ipaddress.IPv6Interface('::1/128')
         always_true_intf6 = AlwaysTrue(intf6._ip)
         self.assertEqual(intf6, always_true_intf6)
+
+    def test_network_eq_with_faux_object(self):
+        class AlwaysTrue:
+            version = 42
+            def __eq__(self, other):
+                return True
+
+        always_true = AlwaysTrue()
+        self.assertEqual(ipaddress.IPv4Network('43.48.0.0/12'), always_true)
+        self.assertEqual(ipaddress.IPv6Network('::eeff:ae3f:d473/128'), always_true)
 
 
 class IpaddrUnitTest(unittest.TestCase):

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -1078,17 +1078,17 @@ class ComparisonTests(unittest.TestCase):
         self.assertRaises(TypeError, v6net_scoped.__lt__, v4net)
         self.assertRaises(TypeError, v6net_scoped.__gt__, v4net)
 
-    def test_network_eq_with_version_attribute(self):
+    def test_network_eq_with_faux_object(self):
         class AlwaysTrue:
             version = 42
             def __eq__(self, other):
                 return True
 
         always_true = AlwaysTrue()
-        self.assertTrue(ipaddress.IPv4Network('43.48.0.0/12') == always_true)
-        self.assertTrue(ipaddress.IPv6Network('::eeff:ae3f:d473/128') == always_true)
+        self.assertEqual(ipaddress.IPv4Network('43.48.0.0/12'), always_true)
+        self.assertEqual(ipaddress.IPv6Network('::eeff:ae3f:d473/128'), always_true)
 
-    def test_address_eq_with_version_attribute(self):
+    def test_address_eq_with_faux_object(self):
         class AlwaysTrue:
             def __init__(self, ip_value):
                 self._ip = ip_value
@@ -1099,19 +1099,19 @@ class ComparisonTests(unittest.TestCase):
 
         addr4 = ipaddress.IPv4Address('192.168.1.1')
         always_true4 = AlwaysTrue(addr4._ip)
-        self.assertTrue(addr4 == always_true4)
+        self.assertEqual(addr4, always_true4)
 
         addr6 = ipaddress.IPv6Address('::1')
         always_true6 = AlwaysTrue(addr6._ip)
-        self.assertTrue(addr6 == always_true6)
+        self.assertEqual(addr6, always_true6)
 
         intf4 = ipaddress.IPv4Interface('192.168.1.1/24')
         always_true_intf4 = AlwaysTrue(intf4._ip)
-        self.assertTrue(intf4 == always_true_intf4)
+        self.assertEqual(intf4, always_true_intf4)
 
         intf6 = ipaddress.IPv6Interface('::1/128')
         always_true_intf6 = AlwaysTrue(intf6._ip)
-        self.assertTrue(intf6 == always_true_intf6)
+        self.assertEqual(intf6, always_true_intf6)
 
 
 class IpaddrUnitTest(unittest.TestCase):

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -1078,6 +1078,41 @@ class ComparisonTests(unittest.TestCase):
         self.assertRaises(TypeError, v6net_scoped.__lt__, v4net)
         self.assertRaises(TypeError, v6net_scoped.__gt__, v4net)
 
+    def test_network_eq_with_version_attribute(self):
+        class AlwaysTrue:
+            version = 42
+            def __eq__(self, other):
+                return True
+
+        always_true = AlwaysTrue()
+        self.assertTrue(ipaddress.IPv4Network('43.48.0.0/12') == always_true)
+        self.assertTrue(ipaddress.IPv6Network('::eeff:ae3f:d473/128') == always_true)
+
+    def test_address_eq_with_version_attribute(self):
+        class AlwaysTrue:
+            def __init__(self, ip_value):
+                self._ip = ip_value
+                self.version = 42
+
+            def __eq__(self, other):
+                return True
+
+        addr4 = ipaddress.IPv4Address('192.168.1.1')
+        always_true4 = AlwaysTrue(addr4._ip)
+        self.assertTrue(addr4 == always_true4)
+
+        addr6 = ipaddress.IPv6Address('::1')
+        always_true6 = AlwaysTrue(addr6._ip)
+        self.assertTrue(addr6 == always_true6)
+
+        intf4 = ipaddress.IPv4Interface('192.168.1.1/24')
+        always_true_intf4 = AlwaysTrue(intf4._ip)
+        self.assertTrue(intf4 == always_true_intf4)
+
+        intf6 = ipaddress.IPv6Interface('::1/128')
+        always_true_intf6 = AlwaysTrue(intf6._ip)
+        self.assertTrue(intf6 == always_true_intf6)
+
 
 class IpaddrUnitTest(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2025-11-17-17-06-56.gh-issue-131647.tyafol.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-17-17-06-56.gh-issue-131647.tyafol.rst
@@ -1,4 +1,4 @@
-Fix :meth:`~ipaddress._BaseAddress.__eq__` and
-:meth:`~ipaddress._BaseNetwork.__eq__` to return ``NotImplemented`` instead
-of ``False`` when comparing with objects that have matching attribute names
-but are not actual address or network objects.
+Fix :mod:`ipaddress` address and network objects' ``__eq__`` methods to
+return ``NotImplemented`` instead of ``False`` when comparing with objects
+that have matching attribute names but are not actual address or network
+objects.

--- a/Misc/NEWS.d/next/Library/2025-11-17-17-06-56.gh-issue-131647.tyafol.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-17-17-06-56.gh-issue-131647.tyafol.rst
@@ -1,0 +1,4 @@
+Fix :meth:`~ipaddress._BaseAddress.__eq__` and
+:meth:`~ipaddress._BaseNetwork.__eq__` to return ``NotImplemented`` instead
+of ``False`` when comparing with objects that have matching attribute names
+but are not actual address or network objects.

--- a/Misc/NEWS.d/next/Library/2025-11-17-17-06-56.gh-issue-131647.tyafol.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-17-17-06-56.gh-issue-131647.tyafol.rst
@@ -1,4 +1,4 @@
-Fix :mod:`ipaddress` address and network objects' ``__eq__`` methods to
-return ``NotImplemented`` instead of ``False`` when comparing with objects
-that have matching attribute names but are not actual address or network
-objects.
+:mod:`ipaddress`: fix equality testing for :class:`~ipaddress.IPv4Address`,
+:class:`~ipaddress.IPv6Address`, :class:`~ipaddress.IPv4Network`, and
+:class:`~ipaddress.IPv6Network` to avoid comparing instances of incorrect
+types.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


compore to other `__eq__` always use subclass check


<!-- gh-issue-number: gh-141647 -->
* Issue: gh-141647
<!-- /gh-issue-number -->
