### PR TITLE
gh-141650: Fix typo in `xml.sax.saxutils.unescape` documentation

### DIFF
--- a/Doc/library/xml.sax.utils.rst
+++ b/Doc/library/xml.sax.utils.rst
@@ -37,7 +37,7 @@ or as base classes.
 
    You can unescape other strings of data by passing a dictionary as the optional
    *entities* parameter.  The keys and values must all be strings; each key will be
-   replaced with its corresponding value.  ``'&amp'``, ``'&lt;'``, and ``'&gt;'``
+   replaced with its corresponding value.  ``'&amp;'``, ``'&lt;'``, and ``'&gt;'``
    are always unescaped, even if *entities* is provided.
 
 


### PR DESCRIPTION
`&amp` → `amp;`

Resolves 141650

<!-- gh-issue-number: gh-141650 -->
* Issue: gh-141650
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141652.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->