### PR TITLE
Replace `type` with `types` for the explanation `type hint` in glossary.rst

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1438,7 +1438,7 @@ Glossary
       See :mod:`typing` and :pep:`484`, which describe this functionality.
 
    type hint
-      An :term:`annotation` that specifies the expected type for a variable, a class
+      An :term:`annotation` that specifies the expected types for a variable, a class
       attribute, or a function parameter or return value.
 
       Type hints are optional and are not enforced by Python but


### PR DESCRIPTION
I replaced `type` with `types` for the explanation **type hint** in `glossary.rst` because a type hint can have multiple(one or more) types.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141668.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->