### PR TITLE
gh-141172: Update to wasi-sdk-29

### DIFF
--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 60
     env:
       WASMTIME_VERSION: 38.0.3
-      WASI_SDK_VERSION: 25
+      WASI_SDK_VERSION: 29
       WASI_SDK_PATH: /opt/wasi-sdk
       CROSS_BUILD_PYTHON: cross-build/build
       CROSS_BUILD_WASI: cross-build/wasm32-wasip1

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -504,6 +504,7 @@ extern "C" {
  * Thread support is stubbed and any attempt to create a new thread fails.
  */
 #if (!defined(HAVE_PTHREAD_STUBS) && \
+     !defined(__wasi__) && \
       (!defined(__EMSCRIPTEN__) || defined(__EMSCRIPTEN_PTHREADS__)))
 #  define Py_CAN_START_THREADS 1
 #endif

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -730,14 +730,12 @@ class SysModuleTest(unittest.TestCase):
         self.assertEqual(len(info), 3)
         self.assertIn(info.name, ('nt', 'pthread', 'pthread-stubs', 'solaris', None))
         self.assertIn(info.lock, ('pymutex', None))
-        if sys.platform.startswith(("linux", "android", "freebsd")):
+        if sys.platform.startswith(("linux", "android", "freebsd", "wasi")):
             self.assertEqual(info.name, "pthread")
         elif sys.platform == "win32":
             self.assertEqual(info.name, "nt")
         elif sys.platform == "emscripten":
             self.assertIn(info.name, {"pthread", "pthread-stubs"})
-        elif sys.platform == "wasi":
-            self.assertEqual(info.name, "pthread-stubs")
 
     def test_abi_info(self):
         info = sys.abi_info

--- a/Misc/NEWS.d/next/Build/2025-11-19-09-21-17.gh-issue-141172.cYWc4x.rst
+++ b/Misc/NEWS.d/next/Build/2025-11-19-09-21-17.gh-issue-141172.cYWc4x.rst
@@ -1,0 +1,1 @@
+Update to WASI SDK 29.

--- a/Tools/wasm/wasi/__main__.py
+++ b/Tools/wasm/wasi/__main__.py
@@ -31,7 +31,7 @@ LOCAL_SETUP_MARKER = (
     b"# Required to statically build extension modules."
 )
 
-WASI_SDK_VERSION = 25
+WASI_SDK_VERSION = 29
 
 WASMTIME_VAR_NAME = "WASMTIME"
 WASMTIME_HOST_RUNNER_VAR = f"{{{WASMTIME_VAR_NAME}}}"
@@ -419,8 +419,8 @@ def main():
         f"{WASMTIME_HOST_RUNNER_VAR} run "
         # Make sure the stack size will work for a pydebug
         # build.
-        # Use 16 MiB stack.
-        "--wasm max-wasm-stack=16777216 "
+        # Use 32 MiB stack.
+        "--wasm max-wasm-stack=33554432 "
         # Enable thread support; causes use of preview1.
         # "--wasm threads=y --wasi threads=y "
         # Map the checkout to / to load the stdlib from /Lib.


### PR DESCRIPTION
This commit updates CI and configuration from wasi-sdk-25 to wasi-sdk-29 which was released recently. This notably includes stubs for pthreads which all return errors, so some adjustment in logic is necessary to retain knowledge that WASI cannot yet spawn threads for example.

This additionally increases the wasm stack allowance to 32MiB from 16MiB to accomodate the `test_recursive_pickle` test in teh `test_functools.py` file. It looks like the Clang/LLVM update that happened in wasi-sdk-29 relative to wasi-sdk-25 is likely the cause of this where presumably functions have more locals than before and/or a slightly adjusted stack space requirement which overflows the stack.

cc @brettcannon
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141172 -->
* Issue: gh-141172
<!-- /gh-issue-number -->
