### PR TITLE
GH-141686: Break cycles created by `JSONEncoder.iterencode`

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -450,8 +450,10 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
 
     def _iterencode_once(o, _current_indent_level):
         nonlocal _iterencode, _iterencode_dict, _iterencode_list
-        yield from _iterencode(o, _current_indent_level)
-        # Break reference cycles due to mutually recursive closures:
-        del _iterencode, _iterencode_dict, _iterencode_list
+        try:
+            yield from _iterencode(o, _current_indent_level)
+        finally:
+            # Break reference cycles due to mutually recursive closures:
+            del _iterencode, _iterencode_dict, _iterencode_list
 
     return _iterencode_once

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -264,17 +264,6 @@ class JSONEncoder(object):
 
 def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
         _key_separator, _item_separator, _sort_keys, _skipkeys, _one_shot,
-        ## HACK: hand-optimized bytecode; turn globals into locals
-        ValueError=ValueError,
-        dict=dict,
-        float=float,
-        id=id,
-        int=int,
-        isinstance=isinstance,
-        list=list,
-        str=str,
-        tuple=tuple,
-        _intstr=int.__repr__,
     ):
 
     def _iterencode_list(lst, _current_indent_level):
@@ -311,7 +300,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                     # Subclasses of int/float may override __repr__, but we still
                     # want to encode them as integers/floats in JSON. One example
                     # within the standard library is IntEnum.
-                    yield buf + _intstr(value)
+                    yield buf + int.__repr__(value)
                 elif isinstance(value, float):
                     # see comment above for int
                     yield buf + _floatstr(value)
@@ -374,7 +363,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                 key = 'null'
             elif isinstance(key, int):
                 # see comment for int/float in _make_iterencode
-                key = _intstr(key)
+                key = int.__repr__(key)
             elif _skipkeys:
                 continue
             else:
@@ -399,7 +388,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                     yield 'false'
                 elif isinstance(value, int):
                     # see comment for int/float in _make_iterencode
-                    yield _intstr(value)
+                    yield int.__repr__(value)
                 elif isinstance(value, float):
                     # see comment for int/float in _make_iterencode
                     yield _floatstr(value)
@@ -434,7 +423,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             yield 'false'
         elif isinstance(o, int):
             # see comment for int/float in _make_iterencode
-            yield _intstr(o)
+            yield int.__repr__(o)
         elif isinstance(o, float):
             # see comment for int/float in _make_iterencode
             yield _floatstr(o)
@@ -458,4 +447,11 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                 raise
             if markers is not None:
                 del markers[markerid]
-    return _iterencode
+
+    def _iterencode_once(o, _current_indent_level):
+        nonlocal _iterencode, _iterencode_dict, _iterencode_list
+        yield from _iterencode(o, _current_indent_level)
+        # Break reference cycles due to mutually recursive closures:
+        del _iterencode, _iterencode_dict, _iterencode_list
+
+    return _iterencode_once

--- a/Misc/NEWS.d/next/Library/2025-11-17-16-53-49.gh-issue-141686.V-xaoI.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-17-16-53-49.gh-issue-141686.V-xaoI.rst
@@ -1,0 +1,2 @@
+Break reference cycles created by each call to :func:`json.dump` or
+:meth:`json.JSONEncoder.iterencode`.


### PR DESCRIPTION
As mentioned in the issue, clearing these cycles explicitly results in a ~10% slowdown for `json.dump` microbenchmarks when the GC is disabled, but a ~20% speedup when the GC is enabled (since we're now eagerly doing the work done less efficiently by the GC).

I've also removed a "hack" that tried to turn globals into locals (in practice these "locals" are actually cells). This may have been faster in the past, but what it really does now is turn cached `LOAD_GLOBAL` specializations into unoptimized `LOAD_DEREF` instructions. Removing these gives another ~10% or so speedup for me.

<!-- gh-issue-number: gh-141686 -->
* Issue: gh-141686
<!-- /gh-issue-number -->
