### PR TITLE
gh-105836: Fix asyncio.run_coroutine_threadsafe leaving underlying cancelled asyncio task running

### DIFF
--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -365,6 +365,25 @@ def _copy_future_state(source, dest):
     else:
         dest.set_result(result)
 
+
+def _cancel_future_in_loop(fut, loop, timeout=None):
+    """Cancel a future in (maybe another) event loop.
+
+    We need to check loop is not running loop to avoid dead lock.
+    """
+    if loop is None or loop is events._get_running_loop():
+        return fut.cancel()
+    cancel_fut = concurrent.futures.Future()
+    def _cancel():
+        try:
+            result = fut.cancel()
+            cancel_fut.set_result(result)
+        except BaseException as exc:
+            cancel_fut.set_exception(exc)
+    loop.call_soon_threadsafe(_cancel)
+    return cancel_fut.result(timeout=timeout)
+
+
 def _chain_future(source, destination):
     """Chain two futures so that when one completes, so does the other.
 
@@ -389,16 +408,13 @@ def _chain_future(source, destination):
 
     def _call_check_cancel(destination):
         if destination.cancelled():
-            if source_loop is None or source_loop is dest_loop:
-                source.cancel()
-            else:
-                source_loop.call_soon_threadsafe(source.cancel)
+            _cancel_future_in_loop(source, source_loop)
 
     def _call_set_state(source):
         if (destination.cancelled() and
                 dest_loop is not None and dest_loop.is_closed()):
             return
-        if dest_loop is None or dest_loop is source_loop:
+        if dest_loop is None or dest_loop is events._get_running_loop():
             _set_state(destination, source)
         else:
             if dest_loop.is_closed():

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3691,7 +3691,14 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
             await asyncio.sleep(0)
 
         self.loop.run_until_complete(target())
-        self.assertEqual(0, len(self.loop._ready))
+
+        # For windows, it's likely to see asyncio.proactor_events
+        # .BaseProactorEventLoop._loop_self_reading as ready task
+        # We should filter it out.
+        ready_tasks = [
+            i for i in self.loop._ready 
+            if i._callback.__name__ != "_loop_self_reading"]
+        self.assertEqual(0, len(ready_tasks))
 
 
 class SleepTests(test_utils.TestCase):

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3688,6 +3688,7 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
 
             thread_future.cancel()
 
+
             await asyncio.sleep(0)
 
         self.loop.run_until_complete(target())

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3682,14 +3682,14 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
 
     def test_run_coroutine_threadsafe_and_cancel(self):
         async def target():
-            # self.loop.run_in_executor(None, _in_another_thread)
             thread_future = asyncio.run_coroutine_threadsafe(self.add(1, 2), self.loop)
             await asyncio.sleep(0)
 
             thread_future.cancel()
             await asyncio.sleep(0)
 
-        self.loop.run_until_complete(target())
+        future = self.loop.run_in_executor(None, target)
+        self.loop.run_until_complete(future)
         self.assertEqual(0, len(self.loop._ready))
 
 

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3696,7 +3696,7 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
         # .BaseProactorEventLoop._loop_self_reading as ready task
         # We should filter it out.
         ready_tasks = [
-            i for i in self.loop._ready 
+            i for i in self.loop._ready
             if i._callback.__name__ != "_loop_self_reading"]
         self.assertEqual(0, len(ready_tasks))
 

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -1,7 +1,6 @@
 """Tests for tasks.py."""
 
 import collections
-from concurrent.futures import thread
 import contextlib
 import contextvars
 import gc
@@ -3689,7 +3688,7 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
 
             thread_future.cancel()
             await asyncio.sleep(0)
-        
+
         self.loop.run_until_complete(target())
         self.assertEqual(0, len(self.loop._ready))
 

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3680,18 +3680,6 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
         (loop, context), kwargs = callback.call_args
         self.assertEqual(context['exception'], exc_context.exception)
 
-    def test_run_coroutine_threadsafe_and_cancel(self):
-        async def target():
-            # self.loop.run_in_executor(None, _in_another_thread)
-            thread_future = asyncio.run_coroutine_threadsafe(self.add(1, 2), self.loop)
-            await asyncio.sleep(0)
-
-            thread_future.cancel()
-            await asyncio.sleep(0)
-
-        self.loop.run_until_complete(target())
-        self.assertEqual(0, len(self.loop._ready))
-
 
 class SleepTests(test_utils.TestCase):
     def setUp(self):

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3680,6 +3680,18 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
         (loop, context), kwargs = callback.call_args
         self.assertEqual(context['exception'], exc_context.exception)
 
+    def test_run_coroutine_threadsafe_and_cancel(self):
+        async def target():
+            # self.loop.run_in_executor(None, _in_another_thread)
+            thread_future = asyncio.run_coroutine_threadsafe(self.add(1, 2), self.loop)
+            await asyncio.sleep(0)
+
+            thread_future.cancel()
+            await asyncio.sleep(0)
+
+        self.loop.run_until_complete(target())
+        self.assertEqual(0, len(self.loop._ready))
+
 
 class SleepTests(test_utils.TestCase):
     def setUp(self):

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3688,7 +3688,6 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
 
             thread_future.cancel()
 
-
             await asyncio.sleep(0)
 
         self.loop.run_until_complete(target())

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3687,6 +3687,7 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
             await asyncio.sleep(0)
 
             thread_future.cancel()
+
             await asyncio.sleep(0)
 
         self.loop.run_until_complete(target())

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -1,6 +1,7 @@
 """Tests for tasks.py."""
 
 import collections
+from concurrent.futures import thread
 import contextlib
 import contextvars
 import gc
@@ -3679,6 +3680,18 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
         self.assertEqual(len(callback.call_args_list), 1)
         (loop, context), kwargs = callback.call_args
         self.assertEqual(context['exception'], exc_context.exception)
+
+    def test_run_coroutine_threadsafe_and_cancel(self):
+        async def target():
+            # self.loop.run_in_executor(None, _in_another_thread)
+            thread_future = asyncio.run_coroutine_threadsafe(self.add(1, 2), self.loop)
+            await asyncio.sleep(0)
+
+            thread_future.cancel()
+            await asyncio.sleep(0)
+        
+        self.loop.run_until_complete(target())
+        self.assertEqual(0, len(self.loop._ready))
 
 
 class SleepTests(test_utils.TestCase):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -2118,6 +2118,7 @@ Xiang Zhang
 Robert Xiao
 Florent Xicluna
 Yanbo, Xie
+Kaisheng Xu
 Xinhang Xu
 Arnon Yaari
 Alakshendra Yadav

--- a/Misc/NEWS.d/next/Library/2025-11-18-15-48-13.gh-issue-105836.sbUw24.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-18-15-48-13.gh-issue-105836.sbUw24.rst
@@ -1,2 +1,2 @@
 Fix :meth:`asyncio.run_coroutine_threadsafe` leaving underlying cancelled
-asyncio task running
+asyncio task running.

--- a/Misc/NEWS.d/next/Library/2025-11-18-15-48-13.gh-issue-105836.sbUw24.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-18-15-48-13.gh-issue-105836.sbUw24.rst
@@ -1,0 +1,2 @@
+Fix :meth:`asyncio.run_coroutine_threadsafe` leaving underlying cancelled
+asyncio task running


### PR DESCRIPTION
* This issue caused by `_chain_future` which supports `concurrent.futures.Future` and `asycio.Future`. While `asyncio.run_coroutine_threadsafe` gives `destination` a `concurrent.futures.Future`, the `dest_loop` is None. Then `dest_loop is source_loop` is not good enough for the check. We should always the current running loop for the future operating.
* In case of `concurrent.futures.Future` created by `asyncio.run_coroutine_threadsafe`, we need to wait for the cancellation before return. That's what I done in `_cancel_future_in_loop`.

<!-- gh-issue-number: gh-105836 -->
* Issue: gh-105836
<!-- /gh-issue-number -->
