### PR TITLE
Add missing backticks in os and decimal docs.

### DIFF
--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -264,7 +264,7 @@ allows the settings to be changed.  This approach meets the needs of most
 applications.
 
 For more advanced work, it may be useful to create alternate contexts using the
-Context() constructor.  To make an alternate active, use the :func:`setcontext`
+``Context()`` constructor.  To make an alternate active, use the :func:`setcontext`
 function.
 
 In accordance with the standard, the :mod:`decimal` module provides two ready to

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -264,7 +264,7 @@ allows the settings to be changed.  This approach meets the needs of most
 applications.
 
 For more advanced work, it may be useful to create alternate contexts using the
-``Context()`` constructor.  To make an alternate active, use the :func:`setcontext`
+:meth:`Context` constructor.  To make an alternate active, use the :func:`setcontext`
 function.
 
 In accordance with the standard, the :mod:`decimal` module provides two ready to

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -558,7 +558,7 @@ process and user.
 
 .. function:: initgroups(username, gid, /)
 
-   Call the system initgroups() to initialize the group access list with all of
+   Call the system ``initgroups()`` to initialize the group access list with all of
    the groups of which the specified username is a member, plus the specified
    group id.
 


### PR DESCRIPTION
Trivial change, just missing backticks.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141699.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->