### PR TITLE
gh-39128: Fix email.utils.unquote() parameter parsing

### DIFF
--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -357,8 +357,16 @@ def parseaddr(addr, *, strict=True):
 def unquote(str):
     """Remove quotes from a string."""
     if len(str) > 1:
-        if str.startswith('"') and str.endswith('"'):
-            return str[1:-1].replace('\\\\', '\\').replace('\\"', '"')
+        if str.startswith('"'):
+            pos = 1
+            while pos < len(str):
+                if str[pos] == '\\' and pos + 1 < len(str):
+                    pos += 2
+                elif str[pos] == '"':
+                    content = str[1:pos]
+                    return re.sub(r'\\(.)', r'\1', content)
+                else:
+                    pos += 1
         if str.startswith('<') and str.endswith('>'):
             return str[1:-1]
     return str

--- a/Lib/test/test_email/test_utils.py
+++ b/Lib/test/test_email/test_utils.py
@@ -186,5 +186,35 @@ class FormatDateTests(unittest.TestCase):
         string = utils.formatdate(timeval, localtime=True)
         self.assertEqual(string, 'Thu, 01 Dec 2011 18:00:00 +0300')
 
+class UnquoteTests(unittest.TestCase):
+
+    def test_unquote_basic(self):
+        self.assertEqual(utils.unquote('"value"'), 'value')
+
+    def test_unquote_with_trailing_garbage(self):
+        self.assertEqual(utils.unquote('"bound"\n\tX-Priority: 3'), 'bound')
+
+    def test_unquote_with_escaped_quote(self):
+        self.assertEqual(utils.unquote(r'"val\"ue"'), 'val"ue')
+
+    def test_unquote_with_escaped_backslash(self):
+        self.assertEqual(utils.unquote(r'"val\\ue"'), r'val\ue')
+
+    def test_unquote_angle_brackets(self):
+        self.assertEqual(utils.unquote('<value>'), 'value')
+
+    def test_unquote_no_quotes(self):
+        self.assertEqual(utils.unquote('value'), 'value')
+
+    def test_unquote_single_char(self):
+        self.assertEqual(utils.unquote('v'), 'v')
+
+    def test_unquote_empty_quoted(self):
+        self.assertEqual(utils.unquote('""'), '')
+
+    def test_unquote_mixed_escapes(self):
+        self.assertEqual(utils.unquote(r'"a\\b\"c"'), r'a\b"c')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2025-11-18-09-59-41.gh-issue-39128.xK7mPq.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-18-09-59-41.gh-issue-39128.xK7mPq.rst
@@ -1,0 +1,3 @@
+Fix :func:`email.utils.unquote` to properly handle quoted strings with
+trailing garbage by extracting only content between quotes and using
+single-pass unescaping for RFC 2822 compliance. Patched by Shamil Abdulaev.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-39128 -->
* Issue: gh-39128
<!-- /gh-issue-number -->
