### PR TITLE
gh-141540: use %r instead of %s in error messages #141540

### DIFF
--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -567,7 +567,7 @@ def _strptime(data_string, format="%a %b %d %H:%M:%S %Y"):
             raise ValueError(
                 f"Missing colon in %:z before '{rest}', got '{data_string}'"
             )
-        raise ValueError("unconverted data remains: %s" % rest)
+        raise ValueError("unconverted data remains: %r" % rest)
 
     iso_year = year = None
     month = day = 1


### PR DESCRIPTION
Changed the `ValueError` in `_strptime.py` to use `%r` instead of `%s`, so trailing whitespace or other hidden characters are clearly visible in the error message.

<!-- gh-issue-number: gh-141540 -->
* Issue: gh-141540
<!-- /gh-issue-number -->
