### PR TITLE
gh-141570: can_colorize: Expect fileno() to raise OSError, as documented

### DIFF
--- a/Lib/_colorize.py
+++ b/Lib/_colorize.py
@@ -1,4 +1,3 @@
-import io
 import os
 import sys
 
@@ -330,7 +329,7 @@ def can_colorize(*, file: IO[str] | IO[bytes] | None = None) -> bool:
 
     try:
         return os.isatty(file.fileno())
-    except io.UnsupportedOperation:
+    except OSError:
         return hasattr(file, "isatty") and file.isatty()
 
 

--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -168,7 +168,7 @@ class TestColorizeFunction(unittest.TestCase):
 
             # The documentation for file.fileno says:
             # > An OSError is raised if the IO object does not use a file descriptor.
-            # See https://github.com/python/cpython/issues/141570
+            # gh-141570: Check OSError is caught and handled
             with unittest.mock.patch("os.isatty", side_effect=ZeroDivisionError):
                 file = unittest.mock.MagicMock()
                 file.fileno.side_effect = OSError

--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -166,6 +166,17 @@ class TestColorizeFunction(unittest.TestCase):
                 file.isatty.return_value = False
                 self.assertEqual(_colorize.can_colorize(file=file), False)
 
+            # The documentation for file.fileno says:
+            # > An OSError is raised if the IO object does not use a file descriptor.
+            # See https://github.com/python/cpython/issues/141570
+            with unittest.mock.patch("os.isatty", side_effect=ZeroDivisionError):
+                file = unittest.mock.MagicMock()
+                file.fileno.side_effect = OSError
+                file.isatty.return_value = True
+                self.assertEqual(_colorize.can_colorize(file=file), True)
+                file.isatty.return_value = False
+                self.assertEqual(_colorize.can_colorize(file=file), False)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
@@ -1,3 +1,3 @@
-In :func:`_colorize.can_colorize`, support file objects rising
+In ``_colorize.can_colorize``, support file objects rising
 :exc:`OSError` from the :meth:`~io.IOBase.fileno` method, as docuemtned. An
 example of such an object is a ``mod_wsgi`` logger.

--- a/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
@@ -1,2 +1,2 @@
 Support :term:`file-like object` raising :exc:`OSError` from :meth:`~io.IOBase.fileno` in color
-detection (``_colorize.can_colorize``). This can occur when `sys.stdout` is redirected.
+detection (``_colorize.can_colorize``). This can occur when ``sys.stdout`` is redirected.

--- a/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
@@ -1,3 +1,2 @@
-In ``_colorize.can_colorize``, support file objects rising
-:exc:`OSError` from the :meth:`~io.IOBase.fileno` method, as docuemtned. An
-example of such an object is a ``mod_wsgi`` logger.
+Support :term:`file-like object` raising :exc:`OSError` from :meth:`~io.IOBase.fileno` in color 
+detection (``_colorize.can_colorize``). This can occur when `sys.stdout` is redirected.

--- a/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
@@ -1,2 +1,2 @@
 Support :term:`file-like object` raising :exc:`OSError` from :meth:`~io.IOBase.fileno` in color
-detection (``_colorize.can_colorize``). This can occur when ``sys.stdout`` is redirected.
+detection (``_colorize.can_colorize()``). This can occur when ``sys.stdout`` is redirected.

--- a/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
@@ -1,2 +1,2 @@
-Support :term:`file-like object` raising :exc:`OSError` from :meth:`~io.IOBase.fileno` in color 
+Support :term:`file-like object` raising :exc:`OSError` from :meth:`~io.IOBase.fileno` in color
 detection (``_colorize.can_colorize``). This can occur when `sys.stdout` is redirected.

--- a/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-18-14-39-31.gh-issue-141570.q3n984.rst
@@ -1,0 +1,3 @@
+In :func:`_colorize.can_colorize`, support file objects rising
+:exc:`OSError` from the :meth:`~io.IOBase.fileno` method, as docuemtned. An
+example of such an object is a ``mod_wsgi`` logger.


### PR DESCRIPTION
In Fedora, we've been given a slightly incomplete reproducer for a problematic Python 3.14 color-related change in argparse that leads to an exception when Python is used from mod_wsgi: https://bugzilla.redhat.com/2414940

mod_wsgi replaces sys.stdout with a custom object that raises OSError on .fileno():

https://github.com/GrahamDumpleton/mod_wsgi/blob/8460dbfcd5c7108892b3cde9fab7cbc1caa27886/src/server/wsgi_logger.c#L434-L440

This should be supported, as the documentation of fileno explicitly says:

> An OSError is raised if the IO object does not use a file descriptor.

https://docs.python.org/3.14/library/io.html#io.IOBase.fileno

The previously expected exception inherits from OSError, so it is still expected.

Fixes https://github.com/python/cpython/issues/141570

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141570 -->
* Issue: gh-141570
<!-- /gh-issue-number -->
