### PR TITLE
gh-135953: Avoid BytesWarning when sampling profiler tests fail

### DIFF
--- a/Lib/test/test_profiling/test_sampling_profiler/helpers.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/helpers.py
@@ -83,7 +83,7 @@ _test_sock.sendall(b"ready")
         response = client_socket.recv(1024)
         if response != b"ready":
             raise RuntimeError(
-                f"Unexpected response from subprocess: {response}"
+                f"Unexpected response from subprocess: {response!r}"
             )
 
         yield SubprocessInfo(proc, client_socket)


### PR DESCRIPTION
In a [buildbot run with `-bb`](https://buildbot.python.org/api/v2/logs/15002974/raw_inline), this failed on BytesWarning: str() on a bytes instance.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135953 -->
* Issue: gh-135953
<!-- /gh-issue-number -->
