### PR TITLE
Fix implicit imports

### DIFF
--- a/Lib/test/test_asyncio/test_eager_task_factory.py
+++ b/Lib/test/test_asyncio/test_eager_task_factory.py
@@ -5,7 +5,7 @@ import contextvars
 import unittest
 
 from unittest import mock
-from asyncio import tasks
+from asyncio import staggered, tasks
 from test.test_asyncio import utils as test_utils
 from test.support.script_helper import assert_python_ok
 
@@ -225,7 +225,7 @@ class EagerTaskFactoryLoopTests:
             await fut
 
         async def run():
-            winner, index, excs = await asyncio.staggered.staggered_race(
+            winner, index, excs = await staggered.staggered_race(
                 [
                     lambda: blocked(),
                     lambda: asyncio.sleep(1, result="sleep1"),
@@ -247,7 +247,7 @@ class EagerTaskFactoryLoopTests:
             raise ValueError("no good")
 
         async def run():
-            winner, index, excs = await asyncio.staggered.staggered_race(
+            winner, index, excs = await staggered.staggered_race(
                 [
                     lambda: fail(),
                     lambda: asyncio.sleep(1, result="sleep1"),

--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -12,10 +12,10 @@ import types
 import unittest
 
 import test.support
-from test.support import requires_specialization_ft, script_helper
+from test.support import import_helper, requires_specialization_ft, script_helper
 
-_testcapi = test.support.import_helper.import_module("_testcapi")
-_testinternalcapi = test.support.import_helper.import_module("_testinternalcapi")
+_testcapi = import_helper.import_module("_testcapi")
+_testinternalcapi = import_helper.import_module("_testinternalcapi")
 
 PAIR = (0,1)
 


### PR DESCRIPTION
`asyncio.staggered` in `Lib/test/test_asyncio/test_eager_task_factory.py` and `test.support.import_helper` in `Lib/test/test_monitoring.py` are both modules that are used without being properly imported in the file (relying on other imports to actually import them). They should be explicitly imported for the sake of correctness and safety (in case they stop being imported in other imports).