### PR TITLE
gh-140920: remove incorrect mentions to `concurrent.futures.interpreter.ExecutionFailed`

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -308,7 +308,7 @@ the bytes over a shared :mod:`socket <socket>` or
 
    .. note::
       The executor may replace uncaught exceptions from *initializer*
-      with :class:`~concurrent.futures.interpreter.ExecutionFailed`.
+      with :class:`~concurrent.interpreters.ExecutionFailed`.
 
    Other caveats from parent :class:`ThreadPoolExecutor` apply here.
 
@@ -320,11 +320,11 @@ likewise serializes the return value when sending it back.
 When a worker's current task raises an uncaught exception, the worker
 always tries to preserve the exception as-is.  If that is successful
 then it also sets the ``__cause__`` to a corresponding
-:class:`~concurrent.futures.interpreter.ExecutionFailed`
+:class:`~concurrent.interpreters.ExecutionFailed`
 instance, which contains a summary of the original exception.
 In the uncommon case that the worker is not able to preserve the
 original as-is then it directly preserves the corresponding
-:class:`~concurrent.futures.interpreter.ExecutionFailed`
+:class:`~concurrent.interpreters.ExecutionFailed`
 instance instead.
 
 

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -715,15 +715,6 @@ Exception classes
 
    .. versionadded:: 3.14
 
-.. exception:: ExecutionFailed
-
-   Raised from :class:`~concurrent.futures.InterpreterPoolExecutor` when
-   the given initializer fails or from
-   :meth:`~concurrent.futures.Executor.submit` when there's an uncaught
-   exception from the submitted task.
-
-   .. versionadded:: 3.14
-
 .. currentmodule:: concurrent.futures.process
 
 .. exception:: BrokenProcessPool


### PR DESCRIPTION
The documentation incorrectly referenced `concurrent.futures.interpreter.ExecutionFailed`,
an exception that does not exist. The actual `ExecutionFailed` class is defined in
`concurrent.interpreters`.

This patch updates the concurrent.futures documentation to point to the correct
exception class.

<!-- gh-issue-number: gh-140920 -->
* Issue: gh-140920 
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141723.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->