### PR TITLE
gh-141721: Fix docstring for LastUpdatedOrderedDict example

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1209,7 +1209,7 @@ If a new entry overwrites an existing entry, the
 original insertion position is changed and moved to the end::
 
     class LastUpdatedOrderedDict(OrderedDict):
-        'Store items in the order the keys were last added'
+        'Store items in the order that the keys were last updated.'
 
         def __setitem__(self, key, value):
             super().__setitem__(key, value)


### PR DESCRIPTION
Single-line docstring fix for #141721 with wording suggested by @StanFromIreland 


<!-- gh-issue-number: gh-141721 -->
* Issue: gh-141721
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141724.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->