### PR TITLE
gh-141729: Doc PyTypeObject.tp_vectorcall grammar fix

### DIFF
--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -638,7 +638,7 @@ The following functions and structs are used to create
          under the :ref:`limited API <limited-c-api>`.
 
       .. versionchanged:: 3.14
-         The field :c:member:`~PyTypeObject.tp_vectorcall` can now set
+         The field :c:member:`~PyTypeObject.tp_vectorcall` can now be set
          using :c:data:`Py_tp_vectorcall`.  See the field's documentation
          for details.
 


### PR DESCRIPTION
This is a trivial PR to simply fix a grammatical issue in the [PyType_Slot.slot](https://docs.python.org/3/c-api/type.html#c.PyType_Slot.slot) change notice for 3.14. 

Should be very simple and straightforward :) 

<!-- gh-issue-number: gh-141729 -->
* Issue: gh-141729
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141730.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->