### PR TITLE
gh-140381: Make test_profiling tests deterministic to fix flakiness

### DIFF
--- a/Lib/test/test_profiling/test_sampling_profiler/test_integration.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_integration.py
@@ -385,49 +385,15 @@ def cpu_intensive_work():
             result = result % 1000000
     return result
 
-def medium_computation():
-    """Medium complexity function."""
-    result = 0
-    for i in range(100):
-        result += i * i
-    return result
-
-def fast_loop():
-    """Fast simple loop."""
-    total = 0
-    for i in range(50):
-        total += i
-    return total
-
-def nested_calls():
-    """Test nested function calls."""
-    def level1():
-        def level2():
-            return medium_computation()
-        return level2()
-    return level1()
-
 def main_loop():
-    """Main test loop with different execution paths."""
-    max_iterations = 1000
+    """Main test loop."""
+    max_iterations = 200
 
-    iteration = 0
-
-    while iteration < max_iterations:
-        iteration += 1
-
-        # Different execution paths - focus on CPU intensive work
-        if iteration % 3 == 0:
-            # Very CPU intensive
-            result = cpu_intensive_work()
-        elif iteration % 2 == 0:
-            # Expensive recursive operation (increased frequency for slower machines)
-            result = slow_fibonacci(12)
+    for iteration in range(max_iterations):
+        if iteration % 2 == 0:
+            result = slow_fibonacci(15)
         else:
-            # Medium operation
-            result = nested_calls()
-
-        # No sleep - keep CPU busy
+            result = cpu_intensive_work()
 
 if __name__ == "__main__":
     main_loop()


### PR DESCRIPTION
The test_sampling_basic_functionality, test_sample_target_script, and
test_sample_target_module tests were failing intermittently on slow
architectures (i686/s390x) because they relied on a time-based workload
with an infinite loop (while True). On slow machines, the profiler's
sampling window would end before enough iterations executed, causing
slow_fibonacci to not appear in the profiling output.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140381 -->
* Issue: gh-140381
<!-- /gh-issue-number -->
