### PR TITLE
[3.14] gh-139103: fix free-threading `dataclass.__init__` perf issue (gh-141596)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-15-23-58-23.gh-issue-139103.9cVYJ0.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-15-23-58-23.gh-issue-139103.9cVYJ0.rst
@@ -1,0 +1,1 @@
+Improve multithreaded scaling of dataclasses on the free-threaded build.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6181,6 +6181,18 @@ type_setattro(PyObject *self, PyObject *name, PyObject *value)
     assert(!_PyType_HasFeature(metatype, Py_TPFLAGS_INLINE_VALUES));
     assert(!_PyType_HasFeature(metatype, Py_TPFLAGS_MANAGED_DICT));
 
+#ifdef Py_GIL_DISABLED
+    // gh-139103: Enable deferred refcounting for functions assigned
+    // to type objects.  This is important for `dataclass.__init__`,
+    // which is generated dynamically.
+    if (value != NULL &&
+        PyFunction_Check(value) &&
+        !_PyObject_HasDeferredRefcount(value))
+    {
+        PyUnstable_Object_EnableDeferredRefcount(value);
+    }
+#endif
+
     PyObject *old_value = NULL;
     PyObject *descr = _PyType_LookupRef(metatype, name);
     if (descr != NULL) {

--- a/Tools/ftscalingbench/ftscalingbench.py
+++ b/Tools/ftscalingbench/ftscalingbench.py
@@ -27,6 +27,7 @@ import queue
 import sys
 import threading
 import time
+from dataclasses import dataclass
 
 # The iterations in individual benchmarks are scaled by this factor.
 WORK_SCALE = 100
@@ -188,6 +189,17 @@ def thread_local_read():
         _ = tmp.x
         _ = tmp.x
 
+
+@dataclass
+class MyDataClass:
+    x: int
+    y: int
+    z: int
+
+@register_benchmark
+def instantiate_dataclass():
+    for _ in range(1000 * WORK_SCALE):
+        obj = MyDataClass(x=1, y=2, z=3)
 
 def bench_one_thread(func):
     t0 = time.perf_counter_ns()


### PR DESCRIPTION
The dataclasses `__init__` function is generated dynamically by a call to `exec()` and so doesn't have deferred reference counting enabled. Enable deferred reference counting on functions when assigned as an attribute to type objects to avoid reference count contention when creating dataclass instances.
(cherry picked from commit ce791541769a41beabec0f515cd62e504d46ff1c)

Co-authored-by: Edward Xu <xuxiangad@gmail.com>

<!-- gh-issue-number: gh-139103 -->
* Issue: gh-139103
<!-- /gh-issue-number -->
