### PR TITLE
gh-141749: align exceptions raised by `pickle.load` with `_pickle.load`

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -1349,12 +1349,19 @@ class _Unpickler:
                 if not key:
                     raise EOFError
                 assert isinstance(key, bytes_types)
-                dispatch[key[0]](self)
+                try:
+                    func = dispatch[key[0]]
+                except KeyError:
+                    raise UnpicklingError(
+                        f"invalid load key, '\\x{key[0]:02x}'.")
+                func(self)
         except _Stop as stopinst:
             return stopinst.value
 
     # Return a list of items pushed in the stack after last MARK instruction.
     def pop_mark(self):
+        if not self.metastack:
+            raise UnpicklingError("could not find MARK")
         items = self.stack
         self.stack = self.metastack.pop()
         self.append = self.stack.append

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -55,7 +55,7 @@ class PyPickleTests(AbstractPickleModuleTests, unittest.TestCase):
 class PyUnpicklerTests(AbstractUnpickleTests, unittest.TestCase):
 
     unpickler = pickle._Unpickler
-    bad_stack_errors = (IndexError,)
+    bad_stack_errors = (pickle.UnpicklingError, IndexError)
     truncated_errors = (pickle.UnpicklingError, EOFError,
                         AttributeError, ValueError,
                         struct.error, IndexError, ImportError)

--- a/Misc/NEWS.d/next/Library/2025-11-19-15-23-30.gh-issue-141749.QRBf7O.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-19-15-23-30.gh-issue-141749.QRBf7O.rst
@@ -1,0 +1,3 @@
+:mod:`pickle`: align exceptions raised by the pure Python implementation of :func:`pickle.load`
+with the C implementation. Previous cases raising :exc:`KeyError` or :exc:`IndexError`
+now raise :exc:`~pickle.UnpicklingError`. Patch by Djoume Salvetti.


### PR DESCRIPTION
Disclaimer: I used Claude Code to help me make this change

This fix addresses error handling inconsistencies in CPython's pure Python `pickle.py` implementation to match the behavior of the C `_pickle` module. The changes make the pure Python implementation raise proper `UnpicklingError` exceptions for invalid pickle data instead of low-level `KeyError` and `IndexError` exceptions.

- [x] Invalid opcodes now raise `UnpicklingError` instead of `KeyError`
- [x] Operations requiring MARK (TUPLE, LIST, DICT, etc.) now raise `UnpicklingError: could not find MARK` instead of `IndexError: pop from empty list`

Note: the C implementation (`_pickle`) always raises `UnpicklingError` for all error conditions because it has explicit error checking. The pure Python implementation can't catch all cases without significant performance overhead, so there are still some cases where the pure Python implementation will raise `IndexError` (e.g., `self.stack.pop()` on empty stack, `self.stack[-1]` on empty stack)

This approach:
- ✅ Improves error messages for common cases
- ✅ Maintains performance (no try-except around every stack operation)
- ✅ Passes all existing tests
- ✅ Makes pure Python implementation more consistent with C implementation
- ✅ Follows the precedent set in the code (e.g., `load_get`, `load_binget` catch `KeyError` for memo access)

## What Gets Fixed

### Before the fix:
```python
>>> pickle.loads(b'\xff\xff\xff')
KeyError: 255

>>> pickle.loads(b'this is not valid pickle data')
IndexError: pop from empty list
```

### After the fix:
```python
>>> pickle.loads(b'\xff\xff\xff')
pickle.UnpicklingError: invalid load key, '\xff'.

>>> pickle.loads(b'this is not valid pickle data')
pickle.UnpicklingError: could not find MARK
```

## Compatibility

- ✅ Backward compatible: Code catching `UnpicklingError` continues to work
- ✅ Forward compatible: Code catching `IndexError` continues to work (for other stack operations)
- ✅ All existing CPython tests pass
- ✅ Behavior is closer to C implementation

## Impact

This fix benefits:
- **Brython**: Primary use case - needs pure Python pickle
- **PyPy**: When using pure Python mode
- **MicroPython**: If it includes pickle
- **Jython**: If using CPython stdlib
- **Debugging**: Better error messages for developers
- **Security tools**: Proper exception types for malformed pickle validation



<!-- gh-issue-number: gh-141749 -->
* Issue: gh-141749
<!-- /gh-issue-number -->
