### PR TITLE
gh-141781: Fix pdb line prefix binding

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2429,7 +2429,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         except KeyboardInterrupt:
             pass
 
-    def print_stack_entry(self, frame_lineno, prompt_prefix=None):     
+    def print_stack_entry(self, frame_lineno, prompt_prefix=None):
         if prompt_prefix is None:         
             prompt_prefix = line_prefix
         frame, lineno = frame_lineno

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -654,7 +654,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     def _get_tb_and_exceptions(self, tb_or_exc):
         """
-        Given a tracecack or an exception, return a tuple of chained exceptions
+        Given a traceback or an exception, return a tuple of chained exceptions
         and current traceback to inspect.
 
         This will deal with selecting the right ``__cause__`` or ``__context__``
@@ -2429,7 +2429,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         except KeyboardInterrupt:
             pass
 
-    def print_stack_entry(self, frame_lineno, prompt_prefix=line_prefix):
+    def print_stack_entry(self, frame_lineno, prompt_prefix=None):     
+        if prompt_prefix is None:         
+            prompt_prefix = line_prefix
         frame, lineno = frame_lineno
         if frame is self.curframe:
             prefix = '> '

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2430,7 +2430,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             pass
 
     def print_stack_entry(self, frame_lineno, prompt_prefix=None):
-        if prompt_prefix is None:         
+        if prompt_prefix is None:
             prompt_prefix = line_prefix
         frame, lineno = frame_lineno
         if frame is self.curframe:

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3567,6 +3567,7 @@ class PdbTestCase(unittest.TestCase):
     def test_find_function_found(self):
         self._assert_find_function(
             """\
+
 def foo():
     pass
 
@@ -3579,6 +3580,20 @@ def quux():
             'bœr',
             ('bœr', 5),
         )
+
+    def test_print_stack_entry_uses_dynamic_line_prefix(self):
+        """Test that pdb.line_prefix binding is dynamic (gh-141781)."""
+        stdout = io.StringIO()
+        p = pdb.Pdb(stdout=stdout)
+
+        # Get the current frame to use for printing
+        frame = sys._getframe()
+
+        with support.swap_attr(pdb, 'line_prefix', 'CUSTOM_PREFIX> '):
+            p.print_stack_entry((frame, frame.f_lineno))
+
+        # Check if the custom prefix appeared in the output
+        self.assertIn('CUSTOM_PREFIX> ', stdout.getvalue())
 
     def test_find_function_found_with_encoding_cookie(self):
         self._assert_find_function(

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3594,9 +3594,9 @@ def quux():
         # Check if the custom prefix appeared in the output
         self.assertIn('CUSTOM_PREFIX> ', stdout.getvalue())
 
-        def test_find_function_found_with_encoding_cookie(self):
-            self._assert_find_function(
-                """\
+    def test_find_function_found_with_encoding_cookie(self):
+        self._assert_find_function(
+            """\
 # coding: iso-8859-15
 def foo():
     pass

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3593,10 +3593,10 @@ def quux():
 
         # Check if the custom prefix appeared in the output
         self.assertIn('CUSTOM_PREFIX> ', stdout.getvalue())
-        
-    def test_find_function_found_with_encoding_cookie(self):
-        self._assert_find_function(
-            """\
+
+        def test_find_function_found_with_encoding_cookie(self):
+            self._assert_find_function(
+                """\
 # coding: iso-8859-15
 def foo():
     pass

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3567,7 +3567,6 @@ class PdbTestCase(unittest.TestCase):
     def test_find_function_found(self):
         self._assert_find_function(
             """\
-
 def foo():
     pass
 
@@ -3594,6 +3593,7 @@ def quux():
 
         # Check if the custom prefix appeared in the output
         self.assertIn('CUSTOM_PREFIX> ', stdout.getvalue())
+        
     def test_find_function_found_with_encoding_cookie(self):
         self._assert_find_function(
             """\

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3594,7 +3594,6 @@ def quux():
 
         # Check if the custom prefix appeared in the output
         self.assertIn('CUSTOM_PREFIX> ', stdout.getvalue())
-
     def test_find_function_found_with_encoding_cookie(self):
         self._assert_find_function(
             """\

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -927,6 +927,7 @@ Kristján Valur Jónsson
 Jens B. Jorgensen
 John Jorgensen
 Sijin Joseph
+Paresh Joshi
 Andreas Jung
 Tattoo Mabonzo K.
 Sarah K.

--- a/Misc/NEWS.d/next/Library/2025-11-24-06-44-45.gh-issue-141781.MsK27r.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-24-06-44-45.gh-issue-141781.MsK27r.rst
@@ -1,0 +1,1 @@
+Fixed an issue where pdb.line_prefix assignment was ignored if assigned after the module was imported.


### PR DESCRIPTION
## Description

This PR fixes a logic issue in `pdb.print_stack_entry`. Previously, `prompt_prefix` used `line_prefix` as a default argument, which caused the value to be bound at definition time (when the module is imported).

This prevented users from customizing `pdb.line_prefix` dynamically after import, as the function would continue using the initial value.

**Changes:**
- Changed the default argument of `prompt_prefix` to `None`.
- Added a check inside the function to assign `line_prefix` if `prompt_prefix` is `None`.
- Fixed a typo in the docstring of `_get_tb_and_exceptions` ("tracecack" -> "traceback").

## Linked Issue

Fixes #141781



<!-- gh-issue-number: gh-141781 -->
* Issue: gh-141781
<!-- /gh-issue-number -->
