### PR TITLE
Fix implicit import in `test_monitoring.py`

### DIFF
--- a/Lib/test/test_asyncio/test_eager_task_factory.py
+++ b/Lib/test/test_asyncio/test_eager_task_factory.py
@@ -5,7 +5,7 @@ import contextvars
 import unittest
 
 from unittest import mock
-from asyncio import staggered, tasks
+from asyncio import tasks
 from test.test_asyncio import utils as test_utils
 from test.support.script_helper import assert_python_ok
 
@@ -225,7 +225,7 @@ class EagerTaskFactoryLoopTests:
             await fut
 
         async def run():
-            winner, index, excs = await staggered.staggered_race(
+            winner, index, excs = await asyncio.staggered.staggered_race(
                 [
                     lambda: blocked(),
                     lambda: asyncio.sleep(1, result="sleep1"),
@@ -247,7 +247,7 @@ class EagerTaskFactoryLoopTests:
             raise ValueError("no good")
 
         async def run():
-            winner, index, excs = await staggered.staggered_race(
+            winner, index, excs = await asyncio.staggered.staggered_race(
                 [
                     lambda: fail(),
                     lambda: asyncio.sleep(1, result="sleep1"),

--- a/Lib/test/test_asyncio/test_eager_task_factory.py
+++ b/Lib/test/test_asyncio/test_eager_task_factory.py
@@ -5,7 +5,7 @@ import contextvars
 import unittest
 
 from unittest import mock
-from asyncio import tasks
+from asyncio import staggered, tasks
 from test.test_asyncio import utils as test_utils
 from test.support.script_helper import assert_python_ok
 
@@ -225,7 +225,7 @@ class EagerTaskFactoryLoopTests:
             await fut
 
         async def run():
-            winner, index, excs = await asyncio.staggered.staggered_race(
+            winner, index, excs = await staggered.staggered_race(
                 [
                     lambda: blocked(),
                     lambda: asyncio.sleep(1, result="sleep1"),
@@ -247,7 +247,7 @@ class EagerTaskFactoryLoopTests:
             raise ValueError("no good")
 
         async def run():
-            winner, index, excs = await asyncio.staggered.staggered_race(
+            winner, index, excs = await staggered.staggered_race(
                 [
                     lambda: fail(),
                     lambda: asyncio.sleep(1, result="sleep1"),

--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -12,10 +12,10 @@ import types
 import unittest
 
 import test.support
-from test.support import requires_specialization_ft, script_helper
+from test.support import import_helper, requires_specialization_ft, script_helper
 
-_testcapi = test.support.import_helper.import_module("_testcapi")
-_testinternalcapi = test.support.import_helper.import_module("_testinternalcapi")
+_testcapi = import_helper.import_module("_testcapi")
+_testinternalcapi = import_helper.import_module("_testinternalcapi")
 
 PAIR = (0,1)
 


### PR DESCRIPTION
`test.support.import_helper` in `Lib/test/test_monitoring.py` is not actually imported in the file, relying on another import to import it. As discussed in the [previous pull request](https://github.com/python/cpython/pull/141722), this would be fine if importing `test.support` itself would import `test.support.import_helper` but that's not the case.
```
% python -c "import test.support; test.support.import_helper"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import test.support; test.support.import_helper
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'test.support' has no attribute 'import_helper'
```