### PR TITLE
[3.14] gh-141784: Fix _remote_debugging_module.c compilation on 32-bit Linux (#141796)

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-11-20-17-01-05.gh-issue-141784.LkYI2n.rst
+++ b/Misc/NEWS.d/next/Build/2025-11-20-17-01-05.gh-issue-141784.LkYI2n.rst
@@ -1,0 +1,4 @@
+Fix ``_remote_debugging_module.c`` compilation on 32-bit Linux. Include
+Python.h before system headers to make sure that
+``_remote_debugging_module.c`` uses the same types (ABI) than Python. Patch
+by Victor Stinner.

--- a/Modules/_remote_debugging_module.c
+++ b/Modules/_remote_debugging_module.c
@@ -11,14 +11,6 @@
  * HEADERS AND INCLUDES
  * ============================================================================ */
 
-#include <errno.h>
-#include <fcntl.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #ifndef Py_BUILD_CORE_BUILTIN
 #    define Py_BUILD_CORE_MODULE 1
 #endif
@@ -29,6 +21,17 @@
 #include <internal/pycore_llist.h>          // struct llist_node
 #include <internal/pycore_stackref.h>       // Py_TAG_BITS
 #include "../Python/remote_debug.h"
+
+// gh-141784: Python.h header must be included first, before system headers.
+// Otherwise, some types such as ino_t can be defined differently, causing ABI
+// issues.
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifndef HAVE_PROCESS_VM_READV
 #    define HAVE_PROCESS_VM_READV 0


### PR DESCRIPTION
Include Python.h before system headers to make sure that _remote_debugging_module.c uses the same types (ABI) than Python.

(cherry picked from commit 722f4bb8c9c6b32a7221e4813058cbb5c3989c10)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141784 -->
* Issue: gh-141784
<!-- /gh-issue-number -->
