### PR TITLE
gh-141801: Use accessors for ASN1_STRING fields

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1644,8 +1644,8 @@ _get_crl_dp(X509 *certificate) {
             }
             uri = gn->d.uniformResourceIdentifier;
             ouri = PyUnicode_FromStringAndSize(
-                    (const char *)ASN1_STRING_get0_data(uri),
-                    ASN1_STRING_length(uri));
+                       (const char *)ASN1_STRING_get0_data(uri),
+                       ASN1_STRING_length(uri));
             if (ouri == NULL)
                 goto done;
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1576,8 +1576,8 @@ _get_aia_uri(X509 *certificate, int nid) {
         }
         uri = ad->location->d.uniformResourceIdentifier;
         ostr = PyUnicode_FromStringAndSize(
-                (const char *)ASN1_STRING_get0_data(uri),
-                ASN1_STRING_length(uri));
+                   (const char *)ASN1_STRING_get0_data(uri),
+                   ASN1_STRING_length(uri));
         if (ostr == NULL) {
             goto fail;
         }

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1437,14 +1437,14 @@ _get_peer_alt_names (_sslmodulestate *state, X509 *certificate) {
                 }
                 PyTuple_SET_ITEM(t, 0, v);
 
-                if (name->d.ip->length == 4) {
-                    unsigned char *p = name->d.ip->data;
+                if (ASN1_STRING_length(name->d.ip) == 4) {
+                    const unsigned char *p = ASN1_STRING_get0_data(name->d.ip);
                     v = PyUnicode_FromFormat(
                         "%d.%d.%d.%d",
                         p[0], p[1], p[2], p[3]
                     );
-                } else if (name->d.ip->length == 16) {
-                    unsigned char *p = name->d.ip->data;
+                } else if (ASN1_STRING_length(name->d.ip) == 16) {
+                    const unsigned char *p = ASN1_STRING_get0_data(name->d.ip);
                     v = PyUnicode_FromFormat(
                         "%X:%X:%X:%X:%X:%X:%X:%X",
                         p[0] << 8 | p[1],
@@ -1575,8 +1575,9 @@ _get_aia_uri(X509 *certificate, int nid) {
             continue;
         }
         uri = ad->location->d.uniformResourceIdentifier;
-        ostr = PyUnicode_FromStringAndSize((char *)uri->data,
-                                           uri->length);
+        ostr = PyUnicode_FromStringAndSize(
+                (const char *)ASN1_STRING_get0_data(uri),
+                ASN1_STRING_length(uri));
         if (ostr == NULL) {
             goto fail;
         }
@@ -1642,8 +1643,9 @@ _get_crl_dp(X509 *certificate) {
                 continue;
             }
             uri = gn->d.uniformResourceIdentifier;
-            ouri = PyUnicode_FromStringAndSize((char *)uri->data,
-                                               uri->length);
+            ouri = PyUnicode_FromStringAndSize(
+                    (const char *)ASN1_STRING_get0_data(uri),
+                    ASN1_STRING_length(uri));
             if (ouri == NULL)
                 goto done;
 


### PR DESCRIPTION
While `ASN1_STRING` is currently exposed, it is better to use the accessors. See https://github.com/openssl/openssl/issues/29117 where, if the type were opaque, OpenSSL's `X509` objects could be much more memory-efficient.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141801 -->
* Issue: gh-141801
<!-- /gh-issue-number -->
