### PR TITLE
gh-141004: Document descriptor and dict proxy type objects

### DIFF
--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -25,8 +25,9 @@ found in the dictionary of type objects.
 
    The type object for member descriptor objects created from
    :c:type:`PyMemberDef` structures. These descriptors expose fields of a
-   C struct as attributes on a type, and correspond to :class:`types.MemberDescriptorType`
-   objects in the Python layer.
+   C struct as attributes on a type, and correspond
+   to :class:`types.MemberDescriptorType` objects in the Python layer.
+
 
 
 .. c:var:: PyTypeObject PyGetSetDescr_Type
@@ -44,8 +45,8 @@ found in the dictionary of type objects.
 
    The type object for method descriptor objects created from
    :c:type:`PyMethodDef` structures. These descriptors expose C functions as
-   methods on a type, and correspond to :class:`types.MemberDescriptorType` objects in the
-   Python layer.
+   methods on a type, and correspond to :class:`types.MemberDescriptorType`
+   objects in the Python layer.
 
 
 .. c:function:: PyObject* PyDescr_NewWrapper(PyTypeObject *type, struct wrapperbase *wrapper, void *wrapped)
@@ -56,8 +57,8 @@ found in the dictionary of type objects.
    The type object for wrapper descriptor objects created by
    :c:func:`PyDescr_NewWrapper` and :c:func:`PyWrapper_New`. Wrapper
    descriptors are used internally to expose special methods implemented
-   via wrapper structures, and appear in Python as :class:`types.WrapperDescriptorType`
-   objects.
+   via wrapper structures, and appear in Python as
+   :class:`types.WrapperDescriptorType` objects.
 
 
 .. c:function:: PyObject* PyDescr_NewClassMethod(PyTypeObject *type, PyMethodDef *method)

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -33,6 +33,7 @@ found in the dictionary of type objects.
 
 
 .. c:var:: PyTypeObject PyMethodDescr_Type
+
    The type object for method descriptor objects created from
    :c:type:`PyMethodDef` structures. These descriptors expose C functions as
    methods on a type, and correspond to ``method_descriptor`` objects in the
@@ -43,6 +44,7 @@ found in the dictionary of type objects.
 
 
 .. c:var:: PyTypeObject PyWrapperDescr_Type
+
    The type object for wrapper descriptor objects created by
    :c:func:`PyDescr_NewWrapper` and :c:func:`PyWrapper_New`. Wrapper
    descriptors are used internally to expose special methods implemented
@@ -87,6 +89,7 @@ Built-in descriptors
 
 
 .. c:var:: PyTypeObject PyGetSetDescr_Type
+   
    The type object for get/set descriptor objects created from
    :c:type:`PyGetSetDef` structures. These descriptors implement attributes
    whose value is computed by C getter and setter functions, and are used

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -26,7 +26,7 @@ found in the dictionary of type objects.
    The type object for member descriptor objects created from
    :c:type:`PyMemberDef` structures. These descriptors expose fields of a
    C struct as attributes on a type, and correspond
-   to :class:`types.MemberDescriptorType` objects in the Python layer.
+   to :class:`types.MemberDescriptorType` objects in Python.
 
 
 
@@ -46,7 +46,7 @@ found in the dictionary of type objects.
    The type object for method descriptor objects created from
    :c:type:`PyMethodDef` structures. These descriptors expose C functions as
    methods on a type, and correspond to :class:`types.MemberDescriptorType`
-   objects in the Python layer.
+   objects in Python.
 
 
 .. c:function:: PyObject* PyDescr_NewWrapper(PyTypeObject *type, struct wrapperbase *wrapper, void *wrapped)
@@ -93,8 +93,8 @@ Built-in descriptors
 
    The type object for C-level class method descriptor objects.
    This is the type of the descriptors created for :func:`classmethod` defined in
-   C extension types, and is the same object as :class:`classmethod` in the
-   Python layer.
+   C extension types, and is the same object as :class:`classmethod`
+   in Python.
 
 
 .. c:function:: PyObject *PyClassMethod_New(PyObject *callable)

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -92,8 +92,8 @@ Built-in descriptors
 .. c:var:: PyTypeObject PyClassMethodDescr_Type
 
    The type object for C-level class method descriptor objects.
-   This is the type of the descriptors created for :func:`classmethod` defined in C
-   extension types, and is the same object as :class:`classmethod` in the
+   This is the type of the descriptors created for :func:`classmethod` defined in
+   C extension types, and is the same object as :class:`classmethod` in the
    Python layer.
 
 

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -25,8 +25,16 @@ found in the dictionary of type objects.
 
    The type object for member descriptor objects created from
    :c:type:`PyMemberDef` structures. These descriptors expose fields of a
-   C struct as attributes on a type, and correspond to ``member_descriptor``
+   C struct as attributes on a type, and correspond to :class:`types.MemberDescriptorType`
    objects in the Python layer.
+
+
+.. c:var:: PyTypeObject PyGetSetDescr_Type
+
+   The type object for get/set descriptor objects created from
+   :c:type:`PyGetSetDef` structures. These descriptors implement attributes
+   whose value is computed by C getter and setter functions, and are used
+   for many built-in type attributes.
 
 
 .. c:function:: PyObject* PyDescr_NewMethod(PyTypeObject *type, struct PyMethodDef *meth)
@@ -36,7 +44,7 @@ found in the dictionary of type objects.
 
    The type object for method descriptor objects created from
    :c:type:`PyMethodDef` structures. These descriptors expose C functions as
-   methods on a type, and correspond to ``method_descriptor`` objects in the
+   methods on a type, and correspond to :class:`types.MemberDescriptorType` objects in the
    Python layer.
 
 
@@ -48,7 +56,7 @@ found in the dictionary of type objects.
    The type object for wrapper descriptor objects created by
    :c:func:`PyDescr_NewWrapper` and :c:func:`PyWrapper_New`. Wrapper
    descriptors are used internally to expose special methods implemented
-   via wrapper structures, and appear in Python as ``wrapper_descriptor``
+   via wrapper structures, and appear in Python as :class:`types.WrapperDescriptorType`
    objects.
 
 
@@ -86,14 +94,6 @@ Built-in descriptors
    This is the type of the descriptors created for :func:`classmethod` defined in C
    extension types, and is the same object as :class:`classmethod` in the
    Python layer.
-
-
-.. c:var:: PyTypeObject PyGetSetDescr_Type
-
-   The type object for get/set descriptor objects created from
-   :c:type:`PyGetSetDef` structures. These descriptors implement attributes
-   whose value is computed by C getter and setter functions, and are used
-   for many built-in type attributes.
 
 
 .. c:function:: PyObject *PyClassMethod_New(PyObject *callable)

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -21,10 +21,33 @@ found in the dictionary of type objects.
 .. c:function:: PyObject* PyDescr_NewMember(PyTypeObject *type, struct PyMemberDef *meth)
 
 
+.. c:var:: PyTypeObject PyMemberDescr_Type
+
+   The type object for member descriptor objects created from
+   :c:type:`PyMemberDef` structures. These descriptors expose fields of a
+   C struct as attributes on a type, and correspond to ``member_descriptor``
+   objects in the Python layer.
+
+
 .. c:function:: PyObject* PyDescr_NewMethod(PyTypeObject *type, struct PyMethodDef *meth)
 
 
+.. c:var:: PyTypeObject PyMethodDescr_Type
+   The type object for method descriptor objects created from
+   :c:type:`PyMethodDef` structures. These descriptors expose C functions as
+   methods on a type, and correspond to ``method_descriptor`` objects in the
+   Python layer.
+
+
 .. c:function:: PyObject* PyDescr_NewWrapper(PyTypeObject *type, struct wrapperbase *wrapper, void *wrapped)
+
+
+.. c:var:: PyTypeObject PyWrapperDescr_Type
+   The type object for wrapper descriptor objects created by
+   :c:func:`PyDescr_NewWrapper` and :c:func:`PyWrapper_New`. Wrapper
+   descriptors are used internally to expose special methods implemented
+   via wrapper structures, and appear in Python as ``wrapper_descriptor``
+   objects.
 
 
 .. c:function:: PyObject* PyDescr_NewClassMethod(PyTypeObject *type, PyMethodDef *method)
@@ -53,6 +76,21 @@ Built-in descriptors
 
    The type of class method objects. This is the same object as
    :class:`classmethod` in the Python layer.
+
+
+.. c:var:: PyTypeObject PyClassMethodDescr_Type
+
+   The type object for C-level class method descriptor objects.
+   This is the type of the descriptors created for :func:`classmethod` defined in C
+   extension types, and is the same object as :class:`classmethod` in the
+   Python layer.
+
+
+.. c:var:: PyTypeObject PyGetSetDescr_Type
+   The type object for get/set descriptor objects created from
+   :c:type:`PyGetSetDef` structures. These descriptors implement attributes
+   whose value is computed by C getter and setter functions, and are used
+   for many built-in type attributes.
 
 
 .. c:function:: PyObject *PyClassMethod_New(PyObject *callable)

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -89,7 +89,7 @@ Built-in descriptors
 
 
 .. c:var:: PyTypeObject PyGetSetDescr_Type
-   
+
    The type object for get/set descriptor objects created from
    :c:type:`PyGetSetDef` structures. These descriptors implement attributes
    whose value is computed by C getter and setter functions, and are used

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -44,7 +44,7 @@ Dictionary Objects
 
 
 .. c:var:: PyTypeObject PyDictProxy_Type
-   
+
    The type object for mapping proxy objects created by
    :c:func:`PyDictProxy_New` and for the read-only ``__dict__`` attribute
    of many built-in types. A :c:type:`PyDictProxy_Type` instance provides a

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -50,7 +50,8 @@ Dictionary Objects
    of many built-in types. A :c:type:`PyDictProxy_Type` instance provides a
    dynamic, read-only view of an underlying dictionary: changes to the
    underlying dictionary are reflected in the proxy, but the proxy itself
-   does not support mutation operations.
+   does not support mutation operations.These objects correspond to 
+   :class:`types.MappingProxyType` in Python.
 
 
 .. c:function:: void PyDict_Clear(PyObject *p)

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -43,6 +43,15 @@ Dictionary Objects
    prevent modification of the dictionary for non-dynamic class types.
 
 
+.. c:var:: PyTypeObject PyDictProxy_Type
+   The type object for mapping proxy objects created by
+   :c:func:`PyDictProxy_New` and for the read-only ``__dict__`` attribute
+   of many built-in types. A :c:type:`PyDictProxy_Type` instance provides a
+   dynamic, read-only view of an underlying dictionary: changes to the
+   underlying dictionary are reflected in the proxy, but the proxy itself
+   does not support mutation operations.
+
+
 .. c:function:: void PyDict_Clear(PyObject *p)
 
    Empty an existing dictionary of all key-value pairs.

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -44,6 +44,7 @@ Dictionary Objects
 
 
 .. c:var:: PyTypeObject PyDictProxy_Type
+   
    The type object for mapping proxy objects created by
    :c:func:`PyDictProxy_New` and for the read-only ``__dict__`` attribute
    of many built-in types. A :c:type:`PyDictProxy_Type` instance provides a

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -50,7 +50,7 @@ Dictionary Objects
    of many built-in types. A :c:type:`PyDictProxy_Type` instance provides a
    dynamic, read-only view of an underlying dictionary: changes to the
    underlying dictionary are reflected in the proxy, but the proxy itself
-   does not support mutation operations.These objects correspond to
+   does not support mutation operations. This corresponds to
    :class:`types.MappingProxyType` in Python.
 
 

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -50,7 +50,7 @@ Dictionary Objects
    of many built-in types. A :c:type:`PyDictProxy_Type` instance provides a
    dynamic, read-only view of an underlying dictionary: changes to the
    underlying dictionary are reflected in the proxy, but the proxy itself
-   does not support mutation operations.These objects correspond to 
+   does not support mutation operations.These objects correspond to
    :class:`types.MappingProxyType` in Python.
 
 


### PR DESCRIPTION
This PR adds C API documentation for six previously undocumented type objects:

**In `Doc/c-api/descriptor.rst`:**
- `PyClassMethodDescr_Type` - type for class method descriptors
- `PyGetSetDescr_Type` - type for get/set descriptors
- `PyMemberDescr_Type` - type for member descriptors
- `PyMethodDescr_Type` - type for method descriptors
- `PyWrapperDescr_Type` - type for wrapper descriptors

**In `Doc/c-api/dict.rst`:**
- `PyDictProxy_Type` - type for mapping proxy objects

Each entry follows the existing documentation style and includes a brief description of the type's purpose and its relationship to the Python layer.

Contributes to #141004.


<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141803.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->