### PR TITLE
Explain that `__add__` is the dunder method for `operator.__concat__`

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -220,7 +220,8 @@ Operations which work with sequences (some of them with mappings too) include:
               __concat__(a, b)
 
    Return ``a + b`` for *a* and *b* sequences.
-   Note: this calls ``__add__`` - there is no ``__concat__`` dunder method.
+   (Note that there is no :meth:`!__concat__`. 
+   Instead, the :meth:`~object.__add__` method is called.)
 
 
 .. function:: contains(a, b)
@@ -520,7 +521,8 @@ will perform the update, so no subsequent assignment is necessary:
               __iconcat__(a, b)
 
    ``a = iconcat(a, b)`` is equivalent to ``a += b`` for *a* and *b* sequences.
-   Note: this calls ``__iadd__`` - there is no ``__iconcat__`` dunder method.
+   (Note that there is no :meth:`!__iconcat__`. 
+   Instead, the :meth:`~object.__iadd__` method is called.)
 
 
 .. function:: ifloordiv(a, b)

--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -220,7 +220,7 @@ Operations which work with sequences (some of them with mappings too) include:
               __concat__(a, b)
 
    Return ``a + b`` for *a* and *b* sequences.
-   (Note that there is no :meth:`!__concat__` method. 
+   (Note that there is no :meth:`!__concat__` method.
    Instead, the :meth:`~object.__add__` method is called.)
 
 
@@ -521,7 +521,7 @@ will perform the update, so no subsequent assignment is necessary:
               __iconcat__(a, b)
 
    ``a = iconcat(a, b)`` is equivalent to ``a += b`` for *a* and *b* sequences.
-   (Note that there is no :meth:`!__iconcat__` method. 
+   (Note that there is no :meth:`!__iconcat__` method.
    Instead, the :meth:`~object.__iadd__` method is called.)
 
 

--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -220,6 +220,7 @@ Operations which work with sequences (some of them with mappings too) include:
               __concat__(a, b)
 
    Return ``a + b`` for *a* and *b* sequences.
+   Note: this calls ``__add__`` - there is no ``__concat__`` dunder method.
 
 
 .. function:: contains(a, b)
@@ -519,6 +520,7 @@ will perform the update, so no subsequent assignment is necessary:
               __iconcat__(a, b)
 
    ``a = iconcat(a, b)`` is equivalent to ``a += b`` for *a* and *b* sequences.
+   Note: this calls ``__iadd__`` - there is no ``__iconcat__`` dunder method.
 
 
 .. function:: ifloordiv(a, b)

--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -220,7 +220,7 @@ Operations which work with sequences (some of them with mappings too) include:
               __concat__(a, b)
 
    Return ``a + b`` for *a* and *b* sequences.
-   (Note that there is no :meth:`!__concat__`. 
+   (Note that there is no :meth:`!__concat__` method. 
    Instead, the :meth:`~object.__add__` method is called.)
 
 
@@ -521,7 +521,7 @@ will perform the update, so no subsequent assignment is necessary:
               __iconcat__(a, b)
 
    ``a = iconcat(a, b)`` is equivalent to ``a += b`` for *a* and *b* sequences.
-   (Note that there is no :meth:`!__iconcat__`. 
+   (Note that there is no :meth:`!__iconcat__` method. 
    Instead, the :meth:`~object.__iadd__` method is called.)
 
 


### PR DESCRIPTION
I found this confusing so added a couple of lines to the documentation

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141807.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->