### PR TITLE
GH-140638: Add a GC "candidates" stat

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -111,7 +111,7 @@ The :mod:`gc` module provides the following functions:
      list) inside this generation;
 
    * ``candidates`` is the total number of objects in this generation which were
-     traversed and considered for collection;
+     considered for collection and traversed;
 
    * ``duration`` is the total time in seconds spent in collections for this
      generation.
@@ -323,7 +323,7 @@ values but should not rebind them):
       that could not be collected and were put in :data:`garbage`.
 
       "candidates": When *phase* is "stop", the total number of objects in this
-      generation which were traversed and considered for collection.
+      generation which were considered for collection and traversed.
 
       "duration": When *phase* is "stop", the time in seconds spent in the
       collection.

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -110,8 +110,8 @@ The :mod:`gc` module provides the following functions:
      to be uncollectable (and were therefore moved to the :data:`garbage`
      list) inside this generation;
 
-   * ``visited`` is the total number of unique objects visited during each
-     collection of this generation;
+   * ``candidates`` is the total number of objects in this generation which were
+     traversed and considered for collection;
 
    * ``duration`` is the total time in seconds spent in collections for this
      generation.
@@ -119,7 +119,7 @@ The :mod:`gc` module provides the following functions:
    .. versionadded:: 3.4
 
    .. versionchanged:: next
-      Add ``duration`` and ``visited``.
+      Add ``duration`` and ``candidates``.
 
 
 .. function:: set_threshold(threshold0, [threshold1, [threshold2]])
@@ -322,8 +322,8 @@ values but should not rebind them):
       "uncollectable": When *phase* is "stop", the number of objects
       that could not be collected and were put in :data:`garbage`.
 
-      "visited": When *phase* is "stop", the number of unique objects visited
-      during the collection.
+      "candidates": When *phase* is "stop", the total number of objects in this
+      generation which were traversed and considered for collection.
 
       "duration": When *phase* is "stop", the time in seconds spent in the
       collection.
@@ -341,7 +341,7 @@ values but should not rebind them):
    .. versionadded:: 3.3
 
    .. versionchanged:: next
-      Add "duration" and "visited".
+      Add "duration" and "candidates".
 
 
 The following constants are provided for use with :func:`set_debug`:

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -110,13 +110,16 @@ The :mod:`gc` module provides the following functions:
      to be uncollectable (and were therefore moved to the :data:`garbage`
      list) inside this generation;
 
+   * ``visited`` is the total number of unique objects visited during each
+     collection of this generation;
+
    * ``duration`` is the total time in seconds spent in collections for this
      generation.
 
    .. versionadded:: 3.4
 
    .. versionchanged:: next
-      Add ``duration``.
+      Add ``duration`` and ``visited``.
 
 
 .. function:: set_threshold(threshold0, [threshold1, [threshold2]])
@@ -319,6 +322,9 @@ values but should not rebind them):
       "uncollectable": When *phase* is "stop", the number of objects
       that could not be collected and were put in :data:`garbage`.
 
+      "visited": When *phase* is "stop", the number of unique objects visited
+      during the collection.
+
       "duration": When *phase* is "stop", the time in seconds spent in the
       collection.
 
@@ -335,7 +341,7 @@ values but should not rebind them):
    .. versionadded:: 3.3
 
    .. versionchanged:: next
-      Add "duration".
+      Add "duration" and "visited".
 
 
 The following constants are provided for use with :func:`set_debug`:

--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -179,7 +179,7 @@ struct gc_collection_stats {
     Py_ssize_t collected;
     /* total number of uncollectable objects (put into gc.garbage) */
     Py_ssize_t uncollectable;
-    // Total number of objects traversed and considered for collection:
+    // Total number of objects considered for collection and traversed:
     Py_ssize_t candidates;
     // Duration of the collection in seconds:
     double duration;
@@ -193,7 +193,7 @@ struct gc_generation_stats {
     Py_ssize_t collected;
     /* total number of uncollectable objects (put into gc.garbage) */
     Py_ssize_t uncollectable;
-    // Total number of objects traversed and considered for collection:
+    // Total number of objects considered for collection and traversed:
     Py_ssize_t candidates;
     // Duration of the collection in seconds:
     double duration;

--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -179,8 +179,8 @@ struct gc_collection_stats {
     Py_ssize_t collected;
     /* total number of uncollectable objects (put into gc.garbage) */
     Py_ssize_t uncollectable;
-    // Total number of objects visited:
-    Py_ssize_t visited;
+    // Total number of objects traversed and considered for collection:
+    Py_ssize_t candidates;
     // Duration of the collection in seconds:
     double duration;
 };
@@ -193,8 +193,8 @@ struct gc_generation_stats {
     Py_ssize_t collected;
     /* total number of uncollectable objects (put into gc.garbage) */
     Py_ssize_t uncollectable;
-    // Total number of objects visited:
-    Py_ssize_t visited;
+    // Total number of objects traversed and considered for collection:
+    Py_ssize_t candidates;
     // Duration of the collection in seconds:
     double duration;
 };

--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -179,6 +179,8 @@ struct gc_collection_stats {
     Py_ssize_t collected;
     /* total number of uncollectable objects (put into gc.garbage) */
     Py_ssize_t uncollectable;
+    // Total number of objects visited:
+    Py_ssize_t visited;
     // Duration of the collection in seconds:
     double duration;
 };
@@ -191,6 +193,8 @@ struct gc_generation_stats {
     Py_ssize_t collected;
     /* total number of uncollectable objects (put into gc.garbage) */
     Py_ssize_t uncollectable;
+    // Total number of objects visited:
+    Py_ssize_t visited;
     // Duration of the collection in seconds:
     double duration;
 };

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -848,12 +848,12 @@ class GCTests(unittest.TestCase):
             self.assertIsInstance(st, dict)
             self.assertEqual(
                 set(st),
-                {"collected", "collections", "uncollectable", "visited", "duration"}
+                {"collected", "collections", "uncollectable", "candidates", "duration"}
             )
             self.assertGreaterEqual(st["collected"], 0)
             self.assertGreaterEqual(st["collections"], 0)
             self.assertGreaterEqual(st["uncollectable"], 0)
-            self.assertGreaterEqual(st["visited"], 0)
+            self.assertGreaterEqual(st["candidates"], 0)
             self.assertGreaterEqual(st["duration"], 0)
         # Check that collection counts are incremented correctly
         if gc.isenabled():
@@ -868,7 +868,7 @@ class GCTests(unittest.TestCase):
         self.assertGreater(new[0]["duration"], old[0]["duration"])
         self.assertEqual(new[1]["duration"], old[1]["duration"])
         self.assertEqual(new[2]["duration"], old[2]["duration"])
-        for stat in ["collected", "uncollectable", "visited"]:
+        for stat in ["collected", "uncollectable", "candidates"]:
             self.assertGreaterEqual(new[0][stat], old[0][stat])
             self.assertEqual(new[1][stat], old[1][stat])
             self.assertEqual(new[2][stat], old[2][stat])
@@ -880,7 +880,7 @@ class GCTests(unittest.TestCase):
         self.assertEqual(new[0]["duration"], old[0]["duration"])
         self.assertEqual(new[1]["duration"], old[1]["duration"])
         self.assertGreater(new[2]["duration"], old[2]["duration"])
-        for stat in ["collected", "uncollectable", "visited"]:
+        for stat in ["collected", "uncollectable", "candidates"]:
             self.assertEqual(new[0][stat], old[0][stat])
             self.assertEqual(new[1][stat], old[1][stat])
             self.assertGreaterEqual(new[2][stat], old[2][stat])
@@ -1319,7 +1319,7 @@ class GCCallbackTests(unittest.TestCase):
             self.assertIn("generation", info)
             self.assertIn("collected", info)
             self.assertIn("uncollectable", info)
-            self.assertIn("visited", info)
+            self.assertIn("candidates", info)
             self.assertIn("duration", info)
 
     def test_collect_generation(self):

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -846,11 +846,14 @@ class GCTests(unittest.TestCase):
         self.assertEqual(len(stats), 3)
         for st in stats:
             self.assertIsInstance(st, dict)
-            self.assertEqual(set(st),
-                             {"collected", "collections", "uncollectable", "duration"})
+            self.assertEqual(
+                set(st),
+                {"collected", "collections", "uncollectable", "visited", "duration"}
+            )
             self.assertGreaterEqual(st["collected"], 0)
             self.assertGreaterEqual(st["collections"], 0)
             self.assertGreaterEqual(st["uncollectable"], 0)
+            self.assertGreaterEqual(st["visited"], 0)
             self.assertGreaterEqual(st["duration"], 0)
         # Check that collection counts are incremented correctly
         if gc.isenabled():
@@ -865,7 +868,7 @@ class GCTests(unittest.TestCase):
         self.assertGreater(new[0]["duration"], old[0]["duration"])
         self.assertEqual(new[1]["duration"], old[1]["duration"])
         self.assertEqual(new[2]["duration"], old[2]["duration"])
-        for stat in ["collected", "uncollectable"]:
+        for stat in ["collected", "uncollectable", "visited"]:
             self.assertGreaterEqual(new[0][stat], old[0][stat])
             self.assertEqual(new[1][stat], old[1][stat])
             self.assertEqual(new[2][stat], old[2][stat])
@@ -877,7 +880,7 @@ class GCTests(unittest.TestCase):
         self.assertEqual(new[0]["duration"], old[0]["duration"])
         self.assertEqual(new[1]["duration"], old[1]["duration"])
         self.assertGreater(new[2]["duration"], old[2]["duration"])
-        for stat in ["collected", "uncollectable"]:
+        for stat in ["collected", "uncollectable", "visited"]:
             self.assertEqual(new[0][stat], old[0][stat])
             self.assertEqual(new[1][stat], old[1][stat])
             self.assertGreaterEqual(new[2][stat], old[2][stat])
@@ -1316,6 +1319,7 @@ class GCCallbackTests(unittest.TestCase):
             self.assertIn("generation", info)
             self.assertIn("collected", info)
             self.assertIn("uncollectable", info)
+            self.assertIn("visited", info)
             self.assertIn("duration", info)
 
     def test_collect_generation(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-20-22-09-22.gh-issue-140638.f6btj0.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-20-22-09-22.gh-issue-140638.f6btj0.rst
@@ -1,0 +1,2 @@
+Expose a ``"visited"`` stat in :func:`gc.get_stats` and
+:data:`gc.callbacks`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-20-22-09-22.gh-issue-140638.f6btj0.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-20-22-09-22.gh-issue-140638.f6btj0.rst
@@ -1,2 +1,2 @@
-Expose a ``"visited"`` stat in :func:`gc.get_stats` and
+Expose a ``"candidates"`` stat in :func:`gc.get_stats` and
 :data:`gc.callbacks`.

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -358,10 +358,11 @@ gc_get_stats_impl(PyObject *module)
     for (i = 0; i < NUM_GENERATIONS; i++) {
         PyObject *dict;
         st = &stats[i];
-        dict = Py_BuildValue("{snsnsnsd}",
+        dict = Py_BuildValue("{snsnsnsnsd}",
                              "collections", st->collections,
                              "collected", st->collected,
                              "uncollectable", st->uncollectable,
+                             "visited", st->visited,
                              "duration", st->duration
                             );
         if (dict == NULL)

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -362,7 +362,7 @@ gc_get_stats_impl(PyObject *module)
                              "collections", st->collections,
                              "collected", st->collected,
                              "uncollectable", st->uncollectable,
-                             "visited", st->visited,
+                             "candidates", st->candidates,
                              "duration", st->duration
                             );
         if (dict == NULL)

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1759,7 +1759,7 @@ gc_collect_region(PyThreadState *tstate,
     assert(!_PyErr_Occurred(tstate));
 
     gc_list_init(&unreachable);
-    stats->visited += deduce_unreachable(from, &unreachable);
+    stats->visited = deduce_unreachable(from, &unreachable);
     validate_consistent_old_space(from);
     untrack_tuples(from);
 

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1320,7 +1320,7 @@ handle_resurrected_objects(PyGC_Head *unreachable, PyGC_Head* still_unreachable,
     // have the PREV_MARK_COLLECTING set, but the objects are going to be
     // removed so we can skip the expense of clearing the flag.
     PyGC_Head* resurrected = unreachable;
-    (void)deduce_unreachable(resurrected, still_unreachable);
+    deduce_unreachable(resurrected, still_unreachable);
     clear_unreachable_mask(still_unreachable);
 
     // Move the resurrected objects to the old generation for future collection.

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1667,6 +1667,7 @@ gc_collect_increment(PyThreadState *tstate, struct gc_collection_stats *stats)
         Py_ssize_t objects_marked = mark_at_start(tstate);
         GC_STAT_ADD(1, objects_transitively_reachable, objects_marked);
         gcstate->work_to_do -= objects_marked;
+        stats->candidates += objects_marked;
         validate_spaces(gcstate);
         return;
     }

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -2376,7 +2376,7 @@ gc_collect_main(PyThreadState *tstate, int generation, _PyGC_Reason reason)
     GC_STAT_ADD(generation, collections, 1);
 
     if (reason != _Py_GC_REASON_SHUTDOWN) {
-        invoke_gc_callback(tstate, "start", generation, 0, 0, 0, 0);
+        invoke_gc_callback(tstate, "start", generation, 0, 0, 0, 0.0);
     }
 
     if (gcstate->debug & _PyGC_DEBUG_STATS) {
@@ -2450,7 +2450,7 @@ gc_collect_main(PyThreadState *tstate, int generation, _PyGC_Reason reason)
     }
 
     if (reason != _Py_GC_REASON_SHUTDOWN) {
-        invoke_gc_callback(tstate, "stop", generation, m, n, state->visited, duration);
+        invoke_gc_callback(tstate, "stop", generation, m, n, state.visited, duration);
     }
 
     assert(!_PyErr_Occurred(tstate));

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -977,7 +977,7 @@ update_refs(const mi_heap_t *heap, const mi_heap_area_t *area,
             void *block, size_t block_size, void *args)
 {
     struct collection_state *state = (struct collection_state *)args;
-    PyObject *op = op_from_block(block, &state->base, false);
+    PyObject *op = op_from_block(block, args, false);
     if (op == NULL) {
         return true;
     }

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -977,7 +977,6 @@ update_refs(const mi_heap_t *heap, const mi_heap_area_t *area,
             void *block, size_t block_size, void *args)
 {
     struct collection_state *state = (struct collection_state *)args;
-    state->visited++;
     PyObject *op = op_from_block(block, &state->base, false);
     if (op == NULL) {
         return true;
@@ -994,6 +993,7 @@ update_refs(const mi_heap_t *heap, const mi_heap_area_t *area,
         gc_clear_unreachable(op);
         return true;
     }
+    state->visited++;
 
     Py_ssize_t refcount = Py_REFCNT(op);
     if (_PyObject_HasDeferredRefcount(op)) {

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -982,10 +982,6 @@ update_refs(const mi_heap_t *heap, const mi_heap_area_t *area,
         return true;
     }
 
-    if (gc_is_alive(op)) {
-        return true;
-    }
-
     // Exclude immortal objects from garbage collection
     if (_Py_IsImmortal(op)) {
         op->ob_tid = 0;
@@ -993,7 +989,11 @@ update_refs(const mi_heap_t *heap, const mi_heap_area_t *area,
         gc_clear_unreachable(op);
         return true;
     }
+    // Marked objects count as candidates, immortals don't:
     state->candidates++;
+    if (gc_is_alive(op)) {
+        return true;
+    }
 
     Py_ssize_t refcount = Py_REFCNT(op);
     if (_PyObject_HasDeferredRefcount(op)) {

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1437,7 +1437,7 @@ deduce_unreachable_heap(PyInterpreterState *interp,
     // Identify objects that are directly reachable from outside the GC heap
     // by computing the difference between the refcount and the number of
     // incoming references.
-    gc_visit_heaps(interp, &update_refs, &state);
+    gc_visit_heaps(interp, &update_refs, &state->base);
 
 #ifdef GC_DEBUG
     // Check that all objects are marked as unreachable and that the computed


### PR DESCRIPTION
This exposes a counter for the number of unique objects seen in the current generation. Previously, something like `sum(len(gc.get_objects(g)) for g in range(gen + 1))` was needed to get the a statistic like this (in this PR I've made the choice to collect this statistic in `update_refs`, and omit immortal but include marked members of the current generation).

It's useful for things like `info["collected"] / info["candidates"]`, to get the efficiency of a collection.

<!-- gh-issue-number: gh-140638 -->
* Issue: gh-140638
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141814.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->