### PR TITLE
gh-119786: Remove mention of `_PyThreadState_BumpFramePointer` from `InternalDocs/interpreter.md`

### DIFF
--- a/InternalDocs/interpreter.md
+++ b/InternalDocs/interpreter.md
@@ -229,8 +229,8 @@ Since 3.11, frames are no longer fully-fledged objects. Instead, a leaner intern
 `_PyInterpreterFrame` structure is used. Most frames are allocated contiguously in a
 per-thread stack (see `_PyThreadState_PushFrame` in [Python/pystate.c](../Python/pystate.c)),
 which improves memory locality and reduces overhead.
-If current `datastack_chunk` has enough space (`_PyThreadState_HasStackSpace`)
-then lightweight `_PyFrame_PushUnchecked` can be used.
+If the current `datastack_chunk` has enough space (`_PyThreadState_HasStackSpace`)
+then the lightweight `_PyFrame_PushUnchecked` can be used instead of `_PyThreadState_PushFrame`.
 
 Sometimes an actual `PyFrameObject` is needed, such as when Python code calls
 `sys._getframe()` or an extension module calls

--- a/InternalDocs/interpreter.md
+++ b/InternalDocs/interpreter.md
@@ -226,10 +226,11 @@ Up through 3.10, the call stack was implemented as a singly-linked list of
 heap allocation for the stack frame.
 
 Since 3.11, frames are no longer fully-fledged objects. Instead, a leaner internal
-`_PyInterpreterFrame` structure is used, which is allocated using a custom allocator
-function (`_PyThreadState_BumpFramePointer()`), which allocates and initializes a
-frame structure. Usually a frame allocation is just a pointer bump, which improves
-memory locality.
+`_PyInterpreterFrame` structure is used. Most frames are allocated contiguously in a
+per-thread stack (see `_PyThreadState_PushFrame` in [Python/pystate.c](../Python/pystate.c)),
+which improves memory locality and reduces overhead.
+If current `datastack_chunk` has enough space (`_PyThreadState_HasStackSpace`)
+then lightweight `_PyFrame_PushUnchecked` can be used.
 
 Sometimes an actual `PyFrameObject` is needed, such as when Python code calls
 `sys._getframe()` or an extension module calls


### PR DESCRIPTION
In https://github.com/python/cpython/pull/93908 function `_PyThreadState_BumpFramePointer` was removed.
But we still have its mention in `InternalDocs/interpreter.md`.
I propose to remove it and slightly change wording around.
For example, functions `_PyThreadState_HasStackSpace` and `_PyFrame_PushUnchecked` could be mentioned.

CC @iritkatriel @markshannon 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119786 -->
* Issue: gh-119786
<!-- /gh-issue-number -->
