### PR TITLE
gh-141817: Add IPV6_HDRINCL constant to the socket module

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -482,6 +482,9 @@ The AF_* and SOCK_* constants are now :class:`AddressFamily` and
    .. versionchanged:: 3.14
       Added support for ``TCP_QUICKACK`` on Windows platforms when available.
 
+   .. versionchanged:: 3.15
+      ``IPV6_HDRINCL`` was added.
+
 
 .. data:: AF_CAN
           PF_CAN

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -482,7 +482,7 @@ The AF_* and SOCK_* constants are now :class:`AddressFamily` and
    .. versionchanged:: 3.14
       Added support for ``TCP_QUICKACK`` on Windows platforms when available.
 
-   .. versionchanged:: 3.15
+   .. versionchanged:: next
       ``IPV6_HDRINCL`` was added.
 
 

--- a/Misc/NEWS.d/next/Library/2025-11-21-21-14-10.gh-issue-141817._v5LdB.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-21-21-14-10.gh-issue-141817._v5LdB.rst
@@ -1,1 +1,1 @@
-Add :data:`socket.IPV6_HDRINCL` constant.
+Add :data:`!socket.IPV6_HDRINCL` constant.

--- a/Misc/NEWS.d/next/Library/2025-11-21-21-14-10.gh-issue-141817._v5LdB.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-21-21-14-10.gh-issue-141817._v5LdB.rst
@@ -1,0 +1,1 @@
+Add :data:`socket.IPV6_HDRINCL` constant.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -8901,6 +8901,9 @@ socket_exec(PyObject *m)
 #ifdef IPV6_HOPLIMIT
     ADD_INT_MACRO(m, IPV6_HOPLIMIT);
 #endif
+#ifdef IPV6_HDRINCL
+    ADD_INT_MACRO(m, IPV6_HDRINCL);
+#endif
 #ifdef IPV6_HOPOPTS
     ADD_INT_MACRO(m, IPV6_HOPOPTS);
 #endif


### PR DESCRIPTION
Add the `socket.IPV6_HDRINCL` constant on platforms that support it.

There are a lot more constants that could also be added. How far should this be taken?

<!-- gh-issue-number: gh-141817 -->
* Issue: gh-141817
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141818.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->