### PR TITLE
[3.13] gh-141659: Fix bad file descriptor error in subprocess on AIX (GH-141660)

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-11-17-08-16-30.gh-issue-141659.QNi9Aj.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-17-08-16-30.gh-issue-141659.QNi9Aj.rst
@@ -1,0 +1,1 @@
+Fix bad file descriptor errors from ``_posixsubprocess`` on AIX.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -512,7 +512,13 @@ _close_open_fds_maybe_unsafe(int start_fd, int *fds_to_keep,
         proc_fd_dir = NULL;
     else
 #endif
+#if defined(_AIX)
+        char fd_path[PATH_MAX];
+        snprintf(fd_path, sizeof(fd_path), "/proc/%ld/fd", (long)getpid());
+        proc_fd_dir = opendir(fd_path);
+#else
         proc_fd_dir = opendir(FD_DIR);
+#endif
     if (!proc_fd_dir) {
         /* No way to get a list of open fds. */
         _close_range_except(start_fd, -1, fds_to_keep, fds_to_keep_len,


### PR DESCRIPTION

/proc/self does not exist on AIX.
(cherry picked from commit 92c5de73b8d7526326c865b1a669b868f0d40c1e)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Fixes https://github.com/python/cpython/issues/141659.


<!-- gh-issue-number: gh-141659 -->
* Issue: gh-141659
<!-- /gh-issue-number -->
