### PR TITLE
gh-141838: Add EmptyList, EmptyDict, EmptySet types for empty collection hinting

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -112,6 +112,12 @@ __all__ = [
     'TypedDict',  # Not really a type.
     'Generator',
 
+    # Empty collection types.
+    'EmptyList',
+    'EmptyDict',
+    'EmptySet',
+    'EmptyTuple',
+
     # Other concrete types.
     'BinaryIO',
     'IO',
@@ -2810,6 +2816,40 @@ DefaultDict = _alias(collections.defaultdict, 2, name='DefaultDict')
 OrderedDict = _alias(collections.OrderedDict, 2)
 Counter = _alias(collections.Counter, 1)
 ChainMap = _alias(collections.ChainMap, 2)
+
+# Empty collection types
+def _empty_list_getitem(self, parameters):
+    raise TypeError(f"{self._name} cannot be subscriptable")
+
+
+def _empty_dict_getitem(self, parameters):
+    raise TypeError(f"{self._name} cannot be subscriptable")
+
+
+def _empty_set_getitem(self, parameters):
+    raise TypeError(f"{self._name} cannot be subscriptable")
+
+
+def _empty_tuple_getitem(self, parameters):
+    raise TypeError(f"{self._name} cannot be subscriptable")
+
+
+EmptyList = _SpecialForm(_empty_list_getitem)
+EmptyList._name = 'EmptyList'
+EmptyList.__doc__ = """Special form for type hinting empty lists: []."""
+
+EmptyDict = _SpecialForm(_empty_dict_getitem)
+EmptyDict._name = 'EmptyDict'
+EmptyDict.__doc__ = """Special form for type hinting empty dicts: {}."""
+
+EmptySet = _SpecialForm(_empty_set_getitem)
+EmptySet._name = 'EmptySet'
+EmptySet.__doc__ = """Special form for type hinting empty sets: set()."""
+
+EmptyTuple = _SpecialForm(_empty_tuple_getitem)
+EmptyTuple._name = 'EmptyTuple'
+EmptyTuple.__doc__ = """Special form for type hinting empty tuples: ()."""
+
 Generator = _alias(collections.abc.Generator, 3, defaults=(types.NoneType, types.NoneType))
 AsyncGenerator = _alias(collections.abc.AsyncGenerator, 2, defaults=(types.NoneType,))
 Type = _alias(type, 1, inst=False, name='Type')


### PR DESCRIPTION
# Feature or enhancement Issue #141838

### Proposal:

## Proposal: Add Empty Collection Type Hints for Enhanced Type Precision

**Problem:** The current type system doesn't distinguish between empty and non-empty containers, which can lead to ambiguity in function contracts and require additional code inspection.

**Current limitation:**
```python
def get_user_data() -> List[Dict[str, str]]:
    # The return type doesn't indicate whether empty results are possible
    if not users_exist:
        return []  # Empty list
    return [{"name": "john"}]
```

**Proposal:** We suggest adding special forms for empty collections:
- `EmptyList` for `[]`
- `EmptyDict` for `{}`
- `EmptySet` for `set()`
- `EmptyTuple` for `()`

**Use cases:**
```python
from typing import EmptyList, EmptyDict

# Clearer function contracts
def initialize() -> EmptyDict:
    return {}

# Optional results with precise types
def find_users(query: str) -> List[User] | EmptyList:
    if not query:
        return []
    return [user1, user2]

# Configuration with empty defaults
def load_settings() -> Dict[str, Setting] | EmptyDict:
    if not config_exists():
        return {}
    return parse_config()
```

**Benefits:**
- More precise type annotations
- Better communication of function semantics
- Enhanced static analysis capabilities
- Self-documenting code without runtime cost

**Implementation consideration:** These could be implemented as `_SpecialForm` instances, similar to existing special types, ensuring no runtime impact.

This would provide developers with additional expressiveness when designing APIs and function interfaces, particularly for cases where empty collections have specific semantic meaning.

### Has this already been discussed elsewhere?

This is a minor feature, which does not need previous discussion elsewhere


<!-- gh-issue-number: gh-141838 -->
* Issue: gh-141838
<!-- /gh-issue-number -->
