### PR TITLE
gh-141833: Remove the bad lines in `test_attr_promotion_failure`

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -2480,8 +2480,6 @@ class TestUopsOptimization(unittest.TestCase):
 
 
         testfunc(_testinternalcapi.TIER2_THRESHOLD)
-        ex = get_first_executor(testfunc)
-        assert ex is not None
         """))
 
     def test_pop_top_specialize_none(self):

--- a/Misc/NEWS.d/next/Tests/2025-11-22-21-15-00.gh-issue-141833.QDZnXH.rst
+++ b/Misc/NEWS.d/next/Tests/2025-11-22-21-15-00.gh-issue-141833.QDZnXH.rst
@@ -1,0 +1,2 @@
+Remove ``assert ex is not None`` and the line getting the executor in
+``test_attr_promotion_failure``.

--- a/Misc/NEWS.d/next/Tests/2025-11-22-21-15-00.gh-issue-141833.QDZnXH.rst
+++ b/Misc/NEWS.d/next/Tests/2025-11-22-21-15-00.gh-issue-141833.QDZnXH.rst
@@ -1,2 +1,0 @@
-Remove ``assert ex is not None`` and the line getting the executor in
-``test_attr_promotion_failure``.


### PR DESCRIPTION
Remove the bad assert (`assert ex is not None`) and the line preceding it getting the executor.

<!-- gh-issue-number: gh-141833 -->
* Issue: gh-141833
<!-- /gh-issue-number -->
