### PR TITLE
gh-120158: Fix inconsistent monitoring state when setting events too frequently

### DIFF
--- a/Lib/test/test_free_threading/test_monitoring.py
+++ b/Lib/test/test_free_threading/test_monitoring.py
@@ -73,6 +73,9 @@ class InstrumentationMultiThreadedMixin:
                 break
 
             self.during_threads()
+            # Sleep to avoid setting monitoring events too rapidly and
+            # overflowing the global version counter
+            time.sleep(0.0001)
 
         self.after_test()
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-22-10-43-26.gh-issue-120158.41_rXd.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-22-10-43-26.gh-issue-120158.41_rXd.rst
@@ -1,0 +1,2 @@
+Fix inconsistent state when enabling or disabling monitoring events too many
+times.

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -2021,12 +2021,12 @@ _PyMonitoring_SetEvents(int tool_id, _PyMonitoringEventSet events)
     if (existing_events == events) {
         return 0;
     }
-    set_events(&interp->monitors, tool_id, events);
     uint32_t new_version = global_version(interp) + MONITORING_VERSION_INCREMENT;
     if (new_version == 0) {
         PyErr_Format(PyExc_OverflowError, "events set too many times");
         return -1;
     }
+    set_events(&interp->monitors, tool_id, events);
     set_global_version(tstate, new_version);
 #ifdef _Py_TIER2
     _Py_Executors_InvalidateAll(interp, 1);


### PR DESCRIPTION
If we overflowed the global version counter (i.e., after 2*24 calls to `_PyMonitoring_SetEvents`), we bailed out after setting global monitoring events but before instrumenting code objects, which led to assertion errors later on.

Also add a `time.sleep()` to `test_free_threading.test_monitoring` to avoid overflowing the global version counter.


<!-- gh-issue-number: gh-120158 -->
* Issue: gh-120158
<!-- /gh-issue-number -->
