### PR TITLE
gh-141623: operator.rst: don't use bitwise keyword

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -110,7 +110,7 @@ The mathematical and bitwise operations are the most numerous:
 .. function:: and_(a, b)
               __and__(a, b)
 
-   Return the bitwise and of *a* and *b*.
+   Return ``a & b``.
 
 
 .. function:: floordiv(a, b)
@@ -134,13 +134,13 @@ The mathematical and bitwise operations are the most numerous:
               __inv__(obj)
               __invert__(obj)
 
-   Return the bitwise inverse of the number *obj*.  This is equivalent to ``~obj``.
+   Return ``~obj``.
 
 
 .. function:: lshift(a, b)
               __lshift__(a, b)
 
-   Return *a* shifted left by *b*.
+   Return ``a << b``.
 
 
 .. function:: mod(a, b)
@@ -152,7 +152,7 @@ The mathematical and bitwise operations are the most numerous:
 .. function:: mul(a, b)
               __mul__(a, b)
 
-   Return ``a * b``, for *a* and *b* numbers.
+   Return ``a * b``.
 
 
 .. function:: matmul(a, b)
@@ -172,25 +172,25 @@ The mathematical and bitwise operations are the most numerous:
 .. function:: or_(a, b)
               __or__(a, b)
 
-   Return the bitwise or of *a* and *b*.
+   Return ``a | b``.
 
 
 .. function:: pos(obj)
               __pos__(obj)
 
-   Return *obj* positive (``+obj``).
+   Return ``+obj``.
 
 
 .. function:: pow(a, b)
               __pow__(a, b)
 
-   Return ``a ** b``, for *a* and *b* numbers.
+   Return ``a ** b``.
 
 
 .. function:: rshift(a, b)
               __rshift__(a, b)
 
-   Return *a* shifted right by *b*.
+   Return ``a >> b``.
 
 
 .. function:: sub(a, b)
@@ -209,7 +209,7 @@ The mathematical and bitwise operations are the most numerous:
 .. function:: xor(a, b)
               __xor__(a, b)
 
-   Return the bitwise exclusive or of *a* and *b*.
+   Return ``a ^ b``.
 
 
 Operations which work with sequences (some of them with mappings too) include:
@@ -403,13 +403,18 @@ Python syntax and the functions in the :mod:`!operator` module.
 +-----------------------+-------------------------+---------------------------------------+
 | Division              | ``a // b``              | ``floordiv(a, b)``                    |
 +-----------------------+-------------------------+---------------------------------------+
-| Bitwise And           | ``a & b``               | ``and_(a, b)``                        |
+| Bitwise And, or       | ``a & b``               | ``and_(a, b)``                        |
+| Intersection          |                         |                                       |
 +-----------------------+-------------------------+---------------------------------------+
-| Bitwise Exclusive Or  | ``a ^ b``               | ``xor(a, b)``                         |
+| Bitwise Exclusive Or, | ``a ^ b``               | ``xor(a, b)``                         |
+| or Symmetric          |                         |                                       |
+| Difference            |                         |                                       |
 +-----------------------+-------------------------+---------------------------------------+
-| Bitwise Inversion     | ``~ a``                 | ``invert(a)``                         |
+| Bitwise Inversion, or | ``~ a``                 | ``invert(a)``                         |
+| Complement            |                         |                                       |
 +-----------------------+-------------------------+---------------------------------------+
-| Bitwise Or            | ``a | b``               | ``or_(a, b)``                         |
+| Bitwise Or, or        | ``a | b``               | ``or_(a, b)``                         |
+| Union                 |                         |                                       |
 +-----------------------+-------------------------+---------------------------------------+
 | Exponentiation        | ``a ** b``              | ``pow(a, b)``                         |
 +-----------------------+-------------------------+---------------------------------------+


### PR DESCRIPTION
IMO this change should be backported to the stable release branches.

<!-- gh-issue-number: gh-141623 -->
* Issue: gh-141623
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141846.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->