### PR TITLE
gh-98552: flush std streams in the multiprocessing forkserver before fork

### DIFF
--- a/Lib/multiprocessing/forkserver.py
+++ b/Lib/multiprocessing/forkserver.py
@@ -326,6 +326,7 @@ def main(listener_fd, alive_r, preload, main_path=None, sys_path=None,
                                     len(fds)))
                         child_r, child_w, *fds = fds
                         s.close()
+                        util._flush_std_streams()
                         pid = os.fork()
                         if pid == 0:
                             # Child

--- a/Misc/NEWS.d/next/Library/2025-11-22-18-00-38.gh-issue-98552.d5KNy-.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-22-18-00-38.gh-issue-98552.d5KNy-.rst
@@ -1,0 +1,4 @@
+The :mod:`multiprocessing` forkserver process now flushes stdout and stderr
+before it forks to avoid the confusion children inheriting any buffered but
+not yet written output data.  Normally there is none, but when using
+:func:`multiprocessing.set_forkserver_preload` there *could* be.


### PR DESCRIPTION
A minor bug discovered by multiple authors working on a fix for the original bug in the linked issue.

<!-- gh-issue-number: gh-98552 -->
* Issue: gh-98552
<!-- /gh-issue-number -->
