### PR TITLE
gh-141674: Docs: Prepend 'Python' to the HTML short title

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -286,7 +286,7 @@ if any('htmlhelp' in arg for arg in sys.argv):
     print("It may be removed in the future\n")
 
 # Short title used e.g. for <title> HTML tags.
-html_short_title = f'Python {version} Documentation'
+html_short_title = f'Python {release} Documentation'
 
 # Deployment preview information
 # (See .readthedocs.yml and https://docs.readthedocs.io/en/stable/reference/environment-variables.html)

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -286,7 +286,7 @@ if any('htmlhelp' in arg for arg in sys.argv):
     print("It may be removed in the future\n")
 
 # Short title used e.g. for <title> HTML tags.
-html_short_title = f'{release} Documentation'
+html_short_title = f'Python {".".join(release.split(".")[:2])} Documentation'
 
 # Deployment preview information
 # (See .readthedocs.yml and https://docs.readthedocs.io/en/stable/reference/environment-variables.html)

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -286,7 +286,7 @@ if any('htmlhelp' in arg for arg in sys.argv):
     print("It may be removed in the future\n")
 
 # Short title used e.g. for <title> HTML tags.
-html_short_title = f'Python {".".join(release.split(".")[:2])} Documentation'
+html_short_title = f'Python {version} Documentation'
 
 # Deployment preview information
 # (See .readthedocs.yml and https://docs.readthedocs.io/en/stable/reference/environment-variables.html)


### PR DESCRIPTION
Now:
<img width="1793" height="805" alt="image" src="https://github.com/user-attachments/assets/8efc7c06-a153-4181-afd0-a045dc6aed4a" />


<!-- gh-issue-number: gh-141674 -->
* Issue: gh-141674
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141868.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->