### PR TITLE
gh-98552: Revert (unneeded, already done elsewhere) "flush std streams in the multiprocessing forkserver before fork (#141849)"

### DIFF
--- a/Lib/multiprocessing/forkserver.py
+++ b/Lib/multiprocessing/forkserver.py
@@ -326,7 +326,6 @@ def main(listener_fd, alive_r, preload, main_path=None, sys_path=None,
                                     len(fds)))
                         child_r, child_w, *fds = fds
                         s.close()
-                        util._flush_std_streams()
                         pid = os.fork()
                         if pid == 0:
                             # Child

--- a/Misc/NEWS.d/next/Library/2025-11-22-18-00-38.gh-issue-98552.d5KNy-.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-22-18-00-38.gh-issue-98552.d5KNy-.rst
@@ -1,4 +1,0 @@
-The :mod:`multiprocessing` forkserver process now flushes stdout and stderr
-before it forks to avoid the confusion children inheriting any buffered but
-not yet written output data.  Normally there is none, but when using
-:func:`multiprocessing.set_forkserver_preload` there *could* be.


### PR DESCRIPTION
This reverts commit 58badb1711e12b6e8b5240ab96cdd01b95012de7.

https://github.com/python/cpython/issues/135335 already took care of this a bit earlier in the code.

<!-- gh-issue-number: gh-98552 -->
* Issue: gh-98552
<!-- /gh-issue-number -->
