### PR TITLE
fix: drop three unused import

### DIFF
--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -31,7 +31,6 @@ import os
 import sys
 import code
 import warnings
-import errno
 
 from .readline import _get_reader, multiline_input, append_history_file
 

--- a/Lib/asyncio/tools.py
+++ b/Lib/asyncio/tools.py
@@ -1,6 +1,6 @@
 """Tools to analyze tasks running in asyncio programs."""
 
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from itertools import count
 from enum import Enum
 import sys

--- a/Lib/shelve.py
+++ b/Lib/shelve.py
@@ -57,7 +57,6 @@ the persistent dictionary on disk, if feasible).
 """
 
 from pickle import DEFAULT_PROTOCOL, dumps, loads
-from io import BytesIO
 
 import collections.abc
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

check the code base and found some unused imports this three maybe can delete for sure.

this can be skip news and issue number
