### PR TITLE
gh-141865: Fix translation of strings in `changes.py` extension

### DIFF
--- a/Doc/tools/templates/dummy.html
+++ b/Doc/tools/templates/dummy.html
@@ -27,8 +27,8 @@ In extensions/implementation_detail.py:
 
 In extensions/changes.py:
 
-{% trans %}Deprecated since version {deprecated}, will be removed in version {removed}{% endtrans %}
-{% trans %}Deprecated since version {deprecated}, removed in version {removed}{% endtrans %}
+{% trans %}Deprecated since version %s, will be removed in version %s{% endtrans %}
+{% trans %}Deprecated since version %s, removed in version %s{% endtrans %}
 
 In docsbuild-scripts, when rewriting indexsidebar.html with actual versions:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141865 -->
* Issue: gh-141865
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141882.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->