### PR TITLE
GH-141890: Fix GC double-counting of marked objects

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-23-19-45-49.gh-issue-141890.99IS5Y.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-23-19-45-49.gh-issue-141890.99IS5Y.rst
@@ -1,0 +1,2 @@
+Fix an issue where garbage collection could run less frequently than
+expected.

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1618,7 +1618,6 @@ mark_at_start(PyThreadState *tstate)
     PyGC_Head *visited = &gcstate->old[gcstate->visited_space].head;
     Py_ssize_t objects_marked = mark_global_roots(tstate->interp, visited, gcstate->visited_space);
     objects_marked += mark_stacks(tstate->interp, visited, gcstate->visited_space, true);
-    gcstate->work_to_do -= objects_marked;
     gcstate->phase = GC_PHASE_COLLECT;
     validate_spaces(gcstate);
     return objects_marked;


### PR DESCRIPTION
This move happens twice: once here, and once in `gc_collect_increment` (the caller).

<!-- gh-issue-number: gh-141890 -->
* Issue: gh-141890
<!-- /gh-issue-number -->
