### PR TITLE
gh-141907: Better handle support for SHA3 for test_hashlib

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -40,16 +40,15 @@ else:
 openssl_hashlib = import_fresh_module('hashlib', fresh=['_hashlib'])
 
 try:
-    from _hashlib import HASH
+    import _hashlib
 except ImportError:
-    HASH = None
-
-try:
-    from _hashlib import HASHXOF, openssl_md_meth_names, get_fips_mode
-except ImportError:
-    HASHXOF = None
-    openssl_md_meth_names = frozenset()
-
+    _hashlib = None
+# The extension module may exist but only define some of these. gh-141907
+HASH = getattr(_hashlib, 'HASH', None)
+HASHXOF = getattr(_hashlib, 'HASHXOF', None)
+openssl_md_meth_names = getattr(_hashlib, 'openssl_md_meth_names', frozenset())
+get_fips_mode = getattr(_hashlib, 'get_fips_mode', None)
+if not get_fips_mode:
     def get_fips_mode():
         return 0
 


### PR DESCRIPTION
It's possible that the SSL library supports only SHA3 algo and doesn't have SHAKE one.

The current test wrongly detect this and set both HASH and HASHXOF to None expecting to have the extra SHA3 attributes present but this should only be true for SHAKE algo.

To better handle this, move the HASH condition to a dedicated try-expect condition and check if HASHXOF is None in the relevant code effectively checking if SHA3 is supported by the SSL library but SHAKE algo needs to use the sha3module one.

<!-- gh-issue-number: gh-141907 -->
* Issue: gh-141907
<!-- /gh-issue-number -->
