### PR TITLE
gh-141926 : Add `--enable-cross-run` configure option to avoid clearing `RUNSHARED` on cross-compile

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -1210,6 +1210,20 @@ the version of the cross compiled host Python.
 
    .. versionadded:: 3.11
 
+.. option:: --enable-cross-run
+
+   Enable running the target CPython binary on the build host during
+   cross-compilation.
+
+   By default, the build system assumes that target binaries cannot be executed
+   on the build host when cross-compiling which can disable optimizations such
+   as PGO.
+
+   When `--enable-cross-run` is used, the build system may attempt to execute
+   the target binaries, which is appropriate for situations where emulated
+   execution is transparently available.
+
+   .. versionadded:: 3.15
 
 Cross compiling example::
 

--- a/Misc/NEWS.d/next/Build/2025-11-24-17-01-16.gh-issue-141926.Rcxj2J.rst
+++ b/Misc/NEWS.d/next/Build/2025-11-24-17-01-16.gh-issue-141926.Rcxj2J.rst
@@ -1,0 +1,2 @@
+Add ```--enable-cross-run`` to allow execution of the target binary (e.g.,
+for PGO) during cross-compilation.

--- a/configure
+++ b/configure
@@ -1094,6 +1094,7 @@ with_suffix
 enable_shared
 with_static_libpython
 enable_profiling
+enable_cross_run
 enable_gil
 with_pydebug
 with_trace_refs
@@ -1829,6 +1830,8 @@ Optional Features:
                           no)
   --enable-profiling      enable C-level code profiling with gprof (default is
                           no)
+  --enable-cross-run      allow running target binaries during
+                          cross-compilation (default is no)
   --disable-gil           enable support for running without the GIL (default
                           is no)
   --enable-pystats        enable internal statistics gathering (default is no)
@@ -7790,8 +7793,30 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LDLIBRARY" >&5
 printf "%s\n" "$LDLIBRARY" >&6; }
 
+# Check for --enable-cross-run
+# Check whether --enable-cross-run was given.
+if test ${enable_cross_run+y}
+then :
+  enableval=$enable_cross_run;
+else case e in #(
+  e) enable_cross_run=no ;;
+esac
+fi
+
+
 if test "$cross_compiling" = yes; then
-  RUNSHARED=
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to keep RUNSHARED for cross build" >&5
+printf %s "checking whether to keep RUNSHARED for cross build... " >&6; }
+  if test "$enable_cross_run" = yes
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes (--enable-cross-run)" >&5
+printf "%s\n" "yes (--enable-cross-run)" >&6; }
+else case e in #(
+  e) RUNSHARED=
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; } ;;
+esac
+fi
 fi
 
 # HOSTRUNNER - Program to run CPython for the host platform

--- a/configure.ac
+++ b/configure.ac
@@ -1630,8 +1630,19 @@ else # shared is disabled
 fi
 AC_MSG_RESULT([$LDLIBRARY])
 
+# Check for --enable-cross-run
+AC_ARG_ENABLE([cross-run],
+  [AS_HELP_STRING([--enable-cross-run],
+    [allow running target binaries during cross-compilation (default is no)])],
+  [],
+  [enable_cross_run=no])
+
 if test "$cross_compiling" = yes; then
-  RUNSHARED=
+  AC_MSG_CHECKING([whether to keep RUNSHARED for cross build])
+  AS_IF([test "$enable_cross_run" = yes],
+    [AC_MSG_RESULT([yes (--enable-cross-run)])],
+    [RUNSHARED=
+     AC_MSG_RESULT([no])])
 fi
 
 # HOSTRUNNER - Program to run CPython for the host platform


### PR DESCRIPTION
This is a fairly simple start to address https://github.com/python/cpython/issues/141926 by retaining `RUNSHARED` via an opt-in configure flag.

A subsequent pull request could add the ability to automatically check if a cross-compiled binary can be executed.

<!-- gh-issue-number: gh-141926 -->
* Issue: gh-141926
<!-- /gh-issue-number -->
