### PR TITLE
gh-141778: Missing validation for allowed constant values in `ast.literal_eval()`

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -72,7 +72,7 @@ def _convert_literal(node):
     """
     if (
         isinstance(node, Constant)
-        and type(value := node.value) in (int, float, complex, bytes, bool,
+        and type(value := node.value) in (int, float, complex, bytes, bool, str, bytes,
                                           type_None, type_Ellipsis)
     ):
         return value

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -22,6 +22,8 @@ that work tightly with the python syntax (template engines for example).
 """
 from _ast import *
 
+type_None = type(None)
+type_Ellipsis = type(...)
 
 def parse(source, filename='<unknown>', mode='exec', *,
           type_comments=False, feature_version=None, optimize=-1, module=None):
@@ -68,8 +70,12 @@ def _convert_literal(node):
     """
     Used by `literal_eval` to convert an AST node into a value.
     """
-    if isinstance(node, Constant):
-        return node.value
+    if (
+        isinstance(node, Constant)
+        and type(value := node.value) in (int, float, complex, bytes, bool,
+                                          type_None, type_Ellipsis)
+    ):
+        return value
     if isinstance(node, Dict) and len(node.keys) == len(node.values):
         return dict(zip(
             map(_convert_literal, node.keys),

--- a/Misc/NEWS.d/next/Library/2025-12-19-06-51-09.gh-issue-141778.mPAupY.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-19-06-51-09.gh-issue-141778.mPAupY.rst
@@ -1,0 +1,1 @@
+Add missing validation for allowed constant values in :func:`ast.literal_eval`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141778 -->
* Issue: gh-141778
<!-- /gh-issue-number -->
