### PR TITLE
gh-140505: Fix 'parameters' to 'arguments' in xmlrpc.client.MultiCall docs

### DIFF
--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -472,7 +472,7 @@ remote server into a single request [#]_.
 
    Create an object used to boxcar method calls. *server* is the eventual target of
    the call. Calls can be made to the result object, but they will immediately
-   return ``None``, and only store the call name and parameters in the
+   return ``None``, and only store the call name and arguments in the
    :class:`MultiCall` object. Calling the object itself causes all stored calls to
    be transmitted as a single ``system.multicall`` request. The result of this call
    is a :term:`generator`; iterating over this generator yields the individual


### PR DESCRIPTION
Fixes #140505

The xmlrpc.client.MultiCall documentation incorrectly used 'parameters' when it should say 'arguments'. 

As noted in the issue, the MultiCall object stores the call name and arguments (not parameters) since the call occurs through a `__getitem__` that returns a `_MultiCallMethod` callable with `*args`. 

This PR changes the word 'parameters' to 'arguments' in line 475 of the MultiCall class documentation.

<!-- gh-issue-number: gh-140505 -->
* Issue: gh-140505
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141942.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->