### PR TITLE
gh-59000: Fix pdb breakpoint resolution for class methods when module not imported

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1487,7 +1487,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             f = self.lookupmodule(parts[0])
             if f:
                 fname = f
-            item = parts[1]
+                item = parts[1]
+            else:
+                return failed
         answer = find_function(item, self.canonic(fname))
         return answer or failed
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4609,7 +4609,6 @@ def bœr():
         """
         stdout, stderr = self.run_pdb_script(script, commands)
         res_lines = [x.strip() for x in stdout.splitlines()]
-        print(res_lines)
         # can't set breakpoint before class C is defined, and gives an error
         self.assertIn("The specified object 'C.foo' is not a function", res_lines[3])
         # can set correctly after the class C is defined

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4590,27 +4590,32 @@ def bœr():
     def test_issue_59000(self):
         script = """
             def foo():
-                pass
+                test_str = "break foo"
 
             class C:
-                def c_foo(self):
-                    pass
                 def foo(self):
-                    pass
+                    test_str = "break C.foo"
 
             foo()
+            C().foo()
         """
         commands = """
             break foo
             break C.foo
-            break C.c_foo
-            break 10
             continue
             break C.foo
+            continue
             quit
         """
         stdout, stderr = self.run_pdb_script(script, commands)
-        self.assertIn("The specified object 'C.c_foo' is not a function", stdout)
+        res_lines = [x.strip() for x in stdout.splitlines()]
+        print(res_lines)
+        # can't set breakpoint before class C is defined, and gives an error
+        self.assertIn("The specified object 'C.foo' is not a function", res_lines[3])
+        # can set correctly after the class C is defined
+        self.assertRegex(res_lines[6], r"Breakpoint 2 at .*main\.py:7")
+        self.assertIn('test_str = "break C.foo"', res_lines[8])
+
 
 
 class ChecklineTests(unittest.TestCase):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4590,7 +4590,7 @@ def bœr():
     def test_issue_59000(self):
         script = """
             def foo():
-                test_str = "break foo"
+                pass
 
             class C:
                 def foo(self):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4595,26 +4595,13 @@ def bœr():
             class C:
                 def foo(self):
                     test_str = "break C.foo"
-
-            foo()
-            C().foo()
         """
         commands = """
-            break foo
             break C.foo
-            continue
-            break C.foo
-            continue
             quit
         """
         stdout, stderr = self.run_pdb_script(script, commands)
-        res_lines = [x.strip() for x in stdout.splitlines()]
-        # can't set breakpoint before class C is defined, and gives an error
-        self.assertIn("The specified object 'C.foo' is not a function", res_lines[3])
-        # can set correctly after the class C is defined
-        self.assertRegex(res_lines[6], r"Breakpoint 2 at .*main\.py:7")
-        self.assertIn('test_str = "break C.foo"', res_lines[8])
-
+        self.assertIn("The specified object 'C.foo' is not a function", stdout)
 
 
 class ChecklineTests(unittest.TestCase):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4594,7 +4594,7 @@ def bœr():
 
             class C:
                 def foo(self):
-                    test_str = "break C.foo"
+                    pass
         """
         commands = """
             break C.foo

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4587,6 +4587,31 @@ def bœr():
             ]))
             self.assertIn('break in bar', stdout)
 
+    def test_issue_59000(self):
+        script = """
+            def foo():
+                pass
+
+            class C:
+                def c_foo(self):
+                    pass
+                def foo(self):
+                    pass
+
+            foo()
+        """
+        commands = """
+            break foo
+            break C.foo
+            break C.c_foo
+            break 10
+            continue
+            break C.foo
+            quit
+        """
+        stdout, stderr = self.run_pdb_script(script, commands)
+        self.assertIn("The specified object 'C.c_foo' is not a function", stdout)
+
 
 class ChecklineTests(unittest.TestCase):
     def setUp(self):

--- a/Misc/NEWS.d/next/Library/2025-11-25-16-00-29.gh-issue-59000.YtOyJy.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-25-16-00-29.gh-issue-59000.YtOyJy.rst
@@ -1,0 +1,1 @@
+Fix :mod:`pdb` breakpoint resolution for class methods when the module defining the class is not imported.


### PR DESCRIPTION
Ref: https://github.com/python/cpython/issues/59000

main.py:

```python3
def foo():
    pass

class C:
    def c_foo(self):
        pass
    def foo(self):
        pass

foo()
```

Reproduction case

```python3
λ › ./python -m pdb main.py                                                                                                                                                                                                                                        vscode_files/cpython fix/pdb_break
> /cpython/main.py(1)<module>()
-> def foo():
(Pdb) b foo
Breakpoint 1 at /cpython/main.py:2
(Pdb) b C.foo
Breakpoint 2 at /cpython/main.py:2
(Pdb) b C.c_foo
*** The specified object 'C.c_foo' is not a function or was not found along sys.path.
(Pdb) b 10
Breakpoint 3 at /cpython/main.py:10
(Pdb) c
> /cpython/main.py(10)<module>()
-> foo()
(Pdb) b C.foo
Breakpoint 4 at/cpython/main.py:8
(Pdb) 
```

After the fix:

```python3
λ › ./python -m pdb main.py                                                                                                                                                                                                                                        vscode_files/cpython fix/pdb_break
> /cpython/main.py(1)<module>()
-> def foo():
(Pdb) b foo
Breakpoint 1 at /cpython/main.py:2
(Pdb) b C.foo
*** The specified object 'C.foo' is not a function or was not found along sys.path.
(Pdb) b C.c_foo
*** The specified object 'C.c_foo' is not a function or was not found along sys.path.
(Pdb) b 10
Breakpoint 2 at /cpython/main.py:10
(Pdb) c
> /cpython/main.py(10)<module>()
-> foo()
(Pdb) b C.foo
Breakpoint 3 at /cpython/main.py:8
(Pdb) 
```
Now, when the module is not imported, executing "break C.foo" no longer incorrectly registers the top-level foo function; instead, it raises a "not found" error.

As this is my first time submitting a pull request, this may not be the optimal solution. I welcome any suggestions and guidance for improvements. Perhaps implementing a function similar to find_function could allow C.foo to be handled correctly before the bytecode is executed.

https://github.com/python/cpython/blob/202fce0dbde1da32d8abc2eb59ddfce6f6a3c9fa/Lib/pdb.py#L1491-L1492



<!-- gh-issue-number: gh-59000 -->
* Issue: gh-59000
<!-- /gh-issue-number -->
