### PR TITLE
gh-141518: Add PyUnstable_InterpreterFrame_GetFrameObject() function

### DIFF
--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -227,7 +227,7 @@ Unless using :pep:`523`, you will not need this.
 
    The interpreter's internal frame representation.
 
-   The structure is intentionally opaque and there are currently no plans to
+   The structure is intentionally opaque, and there are currently no plans to
    stabilize it. Debuggers and profilers can use the internal C API to access
    the structure members.
 

--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -227,6 +227,10 @@ Unless using :pep:`523`, you will not need this.
 
    The interpreter's internal frame representation.
 
+   The structure is intentionally opaque and there are currently no plans to
+   stabilize it. Debuggers and profilers can use the internal C API to access
+   the structure members.
+
    .. versionadded:: 3.11
    .. versionchanged:: next
       Renamed to ``PyUnstable_InterpreterFrame``.

--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -223,13 +223,15 @@ Internal Frames
 
 Unless using :pep:`523`, you will not need this.
 
-.. c:struct:: _PyInterpreterFrame
+.. c:struct:: PyUnstable_InterpreterFrame
 
    The interpreter's internal frame representation.
 
    .. versionadded:: 3.11
+   .. versionchanged:: next
+      Renamed to ``PyUnstable_InterpreterFrame``.
 
-.. c:function:: PyObject* PyUnstable_InterpreterFrame_GetCode(struct _PyInterpreterFrame *frame);
+.. c:function:: PyObject* PyUnstable_InterpreterFrame_GetCode(PyUnstable_InterpreterFrame *frame);
 
     Return a :term:`strong reference` to the code object for the frame.
 
@@ -246,14 +248,14 @@ Unless using :pep:`523`, you will not need this.
    .. versionadded:: next
 
 
-.. c:function:: int PyUnstable_InterpreterFrame_GetLasti(struct _PyInterpreterFrame *frame);
+.. c:function:: int PyUnstable_InterpreterFrame_GetLasti(PyUnstable_InterpreterFrame *frame);
 
    Return the byte offset into the last executed instruction.
 
    .. versionadded:: 3.12
 
 
-.. c:function:: int PyUnstable_InterpreterFrame_GetLine(struct _PyInterpreterFrame *frame);
+.. c:function:: int PyUnstable_InterpreterFrame_GetLine(PyUnstable_InterpreterFrame *frame);
 
    Return the currently executing line number, or -1 if there is no line number.
 

--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -236,6 +236,16 @@ Unless using :pep:`523`, you will not need this.
    .. versionadded:: 3.12
 
 
+.. c:function:: PyFrameObject* PyUnstable_InterpreterFrame_GetFrameObject(PyUnstable_InterpreterFrame *frame)
+
+   Get a frame object from an interpreter frame.
+
+   Return a new :term:`strong reference` on success, or set an exception and
+   return ``NULL`` on error.
+
+   .. versionadded:: next
+
+
 .. c:function:: int PyUnstable_InterpreterFrame_GetLasti(struct _PyInterpreterFrame *frame);
 
    Return the byte offset into the last executed instruction.
@@ -248,5 +258,3 @@ Unless using :pep:`523`, you will not need this.
    Return the currently executing line number, or -1 if there is no line number.
 
    .. versionadded:: 3.12
-
-

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1438,7 +1438,7 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    .. versionadded:: 3.8
 
 
-.. c:type:: PyObject* (*_PyFrameEvalFunction)(PyThreadState *tstate, _PyInterpreterFrame *frame, int throwflag)
+.. c:type:: PyObject* (*_PyFrameEvalFunction)(PyThreadState *tstate, PyUnstable_InterpreterFrame *frame, int throwflag)
 
    Type of a frame evaluation function.
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1099,6 +1099,10 @@ New features
 * Add :c:func:`PyTuple_FromArray` to create a :class:`tuple` from an array.
   (Contributed by Victor Stinner in :gh:`111489`.)
 
+* Add :c:func:`PyUnstable_InterpreterFrame_GetFrameObject` to get a frame
+  object from an interpreter frame.
+  (Contributed by Victor Stinner in :gh:`141518`.)
+
 * Add :c:func:`PyUnstable_Object_Dump` to dump an object to ``stderr``.
   It should only be used for debugging.
   (Contributed by Victor Stinner in :gh:`141070`.)

--- a/Include/cpython/pyframe.h
+++ b/Include/cpython/pyframe.h
@@ -40,6 +40,7 @@ PyAPI_FUNC(int) PyUnstable_InterpreterFrame_GetLasti(
 PyAPI_FUNC(int) PyUnstable_InterpreterFrame_GetLine(
     PyUnstable_InterpreterFrame *frame);
 
+/* Get a frame object from an interpreter frame. */
 PyAPI_FUNC(PyFrameObject*) PyUnstable_InterpreterFrame_GetFrameObject(
     PyUnstable_InterpreterFrame *frame);
 

--- a/Include/cpython/pyframe.h
+++ b/Include/cpython/pyframe.h
@@ -23,18 +23,25 @@ PyAPI_FUNC(PyObject*) PyFrame_GetVarString(PyFrameObject *frame, const char *nam
  * implementing custom frame evaluators with PEP 523. */
 
 struct _PyInterpreterFrame;
+typedef struct _PyInterpreterFrame PyUnstable_InterpreterFrame;
 
 /* Returns the code object of the frame (strong reference).
  * Does not raise an exception. */
-PyAPI_FUNC(PyObject *) PyUnstable_InterpreterFrame_GetCode(struct _PyInterpreterFrame *frame);
+PyAPI_FUNC(PyObject *) PyUnstable_InterpreterFrame_GetCode(
+    PyUnstable_InterpreterFrame *frame);
 
 /* Returns a byte offset into the last executed instruction.
  * Does not raise an exception. */
-PyAPI_FUNC(int) PyUnstable_InterpreterFrame_GetLasti(struct _PyInterpreterFrame *frame);
+PyAPI_FUNC(int) PyUnstable_InterpreterFrame_GetLasti(
+    PyUnstable_InterpreterFrame *frame);
 
 /* Returns the currently executing line number, or -1 if there is no line number.
  * Does not raise an exception. */
-PyAPI_FUNC(int) PyUnstable_InterpreterFrame_GetLine(struct _PyInterpreterFrame *frame);
+PyAPI_FUNC(int) PyUnstable_InterpreterFrame_GetLine(
+    PyUnstable_InterpreterFrame *frame);
+
+PyAPI_FUNC(PyFrameObject*) PyUnstable_InterpreterFrame_GetFrameObject(
+    PyUnstable_InterpreterFrame *frame);
 
 #define PyUnstable_EXECUTABLE_KIND_SKIP 0
 #define PyUnstable_EXECUTABLE_KIND_PY_FUNCTION 1

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -302,7 +302,7 @@ PyAPI_FUNC(void) PyThreadState_DeleteCurrent(void);
 
 /* Frame evaluation API */
 
-typedef PyObject* (*_PyFrameEvalFunction)(PyThreadState *tstate, struct _PyInterpreterFrame *, int);
+typedef PyObject* (*_PyFrameEvalFunction)(PyThreadState *tstate, PyUnstable_InterpreterFrame *, int);
 
 PyAPI_FUNC(_PyFrameEvalFunction) _PyInterpreterState_GetEvalFrameFunc(
     PyInterpreterState *interp);

--- a/Include/internal/pycore_interpframe.h
+++ b/Include/internal/pycore_interpframe.h
@@ -290,7 +290,7 @@ _PyFrame_GetFrameObject(_PyInterpreterFrame *frame)
 {
 
     assert(!_PyFrame_IsIncomplete(frame));
-    PyFrameObject *res =  frame->frame_obj;
+    PyFrameObject *res = frame->frame_obj;
     if (res != NULL) {
         return res;
     }

--- a/Lib/test/test_capi/test_frame.py
+++ b/Lib/test/test_capi/test_frame.py
@@ -4,6 +4,7 @@ from test.support import import_helper
 
 
 _testcapi = import_helper.import_module('_testcapi')
+_testinternalcapi = import_helper.import_module('_testinternalcapi')
 
 
 class FrameTest(unittest.TestCase):
@@ -50,6 +51,35 @@ class FrameTest(unittest.TestCase):
         frame = _testcapi.frame_new(dummy.__code__, globals(), locals())
         # The following line should not cause a segmentation fault.
         self.assertIsNone(frame.f_back)
+
+
+class InterpreterFrameTest(unittest.TestCase):
+
+    @staticmethod
+    def func():
+        return sys._getframe()
+
+    def test_code(self):
+        frame = self.func()
+        code = _testinternalcapi.iframe_getcode(frame)
+        self.assertIs(code, self.func.__code__)
+
+    def test_lasti(self):
+        frame = self.func()
+        lasti = _testinternalcapi.iframe_getlasti(frame)
+        self.assertGreater(lasti, 0)
+        self.assertLess(lasti, len(self.func.__code__.co_code))
+
+    def test_line(self):
+        frame = self.func()
+        line = _testinternalcapi.iframe_getline(frame)
+        firstline = self.func.__code__.co_firstlineno
+        self.assertEqual(line, firstline + 2)
+
+    def test_frame_object(self):
+        frame = sys._getframe()
+        obj = _testinternalcapi.iframe_getframeobject(frame)
+        self.assertIs(obj, frame)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2754,30 +2754,6 @@ class Test_ModuleStateAccess(unittest.TestCase):
         self.assertIs(Subclass().get_defining_module(), self.module)
 
 
-class TestInternalFrameApi(unittest.TestCase):
-
-    @staticmethod
-    def func():
-        return sys._getframe()
-
-    def test_code(self):
-        frame = self.func()
-        code = _testinternalcapi.iframe_getcode(frame)
-        self.assertIs(code, self.func.__code__)
-
-    def test_lasti(self):
-        frame = self.func()
-        lasti = _testinternalcapi.iframe_getlasti(frame)
-        self.assertGreater(lasti, 0)
-        self.assertLess(lasti, len(self.func.__code__.co_code))
-
-    def test_line(self):
-        frame = self.func()
-        line = _testinternalcapi.iframe_getline(frame)
-        firstline = self.func.__code__.co_firstlineno
-        self.assertEqual(line, firstline + 2)
-
-
 SUFFICIENT_TO_DEOPT_AND_SPECIALIZE = 100
 
 class Test_Pep523API(unittest.TestCase):

--- a/Misc/NEWS.d/3.14.0a1.rst
+++ b/Misc/NEWS.d/3.14.0a1.rst
@@ -4222,7 +4222,7 @@ docstrings are now removed from the optimized AST in optimization level 2.
 .. nonce: A7uxqa
 .. section: Core and Builtins
 
-The ``f_executable`` field in the internal :c:struct:`_PyInterpreterFrame`
+The ``f_executable`` field in the internal :c:struct:`!_PyInterpreterFrame`
 struct now uses a tagged pointer.  Profilers and debuggers that uses this
 field should clear the least significant bit to recover the
 :c:expr:`PyObject*` pointer.

--- a/Misc/NEWS.d/next/C_API/2025-11-25-16-35-36.gh-issue-141518.gEueQd.rst
+++ b/Misc/NEWS.d/next/C_API/2025-11-25-16-35-36.gh-issue-141518.gEueQd.rst
@@ -1,0 +1,2 @@
+Add :c:func:`PyUnstable_InterpreterFrame_GetFrameObject` to get a frame
+object from an interpreter frame. Patch by Victor Stinner.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -960,6 +960,17 @@ iframe_getlasti(PyObject *self, PyObject *frame)
 }
 
 static PyObject *
+iframe_getframeobject(PyObject *self, PyObject *frame)
+{
+    if (!PyFrame_Check(frame)) {
+        PyErr_SetString(PyExc_TypeError, "argument must be a frame");
+        return NULL;
+    }
+    struct _PyInterpreterFrame *f = ((PyFrameObject *)frame)->f_frame;
+    return (PyObject*)PyUnstable_InterpreterFrame_GetFrameObject(f);
+}
+
+static PyObject *
 code_returns_only_none(PyObject *self, PyObject *arg)
 {
     if (!PyCode_Check(arg)) {
@@ -2529,6 +2540,7 @@ static PyMethodDef module_functions[] = {
     {"iframe_getcode", iframe_getcode, METH_O, NULL},
     {"iframe_getline", iframe_getline, METH_O, NULL},
     {"iframe_getlasti", iframe_getlasti, METH_O, NULL},
+    {"iframe_getframeobject", iframe_getframeobject, METH_O, NULL},
     {"code_returns_only_none", code_returns_only_none, METH_O, NULL},
     {"get_co_framesize", get_co_framesize, METH_O, NULL},
     {"get_co_localskinds", get_co_localskinds, METH_O, NULL},

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -2457,3 +2457,10 @@ PyFrame_GetGenerator(PyFrameObject *frame)
     assert(!_PyFrame_IsIncomplete(frame->f_frame));
     return frame_generator_get((PyObject *)frame, NULL);
 }
+
+
+PyFrameObject*
+PyUnstable_InterpreterFrame_GetFrameObject(PyUnstable_InterpreterFrame *frame)
+{
+    return (PyFrameObject*)Py_XNewRef(_PyFrame_GetFrameObject(frame));
+}


### PR DESCRIPTION
Add also PyUnstable_InterpreterFrame type.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141518 -->
* Issue: gh-141518
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141950.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->