### PR TITLE
gh-141926: Do not unset `RUNSHARED` when cross-compiling

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-11-25-13-17-47.gh-issue-141926.KmuM2h.rst
+++ b/Misc/NEWS.d/next/Build/2025-11-25-13-17-47.gh-issue-141926.KmuM2h.rst
@@ -1,0 +1,4 @@
+``RUNSHARED`` is no longer cleared when cross-compiling. Previously,
+``RUNSHARED`` was cleared when cross-compiling, which breaks PGO when using
+``--enabled-shared`` on systems where the cross-compiled CPython is otherwise
+executable (e.g., via transparent emulation).

--- a/configure
+++ b/configure
@@ -7790,10 +7790,6 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LDLIBRARY" >&5
 printf "%s\n" "$LDLIBRARY" >&6; }
 
-if test "$cross_compiling" = yes; then
-  RUNSHARED=
-fi
-
 # HOSTRUNNER - Program to run CPython for the host platform
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking HOSTRUNNER" >&5
 printf %s "checking HOSTRUNNER... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -1630,10 +1630,6 @@ else # shared is disabled
 fi
 AC_MSG_RESULT([$LDLIBRARY])
 
-if test "$cross_compiling" = yes; then
-  RUNSHARED=
-fi
-
 # HOSTRUNNER - Program to run CPython for the host platform
 AC_MSG_CHECKING([HOSTRUNNER])
 if test -z "$HOSTRUNNER"


### PR DESCRIPTION
An alternative to https://github.com/python/cpython/pull/141927 just removing what appears to be legacy code instead of providing a way to opt-in to different behavior.

Closes https://github.com/python/cpython/issues/141926
Closes https://github.com/astral-sh/python-build-standalone/issues/864

<!-- gh-issue-number: gh-141926 -->
* Issue: gh-141926
<!-- /gh-issue-number -->
