### PR TITLE
Remove `Misc/ACKS` check from `patchcheck.py` and about doc

### DIFF
--- a/Doc/about.rst
+++ b/Doc/about.rst
@@ -32,8 +32,9 @@ Contributors to the Python documentation
 ----------------------------------------
 
 Many people have contributed to the Python language, the Python standard
-library, and the Python documentation.  See :source:`Misc/ACKS` in the Python
-source distribution for a partial list of contributors.
+library, and the Python documentation.  See the `CPython
+GitHub repository <https://github.com/python/cpython/graphs/contributors>`_
+for a partial list of contributors.
 
 It is only with the input and contributions of the Python community
 that Python has such wonderful documentation -- Thank You!

--- a/Doc/about.rst
+++ b/Doc/about.rst
@@ -33,7 +33,7 @@ Contributors to the Python documentation
 
 Many people have contributed to the Python language, the Python standard
 library, and the Python documentation.  See the `CPython
-GitHub repository <https://github.com/python/cpython/graphs/contributors>`_
+GitHub repository <https://github.com/python/cpython/graphs/contributors>`__
 for a partial list of contributors.
 
 It is only with the input and contributions of the Python community

--- a/Tools/patchcheck/patchcheck.py
+++ b/Tools/patchcheck/patchcheck.py
@@ -176,12 +176,6 @@ def docs_modified(file_paths):
     return bool(file_paths)
 
 
-@status("Misc/ACKS updated", modal=True)
-def credit_given(file_paths):
-    """Check if Misc/ACKS has been changed."""
-    return os.path.join('Misc', 'ACKS') in file_paths
-
-
 @status("Misc/NEWS.d updated with `blurb`", modal=True)
 def reported_news(file_paths):
     """Check if Misc/NEWS.d has been changed."""
@@ -215,8 +209,6 @@ def main():
     misc_files = {p for p in file_paths if p.startswith('Misc')}
     # Docs updated.
     docs_modified(has_doc_files)
-    # Misc/ACKS changed.
-    credit_given(misc_files)
     # Misc/NEWS changed.
     reported_news(misc_files)
     # Regenerated configure, if necessary.


### PR DESCRIPTION
As suggested by Hugo in https://github.com/python/cpython/pull/141952#issuecomment-3577160334, replaced with a link to the GitHub chart.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141960.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->