### PR TITLE
gh-141970: use list unpacking to avoid unnecessary list copies

### DIFF
--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -4,9 +4,8 @@ import struct
 def load_tzdata(key):
     from importlib import resources
 
-    components = key.split("/")
-    package_name = ".".join(["tzdata.zoneinfo"] + components[:-1])
-    resource_name = components[-1]
+    *components, resource_name = key.split("/")
+    package_name = ".".join(["tzdata.zoneinfo"] + components)
 
     try:
         path = resources.files(package_name).joinpath(resource_name)


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141970 -->
* Issue: gh-141970
<!-- /gh-issue-number -->

## Benchmark

```python
from importlib import resources


def load_tzdata1(key):
    components = key.split("/")
    package_name = ".".join(["tzdata.zoneinfo"] + components[:-1])
    resource_name = components[-1]

    try:
        path = resources.files(package_name).joinpath(resource_name)
        # gh-85702: Prevent PermissionError on Windows
        if path.is_dir():
            raise IsADirectoryError
        return path.open("rb")
    except (
        ImportError,
        FileNotFoundError,
        UnicodeEncodeError,
        IsADirectoryError,
    ):
        # There are four types of exception that can be raised that all amount
        # to "we cannot find this key":
        #
        # ImportError: If package_name doesn't exist (e.g. if tzdata is not
        #   installed, or if there's an error in the folder name like
        #   Amrica/New_York)
        # FileNotFoundError: If resource_name doesn't exist in the package
        #   (e.g. Europe/Krasnoy)
        # UnicodeEncodeError: If package_name or resource_name are not UTF-8,
        #   such as keys containing a surrogate character.
        # IsADirectoryError: If package_name without a resource_name specified.
        pass


def load_tzdata2(key):
    *components, resource_name = key.split("/")
    package_name = ".".join(["tzdata.zoneinfo"] + components)

    try:
        path = resources.files(package_name).joinpath(resource_name)
        # gh-85702: Prevent PermissionError on Windows
        if path.is_dir():
            raise IsADirectoryError
        return path.open("rb")
    except (
        ImportError,
        FileNotFoundError,
        UnicodeEncodeError,
        IsADirectoryError,
    ):
        # There are four types of exception that can be raised that all amount
        # to "we cannot find this key":
        #
        # ImportError: If package_name doesn't exist (e.g. if tzdata is not
        #   installed, or if there's an error in the folder name like
        #   Amrica/New_York)
        # FileNotFoundError: If resource_name doesn't exist in the package
        #   (e.g. Europe/Krasnoy)
        # UnicodeEncodeError: If package_name or resource_name are not UTF-8,
        #   such as keys containing a surrogate character.
        # IsADirectoryError: If package_name without a resource_name specified.
        pass


def main():
    import timeit

    key = "America/New_York"
    t1 = timeit.timeit(lambda: load_tzdata1(key), number=1000)
    t2 = timeit.timeit(lambda: load_tzdata2(key), number=1000)

    print(f"load_tzdata1: {t1:.6f} seconds")
    print(f"load_tzdata2: {t2:.6f} seconds")


if __name__ == "__main__":
    main()

```
```
❯ ./python.exe benchmark.py
load_tzdata1: 0.075903 seconds
load_tzdata2: 0.064115 seconds
```
