### PR TITLE
[3.13] gh-141909: Add `PyModuleDef_Slot` and earlier Py_mod_* constants to stable ABI manifest (#141910)

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -404,6 +404,8 @@ The available slot types are:
    ``PyModuleDef`` has non-``NULL`` ``m_traverse``, ``m_clear``,
    ``m_free``; non-zero ``m_size``; or slots other than ``Py_mod_create``.
 
+   .. versionadded:: 3.5
+
 .. c:macro:: Py_mod_exec
 
    Specifies a function that is called to *execute* the module.
@@ -417,6 +419,8 @@ The available slot types are:
 
    If multiple ``Py_mod_exec`` slots are specified, they are processed in the
    order they appear in the *m_slots* array.
+
+   .. versionadded:: 3.5
 
 .. c:macro:: Py_mod_multiple_interpreters
 

--- a/Doc/data/stable_abi.dat
+++ b/Doc/data/stable_abi.dat
@@ -442,6 +442,7 @@ data,PyMethodDescr_Type,3.2,,
 type,PyModuleDef,3.2,,full-abi
 type,PyModuleDef_Base,3.2,,full-abi
 func,PyModuleDef_Init,3.5,,
+type,PyModuleDef_Slot,3.5,,full-abi
 data,PyModuleDef_Type,3.5,,
 func,PyModule_Add,3.13,,
 func,PyModule_AddFunctions,3.7,,
@@ -945,6 +946,10 @@ macro,Py_bf_getbuffer,3.11,,
 macro,Py_bf_releasebuffer,3.11,,
 type,Py_buffer,3.11,,full-abi
 type,Py_intptr_t,3.2,,
+macro,Py_mod_create,3.5,,
+macro,Py_mod_exec,3.5,,
+macro,Py_mod_gil,3.13,,
+macro,Py_mod_multiple_interpreters,3.12,,
 macro,Py_mp_ass_subscript,3.2,,
 macro,Py_mp_length,3.2,,
 macro,Py_mp_subscript,3.2,,

--- a/Misc/stable_abi.toml
+++ b/Misc/stable_abi.toml
@@ -40,7 +40,7 @@
 # - struct_abi_kind: for `struct`, defines how much of the struct is exposed:
 #   - 'full-abi': All of the struct is part of the ABI, including the size
 #     (users may define arrays of these structs).
-#     Typically used for initalization, rather than at runtime.
+#     Typically used for initialization, rather than at runtime.
 #   - 'opaque': No members are part of the ABI, nor is the size. The Limited
 #     API only handles these via pointers. The C definition should be
 #     incomplete (opaque).
@@ -1889,6 +1889,13 @@
     added = '3.5'
 [data.PyModuleDef_Type]
     added = '3.5'
+[const.Py_mod_create]
+    added = '3.5'
+[const.Py_mod_exec]
+    added = '3.5'
+[struct.PyModuleDef_Slot]
+    added = '3.5'
+    struct_abi_kind = 'full-abi'
 
 # New slots in 3.5:
 # d51374ed78a3e3145911a16cdf3b9b84b3ba7d15 - Matrix multiplication (PEP 465)
@@ -2431,6 +2438,9 @@
     added = '3.12'
 [const.Py_TPFLAGS_ITEMS_AT_END]
     added = '3.12'
+[const.Py_mod_multiple_interpreters]
+    added = '3.12'
+
 [function.PyImport_AddModuleRef]
     added = '3.13'
 [function.PyWeakref_GetRef]
@@ -2509,3 +2519,6 @@
     added = '3.13'
 [function.PyEval_GetFrameLocals]
     added = '3.13'
+[const.Py_mod_gil]
+    added = '3.13'
+


### PR DESCRIPTION

These were added to the limited API in 3.5-3.12.
Not including them in `Misc/stable_abi.toml` was a bug.

(cherry picked from commit 202fce0dbde1da32d8abc2eb59ddfce6f6a3c9fa)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141909 -->
* Issue: gh-141909
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--141977.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->