### PR TITLE
gh-141976: Protect against non-progressing specializations in tracing JIT

### DIFF
--- a/Include/cpython/pystats.h
+++ b/Include/cpython/pystats.h
@@ -142,6 +142,7 @@ typedef struct _optimization_stats {
     uint64_t recursive_call;
     uint64_t low_confidence;
     uint64_t unknown_callee;
+    uint64_t trace_immediately_deopts;
     uint64_t executors_invalidated;
     UOpStats opcode[PYSTATS_MAX_UOP_ID + 1];
     uint64_t unsupported_opcode[256];

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-26-20-01-07.gh-issue-141976.K8NDmR.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-26-20-01-07.gh-issue-141976.K8NDmR.rst
@@ -1,1 +1,1 @@
-Protect against specialization failures in the tracing JIT compiler.
+Protect against specialization failures in the tracing JIT compiler for performance reasons.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-26-20-01-07.gh-issue-141976.K8NDmR.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-26-20-01-07.gh-issue-141976.K8NDmR.rst
@@ -1,0 +1,1 @@
+Protect against specialization failures in the tracing JIT compiler.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -620,8 +620,11 @@ _PyJit_translate_single_bytecode_to_trace(
         // in the instruction stream, but rather the deopt.
         // It's important we check for this, as some specializations might make
         // no progress (they can immediately deopt after specializing).
+        // We do this to improve performance, as otherwise a compiled trace
+        // will just deopt immediately.
         if (backoff != adaptive_counter_cooldown().value_and_backoff &&
             backoff != trigger_backoff_counter().value_and_backoff) {
+            OPT_STAT_INC(trace_immediately_deopts);
             opcode = _PyOpcode_Deopt[opcode];
         }
     }

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -610,6 +610,22 @@ _PyJit_translate_single_bytecode_to_trace(
         target--;
     }
 
+    if (_PyOpcode_Caches[_PyOpcode_Deopt[opcode]] > 0) {
+        uint16_t backoff = (this_instr + 1)->counter.value_and_backoff;
+        // adaptive_counter_cooldown is a fresh specialization.
+        // trigger_backoff_counter is what we set during tracing.
+        // All tracing backoffs should be freshly specialized or untouched.
+        // If not, that indicates a deopt during tracing, and
+        // thus the "actual" instruction executed is not the one that is
+        // in the instruction stream, but rather the deopt.
+        // It's important we check for this, as some specializations might make
+        // no progress (they can immediately deopt after specializing).
+        if (backoff != adaptive_counter_cooldown().value_and_backoff &&
+            backoff != trigger_backoff_counter().value_and_backoff) {
+            opcode = _PyOpcode_Deopt[opcode];
+        }
+    }
+
     int old_stack_level = _tstate->jit_tracer_state.prev_state.instr_stacklevel;
 
     // Strange control-flow


### PR DESCRIPTION
I do not have a test for this as it's too hard to test for. We require the following scenario to happen:
1. Non-progressing specialization
2. that deopts

We don't have that many non-progressing specializations to begin with, so any test is a futile fight between the internal implementation details and the JIT.

I have verified this fixes the test case in the issue. I'm not using the test case in the issue as it's dependent on how much stack space we reserve and consume per stack chunk. If we ever change the stack chunks size, the test will break.

<!-- gh-issue-number: gh-141976 -->
* Issue: gh-141976
<!-- /gh-issue-number -->
