### PR TITLE
GH-142002: Revert GC changes to "work_to_do" logic.

### DIFF
--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1493,11 +1493,10 @@ class GCTogglingTests(unittest.TestCase):
             # The free-threaded build doesn't have multiple generations, so
             # just trigger a GC manually.
             gc.collect()
-        assert not detector.gc_happened
         while not detector.gc_happened:
             i += 1
-            if i > 100000:
-                self.fail("gc didn't happen after 100000 iterations")
+            if i > 10000:
+                self.fail("gc didn't happen after 10000 iterations")
             self.assertEqual(len(ouch), 0)
             junk.append([])  # this will eventually trigger gc
 
@@ -1569,8 +1568,8 @@ class GCTogglingTests(unittest.TestCase):
             gc.collect()
         while not detector.gc_happened:
             i += 1
-            if i > 50000:
-                self.fail("gc didn't happen after 50000 iterations")
+            if i > 10000:
+                self.fail("gc didn't happen after 10000 iterations")
             self.assertEqual(len(ouch), 0)
             junk.append([])  # this will eventually trigger gc
 
@@ -1587,8 +1586,8 @@ class GCTogglingTests(unittest.TestCase):
         detector = GC_Detector()
         while not detector.gc_happened:
             i += 1
-            if i > 100000:
-                self.fail("gc didn't happen after 100000 iterations")
+            if i > 10000:
+                self.fail("gc didn't happen after 10000 iterations")
             junk.append([])  # this will eventually trigger gc
 
         try:
@@ -1598,11 +1597,11 @@ class GCTogglingTests(unittest.TestCase):
             detector = GC_Detector()
             while not detector.gc_happened:
                 i += 1
-                if i > 100000:
+                if i > 10000:
                     break
                 junk.append([])  # this may eventually trigger gc (if it is enabled)
 
-            self.assertEqual(i, 100001)
+            self.assertEqual(i, 10001)
         finally:
             gc.enable()
 


### PR DESCRIPTION
This reverts parts of the GH-140262 change.  The changes that affect the tuple untracking are left unchanged.  Revert the changes to the calculation of the increment size, based on the "work_to_do" variable. This causes cyclic garbage to be collected more quickly.  Revert also the change to test_gc.py, which was done because the expected GC collection was taking longer to happen.

With the tuple untrack change, the performance regression as reported by bug GH-139951 is still resolved (work_to_do changes are not required).

One way to test the effect of this change is to run the following quick-and-dirty script.  It creates many reference cycles and then counts how many are not yet collected by the GC.  At the end of the run, the maximum number of outstanding garbage objects are printed.  With Python 3.13 (non-incremental GC), I get a max of less than 100 objects.  With 3.14.0, I get approximately 2000 as the max.  With the "main" branch (and 3.14 branch), I get 10,000 as the max.

[gc_report_cycles.py](https://github.com/user-attachments/files/23784730/gc_report_cycles.py)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.


-->


<!-- gh-issue-number: gh-142002 -->
* Issue: gh-142002
<!-- /gh-issue-number -->
