### PR TITLE
gh-142006: Fix HeaderWriteError in email.policy.default caused by extra newline

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2792,6 +2792,10 @@ def _steal_trailing_WSP_if_exists(lines):
     if lines and lines[-1] and lines[-1][-1] in WSP:
         wsp = lines[-1][-1]
         lines[-1] = lines[-1][:-1]
+        # FIX: If the line is now empty (it was only a space), remove it entirely
+        # to prevent creating an empty line (double newline) in the output.
+        if not lines[-1]:
+            lines.pop()
     return wsp
 
 def _refold_parse_tree(parse_tree, *, policy):

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2792,8 +2792,7 @@ def _steal_trailing_WSP_if_exists(lines):
     if lines and lines[-1] and lines[-1][-1] in WSP:
         wsp = lines[-1][-1]
         lines[-1] = lines[-1][:-1]
-        # FIX: If the line is now empty (it was only a space), remove it entirely
-        # to prevent creating an empty line (double newline) in the output.
+        # gh-142006: if the line is now empty, remove it entirely.
         if not lines[-1]:
             lines.pop()
     return wsp

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -3255,5 +3255,18 @@ class TestFolding(TestEmailBase):
             " filename*1*=_TEST_TES.txt\n",
             )
 
+    def test_fold_unfoldable_element_stealing_whitespace(self):
+        # gh-142006: When an element is too long to fit on the current line
+        # the previous line's trailing whitespace
+        policy = self.policy.clone(max_line_length=10)
+
+        # "a," fits. The space after it should wrap to the next line.
+        # The "long" part (20 chars) forces the wrap because 20 > 10.
+        text = "a, " + ("b" * 20)
+        expected = "a,\n " + ("b" * 20) + "\n"
+
+        token = parser.get_address_list(text)[0]
+        self._test(token, expected, policy=policy)
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -3257,14 +3257,11 @@ class TestFolding(TestEmailBase):
 
     def test_fold_unfoldable_element_stealing_whitespace(self):
         # gh-142006: When an element is too long to fit on the current line
-        # the previous line's trailing whitespace
+        # the previous line's trailing whitespace should not trigger a double newline.
         policy = self.policy.clone(max_line_length=10)
-
-        # "a," fits. The space after it should wrap to the next line.
-        # The "long" part (20 chars) forces the wrap because 20 > 10.
-        text = "a, " + ("b" * 20)
-        expected = "a,\n " + ("b" * 20) + "\n"
-
+        # The non-whitespace text needs to exactly fill the max_line_length (10).
+        text = ("a" * 9) + ", " + ("b" * 20)
+        expected = ("a" * 9) + ",\n " + ("b" * 20) + "\n"
         token = parser.get_address_list(text)[0]
         self._test(token, expected, policy=policy)
 

--- a/Lib/test/test_email/test_policy.py
+++ b/Lib/test/test_email/test_policy.py
@@ -165,6 +165,20 @@ class PolicyAPITests(unittest.TestCase):
         self.assertEqual(p1.fold('Subject', msg['Subject']), expected)
         self.assertEqual(p2.fold('Subject', msg['Subject']), expected)
 
+    def test_fold_address_list_with_stolen_whitespace(self):
+        long_address = (
+            "loooooooooooooooooooooooooooooooooooong@dooooooooooooomainname.example.com, "
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.example.com"
+        )
+        msg = email.message_from_string(f"To: {long_address}\n\n", policy=email.policy.default)
+
+        # This should not raise HeaderWriteError
+        output = msg.as_string()
+        # Verify the output format is correct and clean
+        self.assertIn(long_address.split(',')[0], output)
+        # Ensure header section doesn't have double newlines
+        self.assertNotIn('\n\n', output.split('\n\n')[0])
+
     def test_register_defect(self):
         class Dummy:
             def __init__(self):

--- a/Lib/test/test_email/test_policy.py
+++ b/Lib/test/test_email/test_policy.py
@@ -165,20 +165,6 @@ class PolicyAPITests(unittest.TestCase):
         self.assertEqual(p1.fold('Subject', msg['Subject']), expected)
         self.assertEqual(p2.fold('Subject', msg['Subject']), expected)
 
-    def test_fold_address_list_with_stolen_whitespace(self):
-        long_address = (
-            "loooooooooooooooooooooooooooooooooooong@dooooooooooooomainname.example.com, "
-            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.example.com"
-        )
-        msg = email.message_from_string(f"To: {long_address}\n\n", policy=email.policy.default)
-
-        # This should not raise HeaderWriteError
-        output = msg.as_string()
-        # Verify the output format is correct and clean
-        self.assertIn(long_address.split(',')[0], output)
-        # Ensure header section doesn't have double newlines
-        self.assertNotIn('\n\n', output.split('\n\n')[0])
-
     def test_register_defect(self):
         class Dummy:
             def __init__(self):

--- a/Misc/NEWS.d/next/Library/2025-11-27-10-49-13.gh-issue-142006.nzJDG5.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-27-10-49-13.gh-issue-142006.nzJDG5.rst
@@ -1,0 +1,1 @@
+Fix :exc:`email.errors.HeaderWriteError` in :mod:`email.policy.default` which created double newlines when folding long headers with list separators.

--- a/Misc/NEWS.d/next/Library/2025-11-27-10-49-13.gh-issue-142006.nzJDG5.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-27-10-49-13.gh-issue-142006.nzJDG5.rst
@@ -1,1 +1,1 @@
-Fix :exc:`email.errors.HeaderWriteError` in :mod:`email.policy.default` which incorrectly added double newlines when folding lines containing unfoldable syntactic elements wider than max_line_len.
+Fix a bug in the :mod:`email.policy.default` folding algorithm which incorrectly resulted in a doubled newline when a line ending at exactly max_line_length was followed by an unfoldable token.


### PR DESCRIPTION
## Description

This PR fixes `gh-142006` where `email.policy.default` would raise a `HeaderWriteError` when folding certain long address headers.

**The Issue:**
In `_header_value_parser.py`, the function `_steal_trailing_WSP_if_exists` moves trailing whitespace from the previous line to the current one. However, if the previous line contained *only* that whitespace, it was left as an empty string `''`. When joined, this resulted in a double newline (`\n\n`), which is illegal in headers and triggered the error.

**The Fix:**
Modified `_steal_trailing_WSP_if_exists` to remove the line entirely (`lines.pop()`) if it becomes empty after stealing the whitespace.

**Verification:**
Added a regression test `test_fold_address_list_with_stolen_whitespace` to `Lib/test/test_email/test_policy.py` which reproduces the reported crash and verifies the fix.

## Linked Issue
Fixes gh-142006