### PR TITLE
gh-141858: Speed up `Objects/tupleobject.c` `richcompare` with early identity and length checks

### DIFF
--- a/Lib/test/seq_tests.py
+++ b/Lib/test/seq_tests.py
@@ -250,6 +250,43 @@ class CommonTest(unittest.TestCase):
         checklast = self.type2test([StopCompares(), 1])
         self.assertRaises(DoNotTestEq, checklast.__contains__, 1)
 
+    def test_compare_nan(self):
+        nan = float('nan')
+        a = self.type2test([nan])
+        b = self.type2test([nan])
+        self.assertTrue(a == a)
+        self.assertFalse(a != a)
+        self.assertTrue(a == b)
+        self.assertFalse(a != b)
+        self.assertFalse(a < a)
+        self.assertFalse(a < b)
+        self.assertFalse(a > b)
+
+    def test_compare_decimal_nan(self):
+        import decimal
+        nan = decimal.Decimal("NaN")
+        a = self.type2test([nan])
+        b = self.type2test([nan])
+        self.assertTrue(a == a)
+        self.assertFalse(a != a)
+        self.assertTrue(a == b)
+        self.assertFalse(a != b)
+        self.assertFalse(a < a)
+        self.assertFalse(a < b)
+        self.assertFalse(a > b)
+
+    def test_compare_signed_zero(self):
+        a = self.type2test([0.0])
+        b = self.type2test([-0.0])
+        self.assertTrue(a == a)
+        self.assertFalse(a != a)
+        self.assertTrue(b == b)
+        self.assertFalse(b != b)
+        self.assertTrue(a == b)
+        self.assertFalse(a != b)
+        self.assertFalse(a > b)
+        self.assertFalse(a < b)
+
     def test_len(self):
         self.assertEqual(len(self.type2test()), 0)
         self.assertEqual(len(self.type2test([])), 0)

--- a/Lib/test/seq_tests.py
+++ b/Lib/test/seq_tests.py
@@ -253,11 +253,16 @@ class CommonTest(unittest.TestCase):
     def check_compare_id(self, a, b):
         self.assertTrue(a == a)
         self.assertFalse(a != a)
+        self.assertTrue(b == b)
+        self.assertFalse(b != b)
         self.assertTrue(a == b)
         self.assertFalse(a != b)
         self.assertFalse(a < a)
+        self.assertFalse(b < b)
         self.assertFalse(a < b)
         self.assertFalse(a > b)
+        self.assertFalse(b < a)
+        self.assertFalse(b > a)
 
     def test_compare_nan(self):
         nan = float("nan")
@@ -276,8 +281,6 @@ class CommonTest(unittest.TestCase):
         a = self.type2test([0.0])
         b = self.type2test([-0.0])
         self.check_compare_id(a, b)
-        self.assertTrue(b == b)
-        self.assertFalse(b != b)
 
     def test_len(self):
         self.assertEqual(len(self.type2test()), 0)

--- a/Lib/test/seq_tests.py
+++ b/Lib/test/seq_tests.py
@@ -251,7 +251,7 @@ class CommonTest(unittest.TestCase):
         self.assertRaises(DoNotTestEq, checklast.__contains__, 1)
 
     def test_compare_nan(self):
-        nan = float('nan')
+        nan = float("nan")
         a = self.type2test([nan])
         b = self.type2test([nan])
         self.assertTrue(a == a)

--- a/Lib/test/seq_tests.py
+++ b/Lib/test/seq_tests.py
@@ -250,10 +250,7 @@ class CommonTest(unittest.TestCase):
         checklast = self.type2test([StopCompares(), 1])
         self.assertRaises(DoNotTestEq, checklast.__contains__, 1)
 
-    def test_compare_nan(self):
-        nan = float("nan")
-        a = self.type2test([nan])
-        b = self.type2test([nan])
+    def check_compare_id(self, a, b):
         self.assertTrue(a == a)
         self.assertFalse(a != a)
         self.assertTrue(a == b)
@@ -261,31 +258,26 @@ class CommonTest(unittest.TestCase):
         self.assertFalse(a < a)
         self.assertFalse(a < b)
         self.assertFalse(a > b)
+
+    def test_compare_nan(self):
+        nan = float("nan")
+        a = self.type2test([nan])
+        b = self.type2test([nan])
+        self.check_compare_id(a, b)
 
     def test_compare_decimal_nan(self):
         import decimal
         nan = decimal.Decimal("NaN")
         a = self.type2test([nan])
         b = self.type2test([nan])
-        self.assertTrue(a == a)
-        self.assertFalse(a != a)
-        self.assertTrue(a == b)
-        self.assertFalse(a != b)
-        self.assertFalse(a < a)
-        self.assertFalse(a < b)
-        self.assertFalse(a > b)
+        self.check_compare_id(a, b)
 
     def test_compare_signed_zero(self):
         a = self.type2test([0.0])
         b = self.type2test([-0.0])
-        self.assertTrue(a == a)
-        self.assertFalse(a != a)
+        self.check_compare_id(a, b)
         self.assertTrue(b == b)
         self.assertFalse(b != b)
-        self.assertTrue(a == b)
-        self.assertFalse(a != b)
-        self.assertFalse(a > b)
-        self.assertFalse(a < b)
 
     def test_len(self):
         self.assertEqual(len(self.type2test()), 0)

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -668,8 +668,7 @@ tuple_richcompare(PyObject *v, PyObject *w, int op)
 
     /* Fast path based on identity: if both objects are the same tuple
      * object, we return immediately without comparing items. Elements that
-     * are not equal to themselves (see check_compare_id in
-     * Lib/tests/seq_tests.py) are therefore treated as equal here.
+     * are not equal to themselves are therefore treated as equal here.
      */
     if (v == w) {
         Py_RETURN_RICHCOMPARE(0, 0, op);

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -676,11 +676,11 @@ tuple_richcompare(PyObject *v, PyObject *w, int op)
     vlen = Py_SIZE(vt);
     wlen = Py_SIZE(wt);
 
-    if (vlen != wlen && (op == Py_EQ || op == Py_NE)) {
-        if (op == Py_EQ) {
+    if (vlen != wlen) {
+        switch (op) {
+        case Py_EQ:
             Py_RETURN_FALSE;
-        }
-        else {
+        case Py_NE:
             Py_RETURN_TRUE;
         }
     }

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -666,10 +666,6 @@ tuple_richcompare(PyObject *v, PyObject *w, int op)
     if (!PyTuple_Check(v) || !PyTuple_Check(w))
         Py_RETURN_NOTIMPLEMENTED;
 
-    if (v == w) {
-        Py_RETURN_RICHCOMPARE(0, 0, op);
-    }
-
     vt = (PyTupleObject *)v;
     wt = (PyTupleObject *)w;
 

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -666,6 +666,10 @@ tuple_richcompare(PyObject *v, PyObject *w, int op)
     if (!PyTuple_Check(v) || !PyTuple_Check(w))
         Py_RETURN_NOTIMPLEMENTED;
 
+    if (v == w) {
+        Py_RETURN_RICHCOMPARE(0, 0, op);
+    }
+
     vt = (PyTupleObject *)v;
     wt = (PyTupleObject *)w;
 

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -690,9 +690,6 @@ tuple_richcompare(PyObject *v, PyObject *w, int op)
      * vlen and wlen across the comparison calls.
      */
     for (i = 0; i < vlen && i < wlen; i++) {
-        if (vt->ob_item[i] == wt->ob_item[i]) {
-            continue;
-        }
         int k = PyObject_RichCompareBool(vt->ob_item[i],
                                          wt->ob_item[i], Py_EQ);
         if (k < 0)

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -666,6 +666,11 @@ tuple_richcompare(PyObject *v, PyObject *w, int op)
     if (!PyTuple_Check(v) || !PyTuple_Check(w))
         Py_RETURN_NOTIMPLEMENTED;
 
+    /* Fast path based on identity: if both objects are the same tuple
+     * object, we return immediately without comparing items. Elements that
+     * are not equal to themselves (see check_compare_id in
+     * Lib/tests/seq_tests.py) are therefore treated as equal here.
+     */
     if (v == w) {
         Py_RETURN_RICHCOMPARE(0, 0, op);
     }


### PR DESCRIPTION
- A constant-time short-circuit when comparing a tuple to itself
- An early return for `==` and `!=` when tuple lenghts differ, to avoid a walk through the whole tuple

See below for more detailed benchmarks (9f2a34af747 v. c9015394)
    
**Significant (+ >= 1.05) improvements on pyperformance:**

- dask: 1.30x faster
- Concurrency pools: bench_thread_pool 1.11x faster; bench_mp_pool 1.06x
- Core language ops: comprehensions 1.07x; generators 1.05x
- Serialization/GC: coverage 1.05x

**Significant regressions (+ <= 1.05) on pyperformance**

- asyncio network: asyncio_tcp 1.12x slower

I'm not exactly sure, but my hunch is that's the place hit in `asyncio_tcp`:

- https://github.com/python/cpython/blob/5ec03cf3b086fd01614cbd97bb99d45aac3668fe/Lib/asyncio/events.py#L182-L188

I couldn't reproduce this with a microbenchmark, though.

The `float("nan")` behaviour is not changed:

```
>>> nan = float("nan")
>>> [nan] == [nan]
True
>>> (nan,) == (nan,)
True
>>> nan == nan
False
>>> nan is nan
True
```

# <a name="benchmark"></a>Benchmark

<details>
<summary>The script:</summary>

```python
import pyperf

_BATCH_IDENTITY = 1_000_000
_BATCH_LEN = 256
_BLACKHOLE = [None]

_SELF_TUPLE = tuple(range(128))
_SMALL_TUPLE = (1, 2, 3, 4, 5)
_LARGE_TUPLE = tuple(range(1_000))

_SMALL_TUPLE_COPY = tuple(_SMALL_TUPLE)  # just diff object
_LARGE_TUPLE_COPY = tuple(_LARGE_TUPLE)
_SMALL_DIFF_LEN = _SMALL_TUPLE + (42,)
_EMPTY = ()
_SINGLETON = (None,)

_BASE_LEN = 10_000
_LONG_LEFT = tuple(range(_BASE_LEN))
_LONG_RIGHT = _LONG_LEFT + (_BASE_LEN,)


def bench_eq_self_identity():
    result = False
    for _ in range(_BATCH_IDENTITY):
        result = _SELF_TUPLE == _SELF_TUPLE
    _BLACKHOLE[0] = result


def bench_ne_self_identity():
    result = True
    for _ in range(_BATCH_IDENTITY):
        result = _SELF_TUPLE != _SELF_TUPLE
    _BLACKHOLE[0] = result


def bench_eq_small_same_obj():
    result = False
    for _ in range(_BATCH_IDENTITY):
        result = _SMALL_TUPLE == _SMALL_TUPLE
    _BLACKHOLE[0] = result


def bench_eq_large_same_obj():
    result = False
    for _ in range(_BATCH_IDENTITY):
        result = _LARGE_TUPLE == _LARGE_TUPLE
    _BLACKHOLE[0] = result


def bench_eq_small_diff_len():
    result = False
    for _ in range(_BATCH_IDENTITY):
        result = _SMALL_TUPLE == _SMALL_DIFF_LEN
    _BLACKHOLE[0] = result


def bench_ne_small_diff_len():
    result = False
    for _ in range(_BATCH_IDENTITY):
        result = _SMALL_TUPLE != _SMALL_DIFF_LEN
    _BLACKHOLE[0] = result


def bench_eq_empty_vs_nonempty():
    result = False
    for _ in range(_BATCH_IDENTITY):
        result = _EMPTY == _SINGLETON
    _BLACKHOLE[0] = result


def bench_ne_empty_vs_nonempty():
    result = False
    for _ in range(_BATCH_IDENTITY):
        result = _EMPTY != _SINGLETON
    _BLACKHOLE[0] = result


def bench_eq_large_diff_len():
    result = False
    for _ in range(_BATCH_IDENTITY):
        result = _LONG_LEFT == _LONG_RIGHT
    _BLACKHOLE[0] = result


def bench_ne_large_diff_len():
    result = False
    for _ in range(_BATCH_IDENTITY):
        result = _LONG_LEFT != _LONG_RIGHT
    _BLACKHOLE[0] = result


def bench_eq_small_same_len_diff_obj():
    a = _SMALL_TUPLE
    b = _SMALL_TUPLE_COPY
    acc = 0
    for _ in range(_BATCH_IDENTITY):
        acc ^= (a == b)
    _BLACKHOLE[0] = acc


def bench_ne_small_same_len_diff_obj():
    a = _SMALL_TUPLE
    b = _SMALL_TUPLE_COPY
    acc = 0
    for _ in range(_BATCH_IDENTITY):
        acc ^= (a != b)
    _BLACKHOLE[0] = acc


def bench_eq_small_large_len_diff_obj():
    a = _SMALL_TUPLE
    b = _LARGE_TUPLE_COPY
    acc = 0
    for _ in range(_BATCH_IDENTITY):
        acc ^= (a == b)
    _BLACKHOLE[0] = acc


def bench_ne_small_large_len_diff_obj():
    a = _SMALL_TUPLE
    b = _LARGE_TUPLE_COPY
    acc = 0
    for _ in range(_BATCH_IDENTITY):
        acc ^= (a != b)
    _BLACKHOLE[0] = acc


def bench_mixed_len_mispredict():
    same_a = _SMALL_TUPLE
    same_b = _SMALL_TUPLE_COPY
    diff_b = _SMALL_DIFF_LEN
    acc = 0
    # 95% equal length, 5% different length in an irregular pattern
    for i in range(_BATCH_IDENTITY):
        if (i * 37) % 100 < 95:
            acc ^= (same_a == same_b)
        else:
            acc ^= (same_a == diff_b)
    _BLACKHOLE[0] = acc


def main():
    runner = pyperf.Runner()

    runner.bench_func("tuple_eq_self", bench_eq_self_identity)
    runner.bench_func("tuple_ne_self", bench_ne_self_identity)

    runner.bench_func("tuple_eq_small_same_obj", bench_eq_small_same_obj)
    runner.bench_func("tuple_eq_large_same_obj", bench_eq_large_same_obj)

    runner.bench_func("tuple_eq_small_diff_len", bench_eq_small_diff_len)
    runner.bench_func("tuple_ne_small_diff_len", bench_ne_small_diff_len)

    runner.bench_func("tuple_eq_empty_vs_nonempty", bench_eq_empty_vs_nonempty)
    runner.bench_func("tuple_ne_empty_vs_nonempty", bench_ne_empty_vs_nonempty)

    runner.bench_func("tuple_eq_large_diff_len", bench_eq_large_diff_len)
    runner.bench_func("tuple_ne_large_diff_len", bench_ne_large_diff_len)

    runner.bench_func("tuple_eq_small_same_len_diff_obj", bench_eq_small_same_len_diff_obj)
    runner.bench_func("tuple_ne_small_same_len_diff_obj", bench_ne_small_same_len_diff_obj)

    runner.bench_func("tuple_eq_small_large_len_diff_obj", bench_eq_small_large_len_diff_obj)
    runner.bench_func("tuple_ne_small_large_len_diff_obj", bench_ne_small_large_len_diff_obj)

    runner.bench_func("tuple_eq_mixed_len_mispredict", bench_mixed_len_mispredict)


if __name__ == "__main__":
    main()
```
</details>

The results (with `--rigorous`, on 08134481fb2 v. 9f2a34af747):

| Benchmark                         | 9f2a34af747.tuple_richcompare.py | 08134481fb2.tuple_richcompare.py |
|-----------------------------------|:--------------------------------:|:--------------------------------:|
| tuple_eq_self                     | 77.1 ms                          | 20.5 ms: 3.76x faster            |
| tuple_ne_self                     | 77.0 ms                          | 20.5 ms: 3.75x faster            |
| tuple_eq_small_same_obj           | 23.0 ms                          | 20.5 ms: 1.12x faster            |
| tuple_eq_large_same_obj           | 352 ms                           | 20.5 ms: 17.15x faster           |
| tuple_eq_small_diff_len           | 22.6 ms                          | 20.5 ms: 1.11x faster            |
| tuple_ne_small_diff_len           | 22.7 ms                          | 20.4 ms: 1.11x faster            |
| tuple_eq_empty_vs_nonempty        | 20.6 ms                          | 20.3 ms: 1.01x faster            |
| tuple_ne_empty_vs_nonempty        | 20.6 ms                          | 20.3 ms: 1.01x faster            |
| tuple_eq_large_diff_len           | 3.83 sec                         | 20.4 ms: 187.77x faster          |
| tuple_ne_large_diff_len           | 3.83 sec                         | 20.4 ms: 188.07x faster          |
| tuple_eq_small_same_len_diff_obj  | 28.7 ms                          | 27.1 ms: 1.06x faster            |
| tuple_ne_small_same_len_diff_obj  | 28.8 ms                          | 27.3 ms: 1.06x faster            |
| tuple_eq_small_large_len_diff_obj | 31.0 ms                          | 27.5 ms: 1.12x faster            |
| tuple_ne_small_large_len_diff_obj | 31.0 ms                          | 27.4 ms: 1.13x faster            |
| tuple_eq_mixed_len_mispredict     | 51.6 ms                          | 49.2 ms: 1.05x faster            |
| Geometric mean                    | (ref)                            | 3.05x faster                     |

The environment:

```
% ./python -c "import sysconfig; print(sysconfig.get_config_var('CONFIG_ARGS'))"
'--enable-optimizations' '--with-lto'
```

`sudo ./python -m pyperf system tune` ensured.

# <a name="pyperformance"></a>pyperformance

<details>
<summary>The results:</summary>

```
pyperformance.9f2a34af747.json
==============================

Performance version: 1.13.0
Report on Linux-6.12.57+deb13-amd64-x86_64-with-glibc2.41
Number of logical CPUs: 24
Start date: 2025-11-26 20:05:17.126618
End date: 2025-11-26 21:43:38.389462

pyperformance.c9015394.json
===========================

Performance version: 1.13.0
Report on Linux-6.12.57+deb13-amd64-x86_64-with-glibc2.41
Number of logical CPUs: 24
Start date: 2025-11-29 22:10:52.337718
End date: 2025-11-30 00:03:14.445640

+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| Benchmark                        | pyperformance.9f2a34af747.json | pyperformance.c9015394.json | Change       | Significance            |
+==================================+================================+=============================+==============+=========================+
| 2to3                             | 207 ms                         | 206 ms                      | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_generators                 | 289 ms                         | 285 ms                      | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_cpu_io_mixed          | 394 ms                         | 393 ms                      | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_cpu_io_mixed_tg       | 395 ms                         | 395 ms                      | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_eager                 | 83.3 ms                        | 83.1 ms                     | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_eager_cpu_io_mixed    | 336 ms                         | 334 ms                      | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_eager_cpu_io_mixed_tg | 368 ms                         | 366 ms                      | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_eager_io              | 422 ms                         | 422 ms                      | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_eager_io_tg           | 419 ms                         | 419 ms                      | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_eager_memoization     | 162 ms                         | 161 ms                      | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_eager_memoization_tg  | 205 ms                         | 205 ms                      | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_eager_tg              | 156 ms                         | 155 ms                      | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_io                    | 448 ms                         | 448 ms                      | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_io_tg                 | 429 ms                         | 432 ms                      | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_memoization           | 222 ms                         | 222 ms                      | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_memoization_tg        | 231 ms                         | 232 ms                      | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_none                  | 192 ms                         | 192 ms                      | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| async_tree_none_tg               | 191 ms                         | 192 ms                      | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| asyncio_tcp                      | 252 ms                         | 282 ms                      | 1.12x slower | Significant (t=-43.57)  |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| asyncio_tcp_ssl                  | 1.21 sec                       | 1.25 sec                    | 1.04x slower | Significant (t=-104.85) |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| asyncio_websockets               | 357 ms                         | 360 ms                      | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| bench_mp_pool                    | 13.2 ms                        | 12.5 ms                     | 1.06x faster | Significant (t=7.61)    |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| bench_thread_pool                | 750 us                         | 673 us                      | 1.11x faster | Significant (t=111.96)  |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| bpe_tokeniser                    | 3.58 sec                       | 3.62 sec                    | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| chameleon                        | 11.9 ms                        | 12.2 ms                     | 1.03x slower | Significant (t=-20.77)  |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| chaos                            | 43.8 ms                        | 43.6 ms                     | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| comprehensions                   | 13.0 us                        | 12.2 us                     | 1.07x faster | Significant (t=10.23)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| coroutines                       | 17.1 ms                        | 17.1 ms                     | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| coverage                         | 58.5 ms                        | 55.5 ms                     | 1.05x faster | Significant (t=25.41)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| create_gc_cycles                 | 2.09 ms                        | 2.03 ms                     | 1.03x faster | Significant (t=8.05)    |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| crypto_pyaes                     | 58.3 ms                        | 56.6 ms                     | 1.03x faster | Significant (t=33.13)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| dask                             | 682 ms                         | 526 ms                      | 1.30x faster | Significant (t=290.94)  |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| deepcopy                         | 193 us                         | 192 us                      | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| deepcopy_memo                    | 19.1 us                        | 18.7 us                     | 1.02x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| deepcopy_reduce                  | 2.13 us                        | 2.11 us                     | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| deltablue                        | 2.42 ms                        | 2.41 ms                     | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| django_template                  | 28.3 ms                        | 27.8 ms                     | 1.02x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| docutils                         | 2.11 sec                       | 2.11 sec                    | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| dulwich_log                      | 43.6 ms                        | 44.2 ms                     | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| fannkuch                         | 273 ms                         | 276 ms                      | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| float                            | 56.1 ms                        | 54.1 ms                     | 1.04x faster | Significant (t=7.23)    |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| gc_traversal                     | 4.15 ms                        | 4.11 ms                     | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| generators                       | 22.4 ms                        | 21.6 ms                     | 1.04x faster | Significant (t=19.41)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| genshi_text                      | 17.4 ms                        | 16.7 ms                     | 1.04x faster | Significant (t=13.62)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| genshi_xml                       | 39.5 ms                        | 38.6 ms                     | 1.03x faster | Significant (t=10.97)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| go                               | 89.9 ms                        | 89.3 ms                     | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| hexiom                           | 4.56 ms                        | 4.41 ms                     | 1.03x faster | Significant (t=51.65)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| html5lib                         | 49.5 ms                        | 49.4 ms                     | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| json_dumps                       | 7.49 ms                        | 7.24 ms                     | 1.03x faster | Significant (t=48.11)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| json_loads                       | 18.4 us                        | 18.9 us                     | 1.03x slower | Significant (t=-15.48)  |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| logging_format                   | 4.88 us                        | 4.90 us                     | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| logging_silent                   | 69.2 ns                        | 67.5 ns                     | 1.03x faster | Significant (t=25.17)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| logging_simple                   | 4.40 us                        | 4.41 us                     | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| mako                             | 7.96 ms                        | 7.79 ms                     | 1.02x faster | Significant (t=6.42)    |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| many_optionals                   | 862 us                         | 862 us                      | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| mdp                              | 939 ms                         | 942 ms                      | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| meteor_contest                   | 94.4 ms                        | 92.1 ms                     | 1.02x faster | Significant (t=69.13)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| nbody                            | 68.1 ms                        | 68.0 ms                     | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| nqueens                          | 69.1 ms                        | 69.8 ms                     | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| pathlib                          | 10.0 ms                        | 9.93 ms                     | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| pickle                           | 13.7 us                        | 13.8 us                     | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| pickle_dict                      | 25.0 us                        | 24.5 us                     | 1.02x faster | Significant (t=19.16)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| pickle_list                      | 3.78 us                        | 3.88 us                     | 1.03x slower | Significant (t=-12.63)  |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| pickle_pure_python               | 241 us                         | 240 us                      | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| pidigits                         | 184 ms                         | 183 ms                      | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| pprint_pformat                   | 1.12 sec                       | 1.13 sec                    | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| pprint_safe_repr                 | 547 ms                         | 553 ms                      | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| pyflate                          | 316 ms                         | 315 ms                      | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| python_startup                   | 10.8 ms                        | 10.8 ms                     | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| python_startup_no_site           | 6.34 ms                        | 6.35 ms                     | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| raytrace                         | 212 ms                         | 209 ms                      | 1.02x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| regex_compile                    | 98.5 ms                        | 98.1 ms                     | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| regex_dna                        | 162 ms                         | 160 ms                      | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| regex_effbot                     | 2.26 ms                        | 2.21 ms                     | 1.02x faster | Significant (t=27.90)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| regex_v8                         | 18.4 ms                        | 18.1 ms                     | 1.02x faster | Significant (t=2.70)    |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| richards                         | 33.6 ms                        | 33.0 ms                     | 1.02x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| richards_super                   | 38.2 ms                        | 37.3 ms                     | 1.02x faster | Significant (t=8.54)    |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| scimark_fft                      | 197 ms                         | 196 ms                      | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| scimark_lu                       | 66.5 ms                        | 67.1 ms                     | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| scimark_monte_carlo              | 44.0 ms                        | 42.6 ms                     | 1.03x faster | Significant (t=10.67)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| scimark_sor                      | 74.9 ms                        | 73.9 ms                     | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| scimark_sparse_mat_mult          | 2.99 ms                        | 3.01 ms                     | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| spectral_norm                    | 63.7 ms                        | 62.5 ms                     | 1.02x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sphinx                           | 792 ms                         | 786 ms                      | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sqlalchemy_declarative           | 108 ms                         | 109 ms                      | 1.01x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sqlalchemy_imperative            | 13.2 ms                        | 13.1 ms                     | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sqlglot_v2_normalize             | 83.2 ms                        | 81.0 ms                     | 1.03x faster | Significant (t=27.38)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sqlglot_v2_optimize              | 41.9 ms                        | 40.8 ms                     | 1.03x faster | Significant (t=27.76)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sqlglot_v2_parse                 | 969 us                         | 955 us                      | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sqlglot_v2_transpile             | 1.25 ms                        | 1.23 ms                     | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sqlite_synth                     | 1.98 us                        | 1.97 us                     | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| subparsers                       | 31.3 ms                        | 30.7 ms                     | 1.02x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sympy_expand                     | 360 ms                         | 351 ms                      | 1.02x faster | Significant (t=39.07)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sympy_integrate                  | 16.0 ms                        | 16.0 ms                     | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sympy_str                        | 210 ms                         | 208 ms                      | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| sympy_sum                        | 110 ms                         | 109 ms                      | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| telco                            | 117 ms                         | 115 ms                      | 1.02x faster | Significant (t=13.62)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| tomli_loads                      | 1.51 sec                       | 1.50 sec                    | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| tornado_http                     | 76.7 ms                        | 76.9 ms                     | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| typing_runtime_protocols         | 121 us                         | 118 us                      | 1.02x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| unpack_sequence                  | 31.7 ns                        | 30.8 ns                     | 1.03x faster | Significant (t=18.61)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| unpickle                         | 10.6 us                        | 10.3 us                     | 1.03x faster | Significant (t=9.61)    |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| unpickle_list                    | 3.92 us                        | 3.86 us                     | 1.02x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| unpickle_pure_python             | 156 us                         | 157 us                      | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| xdsl_constant_fold               | 35.9 ms                        | 35.3 ms                     | 1.02x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| xml_etree_generate               | 67.2 ms                        | 67.4 ms                     | 1.00x slower | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| xml_etree_iterparse              | 66.3 ms                        | 65.7 ms                     | 1.01x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| xml_etree_parse                  | 106 ms                         | 106 ms                      | 1.00x faster | Not significant         |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+
| xml_etree_process                | 47.3 ms                        | 46.0 ms                     | 1.03x faster | Significant (t=29.59)   |
+----------------------------------+--------------------------------+-----------------------------+--------------+-------------------------+

Skipped 3 benchmarks only in pyperformance.c9015394.json: connected_components, k_core, shortest_path
```
</details>

# <a name="pyperformance-without-identity-check"></a>pyperformance (without identity check)

**Significant improvements**

- dask: 1.28x faster
- concurrency pools: bench_thread_pool 1.11x; bench_mp_pool 1.08x
- core language: comprehensions 1.06x

**Significant regressions**

- asyncio network: asyncio_tcp 1.10x slower
- low-level: unpack_sequence 1.07x slower (??? `UNPACK_SEQUENCE_TUPLE` and `_LIST` shouldn't call `tuple_richcompare`; the difference is just 2.3ns which might be caused by jitter or by a branch predictor history)

<details>
<summary>The results:</summary>

```

pyperformance.9f2a34af747.json
==============================

Performance version: 1.13.0
Report on Linux-6.12.57+deb13-amd64-x86_64-with-glibc2.41
Number of logical CPUs: 24
Start date: 2025-11-26 20:05:17.126618
End date: 2025-11-26 21:43:38.389462

pyperformance.25d53ebaea3.json
==============================

Performance version: 1.13.0
Report on Linux-6.12.57+deb13-amd64-x86_64-with-glibc2.41
Number of logical CPUs: 24
Start date: 2025-11-27 14:00:59.954246
End date: 2025-11-27 15:54:44.937969

+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| Benchmark                        | pyperformance.9f2a34af747.json | pyperformance.25d53ebaea3.json | Change       | Significance           |
+==================================+================================+================================+==============+========================+
| 2to3                             | 207 ms                         | 207 ms                         | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_generators                 | 289 ms                         | 286 ms                         | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_cpu_io_mixed          | 394 ms                         | 392 ms                         | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_cpu_io_mixed_tg       | 395 ms                         | 394 ms                         | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_eager                 | 83.3 ms                        | 83.3 ms                        | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_eager_cpu_io_mixed    | 336 ms                         | 333 ms                         | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_eager_cpu_io_mixed_tg | 368 ms                         | 366 ms                         | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_eager_io              | 422 ms                         | 425 ms                         | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_eager_io_tg           | 419 ms                         | 421 ms                         | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_eager_memoization     | 162 ms                         | 161 ms                         | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_eager_memoization_tg  | 205 ms                         | 205 ms                         | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_eager_tg              | 156 ms                         | 155 ms                         | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_io                    | 448 ms                         | 450 ms                         | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_io_tg                 | 429 ms                         | 431 ms                         | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_memoization           | 222 ms                         | 221 ms                         | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_memoization_tg        | 231 ms                         | 232 ms                         | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_none                  | 192 ms                         | 194 ms                         | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| async_tree_none_tg               | 191 ms                         | 192 ms                         | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| asyncio_tcp                      | 252 ms                         | 277 ms                         | 1.10x slower | Significant (t=-35.30) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| asyncio_tcp_ssl                  | 1.21 sec                       | 1.24 sec                       | 1.03x slower | Significant (t=-82.44) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| asyncio_websockets               | 357 ms                         | 357 ms                         | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| bench_mp_pool                    | 13.2 ms                        | 12.2 ms                        | 1.08x faster | Significant (t=9.85)   |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| bench_thread_pool                | 750 us                         | 674 us                         | 1.11x faster | Significant (t=113.01) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| bpe_tokeniser                    | 3.58 sec                       | 3.64 sec                       | 1.02x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| chameleon                        | 11.9 ms                        | 11.8 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| chaos                            | 43.8 ms                        | 44.1 ms                        | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| comprehensions                   | 13.0 us                        | 12.3 us                        | 1.06x faster | Significant (t=8.87)   |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| coroutines                       | 17.1 ms                        | 17.0 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| coverage                         | 58.5 ms                        | 57.9 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| create_gc_cycles                 | 2.09 ms                        | 2.03 ms                        | 1.03x faster | Significant (t=8.72)   |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| crypto_pyaes                     | 58.3 ms                        | 57.7 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| dask                             | 682 ms                         | 531 ms                         | 1.28x faster | Significant (t=299.38) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| deepcopy                         | 193 us                         | 196 us                         | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| deepcopy_memo                    | 19.1 us                        | 19.3 us                        | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| deepcopy_reduce                  | 2.13 us                        | 2.16 us                        | 1.02x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| deltablue                        | 2.42 ms                        | 2.42 ms                        | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| django_template                  | 28.3 ms                        | 28.1 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| docutils                         | 2.11 sec                       | 2.12 sec                       | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| dulwich_log                      | 43.6 ms                        | 43.6 ms                        | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| fannkuch                         | 273 ms                         | 268 ms                         | 1.02x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| float                            | 56.1 ms                        | 53.8 ms                        | 1.04x faster | Significant (t=8.11)   |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| gc_traversal                     | 4.15 ms                        | 4.04 ms                        | 1.03x faster | Significant (t=15.82)  |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| generators                       | 22.4 ms                        | 21.7 ms                        | 1.04x faster | Significant (t=21.28)  |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| genshi_text                      | 17.4 ms                        | 17.5 ms                        | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| genshi_xml                       | 39.5 ms                        | 38.7 ms                        | 1.02x faster | Significant (t=10.11)  |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| go                               | 89.9 ms                        | 89.4 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| hexiom                           | 4.56 ms                        | 4.49 ms                        | 1.02x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| html5lib                         | 49.5 ms                        | 50.0 ms                        | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| json_dumps                       | 7.49 ms                        | 7.29 ms                        | 1.03x faster | Significant (t=36.97)  |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| json_loads                       | 18.4 us                        | 18.8 us                        | 1.03x slower | Significant (t=-16.34) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| logging_format                   | 4.88 us                        | 4.87 us                        | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| logging_silent                   | 69.2 ns                        | 67.5 ns                        | 1.03x faster | Significant (t=26.85)  |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| logging_simple                   | 4.40 us                        | 4.37 us                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| mako                             | 7.96 ms                        | 7.95 ms                        | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| many_optionals                   | 862 us                         | 875 us                         | 1.02x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| mdp                              | 939 ms                         | 954 ms                         | 1.02x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| meteor_contest                   | 94.4 ms                        | 95.1 ms                        | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| nbody                            | 68.1 ms                        | 69.9 ms                        | 1.03x slower | Significant (t=-11.08) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| nqueens                          | 69.1 ms                        | 72.1 ms                        | 1.04x slower | Significant (t=-56.52) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| pathlib                          | 10.0 ms                        | 9.94 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| pickle                           | 13.7 us                        | 13.7 us                        | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| pickle_dict                      | 25.0 us                        | 24.3 us                        | 1.03x faster | Significant (t=23.80)  |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| pickle_list                      | 3.78 us                        | 3.89 us                        | 1.03x slower | Significant (t=-13.22) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| pickle_pure_python               | 241 us                         | 241 us                         | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| pidigits                         | 184 ms                         | 184 ms                         | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| pprint_pformat                   | 1.12 sec                       | 1.16 sec                       | 1.04x slower | Significant (t=-31.84) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| pprint_safe_repr                 | 547 ms                         | 570 ms                         | 1.04x slower | Significant (t=-31.75) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| pyflate                          | 316 ms                         | 311 ms                         | 1.02x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| python_startup                   | 10.8 ms                        | 10.8 ms                        | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| python_startup_no_site           | 6.34 ms                        | 6.34 ms                        | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| raytrace                         | 212 ms                         | 213 ms                         | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| regex_compile                    | 98.5 ms                        | 99.4 ms                        | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| regex_dna                        | 162 ms                         | 155 ms                         | 1.04x faster | Significant (t=58.02)  |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| regex_effbot                     | 2.26 ms                        | 2.20 ms                        | 1.03x faster | Significant (t=33.39)  |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| regex_v8                         | 18.4 ms                        | 18.3 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| richards                         | 33.6 ms                        | 33.4 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| richards_super                   | 38.2 ms                        | 37.8 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| scimark_fft                      | 197 ms                         | 198 ms                         | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| scimark_lu                       | 66.5 ms                        | 67.2 ms                        | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| scimark_monte_carlo              | 44.0 ms                        | 43.6 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| scimark_sor                      | 74.9 ms                        | 74.2 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| scimark_sparse_mat_mult          | 2.99 ms                        | 3.10 ms                        | 1.04x slower | Significant (t=-41.64) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| spectral_norm                    | 63.7 ms                        | 63.6 ms                        | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sphinx                           | 792 ms                         | 790 ms                         | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sqlalchemy_declarative           | 108 ms                         | 109 ms                         | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sqlalchemy_imperative            | 13.2 ms                        | 13.3 ms                        | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sqlglot_v2_normalize             | 83.2 ms                        | 83.1 ms                        | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sqlglot_v2_optimize              | 41.9 ms                        | 41.7 ms                        | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sqlglot_v2_parse                 | 969 us                         | 987 us                         | 1.02x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sqlglot_v2_transpile             | 1.25 ms                        | 1.26 ms                        | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sqlite_synth                     | 1.98 us                        | 1.97 us                        | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| subparsers                       | 31.3 ms                        | 31.0 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sympy_expand                     | 360 ms                         | 361 ms                         | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sympy_integrate                  | 16.0 ms                        | 16.2 ms                        | 1.02x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sympy_str                        | 210 ms                         | 212 ms                         | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| sympy_sum                        | 110 ms                         | 110 ms                         | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| telco                            | 117 ms                         | 117 ms                         | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| tomli_loads                      | 1.51 sec                       | 1.54 sec                       | 1.02x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| tornado_http                     | 76.7 ms                        | 76.7 ms                        | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| typing_runtime_protocols         | 121 us                         | 121 us                         | 1.00x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| unpack_sequence                  | 31.7 ns                        | 34.0 ns                        | 1.07x slower | Significant (t=-54.16) |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| unpickle                         | 10.6 us                        | 10.3 us                        | 1.03x faster | Significant (t=10.82)  |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| unpickle_list                    | 3.92 us                        | 3.84 us                        | 1.02x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| unpickle_pure_python             | 156 us                         | 158 us                         | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| xdsl_constant_fold               | 35.9 ms                        | 35.8 ms                        | 1.00x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| xml_etree_generate               | 67.2 ms                        | 68.0 ms                        | 1.01x slower | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| xml_etree_iterparse              | 66.3 ms                        | 65.8 ms                        | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| xml_etree_parse                  | 106 ms                         | 105 ms                         | 1.01x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+
| xml_etree_process                | 47.3 ms                        | 46.6 ms                        | 1.02x faster | Not significant        |
+----------------------------------+--------------------------------+--------------------------------+--------------+------------------------+

Skipped 3 benchmarks only in pyperformance.25d53ebaea3.json: connected_components, k_core, shortest_path
```
</details>

<!-- gh-issue-number: gh-141858 -->
* Issue: gh-141858
<!-- /gh-issue-number -->
