### PR TITLE
gh-142029: Raise `ValueError` instead of crashing on empty name given to `create_builtin()`

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -1258,21 +1258,14 @@ os.does_not_exist
             name = None
         spec = Spec()
 
-        with self.assertRaisesRegex(
-            TypeError,
-            'name must be string, not NoneType'
-        ):
+        with self.assertRaisesRegex(TypeError, 'name must be string, not NoneType'):
             _imp.create_builtin(spec)
 
-        class Spec:
-            name = ""
+        spec.name = ""
         spec = Spec()
 
         # gh-142029
-        with self.assertRaisesRegex(
-            TypeError,
-            'name must not be empty'
-        ):
+        with self.assertRaisesRegex(TypeError,'name must not be empty'):
             _imp.create_builtin(spec)
 
     def test_filter_syntax_warnings_by_module(self):

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -1262,10 +1262,9 @@ os.does_not_exist
             _imp.create_builtin(spec)
 
         spec.name = ""
-        spec = Spec()
 
         # gh-142029
-        with self.assertRaisesRegex(TypeError,'name must not be empty'):
+        with self.assertRaisesRegex(ValueError, 'name must not be empty'):
             _imp.create_builtin(spec)
 
     def test_filter_syntax_warnings_by_module(self):

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -1253,6 +1253,28 @@ os.does_not_exist
                 origin = "a\x00b"
             _imp.create_dynamic(Spec2())
 
+    def test_create_builtin(self):
+        class Spec:
+            name = None
+        spec = Spec()
+
+        with self.assertRaisesRegex(
+            TypeError,
+            'name must be string, not NoneType'
+        ):
+            _imp.create_builtin(spec)
+
+        class Spec:
+            name = ""
+        spec = Spec()
+
+        # gh-142029
+        with self.assertRaisesRegex(
+            TypeError,
+            'name must not be empty'
+        ):
+            _imp.create_builtin(spec)
+
     def test_filter_syntax_warnings_by_module(self):
         module_re = r'test\.test_import\.data\.syntax_warnings\z'
         unload('test.test_import.data.syntax_warnings')

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-28-16-45-07.gh-issue-142029.JuXiKu.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-28-16-45-07.gh-issue-142029.JuXiKu.rst
@@ -1,2 +1,2 @@
 Raise :exc:`TypeError` instead of crashing when empty string is used as a
-name in ``importlib._imp.create_builtin``.
+name in ``_imp.create_builtin()``.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-28-16-45-07.gh-issue-142029.JuXiKu.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-28-16-45-07.gh-issue-142029.JuXiKu.rst
@@ -1,2 +1,2 @@
 Raise :exc:`TypeError` instead of crashing when empty string is used as a
-name in :func:`importlib._imp.create_builtin`.
+name in ``importlib._imp.create_builtin``.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-28-16-45-07.gh-issue-142029.JuXiKu.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-28-16-45-07.gh-issue-142029.JuXiKu.rst
@@ -1,0 +1,2 @@
+Raise :exc:`TypeError` instead of crashing when empty string is used as a
+name in :func:`importlib._imp.create_builtin`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-11-28-16-45-07.gh-issue-142029.JuXiKu.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-11-28-16-45-07.gh-issue-142029.JuXiKu.rst
@@ -1,2 +1,2 @@
-Raise :exc:`TypeError` instead of crashing when empty string is used as a
-name in ``_imp.create_builtin()``.
+Raise :exc:`ValueError` instead of crashing when empty string is used as a name
+in ``_imp.create_builtin()``.

--- a/Python/import.c
+++ b/Python/import.c
@@ -4420,6 +4420,13 @@ _imp_create_builtin(PyObject *module, PyObject *spec)
         return NULL;
     }
 
+    if (PyUnicode_GetLength(name) == 0) {
+        PyErr_Format(PyExc_TypeError,
+                     "name must not be empty");
+        Py_DECREF(name);
+        return NULL;
+    }
+
     PyObject *mod = create_builtin(tstate, name, spec, NULL);
     Py_DECREF(name);
     return mod;

--- a/Python/import.c
+++ b/Python/import.c
@@ -4421,7 +4421,7 @@ _imp_create_builtin(PyObject *module, PyObject *spec)
     }
 
     if (PyUnicode_GetLength(name) == 0) {
-        PyErr_Format(PyExc_TypeError,
+        PyErr_Format(PyExc_ValueError,
                      "name must not be empty");
         Py_DECREF(name);
         return NULL;

--- a/Python/import.c
+++ b/Python/import.c
@@ -4421,8 +4421,7 @@ _imp_create_builtin(PyObject *module, PyObject *spec)
     }
 
     if (PyUnicode_GetLength(name) == 0) {
-        PyErr_Format(PyExc_ValueError,
-                     "name must not be empty");
+        PyErr_Format(PyExc_ValueError, "name must not be empty");
         Py_DECREF(name);
         return NULL;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142029 -->
* Issue: gh-142029
<!-- /gh-issue-number -->
