### PR TITLE
gh-141998: Fix input being colorized when manually reading input via pyrepl readline

### DIFF
--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -374,7 +374,12 @@ class _ReadlineWrapper:
         prompt_str = str(prompt)
         reader.ps1 = prompt_str
         sys.audit("builtins.input", prompt_str)
-        result = reader.readline(startup_hook=self.startup_hook)
+        try:
+            can_colorize = reader.can_colorize
+            reader.can_colorize = False
+            result = reader.readline(startup_hook=self.startup_hook)
+        finally:
+            reader.can_colorize = can_colorize
         sys.audit("builtins.input/result", result)
         return result
 

--- a/Misc/NEWS.d/next/Library/2025-11-28-15-06-07.gh-issue-141998.pOzTvV.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-28-15-06-07.gh-issue-141998.pOzTvV.rst
@@ -1,0 +1,2 @@
+Fixes syntax highlighting/colorization being applied to input that is read
+in via the pyrepl readline interface


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Fixes input read in via `input` or similar (anything that went through the pyrepl readline) being colorized

<!-- gh-issue-number: gh-141998 -->
* Issue: gh-141998
<!-- /gh-issue-number -->
