### PR TITLE
gh-142038: Expand guard for types_world_is_stopped to fix debug builds without assertions

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -81,7 +81,7 @@ class object "PyObject *" "&PyBaseObject_Type"
 
 #define END_TYPE_DICT_LOCK() Py_END_CRITICAL_SECTION2()
 
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(Py_Debug)
 // Return true if the world is currently stopped.
 static bool
 types_world_is_stopped(void)

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -81,7 +81,7 @@ class object "PyObject *" "&PyBaseObject_Type"
 
 #define END_TYPE_DICT_LOCK() Py_END_CRITICAL_SECTION2()
 
-#if !defined(NDEBUG) || defined(Py_Debug)
+#if !defined(NDEBUG) || defined(Py_DEBUG)
 // Return true if the world is currently stopped.
 static bool
 types_world_is_stopped(void)


### PR DESCRIPTION
The `types_world_is_stopped()` function needs to be defined if `NDEBUG` or when we're in a debug build is not defined.

Issue:
 * https://github.com/python/cpython/issues/142038

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142038 -->
* Issue: gh-142038
<!-- /gh-issue-number -->
