### PR TITLE
GH-141808: Do not generate the jit stencils twice in case of PGO builds on Windows.

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-11-28-19-49-01.gh-issue-141808.cV5K12.rst
+++ b/Misc/NEWS.d/next/Build/2025-11-28-19-49-01.gh-issue-141808.cV5K12.rst
@@ -1,0 +1,1 @@
+Do not generate the jit stencils twice in case of PGO builds on Windows.

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -13,6 +13,7 @@
     <GeneratedFrozenModulesDir>$(Py_IntDir)\$(MajorVersionNumber)$(MinorVersionNumber)_frozen\</GeneratedFrozenModulesDir>
     <GeneratedZlibNgDir>$(Py_IntDir)\$(MajorVersionNumber)$(MinorVersionNumber)$(ArchName)_$(Configuration)\zlib-ng\</GeneratedZlibNgDir>
     <GeneratedJitStencilsDir>$(Py_IntDir)\$(MajorVersionNumber)$(MinorVersionNumber)_$(Configuration)</GeneratedJitStencilsDir>
+    <GeneratedJitStencilsDir Condition="$(Configuration) == 'PGUpdate'">$(Py_IntDir)\$(MajorVersionNumber)$(MinorVersionNumber)_PGInstrument</GeneratedJitStencilsDir>
     <TargetName Condition="'$(TargetName)' == ''">$(ProjectName)</TargetName>
     <TargetName>$(TargetName)$(PyDebugExt)</TargetName>
     <GenerateManifest>false</GenerateManifest>


### PR DESCRIPTION
Just re-use them in the PGUpdate phase: by using the same folder as in the PGInstrument phase, the hash will just match and the stencils are not built again. This saves time, especially on old PCs like mine, where the stencils generation takes about a minute.

<!-- gh-issue-number: gh-141808 -->
* Issue: gh-141808
<!-- /gh-issue-number -->
