### PR TITLE
gh-141938: Fix HTTPConnection being stuck in a dirty state when HTTPResponse.begin() raises exceptions/errors

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1449,7 +1449,7 @@ class HTTPConnection:
 
             return response
         except:
-            response.close()
+            self.close()
             raise
 
 try:

--- a/Misc/NEWS.d/next/Library/2025-11-29-00-52-37.gh-issue-141938.ZADQRl.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-29-00-52-37.gh-issue-141938.ZADQRl.rst
@@ -1,0 +1,4 @@
+Fix `http.client.HTTPConnection` to properly reset its internal state when
+reading the response raises an exception such as `TimeoutError`, ensuring
+the connection can be reused or raises appropriate errors on subsequent
+requests.

--- a/Misc/NEWS.d/next/Library/2025-11-29-00-52-37.gh-issue-141938.ZADQRl.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-29-00-52-37.gh-issue-141938.ZADQRl.rst
@@ -1,4 +1,4 @@
-Fix `http.client.HTTPConnection` to properly reset its internal state when
-reading the response raises an exception such as `TimeoutError`, ensuring
+Fix :class:`http.client.HTTPConnection` to properly reset its internal state when
+reading the response raises an exception such as :exc:`TimeoutError`, ensuring
 the connection can be reused or raises appropriate errors on subsequent
 requests.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

When `HTTPConnection.getresponse()` encounters an exception/error (like `TimeoutError`) while reading the response, the outer exception handler calls `response.close()` but not `self.close()`. This closes the socket but leaves the connection's internal state stuck at `_CS_REQ_SENT`, causing subsequent requests on the same connection object to raise `CannotSendRequest`.

This change correctly closes the connection instead of the response.

<!-- gh-issue-number: gh-141938 -->
* Issue: gh-141938
<!-- /gh-issue-number -->
