### PR TITLE
Move to method references for bytearray.take_bytes

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -3240,7 +3240,7 @@ objects.
 
          See the :ref:`What's New <whatsnew315-bytearray-take-bytes>` entry for
          common code patterns which can be optimized with
-         :func:`bytearray.take_bytes`.
+         :meth:`bytearray.take_bytes`.
 
 Since bytearray objects are sequences of integers (akin to a list), for a
 bytearray object *b*, ``b[0]`` will be an integer, while ``b[0:1]`` will be

--- a/Misc/NEWS.d/3.15.0a2.rst
+++ b/Misc/NEWS.d/3.15.0a2.rst
@@ -1451,7 +1451,7 @@ under no memory.
 .. section: Core and Builtins
 
 Update :class:`bytearray` to use a :class:`bytes` under the hood as its
-buffer and add :func:`bytearray.take_bytes` to take it out.
+buffer and add :meth:`bytearray.take_bytes` to take it out.
 
 ..
 

--- a/Misc/NEWS.d/next/Library/2025-11-22-16-33-48.gh-issue-141863.4PLhnv.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-22-16-33-48.gh-issue-141863.4PLhnv.rst
@@ -1,2 +1,2 @@
-Update :ref:`asyncio-streams` to use :func:`bytearray.take_bytes` for a over
+Update :ref:`asyncio-streams` to use :meth:`bytearray.take_bytes` for a over
 10% performance improvement on pyperformance asyncio_tcp benchmark.

--- a/Misc/NEWS.d/next/Library/2025-11-25-22-54-07.gh-issue-141968.vg3AMJ.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-25-22-54-07.gh-issue-141968.vg3AMJ.rst
@@ -1,2 +1,2 @@
 Remove a data copy from :func:`base64.b32decode` and
-:func:`base64.b32encode` by using :func:`bytearray.take_bytes`.
+:func:`base64.b32encode` by using :meth:`bytearray.take_bytes`.

--- a/Misc/NEWS.d/next/Library/2025-11-25-23-22-46.gh-issue-141968.R1sHnJ.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-25-23-22-46.gh-issue-141968.R1sHnJ.rst
@@ -1,2 +1,2 @@
 Remove data copy from :func:`wave.Wave_read.readframes` and
-:func:`wave.Wave_write.writeframes` by using :func:`bytearray.take_bytes`.
+:func:`wave.Wave_write.writeframes` by using :meth:`bytearray.take_bytes`.

--- a/Misc/NEWS.d/next/Library/2025-11-25-23-35-07.gh-issue-141968.b3Gscp.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-25-23-35-07.gh-issue-141968.b3Gscp.rst
@@ -1,2 +1,2 @@
 Remove data copy from :mod:`encodings.idna` :meth:`~codecs.Codec.encode` and
-:meth:`~codecs.IncrementalEncoder.encode` by using :func:`bytearray.take_bytes`.
+:meth:`~codecs.IncrementalEncoder.encode` by using :meth:`bytearray.take_bytes`.


### PR DESCRIPTION
It's a method on an object, so should use :meth:`bytearray.take_bytes` in Sphinx. These were introduced in gh-139871 and 
gh-141968

cc: @picnixz 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142053.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->