### PR TITLE
Docs: Prepare for Sphinx 9

### DIFF
--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -15,7 +15,7 @@ Introduction
     You may also find useful the following article on fetching web resources
     with Python:
 
-    * `Basic Authentication <https://web.archive.org/web/20201215133350/http://www.voidspace.org.uk/python/articles/authentication.shtml>`_
+    * `Basic Authentication <https://web.archive.org/web/20201215133350/http://www.voidspace.org.uk/python/articles/authentication.shtml>`__
 
         A tutorial on *Basic Authentication*, with examples in Python.
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -2095,11 +2095,8 @@ to sockets.
       Accepts any real number, not only integer or float.
 
 
-.. method:: socket.setsockopt(level, optname, value: int)
-.. method:: socket.setsockopt(level, optname, value: buffer)
-   :noindex:
-.. method:: socket.setsockopt(level, optname, None, optlen: int)
-   :noindex:
+.. method:: socket.setsockopt(level, optname, value: int | Buffer)
+            socket.setsockopt(level, optname, None, optlen: int)
 
    .. index:: pair: module; struct
 

--- a/Doc/tools/extensions/glossary_search.py
+++ b/Doc/tools/extensions/glossary_search.py
@@ -38,7 +38,7 @@ def process_glossary_nodes(
             rendered = app.builder.render_partial(definition)
             terms[term.lower()] = {
                 'title': term,
-                'body': rendered['html_body'],
+                'body': rendered['fragment'],
             }
 
 


### PR DESCRIPTION
cc @hugovk @picnixz 

Resolves the following:

```
...\Doc\howto\urllib2.rst:479: ERROR: Duplicate target name, cannot be used as a unique reference: "basic authentication". [docutils]
...\Doc\library\socket.rst:2099: WARNING: more than one target found for cross-reference 'buffer': io.TextIOBase.buffer, unittest.TestResult.buffer [ref.python]
```

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142057.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->