### PR TITLE
gh-142093: clarify which variables appear in function.__closure__

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -570,7 +570,7 @@ Special read-only attributes
        This can be used to get the value of the cell, as well as set the value.
 
        Only names that are actually referenced in the function body are
-       listed in :attr:`~codeobject.co_freevars` and therefore produce
+       listed in :attr:`~codeobject.co_freevars` and therefore have
        entries in ``function.__closure__``. Variables defined in an
        enclosing scope but never referenced inside the function do not
        appear in the closure.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -569,6 +569,13 @@ Special read-only attributes
        A cell object has the attribute ``cell_contents``.
        This can be used to get the value of the cell, as well as set the value.
 
+       Only names that are actually referenced in the function body are
+       listed in :attr:`~codeobject.co_freevars` and therefore produce
+       entries in ``function.__closure__``. Variables defined in an
+       enclosing scope but never referenced inside the function do not
+       appear in the closure.
+
+
 Special writable attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR adds a clarification to the documentation of function.\_\_closure\_\_,
noting that only variables from an enclosing scope that are actually
referenced in the inner function are included in its closure.

Names defined in the outer function but not referenced inside the nested
function do not appear in co_freevars and therefore do not contribute
cells to function.\_\_closure\_\_.

This behavior follows from the definition of free variables in the
execution model, but placing this clarification directly in the
function.\_\_closure\_\_ section improves interpretability for readers
examining closure behavior.

Documentation-only change; no behavioral modifications.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142086.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-142093 -->
* Issue: gh-142093
<!-- /gh-issue-number -->
