### PR TITLE
gh-142085: Avoid raising in `ChainMap.__ior__` before trying `other.__ror__`

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1151,7 +1151,10 @@ class ChainMap(_collections_abc.MutableMapping):
         self.maps[0].clear()
 
     def __ior__(self, other):
-        self.maps[0].update(other)
+        try:
+            self.maps[0].update(other)
+        except TypeError:
+            return NotImplemented
         return self
 
     def __or__(self, other):

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -315,7 +315,7 @@ class TestChainMap(unittest.TestCase):
         class Rescuer:
             def __ror__(self, other):
                 return "fallback"
-        
+
         cm = ChainMap()
         # This should not raise TypeError.
         # Since ChainMap.__ior__ returns NotImplemented, Python calls Rescuer.__ror__,

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -308,7 +308,7 @@ class TestChainMap(unittest.TestCase):
         tmp = ChainMap() | SubclassRor()
         self.assertIs(type(tmp), SubclassRor)
         self.assertIs(type(tmp.maps[0]), dict)
-        
+
     def test_ior_fallback(self):
         # Verify that __ior__ returns NotImplemented for unrecognized types,
         # allowing the other operand to handle the operation via __ror__.

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -308,7 +308,20 @@ class TestChainMap(unittest.TestCase):
         tmp = ChainMap() | SubclassRor()
         self.assertIs(type(tmp), SubclassRor)
         self.assertIs(type(tmp.maps[0]), dict)
-
+        
+    def test_ior_fallback(self):
+        # Verify that __ior__ returns NotImplemented for unrecognized types,
+        # allowing the other operand to handle the operation via __ror__.
+        class Rescuer:
+            def __ror__(self, other):
+                return "fallback"
+        
+        cm = ChainMap()
+        # This should not raise TypeError.
+        # Since ChainMap.__ior__ returns NotImplemented, Python calls Rescuer.__ror__,
+        # and the result ("fallback") is assigned back to 'cm'.
+        cm |= Rescuer()
+        self.assertEqual(cm, "fallback")
 
 ################################################################################
 ### Named Tuples

--- a/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.7u8i9o.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.7u8i9o.rst
@@ -1,2 +1,2 @@
 Fix :class:`ChainMap.__ior__ <collections.ChainMap>` to return :data:`NotImplemented`
-instead of raising :exc:`TypeError`` for unsupported types.
+instead of raising :exc:`TypeError` for unsupported types.

--- a/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.7u8i9o.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.7u8i9o.rst
@@ -1,1 +1,1 @@
-Fix :meth:`~collections.ChainMap.__ior__` to return :const:`NotImplemented` instead of raising :exc:`TypeError` for unsupported types.
+Fix ``ChainMap.__ior__`` to return ``NotImplemented`` instead of raising ``TypeError`` for unsupported types.

--- a/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.7u8i9o.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.7u8i9o.rst
@@ -1,1 +1,2 @@
-Fix ``ChainMap.__ior__`` to return ``NotImplemented`` instead of raising ``TypeError`` for unsupported types.
+Fix :class:`ChainMap.__ior__ <collections.ChainMap>` to return :data:`NotImplemented`
+instead of raising :exc:`TypeError`` for unsupported types.

--- a/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.7u8i9o.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.7u8i9o.rst
@@ -1,0 +1,1 @@
+Fix :meth:`~collections.ChainMap.__ior__` to return :const:`NotImplemented` instead of raising :exc:`TypeError` for unsupported types.

--- a/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.rst
@@ -1,0 +1,1 @@
+Fix :meth:~collections.ChainMap.__ior__ to return :const:NotImplemented instead of raising :exc:TypeError for unsupported types.

--- a/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-29-22-23-00.gh-issue-142085.rst
@@ -1,1 +1,0 @@
-Fix :meth:~collections.ChainMap.__ior__ to return :const:NotImplemented instead of raising :exc:TypeError for unsupported types.


### PR DESCRIPTION
Fixes #142085. ChainMap's `__ior__` method now returns `NotImplemented` instead of raising `TypeError` when `update` fails, allowing the fallback to `__ror__` to work correctly.

<!-- gh-issue-number: gh-142085 -->
* Issue: gh-142085
<!-- /gh-issue-number -->
