### PR TITLE
GH-139257 Use an explicitly named link

### DIFF
--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -15,9 +15,11 @@ Introduction
     You may also find useful the following article on fetching web resources
     with Python:
 
-    * `Basic Authentication <https://web.archive.org/web/20201215133350/http://www.voidspace.org.uk/python/articles/authentication.shtml>`_
+    * `Basic Authentication`_
 
-        A tutorial on *Basic Authentication*, with examples in Python.
+      A tutorial on *Basic Authentication*, with examples in Python.
+
+.. _Basic Authentication: https://web.archive.org/web/20201215133350/http://www.voidspace.org.uk/python/articles/authentication.shtml
 
 **urllib.request** is a Python module for fetching URLs
 (Uniform Resource Locators). It offers a very simple interface, in the form of


### PR DESCRIPTION
Docutils 0.22 does not allow referencing a link that was implicitly named earlier in the document, it complains:

  ERROR: Duplicate target name, cannot be used as a unique reference:
  "basic authentication".

<!-- gh-issue-number: gh-139257 -->
* Issue: gh-139257
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142090.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->