### PR TITLE
gh-141395: Clarify stdout flush behavior for newline characters in print()

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1611,8 +1611,8 @@ are always available.  They are listed here in alphabetical order.
    arguments are converted to text strings, :func:`print` cannot be used with
    binary mode file objects.  For these, use ``file.write(...)`` instead.
 
-   Output buffering is usually determined by *file*.
-   However, if *flush* is true, the stream is forcibly flushed.
+   Output buffering is usually determined by *file*.  However, if *flush* is
+   true, the stream is forcibly flushed.
 
    .. note::
 
@@ -1634,6 +1634,8 @@ are always available.  They are listed here in alphabetical order.
 
       .. code-block:: python
          from time import sleep
+         # This call performs one write operation, so the newline inside the string
+         # does not trigger an immediate flush by itself.
          print("Hello\nWorld")
          sleep(3)
          print("Hi there!")

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1616,27 +1616,29 @@ are always available.  They are listed here in alphabetical order.
    Output buffering is usually determined by *file*.
    However, if *flush* is true, the stream is forcibly flushed.
 
+Output buffering is usually determined by *file*. However, if *flush* is true,
+the stream is forcibly flushed.
+
 .. note::
 
-   In Python, printing a string containing newline characters does not automatically flush stdout.
-   Python performs buffering at the write/operation level, so newlines inside a single write
-   do not necessarily trigger an immediate flush. The exact timing of output may vary depending
-   on the environment:
+   In Python, printing a string containing newline characters does not automatically
+   flush stdout. Python performs buffering at the write/operation level, so newlines
+   inside a single write do not necessarily trigger an immediate flush. The exact
+   timing of output may vary depending on the environment:
 
-   - When stdout is connected to a terminal (TTY), output is line-buffered and typically flushes
-     after the write completes.
-   - When stdout is redirected to a file or pipe, output may be fully buffered and not flush
-     until the buffer fills or flush is requested.
+   - When stdout is connected to a terminal (TTY), output is line-buffered and
+     typically flushes after the write completes.
+   - When stdout is redirected to a file or pipe, output may be fully buffered and
+     not flush until the buffer fills or flush is requested.
 
-   For guaranteed immediate output, use ``flush=True`` or call ``sys.stdout.flush()`` explicitly.
-   Running Python with the ``-u`` flag also forces unbuffered output, which may be useful in
-   scripts requiring immediate writes.
+   For guaranteed immediate output, use ``flush=True`` or call
+   ``sys.stdout.flush()`` explicitly. Running Python with the ``-u`` flag also
+   forces unbuffered output, which may be useful in scripts requiring immediate writes.
 
    Example:
 
    .. code-block:: python
       from time import sleep
-
       # Whether the default end is a newline ('\\n') or any other character,
       # Python performs a single write operation for the entire string.
       # Therefore, newlines inside the string do not cause mid-string flushing.
@@ -1646,6 +1648,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. versionchanged:: 3.3
    Added the *flush* keyword argument.
+
 
 .. class:: property(fget=None, fset=None, fdel=None, doc=None)
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1616,6 +1616,31 @@ are always available.  They are listed here in alphabetical order.
    Output buffering is usually determined by *file*.
    However, if *flush* is true, the stream is forcibly flushed.
 
+.. note::
+
+   In Python, printing a string containing newline characters does not automatically flush stdout. 
+   Python performs buffering at the write/operation level, so newlines inside a single write 
+   do not necessarily trigger an immediate flush. The exact timing of output may vary depending 
+   on the environment:
+
+   - When stdout is connected to a terminal (TTY), output is line-buffered and typically flushes 
+     after the write completes.
+   - When stdout is redirected to a file or pipe, output may be fully buffered and not flush 
+     until the buffer fills or flush is requested.
+
+   For guaranteed immediate output, use ``flush=True`` or call ``sys.stdout.flush()`` explicitly. 
+   Running Python with the ``-u`` flag also forces unbuffered output, which may be useful in 
+   scripts requiring immediate writes.
+
+   Example:
+
+   .. code-block:: python
+
+      from time import sleep
+
+      print("Hello\nWorld", end='')  # Both lines appear together on TTY
+      sleep(3)
+      print("Hi there!")
 
    .. versionchanged:: 3.3
       Added the *flush* keyword argument.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1616,29 +1616,29 @@ are always available.  They are listed here in alphabetical order.
    Output buffering is usually determined by *file*.
    However, if *flush* is true, the stream is forcibly flushed.
 
-.. note::
+   .. note::
 
-   In Python, printing a string containing newline characters does not automatically
-   flush stdout. Python performs buffering at the write/operation level, so newlines
-   inside a single write do not necessarily trigger an immediate flush. The exact
-   timing of output may vary depending on the environment:
+      In Python, printing a string containing newline characters does not automatically
+      flush stdout. Python performs buffering at the write/operation level, so newlines
+      inside a single write do not necessarily trigger an immediate flush. The exact
+      timing of output may vary depending on the environment:
 
-   - When stdout is connected to a terminal (TTY), output is line-buffered and
-     typically flushes after the write completes.
-   - When stdout is redirected to a file or pipe, output may be fully buffered and
-     not flush until the buffer fills or flush is requested.
+      - When stdout is connected to a terminal (TTY), output is line-buffered and
+        typically flushes after the write completes.
+      - When stdout is redirected to a file or pipe, output may be fully buffered and
+        not flush until the buffer fills or flush is requested.
 
-   For guaranteed immediate output, use ``flush=True`` or call
-   ``sys.stdout.flush()`` explicitly. Running Python with the ``-u`` flag also
-   forces unbuffered output, which may be useful in scripts requiring immediate writes.
+      For guaranteed immediate output, use ``flush=True`` or call
+      ``sys.stdout.flush()`` explicitly. Running Python with the ``-u`` flag also
+      forces unbuffered output, which may be useful in scripts requiring immediate writes.
 
-   Example:
+      Example:
 
-   .. code-block:: python
-      from time import sleep
-      print("Hello\nWorld")
-      sleep(3)
-      print("Hi there!")
+      .. code-block:: python
+         from time import sleep
+         print("Hello\nWorld")
+         sleep(3)
+         print("Hi there!")
 
 .. versionchanged:: 3.3
    Added the *flush* keyword argument.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1636,16 +1636,12 @@ are always available.  They are listed here in alphabetical order.
 
    .. code-block:: python
       from time import sleep
-      # Whether the default end is a newline ('\\n') or any other character,
-      # Python performs a single write operation for the entire string.
-      # Therefore, newlines inside the string do not cause mid-string flushing.
       print("Hello\nWorld")
       sleep(3)
       print("Hi there!")
 
 .. versionchanged:: 3.3
    Added the *flush* keyword argument.
-
 
 .. class:: property(fget=None, fset=None, fdel=None, doc=None)
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1633,12 +1633,13 @@ are always available.  They are listed here in alphabetical order.
       Example:
 
       .. code-block:: python
-            from time import sleep
-            # This call performs one write operation, so the newline inside the string
-            # does not trigger an immediate flush by itself.
-            print("Hello\nWorld")
-            sleep(3)
-            print("Hi there!")
+
+         from time import sleep
+         # This call performs one write operation, so the newline inside the string
+         # does not trigger an immediate flush by itself.
+         print("Hello\nWorld")
+         sleep(3)
+         print("Hi there!")
 
    .. versionchanged:: 3.3
       Added the *flush* keyword argument.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1553,7 +1553,6 @@ are always available.  They are listed here in alphabetical order.
    length 1, return its single byte value.
    For example, ``ord(b'a')`` returns the integer ``97``.
 
-
 .. function:: pow(base, exp, mod=None)
 
    Return *base* to the power *exp*; if *mod* is present, return *base* to the
@@ -1594,7 +1593,6 @@ are always available.  They are listed here in alphabetical order.
    .. versionchanged:: 3.8
       Allow keyword arguments.  Formerly, only positional arguments were
       supported.
-
 
 .. function:: print(*objects, sep=' ', end='\n', file=None, flush=False)
 
@@ -1640,8 +1638,8 @@ are always available.  They are listed here in alphabetical order.
          sleep(3)
          print("Hi there!")
 
-.. versionchanged:: 3.3
-   Added the *flush* keyword argument.
+   .. versionchanged:: 3.3
+      Added the *flush* keyword argument.
 
 .. class:: property(fget=None, fset=None, fdel=None, doc=None)
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1616,9 +1616,6 @@ are always available.  They are listed here in alphabetical order.
    Output buffering is usually determined by *file*.
    However, if *flush* is true, the stream is forcibly flushed.
 
-Output buffering is usually determined by *file*. However, if *flush* is true,
-the stream is forcibly flushed.
-
 .. note::
 
    In Python, printing a string containing newline characters does not automatically

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1618,33 +1618,34 @@ are always available.  They are listed here in alphabetical order.
 
 .. note::
 
-   In Python, printing a string containing newline characters does not automatically flush stdout. 
-   Python performs buffering at the write/operation level, so newlines inside a single write 
-   do not necessarily trigger an immediate flush. The exact timing of output may vary depending 
+   In Python, printing a string containing newline characters does not automatically flush stdout.
+   Python performs buffering at the write/operation level, so newlines inside a single write
+   do not necessarily trigger an immediate flush. The exact timing of output may vary depending
    on the environment:
 
-   - When stdout is connected to a terminal (TTY), output is line-buffered and typically flushes 
+   - When stdout is connected to a terminal (TTY), output is line-buffered and typically flushes
      after the write completes.
-   - When stdout is redirected to a file or pipe, output may be fully buffered and not flush 
+   - When stdout is redirected to a file or pipe, output may be fully buffered and not flush
      until the buffer fills or flush is requested.
 
-   For guaranteed immediate output, use ``flush=True`` or call ``sys.stdout.flush()`` explicitly. 
-   Running Python with the ``-u`` flag also forces unbuffered output, which may be useful in 
+   For guaranteed immediate output, use ``flush=True`` or call ``sys.stdout.flush()`` explicitly.
+   Running Python with the ``-u`` flag also forces unbuffered output, which may be useful in
    scripts requiring immediate writes.
 
    Example:
 
    .. code-block:: python
-
       from time import sleep
 
-      print("Hello\nWorld", end='')  # Both lines appear together on TTY
+      # Whether the default end is a newline ('\\n') or any other character,
+      # Python performs a single write operation for the entire string.
+      # Therefore, newlines inside the string do not cause mid-string flushing.
+      print("Hello\nWorld")
       sleep(3)
       print("Hi there!")
 
-   .. versionchanged:: 3.3
-      Added the *flush* keyword argument.
-
+.. versionchanged:: 3.3
+   Added the *flush* keyword argument.
 
 .. class:: property(fget=None, fset=None, fdel=None, doc=None)
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1633,12 +1633,12 @@ are always available.  They are listed here in alphabetical order.
       Example:
 
       .. code-block:: python
-         from time import sleep
-         # This call performs one write operation, so the newline inside the string
-         # does not trigger an immediate flush by itself.
-         print("Hello\nWorld")
-         sleep(3)
-         print("Hi there!")
+            from time import sleep
+            # This call performs one write operation, so the newline inside the string
+            # does not trigger an immediate flush by itself.
+            print("Hello\nWorld")
+            sleep(3)
+            print("Hi there!")
 
    .. versionchanged:: 3.3
       Added the *flush* keyword argument.


### PR DESCRIPTION
This PR adds a note to the print() documentation to clarify how Python’s stdout buffering works with newline (\n) characters inside a single print call.

Motivation:

Current documentation mentions that flush() is implied for writes containing newlines.

However, it does not explain that Python flushes only after the entire write operation, not mid-string.

This can confuse users coming from C, who expect a flush at each newline, and developers writing scripts that rely on immediate output for progress indicators or CLI feedback.


What’s added:

A .. note:: block explaining that stdout behavior depends on the environment (TTY vs redirected stdout).

Guidance on explicitly flushing with flush=True or sys.stdout.flush().

Mention of python -u for unbuffered output.

A short example demonstrating the behavior.


Impact:

Improves clarity for learners and developers.

Aligns documentation with actual behavior across different environments.

Not a behavior change — documentation-only PR.


Related Issue:

Addresses issue #141395

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141395 -->
* Issue: gh-141395
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142094.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->