### PR TITLE
gh-141473: Document not calling Popen.wait after Popen.communicate times out.

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -846,6 +846,11 @@ Instances of the :class:`Popen` class have the following methods:
           proc.kill()
           outs, errs = proc.communicate()
 
+   After a call to :meth:`~Popen.communicate` raises :exc:`TimeoutExpired`, do
+   not call :meth:`~Popen.wait`. Use an additional :meth:`~Popen.communicate`
+   call to finish handling pipes and populate the :attr:`~Popen.returncode`
+   attribute.
+
    .. note::
 
       The data read is buffered in memory, so do not use this method if the data


### PR DESCRIPTION


<!-- gh-issue-number: gh-141473 -->
* Issue: gh-141473
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142101.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->