### PR TITLE
gh-142067: Add missing default value for param in `multiprocessing.Pipe`'s doc

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -890,7 +890,7 @@ For an example of the usage of queues for interprocess communication see
 :ref:`multiprocessing-examples`.
 
 
-.. function:: Pipe([duplex])
+.. function:: Pipe(duplex=True)
 
    Returns a pair ``(conn1, conn2)`` of
    :class:`~multiprocessing.connection.Connection` objects representing the


### PR DESCRIPTION
<!-- gh-issue-number: gh-142067 -->
* Issue: gh-142067
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142109.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->