### PR TITLE
Docs: Upgrade Sphinx to 9.0

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -7,7 +7,7 @@
 # won't suddenly cause build failures. Updating the version is fine as long
 # as no warnings are raised by doing so.
 # Keep this version in sync with ``Doc/conf.py``.
-sphinx~=8.2.0
+sphinx~=9.0.0
 
 blurb
 


### PR DESCRIPTION
Sphinx 9.0.0 was released earlier today.

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142114.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->