### PR TITLE
gh-142108: Document Decimal formatting behavior differences

### DIFF
--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -33,6 +33,7 @@ found in the dictionary of type objects.
 
 
 .. c:var:: PyTypeObject PyMethodDescr_Type
+
    The type object for method descriptor objects created from
    :c:type:`PyMethodDef` structures. These descriptors expose C functions as
    methods on a type, and correspond to ``method_descriptor`` objects in the
@@ -43,6 +44,7 @@ found in the dictionary of type objects.
 
 
 .. c:var:: PyTypeObject PyWrapperDescr_Type
+
    The type object for wrapper descriptor objects created by
    :c:func:`PyDescr_NewWrapper` and :c:func:`PyWrapper_New`. Wrapper
    descriptors are used internally to expose special methods implemented
@@ -87,6 +89,7 @@ Built-in descriptors
 
 
 .. c:var:: PyTypeObject PyGetSetDescr_Type
+   
    The type object for get/set descriptor objects created from
    :c:type:`PyGetSetDef` structures. These descriptors implement attributes
    whose value is computed by C getter and setter functions, and are used

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -25,8 +25,16 @@ found in the dictionary of type objects.
 
    The type object for member descriptor objects created from
    :c:type:`PyMemberDef` structures. These descriptors expose fields of a
-   C struct as attributes on a type, and correspond to ``member_descriptor``
+   C struct as attributes on a type, and correspond to :class:`types.MemberDescriptorType`
    objects in the Python layer.
+
+
+.. c:var:: PyTypeObject PyGetSetDescr_Type
+
+   The type object for get/set descriptor objects created from
+   :c:type:`PyGetSetDef` structures. These descriptors implement attributes
+   whose value is computed by C getter and setter functions, and are used
+   for many built-in type attributes.
 
 
 .. c:function:: PyObject* PyDescr_NewMethod(PyTypeObject *type, struct PyMethodDef *meth)
@@ -36,7 +44,7 @@ found in the dictionary of type objects.
 
    The type object for method descriptor objects created from
    :c:type:`PyMethodDef` structures. These descriptors expose C functions as
-   methods on a type, and correspond to ``method_descriptor`` objects in the
+   methods on a type, and correspond to :class:`types.MemberDescriptorType` objects in the
    Python layer.
 
 
@@ -48,7 +56,7 @@ found in the dictionary of type objects.
    The type object for wrapper descriptor objects created by
    :c:func:`PyDescr_NewWrapper` and :c:func:`PyWrapper_New`. Wrapper
    descriptors are used internally to expose special methods implemented
-   via wrapper structures, and appear in Python as ``wrapper_descriptor``
+   via wrapper structures, and appear in Python as :class:`types.WrapperDescriptorType`
    objects.
 
 
@@ -86,14 +94,6 @@ Built-in descriptors
    This is the type of the descriptors created for :func:`classmethod` defined in C
    extension types, and is the same object as :class:`classmethod` in the
    Python layer.
-
-
-.. c:var:: PyTypeObject PyGetSetDescr_Type
-
-   The type object for get/set descriptor objects created from
-   :c:type:`PyGetSetDef` structures. These descriptors implement attributes
-   whose value is computed by C getter and setter functions, and are used
-   for many built-in type attributes.
 
 
 .. c:function:: PyObject *PyClassMethod_New(PyObject *callable)

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -21,10 +21,33 @@ found in the dictionary of type objects.
 .. c:function:: PyObject* PyDescr_NewMember(PyTypeObject *type, struct PyMemberDef *meth)
 
 
+.. c:var:: PyTypeObject PyMemberDescr_Type
+
+   The type object for member descriptor objects created from
+   :c:type:`PyMemberDef` structures. These descriptors expose fields of a
+   C struct as attributes on a type, and correspond to ``member_descriptor``
+   objects in the Python layer.
+
+
 .. c:function:: PyObject* PyDescr_NewMethod(PyTypeObject *type, struct PyMethodDef *meth)
 
 
+.. c:var:: PyTypeObject PyMethodDescr_Type
+   The type object for method descriptor objects created from
+   :c:type:`PyMethodDef` structures. These descriptors expose C functions as
+   methods on a type, and correspond to ``method_descriptor`` objects in the
+   Python layer.
+
+
 .. c:function:: PyObject* PyDescr_NewWrapper(PyTypeObject *type, struct wrapperbase *wrapper, void *wrapped)
+
+
+.. c:var:: PyTypeObject PyWrapperDescr_Type
+   The type object for wrapper descriptor objects created by
+   :c:func:`PyDescr_NewWrapper` and :c:func:`PyWrapper_New`. Wrapper
+   descriptors are used internally to expose special methods implemented
+   via wrapper structures, and appear in Python as ``wrapper_descriptor``
+   objects.
 
 
 .. c:function:: PyObject* PyDescr_NewClassMethod(PyTypeObject *type, PyMethodDef *method)
@@ -53,6 +76,21 @@ Built-in descriptors
 
    The type of class method objects. This is the same object as
    :class:`classmethod` in the Python layer.
+
+
+.. c:var:: PyTypeObject PyClassMethodDescr_Type
+
+   The type object for C-level class method descriptor objects.
+   This is the type of the descriptors created for :func:`classmethod` defined in C
+   extension types, and is the same object as :class:`classmethod` in the
+   Python layer.
+
+
+.. c:var:: PyTypeObject PyGetSetDescr_Type
+   The type object for get/set descriptor objects created from
+   :c:type:`PyGetSetDef` structures. These descriptors implement attributes
+   whose value is computed by C getter and setter functions, and are used
+   for many built-in type attributes.
 
 
 .. c:function:: PyObject *PyClassMethod_New(PyObject *callable)

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -89,7 +89,7 @@ Built-in descriptors
 
 
 .. c:var:: PyTypeObject PyGetSetDescr_Type
-   
+
    The type object for get/set descriptor objects created from
    :c:type:`PyGetSetDef` structures. These descriptors implement attributes
    whose value is computed by C getter and setter functions, and are used

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -44,7 +44,7 @@ Dictionary Objects
 
 
 .. c:var:: PyTypeObject PyDictProxy_Type
-   
+
    The type object for mapping proxy objects created by
    :c:func:`PyDictProxy_New` and for the read-only ``__dict__`` attribute
    of many built-in types. A :c:type:`PyDictProxy_Type` instance provides a

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -50,7 +50,8 @@ Dictionary Objects
    of many built-in types. A :c:type:`PyDictProxy_Type` instance provides a
    dynamic, read-only view of an underlying dictionary: changes to the
    underlying dictionary are reflected in the proxy, but the proxy itself
-   does not support mutation operations.
+   does not support mutation operations.These objects correspond to 
+   :class:`types.MappingProxyType` in Python.
 
 
 .. c:function:: void PyDict_Clear(PyObject *p)

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -43,6 +43,15 @@ Dictionary Objects
    prevent modification of the dictionary for non-dynamic class types.
 
 
+.. c:var:: PyTypeObject PyDictProxy_Type
+   The type object for mapping proxy objects created by
+   :c:func:`PyDictProxy_New` and for the read-only ``__dict__`` attribute
+   of many built-in types. A :c:type:`PyDictProxy_Type` instance provides a
+   dynamic, read-only view of an underlying dictionary: changes to the
+   underlying dictionary are reflected in the proxy, but the proxy itself
+   does not support mutation operations.
+
+
 .. c:function:: void PyDict_Clear(PyObject *p)
 
    Empty an existing dictionary of all key-value pairs.

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -44,6 +44,7 @@ Dictionary Objects
 
 
 .. c:var:: PyTypeObject PyDictProxy_Type
+   
    The type object for mapping proxy objects created by
    :c:func:`PyDictProxy_New` and for the read-only ``__dict__`` attribute
    of many built-in types. A :c:type:`PyDictProxy_Type` instance provides a

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -50,7 +50,7 @@ Dictionary Objects
    of many built-in types. A :c:type:`PyDictProxy_Type` instance provides a
    dynamic, read-only view of an underlying dictionary: changes to the
    underlying dictionary are reflected in the proxy, but the proxy itself
-   does not support mutation operations.These objects correspond to 
+   does not support mutation operations.These objects correspond to
    :class:`types.MappingProxyType` in Python.
 
 

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -629,6 +629,20 @@ after the decimal point.  The rounding mode for :class:`float` matches that
 of the :func:`round` builtin.  For :class:`~decimal.Decimal`, the rounding
 mode of the current :ref:`context <decimal-context>` will be used.
 
+
+.. note::
+
+   The :class:`~decimal.Decimal` type has special formatting behavior:
+
+   * When using ``__format__`` (f-strings, ``format()``, ``str.format()``),
+    Decimal formats with maximum precision only when precision is **omitted**
+    in ``f``, ``e``, or ``g`` format types. If precision is explicitly specified,
+    it is respected.
+
+   * When using ``%`` formatting (old-style string formatting with the ``%`` operator),
+   Decimal values are first converted to :class:`float`, which may result in
+   precision loss.
+
 The available presentation types for :class:`complex` are the same as those for
 :class:`float` (``'%'`` is not allowed).  Both the real and imaginary components
 of a complex number are formatted as floating-point numbers, according to the


### PR DESCRIPTION
This PR clarifies how `Decimal` behaves differently when formatted using `__format__` (f-strings, `format()`, `str.format()`) versus `%` formatting (old-style string formatting).

**Changes:**
- Added a note in the Format Specification Mini-Language section explaining:
  - For `__format__`: Decimal uses maximum precision only when precision is **omitted** in f/e/g format types; explicit precision is respected
  - For `%` formatting: Decimal values are converted to `float` first, resulting in potential precision loss

**Documentation preview:** (will be auto-generated)

Fixes #142108


<!-- gh-issue-number: gh-142108 -->
* Issue: gh-142108
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142117.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->