### PR TITLE
gh-142066: Fix grammar in multiprocessing Pipes and Queues

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -832,8 +832,8 @@ raising an exception.
 
 One difference from other Python queue implementations, is that :mod:`multiprocessing`
 queues serializes all objects that are put into them using :mod:`pickle`.
-The object return by the get method is a re-created object that does not share memory
-with the original object.
+The object returned by the get method is a re-created object that does not share
+memory with the original object.
 
 Note that one can also create a shared queue by using a manager object -- see
 :ref:`multiprocessing-managers`.


### PR DESCRIPTION
Fixes grammar in the "Pipes and Queues" section of the multiprocessing documentation.

<!-- gh-issue-number: gh-142066 -->
* Issue: gh-142066
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142121.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->