### PR TITLE
gh-142020: ctypes docs: Note that find_library relies on the programs it runs

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1388,6 +1388,9 @@ On Linux, :func:`~ctypes.util.find_library` tries to run external programs
 (``/sbin/ldconfig``, ``gcc``, ``objdump`` and ``ld``) to find the library file.
 It returns the filename of the library file.
 
+Note that if the output of these programs does not correspond to the dynamic
+linker used by Python, the result of this function may be misleading.
+
 .. versionchanged:: 3.6
    On Linux, the value of the environment variable ``LD_LIBRARY_PATH`` is used
    when searching for libraries, if a library cannot be found by any other means.

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -2135,6 +2135,8 @@ Utility functions
 
    The exact functionality is system dependent.
 
+   See :ref:`ctypes-finding-shared-libraries` for complete documentation.
+
 
 .. function:: find_msvcrt()
    :module: ctypes.util


### PR DESCRIPTION
We can be more explicit that `find_library` doesn't just run `ldconfig` -- it also relies on its output to be correct & available.

Not much of a fix, alas.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142020 -->
* Issue: gh-142020
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142134.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->