### PR TITLE
gh-138122: Implement frame caching in RemoteUnwinder to reduce memory reads

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -135,6 +135,8 @@ struct _ts {
     /* Pointer to currently executing frame. */
     struct _PyInterpreterFrame *current_frame;
 
+    struct _PyInterpreterFrame *last_profiled_frame;
+
     Py_tracefunc c_profilefunc;
     Py_tracefunc c_tracefunc;
     PyObject *c_profileobj;

--- a/Include/internal/pycore_debug_offsets.h
+++ b/Include/internal/pycore_debug_offsets.h
@@ -102,6 +102,7 @@ typedef struct _Py_DebugOffsets {
         uint64_t next;
         uint64_t interp;
         uint64_t current_frame;
+        uint64_t last_profiled_frame;
         uint64_t thread_id;
         uint64_t native_thread_id;
         uint64_t datastack_chunk;
@@ -272,6 +273,7 @@ typedef struct _Py_DebugOffsets {
         .next = offsetof(PyThreadState, next), \
         .interp = offsetof(PyThreadState, interp), \
         .current_frame = offsetof(PyThreadState, current_frame), \
+        .last_profiled_frame = offsetof(PyThreadState, last_profiled_frame), \
         .thread_id = offsetof(PyThreadState, thread_id), \
         .native_thread_id = offsetof(PyThreadState, native_thread_id), \
         .datastack_chunk = offsetof(PyThreadState, datastack_chunk), \

--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -1609,6 +1609,7 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(c_parameter_type));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(c_return));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(c_stack));
+    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(cache_frames));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(cached_datetime_module));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(cached_statements));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(cadata));

--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -2054,6 +2054,7 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(stacklevel));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(start));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(statement));
+    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(stats));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(status));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(stderr));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(stdin));

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -332,6 +332,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(c_parameter_type)
         STRUCT_FOR_ID(c_return)
         STRUCT_FOR_ID(c_stack)
+        STRUCT_FOR_ID(cache_frames)
         STRUCT_FOR_ID(cached_datetime_module)
         STRUCT_FOR_ID(cached_statements)
         STRUCT_FOR_ID(cadata)

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -777,6 +777,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(stacklevel)
         STRUCT_FOR_ID(start)
         STRUCT_FOR_ID(statement)
+        STRUCT_FOR_ID(stats)
         STRUCT_FOR_ID(status)
         STRUCT_FOR_ID(stderr)
         STRUCT_FOR_ID(stdin)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -1607,6 +1607,7 @@ extern "C" {
     INIT_ID(c_parameter_type), \
     INIT_ID(c_return), \
     INIT_ID(c_stack), \
+    INIT_ID(cache_frames), \
     INIT_ID(cached_datetime_module), \
     INIT_ID(cached_statements), \
     INIT_ID(cadata), \

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -2052,6 +2052,7 @@ extern "C" {
     INIT_ID(stacklevel), \
     INIT_ID(start), \
     INIT_ID(statement), \
+    INIT_ID(stats), \
     INIT_ID(status), \
     INIT_ID(stderr), \
     INIT_ID(stdin), \

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -1108,6 +1108,10 @@ _PyUnicode_InitStaticStrings(PyInterpreterState *interp) {
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));
     assert(PyUnicode_GET_LENGTH(string) != 1);
+    string = &_Py_ID(cache_frames);
+    _PyUnicode_InternStatic(interp, &string);
+    assert(_PyUnicode_CheckConsistency(string, 1));
+    assert(PyUnicode_GET_LENGTH(string) != 1);
     string = &_Py_ID(cached_datetime_module);
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -2888,6 +2888,10 @@ _PyUnicode_InitStaticStrings(PyInterpreterState *interp) {
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));
     assert(PyUnicode_GET_LENGTH(string) != 1);
+    string = &_Py_ID(stats);
+    _PyUnicode_InternStatic(interp, &string);
+    assert(_PyUnicode_CheckConsistency(string, 1));
+    assert(PyUnicode_GET_LENGTH(string) != 1);
     string = &_Py_ID(status);
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));

--- a/InternalDocs/frames.md
+++ b/InternalDocs/frames.md
@@ -111,6 +111,24 @@ The shim frame points to a special code object containing the `INTERPRETER_EXIT`
 instruction which cleans up the shim frame and returns.
 
 
+### Remote Profiling Frame Cache
+
+The `last_profiled_frame` field in `PyThreadState` supports an optimization for
+remote profilers that sample call stacks from external processes. When a remote
+profiler reads the call stack, it writes the current frame address to this field.
+The eval loop then keeps this pointer valid by updating it to the parent frame
+whenever a frame returns (in `_PyEval_FrameClearAndPop`).
+
+This creates a "high-water mark" that always points to a frame still on the stack.
+On subsequent samples, the profiler can walk from `current_frame` until it reaches
+`last_profiled_frame`, knowing that frames from that point downward are unchanged
+and can be retrieved from a cache. This significantly reduces the amount of remote
+memory reads needed when call stacks are deep and stable at their base.
+
+The update in `_PyEval_FrameClearAndPop` is guarded: it only writes when
+`last_profiled_frame` is non-NULL, avoiding any overhead when profiling is inactive.
+
+
 ### The Instruction Pointer
 
 `_PyInterpreterFrame` has two fields which are used to maintain the instruction

--- a/InternalDocs/frames.md
+++ b/InternalDocs/frames.md
@@ -126,7 +126,9 @@ and can be retrieved from a cache. This significantly reduces the amount of remo
 memory reads needed when call stacks are deep and stable at their base.
 
 The update in `_PyEval_FrameClearAndPop` is guarded: it only writes when
-`last_profiled_frame` is non-NULL, avoiding any overhead when profiling is inactive.
+`last_profiled_frame` is non-NULL AND matches the frame being popped. This
+prevents transient frames (called and returned between profiler samples) from
+corrupting the cache pointer, while avoiding any overhead when profiling is inactive.
 
 
 ### The Instruction Pointer

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -255,6 +255,18 @@ class SampleProfiler:
         print(f"    Hits:             {code_hits:,} ({ANSIColors.GREEN}{code_hits_pct:.1f}%{ANSIColors.RESET})")
         print(f"    Misses:           {code_misses:,} ({ANSIColors.RED}{code_misses_pct:.1f}%{ANSIColors.RESET})")
 
+        # Memory operations
+        memory_reads = stats.get('memory_reads', 0)
+        memory_bytes = stats.get('memory_bytes_read', 0)
+        if memory_bytes >= 1024 * 1024:
+            memory_str = f"{memory_bytes / (1024 * 1024):.1f} MB"
+        elif memory_bytes >= 1024:
+            memory_str = f"{memory_bytes / 1024:.1f} KB"
+        else:
+            memory_str = f"{memory_bytes} B"
+        print(f"  {ANSIColors.CYAN}Memory:{ANSIColors.RESET}")
+        print(f"    Read operations:  {memory_reads:,} ({memory_str})")
+
         # Stale invalidations
         stale_invalidations = stats.get('stale_cache_invalidations', 0)
         if stale_invalidations > 0:

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -27,21 +27,24 @@ _FREE_THREADED_BUILD = sysconfig.get_config_var("Py_GIL_DISABLED") is not None
 
 
 class SampleProfiler:
-    def __init__(self, pid, sample_interval_usec, all_threads, *, mode=PROFILING_MODE_WALL, native=False, gc=True, skip_non_matching_threads=True):
+    def __init__(self, pid, sample_interval_usec, all_threads, *, mode=PROFILING_MODE_WALL, native=False, gc=True, skip_non_matching_threads=True, collect_stats=False):
         self.pid = pid
         self.sample_interval_usec = sample_interval_usec
         self.all_threads = all_threads
         self.mode = mode  # Store mode for later use
+        self.collect_stats = collect_stats
         if _FREE_THREADED_BUILD:
             self.unwinder = _remote_debugging.RemoteUnwinder(
                 self.pid, all_threads=self.all_threads, mode=mode, native=native, gc=gc,
-                skip_non_matching_threads=skip_non_matching_threads, cache_frames=True
+                skip_non_matching_threads=skip_non_matching_threads, cache_frames=True,
+                stats=collect_stats
             )
         else:
             only_active_threads = bool(self.all_threads)
             self.unwinder = _remote_debugging.RemoteUnwinder(
                 self.pid, only_active_thread=only_active_threads, mode=mode, native=native, gc=gc,
-                skip_non_matching_threads=skip_non_matching_threads, cache_frames=True
+                skip_non_matching_threads=skip_non_matching_threads, cache_frames=True,
+                stats=collect_stats
             )
         # Track sample intervals and total sample count
         self.sample_intervals = deque(maxlen=100)
@@ -124,6 +127,10 @@ class SampleProfiler:
             print(f"Sample rate: {sample_rate:.2f} samples/sec")
             print(f"Error rate: {error_rate:.2f}%")
 
+            # Print unwinder stats if stats collection is enabled
+            if self.collect_stats:
+                self._print_unwinder_stats()
+
         # Pass stats to flamegraph collector if it's the right type
         if hasattr(collector, 'set_stats'):
             collector.set_stats(self.sample_interval_usec, running_time, sample_rate, error_rate, missed_samples, mode=self.mode)
@@ -171,16 +178,87 @@ class SampleProfiler:
             (1.0 / min_hz) * 1_000_000 if min_hz > 0 else 0
         )  # Max time = Min Hz
 
+        # Build cache stats string if stats collection is enabled
+        cache_stats_str = ""
+        if self.collect_stats:
+            try:
+                stats = self.unwinder.get_stats()
+                hits = stats.get('frame_cache_hits', 0)
+                partial = stats.get('frame_cache_partial_hits', 0)
+                misses = stats.get('frame_cache_misses', 0)
+                total = hits + partial + misses
+                if total > 0:
+                    hit_pct = (hits + partial) / total * 100
+                    cache_stats_str = f" {ANSIColors.MAGENTA}Cache: {hit_pct:.1f}% ({hits}+{partial}/{misses}){ANSIColors.RESET}"
+            except RuntimeError:
+                pass
+
         # Clear line and print stats
         print(
-            f"\r\033[K{ANSIColors.BOLD_BLUE}Real-time sampling stats:{ANSIColors.RESET} "
-            f"{ANSIColors.YELLOW}Mean: {mean_hz:.1f}Hz ({mean_us_per_sample:.2f}µs){ANSIColors.RESET} "
-            f"{ANSIColors.GREEN}Min: {min_hz:.1f}Hz ({max_us_per_sample:.2f}µs){ANSIColors.RESET} "
-            f"{ANSIColors.RED}Max: {max_hz:.1f}Hz ({min_us_per_sample:.2f}µs){ANSIColors.RESET} "
-            f"{ANSIColors.CYAN}Samples: {self.total_samples}{ANSIColors.RESET}",
+            f"\r\033[K{ANSIColors.BOLD_BLUE}Stats:{ANSIColors.RESET} "
+            f"{ANSIColors.YELLOW}{mean_hz:.1f}Hz ({mean_us_per_sample:.1f}µs){ANSIColors.RESET} "
+            f"{ANSIColors.GREEN}Min: {min_hz:.1f}Hz{ANSIColors.RESET} "
+            f"{ANSIColors.RED}Max: {max_hz:.1f}Hz{ANSIColors.RESET} "
+            f"{ANSIColors.CYAN}N={self.total_samples}{ANSIColors.RESET}"
+            f"{cache_stats_str}",
             end="",
             flush=True,
         )
+
+    def _print_unwinder_stats(self):
+        """Print unwinder statistics including cache performance."""
+        try:
+            stats = self.unwinder.get_stats()
+        except RuntimeError:
+            return  # Stats not enabled
+
+        print(f"\n{ANSIColors.BOLD_BLUE}{'='*50}{ANSIColors.RESET}")
+        print(f"{ANSIColors.BOLD_BLUE}Unwinder Statistics:{ANSIColors.RESET}")
+
+        # Frame cache stats
+        total_samples = stats.get('total_samples', 0)
+        frame_cache_hits = stats.get('frame_cache_hits', 0)
+        frame_cache_partial_hits = stats.get('frame_cache_partial_hits', 0)
+        frame_cache_misses = stats.get('frame_cache_misses', 0)
+        total_lookups = frame_cache_hits + frame_cache_partial_hits + frame_cache_misses
+
+        # Calculate percentages
+        hits_pct = (frame_cache_hits / total_lookups * 100) if total_lookups > 0 else 0
+        partial_pct = (frame_cache_partial_hits / total_lookups * 100) if total_lookups > 0 else 0
+        misses_pct = (frame_cache_misses / total_lookups * 100) if total_lookups > 0 else 0
+
+        print(f"  {ANSIColors.CYAN}Frame Cache:{ANSIColors.RESET}")
+        print(f"    Total samples:    {total_samples:,}")
+        print(f"    Full hits:        {frame_cache_hits:,} ({ANSIColors.GREEN}{hits_pct:.1f}%{ANSIColors.RESET})")
+        print(f"    Partial hits:     {frame_cache_partial_hits:,} ({ANSIColors.YELLOW}{partial_pct:.1f}%{ANSIColors.RESET})")
+        print(f"    Misses:           {frame_cache_misses:,} ({ANSIColors.RED}{misses_pct:.1f}%{ANSIColors.RESET})")
+
+        # Frame read stats
+        frames_from_cache = stats.get('frames_read_from_cache', 0)
+        frames_from_memory = stats.get('frames_read_from_memory', 0)
+        total_frames = frames_from_cache + frames_from_memory
+        cache_frame_pct = (frames_from_cache / total_frames * 100) if total_frames > 0 else 0
+        memory_frame_pct = (frames_from_memory / total_frames * 100) if total_frames > 0 else 0
+
+        print(f"  {ANSIColors.CYAN}Frame Reads:{ANSIColors.RESET}")
+        print(f"    From cache:       {frames_from_cache:,} ({ANSIColors.GREEN}{cache_frame_pct:.1f}%{ANSIColors.RESET})")
+        print(f"    From memory:      {frames_from_memory:,} ({ANSIColors.RED}{memory_frame_pct:.1f}%{ANSIColors.RESET})")
+
+        # Code object cache stats
+        code_hits = stats.get('code_object_cache_hits', 0)
+        code_misses = stats.get('code_object_cache_misses', 0)
+        total_code = code_hits + code_misses
+        code_hits_pct = (code_hits / total_code * 100) if total_code > 0 else 0
+        code_misses_pct = (code_misses / total_code * 100) if total_code > 0 else 0
+
+        print(f"  {ANSIColors.CYAN}Code Object Cache:{ANSIColors.RESET}")
+        print(f"    Hits:             {code_hits:,} ({ANSIColors.GREEN}{code_hits_pct:.1f}%{ANSIColors.RESET})")
+        print(f"    Misses:           {code_misses:,} ({ANSIColors.RED}{code_misses_pct:.1f}%{ANSIColors.RESET})")
+
+        # Stale invalidations
+        stale_invalidations = stats.get('stale_cache_invalidations', 0)
+        if stale_invalidations > 0:
+            print(f"  {ANSIColors.YELLOW}Stale cache invalidations: {stale_invalidations}{ANSIColors.RESET}")
 
 
 def sample(
@@ -228,7 +306,8 @@ def sample(
         mode=mode,
         native=native,
         gc=gc,
-        skip_non_matching_threads=skip_non_matching_threads
+        skip_non_matching_threads=skip_non_matching_threads,
+        collect_stats=realtime_stats  # Collect stats when realtime_stats is enabled
     )
     profiler.realtime_stats = realtime_stats
 
@@ -283,7 +362,8 @@ def sample_live(
         mode=mode,
         native=native,
         gc=gc,
-        skip_non_matching_threads=skip_non_matching_threads
+        skip_non_matching_threads=skip_non_matching_threads,
+        collect_stats=realtime_stats  # Collect stats when realtime_stats is enabled
     )
     profiler.realtime_stats = realtime_stats
 

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -35,13 +35,13 @@ class SampleProfiler:
         if _FREE_THREADED_BUILD:
             self.unwinder = _remote_debugging.RemoteUnwinder(
                 self.pid, all_threads=self.all_threads, mode=mode, native=native, gc=gc,
-                skip_non_matching_threads=skip_non_matching_threads
+                skip_non_matching_threads=skip_non_matching_threads, cache_frames=True
             )
         else:
             only_active_threads = bool(self.all_threads)
             self.unwinder = _remote_debugging.RemoteUnwinder(
                 self.pid, only_active_thread=only_active_threads, mode=mode, native=native, gc=gc,
-                skip_non_matching_threads=skip_non_matching_threads
+                skip_non_matching_threads=skip_non_matching_threads, cache_frames=True
             )
         # Track sample intervals and total sample count
         self.sample_intervals = deque(maxlen=100)

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -307,7 +307,7 @@ def sample(
         native=native,
         gc=gc,
         skip_non_matching_threads=skip_non_matching_threads,
-        collect_stats=realtime_stats  # Collect stats when realtime_stats is enabled
+        collect_stats=realtime_stats,
     )
     profiler.realtime_stats = realtime_stats
 
@@ -363,7 +363,7 @@ def sample_live(
         native=native,
         gc=gc,
         skip_non_matching_threads=skip_non_matching_threads,
-        collect_stats=realtime_stats  # Collect stats when realtime_stats is enabled
+        collect_stats=realtime_stats,
     )
     profiler.realtime_stats = realtime_stats
 

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -2655,11 +2655,11 @@ recurse({depth})
             unwinder_no_cache = make_unwinder(cache_frames=False)
 
             frames_cached = self._sample_frames(
-                client_socket, unwinder_cache, b"ready", b"ack", {"recurse"}, 1024
+                client_socket, unwinder_cache, b"ready", b"ack", {"recurse"}, 1100
             )
             # Sample again with no cache for comparison
             frames_no_cache = self._sample_frames(
-                client_socket, unwinder_no_cache, b"ready2", b"done", {"recurse"}, 1024
+                client_socket, unwinder_no_cache, b"ready2", b"done", {"recurse"}, 1100
             )
 
         self.assertIsNotNone(frames_cached)

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -2724,11 +2724,11 @@ recurse({depth})
             unwinder_no_cache = make_unwinder(cache_frames=False)
 
             frames_cached = self._sample_frames(
-                client_socket, unwinder_cache, b"ready", b"ack", {"recurse"}, 1100
+                client_socket, unwinder_cache, b"ready", b"ack", {"recurse"}, expected_frames=1102
             )
             # Sample again with no cache for comparison
             frames_no_cache = self._sample_frames(
-                client_socket, unwinder_no_cache, b"ready2", b"done", {"recurse"}, 1100
+                client_socket, unwinder_no_cache, b"ready2", b"done", {"recurse"}, expected_frames=1102
             )
 
         self.assertIsNotNone(frames_cached)

--- a/Misc/NEWS.d/next/Library/2025-12-01-14-43-58.gh-issue-138122.nRm3ic.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-01-14-43-58.gh-issue-138122.nRm3ic.rst
@@ -1,5 +1,5 @@
-The :mod:`_remote_debugging` module now implements frame caching in the
-:class:`RemoteUnwinder` class to reduce memory reads when profiling remote
+The ``_remote_debugging`` module now implements frame caching in the
+``RemoteUnwinder`` class to reduce memory reads when profiling remote
 processes. When ``cache_frames=True``, unchanged portions of the call stack
 are reused from previous samples, significantly improving profiling
 performance for deep call stacks.

--- a/Misc/NEWS.d/next/Library/2025-12-01-14-43-58.gh-issue-138122.nRm3ic.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-01-14-43-58.gh-issue-138122.nRm3ic.rst
@@ -1,0 +1,5 @@
+The :mod:`_remote_debugging` module now implements frame caching in the
+:class:`RemoteUnwinder` class to reduce memory reads when profiling remote
+processes. When ``cache_frames=True``, unchanged portions of the call stack
+are reused from previous samples, significantly improving profiling
+performance for deep call stacks.

--- a/Modules/Setup.stdlib.in
+++ b/Modules/Setup.stdlib.in
@@ -41,7 +41,7 @@
 @MODULE__PICKLE_TRUE@_pickle _pickle.c
 @MODULE__QUEUE_TRUE@_queue _queuemodule.c
 @MODULE__RANDOM_TRUE@_random _randommodule.c
-@MODULE__REMOTE_DEBUGGING_TRUE@_remote_debugging _remote_debugging/module.c _remote_debugging/object_reading.c _remote_debugging/code_objects.c _remote_debugging/frames.c _remote_debugging/threads.c _remote_debugging/asyncio.c
+@MODULE__REMOTE_DEBUGGING_TRUE@_remote_debugging _remote_debugging/module.c _remote_debugging/object_reading.c _remote_debugging/code_objects.c _remote_debugging/frames.c _remote_debugging/frame_cache.c _remote_debugging/threads.c _remote_debugging/asyncio.c
 @MODULE__STRUCT_TRUE@_struct _struct.c
 
 # build supports subinterpreters

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -174,6 +174,7 @@ typedef struct {
     uint64_t frames_read_from_cache;         // Total frames retrieved from cache
     uint64_t frames_read_from_memory;        // Total frames read from remote memory
     uint64_t memory_reads;                   // Total remote memory read operations
+    uint64_t memory_bytes_read;              // Total bytes read from remote memory
     uint64_t code_object_cache_hits;         // Code object cache hits
     uint64_t code_object_cache_misses;       // Code object cache misses
     uint64_t stale_cache_invalidations;      // Times stale entries were cleared
@@ -422,6 +423,7 @@ extern int frame_cache_lookup_and_extend(
     uintptr_t *frame_addrs,
     Py_ssize_t *num_addrs,
     Py_ssize_t max_addrs);
+// Returns: 1 = stored, 0 = not stored (graceful), -1 = error
 extern int frame_cache_store(
     RemoteUnwinderObject *unwinder,
     uint64_t thread_id,

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -374,6 +374,7 @@ extern int process_frame_chain(
 /* Frame cache functions */
 extern int frame_cache_init(RemoteUnwinderObject *unwinder);
 extern void frame_cache_cleanup(RemoteUnwinderObject *unwinder);
+extern int clear_last_profiled_frames(RemoteUnwinderObject *unwinder);
 extern void frame_cache_invalidate_stale(RemoteUnwinderObject *unwinder, PyObject *result);
 extern int frame_cache_lookup_and_extend(
     RemoteUnwinderObject *unwinder,

--- a/Modules/_remote_debugging/clinic/module.c.h
+++ b/Modules/_remote_debugging/clinic/module.c.h
@@ -12,7 +12,7 @@ preserve
 PyDoc_STRVAR(_remote_debugging_RemoteUnwinder___init____doc__,
 "RemoteUnwinder(pid, *, all_threads=False, only_active_thread=False,\n"
 "               mode=0, debug=False, skip_non_matching_threads=True,\n"
-"               native=False, gc=False, cache_frames=False)\n"
+"               native=False, gc=False, cache_frames=False, stats=False)\n"
 "--\n"
 "\n"
 "Initialize a new RemoteUnwinder object for debugging a remote Python process.\n"
@@ -34,6 +34,8 @@ PyDoc_STRVAR(_remote_debugging_RemoteUnwinder___init____doc__,
 "        collection.\n"
 "    cache_frames: If True, enable frame caching optimization to avoid re-reading\n"
 "                 unchanged parent frames between samples.\n"
+"    stats: If True, collect statistics about cache hits, memory reads, etc.\n"
+"           Use get_stats() to retrieve the collected statistics.\n"
 "\n"
 "The RemoteUnwinder provides functionality to inspect and debug a running Python\n"
 "process, including examining thread states, stack frames and other runtime data.\n"
@@ -51,7 +53,7 @@ _remote_debugging_RemoteUnwinder___init___impl(RemoteUnwinderObject *self,
                                                int mode, int debug,
                                                int skip_non_matching_threads,
                                                int native, int gc,
-                                               int cache_frames);
+                                               int cache_frames, int stats);
 
 static int
 _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObject *kwargs)
@@ -59,7 +61,7 @@ _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObje
     int return_value = -1;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
 
-    #define NUM_KEYWORDS 9
+    #define NUM_KEYWORDS 10
     static struct {
         PyGC_Head _this_is_not_used;
         PyObject_VAR_HEAD
@@ -68,7 +70,7 @@ _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObje
     } _kwtuple = {
         .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
         .ob_hash = -1,
-        .ob_item = { &_Py_ID(pid), &_Py_ID(all_threads), &_Py_ID(only_active_thread), &_Py_ID(mode), &_Py_ID(debug), &_Py_ID(skip_non_matching_threads), &_Py_ID(native), &_Py_ID(gc), &_Py_ID(cache_frames), },
+        .ob_item = { &_Py_ID(pid), &_Py_ID(all_threads), &_Py_ID(only_active_thread), &_Py_ID(mode), &_Py_ID(debug), &_Py_ID(skip_non_matching_threads), &_Py_ID(native), &_Py_ID(gc), &_Py_ID(cache_frames), &_Py_ID(stats), },
     };
     #undef NUM_KEYWORDS
     #define KWTUPLE (&_kwtuple.ob_base.ob_base)
@@ -77,14 +79,14 @@ _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObje
     #  define KWTUPLE NULL
     #endif  // !Py_BUILD_CORE
 
-    static const char * const _keywords[] = {"pid", "all_threads", "only_active_thread", "mode", "debug", "skip_non_matching_threads", "native", "gc", "cache_frames", NULL};
+    static const char * const _keywords[] = {"pid", "all_threads", "only_active_thread", "mode", "debug", "skip_non_matching_threads", "native", "gc", "cache_frames", "stats", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
         .fname = "RemoteUnwinder",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
-    PyObject *argsbuf[9];
+    PyObject *argsbuf[10];
     PyObject * const *fastargs;
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     Py_ssize_t noptargs = nargs + (kwargs ? PyDict_GET_SIZE(kwargs) : 0) - 1;
@@ -97,6 +99,7 @@ _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObje
     int native = 0;
     int gc = 0;
     int cache_frames = 0;
+    int stats = 0;
 
     fastargs = _PyArg_UnpackKeywords(_PyTuple_CAST(args)->ob_item, nargs, kwargs, NULL, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -173,12 +176,21 @@ _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObje
             goto skip_optional_kwonly;
         }
     }
-    cache_frames = PyObject_IsTrue(fastargs[8]);
-    if (cache_frames < 0) {
+    if (fastargs[8]) {
+        cache_frames = PyObject_IsTrue(fastargs[8]);
+        if (cache_frames < 0) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_kwonly;
+        }
+    }
+    stats = PyObject_IsTrue(fastargs[9]);
+    if (stats < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _remote_debugging_RemoteUnwinder___init___impl((RemoteUnwinderObject *)self, pid, all_threads, only_active_thread, mode, debug, skip_non_matching_threads, native, gc, cache_frames);
+    return_value = _remote_debugging_RemoteUnwinder___init___impl((RemoteUnwinderObject *)self, pid, all_threads, only_active_thread, mode, debug, skip_non_matching_threads, native, gc, cache_frames, stats);
 
 exit:
     return return_value;
@@ -360,4 +372,50 @@ _remote_debugging_RemoteUnwinder_get_async_stack_trace(PyObject *self, PyObject 
 
     return return_value;
 }
-/*[clinic end generated code: output=62866b3fc003b0cc input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(_remote_debugging_RemoteUnwinder_get_stats__doc__,
+"get_stats($self, /)\n"
+"--\n"
+"\n"
+"Get collected statistics about profiling performance.\n"
+"\n"
+"Returns a dictionary containing statistics about cache performance,\n"
+"memory reads, and other profiling metrics. Only available if the\n"
+"RemoteUnwinder was created with stats=True.\n"
+"\n"
+"Returns:\n"
+"    dict: A dictionary containing:\n"
+"        - total_samples: Total number of get_stack_trace calls\n"
+"        - frame_cache_hits: Full cache hits (entire stack unchanged)\n"
+"        - frame_cache_misses: Cache misses requiring full walk\n"
+"        - frame_cache_partial_hits: Partial hits (stopped at cached frame)\n"
+"        - frames_read_from_cache: Total frames retrieved from cache\n"
+"        - frames_read_from_memory: Total frames read from remote memory\n"
+"        - memory_reads: Total remote memory read operations\n"
+"        - code_object_cache_hits: Code object cache hits\n"
+"        - code_object_cache_misses: Code object cache misses\n"
+"        - stale_cache_invalidations: Times stale cache entries were cleared\n"
+"        - frame_cache_hit_rate: Percentage of samples that hit the cache\n"
+"        - code_object_cache_hit_rate: Percentage of code object lookups that hit cache\n"
+"\n"
+"Raises:\n"
+"    RuntimeError: If stats collection was not enabled (stats=False)");
+
+#define _REMOTE_DEBUGGING_REMOTEUNWINDER_GET_STATS_METHODDEF    \
+    {"get_stats", (PyCFunction)_remote_debugging_RemoteUnwinder_get_stats, METH_NOARGS, _remote_debugging_RemoteUnwinder_get_stats__doc__},
+
+static PyObject *
+_remote_debugging_RemoteUnwinder_get_stats_impl(RemoteUnwinderObject *self);
+
+static PyObject *
+_remote_debugging_RemoteUnwinder_get_stats(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _remote_debugging_RemoteUnwinder_get_stats_impl((RemoteUnwinderObject *)self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+/*[clinic end generated code: output=f0582d18e5eb605e input=a9049054013a1b77]*/

--- a/Modules/_remote_debugging/clinic/module.c.h
+++ b/Modules/_remote_debugging/clinic/module.c.h
@@ -12,7 +12,7 @@ preserve
 PyDoc_STRVAR(_remote_debugging_RemoteUnwinder___init____doc__,
 "RemoteUnwinder(pid, *, all_threads=False, only_active_thread=False,\n"
 "               mode=0, debug=False, skip_non_matching_threads=True,\n"
-"               native=False, gc=False)\n"
+"               native=False, gc=False, cache_frames=False)\n"
 "--\n"
 "\n"
 "Initialize a new RemoteUnwinder object for debugging a remote Python process.\n"
@@ -32,6 +32,8 @@ PyDoc_STRVAR(_remote_debugging_RemoteUnwinder___init____doc__,
 "            non-Python code.\n"
 "    gc: If True, include artificial \"<GC>\" frames to denote active garbage\n"
 "        collection.\n"
+"    cache_frames: If True, enable frame caching optimization to avoid re-reading\n"
+"                 unchanged parent frames between samples.\n"
 "\n"
 "The RemoteUnwinder provides functionality to inspect and debug a running Python\n"
 "process, including examining thread states, stack frames and other runtime data.\n"
@@ -48,7 +50,8 @@ _remote_debugging_RemoteUnwinder___init___impl(RemoteUnwinderObject *self,
                                                int only_active_thread,
                                                int mode, int debug,
                                                int skip_non_matching_threads,
-                                               int native, int gc);
+                                               int native, int gc,
+                                               int cache_frames);
 
 static int
 _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObject *kwargs)
@@ -56,7 +59,7 @@ _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObje
     int return_value = -1;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
 
-    #define NUM_KEYWORDS 8
+    #define NUM_KEYWORDS 9
     static struct {
         PyGC_Head _this_is_not_used;
         PyObject_VAR_HEAD
@@ -65,7 +68,7 @@ _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObje
     } _kwtuple = {
         .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
         .ob_hash = -1,
-        .ob_item = { &_Py_ID(pid), &_Py_ID(all_threads), &_Py_ID(only_active_thread), &_Py_ID(mode), &_Py_ID(debug), &_Py_ID(skip_non_matching_threads), &_Py_ID(native), &_Py_ID(gc), },
+        .ob_item = { &_Py_ID(pid), &_Py_ID(all_threads), &_Py_ID(only_active_thread), &_Py_ID(mode), &_Py_ID(debug), &_Py_ID(skip_non_matching_threads), &_Py_ID(native), &_Py_ID(gc), &_Py_ID(cache_frames), },
     };
     #undef NUM_KEYWORDS
     #define KWTUPLE (&_kwtuple.ob_base.ob_base)
@@ -74,14 +77,14 @@ _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObje
     #  define KWTUPLE NULL
     #endif  // !Py_BUILD_CORE
 
-    static const char * const _keywords[] = {"pid", "all_threads", "only_active_thread", "mode", "debug", "skip_non_matching_threads", "native", "gc", NULL};
+    static const char * const _keywords[] = {"pid", "all_threads", "only_active_thread", "mode", "debug", "skip_non_matching_threads", "native", "gc", "cache_frames", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
         .fname = "RemoteUnwinder",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
-    PyObject *argsbuf[8];
+    PyObject *argsbuf[9];
     PyObject * const *fastargs;
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     Py_ssize_t noptargs = nargs + (kwargs ? PyDict_GET_SIZE(kwargs) : 0) - 1;
@@ -93,6 +96,7 @@ _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObje
     int skip_non_matching_threads = 1;
     int native = 0;
     int gc = 0;
+    int cache_frames = 0;
 
     fastargs = _PyArg_UnpackKeywords(_PyTuple_CAST(args)->ob_item, nargs, kwargs, NULL, &_parser,
             /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -160,12 +164,21 @@ _remote_debugging_RemoteUnwinder___init__(PyObject *self, PyObject *args, PyObje
             goto skip_optional_kwonly;
         }
     }
-    gc = PyObject_IsTrue(fastargs[7]);
-    if (gc < 0) {
+    if (fastargs[7]) {
+        gc = PyObject_IsTrue(fastargs[7]);
+        if (gc < 0) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_kwonly;
+        }
+    }
+    cache_frames = PyObject_IsTrue(fastargs[8]);
+    if (cache_frames < 0) {
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _remote_debugging_RemoteUnwinder___init___impl((RemoteUnwinderObject *)self, pid, all_threads, only_active_thread, mode, debug, skip_non_matching_threads, native, gc);
+    return_value = _remote_debugging_RemoteUnwinder___init___impl((RemoteUnwinderObject *)self, pid, all_threads, only_active_thread, mode, debug, skip_non_matching_threads, native, gc, cache_frames);
 
 exit:
     return return_value;
@@ -347,4 +360,4 @@ _remote_debugging_RemoteUnwinder_get_async_stack_trace(PyObject *self, PyObject 
 
     return return_value;
 }
-/*[clinic end generated code: output=99fed5c94cf36881 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=62866b3fc003b0cc input=a9049054013a1b77]*/

--- a/Modules/_remote_debugging/clinic/module.c.h
+++ b/Modules/_remote_debugging/clinic/module.c.h
@@ -392,6 +392,7 @@ PyDoc_STRVAR(_remote_debugging_RemoteUnwinder_get_stats__doc__,
 "        - frames_read_from_cache: Total frames retrieved from cache\n"
 "        - frames_read_from_memory: Total frames read from remote memory\n"
 "        - memory_reads: Total remote memory read operations\n"
+"        - memory_bytes_read: Total bytes read from remote memory\n"
 "        - code_object_cache_hits: Code object cache hits\n"
 "        - code_object_cache_misses: Code object cache misses\n"
 "        - stale_cache_invalidations: Times stale cache entries were cleared\n"
@@ -418,4 +419,4 @@ _remote_debugging_RemoteUnwinder_get_stats(PyObject *self, PyObject *Py_UNUSED(i
 
     return return_value;
 }
-/*[clinic end generated code: output=f0582d18e5eb605e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f1fd6c1d4c4c7254 input=a9049054013a1b77]*/

--- a/Modules/_remote_debugging/code_objects.c
+++ b/Modules/_remote_debugging/code_objects.c
@@ -257,6 +257,11 @@ parse_code_object(RemoteUnwinderObject *unwinder,
 
     if (unwinder && unwinder->code_object_cache != NULL) {
         meta = _Py_hashtable_get(unwinder->code_object_cache, key);
+        if (meta) {
+            STATS_INC(unwinder, code_object_cache_hits);
+        } else {
+            STATS_INC(unwinder, code_object_cache_misses);
+        }
     }
 
     if (meta == NULL) {

--- a/Modules/_remote_debugging/frame_cache.c
+++ b/Modules/_remote_debugging/frame_cache.c
@@ -16,7 +16,11 @@ int
 frame_cache_init(RemoteUnwinderObject *unwinder)
 {
     unwinder->frame_cache = PyMem_Calloc(FRAME_CACHE_MAX_THREADS, sizeof(FrameCacheEntry));
-    return unwinder->frame_cache ? 0 : -1;
+    if (!unwinder->frame_cache) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    return 0;
 }
 
 void

--- a/Modules/_remote_debugging/frame_cache.c
+++ b/Modules/_remote_debugging/frame_cache.c
@@ -1,0 +1,225 @@
+/******************************************************************************
+ * Remote Debugging Module - Frame Cache
+ *
+ * This file contains functions for caching frame information to optimize
+ * repeated stack unwinding for profiling.
+ ******************************************************************************/
+
+#include "_remote_debugging.h"
+
+/* ============================================================================
+ * FRAME CACHE - stores (address, frame_info) pairs per thread
+ * Uses preallocated fixed-size arrays for efficiency and bounded memory.
+ * ============================================================================ */
+
+int
+frame_cache_init(RemoteUnwinderObject *unwinder)
+{
+    unwinder->frame_cache = PyMem_Calloc(FRAME_CACHE_MAX_THREADS, sizeof(FrameCacheEntry));
+    return unwinder->frame_cache ? 0 : -1;
+}
+
+void
+frame_cache_cleanup(RemoteUnwinderObject *unwinder)
+{
+    if (!unwinder->frame_cache) {
+        return;
+    }
+    for (int i = 0; i < FRAME_CACHE_MAX_THREADS; i++) {
+        Py_CLEAR(unwinder->frame_cache[i].frame_list);
+    }
+    PyMem_Free(unwinder->frame_cache);
+    unwinder->frame_cache = NULL;
+}
+
+// Find cache entry by thread_id
+FrameCacheEntry *
+frame_cache_find(RemoteUnwinderObject *unwinder, uint64_t thread_id)
+{
+    if (!unwinder->frame_cache || thread_id == 0) {
+        return NULL;
+    }
+    for (int i = 0; i < FRAME_CACHE_MAX_THREADS; i++) {
+        if (unwinder->frame_cache[i].thread_id == thread_id) {
+            return &unwinder->frame_cache[i];
+        }
+    }
+    return NULL;
+}
+
+// Allocate a cache slot for a thread
+// Returns NULL if cache is full (graceful degradation)
+static FrameCacheEntry *
+frame_cache_alloc_slot(RemoteUnwinderObject *unwinder, uint64_t thread_id)
+{
+    if (!unwinder->frame_cache || thread_id == 0) {
+        return NULL;
+    }
+    // First check if thread already has an entry
+    for (int i = 0; i < FRAME_CACHE_MAX_THREADS; i++) {
+        if (unwinder->frame_cache[i].thread_id == thread_id) {
+            return &unwinder->frame_cache[i];
+        }
+    }
+    // Find empty slot
+    for (int i = 0; i < FRAME_CACHE_MAX_THREADS; i++) {
+        if (unwinder->frame_cache[i].thread_id == 0) {
+            return &unwinder->frame_cache[i];
+        }
+    }
+    // Cache full - graceful degradation
+    return NULL;
+}
+
+// Remove cache entries for threads not seen in the result
+// result structure: list of InterpreterInfo, where InterpreterInfo[1] is threads list,
+// and ThreadInfo[0] is the thread_id
+void
+frame_cache_invalidate_stale(RemoteUnwinderObject *unwinder, PyObject *result)
+{
+    if (!unwinder->frame_cache || !result || !PyList_Check(result)) {
+        return;
+    }
+
+    // Build array of seen thread IDs from result
+    uint64_t seen_threads[FRAME_CACHE_MAX_THREADS];
+    int num_seen = 0;
+
+    Py_ssize_t num_interps = PyList_GET_SIZE(result);
+    for (Py_ssize_t i = 0; i < num_interps && num_seen < FRAME_CACHE_MAX_THREADS; i++) {
+        PyObject *interp_info = PyList_GET_ITEM(result, i);
+        PyObject *threads = PyStructSequence_GetItem(interp_info, 1);
+        if (!threads || !PyList_Check(threads)) {
+            continue;
+        }
+        Py_ssize_t num_threads = PyList_GET_SIZE(threads);
+        for (Py_ssize_t j = 0; j < num_threads && num_seen < FRAME_CACHE_MAX_THREADS; j++) {
+            PyObject *thread_info = PyList_GET_ITEM(threads, j);
+            PyObject *tid_obj = PyStructSequence_GetItem(thread_info, 0);
+            if (tid_obj) {
+                uint64_t tid = PyLong_AsUnsignedLongLong(tid_obj);
+                if (!PyErr_Occurred()) {
+                    seen_threads[num_seen++] = tid;
+                } else {
+                    PyErr_Clear();
+                }
+            }
+        }
+    }
+
+    // Invalidate entries not in seen list
+    for (int i = 0; i < FRAME_CACHE_MAX_THREADS; i++) {
+        if (unwinder->frame_cache[i].thread_id == 0) {
+            continue;
+        }
+        int found = 0;
+        for (int j = 0; j < num_seen; j++) {
+            if (unwinder->frame_cache[i].thread_id == seen_threads[j]) {
+                found = 1;
+                break;
+            }
+        }
+        if (!found) {
+            // Clear this entry
+            Py_CLEAR(unwinder->frame_cache[i].frame_list);
+            unwinder->frame_cache[i].thread_id = 0;
+            unwinder->frame_cache[i].num_addrs = 0;
+        }
+    }
+}
+
+// Find last_profiled_frame in cache and extend frame_info with cached continuation
+// If frame_addrs is provided (not NULL), also extends it with cached addresses
+int
+frame_cache_lookup_and_extend(
+    RemoteUnwinderObject *unwinder,
+    uint64_t thread_id,
+    uintptr_t last_profiled_frame,
+    PyObject *frame_info,
+    uintptr_t *frame_addrs,
+    Py_ssize_t *num_addrs,
+    Py_ssize_t max_addrs)
+{
+    if (!unwinder->frame_cache || last_profiled_frame == 0) {
+        return 0;
+    }
+
+    FrameCacheEntry *entry = frame_cache_find(unwinder, thread_id);
+    if (!entry || !entry->frame_list) {
+        return 0;
+    }
+
+    // Find the index where last_profiled_frame matches
+    Py_ssize_t start_idx = -1;
+    for (Py_ssize_t i = 0; i < entry->num_addrs; i++) {
+        if (entry->addrs[i] == last_profiled_frame) {
+            start_idx = i;
+            break;
+        }
+    }
+
+    if (start_idx < 0) {
+        return 0;  // Not found
+    }
+
+    Py_ssize_t num_frames = PyList_GET_SIZE(entry->frame_list);
+
+    // Extend frame_info with frames from start_idx onwards
+    PyObject *slice = PyList_GetSlice(entry->frame_list, start_idx, num_frames);
+    if (!slice) {
+        return -1;
+    }
+
+    Py_ssize_t cur_size = PyList_GET_SIZE(frame_info);
+    int result = PyList_SetSlice(frame_info, cur_size, cur_size, slice);
+    Py_DECREF(slice);
+
+    if (result < 0) {
+        return -1;
+    }
+
+    // Also extend frame_addrs with cached addresses if provided
+    if (frame_addrs) {
+        for (Py_ssize_t i = start_idx; i < entry->num_addrs && *num_addrs < max_addrs; i++) {
+            frame_addrs[(*num_addrs)++] = entry->addrs[i];
+        }
+    }
+
+    return 1;
+}
+
+// Store frame list with addresses in cache
+int
+frame_cache_store(
+    RemoteUnwinderObject *unwinder,
+    uint64_t thread_id,
+    PyObject *frame_list,
+    const uintptr_t *addrs,
+    Py_ssize_t num_addrs)
+{
+    if (!unwinder->frame_cache || thread_id == 0) {
+        return 0;
+    }
+
+    // Clamp to max frames
+    if (num_addrs > FRAME_CACHE_MAX_FRAMES) {
+        num_addrs = FRAME_CACHE_MAX_FRAMES;
+    }
+
+    FrameCacheEntry *entry = frame_cache_alloc_slot(unwinder, thread_id);
+    if (!entry) {
+        // Cache full - graceful degradation
+        return 0;
+    }
+
+    // Clear old frame_list if replacing
+    Py_CLEAR(entry->frame_list);
+
+    // Store data
+    entry->thread_id = thread_id;
+    memcpy(entry->addrs, addrs, num_addrs * sizeof(uintptr_t));
+    entry->num_addrs = num_addrs;
+    entry->frame_list = Py_NewRef(frame_list);
+
+    return 0;
+}

--- a/Modules/_remote_debugging/frame_cache.c
+++ b/Modules/_remote_debugging/frame_cache.c
@@ -124,6 +124,7 @@ frame_cache_invalidate_stale(RemoteUnwinderObject *unwinder, PyObject *result)
             Py_CLEAR(unwinder->frame_cache[i].frame_list);
             unwinder->frame_cache[i].thread_id = 0;
             unwinder->frame_cache[i].num_addrs = 0;
+            STATS_INC(unwinder, stale_cache_invalidations);
         }
     }
 }

--- a/Modules/_remote_debugging/frame_cache.c
+++ b/Modules/_remote_debugging/frame_cache.c
@@ -221,8 +221,10 @@ frame_cache_store(
     // Clear old frame_list if replacing
     Py_CLEAR(entry->frame_list);
 
-    // Store data - truncate frame_list to match num_addrs
-    entry->frame_list = PyList_GetSlice(frame_list, 0, num_addrs);
+    // Store full frame list (don't truncate to num_addrs - frames beyond the
+    // address array limit are still valid and needed for full cache hits)
+    Py_ssize_t num_frames = PyList_GET_SIZE(frame_list);
+    entry->frame_list = PyList_GetSlice(frame_list, 0, num_frames);
     if (!entry->frame_list) {
         return -1;
     }

--- a/Modules/_remote_debugging/frames.c
+++ b/Modules/_remote_debugging/frames.c
@@ -770,6 +770,14 @@ collect_frames_with_cache(
             Py_DECREF(frame_addresses);
             return -1;
         }
+        if (cache_result == 0) {
+            // Cache miss - continue walking from last_profiled_frame to get the rest
+            if (process_frame_chain(unwinder, last_profiled_frame, chunks, frame_info, gc_frame,
+                                    0, NULL, frame_addresses) < 0) {
+                Py_DECREF(frame_addresses);
+                return -1;
+            }
+        }
     }
 
     // Convert frame_addresses (list of PyLong) to C array for efficient cache storage

--- a/Modules/_remote_debugging/frames.c
+++ b/Modules/_remote_debugging/frames.c
@@ -261,11 +261,13 @@ process_frame_chain(
     uintptr_t gc_frame,
     uintptr_t last_profiled_frame,
     int *stopped_at_cached_frame,
-    PyObject *frame_addresses)  // optional: list to receive frame addresses
+    uintptr_t *frame_addrs,      // optional: C array to receive frame addresses
+    Py_ssize_t *num_addrs,       // in/out: current count / updated count
+    Py_ssize_t max_addrs)        // max capacity of frame_addrs array
 {
     uintptr_t frame_addr = initial_frame_addr;
     uintptr_t prev_frame_addr = 0;
-    const size_t MAX_FRAMES = 1024;
+    const size_t MAX_FRAMES = 1024 + 512;
     size_t frame_count = 0;
 
     // Initialize output flag
@@ -343,14 +345,8 @@ process_frame_chain(
                 return -1;
             }
             // Extra frames use 0 as address (they're synthetic)
-            if (frame_addresses) {
-                PyObject *addr_obj = PyLong_FromUnsignedLongLong(0);
-                if (!addr_obj || PyList_Append(frame_addresses, addr_obj) < 0) {
-                    Py_XDECREF(addr_obj);
-                    Py_DECREF(extra_frame_info);
-                    return -1;
-                }
-                Py_DECREF(addr_obj);
+            if (frame_addrs && *num_addrs < max_addrs) {
+                frame_addrs[(*num_addrs)++] = 0;
             }
             Py_DECREF(extra_frame_info);
         }
@@ -369,14 +365,8 @@ process_frame_chain(
                 return -1;
             }
             // Track the address for this frame
-            if (frame_addresses) {
-                PyObject *addr_obj = PyLong_FromUnsignedLongLong(frame_addr);
-                if (!addr_obj || PyList_Append(frame_addresses, addr_obj) < 0) {
-                    Py_XDECREF(addr_obj);
-                    Py_DECREF(frame);
-                    return -1;
-                }
-                Py_DECREF(addr_obj);
+            if (frame_addrs && *num_addrs < max_addrs) {
+                frame_addrs[(*num_addrs)++] = frame_addr;
             }
             Py_DECREF(frame);
         }
@@ -386,23 +376,6 @@ process_frame_chain(
     }
 
     return 0;
-}
-
-/* ============================================================================
- * FRAME CACHE - stores (address, frame_info) pairs per thread
- * ============================================================================ */
-
-int
-frame_cache_init(RemoteUnwinderObject *unwinder)
-{
-    unwinder->frame_cache = PyDict_New();
-    return unwinder->frame_cache ? 0 : -1;
-}
-
-void
-frame_cache_cleanup(RemoteUnwinderObject *unwinder)
-{
-    Py_CLEAR(unwinder->frame_cache);
 }
 
 // Clear last_profiled_frame for all threads in the target process.
@@ -462,219 +435,6 @@ clear_last_profiled_frames(RemoteUnwinderObject *unwinder)
     return 0;
 }
 
-// Remove cache entries for threads not seen in the result
-// result structure: list of InterpreterInfo, where InterpreterInfo[1] is threads list,
-// and ThreadInfo[0] is the thread_id
-void
-frame_cache_invalidate_stale(RemoteUnwinderObject *unwinder, PyObject *result)
-{
-    if (!unwinder->frame_cache || !result || !PyList_Check(result)) {
-        return;
-    }
-
-    // Build set of seen thread IDs from result
-    PyObject *seen = PySet_New(NULL);
-    if (!seen) {
-        PyErr_Clear();
-        return;
-    }
-
-    // Iterate: result -> interpreters -> threads -> thread_id
-    Py_ssize_t num_interps = PyList_GET_SIZE(result);
-    for (Py_ssize_t i = 0; i < num_interps; i++) {
-        PyObject *interp_info = PyList_GET_ITEM(result, i);
-        // InterpreterInfo[1] is the threads list
-        PyObject *threads = PyStructSequence_GetItem(interp_info, 1);
-        if (!threads || !PyList_Check(threads)) {
-            continue;
-        }
-        Py_ssize_t num_threads = PyList_GET_SIZE(threads);
-        for (Py_ssize_t j = 0; j < num_threads; j++) {
-            PyObject *thread_info = PyList_GET_ITEM(threads, j);
-            // ThreadInfo[0] is the thread_id
-            PyObject *thread_id = PyStructSequence_GetItem(thread_info, 0);
-            if (thread_id && PySet_Add(seen, thread_id) < 0) {
-                PyErr_Clear();
-            }
-        }
-    }
-
-    // Collect keys to remove (can't modify dict while iterating)
-    PyObject *keys_to_remove = PyList_New(0);
-    if (!keys_to_remove) {
-        Py_DECREF(seen);
-        PyErr_Clear();
-        return;
-    }
-
-    PyObject *key, *value;
-    Py_ssize_t pos = 0;
-    while (PyDict_Next(unwinder->frame_cache, &pos, &key, &value)) {
-        int contains = PySet_Contains(seen, key);
-        if (contains == 0) {
-            // Thread ID not seen in current sample, mark for removal
-            if (PyList_Append(keys_to_remove, key) < 0) {
-                PyErr_Clear();
-                break;
-            }
-        } else if (contains < 0) {
-            PyErr_Clear();
-        }
-    }
-
-    // Remove stale entries
-    Py_ssize_t num_to_remove = PyList_GET_SIZE(keys_to_remove);
-    for (Py_ssize_t i = 0; i < num_to_remove; i++) {
-        PyObject *k = PyList_GET_ITEM(keys_to_remove, i);
-        if (PyDict_DelItem(unwinder->frame_cache, k) < 0) {
-            PyErr_Clear();
-        }
-    }
-
-    Py_DECREF(keys_to_remove);
-    Py_DECREF(seen);
-}
-
-// Find last_profiled_frame in cache and extend frame_info with cached continuation
-// Cache format: tuple of (bytes_of_addresses, frame_list)
-// - bytes_of_addresses: raw uintptr_t values packed as bytes
-// - frame_list: Python list of frame info tuples
-// If frame_addresses is provided (not NULL), also extends it with cached addresses
-int
-frame_cache_lookup_and_extend(
-    RemoteUnwinderObject *unwinder,
-    uint64_t thread_id,
-    uintptr_t last_profiled_frame,
-    PyObject *frame_info,
-    PyObject *frame_addresses)
-{
-    if (!unwinder->frame_cache || last_profiled_frame == 0) {
-        return 0;
-    }
-
-    PyObject *key = PyLong_FromUnsignedLongLong(thread_id);
-    if (!key) {
-        PyErr_Clear();
-        return 0;
-    }
-
-    PyObject *cached = PyDict_GetItemWithError(unwinder->frame_cache, key);
-    Py_DECREF(key);
-    if (!cached || PyErr_Occurred()) {
-        PyErr_Clear();
-        return 0;
-    }
-
-    // cached is tuple of (addresses_bytes, frame_list)
-    if (!PyTuple_Check(cached) || PyTuple_GET_SIZE(cached) != 2) {
-        return 0;
-    }
-
-    PyObject *addr_bytes = PyTuple_GET_ITEM(cached, 0);
-    PyObject *frame_list = PyTuple_GET_ITEM(cached, 1);
-
-    if (!PyBytes_Check(addr_bytes) || !PyList_Check(frame_list)) {
-        return 0;
-    }
-
-    const uintptr_t *addrs = (const uintptr_t *)PyBytes_AS_STRING(addr_bytes);
-    Py_ssize_t num_addrs = PyBytes_GET_SIZE(addr_bytes) / sizeof(uintptr_t);
-    Py_ssize_t num_frames = PyList_GET_SIZE(frame_list);
-
-    // Find the index where last_profiled_frame matches
-    Py_ssize_t start_idx = -1;
-    for (Py_ssize_t i = 0; i < num_addrs; i++) {
-        if (addrs[i] == last_profiled_frame) {
-            start_idx = i;
-            break;
-        }
-    }
-
-    if (start_idx < 0) {
-        return 0;  // Not found
-    }
-
-    // Extend frame_info with frames from start_idx onwards
-    // Use list slice for efficiency: frame_info.extend(frame_list[start_idx:])
-    PyObject *slice = PyList_GetSlice(frame_list, start_idx, num_frames);
-    if (!slice) {
-        return -1;
-    }
-
-    // Extend frame_info with the slice using SetSlice at the end
-    Py_ssize_t cur_size = PyList_GET_SIZE(frame_info);
-    int result = PyList_SetSlice(frame_info, cur_size, cur_size, slice);
-    Py_DECREF(slice);
-
-    if (result < 0) {
-        return -1;
-    }
-
-    // Also extend frame_addresses with cached addresses if provided
-    if (frame_addresses) {
-        for (Py_ssize_t i = start_idx; i < num_addrs; i++) {
-            PyObject *addr_obj = PyLong_FromUnsignedLongLong(addrs[i]);
-            if (!addr_obj) {
-                return -1;
-            }
-            if (PyList_Append(frame_addresses, addr_obj) < 0) {
-                Py_DECREF(addr_obj);
-                return -1;
-            }
-            Py_DECREF(addr_obj);
-        }
-    }
-
-    return 1;
-}
-
-// Store frame list with addresses in cache
-// Stores as tuple of (addresses_bytes, frame_list)
-int
-frame_cache_store(
-    RemoteUnwinderObject *unwinder,
-    uint64_t thread_id,
-    PyObject *frame_list,
-    const uintptr_t *addrs,
-    Py_ssize_t num_addrs)
-{
-    if (!unwinder->frame_cache) {
-        return 0;
-    }
-
-    PyObject *key = PyLong_FromUnsignedLongLong(thread_id);
-    if (!key) {
-        PyErr_Clear();
-        return 0;
-    }
-
-    // Create bytes object from addresses array
-    PyObject *addr_bytes = PyBytes_FromStringAndSize(
-        (const char *)addrs, num_addrs * sizeof(uintptr_t));
-    if (!addr_bytes) {
-        Py_DECREF(key);
-        PyErr_Clear();
-        return 0;
-    }
-
-    // Create tuple (addr_bytes, frame_list)
-    PyObject *cache_entry = PyTuple_Pack(2, addr_bytes, frame_list);
-    Py_DECREF(addr_bytes);
-    if (!cache_entry) {
-        Py_DECREF(key);
-        PyErr_Clear();
-        return 0;
-    }
-
-    int result = PyDict_SetItem(unwinder->frame_cache, key, cache_entry);
-    Py_DECREF(key);
-    Py_DECREF(cache_entry);
-    if (result < 0) {
-        PyErr_Clear();
-    }
-    return 0;
-}
-
 // Fast path: check if we have a full cache hit (entire stack unchanged)
 // Returns: 1 if full hit (frame_info populated), 0 if miss, -1 on error
 static int
@@ -693,40 +453,19 @@ try_full_cache_hit(
         return 0;
     }
 
-    PyObject *key = PyLong_FromUnsignedLongLong(thread_id);
-    if (!key) {
-        PyErr_Clear();
-        return 0;
-    }
-
-    PyObject *cached = PyDict_GetItemWithError(unwinder->frame_cache, key);
-    Py_DECREF(key);
-    if (!cached || PyErr_Occurred()) {
-        PyErr_Clear();
-        return 0;
-    }
-
-    if (!PyTuple_Check(cached) || PyTuple_GET_SIZE(cached) != 2) {
-        return 0;
-    }
-
-    PyObject *addr_bytes = PyTuple_GET_ITEM(cached, 0);
-    PyObject *frame_list = PyTuple_GET_ITEM(cached, 1);
-
-    if (!PyBytes_Check(addr_bytes) || !PyList_Check(frame_list)) {
+    FrameCacheEntry *entry = frame_cache_find(unwinder, thread_id);
+    if (!entry || !entry->frame_list) {
         return 0;
     }
 
     // Verify first address matches (sanity check)
-    const uintptr_t *addrs = (const uintptr_t *)PyBytes_AS_STRING(addr_bytes);
-    Py_ssize_t num_addrs = PyBytes_GET_SIZE(addr_bytes) / sizeof(uintptr_t);
-    if (num_addrs == 0 || addrs[0] != frame_addr) {
+    if (entry->num_addrs == 0 || entry->addrs[0] != frame_addr) {
         return 0;
     }
 
     // Full hit! Extend frame_info with entire cached list
     Py_ssize_t cur_size = PyList_GET_SIZE(frame_info);
-    int result = PyList_SetSlice(frame_info, cur_size, cur_size, frame_list);
+    int result = PyList_SetSlice(frame_info, cur_size, cur_size, entry->frame_list);
     return result < 0 ? -1 : 1;
 }
 
@@ -749,66 +488,35 @@ collect_frames_with_cache(
         return full_hit < 0 ? -1 : 0;  // Either error or success
     }
 
-    // Slow path: need to walk frames
-    PyObject *frame_addresses = PyList_New(0);
-    if (!frame_addresses) {
-        return -1;
-    }
+    uintptr_t addrs[FRAME_CACHE_MAX_FRAMES];
+    Py_ssize_t num_addrs = 0;
 
     int stopped_at_cached = 0;
     if (process_frame_chain(unwinder, frame_addr, chunks, frame_info, gc_frame,
-                            last_profiled_frame, &stopped_at_cached, frame_addresses) < 0) {
-        Py_DECREF(frame_addresses);
+                            last_profiled_frame, &stopped_at_cached,
+                            addrs, &num_addrs, FRAME_CACHE_MAX_FRAMES) < 0) {
         return -1;
     }
 
     // If stopped at cached frame, extend with cached continuation (both frames and addresses)
     if (stopped_at_cached) {
         int cache_result = frame_cache_lookup_and_extend(unwinder, thread_id, last_profiled_frame,
-                                                         frame_info, frame_addresses);
+                                                         frame_info, addrs, &num_addrs,
+                                                         FRAME_CACHE_MAX_FRAMES);
         if (cache_result < 0) {
-            Py_DECREF(frame_addresses);
             return -1;
         }
         if (cache_result == 0) {
             // Cache miss - continue walking from last_profiled_frame to get the rest
             if (process_frame_chain(unwinder, last_profiled_frame, chunks, frame_info, gc_frame,
-                                    0, NULL, frame_addresses) < 0) {
-                Py_DECREF(frame_addresses);
+                                    0, NULL, addrs, &num_addrs, FRAME_CACHE_MAX_FRAMES) < 0) {
                 return -1;
             }
         }
     }
 
-    // Convert frame_addresses (list of PyLong) to C array for efficient cache storage
-    Py_ssize_t num_addrs = PyList_GET_SIZE(frame_addresses);
-
-    // After extending from cache, frames and addresses should be in sync
-    assert(PyList_GET_SIZE(frame_info) == num_addrs);
-
-    // Allocate C array for addresses
-    uintptr_t *addrs = (uintptr_t *)PyMem_Malloc(num_addrs * sizeof(uintptr_t));
-    if (!addrs) {
-        Py_DECREF(frame_addresses);
-        PyErr_NoMemory();
-        return -1;
-    }
-
-    // Fill addresses from the Python list
-    for (Py_ssize_t i = 0; i < num_addrs; i++) {
-        PyObject *addr_obj = PyList_GET_ITEM(frame_addresses, i);
-        addrs[i] = PyLong_AsUnsignedLongLong(addr_obj);
-        if (PyErr_Occurred()) {
-            PyErr_Clear();
-            addrs[i] = 0;
-        }
-    }
-
-    // Store in cache
+    // Store in cache (frame_cache_store handles truncation if num_addrs > FRAME_CACHE_MAX_FRAMES)
     frame_cache_store(unwinder, thread_id, frame_info, addrs, num_addrs);
-
-    PyMem_Free(addrs);
-    Py_DECREF(frame_addresses);
 
     return 0;
 }

--- a/Modules/_remote_debugging/frames.c
+++ b/Modules/_remote_debugging/frames.c
@@ -258,14 +258,37 @@ process_frame_chain(
     uintptr_t initial_frame_addr,
     StackChunkList *chunks,
     PyObject *frame_info,
-    uintptr_t gc_frame)
+    uintptr_t gc_frame,
+    uintptr_t last_profiled_frame,
+    int *stopped_at_cached_frame,
+    PyObject *frame_addresses)  // optional: list to receive frame addresses
 {
     uintptr_t frame_addr = initial_frame_addr;
     uintptr_t prev_frame_addr = 0;
     const size_t MAX_FRAMES = 1024;
     size_t frame_count = 0;
 
+    // Initialize output flag
+    if (stopped_at_cached_frame) {
+        *stopped_at_cached_frame = 0;
+    }
+
+    // Quick check: if current_frame == last_profiled_frame, entire stack is unchanged
+    if (last_profiled_frame != 0 && initial_frame_addr == last_profiled_frame) {
+        if (stopped_at_cached_frame) {
+            *stopped_at_cached_frame = 1;
+        }
+        return 0;
+    }
+
     while ((void*)frame_addr != NULL) {
+        // Check if we've reached the cached frame - if so, stop here
+        if (last_profiled_frame != 0 && frame_addr == last_profiled_frame) {
+            if (stopped_at_cached_frame) {
+                *stopped_at_cached_frame = 1;
+            }
+            break;
+        }
         PyObject *frame = NULL;
         uintptr_t next_frame_addr = 0;
         uintptr_t stackpointer = 0;
@@ -286,7 +309,6 @@ process_frame_chain(
             }
         }
         if (frame == NULL && PyList_GET_SIZE(frame_info) == 0) {
-            // If the first frame is missing, the chain is broken:
             const char *e = "Failed to parse initial frame in chain";
             PyErr_SetString(PyExc_RuntimeError, e);
             return -1;
@@ -310,35 +332,51 @@ process_frame_chain(
             extra_frame = &_Py_STR(native);
         }
         if (extra_frame) {
-            // Use "~" as file and 0 as line, since that's what pstats uses:
             PyObject *extra_frame_info = make_frame_info(
                 unwinder, _Py_LATIN1_CHR('~'), _PyLong_GetZero(), extra_frame);
             if (extra_frame_info == NULL) {
                 return -1;
             }
-            int error = PyList_Append(frame_info, extra_frame_info);
-            Py_DECREF(extra_frame_info);
-            if (error) {
-                const char *e = "Failed to append extra frame to frame info list";
-                set_exception_cause(unwinder, PyExc_RuntimeError, e);
+            if (PyList_Append(frame_info, extra_frame_info) < 0) {
+                Py_DECREF(extra_frame_info);
+                set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to append extra frame");
                 return -1;
             }
+            // Extra frames use 0 as address (they're synthetic)
+            if (frame_addresses) {
+                PyObject *addr_obj = PyLong_FromUnsignedLongLong(0);
+                if (!addr_obj || PyList_Append(frame_addresses, addr_obj) < 0) {
+                    Py_XDECREF(addr_obj);
+                    Py_DECREF(extra_frame_info);
+                    return -1;
+                }
+                Py_DECREF(addr_obj);
+            }
+            Py_DECREF(extra_frame_info);
         }
         if (frame) {
             if (prev_frame_addr && frame_addr != prev_frame_addr) {
                 const char *f = "Broken frame chain: expected frame at 0x%lx, got 0x%lx";
                 PyErr_Format(PyExc_RuntimeError, f, prev_frame_addr, frame_addr);
                 Py_DECREF(frame);
-                const char *e = "Frame chain consistency check failed";
-                set_exception_cause(unwinder, PyExc_RuntimeError, e);
+                set_exception_cause(unwinder, PyExc_RuntimeError, "Frame chain consistency check failed");
                 return -1;
             }
 
-            if (PyList_Append(frame_info, frame) == -1) {
+            if (PyList_Append(frame_info, frame) < 0) {
                 Py_DECREF(frame);
-                const char *e = "Failed to append frame to frame info list";
-                set_exception_cause(unwinder, PyExc_RuntimeError, e);
+                set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to append frame");
                 return -1;
+            }
+            // Track the address for this frame
+            if (frame_addresses) {
+                PyObject *addr_obj = PyLong_FromUnsignedLongLong(frame_addr);
+                if (!addr_obj || PyList_Append(frame_addresses, addr_obj) < 0) {
+                    Py_XDECREF(addr_obj);
+                    Py_DECREF(frame);
+                    return -1;
+                }
+                Py_DECREF(addr_obj);
             }
             Py_DECREF(frame);
         }
@@ -346,6 +384,366 @@ process_frame_chain(
         prev_frame_addr = next_frame_addr;
         frame_addr = next_frame_addr;
     }
+
+    return 0;
+}
+
+/* ============================================================================
+ * FRAME CACHE - stores (address, frame_info) pairs per thread
+ * ============================================================================ */
+
+int
+frame_cache_init(RemoteUnwinderObject *unwinder)
+{
+    unwinder->frame_cache = PyDict_New();
+    return unwinder->frame_cache ? 0 : -1;
+}
+
+void
+frame_cache_cleanup(RemoteUnwinderObject *unwinder)
+{
+    Py_CLEAR(unwinder->frame_cache);
+}
+
+// Remove cache entries for threads not seen in the result
+// result structure: list of InterpreterInfo, where InterpreterInfo[1] is threads list,
+// and ThreadInfo[0] is the thread_id
+void
+frame_cache_invalidate_stale(RemoteUnwinderObject *unwinder, PyObject *result)
+{
+    if (!unwinder->frame_cache || !result || !PyList_Check(result)) {
+        return;
+    }
+
+    // Build set of seen thread IDs from result
+    PyObject *seen = PySet_New(NULL);
+    if (!seen) {
+        PyErr_Clear();
+        return;
+    }
+
+    // Iterate: result -> interpreters -> threads -> thread_id
+    Py_ssize_t num_interps = PyList_GET_SIZE(result);
+    for (Py_ssize_t i = 0; i < num_interps; i++) {
+        PyObject *interp_info = PyList_GET_ITEM(result, i);
+        // InterpreterInfo[1] is the threads list
+        PyObject *threads = PyStructSequence_GetItem(interp_info, 1);
+        if (!threads || !PyList_Check(threads)) {
+            continue;
+        }
+        Py_ssize_t num_threads = PyList_GET_SIZE(threads);
+        for (Py_ssize_t j = 0; j < num_threads; j++) {
+            PyObject *thread_info = PyList_GET_ITEM(threads, j);
+            // ThreadInfo[0] is the thread_id
+            PyObject *thread_id = PyStructSequence_GetItem(thread_info, 0);
+            if (thread_id && PySet_Add(seen, thread_id) < 0) {
+                PyErr_Clear();
+            }
+        }
+    }
+
+    // Collect keys to remove (can't modify dict while iterating)
+    PyObject *keys_to_remove = PyList_New(0);
+    if (!keys_to_remove) {
+        Py_DECREF(seen);
+        PyErr_Clear();
+        return;
+    }
+
+    PyObject *key, *value;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(unwinder->frame_cache, &pos, &key, &value)) {
+        int contains = PySet_Contains(seen, key);
+        if (contains == 0) {
+            // Thread ID not seen in current sample, mark for removal
+            if (PyList_Append(keys_to_remove, key) < 0) {
+                PyErr_Clear();
+                break;
+            }
+        } else if (contains < 0) {
+            PyErr_Clear();
+        }
+    }
+
+    // Remove stale entries
+    Py_ssize_t num_to_remove = PyList_GET_SIZE(keys_to_remove);
+    for (Py_ssize_t i = 0; i < num_to_remove; i++) {
+        PyObject *k = PyList_GET_ITEM(keys_to_remove, i);
+        if (PyDict_DelItem(unwinder->frame_cache, k) < 0) {
+            PyErr_Clear();
+        }
+    }
+
+    Py_DECREF(keys_to_remove);
+    Py_DECREF(seen);
+}
+
+// Find last_profiled_frame in cache and extend frame_info with cached continuation
+// Cache format: tuple of (bytes_of_addresses, frame_list)
+// - bytes_of_addresses: raw uintptr_t values packed as bytes
+// - frame_list: Python list of frame info tuples
+// If frame_addresses is provided (not NULL), also extends it with cached addresses
+int
+frame_cache_lookup_and_extend(
+    RemoteUnwinderObject *unwinder,
+    uint64_t thread_id,
+    uintptr_t last_profiled_frame,
+    PyObject *frame_info,
+    PyObject *frame_addresses)
+{
+    if (!unwinder->frame_cache || last_profiled_frame == 0) {
+        return 0;
+    }
+
+    PyObject *key = PyLong_FromUnsignedLongLong(thread_id);
+    if (!key) {
+        PyErr_Clear();
+        return 0;
+    }
+
+    PyObject *cached = PyDict_GetItemWithError(unwinder->frame_cache, key);
+    Py_DECREF(key);
+    if (!cached || PyErr_Occurred()) {
+        PyErr_Clear();
+        return 0;
+    }
+
+    // cached is tuple of (addresses_bytes, frame_list)
+    if (!PyTuple_Check(cached) || PyTuple_GET_SIZE(cached) != 2) {
+        return 0;
+    }
+
+    PyObject *addr_bytes = PyTuple_GET_ITEM(cached, 0);
+    PyObject *frame_list = PyTuple_GET_ITEM(cached, 1);
+
+    if (!PyBytes_Check(addr_bytes) || !PyList_Check(frame_list)) {
+        return 0;
+    }
+
+    const uintptr_t *addrs = (const uintptr_t *)PyBytes_AS_STRING(addr_bytes);
+    Py_ssize_t num_addrs = PyBytes_GET_SIZE(addr_bytes) / sizeof(uintptr_t);
+    Py_ssize_t num_frames = PyList_GET_SIZE(frame_list);
+
+    // Find the index where last_profiled_frame matches
+    Py_ssize_t start_idx = -1;
+    for (Py_ssize_t i = 0; i < num_addrs; i++) {
+        if (addrs[i] == last_profiled_frame) {
+            start_idx = i;
+            break;
+        }
+    }
+
+    if (start_idx < 0) {
+        return 0;  // Not found
+    }
+
+    // Extend frame_info with frames from start_idx onwards
+    // Use list slice for efficiency: frame_info.extend(frame_list[start_idx:])
+    PyObject *slice = PyList_GetSlice(frame_list, start_idx, num_frames);
+    if (!slice) {
+        return -1;
+    }
+
+    // Extend frame_info with the slice using SetSlice at the end
+    Py_ssize_t cur_size = PyList_GET_SIZE(frame_info);
+    int result = PyList_SetSlice(frame_info, cur_size, cur_size, slice);
+    Py_DECREF(slice);
+
+    if (result < 0) {
+        return -1;
+    }
+
+    // Also extend frame_addresses with cached addresses if provided
+    if (frame_addresses) {
+        for (Py_ssize_t i = start_idx; i < num_addrs; i++) {
+            PyObject *addr_obj = PyLong_FromUnsignedLongLong(addrs[i]);
+            if (!addr_obj) {
+                return -1;
+            }
+            if (PyList_Append(frame_addresses, addr_obj) < 0) {
+                Py_DECREF(addr_obj);
+                return -1;
+            }
+            Py_DECREF(addr_obj);
+        }
+    }
+
+    return 1;
+}
+
+// Store frame list with addresses in cache
+// Stores as tuple of (addresses_bytes, frame_list)
+int
+frame_cache_store(
+    RemoteUnwinderObject *unwinder,
+    uint64_t thread_id,
+    PyObject *frame_list,
+    const uintptr_t *addrs,
+    Py_ssize_t num_addrs)
+{
+    if (!unwinder->frame_cache) {
+        return 0;
+    }
+
+    PyObject *key = PyLong_FromUnsignedLongLong(thread_id);
+    if (!key) {
+        PyErr_Clear();
+        return 0;
+    }
+
+    // Create bytes object from addresses array
+    PyObject *addr_bytes = PyBytes_FromStringAndSize(
+        (const char *)addrs, num_addrs * sizeof(uintptr_t));
+    if (!addr_bytes) {
+        Py_DECREF(key);
+        PyErr_Clear();
+        return 0;
+    }
+
+    // Create tuple (addr_bytes, frame_list)
+    PyObject *cache_entry = PyTuple_Pack(2, addr_bytes, frame_list);
+    Py_DECREF(addr_bytes);
+    if (!cache_entry) {
+        Py_DECREF(key);
+        PyErr_Clear();
+        return 0;
+    }
+
+    int result = PyDict_SetItem(unwinder->frame_cache, key, cache_entry);
+    Py_DECREF(key);
+    Py_DECREF(cache_entry);
+    if (result < 0) {
+        PyErr_Clear();
+    }
+    return 0;
+}
+
+// Fast path: check if we have a full cache hit (entire stack unchanged)
+// Returns: 1 if full hit (frame_info populated), 0 if miss, -1 on error
+static int
+try_full_cache_hit(
+    RemoteUnwinderObject *unwinder,
+    uintptr_t frame_addr,
+    uintptr_t last_profiled_frame,
+    uint64_t thread_id,
+    PyObject *frame_info)
+{
+    if (!unwinder->frame_cache || last_profiled_frame == 0) {
+        return 0;
+    }
+    // Full hit only if current frame == last profiled frame
+    if (frame_addr != last_profiled_frame) {
+        return 0;
+    }
+
+    PyObject *key = PyLong_FromUnsignedLongLong(thread_id);
+    if (!key) {
+        PyErr_Clear();
+        return 0;
+    }
+
+    PyObject *cached = PyDict_GetItemWithError(unwinder->frame_cache, key);
+    Py_DECREF(key);
+    if (!cached || PyErr_Occurred()) {
+        PyErr_Clear();
+        return 0;
+    }
+
+    if (!PyTuple_Check(cached) || PyTuple_GET_SIZE(cached) != 2) {
+        return 0;
+    }
+
+    PyObject *addr_bytes = PyTuple_GET_ITEM(cached, 0);
+    PyObject *frame_list = PyTuple_GET_ITEM(cached, 1);
+
+    if (!PyBytes_Check(addr_bytes) || !PyList_Check(frame_list)) {
+        return 0;
+    }
+
+    // Verify first address matches (sanity check)
+    const uintptr_t *addrs = (const uintptr_t *)PyBytes_AS_STRING(addr_bytes);
+    Py_ssize_t num_addrs = PyBytes_GET_SIZE(addr_bytes) / sizeof(uintptr_t);
+    if (num_addrs == 0 || addrs[0] != frame_addr) {
+        return 0;
+    }
+
+    // Full hit! Extend frame_info with entire cached list
+    Py_ssize_t cur_size = PyList_GET_SIZE(frame_info);
+    int result = PyList_SetSlice(frame_info, cur_size, cur_size, frame_list);
+    return result < 0 ? -1 : 1;
+}
+
+// High-level helper: collect frames with cache optimization
+// Returns complete frame_info list, handling all cache logic internally
+int
+collect_frames_with_cache(
+    RemoteUnwinderObject *unwinder,
+    uintptr_t frame_addr,
+    StackChunkList *chunks,
+    PyObject *frame_info,
+    uintptr_t gc_frame,
+    uintptr_t last_profiled_frame,
+    uint64_t thread_id)
+{
+    // Fast path: check for full cache hit first (no allocations needed)
+    int full_hit = try_full_cache_hit(unwinder, frame_addr, last_profiled_frame,
+                                       thread_id, frame_info);
+    if (full_hit != 0) {
+        return full_hit < 0 ? -1 : 0;  // Either error or success
+    }
+
+    // Slow path: need to walk frames
+    PyObject *frame_addresses = PyList_New(0);
+    if (!frame_addresses) {
+        return -1;
+    }
+
+    int stopped_at_cached = 0;
+    if (process_frame_chain(unwinder, frame_addr, chunks, frame_info, gc_frame,
+                            last_profiled_frame, &stopped_at_cached, frame_addresses) < 0) {
+        Py_DECREF(frame_addresses);
+        return -1;
+    }
+
+    // If stopped at cached frame, extend with cached continuation (both frames and addresses)
+    if (stopped_at_cached) {
+        int cache_result = frame_cache_lookup_and_extend(unwinder, thread_id, last_profiled_frame,
+                                                         frame_info, frame_addresses);
+        if (cache_result < 0) {
+            Py_DECREF(frame_addresses);
+            return -1;
+        }
+    }
+
+    // Convert frame_addresses (list of PyLong) to C array for efficient cache storage
+    Py_ssize_t num_addrs = PyList_GET_SIZE(frame_addresses);
+
+    // After extending from cache, frames and addresses should be in sync
+    assert(PyList_GET_SIZE(frame_info) == num_addrs);
+
+    // Allocate C array for addresses
+    uintptr_t *addrs = (uintptr_t *)PyMem_Malloc(num_addrs * sizeof(uintptr_t));
+    if (!addrs) {
+        Py_DECREF(frame_addresses);
+        PyErr_NoMemory();
+        return -1;
+    }
+
+    // Fill addresses from the Python list
+    for (Py_ssize_t i = 0; i < num_addrs; i++) {
+        PyObject *addr_obj = PyList_GET_ITEM(frame_addresses, i);
+        addrs[i] = PyLong_AsUnsignedLongLong(addr_obj);
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+            addrs[i] = 0;
+        }
+    }
+
+    // Store in cache
+    frame_cache_store(unwinder, thread_id, frame_info, addrs, num_addrs);
+
+    PyMem_Free(addrs);
+    Py_DECREF(frame_addresses);
 
     return 0;
 }

--- a/Modules/_remote_debugging/module.c
+++ b/Modules/_remote_debugging/module.c
@@ -814,6 +814,7 @@ Returns:
         - frames_read_from_cache: Total frames retrieved from cache
         - frames_read_from_memory: Total frames read from remote memory
         - memory_reads: Total remote memory read operations
+        - memory_bytes_read: Total bytes read from remote memory
         - code_object_cache_hits: Code object cache hits
         - code_object_cache_misses: Code object cache misses
         - stale_cache_invalidations: Times stale cache entries were cleared
@@ -826,7 +827,7 @@ Raises:
 
 static PyObject *
 _remote_debugging_RemoteUnwinder_get_stats_impl(RemoteUnwinderObject *self)
-/*[clinic end generated code: output=21e36477122be2a0 input=0a037cbf1c572d2b]*/
+/*[clinic end generated code: output=21e36477122be2a0 input=75fef4134c12a8c9]*/
 {
     if (!self->collect_stats) {
         PyErr_SetString(PyExc_RuntimeError,
@@ -857,6 +858,7 @@ _remote_debugging_RemoteUnwinder_get_stats_impl(RemoteUnwinderObject *self)
     ADD_STAT(frames_read_from_cache);
     ADD_STAT(frames_read_from_memory);
     ADD_STAT(memory_reads);
+    ADD_STAT(memory_bytes_read);
     ADD_STAT(code_object_cache_hits);
     ADD_STAT(code_object_cache_misses);
     ADD_STAT(stale_cache_invalidations);

--- a/Modules/_remote_debugging/module.c
+++ b/Modules/_remote_debugging/module.c
@@ -290,7 +290,7 @@ _remote_debugging_RemoteUnwinder___init___impl(RemoteUnwinderObject *self,
 #ifdef Py_GIL_DISABLED
     if (only_active_thread) {
         PyErr_SetString(PyExc_ValueError,
-                       "only_active_thread is not supported when Py_GIL_DISABLED is not defined");
+                       "only_active_thread is not supported in free-threaded builds");
         return -1;
     }
 #endif
@@ -389,7 +389,6 @@ _remote_debugging_RemoteUnwinder___init___impl(RemoteUnwinderObject *self,
 #endif
 
     if (cache_frames && frame_cache_init(self) < 0) {
-        PyErr_NoMemory();
         return -1;
     }
 

--- a/Modules/_remote_debugging/module.c
+++ b/Modules/_remote_debugging/module.c
@@ -386,6 +386,12 @@ _remote_debugging_RemoteUnwinder___init___impl(RemoteUnwinderObject *self,
         return -1;
     }
 
+    // Clear stale last_profiled_frame values from previous profilers
+    // This prevents us from stopping frame walking early due to stale values
+    if (cache_frames) {
+        clear_last_profiled_frames(self);
+    }
+
     return 0;
 }
 

--- a/Modules/_remote_debugging/threads.c
+++ b/Modules/_remote_debugging/threads.c
@@ -296,6 +296,8 @@ unwind_stack_for_thread(
         set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to read thread state");
         goto error;
     }
+    STATS_INC(unwinder, memory_reads);
+    STATS_ADD(unwinder, memory_bytes_read, unwinder->debug_offsets.thread_state.size);
 
     long tid = GET_MEMBER(long, ts, unwinder->debug_offsets.thread_state.native_thread_id);
 
@@ -309,6 +311,8 @@ unwind_stack_for_thread(
         set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to read GC state");
         goto error;
     }
+    STATS_INC(unwinder, memory_reads);
+    STATS_ADD(unwinder, memory_bytes_read, unwinder->debug_offsets.gc.size);
 
     // Calculate thread status using flags (always)
     int status_flags = 0;

--- a/Modules/_remote_debugging/threads.c
+++ b/Modules/_remote_debugging/threads.c
@@ -406,7 +406,7 @@ unwind_stack_for_thread(
     } else {
         // No caching - process entire frame chain
         if (process_frame_chain(unwinder, frame_addr, &chunks, frame_info,
-                                gc_frame, 0, NULL, NULL) < 0) {
+                                gc_frame, 0, NULL, NULL, NULL, 0) < 0) {
             set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to process frame chain");
             goto error;
         }

--- a/Modules/_remote_debugging/threads.c
+++ b/Modules/_remote_debugging/threads.c
@@ -383,9 +383,12 @@ unwind_stack_for_thread(
         goto error;
     }
 
-    if (copy_stack_chunks(unwinder, *current_tstate, &chunks) < 0) {
-        set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to copy stack chunks");
-        goto error;
+    // In cache mode, copying stack chunks is more expensive than direct memory reads
+    if (!unwinder->cache_frames) {
+        if (copy_stack_chunks(unwinder, *current_tstate, &chunks) < 0) {
+            set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to copy stack chunks");
+            goto error;
+        }
     }
 
     if (unwinder->cache_frames) {

--- a/PCbuild/_remote_debugging.vcxproj
+++ b/PCbuild/_remote_debugging.vcxproj
@@ -102,6 +102,7 @@
     <ClCompile Include="..\Modules\_remote_debugging\object_reading.c" />
     <ClCompile Include="..\Modules\_remote_debugging\code_objects.c" />
     <ClCompile Include="..\Modules\_remote_debugging\frames.c" />
+    <ClCompile Include="..\Modules\_remote_debugging\frame_cache.c" />
     <ClCompile Include="..\Modules\_remote_debugging\threads.c" />
     <ClCompile Include="..\Modules\_remote_debugging\asyncio.c" />
   </ItemGroup>

--- a/PCbuild/_remote_debugging.vcxproj.filters
+++ b/PCbuild/_remote_debugging.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="..\Modules\_remote_debugging\frames.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Modules\_remote_debugging\frame_cache.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\Modules\_remote_debugging\threads.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2004,6 +2004,13 @@ clear_gen_frame(PyThreadState *tstate, _PyInterpreterFrame * frame)
 void
 _PyEval_FrameClearAndPop(PyThreadState *tstate, _PyInterpreterFrame * frame)
 {
+    // Update last_profiled_frame for remote profiler frame caching.
+    // By this point, tstate->current_frame is already set to the parent frame.
+    // The guarded check avoids writes when profiling is not active (predictable branch).
+    if (tstate->last_profiled_frame != NULL) {
+        tstate->last_profiled_frame = tstate->current_frame;
+    }
+
     if (frame->owner == FRAME_OWNED_BY_THREAD) {
         clear_thread_frame(tstate, frame);
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2006,8 +2006,11 @@ _PyEval_FrameClearAndPop(PyThreadState *tstate, _PyInterpreterFrame * frame)
 {
     // Update last_profiled_frame for remote profiler frame caching.
     // By this point, tstate->current_frame is already set to the parent frame.
-    // The guarded check avoids writes when profiling is not active (predictable branch).
-    if (tstate->last_profiled_frame != NULL) {
+    // Only update if we're popping the exact frame that was last profiled.
+    // This avoids corrupting the cache when transient frames (called and returned
+    // between profiler samples) update last_profiled_frame to addresses the
+    // profiler never saw.
+    if (tstate->last_profiled_frame != NULL && tstate->last_profiled_frame == frame) {
         tstate->last_profiled_frame = tstate->current_frame;
     }
 

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -1102,6 +1102,115 @@ _Py_RemoteDebug_ReadRemoteMemory(proc_handle_t *handle, uintptr_t remote_address
 #endif
 }
 
+#if defined(__linux__) && HAVE_PROCESS_VM_READV
+// Fallback write using /proc/pid/mem
+static int
+_Py_RemoteDebug_WriteRemoteMemoryFallback(proc_handle_t *handle, uintptr_t remote_address, size_t len, const void* src)
+{
+    if (handle->memfd == -1) {
+        if (open_proc_mem_fd(handle) < 0) {
+            return -1;
+        }
+    }
+
+    struct iovec local[1];
+    Py_ssize_t result = 0;
+    Py_ssize_t written = 0;
+
+    do {
+        local[0].iov_base = (char*)src + result;
+        local[0].iov_len = len - result;
+        off_t offset = remote_address + result;
+
+        written = pwritev(handle->memfd, local, 1, offset);
+        if (written < 0) {
+            PyErr_SetFromErrno(PyExc_OSError);
+            return -1;
+        }
+
+        result += written;
+    } while ((size_t)written != local[0].iov_len);
+    return 0;
+}
+#endif // __linux__
+
+// Platform-independent memory write function
+UNUSED static int
+_Py_RemoteDebug_WriteRemoteMemory(proc_handle_t *handle, uintptr_t remote_address, size_t len, const void* src)
+{
+#ifdef MS_WINDOWS
+    SIZE_T written = 0;
+    SIZE_T result = 0;
+    do {
+        if (!WriteProcessMemory(handle->hProcess, (LPVOID)(remote_address + result), (const char*)src + result, len - result, &written)) {
+            PyErr_SetFromWindowsErr(0);
+            DWORD error = GetLastError();
+            _set_debug_exception_cause(PyExc_OSError,
+                "WriteProcessMemory failed for PID %d at address 0x%lx "
+                "(size %zu, partial write %zu bytes): Windows error %lu",
+                handle->pid, remote_address + result, len - result, result, error);
+            return -1;
+        }
+        result += written;
+    } while (result < len);
+    return 0;
+#elif defined(__linux__) && HAVE_PROCESS_VM_READV
+    if (handle->memfd != -1) {
+        return _Py_RemoteDebug_WriteRemoteMemoryFallback(handle, remote_address, len, src);
+    }
+    struct iovec local[1];
+    struct iovec remote[1];
+    Py_ssize_t result = 0;
+    Py_ssize_t written = 0;
+
+    do {
+        local[0].iov_base = (void*)((char*)src + result);
+        local[0].iov_len = len - result;
+        remote[0].iov_base = (void*)((char*)remote_address + result);
+        remote[0].iov_len = len - result;
+
+        written = process_vm_writev(handle->pid, local, 1, remote, 1, 0);
+        if (written < 0) {
+            if (errno == ENOSYS) {
+                return _Py_RemoteDebug_WriteRemoteMemoryFallback(handle, remote_address, len, src);
+            }
+            PyErr_SetFromErrno(PyExc_OSError);
+            _set_debug_exception_cause(PyExc_OSError,
+                "process_vm_writev failed for PID %d at address 0x%lx "
+                "(size %zu, partial write %zd bytes): %s",
+                handle->pid, remote_address + result, len - result, result, strerror(errno));
+            return -1;
+        }
+
+        result += written;
+    } while ((size_t)written != local[0].iov_len);
+    return 0;
+#elif defined(__APPLE__) && defined(TARGET_OS_OSX) && TARGET_OS_OSX
+    kern_return_t kr = mach_vm_write(
+        handle->task,
+        (mach_vm_address_t)remote_address,
+        (vm_offset_t)src,
+        (mach_msg_type_number_t)len);
+
+    if (kr != KERN_SUCCESS) {
+        switch (kr) {
+        case KERN_PROTECTION_FAILURE:
+            PyErr_SetString(PyExc_PermissionError, "Not enough permissions to write memory");
+            break;
+        case KERN_INVALID_ARGUMENT:
+            PyErr_SetString(PyExc_PermissionError, "Invalid argument to mach_vm_write");
+            break;
+        default:
+            PyErr_Format(PyExc_RuntimeError, "Unknown error writing memory: %d", (int)kr);
+        }
+        return -1;
+    }
+    return 0;
+#else
+    Py_UNREACHABLE();
+#endif
+}
+
 UNUSED static int
 _Py_RemoteDebug_PagedReadRemoteMemory(proc_handle_t *handle,
                                       uintptr_t addr,

--- a/Tools/inspection/benchmark_external_inspection.py
+++ b/Tools/inspection/benchmark_external_inspection.py
@@ -434,7 +434,7 @@ def main():
                     elif args.threads == "only_active":
                         kwargs["only_active_thread"] = True
                     unwinder = _remote_debugging.RemoteUnwinder(
-                        process.pid, **kwargs
+                        process.pid, cache_frames=True, **kwargs
                     )
                     results = benchmark(unwinder, duration_seconds=args.duration)
                 finally:


### PR DESCRIPTION
**This PR makes the profiler up (when we have a lots of repeated frames in the stack) to 15x times faster** :tada: 


This PR implements frame caching in the `RemoteUnwinder` class to significantly reduce memory reads when profiling remote processes with deep call stacks.

When `cache_frames=True`, the unwinder stores the frame chain from each sample and reuses unchanged portions in subsequent samples. Since most profiling samples capture similar call stacks (especially the parent frames), this optimization avoids repeatedly reading the same frame data from the target process.

The implementation adds a `last_profiled_frame` field to the thread state that tracks where the previous sample stopped. On the next sample, if the current frame chain reaches this marker, the cached frames from that point onward are reused instead of being re-read from remote memory.

The sampling profiler now enables frame caching by default.


<!-- gh-issue-number: gh-138122 -->
* Issue: gh-138122
<!-- /gh-issue-number -->
