### PR TITLE
[3.14] Revert "GH-91636: Clear weakrefs created by finalizers. (GH-136401) (#141993)"

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-07-07-17-26-06.gh-issue-91636.GyHU72.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-07-07-17-26-06.gh-issue-91636.GyHU72.rst
@@ -1,3 +1,0 @@
-While performing garbage collection, clear weakrefs to unreachable objects
-that are created during running of finalizers.  If those weakrefs were are
-not cleared, they could reveal unreachable objects.

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -870,7 +870,7 @@ move_legacy_finalizer_reachable(PyGC_Head *finalizers)
  * no object in `unreachable` is weakly referenced anymore.
  */
 static int
-handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old, bool allow_callbacks)
+handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
 {
     PyGC_Head *gc;
     PyObject *op;               /* generally FROM_GC(gc) */
@@ -879,9 +879,7 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old, bool allow_callbacks)
     PyGC_Head *next;
     int num_freed = 0;
 
-    if (allow_callbacks) {
-        gc_list_init(&wrcb_to_call);
-    }
+    gc_list_init(&wrcb_to_call);
 
     /* Clear all weakrefs to the objects in unreachable.  If such a weakref
      * also has a callback, move it into `wrcb_to_call` if the callback
@@ -937,11 +935,6 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old, bool allow_callbacks)
             _PyObject_ASSERT((PyObject *)wr, wr->wr_object == op);
             _PyWeakref_ClearRef(wr);
             _PyObject_ASSERT((PyObject *)wr, wr->wr_object == Py_None);
-
-            if (!allow_callbacks) {
-                continue;
-            }
-
             if (wr->wr_callback == NULL) {
                 /* no callback */
                 continue;
@@ -992,10 +985,6 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old, bool allow_callbacks)
             _PyObject_ASSERT((PyObject *)wr, wrasgc != next);
             gc_list_move(wrasgc, &wrcb_to_call);
         }
-    }
-
-    if (!allow_callbacks) {
-        return 0;
     }
 
     /* Invoke the callbacks we decided to honor.  It's safe to invoke them
@@ -1750,7 +1739,7 @@ gc_collect_region(PyThreadState *tstate,
     }
 
     /* Clear weakrefs and invoke callbacks as necessary. */
-    stats->collected += handle_weakrefs(&unreachable, to, true);
+    stats->collected += handle_weakrefs(&unreachable, to);
     gc_list_validate_space(to, gcstate->visited_space);
     validate_list(to, collecting_clear_unreachable_clear);
     validate_list(&unreachable, collecting_set_unreachable_clear);
@@ -1763,14 +1752,6 @@ gc_collect_region(PyThreadState *tstate,
     PyGC_Head final_unreachable;
     gc_list_init(&final_unreachable);
     handle_resurrected_objects(&unreachable, &final_unreachable, to);
-
-    /* Clear weakrefs to objects in the unreachable set.  No Python-level
-     * code must be allowed to access those unreachable objects.  During
-     * delete_garbage(), finalizers outside the unreachable set might run
-     * and create new weakrefs.  If those weakrefs were not cleared, they
-     * could reveal unreachable objects.  Callbacks are not executed.
-     */
-    handle_weakrefs(&final_unreachable, NULL, false);
 
     /* Call tp_clear on objects in the final_unreachable set.  This will cause
     * the reference cycles to be broken.  It may also cause some objects

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1493,9 +1493,9 @@ move_legacy_finalizer_reachable(struct collection_state *state)
 }
 
 // Clear all weakrefs to unreachable objects. Weakrefs with callbacks are
-// optionally enqueued in `wrcb_to_call`, but not invoked yet.
+// enqueued in `wrcb_to_call`, but not invoked yet.
 static void
-clear_weakrefs(struct collection_state *state, bool enqueue_callbacks)
+clear_weakrefs(struct collection_state *state)
 {
     PyObject *op;
     WORKSTACK_FOR_EACH(&state->unreachable, op) {
@@ -1526,10 +1526,6 @@ clear_weakrefs(struct collection_state *state, bool enqueue_callbacks)
             _PyObject_ASSERT((PyObject *)wr, wr->wr_object == op);
             _PyWeakref_ClearRef(wr);
             _PyObject_ASSERT((PyObject *)wr, wr->wr_object == Py_None);
-
-            if (!enqueue_callbacks) {
-                continue;
-            }
 
             // We do not invoke callbacks for weakrefs that are themselves
             // unreachable. This is partly for historical reasons: weakrefs
@@ -2216,7 +2212,7 @@ gc_collect_internal(PyInterpreterState *interp, struct collection_state *state, 
     interp->gc.long_lived_total = state->long_lived_total;
 
     // Clear weakrefs and enqueue callbacks (but do not call them).
-    clear_weakrefs(state, true);
+    clear_weakrefs(state);
     _PyEval_StartTheWorld(interp);
 
     // Deallocate any object from the refcount merge step
@@ -2227,19 +2223,11 @@ gc_collect_internal(PyInterpreterState *interp, struct collection_state *state, 
     call_weakref_callbacks(state);
     finalize_garbage(state);
 
-    _PyEval_StopTheWorld(interp);
     // Handle any objects that may have resurrected after the finalization.
+    _PyEval_StopTheWorld(interp);
     err = handle_resurrected_objects(state);
     // Clear free lists in all threads
     _PyGC_ClearAllFreeLists(interp);
-    if (err == 0) {
-        // Clear weakrefs to objects in the unreachable set.  No Python-level
-        // code must be allowed to access those unreachable objects.  During
-        // delete_garbage(), finalizers outside the unreachable set might
-        // run and create new weakrefs.  If those weakrefs were not cleared,
-        // they could reveal unreachable objects.
-        clear_weakrefs(state, false);
-    }
     _PyEval_StartTheWorld(interp);
 
     if (err < 0) {


### PR DESCRIPTION
This reverts commit fed2af6f9ea7f3cece57947c988f382f3309f6cb.

We'll skip 3.14.1 and reconsider for 3.14.2.

Re: https://github.com/python/cpython/pull/141993#issuecomment-3597307079


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-91636 -->
* Issue: gh-91636
<!-- /gh-issue-number -->
