### PR TITLE
gh-54872: Remove default OPT=-O for non-GCC compilers

### DIFF
--- a/configure
+++ b/configure
@@ -9619,11 +9619,7 @@ then
 	case $ac_sys_system in
 	    SCO_SV*) OPT="$OPT -m486 -DSCO5"
 	    ;;
-        esac
-	;;
-
-    *)
-	OPT="-O"
+  esac
 	;;
     esac
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -2338,10 +2338,6 @@ then
 	    ;;
         esac
 	;;
-
-    *)
-	OPT="-O"
-	;;
     esac
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -2336,7 +2336,7 @@ then
 	case $ac_sys_system in
 	    SCO_SV*) OPT="$OPT -m486 -DSCO5"
 	    ;;
-        esac
+  esac
 	;;
     esac
 fi


### PR DESCRIPTION
The configure script was setting OPT="-O" by default for non-GCC compilers, which could conflict with user-specified CFLAGS. This change removes the automatic default, allowing users full control over optimization flags via CFLAGS without unexpected conflicts.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->



<!-- gh-issue-number: gh-54872 -->
* Issue: gh-54872
<!-- /gh-issue-number -->
