### PR TITLE
gh-58752: Doc: Clarify sys.path[0] behavior for symbolic and hard links

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -159,6 +159,12 @@ source.
    containing that file is added to the start of :data:`sys.path`, and the
    file is executed as the :mod:`__main__` module.
 
+   If the script name refers to a link, the behavior depends on the link
+   type and operating system. On Unix-like systems, symbolic links are
+   resolved to the target file's directory when added to :data:`sys.path`.
+   Hard links use the link's own directory. On Windows, both hard links
+   and symbolic links use the link's own directory.
+
    If the script name refers to a directory or zipfile, the script name is
    added to the start of :data:`sys.path` and the ``__main__.py`` file in
    that location is executed as the :mod:`__main__` module.


### PR DESCRIPTION
Improve documentation of how Python sets sys.path[0] when the script is accessed via different link types:
- On Unix-like systems, symbolic links are resolved to target directory
- Hard links and Windows file links use the link's own directory

Fixes #58752

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-58752 -->
* Issue: gh-58752
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142160.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->