### PR TITLE
gh-116738: Make cmath module thread-safe

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-01-10-03-08.gh-issue-116738.972YsG.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-01-10-03-08.gh-issue-116738.972YsG.rst
@@ -1,2 +1,2 @@
-Make the :mod:`cmath` module thread-safe during import in free-threading and
-subinterpreter use cases.
+Fix :mod:`cmath` data race when initializing trigonometric tables with
+subinterpreters.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-01-10-03-08.gh-issue-116738.972YsG.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-01-10-03-08.gh-issue-116738.972YsG.rst
@@ -1,0 +1,2 @@
+Make the :mod:`cmath` module thread-safe during import in free-threading and
+subinterpreter use cases.

--- a/Modules/cmathmodule.c
+++ b/Modules/cmathmodule.c
@@ -1215,7 +1215,8 @@ cmath_exec(PyObject *mod)
 }
 
 static int
-init_special_value_tables(void *Py_UNUSED(arg)) {
+init_special_value_tables(void *Py_UNUSED(arg))
+{
 
 #define INIT_SPECIAL_VALUES(NAME, BODY) { Py_complex* p = (Py_complex*)NAME; BODY }
 #define C(REAL, IMAG) p->real = REAL; p->imag = IMAG; ++p;

--- a/Modules/cmathmodule.c
+++ b/Modules/cmathmodule.c
@@ -163,15 +163,14 @@ special_type(double d)
    raised.
 */
 
-#define C(R, I) {(R), (I)}
 static Py_complex acos_special_values[7][7] = {
-  { C(P34,INF), C(P,INF),  C(P,INF),  C(P,-INF),  C(P,-INF),  C(P34,-INF), C(N,INF) },
-  { C(P12,INF), C(U,U),    C(U,U),    C(U,U),     C(U,U),     C(P12,-INF), C(N,N) },
-  { C(P12,INF), C(U,U),    C(P12,0.), C(P12,-0.), C(U,U),     C(P12,-INF), C(P12,N) },
-  { C(P12,INF), C(U,U),    C(P12,0.), C(P12,-0.), C(U,U),     C(P12,-INF), C(P12,N) },
-  { C(P12,INF), C(U,U),    C(U,U),    C(U,U),     C(U,U),     C(P12,-INF), C(N,N) },
-  { C(P14,INF), C(0.,INF), C(0.,INF), C(0.,-INF), C(0.,-INF), C(P14,-INF), C(N,INF) },
-  { C(N,INF),   C(N,N),    C(N,N),    C(N,N),     C(N,N),     C(N,-INF),   C(N,N) }
+  { {P34,INF}, {P,INF},  {P,INF},  {P,-INF},  {P,-INF},  {P34,-INF}, {N,INF} },
+  { {P12,INF}, {U,U},    {U,U},    {U,U},     {U,U},     {P12,-INF}, {N,N} },
+  { {P12,INF}, {U,U},    {P12,0.}, {P12,-0.}, {U,U},     {P12,-INF}, {P12,N} },
+  { {P12,INF}, {U,U},    {P12,0.}, {P12,-0.}, {U,U},     {P12,-INF}, {P12,N} },
+  { {P12,INF}, {U,U},    {U,U},    {U,U},     {U,U},     {P12,-INF}, {N,N} },
+  { {P14,INF}, {0.,INF}, {0.,INF}, {0.,-INF}, {0.,-INF}, {P14,-INF}, {N,INF} },
+  { {N,INF},   {N,N},    {N,N},    {N,N},     {N,N},     {N,-INF},   {N,N} }
 };
 /*[clinic input]
 cmath.acos -> Py_complex_protected
@@ -211,13 +210,13 @@ cmath_acos_impl(PyObject *module, Py_complex z)
 
 
 static Py_complex acosh_special_values[7][7] = {
-  { C(INF,-P34), C(INF,-P),  C(INF,-P),  C(INF,P),  C(INF,P),  C(INF,P34), C(INF,N) },
-  { C(INF,-P12), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,P12), C(N,N) },
-  { C(INF,-P12), C(U,U),     C(0.,-P12), C(0.,P12), C(U,U),    C(INF,P12), C(N,P12) },
-  { C(INF,-P12), C(U,U),     C(0.,-P12), C(0.,P12), C(U,U),    C(INF,P12), C(N,P12) },
-  { C(INF,-P12), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,P12), C(N,N) },
-  { C(INF,-P14), C(INF,-0.), C(INF,-0.), C(INF,0.), C(INF,0.), C(INF,P14), C(INF,N) },
-  { C(INF,N),    C(N,N),     C(N,N),     C(N,N),    C(N,N),    C(INF,N),   C(N,N) }
+  { {INF,-P34}, {INF,-P},  {INF,-P},  {INF,P},  {INF,P},  {INF,P34}, {INF,N} },
+  { {INF,-P12}, {U,U},     {U,U},     {U,U},    {U,U},    {INF,P12}, {N,N} },
+  { {INF,-P12}, {U,U},     {0.,-P12}, {0.,P12}, {U,U},    {INF,P12}, {N,P12} },
+  { {INF,-P12}, {U,U},     {0.,-P12}, {0.,P12}, {U,U},    {INF,P12}, {N,P12} },
+  { {INF,-P12}, {U,U},     {U,U},     {U,U},    {U,U},    {INF,P12}, {N,N} },
+  { {INF,-P14}, {INF,-0.}, {INF,-0.}, {INF,0.}, {INF,0.}, {INF,P14}, {INF,N} },
+  { {INF,N},    {N,N},     {N,N},     {N,N},    {N,N},    {INF,N},   {N,N} }
 };
 
 /*[clinic input]
@@ -274,13 +273,13 @@ cmath_asin_impl(PyObject *module, Py_complex z)
 
 
 static Py_complex asinh_special_values[7][7] = {
-  { C(-INF,-P14), C(-INF,-0.), C(-INF,-0.), C(-INF,0.), C(-INF,0.), C(-INF,P14), C(-INF,N) },
-  { C(-INF,-P12), C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(-INF,P12), C(N,N) },
-  { C(-INF,-P12), C(U,U),      C(-0.,-0.),  C(-0.,0.),  C(U,U),     C(-INF,P12), C(N,N) },
-  { C(INF,-P12),  C(U,U),      C(0.,-0.),   C(0.,0.),   C(U,U),     C(INF,P12),  C(N,N) },
-  { C(INF,-P12),  C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(INF,P12),  C(N,N) },
-  { C(INF,-P14),  C(INF,-0.),  C(INF,-0.),  C(INF,0.),  C(INF,0.),  C(INF,P14),  C(INF,N) },
-  { C(INF,N),     C(N,N),      C(N,-0.),    C(N,0.),    C(N,N),     C(INF,N),    C(N,N) }
+  { {-INF,-P14}, {-INF,-0.}, {-INF,-0.}, {-INF,0.}, {-INF,0.}, {-INF,P14}, {-INF,N} },
+  { {-INF,-P12}, {U,U},      {U,U},      {U,U},     {U,U},     {-INF,P12}, {N,N} },
+  { {-INF,-P12}, {U,U},      {-0.,-0.},  {-0.,0.},  {U,U},     {-INF,P12}, {N,N} },
+  { {INF,-P12},  {U,U},      {0.,-0.},   {0.,0.},   {U,U},     {INF,P12},  {N,N} },
+  { {INF,-P12},  {U,U},      {U,U},      {U,U},     {U,U},     {INF,P12},  {N,N} },
+  { {INF,-P14},  {INF,-0.},  {INF,-0.},  {INF,0.},  {INF,0.},  {INF,P14},  {INF,N} },
+  { {INF,N},     {N,N},      {N,-0.},    {N,0.},    {N,N},     {INF,N},    {N,N} }
 };
 
 /*[clinic input]
@@ -343,13 +342,13 @@ cmath_atan_impl(PyObject *module, Py_complex z)
 
 
 static Py_complex atanh_special_values[7][7] = {
-  { C(-0.,-P12), C(-0.,-P12), C(-0.,-P12), C(-0.,P12), C(-0.,P12), C(-0.,P12), C(-0.,N) },
-  { C(-0.,-P12), C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(-0.,P12), C(N,N) },
-  { C(-0.,-P12), C(U,U),      C(-0.,-0.),  C(-0.,0.),  C(U,U),     C(-0.,P12), C(-0.,N) },
-  { C(0.,-P12),  C(U,U),      C(0.,-0.),   C(0.,0.),   C(U,U),     C(0.,P12),  C(0.,N) },
-  { C(0.,-P12),  C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(0.,P12),  C(N,N) },
-  { C(0.,-P12),  C(0.,-P12),  C(0.,-P12),  C(0.,P12),  C(0.,P12),  C(0.,P12),  C(0.,N) },
-  { C(0.,-P12),  C(N,N),      C(N,N),      C(N,N),     C(N,N),     C(0.,P12),  C(N,N) }
+  { {-0.,-P12}, {-0.,-P12}, {-0.,-P12}, {-0.,P12}, {-0.,P12}, {-0.,P12}, {-0.,N} },
+  { {-0.,-P12}, {U,U},      {U,U},      {U,U},     {U,U},     {-0.,P12}, {N,N} },
+  { {-0.,-P12}, {U,U},      {-0.,-0.},  {-0.,0.},  {U,U},     {-0.,P12}, {-0.,N} },
+  { {0.,-P12},  {U,U},      {0.,-0.},   {0.,0.},   {U,U},     {0.,P12},  {0.,N} },
+  { {0.,-P12},  {U,U},      {U,U},      {U,U},     {U,U},     {0.,P12},  {N,N} },
+  { {0.,-P12},  {0.,-P12},  {0.,-P12},  {0.,P12},  {0.,P12},  {0.,P12},  {0.,N} },
+  { {0.,-P12},  {N,N},      {N,N},      {N,N},     {N,N},     {0.,P12},  {N,N} }
 };
 
 /*[clinic input]
@@ -424,13 +423,13 @@ cmath_cos_impl(PyObject *module, Py_complex z)
 
 /* cosh(infinity + i*y) needs to be dealt with specially */
 static Py_complex cosh_special_values[7][7] = {
-  { C(INF,N), C(U,U), C(INF,0.),  C(INF,-0.), C(U,U), C(INF,N), C(INF,N) },
-  { C(N,N),   C(U,U), C(U,U),     C(U,U),     C(U,U), C(N,N),   C(N,N) },
-  { C(N,0.),  C(U,U), C(1.,0.),   C(1.,-0.),  C(U,U), C(N,0.),  C(N,0.) },
-  { C(N,0.),  C(U,U), C(1.,-0.),  C(1.,0.),   C(U,U), C(N,0.),  C(N,0.) },
-  { C(N,N),   C(U,U), C(U,U),     C(U,U),     C(U,U), C(N,N),   C(N,N) },
-  { C(INF,N), C(U,U), C(INF,-0.), C(INF,0.),  C(U,U), C(INF,N), C(INF,N) },
-  { C(N,N),   C(N,N), C(N,0.),    C(N,0.),    C(N,N), C(N,N),   C(N,N) }
+  { {INF,N}, {U,U}, {INF,0.},  {INF,-0.}, {U,U}, {INF,N}, {INF,N} },
+  { {N,N},   {U,U}, {U,U},     {U,U},     {U,U}, {N,N},   {N,N} },
+  { {N,0.},  {U,U}, {1.,0.},   {1.,-0.},  {U,U}, {N,0.},  {N,0.} },
+  { {N,0.},  {U,U}, {1.,-0.},  {1.,0.},   {U,U}, {N,0.},  {N,0.} },
+  { {N,N},   {U,U}, {U,U},     {U,U},     {U,U}, {N,N},   {N,N} },
+  { {INF,N}, {U,U}, {INF,-0.}, {INF,0.},  {U,U}, {INF,N}, {INF,N} },
+  { {N,N},   {N,N}, {N,0.},    {N,0.},    {N,N}, {N,N},   {N,N} }
 };
 
 /*[clinic input]
@@ -494,13 +493,13 @@ cmath_cosh_impl(PyObject *module, Py_complex z)
 /* exp(infinity + i*y) and exp(-infinity + i*y) need special treatment for
    finite y */
 static Py_complex exp_special_values[7][7] = {
-  { C(0.,0.), C(U,U), C(0.,-0.),  C(0.,0.),  C(U,U), C(0.,0.), C(0.,0.) },
-  { C(N,N),   C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),   C(N,N) },
-  { C(N,N),   C(U,U), C(1.,-0.),  C(1.,0.),  C(U,U), C(N,N),   C(N,N) },
-  { C(N,N),   C(U,U), C(1.,-0.),  C(1.,0.),  C(U,U), C(N,N),   C(N,N) },
-  { C(N,N),   C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),   C(N,N) },
-  { C(INF,N), C(U,U), C(INF,-0.), C(INF,0.), C(U,U), C(INF,N), C(INF,N) },
-  { C(N,N),   C(N,N), C(N,-0.),   C(N,0.),   C(N,N), C(N,N),   C(N,N) }
+  { {0.,0.}, {U,U}, {0.,-0.},  {0.,0.},  {U,U}, {0.,0.}, {0.,0.} },
+  { {N,N},   {U,U}, {U,U},     {U,U},    {U,U}, {N,N},   {N,N} },
+  { {N,N},   {U,U}, {1.,-0.},  {1.,0.},  {U,U}, {N,N},   {N,N} },
+  { {N,N},   {U,U}, {1.,-0.},  {1.,0.},  {U,U}, {N,N},   {N,N} },
+  { {N,N},   {U,U}, {U,U},     {U,U},    {U,U}, {N,N},   {N,N} },
+  { {INF,N}, {U,U}, {INF,-0.}, {INF,0.}, {U,U}, {INF,N}, {INF,N} },
+  { {N,N},   {N,N}, {N,-0.},   {N,0.},   {N,N}, {N,N},   {N,N} }
 };
 
 /*[clinic input]
@@ -561,13 +560,13 @@ cmath_exp_impl(PyObject *module, Py_complex z)
 }
 
 static Py_complex log_special_values[7][7] = {
-  { C(INF,-P34), C(INF,-P),  C(INF,-P),   C(INF,P),   C(INF,P),  C(INF,P34),  C(INF,N) },
-  { C(INF,-P12), C(U,U),     C(U,U),      C(U,U),     C(U,U),    C(INF,P12),  C(N,N) },
-  { C(INF,-P12), C(U,U),     C(-INF,-P),  C(-INF,P),  C(U,U),    C(INF,P12),  C(N,N) },
-  { C(INF,-P12), C(U,U),     C(-INF,-0.), C(-INF,0.), C(U,U),    C(INF,P12),  C(N,N) },
-  { C(INF,-P12), C(U,U),     C(U,U),      C(U,U),     C(U,U),    C(INF,P12),  C(N,N) },
-  { C(INF,-P14), C(INF,-0.), C(INF,-0.),  C(INF,0.),  C(INF,0.), C(INF,P14),  C(INF,N) },
-  { C(INF,N),    C(N,N),     C(N,N),      C(N,N),     C(N,N),    C(INF,N),    C(N,N) }
+  { {INF,-P34}, {INF,-P},  {INF,-P},   {INF,P},   {INF,P},  {INF,P34},  {INF,N} },
+  { {INF,-P12}, {U,U},     {U,U},      {U,U},     {U,U},    {INF,P12},  {N,N} },
+  { {INF,-P12}, {U,U},     {-INF,-P},  {-INF,P},  {U,U},    {INF,P12},  {N,N} },
+  { {INF,-P12}, {U,U},     {-INF,-0.}, {-INF,0.}, {U,U},    {INF,P12},  {N,N} },
+  { {INF,-P12}, {U,U},     {U,U},      {U,U},     {U,U},    {INF,P12},  {N,N} },
+  { {INF,-P14}, {INF,-0.}, {INF,-0.},  {INF,0.},  {INF,0.}, {INF,P14},  {INF,N} },
+  { {INF,N},    {N,N},     {N,N},      {N,N},     {N,N},    {INF,N},    {N,N} }
 };
 
 static Py_complex
@@ -685,13 +684,13 @@ cmath_sin_impl(PyObject *module, Py_complex z)
 
 /* sinh(infinity + i*y) needs to be dealt with specially */
 static Py_complex sinh_special_values[7][7] = {
-  { C(INF,N), C(U,U), C(-INF,-0.), C(-INF,0.), C(U,U), C(INF,N), C(INF,N) },
-  { C(N,N),   C(U,U), C(U,U),      C(U,U),     C(U,U), C(N,N),   C(N,N) },
-  { C(0.,N),  C(U,U), C(-0.,-0.),  C(-0.,0.),  C(U,U), C(0.,N),  C(0.,N) },
-  { C(0.,N),  C(U,U), C(0.,-0.),   C(0.,0.),   C(U,U), C(0.,N),  C(0.,N) },
-  { C(N,N),   C(U,U), C(U,U),      C(U,U),     C(U,U), C(N,N),   C(N,N) },
-  { C(INF,N), C(U,U), C(INF,-0.),  C(INF,0.),  C(U,U), C(INF,N), C(INF,N) },
-  { C(N,N),   C(N,N), C(N,-0.),    C(N,0.),    C(N,N), C(N,N),   C(N,N) }
+  { {INF,N}, {U,U}, {-INF,-0.}, {-INF,0.}, {U,U}, {INF,N}, {INF,N} },
+  { {N,N},   {U,U}, {U,U},      {U,U},     {U,U}, {N,N},   {N,N} },
+  { {0.,N},  {U,U}, {-0.,-0.},  {-0.,0.},  {U,U}, {0.,N},  {0.,N} },
+  { {0.,N},  {U,U}, {0.,-0.},   {0.,0.},   {U,U}, {0.,N},  {0.,N} },
+  { {N,N},   {U,U}, {U,U},      {U,U},     {U,U}, {N,N},   {N,N} },
+  { {INF,N}, {U,U}, {INF,-0.},  {INF,0.},  {U,U}, {INF,N}, {INF,N} },
+  { {N,N},   {N,N}, {N,-0.},    {N,0.},    {N,N}, {N,N},   {N,N} }
 };
 
 /*[clinic input]
@@ -752,13 +751,13 @@ cmath_sinh_impl(PyObject *module, Py_complex z)
 
 
 static Py_complex sqrt_special_values[7][7] = {
-  { C(INF,-INF), C(0.,-INF), C(0.,-INF), C(0.,INF), C(0.,INF), C(INF,INF), C(N,INF) },
-  { C(INF,-INF), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,INF), C(N,N) },
-  { C(INF,-INF), C(U,U),     C(0.,-0.),  C(0.,0.),  C(U,U),    C(INF,INF), C(N,N) },
-  { C(INF,-INF), C(U,U),     C(0.,-0.),  C(0.,0.),  C(U,U),    C(INF,INF), C(N,N) },
-  { C(INF,-INF), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,INF), C(N,N) },
-  { C(INF,-INF), C(INF,-0.), C(INF,-0.), C(INF,0.), C(INF,0.), C(INF,INF), C(INF,N) },
-  { C(INF,-INF), C(N,N),     C(N,N),     C(N,N),    C(N,N),    C(INF,INF), C(N,N) }
+  { {INF,-INF}, {0.,-INF}, {0.,-INF}, {0.,INF}, {0.,INF}, {INF,INF}, {N,INF} },
+  { {INF,-INF}, {U,U},     {U,U},     {U,U},    {U,U},    {INF,INF}, {N,N} },
+  { {INF,-INF}, {U,U},     {0.,-0.},  {0.,0.},  {U,U},    {INF,INF}, {N,N} },
+  { {INF,-INF}, {U,U},     {0.,-0.},  {0.,0.},  {U,U},    {INF,INF}, {N,N} },
+  { {INF,-INF}, {U,U},     {U,U},     {U,U},    {U,U},    {INF,INF}, {N,N} },
+  { {INF,-INF}, {INF,-0.}, {INF,-0.}, {INF,0.}, {INF,0.}, {INF,INF}, {INF,N} },
+  { {INF,-INF}, {N,N},     {N,N},     {N,N},    {N,N},    {INF,INF}, {N,N} }
 };
 
 /*[clinic input]
@@ -859,13 +858,13 @@ cmath_tan_impl(PyObject *module, Py_complex z)
 
 /* tanh(infinity + i*y) needs to be dealt with specially */
 static Py_complex tanh_special_values[7][7] = {
-  { C(-1.,0.), C(U,U), C(-1.,-0.), C(-1.,0.), C(U,U), C(-1.,0.), C(-1.,0.) },
-  { C(N,N),    C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),    C(N,N) },
-  { C(-0.0,N), C(U,U), C(-0.,-0.), C(-0.,0.), C(U,U), C(-0.0,N), C(-0.,N) },
-  { C(0.0,N),  C(U,U), C(0.,-0.),  C(0.,0.),  C(U,U), C(0.0,N),  C(0.,N) },
-  { C(N,N),    C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),    C(N,N) },
-  { C(1.,0.),  C(U,U), C(1.,-0.),  C(1.,0.),  C(U,U), C(1.,0.),  C(1.,0.) },
-  { C(N,N),    C(N,N), C(N,-0.),   C(N,0.),   C(N,N), C(N,N),    C(N,N) }
+  { {-1.,0.}, {U,U}, {-1.,-0.}, {-1.,0.}, {U,U}, {-1.,0.}, {-1.,0.} },
+  { {N,N},    {U,U}, {U,U},     {U,U},    {U,U}, {N,N},    {N,N} },
+  { {-0.0,N}, {U,U}, {-0.,-0.}, {-0.,0.}, {U,U}, {-0.0,N}, {-0.,N} },
+  { {0.0,N},  {U,U}, {0.,-0.},  {0.,0.},  {U,U}, {0.0,N},  {0.,N} },
+  { {N,N},    {U,U}, {U,U},     {U,U},    {U,U}, {N,N},    {N,N} },
+  { {1.,0.},  {U,U}, {1.,-0.},  {1.,0.},  {U,U}, {1.,0.},  {1.,0.} },
+  { {N,N},    {N,N}, {N,-0.},   {N,0.},   {N,N}, {N,N},    {N,N} }
 };
 
 /*[clinic input]
@@ -1050,13 +1049,13 @@ cmath_polar_impl(PyObject *module, Py_complex z)
 */
 
 static Py_complex rect_special_values[7][7] = {
-  { C(INF,N), C(U,U), C(-INF,0.), C(-INF,-0.), C(U,U), C(INF,N), C(INF,N) },
-  { C(N,N),   C(U,U), C(U,U),     C(U,U),      C(U,U), C(N,N),   C(N,N) },
-  { C(0.,0.), C(U,U), C(-0.,0.),  C(-0.,-0.),  C(U,U), C(0.,0.), C(0.,0.) },
-  { C(0.,0.), C(U,U), C(0.,-0.),  C(0.,0.),    C(U,U), C(0.,0.), C(0.,0.) },
-  { C(N,N),   C(U,U), C(U,U),     C(U,U),      C(U,U), C(N,N),   C(N,N) },
-  { C(INF,N), C(U,U), C(INF,-0.), C(INF,0.),   C(U,U), C(INF,N), C(INF,N) },
-  { C(N,N),   C(N,N), C(N,0.),    C(N,0.),     C(N,N), C(N,N),   C(N,N) }
+  { {INF,N}, {U,U}, {-INF,0.}, {-INF,-0.}, {U,U}, {INF,N}, {INF,N} },
+  { {N,N},   {U,U}, {U,U},     {U,U},      {U,U}, {N,N},   {N,N} },
+  { {0.,0.}, {U,U}, {-0.,0.},  {-0.,-0.},  {U,U}, {0.,0.}, {0.,0.} },
+  { {0.,0.}, {U,U}, {0.,-0.},  {0.,0.},    {U,U}, {0.,0.}, {0.,0.} },
+  { {N,N},   {U,U}, {U,U},     {U,U},      {U,U}, {N,N},   {N,N} },
+  { {INF,N}, {U,U}, {INF,-0.}, {INF,0.},   {U,U}, {INF,N}, {INF,N} },
+  { {N,N},   {N,N}, {N,0.},    {N,0.},     {N,N}, {N,N},   {N,N} }
 };
 
 /*[clinic input]

--- a/Modules/cmathmodule.c
+++ b/Modules/cmathmodule.c
@@ -163,15 +163,15 @@ special_type(double d)
    raised.
 */
 
-#define C(R, I) (Py_complex){(R), (I)}
+#define C(R, I) {(R), (I)}
 static Py_complex acos_special_values[7][7] = {
-  C(P34,INF), C(P,INF),  C(P,INF),  C(P,-INF),  C(P,-INF),  C(P34,-INF), C(N,INF),
-  C(P12,INF), C(U,U),    C(U,U),    C(U,U),     C(U,U),     C(P12,-INF), C(N,N),
-  C(P12,INF), C(U,U),    C(P12,0.), C(P12,-0.), C(U,U),     C(P12,-INF), C(P12,N),
-  C(P12,INF), C(U,U),    C(P12,0.), C(P12,-0.), C(U,U),     C(P12,-INF), C(P12,N),
-  C(P12,INF), C(U,U),    C(U,U),    C(U,U),     C(U,U),     C(P12,-INF), C(N,N),
-  C(P14,INF), C(0.,INF), C(0.,INF), C(0.,-INF), C(0.,-INF), C(P14,-INF), C(N,INF),
-  C(N,INF),   C(N,N),    C(N,N),    C(N,N),     C(N,N),     C(N,-INF),   C(N,N),
+  { C(P34,INF), C(P,INF),  C(P,INF),  C(P,-INF),  C(P,-INF),  C(P34,-INF), C(N,INF) },
+  { C(P12,INF), C(U,U),    C(U,U),    C(U,U),     C(U,U),     C(P12,-INF), C(N,N) },
+  { C(P12,INF), C(U,U),    C(P12,0.), C(P12,-0.), C(U,U),     C(P12,-INF), C(P12,N) },
+  { C(P12,INF), C(U,U),    C(P12,0.), C(P12,-0.), C(U,U),     C(P12,-INF), C(P12,N) },
+  { C(P12,INF), C(U,U),    C(U,U),    C(U,U),     C(U,U),     C(P12,-INF), C(N,N) },
+  { C(P14,INF), C(0.,INF), C(0.,INF), C(0.,-INF), C(0.,-INF), C(P14,-INF), C(N,INF) },
+  { C(N,INF),   C(N,N),    C(N,N),    C(N,N),     C(N,N),     C(N,-INF),   C(N,N) }
 };
 /*[clinic input]
 cmath.acos -> Py_complex_protected
@@ -211,13 +211,13 @@ cmath_acos_impl(PyObject *module, Py_complex z)
 
 
 static Py_complex acosh_special_values[7][7] = {
-  C(INF,-P34), C(INF,-P),  C(INF,-P),  C(INF,P),  C(INF,P),  C(INF,P34), C(INF,N),
-  C(INF,-P12), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,P12), C(N,N),
-  C(INF,-P12), C(U,U),     C(0.,-P12), C(0.,P12), C(U,U),    C(INF,P12), C(N,P12),
-  C(INF,-P12), C(U,U),     C(0.,-P12), C(0.,P12), C(U,U),    C(INF,P12), C(N,P12),
-  C(INF,-P12), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,P12), C(N,N),
-  C(INF,-P14), C(INF,-0.), C(INF,-0.), C(INF,0.), C(INF,0.), C(INF,P14), C(INF,N),
-  C(INF,N),    C(N,N),     C(N,N),     C(N,N),    C(N,N),    C(INF,N),   C(N,N),
+  { C(INF,-P34), C(INF,-P),  C(INF,-P),  C(INF,P),  C(INF,P),  C(INF,P34), C(INF,N) },
+  { C(INF,-P12), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,P12), C(N,N) },
+  { C(INF,-P12), C(U,U),     C(0.,-P12), C(0.,P12), C(U,U),    C(INF,P12), C(N,P12) },
+  { C(INF,-P12), C(U,U),     C(0.,-P12), C(0.,P12), C(U,U),    C(INF,P12), C(N,P12) },
+  { C(INF,-P12), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,P12), C(N,N) },
+  { C(INF,-P14), C(INF,-0.), C(INF,-0.), C(INF,0.), C(INF,0.), C(INF,P14), C(INF,N) },
+  { C(INF,N),    C(N,N),     C(N,N),     C(N,N),    C(N,N),    C(INF,N),   C(N,N) }
 };
 
 /*[clinic input]
@@ -274,13 +274,13 @@ cmath_asin_impl(PyObject *module, Py_complex z)
 
 
 static Py_complex asinh_special_values[7][7] = {
-  C(-INF,-P14), C(-INF,-0.), C(-INF,-0.), C(-INF,0.), C(-INF,0.), C(-INF,P14), C(-INF,N),
-  C(-INF,-P12), C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(-INF,P12), C(N,N),
-  C(-INF,-P12), C(U,U),      C(-0.,-0.),  C(-0.,0.),  C(U,U),     C(-INF,P12), C(N,N),
-  C(INF,-P12),  C(U,U),      C(0.,-0.),   C(0.,0.),   C(U,U),     C(INF,P12),  C(N,N),
-  C(INF,-P12),  C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(INF,P12),  C(N,N),
-  C(INF,-P14),  C(INF,-0.),  C(INF,-0.),  C(INF,0.),  C(INF,0.),  C(INF,P14),  C(INF,N),
-  C(INF,N),     C(N,N),      C(N,-0.),    C(N,0.),    C(N,N),     C(INF,N),    C(N,N),
+  { C(-INF,-P14), C(-INF,-0.), C(-INF,-0.), C(-INF,0.), C(-INF,0.), C(-INF,P14), C(-INF,N) },
+  { C(-INF,-P12), C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(-INF,P12), C(N,N) },
+  { C(-INF,-P12), C(U,U),      C(-0.,-0.),  C(-0.,0.),  C(U,U),     C(-INF,P12), C(N,N) },
+  { C(INF,-P12),  C(U,U),      C(0.,-0.),   C(0.,0.),   C(U,U),     C(INF,P12),  C(N,N) },
+  { C(INF,-P12),  C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(INF,P12),  C(N,N) },
+  { C(INF,-P14),  C(INF,-0.),  C(INF,-0.),  C(INF,0.),  C(INF,0.),  C(INF,P14),  C(INF,N) },
+  { C(INF,N),     C(N,N),      C(N,-0.),    C(N,0.),    C(N,N),     C(INF,N),    C(N,N) }
 };
 
 /*[clinic input]
@@ -343,13 +343,13 @@ cmath_atan_impl(PyObject *module, Py_complex z)
 
 
 static Py_complex atanh_special_values[7][7] = {
-  C(-0.,-P12), C(-0.,-P12), C(-0.,-P12), C(-0.,P12), C(-0.,P12), C(-0.,P12), C(-0.,N),
-  C(-0.,-P12), C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(-0.,P12), C(N,N),
-  C(-0.,-P12), C(U,U),      C(-0.,-0.),  C(-0.,0.),  C(U,U),     C(-0.,P12), C(-0.,N),
-  C(0.,-P12),  C(U,U),      C(0.,-0.),   C(0.,0.),   C(U,U),     C(0.,P12),  C(0.,N),
-  C(0.,-P12),  C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(0.,P12),  C(N,N),
-  C(0.,-P12),  C(0.,-P12),  C(0.,-P12),  C(0.,P12),  C(0.,P12),  C(0.,P12),  C(0.,N),
-  C(0.,-P12),  C(N,N),      C(N,N),      C(N,N),     C(N,N),     C(0.,P12),  C(N,N),
+  { C(-0.,-P12), C(-0.,-P12), C(-0.,-P12), C(-0.,P12), C(-0.,P12), C(-0.,P12), C(-0.,N) },
+  { C(-0.,-P12), C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(-0.,P12), C(N,N) },
+  { C(-0.,-P12), C(U,U),      C(-0.,-0.),  C(-0.,0.),  C(U,U),     C(-0.,P12), C(-0.,N) },
+  { C(0.,-P12),  C(U,U),      C(0.,-0.),   C(0.,0.),   C(U,U),     C(0.,P12),  C(0.,N) },
+  { C(0.,-P12),  C(U,U),      C(U,U),      C(U,U),     C(U,U),     C(0.,P12),  C(N,N) },
+  { C(0.,-P12),  C(0.,-P12),  C(0.,-P12),  C(0.,P12),  C(0.,P12),  C(0.,P12),  C(0.,N) },
+  { C(0.,-P12),  C(N,N),      C(N,N),      C(N,N),     C(N,N),     C(0.,P12),  C(N,N) }
 };
 
 /*[clinic input]
@@ -424,13 +424,13 @@ cmath_cos_impl(PyObject *module, Py_complex z)
 
 /* cosh(infinity + i*y) needs to be dealt with specially */
 static Py_complex cosh_special_values[7][7] = {
-  C(INF,N), C(U,U), C(INF,0.),  C(INF,-0.), C(U,U), C(INF,N), C(INF,N),
-  C(N,N),   C(U,U), C(U,U),     C(U,U),     C(U,U), C(N,N),   C(N,N),
-  C(N,0.),  C(U,U), C(1.,0.),   C(1.,-0.),  C(U,U), C(N,0.),  C(N,0.),
-  C(N,0.),  C(U,U), C(1.,-0.),  C(1.,0.),   C(U,U), C(N,0.),  C(N,0.),
-  C(N,N),   C(U,U), C(U,U),     C(U,U),     C(U,U), C(N,N),   C(N,N),
-  C(INF,N), C(U,U), C(INF,-0.), C(INF,0.),  C(U,U), C(INF,N), C(INF,N),
-  C(N,N),   C(N,N), C(N,0.),    C(N,0.),    C(N,N), C(N,N),   C(N,N),
+  { C(INF,N), C(U,U), C(INF,0.),  C(INF,-0.), C(U,U), C(INF,N), C(INF,N) },
+  { C(N,N),   C(U,U), C(U,U),     C(U,U),     C(U,U), C(N,N),   C(N,N) },
+  { C(N,0.),  C(U,U), C(1.,0.),   C(1.,-0.),  C(U,U), C(N,0.),  C(N,0.) },
+  { C(N,0.),  C(U,U), C(1.,-0.),  C(1.,0.),   C(U,U), C(N,0.),  C(N,0.) },
+  { C(N,N),   C(U,U), C(U,U),     C(U,U),     C(U,U), C(N,N),   C(N,N) },
+  { C(INF,N), C(U,U), C(INF,-0.), C(INF,0.),  C(U,U), C(INF,N), C(INF,N) },
+  { C(N,N),   C(N,N), C(N,0.),    C(N,0.),    C(N,N), C(N,N),   C(N,N) }
 };
 
 /*[clinic input]
@@ -494,13 +494,13 @@ cmath_cosh_impl(PyObject *module, Py_complex z)
 /* exp(infinity + i*y) and exp(-infinity + i*y) need special treatment for
    finite y */
 static Py_complex exp_special_values[7][7] = {
-  C(0.,0.), C(U,U), C(0.,-0.),  C(0.,0.),  C(U,U), C(0.,0.), C(0.,0.),
-  C(N,N),   C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),   C(N,N),
-  C(N,N),   C(U,U), C(1.,-0.),  C(1.,0.),  C(U,U), C(N,N),   C(N,N),
-  C(N,N),   C(U,U), C(1.,-0.),  C(1.,0.),  C(U,U), C(N,N),   C(N,N),
-  C(N,N),   C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),   C(N,N),
-  C(INF,N), C(U,U), C(INF,-0.), C(INF,0.), C(U,U), C(INF,N), C(INF,N),
-  C(N,N),   C(N,N), C(N,-0.),   C(N,0.),   C(N,N), C(N,N),   C(N,N),
+  { C(0.,0.), C(U,U), C(0.,-0.),  C(0.,0.),  C(U,U), C(0.,0.), C(0.,0.) },
+  { C(N,N),   C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),   C(N,N) },
+  { C(N,N),   C(U,U), C(1.,-0.),  C(1.,0.),  C(U,U), C(N,N),   C(N,N) },
+  { C(N,N),   C(U,U), C(1.,-0.),  C(1.,0.),  C(U,U), C(N,N),   C(N,N) },
+  { C(N,N),   C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),   C(N,N) },
+  { C(INF,N), C(U,U), C(INF,-0.), C(INF,0.), C(U,U), C(INF,N), C(INF,N) },
+  { C(N,N),   C(N,N), C(N,-0.),   C(N,0.),   C(N,N), C(N,N),   C(N,N) }
 };
 
 /*[clinic input]
@@ -561,13 +561,13 @@ cmath_exp_impl(PyObject *module, Py_complex z)
 }
 
 static Py_complex log_special_values[7][7] = {
-  C(INF,-P34), C(INF,-P),  C(INF,-P),   C(INF,P),   C(INF,P),  C(INF,P34),  C(INF,N),
-  C(INF,-P12), C(U,U),     C(U,U),      C(U,U),     C(U,U),    C(INF,P12),  C(N,N),
-  C(INF,-P12), C(U,U),     C(-INF,-P),  C(-INF,P),  C(U,U),    C(INF,P12),  C(N,N),
-  C(INF,-P12), C(U,U),     C(-INF,-0.), C(-INF,0.), C(U,U),    C(INF,P12),  C(N,N),
-  C(INF,-P12), C(U,U),     C(U,U),      C(U,U),     C(U,U),    C(INF,P12),  C(N,N),
-  C(INF,-P14), C(INF,-0.), C(INF,-0.),  C(INF,0.),  C(INF,0.), C(INF,P14),  C(INF,N),
-  C(INF,N),    C(N,N),     C(N,N),      C(N,N),     C(N,N),    C(INF,N),    C(N,N),
+  { C(INF,-P34), C(INF,-P),  C(INF,-P),   C(INF,P),   C(INF,P),  C(INF,P34),  C(INF,N) },
+  { C(INF,-P12), C(U,U),     C(U,U),      C(U,U),     C(U,U),    C(INF,P12),  C(N,N) },
+  { C(INF,-P12), C(U,U),     C(-INF,-P),  C(-INF,P),  C(U,U),    C(INF,P12),  C(N,N) },
+  { C(INF,-P12), C(U,U),     C(-INF,-0.), C(-INF,0.), C(U,U),    C(INF,P12),  C(N,N) },
+  { C(INF,-P12), C(U,U),     C(U,U),      C(U,U),     C(U,U),    C(INF,P12),  C(N,N) },
+  { C(INF,-P14), C(INF,-0.), C(INF,-0.),  C(INF,0.),  C(INF,0.), C(INF,P14),  C(INF,N) },
+  { C(INF,N),    C(N,N),     C(N,N),      C(N,N),     C(N,N),    C(INF,N),    C(N,N) }
 };
 
 static Py_complex
@@ -685,13 +685,13 @@ cmath_sin_impl(PyObject *module, Py_complex z)
 
 /* sinh(infinity + i*y) needs to be dealt with specially */
 static Py_complex sinh_special_values[7][7] = {
-  C(INF,N), C(U,U), C(-INF,-0.), C(-INF,0.), C(U,U), C(INF,N), C(INF,N),
-  C(N,N),   C(U,U), C(U,U),      C(U,U),     C(U,U), C(N,N),   C(N,N),
-  C(0.,N),  C(U,U), C(-0.,-0.),  C(-0.,0.),  C(U,U), C(0.,N),  C(0.,N),
-  C(0.,N),  C(U,U), C(0.,-0.),   C(0.,0.),   C(U,U), C(0.,N),  C(0.,N),
-  C(N,N),   C(U,U), C(U,U),      C(U,U),     C(U,U), C(N,N),   C(N,N),
-  C(INF,N), C(U,U), C(INF,-0.),  C(INF,0.),  C(U,U), C(INF,N), C(INF,N),
-  C(N,N),   C(N,N), C(N,-0.),    C(N,0.),    C(N,N), C(N,N),   C(N,N),
+  { C(INF,N), C(U,U), C(-INF,-0.), C(-INF,0.), C(U,U), C(INF,N), C(INF,N) },
+  { C(N,N),   C(U,U), C(U,U),      C(U,U),     C(U,U), C(N,N),   C(N,N) },
+  { C(0.,N),  C(U,U), C(-0.,-0.),  C(-0.,0.),  C(U,U), C(0.,N),  C(0.,N) },
+  { C(0.,N),  C(U,U), C(0.,-0.),   C(0.,0.),   C(U,U), C(0.,N),  C(0.,N) },
+  { C(N,N),   C(U,U), C(U,U),      C(U,U),     C(U,U), C(N,N),   C(N,N) },
+  { C(INF,N), C(U,U), C(INF,-0.),  C(INF,0.),  C(U,U), C(INF,N), C(INF,N) },
+  { C(N,N),   C(N,N), C(N,-0.),    C(N,0.),    C(N,N), C(N,N),   C(N,N) }
 };
 
 /*[clinic input]
@@ -752,13 +752,13 @@ cmath_sinh_impl(PyObject *module, Py_complex z)
 
 
 static Py_complex sqrt_special_values[7][7] = {
-  C(INF,-INF), C(0.,-INF), C(0.,-INF), C(0.,INF), C(0.,INF), C(INF,INF), C(N,INF),
-  C(INF,-INF), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,INF), C(N,N),
-  C(INF,-INF), C(U,U),     C(0.,-0.),  C(0.,0.),  C(U,U),    C(INF,INF), C(N,N),
-  C(INF,-INF), C(U,U),     C(0.,-0.),  C(0.,0.),  C(U,U),    C(INF,INF), C(N,N),
-  C(INF,-INF), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,INF), C(N,N),
-  C(INF,-INF), C(INF,-0.), C(INF,-0.), C(INF,0.), C(INF,0.), C(INF,INF), C(INF,N),
-  C(INF,-INF), C(N,N),     C(N,N),     C(N,N),    C(N,N),    C(INF,INF), C(N,N),
+  { C(INF,-INF), C(0.,-INF), C(0.,-INF), C(0.,INF), C(0.,INF), C(INF,INF), C(N,INF) },
+  { C(INF,-INF), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,INF), C(N,N) },
+  { C(INF,-INF), C(U,U),     C(0.,-0.),  C(0.,0.),  C(U,U),    C(INF,INF), C(N,N) },
+  { C(INF,-INF), C(U,U),     C(0.,-0.),  C(0.,0.),  C(U,U),    C(INF,INF), C(N,N) },
+  { C(INF,-INF), C(U,U),     C(U,U),     C(U,U),    C(U,U),    C(INF,INF), C(N,N) },
+  { C(INF,-INF), C(INF,-0.), C(INF,-0.), C(INF,0.), C(INF,0.), C(INF,INF), C(INF,N) },
+  { C(INF,-INF), C(N,N),     C(N,N),     C(N,N),    C(N,N),    C(INF,INF), C(N,N) }
 };
 
 /*[clinic input]
@@ -859,13 +859,13 @@ cmath_tan_impl(PyObject *module, Py_complex z)
 
 /* tanh(infinity + i*y) needs to be dealt with specially */
 static Py_complex tanh_special_values[7][7] = {
-  C(-1.,0.), C(U,U), C(-1.,-0.), C(-1.,0.), C(U,U), C(-1.,0.), C(-1.,0.),
-  C(N,N),    C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),    C(N,N),
-  C(-0.0,N), C(U,U), C(-0.,-0.), C(-0.,0.), C(U,U), C(-0.0,N), C(-0.,N),
-  C(0.0,N),  C(U,U), C(0.,-0.),  C(0.,0.),  C(U,U), C(0.0,N),  C(0.,N),
-  C(N,N),    C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),    C(N,N),
-  C(1.,0.),  C(U,U), C(1.,-0.),  C(1.,0.),  C(U,U), C(1.,0.),  C(1.,0.),
-  C(N,N),    C(N,N), C(N,-0.),   C(N,0.),   C(N,N), C(N,N),    C(N,N),
+  { C(-1.,0.), C(U,U), C(-1.,-0.), C(-1.,0.), C(U,U), C(-1.,0.), C(-1.,0.) },
+  { C(N,N),    C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),    C(N,N) },
+  { C(-0.0,N), C(U,U), C(-0.,-0.), C(-0.,0.), C(U,U), C(-0.0,N), C(-0.,N) },
+  { C(0.0,N),  C(U,U), C(0.,-0.),  C(0.,0.),  C(U,U), C(0.0,N),  C(0.,N) },
+  { C(N,N),    C(U,U), C(U,U),     C(U,U),    C(U,U), C(N,N),    C(N,N) },
+  { C(1.,0.),  C(U,U), C(1.,-0.),  C(1.,0.),  C(U,U), C(1.,0.),  C(1.,0.) },
+  { C(N,N),    C(N,N), C(N,-0.),   C(N,0.),   C(N,N), C(N,N),    C(N,N) }
 };
 
 /*[clinic input]
@@ -1050,13 +1050,13 @@ cmath_polar_impl(PyObject *module, Py_complex z)
 */
 
 static Py_complex rect_special_values[7][7] = {
-  C(INF,N), C(U,U), C(-INF,0.), C(-INF,-0.), C(U,U), C(INF,N), C(INF,N),
-  C(N,N),   C(U,U), C(U,U),     C(U,U),      C(U,U), C(N,N),   C(N,N),
-  C(0.,0.), C(U,U), C(-0.,0.),  C(-0.,-0.),  C(U,U), C(0.,0.), C(0.,0.),
-  C(0.,0.), C(U,U), C(0.,-0.),  C(0.,0.),    C(U,U), C(0.,0.), C(0.,0.),
-  C(N,N),   C(U,U), C(U,U),     C(U,U),      C(U,U), C(N,N),   C(N,N),
-  C(INF,N), C(U,U), C(INF,-0.), C(INF,0.),   C(U,U), C(INF,N), C(INF,N),
-  C(N,N),   C(N,N), C(N,0.),    C(N,0.),     C(N,N), C(N,N),   C(N,N),
+  { C(INF,N), C(U,U), C(-INF,0.), C(-INF,-0.), C(U,U), C(INF,N), C(INF,N) },
+  { C(N,N),   C(U,U), C(U,U),     C(U,U),      C(U,U), C(N,N),   C(N,N) },
+  { C(0.,0.), C(U,U), C(-0.,0.),  C(-0.,-0.),  C(U,U), C(0.,0.), C(0.,0.) },
+  { C(0.,0.), C(U,U), C(0.,-0.),  C(0.,0.),    C(U,U), C(0.,0.), C(0.,0.) },
+  { C(N,N),   C(U,U), C(U,U),     C(U,U),      C(U,U), C(N,N),   C(N,N) },
+  { C(INF,N), C(U,U), C(INF,-0.), C(INF,0.),   C(U,U), C(INF,N), C(INF,N) },
+  { C(N,N),   C(N,N), C(N,0.),    C(N,0.),     C(N,N), C(N,N),   C(N,N) }
 };
 
 /*[clinic input]

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -26,7 +26,6 @@ Modules/posixmodule.c	os_dup2_impl	dup3_works	-
 ## guards around resource init
 Python/thread_pthread.h	PyThread__init_thread	lib_initialized	-
 Modules/_struct.c	-	endian_tables_init_once	-
-Modules/cmathmodule.c	-	special_values_init_once	-
 
 ##-----------------------
 ## other values (not Python-specific)

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -26,6 +26,7 @@ Modules/posixmodule.c	os_dup2_impl	dup3_works	-
 ## guards around resource init
 Python/thread_pthread.h	PyThread__init_thread	lib_initialized	-
 Modules/_struct.c	-	endian_tables_init_once	-
+Modules/cmathmodule.c	-	special_values_init_once	-
 
 ##-----------------------
 ## other values (not Python-specific)
@@ -167,7 +168,6 @@ Python/sysmodule.c	-	_preinit_xoptions	-
 
 # thread-safety
 # XXX need race protection?
-Modules/cmathmodule.c	-	special_values_init_once	-
 Modules/faulthandler.c	faulthandler_dump_traceback	reentrant	-
 Modules/faulthandler.c	faulthandler_dump_c_stack	reentrant	-
 Modules/grpmodule.c	-	group_db_mutex	-

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -167,6 +167,7 @@ Python/sysmodule.c	-	_preinit_xoptions	-
 
 # thread-safety
 # XXX need race protection?
+Modules/cmathmodule.c	-	special_values_init_once	-
 Modules/faulthandler.c	faulthandler_dump_traceback	reentrant	-
 Modules/faulthandler.c	faulthandler_dump_c_stack	reentrant	-
 Modules/grpmodule.c	-	group_db_mutex	-


### PR DESCRIPTION
While investigating thread safety in the `cmath` module, I found that the module is generally thread-safe. However, there is a potential race condition during the initialization of the special value tables in `cmath_exec()`. This is usually safe, but with subinterpreters, a race condition could occur.

The fix converts all special value tables from runtime initialization to static initialization, eliminating the race condition.

I have also created a [test](https://github.com/yoney/cpython/blob/cmath_tsan/Lib/test/test_free_threading/test_cmath.py) to run under ThreadSanitizer. However, I am not including the test in the current PR because, although this PR addresses the issue in the `cmath` module, ThreadSanitizer still reports other issues below when subinterpreters and free-threading are used together. I plan to address those issues.

```
...
SUMMARY: ThreadSanitizer: data race /workspace/cmath_tsan/./Modules/posixmodule.c:18691 in posixmodule_exec
...
SUMMARY: ThreadSanitizer: data race /workspace/cmath_tsan/Objects/exceptions.c:4547 in _PyBuiltins_AddExceptions
...
SUMMARY: ThreadSanitizer: data race /workspace/cmath_tsan/Python/crossinterp_exceptions.h:154 in init_static_exctypes
...
...
```

cc: @mpage @colesbury 

<!-- gh-issue-number: gh-116738 -->
* Issue: gh-116738
<!-- /gh-issue-number -->
