### PR TITLE
gh-142163: Only define `HAVE_THREAD_LOCAL` when `Py_BUILD_CORE` is set

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -509,9 +509,15 @@ extern "C" {
 #  define Py_CAN_START_THREADS 1
 #endif
 
-#ifdef WITH_THREAD
-// HAVE_THREAD_LOCAL is just defined here for compatibility's sake
+
+/* gh-142163: Some libraries rely on HAVE_THREAD_LOCAL being undefined, so
+ * we can only define it only when Py_BUILD_CORE is set.*/
+#ifdef Py_BUILD_CORE
+// This is no longer coupled to _Py_thread_local.
 #  define HAVE_THREAD_LOCAL 1
+#endif
+
+#ifdef WITH_THREAD
 #  ifdef thread_local
 #    define _Py_thread_local thread_local
 #  elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)

--- a/Misc/NEWS.d/next/C_API/2025-12-01-18-17-16.gh-issue-142163.2HiX5A.rst
+++ b/Misc/NEWS.d/next/C_API/2025-12-01-18-17-16.gh-issue-142163.2HiX5A.rst
@@ -1,2 +1,2 @@
 Fix the ``HAVE_THREAD_LOCAL`` macro being defined without the
-``Py_BUILD_CORE`` macro set.
+``Py_BUILD_CORE`` macro set after including :file:`Python.h`.

--- a/Misc/NEWS.d/next/C_API/2025-12-01-18-17-16.gh-issue-142163.2HiX5A.rst
+++ b/Misc/NEWS.d/next/C_API/2025-12-01-18-17-16.gh-issue-142163.2HiX5A.rst
@@ -1,0 +1,2 @@
+Fix the ``HAVE_THREAD_LOCAL`` macro being defined without the
+``Py_BUILD_CORE`` macro set.


### PR DESCRIPTION


<!-- gh-issue-number: gh-142163 -->
* Issue: gh-142163
<!-- /gh-issue-number -->
