### PR TITLE
[3.13] gh-59000: Fix pdb breakpoint resolution for class methods when…

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1262,7 +1262,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             f = self.lookupmodule(parts[0])
             if f:
                 fname = f
-            item = parts[1]
+                item = parts[1]
+            else:
+                return failed
         answer = find_function(item, self.canonic(fname))
         return answer or failed
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4013,6 +4013,54 @@ def bœr():
             self.assertIn('42', stdout)
             self.assertIn('return x + 1', stdout)
 
+    def test_zipimport(self):
+        with os_helper.temp_dir() as temp_dir:
+            os.mkdir(os.path.join(temp_dir, 'source'))
+            zipmodule = textwrap.dedent(
+                """
+                def bar():
+                    pass
+                """
+            )
+            script = textwrap.dedent(
+                f"""
+                import sys; sys.path.insert(0, {repr(os.path.join(temp_dir, 'zipmodule.zip'))})
+                import foo
+                foo.bar()
+                """
+            )
+
+            with zipfile.ZipFile(os.path.join(temp_dir, 'zipmodule.zip'), 'w') as zf:
+                zf.writestr('foo.py', zipmodule)
+            with open(os.path.join(temp_dir, 'script.py'), 'w') as f:
+                f.write(script)
+
+            stdout, _ = self._run_pdb([os.path.join(temp_dir, 'script.py')], '\n'.join([
+                'n',
+                'n',
+                'b foo.bar',
+                'c',
+                'p f"break in {$_frame.f_code.co_name}"',
+                'q'
+            ]))
+            self.assertIn('break in bar', stdout)
+
+    def test_issue_59000(self):
+        script = """
+            def foo():
+                pass
+
+            class C:
+                def foo(self):
+                    pass
+        """
+        commands = """
+            break C.foo
+            quit
+        """
+        stdout, stderr = self.run_pdb_script(script, commands)
+        self.assertIn("The specified object 'C.foo' is not a function", stdout)
+
 
 class ChecklineTests(unittest.TestCase):
     def setUp(self):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4013,38 +4013,6 @@ def bœr():
             self.assertIn('42', stdout)
             self.assertIn('return x + 1', stdout)
 
-    def test_zipimport(self):
-        with os_helper.temp_dir() as temp_dir:
-            os.mkdir(os.path.join(temp_dir, 'source'))
-            zipmodule = textwrap.dedent(
-                """
-                def bar():
-                    pass
-                """
-            )
-            script = textwrap.dedent(
-                f"""
-                import sys; sys.path.insert(0, {repr(os.path.join(temp_dir, 'zipmodule.zip'))})
-                import foo
-                foo.bar()
-                """
-            )
-
-            with zipfile.ZipFile(os.path.join(temp_dir, 'zipmodule.zip'), 'w') as zf:
-                zf.writestr('foo.py', zipmodule)
-            with open(os.path.join(temp_dir, 'script.py'), 'w') as f:
-                f.write(script)
-
-            stdout, _ = self._run_pdb([os.path.join(temp_dir, 'script.py')], '\n'.join([
-                'n',
-                'n',
-                'b foo.bar',
-                'c',
-                'p f"break in {$_frame.f_code.co_name}"',
-                'q'
-            ]))
-            self.assertIn('break in bar', stdout)
-
     def test_issue_59000(self):
         script = """
             def foo():

--- a/Misc/NEWS.d/next/Library/2025-11-25-16-00-29.gh-issue-59000.YtOyJy.rst
+++ b/Misc/NEWS.d/next/Library/2025-11-25-16-00-29.gh-issue-59000.YtOyJy.rst
@@ -1,0 +1,1 @@
+Fix :mod:`pdb` breakpoint resolution for class methods when the module defining the class is not imported.


### PR DESCRIPTION
… module not imported (GH-141949)

(cherry picked from commit 5e58548ebe8f7ac8c6cb0bad775912caa4090515)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-59000 -->
* Issue: gh-59000
<!-- /gh-issue-number -->
