### PR TITLE
gh-142186: make PY_UNWIND available as a local event

### DIFF
--- a/Include/cpython/monitoring.h
+++ b/Include/cpython/monitoring.h
@@ -22,12 +22,14 @@ extern "C" {
 #define PY_MONITORING_EVENT_BRANCH_LEFT 8
 #define PY_MONITORING_EVENT_BRANCH_RIGHT 9
 #define PY_MONITORING_EVENT_STOP_ITERATION 10
+
+#define PY_MONITORING_IS_INSTRUMENTED_EVENT(ev) \
+((ev) <= PY_MONITORING_EVENT_STOP_ITERATION)
+
 #define PY_MONITORING_EVENT_PY_UNWIND 11
 
-// TODO: PY_UNWIND requires no instrumentation so this definition is not
-// entirely correct.
-#define PY_MONITORING_IS_INSTRUMENTED_EVENT(ev) \
-((ev) <= _PY_MONITORING_LOCAL_EVENTS)
+#define PY_MONITORING_IS_LOCAL_EVENT(ev) \
+((ev) < _PY_MONITORING_LOCAL_EVENTS)
 
 
 /* Other events, mainly exceptions */

--- a/Include/cpython/monitoring.h
+++ b/Include/cpython/monitoring.h
@@ -9,7 +9,7 @@ extern "C" {
 
 
 /* Local events.
- * These require bytecode instrumentation */
+ * Some of these require bytecode instrumentation */
 
 #define PY_MONITORING_EVENT_PY_START 0
 #define PY_MONITORING_EVENT_PY_RESUME 1
@@ -22,15 +22,18 @@ extern "C" {
 #define PY_MONITORING_EVENT_BRANCH_LEFT 8
 #define PY_MONITORING_EVENT_BRANCH_RIGHT 9
 #define PY_MONITORING_EVENT_STOP_ITERATION 10
+#define PY_MONITORING_EVENT_PY_UNWIND 11
 
+// TODO: PY_UNWIND requires no instrumentation so this definition is not
+// entirely correct.
 #define PY_MONITORING_IS_INSTRUMENTED_EVENT(ev) \
-    ((ev) < _PY_MONITORING_LOCAL_EVENTS)
+((ev) <= _PY_MONITORING_LOCAL_EVENTS)
+
 
 /* Other events, mainly exceptions */
 
-#define PY_MONITORING_EVENT_RAISE 11
 #define PY_MONITORING_EVENT_EXCEPTION_HANDLED 12
-#define PY_MONITORING_EVENT_PY_UNWIND 13
+#define PY_MONITORING_EVENT_RAISE 13
 #define PY_MONITORING_EVENT_PY_THROW 14
 #define PY_MONITORING_EVENT_RERAISE 15
 

--- a/Include/internal/pycore_instruments.h
+++ b/Include/internal/pycore_instruments.h
@@ -74,7 +74,7 @@ PyAPI_DATA(PyObject) _PyInstrumentation_DISABLE;
 /* Total tool ids available */
 #define  PY_MONITORING_TOOL_IDS 8
 /* Count of all local monitoring events */
-#define  _PY_MONITORING_LOCAL_EVENTS 11
+#define  _PY_MONITORING_LOCAL_EVENTS 12
 /* Count of all "real" monitoring events (not derived from other events) */
 #define _PY_MONITORING_UNGROUPED_EVENTS 16
 /* Count of all  monitoring events */

--- a/Python/ceval.h
+++ b/Python/ceval.h
@@ -431,7 +431,7 @@ monitor_unwind(PyThreadState *tstate,
                _PyInterpreterFrame *frame,
                _Py_CODEUNIT *instr)
 {
-    if (no_tools_for_global_event(tstate, PY_MONITORING_EVENT_PY_UNWIND)) {
+    if (no_tools_for_local_event(tstate, frame, PY_MONITORING_EVENT_PY_UNWIND)) {
         return;
     }
     do_monitor_exc(tstate, frame, instr, PY_MONITORING_EVENT_PY_UNWIND);

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1102,7 +1102,7 @@ get_tools_for_instruction(PyCodeObject *code, PyInterpreterState *interp, int i,
                 event == PY_MONITORING_EVENT_C_RETURN);
         event = PY_MONITORING_EVENT_CALL;
     }
-    if (PY_MONITORING_IS_INSTRUMENTED_EVENT(event)) {
+    if (PY_MONITORING_IS_LOCAL_EVENT(event)) {
         CHECK(debug_check_sanity(interp, code));
         if (code->_co_monitoring->tools) {
             tools = code->_co_monitoring->tools[i];


### PR DESCRIPTION
We make the PY_UNWIND monitoring event available as a code-local event to allow trapping on function exit events when an exception bubbles up. This complements the PY_RETURN event by allowing to catch any function exit event.

## Example

```python
import random, sys

m, e = sys.monitoring, sys.monitoring.events

m.use_tool_id(0, "debugger")

def monitor(event):
    def _(f):
        m.register_callback(0, event, f)
    return _

@monitor(e.PY_START)
def _(*_, **__):
    print("entering", sys._getframe(1))

@monitor(e.PY_UNWIND)
def _(*_, **__):
    print("exiting ", sys._getframe(1), "with exception")

def foo():
    raise RuntimeError()

def bar():
    return foo()

def baz():
    return bar()

m.set_local_events(0, random.choice([foo, bar, baz]).__code__, e.PY_UNWIND | e.PY_START)

try:
    baz()
except Exception:
    pass

# entering <frame at 0x101602f80, file 'test_py_unwind_local.py', line 34, code baz>
# exiting  <frame at 0x101602f80, file 'test_py_unwind_local.py', line 35, code baz> with exception
```

<!-- gh-issue-number: gh-142186 -->
* Issue: gh-142186
<!-- /gh-issue-number -->
