### PR TITLE
[3.14] gh-119452: Read/write CGI data using worker threads

### DIFF
--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -115,7 +115,7 @@ The module defines the following:
    :ref:`kevent-objects` below for the methods supported by kevent objects.
 
 
-.. function:: select(rlist, wlist, xlist[, timeout])
+.. function:: select(rlist, wlist, xlist, timeout=None)
 
    This is a straightforward interface to the Unix :c:func:`!select` system call.
    The first three arguments are iterables of 'waitable objects': either
@@ -130,7 +130,8 @@ The module defines the following:
    Empty iterables are allowed, but acceptance of three empty iterables is
    platform-dependent. (It is known to work on Unix but not on Windows.)  The
    optional *timeout* argument specifies a time-out as a floating-point number
-   in seconds.  When the *timeout* argument is omitted the function blocks until
+   in seconds.
+   When the *timeout* argument is omitted or ``None``, the function blocks until
    at least one file descriptor is ready.  A time-out value of zero specifies a
    poll and never blocks.
 

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1293,6 +1293,11 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
                 while select.select([self.rfile._sock], [], [], 0)[0]:
                     if not self.rfile._sock.recv(1):
                         break
+                try:
+                    p.stdin.close()
+                except OSError:
+                    # already closed?
+                    pass
             if self.command.lower() == "post" and nbytes > 0:
                 def _in_task():
                     """Pipe the input into the process stdin"""
@@ -1312,11 +1317,6 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
                         bytes_left -= len(data)
                         p.stdin.write(data)
                     finish_request()
-                    try:
-                        p.stdin.close()
-                    except OSError:
-                        # already closed
-                        pass
                 request_relay_thread = threading.Thread(target=_in_task)
                 request_relay_thread.start()
             else:


### PR DESCRIPTION
This reads/writes data as available, making the CGI application responsible for managing any timeouts when receiving data from clients.

Data is read in chunks of bounded size, and passed on immediately (except stderr, which is combined into a single message as before). 

This does need 3 threads. (As does process.communicate.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119452 -->
* Issue: gh-119452
<!-- /gh-issue-number -->
