### PR TITLE
[3.14] Revert "gh-119452: Fix a potential virtual memory allocation denial of service in http.server (GH-119455)"

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -134,10 +134,6 @@ DEFAULT_ERROR_MESSAGE = """\
 
 DEFAULT_ERROR_CONTENT_TYPE = "text/html;charset=utf-8"
 
-# Data larger than this will be read in chunks, to prevent extreme
-# overallocation.
-_MIN_READ_BUF_SIZE = 1 << 20
-
 class HTTPServer(socketserver.TCPServer):
 
     allow_reuse_address = True    # Seems to make sense in testing environment
@@ -1288,16 +1284,7 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
                                  env = env
                                  )
             if self.command.lower() == "post" and nbytes > 0:
-                cursize = 0
-                data = self.rfile.read(min(nbytes, _MIN_READ_BUF_SIZE))
-                while (len(data) < nbytes and len(data) != cursize and
-                       select.select([self.rfile._sock], [], [], 0)[0]):
-                    cursize = len(data)
-                    # This is a geometric increase in read size (never more
-                    # than doubling our the current length of data per loop
-                    # iteration).
-                    delta = min(cursize, nbytes - cursize)
-                    data += self.rfile.read(delta)
+                data = self.rfile.read(nbytes)
             else:
                 data = None
             # throw away additional data [see bug #427345]

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -913,20 +913,6 @@ for k, v in os.environ.items():
 print("</pre>")
 """
 
-cgi_file7 = """\
-#!%s
-import os
-import sys
-
-print("Content-type: text/plain")
-print()
-
-content_length = int(os.environ["CONTENT_LENGTH"])
-body = sys.stdin.buffer.read(content_length)
-
-print(f"{content_length} {len(body)}")
-"""
-
 
 @unittest.skipIf(hasattr(os, 'geteuid') and os.geteuid() == 0,
         "This test can't be run reliably as root (issue #13308).")
@@ -966,8 +952,6 @@ class CGIHTTPServerTestCase(BaseTestCase):
         self.file3_path = None
         self.file4_path = None
         self.file5_path = None
-        self.file6_path = None
-        self.file7_path = None
 
         # The shebang line should be pure ASCII: use symlink if possible.
         # See issue #7668.
@@ -1022,11 +1006,6 @@ class CGIHTTPServerTestCase(BaseTestCase):
             file6.write(cgi_file6 % self.pythonexe)
         os.chmod(self.file6_path, 0o777)
 
-        self.file7_path = os.path.join(self.cgi_dir, 'file7.py')
-        with open(self.file7_path, 'w', encoding='utf-8') as file7:
-            file7.write(cgi_file7 % self.pythonexe)
-        os.chmod(self.file7_path, 0o777)
-
         os.chdir(self.parent_dir)
 
     def tearDown(self):
@@ -1049,8 +1028,6 @@ class CGIHTTPServerTestCase(BaseTestCase):
                 os.remove(self.file5_path)
             if self.file6_path:
                 os.remove(self.file6_path)
-            if self.file7_path:
-                os.remove(self.file7_path)
             os.rmdir(self.cgi_child_dir)
             os.rmdir(self.cgi_dir)
             os.rmdir(self.cgi_dir_in_sub_dir)
@@ -1122,21 +1099,6 @@ class CGIHTTPServerTestCase(BaseTestCase):
         res = self.request('/cgi-bin/file2.py', 'POST', params, headers)
 
         self.assertEqual(res.read(), b'1, python, 123456' + self.linesep)
-
-    def test_large_content_length(self):
-        for w in range(15, 25):
-            size = 1 << w
-            body = b'X' * size
-            headers = {'Content-Length' : str(size)}
-            res = self.request('/cgi-bin/file7.py', 'POST', body, headers)
-            self.assertEqual(res.read(), b'%d %d' % (size, size) + self.linesep)
-
-    def test_large_content_length_truncated(self):
-        for w in range(18, 65):
-            size = 1 << w
-            headers = {'Content-Length' : str(size)}
-            res = self.request('/cgi-bin/file1.py', 'POST', b'x', headers)
-            self.assertEqual(res.read(), b'Hello World' + self.linesep)
 
     def test_invaliduri(self):
         res = self.request('/cgi-bin/invalid')

--- a/Misc/NEWS.d/next/Security/2024-05-23-11-44-41.gh-issue-119452.PRfsSv.rst
+++ b/Misc/NEWS.d/next/Security/2024-05-23-11-44-41.gh-issue-119452.PRfsSv.rst
@@ -1,5 +1,0 @@
-Fix a potential memory denial of service in the :mod:`http.server` module.
-When a malicious user is connected to the CGI server on Windows, it could cause
-an arbitrary amount of memory to be allocated.
-This could have led to symptoms including a :exc:`MemoryError`, swapping, out
-of memory (OOM) killed processes or containers, or even system crashes.


### PR DESCRIPTION
This reverts commit 29c657a1f231c0908796e0c9ff6967e15ab20d9b.

The issue needs fixing for Windows. It's an old bug, in CGI, which has been removed in 3.15, so let's revert for 3.14.1.

We have https://github.com/python/cpython/pull/142181 and https://github.com/python/cpython/pull/142185 to consider after that.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119452 -->
* Issue: gh-119452
<!-- /gh-issue-number -->
