### PR TITLE
gh-142188: Fix csv.Sniffer to handle CR and mixed line endings

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -364,7 +364,7 @@ class Sniffer:
         """
         from collections import Counter, defaultdict
 
-        data = list(filter(None, data.split('\n')))
+        data = list(filter(None, data.splitlines()))
 
         # build frequency tables
         chunkLength = min(10, len(data))

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1517,6 +1517,12 @@ ghi\0jkl
         with self.assertRaisesRegex(csv.Error, "Could not determine delimiter"):
             sniffer.sniff(sample)
 
+    def test_sniff_mixed_newlines(self):
+        # gh-142188: Sniffer should handle CR and mixed newlines
+        sample = "User,ID\rAlice,001\nBob,002"
+        sniffer = csv.Sniffer()
+        dialect = sniffer.sniff(sample)
+        self.assertEqual(dialect.delimiter, ',')
 
 class NUL:
     def write(s, *args):

--- a/Misc/NEWS.d/next/Library/2025-12-02-13-21-10.gh-issue-142188.pBpg6S.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-02-13-21-10.gh-issue-142188.pBpg6S.rst
@@ -1,0 +1,1 @@
+Fix `csv.Sniffer` to correctly handle CR (`\r`) and mixed line endings by using `splitlines()`.

--- a/Misc/NEWS.d/next/Library/2025-12-02-13-21-10.gh-issue-142188.pBpg6S.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-02-13-21-10.gh-issue-142188.pBpg6S.rst
@@ -1,1 +1,1 @@
-Fix `csv.Sniffer` to correctly handle CR (`\r`) and mixed line endings by using `splitlines()`.
+Fix ``csv.Sniffer`` to correctly handle CR (``\r``) and mixed line endings by using ``splitlines()``.


### PR DESCRIPTION
This PR fixes `csv.Sniffer` failure on Classic Mac (`\r`) or mixed line endings by replacing hardcoded `split('\n')` with `splitlines()`.

**Issue:**
- Fixes #142188
- The original code `data.split('\n')` ignored `\r`, causing line merging and incorrect delimiter detection (silent corruption).

**Changes:**
- Modified `Lib/csv.py`: Replaced `data.split('\n')` with `data.splitlines()`.
- Added regression test `test_sniff_mixed_newlines` in `Lib/test/test_csv.py`.

**Verification:**
Ran `python -m test test_csv` locally and passed.

<!-- gh-issue-number: gh-142188 -->
* Issue: gh-142188
<!-- /gh-issue-number -->
