### PR TITLE
gh-142168: explicitly initialize `stack_array` in `_PyEval_Vector` and `_PyEvalFramePushAndInit_Ex`

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2060,7 +2060,7 @@ _PyEvalFramePushAndInit_Ex(PyThreadState *tstate, _PyStackRef func,
     PyObject *kwnames = NULL;
     _PyStackRef *newargs;
     PyObject *const *object_array = NULL;
-    _PyStackRef stack_array[8];
+    _PyStackRef stack_array[8] = {0};
     if (has_dict) {
         object_array = _PyStack_UnpackDict(tstate, _PyTuple_ITEMS(callargs), nargs, kwargs, &kwnames);
         if (object_array == NULL) {
@@ -2123,7 +2123,7 @@ _PyEval_Vector(PyThreadState *tstate, PyFunctionObject *func,
     if (kwnames) {
         total_args += PyTuple_GET_SIZE(kwnames);
     }
-    _PyStackRef stack_array[8];
+    _PyStackRef stack_array[8] = {0};
     _PyStackRef *arguments;
     if (total_args <= 8) {
         arguments = stack_array;


### PR DESCRIPTION
To stop the warning.

Reproduce steps:

```
./configure --enable-optimizations --with-lto
make -s -j $(nproc);
```


<!-- gh-issue-number: gh-142168 -->
* Issue: gh-142168
<!-- /gh-issue-number -->
