### PR TITLE
Revert "gh-140482: Preserve and restore `stty echo` as a test environment (#140519)

### DIFF
--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -9,13 +9,6 @@ from test.support import os_helper
 
 from .utils import print_warning
 
-# Import termios to save and restore terminal echo.  This is only available on
-# Unix, and it's fine if the module can't be found.
-try:
-    import termios                                # noqa: F401
-except ModuleNotFoundError:
-    pass
-
 
 class SkipTestEnvironment(Exception):
     pass
@@ -72,7 +65,6 @@ class saved_test_environment:
                  'shutil_archive_formats', 'shutil_unpack_formats',
                  'asyncio.events._event_loop_policy',
                  'urllib.requests._url_tempfiles', 'urllib.requests._opener',
-                 'stty_echo',
                 )
 
     def get_module(self, name):
@@ -299,24 +291,6 @@ class saved_test_environment:
     def restore_warnings_showwarning(self, fxn):
         warnings = self.get_module('warnings')
         warnings.showwarning = fxn
-
-    def get_stty_echo(self):
-        termios = self.try_get_module('termios')
-        if not os.isatty(fd := sys.__stdin__.fileno()):
-            return None
-        attrs = termios.tcgetattr(fd)
-        lflags = attrs[3]
-        return bool(lflags & termios.ECHO)
-    def restore_stty_echo(self, echo):
-        termios = self.get_module('termios')
-        attrs = termios.tcgetattr(fd := sys.__stdin__.fileno())
-        if echo:
-            # Turn echo on.
-            attrs[3] |= termios.ECHO
-        else:
-            # Turn echo off.
-            attrs[3] &= ~termios.ECHO
-        termios.tcsetattr(fd, termios.TCSADRAIN, attrs)
 
     def resource_info(self):
         for name in self.resources:


### PR DESCRIPTION
Reverts https://github.com/python/cpython/pull/140519.

This reverts commit b3c713a0af5f5c4b5704d8019a893a1b70eba941.

Reason: The PR leads to spurious "ENV CHANGED" failures when running tests in an interactive terminal.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140482 -->
* Issue: gh-140482
<!-- /gh-issue-number -->
