### PR TITLE
gh-140482: Avoid changing terminal settings in test_pty

### DIFF
--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -306,10 +306,17 @@ class PtyTest(unittest.TestCase):
             os._exit(0)
 
         try:
+            buf = bytearray()
+            try:
+                while (data := os.read(fd, 1024)) != b'':
+                    buf.extend(data)
+            except OSError as e:
+                if e.errno != errno.EIO:
+                    raise
+
             (pid, status) = os.waitpid(pid, 0)
             self.assertEqual(status, 0)
-            data = os.read(fd, 1024)
-            self.assertEqual(data, b"hi there\r\n")
+            self.assertEqual(buf.take_bytes(), b"hi there\r\n")
         finally:
             os.close(fd)
 

--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -3,7 +3,6 @@ from test.support import (
     is_android, is_apple_mobile, is_wasm32, reap_children, verbose, warnings_helper
 )
 from test.support.import_helper import import_module
-from test.support.os_helper import TESTFN, unlink
 
 # Skip these tests if termios is not available
 import_module('termios')


### PR DESCRIPTION
The previous test_spawn_doesnt_hang test had a few problems:

* It would cause ENV CHANGED failures if other tests were running concurrently due to stty changes
* Typing while the test was running could cause it to fail


<!-- gh-issue-number: gh-140482 -->
* Issue: gh-140482
<!-- /gh-issue-number -->
