### PR TITLE
gh-140125: Increase object recursion depth for `test_json` from 200k to 500k

### DIFF
--- a/Lib/test/test_json/test_recursion.py
+++ b/Lib/test/test_json/test_recursion.py
@@ -71,7 +71,7 @@ class TestRecursion:
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     def test_highly_nested_objects_decoding(self):
-        very_deep = 500000
+        very_deep = 500_000
         # test that loading highly-nested objects doesn't segfault when C
         # accelerations are used. See #12017
         with self.assertRaises(RecursionError):

--- a/Lib/test/test_json/test_recursion.py
+++ b/Lib/test/test_json/test_recursion.py
@@ -71,7 +71,7 @@ class TestRecursion:
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     def test_highly_nested_objects_decoding(self):
-        very_deep = 200000
+        very_deep = 500000
         # test that loading highly-nested objects doesn't segfault when C
         # accelerations are used. See #12017
         with self.assertRaises(RecursionError):
@@ -90,7 +90,7 @@ class TestRecursion:
     def test_highly_nested_objects_encoding(self):
         # See #12051
         l, d = [], {}
-        for x in range(200_000):
+        for x in range(500_000):
             l, d = [l], {'k':d}
         with self.assertRaises(RecursionError):
             with support.infinite_recursion(5000):


### PR DESCRIPTION
<!-- gh-issue-number: gh-140125 -->
* Issue: gh-140125
<!-- /gh-issue-number -->

It appears increasing this recursion depth of the object resolves the issue where it can fail to hit the stack limit on macOS during PGO.

The PGO test runtime seemed unaffected on macOS and the test runtime in CI here seems within noise.