### PR TITLE
gh-142225: Fix `PyABIInfo_VAR` macro

### DIFF
--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -140,7 +140,7 @@ PyAPI_FUNC(int) PyABIInfo_Check(PyABIInfo *info, const char *module_name);
     /////////////////////////////////////////////////////////
 
 #define PyABIInfo_VAR(NAME) \
-    static PyABIInfo NAME = _PyABIInfo_DEFAULT;
+    static PyABIInfo NAME = _PyABIInfo_DEFAULT();
 
 #undef _PyABIInfo_DEFAULT_STABLE
 #undef _PyABIInfo_DEFAULT_FT

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -132,7 +132,7 @@ PyAPI_FUNC(int) PyABIInfo_Check(PyABIInfo *info, const char *module_name);
     )                                                       \
     /////////////////////////////////////////////////////////
 
-#define _PyABIInfo_DEFAULT() {                              \
+#define _PyABIInfo_DEFAULT {                              \
         1, 0,                                               \
         PyABIInfo_DEFAULT_FLAGS,                            \
         PY_VERSION_HEX,                                     \
@@ -140,7 +140,7 @@ PyAPI_FUNC(int) PyABIInfo_Check(PyABIInfo *info, const char *module_name);
     /////////////////////////////////////////////////////////
 
 #define PyABIInfo_VAR(NAME) \
-    static PyABIInfo NAME = _PyABIInfo_DEFAULT();
+    static PyABIInfo NAME = _PyABIInfo_DEFAULT;
 
 #undef _PyABIInfo_DEFAULT_STABLE
 #undef _PyABIInfo_DEFAULT_FT

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -132,7 +132,7 @@ PyAPI_FUNC(int) PyABIInfo_Check(PyABIInfo *info, const char *module_name);
     )                                                       \
     /////////////////////////////////////////////////////////
 
-#define _PyABIInfo_DEFAULT {                              \
+#define _PyABIInfo_DEFAULT {                                \
         1, 0,                                               \
         PyABIInfo_DEFAULT_FLAGS,                            \
         PY_VERSION_HEX,                                     \

--- a/Misc/NEWS.d/next/C_API/2025-12-03-16-35-24.gh-issue-142225.vmCJoo.rst
+++ b/Misc/NEWS.d/next/C_API/2025-12-03-16-35-24.gh-issue-142225.vmCJoo.rst
@@ -1,0 +1,1 @@
+Fixed the :c:macro:`PyABIInfo_VAR` macro.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

```
Include/modsupport.h:143:29: error: '_PyABIInfo_DEFAULT' undeclared here (not in a function); did you mean 'PyABIInfo_STABLE'?
  143 |     static PyABIInfo NAME = _PyABIInfo_DEFAULT;
      |                             ^~~~~~~~~~~~~~~~~~
/tmp/test.c:4:1: note: in expansion of macro 'PyABIInfo_VAR'
    4 | PyABIInfo_VAR(test_abi_info);
      | ^~~~~~~~~~~~~
```

<!-- gh-issue-number: gh-142225 -->
* Issue: gh-142225
<!-- /gh-issue-number -->
