### PR TITLE
[3.13] Revert "[3.13] gh-140797: Forbid capturing groups in re.Scanner lexicon patterns (GH-140944) (GH-140983)"

### DIFF
--- a/Lib/re/__init__.py
+++ b/Lib/re/__init__.py
@@ -399,12 +399,9 @@ class Scanner:
         s = _parser.State()
         s.flags = flags
         for phrase, action in lexicon:
-            sub_pattern = _parser.parse(phrase, flags)
-            if sub_pattern.state.groups != 1:
-                raise ValueError("Cannot use capturing groups in re.Scanner")
             gid = s.opengroup()
             p.append(_parser.SubPattern(s, [
-                (SUBPATTERN, (gid, 0, 0, sub_pattern)),
+                (SUBPATTERN, (gid, 0, 0, _parser.parse(phrase, flags))),
                 ]))
             s.closegroup(gid, p[-1])
         p = _parser.SubPattern(s, [(BRANCH, (None, p))])

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1638,24 +1638,6 @@ class ReTests(unittest.TestCase):
                          (['sum', 'op=', 3, 'op*', 'foo', 'op+', 312.5,
                            'op+', 'bar'], ''))
 
-    def test_bug_gh140797(self):
-        # gh140797: Capturing groups are not allowed in re.Scanner
-
-        msg = r"Cannot use capturing groups in re\.Scanner"
-        # Capturing group throws an error
-        with self.assertRaisesRegex(ValueError, msg):
-            Scanner([("(a)b", None)])
-
-        # Named Group
-        with self.assertRaisesRegex(ValueError, msg):
-            Scanner([("(?P<name>a)", None)])
-
-        # Non-capturing groups should pass normally
-        s = Scanner([("(?:a)b", lambda scanner, token: token)])
-        result, rem = s.scan("ab")
-        self.assertEqual(result,['ab'])
-        self.assertEqual(rem,'')
-
     def test_bug_448951(self):
         # bug 448951 (similar to 429357, but with single char match)
         # (Also test greedy matches.)

--- a/Misc/NEWS.d/next/Library/2025-12-03-19-33-17.gh-issue-140797.YxB27u.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-03-19-33-17.gh-issue-140797.YxB27u.rst
@@ -1,0 +1,3 @@
+Revert changes to the undocumented :class:`!re.Scanner` class. Capturing
+groups are still allowed for backward compatibility, although using them can
+lead to incorrect result. They will be forbidden in future Python versions.


### PR DESCRIPTION
This reverts commit ee894d2abbdb9678f4cecdc15707496a0eea7f85.


<!-- gh-issue-number: gh-140797 -->
* Issue: gh-140797
<!-- /gh-issue-number -->
