### PR TITLE
[3.13] gh-142218: Fix split table dictionary crash (gh-142229)

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1674,6 +1674,14 @@ class DictTest(unittest.TestCase):
 
         self.assertEqual(len(d), 1)
 
+    def test_split_table_update_with_str_subclass(self):
+        class MyStr(str): pass
+        class MyClass: pass
+        obj = MyClass()
+        obj.attr = 1
+        obj.__dict__[MyStr('attr')] = 2
+        self.assertEqual(obj.attr, 2)
+
 
 class CAPITest(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2025-12-03-11-03-35.gh-issue-142218.44Fq_J.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-12-03-11-03-35.gh-issue-142218.44Fq_J.rst
@@ -1,0 +1,2 @@
+Fix crash when inserting into a split table dictionary with a non
+:class:`str` key that matches an existing key.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1873,10 +1873,14 @@ insertdict(PyInterpreterState *interp, PyDictObject *mp,
         uint64_t new_version = _PyDict_NotifyEvent(
                 interp, PyDict_EVENT_MODIFIED, mp, key, value);
         assert(old_value != NULL);
-        assert(!_PyDict_HasSplitTable(mp));
         if (DK_IS_UNICODE(mp->ma_keys)) {
-            PyDictUnicodeEntry *ep = &DK_UNICODE_ENTRIES(mp->ma_keys)[ix];
-            STORE_VALUE(ep, value);
+            if (_PyDict_HasSplitTable(mp)) {
+                STORE_SPLIT_VALUE(mp, ix, value);
+            }
+            else {
+                PyDictUnicodeEntry *ep = &DK_UNICODE_ENTRIES(mp->ma_keys)[ix];
+                STORE_VALUE(ep, value);
+            }
         }
         else {
             PyDictKeyEntry *ep = &DK_ENTRIES(mp->ma_keys)[ix];


### PR DESCRIPTION
This fixes a regression introduced in gh-140558. The interpreter would crash if we inserted a non `str` key into a split table that matches an existing key.
(cherry picked from commit 547d8daf780646e2800bec598ed32085817c8606)


<!-- gh-issue-number: gh-142218 -->
* Issue: gh-142218
<!-- /gh-issue-number -->
