### PR TITLE
Docs: fix RFC index reference for TLS 1.3

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -185,7 +185,7 @@ class _TLSContentType:
 class _TLSAlertType:
     """Alert types for TLSContentType.ALERT messages
 
-    See RFC 8466, section B.2
+    See RFC 8446, section B.2
     """
     CLOSE_NOTIFY = 0
     UNEXPECTED_MESSAGE = 10

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5613,7 +5613,7 @@ class TestEnumerations(unittest.TestCase):
         class Checked_TLSAlertType(enum.IntEnum):
             """Alert types for TLSContentType.ALERT messages
 
-            See RFC 8466, section B.2
+            See RFC 8446, section B.2
             """
             CLOSE_NOTIFY = 0
             UNEXPECTED_MESSAGE = 10


### PR DESCRIPTION
A small typo in Lib/ssl.py.

TLS v1.3 is RFC 84**4**6, not RFC 84**6**6.
