### PR TITLE
gh-141794: Reduce size of compiler stress tests to fix Android warnings

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -992,7 +992,7 @@ class AST_Tests(unittest.TestCase):
     @skip_wasi_stack_overflow()
     @skip_emscripten_stack_overflow()
     def test_ast_recursion_limit(self):
-        crash_depth = 500_000
+        crash_depth = 100_000
         success_depth = 200
         if _testinternalcapi is not None:
             remaining = _testinternalcapi.get_c_recursion_remaining()

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -992,7 +992,8 @@ class AST_Tests(unittest.TestCase):
     @skip_wasi_stack_overflow()
     @skip_emscripten_stack_overflow()
     def test_ast_recursion_limit(self):
-        crash_depth = 100_000
+        # Android test devices have less memory.
+        crash_depth = 100_000 if sys.platform == "android" else 500_000
         success_depth = 200
         if _testinternalcapi is not None:
             remaining = _testinternalcapi.get_c_recursion_remaining()

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -728,7 +728,8 @@ class TestSpecifics(unittest.TestCase):
     def test_compiler_recursion_limit(self):
         # Compiler frames are small
         limit = 100
-        crash_depth = limit * 1000
+        # Android test devices have less memory.
+        crash_depth = limit * (1000 if sys.platform == "android" else 5000)
         success_depth = limit
 
         def check_limit(prefix, repeated, mode="single"):
@@ -1036,11 +1037,13 @@ class TestSpecifics(unittest.TestCase):
         # An implicit test for PyUnicode_FSDecoder().
         compile("42", FakePath("test_compile_pathlike"), "single")
 
+    # bpo-31113: Stack overflow when compile a long sequence of
+    # complex statements.
     @support.requires_resource('cpu')
     def test_stack_overflow(self):
-        # bpo-31113: Stack overflow when compile a long sequence of
-        # complex statements.
-        compile("if a: b\n" * 100000, "<dummy>", "exec")
+        # Android test devices have less memory.
+        size = 100_000 if sys.platform == "android" else 200_000
+        compile("if a: b\n" * size, "<dummy>", "exec")
 
     # Multiple users rely on the fact that CPython does not generate
     # bytecode for dead code blocks. See bpo-37500 for more context.

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -728,7 +728,7 @@ class TestSpecifics(unittest.TestCase):
     def test_compiler_recursion_limit(self):
         # Compiler frames are small
         limit = 100
-        crash_depth = limit * 5000
+        crash_depth = limit * 1000
         success_depth = limit
 
         def check_limit(prefix, repeated, mode="single"):
@@ -1040,7 +1040,7 @@ class TestSpecifics(unittest.TestCase):
     def test_stack_overflow(self):
         # bpo-31113: Stack overflow when compile a long sequence of
         # complex statements.
-        compile("if a: b\n" * 200000, "<dummy>", "exec")
+        compile("if a: b\n" * 100000, "<dummy>", "exec")
 
     # Multiple users rely on the fact that CPython does not generate
     # bytecode for dead code blocks. See bpo-37500 for more context.


### PR DESCRIPTION
This fixes the Android low memory warnings in `test_ast` and `test_compile`, previously discussed in https://github.com/python/cpython/pull/137186#issuecomment-3136301023.

These warnings haven't led to a crash so far. However, the warning will only appear during the first test that brings the memory below a threshold. If a later test exhausts the memory completely, then the warning won't appear again, and the process will simply crash. This separation between the warning and the crash makes the crash much more difficult to understand.

I think this may have been what happened in https://github.com/python/cpython/pull/142228#issuecomment-3612898724, which introduced some leaks. Notice in [this run](https://github.com/python/cpython/actions/runs/19903332309/job/57052958381), the warning appeared during `test_ast`, and the crash happened in `test_random`.

<!-- gh-issue-number: gh-141794 -->
* Issue: gh-141794
<!-- /gh-issue-number -->
