### PR TITLE
GH-142267: Cache formatter to avoid repeated `_set_color` calls

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1,5 +1,4 @@
 # Author: Steven J. Bethard <steven.bethard@gmail.com>.
-# New maintainer as of 29 August 2019:  Raymond Hettinger <raymond.hettinger@gmail.com>
 
 """Command-line parsing library
 
@@ -1570,8 +1569,8 @@ class _ActionsContainer(object):
                             f'instance of it must be passed')
 
         # raise an error if the metavar does not match the type
-        if hasattr(self, "_get_formatter"):
-            formatter = self._get_formatter()
+        if hasattr(self, "_get_validation_formatter"):
+            formatter = self._get_validation_formatter()
             try:
                 formatter._format_args(action, None)
             except TypeError:
@@ -1765,8 +1764,8 @@ class _ActionsContainer(object):
                 action.container._remove_action(action)
 
     def _check_help(self, action):
-        if action.help and hasattr(self, "_get_formatter"):
-            formatter = self._get_formatter()
+        if action.help and hasattr(self, "_get_validation_formatter"):
+            formatter = self._get_validation_formatter()
             try:
                 formatter._expand_help(action)
             except (ValueError, TypeError, KeyError) as exc:
@@ -1920,6 +1919,9 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         self.exit_on_error = exit_on_error
         self.suggest_on_error = suggest_on_error
         self.color = color
+
+        # Cached formatter for validation (avoids repeated _set_color calls)
+        self._cached_formatter = None
 
         add_group = self.add_argument_group
         self._positionals = add_group(_('positional arguments'))
@@ -2751,6 +2753,13 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         formatter = self.formatter_class(prog=self.prog)
         formatter._set_color(self.color)
         return formatter
+
+    def _get_validation_formatter(self):
+        # Return cached formatter for read-only validation operations
+        # (_expand_help and _format_args). Avoids repeated _set_color calls.
+        if self._cached_formatter is None:
+            self._cached_formatter = self._get_formatter()
+        return self._cached_formatter
 
     # =====================
     # Help-printing methods

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1,4 +1,5 @@
 # Author: Steven J. Bethard <steven.bethard@gmail.com>.
+# New maintainer as of 29 August 2019:  Raymond Hettinger <raymond.hettinger@gmail.com>
 
 """Command-line parsing library
 
@@ -2756,7 +2757,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
     def _get_validation_formatter(self):
         # Return cached formatter for read-only validation operations
-        # (_expand_help and _format_args). Avoids repeated _set_color calls.
+        # (_expand_help and _format_args). Avoids repeated slow _set_color calls.
         if self._cached_formatter is None:
             self._cached_formatter = self._get_formatter()
         return self._cached_formatter

--- a/Misc/NEWS.d/next/Library/2025-12-04-23-26-12.gh-issue-142267.yOM6fP.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-04-23-26-12.gh-issue-142267.yOM6fP.rst
@@ -1,0 +1,1 @@
+Improve :mod:`argparse` performance by caching the formatter used for argument validation.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

**bm_subparsers benchmark** (1000 optional arguments, 10 iterations):

| Version | Time | 
|---------|------|
| 3.13 | 0.246s |
| 3.14 | 0.934s |
| 3.15 (main) | 0.883s |
| **3.15 (with fix)** | **0.158s** |

**Profiled with Tachyon** (`./python.exe -m profiling.sampling --live`):

Before:
`🥇 HelpFormatter._set_color (12.6%) │ 🥈 Mapping.get (5.4%) │ 🥉 can_colorize._safe_getenv (4.1%)`

After:
`🥇 <GC> (8.4%) │ 🥈 bm_subparsers (8.3%) │ 🥉 _ActionsContainer.add_argument (7.3%)`


<!-- gh-issue-number: gh-142267 -->
* Issue: gh-142267
* Issue: gh-141571
<!-- /gh-issue-number -->
