### PR TITLE
GH-139862: Remove `color` from HelpFormatter

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -166,7 +166,6 @@ class HelpFormatter(object):
         indent_increment=2,
         max_help_position=24,
         width=None,
-        color=True,
     ):
         # default setting for width
         if width is None:
@@ -174,7 +173,6 @@ class HelpFormatter(object):
             width = shutil.get_terminal_size().columns
             width -= 2
 
-        self._set_color(color)
         self._prog = prog
         self._indent_increment = indent_increment
         self._max_help_position = min(max_help_position,

--- a/Misc/NEWS.d/next/Library/2025-12-04-23-24-24.gh-issue-139862.NBfsD4.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-04-23-24-24.gh-issue-139862.NBfsD4.rst
@@ -1,0 +1,1 @@
+Remove ``color`` parameter from :class:`argparse.HelpFormatter` constructor. Color is controlled by :class:`ArgumentParser`.

--- a/Misc/NEWS.d/next/Library/2025-12-04-23-24-24.gh-issue-139862.NBfsD4.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-04-23-24-24.gh-issue-139862.NBfsD4.rst
@@ -1,1 +1,1 @@
-Remove ``color`` parameter from :class:`argparse.HelpFormatter` constructor. Color is controlled by :class:`ArgumentParser`.
+Remove ``color`` parameter from :class:`!argparse.HelpFormatter` constructor. Color is controlled by :class:`~argparse.ArgumentParser`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

After digging into this, I think that we should just remove color from being passed into HelpFormatter, since this never worked and was never documented. IMO, this should be controlled by the parser anyway.


<!-- gh-issue-number: gh-139862 -->
* Issue: gh-139862
<!-- /gh-issue-number -->
