### PR TITLE
Fix disk space issues in Android CI

### DIFF
--- a/Android/testbed/app/build.gradle.kts
+++ b/Android/testbed/app/build.gradle.kts
@@ -79,7 +79,7 @@ android {
     val androidEnvFile = file("../../android-env.sh").absoluteFile
 
     namespace = "org.python.testbed"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "org.python.testbed"
@@ -92,7 +92,7 @@ android {
             }
             throw GradleException("Failed to find API level in $androidEnvFile")
         }
-        targetSdk = 34
+        targetSdk = 35
 
         versionCode = 1
         versionName = "1.0"


### PR DESCRIPTION
For details, see https://github.com/freakboy3742/pyspamsum/pull/108. Of the ideas listed there, this PR includes the NDK version cleanup and the emulator image change. It doesn't include the idea to use the runner's second disk, as there's no guarantee that will continue to be available in the future.