### PR TITLE
GH-75949: Fix argparse dropping '|' in mutually exclusive groups on line wrap

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -358,7 +358,7 @@ class HelpFormatter(object):
                 # keep optionals and positionals together to preserve
                 # mutually exclusive group formatting (gh-75949)
                 all_actions = optionals + positionals
-                parts, pos_start = self._get_actions_usage_parts(
+                parts, pos_start = self._get_actions_usage_parts_with_split(
                     all_actions, groups, len(optionals)
                 )
                 opt_parts = parts[:pos_start]
@@ -420,13 +420,23 @@ class HelpFormatter(object):
         return f'{t.usage}{prefix}{t.reset}{usage}\n\n'
 
     def _format_actions_usage(self, actions, groups):
-        parts, _ = self._get_actions_usage_parts(actions, groups)
-        return ' '.join(parts)
+        return ' '.join(self._get_actions_usage_parts(actions, groups))
 
     def _is_long_option(self, string):
         return len(string) > 2
 
-    def _get_actions_usage_parts(self, actions, groups, opt_count=None):
+    def _get_actions_usage_parts(self, actions, groups):
+        parts, _ = self._get_actions_usage_parts_with_split(actions, groups)
+        return parts
+
+    def _get_actions_usage_parts_with_split(self, actions, groups, opt_count=None):
+        """Get usage parts with split index for optionals/positionals.
+
+        Returns (parts, pos_start) where pos_start is the index in parts
+        where positionals begin. When opt_count is None, pos_start is None.
+        This preserves mutually exclusive group formatting across the
+        optionals/positionals boundary (gh-75949).
+        """
         # find group indices and identify actions in groups
         group_actions = set()
         inserts = {}

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -358,7 +358,7 @@ class HelpFormatter(object):
                 # keep optionals and positionals together to preserve
                 # mutually exclusive group formatting (gh-75949)
                 all_actions = optionals + positionals
-                parts, pos_start = self._get_actions_usage_parts_split(
+                parts, pos_start = self._get_actions_usage_parts(
                     all_actions, groups, len(optionals)
                 )
                 opt_parts = parts[:pos_start]
@@ -420,23 +420,13 @@ class HelpFormatter(object):
         return f'{t.usage}{prefix}{t.reset}{usage}\n\n'
 
     def _format_actions_usage(self, actions, groups):
-        return ' '.join(self._get_actions_usage_parts(actions, groups))
+        parts, _ = self._get_actions_usage_parts(actions, groups)
+        return ' '.join(parts)
 
     def _is_long_option(self, string):
         return len(string) > 2
 
-    def _get_actions_usage_parts(self, actions, groups):
-        parts, _ = self._get_actions_usage_parts_split(actions, groups, None)
-        return parts
-
-    def _get_actions_usage_parts_split(self, actions, groups, opt_count):
-        """Get usage parts with split index for optionals/positionals.
-
-        Returns (parts, pos_start) where pos_start is the index in parts
-        where positionals begin. When opt_count is None, pos_start is None.
-        This preserves mutually exclusive group formatting across the
-        optionals/positionals boundary (gh-75949).
-        """
+    def _get_actions_usage_parts(self, actions, groups, opt_count=None):
         # find group indices and identify actions in groups
         group_actions = set()
         inserts = {}
@@ -532,15 +522,15 @@ class HelpFormatter(object):
             for i in range(start + group_size, end):
                 parts[i] = None
 
-        # calculate the split point for optionals/positionals
-        # before filtering out None entries
+        # if opt_count is provided, calculate where positionals start in
+        # the final parts list (for wrapping onto separate lines).
+        # Count before filtering None entries since indices shift after.
         if opt_count is not None:
-            # Count non-None parts in the optionals section
             pos_start = sum(1 for p in parts[:opt_count] if p is not None)
         else:
             pos_start = None
 
-        # return the usage parts and split point
+        # return the usage parts and split point (gh-75949)
         return [item for item in parts if item is not None], pos_start
 
     def _format_text(self, text):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4966,6 +4966,28 @@ class TestHelpUsageNoWhitespaceCrash(TestCase):
         ''')
         self.assertEqual(parser.format_usage(), usage)
 
+    def test_mutex_groups_with_mixed_optionals_positionals_wrap(self):
+        # https://github.com/python/cpython/issues/75949
+        # Mutually exclusive groups containing both optionals and positionals
+        # should preserve pipe separators when the usage line wraps.
+        parser = argparse.ArgumentParser(prog='PROG')
+        g = parser.add_mutually_exclusive_group()
+        g.add_argument('-v', '--verbose', action='store_true')
+        g.add_argument('-q', '--quiet', action='store_true')
+        g.add_argument('-x', '--extra-long-option-name', nargs='?')
+        g.add_argument('-y', '--yet-another-long-option', nargs='?')
+        g.add_argument('positional1', nargs='?')
+        g.add_argument('positional2', nargs='?')
+        g.add_argument('positional3', nargs='?')
+        g.add_argument('positional4', nargs='?')
+
+        usage = textwrap.dedent('''\
+        usage: PROG [-h] [-v | -q | -x [EXTRA_LONG_OPTION_NAME] |
+                    -y [YET_ANOTHER_LONG_OPTION] |
+                    positional1 | positional2 | positional3 | positional4]
+        ''')
+        self.assertEqual(parser.format_usage(), usage)
+
 
 class TestHelpVariableExpansion(HelpTestCase):
     """Test that variables are expanded properly in help messages"""

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4976,15 +4976,12 @@ class TestHelpUsageNoWhitespaceCrash(TestCase):
         g.add_argument('-q', '--quiet', action='store_true')
         g.add_argument('-x', '--extra-long-option-name', nargs='?')
         g.add_argument('-y', '--yet-another-long-option', nargs='?')
-        g.add_argument('positional1', nargs='?')
-        g.add_argument('positional2', nargs='?')
-        g.add_argument('positional3', nargs='?')
-        g.add_argument('positional4', nargs='?')
+        g.add_argument('positional', nargs='?')
 
         usage = textwrap.dedent('''\
         usage: PROG [-h] [-v | -q | -x [EXTRA_LONG_OPTION_NAME] |
                     -y [YET_ANOTHER_LONG_OPTION] |
-                    positional1 | positional2 | positional3 | positional4]
+                    positional]
         ''')
         self.assertEqual(parser.format_usage(), usage)
 

--- a/Misc/NEWS.d/next/Library/2025-12-05-16-39-17.gh-issue-75949.pHxW98.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-05-16-39-17.gh-issue-75949.pHxW98.rst
@@ -1,0 +1,1 @@
+Fix :mod:`argparse` to preserve ``|`` separators in mutually exclusive groups when the usage line wraps due to length.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-75949 -->
* Issue: gh-75949
<!-- /gh-issue-number -->
