### PR TITLE
gh-142318: Fix typing `'q'` at interactive help screen exiting Tachyon

### DIFF
--- a/Lib/profiling/sampling/live_collector/collector.py
+++ b/Lib/profiling/sampling/live_collector/collector.py
@@ -861,10 +861,12 @@ class LiveStatsCollector(Collector):
         # Handle help toggle keys
         if ch == ord("h") or ch == ord("H") or ch == ord("?"):
             self.show_help = not self.show_help
+            return
 
         # If showing help, any other key closes it
-        elif self.show_help and ch != -1:
+        if self.show_help and ch != -1:
             self.show_help = False
+            return
 
         # Handle regular commands
         if ch == ord("q") or ch == ord("Q"):

--- a/Lib/test/test_profiling/test_sampling_profiler/test_live_collector_interaction.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_live_collector_interaction.py
@@ -173,6 +173,19 @@ class TestLiveCollectorInteractiveControls(unittest.TestCase):
 
         self.assertTrue(self.collector.show_help)
 
+    def test_help_dismiss_with_q_does_not_quit(self):
+        """Test that pressing 'q' while help is shown only closes help, not quit"""
+        self.assertFalse(self.collector.show_help)
+        self.display.simulate_input(ord("h"))
+        self.collector._handle_input()
+        self.assertTrue(self.collector.show_help)
+
+        self.display.simulate_input(ord("q"))
+        self.collector._handle_input()
+
+        self.assertFalse(self.collector.show_help)
+        self.assertTrue(self.collector.running)
+
     def test_filter_clear(self):
         """Test clearing filter."""
         self.collector.filter_pattern = "test"

--- a/Misc/NEWS.d/next/Library/2025-12-05-18-25-29.gh-issue-142318.EzcQ3N.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-05-18-25-29.gh-issue-142318.EzcQ3N.rst
@@ -1,0 +1,2 @@
+Fix typing ``'q'`` at the help of the interactive tachyon profiler exiting
+the profiler.


### PR DESCRIPTION
Finally a good reason to explore it 😆

<!-- gh-issue-number: gh-142318 -->
* Issue: gh-142318
<!-- /gh-issue-number -->
