### PR TITLE
Modules/termios.c: stop using TC operations that need termio.h

### DIFF
--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -1116,9 +1116,6 @@ static struct constant {
 #ifdef TCFLSH
     {"TCFLSH", TCFLSH},
 #endif
-#ifdef TCGETA
-    {"TCGETA", TCGETA},
-#endif
 #ifdef TCGETS
     {"TCGETS", TCGETS},
 #endif
@@ -1127,15 +1124,6 @@ static struct constant {
 #endif
 #ifdef TCSBRKP
     {"TCSBRKP", TCSBRKP},
-#endif
-#ifdef TCSETA
-    {"TCSETA", TCSETA},
-#endif
-#ifdef TCSETAF
-    {"TCSETAF", TCSETAF},
-#endif
-#ifdef TCSETAW
-    {"TCSETAW", TCSETAW},
 #endif
 #ifdef TCSETS
     {"TCSETS", TCSETS},


### PR DESCRIPTION
Modules/termios.c makes use of TCGETA, TCSETA, TCSETAF and TCSETAW if they are defined. They are defined by kernel headers on a limited set of CPU architectures, but require the "struct termio" definition to exist, and this structure definition has been removed from glibc as of version 2.42.

Since these are seldomly used, we take the approach of just dropping support for those, in order to fix the following build issue:

./Modules/termios.c:1119:16: error: invalid application of 'sizeof' to incomplete type 'struct termio'
 1119 |     {"TCGETA", TCGETA},
      |                ^~~~~~
./Modules/termios.c:1131:16: error: invalid application of 'sizeof' to incomplete type 'struct termio'
 1131 |     {"TCSETA", TCSETA},
      |                ^~~~~~
./Modules/termios.c:1134:17: error: invalid application of 'sizeof' to incomplete type 'struct termio'
 1134 |     {"TCSETAF", TCSETAF},
      |                 ^~~~~~~
./Modules/termios.c:1137:17: error: invalid application of 'sizeof' to incomplete type 'struct termio'
 1137 |     {"TCSETAW", TCSETAW},
      |                 ^~~~~~~
make[1]: *** [Makefile:3403: Modules/termios.o] Error 1

This issue is observed at least on sparc64, but not on more "mainstream" CPU architectures, as they do not define TCGETA/TCSETA/TCSETAF/TCSETAW.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
