### PR TITLE
gh-142236: Improve error location for missing comma in string concatenations

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -1251,8 +1251,7 @@ invalid_expression:
     # !(NAME STRING) is not matched so we don't show this error with some invalid string prefixes like: kf"dsfsdf"
     # Soft keywords need to also be ignored because they can be parsed as NAME NAME
    | !(NAME STRING | SOFT_KEYWORD) a=disjunction b=expression_without_invalid {
-        _PyPegen_check_legacy_stmt(p, a) ? NULL : p->tokens[p->mark-1]->level == 0 ? NULL :
-        RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "invalid syntax. Perhaps you forgot a comma?") }
+        _PyPegen_raise_error_for_missing_comma(p, a, b) }
    | a=disjunction 'if' b=disjunction !('else'|':') { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "expected 'else' after 'if' expression") }
    | a=disjunction 'if' b=disjunction 'else' !expression {
         RAISE_SYNTAX_ERROR_ON_NEXT_TOKEN("expected expression after 'else', but statement is given") }

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -3336,6 +3336,20 @@ case(34)
             lineno=3
         )
 
+    def test_multiline_string_concat_missing_comma_points_to_last_string(self):
+        # gh-142236: For multi-line string concatenations with a missing comma,
+        # the error should point to the last string, not the first.
+        self._check_error(
+            "print(\n"
+            '    "line1"\n'
+            '    "line2"\n'
+            '    "line3"\n'
+            "    x=1\n"
+            ")",
+            "Perhaps you forgot a comma",
+            lineno=4,  # Points to "line3", the last string
+        )
+
     @support.cpython_only
     def test_syntax_error_on_deeply_nested_blocks(self):
         # This raises a SyntaxError, it used to raise a SystemError. Context

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-06-00-38-37.gh-issue-142236.m3EF9E.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-06-00-38-37.gh-issue-142236.m3EF9E.rst
@@ -1,0 +1,3 @@
+Improve the "Perhaps you forgot a comma?" syntax error for multi-line string
+concatenations to point to the last string instead of the first, making it
+easier to locate where the comma is missing. Patch by Pablo Galindo.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -21445,7 +21445,7 @@ invalid_expression_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ invalid_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "!(NAME STRING | SOFT_KEYWORD) disjunction expression_without_invalid"));
-            _res = _PyPegen_check_legacy_stmt ( p , a ) ? NULL : p -> tokens [p -> mark - 1] -> level == 0 ? NULL : RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "invalid syntax. Perhaps you forgot a comma?" );
+            _res = _PyPegen_raise_error_for_missing_comma ( p , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -358,6 +358,7 @@ expr_ty _PyPegen_ensure_real(Parser *p, expr_ty);
 asdl_seq *_PyPegen_join_sequences(Parser *, asdl_seq *, asdl_seq *);
 int _PyPegen_check_barry_as_flufl(Parser *, Token *);
 int _PyPegen_check_legacy_stmt(Parser *p, expr_ty t);
+void *_PyPegen_raise_error_for_missing_comma(Parser *p, expr_ty a, expr_ty b);
 ResultTokenWithMetadata *_PyPegen_check_fstring_conversion(Parser *p, Token *, expr_ty t);
 ResultTokenWithMetadata *_PyPegen_setup_full_format_spec(Parser *, Token *, asdl_expr_seq *, int, int,
                                                          int, int, PyArena *);


### PR DESCRIPTION
When a multi-line string concatenation is missing a comma before the
next argument, the error previously pointed to the first string in the
concatenation, which was confusing because the actual fix needed to be
applied after the last string. This change adds a helper function that
detects multi-line expressions and adjusts the error position to point
to the last line, making it immediately clear where the comma should be
added.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142236 -->
* Issue: gh-142236
<!-- /gh-issue-number -->
