### PR TITLE
gh-142332: Fix usage formatting for positional arguments in mutually exclusive groups in argparse

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -450,16 +450,12 @@ class HelpFormatter(object):
             # produce all arg strings
             elif not action.option_strings:
                 default = self._get_default_metavar_for_positional(action)
-                part = (
-                    t.summary_action
-                    + self._format_args(action, default)
-                    + t.reset
-                )
-
+                part = self._format_args(action, default)
                 # if it's in a group, strip the outer []
                 if action in group_actions:
                     if part[0] == '[' and part[-1] == ']':
                         part = part[1:-1]
+                part = t.summary_action + part + t.reset
 
             # produce the first way to invoke the option in brackets
             else:

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -7342,7 +7342,28 @@ class TestColorized(TestCase):
             ),
         )
 
-    def test_argparse_color_usage(self):
+    def test_argparse_color_mutually_exclusive_group_usage(self):
+        parser = argparse.ArgumentParser(color=True, prog="PROG")
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument('--foo', action='store_true', help='FOO')
+        group.add_argument('--spam', help='SPAM')
+        group.add_argument('badger', nargs='*', help='BADGER')
+
+        prog = self.theme.prog
+        heading = self.theme.heading
+        long = self.theme.summary_long_option
+        short = self.theme.summary_short_option
+        label = self.theme.summary_label
+        pos = self.theme.summary_action
+        reset = self.theme.reset
+
+        self.assertEqual(parser.format_usage(),
+            f"{heading}usage: {reset}{prog}PROG{reset} [{short}-h{reset}] "
+            f"[{long}--foo{reset} | "
+            f"{long}--spam {label}SPAM{reset} | "
+            f"{pos}badger ...{reset}]\n")
+
+    def test_argparse_color_custom_usage(self):
         # Arrange
         parser = argparse.ArgumentParser(
             add_help=False,

--- a/Misc/NEWS.d/next/Library/2025-12-06-13-02-13.gh-issue-142332.PNvXCV.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-06-13-02-13.gh-issue-142332.PNvXCV.rst
@@ -1,2 +1,2 @@
-Fix formatting the usage for positional argument in mutually exclusive group
+Fix usage formatting for positional arguments in mutually exclusive groups in :mod:`argparse`.
 in :mod:`argparse`.

--- a/Misc/NEWS.d/next/Library/2025-12-06-13-02-13.gh-issue-142332.PNvXCV.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-06-13-02-13.gh-issue-142332.PNvXCV.rst
@@ -1,0 +1,2 @@
+Fix formatting the usage for positional argument in mutually exclusive group
+in :mod:`argparse`.


### PR DESCRIPTION


<!-- gh-issue-number: gh-142332 -->
* Issue: gh-142332
<!-- /gh-issue-number -->
