### PR TITLE
gh-141938: document treatment of `OSError` raised by `HTTPConnection.getresponse`

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -319,6 +319,12 @@ HTTPConnection Objects
       :class:`str` or bytes-like object that is not also a file as the
       body representation.
 
+   .. note::
+
+      Note that you must have read the whole response or call :meth:`close`
+      if :meth:`getresponse` raised an non-:exc:`ConnectionError` exception
+      before you can send a new request to the server.
+
    .. versionchanged:: 3.2
       *body* can now be an iterable.
 
@@ -334,15 +340,14 @@ HTTPConnection Objects
    Should be called after a request is sent to get the response from the server.
    Returns an :class:`HTTPResponse` instance.
 
-   .. note::
-
-      Note that you must have read the whole response before you can send a new
-      request to the server.
-
    .. versionchanged:: 3.5
       If a :exc:`ConnectionError` or subclass is raised, the
       :class:`HTTPConnection` object will be ready to reconnect when
       a new request is sent.
+
+      Note that this does not apply to :exc:`OSError`\s raised by the underlying
+      socket. Instead the caller is responsible to call :meth:`close` on the
+      existing connection.
 
 
 .. method:: HTTPConnection.set_debuglevel(level)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141938 -->
* Issue: gh-141938
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142339.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->