### PR TITLE
gh-140189: Temporarily allow CI failures for iOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -691,8 +691,6 @@ jobs:
     - build-ubuntu
     - build-ubuntu-ssltests-awslc
     - build-ubuntu-ssltests-openssl
-    - build-android
-    - build-ios
     - build-wasi
     - test-hypothesis
     - build-asan
@@ -706,6 +704,8 @@ jobs:
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
       with:
         allowed-failures: >-
+          build-android,
+          build-ios,
           build-windows-msi,
           build-ubuntu-ssltests-awslc,
           build-ubuntu-ssltests-openssl,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -691,6 +691,8 @@ jobs:
     - build-ubuntu
     - build-ubuntu-ssltests-awslc
     - build-ubuntu-ssltests-openssl
+    - build-android
+    - build-ios
     - build-wasi
     - test-hypothesis
     - build-asan

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -706,7 +706,6 @@ jobs:
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
       with:
         allowed-failures: >-
-          build-android,
           build-ios,
           build-windows-msi,
           build-ubuntu-ssltests-awslc,


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Both Android and iOS tests are quite flaky right now. Based on the convo in Discord, it seems like allowing failures is the best option. 

<!-- gh-issue-number: gh-140189 -->
* Issue: gh-140189
<!-- /gh-issue-number -->
