### PR TITLE
gh-142315: Don't pass the "real path" of Pdb script target to system functions

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -183,9 +183,13 @@ class _ExecutableTarget:
 
 class _ScriptTarget(_ExecutableTarget):
     def __init__(self, target):
-        self._target = target
         self._check(target)
-        self._replace_sys_path(target)
+        self._target = os.path.realpath(target)
+
+        # If PYTHONSAFEPATH (-P) is not set, sys.path[0] is the directory
+        # of pdb, and we should replace it with the directory of the script
+        if not sys.flags.safe_path:
+            sys.path[0] = os.path.dirname(self._target)
 
     @staticmethod
     def _check(target):
@@ -198,13 +202,6 @@ class _ScriptTarget(_ExecutableTarget):
         if os.path.isdir(target):
             print(f'Error: {target} is a directory')
             sys.exit(1)
-
-    @staticmethod
-    def _replace_sys_path(target):
-        # If PYTHONSAFEPATH (-P) is not set, sys.path[0] is the directory
-        # of pdb, so replace it with the directory of the script
-        if not sys.flags.safe_path:
-            sys.path[0] = os.path.dirname(os.path.realpath(target))
 
     def __repr__(self):
         return self._target

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -184,7 +184,7 @@ class _ExecutableTarget:
 class _ScriptTarget(_ExecutableTarget):
     def __init__(self, target):
         self._check(target)
-        self._target = os.path.realpath(target)
+        self._target = self._safe_realpath(target)
 
         # If PYTHONSAFEPATH (-P) is not set, sys.path[0] is the directory
         # of pdb, and we should replace it with the directory of the script
@@ -202,6 +202,18 @@ class _ScriptTarget(_ExecutableTarget):
         if os.path.isdir(target):
             print(f'Error: {target} is a directory')
             sys.exit(1)
+
+    @staticmethod
+    def _safe_realpath(path):
+        """
+        Return the canonical path (realpath) if it is accessible from the userspace.
+        Otherwise (for example, if the path is a symlink to an anonymous pipe),
+        return the original path.
+
+        See GH-142315.
+        """
+        realpath = os.path.realpath(path)
+        return realpath if os.path.exists(realpath) else path
 
     def __repr__(self):
         return self._target

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -183,14 +183,14 @@ class _ExecutableTarget:
 
 class _ScriptTarget(_ExecutableTarget):
     def __init__(self, target):
-        if not os.path.exists(target):
+        self._target = self._safe_realpath(target)
+
+        if not os.path.exists(self._target):
             print(f'Error: {target} does not exist')
             sys.exit(1)
-        if os.path.isdir(target):
+        if os.path.isdir(self._target):
             print(f'Error: {target} is a directory')
             sys.exit(1)
-
-        self._target = self._safe_realpath(target)
 
         # If PYTHONSAFEPATH (-P) is not set, sys.path[0] is the directory
         # of pdb, and we should replace it with the directory of the script

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -183,14 +183,16 @@ class _ExecutableTarget:
 
 class _ScriptTarget(_ExecutableTarget):
     def __init__(self, target):
-        self._target = os.path.realpath(target)
-
-        if not os.path.exists(self._target):
+        if not os.path.exists(target):
             print(f'Error: {target} does not exist')
             sys.exit(1)
-        if os.path.isdir(self._target):
+        if os.path.isdir(target):
             print(f'Error: {target} is a directory')
             sys.exit(1)
+
+        # Be careful with realpath to support pseudofilesystems (GH-142315).
+        realpath = os.path.realpath(target)
+        self._target = realpath if os.path.exists(realpath) else target
 
         # If safe_path(-P) is not set, sys.path[0] is the directory
         # of pdb, and we should replace it with the directory of the script

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -183,13 +183,9 @@ class _ExecutableTarget:
 
 class _ScriptTarget(_ExecutableTarget):
     def __init__(self, target):
+        self._target = target
         self._check(target)
-        self._target = os.path.realpath(target)
-
-        # If PYTHONSAFEPATH (-P) is not set, sys.path[0] is the directory
-        # of pdb, and we should replace it with the directory of the script
-        if not sys.flags.safe_path:
-            sys.path[0] = os.path.dirname(self._target)
+        self._replace_sys_path(target)
 
     @staticmethod
     def _check(target):
@@ -202,6 +198,13 @@ class _ScriptTarget(_ExecutableTarget):
         if os.path.isdir(target):
             print(f'Error: {target} is a directory')
             sys.exit(1)
+
+    @staticmethod
+    def _replace_sys_path(target):
+        # If PYTHONSAFEPATH (-P) is not set, sys.path[0] is the directory
+        # of pdb, so replace it with the directory of the script
+        if not sys.flags.safe_path:
+            sys.path[0] = os.path.dirname(os.path.realpath(target))
 
     def __repr__(self):
         return self._target

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -183,34 +183,28 @@ class _ExecutableTarget:
 
 class _ScriptTarget(_ExecutableTarget):
     def __init__(self, target):
-        self._target = self._safe_realpath(target)
-
-        if not os.path.exists(self._target):
-            print(f'Error: {target} does not exist')
-            sys.exit(1)
-        if os.path.isdir(self._target):
-            print(f'Error: {target} is a directory')
-            sys.exit(1)
+        self._check(target)
+        self._target = os.path.realpath(target)
 
         # If PYTHONSAFEPATH (-P) is not set, sys.path[0] is the directory
         # of pdb, and we should replace it with the directory of the script
         if not sys.flags.safe_path:
             sys.path[0] = os.path.dirname(self._target)
 
+    @staticmethod
+    def _check(target):
+        """
+        Check that target is plausibly a script.
+        """
+        if not os.path.exists(target):
+            print(f'Error: {target} does not exist')
+            sys.exit(1)
+        if os.path.isdir(target):
+            print(f'Error: {target} is a directory')
+            sys.exit(1)
+
     def __repr__(self):
         return self._target
-
-    @staticmethod
-    def _safe_realpath(path):
-        """
-        Return the canonical path (realpath) if it is accessible from the userspace.
-        Otherwise (for example, if the path is a symlink to an anonymous pipe),
-        return the original path.
-
-        See GH-142315.
-        """
-        realpath = os.path.realpath(path)
-        return realpath if os.path.exists(realpath) else path
 
     @property
     def filename(self):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3652,6 +3652,11 @@ def bœr():
         self.assertIn('None', stdout)
 
     def test_script_target_anonymous_pipe(self):
+        """
+        _ScriptTarget doesn't fail on an anonymous pipe.
+
+        GH-142315
+        """
         fd_dir = self._fd_dir_for_pipe_targets()
         if fd_dir is None:
             self.skipTest('anonymous pipe targets require /proc/self/fd or /dev/fd')

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3561,6 +3561,24 @@ class PdbTestCase(unittest.TestCase):
         self.assertEqual(
             expected, pdb.find_function(func_name, os_helper.TESTFN))
 
+    def _fd_dir_for_pipe_targets(self):
+        """Return a directory exposing live file descriptors, if any."""
+        proc_fd = "/proc/self/fd"
+        if os.path.isdir(proc_fd) and os.path.exists(os.path.join(proc_fd, '0')):
+            return proc_fd
+
+        dev_fd = "/dev/fd"
+        if os.path.isdir(dev_fd) and os.path.exists(os.path.join(dev_fd, '0')):
+            if sys.platform.startswith("freebsd"):
+                try:
+                    if os.stat("/dev").st_dev == os.stat(dev_fd).st_dev:
+                        return None
+                except FileNotFoundError:
+                    return None
+            return dev_fd
+
+        return None
+
     def test_find_function_empty_file(self):
         self._assert_find_function(b'', 'foo', None)
 
@@ -3632,6 +3650,42 @@ def bœr():
 
         stdout, _ = self.run_pdb_script(script, commands)
         self.assertIn('None', stdout)
+
+    def test_script_target_anonymous_pipe(self):
+        fd_dir = self._fd_dir_for_pipe_targets()
+        if fd_dir is None:
+            self.skipTest('anonymous pipe targets require /proc/self/fd or /dev/fd')
+
+        read_fd, write_fd = os.pipe()
+
+        def safe_close(fd):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+        self.addCleanup(safe_close, read_fd)
+        self.addCleanup(safe_close, write_fd)
+
+        pipe_path = os.path.join(fd_dir, str(read_fd))
+        if not os.path.exists(pipe_path):
+            self.skipTest('fd directory does not expose anonymous pipes')
+
+        script_source = 'marker = "via_pipe"\n'
+        os.write(write_fd, script_source.encode('utf-8'))
+        os.close(write_fd)
+
+        original_path0 = sys.path[0]
+        self.addCleanup(sys.path.__setitem__, 0, original_path0)
+
+        target = pdb._ScriptTarget(pipe_path)
+        code_text = target.code
+        namespace = target.namespace
+        exec(code_text, namespace)
+
+        self.assertEqual(namespace['marker'], 'via_pipe')
+        self.assertEqual(namespace['__file__'], target.filename)
+        self.assertIsNone(namespace['__spec__'])
 
     def test_find_function_first_executable_line(self):
         code = textwrap.dedent("""\

--- a/Misc/NEWS.d/next/Library/2025-12-07-02-36-24.gh-issue-142315.02o5E_.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-07-02-36-24.gh-issue-142315.02o5E_.rst
@@ -1,0 +1,1 @@
+Pdb can run scripts from pseudofiles. Patch by Bartosz Sławecki.

--- a/Misc/NEWS.d/next/Library/2025-12-07-02-36-24.gh-issue-142315.02o5E_.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-07-02-36-24.gh-issue-142315.02o5E_.rst
@@ -1,1 +1,2 @@
-Pdb can run scripts from pseudofiles. Patch by Bartosz Sławecki.
+Pdb can now run scripts from anonymous pipes used in process substitution.
+Patch by Bartosz Sławecki.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Oh the irony that this was never a *real* path.

I need to figure out how to test this -- it's a regression, after all, so no excuses this time.

CC @ZeroIntensity `needs backport to 3.13`, `needs backport to 3.14`


<!-- gh-issue-number: gh-142315 -->
* Issue: gh-142315
<!-- /gh-issue-number -->
