### PR TITLE
GH-139862: Fix direct instantiation of `HelpFormatter`

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -189,6 +189,8 @@ class HelpFormatter(object):
         self._whitespace_matcher = _re.compile(r'\s+', _re.ASCII)
         self._long_break_matcher = _re.compile(r'\n\n\n+')
 
+        self._set_color(False)
+
     def _set_color(self, color):
         from _colorize import can_colorize, decolor, get_theme
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5694,6 +5694,11 @@ class TestHelpCustomHelpFormatter(TestCase):
                 a-very-long-command  command that does something
         '''))
 
+    def test_direct_formatter_instantiation(self):
+        formatter = argparse.HelpFormatter(prog="program")
+        formatter.add_usage(usage=None, actions=[], groups=[])
+        help_text = formatter.format_help()
+        self.assertEqual(help_text, "usage: program\n")
 
 # =====================================
 # Optional/Positional constructor tests


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Based on https://github.com/python/cpython/pull/142274#issuecomment-3621939804, the issue here is that `format_help()` eventually accesses `self._theme` but `_theme` was never set since `_set_color()` is no longer called in `__init__`. I think we can initialize `_theme` to a safe default (no color) so that direct instantiation works but the parser can still override it afterward.


<!-- gh-issue-number: gh-139862 -->
* Issue: gh-139862
<!-- /gh-issue-number -->
