### PR TITLE
[3.14] GH-139946: Document argparse includes color codes when redirecting to stderr to file

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -648,7 +648,8 @@ are set.
 
    Error messages will include color codes when redirecting stderr to a
    file. To avoid this, set the |NO_COLOR|_ or :envvar:`PYTHON_COLORS`
-   environment variable (e.g., ``NO_COLOR=1 python script.py 2> errors.txt``).
+   environment variable (for example,
+   ``NO_COLOR=1 python script.py 2> errors.txt``).
 
 .. versionadded:: 3.14
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -644,6 +644,12 @@ variables and terminal capabilities.  However, if ``color=False``, colored
 output is always disabled, even if environment variables like ``FORCE_COLOR``
 are set.
 
+.. note::
+
+   Error messages will include color codes when redirecting stderr to a
+   file. To avoid this, set the :envvar:`NO_COLOR` or :envvar:`PYTHON_COLORS`
+   environment variable (e.g., ``NO_COLOR=1 python script.py 2> errors.txt``).
+
 .. versionadded:: 3.14
 
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -647,7 +647,7 @@ are set.
 .. note::
 
    Error messages will include color codes when redirecting stderr to a
-   file. To avoid this, set the :envvar:`NO_COLOR` or :envvar:`PYTHON_COLORS`
+   file. To avoid this, set the |NO_COLOR|_ or :envvar:`PYTHON_COLORS`
    environment variable (e.g., ``NO_COLOR=1 python script.py 2> errors.txt``).
 
 .. versionadded:: 3.14


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139946 -->
* Issue: gh-139946
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142398.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->