### PR TITLE
gh-142399: Lock both so and otherset when setting a symmetric difference

### DIFF
--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2005,9 +2005,9 @@ set_symmetric_difference_update_impl(PySetObject *so, PyObject *other)
             return NULL;
         }
 
-        Py_BEGIN_CRITICAL_SECTION(so);
+        Py_BEGIN_CRITICAL_SECTION2(so, otherset);
         rv = set_symmetric_difference_update_set(so, otherset);
-        Py_END_CRITICAL_SECTION();
+        Py_END_CRITICAL_SECTION2();
 
         Py_DECREF(otherset);
     }


### PR DESCRIPTION
Only so is locked, which leaves otherset vulnerable.

<!-- gh-issue-number: gh-142399 -->
* Issue: gh-142399
<!-- /gh-issue-number -->
