### PR TITLE
gh-142433: Move deref to below the error when checking for laststring

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-08-17-34-57.gh-issue-142402.iV0ON3.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-08-17-34-57.gh-issue-142402.iV0ON3.rst
@@ -1,0 +1,1 @@
+Move deref of laststring to below the error checking so the deref is applied after the object in strings is replaced.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-08-17-34-57.gh-issue-142402.iV0ON3.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-08-17-34-57.gh-issue-142402.iV0ON3.rst
@@ -1,1 +1,3 @@
-Move deref of laststring to below the error checking so the deref is applied after the object in strings is replaced.
+Fix reference counting when adjacent literal parts are merged while constructing
+:class:`string.templatelib.Template`, preventing the displaced string object
+from leaking.

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -153,6 +153,7 @@ template_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
                     Py_DECREF(interpolations);
                     return NULL;
                 }
+                /* Replace laststring with concat */
                 PyTuple_SET_ITEM(strings, stringsidx - 1, concat);
                 Py_DECREF(laststring);
             }

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -148,13 +148,13 @@ template_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             if (last_was_str) {
                 PyObject *laststring = PyTuple_GET_ITEM(strings, stringsidx - 1);
                 PyObject *concat = PyUnicode_Concat(laststring, item);
-                Py_DECREF(laststring);
                 if (!concat) {
                     Py_DECREF(strings);
                     Py_DECREF(interpolations);
                     return NULL;
                 }
                 PyTuple_SET_ITEM(strings, stringsidx - 1, concat);
+                Py_DECREF(laststring);
             }
             else {
                 PyTuple_SET_ITEM(strings, stringsidx++, Py_NewRef(item));


### PR DESCRIPTION
Move deref of laststring to below the error checking so the deref is applied after the object in strings is replaced.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:


<!-- gh-issue-number: gh-142433 -->
* Issue: gh-142433
<!-- /gh-issue-number -->
