### PR TITLE
[3.13] gh-141794: Reduce size of compiler stress tests to fix Android warnings (GH-142263)

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -993,11 +993,13 @@ class TestSpecifics(unittest.TestCase):
         # An implicit test for PyUnicode_FSDecoder().
         compile("42", FakePath("test_compile_pathlike"), "single")
 
+    # bpo-31113: Stack overflow when compile a long sequence of
+    # complex statements.
     @support.requires_resource('cpu')
     def test_stack_overflow(self):
-        # bpo-31113: Stack overflow when compile a long sequence of
-        # complex statements.
-        compile("if a: b\n" * 200000, "<dummy>", "exec")
+        # Android test devices have less memory.
+        size = 100_000 if sys.platform == "android" else 200_000
+        compile("if a: b\n" * size, "<dummy>", "exec")
 
     # Multiple users rely on the fact that CPython does not generate
     # bytecode for dead code blocks. See bpo-37500 for more context.


### PR DESCRIPTION
(cherry picked from commit f193c8fe9e1d722c9a7f9a2b15f8f1b913755491)

Only 1 out of the 3 changes were relevant on this branch.

<!-- gh-issue-number: gh-141794 -->
* Issue: gh-141794
<!-- /gh-issue-number -->
