### PR TITLE
gh-138122: Fix unused variable warning in threads.c

### DIFF
--- a/Modules/_remote_debugging/threads.c
+++ b/Modules/_remote_debugging/threads.c
@@ -323,6 +323,7 @@ unwind_stack_for_thread(
 #ifdef Py_GIL_DISABLED
     int active = GET_MEMBER(_thread_status, ts, unwinder->debug_offsets.thread_state.status).active;
     has_gil = active;
+    (void)gil_requested;  // unused
 #else
     // Read holds_gil directly from thread state
     has_gil = GET_MEMBER(int, ts, unwinder->debug_offsets.thread_state.holds_gil);


### PR DESCRIPTION


<!-- gh-issue-number: gh-138122 -->
* Issue: gh-138122
<!-- /gh-issue-number -->
