### PR TITLE
[3.14] gh-133932: Tagged ints are heap-safe (free threading)

### DIFF
--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -323,7 +323,7 @@ _PyStackRef_FromPyObjectSteal(PyObject *obj)
 static inline bool
 PyStackRef_IsHeapSafe(_PyStackRef stackref)
 {
-    if (PyStackRef_IsDeferred(stackref)) {
+    if (PyStackRef_IsDeferred(stackref) && !PyStackRef_IsTaggedInt(stackref)) {
         PyObject *obj = PyStackRef_AsPyObjectBorrow(stackref);
         return obj == NULL || _Py_IsImmortal(obj) || _PyObject_HasDeferredRefcount(obj);
     }

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-08-15-46-06.gh-issue-133932.HAxa4p.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-08-15-46-06.gh-issue-133932.HAxa4p.rst
@@ -1,0 +1,2 @@
+Fix crash in the free threading build when clearing frames that hold tagged
+integers.


### PR DESCRIPTION
The previous fix (gh-134494) didn't fix the free threading build.


<!-- gh-issue-number: gh-133932 -->
* Issue: gh-133932
<!-- /gh-issue-number -->
