### PR TITLE
gh-142438: Added missing GIL release in _PySSL_keylog_callback when keylog_bio is unset

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-08-18-12-44.gh-issue-142438.UF_0nd.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-08-18-12-44.gh-issue-142438.UF_0nd.rst
@@ -1,0 +1,1 @@
+Fixed a possible leaked GIL in _PySSL_keylog_callback.

--- a/Modules/_ssl/debughelpers.c
+++ b/Modules/_ssl/debughelpers.c
@@ -131,7 +131,7 @@ _PySSL_keylog_callback(const SSL *ssl, const char *line)
     PyThread_type_lock lock = get_state_sock(ssl_obj)->keylog_lock;
     assert(lock != NULL);
     if (ssl_obj->ctx->keylog_bio == NULL) {
-        return;
+        goto done;
     }
     /*
      * The lock is neither released on exit nor on fork(). The lock is
@@ -155,6 +155,8 @@ _PySSL_keylog_callback(const SSL *ssl, const char *line)
                                              ssl_obj->ctx->keylog_filename);
         ssl_obj->exc = PyErr_GetRaisedException();
     }
+
+done:
     PyGILState_Release(threadstate);
 }
 


### PR DESCRIPTION
In the early return, threadstate is leaked.

We have to release it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142438 -->
* Issue: gh-142438
<!-- /gh-issue-number -->
