### PR TITLE
gh-142442: Increase the borrowed ref from faulthandler_get_fileno when file is not None instead of decreasing when it is None

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-08-18-54-22.gh-issue-142442.SFn1RC.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-08-18-54-22.gh-issue-142442.SFn1RC.rst
@@ -1,0 +1,3 @@
+Fix faulthandler’s fallback to ``sys.stderr`` so it owns the reference it
+returns, preventing an accidental decref of ``sys.stderr`` (or ``None``) when no
+file is provided.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -112,9 +112,9 @@ faulthandler_get_fileno(PyObject **file_ptr)
         }
         if (file == Py_None) {
             PyErr_SetString(PyExc_RuntimeError, "sys.stderr is None");
-            Py_DECREF(file);
             return -1;
         }
+        Py_INCREF(file);
     }
     else if (PyLong_Check(file)) {
         if (PyBool_Check(file)) {


### PR DESCRIPTION
Increase the borrowed ref from faulthandler_get_fileno when file is not None instead of decreasing when it is none

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142442 -->
* Issue: gh-142442
<!-- /gh-issue-number -->
