### PR TITLE
gh-140189: Use macos-14 runner for iOS CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -405,10 +405,10 @@ jobs:
       # https://github.com/actions/runner-images/issues/12751.
       - name: Select Xcode version
         run: |
-          sudo xcode-select --switch /Applications/Xcode_16.4.app
+          sudo xcode-select --switch /Applications/Xcode_15.4.app
 
       - name: Build and test
-        run: python3 Apple ci iOS --fast-ci --simulator 'iPhone 16e,OS=18.5'
+        run: python3 Apple ci iOS --fast-ci --simulator 'iPhone SE (3rd generation),OS=17.5'
 
   build-wasi:
     name: 'WASI'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -392,7 +392,7 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-ios == 'true'
     timeout-minutes: 60
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We're currently seeing a [2-4% failure rate](https://github.com/python/cpython/pull/142365#issuecomment-3626542623) in iOS tests. 

This appears to be caused by a problem with the GitHub Actions macos-15 environment; this environment has been having performance issues since August (see actions/runner-images#12777). 

This PR reverts to the `macos-14` runner, which apparently isn't subject to the issues the `macos-15` runner is experiencing. This means we'll be running iOS tests on an older iOS release (Xcode 15.4, iOS 17.5); but since we're compiling with iOS 13 compatibility, this shouldn't impact anything.

<!-- gh-issue-number: gh-140189 -->
* Issue: gh-140189
<!-- /gh-issue-number -->
