### PR TITLE
[3.13] gh-142282 Fix winreg.QueryValueEx() under race condition (GH-142283)

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-05-18-26-50.gh-issue-142282.g6RQUN.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-05-18-26-50.gh-issue-142282.g6RQUN.rst
@@ -1,0 +1,1 @@
+Fix :func:`winreg.QueryValueEx` to not accidentally read garbage buffer under race condition.

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -1660,7 +1660,7 @@ winreg_QueryValueEx_impl(PyObject *module, HKEY key, const wchar_t *name)
         return PyErr_SetFromWindowsErrWithFunction(rc,
                                                    "RegQueryValueEx");
     }
-    obData = Reg2Py(retBuf, bufSize, typ);
+    obData = Reg2Py(retBuf, retSize, typ);
     PyMem_Free(retBuf);
     if (obData == NULL)
         return NULL;


### PR DESCRIPTION
(cherry picked from commit 3ec941b364778bce4fac6c6100730e120b426849)


<!-- gh-issue-number: gh-142282 -->
* Issue: gh-142282
<!-- /gh-issue-number -->
