### PR TITLE
[3.13] gh-142342: Fix m68k assembler operand constraints for `%fpcr` access (gh-142343)

### DIFF
--- a/Include/internal/pycore_pymath.h
+++ b/Include/internal/pycore_pymath.h
@@ -146,17 +146,17 @@ extern void _Py_set_387controlword(unsigned short);
     unsigned int old_fpcr, new_fpcr
 #define _Py_SET_53BIT_PRECISION_START                                   \
     do {                                                                \
-        __asm__ ("fmove.l %%fpcr,%0" : "=g" (old_fpcr));                \
+        __asm__ ("fmove.l %%fpcr,%0" : "=dm" (old_fpcr));               \
         /* Set double precision / round to nearest.  */                 \
         new_fpcr = (old_fpcr & ~0xf0) | 0x80;                           \
         if (new_fpcr != old_fpcr) {                                     \
-              __asm__ volatile ("fmove.l %0,%%fpcr" : : "g" (new_fpcr));\
+            __asm__ volatile ("fmove.l %0,%%fpcr" : : "dm" (new_fpcr)); \
         }                                                               \
     } while (0)
 #define _Py_SET_53BIT_PRECISION_END                                     \
     do {                                                                \
         if (new_fpcr != old_fpcr) {                                     \
-            __asm__ volatile ("fmove.l %0,%%fpcr" : : "g" (old_fpcr));  \
+            __asm__ volatile ("fmove.l %0,%%fpcr" : : "dm" (old_fpcr)); \
         }                                                               \
     } while (0)
 #endif

--- a/Misc/NEWS.d/next/Core and Builtins/2025-12-08-13-04-37.gh-issue-142343.BTAyML.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-12-08-13-04-37.gh-issue-142343.BTAyML.rst
@@ -1,0 +1,1 @@
+Fix SIGILL crash on m68k due to incorrect assembly constraint.

--- a/configure
+++ b/configure
@@ -24105,8 +24105,8 @@ main (void)
 {
 
   unsigned int fpcr;
-  __asm__ __volatile__ ("fmove.l %%fpcr,%0" : "=g" (fpcr));
-  __asm__ __volatile__ ("fmove.l %0,%%fpcr" : : "g" (fpcr));
+  __asm__ __volatile__ ("fmove.l %%fpcr,%0" : "=dm" (fpcr));
+  __asm__ __volatile__ ("fmove.l %0,%%fpcr" : : "dm" (fpcr));
 
   ;
   return 0;

--- a/configure.ac
+++ b/configure.ac
@@ -6040,8 +6040,8 @@ AS_VAR_IF([ac_cv_gcc_asm_for_x87], [yes], [
 AC_CACHE_CHECK([whether we can use gcc inline assembler to get and set mc68881 fpcr], [ac_cv_gcc_asm_for_mc68881], [
 AC_LINK_IFELSE(   [AC_LANG_PROGRAM([[]], [[
   unsigned int fpcr;
-  __asm__ __volatile__ ("fmove.l %%fpcr,%0" : "=g" (fpcr));
-  __asm__ __volatile__ ("fmove.l %0,%%fpcr" : : "g" (fpcr));
+  __asm__ __volatile__ ("fmove.l %%fpcr,%0" : "=dm" (fpcr));
+  __asm__ __volatile__ ("fmove.l %0,%%fpcr" : : "dm" (fpcr));
 ]])],[ac_cv_gcc_asm_for_mc68881=yes],[ac_cv_gcc_asm_for_mc68881=no])
 ])
 AS_VAR_IF([ac_cv_gcc_asm_for_mc68881], [yes], [


### PR DESCRIPTION
On m68k, an fmove instruction accessing %fpcr may only move from or to a data register or a memory operand. The constraint "g" also permits the use of address registers, which is invalid. The correct constraint is "dm". Beginning with GCC 15, the register allocator picks an address register in the code which causes SIGILL during runtime.
(cherry picked from commit 02c085d48b59c00fb7f4454fb13933e1c2c0b01a)

<!-- gh-issue-number: gh-142342 -->
* Issue: gh-142342
<!-- /gh-issue-number -->
