### PR TITLE
gh-142447: Fix cast warning in pycore_backoff.h

### DIFF
--- a/Include/internal/pycore_backoff.h
+++ b/Include/internal/pycore_backoff.h
@@ -40,7 +40,7 @@ extern "C" {
 #define MAX_VALUE 0x1FFF
 
 #define MAKE_VALUE_AND_BACKOFF(value, backoff) \
-    ((value << BACKOFF_BITS) | backoff)
+    ((uint16_t)(((value) << BACKOFF_BITS) | (backoff)))
 
 // For previous backoff b we use value x such that
 // x + 1 is near to 2**(2*b+1) and x + 1 is prime.

--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -14,6 +14,7 @@
 
 #ifdef TEST_INTERNAL_C_API
    // gh-135906: Check for compiler warnings in the internal C API
+#  include "internal/pycore_backoff.h"
 #  include "internal/pycore_frame.h"
 #endif
 


### PR DESCRIPTION
MAKE_VALUE_AND_BACKOFF() macro casts its result to uint16_t.

Add pycore_backoff.h header to test_cppext tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142447 -->
* Issue: gh-142447
<!-- /gh-issue-number -->
