### PR TITLE
gh-142468: `pdb`: Support `break/clear filename:function` syntax

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1337,7 +1337,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     complete_commands = _complete_bpnumber
 
     def do_break(self, arg, temporary=False):
-        """b(reak) [ ([filename:]lineno | function) [, condition] ]
+        """b(reak) [ [filename:](lineno | function) [, condition] ]
 
         Without argument, list all breaks.
 
@@ -1347,9 +1347,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         present, it is a string specifying an expression which must
         evaluate to true before the breakpoint is honored.
 
-        The line number may be prefixed with a filename and a colon,
-        to specify a breakpoint in another file (probably one that
-        hasn't been loaded yet).  The file is searched for on
+        The line number and function may be prefixed with a filename and
+        a colon, to specify a breakpoint in another file (probably one
+        that hasn't been loaded yet).  The file is searched for on
         sys.path; the .py suffix may be omitted.
         """
         if not arg:
@@ -1388,8 +1388,13 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             try:
                 lineno = int(arg)
             except ValueError:
-                self.error('Bad lineno: %s' % arg)
-                return
+                func = arg
+                ok, filename, ln = find_function(func, self.canonic(filename))
+                if not ok:
+                    self.error('Bad lineno or function name: %s' % arg)
+                    return
+                funcname = ok
+                lineno = int(ln)
         else:
             # no colon; can be lineno or function
             try:

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1389,7 +1389,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 lineno = int(arg)
             except ValueError:
                 func = arg
-                ok, filename, ln = find_function(func, self.canonic(filename))
+                find_res = find_function(func, self.canonic(filename))
+                ok, filename, ln = find_res or (None, None, None)
                 if not ok:
                     self.error('Bad lineno or function name: %s' % arg)
                     return

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1393,8 +1393,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 if not find_res:
                     self.error('Bad lineno or function name: %s' % arg)
                     return
-                funcname, filename, ln = find_res
-                lineno = int(ln)
+                funcname, filename, lineno = find_res
         else:
             # no colon; can be lineno or function
             try:

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1390,11 +1390,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             except ValueError:
                 func = arg
                 find_res = find_function(func, self.canonic(filename))
-                ok, filename, ln = find_res or (None, None, None)
-                if not ok:
+                if not find_res:
                     self.error('Bad lineno or function name: %s' % arg)
                     return
-                funcname = ok
+                funcname, filename, ln = find_res
                 lineno = int(ln)
         else:
             # no colon; can be lineno or function

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1692,7 +1692,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                     if find_res:
                         _, filename, lineno = find_res
                     else:
-                        err = "Invalid line number or function name:(%r)" % arg
+                        err = "Invalid line number or function name:(%s)" % arg
             if not err:
                 bplist = self.get_breaks(filename, lineno)[:]
                 err = self.clear_break(filename, lineno)

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1654,12 +1654,13 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         return reply.strip().lower()
 
     def do_clear(self, arg):
-        """cl(ear) [filename:lineno | bpnumber ...]
+        """cl(ear) [filename:(lineno | function) | bpnumber ...]
 
         With a space separated list of breakpoint numbers, clear
         those breakpoints.  Without argument, clear all breaks (but
         first ask confirmation).  With a filename:lineno argument,
-        clear all breaks at that line in that file.
+        clear all breakpoints at that line.  With a filename:function
+        argument, clear all breakpoints at that function.
         """
         if not arg:
             reply = self._prompt_for_confirmation(

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4622,6 +4622,18 @@ def bœr():
         stdout, stderr = self.run_pdb_script(script, commands)
         self.assertIn("The specified object 'C.foo' is not a function", stdout)
 
+    def test_break_function_with_file(self):
+        script = """
+            def foo():
+                pass
+        """
+        commands = """
+            break main:foo
+            quit
+        """
+        stdout, stderr = self.run_pdb_script(script, commands)
+        self.assertRegex(stdout, r"Breakpoint 1 at .*main\.py:3")
+
 
 class ChecklineTests(unittest.TestCase):
     def setUp(self):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4629,10 +4629,12 @@ def bœr():
         """
         commands = """
             break main:foo
+            clear main:foo
             quit
         """
         stdout, stderr = self.run_pdb_script(script, commands)
         self.assertRegex(stdout, r"Breakpoint 1 at .*main\.py:3")
+        self.assertRegex(stdout, r"Deleted breakpoint 1 at .*main\.py:3")
 
 
 class ChecklineTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2025-12-09-15-18-43.gh-issue-142468.V64wcC.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-09-15-18-43.gh-issue-142468.V64wcC.rst
@@ -1,0 +1,1 @@
+:mod:`pdb` now supports setting breakpoints using the ``filename:function`` syntax

--- a/Misc/NEWS.d/next/Library/2025-12-09-15-18-43.gh-issue-142468.V64wcC.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-09-15-18-43.gh-issue-142468.V64wcC.rst
@@ -1,1 +1,1 @@
-:mod:`pdb` now supports setting breakpoints using the ``filename:function`` syntax.
+:mod:`pdb` now supports setting or clearing breakpoints with the ``filename:function`` syntax.

--- a/Misc/NEWS.d/next/Library/2025-12-09-15-18-43.gh-issue-142468.V64wcC.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-09-15-18-43.gh-issue-142468.V64wcC.rst
@@ -1,1 +1,1 @@
-:mod:`pdb` now supports setting breakpoints using the ``filename:function`` syntax
+:mod:`pdb` now supports setting breakpoints using the ``filename:function`` syntax.


### PR DESCRIPTION


#  Support `break filename:function` syntax
refer: https://github.com/python/cpython/issues/142468
## Description
This PR extends `pdb`'s `break` command to support the `filename:function` syntax.

Previously, when a colon was present in the argument, `pdb` assumed the format was `filename:lineno`. If the part after the colon wasn't an integer, it would raise a "Bad lineno" error.

This change modifies `do_break` to catch the `ValueError` when parsing the line number. If parsing fails, it attempts to resolve the argument as a function name within the specified file using `find_function`.




<!-- gh-issue-number: gh-142468 -->
* Issue: gh-142468
<!-- /gh-issue-number -->
