### PR TITLE
gh-142527: Docs: Clarify that random.seed() discards the sign of an integer input

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -78,7 +78,7 @@ Bookkeeping functions
    instead of the system time (see the :func:`os.urandom` function for details
    on availability).
 
-   If *a* is an int, it is used directly. Note that negative integer seeds are 
+   If *a* is an int, it is used directly. Note that negative integer seeds are
    treated as equivalent to their absolute value, so for example ``seed(-5)`` and
    ``seed(5)`` will produce identical sequences.
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -78,9 +78,7 @@ Bookkeeping functions
    instead of the system time (see the :func:`os.urandom` function for details
    on availability).
 
-   If *a* is an int, it is used directly. Note that negative integer seeds are
-   treated as equivalent to their absolute value, so for example ``seed(-5)`` and
-   ``seed(5)`` will produce identical sequences.
+   If *a* is an int, its absolute value is used directly.
 
    With version 2 (the default), a :class:`str`, :class:`bytes`, or :class:`bytearray`
    object gets converted to an :class:`int` and all of its bits are used.

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -78,7 +78,9 @@ Bookkeeping functions
    instead of the system time (see the :func:`os.urandom` function for details
    on availability).
 
-   If *a* is an int, it is used directly.
+   If *a* is an int, it is used directly. Note that negative integer seeds are 
+   treated as equivalent to their absolute value, so for example ``seed(-5)`` and
+   ``seed(5)`` will produce identical sequences.
 
    With version 2 (the default), a :class:`str`, :class:`bytes`, or :class:`bytearray`
    object gets converted to an :class:`int` and all of its bits are used.


### PR DESCRIPTION
If *a* is an integer, the sign of *a* is discarded in the C source code. Clarify this behavior to prevent foot guns, where a common use case might naively assume that flipping the sign will produce different sequences (e.g. for a train/test split of a synthetic data generator in machine learning).

A bit more context appears in [this tweet](https://x.com/karpathy/status/1998236299862659485), where I was surprised by this behavior, which led to a subtle bug that caused the train and test splits to be identical in a synthetic data generation task.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142483.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->