### PR TITLE
Tachyon: Remove spurious CSS for `stat-card`

### DIFF
--- a/Lib/profiling/sampling/_heatmap_assets/heatmap.css
+++ b/Lib/profiling/sampling/_heatmap_assets/heatmap.css
@@ -75,18 +75,6 @@
   overflow: hidden;
 }
 
-.stat-card::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: linear-gradient(90deg, var(--python-blue), var(--python-gold));
-  opacity: 0;
-  transition: opacity var(--transition-fast);
-}
-
 .stat-card:nth-child(1) { --i: 0; --card-color: 55, 118, 171; }
 .stat-card:nth-child(2) { --i: 1; --card-color: 40, 167, 69; }
 .stat-card:nth-child(3) { --i: 2; --card-color: 255, 193, 7; }
@@ -99,10 +87,6 @@
   background: linear-gradient(135deg, rgba(var(--card-color), 0.08) 0%, var(--bg-primary) 100%);
   transform: translateY(-2px);
   box-shadow: 0 4px 16px rgba(var(--card-color), 0.15);
-}
-
-.stat-card:hover::before {
-  opacity: 1;
 }
 
 .stat-icon {


### PR DESCRIPTION
I'm not quite sure what this is meant to do, but it sure doesn’t look right:


https://github.com/user-attachments/assets/03396880-7cd8-4e8b-ab09-b95353ef26ba

