### PR TITLE
gh-142490: for macOS, use vm_page_size directly from the kernel header

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-09-15-26-02.gh-issue-142490.-ov3D8.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-09-15-26-02.gh-issue-142490.-ov3D8.rst
@@ -1,0 +1,2 @@
+It comes straight from the mach header as a global variable. No need to call
+to get it.

--- a/Modules/_ctypes/malloc_closure.c
+++ b/Modules/_ctypes/malloc_closure.c
@@ -12,6 +12,9 @@
 #  if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
 #    define MAP_ANONYMOUS MAP_ANON
 #  endif
+#  if defined(__APPLE__)
+#    include <mach/vm_page_size.h>
+#  endif
 #endif
 #include "ctypes.h"
 #include "pycore_mmap.h"          // _PyAnnotateMemoryMap()
@@ -55,7 +58,9 @@ static void more_core(void)
     }
 #else
     if (!_pagesize) {
-#ifdef _SC_PAGESIZE
+#ifdef __APPLE__
+        _pagesize = vm_page_size;
+#elif defined(_SC_PAGESIZE)
         _pagesize = sysconf(_SC_PAGESIZE);
 #else
         _pagesize = getpagesize();


### PR DESCRIPTION
We do not need to call sysconf for this at all.

<!-- gh-issue-number: gh-142490 -->
* Issue: gh-142490
<!-- /gh-issue-number -->
