### PR TITLE
[3.13] gh-142457: Support using 3.14 and 3.15 for generation scripts

### DIFF
--- a/configure
+++ b/configure
@@ -3762,7 +3762,7 @@ fi
 
 
 
-for ac_prog in python$PACKAGE_VERSION python3.13 python3.12 python3.11 python3.10 python3 python
+for ac_prog in python$PACKAGE_VERSION python3.15 python 3.14 python3.13 python3.12 python3.11 python3.10 python3 python
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -205,7 +205,7 @@ AC_SUBST([FREEZE_MODULE_DEPS])
 AC_SUBST([PYTHON_FOR_BUILD_DEPS])
 
 AC_CHECK_PROGS([PYTHON_FOR_REGEN],
-  [python$PACKAGE_VERSION python3.13 python3.12 python3.11 python3.10 python3 python],
+  [python$PACKAGE_VERSION python3.15 python 3.14 python3.13 python3.12 python3.11 python3.10 python3 python],
   [python3])
 AC_SUBST([PYTHON_FOR_REGEN])
 


### PR DESCRIPTION
Check for available Python 3.14 and Python 3.15 installations in the `configure` script. This allows us to use the 3.14 version installed by `actions/setup-python` in our 3.13 CI, rather than falling back to a 3.12 copy baked into the image.

I've omitted the blurb entry for this one, because while this is technically a change to the build, these regeneration scripts usually aren't visible in practice. If anyone is strongly in favor of adding a news entry here, feel free to let me know.

<!-- gh-issue-number: gh-142457 -->
* Issue: gh-142457
<!-- /gh-issue-number -->
