### PR TITLE
gh-142474: Clarify -i interaction with PYTHONSTARTUP

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -302,7 +302,8 @@ Miscellaneous options
 
 .. option:: -i
 
-   Enter interactive mode after execution.
+   Enter interactive mode after execution, or force interactive mode even when
+   :data:`sys.stdin` does not appear to be a terminal.
 
    Using the :option:`-i` option will enter interactive mode in any of the following circumstances\:
 
@@ -310,8 +311,13 @@ Miscellaneous options
    * When the :option:`-c` option is used
    * When the :option:`-m` option is used
 
-   Interactive mode will start even when :data:`sys.stdin` does not appear to be a terminal. The
-   :envvar:`PYTHONSTARTUP` file is not read.
+   In these "execute then interact" cases, Python runs the script or command
+   first and does not read the :envvar:`PYTHONSTARTUP` file before entering
+   interactive mode.
+
+   When :option:`-i` is used only to force interactive mode despite redirected
+   standard input (for example, ``python -i < /dev/null``), the interpreter
+   enters interactive mode directly and reads :envvar:`PYTHONSTARTUP` as usual.
 
    This can be useful to inspect global variables or a stack trace when a script
    raises an exception.  See also :envvar:`PYTHONINSPECT`.


### PR DESCRIPTION
## Summary

Clarify the documentation for the `-i` command-line option so that it accurately reflects how it interacts with `PYTHONSTARTUP`.

The updated text distinguishes the two distinct behaviors of `-i`:

* When `-i` is used with a script or with `-c`, Python executes the script or command and *then* enters interactive mode. In these “execute then interact” cases, `PYTHONSTARTUP` is **not** read.

* When `-i` is used solely to force interactive mode even if `stdin` is not a terminal (for example with redirected standard input), the interpreter enters interactive mode directly and `PYTHONSTARTUP` is read as usual. The previous documentation implied it was never read when using `-i`.

## Issue number

Closes gh-142474.

## Type of change

* [x] Documentation change only.

## Testing

* [x] Built documentation locally (`make html`) to confirm RST formatting.
* [x] Verified that the updated wording matches the current behavior of `-i` and `PYTHONSTARTUP`.

## Notes

* Per `.github/CONTRIBUTING.rst`, no NEWS entry is required for this small documentation clarification.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142502.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->