### PR TITLE
gh-142418 Enhance markcoroutinefunction to support functools.partial

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -317,6 +317,7 @@ def markcoroutinefunction(func):
     """
     if hasattr(func, '__func__'):
         func = func.__func__
+    func = functools._unwrap_partial(func)
     func._is_coroutine_marker = _is_coroutine_mark
     return func
 

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -334,6 +334,17 @@ class TestPredicates(IsTestBase):
         self.assertTrue(inspect.iscoroutinefunction(Cl3.do_something_classy))
         self.assertTrue(inspect.iscoroutinefunction(Cl3.do_something_static))
 
+        # Test markcoroutinefunction with functools.partial
+        async def _fn4():
+            pass
+
+        def fn4():
+            return _fn4()
+
+        partial_fn4 = functools.partial(fn4)
+        marked_partial_fn4 = inspect.markcoroutinefunction(partial_fn4)
+        self.assertTrue(inspect.iscoroutinefunction(marked_partial_fn4))
+
         self.assertFalse(
             inspect.iscoroutinefunction(unittest.mock.Mock()))
         self.assertTrue(

--- a/Misc/NEWS.d/next/Library/2025-12-10-02-31-08.gh-issue-142418.XLGNh3.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-10-02-31-08.gh-issue-142418.XLGNh3.rst
@@ -1,0 +1,2 @@
+Fix markcoroutinefunction by letting it set the coroutine function marker on
+underlying function correctly.


### PR DESCRIPTION
Enhance markcoroutinefunction to support functools.partial and added test to cover the corner case.

Based on the PR (https://github.com/python/cpython/pull/99247) that added `markcoroutinefunction`, the purpose is to 

> be able to continue to identify sync functions returning awaitables, without calling them to see that.

Given that, I think this issue indeed reports a bug. The root cause is that markcoroutinefunction sets the mark on partial function object (`joke`), while iscoroutinefunction looks at the underlying function object of partial function object (`manufacturer_of_jokes`). The deeper issue is that markcoroutinefunction and iscoroutinefunction uses different code path to find the function object it operates on.

In order to fix this bug, we can do it in two ways: fix the problem with minimum change or fix it more thoroughly, but riskier.

- minimum change: add `functools._unwrap_partial` to `markcoroutinefunction`
  - This PR implements minimum change.

- fix it more thoroughly: move the logic in `_has_code_flag` to a separate function and reuse it in `markcoroutinefunction` and `_has_coroutine_mark`
  - I do think `if not (isfunction(f) or _signature_is_functionlike(f)):` is appropriate to be applied to `markcoroutinefunction` and `iscoroutinefunction` as well, if the check fails, we raise a ValueError, but it may break user's code, open for discussion.
  - If we do want to check isfunction in iscoroutinefunction, then we don't need https://github.com/python/cpython/pull/120214

```
def _find_underlying_function(f):
    f = functools._unwrap_partialmethod(f)
    while ismethod(f):
        f = f.__func__
    f = functools._unwrap_partial(f)
    return f

def _has_code_flag(f, flag):
    f = _find_underlying_function(f)
    if not (isfunction(f) or _signature_is_functionlike(f)):
        return False
    return bool(f.__code__.co_flags & flag)

def markcoroutinefunction(f):
    f = _find_underlying_function(f)
    f._is_coroutine_marker = _is_coroutine_mark
    return f

def _has_coroutine_mark(f):
    f = _find_underlying_function(f)
    return getattr(f, "_is_coroutine_marker", None) is _is_coroutine_mark


```


<!-- gh-issue-number: gh-142418 -->
* Issue: gh-142418
<!-- /gh-issue-number -->
