### PR TITLE
docs: remove sequence types `object.__radd__` method

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -3158,7 +3158,7 @@ Mutable sequences should provide methods
 like Python standard :class:`list` objects.
 Finally, sequence types should implement addition (meaning concatenation) and
 multiplication (meaning repetition) by defining the methods
-:meth:`~object.__add__`, :meth:`~object.__radd__`, :meth:`~object.__iadd__`,
+:meth:`~object.__add__`, :meth:`~object.__iadd__`,
 :meth:`~object.__mul__`, :meth:`~object.__rmul__` and :meth:`~object.__imul__`
 described below; they should not define other numerical
 operators.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
cpython did not implement `object.__radd__`

<img width="921" height="101" alt="image" src="https://github.com/user-attachments/assets/0b8e83ba-bafc-44fa-aa22-9d5e10428b05" />




<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142507.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->