### PR TITLE
gh-142451: correctly copy HMAC attributes in `HMAC.copy()`

### DIFF
--- a/Lib/hmac.py
+++ b/Lib/hmac.py
@@ -171,6 +171,7 @@ class HMAC:
         # Call __new__ directly to avoid the expensive __init__.
         other = self.__class__.__new__(self.__class__)
         other.digest_size = self.digest_size
+        other.block_size = self.block_size
         if self._hmac:
             other._hmac = self._hmac.copy()
             other._inner = other._outer = None

--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -1076,6 +1076,15 @@ class SanityTestCaseMixin(CreatorMixin):
         self.assertEqual(h.digest_size, self.digest_size)
         self.assertEqual(h.block_size, self.block_size)
 
+    def test_copy(self):
+        # Test a generic copy() and the attributes it exposes.
+        # See https://github.com/python/cpython/issues/142451.
+        h1 = self.hmac_new(b"my secret key", digestmod=self.digestname)
+        h2 = h1.copy()
+        self.assertEqual(h1.name, h2.name)
+        self.assertEqual(h1.digest_size, h2.digest_size)
+        self.assertEqual(h1.block_size, h2.block_size)
+
     def test_repr(self):
         # HMAC object representation may differ across implementations
         raise NotImplementedError

--- a/Misc/NEWS.d/next/Library/2025-12-10-11-02-53.gh-issue-142451.eCLvhG.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-10-11-02-53.gh-issue-142451.eCLvhG.rst
@@ -1,0 +1,2 @@
+:mod:`hmac`: correctly copy :class:`~hmac.HMAC` attributes for objects
+copied through :meth:`HMAC.copy() <hmac.HMAC.copy>`. Patch by Bénédikt Tran.


### PR DESCRIPTION
There was actually a much older issue in `copy()` were we didn't copy the block size. Considering no one has ever complained about this for the past 20 years, I think that no one is actually using `copy()` followed by `.block_size` somewhere... I will backport this as well to 3.13 and 3.14.

<!-- gh-issue-number: gh-142451 -->
* Issue: gh-142451
<!-- /gh-issue-number -->
