### PR TITLE
gh-142414: Unify UNBOUND in Lib/concurrent/interpreters/_queues.py and Lib/concurrent/interpreters/_crossinterp.py.

### DIFF
--- a/Lib/concurrent/interpreters/_crossinterp.py
+++ b/Lib/concurrent/interpreters/_crossinterp.py
@@ -82,10 +82,6 @@ _UNBOUND_FLAG_TO_CONSTANT = {v: k
                              for k, v in _UNBOUND_CONSTANT_TO_FLAG.items()}
 
 
-def register_unbound(unbound, flag):
-    _UNBOUND_CONSTANT_TO_FLAG[unbound] = flag
-
-
 def serialize_unbound(unbound):
     op = unbound
     try:

--- a/Lib/concurrent/interpreters/_crossinterp.py
+++ b/Lib/concurrent/interpreters/_crossinterp.py
@@ -68,17 +68,6 @@ class UnboundItem:
         return f'{self._MODULE}.{self._NAME}'
 #        return f'interpreters._queues.UNBOUND'
 
-    def __hash__(self):
-        return hash((self._NAME, self._MODULE))
-
-    def __reduce__(self):
-        return self._NAME
-
-    def __eq__(self, other):
-        if other is self:
-            return True
-        return repr(other) == repr(self)
-
 
 UNBOUND = object.__new__(UnboundItem)
 UNBOUND_ERROR = object()

--- a/Lib/concurrent/interpreters/_crossinterp.py
+++ b/Lib/concurrent/interpreters/_crossinterp.py
@@ -82,6 +82,10 @@ _UNBOUND_FLAG_TO_CONSTANT = {v: k
                              for k, v in _UNBOUND_CONSTANT_TO_FLAG.items()}
 
 
+def register_unbound(unbound, flag):
+    _UNBOUND_CONSTANT_TO_FLAG[unbound] = flag
+
+
 def serialize_unbound(unbound):
     op = unbound
     try:

--- a/Lib/concurrent/interpreters/_crossinterp.py
+++ b/Lib/concurrent/interpreters/_crossinterp.py
@@ -68,6 +68,17 @@ class UnboundItem:
         return f'{self._MODULE}.{self._NAME}'
 #        return f'interpreters._queues.UNBOUND'
 
+    def __hash__(self):
+        return hash((self._NAME, self._MODULE))
+
+    def __reduce__(self):
+        return self._NAME
+
+    def __eq__(self, other):
+        if other is self:
+            return True
+        return repr(other) == repr(self)
+
 
 UNBOUND = object.__new__(UnboundItem)
 UNBOUND_ERROR = object()

--- a/Lib/concurrent/interpreters/_queues.py
+++ b/Lib/concurrent/interpreters/_queues.py
@@ -47,6 +47,7 @@ _PICKLED = 1
 
 
 UNBOUND = _crossinterp.UnboundItem.singleton('queue', __name__)
+_crossinterp.register_unbound(UNBOUND, 3)
 
 
 def _serialize_unbound(unbound):

--- a/Lib/concurrent/interpreters/_queues.py
+++ b/Lib/concurrent/interpreters/_queues.py
@@ -11,7 +11,7 @@ from _interpqueues import (
     QueueError, QueueNotFoundError,
 )
 from ._crossinterp import (
-    UNBOUND_ERROR, UNBOUND_REMOVE,
+    UNBOUND, UNBOUND_ERROR, UNBOUND_REMOVE,
 )
 
 __all__ = [
@@ -44,10 +44,6 @@ class ItemInterpreterDestroyed(QueueError,
 
 _SHARED_ONLY = 0
 _PICKLED = 1
-
-
-UNBOUND = _crossinterp.UnboundItem.singleton('queue', __name__)
-_crossinterp.register_unbound(UNBOUND, 3)
 
 
 def _serialize_unbound(unbound):

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -427,6 +427,8 @@ class InterpreterPoolExecutorTest(
                         ready.get(timeout=1)  # blocking
                     except interpreters.QueueEmpty:
                         pass
+                    except queues.QueueEmpty:
+                        pass
                     else:
                         done += 1
                 pending -= done

--- a/Misc/NEWS.d/next/Library/2025-12-10-15-27-58.gh-issue-142414.zTHgP-.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-10-15-27-58.gh-issue-142414.zTHgP-.rst
@@ -1,0 +1,1 @@
+Align UNBOUND usage in Lib/concurrent/interpreters/_queues.py and Lib/concurrent/interpreters/_crossinterp.py.

--- a/Misc/NEWS.d/next/Library/2025-12-10-15-27-58.gh-issue-142414.zTHgP-.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-10-15-27-58.gh-issue-142414.zTHgP-.rst
@@ -1,1 +1,1 @@
-Align UNBOUND usage in Lib/concurrent/interpreters/_queues.py and Lib/concurrent/interpreters/_crossinterp.py.
+Align UNBOUND in Lib/concurrent/interpreters/_queues.py and Lib/concurrent/interpreters/_crossinterp.py.

--- a/Misc/NEWS.d/next/Library/2025-12-10-15-27-58.gh-issue-142414.zTHgP-.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-10-15-27-58.gh-issue-142414.zTHgP-.rst
@@ -1,1 +1,1 @@
-Align UNBOUND in Lib/concurrent/interpreters/_queues.py and Lib/concurrent/interpreters/_crossinterp.py.
+Unified the UNBOUND constant in the internal implementation of Lib/concurrent/interpreters.

--- a/Misc/NEWS.d/next/Library/2025-12-10-15-27-58.gh-issue-142414.zTHgP-.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-10-15-27-58.gh-issue-142414.zTHgP-.rst
@@ -1,1 +1,1 @@
-Unified the UNBOUND constant in the internal implementation of Lib/concurrent/interpreters.
+Fix spurious KeyError when concurrent.interpreters is reloaded after import.

--- a/Misc/NEWS.d/next/Library/2025-12-10-15-27-58.gh-issue-142414.zTHgP-.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-10-15-27-58.gh-issue-142414.zTHgP-.rst
@@ -1,1 +1,1 @@
-Fix spurious KeyError when concurrent.interpreters is reloaded after import.
+Fix spurious :exc:`KeyError` when :mod:`concurrent.interpreters` is reloaded after import.


### PR DESCRIPTION
The fix is aligned with [bug reporter's observation](https://github.com/python/cpython/issues/142414#issuecomment-3634163980).

Test with
1. `./python -m test test_interpreters test_struct` (This one triggers OP's issue.)
2. [Repro script](https://github.com/python/cpython/issues/142414#issuecomment-3636804732) by Victor.
3. `./python -m test test_interpreters test_concurrent_futures.test_interpreter_pool` (This one triggers the forever loop after the initial fix.)

<!-- gh-issue-number: gh-142414 -->
* Issue: gh-142414
<!-- /gh-issue-number -->
