### PR TITLE
Tachyon: Fix heatmap line highlight animation overriding heat colors

### DIFF
--- a/Lib/profiling/sampling/_heatmap_assets/heatmap.css
+++ b/Lib/profiling/sampling/_heatmap_assets/heatmap.css
@@ -971,7 +971,6 @@
     outline-offset: -3px;
   }
   100% {
-    background: inherit;
     outline: 3px solid transparent;
     outline-offset: -3px;
   }


### PR DESCRIPTION
Fixes:

[Screencast From 2025-12-10 15-32-38.webm](https://github.com/user-attachments/assets/7ba020fa-1149-4ba2-96ec-95d1356930f3)
