### PR TITLE
gh-142527: Docs: Mention absolute value is used in random.seed()

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -78,10 +78,10 @@ Bookkeeping functions
    instead of the system time (see the :func:`os.urandom` function for details
    on availability).
 
-   If *a* is an int, it is used directly.
+   If *a* is an int, its absolute value is used directly.
 
    With version 2 (the default), a :class:`str`, :class:`bytes`, or :class:`bytearray`
-   object gets converted to an :class:`int` and all of its bits are used.
+   object gets converted to an :class:`int` and all of its bits except the sign are used.
 
    With version 1 (provided for reproducing random sequences from older versions
    of Python), the algorithm for :class:`str` and :class:`bytes` generates a


### PR DESCRIPTION
Fixes #142527 Docs: random.seed() uses the absolute value of its integer argument

Two very short phrase insertions.

<!-- gh-issue-number: gh-142527 -->
* Issue: gh-142527
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142528.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->