### PR TITLE
gh-142536: Test `HTTPStatus` items are stringified as values

### DIFF
--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1262,6 +1262,26 @@ class MiscTestCase(unittest.TestCase):
                 expected.append(name)
         self.assertCountEqual(server.__all__, expected)
 
+    def test_http_status_str_equals_value_str(self):
+        """Ensure string render of an HTTPStatus is the same as of its
+        value attribute."""
+        for http_status_attr in HTTPStatus._member_map_:
+            http_status = getattr(HTTPStatus, http_status_attr)
+            with self.subTest(http_status_attr=http_status_attr):
+                self.assertEqual(str(http_status), str(http_status.value))
+
+    def test_http_status_str_is_numeric(self):
+        """Ensure string render of an HTTPStatus is the same as of its
+        value attribute."""
+        for http_status_attr in HTTPStatus._member_map_:
+            http_status = getattr(HTTPStatus, http_status_attr)
+            with self.subTest(http_status_attr=http_status_attr):
+                self.assertTrue(str(http_status).isdigit())
+
+    def test_http_status_bad_request_str_looks_like_a_number(self):
+        """Ensure string render of ``HTTPStatus.BAD_REQUEST`` is 400."""
+        self.assertEqual(str(HTTPStatus.BAD_REQUEST), '400')
+
 
 class ScriptTestCase(unittest.TestCase):
 


### PR DESCRIPTION
It was discovered by @julianz- [[1]] that this works differently under *NIX and on Windows. So this patch adds a test case to demonstrate the inconsistency.

Specifically, this is how it works on my Gentoo laptop (Python 3.14.0):
```pycon
# linux
>>> import http
>>> str(http.HTTPStatus.CONTINUE), str(http.HTTPStatus.CONTINUE.value)
('100', '100')
```

However, a CI job in Cheroot revealed that on Windows, it's not the number that's returned but the enum name:
```pycon
# windows
>>> import http
>>> str(http.HTTPStatus.BAD_REQUEST)
'HTTPStatus.BAD_REQUEST'
```

The added test seeks to show this cross-platform difference.


[1]: https://github.com/cherrypy/cheroot/pull/800#discussion_r2578222751

[2]: https://github.com/julianz-/cheroot/actions/runs/19812533416/job/56757651666#step:21:3490

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
