### PR TITLE
gh-138122: Add exception profiling mode to the sampling profiler

### DIFF
--- a/Doc/library/profiling.sampling.rst
+++ b/Doc/library/profiling.sampling.rst
@@ -567,12 +567,6 @@ up the call stack (after ``raise`` but before being caught), or when code is
 executing inside an ``except`` block where exception information is still
 present in the thread state.
 
-The profiler detects exceptions by checking two internal thread state fields:
-the ``current_exception`` field (set when an exception is actively propagating)
-and the ``exc_info`` field (set when inside an ``except`` block). When either
-field contains an exception object, the thread is considered to have an active
-exception.
-
 The following example illustrates which code regions are captured:
 
 .. code-block:: python

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -146,6 +146,8 @@ Key features include:
     and blocking. Use this to identify CPU-bound bottlenecks and optimize computational work.
   * **GIL-holding time** (``--mode gil``): Measures time spent holding Python's Global Interpreter
     Lock. Use this to identify which threads dominate GIL usage in multi-threaded applications.
+  * **Exception handling time** (``--mode exception``): Captures samples only from threads with
+    an active exception. Use this to analyze exception handling overhead.
 
 * **Thread-aware profiling**: Option to profile all threads (``-a``) or just the main thread,
   essential for understanding multi-threaded application behavior.
@@ -174,6 +176,10 @@ Key features include:
 * **Async-aware profiling**: Profile async/await code with task-based stack reconstruction
   (``--async-aware``). See which coroutines are consuming time, with options to show only
   running tasks or all tasks including those waiting.
+
+* **Opcode-level profiling**: Gather bytecode opcode information for instruction-level
+  profiling (``--opcodes``). Shows which bytecode instructions are executing, including
+  specializations from the adaptive interpreter.
 
 See :mod:`profiling.sampling` for the complete documentation, including all
 available output formats, profiling modes, and configuration options.

--- a/Include/internal/pycore_debug_offsets.h
+++ b/Include/internal/pycore_debug_offsets.h
@@ -110,7 +110,14 @@ typedef struct _Py_DebugOffsets {
         uint64_t status;
         uint64_t holds_gil;
         uint64_t gil_requested;
+        uint64_t current_exception;
+        uint64_t exc_state;
     } thread_state;
+
+    // Exception stack item offset
+    struct {
+        uint64_t exc_value;
+    } err_stackitem;
 
     // InterpreterFrame offset;
     struct _interpreter_frame {
@@ -282,6 +289,11 @@ typedef struct _Py_DebugOffsets {
         .status = offsetof(PyThreadState, _status), \
         .holds_gil = offsetof(PyThreadState, holds_gil), \
         .gil_requested = offsetof(PyThreadState, gil_requested), \
+        .current_exception = offsetof(PyThreadState, current_exception), \
+        .exc_state = offsetof(PyThreadState, exc_state), \
+    }, \
+    .err_stackitem = { \
+        .exc_value = offsetof(_PyErr_StackItem, exc_value), \
     }, \
     .interpreter_frame = { \
         .size = sizeof(_PyInterpreterFrame), \

--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
@@ -717,6 +717,10 @@ function populateThreadStats(data, selectedThreadId = null) {
 
   const gcPctElem = document.getElementById('gc-pct');
   if (gcPctElem) gcPctElem.textContent = `${(threadStats.gc_pct || 0).toFixed(1)}%`;
+
+  // Exception stats
+  const excPctElem = document.getElementById('exc-pct');
+  if (excPctElem) excPctElem.textContent = `${(threadStats.has_exception_pct || 0).toFixed(1)}%`;
 }
 
 // ============================================================================

--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph_template.html
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph_template.html
@@ -161,6 +161,10 @@
                     <div class="stat-tile-value" id="gc-pct">--</div>
                     <div class="stat-tile-label">GC</div>
                   </div>
+                  <div class="stat-tile stat-tile--red" id="exc-stat">
+                    <div class="stat-tile-value" id="exc-pct">--</div>
+                    <div class="stat-tile-label">Exception</div>
+                  </div>
                 </div>
               </div>
             </section>

--- a/Lib/profiling/sampling/cli.py
+++ b/Lib/profiling/sampling/cli.py
@@ -16,6 +16,7 @@ from .constants import (
     PROFILING_MODE_WALL,
     PROFILING_MODE_CPU,
     PROFILING_MODE_GIL,
+    PROFILING_MODE_EXCEPTION,
     SORT_MODE_NSAMPLES,
     SORT_MODE_TOTTIME,
     SORT_MODE_CUMTIME,
@@ -90,6 +91,7 @@ def _parse_mode(mode_string):
         "wall": PROFILING_MODE_WALL,
         "cpu": PROFILING_MODE_CPU,
         "gil": PROFILING_MODE_GIL,
+        "exception": PROFILING_MODE_EXCEPTION,
     }
     return mode_map[mode_string]
 
@@ -213,10 +215,12 @@ def _add_mode_options(parser):
     mode_group = parser.add_argument_group("Mode options")
     mode_group.add_argument(
         "--mode",
-        choices=["wall", "cpu", "gil"],
+        choices=["wall", "cpu", "gil", "exception"],
         default="wall",
         help="Sampling mode: wall (all samples), cpu (only samples when thread is on CPU), "
-        "gil (only samples when thread holds the GIL). Incompatible with --async-aware",
+        "gil (only samples when thread holds the GIL), "
+        "exception (only samples when thread has an active exception). "
+        "Incompatible with --async-aware",
     )
     mode_group.add_argument(
         "--async-mode",

--- a/Lib/profiling/sampling/collector.py
+++ b/Lib/profiling/sampling/collector.py
@@ -5,6 +5,7 @@ from .constants import (
     THREAD_STATUS_ON_CPU,
     THREAD_STATUS_GIL_REQUESTED,
     THREAD_STATUS_UNKNOWN,
+    THREAD_STATUS_HAS_EXCEPTION,
 )
 
 try:
@@ -170,7 +171,7 @@ class Collector(ABC):
 
         Returns:
             tuple: (aggregate_status_counts, has_gc_frame, per_thread_stats)
-                - aggregate_status_counts: dict with has_gil, on_cpu, etc.
+                - aggregate_status_counts: dict with has_gil, on_cpu, has_exception, etc.
                 - has_gc_frame: bool indicating if any thread has GC frames
                 - per_thread_stats: dict mapping thread_id to per-thread counts
         """
@@ -179,6 +180,7 @@ class Collector(ABC):
             "on_cpu": 0,
             "gil_requested": 0,
             "unknown": 0,
+            "has_exception": 0,
             "total": 0,
         }
         has_gc_frame = False
@@ -200,6 +202,8 @@ class Collector(ABC):
                     status_counts["gil_requested"] += 1
                 if status_flags & THREAD_STATUS_UNKNOWN:
                     status_counts["unknown"] += 1
+                if status_flags & THREAD_STATUS_HAS_EXCEPTION:
+                    status_counts["has_exception"] += 1
 
                 # Track per-thread statistics
                 thread_id = getattr(thread_info, "thread_id", None)
@@ -210,6 +214,7 @@ class Collector(ABC):
                             "on_cpu": 0,
                             "gil_requested": 0,
                             "unknown": 0,
+                            "has_exception": 0,
                             "total": 0,
                             "gc_samples": 0,
                         }
@@ -225,6 +230,8 @@ class Collector(ABC):
                         thread_stats["gil_requested"] += 1
                     if status_flags & THREAD_STATUS_UNKNOWN:
                         thread_stats["unknown"] += 1
+                    if status_flags & THREAD_STATUS_HAS_EXCEPTION:
+                        thread_stats["has_exception"] += 1
 
                     # Check for GC frames in this thread
                     frames = getattr(thread_info, "frame_info", None)

--- a/Lib/profiling/sampling/constants.py
+++ b/Lib/profiling/sampling/constants.py
@@ -5,6 +5,7 @@ PROFILING_MODE_WALL = 0
 PROFILING_MODE_CPU = 1
 PROFILING_MODE_GIL = 2
 PROFILING_MODE_ALL = 3  # Combines GIL + CPU checks
+PROFILING_MODE_EXCEPTION = 4  # Only samples when thread has an active exception
 
 # Sort mode constants
 SORT_MODE_NSAMPLES = 0
@@ -25,6 +26,7 @@ try:
         THREAD_STATUS_ON_CPU,
         THREAD_STATUS_UNKNOWN,
         THREAD_STATUS_GIL_REQUESTED,
+        THREAD_STATUS_HAS_EXCEPTION,
     )
 except ImportError:
     # Fallback for tests or when module is not available
@@ -32,3 +34,4 @@ except ImportError:
     THREAD_STATUS_ON_CPU = (1 << 1)
     THREAD_STATUS_UNKNOWN = (1 << 2)
     THREAD_STATUS_GIL_REQUESTED = (1 << 3)
+    THREAD_STATUS_HAS_EXCEPTION = (1 << 4)

--- a/Lib/profiling/sampling/live_collector/collector.py
+++ b/Lib/profiling/sampling/live_collector/collector.py
@@ -17,6 +17,7 @@ from ..constants import (
     THREAD_STATUS_ON_CPU,
     THREAD_STATUS_UNKNOWN,
     THREAD_STATUS_GIL_REQUESTED,
+    THREAD_STATUS_HAS_EXCEPTION,
     PROFILING_MODE_CPU,
     PROFILING_MODE_GIL,
     PROFILING_MODE_WALL,
@@ -61,6 +62,7 @@ class ThreadData:
     on_cpu: int = 0
     gil_requested: int = 0
     unknown: int = 0
+    has_exception: int = 0
     total: int = 0  # Total status samples for this thread
 
     # Sample counts
@@ -82,6 +84,8 @@ class ThreadData:
             self.gil_requested += 1
         if status_flags & THREAD_STATUS_UNKNOWN:
             self.unknown += 1
+        if status_flags & THREAD_STATUS_HAS_EXCEPTION:
+            self.has_exception += 1
         self.total += 1
 
     def as_status_dict(self):
@@ -91,6 +95,7 @@ class ThreadData:
             "on_cpu": self.on_cpu,
             "gil_requested": self.gil_requested,
             "unknown": self.unknown,
+            "has_exception": self.has_exception,
             "total": self.total,
         }
 
@@ -160,6 +165,7 @@ class LiveStatsCollector(Collector):
             "on_cpu": 0,
             "gil_requested": 0,
             "unknown": 0,
+            "has_exception": 0,
             "total": 0,  # Total thread count across all samples
         }
         self.gc_frame_samples = 0  # Track samples with GC frames
@@ -359,6 +365,7 @@ class LiveStatsCollector(Collector):
                 thread_data.on_cpu += stats.get("on_cpu", 0)
                 thread_data.gil_requested += stats.get("gil_requested", 0)
                 thread_data.unknown += stats.get("unknown", 0)
+                thread_data.has_exception += stats.get("has_exception", 0)
                 thread_data.total += stats.get("total", 0)
                 if stats.get("gc_samples", 0):
                     thread_data.gc_frame_samples += stats["gc_samples"]
@@ -723,6 +730,7 @@ class LiveStatsCollector(Collector):
             "on_cpu": 0,
             "gil_requested": 0,
             "unknown": 0,
+            "has_exception": 0,
             "total": 0,
         }
         self.gc_frame_samples = 0

--- a/Lib/profiling/sampling/live_collector/widgets.py
+++ b/Lib/profiling/sampling/live_collector/widgets.py
@@ -389,6 +389,7 @@ class HeaderWidget(Widget):
         pct_on_gil = (status_counts["has_gil"] / total_threads) * 100
         pct_off_gil = 100.0 - pct_on_gil
         pct_gil_requested = (status_counts["gil_requested"] / total_threads) * 100
+        pct_exception = (status_counts.get("has_exception", 0) / total_threads) * 100
 
         # Get GC percentage based on view mode
         if thread_data:
@@ -425,6 +426,17 @@ class HeaderWidget(Widget):
                 "waiting for gil",
                 self.colors["yellow"],
                 add_separator=True,
+            )
+
+        # Show exception stats
+        if col < width - 15:
+            col = self._add_percentage_stat(
+                line,
+                col,
+                pct_exception,
+                "exc",
+                self.colors["red"],
+                add_separator=(col > 11),
             )
 
         # Always show GC stats

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -17,6 +17,7 @@ from .constants import (
     PROFILING_MODE_CPU,
     PROFILING_MODE_GIL,
     PROFILING_MODE_ALL,
+    PROFILING_MODE_EXCEPTION,
 )
 try:
     from .live_collector import LiveStatsCollector
@@ -300,7 +301,8 @@ def sample(
         all_threads: Whether to sample all threads
         realtime_stats: Whether to print real-time sampling statistics
         mode: Profiling mode - WALL (all samples), CPU (only when on CPU),
-              GIL (only when holding GIL), ALL (includes GIL and CPU status)
+              GIL (only when holding GIL), ALL (includes GIL and CPU status),
+              EXCEPTION (only when thread has an active exception)
         native: Whether to include native frames
         gc: Whether to include GC frames
         opcodes: Whether to include opcode information
@@ -360,7 +362,8 @@ def sample_live(
         all_threads: Whether to sample all threads
         realtime_stats: Whether to print real-time sampling statistics
         mode: Profiling mode - WALL (all samples), CPU (only when on CPU),
-              GIL (only when holding GIL), ALL (includes GIL and CPU status)
+              GIL (only when holding GIL), ALL (includes GIL and CPU status),
+              EXCEPTION (only when thread has an active exception)
         native: Whether to include native frames
         gc: Whether to include GC frames
         opcodes: Whether to include opcode information

--- a/Lib/test/test_profiling/test_sampling_profiler/test_modes.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_modes.py
@@ -427,7 +427,198 @@ cpu_thread.join()
         self.assertEqual(_parse_mode("wall"), 0)
         self.assertEqual(_parse_mode("cpu"), 1)
         self.assertEqual(_parse_mode("gil"), 2)
+        self.assertEqual(_parse_mode("exception"), 4)
 
         # Test invalid mode raises KeyError
         with self.assertRaises(KeyError):
             _parse_mode("invalid")
+
+
+class TestExceptionModeFiltering(unittest.TestCase):
+    """Test exception mode filtering functionality (--mode=exception)."""
+
+    def test_exception_mode_validation(self):
+        """Test that CLI accepts exception mode choice correctly."""
+        from profiling.sampling.cli import main
+
+        test_args = [
+            "profiling.sampling.cli",
+            "attach",
+            "12345",
+            "--mode",
+            "exception",
+        ]
+
+        with (
+            mock.patch("sys.argv", test_args),
+            mock.patch("profiling.sampling.cli.sample") as mock_sample,
+        ):
+            try:
+                main()
+            except (SystemExit, OSError, RuntimeError):
+                pass  # Expected due to invalid PID
+
+        # Should have attempted to call sample with mode=4 (exception mode)
+        mock_sample.assert_called_once()
+        call_args = mock_sample.call_args
+        # Check the mode parameter (should be in kwargs)
+        self.assertEqual(call_args.kwargs.get("mode"), 4)  # PROFILING_MODE_EXCEPTION
+
+    def test_exception_mode_sample_function_call(self):
+        """Test that sample() function correctly uses exception mode."""
+        with (
+            mock.patch(
+                "profiling.sampling.sample.SampleProfiler"
+            ) as mock_profiler,
+        ):
+            # Mock the profiler instance
+            mock_instance = mock.Mock()
+            mock_profiler.return_value = mock_instance
+
+            # Create a real collector instance
+            collector = PstatsCollector(sample_interval_usec=1000, skip_idle=True)
+
+            # Call sample with exception mode
+            profiling.sampling.sample.sample(
+                12345,
+                collector,
+                mode=4,  # PROFILING_MODE_EXCEPTION
+                duration_sec=1,
+            )
+
+            # Verify SampleProfiler was created with correct mode
+            mock_profiler.assert_called_once()
+            call_args = mock_profiler.call_args
+            self.assertEqual(call_args[1]["mode"], 4)  # mode parameter
+
+            # Verify profiler.sample was called
+            mock_instance.sample.assert_called_once()
+
+    def test_exception_mode_cli_argument_parsing(self):
+        """Test CLI argument parsing for exception mode with various options."""
+        from profiling.sampling.cli import main
+
+        test_args = [
+            "profiling.sampling.cli",
+            "attach",
+            "12345",
+            "--mode",
+            "exception",
+            "-i",
+            "500",
+            "-d",
+            "5",
+        ]
+
+        with (
+            mock.patch("sys.argv", test_args),
+            mock.patch("profiling.sampling.cli.sample") as mock_sample,
+        ):
+            try:
+                main()
+            except (SystemExit, OSError, RuntimeError):
+                pass  # Expected due to invalid PID
+
+        # Verify all arguments were parsed correctly
+        mock_sample.assert_called_once()
+        call_args = mock_sample.call_args
+        self.assertEqual(call_args.kwargs.get("mode"), 4)  # exception mode
+        self.assertEqual(call_args.kwargs.get("duration_sec"), 5)
+
+    def test_exception_mode_constants_are_defined(self):
+        """Test that exception mode constant is properly defined."""
+        from profiling.sampling.constants import PROFILING_MODE_EXCEPTION
+        self.assertEqual(PROFILING_MODE_EXCEPTION, 4)
+
+    @requires_subprocess()
+    def test_exception_mode_integration_filtering(self):
+        """Integration test: Exception mode should only capture threads with active exceptions."""
+        # Script with one thread handling an exception and one normal thread
+        exception_vs_normal_script = """
+import time
+import threading
+
+exception_ready = threading.Event()
+
+def normal_worker():
+    x = 0
+    while True:
+        x += 1
+
+def exception_handling_worker():
+    try:
+        raise ValueError("test exception")
+    except ValueError:
+        # Signal AFTER entering except block, then do CPU work
+        exception_ready.set()
+        x = 0
+        while True:
+            x += 1
+
+normal_thread = threading.Thread(target=normal_worker)
+exception_thread = threading.Thread(target=exception_handling_worker)
+normal_thread.start()
+exception_thread.start()
+exception_ready.wait()
+_test_sock.sendall(b"working")
+normal_thread.join()
+exception_thread.join()
+"""
+        with test_subprocess(exception_vs_normal_script, wait_for_working=True) as subproc:
+
+            with (
+                io.StringIO() as captured_output,
+                mock.patch("sys.stdout", captured_output),
+            ):
+                try:
+                    collector = PstatsCollector(sample_interval_usec=5000, skip_idle=True)
+                    profiling.sampling.sample.sample(
+                        subproc.process.pid,
+                        collector,
+                        duration_sec=2.0,
+                        mode=4,  # Exception mode
+                        all_threads=True,
+                    )
+                    collector.print_stats(show_summary=False, mode=4)
+                except (PermissionError, RuntimeError) as e:
+                    self.skipTest(
+                        "Insufficient permissions for remote profiling"
+                    )
+
+                exception_mode_output = captured_output.getvalue()
+
+            # Test wall-clock mode (mode=0) - should capture both functions
+            with (
+                io.StringIO() as captured_output,
+                mock.patch("sys.stdout", captured_output),
+            ):
+                try:
+                    collector = PstatsCollector(sample_interval_usec=5000, skip_idle=False)
+                    profiling.sampling.sample.sample(
+                        subproc.process.pid,
+                        collector,
+                        duration_sec=2.0,
+                        mode=0,  # Wall-clock mode
+                        all_threads=True,
+                    )
+                    collector.print_stats(show_summary=False)
+                except (PermissionError, RuntimeError) as e:
+                    self.skipTest(
+                        "Insufficient permissions for remote profiling"
+                    )
+
+                wall_mode_output = captured_output.getvalue()
+
+            # Verify both modes captured samples
+            self.assertIn("Captured", exception_mode_output)
+            self.assertIn("samples", exception_mode_output)
+            self.assertIn("Captured", wall_mode_output)
+            self.assertIn("samples", wall_mode_output)
+
+            # Exception mode should strongly favor exception_handling_worker over normal_worker
+            self.assertIn("exception_handling_worker", exception_mode_output)
+            self.assertNotIn("normal_worker", exception_mode_output)
+
+            # Wall-clock mode should capture both types of work
+            self.assertIn("exception_handling_worker", wall_mode_output)
+            self.assertIn("normal_worker", wall_mode_output)

--- a/Misc/NEWS.d/next/Library/2025-12-11-04-18-49.gh-issue-138122.m3EF9E.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-11-04-18-49.gh-issue-138122.m3EF9E.rst
@@ -1,0 +1,3 @@
+Add ``--mode=exception`` to the sampling profiler to capture samples only from
+threads with an active exception, useful for analyzing exception handling
+overhead. Patch by Pablo Galindo.

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -109,10 +109,11 @@ typedef enum _WIN32_THREADSTATE {
 #define MAX_TLBC_SIZE 2048
 
 /* Thread status flags */
-#define THREAD_STATUS_HAS_GIL        (1 << 0)
-#define THREAD_STATUS_ON_CPU         (1 << 1)
-#define THREAD_STATUS_UNKNOWN        (1 << 2)
-#define THREAD_STATUS_GIL_REQUESTED  (1 << 3)
+#define THREAD_STATUS_HAS_GIL             (1 << 0)
+#define THREAD_STATUS_ON_CPU              (1 << 1)
+#define THREAD_STATUS_UNKNOWN             (1 << 2)
+#define THREAD_STATUS_GIL_REQUESTED       (1 << 3)
+#define THREAD_STATUS_HAS_EXCEPTION       (1 << 4)
 
 /* Exception cause macro */
 #define set_exception_cause(unwinder, exc_type, message) \
@@ -209,7 +210,8 @@ enum _ProfilingMode {
     PROFILING_MODE_WALL = 0,
     PROFILING_MODE_CPU = 1,
     PROFILING_MODE_GIL = 2,
-    PROFILING_MODE_ALL = 3
+    PROFILING_MODE_ALL = 3,
+    PROFILING_MODE_EXCEPTION = 4
 };
 
 typedef struct {

--- a/Modules/_remote_debugging/module.c
+++ b/Modules/_remote_debugging/module.c
@@ -568,7 +568,8 @@ _remote_debugging_RemoteUnwinder_get_stack_trace_impl(RemoteUnwinderObject *self
                                                            gc_frame);
             if (!frame_info) {
                 // Check if this was an intentional skip due to mode-based filtering
-                if ((self->mode == PROFILING_MODE_CPU || self->mode == PROFILING_MODE_GIL) && !PyErr_Occurred()) {
+                if ((self->mode == PROFILING_MODE_CPU || self->mode == PROFILING_MODE_GIL ||
+                     self->mode == PROFILING_MODE_EXCEPTION) && !PyErr_Occurred()) {
                     // Thread was skipped due to mode filtering, continue to next thread
                     continue;
                 }
@@ -1066,6 +1067,9 @@ _remote_debugging_exec(PyObject *m)
         return -1;
     }
     if (PyModule_AddIntConstant(m, "THREAD_STATUS_GIL_REQUESTED", THREAD_STATUS_GIL_REQUESTED) < 0) {
+        return -1;
+    }
+    if (PyModule_AddIntConstant(m, "THREAD_STATUS_HAS_EXCEPTION", THREAD_STATUS_HAS_EXCEPTION) < 0) {
         return -1;
     }
 


### PR DESCRIPTION
When profiling code it's often valuable to understand what
code paths are executing while exceptions are being handled. The new
--mode=exception option filters samples to only include threads that
have an active exception, making it easy to identify hot spots in error
handling code without noise from normal execution paths.

This works by checking both the thread's current_exception (for
exceptions being raised/propagated) and exc_info (for exceptions being
handled in except blocks). The feature integrates with the existing
profiler infrastructure including the live TUI, flamegraph output, and
gecko format for Firefox Profiler visualization.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138122 -->
* Issue: gh-138122
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142561.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->