### PR TITLE
gh-142495 fix __missing__ data race condition

### DIFF
--- a/Lib/test/test_defaultdict.py
+++ b/Lib/test/test_defaultdict.py
@@ -191,54 +191,42 @@ class TestDefaultDict(unittest.TestCase):
 
     @threading_helper.requires_working_threading()
     def test_no_value_overwrite_race_condition(self):
-        """Test that concurrent access to missing keys doesn't overwrite values."""
-        # Use a factory that returns unique objects so we can detect overwrites
         call_count = 0
 
         def unique_factory():
             nonlocal call_count
             call_count += 1
-            # Return a unique object that identifies this call
             return f"value_{call_count}_{threading.get_ident()}"
 
         d = defaultdict(unique_factory)
         results = {}
 
         def worker(thread_id):
-            # Multiple threads access the same missing key
             for _ in range(5):
                 value = d['shared_key']
                 if 'shared_key' not in results:
                     results['shared_key'] = value
-                # Small delay to increase chance of race conditions
                 time.sleep(0.001)
 
-        # Start multiple threads
         threads = []
         for i in range(3):
             t = threading.Thread(target=worker, args=(i,))
             threads.append(t)
             t.start()
 
-        # Wait for all threads to complete
         for t in threads:
             t.join()
 
-        # Key should exist in the dictionary
         self.assertIn('shared_key', d)
 
-        # All threads should see the same value (no overwrites occurred)
         final_value = d['shared_key']
         self.assertEqual(results['shared_key'], final_value)
 
-        # The value should be from the first successful factory call
         self.assertTrue(final_value.startswith('value_'))
 
-        # Factory should only be called once (since key only inserted once)
         self.assertEqual(call_count, 1)
 
     def test_factory_called_only_when_key_missing(self):
-        """Test that factory is only called when key is truly missing."""
         factory_calls = []
 
         def tracked_factory():
@@ -247,17 +235,14 @@ class TestDefaultDict(unittest.TestCase):
 
         d = defaultdict(tracked_factory)
 
-        # First access should call factory
         value1 = d['key']
         self.assertEqual(value1, [1, 2, 3])
         initial_call_count = len(factory_calls)
 
-        # Multiple subsequent accesses should not call factory
         for _ in range(10):
             value = d['key']
             self.assertEqual(value, [1, 2, 3])
 
-        # Factory call count should not have increased
         self.assertEqual(len(factory_calls), initial_call_count)
 
 

--- a/Lib/test/test_defaultdict.py
+++ b/Lib/test/test_defaultdict.py
@@ -7,6 +7,7 @@ import time
 import unittest
 
 from collections import defaultdict
+from test.support import threading_helper
 
 def foobar():
     return list
@@ -188,6 +189,7 @@ class TestDefaultDict(unittest.TestCase):
         with self.assertRaises(TypeError):
             i |= None
 
+    @threading_helper.requires_working_threading()
     def test_no_value_overwrite_race_condition(self):
         """Test that concurrent access to missing keys doesn't overwrite values."""
         # Use a factory that returns unique objects so we can detect overwrites

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2218,6 +2218,7 @@ defdict_missing(PyObject *op, PyObject *key)
 {
     defdictobject *dd = defdictobject_CAST(op);
     PyObject *factory = dd->default_factory;
+    PyObject *value;
     if (factory == NULL || factory == Py_None) {
         /* XXX Call dict.__missing__(key) */
         PyObject *tup;
@@ -2228,10 +2229,9 @@ defdict_missing(PyObject *op, PyObject *key)
         return NULL;
     }
 
-    PyObject *value = _PyObject_CallNoArgs(factory);
-    if (value == NULL) {
+    value = _PyObject_CallNoArgs(factory);
+    if (value == NULL)
         return NULL;
-    }
 
     /* Use PyDict_SetDefaultRef to atomically insert the value only if the key is absent.
      * This ensures we don't overwrite a value that another thread inserted
@@ -2239,11 +2239,6 @@ defdict_missing(PyObject *op, PyObject *key)
      */
     PyObject *result_value = NULL;
     int res = PyDict_SetDefaultRef(op, key, value, &result_value);
-
-    if (res < 0) {
-        Py_DECREF(value);
-        return NULL;
-    }
 
     if (res != 0) {
         Py_DECREF(value);

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2218,7 +2218,6 @@ defdict_missing(PyObject *op, PyObject *key)
 {
     defdictobject *dd = defdictobject_CAST(op);
     PyObject *factory = dd->default_factory;
-    PyObject *value;
     if (factory == NULL || factory == Py_None) {
         /* XXX Call dict.__missing__(key) */
         PyObject *tup;
@@ -2228,14 +2227,29 @@ defdict_missing(PyObject *op, PyObject *key)
         Py_DECREF(tup);
         return NULL;
     }
-    value = _PyObject_CallNoArgs(factory);
-    if (value == NULL)
-        return value;
-    if (PyObject_SetItem(op, key, value) < 0) {
+
+    PyObject *value = _PyObject_CallNoArgs(factory);
+    if (value == NULL) {
+        return NULL;
+    }
+
+    /* Use PyDict_SetDefaultRef to atomically insert the value only if the key is absent.
+     * This ensures we don't overwrite a value that another thread inserted
+     * between the factory call and this insertion.
+     */
+    PyObject *result_value = NULL;
+    int res = PyDict_SetDefaultRef(op, key, value, &result_value);
+
+    if (res < 0) {
         Py_DECREF(value);
         return NULL;
     }
-    return value;
+
+    if (res != 0) {
+        Py_DECREF(value);
+    }
+
+    return result_value;
 }
 
 static inline PyObject*


### PR DESCRIPTION
The original defdict_missing function in

cpython/Modules/_collectionsmodule.c:2216-2239 had a race

condition where:
1. When __missing__ is called, the factory function is invoked
2. Between the factory call and PyObject_SetItem(), another thread could insert a value for the same key
3. PyObject_SetItem() would overwrite the existing value, violating atomic

fix

1. Atomic Behavior: Uses PyDict_SetDefaultRef() which provides atomic "get or insert default" behavior
2. No Overwrites: Guarantees that existing values are never replaced
3. Thread Safety: The function handles concurrent access correctly
4. Factory Called Only When Needed: The factory is still only called when a key is initially missing
5. Preserves Semantics: The existing behavior and API remain unchanged

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142495 -->
* Issue: gh-142495
<!-- /gh-issue-number -->
