### PR TITLE
gh-142533: Prevent CRLF injection in HTTP headers

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -114,7 +114,7 @@ DEFAULT_ERROR_CONTENT_TYPE = "text/html;charset=utf-8"
 
 def _validate_header_string(value):
     """Validate header values preventing CRLF injection."""
-    if '\r' in value or '\n' in value:
+    if isinstance(value, str) and ('\r' in value or '\n' in value):
         raise ValueError('Invalid header name/value: contains CR or LF')
 
 class HTTPServer(socketserver.TCPServer):

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -552,7 +552,6 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
                     message = ''
             if not hasattr(self, '_headers_buffer'):
                 self._headers_buffer = []
-            _validate_header_string(message)
             self._headers_buffer.append(("%s %d %s\r\n" %
                     (self.protocol_version, code, message)).encode(
                         'latin-1', 'strict'))

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -112,6 +112,11 @@ DEFAULT_ERROR_MESSAGE = """\
 
 DEFAULT_ERROR_CONTENT_TYPE = "text/html;charset=utf-8"
 
+def _validate_header_string(value):
+    """Validate header values preventing CRLF injection."""
+    if '\r' in value or '\n' in value:
+        raise ValueError('Invalid header name/value: contains CR or LF')
+
 class HTTPServer(socketserver.TCPServer):
 
     allow_reuse_address = True    # Seems to make sense in testing environment
@@ -553,6 +558,8 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
 
     def send_header(self, keyword, value):
         """Send a MIME header to the headers buffer."""
+        _validate_header_string(keyword)
+        _validate_header_string(value)
         if self.request_version != 'HTTP/0.9':
             if not hasattr(self, '_headers_buffer'):
                 self._headers_buffer = []

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -552,6 +552,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
                     message = ''
             if not hasattr(self, '_headers_buffer'):
                 self._headers_buffer = []
+            _validate_header_string(message)
             self._headers_buffer.append(("%s %d %s\r\n" %
                     (self.protocol_version, code, message)).encode(
                         'latin-1', 'strict'))

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1052,19 +1052,6 @@ class BaseHTTPRequestHandlerTestCase(unittest.TestCase):
         handler.end_headers()
         self.assertEqual(output.numWrites, 1)
 
-    def test_send_response_only_rejects_crlf_message(self):
-        input = BytesIO(b'GET / HTTP/1.1\r\n\r\n')
-        output = AuditableBytesIO()
-        handler = SocketlessRequestHandler()
-        handler.rfile = input
-        handler.wfile = output
-        handler.request_version = 'HTTP/1.1'
-
-        with self.assertRaises(ValueError) as ctx:
-            handler.send_response_only(418, 'value\r\nSet-Cookie: custom=true')
-        self.assertIn('Invalid header name/value: contains CR or LF',
-                      str(ctx.exception))
-
     def test_header_buffering_of_send_header(self):
 
         input = BytesIO(b'GET / HTTP/1.1\r\n\r\n')

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -503,6 +503,39 @@ class HeaderTests(TestCase):
             '\r\n'
         )
 
+    def test_crlf_rejection_in_setitem(self):
+        h = Headers()
+        for crlf in ('\r\n', '\r', '\n'):
+            with self.subTest(crlf_repr=repr(crlf)):
+                with self.assertRaises(ValueError) as ctx:
+                    h['X-Custom'] = f'value{crlf}Set-Cookie: test'
+                self.assertIn('CR or LF', str(ctx.exception))
+
+    def test_crlf_rejection_in_setdefault(self):
+        for crlf in ('\r\n', '\r', '\n'):
+            with self.subTest(crlf_repr=repr(crlf)):
+                h = Headers()
+                with self.assertRaises(ValueError) as ctx:
+                    h.setdefault('X-Custom', f'value{crlf}Set-Cookie: test')
+                self.assertIn('CR or LF', str(ctx.exception))
+
+    def test_crlf_rejection_in_add_header(self):
+        for crlf in ('\r\n', '\r', '\n'):
+            with self.subTest(location='value', crlf_repr=repr(crlf)):
+                h = Headers()
+                with self.assertRaises(ValueError) as ctx:
+                    h.add_header('X-Custom', f'value{crlf}Set-Cookie: test')
+                self.assertIn('CR or LF', str(ctx.exception))
+
+            with self.subTest(location='param', crlf_repr=repr(crlf)):
+                h = Headers()
+                with self.assertRaises(ValueError) as ctx:
+                    h.add_header('Content-Disposition',
+                                 'attachment',
+                                 filename=f'test{crlf}.txt')
+                self.assertIn('CR or LF', str(ctx.exception))
+
+
 class ErrorHandler(BaseCGIHandler):
     """Simple handler subclass for testing BaseHandler"""
 

--- a/Misc/NEWS.d/next/Library/2025-12-11-22-28-21.gh-issue-142533.SN0f9_.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-11-22-28-21.gh-issue-142533.SN0f9_.rst
@@ -1,0 +1,2 @@
+Reject CR/LF in HTTP headers in `http.server` and `wsgiref.headers` to prevent
+CRLF injection attacks.

--- a/Misc/NEWS.d/next/Library/2025-12-11-22-28-21.gh-issue-142533.SN0f9_.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-11-22-28-21.gh-issue-142533.SN0f9_.rst
@@ -1,2 +1,2 @@
-Reject CR/LF in HTTP headers in `http.server` and `wsgiref.headers` to prevent
-CRLF injection attacks.
+Reject CR/LF in HTTP headers in ``http.server`` and ``wsgiref.headers`` to
+prevent CRLF injection attacks.


### PR DESCRIPTION
The pull request involves a fix for CRLF injection vulnerability in `http.server` and `wsgiref` modules which allows attackers to inject arbitrary HTTP headers or perform HTTP response splitting attacks by including CR (`\r`) and LF (`\n`) characters in header values.

This PR also addresses CRLF issues raised in #55880, #72964 and #73610 as discussed in the linked issue.

This fix adds CRLF validation to `send_header()` method in `http.server`, and to three header-manipulation methods in used by `wsgiref`: `__setitem__()`, `setdefault()`, and `add_header()`.

For exception wording, to ensure consistency across both modules, the same `name/value` agnostic wording pattern as already used in existing `wsgiref` exception messages was used across the change: https://github.com/python/cpython/blob/b1c9582ebe13098195889931bebc274e6997f343/Lib/wsgiref/headers.py#L45

Added tests to verify CR/LF rejection in header names and values across http.server and email.message modules, covering all CRLF variants (\r, \n, \r\n).





<!-- gh-issue-number: gh-142533 -->
* Issue: gh-142533
<!-- /gh-issue-number -->
