### PR TITLE
gh-142606: Fix extra NULL arguments passed to PyObject_CallFunction

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-11-23-57-20.gh-issue-142606.Xd3xTx.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-11-23-57-20.gh-issue-142606.Xd3xTx.rst
@@ -1,3 +1,3 @@
 Fix two internal C API call sites where ``PyObject_CallFunction`` was
 incorrectly passed an extra ``NULL`` argument in
-:class:`collections.deque` and in the import machinery.  (gh-142606)
+:class:`collections.deque` and in the import machinery.

--- a/Misc/NEWS.d/next/Library/2025-12-11-23-57-20.gh-issue-142606.Xd3xTx.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-11-23-57-20.gh-issue-142606.Xd3xTx.rst
@@ -1,3 +1,0 @@
-Fix two internal C API call sites where ``PyObject_CallFunction`` was
-incorrectly passed an extra ``NULL`` argument in
-:class:`collections.deque` and in the import machinery.

--- a/Misc/NEWS.d/next/Library/2025-12-11-23-57-20.gh-issue-142606.Xd3xTx.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-11-23-57-20.gh-issue-142606.Xd3xTx.rst
@@ -1,0 +1,3 @@
+Fix two internal C API call sites where ``PyObject_CallFunction`` was
+incorrectly passed an extra ``NULL`` argument in
+:class:`collections.deque` and in the import machinery.  (gh-142606)

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -634,7 +634,7 @@ deque_copy_impl(dequeobject *deque)
                                      (PyObject *)deque);
     else
         result = PyObject_CallFunction((PyObject *)(Py_TYPE(deque)), "Oi",
-                                       deque, old_deque->maxlen, NULL);
+                                       deque, old_deque->maxlen);
     if (result != NULL && !PyObject_TypeCheck(result, state->deque_type)) {
         PyErr_Format(PyExc_TypeError,
                      "%.200s() must return a deque, not %.200s",

--- a/Python/import.c
+++ b/Python/import.c
@@ -4067,7 +4067,7 @@ PyImport_Import(PyObject *module_name)
        Always use absolute import here.
        Calling for side-effect of import. */
     r = PyObject_CallFunction(import, "OOOOi", module_name, globals,
-                              globals, from_list, 0, NULL);
+                              globals, from_list, 0);
     if (r == NULL)
         goto err;
     Py_DECREF(r);


### PR DESCRIPTION
This PR fixes incorrect calls to PyObject_CallFunction where an extra NULL argument was passed despite the format string already specifying the complete argument list.
PyObject_CallFunction does not use a NULL terminator; it relies solely on the format string to determine how many arguments to read. Providing more arguments than required results in undefined behavior due to va_list misalignment.

The affected calls:
- PyImport_Import() — "OOOOi" was given 6 arguments instead of 5
- deque_copy() — "Oi" was given 3 arguments instead of 2

Both have been corrected by removing the superfluous NULL. No functional changes beyond fixing the API misuse.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142606 -->
* Issue: gh-142606
<!-- /gh-issue-number -->
