### PR TITLE
gh-142595: add type check for namedtuple call during decimal initialization

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-12-02-56-26.gh-issue-142595.wHvTqq.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-12-02-56-26.gh-issue-142595.wHvTqq.rst
@@ -1,0 +1,2 @@
+Added type check during initialization of the :mod:`decimal` module to
+prevent a crash in case of broken stdlib.  Patch by Sergey B Kirpichev.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -7753,10 +7753,14 @@ _decimal_exec(PyObject *m)
 
     /* DecimalTuple */
     ASSIGN_PTR(collections, PyImport_ImportModule("collections"));
-    ASSIGN_PTR(state->DecimalTuple, (PyTypeObject *)PyObject_CallMethod(collections,
-                                 "namedtuple", "(ss)", "DecimalTuple",
-                                 "sign digits exponent"));
-
+    obj = PyObject_CallMethod(collections, "namedtuple", "(ss)", "DecimalTuple",
+                              "sign digits exponent");
+    if (!PyType_Check(obj)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "type is expected from namedtuple call");
+        goto error;
+    }
+    ASSIGN_PTR(state->DecimalTuple, (PyTypeObject *)obj);
     ASSIGN_PTR(obj, PyUnicode_FromString("decimal"));
     CHECK_INT(PyDict_SetItemString(state->DecimalTuple->tp_dict, "__module__", obj));
     Py_CLEAR(obj);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142595 -->
* Issue: gh-142595
<!-- /gh-issue-number -->
