### PR TITLE
gh-64551: Add RFC 5034 AUTH support to poplib

### DIFF
--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -245,7 +245,7 @@ A :class:`POP3` instance has the following methods:
    .. versionadded:: 3.4
 
 
-.. method:: POP3.auth(mechanism, authobject=None, initial_response=None)
+.. method:: POP3.auth(self, mechanism, authobject, *, initial_response_ok=True)
 
    Authenticate using the POP3 ``AUTH`` command as specified in :rfc:`5034`.
 

--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -245,6 +245,18 @@ A :class:`POP3` instance has the following methods:
    .. versionadded:: 3.4
 
 
+.. method:: POP3.auth(mechanism, authobject=None, initial_response=None)
+
+   Authenticate using the POP3 ``AUTH`` command as specified in :rfc:`5034`.
+
+   If *initial_response* is provided (``bytes`` or ``str``), it is
+   base64-encoded and appended to the command after a single space.
+
+   If *authobject* is provided, it is called with the server’s ``bytes``
+   challenge (already base64-decoded) and must return the client response
+   (``bytes`` or ``str``).  Return ``b'*'`` to abort the exchange.
+
+
 Instances of :class:`POP3_SSL` have no additional methods. The interface of this
 subclass is identical to its parent.
 

--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -249,12 +249,17 @@ A :class:`POP3` instance has the following methods:
 
    Authenticate using the POP3 ``AUTH`` command as specified in :rfc:`5034`.
 
-   If *initial_response* is provided (``bytes`` or ``str``), it is
-   base64-encoded and appended to the command after a single space.
+   If *initial_response_ok* is true, ``authobject()`` is called first with no
+   arguments to obtain an optional initial response. It may return :class:`bytes`
+   or :class:`str`; if it returns :const:`None`, no initial response is sent.
+   The returned value is base64-encoded before being sent.
 
-   If *authobject* is provided, it is called with the server’s ``bytes``
-   challenge (already base64-decoded) and must return the client response
-   (``bytes`` or ``str``).  Return ``b'*'`` to abort the exchange.
+   For each server challenge, ``authobject(challenge)`` is called with the
+   base64-decoded ``bytes`` challenge and must return the client response as
+   :class:`bytes` or :class:`str`. If it returns :const:`None`, an empty response
+   is sent. To abort the exchange, return ``b'*'`` (the client sends ``'*'``).
+
+   .. versionadded:: next
 
 
 Instances of :class:`POP3_SSL` have no additional methods. The interface of this

--- a/Lib/poplib.py
+++ b/Lib/poplib.py
@@ -221,27 +221,7 @@ class POP3:
     def auth(self, mechanism, authobject=None, initial_response=None):
         """Authenticate to the POP3 server using the AUTH command (RFC 5034).
 
-        Parameters
-        ----------
-        mechanism : str
-            SASL mechanism name, e.g. 'PLAIN', 'CRAM-MD5'.
-        authobject : callable, optional
-            Challenge-response callback.  Called with a `bytes` challenge
-            (already base64-decoded) and must return `bytes` or `str`.
-            Return ``b'*'`` to abort the exchange.
-        initial_response : bytes or str, optional
-            Initial client response to send immediately after the AUTH command.
-            If you supply this you must **not** supply *authobject*.
-
-        Returns
-        -------
-        bytes
-            The server's final line (``+OK ...`` or ``-ERR ...``).
-
-        Raises
-        ------
-        ValueError
-            If both *authobject* and *initial_response* are given.
+        Result is 'response'.
         """
         if authobject is not None and initial_response is not None:
             raise ValueError('authobject and initial_response are mutually exclusive')

--- a/Lib/poplib.py
+++ b/Lib/poplib.py
@@ -451,7 +451,7 @@ class POP3:
             if len(cmd.encode('ascii')) + 2 <= 255:
                 self._putcmd(cmd)
             else:
-                self._putcmd(f'AUTH {mech}') 
+                self._putcmd(f'AUTH {mech}')
         else:
             self._putcmd(f'AUTH {mech}')
 
@@ -543,7 +543,7 @@ if HAVE_SSL:
             SSL/TLS session.
             """
             raise error_proto('-ERR TLS session already established')
-        
+
 
     __all__.append("POP3_SSL")
 

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -2,6 +2,7 @@
 
 # Modified by Giampaolo Rodola' to give poplib.POP3 and poplib.POP3_SSL
 # a real test suite
+
 import base64
 import poplib
 import socket

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -326,7 +326,7 @@ class TestPOP3Class(TestCase):
 
     def test_auth_plain_initial_response(self):
         secret = b"user\x00adminuser\x00password"
-        resp = self.client.auth("PLAIN", initial_response=secret)
+        resp = self.client.auth("PLAIN", authobject=lambda: secret)
         self.assertStartsWith(resp, b"+OK")
 
     def test_auth_plain_challenge_response(self):
@@ -336,13 +336,9 @@ class TestPOP3Class(TestCase):
         resp = self.client.auth("PLAIN", authobject=authobject)
         self.assertStartsWith(resp, b"+OK")
 
-    def test_auth_rejects_conflicting_args(self):
-        with self.assertRaises(ValueError):
-            self.client.auth("PLAIN", authobject=lambda c: b"x", initial_response=b"y")
-
     def test_auth_unsupported_mechanism(self):
         with self.assertRaises(poplib.error_proto):
-            self.client.auth("FOO")
+            self.client.auth("FOO", authobject=lambda: b"")
 
     def test_auth_cancel(self):
         def authobject(_challenge):
@@ -353,12 +349,12 @@ class TestPOP3Class(TestCase):
     def test_auth_mechanism_case_insensitive(self):
         secret = b"user\x00adminuser\x00password"
         # use lowercase mechanism name to ensure server accepts
-        resp = self.client.auth("plain", initial_response=secret)
+        resp = self.client.auth("plain", authobject=lambda: secret)
         self.assertStartsWith(resp, b"+OK")
 
     def test_auth_initial_response_str(self):
         secret = "user\x00adminuser\x00password"  # str, not bytes
-        resp = self.client.auth("PLAIN", initial_response=secret)
+        resp = self.client.auth("PLAIN", authobject=lambda: secret)
         self.assertStartsWith(resp, b"+OK")
 
     def test_auth_authobject_returns_str(self):

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -332,7 +332,7 @@ class TestPOP3Class(TestCase):
 
     def test_auth_plain_challenge_response(self):
         secret = b"user\x00adminuser\x00password"
-        def authobject(challenge):
+        def authobject():
             return secret
         resp = self.client.auth("PLAIN", authobject=authobject)
         self.assertStartsWith(resp, b"+OK")
@@ -342,10 +342,8 @@ class TestPOP3Class(TestCase):
             self.client.auth("FOO", authobject=lambda: b"")
 
     def test_auth_cancel(self):
-        def authobject(_challenge):
-            return b"*"
         with self.assertRaises(poplib.error_proto):
-            self.client.auth("PLAIN", authobject=authobject)
+            self.client.auth("PLAIN", authobject=lambda chal: b"*", initial_response_ok=False)
 
     def test_auth_mechanism_case_insensitive(self):
         secret = b"user\x00adminuser\x00password"
@@ -359,7 +357,7 @@ class TestPOP3Class(TestCase):
         self.assertStartsWith(resp, b"+OK")
 
     def test_auth_authobject_returns_str(self):
-        def authobject(challenge):
+        def authobject():
             return "user\x00adminuser\x00password"
         resp = self.client.auth("PLAIN", authobject=authobject)
         self.assertStartsWith(resp, b"+OK")

--- a/Misc/NEWS.d/next/Library/2025-12-12-15-09-34.gh-issue-64551.NfWlQX.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-12-15-09-34.gh-issue-64551.NfWlQX.rst
@@ -1,0 +1,1 @@
+Add RFC 5034 AUTH support to poplib

--- a/Misc/NEWS.d/next/Library/2025-12-12-15-09-34.gh-issue-64551.NfWlQX.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-12-15-09-34.gh-issue-64551.NfWlQX.rst
@@ -1,1 +1,1 @@
-Add RFC 5034 AUTH support to poplib
+:mod:`poplib`: add :rfc:`5034` ``AUTH`` support.


### PR DESCRIPTION
Add RFC 5034 AUTH support to poplib

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-64551 -->
* Issue: gh-64551
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142613.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->