### PR TITLE
gh-142568: Fix eval() docs to use 'source' parameter name

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -606,16 +606,16 @@ are always available.  They are listed here in alphabetical order.
       This function executes arbitrary code. Calling it with
       user-supplied input may lead to security vulnerabilities.
 
-   The *expression* argument is parsed and evaluated as a Python expression
+   The *source* argument is parsed and evaluated as a Python expression
    (technically speaking, a condition list) using the *globals* and *locals*
    mappings as global and local namespace.  If the *globals* dictionary is
    present and does not contain a value for the key ``__builtins__``, a
    reference to the dictionary of the built-in module :mod:`builtins` is
-   inserted under that key before *expression* is parsed.  That way you can
+   inserted under that key before *source* is parsed.  That way you can
    control what builtins are available to the executed code by inserting your
    own ``__builtins__`` dictionary into *globals* before passing it to
    :func:`eval`.  If the *locals* mapping is omitted it defaults to the
-   *globals* dictionary.  If both mappings are omitted, the expression is
+   *globals* dictionary.  If both mappings are omitted, the source is
    executed with the *globals* and *locals* in the environment where
    :func:`eval` is called.  Note, *eval()* will only have access to the
    :term:`nested scopes <nested scope>` (non-locals) in the enclosing


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.
-->

## Summary

Fixes an inconsistency in the documentation for `eval()` where the parameter
was referred to as “expression” instead of “source”, which does not match
the function signature.

## Rationale

The function signature and parameter description already use `source`.
Updating the prose ensures consistency and avoids confusion for readers.

## Changes

* Update `Doc/library/functions.rst` to consistently refer to the `source`
  parameter in the `eval()` documentation.

## Testing

Not applicable — documentation-only change.

## Related issue

* gh-142568


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142644.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->