### PR TITLE
gh-142252: Augment functools.cached_property tests for set/delete

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3561,6 +3561,13 @@ class TestCachedProperty(unittest.TestCase):
         self.assertEqual(item.cost, 2)
         self.assertEqual(item.cost, 2) # not 3
 
+        item.cost = 42
+        self.assertEqual(item.cost, 42)
+
+        del item.cost
+        self.assertEqual(item.cost, 3)
+        self.assertEqual(item.cost, 3) # not 4
+
     def test_cached_attribute_name_differs_from_func_name(self):
         item = OptionallyCachedCostItem()
         self.assertEqual(item.get_cost(), 2)


### PR DESCRIPTION
Added tests to verify that setting and deleting a cached_property works as expected, ensuring the cache is overwritten or reset.

<!-- gh-issue-number: gh-142252 -->
* Issue: gh-142252
<!-- /gh-issue-number -->
