### PR TITLE
gh-76007: Deprecate `__version__` attribute in `http.server`

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.20.rst
+++ b/Doc/deprecations/pending-removal-in-3.20.rst
@@ -9,6 +9,7 @@ Pending removal in Python 3.20
   - :mod:`csv`
   - :mod:`!ctypes.macholib`
   - :mod:`decimal` (use :data:`decimal.SPEC_VERSION` instead)
+  - :mod:`http.server`
   - :mod:`imaplib`
   - :mod:`ipaddress`
   - :mod:`json`

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1026,6 +1026,7 @@ New deprecations
     - :mod:`csv`
     - :mod:`!ctypes.macholib`
     - :mod:`decimal` (use :data:`decimal.SPEC_VERSION` instead)
+    - :mod:`http.server`
     - :mod:`imaplib`
     - :mod:`ipaddress`
     - :mod:`json`

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -61,8 +61,6 @@ XXX To do:
 # (Actually, the latter is only true if you know the server configuration
 # at the time the request was made!)
 
-__version__ = "0.6"
-
 __all__ = [
     "HTTPServer", "ThreadingHTTPServer",
     "HTTPSServer", "ThreadingHTTPSServer",
@@ -280,7 +278,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
     # The server software version.  You may want to override this.
     # The format is multiple whitespace-separated strings,
     # where each string is of the form name[/version].
-    server_version = "BaseHTTP/" + __version__
+    server_version = "BaseHTTP"
 
     error_message_format = DEFAULT_ERROR_MESSAGE
     error_content_type = DEFAULT_ERROR_CONTENT_TYPE
@@ -690,7 +688,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
     """
 
-    server_version = "SimpleHTTP/" + __version__
+    server_version = "SimpleHTTP"
     index_pages = ("index.html", "index.htm")
     extensions_map = _encodings_map_default = {
         '.gz': 'application/gzip',
@@ -1078,6 +1076,15 @@ def _main(args=None):
         tls_key=args.tls_key,
         tls_password=tls_key_password,
     )
+
+
+def __getattr__(name):
+    if name == "__version__":
+        from warnings import _deprecated
+
+        _deprecated("__version__", remove=(3, 20))
+        return "0.6"  # Do not change
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1560,6 +1560,16 @@ class CommandLineRunTimeTestCase(unittest.TestCase):
         self.assertEqual(res, self.served_data)
 
 
+class TestModule(unittest.TestCase):
+    def test_deprecated__version__(self):
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            "'__version__' is deprecated and slated for removal in Python 3.20",
+        ) as cm:
+            getattr(http.server, "__version__")
+        self.assertEqual(cm.filename, __file__)
+
+
 def setUpModule():
     unittest.addModuleCleanup(os.chdir, os.getcwd())
 

--- a/Misc/NEWS.d/3.15.0a2.rst
+++ b/Misc/NEWS.d/3.15.0a2.rst
@@ -583,7 +583,7 @@ would raise an error.
 .. nonce: peEgcr
 .. section: Library
 
-Deprecate ``__version__`` from a :mod:`imaplib`. Patch by Hugo van Kemenade.
+Deprecate ``__version__`` from :mod:`imaplib`. Patch by Hugo van Kemenade.
 
 ..
 

--- a/Misc/NEWS.d/next/Library/2025-12-13-00-09-09.gh-issue-76007.Xg1xCO.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-13-00-09-09.gh-issue-76007.Xg1xCO.rst
@@ -1,2 +1,2 @@
-Deprecate ``__version__`` from a :mod:`http.server`. Patch by Hugo van
+Deprecate ``__version__`` from :mod:`http.server`. Patch by Hugo van
 Kemenade.

--- a/Misc/NEWS.d/next/Library/2025-12-13-00-09-09.gh-issue-76007.Xg1xCO.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-13-00-09-09.gh-issue-76007.Xg1xCO.rst
@@ -1,0 +1,2 @@
+Deprecate ``__version__`` from a :mod:`http.server`. Patch by Hugo van
+Kemenade.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

In the [issue](https://github.com/python/cpython/issues/76007#issuecomment-3448691842) @vstinner said:

> IMO it's a good idea to use the Python version as the HTTP server version.

However, the Python version is already part of the combined version string: "BaseHTTP/0.6 Python/3.15.0".

This is made up of:

```python
    def version_string(self):
        """Return the server software version string."""
        return self.server_version + ' ' + self.sys_version
```

And the comments say `server_version` can be a name without a version:

```python
    # The Python system version, truncated to its first component.
    sys_version = "Python/" + sys.version.split()[0]

    # The server software version.  You may want to override this.
    # The format is multiple whitespace-separated strings,
    # where each string is of the form name[/version].
    server_version = "BaseHTTP/" + __version__

```

So better to have something like "BaseHTTP Python/3.15.0" rather than "BaseHTTP/3.15.0 Python/3.15.0".


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142658.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-76007 -->
* Issue: gh-76007
<!-- /gh-issue-number -->
