### PR TITLE
gh-142554: avoid `divmod` crashes due to bad `_pylong.int_divmod`

### DIFF
--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -778,6 +778,18 @@ class PyLongModuleTests(unittest.TestCase):
         a, b = divmod(n*3 + 1, n)
         assert a == 3 and b == 1
 
+    @support.cpython_only  # tests implementation details of CPython.
+    @unittest.skipUnless(_pylong, "_pylong module required")
+    def test_pylong_int_divmod_crash(self):
+        # Regression test for https://github.com/python/cpython/issues/142554.
+        bad_int_divmod = lambda a, b: (1,)
+        # 'k' chosen such that divmod(2**(2*k), 2**k) uses _pylong.int_divmod()
+        k = 10_000
+        a, b = (1 << (2 * k)), (1 << k)
+        with mock.patch.object(_pylong, "int_divmod", wraps=bad_int_divmod):
+            msg = r"tuple of length 2 is required from int_divmod\(\)"
+            self.assertRaisesRegex(ValueError, msg, divmod, a, b)
+
     def test_pylong_str_to_int(self):
         v1 = 1 << 100_000
         s = str(v1)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-13-17-20-38.gh-issue-142554.wNtEFF.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-13-17-20-38.gh-issue-142554.wNtEFF.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`divmod` when :func:`!_pylong.int_divmod` does not
+return a tuple of length two exactly. Patch by Bénédikt Tran.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4434,10 +4434,10 @@ pylong_int_divmod(PyLongObject *v, PyLongObject *w,
     if (result == NULL) {
         return -1;
     }
-    if (!PyTuple_Check(result)) {
+    if (!PyTuple_Check(result) || PyTuple_GET_SIZE(result) != 2) {
         Py_DECREF(result);
         PyErr_SetString(PyExc_ValueError,
-                        "tuple is required from int_divmod()");
+                        "tuple of length 2 is required from int_divmod()");
         return -1;
     }
     PyObject *q = PyTuple_GET_ITEM(result, 0);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142554 -->
* Issue: gh-142554
<!-- /gh-issue-number -->
