### PR TITLE
Add pablogsal as codeowner for profiling sampling files and docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -322,7 +322,7 @@ Tools/build/generate_global_objects.py    @ericsnowcurrently
 # Remote Debugging
 Python/remote_debug.h               @pablogsal
 Python/remote_debugging.c           @pablogsal
-Modules/_remote_debugging_module.c  @pablogsal @ambv @1st1
+Modules/_remote_debugging/          @pablogsal
 
 # Sub-Interpreters
 **/*crossinterp*                          @ericsnowcurrently
@@ -536,6 +536,11 @@ Lib/test/test_remote_pdb.py   @gaogaotiantian
 Lib/pydoc.py                  @AA-Turner
 Lib/pydoc_data/               @AA-Turner
 Lib/test/test_pydoc/          @AA-Turner
+
+# Profiling (Sampling)
+Doc/library/profiling*.rst    @pablogsal
+Lib/profiling/                @pablogsal
+Lib/test/test_profiling/      @pablogsal
 
 # PyREPL
 Lib/_pyrepl/                  @pablogsal @lysnikolaou @ambv


### PR DESCRIPTION
Add ownership entries for the sampling profiler (Tachyon) including
the Lib/profiling/ package, test files, and documentation. Also add
the Modules/_remote_debugging/ directory to the existing remote
debugging section.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
