### PR TITLE
[3.13] gh-142411: Change documentation to reflect the new docstring adjustments in 3.13 (GH-142413)

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -334,8 +334,8 @@ are always available.  They are listed here in alphabetical order.
    ``__debug__`` is true), ``1`` (asserts are removed, ``__debug__`` is false)
    or ``2`` (docstrings are removed too).
 
-   This function raises :exc:`SyntaxError` if the compiled source is invalid,
-   and :exc:`ValueError` if the source contains null bytes.
+   This function raises :exc:`SyntaxError` or :exc:`ValueError` if the compiled
+   source is invalid.
 
    If you want to parse Python code into its AST representation, see
    :func:`ast.parse`.

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -1038,31 +1038,28 @@ blank, visually separating the summary from the rest of the description.  The
 following lines should be one or more paragraphs describing the object's calling
 conventions, its side effects, etc.
 
-The Python parser does not strip indentation from multi-line string literals in
-Python, so tools that process documentation have to strip indentation if
-desired.  This is done using the following convention. The first non-blank line
-*after* the first line of the string determines the amount of indentation for
-the entire documentation string.  (We can't use the first line since it is
-generally adjacent to the string's opening quotes so its indentation is not
-apparent in the string literal.)  Whitespace "equivalent" to this indentation is
-then stripped from the start of all lines of the string.  Lines that are
-indented less should not occur, but if they occur all their leading whitespace
-should be stripped.  Equivalence of whitespace should be tested after expansion
-of tabs (to 8 spaces, normally).
+The Python parser strips indentation from multi-line string literals when they
+serve as module, class, or function docstrings.
 
 Here is an example of a multi-line docstring::
 
    >>> def my_function():
    ...     """Do nothing, but document it.
    ...
-   ...     No, really, it doesn't do anything.
+   ...     No, really, it doesn't do anything:
+   ...
+   ...         >>> my_function()
+   ...         >>>
    ...     """
    ...     pass
    ...
    >>> print(my_function.__doc__)
    Do nothing, but document it.
 
-   No, really, it doesn't do anything.
+   No, really, it doesn't do anything:
+
+       >>> my_function()
+       >>>
 
 
 .. _tut-annotations:


### PR DESCRIPTION
(cherry picked from commit f6b6a99aa5d63702b8e8101864ae08e615131702)

<!-- gh-issue-number: gh-142411 -->
* Issue: gh-142411
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142690.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->