### PR TITLE
[doc] State clearly that open() 'file' param is "name" attr of the result

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1494,6 +1494,12 @@ are always available.  They are listed here in alphabetical order.
    disabled, the raw stream, a subclass of :class:`io.RawIOBase`,
    :class:`io.FileIO`, is returned.
 
+   The *file* argument is saved as the :attr:`~io.IOBase.name` attribute of
+   the returned file object. If *file* is given as a string or bytes object,
+   it will be saved as-is. If it is given as an integer file descriptor,
+   the :attr:`~io.IOBase.name` attribute will contain the file descriptor value.
+   For other object types, the representation of the object will be stored.
+
    .. index::
       single: line-buffered I/O
       single: unbuffered I/O
@@ -1539,6 +1545,10 @@ are always available.  They are listed here in alphabetical order.
 
    .. versionchanged:: 3.11
       The ``'U'`` mode has been removed.
+
+   .. versionchanged:: 3.13
+      Clarified that the *file* argument is saved as the :attr:`~io.IOBase.name`
+      attribute.
 
 .. function:: ord(character, /)
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -363,6 +363,14 @@ I/O Base Classes
       As a convenience, it is allowed to call this method more than once;
       only the first call, however, will have an effect.
 
+   .. attribute:: name
+
+      The name of the underlying file if it has one.
+      This is the *file* argument as passed to :func:`open` or the constructor.
+      The type of this attribute depends on what was originally passed - it may
+      be a string, bytes, integer file descriptor, or other object representation.
+      If there is no underlying file, the attribute may be ``None``.
+
    .. attribute:: closed
 
       ``True`` if the stream is closed.
@@ -700,8 +708,11 @@ Raw File I/O
 
    .. attribute:: name
 
-      The file name.  This is the file descriptor of the file when no name is
-      given in the constructor.
+      The file name.  This is the *name* argument as passed to the constructor.
+      Depending on the type of object that was passed, this may be a string,
+      bytes, integer file descriptor, or other object representation.
+      If the file was opened using a file descriptor, the *name* attribute
+      will contain the file descriptor value.
 
 
 Buffered Streams


### PR DESCRIPTION
## Summary
Update documentation to clearly state that the `file` argument passed to `open()` is stored as the `name` attribute of the returned file object.

## Changes Made
1. **Doc/library/functions.rst**: Added explicit documentation for the `open()` function
2. **Doc/library/io.rst**: Updated documentation for `FileIO.name` and added missing `IOBase.name` attribute

## Key Clarifications
- The `name` attribute stores exactly what was passed as the `file` argument
- It can be string, bytes, integer file descriptor, or other representation
- This behavior is preserved for backward compatibility
- Added `.. versionchanged:: 3.13` directive to document the clarification

## Testing
- Verified documentation builds correctly
- Behavior matches existing Python implementation
- Cross-references between functions.rst and io.rst are consistent

Closes gh-62734

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142694.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->