### PR TITLE
[3.13] gh-142554: avoid `divmod` crashes due to bad `_pylong.int_divmod` (GH-142673)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2025-12-13-17-20-38.gh-issue-142554.wNtEFF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-12-13-17-20-38.gh-issue-142554.wNtEFF.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`divmod` when :func:`!_pylong.int_divmod` does not
+return a tuple of length two exactly. Patch by Bénédikt Tran.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4324,10 +4324,10 @@ pylong_int_divmod(PyLongObject *v, PyLongObject *w,
     if (result == NULL) {
         return -1;
     }
-    if (!PyTuple_Check(result)) {
+    if (!PyTuple_Check(result) || PyTuple_GET_SIZE(result) != 2) {
         Py_DECREF(result);
         PyErr_SetString(PyExc_ValueError,
-                        "tuple is required from int_divmod()");
+                        "tuple of length 2 is required from int_divmod()");
         return -1;
     }
     PyObject *q = PyTuple_GET_ITEM(result, 0);


### PR DESCRIPTION
(cherry picked from commit 4e4163676add8caab2dec6cdb93e1b317cf02a2e)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142554 -->
* Issue: gh-142554
<!-- /gh-issue-number -->
