### PR TITLE
[3.14] gh-142451: correctly copy HMAC attributes in `HMAC.copy()` (GH-142510)

### DIFF
--- a/Lib/hmac.py
+++ b/Lib/hmac.py
@@ -159,6 +159,7 @@ class HMAC:
         # Call __new__ directly to avoid the expensive __init__.
         other = self.__class__.__new__(self.__class__)
         other.digest_size = self.digest_size
+        other.block_size = self.block_size
         if self._hmac:
             other._hmac = self._hmac.copy()
             other._inner = other._outer = None

--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -1076,6 +1076,15 @@ class SanityTestCaseMixin(CreatorMixin):
         self.assertEqual(h.digest_size, self.digest_size)
         self.assertEqual(h.block_size, self.block_size)
 
+    def test_copy(self):
+        # Test a generic copy() and the attributes it exposes.
+        # See https://github.com/python/cpython/issues/142451.
+        h1 = self.hmac_new(b"my secret key", digestmod=self.digestname)
+        h2 = h1.copy()
+        self.assertEqual(h1.name, h2.name)
+        self.assertEqual(h1.digest_size, h2.digest_size)
+        self.assertEqual(h1.block_size, h2.block_size)
+
     def test_repr(self):
         # HMAC object representation may differ across implementations
         raise NotImplementedError

--- a/Misc/NEWS.d/next/Library/2025-12-14-10-00-23.gh-issue-142451._rkf2S.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-14-10-00-23.gh-issue-142451._rkf2S.rst
@@ -1,0 +1,3 @@
+:mod:`hmac`: Ensure that the :attr:`HMAC.block_size <hmac.HMAC.block_size>`
+attribute is correctly copied by :meth:`HMAC.copy <hmac.HMAC.copy>`. Patch
+by Bénédikt Tran.


### PR DESCRIPTION
This is partially cherry-picked from d3ef5ba34d3068b8178d6ff0f39462db6bbc4ad5. Only the pure Python `copy()` method is affected because I didn't migrate HMAC to OpenSSL 3 before 3.15.

<!-- gh-issue-number: gh-142451 -->
* Issue: gh-142451
<!-- /gh-issue-number -->
