### PR TITLE
[3.13] gh-142461: Move misplaced NEWS entries to an appropriate section (GH-142464) (GH-142688)

### DIFF
--- a/Misc/NEWS.d/3.12.0a7.rst
+++ b/Misc/NEWS.d/3.12.0a7.rst
@@ -102,7 +102,7 @@ Shrink the number of inline :opcode:`CACHE` entries used by
 .. date: 2023-03-08-08-37-36
 .. gh-issue: 102491
 .. nonce: SFvvsC
-.. section: Core and Builtins
+.. section: Library
 
 Improve import time of ``platform`` by removing IronPython version parsing.
 The IronPython version parsing was not functional (see
@@ -187,7 +187,7 @@ Improve build support for the Xbox. Patch by Max Bachmann.
 .. date: 2023-02-21-23-42-39
 .. gh-issue: 102027
 .. nonce: fQARG0
-.. section: Core and Builtins
+.. section: Library
 
 Fix SSE2 and SSE3 detection in ``_blake2`` internal module. Patch by Max
 Bachmann.
@@ -207,7 +207,7 @@ Deprecate ``co_lnotab`` in code objects, schedule it for removal in Python
 .. bpo: 1635741
 .. date: 2020-07-04-09-04-41
 .. nonce: ZsP31Y
-.. section: Core and Builtins
+.. section: Library
 
 Adapt :mod:`!_pickle` to :pep:`687`. Patch by Mohamed Koubaa and Erlend
 Aasland.

--- a/Misc/NEWS.d/3.12.0b1.rst
+++ b/Misc/NEWS.d/3.12.0b1.rst
@@ -44,7 +44,7 @@ response to :cve:`2023-24329`. Patch by Illia Volochii.
 .. date: 2023-05-20-23-08-48
 .. gh-issue: 102856
 .. nonce: Knv9WT
-.. section: Core and Builtins
+.. section: Library
 
 Implement PEP 701 changes in the :mod:`tokenize` module. Patch by Marta
 Gómez Macías and Pablo Galindo Salgado
@@ -322,7 +322,7 @@ ruff.
 .. date: 2023-04-24-14-38-16
 .. gh-issue: 103793
 .. nonce: kqoH6Q
-.. section: Core and Builtins
+.. section: Library
 
 Optimized asyncio Task creation by deferring expensive string formatting
 (task name generation) from Task creation to the first time ``get_name`` is
@@ -461,7 +461,7 @@ unpickled.
 .. date: 2023-04-08-17-13-07
 .. gh-issue: 103242
 .. nonce: ysI1b3
-.. section: Core and Builtins
+.. section: Library
 
 Migrate :meth:`~ssl.SSLContext.set_ecdh_curve` method not to use deprecated
 OpenSSL APIs. Patch by Donghee Na.
@@ -573,7 +573,7 @@ raising an :exc:`IndexError`.
 .. bpo: 31821
 .. date: 2019-12-01-12-58-31
 .. nonce: 1FNmwk
-.. section: Core and Builtins
+.. section: Library
 
 Fix :func:`!pause_reading` to work when called from :func:`!connection_made`
 in :mod:`asyncio`.

--- a/Misc/NEWS.d/3.13.0.rst
+++ b/Misc/NEWS.d/3.13.0.rst
@@ -2,7 +2,7 @@
 .. gh-issue: 125008
 .. nonce: ETANpd
 .. release date: 2024-10-07
-.. section: Core and Builtins
+.. section: Library
 
 Fix :func:`tokenize.untokenize` producing invalid syntax for double braces
 preceded by certain escape characters.

--- a/Misc/NEWS.d/3.13.0b1.rst
+++ b/Misc/NEWS.d/3.13.0b1.rst
@@ -60,7 +60,7 @@ for speed.
 .. date: 2024-05-03-18-01-26
 .. gh-issue: 95382
 .. nonce: 73FSEv
-.. section: Core and Builtins
+.. section: Library
 
 Improve performance of :func:`json.dumps` and :func:`json.dump` when using
 the argument *indent*. Depending on the data the encoding using

--- a/Misc/NEWS.d/3.13.0b3.rst
+++ b/Misc/NEWS.d/3.13.0b3.rst
@@ -99,7 +99,7 @@ after exception handlers are moved to the end of the code.
 .. date: 2024-06-12-18-23-15
 .. gh-issue: 120380
 .. nonce: edtqjq
-.. section: Core and Builtins
+.. section: Library
 
 Fix Python implementation of :class:`pickle.Pickler` for :class:`bytes` and
 :class:`bytearray` objects when using protocol version 5. Patch by Bénédikt

--- a/Misc/NEWS.d/3.13.0rc2.rst
+++ b/Misc/NEWS.d/3.13.0rc2.rst
@@ -427,7 +427,7 @@ Riggles.
 .. date: 2024-09-06-19-23-44
 .. gh-issue: 120221
 .. nonce: giJEDT
-.. section: Core and Builtins
+.. section: Library
 
 asyncio REPL is now again properly recognizing KeyboardInterrupts. Display
 of exceptions raised in secondary threads is fixed.

--- a/Misc/NEWS.d/3.13.1.rst
+++ b/Misc/NEWS.d/3.13.1.rst
@@ -1560,7 +1560,7 @@ including SerenityOS.
 .. date: 2024-11-09-16-10-22
 .. gh-issue: 126066
 .. nonce: 9zs4m4
-.. section: Core and Builtins
+.. section: Library
 
 Fix :mod:`importlib` to not write an incomplete .pyc files when a ulimit or
 some other operating system mechanism is preventing the write to go through
@@ -1748,7 +1748,7 @@ https://github.com/python/cpython/issues/122950.)
 .. date: 2024-05-12-03-10-36
 .. gh-issue: 118950
 .. nonce: 5Wc4vp
-.. section: Core and Builtins
+.. section: Library
 
 Fix bug where SSLProtocol.connection_lost wasn't getting called when OSError
 was thrown on writing to socket.
@@ -1758,7 +1758,7 @@ was thrown on writing to socket.
 .. date: 2023-12-30-00-21-45
 .. gh-issue: 113570
 .. nonce: _XQgsW
-.. section: Core and Builtins
+.. section: Library
 
 Fixed a bug in ``reprlib.repr`` where it incorrectly called the repr method
 on shadowed Python built-in types.

--- a/Misc/NEWS.d/3.13.2.rst
+++ b/Misc/NEWS.d/3.13.2.rst
@@ -699,7 +699,7 @@ returns :const:`False`. Patch by Bénédikt Tran.
 .. date: 2025-01-28-06-23-59
 .. gh-issue: 129345
 .. nonce: uOjkML
-.. section: Core and Builtins
+.. section: Library
 
 Fix null pointer dereference in :func:`syslog.openlog` when an audit hook
 raises an exception.

--- a/Misc/NEWS.d/3.13.3.rst
+++ b/Misc/NEWS.d/3.13.3.rst
@@ -856,7 +856,7 @@ Pablo Galindo
 .. date: 2025-02-11-20-38-37
 .. gh-issue: 129983
 .. nonce: _1Fujo
-.. section: Core and Builtins
+.. section: Library
 
 Fix data race in compile_template in :file:`sre.c`.
 

--- a/Misc/NEWS.d/3.13.4.rst
+++ b/Misc/NEWS.d/3.13.4.rst
@@ -655,7 +655,7 @@ docstring to the official docs.
 .. date: 2025-05-30-15-56-19
 .. gh-issue: 134908
 .. nonce: 3a7PxM
-.. section: Core and Builtins
+.. section: Library
 
 Fix crash when iterating over lines in a text file on the :term:`free
 threaded <free threading>` build.
@@ -675,7 +675,7 @@ behavior of list comprehensions in line with other forms of iteration
 .. date: 2025-05-22-14-48-19
 .. gh-issue: 134381
 .. nonce: 2BXhth
-.. section: Core and Builtins
+.. section: Library
 
 Fix :exc:`RuntimeError` when using a not-started :class:`threading.Thread`
 after calling :func:`os.fork`


### PR DESCRIPTION
(cherry picked from commit 7297d3a98d377519c83ef142043ad22376abfe7c)
(cherry picked from commit 87e152d203259784beb3e97067ce1c25ebb7a41c)


<!-- gh-issue-number: gh-142461 -->
* Issue: gh-142461
<!-- /gh-issue-number -->
