### PR TITLE
 gh-106318: Add examples for str.ljust() method 

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2261,6 +2261,14 @@ expression support in the :mod:`re` module).
    done using the specified *fillchar* (default is an ASCII space). The
    original string is returned if *width* is less than or equal to ``len(s)``.
 
+   For example::
+
+      >>> 'Python'.ljust(10)
+      'Python    '
+      >>> 'Python'.ljust(10, '.')
+      'Python....'
+
+   See also :meth:`rjust`.
 
 .. method:: str.lower()
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2274,6 +2274,7 @@ expression support in the :mod:`re` module).
 
    See also :meth:`rjust`.
 
+
 .. method:: str.lower()
 
    Return a copy of the string with all the cased characters [4]_ converted to

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2261,12 +2261,16 @@ expression support in the :mod:`re` module).
    done using the specified *fillchar* (default is an ASCII space). The
    original string is returned if *width* is less than or equal to ``len(s)``.
 
-   For example::
+   For example:
+
+   .. doctest::
 
       >>> 'Python'.ljust(10)
       'Python    '
       >>> 'Python'.ljust(10, '.')
       'Python....'
+      >>> 'Monty Python'.ljust(10, '.')
+      'Monty Python'
 
    See also :meth:`rjust`.
 


### PR DESCRIPTION
WIP to #106318

#106318: Add examples for str.isnumeric() method



<!-- gh-issue-number: gh-106318 -->
* Issue: gh-106318
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142719.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->