### PR TITLE
gh-142721: Use the correct macros defined in TargerConditionals for Apple targets

### DIFF
--- a/Misc/NEWS.d/next/macOS/2025-12-14-15-05-10.gh-issue-142721.ZpCaPm.rst
+++ b/Misc/NEWS.d/next/macOS/2025-12-14-15-05-10.gh-issue-142721.ZpCaPm.rst
@@ -1,0 +1,1 @@
+Corrected the macro names for conditional Apple targets.

--- a/Objects/mimalloc/prim/unix/prim.c
+++ b/Objects/mimalloc/prim/unix/prim.c
@@ -39,7 +39,7 @@ terms of the MIT license. A copy of the license can be found in the file
   #endif
 #elif defined(__APPLE__)
   #include <TargetConditionals.h>
-  #if !TARGET_IOS_IPHONE && !TARGET_IOS_SIMULATOR
+  #if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
   #include <mach/vm_statistics.h>
   #endif
 #elif defined(__FreeBSD__) || defined(__DragonFly__)


### PR DESCRIPTION
mach/vm_statistics.h was always included because #if !TARGET_IOS_IPHONE && !TARGET_IOS_SIMULATOR resolved to true, always.

<!-- gh-issue-number: gh-142721 -->
* Issue: gh-142721
<!-- /gh-issue-number -->
