### PR TITLE
gh-142724: fix error path in `_PyPegen_raise_tokenizer_init_error`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-14-15-43-02.gh-issue-142724.GtJJL9.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-14-15-43-02.gh-issue-142724.GtJJL9.rst
@@ -1,1 +1,0 @@
-Fixed error that would have prevented tuples from being checked.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-14-15-43-02.gh-issue-142724.GtJJL9.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-14-15-43-02.gh-issue-142724.GtJJL9.rst
@@ -1,0 +1,1 @@
+Fixed error that would have prevented tuples from being checked.

--- a/Parser/pegen_errors.c
+++ b/Parser/pegen_errors.c
@@ -43,7 +43,7 @@ _PyPegen_raise_tokenizer_init_error(PyObject *filename)
 
     tuple = PyTuple_Pack(2, errstr, tmp);
     Py_DECREF(tmp);
-    if (!value) {
+    if (!tuple) {
         goto error;
     }
     PyErr_SetObject(PyExc_SyntaxError, tuple);


### PR DESCRIPTION
Value is checked twice by mistake.

<!-- gh-issue-number: gh-142724 -->
* Issue: gh-142724
<!-- /gh-issue-number -->
