### PR TITLE
gh-141081: Don't create .gitignore in site-packages

### DIFF
--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -969,17 +969,20 @@ class SourceFileLoader(FileLoader, SourceLoader):
                 return
 
             if part == _PYCACHE:
-                gitignore = _path_join(parent, '.gitignore')
-                try:
-                    _path_stat(gitignore)
-                except FileNotFoundError:
-                    gitignore_content = b'# Created by CPython\n*\n'
+                # Don't create in site-packages as these are managed
+                # by package installers, not Git
+                if 'site-packages' not in parent:
+                    gitignore = _path_join(parent, '.gitignore')
                     try:
-                        _write_atomic(gitignore, gitignore_content, _mode)
+                        _path_stat(gitignore)
+                    except FileNotFoundError:
+                        gitignore_content = b'# Created by CPython\n*\n'
+                        try:
+                            _write_atomic(gitignore, gitignore_content, _mode)
+                        except OSError:
+                            pass
                     except OSError:
                         pass
-                except OSError:
-                    pass
         try:
             _write_atomic(path, data, _mode)
             _bootstrap._verbose_message('created {!r}', path)

--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -156,13 +156,16 @@ def compile(file, cfile=None, dfile=None, doraise=False, optimize=-1,
         if dirname:
             os.makedirs(dirname)
             if os.path.basename(dirname) == '__pycache__':
-                gitignore = os.path.join(dirname, '.gitignore')
-                if not os.path.exists(gitignore):
-                    try:
-                        with open(gitignore, 'wb') as f:
-                            f.write(b'# Created by CPython\n*\n')
-                    except OSError:
-                        pass
+                # Don't create in site-packages as these are managed
+                # by package installers, not Git
+                if 'site-packages' not in dirname:
+                    gitignore = os.path.join(dirname, '.gitignore')
+                    if not os.path.exists(gitignore):
+                        try:
+                            with open(gitignore, 'wb') as f:
+                                f.write(b'# Created by CPython\n*\n')
+                        except OSError:
+                            pass
     except FileExistsError:
         pass
     if invalidation_mode == PycInvalidationMode.TIMESTAMP:


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The [buildbot failures](https://github.com/python/cpython/pull/141162#issuecomment-3654883104):

```pytb
test_with_pip (test.test_venv.EnsurePipTest.test_with_pip) ... FAIL

======================================================================
FAIL: test_with_pip (test.test_venv.EnsurePipTest.test_with_pip)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/buildbot/buildarea/3.x.itamaro-centos-aws.nogil/build/Lib/test/test_venv.py", line 1047, in test_with_pip
    self.do_test_with_pip(False)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/home/buildbot/buildarea/3.x.itamaro-centos-aws.nogil/build/Lib/test/test_venv.py", line 1023, in do_test_with_pip
    self.assert_pip_not_installed()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/buildbot/buildarea/3.x.itamaro-centos-aws.nogil/build/Lib/test/test_venv.py", line 906, in assert_pip_not_installed
    self.assertEqual(out.strip(), "OK")
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
AssertionError: '' != 'OK'
+ OK
```

The problem was that when pip uninstalls itself, it removes its own files, and then tries to remove empty directories like `__pycache__`. But `__pycache__` contains our `.gitignore` so the dir removal fails.

Instead, let's not add `.gitignore` in `site-packages` dirs, and let the package managers handle those.

[Debian and Ubuntu use `dist-packages`](https://wiki.debian.org/Python#Deviations_from_upstream) rather than `site-packages` -- should we include that as well?

<!-- gh-issue-number: gh-141081 -->
* Issue: gh-141081
<!-- /gh-issue-number -->
