### PR TITLE
gh-142750: Normalize ParamSpec __bound__ when bound is None

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -10029,6 +10029,12 @@ class ParamSpecTests(BaseTestCase):
         self.assertEqual(P.__name__, 'P')
         self.assertIs(P.__module__, None)
 
+    def test_bound(self):
+        P1 = ParamSpec("P1")     
+        P2 = ParamSpec("P2", bound=None)
+        self.assertIs(P1.__bound__, None)
+        self.assertIs(P2.__bound__, None)
+
     def test_valid_uses(self):
         P = ParamSpec('P')
         T = TypeVar('T')

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -10030,7 +10030,7 @@ class ParamSpecTests(BaseTestCase):
         self.assertIs(P.__module__, None)
 
     def test_bound(self):
-        P1 = ParamSpec("P1")     
+        P1 = ParamSpec("P1")
         P2 = ParamSpec("P2", bound=None)
         self.assertIs(P1.__bound__, None)
         self.assertIs(P2.__bound__, None)

--- a/Misc/NEWS.d/next/Library/2025-12-16-01-28-39.gh-issue-142750.9Nlo5U.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-16-01-28-39.gh-issue-142750.9Nlo5U.rst
@@ -1,0 +1,1 @@
+Fix ``typing.ParamSpec(..., bound=None)`` so that ``__bound__`` is ``None`` instead of ``NoneType``.

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -1337,6 +1337,9 @@ paramspec_new_impl(PyTypeObject *type, PyObject *name, PyObject *bound,
         PyErr_SetString(PyExc_ValueError, "Variance cannot be specified with infer_variance.");
         return NULL;
     }
+    if (Py_IsNone(bound)) {
+        bound = NULL;
+    }
     if (bound != NULL) {
         bound = type_check(bound, "Bound must be a type.");
         if (bound == NULL) {


### PR DESCRIPTION
When creating a ParamSpec with bound=None, the runtime __bound__ attribute is set to <class 'NoneType'> instead of None.

This change mirrors TypeVar.__new__ by explicitly converting Py_None to NULL before type checking, ensuring consistency between TypeVar and ParamSpec.

### Steps to reproduce
```python
from typing import ParamSpec, Callable

P1 = ParamSpec("P")
P2 = ParamSpec("P", bound=None)
P3 = ParamSpec("P", bound=Callable[[int, str], float])

def check_bound(label, p, expected):
    got = p.__bound__
    ok = (got is expected)
    exp_s = repr(expected)
    got_s = repr(got)
    print(f"{label}.__bound__ should be {exp_s}, got {got_s}  ->  {'OK' if ok else 'FAIL'}")

check_bound("P1", P1, None)
check_bound("P2", P2, None)
check_bound("P3", P3, Callable[[int, str], float])
```
### Result without the patch
```
d:\MyCode\cpython\PCbuild\amd64>python_d.exe py_bound.py
P1.__bound__ should be None, got <class 'NoneType'>  ->  FAIL
P2.__bound__ should be None, got <class 'NoneType'>  ->  FAIL
P3.__bound__ should be typing.Callable[[int, str], float], got typing.Callable[[int, str], float]  ->  OK
```
### Result with the patch
```
d:\MyCode\cpython\PCbuild\amd64>python_d.exe py_bound.py
P1.__bound__ should be None, got None  ->  OK
P2.__bound__ should be None, got None  ->  OK
P3.__bound__ should be typing.Callable[[int, str], float], got typing.Callable[[int, str], float]  ->  OK
```

<!-- gh-issue-number: gh-142750 -->
* Issue: gh-142750
<!-- /gh-issue-number -->
