### PR TITLE
gh-116738: Make _bz2 module thread-safe

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-15-03-20-24.gh-issue-116738.NNHiTK.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-15-03-20-24.gh-issue-116738.NNHiTK.rst
@@ -1,0 +1,2 @@
+Make the attributes in :mod:`bz2` thread-safe on the :term:`free threaded
+<free threading>` build.


### PR DESCRIPTION
Make the attributes in `_bz2` module thread-safe on the free-threading build. Attributes (`eof`, `needs_input`, `unused_data`) are now stored atomically or accessed via mutex-protected getters.

Even though the operations are protected by locks, the attributes exposed via `PyMemberDef (eof, needs_input, unused_data)` should still be updated atomically while holding the lock, or accessed via mutex‑protected getters, because they can be read without acquiring the lock.

This issue was not addressed in #140555. A small addition that repeatedly reads these attributes shows the issue under tsan build.

```
WARNING: ThreadSanitizer: data race (pid=108285)
  Write of size 1 at 0x7fe4798852d0 by thread T13:
    #0 decompress /workspace/ft_bz2_2_tsan/./Modules/_bz2module.c:537 (_bz2.cpython-315td-x86_64-linux-gnu.so+0x413b) (BuildId: 2102c7cc8b4b2ce3a6fb3e9f1155de897bc09d77)
    #1 _bz2_BZ2Decompressor_decompress_impl /workspace/ft_bz2_2_tsan/./Modules/_bz2module.c:609 (_bz2.cpython-315td-x86_64-linux-gnu.so+0x413b)
    #2 _bz2_BZ2Decompressor_decompress /workspace/ft_bz2_2_tsan/./Modules/clinic/_bz2module.c.h:199 (_bz2.cpython-315td-x86_64-linux-gnu.so+0x413b)
...
...
...
Previous atomic read of size 1 at 0x7fe4798852d0 by thread T11:
    #0 _Py_atomic_load_char_relaxed /workspace/ft_bz2_2_tsan/./Include/cpython/pyatomic_gcc.h:311 (python+0x99f082) (BuildId: 30a2cc7d935ef6048a72a7568dc140a7b80f5953)
    #1 PyMember_GetOne /workspace/ft_bz2_2_tsan/Python/structmember.c:37 (python+0x99f082)
    #2 member_get /workspace/ft_bz2_2_tsan/Objects/descrobject.c:180 (python+0x60f405) (BuildId: 30a2cc7d935ef6048a72a7568dc140a7b80f5953)
...
...
...
SUMMARY: ThreadSanitizer: data race /workspace/ft_bz2_2_tsan/./Modules/_bz2module.c:537 in decompress
```

cc: @mpage @colesbury @emmatyping 

<!-- gh-issue-number: gh-116738 -->
* Issue: gh-116738
<!-- /gh-issue-number -->
