### PR TITLE
gh-142760: Build Windows debug extensions without debug Python

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -51,8 +51,8 @@ A standard interface exists for objects that contain an array of items
 whose size is determined when the object is allocated.
 */
 
-/* Py_DEBUG implies Py_REF_DEBUG. */
-#if defined(Py_DEBUG) && !defined(Py_REF_DEBUG)
+/* Py_DEBUG implies Py_REF_DEBUG, unless explicitly disabled. */
+#if defined(Py_DEBUG) && !defined(Py_NO_PY_REF_DEBUG) && !defined(Py_REF_DEBUG)
 #  define Py_REF_DEBUG
 #endif
 

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -94,8 +94,8 @@ WIN32 is still required for the locale module.
 #endif
 #endif /* Py_BUILD_CORE || Py_BUILD_CORE_BUILTIN || Py_BUILD_CORE_MODULE */
 
-/* _DEBUG implies Py_DEBUG */
-#ifdef _DEBUG
+/* _DEBUG implies Py_DEBUG, unless explicitly disabled. */
+#if defined(_DEBUG) && !defined(Py_WIN_NO_PY_DEBUG) && !defined(Py_DEBUG)
 #  define Py_DEBUG 1
 #endif
 


### PR DESCRIPTION
See details in gh-142760

Documentation to add:
- Doc/whatsnew/3.15.rst
- Doc/extending/windows.rst
- Example doc ref - https://github.com/python/cpython/commit/c3487c941dfa252bde7e69f9d953d4ca9a56408d
