### PR TITLE
gh-142779: Initialize reserved field for proper padding

### DIFF
--- a/Python/perf_jit_trampoline.c
+++ b/Python/perf_jit_trampoline.c
@@ -398,6 +398,7 @@ static void perf_map_jit_write_header(int pid, FILE* out_file) {
     header.version = 1;                           // Current jitdump version
     header.size = sizeof(Header);                 // Header size for validation
     header.elf_mach_target = GetElfMachineArchitecture();  // Target architecture
+    header.reserved = 0;                          // padding reserved for future use
     header.process_id = pid;                      // Process identifier
     header.time_stamp = get_current_time_microseconds();   // Creation time
     header.flags = 0;                             // No special flags currently used


### PR DESCRIPTION
The jitdump specification specifies a reserved field for padding.

Initialize it so no garbage data is embedded in the jitdump files.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142779 -->
* Issue: gh-142779
<!-- /gh-issue-number -->
