### PR TITLE
gh-142754: Ensure that Element & Attr instances have the ownerDocument attribute

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -9,7 +9,7 @@ import unittest
 
 import xml.dom.minidom
 
-from xml.dom.minidom import parse, Attr, Node, Document, parseString
+from xml.dom.minidom import parse, Attr, Node, Document, Element, parseString
 from xml.dom.minidom import getDOMImplementation
 from xml.parsers.expat import ExpatError
 
@@ -190,6 +190,14 @@ class MinidomTest(unittest.TestCase):
 
         # This example used to take at least 30 seconds.
         self.assertLess(end - start, 1)
+
+    def testSetAttributeNodeWithoutOwnerDocument(self):
+        # regression test for gh-142754
+        elem = Element("test")
+        attr = Attr("id")
+        attr.value = "test-id"
+        elem.setAttributeNode(attr)
+        self.assertEqual(elem.getAttribute("id"), "test-id")
 
     def testAppendChildFragment(self):
         dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -364,6 +364,7 @@ class Attr(Node):
     def __init__(self, qName, namespaceURI=EMPTY_NAMESPACE, localName=None,
                  prefix=None):
         self.ownerElement = None
+        self.ownerDocument = None
         self._name = qName
         self.namespaceURI = namespaceURI
         self._prefix = prefix

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -689,6 +689,7 @@ class Element(Node):
 
     def __init__(self, tagName, namespaceURI=EMPTY_NAMESPACE, prefix=None,
                  localName=None):
+        self.ownerDocument = None
         self.parentNode = None
         self.tagName = self.nodeName = tagName
         self.prefix = prefix

--- a/Misc/NEWS.d/next/Library/2025-12-16-11-55-55.gh-issue-142754.xuCrt3.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-16-11-55-55.gh-issue-142754.xuCrt3.rst
@@ -1,0 +1,4 @@
+Add the *ownerDocument* attribute to :mod:`xml.dom.minidom` elements created
+by directly instantiating the Element class. Note that this way of creating
+Element instances is not supported; creator functions like
+:py:meth:`xml.dom.Document.documentElement` should be used instead.

--- a/Misc/NEWS.d/next/Library/2025-12-16-11-55-55.gh-issue-142754.xuCrt3.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-16-11-55-55.gh-issue-142754.xuCrt3.rst
@@ -1,4 +1,4 @@
-Add the *ownerDocument* attribute to :mod:`xml.dom.minidom` elements created
-by directly instantiating the Element class. Note that this way of creating
-Element instances is not supported; creator functions like
+Add the *ownerDocument* attribute to :mod:`xml.dom.minidom` elements and attributes
+created by directly instantiating the ``Element`` or ``Attr`` class. Note that
+this way of creating nodes is not supported; creator functions like
 :py:meth:`xml.dom.Document.documentElement` should be used instead.


### PR DESCRIPTION

`Element` uses `__slots__`, which means that the *ownerDocument*
attribute is not inherited from the superclass.
All other slots (except `_localName`) are set in `__init__`; not
including ownerDocument was apparently an oversight.

Note that creating `Element` directly is not supported; you're supposed
to use Document APIs. AFAICS, all supported ways of creating elements do
set `ownerDocument`.
However, many projects ignore the documentation, and a security fix that
relies on *ownerDocument* can break them.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142754 -->
* Issue: gh-142754
<!-- /gh-issue-number -->
