### PR TITLE
gh-142225: Add PyABIInfo_VAR to to _testcapimodule & _testinternalcapi

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3526,7 +3526,7 @@ _testcapi_exec(PyObject *m)
 PyABIInfo_VAR(abi_info);
 
 static PyModuleDef_Slot _testcapi_slots[] = {
-    {Py_mod_abi, abi_info},
+    {Py_mod_abi, &abi_info},
     {Py_mod_exec, _testcapi_exec},
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3523,7 +3523,10 @@ _testcapi_exec(PyObject *m)
     return 0;
 }
 
+PyABIInfo_VAR(abi_info);
+
 static PyModuleDef_Slot _testcapi_slots[] = {
+    {Py_mod_abi, abi_info},
     {Py_mod_exec, _testcapi_exec},
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -2696,7 +2696,10 @@ module_exec(PyObject *module)
     return 0;
 }
 
+PyABIInfo_VAR(abi_info);
+
 static struct PyModuleDef_Slot module_slots[] = {
+    {Py_mod_abi, abi_info},
     {Py_mod_exec, module_exec},
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -2699,7 +2699,7 @@ module_exec(PyObject *module)
 PyABIInfo_VAR(abi_info);
 
 static struct PyModuleDef_Slot module_slots[] = {
-    {Py_mod_abi, abi_info},
+    {Py_mod_abi, &abi_info},
     {Py_mod_exec, module_exec},
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},

--- a/Tools/c-analyzer/cpython/_analyzer.py
+++ b/Tools/c-analyzer/cpython/_analyzer.py
@@ -76,6 +76,7 @@ _OTHER_SUPPORTED_TYPES = {
     'PyBufferProcs',
     'PyStructSequence_Field[]',
     'PyStructSequence_Desc',
+    'PyABIInfo',
 }
 
 # XXX We should normalize all cases to a single name,


### PR DESCRIPTION
This ensures that `PyABIInfo_VAR` can be declared as documented.

(See `test_modsupport.py` for tests of the functionality.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142225 -->
* Issue: gh-142225
<!-- /gh-issue-number -->
