### PR TITLE
gh-142834:  pdb commands command should use last available breakpoint

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -520,7 +520,8 @@ can be overridden by the local file.
    To remove all commands from a breakpoint, type ``commands`` and follow it
    immediately with ``end``; that is, give no commands.
 
-   With no *bpnumber* argument, ``commands`` refers to the last breakpoint set.
+   With no *bpnumber* argument, ``commands`` refers to the most recently set
+   breakpoint that still exists.
 
    You can use breakpoint commands to start your program up again.  Simply use
    the :pdbcmd:`continue` command, or :pdbcmd:`step`,

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1316,7 +1316,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         if not arg:
             for bp in reversed(bdb.Breakpoint.bpbynumber):
-                if not bp:
+                if bp is None:
                     continue
                 bnum = bp.number
                 break

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1321,7 +1321,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 bnum = bp.number
                 break
             else:
-                self.error('no breakpoints set')
+                self.error('cannot set commands: no existing breakpoint')
                 return
         else:
             try:

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1315,12 +1315,14 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         reached.
         """
         if not arg:
-            for bnum in range(len(bdb.Breakpoint.bpbynumber) - 1, -1, -1):
-                if bdb.Breakpoint.bpbynumber[bnum] is not None:
-                    break
-                if bnum == 0:
-                    self.error('no breakpoints set')
-                    return
+            for bp in reversed(bdb.Breakpoint.bpbynumber):
+                if not bp:
+                    continue
+                bnum = bp.number
+                break
+            else:
+                self.error('no breakpoints set')
+                return
         else:
             try:
                 bnum = int(arg)

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1319,7 +1319,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 if bdb.Breakpoint.bpbynumber[bnum] is not None:
                     break
                 if bnum == 0:
-                    self.error('no breakpoints setted')
+                    self.error('no breakpoints set')
                     return
         else:
             try:

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1315,7 +1315,12 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         reached.
         """
         if not arg:
-            bnum = len(bdb.Breakpoint.bpbynumber) - 1
+            for bnum in range(len(bdb.Breakpoint.bpbynumber) - 1, -1, -1):
+                if bdb.Breakpoint.bpbynumber[bnum] is not None:
+                    break
+                if bnum == 0:
+                    self.error('no breakpoints setted')
+                    return
         else:
             try:
                 bnum = int(arg)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3478,8 +3478,8 @@ def test_pdb_issue_gh_65052():
     (Pdb) continue
     """
 
-def test_pdb_issue_142834():
-    """See issue-142834
+def test_pdb_commands_last_breakpoint():
+    """See GH-142834
 
     >>> def test_function():
     ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
@@ -3494,25 +3494,31 @@ def test_pdb_issue_142834():
     ...     'p "success"',
     ...     'end',
     ...     'continue',
-    ...     '',
+    ...     'clear 1',
+    ...     'commands',
+    ...     'continue',
     ... ]):
     ...    test_function()
-    > <doctest test.test_pdb.test_pdb_issue_142834[0]>(2)test_function()
+    > <doctest test.test_pdb.test_pdb_commands_last_breakpoint[0]>(2)test_function()
     -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) break 4
-    Breakpoint 1 at <doctest test.test_pdb.test_pdb_issue_142834[0]>:4
+    Breakpoint 1 at <doctest test.test_pdb.test_pdb_commands_last_breakpoint[0]>:4
     (Pdb) break 3
-    Breakpoint 2 at <doctest test.test_pdb.test_pdb_issue_142834[0]>:3
+    Breakpoint 2 at <doctest test.test_pdb.test_pdb_commands_last_breakpoint[0]>:3
     (Pdb) clear 2
-    Deleted breakpoint 2 at <doctest test.test_pdb.test_pdb_issue_142834[0]>:3
+    Deleted breakpoint 2 at <doctest test.test_pdb.test_pdb_commands_last_breakpoint[0]>:3
     (Pdb) commands
     (com) p "success"
     (com) end
     (Pdb) continue
     'success'
-    > <doctest test.test_pdb.test_pdb_issue_142834[0]>(4)test_function()
+    > <doctest test.test_pdb.test_pdb_commands_last_breakpoint[0]>(4)test_function()
     -> bar = 2
-    (Pdb)
+    (Pdb) clear 1
+    Deleted breakpoint 1 at <doctest test.test_pdb.test_pdb_commands_last_breakpoint[0]>:4
+    (Pdb) commands
+    *** no breakpoints set
+    (Pdb) continue
     """
 
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3517,7 +3517,7 @@ def test_pdb_commands_last_breakpoint():
     (Pdb) clear 1
     Deleted breakpoint 1 at <doctest test.test_pdb.test_pdb_commands_last_breakpoint[0]>:4
     (Pdb) commands
-    *** no breakpoints set
+    *** cannot set commands: no existing breakpoint
     (Pdb) continue
     """
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3497,20 +3497,20 @@ def test_pdb_issue_142834():
     ...     '',
     ... ]):
     ...    test_function()
-    > <doctest test.test_pdb.test_pdb_issue_gh_xxx[0]>(2)test_function()
+    > <doctest test.test_pdb.test_pdb_issue_142834[0]>(2)test_function()
     -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) break 4
-    Breakpoint 1 at <doctest test.test_pdb.test_pdb_issue_gh_xxx[0]>:4
+    Breakpoint 1 at <doctest test.test_pdb.test_pdb_issue_142834[0]>:4
     (Pdb) break 3
-    Breakpoint 2 at <doctest test.test_pdb.test_pdb_issue_gh_xxx[0]>:3
+    Breakpoint 2 at <doctest test.test_pdb.test_pdb_issue_142834[0]>:3
     (Pdb) clear 2
-    Deleted breakpoint 2 at <doctest test.test_pdb.test_pdb_issue_gh_xxx[0]>:3
+    Deleted breakpoint 2 at <doctest test.test_pdb.test_pdb_issue_142834[0]>:3
     (Pdb) commands
     (com) p "success"
     (com) end
     (Pdb) continue
     'success'
-    > <doctest test.test_pdb.test_pdb_issue_gh_xxx[0]>(4)test_function()
+    > <doctest test.test_pdb.test_pdb_issue_142834[0]>(4)test_function()
     -> bar = 2
     (Pdb)
     """

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3478,6 +3478,43 @@ def test_pdb_issue_gh_65052():
     (Pdb) continue
     """
 
+def test_pdb_issue_142834():
+    """See issue-142834
+
+    >>> def test_function():
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     foo = 1
+    ...     bar = 2
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'break 4',
+    ...     'break 3',
+    ...     'clear 2',
+    ...     'commands',
+    ...     'p "success"',
+    ...     'end',
+    ...     'continue',
+    ...     '',
+    ... ]):
+    ...    test_function()
+    > <doctest test.test_pdb.test_pdb_issue_gh_xxx[0]>(2)test_function()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) break 4
+    Breakpoint 1 at <doctest test.test_pdb.test_pdb_issue_gh_xxx[0]>:4
+    (Pdb) break 3
+    Breakpoint 2 at <doctest test.test_pdb.test_pdb_issue_gh_xxx[0]>:3
+    (Pdb) clear 2
+    Deleted breakpoint 2 at <doctest test.test_pdb.test_pdb_issue_gh_xxx[0]>:3
+    (Pdb) commands
+    (com) p "success"
+    (com) end
+    (Pdb) continue
+    'success'
+    > <doctest test.test_pdb.test_pdb_issue_gh_xxx[0]>(4)test_function()
+    -> bar = 2
+    (Pdb)
+    """
+
 
 @support.force_not_colorized_test_class
 @support.requires_subprocess()

--- a/Misc/NEWS.d/next/Library/2025-12-16-15-32-41.gh-issue-142834.g7mHw_.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-16-15-32-41.gh-issue-142834.g7mHw_.rst
@@ -1,0 +1,2 @@
+:mod:`pdb` ``commands`` command to use the last available breakpoint 
+instead of failing when the most recently created breakpoint was deleted.

--- a/Misc/NEWS.d/next/Library/2025-12-16-15-32-41.gh-issue-142834.g7mHw_.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-16-15-32-41.gh-issue-142834.g7mHw_.rst
@@ -1,1 +1,1 @@
-:mod:`pdb` ``commands`` command to use the last available breakpoint instead of failing when the most recently created breakpoint was deleted.
+Change the :mod:`pdb` ``commands`` command to use the last available breakpoint instead of failing when the most recently created breakpoint was deleted.

--- a/Misc/NEWS.d/next/Library/2025-12-16-15-32-41.gh-issue-142834.g7mHw_.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-16-15-32-41.gh-issue-142834.g7mHw_.rst
@@ -1,2 +1,1 @@
-:mod:`pdb` ``commands`` command to use the last available breakpoint 
-instead of failing when the most recently created breakpoint was deleted.
+:mod:`pdb` ``commands`` command to use the last available breakpoint instead of failing when the most recently created breakpoint was deleted.


### PR DESCRIPTION
#  What this PR does
When commands is invoked without an argument, pdb now finds and uses the last available (non-deleted) breakpoint instead of blindly using the last breakpoint number which might have been deleted.


main.py:
```python3
foo = 1
bar = 2
```

```python3
➜ ./python -m pdb main.py
> /cpython/main.py(2)<module>()
-> foo = 1
(Pdb) b 3    
Breakpoint 1 at /cpython/main.py:3
(Pdb) b 2
Breakpoint 2 at /cpython/main.py:2
(Pdb) clear 2
Deleted breakpoint 2 at /cpython/main.py:2
(Pdb) commands # should set command on breakpoint 1
*** cannot set commands: Breakpoint 2 already deleted
```

after fix:

```python3
➜ ./python -m pdb main.py     
> /cpython/main.py(2)<module>()
-> foo = 1
(Pdb) b 3
Breakpoint 1 at /cpython/main.py:3
(Pdb) b 2
Breakpoint 2 at /cpython/main.py:2
(Pdb) clear 2
Deleted breakpoint 2 at /cpython/main.py:2
(Pdb) commands
(com) p "success"
(com) end
(Pdb) c
'success'
> /home/loyd/code_files/cpython/main.py(3)<module>()
-> bar = 2
```

<!-- gh-issue-number: gh-142834 -->
* Issue: gh-142834
<!-- /gh-issue-number -->
