### PR TITLE
gh-138122: Update Tachyon dark theme colors

### DIFF
--- a/Lib/profiling/sampling/_heatmap_assets/heatmap.css
+++ b/Lib/profiling/sampling/_heatmap_assets/heatmap.css
@@ -5,6 +5,18 @@
    This file extends the shared foundation with heatmap-specific styles.
    ========================================================================== */
 
+/* Heatmap heat colors - using base.css colors with 60% opacity */
+[data-theme="dark"] {
+  --heat-1: rgba(90, 123, 167, 0.60);
+  --heat-2: rgba(106, 148, 168, 0.60);
+  --heat-3: rgba(122, 172, 172, 0.60);
+  --heat-4: rgba(142, 196, 152, 0.60);
+  --heat-5: rgba(168, 216, 136, 0.60);
+  --heat-6: rgba(200, 222, 122, 0.60);
+  --heat-7: rgba(244, 212, 93, 0.60);
+  --heat-8: rgba(255, 122, 69, 0.60);
+}
+
 /* --------------------------------------------------------------------------
    Layout Overrides (Heatmap-specific)
    -------------------------------------------------------------------------- */

--- a/Lib/profiling/sampling/_shared_assets/base.css
+++ b/Lib/profiling/sampling/_shared_assets/base.css
@@ -124,15 +124,15 @@
 
   --header-gradient: linear-gradient(135deg, #21262d 0%, #30363d 100%);
 
-  /* Dark mode heat palette - muted colors that provide sufficient contrast with light text */
-  --heat-1: rgba(74, 123, 167, 0.35);
-  --heat-2: rgba(90, 159, 168, 0.38);
-  --heat-3: rgba(106, 181, 181, 0.40);
-  --heat-4: rgba(126, 196, 136, 0.42);
-  --heat-5: rgba(160, 216, 120, 0.45);
-  --heat-6: rgba(196, 222, 106, 0.48);
-  --heat-7: rgba(244, 212, 77, 0.50);
-  --heat-8: rgba(255, 107, 53, 0.55);
+  /* Dark mode heat palette - cool to warm gradient for visualization */
+  --heat-1: rgba(90, 123, 167, 1);
+  --heat-2: rgba(106, 148, 168, 1);
+  --heat-3: rgba(122, 172, 172, 1);
+  --heat-4: rgba(142, 196, 152, 1);
+  --heat-5: rgba(168, 216, 136, 1);
+  --heat-6: rgba(200, 222, 122, 1);
+  --heat-7: rgba(244, 212, 93, 1);
+  --heat-8: rgba(255, 122, 69, 1);
 
   /* Code view specific - dark mode */
   --code-bg: #0d1117;


### PR DESCRIPTION
When we aligned the dark theme colors with the heatmap legend palette, the flamegraph became too gloomy. To improve clarity and contrast, we should use more muted colors for the heatmap and more vibrant colors for the flamegraph.

Flamegraph before:

<img width="2559" height="1258" alt="image" src="https://github.com/user-attachments/assets/b0cea231-75e3-468c-b61f-20498509a035" />

Flamegraph now:

<img width="2558" height="1258" alt="image" src="https://github.com/user-attachments/assets/314c8086-fcce-4b71-9f2e-9035b9ac4720" />

<!-- gh-issue-number: gh-138122 -->
* Issue: gh-138122
<!-- /gh-issue-number -->
