### PR TITLE
gh-142448: Disable JIT tracing when monitoring is enabled

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-16-20-38-17.gh-issue-142448.mAFqwL.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-16-20-38-17.gh-issue-142448.mAFqwL.rst
@@ -1,0 +1,1 @@
+Fix a bug when using monitoring with the JIT.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5587,9 +5587,14 @@ dummy_func(
             next_instr = this_instr;
             frame->instr_ptr = prev_instr;
             opcode = next_instr->op.code;
-            bool stop_tracing = (opcode == WITH_EXCEPT_START ||
-                opcode == RERAISE || opcode == CLEANUP_THROW ||
-                opcode == PUSH_EXC_INFO || opcode == INTERPRETER_EXIT || opcode >= MIN_INSTRUMENTED_OPCODE);
+            bool stop_tracing = (
+                opcode == WITH_EXCEPT_START ||
+                opcode == RERAISE ||
+                opcode == CLEANUP_THROW ||
+                opcode == PUSH_EXC_INFO ||
+                opcode == INTERPRETER_EXIT ||
+                (opcode >= MIN_INSTRUMENTED_OPCODE && opcode != ENTER_EXECUTOR)
+            );
             int full = !_PyJit_translate_single_bytecode_to_trace(tstate, frame, next_instr, stop_tracing ? _DEOPT : 0);
             if (full) {
                 LEAVE_TRACING();

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5589,7 +5589,7 @@ dummy_func(
             opcode = next_instr->op.code;
             bool stop_tracing = (opcode == WITH_EXCEPT_START ||
                 opcode == RERAISE || opcode == CLEANUP_THROW ||
-                opcode == PUSH_EXC_INFO || opcode == INTERPRETER_EXIT);
+                opcode == PUSH_EXC_INFO || opcode == INTERPRETER_EXIT || opcode >= MIN_INSTRUMENTED_OPCODE);
             int full = !_PyJit_translate_single_bytecode_to_trace(tstate, frame, next_instr, stop_tracing ? _DEOPT : 0);
             if (full) {
                 LEAVE_TRACING();

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -11574,9 +11574,14 @@
             next_instr = this_instr;
             frame->instr_ptr = prev_instr;
             opcode = next_instr->op.code;
-            bool stop_tracing = (opcode == WITH_EXCEPT_START ||
-                                 opcode == RERAISE || opcode == CLEANUP_THROW ||
-                                 opcode == PUSH_EXC_INFO || opcode == INTERPRETER_EXIT || opcode >= MIN_INSTRUMENTED_OPCODE);
+            bool stop_tracing = (
+                                 opcode == WITH_EXCEPT_START ||
+                                 opcode == RERAISE ||
+                                 opcode == CLEANUP_THROW ||
+                                 opcode == PUSH_EXC_INFO ||
+                                 opcode == INTERPRETER_EXIT ||
+                                 (opcode >= MIN_INSTRUMENTED_OPCODE && opcode != ENTER_EXECUTOR)
+            );
             _PyFrame_SetStackPointer(frame, stack_pointer);
             int full = !_PyJit_translate_single_bytecode_to_trace(tstate, frame, next_instr, stop_tracing ? _DEOPT : 0);
             stack_pointer = _PyFrame_GetStackPointer(frame);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -11576,7 +11576,7 @@
             opcode = next_instr->op.code;
             bool stop_tracing = (opcode == WITH_EXCEPT_START ||
                                  opcode == RERAISE || opcode == CLEANUP_THROW ||
-                                 opcode == PUSH_EXC_INFO || opcode == INTERPRETER_EXIT);
+                                 opcode == PUSH_EXC_INFO || opcode == INTERPRETER_EXIT || opcode >= MIN_INSTRUMENTED_OPCODE);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             int full = !_PyJit_translate_single_bytecode_to_trace(tstate, frame, next_instr, stop_tracing ? _DEOPT : 0);
             stack_pointer = _PyFrame_GetStackPointer(frame);


### PR DESCRIPTION
Fixes #142448

Sorry, there is no test as I can't produce something that is self-isolated. Furthermore, it seems this test only works with exceptions + monitoring, which is exceptionally hard to test for (pun intended).

I have verified this fixes both reproducers given by OP.

<!-- gh-issue-number: gh-142448 -->
* Issue: gh-142448
<!-- /gh-issue-number -->
