### PR TITLE
gh-142543: Mark tracer functions as Py_NO_INLINE

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-16-23-26-41.gh-issue-142543.wJKjBs.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-16-23-26-41.gh-issue-142543.wJKjBs.rst
@@ -1,0 +1,1 @@
+Fix a stack overflow on Clang JIT build configurations with full LTO.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -994,7 +994,7 @@ full:
 }
 
 // Returns 0 for do not enter tracing, 1 on enter tracing.
-int
+Py_NO_INLINE int
 _PyJit_TryInitializeTracing(
     PyThreadState *tstate, _PyInterpreterFrame *frame, _Py_CODEUNIT *curr_instr,
     _Py_CODEUNIT *start_instr, _Py_CODEUNIT *close_loop_instr, int curr_stackdepth, int chain_depth,

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -582,6 +582,7 @@ is_terminator(const _PyUOpInstruction *uop)
 
 /* Returns 1 on success (added to trace), 0 on trace end.
  */
+// gh-142543: inlining this function causes stack overflows
 Py_NO_INLINE int
 _PyJit_translate_single_bytecode_to_trace(
     PyThreadState *tstate,
@@ -994,6 +995,7 @@ full:
 }
 
 // Returns 0 for do not enter tracing, 1 on enter tracing.
+// gh-142543: inlining this function causes stack overflows
 Py_NO_INLINE int
 _PyJit_TryInitializeTracing(
     PyThreadState *tstate, _PyInterpreterFrame *frame, _Py_CODEUNIT *curr_instr,
@@ -1066,7 +1068,7 @@ _PyJit_TryInitializeTracing(
     return 1;
 }
 
-void
+Py_NO_INLINE void
 _PyJit_FinalizeTracing(PyThreadState *tstate)
 {
     _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate;

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -582,7 +582,7 @@ is_terminator(const _PyUOpInstruction *uop)
 
 /* Returns 1 on success (added to trace), 0 on trace end.
  */
-int
+Py_NO_INLINE int
 _PyJit_translate_single_bytecode_to_trace(
     PyThreadState *tstate,
     _PyInterpreterFrame *frame,


### PR DESCRIPTION
Fixes #142543

I've verified on my system this fixes the crashes.

<!-- gh-issue-number: gh-142543 -->
* Issue: gh-142543
<!-- /gh-issue-number -->
