### PR TITLE
gh-141070: Rename `PyUnstable_Object_Dump` to `PyObject_Dump`

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -85,7 +85,7 @@ Object Protocol
    instead of the :func:`repr`.
 
 
-.. c:function:: void PyUnstable_Object_Dump(PyObject *op)
+.. c:function:: void PyObject_Dump(PyObject *op)
 
    Dump an object *op* to ``stderr``. This should only be used for debugging.
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1105,7 +1105,7 @@ New features
 * Add :c:func:`PyTuple_FromArray` to create a :class:`tuple` from an array.
   (Contributed by Victor Stinner in :gh:`111489`.)
 
-* Add :c:func:`PyUnstable_Object_Dump` to dump an object to ``stderr``.
+* Add :c:func:`PyObject_Dump` to dump an object to ``stderr``.
   It should only be used for debugging.
   (Contributed by Victor Stinner in :gh:`141070`.)
 

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -295,10 +295,10 @@ PyAPI_FUNC(PyObject *) PyType_GetDict(PyTypeObject *);
 
 PyAPI_FUNC(int) PyObject_Print(PyObject *, FILE *, int);
 PyAPI_FUNC(void) _Py_BreakPoint(void);
-PyAPI_FUNC(void) PyUnstable_Object_Dump(PyObject *);
+PyAPI_FUNC(void) PyObject_Dump(PyObject *);
 
 // Alias for backward compatibility
-#define _PyObject_Dump PyUnstable_Object_Dump
+#define _PyObject_Dump PyObject_Dump
 
 Py_DEPRECATED(3.15) PyAPI_FUNC(PyObject*) _PyObject_GetAttrId(PyObject *, _Py_Identifier *);
 
@@ -391,7 +391,7 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
    but compile away to nothing if NDEBUG is defined.
 
    However, before aborting, Python will also try to call
-   PyUnstable_Object_Dump() on the given object. This may be of use when
+   PyObject_Dump() on the given object. This may be of use when
    investigating bugs in which a particular object is corrupt (e.g. buggy a
    tp_visit method in an extension module breaking the garbage collector), to
    help locate the broken objects.

--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -13,7 +13,7 @@ static inline void
 _PyStaticObject_CheckRefcnt(PyObject *obj) {
     if (!_Py_IsImmortal(obj)) {
         fprintf(stderr, "Immortal Object has less refcnt than expected.\n");
-        PyUnstable_Object_Dump(obj);
+        PyObject_Dump(obj);
     }
 }
 #endif

--- a/Misc/NEWS.d/3.15.0a3.rst
+++ b/Misc/NEWS.d/3.15.0a3.rst
@@ -1461,7 +1461,7 @@ sqlite when used with multiple sub interpreters.
 .. nonce: mkrhjQ
 .. section: C API
 
-Add :c:func:`PyUnstable_Object_Dump` to dump an object to ``stderr``. It
+Add :c:func:`!PyUnstable_Object_Dump` to dump an object to ``stderr``. It
 should only be used for debugging. Patch by Victor Stinner.
 
 ..

--- a/Misc/NEWS.d/next/C_API/2025-12-16-18-39-30.gh-issue-141070.4EKDZ1.rst
+++ b/Misc/NEWS.d/next/C_API/2025-12-16-18-39-30.gh-issue-141070.4EKDZ1.rst
@@ -1,0 +1,1 @@
+Renamed :c:func:`!PyUnstable_Object_Dump` to :c:func:`PyObject_Dump`.

--- a/Modules/_testcapi/object.c
+++ b/Modules/_testcapi/object.c
@@ -507,12 +507,12 @@ pyobject_dump(PyObject *self, PyObject *args)
 
     if (release_gil) {
         Py_BEGIN_ALLOW_THREADS
-        PyUnstable_Object_Dump(op);
+        PyObject_Dump(op);
         Py_END_ALLOW_THREADS
 
     }
     else {
-        PyUnstable_Object_Dump(op);
+        PyObject_Dump(op);
     }
     Py_RETURN_NONE;
 }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -713,7 +713,7 @@ _PyObject_IsFreed(PyObject *op)
 
 /* For debugging convenience.  See Misc/gdbinit for some useful gdb hooks */
 void
-PyUnstable_Object_Dump(PyObject* op)
+PyObject_Dump(PyObject* op)
 {
     if (_PyObject_IsFreed(op)) {
         /* It seems like the object memory has been freed:
@@ -3157,7 +3157,7 @@ _PyObject_AssertFailed(PyObject *obj, const char *expr, const char *msg,
 
         /* This might succeed or fail, but we're about to abort, so at least
            try to provide any extra info we can: */
-        PyUnstable_Object_Dump(obj);
+        PyObject_Dump(obj);
 
         fprintf(stderr, "\n");
         fflush(stderr);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -547,7 +547,7 @@ unicode_check_encoding_errors(const char *encoding, const char *errors)
     }
 
     /* Disable checks during Python finalization. For example, it allows to
-     * call PyUnstable_Object_Dump() during finalization for debugging purpose.
+     * call PyObject_Dump() during finalization for debugging purpose.
      */
     if (_PyInterpreterState_GetFinalizing(interp) != NULL) {
         return 0;

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -2243,7 +2243,7 @@ _PyGC_Fini(PyInterpreterState *interp)
 void
 _PyGC_Dump(PyGC_Head *g)
 {
-    PyUnstable_Object_Dump(FROM_GC(g));
+    PyObject_Dump(FROM_GC(g));
 }
 
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1175,7 +1175,7 @@ fallback:
     }
     if (print_exception_recursive(&ctx, value) < 0) {
         PyErr_Clear();
-        PyUnstable_Object_Dump(value);
+        PyObject_Dump(value);
         fprintf(stderr, "lost sys.stderr\n");
     }
     Py_XDECREF(ctx.seen);
@@ -1193,14 +1193,14 @@ PyErr_Display(PyObject *unused, PyObject *value, PyObject *tb)
     PyObject *file;
     if (PySys_GetOptionalAttr(&_Py_ID(stderr), &file) < 0) {
         PyObject *exc = PyErr_GetRaisedException();
-        PyUnstable_Object_Dump(value);
+        PyObject_Dump(value);
         fprintf(stderr, "lost sys.stderr\n");
-        PyUnstable_Object_Dump(exc);
+        PyObject_Dump(exc);
         Py_DECREF(exc);
         return;
     }
     if (file == NULL) {
-        PyUnstable_Object_Dump(value);
+        PyObject_Dump(value);
         fprintf(stderr, "lost sys.stderr\n");
         return;
     }


### PR DESCRIPTION
See [the DPO thread](https://discuss.python.org/t/bikeshedding-public-function-for-pyobject-dump/105102). As a result of my grumpiness (sorry!), the consensus seems to be that it's fine to keep this in the public API, primarily to save typing time when debugging.

<!-- gh-issue-number: gh-141070 -->
* Issue: gh-141070
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142848.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->