### PR TITLE
gh-142836: Avoid /proc fd pipes on Solaris

### DIFF
--- a/Misc/NEWS.d/next/Tests/2025-12-17-02-02-57.gh-issue-142836.mR-fvK.rst
+++ b/Misc/NEWS.d/next/Tests/2025-12-17-02-02-57.gh-issue-142836.mR-fvK.rst
@@ -1,0 +1,1 @@
+Accommodated Solaris in ``test_pdb.test_script_target_anonymous_pipe``.


### PR DESCRIPTION
## Summary
- skip using /proc/self/fd for pdb anonymous-pipe tests on Solaris, where opening those entries raises EACCES
- refactor fd-directory detection to dedicated helpers and prefer /dev/fd on affected systems
- add NEWS entry for the test fix

## Issue
- fixes gh-142836
