### PR TITLE
gh-142873: Do not check for `PyContextVar_CheckExact` twice in `PyContextVar_Set`

### DIFF
--- a/Python/context.c
+++ b/Python/context.c
@@ -1019,8 +1019,6 @@ static PyObject *
 _contextvars_ContextVar_get_impl(PyContextVar *self, PyObject *default_value)
 /*[clinic end generated code: output=0746bd0aa2ced7bf input=da66664d5d0af4ad]*/
 {
-    ENSURE_ContextVar(self, NULL)
-
     PyObject *val;
     if (PyContextVar_Get((PyObject *)self, default_value, &val) < 0) {
         return NULL;

--- a/Python/context.c
+++ b/Python/context.c
@@ -343,12 +343,6 @@ PyContextVar_Set(PyObject *ovar, PyObject *val)
     ENSURE_ContextVar(ovar, NULL)
     PyContextVar *var = (PyContextVar *)ovar;
 
-    if (!PyContextVar_CheckExact(var)) {
-        PyErr_SetString(
-            PyExc_TypeError, "an instance of ContextVar was expected");
-        return NULL;
-    }
-
     PyContext *ctx = context_get();
     if (ctx == NULL) {
         return NULL;
@@ -1025,11 +1019,7 @@ static PyObject *
 _contextvars_ContextVar_get_impl(PyContextVar *self, PyObject *default_value)
 /*[clinic end generated code: output=0746bd0aa2ced7bf input=da66664d5d0af4ad]*/
 {
-    if (!PyContextVar_CheckExact(self)) {
-        PyErr_SetString(
-            PyExc_TypeError, "an instance of ContextVar was expected");
-        return NULL;
-    }
+    ENSURE_ContextVar(self, NULL)
 
     PyObject *val;
     if (PyContextVar_Get((PyObject *)self, default_value, &val) < 0) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-142873 -->
* Issue: gh-142873
<!-- /gh-issue-number -->
