### PR TITLE
Use other name for JIT contributor

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -920,7 +920,7 @@ code results in constants, the code can be simplified by the JIT.
 The JIT avoids :term:`reference count`\ s where possible. This generally
 reduces the cost of most operations in Python.
 
-(Contributed by Ken Jin, Donghee Na, Nadeshiko Manju, Savannah Ostrowski,
+(Contributed by Ken Jin, Donghee Na, Zheao Li, Savannah Ostrowski,
 Noam Cohen, Tomas Roun, PuQing in :gh:`134584`.)
 
 .. rubric:: Better machine code generation


### PR DESCRIPTION
I've been told this name is fine by them.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142877.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->