### PR TITLE
[3.13] gh-112127: Fix possible use-after-free in atexit.unregister() (GH-114092)

### DIFF
--- a/Lib/test/_test_atexit.py
+++ b/Lib/test/_test_atexit.py
@@ -135,6 +135,19 @@ class GeneralTest(unittest.TestCase):
         finally:
             atexit.unregister(func)
 
+    def test_eq_unregister_clear(self):
+        # Issue #112127: callback's __eq__ may call unregister or _clear
+        class Evil:
+            def __eq__(self, other):
+                action(other)
+                return NotImplemented
+
+        for action in atexit.unregister, lambda o: atexit._clear():
+            with self.subTest(action=action):
+                atexit.register(lambda: None)
+                atexit.unregister(Evil())
+                atexit._clear()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -892,6 +892,7 @@ Jim Jewett
 Pedro Diaz Jimenez
 Orjan Johansen
 Fredrik Johansson
+Benjamin Johnson
 Gregory K. Johnson
 Kent Johnson
 Michael Johnson

--- a/Misc/NEWS.d/next/Library/2025-12-17-14-41-09.gh-issue-112127.13OHQk.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-17-14-41-09.gh-issue-112127.13OHQk.rst
@@ -1,0 +1,2 @@
+Fix possible use-after-free in :func:`atexit.unregister` when the callback
+is unregistered during comparison.

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -287,7 +287,9 @@ atexit_unregister(PyObject *module, PyObject *func)
             continue;
         }
 
-        int eq = PyObject_RichCompareBool(cb->func, func, Py_EQ);
+        PyObject *to_compare = Py_NewRef(cb->func);
+        int eq = PyObject_RichCompareBool(to_compare, func, Py_EQ);
+        Py_DECREF(to_compare);
         if (eq < 0) {
             return NULL;
         }


### PR DESCRIPTION
(cherry picked from commit 2b466c47c333106dc9522ab77898e6972e25a2c6)


<!-- gh-issue-number: gh-112127 -->
* Issue: gh-112127
<!-- /gh-issue-number -->
