### PR TITLE
[3.13] gh-142766: Clear frame when `generator.close()` is called (gh-142838)

### DIFF
--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -246,6 +246,33 @@ class GeneratorTest(unittest.TestCase):
         #This should not raise
         loop()
 
+    def test_close_clears_frame(self):
+        # gh-142766: Test that closing a generator clears its frame
+        class DetectDelete:
+            def __init__(self):
+                DetectDelete.deleted = False
+
+            def __del__(self):
+                DetectDelete.deleted = True
+
+        def generator(arg):
+            yield
+
+        # Test a freshly created generator (not suspended)
+        g = generator(DetectDelete())
+        g.close()
+        self.assertTrue(DetectDelete.deleted)
+
+        # Test a suspended generator
+        g = generator(DetectDelete())
+        next(g)
+        g.close()
+        self.assertTrue(DetectDelete.deleted)
+
+        # Clear via gi_frame.clear()
+        g = generator(DetectDelete())
+        g.gi_frame.clear()
+        self.assertTrue(DetectDelete.deleted)
 
 class ModifyUnderlyingIterableTest(unittest.TestCase):
     iterables = [

--- a/Misc/NEWS.d/next/Core and Builtins/2025-12-16-11-56-20.gh-issue-142766.Uy2HTm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-12-16-11-56-20.gh-issue-142766.Uy2HTm.rst
@@ -1,0 +1,1 @@
+Clear the frame of a generator when :meth:`generator.close` is called.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -366,6 +366,7 @@ gen_close(PyGenObject *gen, PyObject *args)
 
     if (gen->gi_frame_state == FRAME_CREATED) {
         gen->gi_frame_state = FRAME_COMPLETED;
+        gen_clear_frame(gen);
         Py_RETURN_NONE;
     }
     if (FRAME_STATE_FINISHED(gen->gi_frame_state)) {


### PR DESCRIPTION
(cherry picked from commit 25397f9541be89264d35d41a67defcfeaa950844)


<!-- gh-issue-number: gh-142766 -->
* Issue: gh-142766
<!-- /gh-issue-number -->
