### PR TITLE
gh-142881: Fix concurrent and reentrant call of atexit.unregister()

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-17-20-18-17.gh-issue-142881.5IizIQ.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-17-20-18-17.gh-issue-142881.5IizIQ.rst
@@ -1,0 +1,1 @@
+Fix concurrent and reentrant call of :func:`atexit.unregister`.

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -267,7 +267,7 @@ atexit_unregister_locked(PyObject *callbacks, PyObject *func)
         }
         if (cmp == 1) {
             // We found a callback!
-            // But it's index could be changed if it or other callbacks were
+            // But its index could have changed if it or other callbacks were
             // unregistered during the comparison.
             Py_ssize_t j = PyList_GET_SIZE(callbacks) - 1;
             j = Py_MIN(j, i);

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -256,22 +256,36 @@ atexit_ncallbacks(PyObject *module, PyObject *Py_UNUSED(dummy))
 static int
 atexit_unregister_locked(PyObject *callbacks, PyObject *func)
 {
-    for (Py_ssize_t i = 0; i < PyList_GET_SIZE(callbacks); ++i) {
+    for (Py_ssize_t i = PyList_GET_SIZE(callbacks) - 1; i >= 0; --i) {
         PyObject *tuple = Py_NewRef(PyList_GET_ITEM(callbacks, i));
         assert(PyTuple_CheckExact(tuple));
         PyObject *to_compare = PyTuple_GET_ITEM(tuple, 0);
         int cmp = PyObject_RichCompareBool(func, to_compare, Py_EQ);
-        Py_DECREF(tuple);
-        if (cmp < 0)
-        {
+        if (cmp < 0) {
+            Py_DECREF(tuple);
             return -1;
         }
         if (cmp == 1) {
             // We found a callback!
-            if (PyList_SetSlice(callbacks, i, i + 1, NULL) < 0) {
-                return -1;
+            // But it's index could be changed if it or other callbacks were
+            // unregistered during the comparison.
+            Py_ssize_t j = PyList_GET_SIZE(callbacks) - 1;
+            j = Py_MIN(j, i);
+            for (; j >= 0; --j) {
+                if (PyList_GET_ITEM(callbacks, j) == tuple) {
+                    // We found the callback index! For real!
+                    if (PyList_SetSlice(callbacks, j, j + 1, NULL) < 0) {
+                        Py_DECREF(tuple);
+                        return -1;
+                    }
+                    i = j;
+                    break;
+                }
             }
-            --i;
+        }
+        Py_DECREF(tuple);
+        if (i >= PyList_GET_SIZE(callbacks)) {
+            i = PyList_GET_SIZE(callbacks);
         }
     }
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-142881 -->
* Issue: gh-142881
<!-- /gh-issue-number -->
