### PR TITLE
gh-108411: Make typing.IO/BinaryIO arguments positional-only

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3524,7 +3524,7 @@ class IO(Generic[AnyStr]):
         pass
 
     @abstractmethod
-    def read(self, n: int = -1) -> AnyStr:
+    def read(self, n: int = -1, /) -> AnyStr:
         pass
 
     @abstractmethod
@@ -3532,15 +3532,15 @@ class IO(Generic[AnyStr]):
         pass
 
     @abstractmethod
-    def readline(self, limit: int = -1) -> AnyStr:
+    def readline(self, limit: int = -1, /) -> AnyStr:
         pass
 
     @abstractmethod
-    def readlines(self, hint: int = -1) -> list[AnyStr]:
+    def readlines(self, hint: int = -1, /) -> list[AnyStr]:
         pass
 
     @abstractmethod
-    def seek(self, offset: int, whence: int = 0) -> int:
+    def seek(self, offset: int, whence: int = 0, /) -> int:
         pass
 
     @abstractmethod
@@ -3552,7 +3552,7 @@ class IO(Generic[AnyStr]):
         pass
 
     @abstractmethod
-    def truncate(self, size: int | None = None) -> int:
+    def truncate(self, size: int | None = None, /) -> int:
         pass
 
     @abstractmethod
@@ -3560,11 +3560,11 @@ class IO(Generic[AnyStr]):
         pass
 
     @abstractmethod
-    def write(self, s: AnyStr) -> int:
+    def write(self, s: AnyStr, /) -> int:
         pass
 
     @abstractmethod
-    def writelines(self, lines: list[AnyStr]) -> None:
+    def writelines(self, lines: list[AnyStr], /) -> None:
         pass
 
     @abstractmethod
@@ -3572,7 +3572,7 @@ class IO(Generic[AnyStr]):
         pass
 
     @abstractmethod
-    def __exit__(self, type, value, traceback) -> None:
+    def __exit__(self, type, value, traceback, /) -> None:
         pass
 
 
@@ -3582,7 +3582,7 @@ class BinaryIO(IO[bytes]):
     __slots__ = ()
 
     @abstractmethod
-    def write(self, s: bytes | bytearray) -> int:
+    def write(self, s: bytes | bytearray, /) -> int:
         pass
 
     @abstractmethod

--- a/Misc/NEWS.d/next/Library/2025-12-17-02-55-03.gh-issue-108411.up7MAc.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-17-02-55-03.gh-issue-108411.up7MAc.rst
@@ -1,0 +1,2 @@
+``typing.IO`` and ``typing.BinaryIO`` method arguments are now
+positional-only.


### PR DESCRIPTION
`IO` is purported to be the type of the file objects returned by `open`. However, all methods on those objects take positional-only arguments, while `IO`'s methods are declared with regular arguments. As such, the file objects cannot actually be considered to implement `IO`. The same thing applies to `BinaryIO`.

Fix this by adjusting the definition of these ABCs to match the file objects.

This is technically a breaking change, but it is unlikely to actually break anything:

* These methods should never be called at runtime, since they are abstract. Therefore, this should not cause any runtime errors.

* In typeshed these arguments are already positional-only, so this should not cause any errors during typechecking either.


<!-- gh-issue-number: gh-108411 -->
* Issue: gh-108411
<!-- /gh-issue-number -->
