### PR TITLE
gh-139757: Treat call specially in JIT assembly backend optimizer on x86-64 and AArch64

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -50,7 +50,7 @@ jobs:
           ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
   jit:
     name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
-#    needs: interpreter
+    needs: interpreter
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     strategy:
@@ -131,7 +131,7 @@ jobs:
 
   jit-with-disabled-gil:
     name: Free-Threaded (Debug)
-#    needs: interpreter
+    needs: interpreter
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -159,7 +159,7 @@ jobs:
 
   no-opt-jit:
     name: JIT without optimizations (Debug)
-#    needs: interpreter
+    needs: interpreter
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -186,7 +186,7 @@ jobs:
 
   tail-call-jit:
     name: JIT with tail calling interpreter
-#    needs: interpreter
+    needs: interpreter
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -50,7 +50,7 @@ jobs:
           ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
   jit:
     name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
-    needs: interpreter
+#    needs: interpreter
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     strategy:
@@ -131,7 +131,7 @@ jobs:
 
   jit-with-disabled-gil:
     name: Free-Threaded (Debug)
-    needs: interpreter
+#    needs: interpreter
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -159,7 +159,7 @@ jobs:
 
   no-opt-jit:
     name: JIT without optimizations (Debug)
-    needs: interpreter
+#    needs: interpreter
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -186,7 +186,7 @@ jobs:
 
   tail-call-jit:
     name: JIT with tail calling interpreter
-    needs: interpreter
+#    needs: interpreter
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-17-20-31-09.gh-issue-139757.6DWxeQ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-17-20-31-09.gh-issue-139757.6DWxeQ.rst
@@ -1,0 +1,1 @@
+Fix building JIT stencils on free-threaded builds.

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -224,7 +224,7 @@ class Optimizer:
             inst = self._parse_instruction(line)
             block.instructions.append(inst)
             if inst.is_branch() or inst.kind == InstructionKind.CALL:
-                # A block ending in a branch has a target and fallthrough:
+                # A block ending in a branch/call has a target and fallthrough:
                 assert inst.target is not None
                 block.target = self._lookup_label(inst.target)
                 assert block.fallthrough

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -579,7 +579,7 @@ class OptimizerAArch64(Optimizer):  # pylint: disable = too-few-public-methods
     )
 
     # https://developer.arm.com/documentation/ddi0406/b/Application-Level-Architecture/Instruction-Details/Alphabetical-list-of-instructions/BL--BLX--immediate-
-    _re_call = re.compile(r"\s*blx??\s+(?P<target>[\w.]+)")
+    _re_call = re.compile(r"\s*blx?\s+(?P<target>[\w.]+)")
     # https://developer.arm.com/documentation/ddi0602/2025-03/Base-Instructions/B--Branch-
     _re_jump = re.compile(r"\s*b\s+(?P<target>[\w.]+)")
     # https://developer.arm.com/documentation/ddi0602/2025-09/Base-Instructions/RET--Return-from-subroutine-

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -475,7 +475,7 @@ class Optimizer:
         for index, block in enumerate(self._blocks()):
             if block.target and block.fallthrough:
                 branch = block.instructions[-1]
-                assert branch.is_branch()
+                assert branch.is_branch() or branch.kind == InstructionKind.CALL
                 target = branch.target
                 assert target is not None
                 reloc = self._branches[branch.name][1]

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -475,7 +475,9 @@ class Optimizer:
         for index, block in enumerate(self._blocks()):
             if block.target and block.fallthrough:
                 branch = block.instructions[-1]
-                assert branch.is_branch() or branch.kind == InstructionKind.CALL
+                if branch.kind == InstructionKind.CALL:
+                    continue
+                assert branch.is_branch()
                 target = branch.target
                 assert target is not None
                 reloc = self._branches[branch.name][1]

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -629,6 +629,8 @@ class OptimizerX86(Optimizer):  # pylint: disable = too-few-public-methods
         rf"\s*(?P<instruction>{'|'.join(_X86_BRANCHES)})\s+(?P<target>[\w.]+)"
     )
     # https://www.felixcloutier.com/x86/jmp
-    _re_jump = re.compile(r"\s*jmp\s+(?P<target>[\w.]+)")
+    # https://www.felixcloutier.com/x86/call
+    # Calls are also logically jumps to labels.
+    _re_jump = re.compile(r"\s*((?:jmp)|(?:callq?))\s+(?P<target>[\w.]+)")
     # https://www.felixcloutier.com/x86/ret
     _re_return = re.compile(r"\s*ret\b")

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -223,8 +223,13 @@ class Optimizer:
                 block.link = block = _Block()
             inst = self._parse_instruction(line)
             block.instructions.append(inst)
-            if inst.is_branch() or inst.kind == InstructionKind.CALL:
-                # A block ending in a branch/call has a target and fallthrough:
+            if inst.is_branch():
+                # A block ending in a branch has a target and fallthrough:
+                assert inst.target is not None
+                block.target = self._lookup_label(inst.target)
+                assert block.fallthrough
+            elif inst.kind == InstructionKind.CALL:
+                # A block ending in a call has a target and return point after call:
                 assert inst.target is not None
                 block.target = self._lookup_label(inst.target)
                 assert block.fallthrough
@@ -262,7 +267,7 @@ class Optimizer:
         elif match := self._re_call.match(line):
             target = match["target"]
             name = line[: -len(target)].strip()
-            kind = InstructionKind.JUMP
+            kind = InstructionKind.CALL
         elif match := self._re_return.match(line):
             name = line
             kind = InstructionKind.RETURN


### PR DESCRIPTION
On x86-64 and AArch64, a call is effectively a jump to a label with some caveats. As such, the assembly flow optimizer must treat it as such, or it risks emitting invalid optimizations.

The bug triggers in the following code:

```
_JIT_ENTRY:
    call PyStackRef_CLOSE

PyStackRef_CLOSE:
    bar
```

The assembly optimizer currently doesn't see `PyStackRef_CLOSE` as being used, and just optimizes the whole thing away.

The fix informs the assembly optimizer we might jump to `PyStackRef_CLOSE`, thus the label is used and to preserve it.

I verified it fixes the crash on FT builds on my system.


The reason why we didn't see this earlier is that our stencils were at -O3 and that squashed them all into one function. After we switched to -Os, bigger stencils get outlined. It just so happens the biggest stencils are on FT.

<!-- gh-issue-number: gh-139757 -->
* Issue: gh-139757
<!-- /gh-issue-number -->
