### PR TITLE
gh-142918: Fix Context.items/keys/values docstrings (return iterators, not lists)

### DIFF
--- a/Doc/library/contextvars.rst
+++ b/Doc/library/contextvars.rst
@@ -275,16 +275,16 @@ Manual Context Management
 
    .. method:: keys()
 
-      Return a list of all variables in the context object.
+      Return an iterator of all variables in the context object.
 
    .. method:: values()
 
-      Return a list of all variables' values in the context object.
+      Return an iterator of all variables' values in the context object.
 
 
    .. method:: items()
 
-      Return a list of 2-tuples containing all variables and their
+      Return an iterator of 2-tuples containing all variables and their
       values in the context object.
 
 

--- a/Python/clinic/context.c.h
+++ b/Python/clinic/context.c.h
@@ -48,7 +48,7 @@ PyDoc_STRVAR(_contextvars_Context_items__doc__,
 "\n"
 "Return all variables and their values in the context object.\n"
 "\n"
-"The result is returned as a list of 2-tuples (variable, value).");
+"The result is returned as an iterator of 2-tuples (variable, value).");
 
 #define _CONTEXTVARS_CONTEXT_ITEMS_METHODDEF    \
     {"items", (PyCFunction)_contextvars_Context_items, METH_NOARGS, _contextvars_Context_items__doc__},
@@ -66,7 +66,7 @@ PyDoc_STRVAR(_contextvars_Context_keys__doc__,
 "keys($self, /)\n"
 "--\n"
 "\n"
-"Return a list of all variables in the context object.");
+"Return an iterator of all variables in the context object.");
 
 #define _CONTEXTVARS_CONTEXT_KEYS_METHODDEF    \
     {"keys", (PyCFunction)_contextvars_Context_keys, METH_NOARGS, _contextvars_Context_keys__doc__},
@@ -84,7 +84,7 @@ PyDoc_STRVAR(_contextvars_Context_values__doc__,
 "values($self, /)\n"
 "--\n"
 "\n"
-"Return a list of all variables\' values in the context object.");
+"Return an iterator of all variables\' values in the context object.");
 
 #define _CONTEXTVARS_CONTEXT_VALUES_METHODDEF    \
     {"values", (PyCFunction)_contextvars_Context_values, METH_NOARGS, _contextvars_Context_values__doc__},
@@ -256,4 +256,4 @@ token_exit(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3a04b2fddf24c3e9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a6b96499985059cd input=a9049054013a1b77]*/

--- a/Python/context.c
+++ b/Python/context.c
@@ -650,12 +650,12 @@ _contextvars.Context.items
 
 Return all variables and their values in the context object.
 
-The result is returned as a list of 2-tuples (variable, value).
+The result is returned as an iterator of 2-tuples (variable, value).
 [clinic start generated code]*/
 
 static PyObject *
 _contextvars_Context_items_impl(PyContext *self)
-/*[clinic end generated code: output=fa1655c8a08502af input=00db64ae379f9f42]*/
+/*[clinic end generated code: output=fa1655c8a08502af input=f9c1fe4d39962ea0]*/
 {
     return _PyHamt_NewIterItems(self->ctx_vars);
 }
@@ -664,12 +664,12 @@ _contextvars_Context_items_impl(PyContext *self)
 /*[clinic input]
 _contextvars.Context.keys
 
-Return a list of all variables in the context object.
+Return an iterator of all variables in the context object.
 [clinic start generated code]*/
 
 static PyObject *
 _contextvars_Context_keys_impl(PyContext *self)
-/*[clinic end generated code: output=177227c6b63ec0e2 input=114b53aebca3449c]*/
+/*[clinic end generated code: output=177227c6b63ec0e2 input=f806e4e5f77c7e7e]*/
 {
     return _PyHamt_NewIterKeys(self->ctx_vars);
 }
@@ -678,12 +678,12 @@ _contextvars_Context_keys_impl(PyContext *self)
 /*[clinic input]
 _contextvars.Context.values
 
-Return a list of all variables' values in the context object.
+Return an iterator of all variables' values in the context object.
 [clinic start generated code]*/
 
 static PyObject *
 _contextvars_Context_values_impl(PyContext *self)
-/*[clinic end generated code: output=d286dabfc8db6dde input=ce8075d04a6ea526]*/
+/*[clinic end generated code: output=d286dabfc8db6dde input=6f3cb30499d55021]*/
 {
     return _PyHamt_NewIterValues(self->ctx_vars);
 }


### PR DESCRIPTION
`_contextvars.Context.items()`, `.keys()`, and `.values()` return iterator objects, but their docstrings incorrectly claim they return lists. 

Taking items() as an example, its call chain is `_contextvars_Context_items_impl()` → `_PyHamt_NewIterItems()`.
The comment on [_contextvars_Context_items_impl](https://github.com/python/cpython/blob/main/Python/context.c#L648-L661) states that it returns a `list`, but the comment on [_PyHamt_NewIterItems](https://github.com/python/cpython/blob/main/Include/internal/pycore_hamt.h#L110-L111) indicates that it returns an `iterator`.

Update the Argument Clinic docstrings in Python/context.c and regenerate `Python/clinic/context.c.h`. No behavior change.

📚 Documentation preview 📚: https://cpython-previews--142919.org.readthedocs.build/en/142919/library/contextvars.html?readthedocs-diff=true&readthedocs-diff-chunk=1

### Script to reproduce
``` py
import contextvars

ctx = contextvars.copy_context()

print("items() type:", type(ctx.items()))
print("keys()  type:", type(ctx.keys()))
print("values() type:", type(ctx.values()))

print("items() is list?", isinstance(ctx.items(), list))
print("keys()  is list?", isinstance(ctx.keys(), list))
print("values() is list?", isinstance(ctx.values(), list))

print("\nDocstrings say 'list'?")
print("items doc contains 'list':", "list" in (ctx.items.__doc__ or ""))
print("keys  doc contains 'list':", "list" in (ctx.keys.__doc__ or ""))
print("values doc contains 'list':", "list" in (ctx.values.__doc__ or ""))
```

### Result without the patch
``` bash 
d:\MyCode\cpython\PCbuild\amd64>python_d.exe py_context.py
items() type: <class 'items'>
keys()  type: <class 'keys'>
values() type: <class 'values'>
items() is list? False
keys()  is list? False
values() is list? False

Docstrings say 'list'?
items doc contains 'list': True
keys  doc contains 'list': True
values doc contains 'list': True
```

### Result with the patch
``` bash
d:\MyCode\cpython\PCbuild\amd64>python_d.exe py_context.py
items() type: <class 'items'>
keys()  type: <class 'keys'>
values() type: <class 'values'>
items() is list? False
keys()  is list? False
values() is list? False

Docstrings say 'list'?
items doc contains 'list': False  <-- !!!! here
keys  doc contains 'list': False
values doc contains 'list': False
```

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>

<!-- gh-issue-number: gh-142918 -->
* Issue: gh-142918
<!-- /gh-issue-number -->
