### PR TITLE
gh-142927: Tachyon: Fix contrast ratio in top panel

### DIFF
--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph.css
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph.css
@@ -346,10 +346,10 @@ body.resizing-sidebar {
   position: relative;
 }
 
-.summary-card:nth-child(1) { --i: 0; --card-color: 55, 118, 171; }
-.summary-card:nth-child(2) { --i: 1; --card-color: 40, 167, 69; }
-.summary-card:nth-child(3) { --i: 2; --card-color: 255, 193, 7; }
-.summary-card:nth-child(4) { --i: 3; --card-color: 111, 66, 193; }
+.summary-card:nth-child(1) { --i: 0; --card-color: var(--card-blue); }
+.summary-card:nth-child(2) { --i: 1; --card-color: var(--card-green); }
+.summary-card:nth-child(3) { --i: 2; --card-color: var(--card-yellow); }
+.summary-card:nth-child(4) { --i: 3; --card-color: var(--card-purple); }
 
 .summary-card:hover {
   border-color: rgba(var(--card-color), 0.6);

--- a/Lib/profiling/sampling/_heatmap_assets/heatmap.css
+++ b/Lib/profiling/sampling/_heatmap_assets/heatmap.css
@@ -69,12 +69,10 @@
   overflow: hidden;
 }
 
-.stat-card:nth-child(1) { --i: 0; --card-color: 55, 118, 171; }
-.stat-card:nth-child(2) { --i: 1; --card-color: 40, 167, 69; }
-.stat-card:nth-child(3) { --i: 2; --card-color: 184, 140, 5; }
-.stat-card:nth-child(4) { --i: 3; --card-color: 116, 69, 201; }
-.stat-card:nth-child(5) { --i: 4; --card-color: 220, 53, 69; }
-.stat-card:nth-child(6) { --i: 5; --card-color: 23, 162, 184; }
+.stat-card:nth-child(1) { --i: 0; --card-color: var(--card-blue); }
+.stat-card:nth-child(2) { --i: 1; --card-color: var(--card-green); }
+.stat-card:nth-child(3) { --i: 2; --card-color: var(--card-yellow); }
+.stat-card:nth-child(4) { --i: 3; --card-color: var(--card-purple); }
 
 .stat-card:hover {
   border-color: rgba(var(--card-color), 0.6);
@@ -159,8 +157,8 @@
   overflow: hidden;
 }
 
-.rate-card:nth-child(5) { animation-delay: 0.32s; --rate-color: 220, 53, 69; }
-.rate-card:nth-child(6) { animation-delay: 0.40s; --rate-color: 212, 126, 0; }
+.rate-card:nth-child(5) { animation-delay: 0.32s; --rate-color: var(--card-red); }
+.rate-card:nth-child(6) { animation-delay: 0.40s; --rate-color: var(--card-orange); }
 
 .rate-card:hover {
   border-color: rgba(var(--rate-color), 0.5);

--- a/Lib/profiling/sampling/_heatmap_assets/heatmap.css
+++ b/Lib/profiling/sampling/_heatmap_assets/heatmap.css
@@ -71,7 +71,7 @@
 
 .stat-card:nth-child(1) { --i: 0; --card-color: 55, 118, 171; }
 .stat-card:nth-child(2) { --i: 1; --card-color: 40, 167, 69; }
-.stat-card:nth-child(3) { --i: 2; --card-color: 255, 193, 7; }
+.stat-card:nth-child(3) { --i: 2; --card-color: 184, 140, 5; }
 .stat-card:nth-child(4) { --i: 3; --card-color: 116, 69, 201; }
 .stat-card:nth-child(5) { --i: 4; --card-color: 220, 53, 69; }
 .stat-card:nth-child(6) { --i: 5; --card-color: 23, 162, 184; }
@@ -160,7 +160,7 @@
 }
 
 .rate-card:nth-child(5) { animation-delay: 0.32s; --rate-color: 220, 53, 69; }
-.rate-card:nth-child(6) { animation-delay: 0.40s; --rate-color: 255, 152, 0; }
+.rate-card:nth-child(6) { animation-delay: 0.40s; --rate-color: 212, 126, 0; }
 
 .rate-card:hover {
   border-color: rgba(var(--rate-color), 0.5);

--- a/Lib/profiling/sampling/_heatmap_assets/heatmap.css
+++ b/Lib/profiling/sampling/_heatmap_assets/heatmap.css
@@ -72,7 +72,7 @@
 .stat-card:nth-child(1) { --i: 0; --card-color: 55, 118, 171; }
 .stat-card:nth-child(2) { --i: 1; --card-color: 40, 167, 69; }
 .stat-card:nth-child(3) { --i: 2; --card-color: 255, 193, 7; }
-.stat-card:nth-child(4) { --i: 3; --card-color: 111, 66, 193; }
+.stat-card:nth-child(4) { --i: 3; --card-color: 116, 69, 201; }
 .stat-card:nth-child(5) { --i: 4; --card-color: 220, 53, 69; }
 .stat-card:nth-child(6) { --i: 5; --card-color: 23, 162, 184; }
 

--- a/Lib/profiling/sampling/_shared_assets/base.css
+++ b/Lib/profiling/sampling/_shared_assets/base.css
@@ -100,6 +100,14 @@
   /* Heatmap span highlighting colors */
   --span-hot-base: 255, 100, 50;
   --span-cold-base: 150, 150, 150;
+
+  /* Summary card colors - optimized for 4.5:1 contrast on light bg */
+  --card-blue: 44, 102, 149;
+  --card-green: 26, 116, 49;
+  --card-yellow: 134, 100, 4;
+  --card-purple: 102, 57, 166;
+  --card-red: 180, 40, 50;
+  --card-orange: 166, 90, 0;
 }
 
 /* Dark theme */
@@ -162,6 +170,14 @@
   /* Heatmap span highlighting colors - dark theme */
   --span-hot-base: 255, 107, 53;
   --span-cold-base: 189, 189, 189;
+
+  /* Summary card colors - optimized for 4.5:1 contrast on dark bg */
+  --card-blue: 88, 166, 255;
+  --card-green: 63, 185, 80;
+  --card-yellow: 210, 153, 34;
+  --card-purple: 163, 113, 247;
+  --card-red: 248, 113, 113;
+  --card-orange: 251, 146, 60;
 }
 
 /* --------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


## Before

In dark mode, the samples/sec numbers has contrast ratio of 2.9.

In light mode, duration and missed samples are 1.63 and 2.15 respectively.

They should be at least 4.5 to meet WCAG AA guidelines.

<img width="1236" height="207" alt="image" src="https://github.com/user-attachments/assets/36edca2b-3cc5-47a8-acc2-214deff7afb0" />
<img width="1224" height="202" alt="image" src="https://github.com/user-attachments/assets/2eba23d0-76f7-4977-8a9f-119855aca6d7" />


## After

The values suggested by Chrome:

<img width="1224" height="210" alt="image" src="https://github.com/user-attachments/assets/c14b5459-d1f8-4f88-9701-d815dbed3a02" />
<img width="1223" height="209" alt="image" src="https://github.com/user-attachments/assets/acf81436-9413-4ff9-82bf-352b797d30f0" />



<!-- gh-issue-number: gh-142927 -->
* Issue: gh-142927
<!-- /gh-issue-number -->
