### PR TITLE
gh-142681: Preserve Lib/test/data/NormalizationTest-3.2.0.txt in `make distclean`

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -3302,7 +3302,9 @@ clobber: clean
 .PHONY: distclean
 distclean: clobber docclean
 	for file in $(srcdir)/Lib/test/data/* ; do \
-	    if test "$$file" != "$(srcdir)/Lib/test/data/README"; then rm "$$file"; fi; \
+	    if test "$$file" != "$(srcdir)/Lib/test/data/README" \
+	       -a "$$file" != "$(srcdir)/Lib/test/data/NormalizationTest-3.2.0.txt"; \
+	    then rm "$$file"; fi; \
 	done
 	-rm -f core Makefile Makefile.pre config.status Modules/Setup.local \
 	    Modules/Setup.bootstrap Modules/Setup.stdlib \


### PR DESCRIPTION
Small fix to `Makefile.pre.in` so that `make distclean` doesn't leave you with a dirty repo.  Needs backport to 3.14 and 3.13.

<!-- gh-issue-number: gh-142681 -->
* Issue: gh-142681
<!-- /gh-issue-number -->
