### PR TITLE
GH-142928: Add deprecation warning for removal of `color` on `HelpFormatter`

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1078,6 +1078,12 @@ Deprecated
 New deprecations
 ----------------
 
+* :mod:`argparse`:
+
+  * The *color* parameter of :class:`~argparse.HelpFormatter` is deprecated.
+    Use the *color* parameter of :class:`~argparse.ArgumentParser` instead.
+    (Contributed by Savannah Ostrowski in :gh:`142946`.)
+
 * CLI:
 
   * Deprecate :option:`-b` and :option:`!-bb` command-line options

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -166,7 +166,18 @@ class HelpFormatter(object):
         indent_increment=2,
         max_help_position=24,
         width=None,
+        color=None,
     ):
+        # Handle deprecated 'color' parameter for backwards compatibility
+        if color is not None:
+            import warnings
+            warnings.warn(
+                "The 'color' parameter is deprecated. "
+                "Set 'color' in ArgumentParser instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         # default setting for width
         if width is None:
             import shutil

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -168,7 +168,6 @@ class HelpFormatter(object):
         width=None,
         color=None,
     ):
-        # Handle deprecated 'color' parameter for backwards compatibility
         if color is not None:
             import warnings
             warnings.warn(

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5702,6 +5702,12 @@ class TestHelpCustomHelpFormatter(TestCase):
         help_text = formatter.format_help()
         self.assertEqual(help_text, "usage: program\n")
 
+    def test_formatter_color_parameter_deprecated(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            argparse.HelpFormatter(prog="program", color=True)
+        self.assertIn("'color' parameter is deprecated", str(cm.warning))
+        self.assertIn("ArgumentParser", str(cm.warning))
+
 # =====================================
 # Optional/Positional constructor tests
 # =====================================

--- a/Misc/NEWS.d/next/Library/2025-12-18-17-13-10.gh-issue-142928.bcgx78.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-18-17-13-10.gh-issue-142928.bcgx78.rst
@@ -1,0 +1,1 @@
+Deprecate :class:`~argparse.HelpFormatter`'s *color* parameter. Users should use the *color* parameter on :class:`~argparse.ArgumentParser` instead.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Never documented and buggy but alas, still used, so we need a deprecation warning. More context here: https://github.com/python/cpython/pull/142274#issuecomment-3669963268

<!-- gh-issue-number: gh-142928 -->
* Issue: gh-142928
<!-- /gh-issue-number -->
