### PR TITLE
gh-122581: Use parser mutex in default build for subinterpreters

### DIFF
--- a/Include/internal/pycore_parser.h
+++ b/Include/internal/pycore_parser.h
@@ -14,21 +14,6 @@ extern "C" {
 #include "pycore_pyarena.h"         // PyArena
 
 _Py_DECLARE_STR(empty, "")
-#if defined(Py_DEBUG) && defined(Py_GIL_DISABLED)
-#define _parser_runtime_state_INIT \
-    { \
-        .mutex = {0}, \
-        .dummy_name = { \
-            .kind = Name_kind, \
-            .v.Name.id = &_Py_STR(empty), \
-            .v.Name.ctx = Load, \
-            .lineno = 1, \
-            .col_offset = 0, \
-            .end_lineno = 1, \
-            .end_col_offset = 0, \
-        }, \
-    }
-#else
 #define _parser_runtime_state_INIT \
     { \
         .dummy_name = { \
@@ -41,7 +26,6 @@ _Py_DECLARE_STR(empty, "")
             .end_col_offset = 0, \
         }, \
     }
-#endif
 
 extern struct _mod* _PyParser_ASTFromString(
     const char *str,

--- a/Include/internal/pycore_runtime_structs.h
+++ b/Include/internal/pycore_runtime_structs.h
@@ -77,9 +77,7 @@ struct _fileutils_state {
 struct _parser_runtime_state {
 #ifdef Py_DEBUG
     long memo_statistics[_PYPEGEN_NSTATISTICS];
-#ifdef Py_GIL_DISABLED
     PyMutex mutex;
-#endif
 #else
     int _not_used;
 #endif

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -3,9 +3,8 @@
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_parser.h"        // _PYPEGEN_NSTATISTICS
 #include "pycore_pyerrors.h"      // PyExc_IncompleteInputError
-#include "pycore_runtime.h"     // _PyRuntime
+#include "pycore_runtime.h"       // _PyRuntime
 #include "pycore_unicodeobject.h" // _PyUnicode_InternImmortal
-#include "pycore_pyatomic_ft_wrappers.h"
 #include <errcode.h>
 
 #include "lexer/lexer.h"
@@ -303,11 +302,11 @@ error:
 void
 _PyPegen_clear_memo_statistics(void)
 {
-    FT_MUTEX_LOCK(&_PyRuntime.parser.mutex);
+    PyMutex_Lock(&_PyRuntime.parser.mutex);
     for (int i = 0; i < NSTATISTICS; i++) {
         memo_statistics[i] = 0;
     }
-    FT_MUTEX_UNLOCK(&_PyRuntime.parser.mutex);
+    PyMutex_Unlock(&_PyRuntime.parser.mutex);
 }
 
 PyObject *
@@ -318,22 +317,22 @@ _PyPegen_get_memo_statistics(void)
         return NULL;
     }
 
-    FT_MUTEX_LOCK(&_PyRuntime.parser.mutex);
+    PyMutex_Lock(&_PyRuntime.parser.mutex);
     for (int i = 0; i < NSTATISTICS; i++) {
         PyObject *value = PyLong_FromLong(memo_statistics[i]);
         if (value == NULL) {
-            FT_MUTEX_UNLOCK(&_PyRuntime.parser.mutex);
+            PyMutex_Unlock(&_PyRuntime.parser.mutex);
             Py_DECREF(ret);
             return NULL;
         }
         // PyList_SetItem borrows a reference to value.
         if (PyList_SetItem(ret, i, value) < 0) {
-            FT_MUTEX_UNLOCK(&_PyRuntime.parser.mutex);
+            PyMutex_Unlock(&_PyRuntime.parser.mutex);
             Py_DECREF(ret);
             return NULL;
         }
     }
-    FT_MUTEX_UNLOCK(&_PyRuntime.parser.mutex);
+    PyMutex_Unlock(&_PyRuntime.parser.mutex);
     return ret;
 }
 #endif
@@ -359,9 +358,9 @@ _PyPegen_is_memoized(Parser *p, int type, void *pres)
                 if (count <= 0) {
                     count = 1;
                 }
-                FT_MUTEX_LOCK(&_PyRuntime.parser.mutex);
+                PyMutex_Lock(&_PyRuntime.parser.mutex);
                 memo_statistics[type] += count;
-                FT_MUTEX_UNLOCK(&_PyRuntime.parser.mutex);
+                PyMutex_Unlock(&_PyRuntime.parser.mutex);
             }
 #endif
             p->mark = m->mark;


### PR DESCRIPTION
The data race also affected subinterpreters in the default build.

<!-- gh-issue-number: gh-122581 -->
* Issue: gh-122581
<!-- /gh-issue-number -->
