### PR TITLE
gh-138045: Fix importing numpy in legacy subinterpreters by skipping switch to main interpreter when not needed

### DIFF
--- a/Misc/NEWS.d/next/C_API/2026-01-02-10-08-04.gh-issue-138045.nIOA3N.rst
+++ b/Misc/NEWS.d/next/C_API/2026-01-02-10-08-04.gh-issue-138045.nIOA3N.rst
@@ -1,0 +1,3 @@
+Fixed a bug that prevented some extension modules (like numpy <2.40) that
+use single-phase initialization to be correctly imported when using legacy
+subinterpreters.


### PR DESCRIPTION
(singlephase == NULL) check in update_global_state_for_extension could be removed because it's only called with pointers to stack objects.

I've tried creating a minimal working reproducer instead of importing numpy with the example from https://github.com/python/cpython/issues/138045#issuecomment-3216214055 but didn't manage to integrate that into Python's test suite. Maybe someone else has more knowledge on how to create a simple test that reproduce the numpy situation.

The fix can be backported down to 3.13.

<!-- gh-issue-number: gh-138045 -->
* Issue: gh-138045
<!-- /gh-issue-number -->
