### PR TITLE
gh-120321: Fix TSan reported race in gen_clear_frame

### DIFF
--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -153,7 +153,7 @@ _PyGen_Finalize(PyObject *self)
 static void
 gen_clear_frame(PyGenObject *gen)
 {
-    assert(gen->gi_frame_state == FRAME_CLEARED);
+    assert(FT_ATOMIC_LOAD_INT8_RELAXED(gen->gi_frame_state) == FRAME_CLEARED);
     _PyInterpreterFrame *frame = &gen->gi_iframe;
     frame->previous = NULL;
     _PyFrame_ClearExceptCode(frame);


### PR DESCRIPTION
TSan treats compare-exchanges that fail as if they are writes so there is a false positive with the read of gi_frame_state in gen_close.


<!-- gh-issue-number: gh-120321 -->
* Issue: gh-120321
<!-- /gh-issue-number -->
