### PR TITLE
gh-142994, gh-142996: document missing async generator and coroutine field entries in `inspect`

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -273,6 +273,9 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
 +-----------------+-------------------+---------------------------+
 |                 | ag_running        | is the generator running? |
 +-----------------+-------------------+---------------------------+
+|                 | ag_suspended      | is the generator          |
+|                 |                   | suspended?                |
++-----------------+-------------------+---------------------------+
 |                 | ag_code           | code                      |
 +-----------------+-------------------+---------------------------+
 | coroutine       | __name__          | name                      |

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -330,6 +330,7 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
    Add ``gi_suspended`` attribute to generators.
 
 .. versionchanged:: 3.11
+
    Add ``cr_suspended`` attribute to coroutines.
 
 .. versionchanged:: 3.12

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -322,6 +322,10 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
 
    Add ``__builtins__`` attribute to functions.
 
+.. versionchanged:: 3.12
+
+   Add ``ag_suspended`` attribute to async generator.
+
 .. versionchanged:: 3.14
 
    Add ``f_generator`` attribute to frames.

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -295,6 +295,9 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
 |                 |                   | created, or ``None``. See |
 |                 |                   | |coroutine-origin-link|   |
 +-----------------+-------------------+---------------------------+
+|                 | cr_suspended      | is the coroutine          |
+|                 |                   | suspended?                |
++-----------------+-------------------+---------------------------+
 | builtin         | __doc__           | documentation string      |
 +-----------------+-------------------+---------------------------+
 |                 | __name__          | original name of this     |
@@ -321,6 +324,13 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
 .. versionchanged:: 3.10
 
    Add ``__builtins__`` attribute to functions.
+
+.. versionchanged:: 3.11
+
+   Add ``gi_suspended`` attribute to generators.
+
+.. versionchanged:: 3.11
+   Add ``cr_suspended`` attribute to coroutines.
 
 .. versionchanged:: 3.12
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -289,14 +289,14 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
 +-----------------+-------------------+---------------------------+
 |                 | cr_running        | is the coroutine running? |
 +-----------------+-------------------+---------------------------+
+|                 | cr_suspended      | is the coroutine          |
+|                 |                   | suspended?                |
++-----------------+-------------------+---------------------------+
 |                 | cr_code           | code                      |
 +-----------------+-------------------+---------------------------+
 |                 | cr_origin         | where coroutine was       |
 |                 |                   | created, or ``None``. See |
 |                 |                   | |coroutine-origin-link|   |
-+-----------------+-------------------+---------------------------+
-|                 | cr_suspended      | is the coroutine          |
-|                 |                   | suspended?                |
 +-----------------+-------------------+---------------------------+
 | builtin         | __doc__           | documentation string      |
 +-----------------+-------------------+---------------------------+

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -324,7 +324,7 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
 
 .. versionchanged:: 3.12
 
-   Add ``ag_suspended`` attribute to async generator.
+   Add ``ag_suspended`` attribute to async generators.
 
 .. versionchanged:: 3.14
 


### PR DESCRIPTION
Add missing async generator field entries in inspect’s documentation

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142996 -->
* Issue: gh-142996
<!-- /gh-issue-number -->

<!-- gh-issue-number: gh-142994 -->
* Issue: gh-142994
<!-- /gh-issue-number -->

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--142997.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->