### PR TITLE
gh-143010: Prevent a TOCTOU issue by only calling open once

### DIFF
--- a/Lib/mailbox.py
+++ b/Lib/mailbox.py
@@ -2181,11 +2181,7 @@ def _unlock_file(f):
 
 def _create_carefully(path):
     """Create a file if it doesn't exist and open for reading and writing."""
-    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o666)
-    try:
-        return open(path, 'rb+')
-    finally:
-        os.close(fd)
+    return open(path, 'xb+')
 
 def _create_temporary(path):
     """Create a temp file based on path and open for reading and writing."""

--- a/Misc/NEWS.d/next/Library/2025-12-20-01-49-02.gh-issue-143010._-SWX0.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-20-01-49-02.gh-issue-143010._-SWX0.rst
@@ -1,1 +1,1 @@
-mailbox: Fixed a bug in :mod:mailbox where the precise timing of an external event could result in the library opening an existing file instead of a file it expected to create.
+Fixed a bug in :mod:`mailbox` where the precise timing of an external event could result in the library opening an existing file instead of a file it expected to create.

--- a/Misc/NEWS.d/next/Library/2025-12-20-01-49-02.gh-issue-143010._-SWX0.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-20-01-49-02.gh-issue-143010._-SWX0.rst
@@ -1,0 +1,1 @@
+_create_carefully: Prevent a TOCTOU by simplifying.

--- a/Misc/NEWS.d/next/Library/2025-12-20-01-49-02.gh-issue-143010._-SWX0.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-20-01-49-02.gh-issue-143010._-SWX0.rst
@@ -1,1 +1,1 @@
-_create_carefully: Prevent a TOCTOU by simplifying.
+mailbox: Fixed a bug in :mod:mailbox where the precise timing of an external event could result in the library opening an existing file instead of a file it expected to create.


### PR DESCRIPTION
We can literally just use open(path, 'xb+') for _create_carefully


<!-- gh-issue-number: gh-143010 -->
* Issue: gh-143010
<!-- /gh-issue-number -->
