### PR TITLE
gh-129069: fix more thread safety issues in list

### DIFF
--- a/Lib/test/test_free_threading/test_list.py
+++ b/Lib/test/test_free_threading/test_list.py
@@ -91,6 +91,64 @@ class TestList(TestCase):
         with threading_helper.start_threads(threads):
             pass
 
+    def test_reverse(self):
+        def reverse_list(b, l):
+            b.wait()
+            for _ in range(100):
+                l.reverse()
+
+        def reader_list(b, l):
+            b.wait()
+            for _ in range(100):
+                for i in range(10):
+                    self.assertTrue(0 <= l[i] < 10)
+
+        l = list(range(10))
+        barrier = Barrier(2)
+        threads = [Thread(target=reverse_list, args=(barrier, l)),
+                   Thread(target=reader_list, args=(barrier, l))]
+        with threading_helper.start_threads(threads):
+            pass
+
+    def test_slice_assignment1(self):
+        def assign_slice(b, l):
+            b.wait()
+            for _ in range(100):
+                l[2:5] = [7, 8, 9]
+
+        def reader_list(b, l):
+            b.wait()
+            for _ in range(100):
+                self.assertIn(l[2], (2, 7))
+                self.assertIn(l[3], (3, 8))
+                self.assertIn(l[4], (4, 9))
+
+        l = list(range(10))
+        barrier = Barrier(2)
+        threads = [Thread(target=assign_slice, args=(barrier, l)),
+                   Thread(target=reader_list, args=(barrier, l))]
+        with threading_helper.start_threads(threads):
+            pass
+
+    def test_slice_assignment2(self):
+        def assign_slice(b, l):
+            b.wait()
+            for _ in range(100):
+                l[::2] = [10, 11, 12, 13, 14]
+
+        def reader_list(b, l):
+            b.wait()
+            for _ in range(100):
+                for i in range(0, 10, 2):
+                    self.assertIn(l[i], (i, 10 + i // 2))
+
+        l = list(range(10))
+        barrier = Barrier(2)
+        threads = [Thread(target=assign_slice, args=(barrier, l)),
+                   Thread(target=reader_list, args=(barrier, l))]
+        with threading_helper.start_threads(threads):
+            pass
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This PR fixes thread safety of `list.reverse` and slice assignment. Also changes stores to use release rather than relaxed as done in https://github.com/python/cpython/pull/142957.


<!-- gh-issue-number: gh-129069 -->
* Issue: gh-129069
<!-- /gh-issue-number -->
