### PR TITLE
gh-139716: Make `PyStackRef_FromPyObjectSteal` function very lightweight for GIL build as on FT build

### DIFF
--- a/InternalDocs/stackrefs.md
+++ b/InternalDocs/stackrefs.md
@@ -21,8 +21,8 @@ to avoid refcount contention on commonly shared objects.
 Three conversions control ownership:
 
 - `PyStackRef_FromPyObjectNew(obj)` - create a new reference (INCREF if mortal).
-- `PyStackRef_FromPyObjectSteal(obj)` - take over ownership without changing the count unless the
-  object is immortal.
+- `PyStackRef_FromPyObjectSteal(obj)` - take over ownership without changing the count;
+  this function is very lightweight since it does not check or modify any refcount.
 - `PyStackRef_FromPyObjectBorrow(obj)` - create a borrowed stackref (never decref on close).
 
 The `obj` argument must not be `NULL`.


### PR DESCRIPTION
This is another attempt to provide the same StackRef flagging scheme for all builds (GIL, FT, STACKREF_DEBUG).
Instead of adding `_Py_IsImmortal` check to `PyStackRef_FromPyObjectSteal` for FT builds as in https://github.com/python/cpython/pull/141675, we make no checks at all in this function.
As a result, immortal objects will be DECREF'ed with no effect at reference closing.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139716 -->
* Issue: gh-139716
<!-- /gh-issue-number -->
