### PR TITLE
gh-142972: Document arbitrary ordering in `Path.glob`

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1366,12 +1366,12 @@ Reading directories
 
 .. method:: Path.rglob(pattern, *, case_sensitive=None, recurse_symlinks=False)
 
+   Glob the given relative *pattern* recursively.  This is like calling
+   :func:`Path.glob` with "``**/``" added in front of the *pattern*.
+
    .. note::
       The paths are returned in no particular order.
       If you need a specific order, sort the results.
-
-   Glob the given relative *pattern* recursively.  This is like calling
-   :func:`Path.glob` with "``**/``" added in front of the *pattern*.
 
    .. seealso::
       :ref:`pathlib-pattern-language` and :meth:`Path.glob` documentation.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1332,7 +1332,7 @@ Reading directories
        PosixPath('test_pathlib.py')]
 
    .. note::
-      Akin to :mod:`glob`, the paths are returned in no particular order.
+      Akin to :mod:`glob`, the paths are returned with no ordering guarantees.
       If you need a specific order, sort them.
 
    .. seealso::
@@ -1365,6 +1365,10 @@ Reading directories
 
 
 .. method:: Path.rglob(pattern, *, case_sensitive=None, recurse_symlinks=False)
+
+   .. note::
+      Akin to :mod:`glob`, the paths are returned with no ordering guarantees.
+      If you need a specific order, sort them.
 
    Glob the given relative *pattern* recursively.  This is like calling
    :func:`Path.glob` with "``**/``" added in front of the *pattern*.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1320,6 +1320,10 @@ Reading directories
    Glob the given relative *pattern* in the directory represented by this path,
    yielding all matching files (of any kind)::
 
+   .. note::
+      Akin to :mod:`glob`, the paths are returned in no particular order.
+      If you need a specific order, sort them.
+
       >>> sorted(Path('.').glob('*.py'))
       [PosixPath('pathlib.py'), PosixPath('setup.py'), PosixPath('test_pathlib.py')]
       >>> sorted(Path('.').glob('*/*.py'))

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1333,7 +1333,7 @@ Reading directories
 
    .. note::
       Akin to :mod:`glob`, the paths are returned with no ordering guarantees.
-      If you need a specific order, sort them.
+      If you need a specific order, sort the results.
 
    .. seealso::
       :ref:`pathlib-pattern-language` documentation.
@@ -1368,7 +1368,7 @@ Reading directories
 
    .. note::
       Akin to :mod:`glob`, the paths are returned with no ordering guarantees.
-      If you need a specific order, sort them.
+      If you need a specific order, sort the results.
 
    Glob the given relative *pattern* recursively.  This is like calling
    :func:`Path.glob` with "``**/``" added in front of the *pattern*.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1332,7 +1332,7 @@ Reading directories
        PosixPath('test_pathlib.py')]
 
    .. note::
-      Akin to :mod:`glob`, the paths are returned with no ordering guarantees.
+      The paths are returned in no particular order.
       If you need a specific order, sort the results.
 
    .. seealso::
@@ -1367,7 +1367,7 @@ Reading directories
 .. method:: Path.rglob(pattern, *, case_sensitive=None, recurse_symlinks=False)
 
    .. note::
-      Akin to :mod:`glob`, the paths are returned with no ordering guarantees.
+      The paths are returned in no particular order.
       If you need a specific order, sort the results.
 
    Glob the given relative *pattern* recursively.  This is like calling

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1320,10 +1320,6 @@ Reading directories
    Glob the given relative *pattern* in the directory represented by this path,
    yielding all matching files (of any kind)::
 
-   .. note::
-      Akin to :mod:`glob`, the paths are returned in no particular order.
-      If you need a specific order, sort them.
-
       >>> sorted(Path('.').glob('*.py'))
       [PosixPath('pathlib.py'), PosixPath('setup.py'), PosixPath('test_pathlib.py')]
       >>> sorted(Path('.').glob('*/*.py'))
@@ -1334,6 +1330,10 @@ Reading directories
        PosixPath('pathlib.py'),
        PosixPath('setup.py'),
        PosixPath('test_pathlib.py')]
+
+   .. note::
+      Akin to :mod:`glob`, the paths are returned in no particular order.
+      If you need a specific order, sort them.
 
    .. seealso::
       :ref:`pathlib-pattern-language` documentation.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142972 -->
* Issue: gh-142972
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143025.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->