### PR TITLE
[3.13] gh-142145: relax the no-longer-quadratic test timing (GH-143030)

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -174,6 +174,7 @@ class MinidomTest(unittest.TestCase):
         self.assertEqual(dom.documentElement.childNodes[-1].data, "Hello")
         dom.unlink()
 
+    @support.requires_resource('cpu')
     def testAppendChildNoQuadraticComplexity(self):
         impl = getDOMImplementation()
 
@@ -182,14 +183,18 @@ class MinidomTest(unittest.TestCase):
         children = [newdoc.createElement(f"child-{i}") for i in range(1, 2 ** 15 + 1)]
         element = top_element
 
-        start = time.time()
+        start = time.monotonic()
         for child in children:
             element.appendChild(child)
             element = child
-        end = time.time()
+        end = time.monotonic()
 
         # This example used to take at least 30 seconds.
-        self.assertLess(end - start, 10)
+        # Conservative assertion due to the wide variety of systems and
+        # build configs timing based tests wind up run under.
+        # A --with-address-sanitizer --with-pydebug build on a rpi5 still
+        # completes this loop in <0.5 seconds.
+        self.assertLess(end - start, 4)
 
     def testAppendChildFragment(self):
         dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()


### PR DESCRIPTION
* gh-142145: relax the no-longer-quadratic test timing

* require cpu resource

(cherry picked from commit 8d2d7bb)

replaces https://github.com/python/cpython/pull/142210/commits/445c8883d0062fdf547dfdbb0b8a342d3149807c added in the earlier 3.13 backport.