### PR TITLE
gh-139109: Add terminator to JIT code when  halting due to invalid dependencies

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-21-00-25-26.gh-issue-139109.gwSsOL.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-21-00-25-26.gh-issue-139109.gwSsOL.rst
@@ -1,0 +1,1 @@
+Add missing terminator in certain cases when tracing in the new JIT compiler.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -710,7 +710,7 @@ _PyJit_translate_single_bytecode_to_trace(
     }
 
     if (!_tstate->jit_tracer_state.prev_state.dependencies_still_valid) {
-        goto done;
+        goto full;
     }
 
     // This happens when a recursive call happens that we can't trace. Such as Python -> C -> Python calls


### PR DESCRIPTION
So this is a minor thing but I'm quite sure is a bug: `goto done` doesn't append a terminator, `goto full` does. So it's possible that after invaildation when tracing, we end up with a non-terminated trace!

<!-- gh-issue-number: gh-139109 -->
* Issue: gh-139109
<!-- /gh-issue-number -->
