### PR TITLE
gh-143008: fix TextIOWrapper.truncate via re-entrant flush

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-21-17-56-37.gh-issue-143008.aakErJ.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-21-17-56-37.gh-issue-143008.aakErJ.rst
@@ -1,0 +1,1 @@
+Fix crash in :class:`io.TextIOWrapper` when reentrant ``detach()`` called.

--- a/Misc/NEWS.d/next/Library/2025-12-21-17-56-37.gh-issue-143008.aakErJ.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-21-17-56-37.gh-issue-143008.aakErJ.rst
@@ -1,1 +1,1 @@
-Fix crash in :class:`io.TextIOWrapper` when reentrant ``detach()`` called.
+Fix crash in :class:`io.TextIOWrapper` when reentrant :meth:`io.TextIOBase.detach` called.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


This patch fix all  re-entrant flush problem 
by adding an attr flushing
and. refactor the file check to `_textiowrapper_flush`


<!-- gh-issue-number: gh-143008 -->
* Issue: gh-143008
<!-- /gh-issue-number -->


all crash problem in 143008 can be fix cc @jackfromeast can you help to check?
thank you very much!