### PR TITLE
gh-143007: fix crash .TextIOWrapper.seek with a custom __int__ method detaches

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-21-21-30-48.gh-issue-143007.EtzUva.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-21-21-30-48.gh-issue-143007.EtzUva.rst
@@ -1,0 +1,2 @@
+Fix crash in :meth:`io.TextIOWrapper.seek` when a custom cookie's
+``__int__`` method detaches the underlying buffer.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2416,21 +2416,12 @@ typedef struct {
 #endif
 
 static int
-textiowrapper_parse_cookie(textio *self, cookie_type *cookie, PyObject *cookieObj)
+textiowrapper_parse_cookie(cookie_type *cookie, PyObject *cookieObj)
 {
     unsigned char buffer[COOKIE_BUF_LEN];
     PyLongObject *cookieLong = (PyLongObject *)PyNumber_Long(cookieObj);
     if (cookieLong == NULL)
         return -1;
-
-    // gh-143007: PyNumber_Long can call arbitrary code through __int__
-    // which may detach the underlying buffer.
-    if (self->detached) {
-        Py_DECREF(cookieLong);
-        PyErr_SetString(PyExc_ValueError,
-                        "underlying buffer has been detached");
-        return -1;
-    }
 
     if (_PyLong_AsByteArray(cookieLong, buffer, sizeof(buffer),
                             PY_LITTLE_ENDIAN, 0, 1) < 0) {
@@ -2646,7 +2637,7 @@ _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence)
     /* The strategy of seek() is to go back to the safe start point
      * and replay the effect of read(chars_to_skip) from there.
      */
-    if (textiowrapper_parse_cookie(self, &cookie, cookieObj) < 0)
+    if (textiowrapper_parse_cookie(&cookie, cookieObj) < 0)
         goto fail;
 
     /* Seek back to the safe start point. */

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2416,12 +2416,21 @@ typedef struct {
 #endif
 
 static int
-textiowrapper_parse_cookie(cookie_type *cookie, PyObject *cookieObj)
+textiowrapper_parse_cookie(textio *self, cookie_type *cookie, PyObject *cookieObj)
 {
     unsigned char buffer[COOKIE_BUF_LEN];
     PyLongObject *cookieLong = (PyLongObject *)PyNumber_Long(cookieObj);
     if (cookieLong == NULL)
         return -1;
+
+    // gh-143007: PyNumber_Long can call arbitrary code through __int__
+    // which may detach the underlying buffer.
+    if (self->detached) {
+        Py_DECREF(cookieLong);
+        PyErr_SetString(PyExc_ValueError,
+                        "underlying buffer has been detached");
+        return -1;
+    }
 
     if (_PyLong_AsByteArray(cookieLong, buffer, sizeof(buffer),
                             PY_LITTLE_ENDIAN, 0, 1) < 0) {
@@ -2637,7 +2646,7 @@ _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence)
     /* The strategy of seek() is to go back to the safe start point
      * and replay the effect of read(chars_to_skip) from there.
      */
-    if (textiowrapper_parse_cookie(&cookie, cookieObj) < 0)
+    if (textiowrapper_parse_cookie(self, &cookie, cookieObj) < 0)
         goto fail;
 
     /* Seek back to the safe start point. */

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2686,6 +2686,7 @@ _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence)
             goto fail;
         }
         Py_XSETREF(self->snapshot, snapshot);
+
         decoded = PyObject_CallMethodObjArgs(self->decoder, &_Py_ID(decode),
             input_chunk, cookie.need_eof ? Py_True : Py_False, NULL);
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

this patch fix crash .TextIOWrapper.seek with a custom __int__ method detaches

add `textiowrapper_parse_cookie` instead of check detect again to make the code clear

<!-- gh-issue-number: gh-143007 -->
* Issue: gh-143007
<!-- /gh-issue-number -->
