### PR TITLE
gh-142734: fix UAF in `OrderedDict.copy` with concurrent mutations by `__getitem__`

### DIFF
--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -993,8 +993,8 @@ class CPythonOrderedDictTests(OrderedDictTests,
         class MyOD(self.OrderedDict):
             call_count = 0
             def __getitem__(self, key):
-                MyOD.call_count += 1
-                if MyOD.call_count == 1:
+                self.call_count += 1
+                if self.call_count == 1:
                     del self[3]
                 return super().__getitem__(key)
 
@@ -1005,9 +1005,9 @@ class CPythonOrderedDictTests(OrderedDictTests,
         class MyOD(self.OrderedDict):
             call_count = 0
             def __getitem__(self, key):
-                MyOD.call_count += 1
-                if MyOD.call_count == 1:
-                    self.pop(3, None)
+                self.call_count += 1
+                if self.call_count == 1:
+                    self.pop(3)
                 return super().__getitem__(key)
 
         od = MyOD([(1, 'one'), (2, 'two'), (3, 'three')])
@@ -1017,10 +1017,10 @@ class CPythonOrderedDictTests(OrderedDictTests,
         class MyOD(self.OrderedDict):
             call_count = 0
             def __getitem__(self, key):
-                MyOD.call_count += 1
-                if MyOD.call_count == 1:
+                self.call_count += 1
+                if self.call_count == 1:
                     del self[3]
-                elif MyOD.call_count == 2:
+                elif self.call_count == 2:
                     self['new_key'] = 'new_value'
                 return super().__getitem__(key)
 
@@ -1029,11 +1029,12 @@ class CPythonOrderedDictTests(OrderedDictTests,
 
     def test_copy_concurrent_mutation_in__setitem__(self):
         od = None
-
         class MyOD(self.OrderedDict):
+            call_count = 0
             def __setitem__(self, key, value):
-                if od is not None and len(od) > 1:
-                    del od[3]
+                self.call_count += 1
+                if od is not None and len(od) > 1 and self.call_count == 1:
+                    del od[1]
                 return super().__setitem__(key, value)
 
         od = MyOD([(1, 'one'), (2, 'two'), (3, 'three')])

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -995,7 +995,7 @@ class CPythonOrderedDictTests(OrderedDictTests,
             def __getitem__(self, key):
                 self.call_count += 1
                 if self.call_count == 1:
-                    del self[3]
+                    del self[next(iter(self))]
                 return super().__getitem__(key)
 
         od = MyOD([(1, 'one'), (2, 'two'), (3, 'three')])
@@ -1007,7 +1007,7 @@ class CPythonOrderedDictTests(OrderedDictTests,
             def __getitem__(self, key):
                 self.call_count += 1
                 if self.call_count == 1:
-                    self.pop(3)
+                    self.pop(next(iter(self)))
                 return super().__getitem__(key)
 
         od = MyOD([(1, 'one'), (2, 'two'), (3, 'three')])
@@ -1019,7 +1019,7 @@ class CPythonOrderedDictTests(OrderedDictTests,
             def __getitem__(self, key):
                 self.call_count += 1
                 if self.call_count == 1:
-                    del self[3]
+                    del self[next(iter(self))]
                 elif self.call_count == 2:
                     self['new_key'] = 'new_value'
                 return super().__getitem__(key)
@@ -1030,11 +1030,15 @@ class CPythonOrderedDictTests(OrderedDictTests,
     def test_copy_concurrent_mutation_in__setitem__(self):
         od = None
         class MyOD(self.OrderedDict):
-            call_count = 0
+            _instance_count = 0
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                MyOD._instance_count += 1
+
             def __setitem__(self, key, value):
-                self.call_count += 1
-                if od is not None and len(od) > 1 and self.call_count == 1:
-                    del od[1]
+                if self._instance_count == 2 and len(od) > 1:
+                    del od[next(iter(od))]
                 return super().__setitem__(key, value)
 
         od = MyOD([(1, 'one'), (2, 'two'), (3, 'three')])

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -730,32 +730,6 @@ class OrderedDictTests:
         with self.assertRaises(ValueError):
             a |= "BAD"
 
-    def test_getitem_re_entrant_clear_during_copy(self):
-        class Evil(self.OrderedDict):
-            def __getitem__(self, key):
-                super().clear()
-                return None
-
-        evil_dict = Evil([(i, i) for i in range(4)])
-        result = evil_dict.copy()
-
-        self.assertEqual(len(result), 4)
-
-    def test_getitem_re_entrant_modify_during_copy(self):
-        class Modifier(self.OrderedDict):
-            def __getitem__(self, key):
-                self['new_key'] = 'new_value'
-                return super().__getitem__(key)
-
-        original = Modifier([(1, 'one'), (2, 'two')])
-        result = original.copy()
-
-        self.assertIn(1, result)
-        self.assertIn(2, result)
-        self.assertEqual(result[1], 'one')
-        self.assertEqual(result[2], 'two')
-        self.assertEqual(result["new_key"], "new_value")
-
     @support.cpython_only
     def test_ordered_dict_items_result_gc(self):
         # bpo-42536: OrderedDict.items's tuple-reuse speed trick breaks the GC's
@@ -899,6 +873,26 @@ class CPythonOrderedDictSideEffects:
         self.assertEqual(Key.count, 2)
         self.assertDictEqual(dict1, dict.fromkeys((0, 4.2)))
         self.assertDictEqual(dict2, dict.fromkeys((0, Key(), 4.2)))
+
+    def test_getitem_re_entrant_clear_during_copy(self):
+        class Evil(self.OrderedDict):
+            def __getitem__(self, key):
+                super().clear()
+                return None
+
+        evil_dict = Evil([(i, i) for i in range(4)])
+        with self.assertRaises(RuntimeError):
+            result = evil_dict.copy()
+
+    def test_getitem_re_entrant_modify_during_copy(self):
+        class Modifier(self.OrderedDict):
+            def __getitem__(self, key):
+                self['new_key'] = 'new_value'
+                return super().__getitem__(key)
+
+        original = Modifier([(1, 'one'), (2, 'two')])
+        with self.assertRaises(RuntimeError):
+            result = original.copy()
 
 
 @unittest.skipUnless(c_coll, 'requires the C version of the collections module')

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -10,7 +10,6 @@ import struct
 import sys
 import unittest
 import weakref
-
 from collections.abc import MutableMapping
 from test import mapping_tests, support
 from test.support import import_helper

--- a/Misc/NEWS.d/next/Library/2025-12-22-15-02-16.gh-issue-142734.IxVAQh.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-22-15-02-16.gh-issue-142734.IxVAQh.rst
@@ -1,1 +1,1 @@
-fix ordereddict copy heap-use-after-free security issue
+:mod:`collections`: fix use-after-free crashes in :meth:`OrderedDict.copy <dict.copy>` when the dictionary to copy is concurrently mutated.

--- a/Misc/NEWS.d/next/Library/2025-12-22-15-02-16.gh-issue-142734.IxVAQh.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-22-15-02-16.gh-issue-142734.IxVAQh.rst
@@ -1,0 +1,1 @@
+fix ordereddict copy heap-use-after-free security issue

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1268,15 +1268,18 @@ OrderedDict_copy_impl(PyObject *od)
     else {
         PyODictObject *self = _PyODictObject_CAST(od);
         size_t state = self->od_state;
-        _ODictNode *cur;
 
-        _odict_FOREACH(od, cur) {
-            PyObject *key = Py_NewRef(_odictnode_KEY(cur));
+        _odict_FOREACH(od, node) {
+            PyObject *key = Py_NewRef(_odictnode_KEY(node));
             PyObject *value = PyObject_GetItem(od, key);
             if (value == NULL) {
                 Py_DECREF(key);
+                if (self->od_state != state) {
+                    goto invalid_state;
+                }
                 goto fail;
             }
+
             int rc = PyObject_SetItem(od_copy, key, value);
             Py_DECREF(key);
             Py_DECREF(value);

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1274,10 +1274,13 @@ OrderedDict_copy_impl(PyObject *od)
             PyObject *value = PyObject_GetItem(od, key);
             if (value == NULL) {
                 Py_DECREF(key);
-                if (self->od_state != state) {
-                    goto invalid_state;
-                }
                 goto fail;
+            }
+
+            if (self->od_state != state) {
+                Py_DECREF(key);
+                Py_DECREF(value);
+                goto invalid_state;  // 成功获取值但状态改变
             }
 
             int rc = PyObject_SetItem(od_copy, key, value);


### PR DESCRIPTION
fix OrderedDict copy heap-use-after-free security issue

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142734 -->
* Issue: gh-142734
<!-- /gh-issue-number -->
