### PR TITLE
gh-143057: Use atomics for _PyRuntime.tracemalloc.config.tracing

### DIFF
--- a/Include/internal/pycore_tracemalloc.h
+++ b/Include/internal/pycore_tracemalloc.h
@@ -20,8 +20,7 @@ struct _PyTraceMalloc_Config {
         TRACEMALLOC_FINALIZED
     } initialized;
 
-    /* Is tracemalloc tracing memory allocations?
-       Variable protected by the TABLES_LOCK(). */
+    /* Is tracemalloc tracing memory allocations? (Atomic.) */
     int tracing;
 
     /* limit of the number of frames in a traceback, 1 by default.


### PR DESCRIPTION
Use atomics for the _PyRuntime.tracemalloc.config.tracing so we can bail early in `PyTraceMalloc_Track` and `PyTraceMalloc_Untrack` if tracemalloc isn't enabled. This avoids a significant scaling issue when tracemalloc isn't enabled, in extension modules that properly use the PyTraceMalloc_Track API (like numpy).



<!-- gh-issue-number: gh-143057 -->
* Issue: gh-143057
<!-- /gh-issue-number -->
