### PR TITLE
GH-142513: fix missing return in executor_clear

### DIFF
--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1773,6 +1773,7 @@ static int
 executor_clear(PyObject *op)
 {
     executor_invalidate(op);
+    return 0;
 }
 
 void


### PR DESCRIPTION
Fixes also the warnings like
```
C:\a\cpython\cpython\Python\optimizer.c(1776): warning C4716: 'executor_clear': must return a value
```
seen in CI, e.g. https://github.com/python/cpython/actions/runs/20434930925/job/58714738349?pr=143068.


<!-- gh-issue-number: gh-142513 -->
* Issue: gh-142513
<!-- /gh-issue-number -->
