### PR TITLE
gh-122431: update error message for negative nelements in readline_append_h…

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-22-22-36-21.gh-issue-122431.9E3085.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-22-22-36-21.gh-issue-122431.9E3085.rst
@@ -1,0 +1,1 @@
+Corrected the error message in :func:`readline.append_history_file` to state that ``nelements`` must be non-negative instead of positive.

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -391,7 +391,7 @@ readline_append_history_file_impl(PyObject *module, int nelements,
 {
     if (nelements < 0)
     {
-        PyErr_SetString(PyExc_ValueError, "nelements must be positive");
+        PyErr_SetString(PyExc_ValueError, "nelements must be non-negative");
         return NULL;
     }
 


### PR DESCRIPTION
This pull request makes a minor wording correction to an error message in the `readline_append_history_file_impl` function to clarify the requirement for the `nelements` parameter.

* Updated the error message in `readline_append_history_file_impl` to state that "nelements must be non-negative" instead of "positive", improving accuracy and clarity. (`Modules/readline.c`)

<!-- gh-issue-number: gh-122431 -->
* Issue: gh-122431
<!-- /gh-issue-number -->
