### PR TITLE
gh-143082: Fix readline backend check and stdin isatty condition in cmd and pdb modules

### DIFF
--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -111,7 +111,7 @@ class Cmd:
                 import readline
                 self.old_completer = readline.get_completer()
                 readline.set_completer(self.complete)
-                if getattr(readline, 'backend', None) == "editline":
+                if readline.backend == "editline":
                     if self.completekey == 'tab':
                         # libedit uses "^I" instead of "tab"
                         command_string = "bind ^I rl_complete"

--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -111,7 +111,7 @@ class Cmd:
                 import readline
                 self.old_completer = readline.get_completer()
                 readline.set_completer(self.complete)
-                if readline.backend == "editline":
+                if getattr(readline, 'backend', None) == "editline":
                     if self.completekey == 'tab':
                         # libedit uses "^I" instead of "tab"
                         command_string = "bind ^I rl_complete"

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -364,7 +364,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         bdb.Bdb.__init__(self, skip=skip, backend=backend if backend else get_default_backend())
         cmd.Cmd.__init__(self, completekey, stdin, stdout)
         sys.audit("pdb.Pdb")
-        if stdin and not getattr(stdin, 'isatty', lambda: False)():
+        if stdin is not None and stdin is not sys.stdin:
             self.use_rawinput = False
         self.prompt = '(Pdb) '
         self.aliases = {}

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -364,7 +364,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         bdb.Bdb.__init__(self, skip=skip, backend=backend if backend else get_default_backend())
         cmd.Cmd.__init__(self, completekey, stdin, stdout)
         sys.audit("pdb.Pdb")
-        if stdin:
+        if stdin and not getattr(stdin, 'isatty', lambda: False)():
             self.use_rawinput = False
         self.prompt = '(Pdb) '
         self.aliases = {}

--- a/Misc/NEWS.d/next/Windows/2025-12-25-00-38-20.gh-issue-143082.CYUeux.rst
+++ b/Misc/NEWS.d/next/Windows/2025-12-25-00-38-20.gh-issue-143082.CYUeux.rst
@@ -1,0 +1,1 @@
+Fix :mod:`pdb` arrow key history not working when ``stdin`` is ``sys.stdin``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

- Updated the readline backend check to use getattr for compatibility.
- Modified the stdin condition in pdb to ensure isatty is checked correctly, preventing potential issues with non-tty inputs.

**Related Issues:**
- [uv run pytest breaks history in pdb on windows #17174](https://github.com/astral-sh/uv/issues/17174)


<!-- gh-issue-number: gh-143082 -->
* Issue: gh-143082
<!-- /gh-issue-number -->
