### PR TITLE
gh-142145: Avoid timing measurements in quadratic behavior test

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -173,10 +173,8 @@ class MinidomTest(unittest.TestCase):
         self.assertEqual(dom.documentElement.childNodes[-1].data, "Hello")
         dom.unlink()
 
+    @support.requires_resource('cpu')
     def testAppendChildNoQuadraticComplexity(self):
-        # Don't use wall-clock timing (too flaky). Instead count a proxy for the
-        # old quadratic behavior: repeated attribute access, such as of
-        # parentNode/nodeType during document-membership checks.
         impl = getDOMImplementation()
 
         def work(n):
@@ -184,6 +182,7 @@ class MinidomTest(unittest.TestCase):
             element = doc.documentElement
             total_calls = 0
 
+            # Count attribute accesses as a proxy for work done
             def getattribute_counter(self, attr):
                 nonlocal total_calls
                 total_calls += 1

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -2,7 +2,6 @@
 
 import copy
 import pickle
-import time
 import io
 from test import support
 import unittest


### PR DESCRIPTION
Count the number of Element attribute accesses as a proxy for work done. With double the amount of work, a ratio of 2.0 indicates linear scaling and 4.0 quadratic scaling. Use 3.2 as an intermediate threshold.


<!-- gh-issue-number: gh-142145 -->
* Issue: gh-142145
<!-- /gh-issue-number -->
