### PR TITLE
gh-143103: Added `pad` parameter to `base64.z85encode`

### DIFF
--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -267,13 +267,19 @@ Refer to the documentation of the individual functions for more information.
    .. versionadded:: 3.4
 
 
-.. function:: z85encode(s)
+.. function:: z85encode(s, pad=False)
 
    Encode the :term:`bytes-like object` *s* using Z85 (as used in ZeroMQ)
    and return the encoded :class:`bytes`.  See `Z85  specification
    <https://rfc.zeromq.org/spec/32/>`_ for more information.
 
+   If *pad* is true, the input is padded with ``b'\0'`` so its length is a
+   multiple of 4 bytes before encoding.
+
    .. versionadded:: 3.13
+
+   .. versionchanged:: next
+      The *pad* parameter was added.
 
 
 .. function:: z85decode(s)

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -508,9 +508,9 @@ _z85_decode_translation = bytes.maketrans(
 )
 _z85_encode_translation = bytes.maketrans(_b85alphabet, _z85alphabet)
 
-def z85encode(s):
+def z85encode(s, pad=False):
     """Encode bytes-like object b in z85 format and return a bytes object."""
-    return b85encode(s).translate(_z85_encode_translation)
+    return b85encode(s, pad).translate(_z85_encode_translation)
 
 def z85decode(s):
     """Decode the z85-encoded bytes-like object or ASCII string b

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -665,6 +665,7 @@ class BaseXYTestCase(unittest.TestCase):
 
         tests = {
             b'': b'',
+            b'\x86\x4F\xD2\x6F\xB5\x59\xF7\x5B': b'HelloWorld',
             b'www.python.org': b'CxXl-AcVLsz/dgCA+t',
             bytes(range(255)): b"""009c61o!#m2NH?C3>iWS5d]J*6CRx17-skh9337x"""
                 b"""ar.{NbQB=+c[cR@eg&FcfFLssg=mfIi5%2YjuU>)kTv.7l}6Nnnj=AD"""
@@ -839,6 +840,21 @@ class BaseXYTestCase(unittest.TestCase):
         eq(base64.b85decode(b'czAdK'), b"xxx\x00")
         eq(base64.b85decode(b'czAet'), b"xxxx")
         eq(base64.b85decode(b'czAetcmMzZ'), b"xxxxx\x00\x00\x00")
+
+    def test_z85_padding(self):
+        eq = self.assertEqual
+
+        eq(base64.z85encode(b"x", pad=True), b'CMmZz')
+        eq(base64.z85encode(b"xx", pad=True), b'CZ6h*')
+        eq(base64.z85encode(b"xxx", pad=True), b'CZaDk')
+        eq(base64.z85encode(b"xxxx", pad=True), b'CZaET')
+        eq(base64.z85encode(b"xxxxx", pad=True), b'CZaETCMmZz')
+
+        eq(base64.z85decode(b'CMmZz'), b"x\x00\x00\x00")
+        eq(base64.z85decode(b'CZ6h*'), b"xx\x00\x00")
+        eq(base64.z85decode(b'CZaDk'), b"xxx\x00")
+        eq(base64.z85decode(b'CZaET'), b"xxxx")
+        eq(base64.z85decode(b'CZaETCMmZz'), b"xxxxx\x00\x00\x00")
 
     def test_a85decode_errors(self):
         illegal = (set(range(32)) | set(range(118, 256))) - set(b' \t\n\r\v')

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -418,6 +418,7 @@ Lisandro Dalcin
 Darren Dale
 Andrew Dalke
 Lars Damerow
+Hauke Dämpfling
 Evan Dandrea
 Eric Daniel
 Scott David Daniels

--- a/Misc/NEWS.d/next/Library/2025-12-23-17-07-22.gh-issue-143103.LRjXEW.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-23-17-07-22.gh-issue-143103.LRjXEW.rst
@@ -1,0 +1,1 @@
+Add padding support to :func:`base64.z85encode` via the ``pad`` parameter.


### PR DESCRIPTION
This makes `z85encode` analogous to `a85encode` and `b85encode` and allows the user to more easily meet the Z85 specification, which requires input lengths to be a multiple of 4. For details see #143103.

Documentation and tests included. Tests were verified against the [Z85 reference implementation](https://github.com/zeromq/rfc/blob/master/src/spec_32.c) (which I wrapped into a Python module at [haukex/py-z85](https://github.com/haukex/py-z85)).

<!-- gh-issue-number: gh-143103 -->
* Issue: gh-143103
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143106.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->