### PR TITLE
gh-143121: Avoid thread leak in configure

### DIFF
--- a/configure
+++ b/configure
@@ -18190,6 +18190,7 @@ else case e in #(
         if (pthread_attr_init(&attr)) return (-1);
         if (pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM)) return (-1);
         if (pthread_create(&id, &attr, foo, NULL)) return (-1);
+        if (pthread_join(id, NULL)) return (-1);
         return (0);
       }
 _ACEOF

--- a/configure.ac
+++ b/configure.ac
@@ -4760,6 +4760,7 @@ if test "$posix_threads" = "yes"; then
         if (pthread_attr_init(&attr)) return (-1);
         if (pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM)) return (-1);
         if (pthread_create(&id, &attr, foo, NULL)) return (-1);
+        if (pthread_join(id, NULL)) return (-1);
         return (0);
       }]])],
       [ac_cv_pthread_system_supported=yes],


### PR DESCRIPTION
If you are building with `--with-thread-sanitizer` and don't use the suppression file, then running configure will report a thread leak.

Call `pthread_join()` to avoid the thread leak.

<!-- gh-issue-number: gh-143121 -->
* Issue: gh-143121
<!-- /gh-issue-number -->
