### PR TITLE
allow eval and exec to sync given locals mapping to and from fast locals for optimized code object

### DIFF
--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -2080,6 +2080,7 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(sub_key));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(subcalls));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(symmetric_difference_update));
+    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(sync_fast_locals));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(tabsize));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(tag));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(take_bytes));

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -803,6 +803,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(sub_key)
         STRUCT_FOR_ID(subcalls)
         STRUCT_FOR_ID(symmetric_difference_update)
+        STRUCT_FOR_ID(sync_fast_locals)
         STRUCT_FOR_ID(tabsize)
         STRUCT_FOR_ID(tag)
         STRUCT_FOR_ID(take_bytes)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -2078,6 +2078,7 @@ extern "C" {
     INIT_ID(sub_key), \
     INIT_ID(subcalls), \
     INIT_ID(symmetric_difference_update), \
+    INIT_ID(sync_fast_locals), \
     INIT_ID(tabsize), \
     INIT_ID(tag), \
     INIT_ID(take_bytes), \

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -2992,6 +2992,10 @@ _PyUnicode_InitStaticStrings(PyInterpreterState *interp) {
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));
     assert(PyUnicode_GET_LENGTH(string) != 1);
+    string = &_Py_ID(sync_fast_locals);
+    _PyUnicode_InternStatic(interp, &string);
+    assert(_PyUnicode_CheckConsistency(string, 1));
+    assert(PyUnicode_GET_LENGTH(string) != 1);
     string = &_Py_ID(tabsize);
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1112,21 +1112,17 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             self.assertIs(wm.category, SyntaxWarning)
 
     def test_eval_exec_sync_fast_locals(self):
-        def func_assign():
-            a = 1
-
-        def func_read():
+        def func(a, *args, **kwargs):
             b = a + 1
-            a = 3
+            del a
+            args.append(3)
+            kwargs['b'] = kwargs['a'] + 1
 
         for executor in eval, exec:
             with self.subTest(executor=executor.__name__):
-                ns = {}
-                executor(func_assign.__code__, {}, ns, sync_fast_locals=True)
-                self.assertEqual(ns, {'a': 1})
-                ns = {'a': 1}
-                executor(func_read.__code__, {}, ns, sync_fast_locals=True)
-                self.assertEqual(ns, {'a': 3, 'b': 2})
+                ns = {'a': 1, 'args': [2], 'kwargs': {'a': 4}}
+                executor(func, {}, ns, sync_fast_locals=True)
+                self.assertEqual(ns, {'b': 2, 'args': [2, 3], 'kwargs': {'a': 4, 'b': 5}})
 
     def test_filter(self):
         self.assertEqual(list(filter(lambda c: 'a' <= c <= 'z', 'Hello World')), list('elloorld'))

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1121,7 +1121,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         for executor in eval, exec:
             with self.subTest(executor=executor.__name__):
                 ns = {'a': 1, 'args': [2], 'kwargs': {'a': 4}}
-                executor(func, {}, ns, sync_fast_locals=True)
+                executor(func.__code__, {}, ns, sync_fast_locals=True)
                 self.assertEqual(ns, {'b': 2, 'args': [2, 3], 'kwargs': {'a': 4, 'b': 5}})
 
     def test_filter(self):

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1117,6 +1117,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
 
         def func_read():
             b = a + 1
+            a = 3
 
         for executor in eval, exec:
             with self.subTest(executor=executor.__name__):
@@ -1125,8 +1126,8 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
                 self.assertEqual(ns, {'a': 1})
                 ns = {'a': 1}
                 executor(func_read.__code__, {}, ns, sync_fast_locals=True)
-                self.assertEqual(ns, {'a': 1, 'b': 2})
-        
+                self.assertEqual(ns, {'a': 3, 'b': 2})
+
     def test_filter(self):
         self.assertEqual(list(filter(lambda c: 'a' <= c <= 'z', 'Hello World')), list('elloorld'))
         self.assertEqual(list(filter(None, [1, 'hello', [], [3], '', None, 9, 0])), [1, 'hello', [3], 9])

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1111,7 +1111,22 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             self.assertEqual(wm.filename, '<string>')
             self.assertIs(wm.category, SyntaxWarning)
 
+    def test_eval_exec_sync_fast_locals(self):
+        def func_assign():
+            a = 1
 
+        def func_read():
+            b = a + 1
+
+        for executor in eval, exec:
+            with self.subTest(executor=executor.__name__):
+                ns = {}
+                executor(func_assign.__code__, {}, ns, sync_fast_locals=True)
+                self.assertEqual(ns, {'a': 1})
+                ns = {'a': 1}
+                executor(func_read.__code__, {}, ns, sync_fast_locals=True)
+                self.assertEqual(ns, {'a': 1, 'b': 2})
+        
     def test_filter(self):
         self.assertEqual(list(filter(lambda c: 'a' <= c <= 'z', 'Hello World')), list('elloorld'))
         self.assertEqual(list(filter(None, [1, 'hello', [], [3], '', None, 9, 0])), [1, 'hello', [3], 9])

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1041,7 +1041,7 @@ builtin_eval_impl(PyObject *module, PyObject *source, PyObject *globals,
         }
         if (!sync_fast_locals && ((PyCodeObject *)source)->co_flags & CO_OPTIMIZED) {
             Py_DECREF(locals);
-            locals = NULL;
+            locals = globals;
         }
         result = PyEval_EvalCode(source, globals, locals);
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1542,6 +1542,9 @@ _PyEval_SyncLocalsToFast(_PyInterpreterFrame *frame)
         if (value != NULL) {
             frame->localsplus[i] = PyStackRef_FromPyObjectSteal(value);
         }
+        else if (PyErr_ExceptionMatches(PyExc_KeyError)) {
+            PyErr_Clear();
+        }
         else {
             return -1;
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2477,7 +2477,7 @@ _PyEvalFramePushAndInit(PyThreadState *tstate, _PyStackRef func,
     }
     _PyFrame_Initialize(tstate, frame, func, locals, code, 0, previous);
     if (code->co_flags & CO_OPTIMIZED && locals != NULL && locals != func_obj->func_globals &&
-        args == NULL) { /* args can be NULL only when invoked through PyEval_EvalCode */
+        func_obj->func_defaults == NULL) { // this is NULL only when called by PyEval_EvalCode
         for (size_t i = 0; i < argcount; i++) {
             PyStackRef_CLOSE(args[i]);
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2477,7 +2477,7 @@ _PyEvalFramePushAndInit(PyThreadState *tstate, _PyStackRef func,
     }
     _PyFrame_Initialize(tstate, frame, func, locals, code, 0, previous);
     if (code->co_flags & CO_OPTIMIZED && locals != NULL && locals != func_obj->func_globals &&
-        kwnames == NULL) { /* kwnames can be NULL only when invoked through PyEval_EvalCode */
+        args == NULL) { /* args can be NULL only when invoked through PyEval_EvalCode */
         for (size_t i = 0; i < argcount; i++) {
             PyStackRef_CLOSE(args[i]);
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2476,7 +2476,8 @@ _PyEvalFramePushAndInit(PyThreadState *tstate, _PyStackRef func,
         goto fail;
     }
     _PyFrame_Initialize(tstate, frame, func, locals, code, 0, previous);
-    if (code->co_flags & CO_OPTIMIZED && locals != NULL && locals != func_obj->func_globals) {
+    if (code->co_flags & CO_OPTIMIZED && locals != NULL && locals != func_obj->func_globals &&
+        kwnames == NULL) { /* kwnames can be NULL only when invoked through PyEval_EvalCode */
         for (size_t i = 0; i < argcount; i++) {
             PyStackRef_CLOSE(args[i]);
         }


### PR DESCRIPTION
Experimenting with ideas from:
https://discuss.python.org/t/is-there-a-good-way-to-get-the-local-namespace-of-a-given-function-derived-code-object-from-exec/104939