### PR TITLE
gh-143145: Fix possible reference leak in ctypes _build_result()

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-24-14-18-52.gh-issue-143145.eXLw8D.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-24-14-18-52.gh-issue-143145.eXLw8D.rst
@@ -1,0 +1,1 @@
+Fixed a reference leak in ctypes when building results with multiple out parameters.

--- a/Misc/NEWS.d/next/Library/2025-12-24-14-18-52.gh-issue-143145.eXLw8D.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-24-14-18-52.gh-issue-143145.eXLw8D.rst
@@ -1,1 +1,1 @@
-Fixed a reference leak in ctypes when building results with multiple out parameters.
+Fixed a possible reference leak in ctypes when constructing results with multiple output parameters on error.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -4557,6 +4557,7 @@ _build_result(PyObject *result, PyObject *callargs,
             v = PyTuple_GET_ITEM(callargs, i);
             v = PyObject_CallMethodNoArgs(v, &_Py_ID(__ctypes_from_outparam__));
             if (v == NULL || numretvals == 1) {
+                Py_XDECREF(tup);
                 Py_DECREF(callargs);
                 return v;
             }


### PR DESCRIPTION
In `_ctypes._build_result()`, a result tuple is allocated when `numretvals > 1`. If v becomes NULL during result construction, the function returns early without DECREF'ing the tuple, leaking a reference. 
Add `Py_XDECREF(tup)` before returning when `numretvals > 1` and `v == NULL`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143145 -->
* Issue: gh-143145
<!-- /gh-issue-number -->
