### PR TITLE
gh-143132: Add math.sign() function

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -38,6 +38,7 @@ noted otherwise, all return values are floats.
 :func:`fmod(x, y) <fmod>`                             Remainder of division ``x / y``
 :func:`modf(x) <modf>`                                Fractional and integer parts of *x*
 :func:`remainder(x, y) <remainder>`                   Remainder of *x* with respect to *y*
+:func:`sign(x) <sign>`                                Sign of *x*, indicating whether *x* is negative, zero, or positive
 :func:`trunc(x) <trunc>`                              Integer part of *x*
 
 **Floating point manipulation functions**
@@ -226,6 +227,21 @@ Floating point arithmetic
 
    .. versionadded:: 3.7
 
+.. function:: sign(x)
+
+   Return the sign of *x*: ``-1`` if *x < 0*, ``0`` if *x == 0*, and ``1`` if *x > 0*.
+   
+   The function delegates to the object's rich comparison operators. This 
+   allows it to work with various numeric types including :class:`int`, 
+   :class:`float`, :class:`fractions.Fraction`, and :class:`decimal.Decimal`.
+   It is platform-independent, and works with any existing or future scalar type
+   that internally supports numeric comparisons.
+
+   For ``NaN`` inputs, the function returns a float ``NaN``. For other arguments
+   and any scalar numeric type, the result is always an :class:`int`. For non-numeric
+   or non-scalar types, the function raises a :exc:`TypeError`.
+
+   .. versionadded:: 3.15
 
 .. function:: trunc(x)
 

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -30,6 +30,17 @@ PyDoc_STRVAR(math_floor__doc__,
 #define MATH_FLOOR_METHODDEF    \
     {"floor", (PyCFunction)math_floor, METH_O, math_floor__doc__},
 
+PyDoc_STRVAR(math_sign__doc__,
+"sign($module, x, /)\n"
+"--\n"
+"\n"
+"Return the sign of x: -1 if x < 0, 0 if x == 0, 1 if x > 0.\n"
+"\n"
+"For NaN inputs, return a float NaN.");
+
+#define MATH_SIGN_METHODDEF    \
+    {"sign", (PyCFunction)math_sign, METH_O, math_sign__doc__},
+
 PyDoc_STRVAR(math_fmax__doc__,
 "fmax($module, x, y, /)\n"
 "--\n"
@@ -1163,4 +1174,4 @@ math_ulp(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=23b2453ba77453e5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7c346bc2da9ecef4 input=a9049054013a1b77]*/


### PR DESCRIPTION
```
gh-143132: Summary of the changes made
```

Implementation of the `math.sign()` function as proposed in gh-143132. Implementation includes IEEE 754 support, duck-typing, and a test suite.

### Summary of changes
- Added `math.sign` to `Modules/mathmodule.c` using Argument Clinic.
- Implemented logic to handle IEEE 754 edge cases (`NaN`, signed zero, infinity).
- Added support for duck-typing via rich comparison protocols (supports `Decimal`, `Fraction`, `SymPy`, and more, and custom types).
- Added a test suite in `Lib/test/test_math.py`.
- Updated documentation in `Doc/library/math.rst`.

### Testing
- Verified with `python_d.exe -m test -R 3:3 test_math` to ensure no reference leaks.
- All tests passed on local Windows build (including NaN and edge case comparisons).

Closes gh-143132


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143133.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->