### PR TITLE
gh-142975: During GC, mark frozen objects with a merged zero refcount for destruction

### DIFF
--- a/Lib/test/test_free_threading/test_gc.py
+++ b/Lib/test/test_free_threading/test_gc.py
@@ -62,6 +62,38 @@ class TestGC(TestCase):
         with threading_helper.start_threads(gcs + mutators):
             pass
 
+    def test_freeze_object_in_brc_queue(self):
+        # GH-142975: Freezing objects in the BRC queue could result in some
+        # objects having a zero refcount without being deallocated.
+
+        class Weird:
+            # We need a destructor to trigger the check for object resurrection
+            def __del__(self):
+                pass
+
+        # This is owned by the main thread, so the subthread will have to increment
+        # this object's reference count.
+        weird = Weird()
+
+        def evil():
+            gc.freeze()
+
+            # Decrement the reference count from this thread, which will trigger the
+            # slow path during resurrection and add our weird object to the BRC queue.
+            nonlocal weird
+            del weird
+
+            # Collection will merge the object's reference count and make it zero.
+            gc.collect()
+
+            # Unfreeze the object, making it visible to the GC.
+            gc.unfreeze()
+            gc.collect()
+
+        thread = Thread(target=evil)
+        thread.start()
+        thread.join()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1249,18 +1249,6 @@ class GCTests(unittest.TestCase):
         self.assertTrue(new_count - count > (n // 2))
 
 
-    @threading_helper.requires_working_threading()
-    def test_concurrent_freeze_unfreeze():
-        # GH-142975: On the free-threaded build, this would cause problems
-        # with objects that had a per-thread reference count.
-        def weird():
-            gc.freeze()
-            gc.collect()
-            gc.unfreeze()
-
-        threading_helper.run_concurrently(weird, 4)
-
-
 class IncrementalGCTests(unittest.TestCase):
     @unittest.skipIf(_testinternalcapi is None, "requires _testinternalcapi")
     @requires_gil_enabled("Free threading does not support incremental GC")

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1249,6 +1249,18 @@ class GCTests(unittest.TestCase):
         self.assertTrue(new_count - count > (n // 2))
 
 
+    @threading_helper.requires_working_threading()
+    def test_concurrent_freeze_unfreeze():
+        # GH-142975: On the free-threaded build, this would cause problems
+        # with objects that had a per-thread reference count.
+        def weird():
+            gc.freeze()
+            gc.collect()
+            gc.unfreeze()
+
+        threading_helper.run_concurrently(weird, 4)
+
+
 class IncrementalGCTests(unittest.TestCase):
     @unittest.skipIf(_testinternalcapi is None, "requires _testinternalcapi")
     @requires_gil_enabled("Free threading does not support incremental GC")

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-24-13-44-24.gh-issue-142975.8C4vIP.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-24-13-44-24.gh-issue-142975.8C4vIP.rst
@@ -1,0 +1,2 @@
+Fix crash after unfreezing all objects tracked by the garbage collector on
+the :term:`free threaded <free threading>` build.

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -907,9 +907,9 @@ static void
 queue_untracked_obj_decref(PyObject *op, struct collection_state *state)
 {
     assert(Py_REFCNT(op) == 0);
-    // We have to treat frozen objects as untracked in this function or else
-    // they might be picked up in a future collection, which breaks the assumption
-    // that all incoming objects have a non-zero reference count.
+    // gh-142975: We have to treat frozen objects as untracked in this function
+    // or else they might be picked up in a future collection, which breaks the
+    // assumption that all incoming objects have a non-zero reference count.
     if (!_PyObject_GC_IS_TRACKED(op) || gc_is_frozen(op)) {
         // GC objects with zero refcount are handled subsequently by the
         // GC as if they were cyclic trash, but we have to handle dead

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -906,7 +906,11 @@ exit:
 static void
 queue_untracked_obj_decref(PyObject *op, struct collection_state *state)
 {
-    if (!_PyObject_GC_IS_TRACKED(op)) {
+    assert(Py_REFCNT(op) == 0);
+    // We have to treat frozen objects as untracked in this function or else
+    // they might be picked up in a future collection, which breaks the assumption
+    // that all incoming objects have a non-zero reference count.
+    if (!_PyObject_GC_IS_TRACKED(op) || gc_is_frozen(op)) {
         // GC objects with zero refcount are handled subsequently by the
         // GC as if they were cyclic trash, but we have to handle dead
         // non-GC objects here. Add one to the refcount so that we can


### PR DESCRIPTION


<!-- gh-issue-number: gh-142975 -->
* Issue: gh-142975
<!-- /gh-issue-number -->
