### PR TITLE
gh-141707: Fix tarfile type corruption with GNU long names

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1410,6 +1410,12 @@ class TarInfo(object):
         next.offset = self.offset
         if self.type == GNUTYPE_LONGNAME:
             next.name = nts(buf, tarfile.encoding, tarfile.errors)
+            # V7 directory detection in frombuf() may have used garbage
+            # name data. Re-apply it with the actual long name.
+            if next.type == DIRTYPE and not next.name.endswith("/"):
+                next.type = AREGTYPE
+            elif next.type == AREGTYPE and next.name.endswith("/"):
+                next.type = DIRTYPE
         elif self.type == GNUTYPE_LONGLINK:
             next.linkname = nts(buf, tarfile.encoding, tarfile.errors)
 

--- a/Misc/NEWS.d/next/Library/2025-12-24-15-28-43.gh-issue-141707.8vN2Kp.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-24-15-28-43.gh-issue-141707.8vN2Kp.rst
@@ -1,0 +1,1 @@
+Fix :mod:`tarfile` type corruption when extracting files with GNU long names. Regular files were incorrectly identified as directories if the header's name field ended with '/'.


### PR DESCRIPTION
When processing GNU long name headers, tarfile reads the actual name from data blocks but the second header's name field contains garbage. The V7 directory detection in frombuf() could incorrectly mark regular files as directories if this garbage ended with '/'.

This fix re-applies the V7 directory detection after patching the actual long name, correcting any type corruption caused by the garbage name data.

Fixes #141707

<!-- gh-issue-number: gh-141707 -->
* Issue: gh-141707
<!-- /gh-issue-number -->
