### PR TITLE
gh-143164: Fix incorrect error message for ctypes bitfield overflow

### DIFF
--- a/Lib/test/test_ctypes/test_struct_fields.py
+++ b/Lib/test/test_ctypes/test_struct_fields.py
@@ -142,8 +142,8 @@ class FieldsTestBase(StructCheckMixin):
                 byte_offset=0,
                 index=0,
                 _internal_use=True,
-                bit_size=9,
-                bit_offset=0,
+                bit_size=7,
+                bit_offset=2,
             )
 
     # __set__ and __get__ should raise a TypeError in case their self

--- a/Lib/test/test_ctypes/test_struct_fields.py
+++ b/Lib/test/test_ctypes/test_struct_fields.py
@@ -133,7 +133,7 @@ class FieldsTestBase(StructCheckMixin):
     def test_bitfield_overflow_error_message(self):
         with self.assertRaisesRegex(
             ValueError,
-            r"bit field 'x' overflows its type \(0 \+ 9 > 8\)",
+            r"bit field 'x' overflows its type \(2 \+ 7 > 8\)",
         ):
             CField(
                 name="x",

--- a/Lib/test/test_ctypes/test_struct_fields.py
+++ b/Lib/test/test_ctypes/test_struct_fields.py
@@ -130,6 +130,21 @@ class FieldsTestBase(StructCheckMixin):
             self.check_struct(S)
             self.assertEqual(S.largeField.bit_size, size * 8)
 
+    def test_bitfield_overflow_error_message_gh143164(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"bit field 'x' overflows its type \(0 \+ 9 > 8\)",
+        ):
+            CField(
+                name="x",
+                type=c_byte,
+                byte_size=1,
+                byte_offset=0,
+                index=0,
+                _internal_use=True,
+                bit_size=9,
+                bit_offset=0,
+            )
 
     # __set__ and __get__ should raise a TypeError in case their self
     # argument is not a ctype instance.

--- a/Lib/test/test_ctypes/test_struct_fields.py
+++ b/Lib/test/test_ctypes/test_struct_fields.py
@@ -130,7 +130,7 @@ class FieldsTestBase(StructCheckMixin):
             self.check_struct(S)
             self.assertEqual(S.largeField.bit_size, size * 8)
 
-    def test_bitfield_overflow_error_message_gh143164(self):
+    def test_bitfield_overflow_error_message(self):
         with self.assertRaisesRegex(
             ValueError,
             r"bit field 'x' overflows its type \(0 \+ 9 > 8\)",

--- a/Misc/NEWS.d/next/Library/2025-12-25-08-58-55.gh-issue-142164.XrFztf.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-25-08-58-55.gh-issue-142164.XrFztf.rst
@@ -1,1 +1,1 @@
-Fix an incorrect error message for ctypes bitfield overflow.
+Fix the ctypes bitfield overflow error message to report the correct offset and size calculation.

--- a/Misc/NEWS.d/next/Library/2025-12-25-08-58-55.gh-issue-142164.XrFztf.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-25-08-58-55.gh-issue-142164.XrFztf.rst
@@ -1,0 +1,1 @@
+Fix an incorrect error message for ctypes bitfield overflow.

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -160,8 +160,8 @@ PyCField_new_impl(PyTypeObject *type, PyObject *name, PyObject *proto,
         if ((bitfield_size + bit_offset) > byte_size * 8) {
             PyErr_Format(
                 PyExc_ValueError,
-                "bit field %R overflows its type (%zd + %zd >= %zd)",
-                name, bit_offset, byte_size*8);
+                "bit field %R overflows its type (%zd + %zd > %zd)",
+                name, bit_offset, bitfield_size, byte_size * 8);
             goto error;
         }
     }


### PR DESCRIPTION
The previous message did not match the actual overflow check and omitted the bitfield size, making it misleading. Update the message to reflect the correct condition and report all relevant values.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143164 -->
* Issue: gh-143164
<!-- /gh-issue-number -->
