### PR TITLE
gh-143089: Fix ParamSpec default examples to use list instead of tuple

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -592,7 +592,7 @@ class TypeVarTests(BaseTestCase):
         self.assertIs(T.__contravariant__, False)
         self.assertIs(T.__infer_variance__, False)
 
-        T = TypeVar(name="T", default=[])
+        T = TypeVar(name="T", default=())
         self.assertEqual(T.__name__, "T")
         self.assertEqual(T.__constraints__, ())
         self.assertIs(T.__bound__, None)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -592,7 +592,7 @@ class TypeVarTests(BaseTestCase):
         self.assertIs(T.__contravariant__, False)
         self.assertIs(T.__infer_variance__, False)
 
-        T = TypeVar(name="T", default=())
+        T = TypeVar(name="T", default=[])
         self.assertEqual(T.__name__, "T")
         self.assertEqual(T.__constraints__, ())
         self.assertIs(T.__bound__, None)

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -1451,13 +1451,13 @@ The following syntax creates a parameter specification that defaults\n\
 to a callable accepting two positional-only arguments of types int\n\
 and str:\n\
 \n\
-    type IntFuncDefault[**P = (int, str)] = Callable[P, int]\n\
+    type IntFuncDefault[**P = [int, str]] = Callable[P, int]\n\
 \n\
 For compatibility with Python 3.11 and earlier, ParamSpec objects\n\
 can also be created as follows::\n\
 \n\
     P = ParamSpec('P')\n\
-    DefaultP = ParamSpec('DefaultP', default=(int, str))\n\
+    DefaultP = ParamSpec('DefaultP', default=[int, str])\n\
 \n\
 Parameter specification variables exist primarily for the benefit of\n\
 static type checkers.  They are used to forward the parameter types of\n\


### PR DESCRIPTION
This PR fixes incorrect ParamSpec default examples in the ParamSpec
docstring shown by help(ParamSpec).

According to the typing specification, ParamSpec defaults must be a list
literal, ellipsis (`...`), or another ParamSpec. Tuples are not permitted.

The docstring examples previously used tuple defaults. These are updated
to use list defaults to match the typing specification and the existing
documentation.

Closes: gh-143089