### PR TITLE
gh-143181: Fix 'overriden' -> 'overridden' in c-api/module.rst

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -571,7 +571,7 @@ A module's token -- and the *your_token* value to use in the above code -- is:
   of that slot;
 - For modules created from an ``PyModExport_*``
   :ref:`export hook <extension-export-hook>`: the slots array that the export
-  hook returned (unless overriden with :c:macro:`Py_mod_token`).
+  hook returned (unless overridden with :c:macro:`Py_mod_token`).
 
 .. c:macro:: Py_mod_token
 

--- a/Lib/test/test_build_details.py
+++ b/Lib/test/test_build_details.py
@@ -33,7 +33,7 @@ except (FileNotFoundError, ImportError):
 class FormatTestsBase:
     @property
     def contents(self):
-        """Install details file contents. Should be overriden by subclasses."""
+        """Install details file contents. Should be overridden by subclasses."""
         raise NotImplementedError
 
     @property

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1581,7 +1581,7 @@ class DictTest(unittest.TestCase):
         with check_unhashable_key():
             d.get(key)
 
-        # Only TypeError exception is overriden,
+        # Only TypeError exception is overridden,
         # other exceptions are left unchanged.
         class HashError:
             def __hash__(self):

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -661,7 +661,7 @@ class TestSet(TestJointOps, unittest.TestCase):
         with check_unhashable_element():
             myset.discard(elem)
 
-        # Only TypeError exception is overriden,
+        # Only TypeError exception is overridden,
         # other exceptions are left unchanged.
         class HashError:
             def __hash__(self):


### PR DESCRIPTION
Doc/c-api/module.rst line 574:

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143181 -->
* Issue: gh-143181
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143182.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->