### PR TITLE
Remove redundant pycore_optimizer.h includes

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -17,7 +17,6 @@
 
 #include "frameobject.h"          // PyFrameLocalsProxyObject
 #include "opcode.h"               // EXTENDED_ARG
-#include "pycore_optimizer.h"
 
 #include "clinic/frameobject.c.h"
 

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -18,7 +18,6 @@
 #include "pycore_tuple.h"         // _PyTuple_FromArraySteal()
 
 #include "opcode_ids.h"
-#include "pycore_optimizer.h"
 
 
 /* Uncomment this to dump debugging output when assertions fail */


### PR DESCRIPTION
`pycore_optimizer.h` was included redundantly in `Objects/frameobject.c` and `Python/instrumentation.c`. Both includes are unnecessary and can be safely removed. No functional change. It's introduced in 4fa80ce74c6

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
