### PR TITLE
gh-140739: Fix crashes from corrupted remote memory

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-26-14-51-50.gh-issue-140739.BAbZTo.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-26-14-51-50.gh-issue-140739.BAbZTo.rst
@@ -1,2 +1,2 @@
 Fix several crashes due to reading invalid memory in the new Tachyon
-sampling profiler. Patch by Pablo Galindo
+sampling profiler. Patch by Pablo Galindo.

--- a/Misc/NEWS.d/next/Library/2025-12-26-14-51-50.gh-issue-140739.BAbZTo.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-26-14-51-50.gh-issue-140739.BAbZTo.rst
@@ -1,0 +1,2 @@
+Fix several crashes due to reading invalid memory in the new Tachyon
+sampling profiler. Patch by Pablo Galindo

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -140,6 +140,11 @@ typedef enum _WIN32_THREADSTATE {
 #define SIZEOF_GC_RUNTIME_STATE sizeof(struct _gc_runtime_state)
 #define SIZEOF_INTERPRETER_STATE sizeof(PyInterpreterState)
 
+/* Maximum sizes for validation to prevent buffer overflows from corrupted data */
+#define MAX_STACK_CHUNK_SIZE (16 * 1024 * 1024)  /* 16 MB max for stack chunks */
+#define MAX_LONG_DIGITS 64  /* Allows values up to ~2^1920 */
+#define MAX_SET_TABLE_SIZE (1 << 20)  /* 1 million entries max for set iteration */
+
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
@@ -451,6 +456,7 @@ extern PyObject *make_frame_info(
 extern bool parse_linetable(
     const uintptr_t addrq,
     const char* linetable,
+    Py_ssize_t linetable_size,
     int firstlineno,
     LocationInfo* info
 );

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -112,8 +112,16 @@ iterate_set_entries(
     }
 
     Py_ssize_t num_els = GET_MEMBER(Py_ssize_t, set_object, unwinder->debug_offsets.set_object.used);
-    Py_ssize_t set_len = GET_MEMBER(Py_ssize_t, set_object, unwinder->debug_offsets.set_object.mask) + 1;
+    Py_ssize_t mask = GET_MEMBER(Py_ssize_t, set_object, unwinder->debug_offsets.set_object.mask);
     uintptr_t table_ptr = GET_MEMBER(uintptr_t, set_object, unwinder->debug_offsets.set_object.table);
+
+    // Validate mask and num_els to prevent huge loop iterations from garbage data
+    if (mask < 0 || mask >= MAX_SET_TABLE_SIZE || num_els < 0 || num_els > mask + 1) {
+        set_exception_cause(unwinder, PyExc_RuntimeError,
+            "Invalid set object (corrupted remote memory)");
+        return -1;
+    }
+    Py_ssize_t set_len = mask + 1;
 
     Py_ssize_t i = 0;
     Py_ssize_t els = 0;
@@ -812,25 +820,32 @@ append_awaited_by_for_thread(
             return -1;
         }
 
-        if (GET_MEMBER(uintptr_t, task_node, unwinder->debug_offsets.llist_node.next) == 0) {
+        uintptr_t next_node = GET_MEMBER(uintptr_t, task_node, unwinder->debug_offsets.llist_node.next);
+        if (next_node == 0) {
             PyErr_SetString(PyExc_RuntimeError,
                            "Invalid linked list structure reading remote memory");
             set_exception_cause(unwinder, PyExc_RuntimeError, "NULL pointer in task linked list");
             return -1;
         }
 
-        uintptr_t task_addr = (uintptr_t)GET_MEMBER(uintptr_t, task_node, unwinder->debug_offsets.llist_node.next)
-            - (uintptr_t)unwinder->async_debug_offsets.asyncio_task_object.task_node;
+        // Validate next_node to prevent underflow when computing task_addr
+        uintptr_t task_node_offset = (uintptr_t)unwinder->async_debug_offsets.asyncio_task_object.task_node;
+        if (next_node < task_node_offset) {
+            set_exception_cause(unwinder, PyExc_RuntimeError,
+                "Invalid task node pointer (corrupted remote memory)");
+            return -1;
+        }
+        uintptr_t task_addr = next_node - task_node_offset;
 
         if (process_single_task_node(unwinder, task_addr, NULL, result) < 0) {
             set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to process task node in awaited_by");
             return -1;
         }
 
-        // Read next node
+        // Read next node (use already-validated next_node)
         if (_Py_RemoteDebug_PagedReadRemoteMemory(
                 &unwinder->handle,
-                (uintptr_t)GET_MEMBER(uintptr_t, task_node, unwinder->debug_offsets.llist_node.next),
+                next_node,
                 sizeof(task_node),
                 task_node) < 0) {
             set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to read next task node in awaited_by");

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -828,21 +828,15 @@ append_awaited_by_for_thread(
             return -1;
         }
 
-        // Validate next_node to prevent underflow when computing task_addr
-        uintptr_t task_node_offset = (uintptr_t)unwinder->async_debug_offsets.asyncio_task_object.task_node;
-        if (next_node < task_node_offset) {
-            set_exception_cause(unwinder, PyExc_RuntimeError,
-                "Invalid task node pointer (corrupted remote memory)");
-            return -1;
-        }
-        uintptr_t task_addr = next_node - task_node_offset;
+        uintptr_t task_addr = next_node
+            - (uintptr_t)unwinder->async_debug_offsets.asyncio_task_object.task_node;
 
         if (process_single_task_node(unwinder, task_addr, NULL, result) < 0) {
             set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to process task node in awaited_by");
             return -1;
         }
 
-        // Read next node (use already-validated next_node)
+        // Read next node
         if (_Py_RemoteDebug_PagedReadRemoteMemory(
                 &unwinder->handle,
                 next_node,


### PR DESCRIPTION
The remote debugging module reads memory from another Python process
which can be modified or freed at any time due to race conditions.
When garbage data is read, various code paths could cause SIGSEGV
crashes in the profiler process itself rather than gracefully
rejecting the sample.

Add bounds checking and validation for data read from remote memory:
linetable parsing now checks buffer bounds, PyLong reading validates
digit count, stack chunk sizes are bounded, set iteration limits
table size, task pointer arithmetic checks for underflow, TLBC index
is validated against array bounds, and thread list iteration detects
cycles. All cases now reject the sample with an exception instead of
crashing or looping forever.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140739 -->
* Issue: gh-140739
<!-- /gh-issue-number -->
