### PR TITLE
Fix typos in docs

### DIFF
--- a/Doc/library/linecache.rst
+++ b/Doc/library/linecache.rst
@@ -31,7 +31,7 @@ The :mod:`linecache` module defines the following functions:
    .. index:: triple: module; search; path
 
    If *filename* indicates a frozen module (starting with ``'<frozen '``), the function
-   will attepmt to get the real file name from ``module_globals['__file__']`` if
+   will attempt to get the real file name from ``module_globals['__file__']`` if
    *module_globals* is not ``None``.
 
    If a file named *filename* is not found, the function first checks

--- a/Doc/tools/extensions/grammar_snippet.py
+++ b/Doc/tools/extensions/grammar_snippet.py
@@ -191,7 +191,7 @@ class GrammarSnippetDirective(GrammarSnippetBase):
     into something similar to Sphinx productionlist, but better suited
     for our needs:
     - Instead of `::=`, use a colon, as in `Grammar/python.gram`
-    - Show the listing almost as is, with no auto-aligment.
+    - Show the listing almost as is, with no auto-alignment.
       The only special character is the backtick, which marks tokens.
 
     Unlike Sphinx's productionlist, this directive supports options.


### PR DESCRIPTION
Doc/library/linecache.rst:34: attepmt => attempt
Doc/tools/extensions/grammar_snippet.py: 194: aligment => alignment

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143193.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->