### PR TITLE
gh-143192 Avoid incref/decref pair in long_bitwise

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-29-19-31-46.gh-issue-143192.JxGAyl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-29-19-31-46.gh-issue-143192.JxGAyl.rst
@@ -1,0 +1,1 @@
+Improve performance of bitwise operations on multi-digit ints.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5658,7 +5658,7 @@ long_bitwise(PyLongObject *a,
     z = long_alloc(size_z + negz);
     if (z == NULL) {
         Py_XDECREF(new_a);
-        Py_XDECREF(new_a);
+        Py_XDECREF(new_b);
         return NULL;
     }
 


### PR DESCRIPTION
By avoiding the incref/decref on the input arguments we avoid refcount contention in the FT build. Benchmark using `Tools/ftscalingbench/ftscalingbench.py`:
```
import random
data = {'a': random.randint(int(10e45), int(10e46)), 'b': random.randint(int(10e45), int(10e46))}

@register_benchmark
def long_bitwise():
    long_constant = data['a']
    long_constant2 = data['b']
    N = 1000 * WORK_SCALE
  
    for i in range(N):
        long_constant & long_constant2
        long_constant | long_constant2
        long_constant ^ long_constant2
```
Main:
```
Running benchmarks with 8 threads
long_bitwise               7.5x slower
```
PR
```
Running benchmarks with 8 threads
long_bitwise               5.4x faster
```



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143192 -->
* Issue: gh-143192
<!-- /gh-issue-number -->
