### PR TITLE
gh-143201: warnings writes the full source line instead of the truncated one

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-26-17-18-18.gh-issue-143201.UbXuX4.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-26-17-18-18.gh-issue-143201.UbXuX4.rst
@@ -1,0 +1,1 @@
+Print out the truncated line, not the raw sourceline.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -697,7 +697,7 @@ show_warning(PyThreadState *tstate, PyObject *filename, int lineno,
         if (truncated == NULL)
             goto error;
 
-        PyFile_WriteObject(sourceline, f_stderr, Py_PRINT_RAW);
+        PyFile_WriteObject(truncated, f_stderr, Py_PRINT_RAW);
         Py_DECREF(truncated);
         PyFile_WriteString("\n", f_stderr);
     }


### PR DESCRIPTION
The truncated object is meant to be written instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143201 -->
* Issue: gh-143201
<!-- /gh-issue-number -->
