### PR TITLE
gh-140739: Fix missing exception on allocation failure in BinaryWriter

### DIFF
--- a/Modules/_remote_debugging/binary_io_writer.c
+++ b/Modules/_remote_debugging/binary_io_writer.c
@@ -741,6 +741,7 @@ binary_writer_create(const char *filename, uint64_t sample_interval_us, int comp
 
     writer->write_buffer = PyMem_Malloc(WRITE_BUFFER_SIZE);
     if (!writer->write_buffer) {
+        PyErr_NoMemory();
         goto error;
     }
     writer->buffer_size = WRITE_BUFFER_SIZE;
@@ -753,14 +754,17 @@ binary_writer_create(const char *filename, uint64_t sample_interval_us, int comp
         NULL                 /* Use default allocator */
     );
     if (!writer->string_hash) {
+        PyErr_NoMemory();
         goto error;
     }
     writer->strings = PyMem_Malloc(INITIAL_STRING_CAPACITY * sizeof(char *));
     if (!writer->strings) {
+        PyErr_NoMemory();
         goto error;
     }
     writer->string_lengths = PyMem_Malloc(INITIAL_STRING_CAPACITY * sizeof(size_t));
     if (!writer->string_lengths) {
+        PyErr_NoMemory();
         goto error;
     }
     writer->string_capacity = INITIAL_STRING_CAPACITY;
@@ -773,16 +777,19 @@ binary_writer_create(const char *filename, uint64_t sample_interval_us, int comp
         NULL                 /* Use default allocator */
     );
     if (!writer->frame_hash) {
+        PyErr_NoMemory();
         goto error;
     }
     writer->frame_entries = PyMem_Malloc(INITIAL_FRAME_CAPACITY * sizeof(FrameEntry));
     if (!writer->frame_entries) {
+        PyErr_NoMemory();
         goto error;
     }
     writer->frame_capacity = INITIAL_FRAME_CAPACITY;
 
     writer->thread_entries = PyMem_Malloc(INITIAL_THREAD_CAPACITY * sizeof(ThreadEntry));
     if (!writer->thread_entries) {
+        PyErr_NoMemory();
         goto error;
     }
     writer->thread_capacity = INITIAL_THREAD_CAPACITY;


### PR DESCRIPTION
The binary_writer_create function had several error paths where memory
allocation failures would return NULL without setting a Python exception.
This violated the C API contract and caused "returning an error without
exception set" errors when BinaryWriter initialization failed due to
memory pressure.

Added PyErr_NoMemory calls before each goto error for PyMem_Malloc and
_Py_hashtable_new_full failures. Neither of these functions set exceptions
on failure, so callers must do it explicitly. The error label only performs
cleanup and returns NULL, relying on exceptions being set beforehand.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140739 -->
* Issue: gh-140739
<!-- /gh-issue-number -->
