### PR TITLE
gh-142557: fix UAF in `bytearray.__mod__` when object is mutated while formatting `%`-style arguments

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1382,6 +1382,19 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
             except OSError:
                 pass
 
+    def test_mod_use_after_free(self):
+        # Prevent UAF in bytearray % (a1, a2) with re-entrant a[12].__repr__.
+        # Regression test for https://github.com/python/cpython/issues/142557.
+        fmt = bytearray(b"%a %a")
+
+        class S:
+            def __repr__(self):
+                fmt.clear()
+                return "E"
+
+        args = (S(), S())
+        self.assertRaises(BufferError, fmt.__mod__, args)
+
     def test_reverse(self):
         b = bytearray(b'hello')
         self.assertEqual(b.reverse(), None)

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1382,18 +1382,17 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
             except OSError:
                 pass
 
-    def test_mod_use_after_free(self):
-        # Prevent UAF in bytearray % (a1, a2) with re-entrant a[12].__repr__.
+    def test_mod_concurrent_mutation(self):
+        # Prevent crash in __mod__ when formatting mutates the bytearray.
         # Regression test for https://github.com/python/cpython/issues/142557.
-        fmt = bytearray(b"%a %a")
+        fmt = bytearray(b"%a end")
 
         class S:
             def __repr__(self):
                 fmt.clear()
                 return "E"
 
-        args = (S(), S())
-        self.assertRaises(BufferError, fmt.__mod__, args)
+        self.assertRaises(BufferError, fmt.__mod__, S())
 
     def test_reverse(self):
         b = bytearray(b'hello')

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-27-12-25-06.gh-issue-142557.KWOc8b.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-27-12-25-06.gh-issue-142557.KWOc8b.rst
@@ -1,3 +1,3 @@
-Fix a use-after-free crash in :meth:`bytearray.__mod__` when the
+Fix a use-after-free crash in :ref:`bytearray.__mod__ <printf-style-bytes-formatting>` when the
 :meth:`~object.__repr__` method of one of the arguments to format mutates
 the :class:`bytearray`. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-27-12-25-06.gh-issue-142557.KWOc8b.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-27-12-25-06.gh-issue-142557.KWOc8b.rst
@@ -1,3 +1,3 @@
-Fix a use-after-free crash in :ref:`bytearray.__mod__ <printf-style-bytes-formatting>` when the
+Fix a use-after-free crash in :ref:`bytearray.__mod__ <bytes-formatting>` when the
 :meth:`~object.__repr__` method of one of the arguments to format mutates
 the :class:`bytearray`. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-27-12-25-06.gh-issue-142557.KWOc8b.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-27-12-25-06.gh-issue-142557.KWOc8b.rst
@@ -1,3 +1,3 @@
 Fix a use-after-free crash in :ref:`bytearray.__mod__ <bytes-formatting>` when
-the :class:`!bytearray` is mutated while formatting the `%`-style arguments.
+the :class:`!bytearray` is mutated while formatting the ``%``-style arguments.
 Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-27-12-25-06.gh-issue-142557.KWOc8b.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-27-12-25-06.gh-issue-142557.KWOc8b.rst
@@ -1,3 +1,3 @@
-Fix a use-after-free crash in :ref:`bytearray.__mod__ <bytes-formatting>` when the
-:meth:`~object.__repr__` method of one of the arguments to format mutates
-the :class:`bytearray`. Patch by Bénédikt Tran.
+Fix a use-after-free crash in :ref:`bytearray.__mod__ <bytes-formatting>` when
+the :class:`!bytearray` is mutated while formatting the `%`-style arguments.
+Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-27-12-25-06.gh-issue-142557.KWOc8b.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-27-12-25-06.gh-issue-142557.KWOc8b.rst
@@ -1,0 +1,3 @@
+Fix a use-after-free crash in :meth:`bytearray.__mod__` when the
+:meth:`~object.__repr__` method of one of the arguments to format mutates
+the :class:`bytearray`. Patch by Bénédikt Tran.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2837,7 +2837,15 @@ bytearray_mod_lock_held(PyObject *v, PyObject *w)
     _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(v);
     if (!PyByteArray_Check(v))
         Py_RETURN_NOTIMPLEMENTED;
-    return _PyBytes_FormatEx(PyByteArray_AS_STRING(v), PyByteArray_GET_SIZE(v), w, 1);
+
+    PyByteArrayObject *self = _PyByteArray_CAST(v);
+    /* Increase exports to prevent bytearray storage from changing during op. */
+    self->ob_exports++;
+    PyObject *res = _PyBytes_FormatEx(
+        PyByteArray_AS_STRING(v), PyByteArray_GET_SIZE(v), w, 1
+    );
+    self->ob_exports--;
+    return res;
 }
 
 static PyObject *


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142557 -->
* Issue: gh-142557
<!-- /gh-issue-number -->
