### PR TITLE
gh-143200: fix UAFs in `Element.__{set,get}item__` when the element is concurrently mutated

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -3010,32 +3010,72 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
         elem = b.close()
         self.assertEqual(elem[0].tail, 'ABCDEFGHIJKL')
 
-    def test_subscr(self):
-        # Issue #27863
+    def test_subscr_with_clear(self):
+        # See https://github.com/python/cpython/issues/143200.
+        self.do_test_subscr_with_mutating_slice(use_clear_method=True)
+
+    def test_subscr_with_delete(self):
+        # See https://github.com/python/cpython/issues/72050.
+        self.do_test_subscr_with_mutating_slice(use_clear_method=False)
+
+    def do_test_subscr_with_mutating_slice(self, *, use_clear_method):
         class X:
+            def __init__(self, i=0):
+                self.i = i
             def __index__(self):
-                del e[:]
-                return 1
+                if use_clear_method:
+                    e.clear()
+                else:
+                    del e[:]
+                return self.i
 
-        e = ET.Element('elem')
-        e.append(ET.Element('child'))
-        e[:X()]  # shouldn't crash
+        for s in self.get_mutating_slices(X, 10):
+            with self.subTest(s):
+                e = ET.Element('elem')
+                e.extend([ET.Element(f'c{i}') for i in range(10)])
+                e[s]  # shouldn't crash
 
-        e.append(ET.Element('child'))
-        e[0:10:X()]  # shouldn't crash
+    def test_ass_subscr_with_mutating_slice(self):
+        # See https://github.com/python/cpython/issues/72050
+        # and https://github.com/python/cpython/issues/143200.
 
-    def test_ass_subscr(self):
-        # Issue #27863
         class X:
+            def __init__(self, i=0):
+                self.i = i
             def __index__(self):
                 e[:] = []
-                return 1
+                return self.i
+
+        for s in self.get_mutating_slices(X, 10):
+            with self.subTest(s):
+                e = ET.Element('elem')
+                e.extend([ET.Element(f'c{i}') for i in range(10)])
+                e[s] = []  # shouldn't crash
+
+    def get_mutating_slices(self, index_class, n_children):
+        self.assertGreaterEqual(n_children, 10)
+        return [
+            slice(index_class(), None, None),
+            slice(index_class(2), None, None),
+            slice(None, index_class(), None),
+            slice(None, index_class(2), None),
+            slice(0, 2, index_class(1)),
+            slice(0, 2, index_class(2)),
+            slice(0, n_children, index_class(1)),
+            slice(0, n_children, index_class(2)),
+            slice(0, 2 * n_children, index_class(1)),
+            slice(0, 2 * n_children, index_class(2)),
+        ]
+
+    def test_ass_subscr_with_mutating_iterable_value(self):
+        class V:
+            def __iter__(self):
+                e.clear()
+                return iter([ET.Element('a'), ET.Element('b')])
 
         e = ET.Element('elem')
-        for _ in range(10):
-            e.insert(0, ET.Element('child'))
-
-        e[0:10:X()] = []  # shouldn't crash
+        e.extend([ET.Element(f'c{i}') for i in range(10)])
+        e[:] = V()
 
     def test_treebuilder_start(self):
         # Issue #27863

--- a/Misc/NEWS.d/next/Library/2025-12-27-15-41-27.gh-issue-143200.2hEUAl.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-27-15-41-27.gh-issue-143200.2hEUAl.rst
@@ -1,0 +1,4 @@
+:mod:`xml.etree.ElementTree`: fix use-after-free crashes in
+:meth:`~object.__getitem__` and :meth:`~object.__setitem__` methods of
+:class:`~xml.etree.ElementTree.Element` when the element is concurrently
+mutated. Patch by Bénédikt Tran.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1918,8 +1918,6 @@ element_ass_subscr(PyObject *op, PyObject *item, PyObject *value)
              * Note that in the ith iteration, shifting is done i+i places down
              * because i children were already removed.
             */
-            assert(self->extra != NULL);
-            assert(self->extra->children != NULL);
             for (cur = start, i = 0; cur < (size_t)stop; cur += step, ++i) {
                 /* Compute how many children have to be moved, clipping at the
                  * list end.
@@ -1986,9 +1984,6 @@ element_ass_subscr(PyObject *op, PyObject *item, PyObject *value)
                 return -1;
             }
         }
-
-        assert(recycle == NULL);
-        assert(self->extra != NULL);
 
         PyTypeObject *tp = Py_TYPE(self);
         elementtreestate *st = get_elementtree_state_by_type(tp);

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1875,19 +1875,11 @@ element_ass_subscr(PyObject *op, PyObject *item, PyObject *value)
             return -1;
         }
 
-        // Since PySlice_Unpack() may clear 'self->extra', we need
-        // to ensure that it exists now (using a slice for assignment
-        // should not raise IndexError).
-        //
-        // See https://github.com/python/cpython/issues/143200.
-        if (self->extra == NULL) {
-            if (create_extra(self, NULL) < 0) {
-                return -1;
-            }
-        }
-
         if (value == NULL) {
             /* Delete slice */
+            if (self->extra == NULL) {
+                return 0;
+            }
             slicelen = PySlice_AdjustIndices(self->extra->length, &start, &stop,
                                              step);
             if (slicelen <= 0)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143200 -->
* Issue: gh-143200
<!-- /gh-issue-number -->
