### PR TITLE
gh-116738: Add free-threading tests for binascii

### DIFF
--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -1,6 +1,5 @@
 """Test the binascii C module."""
 
-import sys
 import threading
 import unittest
 import binascii
@@ -10,7 +9,6 @@ from test import support
 from test.support import bigmemtest, _1G, _4G
 from test.support.hypothesis_helper import hypothesis
 from test.support import threading_helper
-from test.support.script_helper import assert_python_ok
 
 
 # Note: "*_hex" functions are aliases for "(un)hexlify"
@@ -524,29 +522,10 @@ class ChecksumBigBufferTestCase(unittest.TestCase):
 
 class FreeThreadingTest(unittest.TestCase):
     @unittest.skipUnless(support.Py_GIL_DISABLED,
-                         'only meaningful in free-threaded builds')
-    def test_import_does_not_enable_gil(self):
-        assert_python_ok(
-            '-X', 'gil=0',
-            '-c',
-            (
-                'import sys\n'
-                'if sys._is_gil_enabled():\n'
-                '    raise SystemExit("GIL unexpectedly enabled")\n'
-                'import binascii\n'
-                'if sys._is_gil_enabled():\n'
-                '    raise SystemExit("GIL unexpectedly enabled after import")\n'
-            ),
-        )
-
-    @unittest.skipUnless(support.Py_GIL_DISABLED,
                          'this test can only possibly fail with GIL disabled')
     @threading_helper.reap_threads
     @threading_helper.requires_working_threading()
     def test_free_threading(self):
-        if sys._is_gil_enabled():
-            self.skipTest('test requires running with -X gil=0')
-
         num_threads = 8
         barrier = threading.Barrier(num_threads)
 
@@ -557,20 +536,16 @@ class FreeThreadingTest(unittest.TestCase):
         hexed = binascii.hexlify(payload)
         b64 = binascii.b2a_base64(payload, newline=False)
         expected_crc = binascii.crc32(payload)
+        assertEqual = self.assertEqual
 
         def worker():
             barrier.wait(timeout=support.SHORT_TIMEOUT)
             for _ in range(1000):
-                if binascii.unhexlify(hexed) != payload:
-                    raise AssertionError('unhexlify mismatch')
-                if binascii.hexlify(payload) != hexed:
-                    raise AssertionError('hexlify mismatch')
-                if binascii.a2b_base64(b64) != payload:
-                    raise AssertionError('a2b_base64 mismatch')
-                if binascii.b2a_base64(payload, newline=False) != b64:
-                    raise AssertionError('b2a_base64 mismatch')
-                if binascii.crc32(payload) != expected_crc:
-                    raise AssertionError('crc32 mismatch')
+                assertEqual(binascii.unhexlify(hexed), payload, 'unhexlify mismatch')
+                assertEqual(binascii.hexlify(payload), hexed, 'hexlify mismatch')
+                assertEqual(binascii.a2b_base64(b64), payload, 'a2b_base64 mismatch')
+                assertEqual(binascii.b2a_base64(payload, newline=False), b64, 'b2a_base64 mismatch')
+                assertEqual(binascii.crc32(payload), expected_crc, 'crc32 mismatch')
 
         threads = [threading.Thread(target=worker) for _ in range(num_threads)]
         with threading_helper.catch_threading_exception() as cm:

--- a/Misc/NEWS.d/next/Tests/2025-12-27-20-13-12.gh-issue-116738.efglNB.rst
+++ b/Misc/NEWS.d/next/Tests/2025-12-27-20-13-12.gh-issue-116738.efglNB.rst
@@ -1,0 +1,1 @@
+Added free-threading regression tests for the binascii module.

--- a/Misc/NEWS.d/next/Tests/2025-12-27-20-13-12.gh-issue-116738.efglNB.rst
+++ b/Misc/NEWS.d/next/Tests/2025-12-27-20-13-12.gh-issue-116738.efglNB.rst
@@ -1,1 +1,0 @@
-Added free-threading regression tests for the binascii module.


### PR DESCRIPTION
**Summary**
- Add free-threading regression coverage for `binascii` (gh-116738).
- Assert that importing `binascii` does not enable the GIL when running with `-X gil=0`.
- Add a multi-thread stress test for common `binascii` operations under `-X gil=0`.

**Motivation**
- Built-in extension modules should be thread-safe in free-threaded builds and correctly declare their GIL usage.

**Testing**
- Default build: `./python -m test -j0 test_binascii`
- Free-threaded build: `./python -X gil=0 -m test -j0 test_binascii`

**Issue**
- gh-116738