### PR TITLE
gh-142884: Fix UAF in `array.array.tofile` with concurrent mutations

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1368,20 +1368,18 @@ class NumberTest(BaseTest):
         self.assertEqual(a, b)
 
     def test_tofile_concurrent_mutation(self):
-        # Keep this test in sync with the implementation in
-        # Modules/arraymodule.c:array_array_tofile_impl()
+        # Prevent crash when a writer concurrently mutates the array.
+        # See https://github.com/python/cpython/issues/142884.
+        # Keep 'BLOCKSIZE' in sync with the array.tofile() C implementation.
         BLOCKSIZE = 64 * 1024
         victim = array.array('B', b'\0' * (BLOCKSIZE * 2))
 
         class Writer:
-            cleared = False
             def write(self, data):
-                if not self.cleared:
-                    self.cleared = True
-                    victim.clear()
+                victim.clear()
                 return 0
 
-        victim.tofile(Writer())
+        victim.tofile(Writer())  # should not crash
 
 
 class IntegerNumberTest(NumberTest):

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1368,6 +1368,8 @@ class NumberTest(BaseTest):
         self.assertEqual(a, b)
 
     def test_tofile_concurrent_mutation(self):
+        # Keep this test in sync with the implementation in
+        # Modules/arraymodule.c:array_array_tofile_impl()
         BLOCKSIZE = 64 * 1024
         victim = array.array('B', b'\0' * (BLOCKSIZE * 2))
 

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1367,6 +1367,21 @@ class NumberTest(BaseTest):
         b = array.array(self.typecode, a)
         self.assertEqual(a, b)
 
+    def test_tofile_concurrent_mutation(self):
+        BLOCKSIZE = 64 * 1024
+        victim = array.array('B', b'\0' * (BLOCKSIZE * 2))
+
+        class Writer:
+            cleared = False
+            def write(self, data):
+                if not self.cleared:
+                    self.cleared = True
+                    victim.clear()
+                return 0
+
+        victim.tofile(Writer())
+
+
 class IntegerNumberTest(NumberTest):
     def test_type_error(self):
         a = array.array(self.typecode)

--- a/Misc/NEWS.d/next/Library/2025-12-18-11-41-37.gh-issue-142884.kjgukd.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-18-11-41-37.gh-issue-142884.kjgukd.rst
@@ -1,1 +1,1 @@
-Use-After-Free Vulnerability Fixed in CPython array.array.tofile().
+:mod:`array`: fix a crash in :mod:`array.array.tofile` when the array is concurrently modified by the writer.

--- a/Misc/NEWS.d/next/Library/2025-12-18-11-41-37.gh-issue-142884.kjgukd.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-18-11-41-37.gh-issue-142884.kjgukd.rst
@@ -1,0 +1,1 @@
+Use-After-Free Vulnerability Fixed in CPython array.array.tofile().

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1587,35 +1587,52 @@ static PyObject *
 array_array_tofile_impl(arrayobject *self, PyTypeObject *cls, PyObject *f)
 /*[clinic end generated code: output=4560c628d9c18bc2 input=5a24da7a7b407b52]*/
 {
-    Py_ssize_t nbytes = Py_SIZE(self) * self->ob_descr->itemsize;
     /* Write 64K blocks at a time */
     /* XXX Make the block size settable */
-    int BLOCKSIZE = 64*1024;
+    const Py_ssize_t BLOCKSIZE = 64*1024;
+    const Py_ssize_t itemsize = self->ob_descr->itemsize;
+
+    Py_ssize_t nbytes = Py_SIZE(self) * itemsize;
     Py_ssize_t nblocks = (nbytes + BLOCKSIZE - 1) / BLOCKSIZE;
-    Py_ssize_t i;
 
     if (Py_SIZE(self) == 0)
         goto done;
 
-
     array_state *state = get_array_state_by_class(cls);
     assert(state != NULL);
 
-    for (i = 0; i < nblocks; i++) {
-        char* ptr = self->ob_item + i*BLOCKSIZE;
-        Py_ssize_t size = BLOCKSIZE;
+    for (Py_ssize_t i = 0; i < nblocks; i++) {
+        if (self->ob_item == NULL || Py_SIZE(self) == 0) {
+            break;
+        }
+
+        if (Py_SIZE(self) > PY_SSIZE_T_MAX / itemsize) {
+            return PyErr_NoMemory();
+        }
+
+        Py_ssize_t current_nbytes = Py_SIZE(self) * itemsize;
+        const Py_ssize_t offset = i * BLOCKSIZE;
+        if (offset >= current_nbytes) {
+            break;
+        }
+
+        Py_ssize_t size = current_nbytes - offset;
+        if (size > BLOCKSIZE) {
+            size = BLOCKSIZE;
+        }
+
+        char* ptr = self->ob_item + offset;
         PyObject *bytes, *res;
 
-        if (i*BLOCKSIZE + size > nbytes)
-            size = nbytes - i*BLOCKSIZE;
         bytes = PyBytes_FromStringAndSize(ptr, size);
         if (bytes == NULL)
             return NULL;
+
         res = PyObject_CallMethodOneArg(f, state->str_write, bytes);
         Py_DECREF(bytes);
         if (res == NULL)
             return NULL;
-        Py_DECREF(res); /* drop write result */
+        Py_DECREF(res);
     }
 
   done:

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1600,15 +1600,16 @@ array_array_tofile_impl(arrayobject *self, PyTypeObject *cls, PyObject *f)
 
     Py_ssize_t offset = 0;
     while (1) {
-        if (self->ob_item == NULL || Py_SIZE(self) == 0) {
+        Py_ssize_t total_size = Py_SIZE(self);
+        if (self->ob_item == NULL || total_size == 0) {
             break;
         }
 
-        if (Py_SIZE(self) > max_items) {
+        if (total_size > max_items) {
             return PyErr_NoMemory();
         }
 
-        Py_ssize_t current_nbytes = Py_SIZE(self) * self->ob_descr->itemsize;
+        Py_ssize_t current_nbytes = total_size * self->ob_descr->itemsize;
         if (offset >= current_nbytes) {
             break;
         }


### PR DESCRIPTION
the original code precomputed nblocks at the beginning of the function, but when a reentrant
writer cleared the array during the first callback, self->ob_item became NULL. The loop continued iterating based on the cached values and dereferenced the null pointer.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142884 -->
* Issue: gh-142884
<!-- /gh-issue-number -->
