### PR TITLE
gh-143249: Fix buffer leak when overlapped operation fails to start (OS-Windows)

### DIFF
--- a/Lib/test/test_asyncio/test_windows_utils.py
+++ b/Lib/test/test_asyncio/test_windows_utils.py
@@ -148,5 +148,6 @@ class OverlappedRefleakTests(unittest.TestCase):
         with self.assertRaises(OSError):
             ov.WSARecvFromInto(0x1234, buf, len(buf), 0)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_asyncio/test_windows_utils.py
+++ b/Lib/test/test_asyncio/test_windows_utils.py
@@ -129,5 +129,45 @@ class PopenTests(unittest.TestCase):
             pass
 
 
+class OverlappedLeakTests(unittest.TestCase):
+    def _invalid_socket_handle(self):
+        return 0
+
+    def test_overlapped_wsasendto_failure_releases_user_buffer(self):
+        ov = _overlapped.Overlapped()
+        buf = bytearray(4096)
+        with self.assertRaises(OSError):
+            ov.WSASendTo(self._invalid_socket_handle(),
+                         memoryview(buf), 0, ("127.0.0.1", 1))
+        # If the exported buffer is still held, this will raise BufferError.
+        buf.append(1)
+
+    def test_overlapped_wsarecvfrominto_failure_releases_user_buffer(self):
+        ov = _overlapped.Overlapped()
+        buf = bytearray(4096)
+        with self.assertRaises(OSError):
+            ov.WSARecvFromInto(self._invalid_socket_handle(),
+                               memoryview(buf), len(buf), 0)
+        # If the exported buffer is still held, this will raise BufferError.
+        buf.append(1)
+
+    @support.refcount_test
+    def test_overlapped_wsarecvfrom_failure_does_not_leak_allocated_buffer(self):
+        gettotalrefcount = support.get_attribute(sys, "gettotalrefcount")
+
+        def run_once():
+            ov = _overlapped.Overlapped()
+            with self.assertRaises(OSError):
+                ov.WSARecvFrom(self._invalid_socket_handle(), 4096, 0)
+
+        # Warm up
+        run_once()
+        before = gettotalrefcount()
+        for _ in range(2000):
+            run_once()
+        after = gettotalrefcount()
+        self.assertAlmostEqual(after - before, 0, delta=20)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2025-12-28-14-41-02.gh-issue-143249.K4vEp4.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-28-14-41-02.gh-issue-143249.K4vEp4.rst
@@ -1,0 +1,1 @@
+Fix possible buffer leaks in Windows overlapped I/O operations when the operation fails.

--- a/Misc/NEWS.d/next/Library/2025-12-28-14-41-02.gh-issue-143249.K4vEp4.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-28-14-41-02.gh-issue-143249.K4vEp4.rst
@@ -1,1 +1,1 @@
-Fix possible buffer leaks in Windows overlapped I/O operations when the operation fails.
+Fix possible buffer leaks in Windows overlapped I/O on error handling.

--- a/Misc/NEWS.d/next/Library/2025-12-28-14-41-04.gh-issue-143249.K4vEp4.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-28-14-41-04.gh-issue-143249.K4vEp4.rst
@@ -1,1 +1,0 @@
-Fix possible buffer leaks in Windows overlapped I/O operations when the operation fails.

--- a/Misc/NEWS.d/next/Library/2025-12-28-14-41-04.gh-issue-143249.K4vEp4.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-28-14-41-04.gh-issue-143249.K4vEp4.rst
@@ -1,0 +1,1 @@
+Fix possible buffer leaks in Windows overlapped I/O operations when the operation fails.

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -1806,7 +1806,7 @@ _overlapped_Overlapped_WSASendTo_impl(OverlappedObject *self, HANDLE handle,
         case ERROR_IO_PENDING:
             Py_RETURN_NONE;
         default:
-            self->type = TYPE_NOT_STARTED;
+            Overlapped_clear(self);
             return SetFromWindowsErr(err);
     }
 }
@@ -1873,7 +1873,7 @@ _overlapped_Overlapped_WSARecvFrom_impl(OverlappedObject *self,
     case ERROR_IO_PENDING:
         Py_RETURN_NONE;
     default:
-        self->type = TYPE_NOT_STARTED;
+        Overlapped_clear(self);
         return SetFromWindowsErr(err);
     }
 }
@@ -1940,7 +1940,7 @@ _overlapped_Overlapped_WSARecvFromInto_impl(OverlappedObject *self,
     case ERROR_IO_PENDING:
         Py_RETURN_NONE;
     default:
-        self->type = TYPE_NOT_STARTED;
+        Overlapped_clear(self);
         return SetFromWindowsErr(err);
     }
 }


### PR DESCRIPTION
On Windows, some overlapped I/O operations leak buffers when they fail to start, notably in `WSASendTo()`, `WSARecvFrom()`, and `WSARecvFromInto()`.

This change ensures that buffers are released on failure by clearing the overlapped state, following the same pattern used in other overlapped error paths. This issue is similar in nature to commit 5485085b324, which fixed related overlapped cleanup problems.

### Python script for tracking leaks
``` py
import sys
import _overlapped

def total():
    return sys.gettotalrefcount()

if not hasattr(sys, "gettotalrefcount"):
    raise SystemExit("need a debug build (Py_DEBUG) for gettotalrefcount")

before = total()

N = 20000
STEP = 1000

for i in range(1, N + 1):
    ov = _overlapped.Overlapped()
    buf = memoryview(bytearray(4096))
    try:
        ov.WSASendTo(0x1234, buf, 0, ("127.0.0.1", 1))
    except OSError:
        pass

    if i % STEP == 0:
        now = total()
        print(f"{i:6d}: totalrefcount delta = {now - before:+d}")

after = total()
print(f"done: N={N}, totalrefcount delta = {after - before:+d}")

```
### Result without the patch
``` bash
d:\MyCode\cpython\PCbuild\amd64>python_d.exe py_overlapped_leak.py
  1000: totalrefcount delta = +4007
  2000: totalrefcount delta = +8009
  3000: totalrefcount delta = +11906
  4000: totalrefcount delta = +15906
  5000: totalrefcount delta = +19906
......
 19000: totalrefcount delta = +75906
 20000: totalrefcount delta = +79906
done: N=20000, totalrefcount delta = +79905
```
### Result with the patch
``` bash
d:\MyCode\cpython\PCbuild\amd64>python_d.exe py_overlapped_leak.py
  1000: totalrefcount delta = +10
  2000: totalrefcount delta = +10
  3000: totalrefcount delta = +10
  4000: totalrefcount delta = +10
  5000: totalrefcount delta = +10
......
 19000: totalrefcount delta = +10
 20000: totalrefcount delta = +10
done: N=20000, totalrefcount delta = +9
```

<!-- gh-issue-number: gh-143249 -->
* Issue: gh-143249
<!-- /gh-issue-number -->
