### PR TITLE
gh-143253: Add libabigail suppression file for internal types

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -143,6 +143,9 @@ Misc/externals.spdx.json      @sethmlarson
 Misc/sbom.spdx.json           @sethmlarson
 Tools/build/generate_sbom.py  @sethmlarson
 
+# ABI check
+Misc/libabigail.abignore      @encukou
+
 
 # ----------------------------------------------------------------------------
 # Platform Support

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1883,7 +1883,7 @@ regen-abidump: all
 
 .PHONY: check-abidump
 check-abidump: all
-	abidiff $(srcdir)/Doc/data/python$(LDVERSION).abi "libpython$(LDVERSION).so" --drop-private-types --no-architecture --no-added-syms
+	abidiff $(srcdir)/Doc/data/python$(LDVERSION).abi "libpython$(LDVERSION).so" --drop-private-types --no-architecture --no-added-syms --suppressions $(srcdir)/Misc/libabigail.abignore
 
 .PHONY: regen-limited-abi
 regen-limited-abi: all

--- a/Misc/libabigail.abignore
+++ b/Misc/libabigail.abignore
@@ -1,0 +1,21 @@
+# libabigail suppression file for CPython ABI checks
+#
+# Suppress types defined directly in internal headers (pycore_*.h)
+# Regex matches filenames NOT starting with "pycore_", so pycore_* types are suppressed.
+[suppress_type]
+  source_location_not_regexp = ^([^p]|p[^y]|py[^c]|pyc[^o]|pyco[^r]|pycor[^e]|pycore[^_])
+  accessed_through = pointer
+
+# Suppress public typedefs that alias internal structs.
+# These are public names but their underlying struct layout is internal.
+[suppress_type]
+  name = PyInterpreterState
+  accessed_through = pointer
+
+[suppress_type]
+  name = _PyRuntimeState
+  accessed_through = pointer
+
+[suppress_type]
+  name = PyThreadState
+  accessed_through = pointer

--- a/Misc/libabigail.abignore
+++ b/Misc/libabigail.abignore
@@ -19,3 +19,7 @@
 [suppress_type]
   name = PyThreadState
   accessed_through = pointer
+
+[suppress_variable]
+  name = _PyRuntime
+  type_name = _PyRuntimeState


### PR DESCRIPTION
Changes to internal structs in Include/internal/pycore_*.h cause false
positive ABI violations in make check-abidump because these types are
transitively reachable from public APIs like PyInterpreterState. The
internal struct layout is not part of the public ABI contract.

This adds a suppression specification file that filters out types
defined in pycore_*.h files using a regex pattern, and explicitly
suppresses PyInterpreterState, _PyRuntimeState, and PyThreadState
which are public typedefs aliasing internal structs. The Makefile
is updated to pass the suppression file to abidiff.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143253 -->
* Issue: gh-143253
<!-- /gh-issue-number -->
