### PR TITLE
gh-69686: Remove untrue part of `__import__` replacement docs

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -832,9 +832,7 @@ entirely with a custom meta path hook.
 
 If it is acceptable to only alter the behaviour of import statements
 without affecting other APIs that access the import system, then replacing
-the builtin :func:`__import__` function may be sufficient. This technique
-may also be employed at the module level to only alter the behaviour of
-import statements within that module.
+the builtin :func:`__import__` function may be sufficient.
 
 To selectively prevent the import of some modules from a hook early on the
 meta path (rather than disabling the standard import system entirely),


### PR DESCRIPTION
As far as I know (and based on the information in the linked issue), this statement in the docs hasn't been true since at least Python 2.7.

<!-- gh-issue-number: gh-69686 -->
* Issue: gh-69686
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143261.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->