### PR TITLE
gh-143048: Remove outdated curses reference in interactive mode docs

### DIFF
--- a/Doc/tutorial/appendix.rst
+++ b/Doc/tutorial/appendix.rst
@@ -14,7 +14,7 @@ There are two variants of the interactive :term:`REPL`.  The classic
 basic interpreter is supported on all platforms with minimal line
 control capabilities.
 
-On Windows, or Unix-like systems with :mod:`curses` support,
+On Windows and Unix-like systems,
 a new interactive shell is used by default since Python 3.13.
 This one supports color, multiline editing, history browsing, and
 paste mode.  To disable color, see :ref:`using-on-controlling-color` for


### PR DESCRIPTION
The curses module dependency was removed for the new REPL in GH-136758 so the documentation should no longer mention it as a requirement.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143048 -->
* Issue: gh-143048
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143264.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->