### PR TITLE
gh-142918: Fix Context docstrings to say iterator instead of list

### DIFF
--- a/Doc/library/contextvars.rst
+++ b/Doc/library/contextvars.rst
@@ -275,16 +275,16 @@ Manual Context Management
 
    .. method:: keys()
 
-      Return a list of all variables in the context object.
+      Return an iterator of all variables in the context object.
 
    .. method:: values()
 
-      Return a list of all variables' values in the context object.
+      Return an iterator of all variables' values in the context object.
 
 
    .. method:: items()
 
-      Return a list of 2-tuples containing all variables and their
+      Return an iterator of 2-tuples containing all variables and their
       values in the context object.
 
 

--- a/Python/clinic/context.c.h
+++ b/Python/clinic/context.c.h
@@ -48,7 +48,7 @@ PyDoc_STRVAR(_contextvars_Context_items__doc__,
 "\n"
 "Return all variables and their values in the context object.\n"
 "\n"
-"The result is returned as a list of 2-tuples (variable, value).");
+"The result is returned as an iterator of 2-tuples (variable, value).");
 
 #define _CONTEXTVARS_CONTEXT_ITEMS_METHODDEF    \
     {"items", (PyCFunction)_contextvars_Context_items, METH_NOARGS, _contextvars_Context_items__doc__},
@@ -66,7 +66,7 @@ PyDoc_STRVAR(_contextvars_Context_keys__doc__,
 "keys($self, /)\n"
 "--\n"
 "\n"
-"Return a list of all variables in the context object.");
+"Return an iterator of all variables in the context object.");
 
 #define _CONTEXTVARS_CONTEXT_KEYS_METHODDEF    \
     {"keys", (PyCFunction)_contextvars_Context_keys, METH_NOARGS, _contextvars_Context_keys__doc__},
@@ -84,7 +84,7 @@ PyDoc_STRVAR(_contextvars_Context_values__doc__,
 "values($self, /)\n"
 "--\n"
 "\n"
-"Return a list of all variables\' values in the context object.");
+"Return an iterator of all variables\' values in the context object.");
 
 #define _CONTEXTVARS_CONTEXT_VALUES_METHODDEF    \
     {"values", (PyCFunction)_contextvars_Context_values, METH_NOARGS, _contextvars_Context_values__doc__},
@@ -256,4 +256,4 @@ token_exit(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3a04b2fddf24c3e9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a6b96499985059cd input=a9049054013a1b77]*/

--- a/Python/context.c
+++ b/Python/context.c
@@ -650,12 +650,12 @@ _contextvars.Context.items
 
 Return all variables and their values in the context object.
 
-The result is returned as a list of 2-tuples (variable, value).
+The result is returned as an iterator of 2-tuples (variable, value).
 [clinic start generated code]*/
 
 static PyObject *
 _contextvars_Context_items_impl(PyContext *self)
-/*[clinic end generated code: output=fa1655c8a08502af input=00db64ae379f9f42]*/
+/*[clinic end generated code: output=fa1655c8a08502af input=f9c1fe4d39962ea0]*/
 {
     return _PyHamt_NewIterItems(self->ctx_vars);
 }
@@ -664,12 +664,12 @@ _contextvars_Context_items_impl(PyContext *self)
 /*[clinic input]
 _contextvars.Context.keys
 
-Return a list of all variables in the context object.
+Return an iterator of all variables in the context object.
 [clinic start generated code]*/
 
 static PyObject *
 _contextvars_Context_keys_impl(PyContext *self)
-/*[clinic end generated code: output=177227c6b63ec0e2 input=114b53aebca3449c]*/
+/*[clinic end generated code: output=177227c6b63ec0e2 input=f806e4e5f77c7e7e]*/
 {
     return _PyHamt_NewIterKeys(self->ctx_vars);
 }
@@ -678,12 +678,12 @@ _contextvars_Context_keys_impl(PyContext *self)
 /*[clinic input]
 _contextvars.Context.values
 
-Return a list of all variables' values in the context object.
+Return an iterator of all variables' values in the context object.
 [clinic start generated code]*/
 
 static PyObject *
 _contextvars_Context_values_impl(PyContext *self)
-/*[clinic end generated code: output=d286dabfc8db6dde input=ce8075d04a6ea526]*/
+/*[clinic end generated code: output=d286dabfc8db6dde input=6f3cb30499d55021]*/
 {
     return _PyHamt_NewIterValues(self->ctx_vars);
 }


### PR DESCRIPTION
The Context.items(), Context.keys(), and Context.values() methods return iterators, not lists. Updated the docstrings in both the C source and the documentation to accurately reflect this behavior.

Files modified:
- Python/context.c: Updated clinic input docstrings
- Python/clinic/context.c.h: Regenerated by clinic tool
- Doc/library/contextvars.rst: Updated documentation

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142918 -->
* Issue: gh-142918
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143266.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->