### PR TITLE
gh-140025: Fix queue.SimpleQueue.__sizeof__() to account for buffer

### DIFF
--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -524,6 +524,15 @@ queue_free(void *m)
     (void)queue_clear((PyObject *)m);
 }
 
+static PyObject *
+simplequeue_sizeof(simplequeueobject *self, PyObject *Py_UNUSED(ignored))
+{
+    Py_ssize_t res = _PyObject_SIZE(Py_TYPE(self));
+    // Add size of the RingBuf items array
+    res += self->buf.items_cap * sizeof(PyObject *);
+    return PyLong_FromSsize_t(res);
+}
+
 #include "clinic/_queuemodule.c.h"
 
 
@@ -534,6 +543,8 @@ static PyMethodDef simplequeue_methods[] = {
     _QUEUE_SIMPLEQUEUE_PUT_METHODDEF
     _QUEUE_SIMPLEQUEUE_PUT_NOWAIT_METHODDEF
     _QUEUE_SIMPLEQUEUE_QSIZE_METHODDEF
+    {"__sizeof__",           (PyCFunction)simplequeue_sizeof,
+    METH_NOARGS,             PyDoc_STR("Return the size of the SimpleQueue in memory, in bytes.")},
     {"__class_getitem__",    Py_GenericAlias,
     METH_O|METH_CLASS,       PyDoc_STR("See PEP 585")},
     {NULL,           NULL}              /* sentinel */


### PR DESCRIPTION
Fixes #140025

## Summary
The `__sizeof__()` method for `queue.SimpleQueue` now properly accounts for the dynamically allocated internal buffer.

## Problem
Previously, `SimpleQueue.__sizeof__()` only returned the basic object size, ignoring the underlying `RingBuf` data structure that holds the queued items.

## Solution
Implemented a custom `__sizeof__()` method that includes:
- Base object size
- Size of the dynamically allocated items array: `items_cap * sizeof(PyObject*)`

## Example
```python
import queue
q = queue.SimpleQueue()
initial_size = q.__sizeof__()

# Add many items to grow the buffer
for i in range(1000):
    q.put(i)

# Now __sizeof__() correctly reflects the larger buffer
larger_size = q.__sizeof__()
assert larger_size > initial_size
```

## Changes
- Added `simplequeue_sizeof()` function in `Modules/_queuemodule.c`
- Added `__sizeof__` to `simplequeue_methods` array

<!-- gh-issue-number: gh-140025 -->
* Issue: gh-140025
<!-- /gh-issue-number -->
