### PR TITLE
gh-140764: Improve syntax warning hint for missing commas

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -1520,7 +1520,7 @@ class GrammarTests(unittest.TestCase):
         def check(test):
             self.check_syntax_warning(test, msg)
 
-        msg=r'is not callable; perhaps you missed a comma\?'
+        msg=r'is not callable; did you miss a comma to separate sequence elements\?'
         check('[(1, 2) (3, 4)]')
         check('[(x, y) (3, 4)]')
         check('[[1, 2] (3, 4)]')
@@ -1543,7 +1543,7 @@ class GrammarTests(unittest.TestCase):
         check('[t"{x}" (3, 4)]')
         check('[t"x={x}" (3, 4)]')
 
-        msg=r'is not subscriptable; perhaps you missed a comma\?'
+        msg=r'is not subscriptable; did you miss a comma to separate sequence elements\?'
         check('[{1, 2} [i, j]]')
         check('[{i for i in range(5)} [i, j]]')
         check('[(i for i in range(5)) [i, j]]')
@@ -1557,7 +1557,7 @@ class GrammarTests(unittest.TestCase):
         check('[t"{x}" [i, j]]')
         check('[t"x={x}" [i, j]]')
 
-        msg=r'indices must be integers or slices, not tuple; perhaps you missed a comma\?'
+        msg=r'indices must be integers or slices, not tuple; did you miss a comma to separate sequence elements\?'
         check('[(1, 2) [i, j]]')
         check('[(x, y) [i, j]]')
         check('[[1, 2] [i, j]]')

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -3650,7 +3650,7 @@ check_caller(compiler *c, expr_ty e)
     case Interpolation_kind: {
         location loc = LOC(e);
         return _PyCompile_Warn(c, loc, "'%.200s' object is not callable; "
-                                       "perhaps you missed a comma?",
+                                       "did you miss a comma to separate sequence elements?",
                                        infer_type(e)->tp_name);
     }
     default:
@@ -3681,7 +3681,7 @@ check_subscripter(compiler *c, expr_ty e)
     case Lambda_kind: {
         location loc = LOC(e);
         return _PyCompile_Warn(c, loc, "'%.200s' object is not subscriptable; "
-                                       "perhaps you missed a comma?",
+                                       "did you miss a comma to separate sequence elements?",
                                        infer_type(e)->tp_name);
     }
     default:
@@ -3716,7 +3716,7 @@ check_index(compiler *c, expr_ty e, expr_ty s)
         location loc = LOC(e);
         return _PyCompile_Warn(c, loc, "%.200s indices must be integers "
                                        "or slices, not %.200s; "
-                                       "perhaps you missed a comma?",
+                                       "did you miss a comma to separate sequence elements?",
                                        infer_type(e)->tp_name,
                                        index_type->tp_name);
     }


### PR DESCRIPTION
Fixes #140764

## Summary
Makes the syntax warning hint clearer when detecting potentially missing commas in sequence literals.

## Problem
Current warning: `'int' object is not subscriptable; perhaps you missed a comma?`

This hint can be cryptic - it's not immediately obvious that it's suggesting the code might have been meant as separate items in a sequence.

## Solution  
New warning: `'int' object is not subscriptable; did you miss a comma to separate sequence elements?`

## Example
```python
# Before:
>>> lambda: 1[2]
<input>:1: SyntaxWarning: 'int' object is not subscriptable; perhaps you missed a comma?

# After:
>>> lambda: 1[2]
<input>:1: SyntaxWarning: 'int' object is not subscriptable; did you miss a comma to separate sequence elements?
```

Much clearer what the intended fix might be!

## Changes
- Updated 3 warning messages in `Python/codegen.c`:
  - Callable check
  - Subscriptable check
  - Index type check
- Updated corresponding test regex patterns in `Lib/test/test_grammar.py`

## Test Plan
- All existing tests updated to match new message
- Warning still triggers in same cases, just with clearer text
- No behavioral changes, only message improvement

<!-- gh-issue-number: gh-140764 -->
* Issue: gh-140764
<!-- /gh-issue-number -->
