### PR TITLE
gh-143236: fix _PyEval_LoadName has use-after-free issue

### DIFF
--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -187,22 +187,14 @@ class ClearTest(unittest.TestCase):
 
         frame = get_frame()
 
-        class Fuse:
-            cleared = False
-            def __init__(self, s):
-                self.s = s
-            def __hash__(self):
-                return hash(self.s)
-            def __eq__(self, other):
-                if not Fuse.cleared and other == "boom":
-                    Fuse.cleared = True
-                    Fuse.frame.clear()
-                return False
+        class Fuse(dict):
+            def __getitem__(self, key):
+                if key == "boom":
+                    frame.clear()
+                raise KeyError(key)
 
-        Fuse.frame = frame
-        frame.f_locals[Fuse("boom")] = 0
         with self.assertRaises(NameError):
-            exec("boom", {}, frame.f_locals)
+            exec("boom", {}, Fuse())
 
 
 class FrameAttrsTest(unittest.TestCase):

--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -187,15 +187,18 @@ class ClearTest(unittest.TestCase):
 
         frame = get_frame()
 
-        class Fuse(str):
+        class Fuse:
             cleared = False
-            __hash__ = str.__hash__
+            def __init__(self, s):
+                self.s = s
+            def __hash__(self):
+                return hash(self.s)
             def __eq__(self, other):
                 if not Fuse.cleared and other == "boom":
                     Fuse.cleared = True
                     Fuse.frame.clear()
                     return False
-                return super().__eq__(other)
+                return True
 
         Fuse.frame = frame
         frame.f_locals[Fuse("boom")] = 0

--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -197,8 +197,7 @@ class ClearTest(unittest.TestCase):
                 if not Fuse.cleared and other == "boom":
                     Fuse.cleared = True
                     Fuse.frame.clear()
-                    return False
-                return True
+                return False
 
         Fuse.frame = frame
         frame.f_locals[Fuse("boom")] = 0

--- a/Misc/NEWS.d/next/Library/2025-12-30-13-56-40.gh-issue-143236.IxHw2y.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-30-13-56-40.gh-issue-143236.IxHw2y.rst
@@ -1,1 +1,1 @@
-Fix a bug in `ceval` where the load name has use-after-free bug.
+Fix a bug in ceval where the load name has use-after-free bug.

--- a/Misc/NEWS.d/next/Library/2025-12-30-13-56-40.gh-issue-143236.IxHw2y.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-30-13-56-40.gh-issue-143236.IxHw2y.rst
@@ -1,1 +1,1 @@
-Fix a bug in :mod:`ceval` where the load name has use-after-free bug.
+Fix a bug in `ceval` where the load name has use-after-free bug.

--- a/Misc/NEWS.d/next/Library/2025-12-30-13-56-40.gh-issue-143236.IxHw2y.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-30-13-56-40.gh-issue-143236.IxHw2y.rst
@@ -1,0 +1,1 @@
+Fix a bug in :mod:`ceval` where the load name has use-after-free bug.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4061,9 +4061,17 @@ _PyEval_LoadName(PyThreadState *tstate, _PyInterpreterFrame *frame, PyObject *na
                             "no locals found");
         return NULL;
     }
-    if (PyMapping_GetOptionalItem(frame->f_locals, name, &value) < 0) {
+
+    PyObject *locals = frame->f_locals;
+    Py_INCREF(locals);
+
+    if (PyMapping_GetOptionalItem(locals, name, &value) < 0) {
+        Py_DECREF(locals);
         return NULL;
     }
+
+    Py_DECREF(locals);
+
     if (value != NULL) {
         return value;
     }


### PR DESCRIPTION
fix _PyEval_LoadName has use-after-free issue

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143236 -->
* Issue: gh-143236
<!-- /gh-issue-number -->
