### PR TITLE
gh-143189: fix insertdict() for non-Unicode key

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1646,7 +1646,7 @@ class DictTest(unittest.TestCase):
         obj2 = MyClass()
         d = obj2.__dict__
         d[MyStr("attr1")] = 2
-        assert isinstance(list(d)[0], MyStr)
+        self.assertIsInstance(list(d)[0], MyStr)
 
 
 class CAPITest(unittest.TestCase):

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1602,6 +1602,7 @@ class DictTest(unittest.TestCase):
             d.get(key2)
 
     def test_clear_at_lookup(self):
+        # gh-140551 dict crash if clear is called at lookup stage
         class X:
             def __hash__(self):
                 return 1
@@ -1622,12 +1623,30 @@ class DictTest(unittest.TestCase):
         self.assertEqual(len(d), 1)
 
     def test_split_table_update_with_str_subclass(self):
+        # gh-142218: inserting into a split table dictionary with a non str
+        # key that matches an existing key.
         class MyStr(str): pass
         class MyClass: pass
         obj = MyClass()
         obj.attr = 1
         obj.__dict__[MyStr('attr')] = 2
         self.assertEqual(obj.attr, 2)
+
+    def test_split_table_insert_with_str_subclass(self):
+        # gh-143189: inserting into split table dictionary with a non str
+        # key that matches an existing key in the shared table but not in
+        # the dict yet.
+
+        class MyStr(str): pass
+        class MyClass: pass
+
+        obj = MyClass()
+        obj.attr1 = 1
+
+        obj2 = MyClass()
+        d = obj2.__dict__
+        d[MyStr("attr1")] = 2
+        assert isinstance(list(d)[0], MyStr)
 
 
 class CAPITest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-30-06-48-48.gh-issue-143189.in_sv2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-30-06-48-48.gh-issue-143189.in_sv2.rst
@@ -1,0 +1,3 @@
+Fix crash when inserting a non-:class:`str` key into a split table
+dictionary when the key matches an existing key in the split table
+but has no corresponding value in the dict.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1877,7 +1877,7 @@ static int
 insertdict(PyDictObject *mp,
            PyObject *key, Py_hash_t hash, PyObject *value)
 {
-    PyObject *old_value;
+    PyObject *old_value = NULL;
     Py_ssize_t ix;
 
     ASSERT_DICT_LOCKED(mp);
@@ -1898,11 +1898,14 @@ insertdict(PyDictObject *mp,
             goto Fail;
     }
 
-    if (ix == DKIX_EMPTY) {
+    if (old_value == NULL) {
         // insert_combined_dict() will convert from non DICT_KEYS_GENERAL table
         // into DICT_KEYS_GENERAL table if key is not Unicode.
         // We don't convert it before _Py_dict_lookup because non-Unicode key
         // may change generic table into Unicode table.
+        //
+        // NOTE: ix may not be DKIX_EMPTY because split table may have key
+        // without value.
         if (insert_combined_dict(mp, hash, key, value) < 0) {
             goto Fail;
         }


### PR DESCRIPTION
When iserting non unicode key into split table, matching Unicode key may be in the shared split table without its value.


<!-- gh-issue-number: gh-143189 -->
* Issue: gh-143189
<!-- /gh-issue-number -->
