### PR TITLE
Update docstrings of `typing.Hashable`, `typing.List`, etc., to reflect their deprecation

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1562,9 +1562,9 @@ class _SpecialGenericAlias(_NotIterable, _BaseGenericAlias, _root=True):
         self._nparams = nparams
         self._defaults = defaults
         if origin.__module__ == 'builtins':
-            self.__doc__ = f'A generic version of {origin.__qualname__}.'
+            self.__doc__ = f'Deprecated alias to {origin.__qualname__}.'
         else:
-            self.__doc__ = f'A generic version of {origin.__module__}.{origin.__qualname__}.'
+            self.__doc__ = f'Deprecated alias to {origin.__module__}.{origin.__qualname__}.'
 
     @_tp_cache
     def __getitem__(self, params):


### PR DESCRIPTION
Currently some of the typing-module stdlib aliases have docstrings that reflect their deprecation, but others inherit a generic docstring that does not mention any deprecation (and implies that they add something over and above the stdlib class that they're aliasing):

```pycon
>>> from typing import *
>>> help(Tuple)
Help on _TupleType in module typing:

Tuple = typing.Tuple
    Deprecated alias to builtins.tuple.

    Tuple[X, Y] is the cross-product type of X and Y.

    Example: Tuple[T1, T2] is a tuple of two elements corresponding
    to type variables T1 and T2.  Tuple[int, float, str] is a tuple
    of an int, a float and a string.

    To specify a variable-length tuple of homogeneous type, use Tuple[T, ...].

>>> help(Hashable)
Help on _SpecialGenericAlias in module typing:

Hashable = typing.Hashable
    A generic version of collections.abc.Hashable.
```

This PR improves the generic fallback docstring so that it's consistent with the "manual" docstrings we give for the aliases like `Tuple` and `Callable`:

```pycon
>>> from typing import *
>>> help(Tuple)
Help on _TupleType in module typing:

Tuple = typing.Tuple
    Deprecated alias to builtins.tuple.

    Tuple[X, Y] is the cross-product type of X and Y.

    Example: Tuple[T1, T2] is a tuple of two elements corresponding
    to type variables T1 and T2.  Tuple[int, float, str] is a tuple
    of an int, a float and a string.

    To specify a variable-length tuple of homogeneous type, use Tuple[T, ...].

>>> help(Hashable)
Help on _SpecialGenericAlias in module typing:

Hashable = typing.Hashable
    Deprecated alias to collections.abc.Hashable.
```