### PR TITLE
gh-142965: Fix Concatenate documentation to reflect valid use cases

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1174,7 +1174,8 @@ These can be used as types in annotations. They all support subscription using
    or transforms parameters of another
    callable.  Usage is in the form
    ``Concatenate[Arg1Type, Arg2Type, ..., ParamSpecVariable]``. ``Concatenate``
-   is currently only valid when used as the first argument to a :ref:`Callable <annotating-callables>`.
+   is valid when used in :ref:`Callable <annotating-callables>` type hints
+   and when instantiating user-defined generic classes with :class:`ParamSpec` parameters.
    The last parameter to ``Concatenate`` must be a :class:`ParamSpec` or
    ellipsis (``...``).
 


### PR DESCRIPTION
## Summary
- Fixed incorrect documentation for `typing.Concatenate` that claimed it is only valid as the first argument to `Callable`
- Updated to reflect that `Concatenate` can also be used when instantiating user-defined generic classes with `ParamSpec` parameters, as specified in PEP 612

## Test plan
- Documentation change only, no code changes
- Verified RST syntax is correct

Fixes #142965

<!-- gh-issue-number: gh-142965 -->
* Issue: gh-142965
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143316.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->