### PR TITLE
Document missing type flags as part of Stable ABI

### DIFF
--- a/Misc/stable_abi.toml
+++ b/Misc/stable_abi.toml
@@ -1784,6 +1784,8 @@
     added = '3.2'
 [const.Py_TPFLAGS_BASETYPE]
     added = '3.2'
+[const.Py_TPFLAGS_HEAPTYPE]
+    added = '3.2'
 [const.Py_TPFLAGS_HAVE_GC]
     added = '3.2'
 [const.Py_TPFLAGS_READY]

--- a/Misc/stable_abi.toml
+++ b/Misc/stable_abi.toml
@@ -1786,6 +1786,28 @@
     added = '3.2'
 [const.Py_TPFLAGS_HAVE_GC]
     added = '3.2'
+[const.Py_TPFLAGS_READY]
+    added = '3.2'
+[const.Py_TPFLAGS_READYING]
+    added = '3.2'
+[const.Py_TPFLAGS_IS_ABSTRACT]
+    added = '3.2'
+[const.Py_TPFLAGS_LONG_SUBCLASS]
+    added = '3.2'
+[const.Py_TPFLAGS_LIST_SUBCLASS]
+    added = '3.2'
+[const.Py_TPFLAGS_TUPLE_SUBCLASS]
+    added = '3.2'
+[const.Py_TPFLAGS_BYTES_SUBCLASS]
+    added = '3.2'
+[const.Py_TPFLAGS_UNICODE_SUBCLASS]
+    added = '3.2'
+[const.Py_TPFLAGS_DICT_SUBCLASS]
+    added = '3.2'
+[const.Py_TPFLAGS_BASE_EXC_SUBCLASS]
+    added = '3.2'
+[const.Py_TPFLAGS_TYPE_SUBCLASS]
+    added = '3.2'
 
 [const.METH_VARARGS]
     added = '3.2'
@@ -2274,6 +2296,13 @@
 [function.PyGC_Enable]
     added = '3.10'
 [function.PyGC_IsEnabled]
+    added = '3.10'
+
+# New type flags in 3.10
+
+[const.Py_TPFLAGS_DISALLOW_INSTANTIATION]
+    added = '3.10'
+[const.Py_TPFLAGS_IMMUTABLETYPE]
     added = '3.10'
 
 # Add new C API in Python 3.11


### PR DESCRIPTION
The documentation is currently pretty inconsistent about listing the type flags as part of the Stable ABI. Some are listed and some aren't. I've hopefully got all the important ones.

I haven't done `_Py_TPFLAGS_MATCH_SELF` which is exposed in the Limited API but starts with an underscore.

I also haven't done things like `Py_TPFLAGS_VALID_VERSION_TAG`, `Py_TPFLAGS_HAVE_FINALIZE`, `Py_TPFLAGS_HAVE_VERSION_TAG` which are exposed in the Limited API but now don't do anything.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
