### PR TITLE
gh-143361: Pass PY_VECTORCALL_ARGUMENTS_OFFSET in _Py_CallBuiltinClass_StackRefSteal

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-02-17-11-16.gh-issue-143361.YDnvdC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-02-17-11-16.gh-issue-143361.YDnvdC.rst
@@ -1,2 +1,2 @@
-Add PY_VECTORCALL_ARGUMENTS_OFFSET to _Py_CallBuiltinClass_StackRefSteal to
+Add ``PY_VECTORCALL_ARGUMENTS_OFFSET`` to ``_Py_CallBuiltinClass_StackRefSteal`` to
 avoid redundant allocations

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-02-17-11-16.gh-issue-143361.YDnvdC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-02-17-11-16.gh-issue-143361.YDnvdC.rst
@@ -1,0 +1,2 @@
+Add PY_VECTORCALL_ARGUMENTS_OFFSET to _Py_CallBuiltinClass_StackRefSteal to
+avoid redundant allocations

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1273,7 +1273,7 @@ _Py_CallBuiltinClass_StackRefSteal(
         goto cleanup;
     }
     PyTypeObject *tp = (PyTypeObject *)PyStackRef_AsPyObjectBorrow(callable);
-    res = tp->tp_vectorcall((PyObject *)tp, args_o, total_args, NULL);
+    res = tp->tp_vectorcall((PyObject *)tp, args_o, total_args | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
     STACKREFS_TO_PYOBJECTS_CLEANUP(args_o);
     assert((res != NULL) ^ (PyErr_Occurred() != NULL));
 cleanup:


### PR DESCRIPTION
This PR fixes a missed optimization. 

The function `_Py_CallBuiltinClass_StackRefSteal` uses `STACKREFS_TO_PYOBJECTS`. However, the code was not passing the `PY_VECTORCALL_ARGUMENTS_OFFSET` flag to the callee. This forced vector-callable types to reallocate and copy the arguments whenever they needed to prepend an argument.

**Verification**
Using LLDB to inspect `long_vectorcall` when reached via this path:
- Before fix: `nargsf = 1`
- After fix: `nargsf = 0x8000000000000001` (High bit correctly set)

**Benchmarks**
I ran a small benchmark file allocating a class in a tight loop to trigger the path:

- Baseline: 1.6193s
- Optimized: 1.5560s
- Result: ~3.9% speedup in this specific specialized call path.

gh-143361

<details>
<summary>Benchmark script</summary>

```python
import time

class Worker:
    def __init__(self, a, b, c):
        self.a = a
        self.b = b
        self.c = c

def run_benchmark(iterations):
    cls = Worker
    start = time.perf_counter()
    for _ in range(iterations):
        cls(1, 2, 3)
        cls(4, 5, 6)
        cls(7, 8, 9)
        cls(10, 11, 12)
        cls(13, 14, 15)
    return time.perf_counter() - start

run_benchmark(10000) #warm it up

ITERS = 1_000_000
print(f"Time: {run_benchmark(ITERS):.4f}s")

</details>