### PR TITLE
gh-138122: Skip threads on EPERM in blocking mode profiler

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-01-02-17-26-33.gh-issue-143368.m3EF9E.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-02-17-26-33.gh-issue-143368.m3EF9E.rst
@@ -1,0 +1,3 @@
+Fix endless retry loop in :mod:`profiling.sampling` blocking mode when
+threads cannot be seized due to ``EPERM``. Such threads are now skipped
+instead of causing repeated error messages. Patch by Pablo Galindo.


### PR DESCRIPTION
When using blocking mode in the remote debugging profiler, ptrace calls
to seize threads can fail with EPERM if the thread has exited between
listing and attaching, is in a special kernel state, or is already being
traced. Previously this raised a RuntimeError that was caught by the
Python sampling loop,and retried indefinitely since EPERM is
a persistent condition that will not resolve on its own.

Treat EPERM the same as ESRCH by returning 1 (skip this thread) instead
of -1 (fatal error). This allows profiling to continue with the threads
that can be traced rather than entering an endless retry loop printing
the same error message repeatedly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138122 -->
* Issue: gh-138122
<!-- /gh-issue-number -->
