### PR TITLE
gh-142095: Use thread local frame info in `py-bt` and `py-bt-full` when available

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2026-01-02-11-44-56.gh-issue-142095.4ssgnM.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2026-01-02-11-44-56.gh-issue-142095.4ssgnM.rst
@@ -1,0 +1,2 @@
+Make gdb 'py-bt' command use frame from thread local state when available.
+Patch by Sam Gross and Victor Stinner.

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1275,8 +1275,9 @@ class PyFramePtr:
             if not interp_frame:
                 sys.stdout.write('  (unable to read python frame information)\n')
                 return None
-            elif interp_frame.is_shim():
+            if interp_frame.is_shim():
                 return interp_frame.previous()
+
             if frame_index is not None:
                 line = interp_frame.get_truncated_repr(MAX_OUTPUT_LEN)
                 sys.stdout.write('#%i %s\n' % (frame_index, line))

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1268,7 +1268,7 @@ class PyFramePtr:
                      lineno,
                      self.co_name.proxyval(visited)))
 
-    def print_traceback_until_shim(self, frame_index = None):
+    def print_traceback_until_shim(self, frame_index=None):
         # Print traceback for _PyInterpreterFrame and return previous frame
         interp_frame = self
         while True:

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1252,7 +1252,7 @@ class PyFramePtr:
                      lineno,
                      self.co_name.proxyval(visited)))
 
-    def print_traceback_until_shim(self, frame_index: int | None = None):
+    def print_traceback_until_shim(self, frame_index = None):
         # Print traceback for _PyInterpreterFrame and return previous frame
         interp_frame = self
         while True:

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -2081,8 +2081,6 @@ def print_traceback_helper(full_info):
                 if full_info:
                     if info:
                         sys.stdout.write('#%i %s\n' % (frame_index, info))
-                    else:
-                        sys.stdout.write('#%i\n' % frame_index)
                 elif info:
                     sys.stdout.write('  %s\n' % info)
             frame = frame.older()

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1043,17 +1043,18 @@ class PyFramePtr:
 
     def __init__(self, gdbval):
         self._gdbval = gdbval
+        if self.is_optimized_out():
+            return
+        self.co = self._f_code()
+        if self.is_shim():
+            return
+        self.co_name = self.co.pyop_field('co_name')
+        self.co_filename = self.co.pyop_field('co_filename')
 
-        if not self.is_optimized_out():
-            self.co = self._f_code()
-            if not self.is_shim():
-                self.co_name = self.co.pyop_field('co_name')
-                self.co_filename = self.co.pyop_field('co_filename')
-
-                self.f_lasti = self._f_lasti()
-                self.co_nlocals = int_from_int(self.co.field('co_nlocals'))
-                pnames = self.co.field('co_localsplusnames')
-                self.co_localsplusnames = PyTupleObjectPtr.from_pyobject_ptr(pnames)
+        self.f_lasti = self._f_lasti()
+        self.co_nlocals = int_from_int(self.co.field('co_nlocals'))
+        pnames = self.co.field('co_localsplusnames')
+        self.co_localsplusnames = PyTupleObjectPtr.from_pyobject_ptr(pnames)
 
     @staticmethod
     def get_thread_state():


### PR DESCRIPTION
In optimized and `-Og` builds, arguments and local variables are frequently unavailable in gdb. This makes `py-bt` fail to print anything useful. Use the `PyThreadState*` pointers `_Py_tss_gilstate` and `Py_tss_tstate` to find the interpreter frame if we can't get the frame from the `_PyEval_EvalFrameDefault` call.

<!-- gh-issue-number: gh-142095 -->
* Issue: gh-142095
<!-- /gh-issue-number -->
