### PR TITLE
gh-142968: Add type checks to token.ISTERMINAL and ISNONTERMINAL

### DIFF
--- a/Lib/test/test_token.py
+++ b/Lib/test/test_token.py
@@ -1,0 +1,17 @@
+import unittest
+import token
+
+class TokenTest(unittest.TestCase):
+    def test_terminal_validations(self):
+        # Regression test for gh-142968
+        self.assertRaises(TypeError, token.ISTERMINAL, 0.5)
+        self.assertRaises(TypeError, token.ISNONTERMINAL, 0.5)
+        self.assertRaises(TypeError, token.ISTERMINAL, "string")
+        self.assertRaises(TypeError, token.ISNONTERMINAL, "string")
+
+        # (sanity check)
+        self.assertIs(token.ISTERMINAL(1), True)
+        self.assertIs(token.ISNONTERMINAL(1), False)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/token.py
+++ b/Lib/token.py
@@ -135,9 +135,13 @@ EXACT_TOKEN_TYPES = {
 }
 
 def ISTERMINAL(x: int) -> bool:
+    if not isinstance(x,int):
+        raise TypeError(f"expected integer, got {type(x).__name__}")
     return x < NT_OFFSET
 
 def ISNONTERMINAL(x: int) -> bool:
+    if not isinstance(x,int):
+        raise TypeError(f"expected integer, got {type(x).__name__}")
     return x >= NT_OFFSET
 
 def ISEOF(x: int) -> bool:

--- a/Misc/NEWS.d/next/Library/2026-01-03-14-30-00.gh-issue-142968.manual.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-03-14-30-00.gh-issue-142968.manual.rst
@@ -1,0 +1,1 @@
+Add type checks to :func:`token.ISTERMINAL` and :func:`token.ISNONTERMINAL`.

--- a/Tools/build/generate_token.py
+++ b/Tools/build/generate_token.py
@@ -279,9 +279,13 @@ EXACT_TOKEN_TYPES = {
 }
 
 def ISTERMINAL(x: int) -> bool:
+    if not isinstance(x,int):
+        raise TypeError(f"expected integer, got {type(x).__name__}")
     return x < NT_OFFSET
 
 def ISNONTERMINAL(x: int) -> bool:
+    if not isinstance(x,int):
+        raise TypeError(f"expected integer, got {type(x).__name__}")
     return x >= NT_OFFSET
 
 def ISEOF(x: int) -> bool:


### PR DESCRIPTION
# Description

This PR fixes gh-142968 by adding explicit type checks to `token.ISTERMINAL` and `token.ISNONTERMINAL`.

Previously, these functions accepted floats (e.g., `0.5`) without error, which was inconsistent with PyPy and the expected behavior of token validation. They now raise a `TypeError` for non-integer inputs, matching the behavior described in the issue.

# Changes Made
* Modified `Tools/build/generate_token.py` to inject type checks into the generated `Lib/token.py`.
* Regenerated `Lib/token.py` using the tool.
* Added a new test file `Lib/test/test_token.py` with regression tests for these functions.

# Verification
* Validated that `token.ISTERMINAL(0.5)` now raises `TypeError`.
* Ran `python -m test -v test_token` and confirmed all tests pass.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
