### PR TITLE
gh-143401: Check for unique reference for _BINARY_OP_INPLACE_ADD_UNICODE

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-04-00-04-53.gh-issue-143401.m8lb4b.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-04-00-04-53.gh-issue-143401.m8lb4b.rst
@@ -1,0 +1,1 @@
+Fix an incorrect optimization regarding string concatenation.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -808,9 +808,9 @@ dummy_func(
             DEAD(right);
             PyStackRef_CLOSE_SPECIALIZED(left, _PyUnicode_ExactDealloc);
             DEAD(left);
+            *target_local = PyStackRef_NULL;
             ERROR_IF(temp == NULL);
             res = PyStackRef_FromPyObjectSteal(temp);
-            *target_local = PyStackRef_NULL;
         }
 
        op(_GUARD_BINARY_OP_EXTEND, (descr/4, left, right -- left, right)) {

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -4954,6 +4954,13 @@
                 SET_CURRENT_CACHED_VALUES(2);
                 JUMP_TO_JUMP_TARGET();
             }
+            if (!_PyObject_IsUniquelyReferenced(PyStackRef_AsPyObjectBorrow(*target_local))) {
+                UOP_STAT_INC(uopcode, miss);
+                _tos_cache1 = right;
+                _tos_cache0 = left;
+                SET_CURRENT_CACHED_VALUES(2);
+                JUMP_TO_JUMP_TARGET();
+            }
             STAT_INC(BINARY_OP, hit);
             assert(Py_REFCNT(left_o) >= 2 || !PyStackRef_IsHeapSafe(left));
             PyObject *temp = PyStackRef_AsPyObjectSteal(*target_local);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -4974,6 +4974,7 @@
             stack_pointer = _PyFrame_GetStackPointer(frame);
             PyStackRef_CLOSE_SPECIALIZED(right, _PyUnicode_ExactDealloc);
             PyStackRef_CLOSE_SPECIALIZED(left, _PyUnicode_ExactDealloc);
+            *target_local = PyStackRef_NULL;
             if (temp == NULL) {
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -4981,7 +4982,6 @@
                 JUMP_TO_ERROR();
             }
             res = PyStackRef_FromPyObjectSteal(temp);
-            *target_local = PyStackRef_NULL;
             _tos_cache0 = res;
             _tos_cache1 = PyStackRef_ZERO_BITS;
             _tos_cache2 = PyStackRef_ZERO_BITS;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -425,6 +425,11 @@
                     assert(_PyOpcode_Deopt[opcode] == (BINARY_OP));
                     JUMP_TO_PREDICTED(BINARY_OP);
                 }
+                if (!_PyObject_IsUniquelyReferenced(PyStackRef_AsPyObjectBorrow(*target_local))) {
+                    UPDATE_MISS_STATS(BINARY_OP);
+                    assert(_PyOpcode_Deopt[opcode] == (BINARY_OP));
+                    JUMP_TO_PREDICTED(BINARY_OP);
+                }
                 STAT_INC(BINARY_OP, hit);
                 assert(Py_REFCNT(left_o) >= 2 || !PyStackRef_IsHeapSafe(left));
                 PyObject *temp = PyStackRef_AsPyObjectSteal(*target_local);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -439,11 +439,11 @@
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 PyStackRef_CLOSE_SPECIALIZED(right, _PyUnicode_ExactDealloc);
                 PyStackRef_CLOSE_SPECIALIZED(left, _PyUnicode_ExactDealloc);
+                *target_local = PyStackRef_NULL;
                 if (temp == NULL) {
                     JUMP_TO_LABEL(pop_2_error);
                 }
                 res = PyStackRef_FromPyObjectSteal(temp);
-                *target_local = PyStackRef_NULL;
             }
             stack_pointer[-2] = res;
             stack_pointer += -1;


### PR DESCRIPTION
Fixes https://github.com/python/cpython/issues/143401

I think this only became a problem after we introduced `LOAD_FAST_BORROW`. So we should fix it.

<!-- gh-issue-number: gh-143401 -->
* Issue: gh-143401
<!-- /gh-issue-number -->
