### PR TITLE
gh-143405: Fix free-threaded build detection for Py_GIL_DISABLED

### DIFF
--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -41,7 +41,7 @@ try:
 except ImportError:
     LiveStatsCollector = None
 
-_FREE_THREADED_BUILD = sysconfig.get_config_var("Py_GIL_DISABLED") is not None
+_FREE_THREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 # Minimum number of samples required before showing the TUI
 # If fewer samples are collected, we skip the TUI and just print a message
 MIN_SAMPLES_FOR_TUI = 200


### PR DESCRIPTION
~~Fix inverted mapping between all_threads and only_active_thread in the non-free-threaded RemoteUnwinder code path.~~

~~Add a regression test to ensure the correct behavior.~~

`sysconfig.get_config_var("Py_GIL_DISABLED")` may be defined as 0 on non-free-threaded builds. The previous check used `is not None`, which incorrectly treated `Py_GIL_DISABLED=0` as a free-threaded build.

<!-- gh-issue-number: gh-143405 -->
* Issue: gh-143405
<!-- /gh-issue-number -->
