### PR TITLE
gh-143309: fix `test_execve_env_concurrent_mutation_with_fspath_posix` buildbot failure

### DIFF
--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -2627,6 +2627,8 @@ class ExecTests(unittest.TestCase):
     # See https://github.com/python/cpython/issues/137934 and the other
     # related issues for the reason why we cannot test this on Windows.
     @unittest.skipIf(os.name == "nt", "POSIX-specific test")
+    @unittest.skipUnless(unix_shell and os.path.exists(unix_shell),
+                        "requires a shell")
     def test_execve_env_concurrent_mutation_with_fspath_posix(self):
         # Prevent crash when mutating environment during parsing.
         # Regression test for https://github.com/python/cpython/issues/143309.
@@ -2648,9 +2650,9 @@ class ExecTests(unittest.TestCase):
             def keys(self): return KEYS
             def values(self): return VALUES
 
-        args = [sys.executable, '-c', "print({message!r})"]
+        args = [{unix_shell!r}, '-c', 'echo \"{message!s}\"']
         os.execve(args[0], args, MyEnv())
-        """.format(message=message)
+        """.format(unix_shell=unix_shell, message=message)
 
         # Use '__cleanenv' to signal to assert_python_ok() not
         # to do a copy of os.environ on its own.

--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -2660,8 +2660,7 @@ class ExecTests(unittest.TestCase):
         with os_helper.EnvironmentVarGuard() as env:
             env.clear()
             env.update(minimal)
-            rc, out, _ = assert_python_ok('-c', code, **env)
-        self.assertEqual(rc, 0)
+            _, out, _ = assert_python_ok('-c', code, **env)
         self.assertIn(bytes(message, "ascii"), out)
 
     @unittest.skipUnless(sys.platform == "win32", "Win32-specific test")


### PR DESCRIPTION
It doesn't matter whether I spawn Python itself or another utility. I'm not sure if the issue with builbots is the fact that Python is installed as a shared library (and thus we're lacking some LD* variables in the spawned process) or if it's something else.

<!-- gh-issue-number: gh-143309 -->
* Issue: gh-143309
<!-- /gh-issue-number -->
