### PR TITLE
gh-143423: Fix free-threaded build detection in sampling profiler

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-01-05-05-31-05.gh-issue-143423.X7YdnR.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-05-05-31-05.gh-issue-143423.X7YdnR.rst
@@ -1,0 +1,1 @@
+Fix free-threaded build detection in the sampling profiler when Py_GIL_DISABLED is set to 0.


### PR DESCRIPTION
### Description
This PR corrects a logic error in `Lib/profiling/sampling/sample.py` where `_FREE_THREADED_BUILD` was incorrectly evaluated as `True` on Windows non-free-threaded builds when `Py_GIL_DISABLED` was explicitly set to `0`.

The detection has been updated from an `is not None` check to a `bool()` cast, which correctly handles:
- `1` -> `True`
- `0` -> `False`
- `None` -> `False` (standard builds)

Additionally, I have updated `_new_unwinder` to properly handle the `all_threads` vs `only_active_thread` parameters based on the detected build type.

### Tests
- Verified reproduction by checking that `_FREE_THREADED_BUILD` returns `False` when `sysconfig.get_config_var("Py_GIL_DISABLED")` is `0`.
- Ran the official test suite: `./python -m test test_profiling` (Passed).

<!-- gh-issue-number: gh-143423 -->
* Issue: gh-143423
<!-- /gh-issue-number -->
