### PR TITLE
gh-143429: Use compile-time NaN encoding detection for test_struct

### DIFF
--- a/Lib/test/test_capi/test_float.py
+++ b/Lib/test/test_capi/test_float.py
@@ -1,6 +1,5 @@
 import math
 import random
-import platform
 import sys
 import unittest
 import warnings
@@ -215,8 +214,8 @@ class CAPIFloatTest(unittest.TestCase):
                     # PyFloat_Pack/Unpack*() API.  See also gh-130317 and
                     # e.g. https://developercommunity.visualstudio.com/t/155064
                     signaling = 0
-                    if platform.machine().startswith('parisc'):
-                        # HP PA RISC uses 0 for quiet, see:
+                    if _testcapi.nan_msb_is_signaling:
+                        # HP PA RISC and some MIPS CPUs use 0 for quiet, see:
                         # https://en.wikipedia.org/wiki/NaN#Encoding
                         signaling = 1
                 i = make_nan(size, sign, not signaling)

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -5,7 +5,6 @@ import gc
 import math
 import operator
 import unittest
-import platform
 import struct
 import sys
 import weakref

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -944,7 +944,7 @@ class UnpackIteratorTest(unittest.TestCase):
 
         # Skip NaN encoding checks for MIPS because `math.nan` changes its value
         # depending on toolchain settings. See:
-        # https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/MIPS-Options.html#index-mnan_003d2008
+        # https://gcc.gnu.org/onlinedocs/gcc/MIPS-Options.html#index-mnan_003d2008
         if not platform.machine().startswith('mips'):
             packed = struct.pack('<e', math.nan)
             self.assertEqual(packed[1] & 0x7e, expected)

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -944,7 +944,6 @@ class UnpackIteratorTest(unittest.TestCase):
 
         # Skip NaN encoding checks for MIPS because `math.nan` changes its value
         # depending on toolchain settings. See:
-        # https://en.wikipedia.org/wiki/NaN#Encoding
         # https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/MIPS-Options.html#index-mnan_003d2008
         if not platform.machine().startswith('mips'):
             packed = struct.pack('<e', math.nan)

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -22,8 +22,6 @@ byteorders = '', '@', '=', '<', '>', '!'
 INF = float('inf')
 NAN = float('nan')
 
-_testcapi = import_helper.import_module('_testcapi')
-
 def iter_integer_formats(byteorders=byteorders):
     for code in integer_codes:
         for byteorder in byteorders:
@@ -892,6 +890,7 @@ class UnpackIteratorTest(unittest.TestCase):
         self.assertRaises(StopIteration, next, it)
 
     def test_half_float(self):
+        _testcapi = import_helper.import_module('_testcapi')
         # Little-endian examples from:
         # http://en.wikipedia.org/wiki/Half_precision_floating-point_format
         format_bits_float__cleanRoundtrip_list = [
@@ -936,7 +935,7 @@ class UnpackIteratorTest(unittest.TestCase):
 
         # Check that packing produces a bit pattern representing a quiet NaN:
         # all exponent bits and the msb of the fraction should all be 1.
-        if _testcapi.nan_encoding == 'parisc':
+        if _testcapi.nan_msb_is_signaling:
             # HP PA RISC and some MIPS CPUs use 0 for quiet, see:
             # https://en.wikipedia.org/wiki/NaN#Encoding
             expected = 0x7c

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -942,10 +942,15 @@ class UnpackIteratorTest(unittest.TestCase):
         else:
             expected = 0x7e
 
-        packed = struct.pack('<e', math.nan)
-        self.assertEqual(packed[1] & 0x7e, expected)
-        packed = struct.pack('<e', -math.nan)
-        self.assertEqual(packed[1] & 0x7e, expected)
+        # Skip NaN encoding checks for MIPS because `math.nan` changes its value
+        # depending on toolchain settings. See:
+        # https://en.wikipedia.org/wiki/NaN#Encoding
+        # https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/MIPS-Options.html#index-mnan_003d2008
+        if not platform.machine().startswith('mips'):
+            packed = struct.pack('<e', math.nan)
+            self.assertEqual(packed[1] & 0x7e, expected)
+            packed = struct.pack('<e', -math.nan)
+            self.assertEqual(packed[1] & 0x7e, expected)
 
         # Checks for round-to-even behavior
         format_bits_float__rounding_list = [

--- a/Modules/_testcapi/float.c
+++ b/Modules/_testcapi/float.c
@@ -171,5 +171,9 @@ _PyTestCapi_Init_Float(PyObject *mod)
         return -1;
     }
 
-    return 0;
+#if (defined(__mips__) && !defined(__mips_nan2008)) || defined(__hppa__)
+    return PyModule_Add(mod, "nan_msb_is_signaling", PyBool_FromLong(1));
+#else
+    return PyModule_Add(mod, "nan_msb_is_signaling", PyBool_FromLong(0));
+#endif
 }

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3359,6 +3359,12 @@ _testcapi_exec(PyObject *m)
     PyModule_AddObject(m, "INT64_MAX", PyLong_FromInt64(INT64_MAX));
     PyModule_AddObject(m, "UINT64_MAX", PyLong_FromUInt64(UINT64_MAX));
 
+#if (defined(__mips__) && !defined(__mips_nan2008)) || defined(__hppa__)
+    PyModule_Add(m, "nan_encoding", PyUnicode_FromString("parisc"));
+#else
+    PyModule_Add(m, "nan_encoding", PyUnicode_FromString("regular"));
+#endif
+
     if (PyModule_AddIntMacro(m, _Py_STACK_GROWS_DOWN)) {
         return -1;
     }

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3359,12 +3359,6 @@ _testcapi_exec(PyObject *m)
     PyModule_AddObject(m, "INT64_MAX", PyLong_FromInt64(INT64_MAX));
     PyModule_AddObject(m, "UINT64_MAX", PyLong_FromUInt64(UINT64_MAX));
 
-#if (defined(__mips__) && !defined(__mips_nan2008)) || defined(__hppa__)
-    PyModule_Add(m, "nan_encoding", PyUnicode_FromString("parisc"));
-#else
-    PyModule_Add(m, "nan_encoding", PyUnicode_FromString("regular"));
-#endif
-
     if (PyModule_AddIntMacro(m, _Py_STACK_GROWS_DOWN)) {
         return -1;
     }


### PR DESCRIPTION
### Description

This PR uses C macros to detect NaN encoding schemes for Lib/test/test_struct.py, instead of detecting the host machine.

`math.nan` depends on toolchain settings for a MIPS build, as setting `-mnan=legacy` and `-mnan=2008` result in different `__builtin_nan` behavior for GCC.

### Tests

- Ran the official test suite: ./python -m test test_struct (Passed).


<!-- gh-issue-number: gh-143429 -->
* Issue: gh-143429
<!-- /gh-issue-number -->
