### PR TITLE
gh-143394: filter for turning off automatic margins in test_no_newline

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1899,12 +1899,16 @@ class TestMain(ReplTestCase):
             safe_patterns.append(r'\x1b\[\?25[hl]')  # cursor visibility
             safe_patterns.append(r'\x1b\[\?12[hl]')  # cursor blinking
 
-        # rmam - turn off automatic margins
+        # rmam / smam - automatic margins
         rmam = ti.get("rmam")
+        smam = ti.get("smam")
         if rmam:
             safe_patterns.append(re.escape(rmam.decode("ascii")))
-        else:
-            safe_patterns.append(r'\x1b\[\?7l')
+        if smam:
+            safe_patterns.append(re.escape(smam.decode("ascii")))
+        if not rmam and not smam:
+            safe_patterns.append(r'\x1b\[\?7l') # turn off automatic margins
+            safe_patterns.append(r'\x1b\[\?7h') # turn on automatic margins
 
         # Modern extensions not in standard terminfo - always use patterns
         safe_patterns.append(r'\x1b\[\?2004[hl]')  # bracketed paste mode

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1899,6 +1899,13 @@ class TestMain(ReplTestCase):
             safe_patterns.append(r'\x1b\[\?25[hl]')  # cursor visibility
             safe_patterns.append(r'\x1b\[\?12[hl]')  # cursor blinking
 
+        # rmam - turn off automatic margins
+        rmam = ti.get("rmam")
+        if rmam:
+            safe_patterns.append(re.escape(rmam.decode("ascii")))
+        else:
+            safe_patterns.append(r'\x1b\[\?7l')
+
         # Modern extensions not in standard terminfo - always use patterns
         safe_patterns.append(r'\x1b\[\?2004[hl]')  # bracketed paste mode
         safe_patterns.append(r'\x1b\[\?12[hl]')  # cursor blinking (may be separate)


### PR DESCRIPTION
@smontanaro This should fix your issue.

Sorry, I cannot test because I have no Mac.

Also, I don't know why CI and buildbots did not complain before, see

https://github.com/python/cpython/blob/68fcb958eb0c023cb895217fdf384206b09d12e8/Lib/_pyrepl/unix_console.py#L390-L391
https://github.com/python/cpython/blob/68fcb958eb0c023cb895217fdf384206b09d12e8/Lib/_pyrepl/unix_console.py#L166-L168


<!-- gh-issue-number: gh-143394 -->
* Issue: gh-143394
<!-- /gh-issue-number -->
