### PR TITLE
gh-69605: In test_pyrepl.test_already_imported*, invalidate FS import caches

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1192,6 +1192,7 @@ class TestPyReplModuleCompleter(TestCase):
                 (dir1 / mod).mkdir()
                 (dir1 / mod / "__init__.py").touch()
                 (dir1 / mod / "foo.py").touch()
+                pkgutil.get_importer(_dir1).invalidate_caches()
                 module = importlib.import_module(mod)
                 assert module.__spec__
                 if mod == "no_origin":


### PR DESCRIPTION
This makes the test robust against file systems with low timestamp resolution, which otherwise would fail to re-import in the tight loop of the test.

<!-- gh-issue-number: gh-69605 -->
* Issue: gh-69605
<!-- /gh-issue-number -->
