### PR TITLE
gh-138205: explicit mention to `mmap.mmap.resize` in "Porting to Python 3.15" notes

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1412,7 +1412,7 @@ that may require changes to your code.
   :func:`resource.setrlimit` and :func:`resource.prlimit` is now deprecated.
   (Contributed by Serhiy Storchaka in :gh:`137044`.)
 
-* :meth:`~mmap.mmap.resize` has been removed on platforms that don't support the
+* :meth:`mmap.mmap.resize` has been removed on platforms that don't support the
   underlying syscall, instead of raising a :exc:`SystemError`.
 
 * A resource warning is now emitted for an unclosed


### PR DESCRIPTION
The porting guide for 3.15 say that "`resize()` has been removed on platforms", leaving the reader to guess which module the method is in. The full name should be used.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143440.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-138205 -->
* Issue: gh-138205
<!-- /gh-issue-number -->
