### PR TITLE
[3.13] gh-143003: Fix possible shared buffer overflow in `bytearray.extend()` (GH-143086)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2025-12-23-00-13-02.gh-issue-143003.92g5qW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-12-23-00-13-02.gh-issue-143003.92g5qW.rst
@@ -1,0 +1,2 @@
+Fix an overflow of the shared empty buffer in :meth:`bytearray.extend` when
+``__length_hint__()`` returns 0 for non-empty iterator.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -1871,7 +1871,6 @@ bytearray_extend(PyByteArrayObject *self, PyObject *iterable_of_ints)
             Py_DECREF(bytearray_obj);
             return NULL;
         }
-        buf[len++] = value;
         Py_DECREF(item);
 
         if (len >= buf_size) {
@@ -1881,7 +1880,7 @@ bytearray_extend(PyByteArrayObject *self, PyObject *iterable_of_ints)
                 Py_DECREF(bytearray_obj);
                 return PyErr_NoMemory();
             }
-            addition = len >> 1;
+            addition = len ? len >> 1 : 1;
             if (addition > PY_SSIZE_T_MAX - len - 1)
                 buf_size = PY_SSIZE_T_MAX;
             else
@@ -1895,6 +1894,7 @@ bytearray_extend(PyByteArrayObject *self, PyObject *iterable_of_ints)
                have invalidated it. */
             buf = PyByteArray_AS_STRING(bytearray_obj);
         }
+        buf[len++] = value;
     }
     Py_DECREF(it);
 


### PR DESCRIPTION

When `__length_hint__()` returns 0 for non-empty iterator, the data can be written past the shared 0-terminated buffer, corrupting it. (cherry picked from commit 522563549a49d28e763635c58274a23a6055f041)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143003 -->
* Issue: gh-143003
<!-- /gh-issue-number -->
