### PR TITLE
gh-143445: Optimize deepcopy for 1.04x speedup

### DIFF
--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -230,7 +230,7 @@ def _reconstruct(x, memo, func, args,
                  *, deepcopy=deepcopy):
     deep = memo is not None
     if deep and args:
-        args = (deepcopy(arg, memo) for arg in args)
+        args = [deepcopy(arg, memo) for arg in args]
     y = func(*args)
     if deep:
         memo[id(x)] = y

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1931,6 +1931,7 @@ James Tocknell
 Bennett Todd
 R Lindsay Todd
 Eugene Toder
+Heikki Toivonen
 Erik Tollerud
 Stephen Tonkin
 Matias Torchinsky

--- a/Misc/NEWS.d/next/Library/2026-01-05-12-20-42.gh-issue-143445.rgxnbL.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-05-12-20-42.gh-issue-143445.rgxnbL.rst
@@ -1,0 +1,1 @@
+Optimize deepcopy in :mod:`copy`, pyperformance reports 1.04x speedup.

--- a/Misc/NEWS.d/next/Library/2026-01-05-12-20-42.gh-issue-143445.rgxnbL.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-05-12-20-42.gh-issue-143445.rgxnbL.rst
@@ -1,1 +1,1 @@
-Optimize deepcopy in :mod:`copy`, pyperformance reports 1.04x speedup.
+Speed up :func:`copy.deepcopy` by 1.04x.


### PR DESCRIPTION
Gains according to pyperformance:
```
deepcopy:
Mean +- std dev: 411 us +- 2 us -> 396 us +- 3 us: 1.04x faster
Significant (t=28.94)

deepcopy_reduce:
Mean +- std dev: 4.38 us +- 0.05 us -> 4.23 us +- 0.04 us: 1.04x faster
Significant (t=20.05)
```

<!-- gh-issue-number: gh-143445 -->
* Issue: gh-143445
<!-- /gh-issue-number -->
