### PR TITLE
gh-143394: On macOS, run main PyREPL tests as "Apple Terminal" as well

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -2012,6 +2012,17 @@ class TestMain(ReplTestCase):
         self.assertIn(expected_output_sequence, cleaned_output)
 
 
+@skipUnless(sys.platform == "darwin", "macOS only")
+class TestMainAppleTerminal(TestMain):
+    """Test the REPL with Apple Terminal's TERM_PROGRAM set."""
+
+    def run_repl(self, repl_input, env=None, **kwargs):
+        if env is None:
+            env = os.environ.copy()
+        env["TERM_PROGRAM"] = "Apple_Terminal"
+        return super().run_repl(repl_input, env=env, **kwargs)
+
+
 class TestPyReplCtrlD(TestCase):
     """Test Ctrl+D behavior in _pyrepl to match old pre-3.13 REPL behavior.
 


### PR DESCRIPTION
This would have prevented the issue introduced in gh-138732 by catching the missing safe escape code:

<img width="744" height="351" alt="Screenshot 2026-01-05 at 23 23 04" src="https://github.com/user-attachments/assets/d0453309-6c70-4e56-bc40-7f2593ddc38f" />


<!-- gh-issue-number: gh-143394 -->
* Issue: gh-143394
<!-- /gh-issue-number -->
