### PR TITLE
gh-143469: enable LOAD_ATTR_MODULE specialization even if `__getattr__` is defined

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-06-12-30-03.gh-issue-143469.vHVhEY.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-06-12-30-03.gh-issue-143469.vHVhEY.rst
@@ -1,0 +1,1 @@
+Enable :opcode:`!LOAD_ATTR_MODULE` specialization even if :func:`!__getattr__` is defined in module.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -365,14 +365,8 @@ specialize_module_load_attr_lock_held(PyDictObject *dict, _Py_CODEUNIT *instr, P
         SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_NON_STRING);
         return -1;
     }
-    Py_ssize_t index = _PyDict_LookupIndex(dict, &_Py_ID(__getattr__));
+    Py_ssize_t index = _PyDict_LookupIndex(dict, name);
     assert(index != DKIX_ERROR);
-    if (index != DKIX_EMPTY) {
-        SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_MODULE_ATTR_NOT_FOUND);
-        return -1;
-    }
-    index = _PyDict_LookupIndex(dict, name);
-    assert (index != DKIX_ERROR);
     if (index != (uint16_t)index) {
         SPECIALIZATION_FAIL(LOAD_ATTR,
                             index == DKIX_EMPTY ?


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143469 -->
* Issue: gh-143469
<!-- /gh-issue-number -->
