### PR TITLE
Allow Android to fail CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -691,7 +691,6 @@ jobs:
     - build-ubuntu
     - build-ubuntu-ssltests-awslc
     - build-ubuntu-ssltests-openssl
-    - build-android
     - build-ios
     - build-wasi
     - test-hypothesis
@@ -706,6 +705,7 @@ jobs:
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
       with:
         allowed-failures: >-
+          build-android,
           build-windows-msi,
           build-ubuntu-ssltests-awslc,
           build-ubuntu-ssltests-openssl,


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Temporarily allow Android CI to fail, because we're getting lots of permission errors downloading files over the network:


```
  * What went wrong:
  Execution failed for task ':app:checkDebugAarMetadata'.
  > Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
     > Could not resolve org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4.
       Required by:
           project :app > androidx.appcompat:appcompat:1.6.1 > androidx.fragment:fragment:1.3.6 > androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
           project :app > androidx.appcompat:appcompat:1.6.1 > androidx.lifecycle:lifecycle-runtime:2.6.1 > androidx.lifecycle:lifecycle-common:2.6.1
        > Could not resolve org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4.
           > Could not parse POM https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.6.4/kotlinx-coroutines-android-1.6.4.pom
              > Could not resolve org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4.
                 > Could not resolve org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4.
                    > Could not get resource 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.6.4/kotlinx-coroutines-bom-1.6.4.pom'.
                       > Could not GET 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.6.4/kotlinx-coroutines-bom-1.6.4.pom'. Received status code 403 from server: Forbidden

```
https://github.com/python/cpython/actions/runs/20746535567/job/59565172477?pr=123305