### PR TITLE
Fix a typo in STORE_SLICE docs

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -768,7 +768,7 @@ not have to be) the original ``STACK[-2]``.
       end = STACK.pop()
       start = STACK.pop()
       container = STACK.pop()
-      values = STACK.pop()
+      value = STACK.pop()
       container[start:end] = value
 
    .. versionadded:: 3.12


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143500.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->