### PR TITLE
gh-141004: Document symbol visibility macros (PyAPI_DATA, Py_EXPORTED_SYMBOL, Py_LOCAL_SYMBOL,Py_IMPORTED_SYMBOL)

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -405,7 +405,7 @@ complete listing.
    Macro used by CPython to declare a function as part of the C API.
    Its expansion depends on the platform and build configuration.
    This macro is intended for defining CPython's C API itself;
-   extension modulesshould not use it for their own symbols.
+   extension modules should not use it for their own symbols.
 
 
 .. c:macro:: PyAPI_DATA(type)

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -388,7 +388,7 @@ complete listing.
 
    Macro used to declare a symbol (function or data) as exported.
    On Windows, this expands to ``__declspec(dllexport)``.
-   On other platforms with visibility support, it
+   On compatible versions of GCC/Clang, it
    expands to ``__attribute__((visibility("default")))``.
    This macro is for defining the C API itself; extension modules should not use it.
 

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -397,7 +397,6 @@ complete listing.
 
    Macro used to declare a symbol as imported.
    On Windows, this expands to ``__declspec(dllimport)``.
-   On other platforms, it is usually empty or standard visibility.
    This macro is for defining the C API itself; extension modules should not use it.
 
 

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -410,9 +410,8 @@ complete listing.
 
 .. c:macro:: PyAPI_DATA(type)
 
-   Macro used to declare a public global variable.
-   It expands to ``extern Py_EXPORTED_SYMBOL type`` or ``extern Py_IMPORTED_SYMBOL type``
-   depending on whether the core is being built or used.
+   Macro used by CPython to declare a public global variable as part of the C API.
+   Its expansion depends on the platform and build configuration.
    This macro is intended for defining CPython's C API itself;
    extension modules should not use it for their own symbols.
 

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -376,6 +376,39 @@ complete listing.
       sizeof(array) / sizeof((array)[0])
 
 
+.. c:macro:: Py_EXPORTED_SYMBOL
+
+   Macro used to declare a symbol (function or data) as exported from a shared library.
+   On Windows, this expands to ``__declspec(dllexport)``.
+   On other platforms with visibility support, it
+   expands to ``__attribute__((visibility("default")))``. 
+
+
+.. c:macro:: Py_IMPORTED_SYMBOL
+
+   Macro used to declare a symbol as imported from a shared library.
+   On Windows, this expands to ``__declspec(dllimport)``.
+   On other platforms, it is usually empty or standard visibility.
+
+
+.. c:macro:: PyAPI_DATA(type)
+
+   Macro used to declare a public global variable.
+   It expands to ``extern Py_EXPORTED_SYMBOL type`` or ``extern Py_IMPORTED_SYMBOL type``
+   depending on whether the core is being built or used.
+
+   Example usage::
+
+      PyAPI_DATA(PyObject *) _Py_NoneStruct;  
+
+
+.. c:macro:: Py_LOCAL_SYMBOL
+
+   Macro used to declare a symbol as local to the shared library (hidden).
+   It ensures the symbol is not exported.
+   On platforms with visibility support, it
+   expands to ``__attribute__((visibility("hidden")))``. 
+                
 .. _api-objects:
 
 Objects, Types and Reference Counts

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -415,10 +415,6 @@ complete listing.
    This macro is intended for defining CPython's C API itself;
    extension modules should not use it for their own symbols.
 
-   Example usage::
-
-      PyAPI_DATA(const unsigned long) Py_Version;
-
 
 .. _api-objects:
 

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -416,7 +416,7 @@ complete listing.
 
    Example usage::
 
-      PyAPI_DATA(PyObject *) _Py_NoneStruct;
+      PyAPI_DATA(const unsigned long) Py_Version;
 
 
 .. _api-objects:

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -222,6 +222,13 @@ complete listing.
    Equivalent to :c:macro:`Py_LOCAL` but additionally requests the function
    be inlined.
 
+.. c:macro:: Py_LOCAL_SYMBOL
+
+   Macro used to declare a symbol as local to the shared library (hidden).
+   It ensures the symbol is not exported.
+   On platforms with visibility support, it
+   expands to ``__attribute__((visibility("hidden")))``.
+
 .. c:macro:: Py_MAX(x, y)
 
    Return the maximum value between ``x`` and ``y``.
@@ -378,17 +385,27 @@ complete listing.
 
 .. c:macro:: Py_EXPORTED_SYMBOL
 
-   Macro used to declare a symbol (function or data) as exported from a shared library.
+   Macro used to declare a symbol (function or data) as exported.
    On Windows, this expands to ``__declspec(dllexport)``.
    On other platforms with visibility support, it
    expands to ``__attribute__((visibility("default")))``.
+   This macro is for defining the C API itself; extension modules should not use it.
 
 
 .. c:macro:: Py_IMPORTED_SYMBOL
 
-   Macro used to declare a symbol as imported from a shared library.
+   Macro used to declare a symbol as imported.
    On Windows, this expands to ``__declspec(dllimport)``.
    On other platforms, it is usually empty or standard visibility.
+   This macro is for defining the C API itself; extension modules should not use it.
+
+
+.. c:macro:: PyAPI_FUNC(type)
+
+   Macro used by CPython to declare a function as part of the C API.
+   Its expansion depends on the platform and build configuration.
+   This macro is intended for defining CPython's C API itself;
+   extension modulesshould not use it for their own symbols.
 
 
 .. c:macro:: PyAPI_DATA(type)
@@ -400,14 +417,6 @@ complete listing.
    Example usage::
 
       PyAPI_DATA(PyObject *) _Py_NoneStruct;
-
-
-.. c:macro:: Py_LOCAL_SYMBOL
-
-   Macro used to declare a symbol as local to the shared library (hidden).
-   It ensures the symbol is not exported.
-   On platforms with visibility support, it
-   expands to ``__attribute__((visibility("hidden")))``.
 
 
 .. _api-objects:

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -225,8 +225,9 @@ complete listing.
 .. c:macro:: Py_LOCAL_SYMBOL
 
    Macro used to declare a symbol as local to the shared library (hidden).
-   It ensures the symbol is not exported.
-   On platforms with visibility support, it
+   On supported platforms, it ensures the symbol is not exported.
+
+   On compatible versions of GCC/Clang, it
    expands to ``__attribute__((visibility("hidden")))``.
 
 .. c:macro:: Py_MAX(x, y)

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -413,6 +413,8 @@ complete listing.
    Macro used to declare a public global variable.
    It expands to ``extern Py_EXPORTED_SYMBOL type`` or ``extern Py_IMPORTED_SYMBOL type``
    depending on whether the core is being built or used.
+   This macro is intended for defining CPython's C API itself;
+   extension modules should not use it for their own symbols.
 
    Example usage::
 

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -381,7 +381,7 @@ complete listing.
    Macro used to declare a symbol (function or data) as exported from a shared library.
    On Windows, this expands to ``__declspec(dllexport)``.
    On other platforms with visibility support, it
-   expands to ``__attribute__((visibility("default")))``. 
+   expands to ``__attribute__((visibility("default")))``.
 
 
 .. c:macro:: Py_IMPORTED_SYMBOL
@@ -399,7 +399,7 @@ complete listing.
 
    Example usage::
 
-      PyAPI_DATA(PyObject *) _Py_NoneStruct;  
+      PyAPI_DATA(PyObject *) _Py_NoneStruct;
 
 
 .. c:macro:: Py_LOCAL_SYMBOL
@@ -407,8 +407,9 @@ complete listing.
    Macro used to declare a symbol as local to the shared library (hidden).
    It ensures the symbol is not exported.
    On platforms with visibility support, it
-   expands to ``__attribute__((visibility("hidden")))``. 
-                
+   expands to ``__attribute__((visibility("hidden")))``.
+
+
 .. _api-objects:
 
 Objects, Types and Reference Counts

--- a/Tools/check-c-api-docs/ignored_c_api.txt
+++ b/Tools/check-c-api-docs/ignored_c_api.txt
@@ -18,11 +18,6 @@ Py_HasFileSystemDefaultEncoding
 Py_UTF8Mode
 # pyhash.h
 Py_HASH_EXTERNAL
-# exports.h
-PyAPI_DATA
-Py_EXPORTED_SYMBOL
-Py_IMPORTED_SYMBOL
-Py_LOCAL_SYMBOL
 # modsupport.h
 PyABIInfo_FREETHREADING_AGNOSTIC
 # moduleobject.h


### PR DESCRIPTION
This PR documents several symbol visibility macros that were identified as undocumented in issue #141004. These macros are defined in `Include/exports.h` and are used to control symbol visibility and linkage (dllexport/dllimport) across platforms.

Macros documented in `Doc/c-api/intro.rst`:
- `Py_EXPORTED_SYMBOL`
- `Py_IMPORTED_SYMBOL`
- `Py_LOCAL_SYMBOL`
- `PyAPI_DATA`

<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143508.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->