### PR TITLE
[3.13] gh-142991: Fix socketmodule.c build: remove _Py_FALLTHROUGH

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2652,7 +2652,6 @@ getsockaddrlen(PySocketSockObject *s, socklen_t *len_ret)
 #ifdef AF_DIVERT
     case AF_DIVERT:
         /* FreeBSD divert(4) sockets use sockaddr_in: fall-through */
-       _Py_FALLTHROUGH;
 #endif /* AF_DIVERT */
 
     case AF_INET:


### PR DESCRIPTION
Fix commit 7f936694dbc0dc0dbb07d98fa668776c4e4ca595 backport which uses _Py_FALLTHROUGH: this macro only exists in Python 3.14 and newer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142991 -->
* Issue: gh-142991
<!-- /gh-issue-number -->
