### PR TITLE
gh-143517: Fix an edge case in rewriting stringified starred annotations

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -1096,7 +1096,7 @@ def _rewrite_star_unpack(arg):
     """If the given argument annotation expression is a star unpack e.g. `'*Ts'`
        rewrite it to a valid expression.
        """
-    if arg.startswith("*"):
+    if arg.lstrip().startswith("*"):
         return f"({arg},)[0]"  # E.g. (*Ts,)[0] or (*tuple[int, int],)[0]
     else:
         return arg

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -885,6 +885,9 @@ class TestGetAnnotations(unittest.TestCase):
         def f(*args: "*tuple[int, ...]"): ...
         self.assertEqual(get_annotations(f, eval_str=True),
                          {'args': (*tuple[int, ...],)[0]})
+        def f(*args: " *tuple[int, ...]"): ...
+        self.assertEqual(get_annotations(f, eval_str=True),
+                         {'args': (*tuple[int, ...],)[0]})
 
 
     def test_stringized_annotations_on_wrapper(self):

--- a/Misc/NEWS.d/next/Library/2026-01-07-15-49-06.gh-issue-143517.FP5KgL.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-07-15-49-06.gh-issue-143517.FP5KgL.rst
@@ -1,0 +1,4 @@
+:func:`annotationlib.get_annotations` no longer raises a :exc:`SyntaxError`
+when evaluating a stringified starred annotation that starts with one
+or more whitespace characters followed by a ``*``.
+Patch by Bartosz Sławecki.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143517 -->
* Issue: gh-143517
<!-- /gh-issue-number -->
