### PR TITLE
[3.13] gh-138568: Make `help` mode in PyREPL not exit on empty line input (GH-143512)

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2028,10 +2028,11 @@ has the same effect as typing a particular string at the help> prompt.
         while True:
             try:
                 request = self.getline('help> ')
-                if not request: break
             except (KeyboardInterrupt, EOFError):
                 break
             request = request.strip()
+            if not request:
+                continue  # back to the prompt
 
             # Make sure significant trailing quoting marks of literals don't
             # get deleted while cleaning input

--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -2175,9 +2175,46 @@ class PydocUrlHandlerTest(PydocBaseTest):
 
 
 class TestHelper(unittest.TestCase):
+    def mock_interactive_session(self, inputs):
+        """
+        Given a list of inputs, run an interactive help session.  Returns a string
+        of what would be shown on screen.
+        """
+        input_iter = iter(inputs)
+
+        def mock_getline(prompt):
+            output.write(prompt)
+            next_input = next(input_iter)
+            output.write(next_input + os.linesep)
+            return next_input
+
+        with captured_stdout() as output:
+            helper = pydoc.Helper(output=output)
+            with unittest.mock.patch.object(helper, "getline", mock_getline):
+                helper.interact()
+
+        # handle different line endings across platforms consistently
+        return output.getvalue().strip().splitlines(keepends=False)
+
     def test_keywords(self):
         self.assertEqual(sorted(pydoc.Helper.keywords),
                          sorted(keyword.kwlist))
+
+    def test_interact_empty_line_continues(self):
+        # gh-138568: test pressing Enter without input should continue in help session
+        self.assertEqual(
+            self.mock_interactive_session(["", "    ", "quit"]),
+            ["help> ", "help>     ", "help> quit"],
+        )
+
+    def test_interact_quit_commands_exit(self):
+        quit_commands = ["quit", "q", "exit"]
+        for quit_cmd in quit_commands:
+            with self.subTest(quit_command=quit_cmd):
+                self.assertEqual(
+                    self.mock_interactive_session([quit_cmd]),
+                    [f"help> {quit_cmd}"],
+                )
 
 
 class PydocWithMetaClasses(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2025-09-06-08-29-08.gh-issue-138568.iZlalC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-09-06-08-29-08.gh-issue-138568.iZlalC.rst
@@ -1,0 +1,2 @@
+Adjusted the built-in :func:`help` function so that empty inputs are ignored in
+interactive mode.


### PR DESCRIPTION
(cherry picked from commit b3e4a3462f6011cacdfc58c565c69e4d7de6b9cd)

<!-- gh-issue-number: gh-138568 -->
* Issue: gh-138568
<!-- /gh-issue-number -->
