### PR TITLE
gh-143513: Clarify changed argument name of ResourceReader.is_resource()

### DIFF
--- a/Doc/library/importlib.resources.abc.rst
+++ b/Doc/library/importlib.resources.abc.rst
@@ -63,11 +63,14 @@
        If the resource does not concretely exist on the file system,
        raise :exc:`FileNotFoundError`.
 
-    .. method:: is_resource(name)
+    .. method:: is_resource(path)
        :abstractmethod:
 
-       Returns ``True`` if the named *name* is considered a resource.
-       :exc:`FileNotFoundError` is raised if *name* does not exist.
+       Returns ``True`` if the named *path* is considered a resource.
+       :exc:`FileNotFoundError` is raised if *path* does not exist.
+
+       .. versionchanged:: 3.10
+          The argument *name* was renamed to *path*.
 
     .. method:: contents()
        :abstractmethod:


### PR DESCRIPTION
refs #143513

<!-- gh-issue-number: gh-143513 -->
* Issue: gh-143513
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143523.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->