### PR TITLE
gh-129824: Fix data race on runtime->gilstate.check_enabled

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2435,7 +2435,7 @@ new_interpreter(PyThreadState **tstate_p,
 
     /* Issue #10915, #15751: The GIL API doesn't work with multiple
        interpreters: disable PyGILState_Check(). */
-    runtime->gilstate.check_enabled = 0;
+    _Py_atomic_store_int_relaxed(&runtime->gilstate.check_enabled, 0);
 
     // XXX Might new_interpreter() have been called without the GIL held?
     PyThreadState *save_tstate = _PyThreadState_GET();

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2832,7 +2832,7 @@ int
 PyGILState_Check(void)
 {
     _PyRuntimeState *runtime = &_PyRuntime;
-    if (!runtime->gilstate.check_enabled) {
+    if (!_Py_atomic_load_int_relaxed(&runtime->gilstate.check_enabled)) {
         return 1;
     }
 


### PR DESCRIPTION
The new_interpreter() function can be called concurrently.


<!-- gh-issue-number: gh-129824 -->
* Issue: gh-129824
<!-- /gh-issue-number -->
