### PR TITLE
gh-143545: Fix UAF in lsprof via re-entrant external timer

### DIFF
--- a/Lib/test/test_lsprof_uaf.py
+++ b/Lib/test/test_lsprof_uaf.py
@@ -1,0 +1,37 @@
+"""Test for gh-143545: UAF in lsprof via re-entrant external timer."""
+import unittest
+import cProfile
+
+
+class ReentrantTimerTest(unittest.TestCase):
+    """Test that profiler handles re-entrant timer correctly."""
+
+    def test_reentrant_timer_index(self):
+        """Clearing profiler during timer.__index__ should not crash."""
+
+        class Timer:
+            def __init__(self, profiler):
+                self.profiler = profiler
+
+            def __call__(self):
+                return self
+
+            def __index__(self):
+                self.profiler.clear()
+                return 0
+
+        prof = cProfile.Profile()
+        prof.timer = Timer(prof)
+
+        def victim():
+            pass
+
+        # Should not crash with use-after-free
+        try:
+            prof._pystart_callback(victim.__code__, 0)
+        except (RuntimeError, ValueError):
+            pass  # Expected if we block the operation
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Misc/NEWS.d/next/Security/2026-01-08-08-05-23.gh-issue-143545.qruuXH.rst
+++ b/Misc/NEWS.d/next/Security/2026-01-08-08-05-23.gh-issue-143545.qruuXH.rst
@@ -1,0 +1,1 @@
+Fix use-after-free in :mod:`cProfile` when external timer's ``__index__`` method clears the profiler during callback.

--- a/Misc/NEWS.d/next/Security/2026-01-08-08-05-23.gh-issue-143545.qruuXH.rst
+++ b/Misc/NEWS.d/next/Security/2026-01-08-08-05-23.gh-issue-143545.qruuXH.rst
@@ -1,1 +1,1 @@
-Fix use-after-free in :mod:`cProfile` when external timer's ``__index__`` method clears the profiler during callback.
+Fix use-after-free in the ``_lsprof`` module when external timer's ``__index__`` method clears the profiler during callback.

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -326,7 +326,7 @@ initContext(ProfilerObject *pObj, ProfilerContext *self, ProfilerEntry *entry)
         if (subentry)
             ++subentry->recursionLevel;
     }
-     pObj->inCallback = 1;   
+     pObj->inCallback = 1;
  self->t0 = call_timer(pObj);
 pObj->inCallback = 0;
 }


### PR DESCRIPTION
Fix use-after-free in `_lsprof` module when external timer's `__index__` method clears the profiler during callback.

## Problem

`prof._pystart_callback` installs a new `ProfilerContext` and calls the external timer. If the timer's `__index__` clears the profiler, it frees `currentProfilerContext` while `initContext` or `Stop` still writes to it, causing heap-use-after-free.

## Solution

Added `inCallback` flag to `ProfilerObject` to prevent `clearEntries` from freeing memory while timer callback is executing.

## Changes

- Added `int inCallback` field to `ProfilerObject` struct
- Set flag before/after `call_timer()` in `initContext` and `Stop`
- Check flag at start of `clearEntries` to prevent freeing during callback
- Added test case `test_lsprof_uaf.py`

Closes #143545

<!-- gh-issue-number: gh-143545 -->
* Issue: gh-143545
<!-- /gh-issue-number -->
