### PR TITLE
Add Emscripten test skips for recently added tests.

### DIFF
--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -41,7 +41,7 @@ try:
 except ImportError:
     LiveStatsCollector = None
 
-_FREE_THREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+_FREE_THREADED_BUILD = sysconfig.get_config_var("Py_GIL_DISABLED") is not None
 # Minimum number of samples required before showing the TUI
 # If fewer samples are collected, we skip the TUI and just print a message
 MIN_SAMPLES_FOR_TUI = 200

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -41,7 +41,7 @@ try:
 except ImportError:
     LiveStatsCollector = None
 
-_FREE_THREADED_BUILD = sysconfig.get_config_var("Py_GIL_DISABLED") is not None
+_FREE_THREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 # Minimum number of samples required before showing the TUI
 # If fewer samples are collected, we skip the TUI and just print a message
 MIN_SAMPLES_FOR_TUI = 200

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -1,8 +1,6 @@
 # Python test set -- part 1, grammar.
 # This just tests whether the parser accepts them all.
 
-from test.support import check_syntax_error, skip_wasi_stack_overflow
-from test.support import import_helper
 import annotationlib
 import inspect
 import unittest
@@ -18,6 +16,12 @@ import test.typinganndata.ann_module as ann_module
 import typing
 from test.typinganndata import ann_module2
 import test
+from test.support import (
+    check_syntax_error,
+    import_helper,
+    skip_emscripten_stack_overflow,
+    skip_wasi_stack_overflow,
+)
 from test.support.numbers import (
     VALID_UNDERSCORE_LITERALS,
     INVALID_UNDERSCORE_LITERALS,
@@ -250,6 +254,7 @@ the \'lazy\' dog.\n\
             self.assertIn("was never closed", str(cm.exception))
 
     @skip_wasi_stack_overflow()
+    @skip_emscripten_stack_overflow()
     def test_max_level(self):
         # Macro defined in Parser/lexer/state.h
         MAXLEVEL = 200

--- a/Lib/test/test_profiling/test_sampling_profiler/test_cli.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_cli.py
@@ -714,6 +714,7 @@ class TestSampleProfilerCLI(unittest.TestCase):
             with self.assertRaisesRegex(SamplingModuleNotFoundError, "Module '[\\w/.]+' not found."):
                 main()
 
+    @unittest.skipIf(is_emscripten, "subprocess not available")
     def test_cli_attach_nonexistent_pid(self):
         fake_pid = "99999"
         with mock.patch("sys.argv", ["profiling.sampling.cli", "attach", fake_pid]):

--- a/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
@@ -7,6 +7,8 @@ import os
 import tempfile
 import unittest
 
+from test.support import is_emscripten
+
 try:
     import _remote_debugging  # noqa: F401
     from profiling.sampling.pstats_collector import PstatsCollector
@@ -599,6 +601,7 @@ class TestSampleProfilerComponents(unittest.TestCase):
         self.assertGreater(stack_table["length"], 0)
         self.assertGreater(len(stack_table["frame"]), 0)
 
+    @unittest.skipIf(is_emscripten, "threads not available")
     def test_gecko_collector_export(self):
         """Test Gecko profile export functionality."""
         gecko_out = tempfile.NamedTemporaryFile(suffix=".json", delete=False)


### PR DESCRIPTION
Some minor changes to some tests that recently started failing on Emscripten:

* Tests from #139485 that can't run on Emscripten because of the lack of threads
* ~~A tweak to how free-threading is detected in the profiler tests, matching other usages (because an environment variable value of `Py_GIL_DISABLED=0` shouldn't be interpreted as "GIL disabled")~~ Not sure what is going on with this one, but it caused all the Windows and Ubuntu tests to fail.
* A test that now fails as a result of a change made by #130396

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
