### PR TITLE
gh-65784: Add support for parametrized resource wantobjects in regrtests

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -134,6 +134,9 @@ resources to test.  Currently only the following are defined:
                 and 3.9 to test backwards compatibility. These tests
                 may take very long to complete.
 
+    wantobjects -    Allows to run Tkinter tests with the specified value of
+                     tkinter.wantobjects.
+
 To enable all resources except one, use '-uall,-<resource>'.  For
 example, to run all the tests except for the gui tests, give the
 option '-uall,-gui'.

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -41,7 +41,7 @@ ALL_RESOURCES = ('audio', 'console', 'curses', 'largefile', 'network',
 # - tzdata: while needed to validate fully test_datetime, it makes
 #   test_datetime too slow (15-20 min on some buildbots) and so is disabled by
 #   default (see bpo-30822).
-RESOURCE_NAMES = ALL_RESOURCES + ('extralargefile', 'tzdata', 'xpickle')
+RESOURCE_NAMES = ALL_RESOURCES + ('extralargefile', 'tzdata', 'xpickle', 'wantobjects')
 
 
 # Types for types hints

--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -817,6 +817,10 @@ class BigmemTclTest(unittest.TestCase):
 
 
 def setUpModule():
+    wantobjects = support.get_resource_value('wantobjects')
+    if wantobjects is not None:
+        unittest.enterModuleContext(
+            support.swap_attr(tkinter, 'wantobjects', int(wantobjects)))
     if support.verbose:
         tcl = Tcl()
         print('patchlevel =', tcl.call('info', 'patchlevel'), flush=True)

--- a/Lib/test/test_tkinter/__init__.py
+++ b/Lib/test/test_tkinter/__init__.py
@@ -22,3 +22,9 @@ requires('gui')
 
 def load_tests(*args):
     return load_package_tests(os.path.dirname(__file__), *args)
+
+def setUpModule():
+    wantobjects = support.get_resource_value('wantobjects')
+    if wantobjects is not None:
+        unittest.enterModuleContext(
+            support.swap_attr(tkinter, 'wantobjects', int(wantobjects)))

--- a/Lib/test/test_tkinter/support.py
+++ b/Lib/test/test_tkinter/support.py
@@ -1,5 +1,14 @@
 import functools
 import tkinter
+import unittest
+from test import support
+
+
+def setUpModule():
+    wantobjects = support.get_resource_value('wantobjects')
+    if wantobjects is not None:
+        unittest.enterModuleContext(
+            support.swap_attr(tkinter, 'wantobjects', int(wantobjects)))
 
 class AbstractTkTest:
 
@@ -10,6 +19,8 @@ class AbstractTkTest:
         tkinter.NoDefaultRoot()
         cls.root = tkinter.Tk()
         cls.wantobjects = cls.root.wantobjects()
+        if support.is_resource_enabled('wantobjects'):
+            assert cls.wantobjects == int(support.get_resource_value('wantobjects'))
         # De-maximize main window.
         # Some window managers can maximize new windows.
         cls.root.wm_state('normal')

--- a/Lib/test/test_tkinter/test_colorchooser.py
+++ b/Lib/test/test_tkinter/test_colorchooser.py
@@ -1,7 +1,7 @@
 import unittest
 import tkinter
 from test.support import requires, swap_attr
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import AbstractDefaultRootTest, AbstractTkTest
 from tkinter import colorchooser
 from tkinter.colorchooser import askcolor

--- a/Lib/test/test_tkinter/test_colorchooser.py
+++ b/Lib/test/test_tkinter/test_colorchooser.py
@@ -1,6 +1,7 @@
 import unittest
 import tkinter
 from test.support import requires, swap_attr
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import AbstractDefaultRootTest, AbstractTkTest
 from tkinter import colorchooser
 from tkinter.colorchooser import askcolor

--- a/Lib/test/test_tkinter/test_font.py
+++ b/Lib/test/test_tkinter/test_font.py
@@ -3,6 +3,7 @@ import unittest
 import tkinter
 from tkinter import font
 from test.support import requires, gc_collect, ALWAYS_EQ
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import AbstractTkTest, AbstractDefaultRootTest
 
 requires('gui')

--- a/Lib/test/test_tkinter/test_font.py
+++ b/Lib/test/test_tkinter/test_font.py
@@ -3,7 +3,7 @@ import unittest
 import tkinter
 from tkinter import font
 from test.support import requires, gc_collect, ALWAYS_EQ
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import AbstractTkTest, AbstractDefaultRootTest
 
 requires('gui')

--- a/Lib/test/test_tkinter/test_geometry_managers.py
+++ b/Lib/test/test_tkinter/test_geometry_managers.py
@@ -4,7 +4,7 @@ import tkinter
 from tkinter import TclError
 from test.support import requires
 
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import pixels_conv
 from test.test_tkinter.widget_tests import AbstractWidgetTest
 

--- a/Lib/test/test_tkinter/test_geometry_managers.py
+++ b/Lib/test/test_tkinter/test_geometry_managers.py
@@ -4,6 +4,7 @@ import tkinter
 from tkinter import TclError
 from test.support import requires
 
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import pixels_conv
 from test.test_tkinter.widget_tests import AbstractWidgetTest
 

--- a/Lib/test/test_tkinter/test_images.py
+++ b/Lib/test/test_tkinter/test_images.py
@@ -3,7 +3,7 @@ import unittest
 import tkinter
 from test import support
 from test.support import os_helper
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import AbstractTkTest, AbstractDefaultRootTest, requires_tk
 
 support.requires('gui')

--- a/Lib/test/test_tkinter/test_images.py
+++ b/Lib/test/test_tkinter/test_images.py
@@ -3,6 +3,7 @@ import unittest
 import tkinter
 from test import support
 from test.support import os_helper
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import AbstractTkTest, AbstractDefaultRootTest, requires_tk
 
 support.requires('gui')

--- a/Lib/test/test_tkinter/test_loadtk.py
+++ b/Lib/test/test_tkinter/test_loadtk.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 import test.support as test_support
 from test.support import os_helper
+from test.test_tkinter.support import setUpModule
 from tkinter import Tcl, TclError
 
 test_support.requires('gui')

--- a/Lib/test/test_tkinter/test_loadtk.py
+++ b/Lib/test/test_tkinter/test_loadtk.py
@@ -3,7 +3,7 @@ import sys
 import unittest
 import test.support as test_support
 from test.support import os_helper
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from tkinter import Tcl, TclError
 
 test_support.requires('gui')

--- a/Lib/test/test_tkinter/test_messagebox.py
+++ b/Lib/test/test_tkinter/test_messagebox.py
@@ -1,6 +1,7 @@
 import unittest
 import tkinter
 from test.support import requires, swap_attr
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import AbstractDefaultRootTest
 from tkinter.commondialog import Dialog
 from tkinter.messagebox import showinfo

--- a/Lib/test/test_tkinter/test_messagebox.py
+++ b/Lib/test/test_tkinter/test_messagebox.py
@@ -1,7 +1,7 @@
 import unittest
 import tkinter
 from test.support import requires, swap_attr
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import AbstractDefaultRootTest
 from tkinter.commondialog import Dialog
 from tkinter.messagebox import showinfo

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -5,6 +5,7 @@ import tkinter
 from tkinter import TclError
 import enum
 from test import support
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import (AbstractTkTest, AbstractDefaultRootTest,
                                        requires_tk, get_tk_patchlevel)
 

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -5,7 +5,7 @@ import tkinter
 from tkinter import TclError
 import enum
 from test import support
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import (AbstractTkTest, AbstractDefaultRootTest,
                                        requires_tk, get_tk_patchlevel)
 

--- a/Lib/test/test_tkinter/test_simpledialog.py
+++ b/Lib/test/test_tkinter/test_simpledialog.py
@@ -1,6 +1,7 @@
 import unittest
 import tkinter
 from test.support import requires, swap_attr
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import AbstractDefaultRootTest
 from tkinter.simpledialog import Dialog, askinteger
 

--- a/Lib/test/test_tkinter/test_simpledialog.py
+++ b/Lib/test/test_tkinter/test_simpledialog.py
@@ -1,7 +1,7 @@
 import unittest
 import tkinter
 from test.support import requires, swap_attr
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import AbstractDefaultRootTest
 from tkinter.simpledialog import Dialog, askinteger
 

--- a/Lib/test/test_tkinter/test_text.py
+++ b/Lib/test/test_tkinter/test_text.py
@@ -1,7 +1,7 @@
 import unittest
 import tkinter
 from test.support import requires
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import AbstractTkTest
 
 requires('gui')

--- a/Lib/test/test_tkinter/test_text.py
+++ b/Lib/test/test_tkinter/test_text.py
@@ -1,6 +1,7 @@
 import unittest
 import tkinter
 from test.support import requires
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import AbstractTkTest
 
 requires('gui')

--- a/Lib/test/test_tkinter/test_variables.py
+++ b/Lib/test/test_tkinter/test_variables.py
@@ -6,6 +6,7 @@ import tkinter
 from tkinter import (Variable, StringVar, IntVar, DoubleVar, BooleanVar, Tcl,
                      TclError)
 from test.support import ALWAYS_EQ
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import AbstractDefaultRootTest, tcl_version
 
 

--- a/Lib/test/test_tkinter/test_variables.py
+++ b/Lib/test/test_tkinter/test_variables.py
@@ -6,7 +6,7 @@ import tkinter
 from tkinter import (Variable, StringVar, IntVar, DoubleVar, BooleanVar, Tcl,
                      TclError)
 from test.support import ALWAYS_EQ
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import AbstractDefaultRootTest, tcl_version
 
 

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -4,7 +4,7 @@ from tkinter import TclError
 import os
 from test.support import requires
 
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import (requires_tk, tk_version,
                                   get_tk_patchlevel, widget_eq,
                                   AbstractDefaultRootTest)

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -4,6 +4,7 @@ from tkinter import TclError
 import os
 from test.support import requires
 
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import (requires_tk, tk_version,
                                   get_tk_patchlevel, widget_eq,
                                   AbstractDefaultRootTest)

--- a/Lib/test/test_ttk/__init__.py
+++ b/Lib/test/test_ttk/__init__.py
@@ -30,6 +30,10 @@ class TestModule(unittest.TestCase):
 
 
 def setUpModule():
+    wantobjects = support.get_resource_value('wantobjects')
+    if wantobjects is not None:
+        unittest.enterModuleContext(
+            support.swap_attr(tkinter, 'wantobjects', int(wantobjects)))
     root = None
     try:
         root = tkinter.Tk()

--- a/Lib/test/test_ttk/test_extensions.py
+++ b/Lib/test/test_ttk/test_extensions.py
@@ -3,7 +3,7 @@ import unittest
 import tkinter
 from tkinter import ttk
 from test.support import requires, gc_collect
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import AbstractTkTest, AbstractDefaultRootTest
 
 requires('gui')

--- a/Lib/test/test_ttk/test_extensions.py
+++ b/Lib/test/test_ttk/test_extensions.py
@@ -3,6 +3,7 @@ import unittest
 import tkinter
 from tkinter import ttk
 from test.support import requires, gc_collect
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import AbstractTkTest, AbstractDefaultRootTest
 
 requires('gui')

--- a/Lib/test/test_ttk/test_style.py
+++ b/Lib/test/test_ttk/test_style.py
@@ -5,7 +5,7 @@ from tkinter import ttk
 from tkinter import TclError
 from test import support
 from test.support import requires
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import AbstractTkTest, get_tk_patchlevel
 
 requires('gui')

--- a/Lib/test/test_ttk/test_style.py
+++ b/Lib/test/test_ttk/test_style.py
@@ -5,6 +5,7 @@ from tkinter import ttk
 from tkinter import TclError
 from test import support
 from test.support import requires
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import AbstractTkTest, get_tk_patchlevel
 
 requires('gui')

--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -5,7 +5,7 @@ from test.support import requires, gc_collect
 import sys
 
 from test.test_ttk_textonly import MockTclObj
-from test.test_tkinter.support import setUpModule
+from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import (
     AbstractTkTest, requires_tk, tk_version, get_tk_patchlevel,
     simulate_mouse_click, AbstractDefaultRootTest)

--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -5,6 +5,7 @@ from test.support import requires, gc_collect
 import sys
 
 from test.test_ttk_textonly import MockTclObj
+from test.test_tkinter.support import setUpModule
 from test.test_tkinter.support import (
     AbstractTkTest, requires_tk, tk_version, get_tk_patchlevel,
     simulate_mouse_click, AbstractDefaultRootTest)

--- a/Misc/NEWS.d/next/Tests/2026-01-08-16-56-59.gh-issue-65784.aKNo1U.rst
+++ b/Misc/NEWS.d/next/Tests/2026-01-08-16-56-59.gh-issue-65784.aKNo1U.rst
@@ -1,0 +1,3 @@
+Add support for parametrized resource ``wantobjects`` in regrtests,
+which allows to run Tkinter tests with the specified value of
+:data:`!tkinter.wantobjects`, for example ``-u wantobjects=0``.


### PR DESCRIPTION
This allows to run Tkinter tests with the specified value of tkinter.wantobjects, for example "-u wantobjects=0".


<!-- gh-issue-number: gh-65784 -->
* Issue: gh-65784
<!-- /gh-issue-number -->
