### PR TITLE
gh-127750: Fix annotations in singledispatchmethod signature tests

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3448,44 +3448,39 @@ class TestSingleDispatch(unittest.TestCase):
 
     def test_method_signatures(self):
         class A:
-            def m(self, item: int, arg) -> str:
-                return str(item)
-            @classmethod
-            def cm(cls, item: int, arg) -> str:
-                return str(item)
             @functools.singledispatchmethod
-            def func(self, item: int, arg) -> str:
+            def func(self, item, arg: int) -> str:
                 return str(item)
             @func.register
-            def _(self, item: bytes, arg) -> str:
+            def _(self, item: int, arg: bytes) -> str:
                 return str(item)
 
             @functools.singledispatchmethod
             @classmethod
-            def cls_func(cls, item: int, arg) -> str:
+            def cls_func(cls, item, arg: int) -> str:
                 return str(arg)
             @func.register
             @classmethod
-            def _(cls, item: bytes, arg) -> str:
+            def _(cls, item: int, arg: bytes) -> str:
                 return str(item)
 
             @functools.singledispatchmethod
             @staticmethod
-            def static_func(item: int, arg) -> str:
+            def static_func(item, arg: int) -> str:
                 return str(arg)
             @func.register
             @staticmethod
-            def _(item: bytes, arg) -> str:
+            def _(item: int, arg: bytes) -> str:
                 return str(item)
 
         self.assertEqual(str(Signature.from_callable(A.func)),
-                         '(self, item: int, arg) -> str')
+                         '(self, item, arg: int) -> str')
         self.assertEqual(str(Signature.from_callable(A().func)),
-                         '(self, item: int, arg) -> str')
+                         '(self, item, arg: int) -> str')
         self.assertEqual(str(Signature.from_callable(A.cls_func)),
-                         '(cls, item: int, arg) -> str')
+                         '(cls, item, arg: int) -> str')
         self.assertEqual(str(Signature.from_callable(A.static_func)),
-                         '(item: int, arg) -> str')
+                         '(item, arg: int) -> str')
 
     def test_method_non_descriptor(self):
         class Callable:

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3448,44 +3448,44 @@ class TestSingleDispatch(unittest.TestCase):
 
     def test_method_signatures(self):
         class A:
-            def m(self, item, arg: int) -> str:
+            def m(self, item: int, arg) -> str:
                 return str(item)
             @classmethod
-            def cm(cls, item, arg: int) -> str:
+            def cm(cls, item: int, arg) -> str:
                 return str(item)
             @functools.singledispatchmethod
-            def func(self, item, arg: int) -> str:
+            def func(self, item: int, arg) -> str:
                 return str(item)
             @func.register
-            def _(self, item, arg: bytes) -> str:
+            def _(self, item: bytes, arg) -> str:
                 return str(item)
 
             @functools.singledispatchmethod
             @classmethod
-            def cls_func(cls, item, arg: int) -> str:
+            def cls_func(cls, item: int, arg) -> str:
                 return str(arg)
             @func.register
             @classmethod
-            def _(cls, item, arg: bytes) -> str:
+            def _(cls, item: bytes, arg) -> str:
                 return str(item)
 
             @functools.singledispatchmethod
             @staticmethod
-            def static_func(item, arg: int) -> str:
+            def static_func(item: int, arg) -> str:
                 return str(arg)
             @func.register
             @staticmethod
-            def _(item, arg: bytes) -> str:
+            def _(item: bytes, arg) -> str:
                 return str(item)
 
         self.assertEqual(str(Signature.from_callable(A.func)),
-                         '(self, item, arg: int) -> str')
+                         '(self, item: int, arg) -> str')
         self.assertEqual(str(Signature.from_callable(A().func)),
-                         '(self, item, arg: int) -> str')
+                         '(self, item: int, arg) -> str')
         self.assertEqual(str(Signature.from_callable(A.cls_func)),
-                         '(cls, item, arg: int) -> str')
+                         '(cls, item: int, arg) -> str')
         self.assertEqual(str(Signature.from_callable(A.static_func)),
-                         '(item, arg: int) -> str')
+                         '(item: int, arg) -> str')
 
     def test_method_non_descriptor(self):
         class Callable:


### PR DESCRIPTION
Follow-up to gh-130309.
See https://github.com/python/cpython/pull/130309/changes#r2663516538.

<details>

These functions don't annotate parameters for values used in single-dispatching (`item`), they annotate parameters one later (`arg`).

This being legal relies on a bug -- GH-84644, which is that `singledispatch` doesn't verify the annotation is on the "first" parameter.

In practice, it doesn't matter how you annotate `func` here, because it's a default callback. But what matters is that any function passed to `register()` annotates the target parameter (always first positional in `singledispatch` and always second positional in `singledispatchmethod` (unless staticmethod, then the first) etc.) for the value to single-dispatch on; not some other, unrelated parameter (or return type, as presented in GH-84644).

Let's have a class with the same registree signature as these from the test:

```py
class A:
    @functools.singledispatchmethod
    def func(self, item, arg: int) -> str:
        return 'argint'
    @func.register
    def _(self, item, arg: bytes) -> str:
        return 'argbytes'

a = A()
print(a.func(b'', 1))
```

For this code, the output would be `argbytes`, even though `arg` is an integer `1`.

</details>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127750 -->
* Issue: gh-127750
<!-- /gh-issue-number -->
