### PR TITLE
gh-141004: GHA: Run `check-c-api-docs` check on docs-only PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,22 +144,12 @@ jobs:
         run: make check-c-globals
 
   check-c-api-docs:
-    name: 'Check if all C APIs are documented'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    name: C API Docs
     needs: build-context
     if: >-
       needs.build-context.outputs.run-tests == 'true'
       || needs.build-context.outputs.run-docs == 'true'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Check for undocumented C APIs
-        run: python Tools/check-c-api-docs/main.py
+    uses: ./.github/workflows/reusable-check-c-api-docs.yml
 
   build-windows:
     name: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,9 +142,24 @@ jobs:
       - name: Check for unsupported C global variables
         if: github.event_name == 'pull_request'  # $GITHUB_EVENT_NAME
         run: make check-c-globals
-      - name: Check for undocumented C APIs
-        run: make check-c-api-docs
 
+  check-c-api-docs:
+    name: 'Check if all C APIs are documented'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build-context
+    if: >-
+      needs.build-context.outputs.run-tests == 'true'
+      || needs.build-context.outputs.run-docs == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Check for undocumented C APIs
+        run: python Tools/check-c-api-docs/main.py
 
   build-windows:
     name: >-
@@ -685,6 +700,7 @@ jobs:
     - check-docs
     - check-autoconf-regen
     - check-generated-files
+    - check-c-api-docs
     - build-windows
     - build-windows-msi
     - build-macos
@@ -719,6 +735,12 @@ jobs:
             check-autoconf-regen,
             check-generated-files,
             '
+            || ''
+          }}
+          ${{
+            !fromJSON(needs.build-context.outputs.run-tests)
+            && !fromJSON(needs.build-context.outputs.run-docs)
+            && 'check-c-api-docs,'
             || ''
           }}
           ${{ !fromJSON(needs.build-context.outputs.run-windows-tests) && 'build-windows,' || '' }}

--- a/.github/workflows/reusable-check-c-api-docs.yml
+++ b/.github/workflows/reusable-check-c-api-docs.yml
@@ -2,7 +2,6 @@ name: Reusable C API Docs Check
 
 on:
   workflow_call:
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-check-c-api-docs.yml
+++ b/.github/workflows/reusable-check-c-api-docs.yml
@@ -1,0 +1,26 @@
+name: Reusable C API Docs Check
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  check-c-api-docs:
+    name: 'Check if all C APIs are documented'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Check for undocumented C APIs
+        run: python Tools/check-c-api-docs/main.py


### PR DESCRIPTION
As mentioned in https://github.com/python/cpython/pull/143564#pullrequestreview-3639615899 by @ZeroIntensity:

> One extra thing I would like to do is run the script on docs PRs, since a name being documented while also being in ignored_c_api.txt will cause it to fail. So, if someone merges new documentation without updating ignored_c_api.txt, we'll see blocking failures on all C code PRs until we fix it. I haven't looked too closely at the GHA for change detection, but if you see an easy way to do that, would you mind doing it in this PR?

We could keep it in the `check-generated-files` job, but that would make it quite messy as all the other checks would have to be excluded in the case when only `run-docs` is true. And, to avoid having to configure, I run the script directly (since it uses `PYTHON_FOR_REGEN` anyway, there shouldn't be a difference).

On this PR, [the new job ran in 13 seconds](https://github.com/python/cpython/actions/runs/20824467576/job/59821920668?pr=143573).

<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->
