### PR TITLE
gh-143513: Clarify historic behaviour of importlib ResourceReader

### DIFF
--- a/Doc/library/importlib.resources.abc.rst
+++ b/Doc/library/importlib.resources.abc.rst
@@ -89,7 +89,11 @@
        the file system then those subdirectory names can be used
        directly.
 
-       The abstract method returns an iterable of no items.
+       The abstract method raises :exc:`FileNotFoundError`.
+
+       .. versionchanged:: 3.10
+          The abstract method changed from returning an empty iterable
+          to raising :exc:`FileNotFoundError`.
 
 
 .. class:: Traversable


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143513 -->
* Issue: gh-143513
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143574.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->