### PR TITLE
gh-143542: Speed up decode_header by 1.02x

### DIFF
--- a/Lib/email/header.py
+++ b/Lib/email/header.py
@@ -89,18 +89,24 @@ def decode_header(header):
     words = []
     for line in header.splitlines():
         parts = ecre.split(line)
+        i = 0
+        parts_len = len(parts)
         first = True
-        while parts:
-            unencoded = parts.pop(0)
+        while i < parts_len:
+            unencoded = parts[i]
+            i += 1
             if first:
                 unencoded = unencoded.lstrip()
                 first = False
             if unencoded:
                 words.append((unencoded, None, None))
-            if parts:
-                charset = parts.pop(0).lower()
-                encoding = parts.pop(0).lower()
-                encoded = parts.pop(0)
+            if i < parts_len:
+                charset = parts[i].lower()
+                i += 1
+                encoding = parts[i].lower()
+                i += 1
+                encoded = parts[i]
+                i += 1
                 words.append((encoded, encoding, charset))
     # Now loop over words and remove words that consist of whitespace
     # between two encoded strings.

--- a/Misc/NEWS.d/next/Library/2026-01-08-10-28-03.gh-issue-143542.mRWYXf.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-08-10-28-03.gh-issue-143542.mRWYXf.rst
@@ -1,0 +1,1 @@
+Speed up :func:`email.header.decode_header` by 1.02x.


### PR DESCRIPTION
Avoid doing `list.pop(0)` in a loop, and use indexes instead.

pyperf report:
```
Mean +- std dev: [decode_header_baseline] 6.21 us +- 0.05 us ->
[decode_header_optimized] 6.11 us +- 0.06 us: 1.02x faster
```

<!-- gh-issue-number: gh-143542 -->
* Issue: gh-143542
<!-- /gh-issue-number -->
