### PR TITLE
gh-106318: Add doctest role and 'See also' for str.removeprefix()

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2369,7 +2369,9 @@ expression support in the :mod:`re` module).
 
    If the string starts with the *prefix* string, return
    ``string[len(prefix):]``. Otherwise, return a copy of the original
-   string::
+   string:
+
+   .. doctest::
 
       >>> 'TestHook'.removeprefix('Test')
       'Hook'
@@ -2377,6 +2379,8 @@ expression support in the :mod:`re` module).
       'BaseTestCase'
 
    .. versionadded:: 3.9
+
+   See also :meth:`removesuffix` and :meth:`startswith`.
 
 
 .. method:: str.removesuffix(suffix, /)


### PR DESCRIPTION
WIP to https://github.com/python/cpython/issues/106318

https://github.com/python/cpython/issues/106318: Add doctest role and 'See also' for str.removeprefix()

<!-- gh-issue-number: gh-106318 -->
* Issue: gh-106318
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143579.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->