### PR TITLE
 gh-106318: Improve str.removeprefix() and str.removesuffix() docs

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2387,7 +2387,9 @@ expression support in the :mod:`re` module).
 
    If the string ends with the *suffix* string and that *suffix* is not empty,
    return ``string[:-len(suffix)]``. Otherwise, return a copy of the
-   original string::
+   original string:
+
+   .. doctest::
 
       >>> 'MiscTests'.removesuffix('Tests')
       'Misc'
@@ -2395,6 +2397,8 @@ expression support in the :mod:`re` module).
       'TmpDirMixin'
 
    .. versionadded:: 3.9
+
+   See also :meth:`removeprefix` and :meth:`endswith`.
 
 
 .. method:: str.replace(old, new, /, count=-1)

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2369,7 +2369,9 @@ expression support in the :mod:`re` module).
 
    If the string starts with the *prefix* string, return
    ``string[len(prefix):]``. Otherwise, return a copy of the original
-   string::
+   string:
+
+   .. doctest::
 
       >>> 'TestHook'.removeprefix('Test')
       'Hook'
@@ -2377,6 +2379,8 @@ expression support in the :mod:`re` module).
       'BaseTestCase'
 
    .. versionadded:: 3.9
+
+   See also :meth:`removesuffix` and :meth:`startswith`.
 
 
 .. method:: str.removesuffix(suffix, /)


### PR DESCRIPTION
WIP to https://github.com/python/cpython/issues/106318

https://github.com/python/cpython/issues/106318: Improve str.removeprefix() and str.removesuffix() docs.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143580.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-106318 -->
* Issue: gh-106318
<!-- /gh-issue-number -->
