### PR TITLE
GH-139686: Revert "gh-139686: Make reloading a lazy module no-op (GH-139857)"

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -210,12 +210,6 @@ Functions
        :exc:`ModuleNotFoundError` is raised when the module being reloaded lacks
        a :class:`~importlib.machinery.ModuleSpec`.
 
-   .. versionchanged:: 3.15
-       If *module* is a lazy module that has not yet been materialized (i.e.,
-       loaded via :class:`importlib.util.LazyLoader` and not yet accessed),
-       calling :func:`reload` is a no-op and returns the module unchanged.
-       This prevents the reload from unintentionally triggering the lazy load.
-
    .. warning::
       This function is not thread-safe. Calling it from multiple threads can result
       in unexpected behavior. It's recommended to use the :class:`threading.Lock`

--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -97,11 +97,6 @@ def reload(module):
     The module must have been successfully imported before.
 
     """
-    # If a LazyModule has not yet been materialized, reload is a no-op.
-    if importlib_util := sys.modules.get('importlib.util'):
-        if lazy_module_type := getattr(importlib_util, '_LazyModule', None):
-            if isinstance(module, lazy_module_type):
-                return module
     try:
         name = module.__spec__.name
     except AttributeError:

--- a/Lib/test/test_importlib/test_lazy.py
+++ b/Lib/test/test_importlib/test_lazy.py
@@ -10,9 +10,6 @@ import unittest
 from test.support import threading_helper
 from test.test_importlib import util as test_util
 
-# Make sure sys.modules[util] is in sync with the import.
-# That is needed as other tests may reload util.
-sys.modules['importlib.util'] = util
 
 class CollectInit:
 
@@ -195,7 +192,7 @@ class LazyLoaderTests(unittest.TestCase):
             sys.modules['json'] = module
             loader.exec_module(module)
 
-            # Trigger load with attribute lookup, ensure expected behavior.
+            # Trigger load with attribute lookup, ensure expected behavior
             test_load = module.loads('{}')
             self.assertEqual(test_load, {})
 
@@ -226,26 +223,6 @@ sys.modules[__name__].__class__ = ImmutableModule
             module.CONSTANT = 2.71
         with self.assertRaises(AttributeError):
             del module.CONSTANT
-
-    def test_reload(self):
-        # Reloading a lazy module that hasn't been materialized is a no-op.
-        module = self.new_module()
-        sys.modules[TestingImporter.module_name] = module
-
-        # Change the source code to add a new attribute.
-        TestingImporter.source_code = 'attr = 42\nnew_attr = 123\n__name__ = {!r}'.format(TestingImporter.mutated_name)
-        self.assertIsInstance(module, util._LazyModule)
-
-        # Reload the module (should be a no-op since not materialized).
-        reloaded = importlib.reload(module)
-        self.assertIs(reloaded, module)
-        self.assertIsInstance(module, util._LazyModule)
-
-        # Access the new attribute (should trigger materialization, and new_attr should exist).
-        self.assertEqual(module.attr, 42)
-        self.assertNotIsInstance(module, util._LazyModule)
-        self.assertTrue(hasattr(module, 'new_attr'))
-        self.assertEqual(module.new_attr, 123)
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/3.15.0a3.rst
+++ b/Misc/NEWS.d/3.15.0a3.rst
@@ -843,15 +843,6 @@ for :term:`stdlib` modules.
 
 ..
 
-.. date: 2025-10-09-15-46-18
-.. gh-issue: 139686
-.. nonce: XwIZB2
-.. section: Library
-
-Make importlib.reload no-op for lazy modules.
-
-..
-
 .. date: 2025-09-09-13-00-42
 .. gh-issue: 138697
 .. nonce: QVwJw_

--- a/Misc/NEWS.d/next/Library/2026-01-08-13-41-58.gh-issue-139686.S_nzkl.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-08-13-41-58.gh-issue-139686.S_nzkl.rst
@@ -1,0 +1,3 @@
+Revert 0a97941245f1dda6d838f9aaf0512104e5253929 and
+57db12514ac686f0a752ec8fe1c08b6daa0c6219 which made importlib.reload a no-op
+for lazy modules; caused Buildbot failures.


### PR DESCRIPTION
This reverts commits 57db12514ac686f0a752ec8fe1c08b6daa0c6219 and 0a97941245f1dda6d838f9aaf0512104e5253929.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139686 -->
* Issue: gh-139686
<!-- /gh-issue-number -->
