### PR TITLE
Test: remove unintended unittest.main() in live collector tests

### DIFF
--- a/Lib/test/test_profiling/test_sampling_profiler/test_live_collector_interaction.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_live_collector_interaction.py
@@ -705,10 +705,6 @@ class TestLiveCollectorFilterInput(unittest.TestCase):
         self.assertTrue(self.display.contains_text("myfilter"))
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestLiveCollectorThreadNavigation(unittest.TestCase):
     """Tests for thread navigation functionality."""
 


### PR DESCRIPTION
The test file contained a stray `unittest.main()` in the middle of the module. Removed it.
