### PR TITLE
gh-143460: Skip infinite recusion tests for infinite stack size

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2438,6 +2438,7 @@ class AbstractPicklingErrorTests:
         with self.assertRaises(TypeError):
             self.dumps(c)
 
+    @support.skip_if_unlimited_stack_size()
     @no_tracing
     def test_bad_getattr(self):
         # Issue #3514: crash when there is an infinite loop in __getattr__

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2438,7 +2438,7 @@ class AbstractPicklingErrorTests:
         with self.assertRaises(TypeError):
             self.dumps(c)
 
-    @support.skip_if_unlimited_stack_size()
+    @support.skip_if_unlimited_stack_size
     @no_tracing
     def test_bad_getattr(self):
         # Issue #3514: crash when there is an infinite loop in __getattr__

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1786,7 +1786,7 @@ def skip_if_unlimited_stack_size(test):
 
     import resource
     curlim, maxlim = resource.getrlimit(resource.RLIMIT_STACK)
-    unlimited_stack_size_cond = curlim == maxlim and curlim in (-1, 0xFFFFFFFFFFFFFFFF)
+    unlimited_stack_size_cond = curlim == maxlim and curlim in (-1, 0xFFFF_FFFF_FFFF_FFFF)
     reason = "Not run due to unlimited stack size"
     return unittest.skipIf(unlimited_stack_size_cond, reason)(test)
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1772,7 +1772,7 @@ def skip_if_pgo_task(test):
     return test if ok else unittest.skip(msg)(test)
 
 
-def skip_if_unlimited_stack_size():
+def skip_if_unlimited_stack_size(test):
     """
     Skip decorator for tests not run when an unlimited stack size is configured.
 
@@ -1781,11 +1781,16 @@ def skip_if_unlimited_stack_size():
 
     See gh-143460: Python 3.14/3.15a build aborting due to OOM during test_functools / test_json
     """
+    if is_wasi:
+        return test
+    if sys.platform.startswith('win'):
+        return test
+
     import resource
     stack_size = resource.getrlimit(resource.RLIMIT_STACK)
-    reason = "Not run due to unlimited stack size"
     unlimited_stack_size_cond = stack_size == (-1, -1) or stack_size == (0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)
-    return unittest.skipIf(unlimited_stack_size_cond, reason)
+    reason = "Not run due to unlimited stack size"
+    return unittest.skipIf(unlimited_stack_size_cond, reason)(test)
 
 
 def detect_api_mismatch(ref_api, other_api, *, ignore=()):

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1787,8 +1787,8 @@ def skip_if_unlimited_stack_size(test):
         return test
 
     import resource
-    stack_size = resource.getrlimit(resource.RLIMIT_STACK)
-    unlimited_stack_size_cond = stack_size == (-1, -1) or stack_size == (0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)
+    curlim, maxlim = resource.getrlimit(resource.RLIMIT_STACK)
+    unlimited_stack_size_cond = curlim == maxlim and curlim in (-1, 0xFFFFFFFFFFFFFFFF)
     reason = "Not run due to unlimited stack size"
     return unittest.skipIf(unlimited_stack_size_cond, reason)(test)
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1773,17 +1773,15 @@ def skip_if_pgo_task(test):
 
 
 def skip_if_unlimited_stack_size(test):
-    """
-    Skip decorator for tests not run when an unlimited stack size is configured.
+    """Skip decorator for tests not run when an unlimited stack size is configured.
 
-    Tests using support.infinite_recursion([...]) may otherwise run into an infinite loop,
-    running until the memory on the system is filled and crashing due to OOM.
+    Tests using support.infinite_recursion([...]) may otherwise run into
+    an infinite loop, running until the memory on the system is filled and
+    crashing due to OOM.
 
-    See gh-143460: Python 3.14/3.15a build aborting due to OOM during test_functools / test_json
+    See https://github.com/python/cpython/issues/143460.
     """
-    if is_wasi:
-        return test
-    if sys.platform.startswith('win'):
+    if is_wasi or os.name == "nt":
         return test
 
     import resource

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -989,7 +989,7 @@ class AST_Tests(unittest.TestCase):
         enum._test_simple_enum(_Precedence, _ast_unparse._Precedence)
 
     @support.cpython_only
-    @skip_if_unlimited_stack_size()
+    @skip_if_unlimited_stack_size
     @skip_wasi_stack_overflow()
     @skip_emscripten_stack_overflow()
     def test_ast_recursion_limit(self):
@@ -1128,7 +1128,7 @@ class CopyTests(unittest.TestCase):
                     ast2 = pickle.loads(pickle.dumps(tree, protocol))
                     self.assertEqual(to_tuple(ast2), to_tuple(tree))
 
-    @skip_if_unlimited_stack_size()
+    @skip_if_unlimited_stack_size
     def test_copy_with_parents(self):
         # gh-120108
         code = """
@@ -1976,7 +1976,7 @@ Module(
         exec(code, ns)
         self.assertIn('sleep', ns)
 
-    @skip_if_unlimited_stack_size()
+    @skip_if_unlimited_stack_size
     @skip_emscripten_stack_overflow()
     def test_recursion_direct(self):
         e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0, operand=ast.Constant(1))
@@ -1985,7 +1985,7 @@ Module(
             with support.infinite_recursion():
                 compile(ast.Expression(e), "<test>", "eval")
 
-    @skip_if_unlimited_stack_size()
+    @skip_if_unlimited_stack_size
     @skip_emscripten_stack_overflow()
     def test_recursion_indirect(self):
         e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0, operand=ast.Constant(1))

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -25,7 +25,7 @@ except ImportError:
 
 from test import support
 from test.support import os_helper
-from test.support import skip_emscripten_stack_overflow, skip_wasi_stack_overflow
+from test.support import skip_emscripten_stack_overflow, skip_wasi_stack_overflow, skip_if_unlimited_stack_size
 from test.support.ast_helper import ASTTestMixin
 from test.support.import_helper import ensure_lazy_imports
 from test.test_ast.utils import to_tuple
@@ -989,6 +989,7 @@ class AST_Tests(unittest.TestCase):
         enum._test_simple_enum(_Precedence, _ast_unparse._Precedence)
 
     @support.cpython_only
+    @skip_if_unlimited_stack_size()
     @skip_wasi_stack_overflow()
     @skip_emscripten_stack_overflow()
     def test_ast_recursion_limit(self):
@@ -1127,6 +1128,7 @@ class CopyTests(unittest.TestCase):
                     ast2 = pickle.loads(pickle.dumps(tree, protocol))
                     self.assertEqual(to_tuple(ast2), to_tuple(tree))
 
+    @skip_if_unlimited_stack_size()
     def test_copy_with_parents(self):
         # gh-120108
         code = """
@@ -1974,6 +1976,7 @@ Module(
         exec(code, ns)
         self.assertIn('sleep', ns)
 
+    @skip_if_unlimited_stack_size()
     @skip_emscripten_stack_overflow()
     def test_recursion_direct(self):
         e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0, operand=ast.Constant(1))
@@ -1982,6 +1985,7 @@ Module(
             with support.infinite_recursion():
                 compile(ast.Expression(e), "<test>", "eval")
 
+    @skip_if_unlimited_stack_size()
     @skip_emscripten_stack_overflow()
     def test_recursion_indirect(self):
         e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0, operand=ast.Constant(1))

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -438,7 +438,7 @@ class TestPartial:
         self.assertIs(type(r[0]), tuple)
 
     @support.skip_if_sanitizer("thread sanitizer crashes in __tsan::FuncEntry", thread=True)
-    @support.skip_if_unlimited_stack_size()
+    @support.skip_if_unlimited_stack_size
     @support.skip_emscripten_stack_overflow()
     def test_recursive_pickle(self):
         with replaced_module('functools', self.module):
@@ -2140,7 +2140,7 @@ class TestLRU:
     @support.skip_on_s390x
     @unittest.skipIf(support.is_wasi, "WASI has limited C stack")
     @support.skip_if_sanitizer("requires deep stack", ub=True, thread=True)
-    @support.skip_if_unlimited_stack_size()
+    @support.skip_if_unlimited_stack_size
     @support.skip_emscripten_stack_overflow()
     def test_lru_recursion(self):
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -438,6 +438,7 @@ class TestPartial:
         self.assertIs(type(r[0]), tuple)
 
     @support.skip_if_sanitizer("thread sanitizer crashes in __tsan::FuncEntry", thread=True)
+    @support.skip_if_unlimited_stack_size()
     @support.skip_emscripten_stack_overflow()
     def test_recursive_pickle(self):
         with replaced_module('functools', self.module):
@@ -2139,6 +2140,7 @@ class TestLRU:
     @support.skip_on_s390x
     @unittest.skipIf(support.is_wasi, "WASI has limited C stack")
     @support.skip_if_sanitizer("requires deep stack", ub=True, thread=True)
+    @support.skip_if_unlimited_stack_size()
     @support.skip_emscripten_stack_overflow()
     def test_lru_recursion(self):
 

--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -317,7 +317,7 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
             self.assertRaises(RecursionError, issubclass, int, X())
             self.assertRaises(RecursionError, isinstance, 1, X())
 
-    @support.skip_if_unlimited_stack_size()
+    @support.skip_if_unlimited_stack_size
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     def test_infinite_recursion_via_bases_tuple(self):
@@ -329,7 +329,7 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
             with self.assertRaises(RecursionError):
                 issubclass(Failure(), int)
 
-    @support.skip_if_unlimited_stack_size()
+    @support.skip_if_unlimited_stack_size
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     def test_infinite_cycle_in_bases(self):

--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -317,6 +317,7 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
             self.assertRaises(RecursionError, issubclass, int, X())
             self.assertRaises(RecursionError, isinstance, 1, X())
 
+    @support.skip_if_unlimited_stack_size()
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     def test_infinite_recursion_via_bases_tuple(self):
@@ -328,6 +329,7 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
             with self.assertRaises(RecursionError):
                 issubclass(Failure(), int)
 
+    @support.skip_if_unlimited_stack_size()
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     def test_infinite_cycle_in_bases(self):

--- a/Lib/test/test_json/test_recursion.py
+++ b/Lib/test/test_json/test_recursion.py
@@ -68,6 +68,7 @@ class TestRecursion:
             self.fail("didn't raise ValueError on default recursion")
 
 
+    @support.skip_if_unlimited_stack_size()
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     def test_highly_nested_objects_decoding(self):
@@ -84,6 +85,7 @@ class TestRecursion:
             with support.infinite_recursion():
                 self.loads('[' * very_deep + '1' + ']' * very_deep)
 
+    @support.skip_if_unlimited_stack_size()
     @support.skip_wasi_stack_overflow()
     @support.skip_emscripten_stack_overflow()
     @support.requires_resource('cpu')
@@ -99,6 +101,7 @@ class TestRecursion:
             with support.infinite_recursion(5000):
                 self.dumps(d)
 
+    @support.skip_if_unlimited_stack_size()
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     def test_endless_recursion(self):

--- a/Lib/test/test_json/test_recursion.py
+++ b/Lib/test/test_json/test_recursion.py
@@ -68,7 +68,7 @@ class TestRecursion:
             self.fail("didn't raise ValueError on default recursion")
 
 
-    @support.skip_if_unlimited_stack_size()
+    @support.skip_if_unlimited_stack_size
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     def test_highly_nested_objects_decoding(self):
@@ -85,7 +85,7 @@ class TestRecursion:
             with support.infinite_recursion():
                 self.loads('[' * very_deep + '1' + ']' * very_deep)
 
-    @support.skip_if_unlimited_stack_size()
+    @support.skip_if_unlimited_stack_size
     @support.skip_wasi_stack_overflow()
     @support.skip_emscripten_stack_overflow()
     @support.requires_resource('cpu')
@@ -101,7 +101,7 @@ class TestRecursion:
             with support.infinite_recursion(5000):
                 self.dumps(d)
 
-    @support.skip_if_unlimited_stack_size()
+    @support.skip_if_unlimited_stack_size
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     def test_endless_recursion(self):

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -672,6 +672,7 @@ class TestSupport(unittest.TestCase):
         """)
         script_helper.assert_python_ok("-c", code)
 
+    @support.skip_if_unlimited_stack_size()
     def test_recursion(self):
         # Test infinite_recursion() and get_recursion_available() functions.
         def recursive_function(depth):

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -672,7 +672,7 @@ class TestSupport(unittest.TestCase):
         """)
         script_helper.assert_python_ok("-c", code)
 
-    @support.skip_if_unlimited_stack_size()
+    @support.skip_if_unlimited_stack_size
     def test_recursion(self):
         # Test infinite_recursion() and get_recursion_available() functions.
         def recursive_function(depth):

--- a/Lib/test/test_tomllib/test_misc.py
+++ b/Lib/test/test_tomllib/test_misc.py
@@ -93,6 +93,7 @@ class TestMiscellaneous(unittest.TestCase):
         }
         self.assertEqual(obj_copy, expected_obj)
 
+    @support.skip_if_unlimited_stack_size()
     def test_inline_array_recursion_limit(self):
         with support.infinite_recursion(max_depth=100):
             available = support.get_recursion_available()
@@ -104,6 +105,7 @@ class TestMiscellaneous(unittest.TestCase):
                 recursive_array_toml = "arr = " + nest_count * "[" + nest_count * "]"
                 tomllib.loads(recursive_array_toml)
 
+    @support.skip_if_unlimited_stack_size()
     def test_inline_table_recursion_limit(self):
         with support.infinite_recursion(max_depth=100):
             available = support.get_recursion_available()

--- a/Lib/test/test_tomllib/test_misc.py
+++ b/Lib/test/test_tomllib/test_misc.py
@@ -93,7 +93,7 @@ class TestMiscellaneous(unittest.TestCase):
         }
         self.assertEqual(obj_copy, expected_obj)
 
-    @support.skip_if_unlimited_stack_size()
+    @support.skip_if_unlimited_stack_size
     def test_inline_array_recursion_limit(self):
         with support.infinite_recursion(max_depth=100):
             available = support.get_recursion_available()
@@ -105,7 +105,7 @@ class TestMiscellaneous(unittest.TestCase):
                 recursive_array_toml = "arr = " + nest_count * "[" + nest_count * "]"
                 tomllib.loads(recursive_array_toml)
 
-    @support.skip_if_unlimited_stack_size()
+    @support.skip_if_unlimited_stack_size
     def test_inline_table_recursion_limit(self):
         with support.infinite_recursion(max_depth=100):
             available = support.get_recursion_available()

--- a/Misc/NEWS.d/next/Tests/2026-01-09-13-52-10.gh-issue-143460._nW2jt.rst
+++ b/Misc/NEWS.d/next/Tests/2026-01-09-13-52-10.gh-issue-143460._nW2jt.rst
@@ -1,0 +1,1 @@
+Skip tests relying on infinite recusion if stack size is unlimited.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Avoid tests being killed due to OOM on Linux if a system is configured with `ulimit -s unlimited` by skipping tests relying on infinite recursion via `infinite_recursion` with a high passed number.

While unclear if Python should support `ulimit -s unlimited`, we should at least try to avoid failing a PGO build running tests due to an unlimited stack size being set.

---

Note: While this lets `make` pass on the systems I've tested on (with PGO enabled), `make test` will fail with `ulimit -s unlimited`. 
On a system with sufficient amount of memory, I saw several of these errors:

```
Traceback (most recent call last):
  File "/dev/shm/reuter1/jupiter/Python/3.14.2/GCCcore-15.2.0/Python-3.14.2/Lib/test/test_dictviews.py", line 286, in test_deeply_nested_repr
    self.assertRaises(RecursionError, repr, d)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: RecursionError not raised by repr
```

whereas on my personal machine, I saw some tests with typical recursion (not using `infinite_recursion`) still filling up the memory due to the machine having substantially less RAM. There were also two or three timeouts, but without triggering OOM.

Based on https://github.com/python/cpython/issues/143460#issuecomment-3715320444, I'd consider this acceptable, but I can also do another round of going through the tests to exclude any test that could yield issues with `ulimit -s unlimited`.

<!-- gh-issue-number: gh-143460 -->
* Issue: gh-143460
<!-- /gh-issue-number -->
