### PR TITLE
gh-143552: Fix inspect.getcoroutinestate for generator-based coroutines

### DIFF
--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -2878,7 +2878,7 @@ class TestGetCoroutineState(unittest.TestCase):
 
     def test_created(self):
         self.assertEqual(self._coroutinestate(), inspect.CORO_CREATED)
-    
+
     def test_generator_based_coroutine_introspection(self):
         from inspect import getcoroutinestate
         from types import coroutine

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -2878,6 +2878,17 @@ class TestGetCoroutineState(unittest.TestCase):
 
     def test_created(self):
         self.assertEqual(self._coroutinestate(), inspect.CORO_CREATED)
+    
+    def test_generator_based_coroutine_introspection(self):
+        from inspect import getcoroutinestate
+        from types import coroutine
+
+        @coroutine
+        def gen_coro():
+            yield
+
+        # Must not raise AttributeError
+        getcoroutinestate(gen_coro())
 
     def test_suspended(self):
         self.coroutine.send(None)
@@ -2925,6 +2936,7 @@ class TestGetCoroutineState(unittest.TestCase):
         coro.send(None)
         self.assertEqual(inspect.getcoroutinelocals(coro),
                          {'a': None, 'gencoro': gencoro, 'b': 'spam'})
+
 
 
 @support.requires_working_socket()

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -935,6 +935,36 @@ gen_getcode(PyObject *self, void *Py_UNUSED(ignored))
     return _gen_getcode(gen, "gi_code");
 }
 
+static PyObject *
+gen_get_cr_frame(PyObject *self, void *closure)
+{
+    return gen_getframe((PyGenObject *)self, closure);
+}
+
+static PyObject *
+gen_get_cr_code(PyObject *self, void *closure)
+{
+    return gen_getcode((PyGenObject *)self, closure);
+}
+
+static PyObject *
+gen_get_cr_running(PyObject *self, void *closure)
+{
+    return gen_getrunning((PyGenObject *)self, closure);
+}
+
+static PyObject *
+gen_get_cr_suspended(PyObject *self, void *closure)
+{
+    return gen_getsuspended((PyGenObject *)self, closure);
+}
+
+static PyObject *
+gen_get_cr_origin(PyObject *self, void *closure)
+{
+    Py_RETURN_NONE;
+}
+
 static PyGetSetDef gen_getsetlist[] = {
     {"__name__", gen_get_name, gen_set_name,
      PyDoc_STR("name of the generator")},
@@ -946,6 +976,11 @@ static PyGetSetDef gen_getsetlist[] = {
     {"gi_frame", gen_getframe,  NULL, NULL},
     {"gi_suspended", gen_getsuspended,  NULL, NULL},
     {"gi_code", gen_getcode,  NULL, NULL},
+    {"cr_running", gen_get_cr_running, NULL, NULL},
+    {"cr_frame", gen_get_cr_frame, NULL, NULL},
+    {"cr_code", gen_get_cr_code, NULL, NULL},
+    {"cr_suspended", gen_get_cr_suspended, NULL, NULL},
+    {"cr_origin", gen_get_cr_origin, NULL, NULL},
     {NULL} /* Sentinel */
 };
 

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -938,25 +938,25 @@ gen_getcode(PyObject *self, void *Py_UNUSED(ignored))
 static PyObject *
 gen_get_cr_frame(PyObject *self, void *closure)
 {
-    return gen_getframe((PyGenObject *)self, closure);
+    return gen_getframe((PyObject *)self, closure);
 }
 
 static PyObject *
 gen_get_cr_code(PyObject *self, void *closure)
 {
-    return gen_getcode((PyGenObject *)self, closure);
+    return gen_getcode((PyObject *)self, closure);
 }
 
 static PyObject *
 gen_get_cr_running(PyObject *self, void *closure)
 {
-    return gen_getrunning((PyGenObject *)self, closure);
+    return gen_getrunning((PyObject *)self, closure);
 }
 
 static PyObject *
 gen_get_cr_suspended(PyObject *self, void *closure)
 {
-    return gen_getsuspended((PyGenObject *)self, closure);
+    return gen_getsuspended((PyObject *)self, closure);
 }
 
 static PyObject *


### PR DESCRIPTION
Generator-based coroutines created via types.coroutine() are plain generators
and do not expose the coroutine introspection attributes expected by
inspect.getcoroutinestate(), causing AttributeError.

This change adds minimal read-only aliases on generators for the required
cr_* attributes, delegating to existing gi_* state, restoring compatibility
without altering semantics.

Fixes gh-143552.
