### PR TITLE
gh-143620: Fix race condition in test_traceback_when_child_process_terminates_abruptly

### DIFF
--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -115,7 +115,11 @@ class ProcessPoolExecutorTest(ExecutorTest):
             with self.assertRaises(BrokenProcessPool) as bpe:
                 future.result()
 
-        cause = bpe.exception.__cause__
+            for _ in support.sleeping_retry(support.SHORT_TIMEOUT):
+                cause = bpe.exception.__cause__
+                if isinstance(cause, futures.process._RemoteTraceback):
+                    break
+
         self.assertIsInstance(cause, futures.process._RemoteTraceback)
         self.assertIn(
             f"terminated abruptly with exit code {exit_code}", cause.tb


### PR DESCRIPTION
Fixes gh-143620

There is a race condition in `test_concurrent_futures.test_process_pool`. The test asserts that a `BrokenProcessPool` exception has a `__cause__` immediately after `future.result()` raises.

In `concurrent.futures.process`, the `_terminate_broken` method sets the exception on the future before it attaches the `_RemoteTraceback` to the `__cause__` attr. Sometimes the test thread wakes up and inspects the exception while `__cause__` is still `None`, which leads to a test failure. I was able to repro (see issue for more details) by injecting a delay in `_terminate_broken` between the `set_exception()` call and the `__cause__` assignment. This causes a 100% failure rate with `AssertionError: None is not an instance of _RemoteTraceback`.

My proposed fix is to update the test to use `support.sleeping_retry` to wait for the `__cause__` to be populated. This seems to be the pattern elsewhere in the test suite. 