### PR TITLE
gh-143054: Disallow non-top-level Cut for now

### DIFF
--- a/Doc/reference/grammar.rst
+++ b/Doc/reference/grammar.rst
@@ -12,8 +12,17 @@ The notation used here is the same as in the preceding docs,
 and is described in the :ref:`notation <notation>` section,
 except for an extra complication:
 
-* ``~`` ("cut"): commit to the current alternative and fail the rule
-  even if this fails to parse
+* ``~`` ("cut"): commit to the current alternative; fail the rule
+  if the alternative fails to parse
+
+  Python mainly uses cuts for optimizations or improved error
+  messages. They often appear to be useless in the listing below.
+
+  .. see gh-143054, and CutValidator in the source, if you want to change this:
+
+  Cuts currently don't appear inside parentheses, brackets, lookaheads
+  and similar.
+  Their behavior in these contexts is deliberately left unspecified.
 
 .. literalinclude:: ../../Grammar/python.gram
   :language: peg

--- a/Lib/test/test_peg_generator/test_pegen.py
+++ b/Lib/test/test_peg_generator/test_pegen.py
@@ -755,6 +755,30 @@ class TestPegen(unittest.TestCase):
             ],
         )
 
+    def test_cut_is_local_in_rule(self) -> None:
+        grammar = """
+        start:
+            | inner
+            | 'x' { "ok" }
+        inner:
+            | 'x' ~ 'y'
+            | 'x'
+        """
+        parser_class = make_parser(grammar)
+        node = parse_string("x", parser_class)
+        self.assertEqual(node, 'ok')
+
+    def test_cut_is_local_in_parens(self) -> None:
+        # we currently don't guarantee this behavior, see gh-143054
+        grammar = """
+        start:
+            | ('x' ~ 'y' | 'x')
+            | 'x' { "ok" }
+        """
+        parser_class = make_parser(grammar)
+        node = parse_string("x", parser_class)
+        self.assertEqual(node, 'ok')
+
     def test_dangling_reference(self) -> None:
         grammar = """
         start: foo ENDMARKER

--- a/Tools/peg_generator/pegen/validator.py
+++ b/Tools/peg_generator/pegen/validator.py
@@ -1,5 +1,5 @@
 from pegen import grammar
-from pegen.grammar import Alt, GrammarVisitor, Rhs, Rule, Cut, Repeat, Opt, NamedItem
+from pegen.grammar import Alt, GrammarVisitor, Rhs, Rule
 
 
 class ValidationError(Exception):

--- a/Tools/peg_generator/pegen/validator.py
+++ b/Tools/peg_generator/pegen/validator.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pegen import grammar
 from pegen.grammar import Alt, GrammarVisitor, Rhs, Rule
 
@@ -61,10 +63,10 @@ class CutValidator(GrammarValidator):
     See gh-143054.
     """
 
-    def visit(self, node: Any, parents: tuple[Any] = ()) -> None:
+    def visit(self, node: Any, parents: tuple[Any, ...] = ()) -> None:
         super().visit(node, parents=(*parents, node))
 
-    def visit_Cut(self, node: Alt, parents: tuple[Any] = ()) -> None:
+    def visit_Cut(self, node: Alt, parents: tuple[Any, ...] = ()) -> None:
         parent_types = [type(p).__name__ for p in parents]
         if parent_types != ['Rule', 'Rhs', 'Alt', 'NamedItem', 'Cut']:
             raise ValidationError(


### PR DESCRIPTION
The behaviour of Cut in nested parentheses, Repeat, Opt, and similar is somewhat chaotic. Apparently even the academic papers on PEG aren't as clear as they could be.

And it doesn't really matter. Python only uses top-level cuts. When/if that changes, we can clarify as much as necessary (and even change the implementation to make sense for what we'll need).

For now, document that this is deliberately unspecified, and add a test to make sure any decision is deliberate, tested and documented.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143054 -->
* Issue: gh-143054
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143622.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->