### PR TITLE
gh-143602: Fix duplicate buffer exports in io.BytesIO.write

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -952,20 +952,21 @@ class BytesIO(BufferedIOBase):
         if isinstance(b, str):
             raise TypeError("can't write str to binary stream")
         with memoryview(b) as view:
-            n = view.nbytes  # Size of any bytes-like object
             if self.closed:
                 raise ValueError("write to closed file")
-        if n == 0:
-            return 0
 
-        with self._lock:
-            pos = self._pos
-            if pos > len(self._buffer):
-                # Pad buffer to pos with null bytes.
-                self._buffer.resize(pos)
-            self._buffer[pos:pos + n] = b
-            self._pos += n
-        return n
+            n = view.nbytes  # Size of any bytes-like object
+            if n == 0:
+                return 0
+
+            with self._lock:
+                pos = self._pos
+                if pos > len(self._buffer):
+                    # Pad buffer to pos with null bytes.
+                    self._buffer.resize(pos)
+                self._buffer[pos:pos + n] = view
+                self._pos += n
+            return n
 
     def seek(self, pos, whence=0):
         if self.closed:

--- a/Misc/NEWS.d/next/Library/2026-01-09-12-37-19.gh-issue-143602.V8vQpj.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-09-12-37-19.gh-issue-143602.V8vQpj.rst
@@ -1,2 +1,2 @@
-Fix a inconsistency issue in :meth:~io.BytesIO.write that leads to
+Fix a inconsistency issue in :meth:`~io.BytesIO.write` that leads to
 unexpected buffer overwrite by deduplicating the buffer exports.

--- a/Misc/NEWS.d/next/Library/2026-01-09-12-37-19.gh-issue-143602.V8vQpj.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-09-12-37-19.gh-issue-143602.V8vQpj.rst
@@ -1,2 +1,2 @@
-Fix a inconsistency issue in :meth:`~io.BytesIO.write` that leads to
+Fix a inconsistency issue in :meth:`~io.RawIOBase.write` that leads to
 unexpected buffer overwrite by deduplicating the buffer exports.

--- a/Misc/NEWS.d/next/Library/2026-01-09-12-37-19.gh-issue-143602.V8vQpj.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-09-12-37-19.gh-issue-143602.V8vQpj.rst
@@ -1,0 +1,2 @@
+Fix a inconsistency issue in :meth:~io.BytesIO.write that leads to
+unexpected buffer overwrite by deduplicating the buffer exports.


### PR DESCRIPTION
Fix a inconsistency issue in io.BytesIO.write() where the buffer was exported twice, which could lead to unexpected data overwrites and position drift when the buffer changes between exports.

<!-- gh-issue-number: gh-143602 -->
* Issue: gh-143602
<!-- /gh-issue-number -->
