### PR TITLE
Doc: remove duplicate GitHub issue reference in "What's New in Python 3.13"

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2340,7 +2340,7 @@ Limited C API Changes
   * :c:func:`PySys_AuditTuple`
   * :c:func:`PyType_GetModuleByDef`
 
-  (Contributed by Victor Stinner in :gh:`85283`, :gh:`85283`, and :gh:`116936`.)
+  (Contributed by Victor Stinner in :gh:`85283` and :gh:`116936`.)
 
 * Python built with :option:`--with-trace-refs` (tracing references)
   now supports the :ref:`Limited API <limited-c-api>`.


### PR DESCRIPTION
Hi, I believe that it was a typo (the same gh appear twice; 85283).

I found it while I was translating the corresponding Korean repo.

Thank you!

With warm regards
emmanuel

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143654.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->