### PR TITLE
gh-143658: importlib.metadata: Use `str.translate` to improve performance of `importlib.metadata.Prepared.normalized`

### DIFF
--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -890,7 +890,7 @@ class Lookup:
         return itertools.chain(infos, eggs)
 
 
-# Translation table for Prepared.normalize: lowercase and 
+# Translation table for Prepared.normalize: lowercase and
 # replace "-" (hyphen) and "." (dot) with "_" (underscore).
 _normalize_table = str.maketrans(
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ-.",

--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -890,7 +890,8 @@ class Lookup:
         return itertools.chain(infos, eggs)
 
 
-# Translation table for Prepared.normalize: lowercase and replace - . with _
+# Translation table for Prepared.normalize: lowercase and 
+# replace "-" (hyphen) and "." (dot) with "_" (underscore).
 _normalize_table = str.maketrans(
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ-.",
     "abcdefghijklmnopqrstuvwxyz__",

--- a/Lib/test/test_importlib/metadata/test_api.py
+++ b/Lib/test/test_importlib/metadata/test_api.py
@@ -6,6 +6,7 @@ import unittest
 from importlib.metadata import (
     Distribution,
     PackageNotFoundError,
+    Prepared,
     distribution,
     entry_points,
     files,
@@ -313,3 +314,35 @@ class InvalidateCache(unittest.TestCase):
     def test_invalidate_cache(self):
         # No externally observable behavior, but ensures test coverage...
         importlib.invalidate_caches()
+
+
+class PreparedTests(unittest.TestCase):
+    def test_normalize(self):
+        tests = [
+            # Simple
+            ("sample", "sample"),
+            # Mixed case
+            ("Sample", "sample"),
+            ("SAMPLE", "sample"),
+            ("SaMpLe", "sample"),
+            # Separator conversions
+            ("sample-pkg", "sample_pkg"),
+            ("sample.pkg", "sample_pkg"),
+            ("sample_pkg", "sample_pkg"),
+            # Multiple separators
+            ("sample---pkg", "sample_pkg"),
+            ("sample___pkg", "sample_pkg"),
+            ("sample...pkg", "sample_pkg"),
+            # Mixed separators
+            ("sample-._pkg", "sample_pkg"),
+            ("sample_.-pkg", "sample_pkg"),
+            # Complex
+            ("Sample__Pkg-name.foo", "sample_pkg_name_foo"),
+            # Uppercase with separators
+            ("SAMPLE-PKG", "sample_pkg"),
+            ("Sample.Pkg", "sample_pkg"),
+            ("SAMPLE_PKG", "sample_pkg"),
+        ]
+        for name, expected in tests:
+            with self.subTest(name=name):
+                self.assertEqual(Prepared.normalize(name), expected)

--- a/Lib/test/test_importlib/metadata/test_api.py
+++ b/Lib/test/test_importlib/metadata/test_api.py
@@ -338,6 +338,7 @@ class PreparedTests(unittest.TestCase):
             ("sample_.-pkg", "sample_pkg"),
             # Complex
             ("Sample__Pkg-name.foo", "sample_pkg_name_foo"),
+            ("Sample__Pkg.name__foo", "sample_pkg_name_foo"),
             # Uppercase with separators
             ("SAMPLE-PKG", "sample_pkg"),
             ("Sample.Pkg", "sample_pkg"),

--- a/Misc/NEWS.d/next/Library/2026-01-10-15-40-57.gh-issue-143658.Ox6pE5.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-10-15-40-57.gh-issue-143658.Ox6pE5.rst
@@ -1,0 +1,2 @@
+:mod:`importlib.metadata`: Use ``translate`` to improve performance of
+``canonicalize_name``. Patch by Hugo van Kemenade and Henry Schreiner.

--- a/Misc/NEWS.d/next/Library/2026-01-10-15-40-57.gh-issue-143658.Ox6pE5.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-10-15-40-57.gh-issue-143658.Ox6pE5.rst
@@ -1,2 +1,3 @@
-:mod:`importlib.metadata`: Use ``translate`` to improve performance of
-``canonicalize_name``. Patch by Hugo van Kemenade and Henry Schreiner.
+:mod:`importlib.metadata`: Use :meth:`str.translate` to improve performance of
+:meth:`!importlib.metadata.Prepared.normalize`. Patch by Hugo van Kemenade and
+Henry Schreiner.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

We can apply @henryiii's improvement to `packaging` in https://github.com/pypa/packaging/pull/1030 (see also https://iscinumpy.dev/post/packaging-faster/) to improve the performance of `canonicalize_name` and make it ~3.7 times faster.

## Benchmark

Run `Prepared.normalize(n)` on every name in PyPI:

```python
# benchmark_names_stdlib.py
import sqlite3
import timeit
from importlib.metadata import Prepared

# Get data with:
# curl -L https://github.com/pypi-data/pypi-json-data/releases/download/latest/pypi-data.sqlite.gz | gzip -d > pypi-data.sqlite
# Or ues pre-cached files from:
# https://gist.github.com/hugovk/efdbee0620cc64df7b405b52cf0b6e42

CACHE_FILE = "/tmp/bench/names.txt"
DB_FILE = "/tmp/bench/pypi-data.sqlite"

try:
    with open(CACHE_FILE) as f:
        TEST_ALL_NAMES = [line.rstrip("\n") for line in f]
except FileNotFoundError:
    TEST_ALL_NAMES = []
    with sqlite3.connect(DB_FILE) as conn:
        with open(CACHE_FILE, "w") as cache:
            for (name,) in conn.execute("SELECT name FROM projects"):
                if name:
                    TEST_ALL_NAMES.append(name)
                    cache.write(name + "\n")


def bench():
    for n in TEST_ALL_NAMES:
        Prepared.normalize(n)


if __name__ == "__main__":
    print(f"Loaded {len(TEST_ALL_NAMES):,} names")
    t = timeit.timeit("bench()", globals=globals(), number=1)
    print(f"Time: {t:.4f} seconds")
```

Benchmark data can be found at https://gist.github.com/hugovk/efdbee0620cc64df7b405b52cf0b6e42



## Before

With optimisations:

```console
❯ ./python.exe benchmark_names_stdlib.py
Loaded 8,344,947 names
Time: 5.1483 seconds
```

## After

```console
❯ ./python.exe benchmark_names_stdlib.py
Loaded 8,344,947 names
Time: 1.3754 seconds
```

3.7 times faster.


<!-- gh-issue-number: gh-143658 -->
* Issue: gh-143658
<!-- /gh-issue-number -->
