### PR TITLE
gh-143638: Forbid cuncurrent use of the Pickler and Unpickler objects in C implementation

### DIFF
--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -419,6 +419,58 @@ if has_c_implementation:
                 unpickler.memo = {-1: None}
             unpickler.memo = {1: None}
 
+        def test_concurrent_pickler_dump(self):
+            f = io.BytesIO()
+            pickler = self.pickler_class(f)
+            class X:
+                def __reduce__(slf):
+                    self.assertRaises(RuntimeError, pickler.dump, 42)
+                    return list, ()
+            pickler.dump(X())  # should not crash
+            self.assertEqual(pickle.loads(f.getvalue()), [])
+
+        def test_concurrent_pickler_dump_and_clear_memo(self):
+            for clear_memo in [lambda: pickler.clear_memo(), lambda: pickler.memo.clear()]:
+                f = io.BytesIO()
+                pickler = self.pickler_class(f)
+                class X:
+                    def __reduce__(slf):
+                        self.assertRaises(RuntimeError, clear_memo)
+                        return list, (('inner',),), None, iter((slf,))
+                pickler.dump(['outer', X()])
+                unpickled = pickle.loads(f.getvalue())
+                self.assertIs(unpickled[1][1], unpickled[1])
+
+        def test_concurrent_pickler_dump_and_init(self):
+            f = io.BytesIO()
+            pickler = self.pickler_class(f)
+            class X:
+                def __reduce__(slf):
+                    self.assertRaises(RuntimeError, pickler.__init__, f)
+                    return list, ()
+            pickler.dump([X()])  # should not fail
+            self.assertEqual(pickle.loads(f.getvalue()), [[]])
+
+        def test_concurrent_unpickler_load(self):
+            global reducer
+            def reducer():
+                self.assertRaises(RuntimeError, unpickler.load)
+                return 42
+            f = io.BytesIO(b'(c%b\nreducer\n(tRl.' % (__name__.encode(),))
+            unpickler = self.unpickler_class(f)
+            unpickled = unpickler.load()  # should not fail
+            self.assertEqual(unpickled, [42])
+
+        def test_concurrent_unpickler_load_and_init(self):
+            global reducer
+            def reducer():
+                self.assertRaises(RuntimeError, unpickler.__init__, f)
+                return 42
+            f = io.BytesIO(b'(c%b\nreducer\n(tRl.' % (__name__.encode(),))
+            unpickler = self.unpickler_class(f)
+            unpickled = unpickler.load()  # should not crash
+            self.assertEqual(unpickled, [42])
+
     class CDispatchTableTests(AbstractDispatchTableTests, unittest.TestCase):
         pickler_class = pickle.Pickler
         def get_dispatch_table(self):
@@ -467,7 +519,7 @@ if has_c_implementation:
         check_sizeof = support.check_sizeof
 
         def test_pickler(self):
-            basesize = support.calcobjsize('7P2n3i2n3i2P')
+            basesize = support.calcobjsize('7P2n3i2n4i2P')
             p = _pickle.Pickler(io.BytesIO())
             self.assertEqual(object.__sizeof__(p), basesize)
             MT_size = struct.calcsize('3nP0n')
@@ -484,7 +536,7 @@ if has_c_implementation:
                 0)  # Write buffer is cleared after every dump().
 
         def test_unpickler(self):
-            basesize = support.calcobjsize('2P2n3P 2P2n2i5P 2P3n8P2n2i')
+            basesize = support.calcobjsize('2P2n3P 2P2n2i5P 2P3n8P2n3i')
             unpickler = _pickle.Unpickler
             P = struct.calcsize('P')  # Size of memo table entry.
             n = struct.calcsize('n')  # Size of mark table entry.

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -429,18 +429,6 @@ if has_c_implementation:
             pickler.dump(X())  # should not crash
             self.assertEqual(pickle.loads(f.getvalue()), [])
 
-        def test_concurrent_pickler_dump_and_clear_memo(self):
-            for clear_memo in [lambda: pickler.clear_memo(), lambda: pickler.memo.clear()]:
-                f = io.BytesIO()
-                pickler = self.pickler_class(f)
-                class X:
-                    def __reduce__(slf):
-                        self.assertRaises(RuntimeError, clear_memo)
-                        return list, (('inner',),), None, iter((slf,))
-                pickler.dump(['outer', X()])
-                unpickled = pickle.loads(f.getvalue())
-                self.assertIs(unpickled[1][1], unpickled[1])
-
         def test_concurrent_pickler_dump_and_init(self):
             f = io.BytesIO()
             pickler = self.pickler_class(f)

--- a/Misc/NEWS.d/next/Library/2026-01-10-16-42-47.gh-issue-143638.du5G7d.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-10-16-42-47.gh-issue-143638.du5G7d.rst
@@ -1,0 +1,4 @@
+Forbid reentrant calls of the :class:`pickle.Pickler` and
+:class:`pickle.Unpickler` methods for the C implementation. Previously, this
+could cause crash or data corruption, now concurrent calls of methods of the
+same object raise :exc:`RuntimeError`.


### PR DESCRIPTION
Previously, this could cause crash or data corruption, now concurrent calls of methods of the same object raise RuntimeError.


<!-- gh-issue-number: gh-143638 -->
* Issue: gh-143638
<!-- /gh-issue-number -->
