### PR TITLE
gh-143663: Perform path normalization in TarFile.extractall()

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2487,13 +2487,11 @@ class TarFile(object):
 
         if isinstance(member, str):
             unfiltered = self.getmember(member)
-            if os.sep != r'/':
-                unfiltered = unfiltered.replace(r'/', os.sep)
         else:
             unfiltered = member
-            if os.sep != r'/':
+            
+        if os.sep != r'/':
                 unfiltered.path = unfiltered.path.replace(r'/', os.sep)
-
         filtered = None
         try:
             filtered = filter_function(unfiltered, path)

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2437,7 +2437,6 @@ class TarFile(object):
                                                  'excluded by filter')
                     continue
                 dirpath = os.path.join(path, tarinfo.name)
-                dirpath = os.path.normpath(dirpath)
                 try:
                     lstat = os.lstat(dirpath)
                 except FileNotFoundError:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2487,8 +2487,10 @@ class TarFile(object):
 
         if isinstance(member, str):
             unfiltered = self.getmember(member)
+            unfiltered = unfiltered.replace(r'/', os.sep)
         else:
             unfiltered = member
+            unfiltered.path = unfiltered.path.replace(r'/', os.sep)
 
         filtered = None
         try:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2437,6 +2437,7 @@ class TarFile(object):
                                                  'excluded by filter')
                     continue
                 dirpath = os.path.join(path, tarinfo.name)
+                dirpath = os.path.normpath(dirpath)
                 try:
                     lstat = os.lstat(dirpath)
                 except FileNotFoundError:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2438,7 +2438,7 @@ class TarFile(object):
                     continue
                 dirpath = os.path.join(path, tarinfo.name)
                 try:
-                    lstat = os.lstat(dirpath)
+                    lstat = os.lstat(dirpath.replace(r'/', os.sep))
                 except FileNotFoundError:
                     self._log_no_directory_fixup(tarinfo, 'missing')
                     continue
@@ -2489,9 +2489,7 @@ class TarFile(object):
             unfiltered = self.getmember(member)
         else:
             unfiltered = member
-            
-        if os.sep != r'/':
-                unfiltered.path = unfiltered.path.replace(r'/', os.sep)
+
         filtered = None
         try:
             filtered = filter_function(unfiltered, path)

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2487,10 +2487,12 @@ class TarFile(object):
 
         if isinstance(member, str):
             unfiltered = self.getmember(member)
-            unfiltered = unfiltered.replace(r'/', os.sep)
+            if os.sep != r'/':
+                unfiltered = unfiltered.replace(r'/', os.sep)
         else:
             unfiltered = member
-            unfiltered.path = unfiltered.path.replace(r'/', os.sep)
+            if os.sep != r'/':
+                unfiltered.path = unfiltered.path.replace(r'/', os.sep)
 
         filtered = None
         try:

--- a/Misc/NEWS.d/next/Library/2026-01-10-17-39-09.gh-issue-143663.9LEFAf.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-10-17-39-09.gh-issue-143663.9LEFAf.rst
@@ -1,0 +1,1 @@
+Add path normalization to `TarFile.extractall()`.

--- a/Misc/NEWS.d/next/Library/2026-01-10-17-39-09.gh-issue-143663.9LEFAf.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-10-17-39-09.gh-issue-143663.9LEFAf.rst
@@ -1,1 +1,1 @@
-:meth:`tarfile.TarFile._get_extract_tarinfo` now uses OS-specific separators.
+:mod:`tarfile`: :meth:`TarFile.extractall` now uses OS-specific separators to call lstat. This fixes a failure case with raw Win32 paths on Windows.

--- a/Misc/NEWS.d/next/Library/2026-01-10-17-39-09.gh-issue-143663.9LEFAf.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-10-17-39-09.gh-issue-143663.9LEFAf.rst
@@ -1,1 +1,1 @@
-:mod:`tarfile`: Add path normalization to :meth:`TarFile.extractall`.
+:meth:`tarfile.TarFile._get_extract_tarinfo` now uses OS-specific separators.

--- a/Misc/NEWS.d/next/Library/2026-01-10-17-39-09.gh-issue-143663.9LEFAf.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-10-17-39-09.gh-issue-143663.9LEFAf.rst
@@ -1,1 +1,1 @@
-Add path normalization to `TarFile.extractall()`.
+:mod:`tarfile`: Add path normalization to :meth:`TarFile.extractall`.

--- a/Misc/NEWS.d/next/Library/2026-01-10-17-39-09.gh-issue-143663.9LEFAf.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-10-17-39-09.gh-issue-143663.9LEFAf.rst
@@ -1,1 +1,2 @@
-:mod:`tarfile`: :meth:`TarFile.extractall` now uses OS-specific separators to call lstat. This fixes a failure case with raw Win32 paths on Windows.
+:meth:`tarfile.TarFile.extractall` now uses OS-specific separators to call
+lstat.


### PR DESCRIPTION
This PR fixes an issue on Windows caused by non-normalized destination paths when calling `extractall()`.
* Issue: #143663 

<!-- gh-issue-number: gh-143663 -->
* Issue: gh-143663
<!-- /gh-issue-number -->
