### PR TITLE
gh-143635: Fix crash in `_Py_typing_type_repr`

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -259,7 +259,7 @@ class BaseTest(unittest.TestCase):
 
         params = []
         params.append(Zap(params))
-        alias = type(list[int])(list, (params,))
+        alias = GenericAlias(list, (params,))
         repr_str = repr(alias)
         self.assertTrue(repr_str.startswith("list[["), repr_str)
 
@@ -277,9 +277,22 @@ class BaseTest(unittest.TestCase):
 
         params = []
         params.append(Zap(params))
-        alias = type(list[int])(list, (params,))
+        alias = GenericAlias(list, (params,))
         repr_str = repr(alias)
         self.assertTrue(repr_str.startswith("list[["), repr_str)
+
+    def test_evil_repr3(self):
+        # gh-143823
+        lst = []
+        class X:
+            def __repr__(self):
+                lst.clear()
+                return "x"
+
+        lst += [X(), 1]
+        ga = GenericAlias(int, lst)
+        with self.assertRaises(IndexError):
+            repr(ga)
 
     def test_exposed_type(self):
         import types

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-11-20-11-36.gh-issue-143670.klnGoD.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-11-20-11-36.gh-issue-143670.klnGoD.rst
@@ -1,0 +1,1 @@
+Fixes a crash in ``_Py_typing_type_repr`` function.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-11-20-11-36.gh-issue-143670.klnGoD.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-11-20-11-36.gh-issue-143670.klnGoD.rst
@@ -1,1 +1,1 @@
-Fixes a crash in ``_Py_typing_type_repr`` function.
+Fixes a crash in ``ga_repr_items_list`` function.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -68,10 +68,15 @@ ga_repr_items_list(PyUnicodeWriter *writer, PyObject *p)
                 return -1;
             }
         }
-        PyObject *item = PyList_GET_ITEM(p, i);
+        PyObject *item = PyList_GetItemRef(p, i);
+        if (item == NULL) {
+            return -1;  // list can be mutated in a callback
+        }
         if (_Py_typing_type_repr(writer, item) < 0) {
+            Py_DECREF(item);
             return -1;
         }
+        Py_DECREF(item);
     }
 
     if (PyUnicodeWriter_WriteChar(writer, ']') < 0) {

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -270,14 +270,13 @@ _Py_typing_type_repr(PyUnicodeWriter *writer, PyObject *p)
     if (p == Py_Ellipsis) {
         // The Ellipsis object
         r = PyUnicode_FromString("...");
-        goto cleanup;
+        goto exit;
     }
 
     if (p == (PyObject *)&_PyNone_Type) {
         return PyUnicodeWriter_WriteASCII(writer, "None", 4);
     }
 
-    Py_INCREF(p);  // gh-143635
     if ((rc = PyObject_HasAttrWithError(p, &_Py_ID(__origin__))) > 0 &&
         (rc = PyObject_HasAttrWithError(p, &_Py_ID(__args__))) > 0)
     {
@@ -317,8 +316,6 @@ _Py_typing_type_repr(PyUnicodeWriter *writer, PyObject *p)
 use_repr:
     r = PyObject_Repr(p);
 exit:
-    Py_DECREF(p);  // gh-143635
-cleanup:
     Py_XDECREF(qualname);
     Py_XDECREF(module);
     if (r == NULL) {

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -270,13 +270,14 @@ _Py_typing_type_repr(PyUnicodeWriter *writer, PyObject *p)
     if (p == Py_Ellipsis) {
         // The Ellipsis object
         r = PyUnicode_FromString("...");
-        goto exit;
+        goto cleanup;
     }
 
     if (p == (PyObject *)&_PyNone_Type) {
         return PyUnicodeWriter_WriteASCII(writer, "None", 4);
     }
 
+    Py_INCREF(p);  // gh-143635
     if ((rc = PyObject_HasAttrWithError(p, &_Py_ID(__origin__))) > 0 &&
         (rc = PyObject_HasAttrWithError(p, &_Py_ID(__args__))) > 0)
     {
@@ -316,6 +317,8 @@ _Py_typing_type_repr(PyUnicodeWriter *writer, PyObject *p)
 use_repr:
     r = PyObject_Repr(p);
 exit:
+    Py_DECREF(p);  // gh-143635
+cleanup:
     Py_XDECREF(qualname);
     Py_XDECREF(module);
     if (r == NULL) {


### PR DESCRIPTION
I also added one more test case for a second possible crash in the same function.

<!-- gh-issue-number: gh-143635 -->
* Issue: gh-143635
<!-- /gh-issue-number -->
