### PR TITLE
gh-143674: Document F/D complex format characters in struct module

### DIFF
--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2689,7 +2689,7 @@ these can be preceded by a decimal repeat count:\n\
   ?: _Bool (requires C99; if not available, char is used instead)\n\
   h:short; H:unsigned short; i:int; I:unsigned int;\n\
   l:long; L:unsigned long; f:float; d:double; e:half-float.\n\
-  F:complex (two floats); D:complex (two doubles).\n\
+  F:float complex; D:double complex.\n\
 Special cases (preceding decimal count indicates length):\n\
   s:string (array of char); p: pascal string (with count byte).\n\
 Special cases (only available in native format):\n\

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2689,6 +2689,7 @@ these can be preceded by a decimal repeat count:\n\
   ?: _Bool (requires C99; if not available, char is used instead)\n\
   h:short; H:unsigned short; i:int; I:unsigned int;\n\
   l:long; L:unsigned long; f:float; d:double; e:half-float.\n\
+  F:complex (two floats); D:complex (two doubles).\n\
 Special cases (preceding decimal count indicates length):\n\
   s:string (array of char); p: pascal string (with count byte).\n\
 Special cases (only available in native format):\n\


### PR DESCRIPTION
Fixes https://github.com/python/cpython/issues/143674

## Changes
- Added documentation for `F` (complex from two floats) and `D` (complex from two doubles) format characters to the struct module docstring

## Rationale
These format characters are implemented in the struct module (lines 858-859, 1189-1190, 1504-1505 in Modules/_struct.c) but were missing from the module's docstring documentation. Users consulting the docstring with `help(struct)` would not know these options exist.

## Testing
- Verified that F and D format characters are implemented in the code
- Confirmed the docstring change follows the existing format and style
- The change is minimal and only adds missing documentation

## Checklist
- [x] Minimal change - only added missing documentation
- [x] Followed existing docstring format and style
- [x] Commit message follows CPython guidelines

<!-- gh-issue-number: gh-143674 -->
* Issue: gh-143674
<!-- /gh-issue-number -->
