### PR TITLE
[3.13] gh-143638: Forbid cuncurrent use of the Pickler and Unpickler objects in C implementation (GH-143664)

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-01-10-16-42-47.gh-issue-143638.du5G7d.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-10-16-42-47.gh-issue-143638.du5G7d.rst
@@ -1,0 +1,4 @@
+Forbid reentrant calls of the :class:`pickle.Pickler` and
+:class:`pickle.Unpickler` methods for the C implementation. Previously, this
+could cause crash or data corruption, now concurrent calls of methods of the
+same object raise :exc:`RuntimeError`.


### PR DESCRIPTION
Previously, this could cause crash or data corruption, now concurrent calls of methods of the same object raise RuntimeError.
(cherry picked from commit d1282efb2b847bf9274d78c5f15ea00499b2c894)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143638 -->
* Issue: gh-143638
<!-- /gh-issue-number -->
