### PR TITLE
gh-143689: Fix BufferedReader.read1 leaving object in reentrant state on error

### DIFF
--- a/Lib/test/test_io/test_bufferedio.py
+++ b/Lib/test/test_io/test_bufferedio.py
@@ -638,6 +638,7 @@ class CBufferedReaderTest(BufferedReaderTest, SizeofTest, CTestCase):
             with self.assertRaises(MemoryError):
                 bufio.read1(huge)
 
+            # Used to crash before gh-143689:
             self.assertEqual(bufio.read1(1), b"h")
 
 

--- a/Lib/test/test_io/test_bufferedio.py
+++ b/Lib/test/test_io/test_bufferedio.py
@@ -623,6 +623,19 @@ class CBufferedReaderTest(BufferedReaderTest, SizeofTest, CTestCase):
             bufio.readline()
         self.assertIsInstance(cm.exception.__cause__, TypeError)
 
+    def test_read1_error_does_not_cause_reentrant_failure(self):
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with self.open(os_helper.TESTFN, "wb") as f:
+            f.write(b"hello")
+
+        with self.open(os_helper.TESTFN, "rb", buffering=0) as raw:
+            bufio = self.tp(raw, buffer_size=8)
+            huge = 10**18
+            with self.assertRaises(MemoryError):
+                bufio.read1(huge)
+
+            self.assertEqual(bufio.read1(1), b"h")
+
 
 class PyBufferedReaderTest(BufferedReaderTest, PyTestCase):
     tp = pyio.BufferedReader

--- a/Lib/test/test_io/test_bufferedio.py
+++ b/Lib/test/test_io/test_bufferedio.py
@@ -634,7 +634,9 @@ class CBufferedReaderTest(BufferedReaderTest, SizeofTest, CTestCase):
 
         with self.open(os_helper.TESTFN, "rb", buffering=0) as raw:
             bufio = self.tp(raw, buffer_size=8)
-            huge = 10**18
+            # To request a size that is far too huge to ever be satisfied,
+            # so that the internal buffer allocation reliably fails with MemoryError.
+            huge = sys.maxsize // 2 + 1
             with self.assertRaises(MemoryError):
                 bufio.read1(huge)
 

--- a/Lib/test/test_io/test_bufferedio.py
+++ b/Lib/test/test_io/test_bufferedio.py
@@ -10,8 +10,7 @@ import weakref
 from collections import deque, UserList
 from itertools import cycle, count
 from test import support
-from test.support import check_sanitizer
-from test.support import os_helper, threading_helper
+from test.support import check_sanitizer, os_helper, threading_helper
 from .utils import byteslike, CTestCase, PyTestCase
 
 

--- a/Misc/NEWS.d/next/Library/2026-01-11-14-14-19.gh-issue-143689.fzHJ2W.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-11-14-14-19.gh-issue-143689.fzHJ2W.rst
@@ -1,1 +1,1 @@
-Fixed BufferedReader.read1() leaving the object in a reentrant state after an error.
+Fix :meth:`io.BufferedReader.read1` state cleanup on buffer allocation failure.

--- a/Misc/NEWS.d/next/Library/2026-01-11-14-14-19.gh-issue-143689.fzHJ2W.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-11-14-14-19.gh-issue-143689.fzHJ2W.rst
@@ -1,0 +1,1 @@
+Fixed BufferedReader.read1() leaving the object in a reentrant state after an error.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1073,6 +1073,7 @@ _io__Buffered_read1_impl(buffered *self, Py_ssize_t n)
 
     PyBytesWriter *writer = PyBytesWriter_Create(n);
     if (writer == NULL) {
+        LEAVE_BUFFERED(self)
         return NULL;
     }
 


### PR DESCRIPTION
BufferedReader.read1() could leave the buffered object in a
reentrant (locked) state when an exception was raised while
allocating the output buffer.

This change ensures the internal buffered lock is always released
on error, keeping the object in a consistent state after failures.

<!-- gh-issue-number: gh-143689 -->
* Issue: gh-143689
<!-- /gh-issue-number -->
