### PR TITLE
gh-143728: Keep `TypedDict` and `NamedTuple` in `class` role in docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2369,7 +2369,7 @@ These functions and classes should not be used directly as annotations.
 Their intended purpose is to be building blocks for creating and declaring
 types.
 
-.. class:: NamedTuple
+.. function:: NamedTuple
 
    Typed version of :func:`collections.namedtuple`.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2369,7 +2369,7 @@ These functions and classes should not be used directly as annotations.
 Their intended purpose is to be building blocks for creating and declaring
 types.
 
-.. function:: NamedTuple
+.. class:: NamedTuple
 
    Typed version of :func:`collections.namedtuple`.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2369,7 +2369,7 @@ These functions and classes should not be used directly as annotations.
 Their intended purpose is to be building blocks for creating and declaring
 types.
 
-.. function:: NamedTuple
+.. class:: NamedTuple
 
    Typed version of :func:`collections.namedtuple`.
 
@@ -2589,7 +2589,7 @@ types.
       for more details.
 
 
-.. function:: TypedDict
+.. class:: TypedDict(dict)
 
    Special construct to add type hints to a dictionary.
    At runtime ":class:`!TypedDict` instances" are simply :class:`dicts <dict>`.


### PR DESCRIPTION
Partially reverts GH-143692; see https://github.com/python/cpython/pull/143692#issuecomment-3735057203

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-86139 -->
* Issue: gh-86139
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143702.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-143728 -->
* Issue: gh-143728
<!-- /gh-issue-number -->
