### PR TITLE
gh-144194: Fix mmap failure check in perf_jit_trampoline.c

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-23-20-20-42.gh-issue-144194.IbXfxd.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-23-20-20-42.gh-issue-144194.IbXfxd.rst
@@ -1,0 +1,1 @@
+Fix error handling in perf jitdump initialization on memory allocation failure.

--- a/Python/perf_jit_trampoline.c
+++ b/Python/perf_jit_trampoline.c
@@ -1083,7 +1083,8 @@ static void* perf_map_jit_init(void) {
         0                        // Offset 0 (first page)
     );
 
-    if (perf_jit_map_state.mapped_buffer == NULL) {
+    if (perf_jit_map_state.mapped_buffer == MAP_FAILED) {
+        perf_jit_map_state.mapped_buffer = NULL;
         close(fd);
         return NULL;  // Memory mapping failed
     }


### PR DESCRIPTION
mmap() returns MAP_FAILED ((void*)-1) on error, not NULL. The current check never detects mmap failures, so jitdump initialization proceeds even when the memory mapping fails.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144194 -->
* Issue: gh-144194
<!-- /gh-issue-number -->
