### PR TITLE
gh-139707: Copy-strip change to idle.rst into idlelib

### DIFF
--- a/Lib/idlelib/help.html
+++ b/Lib/idlelib/help.html
@@ -16,6 +16,12 @@ through multiple files (grep)</p></li>
 of global and local namespaces</p></li>
 <li><p>configuration, browsers, and other dialogs</p></li>
 </ul>
+<p>The IDLE application is implemented in the <a class="reference internal" href="#module-idlelib" title="idlelib: Implementation package for the IDLE shell/editor."><code class="xref py py-mod docutils literal notranslate"><span class="pre">idlelib</span></code></a> package.</p>
+<p>This is an <a class="reference internal" href="../glossary.html#term-optional-module"><span class="xref std std-term">optional module</span></a>.
+If it is missing from your copy of CPython,
+look for documentation from your distributor (that is,
+whoever provided Python to you).
+If you are the distributor, see <a class="reference internal" href="../using/configure.html#optional-module-requirements"><span class="std std-ref">Requirements for optional modules</span></a>.</p>
 <section id="menus">
 <h2>Menus<a class="headerlink" href="#menus" title="Link to this heading">¶</a></h2>
 <p>IDLE has two main window types, the Shell window and the Editor window.  It is
@@ -516,7 +522,7 @@ looked for in the user’s home directory.  Statements in this file will be
 executed in the Tk namespace, so this file is not useful for importing
 functions to be used from IDLE’s Python shell.</p>
 <section id="command-line-usage">
-<h3>Command line usage<a class="headerlink" href="#command-line-usage" title="Link to this heading">¶</a></h3>
+<span id="idlelib-cli"></span><h3>Command-line usage<a class="headerlink" href="#command-line-usage" title="Link to this heading">¶</a></h3>
 <p>IDLE can be invoked from the command line with various options. The general syntax is:</p>
 <div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>python<span class="w"> </span>-m<span class="w"> </span>idlelib<span class="w"> </span><span class="o">[</span>options<span class="o">]</span><span class="w"> </span><span class="o">[</span>file<span class="w"> </span>...<span class="o">]</span>
 </pre></div>


### PR DESCRIPTION
On Windows, running `python -c "from idlelib.help import copy_strip; copy_strip()"` after idle.html is built results in `f:\dev\3x\Doc\build\html\library\idle.html
copied to f:\dev\3x\Lib\idlelib\help.html`
This PR commits the change to idlelib/help.html.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139707 -->
* Issue: gh-139707
<!-- /gh-issue-number -->
