### PR TITLE
[3.13] gh-142881: Fix concurrent and reentrant call of atexit.unregister() (GH-142901)

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-12-17-20-18-17.gh-issue-142881.5IizIQ.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-17-20-18-17.gh-issue-142881.5IizIQ.rst
@@ -1,0 +1,1 @@
+Fix concurrent and reentrant call of :func:`atexit.unregister`.

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -57,6 +57,9 @@ static void
 atexit_delete_cb(struct atexit_state *state, int i)
 {
     atexit_py_callback *cb = state->callbacks[i];
+    if (cb == NULL) {
+        return;
+    }
     state->callbacks[i] = NULL;
 
     Py_DECREF(cb->func);


### PR DESCRIPTION
(cherry picked from commit dbd10a6c29ba1cfc9348924a090b5dc514470002)


<!-- gh-issue-number: gh-142881 -->
* Issue: gh-142881
<!-- /gh-issue-number -->
