### PR TITLE
gh-143632: Disable PR_SET_VMA_ANON_NAME on musl libc

### DIFF
--- a/configure
+++ b/configure
@@ -23965,6 +23965,9 @@ printf "%s\n" "#define HAVE_UT_NAMESIZE 1" >>confdefs.h
 
 fi
 
+# musl libc redefines struct prctl_mm_map and conflicts with linux/prctl.h
+if test "$ac_cv_libc" != musl
+then :
 
 ac_fn_check_decl "$LINENO" "PR_SET_VMA_ANON_NAME" "ac_cv_have_decl_PR_SET_VMA_ANON_NAME" "#include <linux/prctl.h>
                #include <sys/prctl.h>
@@ -23985,6 +23988,7 @@ printf "%s\n" "#define HAVE_PR_SET_VMA_ANON_NAME 1" >>confdefs.h
 fi
 
 
+fi
 # check for openpty, login_tty, and forkpty
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -5594,14 +5594,15 @@ AC_CHECK_DECLS([UT_NAMESIZE],
                          [Define if you have the 'HAVE_UT_NAMESIZE' constant.])],
               [],
               [@%:@include <utmp.h>])
-
+# musl libc redefines struct prctl_mm_map and conflicts with linux/prctl.h
+AS_IF([test "$ac_cv_libc" != musl], [
 AC_CHECK_DECLS([PR_SET_VMA_ANON_NAME],
               [AC_DEFINE([HAVE_PR_SET_VMA_ANON_NAME], [1],
                          [Define if you have the 'PR_SET_VMA_ANON_NAME' constant.])],
               [],
               [@%:@include <linux/prctl.h>
                @%:@include <sys/prctl.h>])
-
+])
 # check for openpty, login_tty, and forkpty
 
 AC_CHECK_FUNCS([openpty], [],


### PR DESCRIPTION
On Alpine Linux (musl libc), enabling `PR_SET_VMA_ANON_NAME` can cause build failures due to redefinition of
`struct prctl_mm_map`.
musl libc redefines this struct in `sys/prctl.h`, which conflicts with `linux/prctl.h`. The configure check for `PR_SET_VMA_ANON_NAME` is not realiable on musl and may pass on
some architectures but fail later during build.
This change disables the feature detection on musl to avoid the header conflict and keep the build behavior consistent.
Note: `configure` was not regenerated locally since CPython
does not support autoreconf on macOS.

Fixes gh-143632.
