### PR TITLE
Bump automatic certificate update on Windows during builds

### DIFF
--- a/PCbuild/get_external.py
+++ b/PCbuild/get_external.py
@@ -49,6 +49,7 @@ def retrieve_with_retries(download_location, output_path, reporthook,
         except (urllib.error.URLError, ConnectionError) as ex:
             if attempt == max_retries:
                 raise OSError(f'Download from {download_location} failed.') from ex
+            trigger_automatic_root_certificate_update(download_location)
             time.sleep(2.25**attempt)
         else:
             return resp

--- a/PCbuild/get_external.py
+++ b/PCbuild/get_external.py
@@ -25,8 +25,8 @@ def trigger_automatic_root_certificate_update(url: str, timeout: int = 30) -> No
                 "-Command",
                 f"Invoke-WebRequest -Uri '{escaped_url}'"
                 f" -UseBasicParsing -Method HEAD -MaximumRedirection 0"
-                f" -TimeoutSec {timeout} -ErrorAction SilentlyContinue"
-                f" | Out-Null",
+                f" -TimeoutSec {timeout}"# -ErrorAction SilentlyContinue"
+                #f" | Out-Null",
             ],
             check=True,
             capture_output=True,

--- a/PCbuild/get_external.py
+++ b/PCbuild/get_external.py
@@ -14,7 +14,7 @@ import urllib.request
 import zipfile
 
 
-@functools.cache
+#@functools.cache
 def trigger_automatic_root_certificate_update(url: str, timeout: int = 30) -> None:
     escaped_url = url.replace("'", "''")
     try:
@@ -32,8 +32,8 @@ def trigger_automatic_root_certificate_update(url: str, timeout: int = 30) -> No
             capture_output=True,
             timeout=timeout + 5,
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        pass
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        print(e)
 
 
 def retrieve_with_retries(download_location, output_path, reporthook,

--- a/PCbuild/get_external.py
+++ b/PCbuild/get_external.py
@@ -14,7 +14,7 @@ import urllib.request
 import zipfile
 
 
-#@functools.cache
+@functools.cache
 def trigger_automatic_root_certificate_update(url: str, timeout: int = 30) -> None:
     escaped_url = url.replace("'", "''")
     try:
@@ -25,8 +25,7 @@ def trigger_automatic_root_certificate_update(url: str, timeout: int = 30) -> No
                 "-Command",
                 f"Invoke-WebRequest -Uri '{escaped_url}'"
                 f" -UseBasicParsing -Method HEAD -MaximumRedirection 0"
-                f" -TimeoutSec {timeout}"# -ErrorAction SilentlyContinue"
-                #f" | Out-Null",
+                f" -TimeoutSec {timeout}",
             ],
             check=True,
             capture_output=True,


### PR DESCRIPTION
Without this, OpenSSL that we use to download external dependencies might use a stale certificate store and be unable to connect to servers. We need to use a Windows-specific HTTP client that uses CryptoAPI directly to trigger certificate updates.

We only do it on failure to avoid hitting servers twice. And we only do it once per each URL.
