### PR TITLE
gh-143460: Correct unlimited stack size skip for Emscripten

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1781,7 +1781,7 @@ def skip_if_unlimited_stack_size(test):
 
     See https://github.com/python/cpython/issues/143460.
     """
-    if is_wasi or os.name == "nt":
+    if is_emscripten or is_wasi or os.name == "nt":
         return test
 
     import resource


### PR DESCRIPTION
#143606 added a test skip decorator for tests when an infinite stack size is configured. That test skip included a shortcut for WASI (which doesn't have a `resource` module), but missing Emscripten (which has the same limitation).


<!-- gh-issue-number: gh-143460 -->
* Issue: gh-143460
<!-- /gh-issue-number -->
