### PR TITLE
[3.13] gh-139707: Copy-strip change to idle.rst into idlelib

### DIFF
--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -37,6 +37,11 @@ IDLE has the following features:
 
 * configuration, browsers, and other dialogs
 
+The IDLE application is implemented in the :mod:`idlelib` package.
+
+This is an optional module. If it is missing from your copy of CPython, look for documentation from your distributor (that is, whoever provided Python to you).
+If you are the distributor, see Requirements for optional modules.
+
 Menus
 -----
 

--- a/Lib/idlelib/help.html
+++ b/Lib/idlelib/help.html
@@ -1,6 +1,6 @@
 <section id="idle">
 <span id="idle-python-editor-and-shell"></span><h1>IDLE — Python editor and shell<a class="headerlink" href="#idle" title="Link to this heading">¶</a></h1>
-<p><strong>Source code:</strong> <a class="extlink-source reference external" href="https://github.com/python/cpython/tree/3.13/Lib/idlelib/">Lib/idlelib/</a></p>
+<p><strong>Source code:</strong> <a class="extlink-source reference external" href="https://github.com/python/cpython/tree/main/Lib/idlelib/">Lib/idlelib/</a></p>
 <span class="target" id="index-0"></span><hr class="docutils" />
 <p>IDLE is Python’s Integrated Development and Learning Environment.</p>
 <p>IDLE has the following features:</p>
@@ -839,7 +839,7 @@ also used for testing.</p>
 </section>
 <section id="module-idlelib">
 <span id="idlelib-implementation-of-idle-application"></span><h2>idlelib — implementation of IDLE application<a class="headerlink" href="#module-idlelib" title="Link to this heading">¶</a></h2>
-<p><strong>Source code:</strong> <a class="extlink-source reference external" href="https://github.com/python/cpython/tree/3.13/Lib/idlelib">Lib/idlelib</a></p>
+<p><strong>Source code:</strong> <a class="extlink-source reference external" href="https://github.com/python/cpython/tree/main/Lib/idlelib">Lib/idlelib</a></p>
 <hr class="docutils" />
 <p>The Lib/idlelib package implements the IDLE application.  See the rest
 of this page for how to use IDLE.</p>

--- a/Lib/idlelib/help.html
+++ b/Lib/idlelib/help.html
@@ -1,6 +1,6 @@
 <section id="idle">
 <span id="idle-python-editor-and-shell"></span><h1>IDLE — Python editor and shell<a class="headerlink" href="#idle" title="Link to this heading">¶</a></h1>
-<p><strong>Source code:</strong> <a class="extlink-source reference external" href="https://github.com/python/cpython/tree/main/Lib/idlelib/">Lib/idlelib/</a></p>
+<p><strong>Source code:</strong> <a class="extlink-source reference external" href="https://github.com/python/cpython/tree/3.13/Lib/idlelib/">Lib/idlelib/</a></p>
 <span class="target" id="index-0"></span><hr class="docutils" />
 <p>IDLE is Python’s Integrated Development and Learning Environment.</p>
 <p>IDLE has the following features:</p>
@@ -16,6 +16,9 @@ through multiple files (grep)</p></li>
 of global and local namespaces</p></li>
 <li><p>configuration, browsers, and other dialogs</p></li>
 </ul>
+<p>The IDLE application is implemented in the <a class="reference internal" href="#module-idlelib" title="idlelib: Implementation package for the IDLE shell/editor."><code class="xref py py-mod docutils literal notranslate"><span class="pre">idlelib</span></code></a> package.</p>
+<p>This is an optional module. If it is missing from your copy of CPython, look for documentation from your distributor (that is, whoever provided Python to you).
+If you are the distributor, see Requirements for optional modules.</p>
 <section id="menus">
 <h2>Menus<a class="headerlink" href="#menus" title="Link to this heading">¶</a></h2>
 <p>IDLE has two main window types, the Shell window and the Editor window.  It is
@@ -516,7 +519,7 @@ looked for in the user’s home directory.  Statements in this file will be
 executed in the Tk namespace, so this file is not useful for importing
 functions to be used from IDLE’s Python shell.</p>
 <section id="command-line-usage">
-<h3>Command line usage<a class="headerlink" href="#command-line-usage" title="Link to this heading">¶</a></h3>
+<span id="idlelib-cli"></span><h3>Command-line usage<a class="headerlink" href="#command-line-usage" title="Link to this heading">¶</a></h3>
 <p>IDLE can be invoked from the command line with various options. The general syntax is:</p>
 <div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>python<span class="w"> </span>-m<span class="w"> </span>idlelib<span class="w"> </span><span class="o">[</span>options<span class="o">]</span><span class="w"> </span><span class="o">[</span>file<span class="w"> </span>...<span class="o">]</span>
 </pre></div>
@@ -836,7 +839,7 @@ also used for testing.</p>
 </section>
 <section id="module-idlelib">
 <span id="idlelib-implementation-of-idle-application"></span><h2>idlelib — implementation of IDLE application<a class="headerlink" href="#module-idlelib" title="Link to this heading">¶</a></h2>
-<p><strong>Source code:</strong> <a class="extlink-source reference external" href="https://github.com/python/cpython/tree/main/Lib/idlelib">Lib/idlelib</a></p>
+<p><strong>Source code:</strong> <a class="extlink-source reference external" href="https://github.com/python/cpython/tree/3.13/Lib/idlelib">Lib/idlelib</a></p>
 <hr class="docutils" />
 <p>The Lib/idlelib package implements the IDLE application.  See the rest
 of this page for how to use IDLE.</p>


### PR DESCRIPTION
Copy net new text in idle.rst from main to 3.13.
Make 3.13 docs and copy-strip idle.html to idlelib/help.html.
See https://github.com/python/cpython/issues/139707#issuecomment-3737374788 and PR #143718 message for more.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139707 -->
* Issue: gh-139707
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143767.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->