### PR TITLE
gh-142883: avoid crash when __index__ changes array type during multiplication.

### DIFF
--- a/Lib/test/test_numeric_tower.py
+++ b/Lib/test/test_numeric_tower.py
@@ -225,6 +225,29 @@ class ComparisonTest(unittest.TestCase):
                 self.assertRaises(TypeError, op, z, v)
                 self.assertRaises(TypeError, op, v, z)
 
+class IndexMutationDuringNumericOpTest(unittest.TestCase):
+    
+    def test_index_mutates_lhs_type_during_operation(self):
+        import array
 
+        class Good(array.array):
+            pass
+
+        class Hide(type):
+            def mro(cls):
+                return (cls, object)
+
+        class Bad(Good, metaclass=Hide):
+            pass
+
+        arr = Good('b', b'x')
+
+        class Count:
+            def __index__(self):
+                arr.__class__ = Bad
+                return 2
+
+        with self.assertRaises(TypeError):
+            arr * Count()
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_numeric_tower.py
+++ b/Lib/test/test_numeric_tower.py
@@ -226,7 +226,6 @@ class ComparisonTest(unittest.TestCase):
                 self.assertRaises(TypeError, op, v, z)
 
 class IndexMutationDuringNumericOpTest(unittest.TestCase):
-    
     def test_index_mutates_lhs_type_during_operation(self):
         import array
 

--- a/Lib/test/test_numeric_tower.py
+++ b/Lib/test/test_numeric_tower.py
@@ -249,5 +249,7 @@ class IndexMutationDuringNumericOpTest(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             arr * Count()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_numeric_tower.py
+++ b/Lib/test/test_numeric_tower.py
@@ -225,6 +225,7 @@ class ComparisonTest(unittest.TestCase):
                 self.assertRaises(TypeError, op, z, v)
                 self.assertRaises(TypeError, op, v, z)
 
+
 class IndexMutationDuringNumericOpTest(unittest.TestCase):
     def test_index_mutates_lhs_type_during_operation(self):
         import array

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-13-07-08-20.gh-issue-142883.Ko9RA-.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-13-07-08-20.gh-issue-142883.Ko9RA-.rst
@@ -1,0 +1,2 @@
+Fixed a crash during array multiplication when ``__index__`` changes the
+array’s class while the operation is in progress.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-13-array-index-crash.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-13-array-index-crash.rst
@@ -1,3 +1,0 @@
-Fixed a crash during array multiplication when __index__ changes the array’s
-class while the operation is in progress.
-

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-13-array-index-crash.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-13-array-index-crash.rst
@@ -1,0 +1,3 @@
+Fixed a crash during array multiplication when __index__ changes the array’s
+class while the operation is in progress.
+

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -9714,6 +9714,7 @@ wrap_indexargfunc(PyObject *self, PyObject *args, void *wrapped)
     ssizeargfunc func = (ssizeargfunc)wrapped;
     PyObject* o;
     Py_ssize_t i;
+    PyTypeObject *type_before = Py_TYPE(self);
 
     if (!check_num_args(args, 1))
         return NULL;
@@ -9721,6 +9722,11 @@ wrap_indexargfunc(PyObject *self, PyObject *args, void *wrapped)
     i = PyNumber_AsSsize_t(o, PyExc_OverflowError);
     if (i == -1 && PyErr_Occurred())
         return NULL;
+    if (Py_TYPE(self) != type_before) {
+        PyErr_SetString(PyExc_TypeError,
+                        "object mutated during numeric operation");
+        return NULL;
+    }
     return (*func)(self, i);
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -9715,18 +9715,25 @@ wrap_indexargfunc(PyObject *self, PyObject *args, void *wrapped)
     PyObject* o;
     Py_ssize_t i;
     PyTypeObject *type_before = Py_TYPE(self);
+    Py_INCREF(type_before);
 
-    if (!check_num_args(args, 1))
+    if (!check_num_args(args, 1)){
+        Py_DECREF(type_before);
         return NULL;
+    }
     o = PyTuple_GET_ITEM(args, 0);
     i = PyNumber_AsSsize_t(o, PyExc_OverflowError);
-    if (i == -1 && PyErr_Occurred())
+    if (i == -1 && PyErr_Occurred()){
+        Py_DECREF(type_before);
         return NULL;
+    }
     if (Py_TYPE(self) != type_before) {
+        Py_DECREF(type_before);
         PyErr_SetString(PyExc_TypeError,
                         "object mutated during numeric operation");
         return NULL;
     }
+    Py_DECREF(type_before);
     return (*func)(self, i);
 }
 


### PR DESCRIPTION
`__index__` can change the array’s class during multiplication. After that,
the old function is still called, which can cause a crash. This adds a
check to avoid that and raises TypeError instead.

A regression test is also added.

<!-- gh-issue-number: gh-142883 -->
* Issue: gh-142883
<!-- /gh-issue-number -->
