### PR TITLE
Add regression test for add() after remove() with hash collision in set

### DIFF
--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -20,6 +20,14 @@ def check_pass_thru():
     raise PassThru
     yield 1
 
+class CustomHash:
+    def __init__(self, hash):
+        self.hash = hash
+    def __hash__(self):
+        return self.hash
+    def __repr__(self):
+        return f'<CustomHash {self.hash} at {id(self):#x}>'
+
 class BadCmp:
     def __hash__(self):
         return 1
@@ -674,6 +682,28 @@ class TestSet(TestJointOps, unittest.TestCase):
             myset.add(elem2)
         with self.assertRaises(KeyError):
             myset.discard(elem2)
+
+    def test_hash_collision_remove_add(self):
+        self.maxDiff = None
+        # There should be enough space, so all elements with unique hash
+        # will be placed in corresponding cells without collision.
+        n = 64
+        elems = [CustomHash(h) for h in range(n)]
+        # Elements with hash collision.
+        a = CustomHash(n)
+        b = CustomHash(n)
+        elems += [a, b]
+        s = self.thetype(elems)
+        self.assertEqual(len(s), len(elems), s)
+        s.remove(a)
+        # "a" has been replaced with a dummy.
+        del elems[n]
+        self.assertEqual(len(s), len(elems), s)
+        self.assertEqual(s, set(elems))
+        s.add(b)
+        # "b" should not replace the dummy.
+        self.assertEqual(len(s), len(elems), s)
+        self.assertEqual(s, set(elems))
 
 
 class SetSubclass(set):


### PR DESCRIPTION
This will catch possible regressions like in #142007.

Just for the case, added also a similar test for dict.