### PR TITLE
gh-141004: Mark up docs of old PyMem macros

### DIFF
--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -293,17 +293,23 @@ The following type-oriented macros are provided for convenience.  Note  that
 
    Same as :c:func:`PyMem_Free`.
 
-In addition, the following macro sets are provided for calling the Python memory
-allocator directly, without involving the C API functions listed above. However,
-note that their use does not preserve binary compatibility across Python
-versions and is therefore deprecated in extension modules.
+.. c:macro:: PyMem_MALLOC(size)
+             PyMem_NEW(type, size)
+             PyMem_REALLOC(ptr, size)
+             PyMem_RESIZE(ptr, type, size)
+             PyMem_FREE(ptr)
+             PyMem_DEL(ptr)
 
-* ``PyMem_MALLOC(size)``
-* ``PyMem_NEW(type, size)``
-* ``PyMem_REALLOC(ptr, size)``
-* ``PyMem_RESIZE(ptr, type, size)``
-* ``PyMem_FREE(ptr)``
-* ``PyMem_DEL(ptr)``
+   These macros are :term:`soft deprecated` aliases for the APIs above,
+   provided for backwards compatibility.
+
+   .. versionchanged:: 3.4
+
+      The macros are now aliases of the corresponding mixed-case names.
+      Previously, their of the macros was the same, but their use did
+      not preserve binary compatibility across Python versions.
+
+   .. deprecated:: 2.0
 
 
 .. _objectinterface:

--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -293,23 +293,39 @@ The following type-oriented macros are provided for convenience.  Note  that
 
    Same as :c:func:`PyMem_Free`.
 
-.. c:macro:: PyMem_MALLOC(size)
-             PyMem_NEW(type, size)
-             PyMem_REALLOC(ptr, size)
-             PyMem_RESIZE(ptr, type, size)
-             PyMem_FREE(ptr)
-             PyMem_DEL(ptr)
 
-   These macros are :term:`soft deprecated` aliases for the APIs above,
-   provided for backwards compatibility.
+Deprecated aliases
+------------------
 
-   .. versionchanged:: 3.4
+These are :term:`soft deprecated` aliases to existing functions and macros.
+They exist solely for backwards compatibility.
 
-      The macros are now aliases of the corresponding mixed-case names.
-      Previously, their behavior was the same, but their use did
-      not preserve binary compatibility across Python versions.
+.. list-table::
+   :widths: auto
+   :header-rows: 1
 
-   .. deprecated:: 2.0
+   * * Deprecated alias
+     * Corresponding function or macro
+   * * .. c:macro:: PyMem_MALLOC(size)
+     * :c:func:`PyMem_Malloc`
+   * * .. c:macro:: PyMem_NEW(type, size)
+     * :c:macro:`PyMem_New`
+   * * .. c:macro:: PyMem_REALLOC(ptr, size)
+     * :c:func:`PyMem_Realloc`
+   * * .. c:macro:: PyMem_RESIZE(ptr, type, size)
+     * :c:macro:`PyMem_Resize`
+   * * .. c:macro:: PyMem_FREE(ptr)
+     * :c:func:`PyMem_Free`
+   * * .. c:macro:: PyMem_DEL(ptr)
+     * :c:func:`PyMem_Free`
+
+.. versionchanged:: 3.4
+
+   The macros are now aliases of the corresponding functions and macros.
+   Previously, their behavior was the same, but their use did not necessarily
+   preserve binary compatibility across Python versions.
+
+.. deprecated:: 2.0
 
 
 .. _objectinterface:

--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -306,7 +306,7 @@ The following type-oriented macros are provided for convenience.  Note  that
    .. versionchanged:: 3.4
 
       The macros are now aliases of the corresponding mixed-case names.
-      Previously, their of the macros was the same, but their use did
+      Previously, their behavior was the same, but their use did
       not preserve binary compatibility across Python versions.
 
    .. deprecated:: 2.0


### PR DESCRIPTION
These had a docs-only deprecation notice since the first version of the docs in this repo. Nowadays we call things “soft deprecated” if there's just a note in the docs.

The `deprecated` directive needs a version, I went with the first one that had the notice ([2.0](https://docs.python.org/release/2.0/api/memoryInterface.html); it's not in [1.6](https://docs.python.org/release/1.6/api/memoryInterface.html)).

Since PEP 445, they are now direct aliases; there are no (additional) binary compatibility concerns over the preferred names.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143783.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->