### PR TITLE
gh-143804: highlight default empty-line command repetition in `cmd.Cmd` documentation

### DIFF
--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -99,9 +99,9 @@ When the user enters an empty line in response to the prompt, ``Cmd`` does
 **not** ignore the input by default. Instead, it repeats the last non-empty
 command entered.
 
-This behavior is implemented by :meth:`Cmd.emptyline`. Subclasses that do not
+This behavior is implemented by :meth:`emptyline`. Subclasses that do not
 want empty input to repeat the previous command  should override
-:meth:`Cmd.emptyline` to do nothing::
+:meth:`emptyline` to do nothing::
 
    def emptyline(self):
        pass
@@ -139,6 +139,8 @@ want empty input to repeat the previous command  should override
    Method called on an input line when the command prefix is not recognized. If
    this method is not overridden, it prints an error message and returns.
 
+   Note that if :meth:`emptyline` is not overridden, empty input may cause
+   the previous command to be repeated and passed again to this method.
 
 .. method:: Cmd.completedefault(text, line, begidx, endidx)
 

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -99,9 +99,9 @@ When the user enters an empty line in response to the prompt, ``Cmd`` does
 **not** ignore the input by default. Instead, it repeats the last non-empty
 command entered.
 
-This behavior is implemented by :meth:`emptyline`. Subclasses that do not
+This behavior is implemented by :meth:`Cmd.emptyline`. Subclasses that do not
 want empty input to repeat the previous command  should override
-:meth:`emptyline` to do nothing::
+:meth:`Cmd.emptyline` to do nothing::
 
    def emptyline(self):
        pass

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -139,7 +139,7 @@ want empty input to repeat the previous command  should override
    Method called on an input line when the command prefix is not recognized. If
    this method is not overridden, it prints an error message and returns.
 
-   Note that if :meth:`emptyline` is not overridden, empty input may cause
+   Note that if :meth:`emptyline` is not overridden, empty input will cause
    the previous command to be repeated and passed again to this method.
 
 .. method:: Cmd.completedefault(text, line, begidx, endidx)

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -93,6 +93,18 @@ A :class:`Cmd` instance has the following methods:
    are the beginning and ending indexes of the prefix text, which could be used to
    provide different completion depending upon which position the argument is in.
 
+.. rubric:: Empty input behavior
+
+When the user enters an empty line in response to the prompt, ``Cmd`` does
+**not** ignore the input by default. Instead, it repeats the last non-empty
+command entered.
+
+This behavior is implemented by :meth:`Cmd.emptyline`. Subclasses that do not
+want empty input to repeat the previous command  should override
+:meth:`Cmd.emptyline` to do nothing::
+
+   def emptyline(self):
+       pass
 
 .. method:: Cmd.do_help(arg)
 

--- a/Misc/NEWS.d/next/Documentation/2026-01-14-00-09-43.gh-issue-143804.KHeDcP.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-01-14-00-09-43.gh-issue-143804.KHeDcP.rst
@@ -1,0 +1,2 @@
+Clarified the documentation of :mod:`cmd` regarding the default handling of
+empty input lines.


### PR DESCRIPTION
Currently, the only place that explains empty-line repetition is the method-level docstring of Cmd.emptyline(). This is too deep in the page hierarchy and easy to miss. First-time users are surprised when overriding `Cmd.default()`, as in #143804.

This PR adds an explicit note in the `cmdloop()` documentation, that is where users conceptually learn how input is processed.

The `default()` docstring gives no hint that it may be invoked due to empty input. This PR also adds a single cross-reference sentence to `default()`. 


<!-- gh-issue-number: gh-143804 -->
* Issue: gh-143804
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143808.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->