### PR TITLE
gh-143811: Add helpful default error messages to `AttributeError` and `NameError`

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2020,7 +2020,7 @@ class NameErrorTests(unittest.TestCase):
                 sys.__excepthook__(*sys.exc_info())
 
         # 'spam' should appear even when message was empty.
-        self.assertIn("'spam'", err.getvalue())
+        self.assertIn("name 'spam' is not defined", err.getvalue())
 
     # Note: name suggestion tests live in `test_traceback`.
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2072,7 +2072,7 @@ class AttributeErrorTests(unittest.TestCase):
                     # Provide no message.
                     raise AttributeError
 
-            A.bluch
+            A().bluch
 
         try:
             f()
@@ -2080,8 +2080,8 @@ class AttributeErrorTests(unittest.TestCase):
             with support.captured_stderr() as err:
                 sys.__excepthook__(*sys.exc_info())
 
-        # 'bluch' should appear even when message was empty.
-        self.assertIn("'bluch'", err.getvalue())
+        # Should appear even when no message was provided.
+        self.assertIn("'A' object has no attribute 'bluch'", err.getvalue())
 
     # Note: name suggestion tests live in `test_traceback`.
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4942,8 +4942,8 @@ class SuggestionFormattingTestBase(SuggestionFormattingTestMixin):
                 exc.args = ()
                 raise
         actual = self.get_suggestion(func)
-        self.assertIn("'spam'", actual)
-        self.assertIn("'span'?", actual)
+        self.assertIn("name 'spam' is not defined", actual)
+        self.assertIn("Did you mean: 'span'?", actual)
 
 
 class PurePythonSuggestionFormattingTests(

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4259,6 +4259,7 @@ class GetattrSuggestionTests(BaseSuggestionTests):
                 raise AttributeError()
 
         actual = self.get_suggestion(A(), 'bluch')
+        self.assertIn("'A' object has no attribute 'bluch'.", actual)
         self.assertIn("blech", actual)
 
         class A:
@@ -4267,6 +4268,7 @@ class GetattrSuggestionTests(BaseSuggestionTests):
                 raise AttributeError
 
         actual = self.get_suggestion(A(), 'bluch')
+        self.assertIn("'A' object has no attribute 'bluch'.", actual)
         self.assertIn("blech", actual)
 
     def test_suggestions_invalid_args(self):
@@ -4930,6 +4932,18 @@ class SuggestionFormattingTestBase(SuggestionFormattingTestMixin):
         actual = self.get_suggestion(func)
         self.assertIn("forget to import '_io'", actual)
 
+    def test_name_error_empty(self):
+        """See GH-143811."""
+        def func():
+            span = 42
+            try:
+                spam
+            except NameError as exc:
+                exc.args = ()
+                raise
+        actual = self.get_suggestion(func)
+        self.assertIn("'spam'", actual)
+        self.assertIn("'span'?", actual)
 
 
 class PurePythonSuggestionFormattingTests(

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1133,7 +1133,7 @@ class TracebackException:
                         obj_type_name = object.__getattribute__(obj_type, "__name__")
                         self._str = f"{obj_type_name!r} object has no attribute {wrong_name!r}"
                 else:  # NameError
-                    self._str = repr(wrong_name)
+                    self._str = f"name {wrong_name!r} is not defined"
             if suggestion:
                 self._str += f". Did you mean: '{suggestion}'?"
             if issubclass(exc_type, NameError):

--- a/Misc/NEWS.d/next/Library/2026-01-13-19-51-37.gh-issue-143811.PLHsyK.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-13-19-51-37.gh-issue-143811.PLHsyK.rst
@@ -1,0 +1,3 @@
+:exc:`AttributeError` and :exc:`NameError` exceptions raised with no message
+now get helpful default messages when displaying traceback. Patch by Bartosz
+Sławecki.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143811 -->
* Issue: gh-143811
<!-- /gh-issue-number -->

CC @a12k for review