### PR TITLE
gh-143807: Limit executor growth

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-13-19-31-56.gh-issue-143807.H5KP1C.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-13-19-31-56.gh-issue-143807.H5KP1C.rst
@@ -1,0 +1,1 @@
+Place a limit on the number of JIT executors.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -72,6 +72,9 @@ get_index_for_executor(PyCodeObject *code, _Py_CODEUNIT *instr)
     }
     assert(size <= capacity);
     if (size == capacity) {
+        if (capacity * 2 >= MAX_EXECUTORS_SIZE) {
+            return -1;
+        }
         /* Array is full. Grow array */
         int new_capacity = capacity ? capacity * 2 : 4;
         _PyExecutorArray *new = PyMem_Realloc(

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -72,11 +72,11 @@ get_index_for_executor(PyCodeObject *code, _Py_CODEUNIT *instr)
     }
     assert(size <= capacity);
     if (size == capacity) {
-        if (capacity * 2 >= MAX_EXECUTORS_SIZE) {
-            return -1;
-        }
         /* Array is full. Grow array */
         int new_capacity = capacity ? capacity * 2 : 4;
+        if (new_capacity >= MAX_EXECUTORS_SIZE) {
+            return -1;
+        }
         _PyExecutorArray *new = PyMem_Realloc(
             old,
             offsetof(_PyExecutorArray, executors) +


### PR DESCRIPTION
No unit test, because the repro provided doesn't repro on my system.

The requirement is there can only be 255 executors in a single code object, as the executor index is bounded by `oparg`, whch is a `int8_t`.

<!-- gh-issue-number: gh-143807 -->
* Issue: gh-143807
<!-- /gh-issue-number -->
