### PR TITLE
gh-131178: Add CLI tests for the profile module

### DIFF
--- a/Lib/test/test_profile.py
+++ b/Lib/test/test_profile.py
@@ -134,6 +134,34 @@ class ProfileTest(unittest.TestCase):
 
             self.assertTrue(os.path.exists('out.pstats'))
 
+    def test_sort(self):
+        status, stdout, stderr = assert_python_ok(
+            '-m', self.profilermodule.__name__,
+            '-s', 'time', '-m', 'timeit', '-n', '1'
+        )
+
+        output = stdout.decode()
+
+        self.assertIn("Ordered by:", output)
+
+    def test_help(self):
+        status1, stdout1, stderr1 = assert_python_ok('-m', self.profilermodule.__name__, '-h')
+        status2, stdout2, stderr2 = assert_python_ok('-m', self.profilermodule.__name__, '--help')
+
+        output1 = stdout1.decode()
+        output2 = stdout2.decode()
+
+        self.assertIn("Usage:", output1)
+        self.assertIn("Options:", output1)
+        self.assertEqual(output1, output2)
+
+    def test_invalid_option(self):
+        status, stdout, stderr = assert_python_failure('-m', self.profilermodule.__name__, '-invalidop')
+
+        output = stderr.decode()
+
+        self.assertIn("error: no such option", output)
+
 
 def regenerate_expected_output(filename, cls):
     filename = filename.rstrip('co')


### PR DESCRIPTION
### Summary
This PR adds comprehensive command-line interface tests for the `profile` module to improve test coverage and ensure CLI stability, as part of the effort in gh-131178.

### Changes
- Added test for the help interface (`-h`, `--help`).
- Added test for sorting using the `-s` option.
- Added negative test for invalid CLI options

