### PR TITLE
gh-143834: Fix PyLong_AsNativeBytes docs for negative number padding 

### DIFF
--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -453,7 +453,8 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
    Otherwise, returns the number of bytes required to store the value.
    If this is equal to or less than *n_bytes*, the entire value was copied.
-   All *n_bytes* of the buffer are written: remaining bytes filled by copies of the sign bit.
+   All *n_bytes* of the buffer are written: remaining bytes filled by 
+   copies of the sign bit.
 
    If the returned value is greater than *n_bytes*, the value was
    truncated: as many of the lowest bits of the value as could fit are written,

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -453,8 +453,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
    Otherwise, returns the number of bytes required to store the value.
    If this is equal to or less than *n_bytes*, the entire value was copied.
-   All *n_bytes* of the buffer are written: large buffers are padded with
-   zeroes.
+   All *n_bytes* of the buffer are written: remaining bytes filled by copies of the sign bit.
 
    If the returned value is greater than *n_bytes*, the value was
    truncated: as many of the lowest bits of the value as could fit are written,

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -453,7 +453,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
    Otherwise, returns the number of bytes required to store the value.
    If this is equal to or less than *n_bytes*, the entire value was copied.
-   All *n_bytes* of the buffer are written: remaining bytes filled by 
+   All *n_bytes* of the buffer are written: remaining bytes filled by
    copies of the sign bit.
 
    If the returned value is greater than *n_bytes*, the value was


### PR DESCRIPTION
## Summary
- Corrects the `PyLong_AsNativeBytes` documentation to accurately describe buffer padding behavior
- Changed "large buffers are padded with zeroes" to "remaining bytes filled by copies of the sign bit"
- Issue is in this document: https://docs.python.org/3.15/c-api/long.html#c.PyLong_AsNativeBytes

## Issue
Fixes #143834

<!-- gh-issue-number: gh-143834 -->
* Issue: gh-143834
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143840.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->