### PR TITLE
GH-143842: Make optimizer color table static

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-01-15-03-36-16.gh-issue-143842.EZLutl.rst
+++ b/Misc/NEWS.d/next/Build/2026-01-15-03-36-16.gh-issue-143842.EZLutl.rst
@@ -1,0 +1,2 @@
+Prevent static builds from clashing with curses by making the optimizer
+COLORS table static.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -2009,7 +2009,7 @@ find_line_number(PyCodeObject *code, _PyExecutorObject *executor)
 #define BLACK "#000000"
 #define LOOP "#00c000"
 
-const char *COLORS[10] = {
+static const char *COLORS[10] = {
     "9",
     "8",
     "7",


### PR DESCRIPTION
Fixes GH-143842.

When building a static Python with PGO+LTO and a static `_curses` extension, the optimizer’s `COLORS` array collided with the curses `COLORS` symbol. Make the optimizer color table `static` to avoid the global symbol clash.

Tests: not run (build fix only).