### PR TITLE
[3.13] gh-143635: Fix crash in `ga_repr_items_list` (GH-143670)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2026-01-11-20-11-36.gh-issue-143670.klnGoD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2026-01-11-20-11-36.gh-issue-143670.klnGoD.rst
@@ -1,0 +1,1 @@
+Fixes a crash in ``ga_repr_items_list`` function.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -133,10 +133,15 @@ ga_repr_items_list(_PyUnicodeWriter *writer, PyObject *p)
                 return -1;
             }
         }
-        PyObject *item = PyList_GET_ITEM(p, i);
+        PyObject *item = PyList_GetItemRef(p, i);
+        if (item == NULL) {
+            return -1;  // list can be mutated in a callback
+        }
         if (ga_repr_item(writer, item) < 0) {
+            Py_DECREF(item);
             return -1;
         }
+        Py_DECREF(item);
     }
 
     if (_PyUnicodeWriter_WriteASCIIString(writer, "]", 1) < 0) {


### PR DESCRIPTION
(cherry picked from commit bdba5f0db2ab29f3deedb9416f3c143d33e4ab66)


<!-- gh-issue-number: gh-143635 -->
* Issue: gh-143635
<!-- /gh-issue-number -->
