### PR TITLE
[3.13] gh-141805: Fix crash after concurrent addition objects with the same hash to set (GH-143815)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2026-01-13-22-26-49.gh-issue-141805.QzIKPS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2026-01-13-22-26-49.gh-issue-141805.QzIKPS.rst
@@ -1,0 +1,3 @@
+Fix crash in :class:`set` when objects with the same hash are concurrently
+added to the set after removing an element with the same hash while the set
+still contains elements with the same hash.

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -185,6 +185,9 @@ set_add_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
   found_unused_or_dummy:
     if (freeslot == NULL)
         goto found_unused;
+    if (freeslot->hash != -1) {
+        goto restart;
+    }
     FT_ATOMIC_STORE_SSIZE_RELAXED(so->used, so->used + 1);
     freeslot->key = key;
     freeslot->hash = hash;


### PR DESCRIPTION
This happens when the set contained several elements with the same hash, and then some of them were removed.
(cherry picked from commit b8e925b4f8f6c5e28fbebc4f3965bf77610698b3)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141805 -->
* Issue: gh-141805
<!-- /gh-issue-number -->
