### PR TITLE
gh-143860: Clarify argparse.parse_args argument order

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1491,7 +1491,7 @@ The parse_args() method
    created and how they are assigned. See the documentation for
    :meth:`!add_argument` for details.
 
-   * args_ - List of strings to parse, in the order they appear.  The default is taken from
+   * args_ - List of strings to parse, in normal iteration order.  The default is taken from
      :data:`sys.argv`.
 
    * namespace_ - An object to take the attributes.  The default is a new empty

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1491,7 +1491,7 @@ The parse_args() method
    created and how they are assigned. See the documentation for
    :meth:`!add_argument` for details.
 
-   * args_ - List of strings to parse.  The default is taken from
+   * args_ - List of strings to parse, in the order they appear.  The default is taken from
      :data:`sys.argv`.
 
    * namespace_ - An object to take the attributes.  The default is a new empty


### PR DESCRIPTION
Clarify the wording for the `args` parameter of
ArgumentParser.parse_args() to make the processing order explicit.

No behavioral changes.


<!-- gh-issue-number: gh-143860 -->
* Issue: gh-143860
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143863.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->