### PR TITLE
gh-141004: Mark up constants for `PyOS_double_to_string`

### DIFF
--- a/Doc/c-api/conversion.rst
+++ b/Doc/c-api/conversion.rst
@@ -130,6 +130,8 @@ The following functions provide locale-independent string to number conversions.
 
    *flags* can be zero or more of the following values or-ed together:
 
+   .. c:namespace:: NULL
+
    .. c:macro:: Py_DTSF_SIGN
 
       Always precede the returned string with a sign
@@ -151,9 +153,21 @@ The following functions provide locale-independent string to number conversions.
 
       .. versionadded:: 3.11
 
-   If *ptype* is non-``NULL``, then the value it points to will be set to one of
-   ``Py_DTST_FINITE``, ``Py_DTST_INFINITE``, or ``Py_DTST_NAN``, signifying that
-   *val* is a finite number, an infinite number, or not a number, respectively.
+   If *ptype* is non-``NULL``, then the value it points to will be set to one
+   of the following constants depending on the type of *val*:
+
+   .. list-table::
+      :header-rows: 1
+      :align: left
+
+      * - *\*ptype*
+        - type of *val*
+      * - .. c:macro:: Py_DTST_FINITE
+        - finite number
+      * - .. c:macro:: Py_DTST_INFINITE
+        - infinite number
+      * - .. c:macro:: Py_DTST_NAN
+        - not a number
 
    The return value is a pointer to *buffer* with the converted string or
    ``NULL`` if the conversion failed. The caller is responsible for freeing the


### PR DESCRIPTION
This ensures they show up as C macros in search and the Sphinx inventory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141004 -->
* Issue: gh-141004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143867.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->