### PR TITLE
gh-141431: Preserve UTC semantics for ZIP timestamps

### DIFF
--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -307,7 +307,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         twenty_thirty_eight_pyc = make_pyc(test_co, 2**32 - 1, len(test_src))
         files = {TESTMOD + ".py": test_src,
                  TESTMOD + pyc_ext: twenty_thirty_eight_pyc}
-        self.doTest(".py", files, TESTMOD)
+        self.doTest(".pyc", files, TESTMOD)
 
     def testPackage(self):
         packdir = TESTPACK + os.sep

--- a/Lib/zipimport.py
+++ b/Lib/zipimport.py
@@ -17,6 +17,7 @@ import _imp  # for check_hash_based_pycs
 import _io  # for open
 import marshal  # for loads
 import time  # for mktime
+import calendar
 
 __all__ = ['ZipImportError', 'zipimporter']
 
@@ -749,7 +750,7 @@ def _compile_source(pathname, source, module):
 # Convert the date/time values found in the Zip archive to a value
 # that's compatible with the time stamp stored in .pyc files.
 def _parse_dostime(d, t):
-    return time.mktime((
+    return calendar.timegm((
         (d >> 9) + 1980,    # bits 9..15: year
         (d >> 5) & 0xF,     # bits 5..8: month
         d & 0x1F,           # bits 0..4: day


### PR DESCRIPTION
Zip file timestamps don’t store timezone information. Using local time can make files inside zipapps look stale when moved between timezones. This change treats DOS timestamps as UTC while keeping zipimport safe during startup.

<!-- gh-issue-number: gh-141431 -->
* Issue: gh-141431
<!-- /gh-issue-number -->
