### PR TITLE
[3.13] gh-142829: Fix use-after-free in `Context.__eq__` via re-entrant `ContextVar.set` (GH-142905)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2025-12-17-19-45-10.gh-issue-142829.ICtLXy.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-12-17-19-45-10.gh-issue-142829.ICtLXy.rst
@@ -1,0 +1,3 @@
+Fix a use-after-free crash in :class:`contextvars.Context` comparison when a
+custom ``__eq__`` method modifies the context via
+:meth:`~contextvars.ContextVar.set`.


### PR DESCRIPTION
(cherry picked from commit a4086d7f89e5d388e4ffcdb13e4fba0255234286)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142829 -->
* Issue: gh-142829
<!-- /gh-issue-number -->
