### PR TITLE
gh-143874: Fix pdb expression output leaking to debuggee stdoutpython/cpython

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -888,7 +888,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         locals.update(pdb_eval["write_back"])
         eval_result = pdb_eval["result"]
         if eval_result is not None:
-            print(repr(eval_result))
+            self.message(repr(eval_result))
 
         return True
 

--- a/Lib/test/test_remote_pdb.py
+++ b/Lib/test/test_remote_pdb.py
@@ -1007,6 +1007,28 @@ class RemotePdbTestCase(unittest.TestCase):
             prompts = [o for o in outputs if 'prompt' in o]
             self.assertEqual(len(prompts), 2)  # Should have sent 2 prompts
 
+    def test_expression_evaluation_output(self):
+        """Test that expression evaluation results are sent through the socket, not to debuggee stdout."""
+        # Test lambda expression
+        self.pdb.default("(lambda: 123)()")
+        
+        outputs = self.sockfile.get_output()
+        # Should have a message with the result
+        messages = [o for o in outputs if 'message' in o]
+        self.assertTrue(any('123' in o.get('message', '') for o in messages),
+                        f"Expected '123' in output messages, got: {messages}")
+
+    def test_expression_evaluation_sum(self):
+        """Test that sum expression evaluation results are sent through the socket."""
+        # Test sum expression
+        self.pdb.default("sum(i for i in (1, 2, 3))")
+        
+        outputs = self.sockfile.get_output()
+        # Should have a message with the result
+        messages = [o for o in outputs if 'message' in o]
+        self.assertTrue(any('6' in o.get('message', '') for o in messages),
+                        f"Expected '6' in output messages, got: {messages}")
+
 
 @requires_subprocess()
 @unittest.skipIf(is_wasi, "WASI does not support TCP sockets")


### PR DESCRIPTION
Fixes issue #143874

### Problem
In remote or dual-terminal debugging setups, expressions evaluated at the pdb
prompt printed their results to the debuggee's stdout instead of the debugger
output stream.

### Cause
In remote pdb mode, expression results were printed directly using `print()`,
bypassing pdb’s output redirection mechanism.

### Fix
Route expression output through `self.message()` so results are sent through the
appropriate pdb output stream, including the socket-based remote debugger.

### Tests
Added regression tests to ensure expression evaluation output is correctly routed
in remote pdb sessions.
