### PR TITLE
[3.14] gh-143880: Fix data race in `functools.partial` in free threading build

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-01-15-13-03-22.gh-issue-143880.sWoLsf.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-15-13-03-22.gh-issue-143880.sWoLsf.rst
@@ -1,0 +1,1 @@
+Fix data race in :func:`functools.partial` in the :term:`free threading` build.

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -375,7 +375,9 @@ partial_vectorcall_fallback(PyThreadState *tstate, partialobject *pto,
                             PyObject *const *args, size_t nargsf,
                             PyObject *kwnames)
 {
+#ifndef Py_GIL_DISABLED
     pto->vectorcall = NULL;
+#endif
     Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
     return _PyObject_MakeTpCall(tstate, (PyObject *)pto, args, nargs, kwnames);
 }


### PR DESCRIPTION
The assignment to `pto->vectorcall` isn't thread-safe in the free threading build. Note that this is already fixed in the main branch.


<!-- gh-issue-number: gh-143880 -->
* Issue: gh-143880
<!-- /gh-issue-number -->
