### PR TITLE
gh-143883: Add missing named parameters in public PyModExport C bindings

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -428,7 +428,7 @@ To retrieve the state from a given module, use the following functions:
 
 .. c:function:: int PyModule_GetStateSize(PyObject *module, Py_ssize_t *result)
 
-   Set *\*result* to the size of the state for the module *module*, as specified
+   Set *\*result* to the size of *module*'s state, as specified
    using :c:macro:`Py_mod_state_size` (or :c:member:`PyModuleDef.m_size`),
    and return 0.
 
@@ -597,7 +597,7 @@ A module's token -- and the *your_token* value to use in the above code -- is:
 
 .. c:function:: int PyModule_GetToken(PyObject *module, void** result)
 
-   Set *\*result* to the module token for the module *module* and return 0.
+   Set *\*result* to the module token for *module* and return 0.
 
    On error, set *\*result* to NULL, and return -1 with an exception set.
 
@@ -645,7 +645,7 @@ rather than from an extension's :ref:`export hook <extension-export-hook>`.
 
 .. c:function:: int PyModule_Exec(PyObject *module)
 
-   Execute the :c:data:`Py_mod_exec` slot(s) of the given module, *module*.
+   Execute the :c:data:`Py_mod_exec` slot(s) of *module*.
 
    On success, return 0.
    On error, return -1 with an exception set.

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -415,7 +415,7 @@ functions to avoid reference leaks.
 
 To retrieve the state from a given module, use the following functions:
 
-.. c:function:: void* PyModule_GetState(PyObject *module)
+.. c:function:: void* PyModule_GetState(PyObject *mod)
 
    Return the "state" of the module, that is, a pointer to the block of memory
    allocated at module creation time, or ``NULL``.  See
@@ -426,10 +426,10 @@ To retrieve the state from a given module, use the following functions:
    module state.
 
 
-.. c:function:: int PyModule_GetStateSize(PyObject *, Py_ssize_t *result)
+.. c:function:: int PyModule_GetStateSize(PyObject *mod, Py_ssize_t *result)
 
-   Set *\*result* to the size of the module's state, as specified using
-   :c:macro:`Py_mod_state_size` (or :c:member:`PyModuleDef.m_size`),
+   Set *\*result* to the size of the state for the module *mod*, as specified
+   using :c:macro:`Py_mod_state_size` (or :c:member:`PyModuleDef.m_size`),
    and return 0.
 
    On error, set *\*result* to -1, and return -1 with an exception set.
@@ -549,10 +549,10 @@ This means that if you have a module object, but you are not sure if it
 
 .. code-block:: c
 
-   PyObject *module = <the module in question>
+   PyObject *mod = <the module in question>
 
    void *module_token;
-   if (PyModule_GetToken(module, &module_token) < 0) {
+   if (PyModule_GetToken(mod, &module_token) < 0) {
        return NULL;
    }
    if (module_token != your_token) {
@@ -595,9 +595,9 @@ A module's token -- and the *your_token* value to use in the above code -- is:
 
    .. versionadded:: 3.15
 
-.. c:function:: int PyModule_GetToken(PyObject *module, void** result)
+.. c:function:: int PyModule_GetToken(PyObject *mod, void** result)
 
-   Set *\*result* to the module's token and return 0.
+   Set *\*result* to the module token for the module *mod* and return 0.
 
    On error, set *\*result* to NULL, and return -1 with an exception set.
 
@@ -643,14 +643,14 @@ rather than from an extension's :ref:`export hook <extension-export-hook>`.
 
    .. versionadded:: 3.15
 
-.. c:function:: int PyModule_Exec(PyObject *module)
+.. c:function:: int PyModule_Exec(PyObject *mod)
 
-   Execute the :c:data:`Py_mod_exec` slot(s) of the given *module*.
+   Execute the :c:data:`Py_mod_exec` slot(s) of the given module, *mod*.
 
    On success, return 0.
    On error, return -1 with an exception set.
 
-   For clarity: If *module* has no slots, for example if it uses
+   For clarity: If *mod* has no slots, for example if it uses
    :ref:`legacy single-phase initialization <single-phase-initialization>`,
    this function does nothing and returns 0.
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -415,7 +415,7 @@ functions to avoid reference leaks.
 
 To retrieve the state from a given module, use the following functions:
 
-.. c:function:: void* PyModule_GetState(PyObject *mod)
+.. c:function:: void* PyModule_GetState(PyObject *module)
 
    Return the "state" of the module, that is, a pointer to the block of memory
    allocated at module creation time, or ``NULL``.  See
@@ -426,9 +426,9 @@ To retrieve the state from a given module, use the following functions:
    module state.
 
 
-.. c:function:: int PyModule_GetStateSize(PyObject *mod, Py_ssize_t *result)
+.. c:function:: int PyModule_GetStateSize(PyObject *module, Py_ssize_t *result)
 
-   Set *\*result* to the size of the state for the module *mod*, as specified
+   Set *\*result* to the size of the state for the module *module*, as specified
    using :c:macro:`Py_mod_state_size` (or :c:member:`PyModuleDef.m_size`),
    and return 0.
 
@@ -549,10 +549,10 @@ This means that if you have a module object, but you are not sure if it
 
 .. code-block:: c
 
-   PyObject *mod = <the module in question>
+   PyObject *module = <the module in question>
 
    void *module_token;
-   if (PyModule_GetToken(mod, &module_token) < 0) {
+   if (PyModule_GetToken(module, &module_token) < 0) {
        return NULL;
    }
    if (module_token != your_token) {
@@ -595,9 +595,9 @@ A module's token -- and the *your_token* value to use in the above code -- is:
 
    .. versionadded:: 3.15
 
-.. c:function:: int PyModule_GetToken(PyObject *mod, void** result)
+.. c:function:: int PyModule_GetToken(PyObject *module, void** result)
 
-   Set *\*result* to the module token for the module *mod* and return 0.
+   Set *\*result* to the module token for the module *module* and return 0.
 
    On error, set *\*result* to NULL, and return -1 with an exception set.
 
@@ -643,14 +643,14 @@ rather than from an extension's :ref:`export hook <extension-export-hook>`.
 
    .. versionadded:: 3.15
 
-.. c:function:: int PyModule_Exec(PyObject *mod)
+.. c:function:: int PyModule_Exec(PyObject *module)
 
-   Execute the :c:data:`Py_mod_exec` slot(s) of the given module, *mod*.
+   Execute the :c:data:`Py_mod_exec` slot(s) of the given module, *module*.
 
    On success, return 0.
    On error, return -1 with an exception set.
 
-   For clarity: If *mod* has no slots, for example if it uses
+   For clarity: If *module* has no slots, for example if it uses
    :ref:`legacy single-phase initialization <single-phase-initialization>`,
    this function does nothing and returns 0.
 

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -118,11 +118,11 @@ PyAPI_FUNC(int) PyUnstable_Module_SetGIL(PyObject *module, void *gil);
 #endif
 
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= _Py_PACK_VERSION(3, 15)
-PyAPI_FUNC(PyObject *) PyModule_FromSlotsAndSpec(const PyModuleDef_Slot *,
+PyAPI_FUNC(PyObject *) PyModule_FromSlotsAndSpec(const PyModuleDef_Slot *slots,
                                                  PyObject *spec);
 PyAPI_FUNC(int) PyModule_Exec(PyObject *mod);
 PyAPI_FUNC(int) PyModule_GetStateSize(PyObject *mod, Py_ssize_t *result);
-PyAPI_FUNC(int) PyModule_GetToken(PyObject *, void **result);
+PyAPI_FUNC(int) PyModule_GetToken(PyObject *module, void **result);
 #endif
 
 #ifndef _Py_OPAQUE_PYOBJECT

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -122,7 +122,7 @@ PyAPI_FUNC(PyObject *) PyModule_FromSlotsAndSpec(const PyModuleDef_Slot *slots,
                                                  PyObject *spec);
 PyAPI_FUNC(int) PyModule_Exec(PyObject *mod);
 PyAPI_FUNC(int) PyModule_GetStateSize(PyObject *mod, Py_ssize_t *result);
-PyAPI_FUNC(int) PyModule_GetToken(PyObject *module, void **result);
+PyAPI_FUNC(int) PyModule_GetToken(PyObject *mod, void **result);
 #endif
 
 #ifndef _Py_OPAQUE_PYOBJECT

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -120,9 +120,9 @@ PyAPI_FUNC(int) PyUnstable_Module_SetGIL(PyObject *module, void *gil);
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= _Py_PACK_VERSION(3, 15)
 PyAPI_FUNC(PyObject *) PyModule_FromSlotsAndSpec(const PyModuleDef_Slot *slots,
                                                  PyObject *spec);
-PyAPI_FUNC(int) PyModule_Exec(PyObject *mod);
-PyAPI_FUNC(int) PyModule_GetStateSize(PyObject *mod, Py_ssize_t *result);
-PyAPI_FUNC(int) PyModule_GetToken(PyObject *mod, void **result);
+PyAPI_FUNC(int) PyModule_Exec(PyObject *module);
+PyAPI_FUNC(int) PyModule_GetStateSize(PyObject *module, Py_ssize_t *result);
+PyAPI_FUNC(int) PyModule_GetToken(PyObject *module, void **result);
 #endif
 
 #ifndef _Py_OPAQUE_PYOBJECT


### PR DESCRIPTION
See the linked issue for details.

<!-- gh-issue-number: gh-143883 -->
* Issue: gh-143883
<!-- /gh-issue-number -->
