### PR TITLE
gh-143672: Add more tests for struct.pack_into()

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -433,41 +433,11 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         self.assertEqual(s.unpack_from(buffer=test_string, offset=2),
                          (b'cd01',))
 
-    def test_pack_into(self):
+    def _test_pack_into(self, pack_into):
         test_string = b'Reykjavik rocks, eow!'
-        writable_buf = array.array('b', b' '*100)
-        fmt = '21s'
-        s = struct.Struct(fmt)
+        writable_buf = memoryview(array.array('b', b' '*100))
 
         # Test without offset
-        s.pack_into(writable_buf, 0, test_string)
-        from_buf = writable_buf.tobytes()[:len(test_string)]
-        self.assertEqual(from_buf, test_string)
-
-        # Test with offset.
-        s.pack_into(writable_buf, 10, test_string)
-        from_buf = writable_buf.tobytes()[:len(test_string)+10]
-        self.assertEqual(from_buf, test_string[:10] + test_string)
-
-        # Go beyond boundaries.
-        small_buf = array.array('b', b' '*10)
-        self.assertRaises((ValueError, struct.error), s.pack_into, small_buf, 0,
-                          test_string)
-        self.assertRaises((ValueError, struct.error), s.pack_into, small_buf, 2,
-                          test_string)
-
-        # Test bogus offset (issue 3694)
-        sb = small_buf
-        self.assertRaises((TypeError, struct.error), struct.pack_into, b'', sb,
-                          None)
-
-    def test_pack_into_fn(self):
-        test_string = b'Reykjavik rocks, eow!'
-        writable_buf = array.array('b', b' '*100)
-        fmt = '21s'
-        pack_into = lambda *args: struct.pack_into(fmt, *args)
-
-        # Test without offset.
         pack_into(writable_buf, 0, test_string)
         from_buf = writable_buf.tobytes()[:len(test_string)]
         self.assertEqual(from_buf, test_string)
@@ -477,12 +447,49 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         from_buf = writable_buf.tobytes()[:len(test_string)+10]
         self.assertEqual(from_buf, test_string[:10] + test_string)
 
+        # Test with negative offset.
+        pack_into(writable_buf, -30, test_string)
+        from_buf = writable_buf.tobytes()[-30:-30+len(test_string)]
+        self.assertEqual(from_buf, test_string)
+
         # Go beyond boundaries.
         small_buf = array.array('b', b' '*10)
-        self.assertRaises((ValueError, struct.error), pack_into, small_buf, 0,
-                          test_string)
-        self.assertRaises((ValueError, struct.error), pack_into, small_buf, 2,
-                          test_string)
+        with self.assertRaises((ValueError, struct.error)):
+            pack_into(small_buf, 0, test_string)
+        with self.assertRaises((ValueError, struct.error)):
+            pack_into(writable_buf, 90, test_string)
+        with self.assertRaises((ValueError, struct.error)):
+            pack_into(writable_buf, -10, test_string)
+        with self.assertRaises((ValueError, struct.error)):
+            pack_into(writable_buf, 150, test_string)
+        with self.assertRaises((ValueError, struct.error)):
+            pack_into(writable_buf, -150, test_string)
+
+        # Test invalid buffer.
+        self.assertRaises(TypeError, pack_into, b' '*100, 0, test_string)
+        self.assertRaises(TypeError, pack_into, ' '*100, 0, test_string)
+        self.assertRaises(TypeError, pack_into, [0]*100, 0, test_string)
+        self.assertRaises(TypeError, pack_into, None, 0, test_string)
+        self.assertRaises(TypeError, pack_into, writable_buf[::2], 0, test_string)
+        self.assertRaises(TypeError, pack_into, writable_buf[::-1], 0, test_string)
+
+        # Test bogus offset (issue bpo-3694)
+        with self.assertRaises(TypeError):
+            pack_into(writable_buf, None, test_string)
+        with self.assertRaises(TypeError):
+            pack_into(writable_buf, 0.0, test_string)
+        with self.assertRaises((IndexError, OverflowError)):
+            pack_into(writable_buf, 2**1000, test_string)
+        with self.assertRaises((IndexError, OverflowError)):
+            pack_into(writable_buf, -2**1000, test_string)
+
+    def test_pack_into(self):
+        s = struct.Struct('21s')
+        self._test_pack_into(s.pack_into)
+
+    def test_pack_into_fn(self):
+        pack_into = lambda *args: struct.pack_into('21s', *args)
+        self._test_pack_into(pack_into)
 
     def test_unpack_with_buffer(self):
         # SF bug 1563759: struct.unpack doesn't support buffer protocol objects


### PR DESCRIPTION
Add tests for negative offset, out of bound offset, invalid type of offset, non-writeable buffer, non-continuous buffer, invalid type of buffer.

Repeat all tests for struct.Struct.pack_into().


<!-- gh-issue-number: gh-143672 -->
* Issue: gh-143672
<!-- /gh-issue-number -->
