### PR TITLE
Doc: clarify os.rename doesn't atomically replace dst contents (gh-143909)

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2774,8 +2774,14 @@ features:
 
 .. function:: rename(src, dst, *, src_dir_fd=None, dst_dir_fd=None)
 
-   Rename the file or directory *src* to *dst*. If *dst* exists, the operation
-   will fail with an :exc:`OSError` subclass in a number of cases:
+   Rename the file or directory *src* to *dst*. If *dst* exists,
+   the operation overwrites it **atomically relative to the
+   filesystem namespace** (dst path guaranteed to point to src or not exist
+   after the call, per POSIX rename(2)).  **Not atomic for content replacement:
+   old dst contents may remain briefly accessible on Unix (new dst appears first,
+   old unlinked after).**  On Windows, dst is silently overwritten if permitted;
+   otherwise :exc:`PermissionError` is raised.
+
 
    On Windows, if *dst* exists a :exc:`FileExistsError` is always raised.
    The operation may fail if *src* and *dst* are on different filesystems. Use


### PR DESCRIPTION
Docs claim atomic overwrite when dst exists. Wrong—Unix leaves old contents readable briefly (new dst appears first, old unlinked after). Matches POSIX but needs explicit warning.

Replaces vague "atomic" block with namespace vs content distinction. No behavior change.

Fixes #143909. CC @pablogsal @a12k1

<!-- gh-issue-number: gh-143909 -->
* Issue: gh-143909
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--143937.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->