### PR TITLE
Notify Sviat and Hugo of GHA changes through codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,7 +63,7 @@
 .azure-pipelines/             @AA-Turner
 
 # GitHub & related scripts
-.github/                               @ezio-melotti @hugovk @AA-Turner
+.github/                               @ezio-melotti @hugovk @AA-Turner @webknjaz
 Tools/build/compute-changes.py         @AA-Turner
 Tools/build/verify_ensurepip_wheels.py @AA-Turner @pfmoore @pradyunsg
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,7 +64,7 @@
 
 # GitHub & related scripts
 .github/                               @ezio-melotti @hugovk @AA-Turner @webknjaz
-Tools/build/compute-changes.py         @AA-Turner @hugovk
+Tools/build/compute-changes.py         @AA-Turner @hugovk @webknjaz
 Tools/build/verify_ensurepip_wheels.py @AA-Turner @pfmoore @pradyunsg
 
 # Pre-commit

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,7 +64,7 @@
 
 # GitHub & related scripts
 .github/                               @ezio-melotti @hugovk @AA-Turner @webknjaz
-Tools/build/compute-changes.py         @AA-Turner
+Tools/build/compute-changes.py         @AA-Turner @hugovk
 Tools/build/verify_ensurepip_wheels.py @AA-Turner @pfmoore @pradyunsg
 
 # Pre-commit


### PR DESCRIPTION
This is a follow-up to getting the triage bit [[1]] as suggested by Petr privately, prior to the nomination.

The patch is meant to ping me regarding any PRs that touch GitHub Actions CI/CD instead of Petr doing so manually.

[1]: https://github.com/python/core-workflow/issues/591