### PR TITLE
gh-143943: add missing header file for `pycore_optimizer_types.h`

### DIFF
--- a/Include/internal/pycore_optimizer_types.h
+++ b/Include/internal/pycore_optimizer_types.h
@@ -8,6 +8,7 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+#include <stdbool.h>
 #include "pycore_uop.h"  // UOP_MAX_TRACE_LENGTH
 
 // Holds locals, stack, locals, stack ... (in that order)


### PR DESCRIPTION
The `stdbool.h` was not included in the recently added `pycore_optimizer_types.h`, causing compilation errors on some platforms  where `bool` is not implicitly available through other headers.

<!-- gh-issue-number: gh-143943 -->
* Issue: gh-143943
<!-- /gh-issue-number -->
