### PR TITLE
gh-142913: fix `_testinternalcapi` build failure due to undefined JIT symbols

### DIFF
--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -225,7 +225,7 @@ PyAPI_FUNC(int) _PyDumpExecutors(FILE *out);
 PyAPI_FUNC(void) _Py_ClearExecutorDeletionList(PyInterpreterState *interp);
 #endif
 
-int _PyJit_translate_single_bytecode_to_trace(PyThreadState *tstate, _PyInterpreterFrame *frame, _Py_CODEUNIT *next_instr, int stop_tracing_opcode);
+PyAPI_FUNC(int) _PyJit_translate_single_bytecode_to_trace(PyThreadState *tstate, _PyInterpreterFrame *frame, _Py_CODEUNIT *next_instr, int stop_tracing_opcode);
 
 PyAPI_FUNC(int)
 _PyJit_TryInitializeTracing(PyThreadState *tstate, _PyInterpreterFrame *frame,
@@ -233,7 +233,7 @@ _PyJit_TryInitializeTracing(PyThreadState *tstate, _PyInterpreterFrame *frame,
     _Py_CODEUNIT *close_loop_instr, int curr_stackdepth, int chain_depth, _PyExitData *exit,
     int oparg, _PyExecutorObject *current_executor);
 
-void _PyJit_FinalizeTracing(PyThreadState *tstate, int err);
+PyAPI_FUNC(void) _PyJit_FinalizeTracing(PyThreadState *tstate, int err);
 void _PyJit_TracerFree(_PyThreadStateImpl *_tstate);
 
 void _PyJit_Tracer_InvalidateDependency(PyThreadState *old_tstate, void *obj);


### PR DESCRIPTION
**Root cause:**

The fix in 949b5ec removed the Tier 2 interpreter loop from `Modules/_testinternalcapi/interpreter.c`, but `test_cases.c.h` is generated from `Python/bytecodes.c` and still contains the `TRACE_RECORD` and `TRACE_END` instructions which call:

- `_PyJit_translate_single_bytecode_to_trace()`
- `_PyJit_TryInitializeTracing()`
- `_PyJit_FinalizeTracing()`

These functions are defined in `Python/optimizer.c` but are not exported (missing `PyAPI_FUNC`), causing link failures when building the shared library.

<!-- gh-issue-number: gh-142913 -->
* Issue: gh-142913
<!-- /gh-issue-number -->
