### PR TITLE
gh-143968: Prevent pathlib.Path.copy() from processing special files (FIFO, devices)

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -1328,8 +1328,13 @@ class Path(PurePath):
                     child, follow_symlinks, preserve_metadata)
             if preserve_metadata:
                 _copy_info(source.info, self)
-        else:
+        elif source.info.is_file():
             self._copy_from_file(source, preserve_metadata)
+        elif not source.info.exists(follow_symlinks=follow_symlinks):
+            self._copy_from_file(source, preserve_metadata)
+        else:
+            raise io.UnsupportedOperation(
+                f"{source!r} is a special file and cannot be copied")
 
     def _copy_from_file(self, source, preserve_metadata=False):
         ensure_different_files(source, self)

--- a/Lib/test/test_pathlib/test_copy.py
+++ b/Lib/test/test_pathlib/test_copy.py
@@ -187,7 +187,6 @@ if not is_pypi:
 
         def test_copy_char_device(self):
             import io
-            import os
             # /dev/null is a character device on POSIX
             source = Path('/dev/null')
             if not source.exists() or not source.is_char_device():

--- a/Lib/test/test_pathlib/test_copy.py
+++ b/Lib/test/test_pathlib/test_copy.py
@@ -169,6 +169,36 @@ if not is_pypi:
         source_ground = LocalPathGround(Path)
         target_ground = LocalPathGround(Path)
 
+        def test_copy_fifo(self):
+            import io
+            import os
+            if not hasattr(os, 'mkfifo'):
+                self.skipTest('os.mkfifo() required')
+            
+            source = self.source_root / 'test.fifo'
+            try:
+                os.mkfifo(source)
+            except OSError:
+                self.skipTest("cannot create fifo")
+                
+            target = self.target_root / 'copy_fifo'
+            with self.assertRaises(io.UnsupportedOperation): 
+                source.copy(target)
+
+        def test_copy_char_device(self):
+            import io
+            import os
+            # /dev/null is a character device on POSIX
+            source = Path('/dev/null')
+            if not source.exists() or not source.is_char_device():
+                self.skipTest('/dev/null required')
+            
+            target = self.target_root / 'copy_null'
+            # This should fail immediately with UnsupportedOperation
+            # If it were buggy, it might loop infinitely or copy empty file depending on implementation
+            with self.assertRaises(io.UnsupportedOperation):
+                source.copy(target)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_pathlib/test_copy.py
+++ b/Lib/test/test_pathlib/test_copy.py
@@ -174,15 +174,15 @@ if not is_pypi:
             import os
             if not hasattr(os, 'mkfifo'):
                 self.skipTest('os.mkfifo() required')
-            
+
             source = self.source_root / 'test.fifo'
             try:
                 os.mkfifo(source)
             except OSError:
                 self.skipTest("cannot create fifo")
-                
+
             target = self.target_root / 'copy_fifo'
-            with self.assertRaises(io.UnsupportedOperation): 
+            with self.assertRaises(io.UnsupportedOperation):
                 source.copy(target)
 
         def test_copy_char_device(self):
@@ -192,7 +192,7 @@ if not is_pypi:
             source = Path('/dev/null')
             if not source.exists() or not source.is_char_device():
                 self.skipTest('/dev/null required')
-            
+
             target = self.target_root / 'copy_null'
             # This should fail immediately with UnsupportedOperation
             # If it were buggy, it might loop infinitely or copy empty file depending on implementation

--- a/Misc/NEWS.d/next/Library/2026-01-17-15-49-04.gh-issue-143968.5R_yPR.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-17-15-49-04.gh-issue-143968.5R_yPR.rst
@@ -1,0 +1,1 @@
+Prevent :meth:`pathlib.Path.copy` from attempting to copy special files like FIFOs or character devices, avoiding hangs or infinite loops.


### PR DESCRIPTION
Closes gh-143968

[3.14] gh-143968: Prevent pathlib.Path.copy() from processing special files (FIFO, devices)

## Description

This PR addresses an issue where `pathlib.Path.copy()` (introduced for 3.14) could indiscriminately attempt to open and read from special files like FIFOs (named pipes) or character devices (e.g., `/dev/zero`).

### The Problem
*   **FIFOs**: Reading from a FIFO without a writer blocks indefinitely, causing the Python process to hang.
*   **Infinite Sources**: Reading from `/dev/zero` results in an infinite loop that continues until disk space is exhausted or the process is killed.

### The Fix
The copy logic in `_copy_from` inside `Lib/pathlib/__init__.py` has been modified to explicitly check `is_file()` before attempting to copy content.
*   If the source is a regular file, it proceeds as normal.
*   If it is a directory (already handled), it recurses.
*   **New Behavior**: If it is a special file (but exists), it raises `io.UnsupportedOperation`.
    *   This aligns with `shutil.copyfile`'s philosophy of safely handling special files by refusing to copy them as streams.
*   Existing behavior for dangling symlinks (raising `FileNotFoundError`) is strictly preserved.

## Tests
Added new test cases in `Lib/test/test_pathlib/test_copy.py` to cover these scenarios:
*   `test_copy_fifo`: Verifies that copying a FIFO (created via `os.mkfifo`) raises `UnsupportedOperation` immediately instead of blocking.
*   `test_copy_char_device`: Verifies that copying a character device (e.g., `/dev/null`) raises `UnsupportedOperation`.

## Validation
*   Ran `python -m test test_pathlib` locally and all 1375 tests passed.


<!-- gh-issue-number: gh-143968 -->
* Issue: gh-143968
<!-- /gh-issue-number -->
