### PR TITLE
gh-143969: Fix frozen+slotted dataclass __setattr__ crash ambiguity

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -732,20 +732,29 @@ def _frozen_get_del_attr(cls, fields, func_builder):
     if fields:
         condition += ' or name in {' + ', '.join(repr(f.name) for f in fields) + '}'
 
-    func_builder.add_fn('__setattr__',
-                        ('self', 'name', 'value'),
-                        (f'  if {condition}:',
-                          '   raise FrozenInstanceError(f"cannot assign to field {name!r}")',
-                         f'  super(cls, self).__setattr__(name, value)'),
-                        locals=locals,
-                        overwrite_error=True)
-    func_builder.add_fn('__delattr__',
-                        ('self', 'name'),
-                        (f'  if {condition}:',
-                          '   raise FrozenInstanceError(f"cannot delete field {name!r}")',
-                         f'  super(cls, self).__delattr__(name)'),
-                        locals=locals,
-                        overwrite_error=True)
+    func_builder.add_fn(
+        '__setattr__',
+        ('self', 'name', 'value'),
+        (
+            f'  if {condition}:',
+            '   raise FrozenInstanceError(f"cannot assign to field {name!r}")',
+            '  object.__setattr__(self, name, value)',
+        ),
+        locals=locals,
+        overwrite_error=True,
+    )
+
+    func_builder.add_fn(
+        '__delattr__',
+        ('self', 'name'),
+        (
+            f'  if {condition}:',
+            '   raise FrozenInstanceError(f"cannot delete field {name!r}")',
+            '  object.__delattr__(self, name)',
+        ),
+        locals=locals,
+        overwrite_error=True,
+    )
 
 
 def _is_classvar(a_type, typing):

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -732,29 +732,20 @@ def _frozen_get_del_attr(cls, fields, func_builder):
     if fields:
         condition += ' or name in {' + ', '.join(repr(f.name) for f in fields) + '}'
 
-    func_builder.add_fn(
-        '__setattr__',
-        ('self', 'name', 'value'),
-        (
-            f'  if {condition}:',
-            '   raise FrozenInstanceError(f"cannot assign to field {name!r}")',
-            '  object.__setattr__(self, name, value)',
-        ),
-        locals=locals,
-        overwrite_error=True,
-    )
-
-    func_builder.add_fn(
-        '__delattr__',
-        ('self', 'name'),
-        (
-            f'  if {condition}:',
-            '   raise FrozenInstanceError(f"cannot delete field {name!r}")',
-            '  object.__delattr__(self, name)',
-        ),
-        locals=locals,
-        overwrite_error=True,
-    )
+    func_builder.add_fn('__setattr__',
+                        ('self', 'name', 'value'),
+                        (f'  if {condition}:',
+                          '   raise FrozenInstanceError(f"cannot assign to field {name!r}")',
+                         f'  super(cls, self).__setattr__(name, value)'),
+                        locals=locals,
+                        overwrite_error=True)
+    func_builder.add_fn('__delattr__',
+                        ('self', 'name'),
+                        (f'  if {condition}:',
+                          '   raise FrozenInstanceError(f"cannot delete field {name!r}")',
+                         f'  super(cls, self).__delattr__(name)'),
+                        locals=locals,
+                        overwrite_error=True)
 
 
 def _is_classvar(a_type, typing):

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -3404,6 +3404,14 @@ class TestFrozen(unittest.TestCase):
 
             c = C('hello')
             self.assertEqual(deepcopy(c), c)
+    def test_frozen_slots_setattr(self):
+        # gh-143969: Ensure frozen+slots uses object.__setattr__
+        @dataclass(frozen=True, slots=True)
+        class A:
+            x: int
+        a = A(1)
+        with self.assertRaisesRegex(FrozenInstanceError, 'cannot assign to field'):
+            a.x = 2
 
 
 class TestSlots(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2026-01-17-23-15-55.gh-issue-143969.Waq8zN.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-17-23-15-55.gh-issue-143969.Waq8zN.rst
@@ -1,0 +1,2 @@
+Fixed a crash in frozen slotted dataclasses where assigning to an attribute
+could raise an internal TypeError instead of failing cleanly.

--- a/Misc/NEWS.d/next/Library/2026-01-17-23-15-55.gh-issue-143969.Waq8zN.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-17-23-15-55.gh-issue-143969.Waq8zN.rst
@@ -1,2 +1,2 @@
 Fixed a crash in frozen slotted dataclasses where assigning to an attribute
-could raise an internal TypeError instead of failing cleanly.
+could raise an internal :exc:`TypeError` instead of failing cleanly.


### PR DESCRIPTION
Fixed Misleading "Not an instance or subtype" error when assigning to property of frozen, slotted dataclass.

Fix a crash in frozen dataclasses with slots where the generated
__setattr__ and __delattr__ methods used super(cls, self).

When slots rebuild the class, the captured cls no longer matches the
instance type, causing a TypeError at runtime.

Use object.__setattr__ and object.__delattr__ instead to preserve frozen
semantics safely.

gh-143969
