### PR TITLE
[3.13] gh-143916: Reject control characters in wsgiref.headers.Headers (GH-143917)

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2856,3 +2856,10 @@ def linked_to_musl():
     except (OSError, subprocess.CalledProcessError):
         return False
     return ('musl' in stdout)
+
+
+def control_characters_c0() -> list[str]:
+    """Returns a list of C0 control characters as strings.
+    C0 control characters defined as the byte range 0x00-0x1F, and 0x7F.
+    """
+    return [chr(c) for c in range(0x00, 0x20)] + ["\x7F"]

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -1,6 +1,6 @@
 from unittest import mock
 from test import support
-from test.support import socket_helper
+from test.support import socket_helper, control_characters_c0
 from test.test_httpservers import NoLogRequestHandler
 from unittest import TestCase
 from wsgiref.util import setup_testing_defaults
@@ -502,6 +502,16 @@ class HeaderTests(TestCase):
             'Foo: bar; cheese\r\n'
             '\r\n'
         )
+
+    def testRaisesControlCharacters(self):
+        headers = Headers()
+        for c0 in control_characters_c0():
+            self.assertRaises(ValueError, headers.__setitem__, f"key{c0}", "val")
+            self.assertRaises(ValueError, headers.__setitem__, "key", f"val{c0}")
+            self.assertRaises(ValueError, headers.add_header, f"key{c0}", "val", param="param")
+            self.assertRaises(ValueError, headers.add_header, "key", f"val{c0}", param="param")
+            self.assertRaises(ValueError, headers.add_header, "key", "val", param=f"param{c0}")
+
 
 class ErrorHandler(BaseCGIHandler):
     """Simple handler subclass for testing BaseHandler"""

--- a/Lib/wsgiref/headers.py
+++ b/Lib/wsgiref/headers.py
@@ -9,6 +9,7 @@ written by Barry Warsaw.
 # existence of which force quoting of the parameter value.
 import re
 tspecials = re.compile(r'[ \(\)<>@,;:\\"/\[\]\?=]')
+_control_chars_re = re.compile(r'[\x00-\x1F\x7F]')
 
 def _formatparam(param, value=None, quote=1):
     """Convenience function to format and return a key=value pair.
@@ -41,6 +42,8 @@ class Headers:
     def _convert_string_type(self, value):
         """Convert/check value type."""
         if type(value) is str:
+            if _control_chars_re.search(value):
+                raise ValueError("Control characters not allowed in headers")
             return value
         raise AssertionError("Header names/values must be"
             " of type str (got {0})".format(repr(value)))

--- a/Misc/NEWS.d/next/Security/2026-01-16-11-07-36.gh-issue-143916.dpWeOD.rst
+++ b/Misc/NEWS.d/next/Security/2026-01-16-11-07-36.gh-issue-143916.dpWeOD.rst
@@ -1,0 +1,2 @@
+Reject C0 control characters within wsgiref.headers.Headers fields, values,
+and parameters.


### PR DESCRIPTION
* Add 'test.support' fixture for C0 control characters
* gh-143916: Reject control characters in wsgiref.headers.Headers

(cherry picked from commit f7fceed79ca1bceae8dbe5ba5bc8928564da7211)