### PR TITLE
gh-143978: Fix typo in ignored.tsv

### DIFF
--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -347,7 +347,7 @@ Objects/obmalloc.c	-	obmalloc_state_main	-
 Objects/obmalloc.c	-	obmalloc_state_initialized	-
 Objects/typeobject.c	-	name_op	-
 Objects/typeobject.c	-	slotdefs	-
-# It initialized only once when main interpeter starts
+# It initialized only once when main interpreter starts
 Objects/typeobject.c	-	slotdefs_name_counts	-
 Objects/unicodeobject.c	-	stripfuncnames	-
 Objects/unicodeobject.c	-	utf7_category	-

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -347,7 +347,7 @@ Objects/obmalloc.c	-	obmalloc_state_main	-
 Objects/obmalloc.c	-	obmalloc_state_initialized	-
 Objects/typeobject.c	-	name_op	-
 Objects/typeobject.c	-	slotdefs	-
-# It initialized only once when main interpreter starts
+# It is initialized only once when main interpreter starts
 Objects/typeobject.c	-	slotdefs_name_counts	-
 Objects/unicodeobject.c	-	stripfuncnames	-
 Objects/unicodeobject.c	-	utf7_category	-


### PR DESCRIPTION
"# It initialized only once when main interpeter starts" ("interpeter") has to be "# It initialized only once when main interpreter starts" ("interpreter").

Fixes #143978 

<!-- gh-issue-number: gh-143978 -->
* Issue: gh-143978
<!-- /gh-issue-number -->
