### PR TITLE
gh-102809: No longer mention `Misc/gdbinit` in the code

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -711,7 +711,7 @@ _PyObject_IsFreed(PyObject *op)
 }
 
 
-/* For debugging convenience.  See Misc/gdbinit for some useful gdb hooks */
+/* For debugging convenience. */
 void
 PyObject_Dump(PyObject* op)
 {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

`Misc/gdbinit` was removed in GH-102854 (3.12.0a7).


<!-- gh-issue-number: gh-102809 -->
* Issue: gh-102809
<!-- /gh-issue-number -->
