### PR TITLE
gh-143986: Modernize Lib/uuid.py: use f-strings

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -323,7 +323,7 @@ class UUID:
         return self.int
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, str(self))
+        return f'{self.__class__.__name__}({str(self)!r})'
 
     def __setattr__(self, name, value):
         raise TypeError('UUID objects are immutable')
@@ -611,7 +611,7 @@ def _arp_getnode():
         return mac
 
     # This works on Linux, FreeBSD and NetBSD
-    mac = _find_mac_near_keyword('arp', '-an', [os.fsencode('(%s)' % ip_addr)],
+    mac = _find_mac_near_keyword('arp', '-an', [os.fsencode(f'({ip_addr})')],
                     lambda i: i+2)
     # Return None instead of 0.
     if mac:
@@ -718,7 +718,7 @@ def getnode():
             continue
         if (_node is not None) and (0 <= _node < (1 << 48)):
             return _node
-    assert False, '_random_getnode() returned invalid value: {}'.format(_node)
+    assert False, f'_random_getnode() returned invalid value: {_node}'
 
 
 _last_timestamp = None

--- a/Misc/NEWS.d/next/Library/2026-01-18-07-09-38.gh-issue-143986.rt0Hht.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-18-07-09-38.gh-issue-143986.rt0Hht.rst
@@ -1,0 +1,1 @@
+Modernize the :mod:`uuid` module to use f-strings.


### PR DESCRIPTION
# Description
`Lib/uuid.py` currently uses older string formatting methods (`%` operator and `.format()`) in a few places. This task resolves to modernizing these to use f-strings (PEP 498) for improved readability and consistency with modern Python codebases.

# Proposed Changes
- Replace `'%s(%r)' % (self.__class__.__name__, str(self))` with `f'{self.__class__.__name__}({str(self)!r})'` in `UUID.__repr__`.
- Replace `os.fsencode('(%s)' % ip_addr)` with `os.fsencode(f'({ip_addr})')` in `_arp_getnode`.
- Replace `assert False, '_random_getnode() returned invalid value: {}'.format(_node)` with `f-string` version in `getnode`.

# Verification
- Run `python Lib/test/test_uuid.py` to ensure all tests pass.


<!-- gh-issue-number: gh-143986 -->
* Issue: gh-143986
<!-- /gh-issue-number -->
