### PR TITLE
gh-143990: Preserve negative pixel sizes in tkinter.font.Font

### DIFF
--- a/Lib/test/test_tkinter/test_font.py
+++ b/Lib/test/test_tkinter/test_font.py
@@ -130,6 +130,15 @@ class FontTest(AbstractTkTest, unittest.TestCase):
         with self.assertRaisesRegex(TypeError, 'is not a container or iterable'):
             self.font in self.font
 
+    def test_negative_pixel_size(self):
+        # gh-143990: negative sizes (pixels) should be preserved in Font objects
+        pixel_size = -14
+        f = font.Font(self.root, family='Helvetica', size=pixel_size)
+        self.assertEqual(f.cget("size"), pixel_size)
+        # Test initialization with font tuple
+        f2 = font.Font(self.root, font=('Helvetica', pixel_size))
+        self.assertEqual(f2.cget("size"), pixel_size)
+
 
 class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):
 

--- a/Lib/tkinter/font.py
+++ b/Lib/tkinter/font.py
@@ -72,7 +72,21 @@ class Font:
         tk = getattr(root, 'tk', root)
         if font:
             # get actual settings corresponding to the given font
-            font = tk.splitlist(tk.call("font", "actual", font))
+            font_opts = tk.splitlist(tk.call("font", "actual", font))
+            #if input was passed as tuple, restore
+            # font actual will normalize negative (pixel) -> positive(points)
+            if isinstance(font, tuple) and len(font) >= 2:
+                # format=(family, size, styles)
+                req_size = font[1]
+                if isinstance(req_size, (int, float)):
+                    opt=list(font_opts)
+                    try:
+                        i = opt.index('-size')
+                        opt[i+1] = str(req_size)
+                        font_opts = tuple(opt)
+                    except ValueError:
+                        pass
+            font = font_opts
         else:
             font = self._set(options)
         if not name:

--- a/Misc/NEWS.d/next/Library/2026-01-18-15-07-12.gh-issue-143990.0_lU8l.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-18-15-07-12.gh-issue-143990.0_lU8l.rst
@@ -1,0 +1,3 @@
+Preserve negative font sizes (pixels) in :class:`tkinter.font.Font` when
+defined via a tuple. Previously, these were incorrectly normalized to
+positive sizes (points) by Tcl's ``font actual`` command.


### PR DESCRIPTION
gh-143990: Preserve negative pixel sizes in tkinter.font.Font

### Summary
This PR fixes a bug where tkinter.font.Font objects would lose their negative sign (representing pixel size) and convert it to a positive integer (representing points) during initialization.

### details
The Font.__init__ method calls tk.call("font", "actual", font). In Tcl/Tk, font actual resolves the requested font to the system's closest match. If a font is requested in pixels (e.g., -14), Tcl calculates the equivalent point size (e.g., 11) based on the current DPI.

The current implementation in tkinter/font.py was blindly accepting this resolved value and overwriting the user's original request. This fix checks if the input was a tuple containing a size, and if so, restores that specific size after the font actual call.


### Changes

Modified Lib/tkinter/font.py to preserve the user-requested size.
Added a regression test test_negative_pixel_size to Lib/test/test_tkinter/test_font.py.
Verified that Font.cget("size") now returns the correct negative integer.