### PR TITLE
gh-143993: Document ways to disable remote debugging support

### DIFF
--- a/Doc/howto/remote_debugging.rst
+++ b/Doc/howto/remote_debugging.rst
@@ -11,9 +11,10 @@ Most platforms require elevated privileges to attach to another Python process.
 .. note::
 
    You can disable remote debugging support in a Python interpreter by (1) setting the
-   ``PYTHON_DISABLE_REMOTE_DEBUG`` environment variable to any value before starting
-   the interpreter, (2) using the ``-X disable-remote-debug`` command-line option, or
-   (3) compiling Python with the ``--without-remote-debug`` build flag.
+   :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to any value before
+   starting the interpreter, (2) using the :option:`-X disable_remote_debug`
+   command-line option, or (3) compiling Python with the :option:`--without-remote-debug`
+   build flag.
 
 .. _permission-requirements:
 

--- a/Doc/howto/remote_debugging.rst
+++ b/Doc/howto/remote_debugging.rst
@@ -8,6 +8,13 @@ execute Python code remotely.
 
 Most platforms require elevated privileges to attach to another Python process.
 
+.. note::
+
+   You can disable remote debugging support in a Python interpreter by (1) setting the
+   ``PYTHON_DISABLE_REMOTE_DEBUG`` environment variable to any value before starting
+   the interpreter, (2) using the ``-X disable-remote-debug`` command-line option, or
+   (3) compiling Python with the ``--without-remote-debug`` build flag.
+
 .. _permission-requirements:
 
 Permission requirements
@@ -614,4 +621,3 @@ To inject and execute a Python script in a remote process:
 6. Set ``_PY_EVAL_PLEASE_STOP_BIT`` in the ``eval_breaker`` field.
 7. Resume the process (if suspended). The script will execute at the next safe
    evaluation point.
-

--- a/Doc/howto/remote_debugging.rst
+++ b/Doc/howto/remote_debugging.rst
@@ -10,11 +10,12 @@ Most platforms require elevated privileges to attach to another Python process.
 
 .. note::
 
-   You can disable remote debugging support in a Python interpreter by (1) setting the
-   :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to any value before
-   starting the interpreter, (2) using the :option:`-X disable_remote_debug`
-   command-line option, or (3) compiling Python with the :option:`--without-remote-debug`
-   build flag.
+   To disable remote debugging support, use any of the following:
+
+   * Set the :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to
+     any value before starting the interpreter.
+   * Use the :option:`-X disable_remote_debug` command-line option.
+   * Compile Python with the :option:`--without-remote-debug` build flag.
 
 .. _permission-requirements:
 

--- a/Doc/howto/remote_debugging.rst
+++ b/Doc/howto/remote_debugging.rst
@@ -13,8 +13,8 @@ Disabling remote debugging
 
 To disable remote debugging support, use any of the following:
 
-* Set the :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to
-  any value before starting the interpreter.
+* Set the :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to ``1`` before
+  starting the interpreter.
 * Use the :option:`-X disable_remote_debug` command-line option.
 * Compile Python with the :option:`--without-remote-debug` build flag.
 

--- a/Doc/howto/remote_debugging.rst
+++ b/Doc/howto/remote_debugging.rst
@@ -8,14 +8,15 @@ execute Python code remotely.
 
 Most platforms require elevated privileges to attach to another Python process.
 
-.. note::
+Disabling remote debugging
+--------------------------
 
-   To disable remote debugging support, use any of the following:
+To disable remote debugging support, use any of the following:
 
-   * Set the :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to
-     any value before starting the interpreter.
-   * Use the :option:`-X disable_remote_debug` command-line option.
-   * Compile Python with the :option:`--without-remote-debug` build flag.
+* Set the :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to
+  any value before starting the interpreter.
+* Use the :option:`-X disable_remote_debug` command-line option.
+* Compile Python with the :option:`--without-remote-debug` build flag.
 
 .. _permission-requirements:
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1999,11 +1999,12 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
    .. note::
 
-      You can disable remote debugging support in a Python interpreter by (1) setting
-      the :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to any value before
-      starting the interpreter, (2) using the :option:`-X disable_remote_debug`
-      command-line option, or (3) compiling Python with the
-      :option:`--without-remote-debug` build flag.
+      To disable remote debugging support, use any of the following:
+
+      * Set the :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to
+        any value before starting the interpreter.
+      * Use the :option:`-X disable_remote_debug` command-line option.
+      * Compile Python with the :option:`--without-remote-debug` build flag.
 
    .. audit-event:: sys.remote_exec pid script_path
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1997,6 +1997,13 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    interpreter is pre-release (alpha, beta, or release candidate) then the
    local and remote interpreters must be the same exact version.
 
+   .. note::
+
+      You can disable remote debugging support in a Python interpreter by (1) setting the
+      ``PYTHON_DISABLE_REMOTE_DEBUG`` environment variable to any value before starting
+      the interpreter, (2) using the ``-X disable-remote-debug`` command-line option, or
+      (3) compiling Python with the ``--without-remote-debug`` build flag.
+
    .. audit-event:: sys.remote_exec pid script_path
 
       When the code is executed in the remote process, an

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1999,10 +1999,11 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
    .. note::
 
-      You can disable remote debugging support in a Python interpreter by (1) setting the
-      ``PYTHON_DISABLE_REMOTE_DEBUG`` environment variable to any value before starting
-      the interpreter, (2) using the ``-X disable-remote-debug`` command-line option, or
-      (3) compiling Python with the ``--without-remote-debug`` build flag.
+      You can disable remote debugging support in a Python interpreter by (1) setting
+      the :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to any value before
+      starting the interpreter, (2) using the :option:`-X disable_remote_debug`
+      command-line option, or (3) compiling Python with the
+      :option:`--without-remote-debug` build flag.
 
    .. audit-event:: sys.remote_exec pid script_path
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -2001,8 +2001,8 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
       To disable remote debugging support, use any of the following:
 
-      * Set the :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to
-        any value before starting the interpreter.
+      * Set the :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to ``1``
+        before starting the interpreter.
       * Use the :option:`-X disable_remote_debug` command-line option.
       * Compile Python with the :option:`--without-remote-debug` build flag.
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1997,14 +1997,8 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    interpreter is pre-release (alpha, beta, or release candidate) then the
    local and remote interpreters must be the same exact version.
 
-   .. note::
-
-      To disable remote debugging support, use any of the following:
-
-      * Set the :envvar:`PYTHON_DISABLE_REMOTE_DEBUG` environment variable to ``1``
-        before starting the interpreter.
-      * Use the :option:`-X disable_remote_debug` command-line option.
-      * Compile Python with the :option:`--without-remote-debug` build flag.
+   See :ref:`remote-debugging` for more information about the remote debugging
+   mechanism.
 
    .. audit-event:: sys.remote_exec pid script_path
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -2018,6 +2018,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
    .. availability:: Unix, Windows.
    .. versionadded:: 3.14
+      See :pep:`768` for more details.
 
 
 .. function:: _enablelegacywindowsfsencoding()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Although PEP 768 mentions how to disable the mechanism of remote debugging, it is not documented in the Python docs.

This change adds a note on how to disable remote debugging support in a Python interpreter to the remote debugging how-to and to the `sys.remote_exec` docs.


<!-- gh-issue-number: gh-143993 -->
* Issue: gh-143993
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: 

* https://cpython-previews--143994.org.readthedocs.build/en/143994/howto/remote_debugging.html#remote-debugging
* https://cpython-previews--143994.org.readthedocs.build/en/143994/library/sys.html#sys.remote_exec

<!-- readthedocs-preview cpython-previews end -->