### PR TITLE
gh-143959: Split datetime tests requiring _datetime

### DIFF
--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -2,19 +2,24 @@ import unittest
 import sys
 import functools
 
-from test import support
-from test.support.import_helper import import_fresh_module
+from test.support.import_helper import import_fresh_module, import_module
 
 
 TESTS = 'test.datetimetester'
 
 def load_tests(loader, tests, pattern):
     try:
-        pure_tests = import_fresh_module(TESTS,
-                                         fresh=['datetime', '_pydatetime', '_strptime'],
-                                         blocked=['_datetime'])
+        pure_tests = import_fresh_module(
+            TESTS,
+            fresh=['datetime', '_pydatetime', '_strptime'],
+            blocked=['_datetime'],
+        )
         fast_tests = None
-        if support.import_module('_datetime', required=False):
+        try:
+            import_module('_datetime')
+        except ImportError:
+            fast_tests = None
+        else:
             fast_tests = import_fresh_module(
                 TESTS,
                 fresh=['datetime', '_strptime'],

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -57,7 +57,7 @@ def load_tests(loader, tests, pattern):
                 def setUpClass(cls_, module=module):
                     if suffix == "_Fast" and not has_datetime:
                         raise unittest.SkipTest("requires _datetime module")
-                    
+
                     cls_._save_sys_modules = sys.modules.copy()
                     sys.modules[TESTS] = module
                     sys.modules['datetime'] = module.datetime_module

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -8,12 +8,6 @@ TESTS = 'test.datetimetester'
 
 def load_tests(loader, tests, pattern):
     try:
-        pure_tests = import_fresh_module(
-            TESTS,
-            fresh=['datetime', '_pydatetime', '_strptime'],
-            blocked=['_datetime'],
-        )
-
         try:
             import _datetime
         except ImportError:
@@ -21,7 +15,11 @@ def load_tests(loader, tests, pattern):
         else:
             has_datetime = True
             del _datetime
-
+        pure_tests = import_fresh_module(
+            TESTS,
+            fresh=['datetime', '_pydatetime', '_strptime'],
+            blocked=['_datetime'],
+        )
         fast_tests = import_fresh_module(
             TESTS,
             fresh=['datetime', '_strptime'],

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -11,9 +11,9 @@ def load_tests(loader, tests, pattern):
         try:
             import _datetime
         except ImportError:
-            has_datetime = False
+            has_datetime_ext = False
         else:
-            has_datetime = True
+            has_datetime_ext = True
             del _datetime
         pure_tests = import_fresh_module(TESTS,
                                          fresh=['datetime', '_pydatetime', '_strptime'],
@@ -52,7 +52,7 @@ def load_tests(loader, tests, pattern):
             class Wrapper(cls):
                 @classmethod
                 def setUpClass(cls_, module=module):
-                    if module is fast_tests and not has_datetime:
+                    if module is fast_tests and not has_datetime_ext:
                         raise unittest.SkipTest("requires _datetime module")
 
                     cls_._save_sys_modules = sys.modules.copy()

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -2,8 +2,7 @@ import unittest
 import sys
 import functools
 
-from test.support.import_helper import import_fresh_module, import_module
-
+from test.support.import_helper import import_fresh_module
 
 TESTS = 'test.datetimetester'
 
@@ -14,28 +13,26 @@ def load_tests(loader, tests, pattern):
             fresh=['datetime', '_pydatetime', '_strptime'],
             blocked=['_datetime'],
         )
-        fast_tests = None
         try:
-            import_module('_datetime')
+            import _datetime
+            has_datetime = True
         except ImportError:
-            fast_tests = None
-        else:
-            fast_tests = import_fresh_module(
-                TESTS,
-                fresh=['datetime', '_strptime'],
-                blocked=['_pydatetime'],
-            )
+            has_datetime = False
+
+        fast_tests = import_fresh_module(
+            TESTS,
+            fresh=['datetime', '_strptime'],
+            blocked=['_pydatetime'],
+        )
     finally:
         # XXX: import_fresh_module() is supposed to leave sys.module cache untouched,
         # XXX: but it does not, so we have to cleanup ourselves.
         for modname in ['datetime', '_datetime', '_pydatetime', '_strptime']:
             sys.modules.pop(modname, None)
 
-    test_modules = [pure_tests]
-    test_suffixes = ["_Pure"]
-    if fast_tests is not None:
-        test_modules.append(fast_tests)
-        test_suffixes.append("_Fast")
+    test_modules = [pure_tests, fast_tests]
+    test_suffixes = ["_Pure", "_Fast"]
+
     # XXX(gb) First run all the _Pure tests, then all the _Fast tests.  You might
     # not believe this, but in spite of all the sys.modules trickery running a _Pure
     # test last will leave a mix of pure and native datetime stuff lying around.
@@ -58,6 +55,9 @@ def load_tests(loader, tests, pattern):
             class Wrapper(cls):
                 @classmethod
                 def setUpClass(cls_, module=module):
+                    if suffix == "_Fast" and not has_datetime:
+                        raise unittest.SkipTest("requires _datetime module")
+                    
                     cls_._save_sys_modules = sys.modules.copy()
                     sys.modules[TESTS] = module
                     sys.modules['datetime'] = module.datetime_module

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -1,7 +1,6 @@
 import unittest
 import sys
 import functools
-import importlib.util
 
 from test.support.import_helper import import_fresh_module
 
@@ -15,8 +14,13 @@ def load_tests(loader, tests, pattern):
             blocked=['_datetime'],
         )
 
-        # Check availability without importing _datetime
-        has_datetime = importlib.util.find_spec('_datetime') is not None
+        try:
+            import _datetime
+        except ImportError:
+            has_datetime = False
+        else:
+            has_datetime = True
+            del _datetime
 
         fast_tests = import_fresh_module(
             TESTS,
@@ -54,7 +58,7 @@ def load_tests(loader, tests, pattern):
             class Wrapper(cls):
                 @classmethod
                 def setUpClass(cls_, module=module):
-                    if suffix == "_Fast" and not has_datetime:
+                    if module is fast_tests and not has_datetime:
                         raise unittest.SkipTest("requires _datetime module")
 
                     cls_._save_sys_modules = sys.modules.copy()

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -1,6 +1,7 @@
 import unittest
 import sys
 import functools
+import importlib.util
 
 from test.support.import_helper import import_fresh_module
 
@@ -13,11 +14,9 @@ def load_tests(loader, tests, pattern):
             fresh=['datetime', '_pydatetime', '_strptime'],
             blocked=['_datetime'],
         )
-        try:
-            import _datetime
-            has_datetime = True
-        except ImportError:
-            has_datetime = False
+
+        # Check availability without importing _datetime
+        has_datetime = importlib.util.find_spec('_datetime') is not None
 
         fast_tests = import_fresh_module(
             TESTS,

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -18,17 +18,19 @@ def load_tests(loader, tests, pattern):
         pure_tests = import_fresh_module(TESTS,
                                          fresh=['datetime', '_pydatetime', '_strptime'],
                                          blocked=['_datetime'])
-        fast_tests = import_fresh_module(TESTS,
-                                         fresh=['datetime', '_strptime'],
-                                         blocked=['_pydatetime'])
+        fast_tests = None
+        if has_datetime_ext:
+            fast_tests = import_fresh_module(TESTS,
+                                             fresh=['datetime', '_strptime'],
+                                             blocked=['_pydatetime'])
     finally:
         # XXX: import_fresh_module() is supposed to leave sys.module cache untouched,
         # XXX: but it does not, so we have to cleanup ourselves.
         for modname in ['datetime', '_datetime', '_pydatetime', '_strptime']:
             sys.modules.pop(modname, None)
 
-    test_modules = [pure_tests, fast_tests]
-    test_suffixes = ["_Pure", "_Fast"]
+    test_modules = [pure_tests]
+    test_suffixes = ["_Pure"]
 
     # XXX(gb) First run all the _Pure tests, then all the _Fast tests.  You might
     # not believe this, but in spite of all the sys.modules trickery running a _Pure
@@ -52,9 +54,6 @@ def load_tests(loader, tests, pattern):
             class Wrapper(cls):
                 @classmethod
                 def setUpClass(cls_, module=module):
-                    if module is fast_tests and not has_datetime_ext:
-                        raise unittest.SkipTest("requires _datetime module")
-
                     cls_._save_sys_modules = sys.modules.copy()
                     sys.modules[TESTS] = module
                     sys.modules['datetime'] = module.datetime_module

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -15,16 +15,12 @@ def load_tests(loader, tests, pattern):
         else:
             has_datetime = True
             del _datetime
-        pure_tests = import_fresh_module(
-            TESTS,
-            fresh=['datetime', '_pydatetime', '_strptime'],
-            blocked=['_datetime'],
-        )
-        fast_tests = import_fresh_module(
-            TESTS,
-            fresh=['datetime', '_strptime'],
-            blocked=['_pydatetime'],
-        )
+        pure_tests = import_fresh_module(TESTS,
+                                         fresh=['datetime', '_pydatetime', '_strptime'],
+                                         blocked=['_datetime'])
+        fast_tests = import_fresh_module(TESTS,
+                                         fresh=['datetime', '_strptime'],
+                                         blocked=['_pydatetime'])
     finally:
         # XXX: import_fresh_module() is supposed to leave sys.module cache untouched,
         # XXX: but it does not, so we have to cleanup ourselves.


### PR DESCRIPTION
This PR splits the datetime tests into two groups:

- Pure-Python tests that do not require `_datetime`
- Fast C-accelerated tests that require `_datetime`

The `_Fast` tests are only loaded when `_datetime` is available, allowing
the test suite to run correctly on builds where `_datetime` is not present.

No test behavior is changed.

<!-- gh-issue-number: gh-143959 -->
* Issue: gh-143959
<!-- /gh-issue-number -->
