### PR TITLE
gh-143959: Make _datetime optional for test_sys

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1,6 +1,5 @@
 import builtins
 import codecs
-import _datetime
 import gc
 import io
 import locale
@@ -1566,6 +1565,8 @@ class SizeofTest(unittest.TestCase):
         self.assertEqual(sys.getsizeof(True, -1), size('') + self.longdigit)
 
     def test_objecttypes(self):
+        import _datetime
+
         # check all types defined in Objects/
         calcsize = struct.calcsize
         size = test.support.calcobjsize

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1741,8 +1741,12 @@ class SizeofTest(unittest.TestCase):
             x = property(getx, setx, delx, "")
             check(x, size('5Pi'))
         # PyCapsule
-        import _datetime
-        check(_datetime.datetime_CAPI, size('6P'))
+        try:
+            import _datetime
+        except ModuleNotFoundError:
+            pass
+        else:
+            check(_datetime.datetime_CAPI, size('6P'))
         # rangeiterator
         check(iter(range(1)), size('3l'))
         check(iter(range(2**65)), size('3P'))

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1565,8 +1565,6 @@ class SizeofTest(unittest.TestCase):
         self.assertEqual(sys.getsizeof(True, -1), size('') + self.longdigit)
 
     def test_objecttypes(self):
-        import _datetime
-
         # check all types defined in Objects/
         calcsize = struct.calcsize
         size = test.support.calcobjsize
@@ -1743,6 +1741,7 @@ class SizeofTest(unittest.TestCase):
             x = property(getx, setx, delx, "")
             check(x, size('5Pi'))
         # PyCapsule
+        import _datetime
         check(_datetime.datetime_CAPI, size('6P'))
         # rangeiterator
         check(iter(range(1)), size('3l'))


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The `_datetime` dependency of `test_sys` is only required for `@cpython_only` decorated test.


<!-- gh-issue-number: gh-143959 -->
* Issue: gh-143959
<!-- /gh-issue-number -->
