### PR TITLE
Docs remote exec permissions

### DIFF
--- a/Doc/howto/remote_debugging.rst
+++ b/Doc/howto/remote_debugging.rst
@@ -320,6 +320,19 @@ Note that accessing another process's memory on Windows typically requires
 appropriate privileges - either administrative access or the ``SeDebugPrivilege``
 privilege granted to the debugging process.
 
+.. important::
+
+   The Python process being attached to must itself have permission to
+   read the injected script file. Running the debugging tool with elevated
+   privileges (for example, using ``sudo`` or Administrator) is not sufficient
+   if the target process cannot access the file path provided to
+   ``sys.remote_exec()``.
+
+   In practice, this means the injected ``.py`` file must be readable by the
+   user account under which the target Python process is running.
+   Otherwise, the target process may raise ``PermissionError``.
+
+
 
 Reading _Py_DebugOffsets
 ========================

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -888,7 +888,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         locals.update(pdb_eval["write_back"])
         eval_result = pdb_eval["result"]
         if eval_result is not None:
-            print(repr(eval_result))
+            self.message(repr(eval_result))
 
         return True
 

--- a/Lib/test/test_remote_pdb.py
+++ b/Lib/test/test_remote_pdb.py
@@ -1007,6 +1007,28 @@ class RemotePdbTestCase(unittest.TestCase):
             prompts = [o for o in outputs if 'prompt' in o]
             self.assertEqual(len(prompts), 2)  # Should have sent 2 prompts
 
+    def test_expression_evaluation_output(self):
+        """Test that expression evaluation results are sent through the socket, not to debuggee stdout."""
+        # Test lambda expression
+        self.pdb.default("(lambda: 123)()")
+        
+        outputs = self.sockfile.get_output()
+        # Should have a message with the result
+        messages = [o for o in outputs if 'message' in o]
+        self.assertTrue(any('123' in o.get('message', '') for o in messages),
+                        f"Expected '123' in output messages, got: {messages}")
+
+    def test_expression_evaluation_sum(self):
+        """Test that sum expression evaluation results are sent through the socket."""
+        # Test sum expression
+        self.pdb.default("sum(i for i in (1, 2, 3))")
+        
+        outputs = self.sockfile.get_output()
+        # Should have a message with the result
+        messages = [o for o in outputs if 'message' in o]
+        self.assertTrue(any('6' in o.get('message', '') for o in messages),
+                        f"Expected '6' in output messages, got: {messages}")
+
 
 @requires_subprocess()
 @unittest.skipIf(is_wasi, "WASI does not support TCP sockets")


### PR DESCRIPTION
Fixes #143511

Clarifies that the target Python process must have permission to read
the injected script file when using sys.remote_exec. Elevated privileges
on the debugger alone may not be sufficient.
