### PR TITLE
gh-144023: prevent follow_symlinks from being allowed with an fd of 0

### DIFF
--- a/Lib/test/test_os/test_posix.py
+++ b/Lib/test/test_os/test_posix.py
@@ -668,6 +668,18 @@ class PosixTester(unittest.TestCase):
         finally:
             fp.close()
 
+    @unittest.skipUnless(hasattr(posix, 'stat'),
+                         'test needs posix.stat()')
+    @unittest.skipUnless(os.stat in os.supports_follow_symlinks,
+                         'test needs follow_symlinks support in os.stat()')
+    def test_stat_fd_zero_follow_symlinks(self):
+        with self.assertRaisesRegex(ValueError,
+                'cannot use fd and follow_symlinks together'):
+            posix.stat(0, follow_symlinks=False)
+        with self.assertRaisesRegex(ValueError,
+                'cannot use fd and follow_symlinks together'):
+            posix.stat(1, follow_symlinks=False)
+
     def check_statlike_path(self, func):
         self.assertTrue(func(os_helper.TESTFN))
         self.assertTrue(func(os.fsencode(os_helper.TESTFN)))

--- a/Misc/NEWS.d/next/Library/2026-01-19-00-57-40.gh-issue-144023.29XUcp.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-19-00-57-40.gh-issue-144023.29XUcp.rst
@@ -1,0 +1,2 @@
+Fixed validation of file descriptor 0 in posix functions when used with
+follow_symlinks parameter.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1637,7 +1637,7 @@ static int
 fd_and_follow_symlinks_invalid(const char *function_name, int fd,
                                int follow_symlinks)
 {
-    if ((fd > 0) && (!follow_symlinks)) {
+    if ((fd >= 0) && (!follow_symlinks)) {
         PyErr_Format(PyExc_ValueError,
                      "%s: cannot use fd and follow_symlinks together",
                      function_name);


### PR DESCRIPTION
fd_and_follow_symlinks_invalid lets you use fd and follow_symlinks together if fd is 0.

This is incorrect, as 0 is a valid fd.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144023 -->
* Issue: gh-144023
<!-- /gh-issue-number -->
