### PR TITLE
gh-144030: add check that argument is callable to Python version of functools.lru_cache

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -602,6 +602,9 @@ def lru_cache(maxsize=128, typed=False):
     return decorating_function
 
 def _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo):
+    if not callable(user_function):
+        raise TypeError("the first argument must be callable")
+
     # Constants shared by all lru cache instances:
     sentinel = object()          # unique object used to signal cache misses
     make_key = _make_key         # build a key from the function arguments

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2158,9 +2158,11 @@ class TestLRU:
                     fib(support.exceeds_recursion_limit())
 
     def test_lru_checks_arg_is_callable(self):
-        with self.assertRaises(TypeError) as te:
+        with self.assertRaisesRegex(
+            TypeError,
+            "the first argument must be callable",
+        ):
             self.module.lru_cache(1)('hello')
-        self.assertIn("the first argument must be callable", str(te.exception))
 
 
 @py_functools.lru_cache()

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2157,6 +2157,11 @@ class TestLRU:
                 with self.assertRaises(RecursionError):
                     fib(support.exceeds_recursion_limit())
 
+    def test_lru_checks_arg_is_callable(self):
+        with self.assertRaises(TypeError) as te:
+            self.module.lru_cache(1)('hello')
+        self.assertIn("the first argument must be callable", str(te.exception))
+
 
 @py_functools.lru_cache()
 def py_cached_func(x, y):

--- a/Misc/NEWS.d/next/Library/2026-01-19-12-48-59.gh-issue-144030.7OK_gB.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-19-12-48-59.gh-issue-144030.7OK_gB.rst
@@ -1,0 +1,3 @@
+The Python implementation of :func:`functools.lru_cache` differed from the
+default C implementation in that it did not check that its argument is
+callable. This discrepancy is now fixed and both raise a :class:`TypeError`.

--- a/Misc/NEWS.d/next/Library/2026-01-19-12-48-59.gh-issue-144030.7OK_gB.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-19-12-48-59.gh-issue-144030.7OK_gB.rst
@@ -1,3 +1,3 @@
 The Python implementation of :func:`functools.lru_cache` differed from the
 default C implementation in that it did not check that its argument is
-callable. This discrepancy is now fixed and both raise a :class:`TypeError`.
+callable. This discrepancy is now fixed and both raise a :exc:`TypeError`.


### PR DESCRIPTION
The C version has this check, the Python version doesn't so far. This PR makes the behaviours agree again

<!-- gh-issue-number: gh-144030 -->
* Issue: gh-144030
<!-- /gh-issue-number -->
