### PR TITLE
gh-144048: Use flexible array members

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -58,7 +58,7 @@ typedef struct _stack_chunk {
     struct _stack_chunk *previous;
     size_t size;
     size_t top;
-    PyObject * data[1]; /* Variable sized */
+    PyObject * data[];
 } _PyStackChunk;
 
 /* Minimum size of data stack chunk */

--- a/Modules/_sre/sre.h
+++ b/Modules/_sre/sre.h
@@ -65,7 +65,7 @@ typedef struct {
     struct {
         Py_ssize_t index;
         PyObject *literal;  /* NULL if empty */
-    } items[0];
+    } items[];
 } TemplateObject;
 
 typedef struct SRE_REPEAT_T {

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -1042,7 +1042,7 @@ memoryview__from_flags_impl(PyTypeObject *type, PyObject *object, int flags)
 
 typedef struct {
     Py_buffer view;
-    Py_ssize_t array[1];
+    Py_ssize_t array[];
 } Py_buffer_full;
 
 int


### PR DESCRIPTION
Not all cases can be converted because some structs with this are members in the middle of bigger structs, so changing them introduces warnings. Leave them alone for now.

<!-- gh-issue-number: gh-144048 -->
* Issue: gh-144048
<!-- /gh-issue-number -->
