### PR TITLE
gh-144050: Fix stat.filemode pure Python file type detection

### DIFF
--- a/Lib/stat.py
+++ b/Lib/stat.py
@@ -166,9 +166,14 @@ def filemode(mode):
     perm = []
     for index, table in enumerate(_filemode_table):
         for bit, char in table:
-            if mode & bit == bit:
-                perm.append(char)
-                break
+            if index == 0:
+                if (mode & S_IFMT) == bit:
+                    perm.append(char)
+                    break
+            else:
+                if mode & bit == bit:
+                    perm.append(char)
+                    break
         else:
             if index == 0:
                 # Unknown filetype

--- a/Lib/stat.py
+++ b/Lib/stat.py
@@ -167,7 +167,7 @@ def filemode(mode):
     for index, table in enumerate(_filemode_table):
         for bit, char in table:
             if index == 0:
-                if (mode & S_IFMT) == bit:
+                if S_IFMT(mode) == bit:
                     perm.append(char)
                     break
             else:

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -165,7 +165,8 @@ class TestFilemode:
 
     def test_filemode_does_not_misclassify_random_bits(self):
         # gh-144050 regression test
-        self.assertEqual(self.statmod.filemode(32767)[0], "?")
+        self.assertEqual(self.statmod.filemode(0o77777)[0], "?")
+        self.assertEqual(self.statmod.filemode(0o177777)[0], "?")
 
     @os_helper.skip_unless_working_chmod
     def test_directory(self):

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -163,6 +163,10 @@ class TestFilemode:
                              self.statmod.S_IFREG)
             self.assertEqual(self.statmod.S_IMODE(st_mode), 0o666)
 
+    def test_filemode_does_not_misclassify_random_bits(self):
+        # gh-144050 regression test
+        self.assertEqual(self.statmod.filemode(32767)[0], "?")
+
     @os_helper.skip_unless_working_chmod
     def test_directory(self):
         os.mkdir(TESTFN)

--- a/Misc/NEWS.d/next/Library/2026-01-20-16-35-55.gh-issue-144050.0kKFbF.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-20-16-35-55.gh-issue-144050.0kKFbF.rst
@@ -1,0 +1,2 @@
+Fix stat.filemode in the pure-Python implementation to avoid misclassifying
+invalid mode values as block devices.

--- a/Misc/NEWS.d/next/Library/2026-01-20-16-35-55.gh-issue-144050.0kKFbF.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-20-16-35-55.gh-issue-144050.0kKFbF.rst
@@ -1,2 +1,2 @@
-Fix stat.filemode in the pure-Python implementation to avoid misclassifying
+Fix :func:`stat.filemode` in the pure-Python implementation to avoid misclassifying
 invalid mode values as block devices.


### PR DESCRIPTION
This PR fixes a discrepancy between the C and pure Python implementations
of stat.filemode.

The pure Python implementation could misclassify arbitrary bit patterns
(e.g. 32767) as block devices. File type detection now correctly uses
(mode & S_IFMT) for file types, matching the C implementation.

A regression test is added to prevent this issue from recurring.

Fixes #144050

<!-- gh-issue-number: gh-144050 -->
* Issue: gh-144050
<!-- /gh-issue-number -->
