### PR TITLE
gh-144069: Fix memory leak in _dbm.open() on failure

### DIFF
--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -71,6 +71,11 @@ class AnyDBMTestCase:
     def test_anydbm_not_existing(self):
         self.assertRaises(dbm.error, dbm.open, _fname)
 
+    def test_open_nonexistent_directory(self):
+        missing_dir = os.path.join(dirname + "_does_not_exist", "test.db")
+        with self.assertRaises(OSError):
+            dbm.open(missing_dir, "c")
+
     def test_anydbm_creation(self):
         f = dbm.open(_fname, 'c')
         self.assertEqual(list(f.keys()), [])
@@ -244,10 +249,6 @@ class AnyDBMTestCase:
         self.addCleanup(cleaunup_test_dir)
         setup_test_dir()
 
-    def test_open_nonexistent_directory(self):
-        missing_dir = os.path.join(dirname + "_does_not_exist", "test.db")
-        with self.assertRaises(OSError):
-            dbm.open(missing_dir, "c")
 
 class WhichDBTestCase(unittest.TestCase):
     def test_whichdb(self):

--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -244,6 +244,10 @@ class AnyDBMTestCase:
         self.addCleanup(cleaunup_test_dir)
         setup_test_dir()
 
+    def test_open_nonexistent_directory(self):
+        missing_dir = os.path.join(dirname + "_does_not_exist", "test.db")
+        with self.assertRaises(OSError):
+            dbm.open(missing_dir, "c")
 
 class WhichDBTestCase(unittest.TestCase):
     def test_whichdb(self):

--- a/Misc/NEWS.d/next/C_API/2026-01-20-20-17-16.gh-issue-144069.IE5fug.rst
+++ b/Misc/NEWS.d/next/C_API/2026-01-20-20-17-16.gh-issue-144069.IE5fug.rst
@@ -1,0 +1,2 @@
+Fix a memory leak in :func:`dbm.open` when database creation fails, such as
+when the target directory does not exist.

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -85,11 +85,16 @@ newdbmobject(_dbm_state *state, const char *file, int flags, int mode)
     }
     dp->di_size = -1;
     dp->flags = flags;
+    dp->di_dbm = NULL;
     PyObject_GC_Track(dp);
 
     /* See issue #19296 */
-    if ( (dp->di_dbm = dbm_open((char *)file, flags, mode)) == 0 ) {
+    if ( (dp->di_dbm = dbm_open((char *)file, flags, mode)) == NULL ) {
         PyErr_SetFromErrnoWithFilename(state->dbm_error, file);
+        if (dp->di_dbm != NULL) {
+            dbm_close(dp->di_dbm);
+            dp->di_dbm = NULL;
+        }
         Py_DECREF(dp);
         return NULL;
     }

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -91,10 +91,6 @@ newdbmobject(_dbm_state *state, const char *file, int flags, int mode)
     /* See issue #19296 */
     if ( (dp->di_dbm = dbm_open((char *)file, flags, mode)) == NULL ) {
         PyErr_SetFromErrnoWithFilename(state->dbm_error, file);
-        if (dp->di_dbm != NULL) {
-            dbm_close(dp->di_dbm);
-            dp->di_dbm = NULL;
-        }
         Py_DECREF(dp);
         return NULL;
     }
@@ -110,6 +106,7 @@ dbm_dealloc(PyObject *self)
     PyObject_GC_UnTrack(dp);
     if (dp->di_dbm) {
         dbm_close(dp->di_dbm);
+        dp->di_dbm = NULL;
     }
     PyTypeObject *tp = Py_TYPE(dp);
     tp->tp_free(dp);


### PR DESCRIPTION
gh-144069

Fix a memory leak in _dbm.open() when dbm_open() fails (for example when
attempting to create a database in a non-existent directory).

dbm_open() may allocate internal DBM resources even if it returns NULL.
Ensure that any partially allocated DBM handle is properly closed on
error paths to avoid leaking memory.

Add a regression test exercising dbm.open() on a path with a missing
parent directory.
