### PR TITLE
gh-144067: Fix memory leak when initscr() follows setupterm()

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-01-20-20-13-35.gh-issue-144067.5YEhzs.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-20-20-13-35.gh-issue-144067.5YEhzs.rst
@@ -1,0 +1,2 @@
+Fix a memory leak in the curses module when setupterm() is called before
+initscr(), where the previously allocated terminal state was not freed.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3731,6 +3731,9 @@ _curses_initscr_impl(PyObject *module)
         }
         return PyCursesWindow_New(state, stdscr, NULL, NULL);
     }
+    if (cur_term != NULL) {
+        del_curterm(cur_term);
+        cur_term = NULL;
 
     win = initscr();
 

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3734,7 +3734,7 @@ _curses_initscr_impl(PyObject *module)
     if (cur_term != NULL) {
         del_curterm(cur_term);
         cur_term = NULL;
-
+    }
     win = initscr();
 
     if (win == NULL) {


### PR DESCRIPTION
Calling setupterm() before initscr() can leak memory: setupterm()
allocates the global ncurses cur_term, and initscr() internally
reinitializes the terminal (via newterm()) without freeing the
existing cur_term.

This change frees an existing cur_term before calling initscr(),
preventing the leak observed under ASAN.

Note: the _curses module is not available on Windows, so this change
was not runtime-tested locally. The fix is minimal and follows the
ncurses API’s ownership rules; Linux/macOS CI should cover the affected
code path.


<!-- gh-issue-number: gh-144067 -->
* Issue: gh-144067
<!-- /gh-issue-number -->
