### PR TITLE
gh-144068: fix JIT tracer memory leak when daemon thread exits

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-21-02-30-06.gh-issue-144068.9TTu7v.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-21-02-30-06.gh-issue-144068.9TTu7v.rst
@@ -1,0 +1,1 @@
+Fix JIT tracer memory leak, ensure the JIT tracer state is freed when daemon threads are cleaned up during interpreter shutdown.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1836,6 +1836,10 @@ PyThreadState_Clear(PyThreadState *tstate)
 
     _PyThreadState_ClearMimallocHeaps(tstate);
 
+#ifdef _Py_TIER2
+    _PyJit_TracerFree((_PyThreadStateImpl *)tstate);
+#endif
+
     tstate->_status.cleared = 1;
 
     // XXX Call _PyThreadStateSwap(runtime, NULL) here if "current".


### PR DESCRIPTION
Call `_PyJit_TracerFree` in `PyThreadState_Clear` to ensure the JIT tracer state is freed when daemon threads are cleaned up during interpreter shutdown via `_PyThreadState_DeleteList`.

<!-- gh-issue-number: gh-144068 -->
* Issue: gh-144068
<!-- /gh-issue-number -->
