### PR TITLE
[3.13] gh-143866: Verify return value of `pathlib.write_{bytes,text}` methods in tests (GH-143870)

### DIFF
--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1630,20 +1630,22 @@ class DummyPathTest(DummyPurePathTest):
 
     def test_read_write_bytes(self):
         p = self.cls(self.base)
-        (p / 'fileA').write_bytes(b'abcdefg')
-        self.assertEqual((p / 'fileA').read_bytes(), b'abcdefg')
+        data  = b'abcdefg'
+        self.assertEqual(len(data), (p / 'fileA').write_bytes(data))
+        self.assertEqual((p / 'fileA').read_bytes(), data)
         # Check that trying to write str does not truncate the file.
         self.assertRaises(TypeError, (p / 'fileA').write_bytes, 'somestr')
-        self.assertEqual((p / 'fileA').read_bytes(), b'abcdefg')
+        self.assertEqual((p / 'fileA').read_bytes(), data)
 
     def test_read_write_text(self):
         p = self.cls(self.base)
-        (p / 'fileA').write_text('äbcdefg', encoding='latin-1')
+        data = 'äbcdefg'
+        self.assertEqual(len(data), (p / 'fileA').write_text(data, encoding='latin-1'))
         self.assertEqual((p / 'fileA').read_text(
             encoding='utf-8', errors='ignore'), 'bcdefg')
         # Check that trying to write bytes does not truncate the file.
         self.assertRaises(TypeError, (p / 'fileA').write_text, b'somebytes')
-        self.assertEqual((p / 'fileA').read_text(encoding='latin-1'), 'äbcdefg')
+        self.assertEqual((p / 'fileA').read_text(encoding='latin-1'), data)
 
     def test_read_text_with_newlines(self):
         p = self.cls(self.base)


### PR DESCRIPTION
(cherry picked from commit cb6a662bb0f7a9da9d4ba9dda820053f8d54a9f8)

Co-authored-by: b9788213 <b9788213@gmail.com>
Co-authored-by: sobolevn <mail@sobolevn.me>

<!-- gh-issue-number: gh-143866 -->
* Issue: gh-143866
<!-- /gh-issue-number -->
