### PR TITLE
gh-144057: Document caution regarding use of importlib.reload in production code

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -2218,6 +2218,10 @@ changed module, do this::
    import modname
    importlib.reload(modname)
 
+Note that :func:`importlib.reload` was originally designed for use in
+development and debugging, not for use in production code.  Reloading modules
+in a running program is tricky and error-prone.
+
 Warning: this technique is not 100% fool-proof.  In particular, modules
 containing statements like ::
 


### PR DESCRIPTION
resolves #144057 

<!-- gh-issue-number: gh-144057 -->
* Issue: gh-144057
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144080.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->