### PR TITLE
gh-144054: no deferred refcount for untracked

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -362,7 +362,7 @@ static uint32_t function_get_version(PyObject *o, int opcode);
 static void
 maybe_enable_deferred_ref_count(PyObject *op)
 {
-    if (!_Py_IsOwnedByCurrentThread(op)) {
+    if (!_Py_IsOwnedByCurrentThread(op) && _PyObject_GC_IS_TRACKED(op)) {
         // For module level variables that are heavily used from multiple
         // threads, deferred reference counting provides good scaling
         // benefits.  The downside is that the object will only be deallocated


### PR DESCRIPTION
This reverts gh-144055 and fixes the bug in a different way.  Deferred reference counting relies on the object being tracked by the GC, otherwise the object will live until interpreter shutdown.  So, take care that we do not enable deferred reference counting for objects that are untracked.  Also, if a tuple has deferred reference counting enabled, don't untrack it.


<!-- gh-issue-number: gh-144054 -->
* Issue: gh-144054
<!-- /gh-issue-number -->
