### PR TITLE
gh-143658: Use `str.lower` and `replace` to further improve performance of `importlib.metadata.Prepared.normalized`

### DIFF
--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -890,14 +890,6 @@ class Lookup:
         return itertools.chain(infos, eggs)
 
 
-# Translation table for Prepared.normalize: lowercase and
-# replace "-" (hyphen) and "." (dot) with "_" (underscore).
-_normalize_table = str.maketrans(
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZ-.",
-    "abcdefghijklmnopqrstuvwxyz__",
-)
-
-
 class Prepared:
     """
     A prepared search query for metadata on a possibly-named package.
@@ -933,9 +925,8 @@ class Prepared:
         """
         PEP 503 normalization plus dashes as underscores.
         """
-        # Emulates ``re.sub(r"[-_.]+", "-", name).lower()`` from PEP 503
-        # About 3x faster, safe since packages only support alphanumeric characters
-        value = name.translate(_normalize_table)
+        # Much faster than re.sub, and even faster than str.translate
+        value = name.lower().replace("-", "_").replace(".", "_")
         # Condense repeats (faster than regex)
         while "__" in value:
             value = value.replace("__", "_")

--- a/Misc/NEWS.d/next/Library/2026-01-20-20-54-46.gh-issue-143658.v8i1jE.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-20-20-54-46.gh-issue-143658.v8i1jE.rst
@@ -1,0 +1,4 @@
+:mod:`importlib.metadata`: Use :meth:`str.lower` and :meth:`str.replace` to
+further improve performance of
+:meth:`!importlib.metadata.Prepared.normalize`. Patch by Hugo van Kemenade
+and Henry Schreiner.


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Follow on from https://github.com/python/cpython/pull/143660 which replaced `re.sub` with `str.translate`.

@henryiii discovered that whilst that is an improvement on Python 3.10-3.11 and 3.14, the performance of `str.translate` is much worse on Python 3.12 and 3.13, and can be worse than the original `re.sub`.

Further, his fix in https://github.com/pypa/packaging/pull/1064 to replace `str.translate` with `str.lower` and `str.replace` calls is better than both the other options across all Python versions, to varying degrees.

I benchmarked all three across all available Python Build Standalone versions from 3.10-3.15 on macOS:

<img width="2700" height="1200" alt="image" src="https://github.com/user-attachments/assets/42493afc-2654-4d30-8ab3-27f5eefac9f0" />

I also benchmarked Windows and Ubuntu it's the same pattern.

Whilst the improvement isn't as large for CPython 3.15 as it is for libraries such as `packaging` that support a wide range of Pythons, `importlib.metadata` does have a backport, and I'll update https://github.com/python/importlib_metadata/pull/529 once this is merged.


<!-- gh-issue-number: gh-143658 -->
* Issue: gh-143658
<!-- /gh-issue-number -->
