### PR TITLE
Doc: fix incorrect reference in `isasyncgenfunction` docs

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -524,7 +524,7 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
 
    .. versionchanged:: 3.13
       Functions wrapped in :func:`functools.partialmethod` now return ``True``
-      if the wrapped function is a :term:`coroutine function`.
+      if the wrapped function is a :term:`asynchronous generator` function.
 
 .. function:: isasyncgen(object)
 


### PR DESCRIPTION
Fix a documentation typo: `isasyncgenfunction()` applies to `asynchronous generator` functions, not `coroutine functions`. 

### Test python script
``` py

import functools
import inspect

async def agen():
    yield 1
    yield 2

print(inspect.isasyncgenfunction(agen))     # output: True
print(inspect.iscoroutinefunction(agen))    # output: Fasle
print(inspect.isgeneratorfunction(agen))    # output: Fasle

class C:
    async def agen2(self):
        yield 1
    
    agen2_pm = functools.partialmethod(agen2)

print(inspect.isasyncgenfunction(C.agen2))  # output: True
print(inspect.iscoroutinefunction(C.agen2)) # output: Fasle
print(inspect.isgeneratorfunction(C.agen2)) # output: Fasle

print(inspect.isasyncgenfunction(C.agen2_pm))  # output: True  <------------------- !!!
print(inspect.iscoroutinefunction(C.agen2_pm)) # output: Fasle
print(inspect.isgeneratorfunction(C.agen2_pm)) # output: Fasle
```

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144099.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->