### PR TITLE
refactor: use boolean literals instead of integers 0/1

### DIFF
--- a/Lib/test/test_tkinter/test_text.py
+++ b/Lib/test/test_tkinter/test_text.py
@@ -17,9 +17,9 @@ class TextTest(AbstractTkTest, unittest.TestCase):
         text = self.text
         olddebug = text.debug()
         try:
-            text.debug(0)
+            text.debug(False)
             self.assertEqual(text.debug(), 0)
-            text.debug(1)
+            text.debug(True)
             self.assertEqual(text.debug(), 1)
         finally:
             text.debug(olddebug)


### PR DESCRIPTION
# refactor: use boolean literals instead of integers 0/1


In Lib/test/test_tkinter/test_text.py lines 20 and 22 refactored to use boolean literals instead of integers 0/1.
