### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/reusable-check-c-api-docs.yml
+++ b/.github/workflows/reusable-check-c-api-docs.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Check for undocumented C APIs

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: "Check PRs"
-      uses: actions/stale@v9
+      uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity.'


### PR DESCRIPTION
This PR updates outdated GitHub Action versions. The following files have been updated:  
- `.github/workflows/reusable-check-c-api-docs.yml` (actions/checkout from `v4` to `v6`, actions/setup-python from `v5` to `v6`, and actions/stale from `v9` to `v10`).  

The changes will be tested in the CI pipeline of the pull request.