### PR TITLE
gh-144100: Fix crash for POINTER(str) used in ctypes argtypes

### DIFF
--- a/Lib/test/test_ctypes/test_pointers.py
+++ b/Lib/test/test_ctypes/test_pointers.py
@@ -3,7 +3,6 @@ import ctypes
 import gc
 import sys
 import unittest
-import os
 from ctypes import (CDLL, CFUNCTYPE, Structure,
                     POINTER, pointer, _Pointer,
                     byref, sizeof,

--- a/Lib/test/test_ctypes/test_pointers.py
+++ b/Lib/test/test_ctypes/test_pointers.py
@@ -475,8 +475,8 @@ class PointerTypeCacheTestCase(unittest.TestCase):
 
 class TestPointerStringProto(unittest.TestCase):
     def test_pointer_string_proto_argtypes_error(self):
-
-        BadType = ctypes.POINTER("BugTrigger")
+        with self.assertWarns(DeprecationWarning):
+            BadType = ctypes.POINTER("BugTrigger")
 
         if os.name == "nt":
             libc = ctypes.WinDLL("kernel32.dll")

--- a/Lib/test/test_ctypes/test_pointers.py
+++ b/Lib/test/test_ctypes/test_pointers.py
@@ -3,6 +3,7 @@ import ctypes
 import gc
 import sys
 import unittest
+import os
 from ctypes import (CDLL, CFUNCTYPE, Structure,
                     POINTER, pointer, _Pointer,
                     byref, sizeof,
@@ -471,6 +472,23 @@ class PointerTypeCacheTestCase(unittest.TestCase):
             self.assertIs(ptr._type_, C)
         ptr.set_type(c_int)
         self.assertIs(ptr._type_, c_int)
+
+class TestPointerStringProto(unittest.TestCase):
+    def test_pointer_string_proto_argtypes_error(self):
+
+        BadType = ctypes.POINTER("BugTrigger")
+
+        if os.name == "nt":
+            libc = ctypes.WinDLL("kernel32.dll")
+            func = libc.GetCurrentProcessId
+        else:
+            libc = ctypes.CDLL(None)
+            func = libc.getpid
+
+        func.argtypes = (BadType,)
+
+        with self.assertRaises(ctypes.ArgumentError):
+            func(ctypes.byref(ctypes.c_int(0)))
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_ctypes/test_pointers.py
+++ b/Lib/test/test_ctypes/test_pointers.py
@@ -404,6 +404,16 @@ class PointersTestCase(unittest.TestCase):
         self.assertEqual(len(ws_typ), 0, ws_typ)
         self.assertEqual(len(ws_ptr), 0, ws_ptr)
 
+    def test_pointer_proto_missing_argtypes_error(self):
+        class BadType(ctypes._Pointer):
+            # _type_ is intentionally missing
+            pass
+
+        func = ctypes.pythonapi.Py_GetVersion
+        func.argtypes = (BadType,)
+
+        with self.assertRaises(ctypes.ArgumentError):
+            func(None)
 
 class PointerTypeCacheTestCase(unittest.TestCase):
     # dummy tests to check warnings and base behavior
@@ -472,23 +482,6 @@ class PointerTypeCacheTestCase(unittest.TestCase):
             self.assertIs(ptr._type_, C)
         ptr.set_type(c_int)
         self.assertIs(ptr._type_, c_int)
-
-class TestPointerStringProto(unittest.TestCase):
-    def test_pointer_string_proto_argtypes_error(self):
-        with self.assertWarns(DeprecationWarning):
-            BadType = ctypes.POINTER("BugTrigger")
-
-        if os.name == "nt":
-            libc = ctypes.WinDLL("kernel32.dll")
-            func = libc.GetCurrentProcessId
-        else:
-            libc = ctypes.CDLL(None)
-            func = libc.getpid
-
-        func.argtypes = (BadType,)
-
-        with self.assertRaises(ctypes.ArgumentError):
-            func(ctypes.byref(ctypes.c_int(0)))
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_ctypes/test_pointers.py
+++ b/Lib/test/test_ctypes/test_pointers.py
@@ -412,7 +412,7 @@ class PointersTestCase(unittest.TestCase):
         func.argtypes = (BadType,)
 
         with self.assertRaises(ctypes.ArgumentError):
-            func(None)
+            func(object())
 
 class PointerTypeCacheTestCase(unittest.TestCase):
     # dummy tests to check warnings and base behavior

--- a/Misc/NEWS.d/next/Library/2026-01-21-19-39-07.gh-issue-144100.hLMZ8Y.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-21-19-39-07.gh-issue-144100.hLMZ8Y.rst
@@ -1,0 +1,3 @@
+Fixed a crash in ctypes when using a deprecated ``POINTER(str)`` type in
+``argtypes``. Instead of aborting, ctypes now raises a proper Python
+exception when the pointer target type is unresolved.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1422,7 +1422,7 @@ PyCPointerType_from_param_impl(PyObject *type, PyTypeObject *cls,
     if(typeinfo->proto == NULL){
         PyErr_SetString(
             PyExc_TypeError,
-            "cannot convert argument: POINTER target type is unresolved"
+            "cannot convert argument: POINTER _type_ type is not set"
         );
         return NULL;
     }

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1419,7 +1419,7 @@ PyCPointerType_from_param_impl(PyObject *type, PyTypeObject *cls,
     /* If we expect POINTER(<type>), but receive a <type> instance, accept
        it by calling byref(<type>).
     */
-    if(typeinfo->proto == NULL){
+    if (typeinfo->proto == NULL) {
         PyErr_SetString(
             PyExc_TypeError,
             "cannot convert argument: POINTER _type_ type is not set"

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1419,7 +1419,13 @@ PyCPointerType_from_param_impl(PyObject *type, PyTypeObject *cls,
     /* If we expect POINTER(<type>), but receive a <type> instance, accept
        it by calling byref(<type>).
     */
-    assert(typeinfo->proto);
+    if(typeinfo->proto == NULL){
+        PyErr_SetString(
+            PyExc_TypeError,
+            "cannot convert argument: POINTER target type is unresolved"
+        );
+        return NULL;
+    }
     switch (PyObject_IsInstance(value, typeinfo->proto)) {
     case 1:
         Py_INCREF(value); /* _byref steals a refcount */


### PR DESCRIPTION
It fixes a crash in `ctypes` that occur when a deprecated `POINTER(str)` type was used in `argtypes`.

When such a pointer type was encountered during argument conversion, `ctypes` would hit an internal assertion and abort the interpreter in debug builds. 
This PR replaces the assertion with proper error handling and raises a Python exception instead.



<!-- gh-issue-number: gh-144100 -->
* Issue: gh-144100
<!-- /gh-issue-number -->
