### PR TITLE
gh-142913: Revert adding test_replaced_interpreter

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2857,24 +2857,6 @@ class Test_Pep523API(unittest.TestCase):
         names = ["func", "outer", "outer", "inner", "inner", "outer", "inner"]
         self.do_test(func, names)
 
-    def test_replaced_interpreter(self):
-        def inner():
-            yield 'abc'
-        def outer():
-            yield from inner()
-        def func():
-            list(outer())
-        _testinternalcapi.set_eval_frame_interp()
-        try:
-            func()
-        finally:
-            _testinternalcapi.set_eval_frame_default()
-
-        stats = _testinternalcapi.get_eval_frame_stats()
-
-        self.assertEqual(stats["resumes"], 5)
-        self.assertEqual(stats["loads"], 5)
-
 
 @unittest.skipUnless(support.Py_GIL_DISABLED, 'need Py_GIL_DISABLED')
 class TestPyThreadId(unittest.TestCase):


### PR DESCRIPTION
This partially reverts commit 4d5a676aa0811563ea78ae58ef89cdc0295bf7ed (GH-142911)

This test fails when re-run in --huntrleaks mode.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142913 -->
* Issue: gh-142913
<!-- /gh-issue-number -->
