### PR TITLE
gh-141984: Reword and reorganize the first part of Atoms docs

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1852,6 +1852,8 @@ to the object:
 13891296
 
 
+.. _faq-identity-with-is:
+
 When can I rely on identity tests with the *is* operator?
 ---------------------------------------------------------
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -265,9 +265,17 @@ The constructors :func:`int`, :func:`float`, and
    pair: operator; % (percent)
    pair: operator; **
 
+.. _stdtypes-mixed-arithmetic:
+
 Python fully supports mixed arithmetic: when a binary arithmetic operator has
-operands of different numeric types, the operand with the "narrower" type is
-widened to that of the other, where integer is narrower than floating point.
+operands of different built-in numeric types, the operand with the "narrower"
+type is widened to that of the other:
+
+* If both arguments are complex numbers, no conversion is performed;
+* if either argument is a complex or a floating-point number, the other is
+  converted to a floating-point number;
+* otherwise, both must be integers and no conversion is necessary.
+
 Arithmetic with complex and real operands is defined by the usual mathematical
 formula, for example::
 

--- a/Doc/library/token.rst
+++ b/Doc/library/token.rst
@@ -50,8 +50,7 @@ The token constants are:
 
 .. data:: NAME
 
-   Token value that indicates an :ref:`identifier <identifiers>`.
-   Note that keywords are also initially tokenized as ``NAME`` tokens.
+   Token value that indicates an :ref:`identifier or keyword <identifiers>`.
 
 .. data:: NUMBER
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -89,7 +89,7 @@ Evaluation of these atoms yields the corresponding value.
 
    Several more built-in constants are available as global variables,
    but only the ones mentioned here are :ref:`keywords <keywords>`.
-   In particular, these names cannot be reassigned or used as attributes
+   In particular, these names cannot be reassigned or used as attributes:
 
    .. code-block:: pycon
 
@@ -1532,7 +1532,7 @@ The floor division operation can be customized using the special
    pair: operator; % (percent)
 
 The ``%`` (modulo) operator yields the remainder from the division of the first
-argument by the second.  The numeric arguments are first converted to a
+argument by the second.  The numeric arguments are first
 :ref:`converted to a common type <stdtypes-mixed-arithmetic>`.
 A zero right argument raises the :exc:`ZeroDivisionError` exception.  The
 arguments may be floating-point numbers, e.g., ``3.14%0.7`` equals ``0.34``

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1516,7 +1516,8 @@ This operation can be customized using the special :meth:`~object.__matmul__` an
    pair: operator; //
 
 The ``/`` (division) and ``//`` (floor division) operators yield the quotient of
-their arguments.  The numeric arguments are first converted to a common type.
+their arguments.  The numeric arguments are first
+:ref:`converted to a common type <stdtypes-mixed-arithmetic>`.
 Division of integers yields a float, while floor division of integers results in an
 integer; the result is that of mathematical division with the 'floor' function
 applied to the result.  Division by zero raises the :exc:`ZeroDivisionError`

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -13,7 +13,7 @@ This chapter explains the meaning of the elements of expressions in Python.
 :ref:`grammar notation <notation>` will be used to describe syntax,
 not lexical analysis.
 
-When (one alternative of) a syntax rule has the form
+When (one alternative of) a syntax rule has the form:
 
 .. productionlist:: python-grammar
    name: othername
@@ -31,7 +31,7 @@ Arithmetic conversions
 
 When a description of an arithmetic operator below uses the phrase "the numeric
 arguments are converted to a common real type", this means that the operator
-implementation for built-in numeric types works as described in
+implementation for built-in numeric types works as described in the
 :ref:`Numeric Types <stdtypes-mixed-arithmetic>` section of the standard
 library documentation.
 


### PR DESCRIPTION
This freshens up Syntax Notes, Atoms introduction, Built-in constants, and Literals.
Identifiers and enclosed forms are left for a future PR.

References to mixed arithmetic are changed to link to the stdtypes documentation. In later passes I want to move the runtime semantics there; for now I want to make the “When a description of an arithmetic operator” note in the intro more correct.


<!-- gh-issue-number: gh-141984 -->
* Issue: gh-141984
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144117.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->