### PR TITLE
gh-143916: Allow HTAB in wsgiref header values

### DIFF
--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -509,7 +509,7 @@ class HeaderTests(TestCase):
                 headers = Headers()
                 self.assertRaises(ValueError, headers.__setitem__, f"key{c0}", "val")
                 self.assertRaises(ValueError, headers.add_header, f"key{c0}", "val", param="param")
-                # HTAB is allowed in values, not names.
+                # HTAB (\x09) is allowed in values, not names.
                 if c0 == "\t":
                     headers["key"] = f"val{c0}"
                     headers.add_header("key", f"val{c0}")

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -504,14 +504,20 @@ class HeaderTests(TestCase):
         )
 
     def testRaisesControlCharacters(self):
-        headers = Headers()
         for c0 in control_characters_c0():
-            self.assertRaises(ValueError, headers.__setitem__, f"key{c0}", "val")
-            self.assertRaises(ValueError, headers.__setitem__, "key", f"val{c0}")
-            self.assertRaises(ValueError, headers.add_header, f"key{c0}", "val", param="param")
-            self.assertRaises(ValueError, headers.add_header, "key", f"val{c0}", param="param")
-            self.assertRaises(ValueError, headers.add_header, "key", "val", param=f"param{c0}")
-
+            with self.subTest(c0):
+                headers = Headers()
+                self.assertRaises(ValueError, headers.__setitem__, f"key{c0}", "val")
+                self.assertRaises(ValueError, headers.add_header, f"key{c0}", "val", param="param")
+                # HTAB is allowed in values, not names.
+                if c0 == "\t":
+                    headers["key"] = f"val{c0}"
+                    headers.add_header("key", f"val{c0}")
+                    headers.setdefault(f"key", f"val{c0}")
+                else:
+                    self.assertRaises(ValueError, headers.__setitem__, "key", f"val{c0}")
+                    self.assertRaises(ValueError, headers.add_header, "key", f"val{c0}", param="param")
+                    self.assertRaises(ValueError, headers.add_header, "key", "val", param=f"param{c0}")
 
 class ErrorHandler(BaseCGIHandler):
     """Simple handler subclass for testing BaseHandler"""

--- a/Lib/wsgiref/headers.py
+++ b/Lib/wsgiref/headers.py
@@ -61,7 +61,7 @@ class Headers:
         """Set the value of a header."""
         del self[name]
         self._headers.append(
-            (self._convert_string_type(name, name=True), self._convert_string_type(val)))
+            (self._convert_string_type(name, name=True), self._convert_string_type(val, name=False)))
 
     def __delitem__(self,name):
         """Delete all occurrences of a header, if present.
@@ -157,7 +157,7 @@ class Headers:
         result = self.get(name)
         if result is None:
             self._headers.append((self._convert_string_type(name, name=True),
-                self._convert_string_type(value)))
+                self._convert_string_type(value, name=False)))
             return value
         else:
             return result
@@ -180,13 +180,13 @@ class Headers:
         """
         parts = []
         if _value is not None:
-            _value = self._convert_string_type(_value)
+            _value = self._convert_string_type(_value, name=False)
             parts.append(_value)
         for k, v in _params.items():
             k = self._convert_string_type(k, name=True)
             if v is None:
                 parts.append(k.replace('_', '-'))
             else:
-                v = self._convert_string_type(v)
+                v = self._convert_string_type(v, name=False)
                 parts.append(_formatparam(k.replace('_', '-'), v))
         self._headers.append((self._convert_string_type(_name, name=True), "; ".join(parts)))

--- a/Lib/wsgiref/headers.py
+++ b/Lib/wsgiref/headers.py
@@ -41,7 +41,7 @@ class Headers:
         if __debug__:
             for k, v in headers:
                 self._convert_string_type(k, name=True)
-                self._convert_string_type(v)
+                self._convert_string_type(v, name=False)
 
     def _convert_string_type(self, value, *, name):
         """Convert/check value type."""

--- a/Lib/wsgiref/headers.py
+++ b/Lib/wsgiref/headers.py
@@ -43,10 +43,11 @@ class Headers:
                 self._convert_string_type(k, name=True)
                 self._convert_string_type(v)
 
-    def _convert_string_type(self, value, *, name=False):
+    def _convert_string_type(self, value, *, name):
         """Convert/check value type."""
         if type(value) is str:
-            if (_name_disallowed_re if name else _value_disallowed_re).search(value):
+            regex = (_name_disallowed_re if name else _value_disallowed_re)
+            if regex.search(value):
                 raise ValueError("Control characters not allowed in headers")
             return value
         raise AssertionError("Header names/values must be"

--- a/Lib/wsgiref/headers.py
+++ b/Lib/wsgiref/headers.py
@@ -9,7 +9,11 @@ written by Barry Warsaw.
 # existence of which force quoting of the parameter value.
 import re
 tspecials = re.compile(r'[ \(\)<>@,;:\\"/\[\]\?=]')
-_control_chars_re = re.compile(r'[\x00-\x1F\x7F]')
+# Disallowed characters for headers and values.
+# HTAB (\x09) is allowed in header values, but
+# not in header names. (RFC 9110 Section 5.5)
+_name_disallowed_re = re.compile(r'[\x00-\x1F\x7F]')
+_value_disallowed_re = re.compile(r'[\x00-\x08\x0A-\x1F\x7F]')
 
 def _formatparam(param, value=None, quote=1):
     """Convenience function to format and return a key=value pair.
@@ -36,13 +40,13 @@ class Headers:
         self._headers = headers
         if __debug__:
             for k, v in headers:
-                self._convert_string_type(k)
+                self._convert_string_type(k, name=True)
                 self._convert_string_type(v)
 
-    def _convert_string_type(self, value):
+    def _convert_string_type(self, value, *, name=False):
         """Convert/check value type."""
         if type(value) is str:
-            if _control_chars_re.search(value):
+            if (_name_disallowed_re if name else _value_disallowed_re).search(value):
                 raise ValueError("Control characters not allowed in headers")
             return value
         raise AssertionError("Header names/values must be"
@@ -56,14 +60,14 @@ class Headers:
         """Set the value of a header."""
         del self[name]
         self._headers.append(
-            (self._convert_string_type(name), self._convert_string_type(val)))
+            (self._convert_string_type(name, name=True), self._convert_string_type(val)))
 
     def __delitem__(self,name):
         """Delete all occurrences of a header, if present.
 
         Does *not* raise an exception if the header is missing.
         """
-        name = self._convert_string_type(name.lower())
+        name = self._convert_string_type(name.lower(), name=True)
         self._headers[:] = [kv for kv in self._headers if kv[0].lower() != name]
 
     def __getitem__(self,name):
@@ -90,13 +94,13 @@ class Headers:
         fields deleted and re-inserted are always appended to the header list.
         If no fields exist with the given name, returns an empty list.
         """
-        name = self._convert_string_type(name.lower())
+        name = self._convert_string_type(name.lower(), name=True)
         return [kv[1] for kv in self._headers if kv[0].lower()==name]
 
 
     def get(self,name,default=None):
         """Get the first header value for 'name', or return 'default'"""
-        name = self._convert_string_type(name.lower())
+        name = self._convert_string_type(name.lower(), name=True)
         for k,v in self._headers:
             if k.lower()==name:
                 return v
@@ -151,7 +155,7 @@ class Headers:
         and value 'value'."""
         result = self.get(name)
         if result is None:
-            self._headers.append((self._convert_string_type(name),
+            self._headers.append((self._convert_string_type(name, name=True),
                 self._convert_string_type(value)))
             return value
         else:
@@ -178,10 +182,10 @@ class Headers:
             _value = self._convert_string_type(_value)
             parts.append(_value)
         for k, v in _params.items():
-            k = self._convert_string_type(k)
+            k = self._convert_string_type(k, name=True)
             if v is None:
                 parts.append(k.replace('_', '-'))
             else:
                 v = self._convert_string_type(v)
                 parts.append(_formatparam(k.replace('_', '-'), v))
-        self._headers.append((self._convert_string_type(_name), "; ".join(parts)))
+        self._headers.append((self._convert_string_type(_name, name=True), "; ".join(parts)))


### PR DESCRIPTION
In https://github.com/python/cpython/pull/143917 we were overzealous, `HTAB` (0x09) is allowed in header values but not header names.

<!-- gh-issue-number: gh-143916 -->
* Issue: gh-143916
<!-- /gh-issue-number -->
