### PR TITLE
[3.13] gh-144085: Add `{gi,cr}_suspended` to `inspect` comments and `generator/coroutine` tests (GH-144086)

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -465,6 +465,8 @@ def isgenerator(object):
         gi_frame        frame object or possibly None once the generator has
                         been exhausted
         gi_running      set to 1 when generator is executing, 0 otherwise
+        gi_suspended    set to 1 when the generator is suspended at a yield point, 0 otherwise
+        gi_yieldfrom    object being iterated by yield from or None
         next            return the next item from the container
         send            resumes the generator and "sends" a value that becomes
                         the result of the current yield-expression

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -2164,8 +2164,8 @@ class CoroutineTests(unittest.TestCase):
         self.assertIs(wrapper.__name__, gen.__name__)
 
         # Test AttributeErrors
-        for name in {'gi_running', 'gi_frame', 'gi_code', 'gi_yieldfrom',
-                     'cr_running', 'cr_frame', 'cr_code', 'cr_await'}:
+        for name in {'gi_running', 'gi_frame', 'gi_code', 'gi_yieldfrom', 'gi_suspended',
+                     'cr_running', 'cr_frame', 'cr_code', 'cr_await', 'cr_suspended'}:
             with self.assertRaises(AttributeError):
                 getattr(wrapper, name)
 
@@ -2174,14 +2174,17 @@ class CoroutineTests(unittest.TestCase):
         gen.gi_frame = object()
         gen.gi_code = object()
         gen.gi_yieldfrom = object()
+        gen.gi_suspended = object()
         self.assertIs(wrapper.gi_running, gen.gi_running)
         self.assertIs(wrapper.gi_frame, gen.gi_frame)
         self.assertIs(wrapper.gi_code, gen.gi_code)
         self.assertIs(wrapper.gi_yieldfrom, gen.gi_yieldfrom)
+        self.assertIs(wrapper.gi_suspended, gen.gi_suspended)
         self.assertIs(wrapper.cr_running, gen.gi_running)
         self.assertIs(wrapper.cr_frame, gen.gi_frame)
         self.assertIs(wrapper.cr_code, gen.gi_code)
         self.assertIs(wrapper.cr_await, gen.gi_yieldfrom)
+        self.assertIs(wrapper.cr_suspended, gen.gi_suspended)
 
         wrapper.close()
         gen.close.assert_called_once_with()
@@ -2300,7 +2303,7 @@ class CoroutineTests(unittest.TestCase):
         self.assertIs(wrapper.__await__(), gen)
 
         for name in ('__name__', '__qualname__', 'gi_code',
-                     'gi_running', 'gi_frame'):
+                     'gi_running', 'gi_frame', 'gi_suspended'):
             self.assertIs(getattr(foo(), name),
                           getattr(gen, name))
         self.assertIs(foo().cr_code, gen.gi_code)
@@ -2363,8 +2366,8 @@ class CoroutineTests(unittest.TestCase):
         self.assertEqual(repr(wrapper), str(wrapper))
         self.assertTrue(set(dir(wrapper)).issuperset({
             '__await__', '__iter__', '__next__', 'cr_code', 'cr_running',
-            'cr_frame', 'gi_code', 'gi_frame', 'gi_running', 'send',
-            'close', 'throw'}))
+            'cr_frame', 'cr_suspended', 'gi_code', 'gi_frame', 'gi_running',
+            'gi_suspended', 'send', 'close', 'throw'}))
 
 
 class FunctionTests(unittest.TestCase):


### PR DESCRIPTION
(cherry picked from commit 4ef30a5871db2043712945e64f33af81938d68dc)

This backport resolves a docstring conflict in `Lib/inspect.py` by applying the minimal necessary change.

While an alternative would be to first cherry-pick [gh-122059](https://github.com/python/cpython/pull/122059) and then [gh-144086](https://github.com/python/cpython/pull/144086), this PR instead follows the minimal-change principle by directly adding the two missing attribute lines (`gi_suspended` and `gi_yieldfrom`) to the existing 3.13 docstring layout.

This approach avoids broader docstring reformatting and is consistent with prior guidance for stable branches, where docstring changes should be kept minimal (see discussion in [gh-122059](https://github.com/python/cpython/pull/122059#issuecomment-2255485727)).

No behavioral changes; this backport is limited to documentation consistency with the already-merged tests.

<!-- gh-issue-number: gh-144085 -->
* Issue: gh-144085
<!-- /gh-issue-number -->
