### PR TITLE
tests: asyncio: collect garbage in run_until_complete_nesting

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -287,6 +287,7 @@ class EventLoopTestsMixin:
         ):
             self.assertRaises(
                 RuntimeError, self.loop.run_until_complete, coro2())
+            support.gc_collect()
 
     # Note: because of the default Windows timing granularity of
     # 15.6 msec, we use fairly long sleep times here (~100 msec).


### PR DESCRIPTION
The test checks that coro1 emits a runtime warning when it is garbage collected. cpython will do this collection immediately, but other implementations such as PyPy might not. Add the appropriate call to support.gc_collect() to ensure the warning is emitted while still in the with statement.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
