### PR TITLE
gh-144161: Clarify additional immortalization in free-threaded build

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1754,7 +1754,7 @@ They all return ``NULL`` or ``-1`` if an exception occurs.
    You must keep a reference to the result to benefit from interning.
 
    .. note::
-      On the free-threaded build, all interned strings are :term:`immortal`.
+      On the :term:`free threaded <free threading>` build, all interned strings are :term:`immortal`.
       This may change in the future.
 
 .. c:function:: PyObject* PyUnicode_InternFromString(const char *str)

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1754,7 +1754,7 @@ They all return ``NULL`` or ``-1`` if an exception occurs.
    You must keep a reference to the result to benefit from interning.
 
    .. note::
-      On the :term:`free threaded` build, all interned strings are :term:`immortal`.
+      On the :term:`free-threaded` build, all interned strings are :term:`immortal`.
       This may change in the future.
 
 .. c:function:: PyObject* PyUnicode_InternFromString(const char *str)

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1753,6 +1753,8 @@ They all return ``NULL`` or ``-1`` if an exception occurs.
    Note that interned strings are not “immortal”.
    You must keep a reference to the result to benefit from interning.
 
+   .. note::
+      In the free-threaded build, all interned strings are :term:`immortal`.
 
 .. c:function:: PyObject* PyUnicode_InternFromString(const char *str)
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1754,7 +1754,7 @@ They all return ``NULL`` or ``-1`` if an exception occurs.
    You must keep a reference to the result to benefit from interning.
 
    .. note::
-      On the :term:`free-threaded <free threading>` build,
+      On the :term:`free threaded <free threading>` build,
       all interned strings are :term:`immortal`.
       This may change in the future.
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1754,7 +1754,7 @@ They all return ``NULL`` or ``-1`` if an exception occurs.
    You must keep a reference to the result to benefit from interning.
 
    .. note::
-      On the :term:`free-threaded` build, all interned strings are :term:`immortal`.
+      On the free-threaded build, all interned strings are :term:`immortal`.
       This may change in the future.
 
 .. c:function:: PyObject* PyUnicode_InternFromString(const char *str)

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1754,7 +1754,7 @@ They all return ``NULL`` or ``-1`` if an exception occurs.
    You must keep a reference to the result to benefit from interning.
 
    .. note::
-      On the :term:`free threaded <free threading>` build,
+      On the :term:`free-threaded <free threading>` build,
       all interned strings are :term:`immortal`.
       This may change in the future.
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1754,7 +1754,7 @@ They all return ``NULL`` or ``-1`` if an exception occurs.
    You must keep a reference to the result to benefit from interning.
 
    .. note::
-      On the :term:`free threaded <free threading>` build, 
+      On the :term:`free threaded <free threading>` build,
       all interned strings are :term:`immortal`.
       This may change in the future.
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1750,11 +1750,11 @@ They all return ``NULL`` or ``-1`` if an exception occurs.
    :c:expr:`PyUnicode_CheckExact(*p_unicode)` must be true. If it is not,
    then -- as with any other error -- the argument is left unchanged.
 
-   Note that interned strings are not “immortal”.
+   Interned strings are not :term:`immortal`.
    You must keep a reference to the result to benefit from interning.
 
    .. note::
-      In the free-threaded build, all interned strings are :term:`immortal`.
+      In the free-threaded build, all interned strings **are** :term:`immortal`.
 
 .. c:function:: PyObject* PyUnicode_InternFromString(const char *str)
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1754,7 +1754,8 @@ They all return ``NULL`` or ``-1`` if an exception occurs.
    You must keep a reference to the result to benefit from interning.
 
    .. note::
-      On the :term:`free threaded <free threading>` build, all interned strings are :term:`immortal`.
+      On the :term:`free threaded <free threading>` build, 
+      all interned strings are :term:`immortal`.
       This may change in the future.
 
 .. c:function:: PyObject* PyUnicode_InternFromString(const char *str)

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1750,11 +1750,12 @@ They all return ``NULL`` or ``-1`` if an exception occurs.
    :c:expr:`PyUnicode_CheckExact(*p_unicode)` must be true. If it is not,
    then -- as with any other error -- the argument is left unchanged.
 
-   Interned strings are not :term:`immortal`.
+   Strings interned by this function are not :term:`immortal`.
    You must keep a reference to the result to benefit from interning.
 
    .. note::
-      In the free-threaded build, all interned strings **are** :term:`immortal`.
+      On the :term:`free threaded` build, all interned strings are :term:`immortal`.
+      This may change in the future.
 
 .. c:function:: PyObject* PyUnicode_InternFromString(const char *str)
 

--- a/Doc/howto/free-threading-python.rst
+++ b/Doc/howto/free-threading-python.rst
@@ -99,12 +99,12 @@ This section describes known limitations of the free-threaded CPython build.
 Immortalization
 ---------------
 
-In the free-threaded build, some objects are :term:`immortal`.
+The free-threaded build introduces additional :term:`immortal` objects.
 Immortal objects are not deallocated and have reference counts that are
 never modified.  This is done to avoid reference count contention that would
 prevent efficient multi-threaded scaling.
 
-As of the 3.14 release, immortalization is limited to:
+As of the 3.14 release, this additional immortalization is limited to:
 
 * Code constants: numeric literals, string literals, and tuple literals
   composed of other constants.

--- a/Doc/howto/free-threading-python.rst
+++ b/Doc/howto/free-threading-python.rst
@@ -99,7 +99,7 @@ This section describes known limitations of the free-threaded CPython build.
 Immortalization
 ---------------
 
-The free-threaded build introduces additional :term:`immortal` objects.
+On the free-threaded build, more objects are made immortal.
 Immortal objects are not deallocated and have reference counts that are
 never modified.  This is done to avoid reference count contention that would
 prevent efficient multi-threaded scaling.

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1326,7 +1326,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    return value of :func:`intern` around to benefit from it.
 
    .. note::
-      On the :term:`free threaded` build, all interned strings are :term:`immortal`.
+      On the :term:`free-threaded` build, all interned strings are :term:`immortal`.
       This may change in the future.
 
 .. function:: _is_gil_enabled()

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1326,7 +1326,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    return value of :func:`intern` around to benefit from it.
 
    .. note::
-      On the :term:`free threaded <free threading>` build, 
+      On the :term:`free threaded <free threading>` build,
       all interned strings are :term:`immortal`.
       This may change in the future.
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1326,7 +1326,8 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    return value of :func:`intern` around to benefit from it.
 
    .. note::
-      On the :term:`free threaded <free threading>` build, all interned strings are :term:`immortal`.
+      On the :term:`free threaded <free threading>` build, 
+      all interned strings are :term:`immortal`.
       This may change in the future.
 
 .. function:: _is_gil_enabled()

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1326,7 +1326,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    return value of :func:`intern` around to benefit from it.
 
    .. note::
-      On the :term:`free-threaded <free threading>` build,
+      On the :term:`free threaded <free threading>` build,
       all interned strings are :term:`immortal`.
       This may change in the future.
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1327,7 +1327,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
    .. note::
 
-      In the free-threaded build, all interned strings are :term:`immortal`.
+      In the free-threaded build, all interned strings **are** :term:`immortal`.
 
 .. function:: _is_gil_enabled()
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1326,7 +1326,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    return value of :func:`intern` around to benefit from it.
 
    .. note::
-      On the :term:`free threaded <free threading>` build,
+      On the :term:`free-threaded <free threading>` build,
       all interned strings are :term:`immortal`.
       This may change in the future.
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1326,7 +1326,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    return value of :func:`intern` around to benefit from it.
 
    .. note::
-      On the :term:`free-threaded` build, all interned strings are :term:`immortal`.
+      On the free-threaded build, all interned strings are :term:`immortal`.
       This may change in the future.
 
 .. function:: _is_gil_enabled()

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1326,7 +1326,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    return value of :func:`intern` around to benefit from it.
 
    .. note::
-      On the free-threaded build, all interned strings are :term:`immortal`.
+      On the :term:`free threaded <free threading>` build, all interned strings are :term:`immortal`.
       This may change in the future.
 
 .. function:: _is_gil_enabled()

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1326,8 +1326,8 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    return value of :func:`intern` around to benefit from it.
 
    .. note::
-
-      In the free-threaded build, all interned strings **are** :term:`immortal`.
+      On the :term:`free threaded` build, all interned strings are :term:`immortal`.
+      This may change in the future.
 
 .. function:: _is_gil_enabled()
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1325,6 +1325,9 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    Interned strings are not :term:`immortal`; you must keep a reference to the
    return value of :func:`intern` around to benefit from it.
 
+   .. note::
+
+      In the free-threaded build, all interned strings are :term:`immortal`.
 
 .. function:: _is_gil_enabled()
 


### PR DESCRIPTION
Clarify that the objects listed in the free-threading HOWTO are additional immortalizations specific to the free-threaded build.

This addresses the inconsistency reported in #144161, where `sys.intern()` documentation states that interned strings are not immortal, while the free-threading HOWTO suggested otherwise. Both are correct for their respective contexts (default vs. free-threaded builds).

Changes follow the suggestion by @Prometheus3375 in the issue discussion.

<!-- gh-issue-number: gh-144161 -->
* Issue: gh-144161
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144176.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->