### PR TITLE
gh-144169: Fix warning formatting in ast_type_init()

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -489,6 +489,10 @@ class AST_Tests(unittest.TestCase):
         # Arbitrary keyword arguments are supported (but deprecated)
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(ast.Constant(1, foo='bar').foo, 'bar')
+        # gh-144169: non-string keys must not crash
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(TypeError):
+                ast.Constant(1, **{object(): 'bar'})
 
         with self.assertRaisesRegex(TypeError, "Constant got multiple values for argument 'value'"):
             ast.Constant(1, value=2)

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -965,7 +965,7 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
                 else if (contains == 0) {
                     if (PyErr_WarnFormat(
                         PyExc_DeprecationWarning, 1,
-                        "%.400s.__init__ got an unexpected keyword argument '%U'. "
+                        "%.400s.__init__ got an unexpected keyword argument %R. "
                         "Support for arbitrary keyword arguments is deprecated "
                         "and will be removed in Python 3.15.",
                         Py_TYPE(self)->tp_name, key

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -5249,7 +5249,7 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
                 else if (contains == 0) {
                     if (PyErr_WarnFormat(
                         PyExc_DeprecationWarning, 1,
-                        "%.400s.__init__ got an unexpected keyword argument '%U'. "
+                        "%.400s.__init__ got an unexpected keyword argument %R. "
                         "Support for arbitrary keyword arguments is deprecated "
                         "and will be removed in Python 3.15.",
                         Py_TYPE(self)->tp_name, key


### PR DESCRIPTION
Replace "%U" with "%R" since the argument can be an arbitrary object.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144169 -->
* Issue: gh-144169
<!-- /gh-issue-number -->
