### PR TITLE
gh-134160: "First extension module" tutorial improvements

### DIFF
--- a/Doc/includes/capi-extension/spammodule-01.c
+++ b/Doc/includes/capi-extension/spammodule-01.c
@@ -12,7 +12,7 @@
 static PyObject *
 spam_system(PyObject *self, PyObject *arg)
 {
-   const char *command = PyUnicode_AsUTF8(arg);
+   const char *command = PyUnicode_AsUTF8AndSize(arg, NULL);
    if (command == NULL) {
       return NULL;
    }


### PR DESCRIPTION
I've run through the tutorial with a mentee (best way to test tutorials btw!) and found some things to improve.

- Pass -v to pip, so compiler output is visible
- Move the call ``spam.system(3)`` up so that error handling is tested right after it's added
- Use `PyUnicode_AsUTF8AndSize` as `PyUnicode_AsUTF8` is not in the Limited API.
- Add a footnote about embedded NULs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134160 -->
* Issue: gh-134160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144183.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->