### PR TITLE
gh-142694: Clarify open() accepts objects with name attribute

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1352,9 +1352,10 @@ are always available.  They are listed here in alphabetical order.
    :ref:`tut-files` for more examples of how to use this function.
 
    *file* is a :term:`path-like object` giving the pathname (absolute or
-   relative to the current working directory) of the file to be opened or an
-   integer file descriptor of the file to be wrapped.  (If a file descriptor is
-   given, it is closed when the returned I/O object is closed unless *closefd*
+   relative to the current working directory) of the file to be opened,
+   or an object with a ``name`` attribute, or an integer file descriptor
+   of the file to be wrapped. (If a file descriptor is given, 
+   it is closed when the returned I/O object is closed unless *closefd*
    is set to ``False``.)
 
    *mode* is an optional string that specifies the mode in which the file is

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1346,7 +1346,7 @@ are always available.  They are listed here in alphabetical order.
    single: file object; open() built-in function
 
 .. function:: open(file, mode='r', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
-
+`
    Open *file* and return a corresponding :term:`file object`.  If the file
    cannot be opened, an :exc:`OSError` is raised. See
    :ref:`tut-files` for more examples of how to use this function.
@@ -1367,7 +1367,7 @@ are always available.  They are listed here in alphabetical order.
    *encoding* is not specified the encoding used is platform-dependent:
    :func:`locale.getencoding` is called to get the current locale encoding.
    (For reading and writing raw bytes use binary mode and leave
-   *encoding* unspecified.)  The available modes are:
+   *encoding* unspecified.)  The available modes are:`
 
    .. _filemodes:
 

--- a/tatus
+++ b/tatus
@@ -1,0 +1,18 @@
+[1mdiff --git a/Doc/library/functions.rst b/Doc/library/functions.rst[m
+[1mindex cd819b8d06..cfa6d9620d 100644[m
+[1m--- a/Doc/library/functions.rst[m
+[1m+++ b/Doc/library/functions.rst[m
+[36m@@ -1352,9 +1352,10 @@[m [mare always available.  They are listed here in alphabetical order.[m
+    :ref:`tut-files` for more examples of how to use this function.[m
+ [m
+    *file* is a :term:`path-like object` giving the pathname (absolute or[m
+[31m-   relative to the current working directory) of the file to be opened or an[m
+[31m-   integer file descriptor of the file to be wrapped.  (If a file descriptor is[m
+[31m-   given, it is closed when the returned I/O object is closed unless *closefd*[m
+[32m+[m[32m   relative to the current working directory) of the file to be opened,[m
+[32m+[m[32m   or an object with a ``name`` attribute, or an integer file descriptor[m
+[32m+[m[32m   of the file to be wrapped. (If a file descriptor is given,[m[41m [m
+[32m+[m[32m   it is closed when the returned I/O object is closed unless *closefd*[m
+    is set to ``False``.)[m
+ [m
+    *mode* is an optional string that specifies the mode in which the file is[m


### PR DESCRIPTION
This PR updates the documentation for open() to clarify that objects with a name attribute are also accepted as valid file arguments.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144187.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->