### PR TITLE
gh-144228: Remove `HAVE_STRERROR` build flag

### DIFF
--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -54,7 +54,6 @@ WIN32 is still required for the locale module.
 #define HAVE_TMPFILE
 #define HAVE_TMPNAM
 #define HAVE_CLOCK
-#define HAVE_STRERROR
 
 #include <io.h>
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144228 -->
* Issue: gh-144228
<!-- /gh-issue-number -->
