### PR TITLE
gh-144228: Remove `HAVE_X509_VERIFY_PARAM_SET1_HOST` build flag

### DIFF
--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -759,9 +759,6 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 /* framework name */
 #define _PYTHONFRAMEWORK ""
 
-/* Define if libssl has X509_VERIFY_PARAM_set1_host and related function */
-#define HAVE_X509_VERIFY_PARAM_SET1_HOST 1
-
 // Truncate the thread name to 32766 characters.
 #define _PYTHREAD_NAME_MAXLEN 32766
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

There's also `HAVE_X509_VERIFY_PARAM_set1_host` in configure.ac, but it appears to be unrelated.


<!-- gh-issue-number: gh-144228 -->
* Issue: gh-144228
<!-- /gh-issue-number -->
