### PR TITLE
Test: fix stale uops usage in `test_capi/test_opt.py`

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -3750,6 +3750,7 @@ class TestUopsOptimization(unittest.TestCase):
         res, ex = self._run_with_optimizer(test_is_none, TIER2_THRESHOLD)
         self.assertEqual(res, True)
         self.assertIsNotNone(ex)
+        uops = get_opnames(ex)
 
         self.assertIn("_IS_OP", uops)
         self.assertIn("_POP_TOP_NOP", uops)


### PR DESCRIPTION
Recompute uops for `test_is_none` instead of reusing the previous test's value.
