### PR TITLE
gh-144254: set TCP_NODELAY by default (disable nagle algorithm)

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-01-26-18-11-56.gh-issue-144254.QQwUp2.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-26-18-11-56.gh-issue-144254.QQwUp2.rst
@@ -1,0 +1,1 @@
+set TCP_NODELAY by default (disable nagle algorithm)


### PR DESCRIPTION
See context in the associated ticket https://github.com/python/cpython/issues/144254

Raising the PR to verify that the build and all tests are passing.

The change itself is relatively simple.
Not sure if we should catch the return from the `setsockopt()`.


<!-- gh-issue-number: gh-144254 -->
* Issue: gh-144254
<!-- /gh-issue-number -->
