### PR TITLE
gh-144264: Speed up Base64 decoding of data containing ignored characters

### DIFF
--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -202,16 +202,16 @@ class BinASCIITest(unittest.TestCase):
         assertNonBase64Data(b'a\nb==', b'i', ignorechars=bytearray(b'\n'))
         assertNonBase64Data(b'a\nb==', b'i', ignorechars=memoryview(b'\n'))
 
-        # Same byte in the bit cache: '\r' >> 3 == '\n' >> 3.
+        # Same cell in the cache: '\r' >> 3 == '\n' >> 3.
         data = self.type2test(b'\r\n')
         with self.assertRaises(binascii.Error):
             binascii.a2b_base64(data, ignorechars=b'\r')
         self.assertEqual(binascii.a2b_base64(data, ignorechars=b'\r\n'), b'')
-        # Same mask in the bit cache: ':' & 7 == '\n' & 7.
-        data = self.type2test(b':\n')
+        # Same bit mask in the cache: '*' & 31 == '\n' & 31.
+        data = self.type2test(b'*\n')
         with self.assertRaises(binascii.Error):
-            binascii.a2b_base64(data, ignorechars=b':')
-        self.assertEqual(binascii.a2b_base64(data, ignorechars=b':\n'), b'')
+            binascii.a2b_base64(data, ignorechars=b'*')
+        self.assertEqual(binascii.a2b_base64(data, ignorechars=b'*\n'), b'')
 
         data = self.type2test(b'a\nb==')
         with self.assertRaises(TypeError):

--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -202,6 +202,17 @@ class BinASCIITest(unittest.TestCase):
         assertNonBase64Data(b'a\nb==', b'i', ignorechars=bytearray(b'\n'))
         assertNonBase64Data(b'a\nb==', b'i', ignorechars=memoryview(b'\n'))
 
+        # Same byte in the bit cache: '\r' >> 3 == '\n' >> 3.
+        data = self.type2test(b'\r\n')
+        with self.assertRaises(binascii.Error):
+            binascii.a2b_base64(data, ignorechars=b'\r')
+        self.assertEqual(binascii.a2b_base64(data, ignorechars=b'\r\n'), b'')
+        # Same mask in the bit cache: ':' & 7 == '\n' & 7.
+        data = self.type2test(b':\n')
+        with self.assertRaises(binascii.Error):
+            binascii.a2b_base64(data, ignorechars=b':')
+        self.assertEqual(binascii.a2b_base64(data, ignorechars=b':\n'), b'')
+
         data = self.type2test(b'a\nb==')
         with self.assertRaises(TypeError):
             binascii.a2b_base64(data, ignorechars='')

--- a/Misc/NEWS.d/next/Library/2026-01-27-10-02-04.gh-issue-144264.Wmzbol.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-27-10-02-04.gh-issue-144264.Wmzbol.rst
@@ -1,0 +1,3 @@
+Speed up Base64 decoding of data containing ignored characters (both in
+non-strict mode and with an explicit *ignorechars* argument).
+It is now up to 2 times faster for multiline Base64 data.

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -476,11 +476,11 @@ ignorechar(unsigned char c, Py_buffer *ignorechars, char ignorecache[32])
     if (ignorechars->buf == NULL) {
         return 0;
     }
-    if (ignorecache[c >> 8] & (1 << (c & 7))) {
+    if (ignorecache[c >> 3] & (1 << (c & 7))) {
         return 1;
     }
     if (memchr(ignorechars->buf, c, ignorechars->len)) {
-        ignorecache[c >> 8] |= 1 << (c & 7);
+        ignorecache[c >> 3] |= 1 << (c & 7);
         return 1;
     }
     return 0;


### PR DESCRIPTION
Try the fast path again after decoding a quad the slow path. Use a bitmap cache for the ignorechars argument.


<!-- gh-issue-number: gh-144264 -->
* Issue: gh-144264
<!-- /gh-issue-number -->
