### PR TITLE
gh-144281: Fix crash on memoryview slice assignment with shared memory

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4938,7 +4938,7 @@ class _TestSharedMemory(BaseTestCase):
         mv = shm.buf
         shm.close()
         shm.unlink()
-        with self.assertRaises(BufferError):
+        with self.assertRaises((BufferError, ValueError)):
             mv[:5] = b'hello'
 
     @unittest.skipIf(os.name != "posix", "resource_tracker is posix only")

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4987,6 +4987,15 @@ class _TestSharedMemory(BaseTestCase):
             resource_tracker.unregister(mem._name, "shared_memory")
             mem.close()
 
+    def test_shared_memory_slice_assignment_no_crash():
+        from multiprocessing import shared_memory
+        shm = shared_memory.SharedMemory(create=True, size=10)
+        try:
+            shm.buf[:5] = b'hello'
+        finally:
+            shm.close()
+            shm.unlink()
+
 #
 # Test to verify that `Finalize` works.
 #

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4932,6 +4932,15 @@ class _TestSharedMemory(BaseTestCase):
                     "resource_tracker: There appear to be 1 leaked "
                     "shared_memory objects to clean up at shutdown", err)
 
+    def test_shared_memory_slice_assignment_no_crash(self):
+        from multiprocessing import shared_memory
+        shm = shared_memory.SharedMemory(create=True, size=10)
+        try:
+            shm.buf[:5] = b'hello'
+        finally:
+            shm.close()
+            shm.unlink()
+
     @unittest.skipIf(os.name != "posix", "resource_tracker is posix only")
     @resource_tracker_format_subtests
     def test_shared_memory_untracking(self):
@@ -4986,15 +4995,6 @@ class _TestSharedMemory(BaseTestCase):
                 pass
             resource_tracker.unregister(mem._name, "shared_memory")
             mem.close()
-
-    def test_shared_memory_slice_assignment_no_crash():
-        from multiprocessing import shared_memory
-        shm = shared_memory.SharedMemory(create=True, size=10)
-        try:
-            shm.buf[:5] = b'hello'
-        finally:
-            shm.close()
-            shm.unlink()
 
 #
 # Test to verify that `Finalize` works.

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4935,11 +4935,11 @@ class _TestSharedMemory(BaseTestCase):
     def test_shared_memory_slice_assignment_no_crash(self):
         from multiprocessing import shared_memory
         shm = shared_memory.SharedMemory(create=True, size=10)
-        try:
-            shm.buf[:5] = b'hello'
-        finally:
-            shm.close()
-            shm.unlink()
+        mv = shm.buf
+        shm.close()
+        shm.unlink()
+        with self.assertRaises(BufferError):
+            mv[:5] = b'hello'
 
     @unittest.skipIf(os.name != "posix", "resource_tracker is posix only")
     @resource_tracker_format_subtests

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-27-23-35-19.gh-issue-144281.IiakEV.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-27-23-35-19.gh-issue-144281.IiakEV.rst
@@ -1,0 +1,2 @@
+Fix a possible interpreter crash during memoryview slice assignment when the
+underlying buffer is backed by shared memory.

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -2656,6 +2656,11 @@ memory_ass_sub(PyObject *_self, PyObject *key, PyObject *value)
 
     CHECK_RELEASED_INT(self);
 
+    if (view->buf == NULL) {
+        PyErr_SetString(PyExc_BufferError, "memoryview: underlying buffer is no longer valid");
+        return -1;
+    }
+
     fmt = adjust_fmt(view);
     if (fmt == NULL)
         return -1;


### PR DESCRIPTION
Fix a possible interpreter crash when assigning to a memoryview slice backed by shared memory by validating the underlying buffer before writing. A regression test and NEWS entry are included.


<!-- gh-issue-number: gh-144281 -->
* Issue: gh-144281
<!-- /gh-issue-number -->
