### PR TITLE
[3.13] gh-144257: document return values of PyModule_SetDocString (GH-144258)

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -529,6 +529,9 @@ objects dynamically. Note that both ``PyModule_FromDefAndSpec`` and
    ``PyModuleDef``, using either ``PyModule_Create`` or
    ``PyModule_FromDefAndSpec``.
 
+   Return ``0`` on success.
+   Return ``-1`` with an exception set on error.
+
    .. versionadded:: 3.5
 
 .. c:function:: int PyModule_AddFunctions(PyObject *module, PyMethodDef *functions)


### PR DESCRIPTION
As requested by @ZeroIntensity: https://github.com/python/cpython/pull/144258#issuecomment-3803515612

<!-- gh-issue-number: gh-144257 -->
* Issue: gh-144257
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144286.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->