### PR TITLE
gh-120321: Add missing "return false" in gen_try_set_executing

### DIFF
--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -529,6 +529,7 @@ gen_try_set_executing(PyGenObject *gen)
                 return true;
             }
         }
+        return false;
     }
 #endif
     // Use faster non-atomic modifications in the GIL-enabled build and when


### PR DESCRIPTION
We didn't catch this because of a combination of:

1) falling through to the if-statement below works

2) we only specialized FOR_ITER_GEN for uniquely referenced generators,
   so we didn't trigger the non-thread-safe behavior.


<!-- gh-issue-number: gh-120321 -->
* Issue: gh-120321
<!-- /gh-issue-number -->
