### PR TITLE
gh-120321: Make gi_yieldfrom thread-safe in free-threading build

### DIFF
--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -44,15 +44,16 @@ extern PyFrameObject* _PyFrame_New_NoTrack(PyCodeObject *code);
 /* other API */
 
 typedef enum _framestate {
-    FRAME_CREATED = -3,
-    FRAME_SUSPENDED = -2,
-    FRAME_SUSPENDED_YIELD_FROM = -1,
+    FRAME_CREATED = -4,
+    FRAME_SUSPENDED = -3,
+    FRAME_SUSPENDED_YIELD_FROM = -2,
+    FRAME_SUSPENDED_YIELD_FROM_LOCKED = -1,
     FRAME_EXECUTING = 0,
     FRAME_COMPLETED = 1,
     FRAME_CLEARED = 4
 } PyFrameState;
 
-#define FRAME_STATE_SUSPENDED(S) ((S) == FRAME_SUSPENDED || (S) == FRAME_SUSPENDED_YIELD_FROM)
+#define FRAME_STATE_SUSPENDED(S) ((S) >= FRAME_SUSPENDED && (S) <= FRAME_SUSPENDED_YIELD_FROM_LOCKED)
 #define FRAME_STATE_FINISHED(S) ((S) >= FRAME_COMPLETED)
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_lock.h
+++ b/Include/internal/pycore_lock.h
@@ -70,6 +70,9 @@ PyMutex_LockFlags(PyMutex *m, _PyLockFlags flags)
 // error messages) otherwise returns 0.
 extern int _PyMutex_TryUnlock(PyMutex *m);
 
+// Yield the processor to other threads (e.g., sched_yield).
+extern void _Py_yield(void);
+
 
 // PyEvent is a one-time event notification
 typedef struct {

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-27-17-49-43.gh-issue-120321.Vo7c9T.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-27-17-49-43.gh-issue-120321.Vo7c9T.rst
@@ -1,0 +1,2 @@
+Made :attr:`~generator.gi_yieldfrom` thread-safe in the free-threading build
+by using a lightweight lock on the frame state.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-27-17-49-43.gh-issue-120321.Vo7c9T.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-27-17-49-43.gh-issue-120321.Vo7c9T.rst
@@ -1,2 +1,2 @@
-Made :attr:`~generator.gi_yieldfrom` thread-safe in the free-threading build
+Made ``gi_yieldfrom`` thread-safe in the free-threading build
 by using a lightweight lock on the frame state.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3391,7 +3391,9 @@ _PyEval_GetAwaitable(PyObject *iterable, int oparg)
     else if (PyCoro_CheckExact(iter)) {
         PyCoroObject *coro = (PyCoroObject *)iter;
         int8_t frame_state = FT_ATOMIC_LOAD_INT8_RELAXED(coro->cr_frame_state);
-        if (frame_state == FRAME_SUSPENDED_YIELD_FROM) {
+        if (frame_state == FRAME_SUSPENDED_YIELD_FROM ||
+            frame_state == FRAME_SUSPENDED_YIELD_FROM_LOCKED)
+        {
             /* `iter` is a coroutine object that is being awaited. */
             Py_CLEAR(iter);
             _PyErr_SetString(PyThreadState_GET(), PyExc_RuntimeError,

--- a/Python/lock.c
+++ b/Python/lock.c
@@ -40,7 +40,7 @@ struct mutex_entry {
     int handed_off;
 };
 
-static void
+void
 _Py_yield(void)
 {
 #ifdef MS_WINDOWS


### PR DESCRIPTION
Add a FRAME_SUSPENDED_YIELD_FROM_LOCKED state that acts as a brief lock, preventing other threads from transitioning the frame state while gen_getyieldfrom reads the yield-from object off the stack.


<!-- gh-issue-number: gh-120321 -->
* Issue: gh-120321
<!-- /gh-issue-number -->
