### PR TITLE
gh-144259: Fix Windows EOL wrap by syncing real console cursor 

### DIFF
--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -289,9 +289,7 @@ class WindowsConsole(Console):
 
         self.__write(newline[x_pos:])
         if wlen(newline) == self.width:
-            did_wrap = self._has_wrapped_to_next_row(y)
-            if did_wrap is True:
-                # Terminal wrapped to next row.
+            if self._has_wrapped_to_next_row(y):
                 self.posxy = 0, y + 1
             else:
                 # Terminal did not wrap; cursor stays at end-of-line.

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -247,14 +247,9 @@ class WindowsConsole(Console):
         if nt is not None and nt._is_inputhook_installed():
             return nt._inputhook
 
-    def _has_wrapped_to_next_row(self, y: int) -> bool | None:
+    def _has_wrapped_to_next_row(self, y: int) -> bool:
         """
-        Return whether the real console cursor wrapped to the next row.
-
-        Returns:
-            True  - cursor wrapped to the next visible row
-            False - cursor did not wrap
-            None  - cannot query the real cursor position (e.g. invalid handle)
+        Return True if the real console cursor wrapped to the next visible row.
         """
         info = CONSOLE_SCREEN_BUFFER_INFO()
         if not GetConsoleScreenBufferInfo(OutHandle, info):

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -258,10 +258,7 @@ class WindowsConsole(Console):
         """
         info = CONSOLE_SCREEN_BUFFER_INFO()
         if not GetConsoleScreenBufferInfo(OutHandle, info):
-            err = get_last_error()
-            if err == 6:  # ERROR_INVALID_HANDLE
-                return None
-            raise WinError(err)
+            raise WinError(get_last_error())
 
         win_y = int(info.dwCursorPosition.Y - info.srWindow.Top)
         expected = y - self.__offset

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -272,22 +272,17 @@ class WindowsConsole(Console):
 
         self.__write(newline[x_pos:])
         if wlen(newline) == self.width:
-            if self.__vt_support:
-                info = CONSOLE_SCREEN_BUFFER_INFO()
-                if not GetConsoleScreenBufferInfo(OutHandle, info):
-                    raise WinError(GetLastError())
-                win_y = int(info.dwCursorPosition.Y - info.srWindow.Top)
-                expected = y - self.__offset
-                if win_y == expected + 1:
-                    # Terminal wrapped to next row.
-                    self.posxy = 0, y + 1
-                else:
-                    # Terminal did not wrap; cursor stays at end-of-line.
-                    self.posxy = self.width, y
-            else:
-                # If we wrapped we want to start at the next line
-                self._move_relative(0, y + 1)
+            info = CONSOLE_SCREEN_BUFFER_INFO()
+            if not GetConsoleScreenBufferInfo(OutHandle, info):
+                raise WinError(get_last_error())
+            win_y = int(info.dwCursorPosition.Y - info.srWindow.Top)
+            expected = y - self.__offset
+            if win_y == expected + 1:
+                # Terminal wrapped to next row.
                 self.posxy = 0, y + 1
+            else:
+                # Terminal did not wrap; cursor stays at end-of-line.
+                self.posxy = self.width, y
         else:
             self.posxy = wlen(newline), y
 

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -2205,28 +2205,3 @@ class TestHasWrappedToNextRow(TestCase):
         with patch.object(wc, "GetConsoleScreenBufferInfo", side_effect=fake_gcsbi), \
              patch.object(wc, "OutHandle", 1):
             self.assertIs(con._has_wrapped_to_next_row(y), False)
-
-    def test_returns_none_on_invalid_handle(self):
-        con, wc = self._make_console_like(offset=0)
-        y = 3
-
-        def fake_gcsbi(_h, info):
-            return False
-
-        with patch.object(wc, "GetConsoleScreenBufferInfo", side_effect=fake_gcsbi), \
-             patch.object(wc, "OutHandle", 1), \
-             patch.object(wc, "get_last_error", return_value=6):  # ERROR_INVALID_HANDLE
-            self.assertIs(con._has_wrapped_to_next_row(y), None)
-
-    def test_raises_on_unexpected_error(self):
-        con, wc = self._make_console_like(offset=0)
-        y = 3
-
-        def fake_gcsbi(_h, info):
-            return False
-
-        with patch.object(wc, "GetConsoleScreenBufferInfo", side_effect=fake_gcsbi), \
-             patch.object(wc, "OutHandle", 1), \
-             patch.object(wc, "get_last_error", return_value=5):  # ERROR_ACCESS_DENIED
-            with self.assertRaises(OSError):
-                con._has_wrapped_to_next_row(y)

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -2111,7 +2111,7 @@ class TestPyReplCtrlD(TestCase):
 class TestWindowsConsoleVtEolWrap(TestCase):
     """
     When a line exactly fills the terminal width, VT terminals differ on whether
-    the cursor immediately wraps to the next row. In VT mode we must synchronize 
+    the cursor immediately wraps to the next row. In VT mode we must synchronize
     our logical cursor position with the real console cursor.
     """
     def _make_console_like(self, *, width: int, offset: int, vt: bool):

--- a/Lib/test/test_pyrepl/test_windows_console.py
+++ b/Lib/test/test_pyrepl/test_windows_console.py
@@ -41,6 +41,7 @@ class WindowsConsoleTests(TestCase):
         console._hide_cursor = MagicMock()
         console._show_cursor = MagicMock()
         console._getscrollbacksize = MagicMock(42)
+        console._has_wrapped_to_next_row = MagicMock(return_value=False)
         console.out = MagicMock()
 
         height = kwargs.get("height", 25)

--- a/Misc/NEWS.d/next/Library/2026-01-28-06-50-37.gh-issue-144259.Xslknn.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-28-06-50-37.gh-issue-144259.Xslknn.rst
@@ -1,1 +1,1 @@
-Fix Windows VT REPL cursor desynchronization when a line exactly fills the terminal width.
+Fix Windows REPL cursor desynchronization when a line exactly fills the terminal width.

--- a/Misc/NEWS.d/next/Library/2026-01-28-06-50-37.gh-issue-144259.Xslknn.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-28-06-50-37.gh-issue-144259.Xslknn.rst
@@ -1,0 +1,1 @@
+Fix Windows VT REPL cursor desynchronization when a line exactly fills the terminal width.


### PR DESCRIPTION
Long log:

Windows VT terminals do not consistently wrap the cursor when a line
exactly fills the terminal width.
Previously we assumed a wrap always happened, which could desynchronize
the logical cursor from the real console cursor and break subsequent
cursor movement.
This change queries the real cursor position and updates posxy
accordingly, and adds regression tests for both wrap and no-wrap cases.


**Video with the patch**


https://github.com/user-attachments/assets/df74319a-92c2-4e0e-89d9-ce4bee374230





Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>

<!-- gh-issue-number: gh-144259 -->
* Issue: gh-144259
<!-- /gh-issue-number -->
