### PR TITLE
gh-144307: fix refcount leak in `finalize_remove_modules()`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-01-29-02-18-08.gh-issue-144307.CLbm_o.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-01-29-02-18-08.gh-issue-144307.CLbm_o.rst
@@ -1,0 +1,1 @@
+Prevent a reference leak in module teardown at interpreter finalization.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1622,6 +1622,7 @@ finalize_remove_modules(PyObject *modules, int verbose)
                 PyObject *value = PyObject_GetItem(modules, key);
                 if (value == NULL) {
                     PyErr_FormatUnraisable("Exception ignored while removing modules");
+                    Py_DECREF(key);
                     continue;
                 }
                 CLEAR_MODULE(key, value);


### PR DESCRIPTION
`PyIter_Next()` returns a new reference, but `finalize_remove_modules()` failed to DECREF `key` when `PyObject_GetItem()` returns NULL. Fix by DECREF'ing `key` before continuing.


<!-- gh-issue-number: gh-144307 -->
* Issue: gh-144307
<!-- /gh-issue-number -->
