### PR TITLE
gh-144309: Build Python with POSIX 2024

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-01-28-19-04-12.gh-issue-144309.3sMFOh.rst
+++ b/Misc/NEWS.d/next/Build/2026-01-28-19-04-12.gh-issue-144309.3sMFOh.rst
@@ -1,0 +1,1 @@
+Build Python with POSIX 2024, instead of POSIX 2008. Patch by Victor Stinner.

--- a/configure
+++ b/configure
@@ -4753,9 +4753,9 @@ esac
 
 if test $define_xopen_source = yes
 then
-  # X/Open 7, incorporating POSIX.1-2008
+  # X/Open 8, incorporating POSIX.1-2024
 
-printf "%s\n" "#define _XOPEN_SOURCE 700" >>confdefs.h
+printf "%s\n" "#define _XOPEN_SOURCE 800" >>confdefs.h
 
 
   # On Tru64 Unix 4.0F, defining _XOPEN_SOURCE also requires
@@ -4767,7 +4767,7 @@ printf "%s\n" "#define _XOPEN_SOURCE_EXTENDED 1" >>confdefs.h
 
 
 
-printf "%s\n" "#define _POSIX_C_SOURCE 200809L" >>confdefs.h
+printf "%s\n" "#define _POSIX_C_SOURCE 202405L" >>confdefs.h
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -916,8 +916,8 @@ esac
 
 if test $define_xopen_source = yes
 then
-  # X/Open 7, incorporating POSIX.1-2008
-  AC_DEFINE([_XOPEN_SOURCE], [700],
+  # X/Open 8, incorporating POSIX.1-2024
+  AC_DEFINE([_XOPEN_SOURCE], [800],
             [Define to the level of X/Open that your system supports])
 
   # On Tru64 Unix 4.0F, defining _XOPEN_SOURCE also requires
@@ -927,8 +927,8 @@ then
   AC_DEFINE([_XOPEN_SOURCE_EXTENDED], [1],
             [Define to activate Unix95-and-earlier features])
 
-  AC_DEFINE([_POSIX_C_SOURCE], [200809L],
-            [Define to activate features from IEEE Stds 1003.1-2008])
+  AC_DEFINE([_POSIX_C_SOURCE], [202405L],
+            [Define to activate features from IEEE Std 1003.1-2024])
 fi
 
 # On HP-UX mbstate_t requires _INCLUDE__STDC_A1_SOURCE

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -2039,7 +2039,7 @@
 /* Define on NetBSD to activate all library features */
 #undef _NETBSD_SOURCE
 
-/* Define to activate features from IEEE Stds 1003.1-2008 */
+/* Define to activate features from IEEE Std 1003.1-2024 */
 #undef _POSIX_C_SOURCE
 
 /* Define if you have POSIX threads, and your system does not define that. */


### PR DESCRIPTION
On FreeBSD, the ppoll() function is only visible if the POSIX version is 2024 or newer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144309 -->
* Issue: gh-144309
<!-- /gh-issue-number -->
