### PR TITLE
gh-139801: fix BaseProxy pickling with custom authkey

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -909,9 +909,7 @@ class BaseProxy(object):
             util.info('incref failed: %s' % e)
 
     def __reduce__(self):
-        kwds = {}
-        if get_spawning_popen() is not None:
-            kwds['authkey'] = self._authkey
+        kwds = {"authkey": self._authkey}
 
         if getattr(self, '_isauto', False):
             kwds['exposed'] = self._exposed_


### PR DESCRIPTION
Always save `authkey` in `BaseProxy.__reduce__()` so proxy created with a custom authkey could be picklable.

Fixes gh-139801.