### PR TITLE
gh-144295: Fix data race in dict method lookup and global load

### DIFF
--- a/Lib/test/test_free_threading/test_dict.py
+++ b/Lib/test/test_free_threading/test_dict.py
@@ -245,5 +245,27 @@ class TestDict(TestCase):
         with threading_helper.start_threads([t1, t2]):
             pass
 
+    def test_racing_dict_update_and_method_lookup(self):
+        # gh-144295: test race between dict modifications and method lookups.
+        # Uses BytesIO because the race requires a type without Py_TPFLAGS_INLINE_VALUES
+        # for the _PyDict_GetMethodStackRef code path.
+        import io
+        obj = io.BytesIO()
+
+        def writer():
+            for _ in range(10000):
+                obj.x = 1
+                del obj.x
+
+        def reader():
+            for _ in range(10000):
+                obj.getvalue()
+
+        t1 = Thread(target=writer)
+        t2 = Thread(target=reader)
+
+        with threading_helper.start_threads([t1, t2]):
+            pass
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In `_PyDict_GetMethodStackRef`, only use the fast-path unicode lookup when the dict is owned by the current thread or already marked as shared. This prevents a race between the lookup and concurrent dict resizes, which may free the PyDictKeysObject (i.e., it ensures that the resize uses QSBR).

Address a similar issue in `_Py_dict_lookup_threadsafe_stackref` by calling `ensure_shared_on_read()`.


<!-- gh-issue-number: gh-144295 -->
* Issue: gh-144295
<!-- /gh-issue-number -->
