### PR TITLE
gh-144270: Fix xml.etree.ElementTree.SubElement signature inconsistency

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -4764,6 +4764,11 @@ class TestModule(unittest.TestCase):
         ) as cm:
                 getattr(ET, "VERSION")
         self.assertEqual(cm.filename, __file__)
+    
+    def test_subelement_parent_positional_only(self):
+        root = ET.Element("root")
+        with self.assertRaises(TypeError):
+            ET.SubElement(root, "child", parent="0")
 
 
 # --------------------------------------------------------------------

--- a/Misc/NEWS.d/next/Library/2026-01-28-20-06-13.gh-issue-144270.Whq3TD.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-28-20-06-13.gh-issue-144270.Whq3TD.rst
@@ -1,0 +1,1 @@
+Fix xml.etree.ElementTree.SubElement to reject ``parent`` passed as a keyword argument, making the Python signature consistent with the C implementation.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -611,6 +611,13 @@ subelement(PyObject *self, PyObject *args, PyObject *kwds)
     ElementObject* parent;
     PyObject* tag;
     PyObject* attrib = NULL;
+    if (kwds && PyDict_Contains(kwds, PyUnicode_FromString("parent"))) {
+        PyErr_SetString(
+            PyExc_TypeError,
+            "SubElement() got some positional-only arguments passed as keyword arguments"
+        );
+         return NULL;
+    }
     if (!PyArg_ParseTuple(args, "O!O|O!:SubElement",
                           st->Element_Type, &parent, &tag,
                           &PyDict_Type, &attrib)) {


### PR DESCRIPTION
The Python and C implementations of `xml.etree.ElementTree.SubElement` exposed different call signatures the Python version allowed parent as a keyword argument, while the C version did not. This change makes the Python signature consistent with the C implementation. Passing parent as a keyword argument now raises TypeError. A regression test is added.

<!-- gh-issue-number: gh-144270 -->
* Issue: gh-144270
<!-- /gh-issue-number -->
