### PR TITLE
gh-144001: Simplify Base64 decoding with altchars and ignorechars specified

### DIFF
--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -91,7 +91,8 @@ POST request.
    ``False`` otherwise.
 
    If *validate* is false, characters that are neither
-   in the normal base-64 alphabet nor the alternative alphabet are
+   in the normal base-64 alphabet nor (if *ignorechars* is not specified)
+   the alternative alphabet are
    discarded prior to the padding check, but the ``+`` and ``/`` characters
    keep their meaning if they are not in *altchars* (they will be discarded
    in future Python versions).
@@ -101,13 +102,12 @@ POST request.
 
    For more information about the strict base64 check, see :func:`binascii.a2b_base64`
 
+   .. versionchanged:: next
+      Added the *ignorechars* parameter.
+
    .. deprecated:: next
       Accepting the ``+`` and ``/`` characters with an alternative alphabet
       is now deprecated.
-
-
-   .. versionchanged:: next
-      Added the *ignorechars* parameter.
 
 
 .. function:: standard_b64encode(s)


### PR DESCRIPTION
Treat "+" and "/" like other characters not in the alternative Base64 alphabet when both altchars and ignorechars are specified. E.g. discard them if they are not in altchars but are in ignorechars, and set error if they are not in altchars and not in ignorechars. Only emit warnings if ignorechars is not specified.


<!-- gh-issue-number: gh-144001 -->
* Issue: gh-144001
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144324.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->