### PR TITLE
[3.13] gh-144307: Fix a reference leak during module teardown (GH-144308)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2026-01-29-02-18-08.gh-issue-144307.CLbm_o.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2026-01-29-02-18-08.gh-issue-144307.CLbm_o.rst
@@ -1,0 +1,1 @@
+Prevent a reference leak in module teardown at interpreter finalization.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1609,6 +1609,7 @@ finalize_remove_modules(PyObject *modules, int verbose)
                 PyObject *value = PyObject_GetItem(modules, key);
                 if (value == NULL) {
                     PyErr_FormatUnraisable("Exception ignored on removing modules");
+                    Py_DECREF(key);
                     continue;
                 }
                 CLEAR_MODULE(key, value);


### PR DESCRIPTION
(cherry picked from commit 219b7ac9d562701bbde21d7e17845c4942b83338)

<!-- gh-issue-number: gh-144307 -->
* Issue: gh-144307
<!-- /gh-issue-number -->
