### PR TITLE
gh-140824: Fix _Py_DumpExtensionModules() to ignore sub-modules

### DIFF
--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -388,12 +388,11 @@ class FaultHandlerTests(unittest.TestCase):
 
     @skip_segfault_on_android
     def test_dump_ext_modules(self):
-        # Disable sys.stdlib_module_names
+        # Don't filter stdlib module names: disable sys.stdlib_module_names
         code = """
             import faulthandler
             import sys
             import math
-            # Don't filter stdlib module names
             sys.stdlib_module_names = frozenset()
             faulthandler.enable()
             faulthandler._sigsegv()
@@ -418,8 +417,7 @@ class FaultHandlerTests(unittest.TestCase):
             """
         stderr, exitcode = self.get_output(code)
         stderr = '\n'.join(stderr)
-        match = re.search(r'^Extension modules:', stderr, re.MULTILINE)
-        self.assertIsNone(match)
+        self.assertNotIn('Extension modules:', stderr)
 
     def test_is_enabled(self):
         orig_stderr = sys.stderr

--- a/Misc/NEWS.d/next/Library/2026-01-30-13-23-06.gh-issue-140824.J1OCrC.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-30-13-23-06.gh-issue-140824.J1OCrC.rst
@@ -1,0 +1,3 @@
+When :mod:`faulthandler` dumps the list of third-party extension modules,
+ignore ``math.integer`` sub-module since ``math`` package is part of
+:data:`sys.stdlib_module_names`. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Library/2026-01-30-13-23-06.gh-issue-140824.J1OCrC.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-30-13-23-06.gh-issue-140824.J1OCrC.rst
@@ -1,3 +1,2 @@
 When :mod:`faulthandler` dumps the list of third-party extension modules,
-ignore ``math.integer`` sub-module since ``math`` package is part of
-:data:`sys.stdlib_module_names`. Patch by Victor Stinner.
+ignore sub-modules of stdlib packages. Patch by Victor Stinner.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3393,11 +3393,24 @@ _Py_DumpExtensionModules(int fd, PyInterpreterState *interp)
             Py_hash_t hash;
             // if stdlib_module_names is not NULL, it is always a frozenset.
             while (_PySet_NextEntry(stdlib_module_names, &i, &item, &hash)) {
-                if (PyUnicode_Check(item)
-                    && PyUnicode_Compare(key, item) == 0)
-                {
-                    is_stdlib_ext = 1;
-                    break;
+                if (!PyUnicode_Check(item)) {
+                    continue;
+                }
+                Py_ssize_t len = PyUnicode_GET_LENGTH(item);
+                if (PyUnicode_Tailmatch(key, item, 0, len, -1) == 1) {
+                    Py_ssize_t key_len = PyUnicode_GET_LENGTH(key);
+                    if (key_len == len) {
+                        is_stdlib_ext = 1;
+                        break;
+                    }
+                    assert(key_len > len);
+
+                    // Ignore "math.integer" if key starts with "math."
+                    Py_UCS4 ch = PyUnicode_ReadChar(key, len);
+                    if (ch == '.') {
+                        is_stdlib_ext = 1;
+                        break;
+                    }
                 }
             }
             if (is_stdlib_ext) {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3405,7 +3405,8 @@ _Py_DumpExtensionModules(int fd, PyInterpreterState *interp)
                     }
                     assert(key_len > len);
 
-                    // Ignore "math.integer" if key starts with "math."
+                    // Ignore sub-modules of stdlib packages. For example,
+                    // ignore "math.integer" if key starts with "math.".
                     Py_UCS4 ch = PyUnicode_ReadChar(key, len);
                     if (ch == '.') {
                         is_stdlib_ext = 1;


### PR DESCRIPTION
Ignore "math.integer" extension if "math" is in
sys.stdlib_module_names.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140824 -->
* Issue: gh-140824
<!-- /gh-issue-number -->
