### PR TITLE
GH-142407: Doc: Clarify shutil.copyfile() does not use CopyFile2 on Windows

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -538,9 +538,17 @@ On Linux :func:`os.copy_file_range` or :func:`os.sendfile` is used.
 
 On Solaris :func:`os.sendfile` is used.
 
-On Windows :func:`shutil.copyfile` uses a bigger default buffer size (1 MiB
-instead of 64 KiB) and a :func:`memoryview`-based variant of
-:func:`shutil.copyfileobj` is used.
+On Windows, :func:`shutil.copy`, :func:`shutil.copy2`, :func:`shutil.copytree`,
+and :func:`shutil.move` use the native ``CopyFile2`` API (available on Windows 8
+and later) when possible. This performs the copy entirely in kernel space,
+supports copy-on-write, and avoids copying data through userspace buffers,
+resulting in significantly better performance—especially for large files or
+files on network shares.
+
+In contrast, :func:`shutil.copyfile` does **not** use ``CopyFile2``; it still
+performs a userspace read/write loop (albeit with a larger 1 MiB buffer since
+Python 3.8). Therefore, for best performance on Windows, prefer :func:`copy2`
+over :func:`copyfile` when preserving metadata (like timestamps) is acceptable.
 
 If the fast-copy operation fails and no data was written in the destination
 file then shutil will silently fallback on using less efficient


### PR DESCRIPTION
The current documentation for `shutil` implies that all copy functions benefit from fast kernel-space copying on Windows via the `CopyFile2` API. However, `shutil.copyfile()` is an exception — it still uses a userspace read/write loop.

This PR clarifies that:
- `shutil.copy()`, `copy2()`, `copytree()`, and `move()` use `CopyFile2` (when available)
- `shutil.copyfile()` does **not**, and remains a buffered userspace copy
- Provides practical guidance: prefer `copy2()` over `copyfile()` for better performance on Windows when metadata preservation is acceptable

The change has been verified by:
- Building the docs locally with `make html` (0 warnings)
- Confirming the rendered HTML displays the updated text correctly

Related to GH-142407.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144354.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->