### PR TITLE
gh-106318: Add doctest role for str.splitlines() examples

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2704,7 +2704,9 @@ expression support in the :mod:`re` module).
 
       ``\v`` and ``\f`` added to list of line boundaries.
 
-   For example::
+   For example:
+
+   .. doctest::
 
       >>> 'ab c\n\nde fg\rkl\r\n'.splitlines()
       ['ab c', '', 'de fg', 'kl']
@@ -2713,14 +2715,18 @@ expression support in the :mod:`re` module).
 
    Unlike :meth:`~str.split` when a delimiter string *sep* is given, this
    method returns an empty list for the empty string, and a terminal line
-   break does not result in an extra line::
+   break does not result in an extra line:
+
+   .. doctest::
 
       >>> "".splitlines()
       []
       >>> "One line\n".splitlines()
       ['One line']
 
-   For comparison, ``split('\n')`` gives::
+   For comparison, ``split('\n')`` gives:
+
+   .. doctest::
 
       >>> ''.split('\n')
       ['']


### PR DESCRIPTION
WIP to https://github.com/python/cpython/issues/106318

https://github.com/python/cpython/issues/106318: Add doctest role for str.splitlines() examples

<!-- gh-issue-number: gh-106318 -->
* Issue: gh-106318
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144368.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->