### PR TITLE
gh-106318: Add examples for `str.startswith()` method

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2735,6 +2735,21 @@ expression support in the :mod:`re` module).
    test string beginning at that position.  With optional *end*, stop comparing
    string at that position.
 
+   For example:
+
+   .. doctest::
+
+      >>> 'Python'.startswith('Py')
+      True
+      >>> 'a tuple of prefixes'.startswith(('at', 'in'))
+      False
+      >>> 'a tuple of prefixes'.startswith(('at', 'a'))
+      True
+      >>> 'Python is amazing'.startswith('is', 7)
+      True
+
+   See also :meth:`endswith` and :meth:`removeprefix`.
+
 
 .. method:: str.strip(chars=None, /)
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2741,8 +2741,6 @@ expression support in the :mod:`re` module).
 
       >>> 'Python'.startswith('Py')
       True
-      >>> 'a tuple of prefixes'.startswith(('at', 'in'))
-      False
       >>> 'a tuple of prefixes'.startswith(('at', 'a'))
       True
       >>> 'Python is amazing'.startswith('is', 7)


### PR DESCRIPTION
WIP to https://github.com/python/cpython/issues/106318

https://github.com/python/cpython/issues/106318: Add examples for str.startwith() method

<!-- gh-issue-number: gh-106318 -->
* Issue: gh-106318
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144369.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->