### PR TITLE
Fix argument redefinition in function

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -316,11 +316,14 @@ def get_docstring(node, clean=True):
     """
     if not isinstance(node, (AsyncFunctionDef, FunctionDef, ClassDef, Module)):
         raise TypeError("%r can't have docstrings" % node.__class__.__name__)
-    if not(node.body and isinstance(node.body[0], Expr)):
+    if not (node.body and isinstance(node.body[0], Expr)):
         return None
-    node = node.body[0].value
-    if isinstance(node, Constant) and isinstance(node.value, str):
-        text = node.value
+    checking_node = node.body[0].value
+    if (
+        isinstance(checking_node, Constant)
+        and isinstance(checking_node.value, str)
+    ):
+        text = checking_node.value
     else:
         return None
     if clean:


### PR DESCRIPTION
Fix "node" argument redefinition in get_docstring function, add space in if statement