### PR TITLE
Fix unused variable 'COLORS' warning in optimizer.c

### DIFF
--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1993,6 +1993,8 @@ find_line_number(PyCodeObject *code, _PyExecutorObject *executor)
 #define BLACK "#000000"
 #define LOOP "#00c000"
 
+#ifdef Py_STATS
+
 static const char *COLORS[10] = {
     "9",
     "8",
@@ -2005,8 +2007,6 @@ static const char *COLORS[10] = {
     "1",
     WHITE,
 };
-
-#ifdef Py_STATS
 const char *
 get_background_color(_PyUOpInstruction const *inst, uint64_t max_hotness)
 {


### PR DESCRIPTION
Move the `COLORS` array to the `#ifdef Py_STATS` block, as it's only used by the `get_background_color()` function which is also used in `Py_STATS block` block.

This Will fix the "unused variable 'COLORS'" warning when building without stats enabled.