### PR TITLE
Clearer description of elements regarding mapping order

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -68,7 +68,7 @@ The class can be used to simulate nested scopes and is useful in templating.
     .. attribute:: maps
 
         A user updateable list of mappings.  The list is ordered from
-        first-searched to last-searched.  It is the only stored state and can
+        first-searched-mapping to last-searched-mapping.  It is the only stored state and can
         be modified to change which mappings are searched.  The list should
         always contain at least one mapping.
 


### PR DESCRIPTION
The original wording of 'The list is ordered from first-searched to last-searched' contains a slight ambiguity hence adds cognitive load for a reader, e.g., 'first-searched [...What?]'.

This fixes "dangling modifier" (adjective without a noun) and decreases the cognitive load with the cost of adding one word with hyphen. It also designates the elements to 'mapping' which is consistent with the preceding sentence: "A user updateable list of mappings. " , which should benefit readers as well.

(No issue number for this pull request as this is a trivial, yet helpful hopefully, change)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144374.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->