### PR TITLE
gh-144377: Clean up sqlite3 Connection's list of weakrefs to Cursor objects

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -144,7 +144,6 @@ class _sqlite3.Connection "pysqlite_Connection *" "clinic_state()->ConnectionTyp
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=67369db2faf80891]*/
 
-static int _pysqlite_drop_unused_cursor_references(pysqlite_Connection* self);
 static void incref_callback_context(callback_context *ctx);
 static void decref_callback_context(callback_context *ctx);
 static void set_callback_context(callback_context **ctx_pp,
@@ -285,17 +284,10 @@ pysqlite_connection_init_impl(pysqlite_Connection *self, PyObject *database,
         goto error;
     }
 
-    /* Create lists of weak references to cursors and blobs */
-    PyObject *cursors = PyList_New(0);
-    if (cursors == NULL) {
-        Py_DECREF(statement_cache);
-        goto error;
-    }
-
+    /* Create lists of weak references to blobs */
     PyObject *blobs = PyList_New(0);
     if (blobs == NULL) {
         Py_DECREF(statement_cache);
-        Py_DECREF(cursors);
         goto error;
     }
 
@@ -308,9 +300,7 @@ pysqlite_connection_init_impl(pysqlite_Connection *self, PyObject *database,
     self->check_same_thread = check_same_thread;
     self->thread_ident = PyThread_get_thread_ident();
     self->statement_cache = statement_cache;
-    self->cursors = cursors;
     self->blobs = blobs;
-    self->created_cursors = 0;
     self->row_factory = Py_NewRef(Py_None);
     self->text_factory = Py_NewRef(&PyUnicode_Type);
     self->trace_ctx = NULL;
@@ -392,7 +382,6 @@ connection_traverse(PyObject *op, visitproc visit, void *arg)
     pysqlite_Connection *self = _pysqlite_Connection_CAST(op);
     Py_VISIT(Py_TYPE(self));
     Py_VISIT(self->statement_cache);
-    Py_VISIT(self->cursors);
     Py_VISIT(self->blobs);
     Py_VISIT(self->row_factory);
     Py_VISIT(self->text_factory);
@@ -417,7 +406,6 @@ connection_clear(PyObject *op)
 {
     pysqlite_Connection *self = _pysqlite_Connection_CAST(op);
     Py_CLEAR(self->statement_cache);
-    Py_CLEAR(self->cursors);
     Py_CLEAR(self->blobs);
     Py_CLEAR(self->row_factory);
     Py_CLEAR(self->text_factory);
@@ -558,11 +546,6 @@ pysqlite_connection_cursor_impl(pysqlite_Connection *self, PyObject *factory)
         PyErr_Format(PyExc_TypeError,
                      "factory must return a cursor, not %.100s",
                      Py_TYPE(cursor)->tp_name);
-        Py_DECREF(cursor);
-        return NULL;
-    }
-
-    if (_pysqlite_drop_unused_cursor_references(self) < 0) {
         Py_DECREF(cursor);
         return NULL;
     }
@@ -1065,38 +1048,6 @@ final_callback(sqlite3_context *context)
 
 error:
     PyGILState_Release(threadstate);
-}
-
-static int
-_pysqlite_drop_unused_cursor_references(pysqlite_Connection* self)
-{
-    /* we only need to do this once in a while */
-    if (self->created_cursors++ < 200) {
-        return 0;
-    }
-
-    self->created_cursors = 0;
-
-    PyObject* new_list = PyList_New(0);
-    if (!new_list) {
-        return -1;
-    }
-
-    assert(PyList_CheckExact(self->cursors));
-    Py_ssize_t imax = PyList_GET_SIZE(self->cursors);
-    for (Py_ssize_t i = 0; i < imax; i++) {
-        PyObject* weakref = PyList_GET_ITEM(self->cursors, i);
-        if (_PyWeakref_IsDead(weakref)) {
-            continue;
-        }
-        if (PyList_Append(new_list, weakref) != 0) {
-            Py_DECREF(new_list);
-            return -1;
-        }
-    }
-
-    Py_SETREF(self->cursors, new_list);
-    return 0;
 }
 
 /* Allocate a UDF/callback context structure. In order to ensure that the state

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -38,7 +38,6 @@
 #include "pycore_pyerrors.h"      // _PyErr_ChainExceptions1()
 #include "pycore_pylifecycle.h"   // _Py_IsInterpreterFinalizing()
 #include "pycore_unicodeobject.h" // _PyUnicode_AsUTF8NoNUL
-#include "pycore_weakref.h"
 
 #include <stdbool.h>
 

--- a/Modules/_sqlite/connection.h
+++ b/Modules/_sqlite/connection.h
@@ -70,13 +70,8 @@ typedef struct
 
     PyObject *statement_cache;
 
-    /* Lists of weak references to cursors and blobs used within this connection */
-    PyObject *cursors;
+    /* Lists of weak references to blobs used within this connection */
     PyObject *blobs;
-
-    /* Counters for how many cursors were created in the connection. May be
-     * reset to 0 at certain intervals */
-    int created_cursors;
 
     PyObject* row_factory;
 

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -99,28 +99,6 @@ class _sqlite3.Cursor "pysqlite_Cursor *" "clinic_state()->CursorType"
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=3c5b8115c5cf30f1]*/
 
-/*
- * Registers a cursor with the connection.
- *
- * 0 => error; 1 => ok
- */
-static int
-register_cursor(pysqlite_Connection *connection, PyObject *cursor)
-{
-    PyObject *weakref = PyWeakref_NewRef((PyObject *)cursor, NULL);
-    if (weakref == NULL) {
-        return 0;
-    }
-
-    if (PyList_Append(connection->cursors, weakref) < 0) {
-        Py_CLEAR(weakref);
-        return 0;
-    }
-
-    Py_DECREF(weakref);
-    return 1;
-}
-
 /*[clinic input]
 _sqlite3.Cursor.__init__ as pysqlite_cursor_init
 
@@ -157,10 +135,6 @@ pysqlite_cursor_init_impl(pysqlite_Cursor *self,
     Py_XSETREF(self->row_factory, Py_None);
 
     if (!pysqlite_check_thread(self->connection)) {
-        return -1;
-    }
-
-    if (!register_cursor(connection, (PyObject *)self)) {
         return -1;
     }
 


### PR DESCRIPTION
This cleans up the code for an unused (as far as I can see) list of Cursor weakrefs.

Closes #144377 

<!-- gh-issue-number: gh-144377 -->
* Issue: gh-144377
<!-- /gh-issue-number -->
