### PR TITLE
gh-144380: Fix incorrect type check in `buffered_iternext()`

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-02-01-15-25-00.gh-issue-144380.U7py_s.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-01-15-25-00.gh-issue-144380.U7py_s.rst
@@ -1,0 +1,1 @@
+Improve performance of :class:`io.BufferedReader` line iteration by ~49%.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1505,8 +1505,8 @@ buffered_iternext(PyObject *op)
 
     _PyIO_State *state = find_io_state_by_def(Py_TYPE(self));
     tp = Py_TYPE(self);
-    if (Py_IS_TYPE(tp, state->PyBufferedReader_Type) ||
-        Py_IS_TYPE(tp, state->PyBufferedRandom_Type))
+    if (tp == state->PyBufferedReader_Type ||
+        tp == state->PyBufferedRandom_Type)
     {
         /* Skip method call overhead for speed */
         line = _buffered_readline(self, -1);


### PR DESCRIPTION
Fix incorrect type check in `buffered_iternext()` that prevented the fast path from ever being taken, slowing down iteration over buffered binary files.

Since `tp` is already a type object, `Py_IS_TYPE(tp, X)` expands to `Py_TYPE(tp) == X`, which compares the `type` itself against `BufferedReader`. This is always false, so the fast path was never taken.

pyperf benchmark:
```
+----------------+---------+-----------------------+
| Benchmark      | buggy   | fixed                 |
+================+=========+=======================+
| iteration      | 3.05 ms | 2.04 ms: 1.49x faster |
+----------------+---------+-----------------------+
```

Closes: #144380

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144380 -->
* Issue: gh-144380
<!-- /gh-issue-number -->
