### PR TITLE
implementation of the `minmax` function

### DIFF
--- a/Doc/howto/sorting.rst
+++ b/Doc/howto/sorting.rst
@@ -401,9 +401,9 @@ library provides several tools that do less work than a full sort:
   require almost no auxiliary memory.
 
 * :func:`minmax` returns both the smallest and largest values,
-respectively. This functions make a single pass over the input data and
-require almost no auxiliary memory. This function is useful if both `min` and
-`max` need to be called and thus is more efficient for larger datasets.
+  respectively. This functions make a single pass over the input data and
+  require almost no auxiliary memory. This function is useful if both :meth:`min` and
+  :meth:`max` need to be called and thus is more efficient for larger datasets.
 
 * :func:`heapq.nsmallest` and :func:`heapq.nlargest` return
   the *n* smallest and largest values, respectively.  These functions

--- a/Doc/howto/sorting.rst
+++ b/Doc/howto/sorting.rst
@@ -400,6 +400,11 @@ library provides several tools that do less work than a full sort:
   respectively.  These functions make a single pass over the input data and
   require almost no auxiliary memory.
 
+* :func:`minmax` returns both the smallest and largest values,
+respectively. This functions make a single pass over the input data and
+require almost no auxiliary memory. This function is useful if both `min` and
+`max` need to be called and thus is more efficient for larger datasets.
+
 * :func:`heapq.nsmallest` and :func:`heapq.nlargest` return
   the *n* smallest and largest values, respectively.  These functions
   make a single pass over the data keeping only *n* elements in memory

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1295,6 +1295,28 @@ are always available.  They are listed here in alphabetical order.
    .. versionchanged:: 3.8
       The *key* can be ``None``.
 
+.. function:: minmax(iterable, /, *, key=None)
+              minmax(iterable, /, *, default, key=None)
+              minmax(arg1, arg2, /, *args, key=None)
+
+   Return the smallest and largest items respectively in an iterable or the smallest and largest
+   of two or more arguments.
+
+   If one positional argument is provided, it should be an :term:`iterable`.
+   The smallest and largest items in the iterable are returned.  If two or more positional
+   arguments are provided, the smallest and largest of the positional arguments are
+   returned.
+
+   There are two optional keyword-only arguments. The *key* argument specifies
+   a one-argument ordering function like that used for :meth:`list.sort`. The
+   *default* argument specifies an object to return if the provided iterable is
+   empty. If the iterable is empty and *default* is not provided, a
+   :exc:`ValueError` is raised.
+
+   If multiple items are minimal / maximal, the function returns the first one
+   encountered.  This is consistent with other sort-stability preserving tools
+   such as ``(sorted(iterable, key=keyfunc)[0], sorted(iterable, key=keyfunc)[-1])``
+   and ``(heapq.nsmallest(1,iterable, key=keyfunc), heapq.nlargest(1,iterable, key=keyfunc))``.
 
 .. function:: next(iterator, /)
               next(iterator, default, /)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1630,6 +1630,72 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         self.assertEqual(min(data, key=f),
                          sorted(data, key=f)[0])
 
+
+    def test_minmax(self):
+        self.assertEqual(minmax('123123'), ('1', '3'))
+        self.assertEqual(minmax(1, 2, 3), (1, 3))
+        self.assertEqual(minmax((1, 2, 3, 1, 2, 3)), (1, 3))
+        self.assertEqual(minmax([1, 2, 3, 1, 2, 3]), (1, 3))
+
+        self.assertEqual(minmax(1, 2, 3.0), (1, 3.0))
+        self.assertEqual(minmax(1, 2.0, 3), (1, 3))
+        self.assertEqual(minmax(1.0, 2, 3), (1.0, 3))
+
+        with self.assertRaisesRegex(
+                TypeError,
+                'minmax expected at least 1 argument, got 0'
+        ):
+            minmax()
+
+        self.assertRaises(TypeError, minmax, 42)
+        with self.assertRaisesRegex(
+                ValueError,
+                r'minmax\(\) iterable argument is empty'
+        ):
+            minmax(())
+        class BadSeq:
+            def __getitem__(self, index):
+                raise ValueError
+        self.assertRaises(ValueError, minmax, BadSeq())
+
+        for stmt in (
+                "minmax(key=int)",                 # no args
+                "minmax(default=None)",
+                "minmax(1, 2, default=None)",      # require container for default
+                "minmax(default=None, key=int)",
+                "minmax(1, key=int)",              # single arg not iterable
+                "minmax(1, 2, keystone=int)",      # wrong keyword
+                "minmax(1, 2, key=int, abc=int)",  # two many keywords
+                "minmax(1, 2, key=1)",             # keyfunc is not callable
+        ):
+            try:
+                exec(stmt, globals())
+            except TypeError:
+                pass
+            else:
+                self.fail(stmt)
+
+        self.assertEqual(minmax((1,), key=neg), (1, 1))     # one elem iterable
+        self.assertEqual(minmax((1,2), key=neg),(2, 1))    # two elem iterable
+        self.assertEqual(minmax(1, 2, key=neg), (2, 1))     # two elems
+
+        self.assertEqual(minmax((), default=None), (None, None))    # zero elem iterable
+        self.assertEqual(minmax((1,), default=None), (1, 1))     # one elem iterable
+        self.assertEqual(minmax((1,2), default=None), (1, 2))    # two elem iterable
+
+        self.assertEqual(minmax((), default=1, key=neg), (1, 1))
+        self.assertEqual(minmax((1, 2), default=1, key=neg), (2, 1))
+
+        self.assertEqual(minmax((1, 2), key=None), (1, 2))
+
+        data = [random.randrange(200) for i in range(100)]
+        keys = dict((elem, random.randrange(50)) for elem in data)
+        f = keys.__getitem__
+
+        sorted_vals = sorted(data, key=f)
+        self.assertEqual(minmax(data, key=f),
+                         (sorted_vals[0], sorted_vals[-1]))
+
     def test_next(self):
         it = iter(range(2))
         self.assertEqual(next(it), 0)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-01-15-31-11.gh-issue-144382.EyosHQ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-01-15-31-11.gh-issue-144382.EyosHQ.rst
@@ -1,0 +1,4 @@
+This creates a new builtin function called `minmax`, which does work similar
+to the functions `min` and `max`; however, is more efficient than running
+`min` and then `max` and computes the smallest and largest elements of the
+iterable in a single pass; rather than 2 passes.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-01-15-31-11.gh-issue-144382.EyosHQ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-01-15-31-11.gh-issue-144382.EyosHQ.rst
@@ -1,4 +1,4 @@
-This creates a new builtin function called `minmax`, which does work similar
-to the functions `min` and `max`; however, is more efficient than running
-`min` and then `max` and computes the smallest and largest elements of the
+This creates a new builtin function called ``minmax``, which does work similar
+to the functions ``min`` and ``max``; however, is more efficient than running
+``min`` and then ``max`` and computes the smallest and largest elements of the
 iterable in a single pass; rather than 2 passes.


### PR DESCRIPTION
# The `minmax` function implementation

This pull request implements the `minmax` function, which is very similar to the `min` and `max` functions; however, makes it much more efficient to compute both the `min` and the `max` values in a single pass. This is extremely useful for a lot of applications, for example it can be used inside the `textwrap.dedent` (#131919 ) function inside Python, the `min` and `max` functions are also very often used inside statical methods to compute the range of values.

The advantage of this system is that instead of doing 2 passes inside the dataset / iterable, it can be once.

The function would be defined as:
```
(min_val, max_val) = minmax([1,2,34,45,6])
```

This probably needs a PEP (I am just familiar enough with the process so I am putting Pull request first)