### PR TITLE
gh-139109: Replace `_CHECK_STACK_SPACE` with `_CHECK_STACK_SPACE_OPERAND` in JIT optiimizer

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1264,6 +1264,7 @@ class TestUopsOptimization(unittest.TestCase):
             ("_CHECK_STACK_SPACE_OPERAND", largest_stack), uops_and_operands
         )
 
+    @unittest.skip("reopen when we combine multiple stack space checks into one")
     def test_combine_stack_space_checks_recursion(self):
         def dummy15(x):
             while x > 0:
@@ -1286,12 +1287,12 @@ class TestUopsOptimization(unittest.TestCase):
 
         uops_and_operands = [(opcode, operand) for opcode, _, _, operand in ex]
         uop_names = [uop[0] for uop in uops_and_operands]
-        self.assertEqual(uop_names.count("_PUSH_FRAME"), 12)
+        self.assertEqual(uop_names.count("_PUSH_FRAME"), 2)
         self.assertEqual(uop_names.count("_RETURN_VALUE"), 0)
-        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE"), 0)
-        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 12)
-        framesize = _testinternalcapi.get_co_framesize(dummy15.__code__)
-        self.assertIn(("_CHECK_STACK_SPACE_OPERAND", framesize), uops_and_operands)
+        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE"), 1)
+        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 1)
+        largest_stack = _testinternalcapi.get_co_framesize(dummy15.__code__)
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND", largest_stack), uops_and_operands)
 
     def test_many_nested(self):
         # overflow the trace_stack

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1022,7 +1022,6 @@ class TestUopsOptimization(unittest.TestCase):
         # Constant narrowing allows constant folding for second comparison
         self.assertLessEqual(count_ops(ex, "_COMPARE_OP_STR"), 1)
 
-    @unittest.skip("gh-139109 WIP")
     def test_combine_stack_space_checks_sequential(self):
         def dummy12(x):
             return x - 1
@@ -1046,12 +1045,14 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertEqual(uop_names.count("_PUSH_FRAME"), 2)
         self.assertEqual(uop_names.count("_RETURN_VALUE"), 2)
         self.assertEqual(uop_names.count("_CHECK_STACK_SPACE"), 0)
-        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 1)
-        # sequential calls: max(12, 13) == 13
-        largest_stack = _testinternalcapi.get_co_framesize(dummy13.__code__)
-        self.assertIn(("_CHECK_STACK_SPACE_OPERAND", largest_stack), uops_and_operands)
+        # Each call gets its own _CHECK_STACK_SPACE_OPERAND
+        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 2)
+        # Each _CHECK_STACK_SPACE_OPERAND has the framesize of its function
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND",
+                       _testinternalcapi.get_co_framesize(dummy12.__code__)), uops_and_operands)
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND",
+                       _testinternalcapi.get_co_framesize(dummy13.__code__)), uops_and_operands)
 
-    @unittest.skip("gh-139109 WIP")
     def test_combine_stack_space_checks_nested(self):
         def dummy12(x):
             return x + 3
@@ -1074,15 +1075,12 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertEqual(uop_names.count("_PUSH_FRAME"), 2)
         self.assertEqual(uop_names.count("_RETURN_VALUE"), 2)
         self.assertEqual(uop_names.count("_CHECK_STACK_SPACE"), 0)
-        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 1)
-        # nested calls: 15 + 12 == 27
-        largest_stack = (
-            _testinternalcapi.get_co_framesize(dummy15.__code__) +
-            _testinternalcapi.get_co_framesize(dummy12.__code__)
-        )
-        self.assertIn(("_CHECK_STACK_SPACE_OPERAND", largest_stack), uops_and_operands)
+        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 2)
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND",
+                       _testinternalcapi.get_co_framesize(dummy15.__code__)), uops_and_operands)
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND",
+                       _testinternalcapi.get_co_framesize(dummy12.__code__)), uops_and_operands)
 
-    @unittest.skip("gh-139109 WIP")
     def test_combine_stack_space_checks_several_calls(self):
         def dummy12(x):
             return x + 3
@@ -1110,15 +1108,14 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertEqual(uop_names.count("_PUSH_FRAME"), 4)
         self.assertEqual(uop_names.count("_RETURN_VALUE"), 4)
         self.assertEqual(uop_names.count("_CHECK_STACK_SPACE"), 0)
-        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 1)
-        # max(12, 18 + max(12, 13)) == 31
-        largest_stack = (
-            _testinternalcapi.get_co_framesize(dummy18.__code__) +
-            _testinternalcapi.get_co_framesize(dummy13.__code__)
-        )
-        self.assertIn(("_CHECK_STACK_SPACE_OPERAND", largest_stack), uops_and_operands)
+        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 4)
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND",
+                       _testinternalcapi.get_co_framesize(dummy12.__code__)), uops_and_operands)
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND",
+                       _testinternalcapi.get_co_framesize(dummy13.__code__)), uops_and_operands)
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND",
+                       _testinternalcapi.get_co_framesize(dummy18.__code__)), uops_and_operands)
 
-    @unittest.skip("gh-139109 WIP")
     def test_combine_stack_space_checks_several_calls_different_order(self):
         # same as `several_calls` but with top-level calls reversed
         def dummy12(x):
@@ -1147,15 +1144,14 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertEqual(uop_names.count("_PUSH_FRAME"), 4)
         self.assertEqual(uop_names.count("_RETURN_VALUE"), 4)
         self.assertEqual(uop_names.count("_CHECK_STACK_SPACE"), 0)
-        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 1)
-        # max(18 + max(12, 13), 12) == 31
-        largest_stack = (
-            _testinternalcapi.get_co_framesize(dummy18.__code__) +
-            _testinternalcapi.get_co_framesize(dummy13.__code__)
-        )
-        self.assertIn(("_CHECK_STACK_SPACE_OPERAND", largest_stack), uops_and_operands)
+        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 4)
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND",
+                       _testinternalcapi.get_co_framesize(dummy12.__code__)), uops_and_operands)
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND",
+                       _testinternalcapi.get_co_framesize(dummy13.__code__)), uops_and_operands)
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND",
+                       _testinternalcapi.get_co_framesize(dummy18.__code__)), uops_and_operands)
 
-    @unittest.skip("gh-139109 WIP")
     def test_combine_stack_space_complex(self):
         def dummy0(x):
             return x
@@ -1193,19 +1189,8 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertEqual(uop_names.count("_RETURN_VALUE"), 15)
 
         self.assertEqual(uop_names.count("_CHECK_STACK_SPACE"), 0)
-        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 1)
-        largest_stack = (
-            _testinternalcapi.get_co_framesize(dummy6.__code__) +
-            _testinternalcapi.get_co_framesize(dummy5.__code__) +
-            _testinternalcapi.get_co_framesize(dummy2.__code__) +
-            _testinternalcapi.get_co_framesize(dummy1.__code__) +
-            _testinternalcapi.get_co_framesize(dummy0.__code__)
-        )
-        self.assertIn(
-            ("_CHECK_STACK_SPACE_OPERAND", largest_stack), uops_and_operands
-        )
+        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 15)
 
-    @unittest.skip("gh-139109 WIP")
     def test_combine_stack_space_checks_large_framesize(self):
         # Create a function with a large framesize. This ensures _CHECK_STACK_SPACE is
         # actually doing its job. Note that the resulting trace hits
@@ -1250,24 +1235,13 @@ class TestUopsOptimization(unittest.TestCase):
 
         uops_and_operands = [(opcode, operand) for opcode, _, _, operand in ex]
         uop_names = [uop[0] for uop in uops_and_operands]
-        self.assertEqual(uop_names.count("_PUSH_FRAME"), 2)
-        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 1)
+        self.assertGreaterEqual(uop_names.count("_PUSH_FRAME"), 1)
+        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE"), 0)
+        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"),
+                         uop_names.count("_PUSH_FRAME"))
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND",
+                       _testinternalcapi.get_co_framesize(dummy15.__code__)), uops_and_operands)
 
-        # this hits a different case during trace projection in refcount test runs only,
-        # so we need to account for both possibilities
-        self.assertIn(uop_names.count("_CHECK_STACK_SPACE"), [0, 1])
-        if uop_names.count("_CHECK_STACK_SPACE") == 0:
-            largest_stack = (
-                _testinternalcapi.get_co_framesize(dummy15.__code__) +
-                _testinternalcapi.get_co_framesize(dummy_large.__code__)
-            )
-        else:
-            largest_stack = _testinternalcapi.get_co_framesize(dummy15.__code__)
-        self.assertIn(
-            ("_CHECK_STACK_SPACE_OPERAND", largest_stack), uops_and_operands
-        )
-
-    @unittest.skip("gh-139109 WIP")
     def test_combine_stack_space_checks_recursion(self):
         def dummy15(x):
             while x > 0:
@@ -1290,12 +1264,12 @@ class TestUopsOptimization(unittest.TestCase):
 
         uops_and_operands = [(opcode, operand) for opcode, _, _, operand in ex]
         uop_names = [uop[0] for uop in uops_and_operands]
-        self.assertEqual(uop_names.count("_PUSH_FRAME"), 2)
+        self.assertEqual(uop_names.count("_PUSH_FRAME"), 12)
         self.assertEqual(uop_names.count("_RETURN_VALUE"), 0)
-        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE"), 1)
-        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 1)
-        largest_stack = _testinternalcapi.get_co_framesize(dummy15.__code__)
-        self.assertIn(("_CHECK_STACK_SPACE_OPERAND", largest_stack), uops_and_operands)
+        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE"), 0)
+        self.assertEqual(uop_names.count("_CHECK_STACK_SPACE_OPERAND"), 12)
+        framesize = _testinternalcapi.get_co_framesize(dummy15.__code__)
+        self.assertIn(("_CHECK_STACK_SPACE_OPERAND", framesize), uops_and_operands)
 
     def test_many_nested(self):
         # overflow the trace_stack

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5362,7 +5362,6 @@ dummy_func(
         tier2 op(_CHECK_STACK_SPACE_OPERAND, (framesize/2 --)) {
             assert(framesize <= INT_MAX);
             DEOPT_IF(!_PyThreadState_HasStackSpace(tstate, framesize));
-            DEOPT_IF(tstate->py_recursion_remaining <= 1);
         }
 
         op(_SAVE_RETURN_OFFSET, (--)) {

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -18557,11 +18557,6 @@
                 SET_CURRENT_CACHED_VALUES(0);
                 JUMP_TO_JUMP_TARGET();
             }
-            if (tstate->py_recursion_remaining <= 1) {
-                UOP_STAT_INC(uopcode, miss);
-                SET_CURRENT_CACHED_VALUES(0);
-                JUMP_TO_JUMP_TARGET();
-            }
             SET_CURRENT_CACHED_VALUES(0);
             assert(WITHIN_STACK_BOUNDS_IGNORING_CACHE());
             break;
@@ -18574,12 +18569,6 @@
             uint32_t framesize = (uint32_t)CURRENT_OPERAND0_32();
             assert(framesize <= INT_MAX);
             if (!_PyThreadState_HasStackSpace(tstate, framesize)) {
-                UOP_STAT_INC(uopcode, miss);
-                _tos_cache0 = _stack_item_0;
-                SET_CURRENT_CACHED_VALUES(1);
-                JUMP_TO_JUMP_TARGET();
-            }
-            if (tstate->py_recursion_remaining <= 1) {
                 UOP_STAT_INC(uopcode, miss);
                 _tos_cache0 = _stack_item_0;
                 SET_CURRENT_CACHED_VALUES(1);
@@ -18605,13 +18594,6 @@
                 SET_CURRENT_CACHED_VALUES(2);
                 JUMP_TO_JUMP_TARGET();
             }
-            if (tstate->py_recursion_remaining <= 1) {
-                UOP_STAT_INC(uopcode, miss);
-                _tos_cache1 = _stack_item_1;
-                _tos_cache0 = _stack_item_0;
-                SET_CURRENT_CACHED_VALUES(2);
-                JUMP_TO_JUMP_TARGET();
-            }
             _tos_cache1 = _stack_item_1;
             _tos_cache0 = _stack_item_0;
             SET_CURRENT_CACHED_VALUES(2);
@@ -18628,14 +18610,6 @@
             uint32_t framesize = (uint32_t)CURRENT_OPERAND0_32();
             assert(framesize <= INT_MAX);
             if (!_PyThreadState_HasStackSpace(tstate, framesize)) {
-                UOP_STAT_INC(uopcode, miss);
-                _tos_cache2 = _stack_item_2;
-                _tos_cache1 = _stack_item_1;
-                _tos_cache0 = _stack_item_0;
-                SET_CURRENT_CACHED_VALUES(3);
-                JUMP_TO_JUMP_TARGET();
-            }
-            if (tstate->py_recursion_remaining <= 1) {
                 UOP_STAT_INC(uopcode, miss);
                 _tos_cache2 = _stack_item_2;
                 _tos_cache1 = _stack_item_1;

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1088,13 +1088,19 @@ dummy_func(void) {
     }
 
     op(_CHECK_STACK_SPACE, (unused, unused, unused[oparg] -- unused, unused, unused[oparg])) {
+        assert((this_instr + 1)->opcode == _CHECK_RECURSION_REMAINING);
+        assert((this_instr + 4)->opcode == _PUSH_FRAME);
+        PyCodeObject *co = get_code_with_logging((this_instr + 4));
+        if (co == NULL) {
+            ctx->done = true;
+            break;
+        }
+        ADD_OP(_CHECK_STACK_SPACE_OPERAND, 0, co->co_framesize);
+        REPLACE_OP((this_instr + 1), _NOP, 0, 0);
     }
 
     op (_CHECK_STACK_SPACE_OPERAND, (framesize/2 -- )) {
         (void)framesize;
-        /* We should never see _CHECK_STACK_SPACE_OPERANDs.
-        * They are only created at the end of this pass. */
-        Py_UNREACHABLE();
     }
 
     op(_PUSH_FRAME, (new_frame -- )) {

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1088,7 +1088,6 @@ dummy_func(void) {
     }
 
     op(_CHECK_STACK_SPACE, (unused, unused, unused[oparg] -- unused, unused, unused[oparg])) {
-        assert((this_instr + 1)->opcode == _CHECK_RECURSION_REMAINING);
         assert((this_instr + 4)->opcode == _PUSH_FRAME);
         PyCodeObject *co = get_code_with_logging((this_instr + 4));
         if (co == NULL) {
@@ -1096,7 +1095,6 @@ dummy_func(void) {
             break;
         }
         ADD_OP(_CHECK_STACK_SPACE_OPERAND, 0, co->co_framesize);
-        REPLACE_OP((this_instr + 1), _NOP, 0, 0);
     }
 
     op (_CHECK_STACK_SPACE_OPERAND, (framesize/2 -- )) {

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -3031,7 +3031,6 @@
         }
 
         case _CHECK_STACK_SPACE: {
-            assert((this_instr + 1)->opcode == _CHECK_RECURSION_REMAINING);
             assert((this_instr + 4)->opcode == _PUSH_FRAME);
             PyCodeObject *co = get_code_with_logging((this_instr + 4));
             if (co == NULL) {
@@ -3039,7 +3038,6 @@
                 break;
             }
             ADD_OP(_CHECK_STACK_SPACE_OPERAND, 0, co->co_framesize);
-            REPLACE_OP((this_instr + 1), _NOP, 0, 0);
             break;
         }
 

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -3031,6 +3031,15 @@
         }
 
         case _CHECK_STACK_SPACE: {
+            assert((this_instr + 1)->opcode == _CHECK_RECURSION_REMAINING);
+            assert((this_instr + 4)->opcode == _PUSH_FRAME);
+            PyCodeObject *co = get_code_with_logging((this_instr + 4));
+            if (co == NULL) {
+                ctx->done = true;
+                break;
+            }
+            ADD_OP(_CHECK_STACK_SPACE_OPERAND, 0, co->co_framesize);
+            REPLACE_OP((this_instr + 1), _NOP, 0, 0);
             break;
         }
 
@@ -3938,7 +3947,6 @@
         case _CHECK_STACK_SPACE_OPERAND: {
             uint32_t framesize = (uint32_t)this_instr->operand0;
             (void)framesize;
-            Py_UNREACHABLE();
             break;
         }
 


### PR DESCRIPTION
Refer: https://github.com/python/cpython/issues/144388
This implements a simple one-to-one replacement of `_CHECK_STACK_SPACE` with `_CHECK_STACK_SPACE_OPERAND` in the JIT optimizer.
Also open and rewrite all the tests that are disabled in https://github.com/python/cpython/issues/139109.



<!-- gh-issue-number: gh-139109 -->
* Issue: gh-139109
<!-- /gh-issue-number -->
