### PR TITLE
gh-144376: Only run 'address' fuzzer for python3-libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -655,11 +655,14 @@ jobs:
       matrix:
         sanitizer:
         - address
-        - undefined
-        - memory
         oss-fuzz-project-name:
         - cpython3
         - python3-libraries
+        include:
+        - sanitizer: undefined
+          oss-fuzz-project-name: cpython3
+        - sanitizer: memory
+          oss-fuzz-project-name: cpython3
         exclude:
         # Note that the 'no-exclude' sentinel below is to prevent
         # an empty string value from excluding all jobs and causing


### PR DESCRIPTION
At the moment the `python3-libraries` fuzzer [only supports the `address` fuzzer](https://github.com/google/oss-fuzz/blob/eeeb46f5490353d48e2eb1b8635f58a98865caef/projects/python3-libraries/project.yaml#L13-L16), not memory or undefined. Disable these for now as they are holding up otherwise valid pull requests.

<!-- gh-issue-number: gh-144376 -->
* Issue: gh-144376
<!-- /gh-issue-number -->
