### PR TITLE
gh-74453: Add stronger security warning to os.path.commonprefix

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -101,7 +101,7 @@ the :mod:`glob` module.)
    prefix of all strings in *list*.  If *list* is empty, return the empty string
    (``''``).
 
-   .. danger::
+   .. warning::
 
       This function may return invalid paths because it works a
       character at a time.

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -103,12 +103,11 @@ the :mod:`glob` module.)
 
    .. danger::
 
+      This function may return invalid paths because it works a
+      character at a time.
       If you need a **common path prefix**, then the algorithm
       implemented in this function is not secure. Use
       :func:`commonpath` for finding a common path prefix.
-      This function may return invalid paths because it works a
-      character at a time.  To obtain a valid path, see
-      :func:`commonpath`.
 
       ::
 

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -97,12 +97,15 @@ the :mod:`glob` module.)
 
 .. function:: commonprefix(list, /)
 
-   Return the longest path prefix (taken character-by-character) that is a
-   prefix of all paths in  *list*.  If *list* is empty, return the empty string
+   Return the longest string prefix (taken character-by-character) that is a
+   prefix of all strings in *list*.  If *list* is empty, return the empty string
    (``''``).
 
-   .. note::
+   .. danger::
 
+      If you need a **common path prefix**, then the algorithm
+      implemented in this function is not secure. Use
+      :func:`commonpath` for finding a common path prefix.
       This function may return invalid paths because it works a
       character at a time.  To obtain a valid path, see
       :func:`commonpath`.


### PR DESCRIPTION
The first part of closing #74453, this documentation update I believe is less controversial than a deprecation. I'm recommending backporting this warning, as all Python versions supported today have `commonpath()`.

The mix-up that `commonprefix` is acceptable for generating a path prefix (versus a string prefix) occurred at least once in a critical packaging tool: https://www.cve.org/CVERecord?id=CVE-2026-1703 Given its usage (40K+ hits on GitHub) I suspect this is not the only occurrence.

<!-- gh-issue-number: gh-74453 -->
* Issue: gh-74453
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144401.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->