### PR TITLE
gh-144386: Add support for descriptors in ExitStack and AsyncExitStack

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -564,6 +564,10 @@ Functions and classes provided:
          Raises :exc:`TypeError` instead of :exc:`AttributeError` if *cm*
          is not a context manager.
 
+      .. versionchanged:: next
+         Added support for arbitrary descriptors :meth:`!__enter__` and
+         :meth:`!__exit__`.
+
    .. method:: push(exit)
 
       Adds a context manager's :meth:`~object.__exit__` method to the callback stack.
@@ -581,6 +585,9 @@ Functions and classes provided:
 
       The passed in object is returned from the function, allowing this
       method to be used as a function decorator.
+
+      .. versionchanged:: next
+         Added support for arbitrary descriptors :meth:`!__exit__`.
 
    .. method:: callback(callback, /, *args, **kwds)
 
@@ -639,10 +646,16 @@ Functions and classes provided:
          Raises :exc:`TypeError` instead of :exc:`AttributeError` if *cm*
          is not an asynchronous context manager.
 
+      .. versionchanged:: next
+         Added support for arbitrary descriptors :meth:`!__aenter__` and :meth:`!__aexit__`.
+
    .. method:: push_async_exit(exit)
 
       Similar to :meth:`ExitStack.push` but expects either an asynchronous context manager
       or a coroutine function.
+
+      .. versionchanged:: next
+         Added support for arbitrary descriptors :meth:`!__aexit__`.
 
    .. method:: push_async_callback(callback, /, *args, **kwds)
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -551,7 +551,7 @@ concurrent.futures
 contextlib
 ----------
 
-* Added support for arbitrary descriptors :meth:`__enter__`,
+* Added support for arbitrary descriptors :meth:`!__enter__`,
   :meth:`!__exit__`, :meth:`!__aenter__`, and :meth:`!__aexit__` in
   :class:`~contextlib.ExitStack` and :class:`contextlib.AsyncExitStack`, for
   consistency with the :keyword:`with` and :keyword:`async with` statements.

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -548,6 +548,16 @@ concurrent.futures
   (Contributed by Jonathan Berg in :gh:`139486`.)
 
 
+contextlib
+----------
+
+* Added support for arbitrary descriptors :meth:`__enter__`,
+  :meth:`!__exit__`, :meth:`!__aenter__`, and :meth:`!__aexit__` in
+  :class:`~contextlib.ExitStack` and :class:`contextlib.AsyncExitStack`, for
+  consistency with the :keyword:`with` and :keyword:`async with` statements.
+  (Contributed by Serhiy Storchaka in :gh:`144386`.)
+
+
 dataclasses
 -----------
 

--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -1,11 +1,12 @@
 """Utilities for with-statement contexts.  See PEP 343."""
 import abc
+from inspect import getattr_static, _descriptor_get
 import os
 import sys
 import _collections_abc
 from collections import deque
 from functools import wraps
-from types import MethodType, GenericAlias
+from types import GenericAlias
 
 __all__ = ["asynccontextmanager", "contextmanager", "closing", "nullcontext",
            "AbstractContextManager", "AbstractAsyncContextManager",
@@ -469,12 +470,21 @@ class suppress(AbstractContextManager):
         return False
 
 
+def _lookup_special(obj, name, default):
+    # Follow the standard lookup behaviour for special methods.
+    cls = type(obj)
+    try:
+        descr = getattr_static(cls, name)
+    except AttributeError:
+        return default
+    return _descriptor_get(descr, obj)
+
+
+_sentinel = ['SENTINEL']
+
+
 class _BaseExitStack:
     """A base class for ExitStack and AsyncExitStack."""
-
-    @staticmethod
-    def _create_exit_wrapper(cm, cm_exit):
-        return MethodType(cm_exit, cm)
 
     @staticmethod
     def _create_cb_wrapper(callback, /, *args, **kwds):
@@ -499,17 +509,8 @@ class _BaseExitStack:
         Also accepts any object with an __exit__ method (registering a call
         to the method instead of the object itself).
         """
-        # We use an unbound method rather than a bound method to follow
-        # the standard lookup behaviour for special methods.
-        _cb_type = type(exit)
-
-        try:
-            exit_method = _cb_type.__exit__
-        except AttributeError:
-            # Not a context manager, so assume it's a callable.
-            self._push_exit_callback(exit)
-        else:
-            self._push_cm_exit(exit, exit_method)
+        exit_method = _lookup_special(exit, '__exit__', exit)
+        self._push_exit_callback(exit_method)
         return exit  # Allow use as a decorator.
 
     def enter_context(self, cm):
@@ -518,17 +519,18 @@ class _BaseExitStack:
         If successful, also pushes its __exit__ method as a callback and
         returns the result of the __enter__ method.
         """
-        # We look up the special methods on the type to match the with
-        # statement.
-        cls = type(cm)
-        try:
-            _enter = cls.__enter__
-            _exit = cls.__exit__
-        except AttributeError:
+        _enter = _lookup_special(cm, '__enter__', _sentinel)
+        if _enter is _sentinel:
+            cls = type(cm)
             raise TypeError(f"'{cls.__module__}.{cls.__qualname__}' object does "
-                            f"not support the context manager protocol") from None
-        result = _enter(cm)
-        self._push_cm_exit(cm, _exit)
+                            f"not support the context manager protocol")
+        _exit = _lookup_special(cm, '__exit__', _sentinel)
+        if _exit is _sentinel:
+            cls = type(cm)
+            raise TypeError(f"'{cls.__module__}.{cls.__qualname__}' object does "
+                            f"not support the context manager protocol")
+        result = _enter()
+        self._push_exit_callback(_exit)
         return result
 
     def callback(self, callback, /, *args, **kwds):
@@ -543,11 +545,6 @@ class _BaseExitStack:
         _exit_wrapper.__wrapped__ = callback
         self._push_exit_callback(_exit_wrapper)
         return callback  # Allow use as a decorator
-
-    def _push_cm_exit(self, cm, cm_exit):
-        """Helper to correctly register callbacks to __exit__ methods."""
-        _exit_wrapper = self._create_exit_wrapper(cm, cm_exit)
-        self._push_exit_callback(_exit_wrapper, True)
 
     def _push_exit_callback(self, callback, is_sync=True):
         self._exit_callbacks.append((is_sync, callback))
@@ -642,10 +639,6 @@ class AsyncExitStack(_BaseExitStack, AbstractAsyncContextManager):
     """
 
     @staticmethod
-    def _create_async_exit_wrapper(cm, cm_exit):
-        return MethodType(cm_exit, cm)
-
-    @staticmethod
     def _create_async_cb_wrapper(callback, /, *args, **kwds):
         async def _exit_wrapper(exc_type, exc, tb):
             await callback(*args, **kwds)
@@ -657,16 +650,18 @@ class AsyncExitStack(_BaseExitStack, AbstractAsyncContextManager):
         If successful, also pushes its __aexit__ method as a callback and
         returns the result of the __aenter__ method.
         """
-        cls = type(cm)
-        try:
-            _enter = cls.__aenter__
-            _exit = cls.__aexit__
-        except AttributeError:
+        _enter = _lookup_special(cm, '__aenter__', _sentinel)
+        if _enter is _sentinel:
+            cls = type(cm)
             raise TypeError(f"'{cls.__module__}.{cls.__qualname__}' object does "
-                            f"not support the asynchronous context manager protocol"
-                           ) from None
-        result = await _enter(cm)
-        self._push_async_cm_exit(cm, _exit)
+                            f"not support the asynchronous context manager protocol")
+        _exit = _lookup_special(cm, '__aexit__', _sentinel)
+        if _exit is _sentinel:
+            cls = type(cm)
+            raise TypeError(f"'{cls.__module__}.{cls.__qualname__}' object does "
+                            f"not support the asynchronous context manager protocol")
+        result = await _enter()
+        self._push_exit_callback(_exit, False)
         return result
 
     def push_async_exit(self, exit):
@@ -677,14 +672,8 @@ class AsyncExitStack(_BaseExitStack, AbstractAsyncContextManager):
         Also accepts any object with an __aexit__ method (registering a call
         to the method instead of the object itself).
         """
-        _cb_type = type(exit)
-        try:
-            exit_method = _cb_type.__aexit__
-        except AttributeError:
-            # Not an async context manager, so assume it's a coroutine function
-            self._push_exit_callback(exit, False)
-        else:
-            self._push_async_cm_exit(exit, exit_method)
+        exit_method = _lookup_special(exit, '__aexit__', exit)
+        self._push_exit_callback(exit_method, False)
         return exit  # Allow use as a decorator
 
     def push_async_callback(self, callback, /, *args, **kwds):
@@ -703,12 +692,6 @@ class AsyncExitStack(_BaseExitStack, AbstractAsyncContextManager):
     async def aclose(self):
         """Immediately unwind the context stack."""
         await self.__aexit__(None, None, None)
-
-    def _push_async_cm_exit(self, cm, cm_exit):
-        """Helper to correctly register coroutine function to __aexit__
-        method."""
-        _exit_wrapper = self._create_async_exit_wrapper(cm, cm_exit)
-        self._push_exit_callback(_exit_wrapper, False)
 
     async def __aenter__(self):
         return self

--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -1,6 +1,5 @@
 """Utilities for with-statement contexts.  See PEP 343."""
 import abc
-from inspect import getattr_static, _descriptor_get
 import os
 import sys
 import _collections_abc
@@ -472,6 +471,7 @@ class suppress(AbstractContextManager):
 
 def _lookup_special(obj, name, default):
     # Follow the standard lookup behaviour for special methods.
+    from inspect import getattr_static, _descriptor_get
     cls = type(obj)
     try:
         descr = getattr_static(cls, name)

--- a/Misc/NEWS.d/next/Library/2026-02-03-14-16-49.gh-issue-144386.9Wa59r.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-03-14-16-49.gh-issue-144386.9Wa59r.rst
@@ -1,0 +1,4 @@
+Add support for arbitrary descriptors :meth:`!__enter__`, :meth:`!__exit__`,
+:meth:`!__aenter__`, and :meth:`!__aexit__` in :class:`contextlib.ExitStack`
+and :class:`contextlib.AsyncExitStack`, for consistency with the
+:keyword:`with` and :keyword:`async with` statements.


### PR DESCRIPTION
`__enter__()`, `__exit__()`, `__aenter__()`, and `__aexit__()` can now be arbitrary descriptors, not only normal methods, for consistency with the "with" and "async with" statements.


<!-- gh-issue-number: gh-144386 -->
* Issue: gh-144386
<!-- /gh-issue-number -->
