### PR TITLE
Document `ValueError` being raised by `UUID` constructor

### DIFF
--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -66,6 +66,7 @@ which relays any information about the UUID's safety, using this enumeration:
       UUID(int=0x12345678123456781234567812345678)
 
    Exactly one of *hex*, *bytes*, *bytes_le*, *fields*, or *int* must be given.
+   If any of these arguments are malformed, a :exc:`ValueError` is raised.
    The *version* argument is optional; if given, the resulting UUID will have its
    variant and version number set according to :rfc:`9562`, overriding bits in the
    given *hex*, *bytes*, *bytes_le*, *fields*, or *int*.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This is a trivial improvement that I think doesn't require an issue.



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144425.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->