### PR TITLE
gh-144433: clarify `unittest.mock.patch.dict` copy behavior

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1847,7 +1847,7 @@ class _patch_dict(object):
     """
     Patch a dictionary, or dictionary like object, and restore the dictionary
     to its original state after the test, where the restored dictionary is
-    a copy of the dictionary as it was before the test.
+    a shallow copy of the dictionary as it was before the test.
 
     `in_dict` can be a dictionary or a mapping like container. If it is a
     mapping then it must at least support getting, setting and deleting items


### PR DESCRIPTION
Update wording to indicate that unittest.mock patch.dict will make a shallow copy of the patched dict (opposed to a deep copy)

<!-- gh-issue-number: gh-144433 -->
* Issue: gh-144433
<!-- /gh-issue-number -->
