### PR TITLE
gh-144424: Clean up dead weakrefs to sqlite3 Blob objects

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-08-01-10-31-24.gh-issue-144424.Rj5tcX.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-01-10-31-24.gh-issue-144424.Rj5tcX.rst
@@ -1,0 +1,2 @@
+Fixed the cleanup of weakref objects created by
+:meth:`sqlite3.Connection.blobopen`.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1060,7 +1060,8 @@ static int
 _pysqlite_drop_unused_blob_references(pysqlite_Connection* self)
 {
     /* we only need to do this once in a while */
-    if (self->created_blobs++ < 200) {
+    self->created_blobs++;
+    if (self->created_blobs < 200 || self->created_blobs < PyList_GET_SIZE(self->blobs) / 4) {
         return 0;
     }
 

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1076,7 +1076,7 @@ _pysqlite_drop_unused_blob_references(pysqlite_Connection* self)
     for (Py_ssize_t i = 0; i < imax; i++) {
         PyObject* weakref = PyList_GET_ITEM(self->blobs, i);
         if (_PyWeakref_IsDead(weakref)) {
-          continue;
+            continue;
         }
         if (PyList_Append(new_list, weakref) != 0) {
             Py_DECREF(new_list);

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -38,6 +38,7 @@
 #include "pycore_pyerrors.h"      // _PyErr_ChainExceptions1()
 #include "pycore_pylifecycle.h"   // _Py_IsInterpreterFinalizing()
 #include "pycore_unicodeobject.h" // _PyUnicode_AsUTF8NoNUL
+#include "pycore_weakref.h"
 
 #include <stdbool.h>
 
@@ -143,6 +144,7 @@ class _sqlite3.Connection "pysqlite_Connection *" "clinic_state()->ConnectionTyp
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=67369db2faf80891]*/
 
+static int _pysqlite_drop_unused_blob_references(pysqlite_Connection* self);
 static void incref_callback_context(callback_context *ctx);
 static void decref_callback_context(callback_context *ctx);
 static void set_callback_context(callback_context **ctx_pp,
@@ -300,6 +302,7 @@ pysqlite_connection_init_impl(pysqlite_Connection *self, PyObject *database,
     self->thread_ident = PyThread_get_thread_ident();
     self->statement_cache = statement_cache;
     self->blobs = blobs;
+    self->created_blobs = 0;
     self->row_factory = Py_NewRef(Py_None);
     self->text_factory = Py_NewRef(&PyUnicode_Type);
     self->trace_ctx = NULL;
@@ -621,6 +624,10 @@ blobopen_impl(pysqlite_Connection *self, const char *table, const char *col,
     rc = PyList_Append(self->blobs, weakref);
     Py_DECREF(weakref);
     if (rc < 0) {
+        goto error;
+    }
+
+    if (_pysqlite_drop_unused_blob_references(self) < 0) {
         goto error;
     }
 
@@ -1047,6 +1054,38 @@ final_callback(sqlite3_context *context)
 
 error:
     PyGILState_Release(threadstate);
+}
+
+static int
+_pysqlite_drop_unused_blob_references(pysqlite_Connection* self)
+{
+    /* we only need to do this once in a while */
+    if (self->created_blobs++ < 200) {
+        return 0;
+    }
+
+    self->created_blobs = 0;
+
+    PyObject* new_list = PyList_New(0);
+    if (!new_list) {
+        return -1;
+    }
+
+    assert(PyList_CheckExact(self->blobs));
+    Py_ssize_t imax = PyList_GET_SIZE(self->blobs);
+    for (Py_ssize_t i = 0; i < imax; i++) {
+        PyObject* weakref = PyList_GET_ITEM(self->blobs, i);
+        if (_PyWeakref_IsDead(weakref)) {
+          continue;
+        }
+        if (PyList_Append(new_list, weakref) != 0) {
+            Py_DECREF(new_list);
+            return -1;
+        }
+    }
+
+    Py_SETREF(self->blobs, new_list);
+    return 0;
 }
 
 /* Allocate a UDF/callback context structure. In order to ensure that the state

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -38,6 +38,7 @@
 #include "pycore_pyerrors.h"      // _PyErr_ChainExceptions1()
 #include "pycore_pylifecycle.h"   // _Py_IsInterpreterFinalizing()
 #include "pycore_unicodeobject.h" // _PyUnicode_AsUTF8NoNUL
+#include "pycore_weakref.h"
 
 #include <stdbool.h>
 
@@ -143,6 +144,7 @@ class _sqlite3.Connection "pysqlite_Connection *" "clinic_state()->ConnectionTyp
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=67369db2faf80891]*/
 
+static int _pysqlite_drop_unused_blob_references(pysqlite_Connection* self);
 static void incref_callback_context(callback_context *ctx);
 static void decref_callback_context(callback_context *ctx);
 static void set_callback_context(callback_context **ctx_pp,
@@ -300,6 +302,7 @@ pysqlite_connection_init_impl(pysqlite_Connection *self, PyObject *database,
     self->thread_ident = PyThread_get_thread_ident();
     self->statement_cache = statement_cache;
     self->blobs = blobs;
+    self->created_blobs = 0;
     self->row_factory = Py_NewRef(Py_None);
     self->text_factory = Py_NewRef(&PyUnicode_Type);
     self->trace_ctx = NULL;
@@ -662,6 +665,10 @@ blobopen_impl(pysqlite_Connection *self, const char *table, const char *col,
     rc = PyList_Append(self->blobs, weakref);
     Py_DECREF(weakref);
     if (rc < 0) {
+        goto error;
+    }
+
+    if (_pysqlite_drop_unused_blob_references(self) < 0) {
         goto error;
     }
 
@@ -1088,6 +1095,38 @@ final_callback(sqlite3_context *context)
 
 error:
     PyGILState_Release(threadstate);
+}
+
+static int
+_pysqlite_drop_unused_blob_references(pysqlite_Connection* self)
+{
+    /* we only need to do this once in a while */
+    if (self->created_blobs++ < 200) {
+        return 0;
+    }
+
+    self->created_blobs = 0;
+
+    PyObject* new_list = PyList_New(0);
+    if (!new_list) {
+        return -1;
+    }
+
+    assert(PyList_CheckExact(self->blobs));
+    Py_ssize_t imax = PyList_GET_SIZE(self->blobs);
+    for (Py_ssize_t i = 0; i < imax; i++) {
+        PyObject* weakref = PyList_GET_ITEM(self->blobs, i);
+        if (_PyWeakref_IsDead(weakref)) {
+          continue;
+        }
+        if (PyList_Append(new_list, weakref) != 0) {
+            Py_DECREF(new_list);
+            return -1;
+        }
+    }
+
+    Py_SETREF(self->blobs, new_list);
+    return 0;
 }
 
 /* Allocate a UDF/callback context structure. In order to ensure that the state

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1101,7 +1101,8 @@ static int
 _pysqlite_drop_unused_blob_references(pysqlite_Connection* self)
 {
     /* we only need to do this once in a while */
-    if (self->created_blobs++ < 200) {
+    self->created_blobs++;
+    if (self->created_blobs < 200 || self->created_blobs < PyList_GET_SIZE(self->blobs) / 4) {
         return 0;
     }
 

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1117,7 +1117,7 @@ _pysqlite_drop_unused_blob_references(pysqlite_Connection* self)
     for (Py_ssize_t i = 0; i < imax; i++) {
         PyObject* weakref = PyList_GET_ITEM(self->blobs, i);
         if (_PyWeakref_IsDead(weakref)) {
-          continue;
+            continue;
         }
         if (PyList_Append(new_list, weakref) != 0) {
             Py_DECREF(new_list);

--- a/Modules/_sqlite/connection.h
+++ b/Modules/_sqlite/connection.h
@@ -73,6 +73,10 @@ typedef struct
     /* Lists of weak references to blobs used within this connection */
     PyObject *blobs;
 
+    /* Counter for how many blobs were opened in this connection;
+     * May be reset to 0 at certain intervals. */
+    int created_blobs;
+
     PyObject* row_factory;
 
     /* Determines how bytestrings from SQLite are converted to Python objects:


### PR DESCRIPTION
Using `conn.blobopen()` puts a weakref to the new blob object into a list, but dead weakrefs are never cleaned up.

This adds a check to go through and clean up dead weakrefs on every 200th blob opened, closely based on the code I removed in #144378 doing the same thing for Cursor weakrefs.

Closes #144424.

<!-- gh-issue-number: gh-144424 -->
* Issue: gh-144424
<!-- /gh-issue-number -->
