### PR TITLE
gh-143700: Document secrets.DEFAULT_ENTROPY

### DIFF
--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -62,6 +62,14 @@ The :mod:`secrets` module provides functions for generating secure
 tokens, suitable for applications such as password resets,
 hard-to-guess URLs, and similar.
 
+.. data:: DEFAULT_ENTROPY
+
+   The default number of bytes of randomness used by the ``token_*``
+   functions when *nbytes* is not specified.  This is an opaque value
+   that may change at any time, including during maintenance releases.
+   Users who need a specific amount of entropy should explicitly pass
+   the *nbytes* argument.
+
 .. function:: token_bytes([nbytes=None])
 
    Return a random byte string containing *nbytes* number of bytes.


### PR DESCRIPTION
## Summary
- Add documentation for `secrets.DEFAULT_ENTROPY` constant
- Document it as an opaque value that may change at any time
- Encourage users to explicitly pass `nbytes` if they need a specific amount of entropy

Closes #143700

## Test plan
- [x] Verified against source code (`Lib/secrets.py:31`)
- [x] `make check` in Doc/ directory passed

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- gh-issue-number: gh-143700 -->
* Issue: gh-143700
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144447.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->