### PR TITLE
gh-142412: Add warning about urlsplit's netloc parsing and open redirects

### DIFF
--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -530,6 +530,17 @@ code before trusting a returned component part.  Does that ``scheme`` make
 sense?  Is that a sensible ``path``?  Is there anything strange about that
 ``hostname``?  etc.
 
+.. warning::
+
+   :func:`urlsplit` (and :func:`urlparse`) does not consider a URL's
+   :attr:`~urllib.parse.SplitResult.netloc` to be present unless
+   it is preceded by ``//``.  This means that, for example, the URL
+   ``///example.com/path`` will be parsed with an empty ``netloc`` and a
+   ``path`` of ``/example.com/path``.  This behavior may lead to open redirect
+   vulnerabilities in applications that rely on checking the ``netloc`` to
+   validate redirect URLs.  Always carefully validate redirect targets,
+   preferably using an allowlist of known-safe URLs or hosts.
+
 What constitutes a URL is not universally well defined.  Different applications
 have different needs and desired constraints.  For instance the living `WHATWG
 spec`_ describes what user facing web clients such as a web browser require.


### PR DESCRIPTION
## Summary
- Adds a warning to the URL parsing security section explaining that `urlsplit`/`urlparse` only parse the `netloc` when preceded by `//`
- Documents that URLs like `///example.com/path` result in an empty `netloc` and a `path` of `/example.com/path`
- Warns that this behavior may lead to open redirect vulnerabilities if applications rely solely on checking the `netloc` to validate redirect URLs

## Test plan
- [x] `make check` passed in Doc/ directory
- [x] Documentation builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-142412 -->
* Issue: gh-142412
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144448.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->