### PR TITLE
gh-142044: Add note to prefer `asyncio.timeout[_at]` over `asyncio.Timeout`

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -766,6 +766,11 @@ Timeouts
     The context manager produced by :func:`asyncio.timeout` can be
     rescheduled to a different deadline and inspected.
 
+    .. note::
+
+       Prefer using :func:`asyncio.timeout` or :func:`asyncio.timeout_at`
+       rather than instantiating :class:`Timeout` directly.
+
     .. class:: Timeout(when)
 
        An :ref:`asynchronous context manager <async-context-managers>`

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -766,15 +766,13 @@ Timeouts
     The context manager produced by :func:`asyncio.timeout` can be
     rescheduled to a different deadline and inspected.
 
-    .. note::
-
-       Prefer using :func:`asyncio.timeout` or :func:`asyncio.timeout_at`
-       rather than instantiating :class:`Timeout` directly.
-
     .. class:: Timeout(when)
 
        An :ref:`asynchronous context manager <async-context-managers>`
        for cancelling overdue coroutines.
+
+       Prefer using :func:`asyncio.timeout` or :func:`asyncio.timeout_at`
+       rather than instantiating :class:`Timeout` directly.
 
        ``when`` should be an absolute time at which the context should time out,
        as measured by the event loop's clock:

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -772,7 +772,7 @@ Timeouts
        for cancelling overdue coroutines.
 
        Prefer using :func:`asyncio.timeout` or :func:`asyncio.timeout_at`
-       rather than instantiating :class:`Timeout` directly.
+       rather than instantiating :class:`!Timeout` directly.
 
        ``when`` should be an absolute time at which the context should time out,
        as measured by the event loop's clock:


### PR DESCRIPTION
## Summary
- Adds a note to the `Timeout` class documentation recommending that users prefer `asyncio.timeout()` or `asyncio.timeout_at()` rather than instantiating `Timeout` directly
- This matches the guidance already present in the source code docstring at `Lib/asyncio/timeouts.py:26-28`

## Test plan
- [x] `make check` passed in Doc/ directory
- [x] Documentation builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-142044 -->
* Issue: gh-142044
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144449.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->