### PR TITLE
gh-140490: Document changes for `PurePath.stem` in Python 3.14

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -486,6 +486,10 @@ Pure paths provide the following methods and properties:
       >>> PurePosixPath('my/library').stem
       'library'
 
+   .. versionchanged:: 3.14
+
+      A single dot ("``.``") is now considered a valid suffix.
+
 
 .. method:: PurePath.as_posix()
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -488,7 +488,7 @@ Pure paths provide the following methods and properties:
 
    .. versionchanged:: 3.14
 
-      A single dot ("``.``") is now considered a valid suffix.
+      A single dot ("``.``") is considered a valid suffix.
 
 
 .. method:: PurePath.as_posix()


### PR DESCRIPTION
## Summary
- Adds `versionchanged:: 3.14` note to `PurePath.stem` attribute documentation
- Explains that `stem` behavior changed because a single dot is now considered a valid suffix
- Example: `PurePosixPath('my/file.').stem` previously returned `'file.'`, now returns `'file'`

The `suffix`, `suffixes`, and `with_suffix` docs already have this note, but `stem` was missing it.

## Test plan
- [x] `make check` passed in Doc/ directory
- [x] Documentation builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-140490 -->
* Issue: gh-140490
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144450.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->