### PR TITLE
gh-138186: Use 'predicate' instead of 'function' in filterfalse docstring

### DIFF
--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -871,12 +871,12 @@ exit:
 }
 
 PyDoc_STRVAR(itertools_filterfalse__doc__,
-"filterfalse(function, iterable, /)\n"
+"filterfalse(predicate, iterable, /)\n"
 "--\n"
 "\n"
-"Return those items of iterable for which function(item) is false.\n"
+"Return those items of iterable for which predicate(item) is false.\n"
 "\n"
-"If function is None, return the items that are false.");
+"If predicate is None, return the items that are false.");
 
 static PyObject *
 itertools_filterfalse_impl(PyTypeObject *type, PyObject *func, PyObject *seq);
@@ -980,4 +980,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7f385837b13edbeb input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a44797ba1e4a8cce input=a9049054013a1b77]*/

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3245,17 +3245,17 @@ typedef struct {
 /*[clinic input]
 @classmethod
 itertools.filterfalse.__new__
-    function as func: object
+    predicate as func: object
     iterable as seq: object
     /
-Return those items of iterable for which function(item) is false.
+Return those items of iterable for which predicate(item) is false.
 
-If function is None, return the items that are false.
+If predicate is None, return the items that are false.
 [clinic start generated code]*/
 
 static PyObject *
 itertools_filterfalse_impl(PyTypeObject *type, PyObject *func, PyObject *seq)
-/*[clinic end generated code: output=55f87eab9fc0484e input=2d684a2c66f99cde]*/
+/*[clinic end generated code: output=55f87eab9fc0484e input=a7df36679f5f66d6]*/
 {
     PyObject *it;
     filterfalseobject *lz;


### PR DESCRIPTION
## Summary
- Changes the parameter name in `itertools.filterfalse`'s docstring from `function` to `predicate`
- This makes it consistent with:
  - The RST documentation (`Doc/library/itertools.rst`) which already uses `predicate`
  - The similar functions `dropwhile` and `takewhile` which use `predicate`

Before:
```
>>> help(itertools.filterfalse)
filterfalse(function, iterable, /)
```

After:
```
>>> help(itertools.filterfalse)
filterfalse(predicate, iterable, /)
```

## Test plan
- [x] `make check` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-138186 -->
* Issue: gh-138186
<!-- /gh-issue-number -->
