### PR TITLE
gh-69223: Document that add_argument returns an Action object

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -698,6 +698,8 @@ The add_argument() method
 
    * deprecated_ - Whether or not use of the argument is deprecated.
 
+   The method returns an :class:`Action` object representing the argument.
+
 The following sections describe how each of these are used.
 
 


### PR DESCRIPTION
## Summary
- Documents that `ArgumentParser.add_argument()` returns an `Action` object
- This is useful for users who want to customize or inspect argument properties after creation

## Test plan
- [x] `make check` passed
- [x] Documentation builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-69223 -->
* Issue: gh-69223
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144452.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->