### PR TITLE
gh-72798: Add mapping example to str.translate documentation

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2846,6 +2846,12 @@ expression support in the :mod:`re` module).
    You can use :meth:`str.maketrans` to create a translation map from
    character-to-character mappings in different formats.
 
+   The following example uses a mapping to replace ``'a'`` with ``'X'``,
+   ``'b'`` with ``'Y'``, and delete ``'c'``::
+
+      >>> 'abc123'.translate({ord('a'): 'X', ord('b'): 'Y', ord('c'): None})
+      'XY123'
+
    See also the :mod:`codecs` module for a more flexible approach to custom
    character mappings.
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2847,7 +2847,9 @@ expression support in the :mod:`re` module).
    character-to-character mappings in different formats.
 
    The following example uses a mapping to replace ``'a'`` with ``'X'``,
-   ``'b'`` with ``'Y'``, and delete ``'c'``::
+   ``'b'`` with ``'Y'``, and delete ``'c'``:
+
+   .. doctest::
 
       >>> 'abc123'.translate({ord('a'): 'X', ord('b'): 'Y', ord('c'): None})
       'XY123'


### PR DESCRIPTION
## Summary
- Adds an example showing how to use `str.translate` with a dictionary mapping directly
- Demonstrates character replacement (`'a'` → `'X'`, `'b'` → `'Y'`) and deletion (`'c'` → `None`)

## Test plan
- [x] `make check` passed
- [x] Documentation builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-72798 -->
* Issue: gh-72798
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144454.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->