### PR TITLE
gh-62734: Document that open()'s file param becomes name attribute

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1355,7 +1355,8 @@ are always available.  They are listed here in alphabetical order.
    relative to the current working directory) of the file to be opened or an
    integer file descriptor of the file to be wrapped.  (If a file descriptor is
    given, it is closed when the returned I/O object is closed unless *closefd*
-   is set to ``False``.)
+   is set to ``False``.)  The value passed as *file* is stored in the
+   :attr:`~io.IOBase.name` attribute of the returned file object.
 
    *mode* is an optional string that specifies the mode in which the file is
    opened.  It defaults to ``'r'`` which means open for reading in text mode.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1356,7 +1356,7 @@ are always available.  They are listed here in alphabetical order.
    integer file descriptor of the file to be wrapped.  (If a file descriptor is
    given, it is closed when the returned I/O object is closed unless *closefd*
    is set to ``False``.)  The value passed as *file* is stored in the
-   :attr:`~io.IOBase.name` attribute of the returned file object.
+   :attr:`~io.FileIO.name` attribute of the returned file object.
 
    *mode* is an optional string that specifies the mode in which the file is
    opened.  It defaults to ``'r'`` which means open for reading in text mode.


### PR DESCRIPTION
## Summary
- Clarifies that the value passed as the *file* parameter to `open()` is stored in the `name` attribute of the returned file object

## Test plan
- [x] `make check` passed
- [x] Documentation builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-62734 -->
* Issue: gh-62734
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144455.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->