### PR TITLE
gh-140771: Add class directive for xmlparser in pyexpat docs

### DIFF
--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -51,9 +51,15 @@ This module provides one exception and one type object:
    Alias for :exc:`ExpatError`.
 
 
+.. class:: xmlparser
+
+   The type of XML parser objects returned by the :func:`ParserCreate` function.
+   This type is available as ``xml.parsers.expat.XMLParserType``.
+
+
 .. data:: XMLParserType
 
-   The type of the return values from the :func:`ParserCreate` function.
+   Alias for :class:`xmlparser`.
 
 The :mod:`xml.parsers.expat` module contains two functions:
 


### PR DESCRIPTION
## Summary
- Adds a `.. class:: xmlparser` directive so that all `:class:`xmlparser`` references in the documentation resolve properly
- Documents that the type is available as `xml.parsers.expat.XMLParserType`
- Updates `XMLParserType` to be documented as an alias for the class

This fixes the broken cross-references throughout the pyexpat documentation.

## Test plan
- [x] `make check` passed
- [x] Documentation builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-140771 -->
* Issue: gh-140771
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144456.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->