### PR TITLE
gh-140922: Document fnmatch.translate \Z to \z change in 3.14

### DIFF
--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -116,6 +116,10 @@ functions: :func:`fnmatch`, :func:`fnmatchcase`, :func:`.filter`, :func:`.filter
       >>> reobj.match('foobar.txt')
       <re.Match object; span=(0, 10), match='foobar.txt'>
 
+   .. versionchanged:: 3.14
+      The generated regular expression now uses ``\z`` instead of ``\Z``.
+      Both are equivalent; ``\Z`` is still accepted for compatibility.
+
 
 .. seealso::
 


### PR DESCRIPTION
## Summary
- Adds `versionchanged:: 3.14` note to `fnmatch.translate()` documentation
- Explains that the generated regular expression now uses `\z` instead of `\Z`
- Notes that both are equivalent and `\Z` is still accepted for compatibility

## Source verification
- Verified in `Lib/fnmatch.py:188` that `\z` is used
- Commit `add0ca9ea00` made this change

## Test plan
- [x] `make check` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-140922 -->
* Issue: gh-140922
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144457.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->