### PR TITLE
gh-136879: Make os.spawn* arg signatures consistent with os.exec*

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -5254,10 +5254,10 @@ written in Python, such as a mail server's external command delivery program.
    .. versionadded:: 3.7
 
 
-.. function:: spawnl(mode, path, ...)
-              spawnle(mode, path, ..., env)
-              spawnlp(mode, file, ...)
-              spawnlpe(mode, file, ..., env)
+.. function:: spawnl(mode, path, arg0, arg1, ...)
+              spawnle(mode, path, arg0, arg1, ..., env)
+              spawnlp(mode, file, arg0, arg1, ...)
+              spawnlpe(mode, file, arg0, arg1, ..., env)
               spawnv(mode, path, args)
               spawnve(mode, path, args, env)
               spawnvp(mode, file, args)


### PR DESCRIPTION
## Summary
- Updates `os.spawnl`, `spawnle`, `spawnlp`, and `spawnlpe` function signatures to show `arg0, arg1, ...` explicitly
- This matches the documentation style of the `os.execl` family of functions

Before: `spawnl(mode, path, ...)`
After: `spawnl(mode, path, arg0, arg1, ...)`

## Source verification
- Verified in `Lib/os.py` that both exec* and spawn* use `*args` parameter

## Test plan
- [x] `make check` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-136879 -->
* Issue: gh-136879
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144458.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->