### PR TITLE
gh-128805: Clarify cElementTree deprecation notice

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -17,7 +17,9 @@ for parsing and creating XML data.
    This module will use a fast implementation whenever available.
 
 .. deprecated:: 3.3
-   The :mod:`!xml.etree.cElementTree` module is deprecated.
+   The :mod:`!xml.etree.cElementTree` module, which is an alias for
+   :mod:`xml.etree.ElementTree`, is deprecated. Use :mod:`xml.etree.ElementTree`
+   directly instead.
 
 
 .. note::


### PR DESCRIPTION
## Summary
- Clarifies that `xml.etree.cElementTree` is an alias for `xml.etree.ElementTree`
- Advises users to use `xml.etree.ElementTree` directly instead

The existing deprecation notice was confusing because it mentioned `cElementTree` without explaining its relationship to `ElementTree`, leading users to wonder if the entire `ElementTree` module was deprecated.

## Test plan
- [x] Verified `Lib/xml/etree/cElementTree.py` is indeed just an alias that imports from `xml.etree.ElementTree`
- [x] `make check` passes
- [x] `make html` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-128805 -->
* Issue: gh-128805
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144459.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->