### PR TITLE
gh-133360: Document zipfile.Path.glob, rglob, and match methods

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -687,6 +687,29 @@ Path objects are traversable using the ``/`` operator or ``joinpath``.
 
    Read the current file as bytes.
 
+.. method:: Path.glob(pattern)
+
+   Iterate over all files in the directory represented by this path that
+   match the given relative glob *pattern*, yielding :class:`~zipfile.Path`
+   objects. The *pattern* must not be empty.
+
+   .. versionadded:: 3.12
+
+.. method:: Path.rglob(pattern)
+
+   Recursively iterate over all files matching the given relative glob
+   *pattern*. This is equivalent to calling :meth:`~Path.glob` with ``"**/``
+   added in front of the pattern.
+
+   .. versionadded:: 3.12
+
+.. method:: Path.match(path_pattern)
+
+   Match this path against the provided glob-style *path_pattern*. Return
+   ``True`` if matching is successful, ``False`` otherwise.
+
+   .. versionadded:: 3.12
+
 .. method:: Path.joinpath(*other)
 
    Return a new Path object with each of the *other* arguments


### PR DESCRIPTION
## Summary
- Documents `zipfile.Path.glob()` method
- Documents `zipfile.Path.rglob()` method
- Documents `zipfile.Path.match()` method

These methods were added in Python 3.12 but were not documented.

## Test plan
- [x] Verified implementations exist in `Lib/zipfile/_path/__init__.py`
- [x] `make check` passes
- [x] `make html` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-133360 -->
* Issue: gh-133360
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144460.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->