### PR TITLE
gh-129745: Fix urlparse example to properly parse params

### DIFF
--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -69,8 +69,8 @@ or on combining URL components into a URL string.
       :options: +NORMALIZE_WHITESPACE
 
       >>> from urllib.parse import urlparse
-      >>> urlparse("scheme://netloc/path;parameters?query#fragment")
-      ParseResult(scheme='scheme', netloc='netloc', path='/path;parameters', params='',
+      >>> urlparse("http://netloc/path;parameters?query#fragment")
+      ParseResult(scheme='http', netloc='netloc', path='/path', params='parameters',
                   query='query', fragment='fragment')
       >>> o = urlparse("http://docs.python.org:80/3/library/urllib.parse.html?"
       ...              "highlight=params#url-parsing")


### PR DESCRIPTION
## Summary
Changed the `urlparse()` example from using `scheme://` to `http://` so that the params component is correctly parsed.

The generic `scheme` isn't in the list of schemes that support parameter parsing (`uses_params`), so the previous example was showing params remaining in the path (`path='/path;parameters'`) rather than being extracted (`path='/path', params='parameters'`).

## Test plan
- [x] Verified `http` is in `uses_params` and correctly parses params
- [x] `make check` passes
- [x] `make html` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-129745 -->
* Issue: gh-129745
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144461.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->