### PR TITLE
gh-144330: Initialize classmethod and staticmethod in new

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1727,6 +1727,18 @@ class ClassPropertiesAndMethods(unittest.TestCase):
                     del method.__annotate__
                     self.assertIs(method.__annotate__, original_annotate)
 
+    def test_classmethod_without_dict_access(self):
+        class Spam:
+            @classmethod
+            def method(cls, x, y):
+                pass
+
+        obj = Spam.__dict__['method']
+        self.assertIsInstance(obj, classmethod)
+        self.assertEqual(obj.__annotations__, {})
+        self.assertEqual(obj.__name__, 'method')
+        self.assertEqual(obj.__module__, __name__)
+
     def test_staticmethod_annotations_without_dict_access(self):
         # gh-125017: this used to crash
         class Spam:
@@ -1737,15 +1749,8 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         obj = Spam.__dict__['__new__']
         self.assertIsInstance(obj, staticmethod)
         self.assertEqual(obj.__annotations__, {})
-
-    @support.refcount_test
-    def test_refleaks_in_classmethod___init__(self):
-        gettotalrefcount = support.get_attribute(sys, 'gettotalrefcount')
-        cm = classmethod(None)
-        refs_before = gettotalrefcount()
-        for i in range(100):
-            cm.__init__(None)
-        self.assertAlmostEqual(gettotalrefcount() - refs_before, 0, delta=10)
+        self.assertEqual(obj.__name__, '__new__')
+        self.assertEqual(obj.__module__, __name__)
 
     @support.impl_detail("the module 'xxsubtype' is internal")
     @unittest.skipIf(xxsubtype is None, "requires xxsubtype module")
@@ -1821,15 +1826,6 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         self.assertEqual(sm.__dict__, {"x" : 42, '__doc__': None.__doc__})
         del sm.x
         self.assertNotHasAttr(sm, "x")
-
-    @support.refcount_test
-    def test_refleaks_in_staticmethod___init__(self):
-        gettotalrefcount = support.get_attribute(sys, 'gettotalrefcount')
-        sm = staticmethod(None)
-        refs_before = gettotalrefcount()
-        for i in range(100):
-            sm.__init__(None)
-        self.assertAlmostEqual(gettotalrefcount() - refs_before, 0, delta=10)
 
     @support.impl_detail("the module 'xxsubtype' is internal")
     @unittest.skipIf(xxsubtype is None, "requires xxsubtype module")

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-04-11-19-45.gh-issue-144330.kOowSb.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-04-11-19-45.gh-issue-144330.kOowSb.rst
@@ -1,0 +1,2 @@
+Move ``classmethod`` and ``staticmethod`` initialization from ``__init__()``
+to ``__new__()``. Patch by Victor Stinner.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2446,13 +2446,17 @@ static PyTypeObject* static_types[] = {
     &PyBaseObject_Type,
     &PyType_Type,
 
+    // PyStaticMethod_Type and PyCFunction_Type are used by PyType_Ready()
+    // on other types and so must be initialized first.
+    &PyStaticMethod_Type,
+    &PyCFunction_Type,
+
     // Static types with base=&PyBaseObject_Type
     &PyAsyncGen_Type,
     &PyByteArrayIter_Type,
     &PyByteArray_Type,
     &PyBytesIter_Type,
     &PyBytes_Type,
-    &PyCFunction_Type,
     &PyCallIter_Type,
     &PyCapsule_Type,
     &PyCell_Type,
@@ -2509,7 +2513,6 @@ static PyTypeObject* static_types[] = {
     &PySetIter_Type,
     &PySet_Type,
     &PySlice_Type,
-    &PyStaticMethod_Type,
     &PyStdPrinter_Type,
     &PySuper_Type,
     &PyTraceBack_Type,


### PR DESCRIPTION
Move classmethod and staticmethod initialization from `__init__()` to `__new__()`.

PyClassMethod_New() and PyStaticMethod_New() now copy attributes of the wrapped functions: `__module__`, `__name__`, `__qualname__` and `__doc__`.

Change static type initialization: initialize PyStaticMethod_Type and PyCFunction_Type earlier.

Remove test_refleaks_in_classmethod___init__() and test_refleaks_in_staticmethod___init__() tests from test_descr since classmethod and staticmethod have no `__init__()` method anymore.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144330 -->
* Issue: gh-144330
<!-- /gh-issue-number -->
