### PR TITLE
Itertools recipes:  Replace the tabulate() example with running_mean()

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -860,7 +860,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
        return chain([value], iterable)
 
    def running_mean(iterable):
-       "Yield the cumulative arithmetic mean."
+       "Yield the average of all values seen so far."
        # running_mean([8.5, 9.5, 7.5, 7.0]) -> 8.5 9.0 8.5 8.0
        return map(truediv, accumulate(iterable), count(1))
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -845,7 +845,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
    from contextlib import suppress
    from functools import reduce
    from math import comb, isqrt, prod, sumprod
-   from operator import getitem, is_not, itemgetter, mul, neg
+   from operator import getitem, is_not, itemgetter, mul, neg, truediv
 
    # ==== Basic one liners ====
 
@@ -861,6 +861,11 @@ and :term:`generators <generator>` which incur interpreter overhead.
    def tabulate(function, start=0):
        "Return function(0), function(1), ..."
        return map(function, count(start))
+
+   def running_mean(iterable):
+       "Yield the cumulative arithmetic mean."
+       # running_mean([8.5, 9.5, 7.5, 7.0]) -> 8.5 9.0 8.5 8.0
+       return map(truediv, accumulate(iterable), count(1))
 
    def repeatfunc(function, times=None, *args):
        "Repeat calls to a function with specified arguments."
@@ -1232,6 +1237,10 @@ and :term:`generators <generator>` which incur interpreter overhead.
 
     >>> list(islice(tabulate(lambda x: 2*x), 4))
     [0, 2, 4, 6]
+
+
+    >>> list(running_median([8.5, 9.5, 7.5, 7.0]))
+   [8.5, 9.0, 8.5, 8.0]
 
 
     >>> for _ in loops(5):

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -859,10 +859,6 @@ and :term:`generators <generator>` which incur interpreter overhead.
        # prepend(1, [2, 3, 4]) → 1 2 3 4
        return chain([value], iterable)
 
-   def tabulate(function, start=0):
-       "Return function(0), function(1), ..."
-       return map(function, count(start))
-
    def running_mean(iterable):
        "Yield the cumulative arithmetic mean."
        # running_mean([8.5, 9.5, 7.5, 7.0]) -> 8.5 9.0 8.5 8.0
@@ -1239,10 +1235,6 @@ and :term:`generators <generator>` which incur interpreter overhead.
 
     >>> list(enumerate('abc'))
     [(0, 'a'), (1, 'b'), (2, 'c')]
-
-
-    >>> list(islice(tabulate(lambda x: 2*x), 4))
-    [0, 2, 4, 6]
 
 
     >>> list(running_median([8.5, 9.5, 7.5, 7.0]))
@@ -1813,6 +1805,10 @@ and :term:`generators <generator>` which incur interpreter overhead.
 
     # Old recipes and their tests which are guaranteed to continue to work.
 
+    def tabulate(function, start=0):
+        "Return function(0), function(1), ..."
+        return map(function, count(start))
+
     def old_sumprod_recipe(vec1, vec2):
         "Compute a sum of products."
         return sum(starmap(operator.mul, zip(vec1, vec2, strict=True)))
@@ -1891,6 +1887,10 @@ and :term:`generators <generator>` which incur interpreter overhead.
 
 .. doctest::
     :hide:
+
+    >>> list(islice(tabulate(lambda x: 2*x), 4))
+    [0, 2, 4, 6]
+
 
     >>> dotproduct([1,2,3], [4,5,6])
     32

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -1238,7 +1238,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
 
 
     >>> list(running_median([8.5, 9.5, 7.5, 7.0]))
-   [8.5, 9.0, 8.5, 8.0]
+    [8.5, 9.0, 8.5, 8.0]
 
 
     >>> for _ in loops(5):

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -847,6 +847,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
    from math import comb, isqrt, prod, sumprod
    from operator import getitem, is_not, itemgetter, mul, neg, truediv
 
+
    # ==== Basic one liners ====
 
    def take(n, iterable):
@@ -917,6 +918,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
        "Returns True if all the elements are equal to each other."
        # all_equal('4٤௪౪໔', key=int) → True
        return len(take(2, groupby(iterable, key))) <= 1
+
 
    # ==== Data pipelines ====
 
@@ -1026,6 +1028,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
            while True:
                yield function()
 
+
    # ==== Mathematical operations ====
 
    def multinomial(*counts):
@@ -1045,6 +1048,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
        # sum_of_squares([10, 20, 30]) → 1400
        return sumprod(*tee(iterable))
 
+
    # ==== Matrix operations ====
 
    def reshape(matrix, columns):
@@ -1062,6 +1066,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
        # matmul([(7, 5), (3, 5)], [(2, 5), (7, 9)]) → (49, 80) (41, 60)
        n = len(m2[0])
        return batched(starmap(sumprod, product(m1, transpose(m2))), n)
+
 
    # ==== Polynomial arithmetic ====
 
@@ -1118,6 +1123,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
        n = len(coefficients)
        powers = reversed(range(1, n))
        return list(map(mul, coefficients, powers))
+
 
    # ==== Number theory ====
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -861,7 +861,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
 
    def running_mean(iterable):
        "Yield the average of all values seen so far."
-       # running_mean([8.5, 9.5, 7.5, 7.0]) -> 8.5 9.0 8.5 8.0
+       # running_mean([8.5, 9.5, 7.5, 6.5]) -> 8.5 9.0 8.5 8.0
        return map(truediv, accumulate(iterable), count(1))
 
    def repeatfunc(function, times=None, *args):
@@ -1237,7 +1237,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
     [(0, 'a'), (1, 'b'), (2, 'c')]
 
 
-    >>> list(running_mean([8.5, 9.5, 7.5, 7.0]))
+    >>> list(running_mean([8.5, 9.5, 7.5, 6.5]))
     [8.5, 9.0, 8.5, 8.0]
 
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -1237,7 +1237,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
     [(0, 'a'), (1, 'b'), (2, 'c')]
 
 
-    >>> list(running_median([8.5, 9.5, 7.5, 7.0]))
+    >>> list(running_mean([8.5, 9.5, 7.5, 7.0]))
     [8.5, 9.0, 8.5, 8.0]
 
 


### PR DESCRIPTION
The `tabulate` example duplicates what is written in module introduction.  

It is replaced with `running_mean`, a more relevant example and one that demonstrates more tooling, such as `accumulate` and the `operator` module.



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144483.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->