### PR TITLE
gh-144484: Warn users not to use wsgiref in production

### DIFF
--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -11,6 +11,11 @@
 
 --------------
 
+.. warning::
+
+   :mod:`wsgiref` is a reference implementation and is not recommended for
+   production. The module only implements basic security checks.
+
 The Web Server Gateway Interface (WSGI) is a standard interface between web
 server software and web applications written in Python. Having a standard
 interface makes it easy to use an application that supports WSGI with a number


### PR DESCRIPTION
Follow-up from the precautionary CVE for `wsgiref`, where even though the module is documented as a reference implementation (instead of production-ready), there isn't any explicit docs for this like other modules with this property (eg: `http.server`).

<!-- gh-issue-number: gh-144484 -->
* Issue: gh-144484
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144487.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->