### PR TITLE
Docs: Pull expat license from `Modules/expat/` in `license.rst`

### DIFF
--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -848,29 +848,10 @@ expat
 -----
 
 The :mod:`pyexpat <xml.parsers.expat>` extension is built using an included copy of the expat
-sources unless the build is configured ``--with-system-expat``::
+sources unless the build is configured ``--with-system-expat``:
 
-  Copyright (c) 1998, 1999, 2000 Thai Open Source Software Center Ltd
-                                 and Clark Cooper
-
-  Permission is hereby granted, free of charge, to any person obtaining
-  a copy of this software and associated documentation files (the
-  "Software"), to deal in the Software without restriction, including
-  without limitation the rights to use, copy, modify, merge, publish,
-  distribute, sublicense, and/or sell copies of the Software, and to
-  permit persons to whom the Software is furnished to do so, subject to
-  the following conditions:
-
-  The above copyright notice and this permission notice shall be included
-  in all copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+.. literalinclude:: ../Modules/expat/COPYING
+  :language: text
 
 
 libffi

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -848,7 +848,7 @@ expat
 -----
 
 The :mod:`pyexpat <xml.parsers.expat>` extension is built using an included copy of the expat
-sources unless the build is configured ``--with-system-expat``:
+sources unless the build is configured :option:`--with-system-expat`:
 
 .. literalinclude:: ../Modules/expat/COPYING
   :language: text


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
To avoid the burden of updating both, see https://github.com/python/cpython/pull/144365#discussion_r2764785101.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144488.org.readthedocs.build/en/144488/license.html#expat

<!-- readthedocs-preview cpython-previews end -->