### PR TITLE
gh-144493: Improve error message in _overlapped.BindLocal()

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-02-05-17-15-31.gh-issue-144493.XuxwVu.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-05-17-15-31.gh-issue-144493.XuxwVu.rst
@@ -1,1 +1,1 @@
-Improve an exception error message in ``_overlapped.BindLocal()`` that is raised when :meth:`asyncio.loop.sock_connect()` is called on a :class:`asyncio.ProactorEventLoop` with a socket that has an invalid address family.
+Improve an exception error message in ``_overlapped.BindLocal()`` that is raised when :meth:`asyncio.loop.sock_connect` is called on a :class:`asyncio.ProactorEventLoop` with a socket that has an invalid address family.

--- a/Misc/NEWS.d/next/Library/2026-02-05-17-15-31.gh-issue-144493.XuxwVu.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-05-17-15-31.gh-issue-144493.XuxwVu.rst
@@ -1,0 +1,1 @@
+Improve an exception error message in ``_overlapped.BindLocal()`` that is raised when :meth:`asyncio.loop.sock_connect()` is called on a :class:`asyncio.ProactorEventLoop` with a socket that has an invalid address family.

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -559,7 +559,7 @@ _overlapped_BindLocal_impl(PyObject *module, HANDLE Socket, int Family)
         ret = bind((SOCKET)Socket, (SOCKADDR*)&addr, sizeof(addr))
                 != SOCKET_ERROR;
     } else {
-        PyErr_SetString(PyExc_ValueError, "expected tuple of length 2 or 4");
+        PyErr_SetString(PyExc_ValueError, "Only AF_INET and AF_INET6 families are supported");
         return NULL;
     }
 


### PR DESCRIPTION
Replace a confusing error message with one that actually explains what the error is in `_overlapped.BindLocal()`.

Fixes: https://github.com/python/cpython/issues/144493

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144493 -->
* Issue: gh-144493
<!-- /gh-issue-number -->
