### PR TITLE
gh-74955: Document that __all__ must contain strings in normalization form NFKC

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -831,7 +831,9 @@ where the :keyword:`import` statement occurs.
 
 The *public names* defined by a module are determined by checking the module's
 namespace for a variable named ``__all__``; if defined, it must be a sequence
-of strings which are names defined or imported by that module.  The names
+of strings which are names defined or imported by that module.
+Names containing non-ASCII characters must be in the `normalization form`_
+NFKC; see :ref:`lexical-names-nonascii` for details.  The names
 given in ``__all__`` are all considered public and are required to exist.  If
 ``__all__`` is not defined, the set of public names includes all names found
 in the module's namespace which do not begin with an underscore character

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -867,6 +867,8 @@ determine dynamically the modules to be loaded.
 
 .. audit-event:: import module,filename,sys.path,sys.meta_path,sys.path_hooks import
 
+.. _normalization form: https://www.unicode.org/reports/tr15/#Norm_Forms
+
 .. _future:
 
 Future statements


### PR DESCRIPTION


<!-- gh-issue-number: gh-74955 -->
* Issue: gh-74955
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144504.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->