### PR TITLE
More realistic lru_cache example

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -180,8 +180,8 @@ The :mod:`functools` module defines the following functions:
    the *maxsize* at its default value of 128::
 
        @lru_cache
-       def count_vowels(sentence):
-           return sum(sentence.count(vowel) for vowel in 'AEIOUaeiou')
+       def count_vowels(word):
+           return sum(word.count(vowel) for vowel in 'AEIOUaeiou')
 
    If *maxsize* is set to ``None``, the LRU feature is disabled and the cache can
    grow without bound.


### PR DESCRIPTION
Change the parameter name from `sentence` to `word`.  Vowel count caching makes more sense at the word level than the sentence level.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144517.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->