### PR TITLE
gh-140009: Optimize dict object by replacing PyTuple_Pack with PyTuple_FromArray

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-06-03-40-59.gh-issue-140009.a1b2c3.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-06-03-40-59.gh-issue-140009.a1b2c3.rst
@@ -1,0 +1,1 @@
+Improve performance of dict object by replacing PyTuple_Pack with PyTuple_FromArray for small tuples.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5083,7 +5083,8 @@ dictiter_new(PyDictObject *dict, PyTypeObject *itertype)
     }
     if (itertype == &PyDictIterItem_Type ||
         itertype == &PyDictRevIterItem_Type) {
-        di->di_result = PyTuple_Pack(2, Py_None, Py_None);
+        PyObject *items[] = {Py_None, Py_None};
+        di->di_result = PyTuple_FromArray(items, 2);
         if (di->di_result == NULL) {
             Py_DECREF(di);
             return NULL;
@@ -6284,7 +6285,8 @@ dictitems_xor_lock_held(PyObject *d1, PyObject *d2)
             }
         }
         else {
-            PyObject *pair = PyTuple_Pack(2, key, val2);
+            PyObject *items[] = {key, val2};
+            PyObject *pair = PyTuple_FromArray(items, 2);
             if (pair == NULL) {
                 goto error;
             }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

gh-140009: Optimize dict object by replacing PyTuple_Pack with PyTuple_FromArray
## Summary
This PR replaces `PyTuple_Pack` with `PyTuple_FromArray` in `Objects/dictobject.c` for creating small tuples (size 2). 

`PyTuple_FromArray` is more efficient than `PyTuple_Pack` because it avoids the overhead of variadic arguments (`va_args`) processing by taking a pointer to a pre-allocated array of `PyObject*`.

## Changes
- **dictiter_new**: Replaced `PyTuple_Pack(2, Py_None, Py_None)` with `PyTuple_FromArray` using a stack-allocated array.
- **dictitems_xor_lock_held**: Replaced `PyTuple_Pack(2, key, val2)` with `PyTuple_FromArray`.

## Performance Impact
This is part of a general effort to optimize small tuple creation across the codebase. Replacing `PyTuple_Pack` with `PyTuple_FromArray` for small, fixed-size tuples reduces call overhead.

<!-- gh-issue-number: gh-140009 -->
* Issue: gh-140009
<!-- /gh-issue-number -->
