### PR TITLE
gh-144533: Use pybuilddir.txt to find _sysconfigdata for WASI

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-02-06-13-49-09.gh-issue-144533.1k4jaE.rst
+++ b/Misc/NEWS.d/next/Build/2026-02-06-13-49-09.gh-issue-144533.1k4jaE.rst
@@ -1,0 +1,1 @@
+Use ``pybuilddir.txt`` to find ``_sysconfigdata`` for the WASI build script.


### PR DESCRIPTION
* Issue: gh-144533

Use `pybuilddir.txt` to find `_sysconfigdata` for the WASI build script.

The previous implementation hardcoded the path pattern to `build/lib.wasi-wasm32-{python_version}`. This change makes the script more robust by reading the exact build directory from `pybuilddir.txt` if it exists. It falls back to the hardcoded path if the file is missing to ensure backward compatibility during early build stages.