### PR TITLE
gh-144490: Fix test_cppext: test the internal C API

### DIFF
--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -25,6 +25,8 @@ SETUP = os.path.join(os.path.dirname(__file__), 'setup.py')
 @support.requires_subprocess()
 @support.requires_resource('cpu')
 class BaseTests:
+    TEST_INTERNAL_C_API = False
+
     def test_build(self):
         self.check_build('_testcppext')
 
@@ -63,6 +65,7 @@ class BaseTests:
             if limited:
                 env['CPYTHON_TEST_LIMITED'] = '1'
             env['CPYTHON_TEST_EXT_NAME'] = extension_name
+            env['TEST_INTERNAL_C_API'] = str(int(self.TEST_INTERNAL_C_API))
             if support.verbose:
                 print('Run:', ' '.join(map(shlex.quote, cmd)))
                 subprocess.run(cmd, check=True, env=env)

--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -30,22 +30,6 @@ class BaseTests:
     def test_build(self):
         self.check_build('_testcppext')
 
-    def test_build_cpp03(self):
-        # In public docs, we say C API is compatible with C++11. However,
-        # in practice we do maintain C++03 compatibility in public headers.
-        # Please ask the C API WG before adding a new C++11-only feature.
-        self.check_build('_testcpp03ext', std='c++03')
-
-    @unittest.skipIf(support.MS_WINDOWS, "MSVC doesn't support /std:c++11")
-    def test_build_cpp11(self):
-        self.check_build('_testcpp11ext', std='c++11')
-
-    # Only test C++14 on MSVC.
-    # On s390x RHEL7, GCC 4.8.5 doesn't support C++14.
-    @unittest.skipIf(not support.MS_WINDOWS, "need Windows")
-    def test_build_cpp14(self):
-        self.check_build('_testcpp14ext', std='c++14')
-
     def check_build(self, extension_name, std=None, limited=False):
         venv_dir = 'env'
         with support.setup_venv_with_pip_setuptools(venv_dir) as python_exe:
@@ -114,6 +98,22 @@ class TestPublicCAPI(BaseTests, unittest.TestCase):
     @support.requires_gil_enabled('incompatible with Free Threading')
     def test_build_limited(self):
         self.check_build('_testcppext_limited', limited=True)
+
+    def test_build_cpp03(self):
+        # In public docs, we say C API is compatible with C++11. However,
+        # in practice we do maintain C++03 compatibility in public headers.
+        # Please ask the C API WG before adding a new C++11-only feature.
+        self.check_build('_testcpp03ext', std='c++03')
+
+    @unittest.skipIf(support.MS_WINDOWS, "MSVC doesn't support /std:c++11")
+    def test_build_cpp11(self):
+        self.check_build('_testcpp11ext', std='c++11')
+
+    # Only test C++14 on MSVC.
+    # On s390x RHEL7, GCC 4.8.5 doesn't support C++14.
+    @unittest.skipIf(not support.MS_WINDOWS, "need Windows")
+    def test_build_cpp14(self):
+        self.check_build('_testcpp14ext', std='c++14')
 
 
 class TestInteralCAPI(BaseTests, unittest.TestCase):

--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -15,6 +15,11 @@
 #ifdef TEST_INTERNAL_C_API
    // gh-135906: Check for compiler warnings in the internal C API
 #  include "internal/pycore_frame.h"
+   // mimalloc emits many compiler warnings when Python is built in debug
+   // mode (when MI_DEBUG is not zero)
+#  ifndef Py_DEBUG
+#    include "internal/pycore_backoff.h"
+#  endif
 #endif
 
 #ifndef MODULE_NAME

--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -14,7 +14,6 @@
 
 #ifdef TEST_INTERNAL_C_API
    // gh-135906: Check for compiler warnings in the internal C API
-#  include "internal/pycore_backoff.h"
 #  include "internal/pycore_frame.h"
 #endif
 

--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -21,6 +21,7 @@
    // in free-threaded mode.
 #  if !defined(Py_DEBUG) && !(defined(MS_WINDOWS) && defined(Py_GIL_DISABLED))
 #    include "internal/pycore_backoff.h"
+#    include "internal/pycore_cell.h"
 #  endif
 #endif
 

--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -7,7 +7,7 @@
 #undef NDEBUG
 
 #ifdef TEST_INTERNAL_C_API
-#  define Py_BUILD_CORE 1
+#  define Py_BUILD_CORE_MODULE 1
 #endif
 
 #include "Python.h"
@@ -17,7 +17,9 @@
 #  include "internal/pycore_frame.h"
    // mimalloc emits many compiler warnings when Python is built in debug
    // mode (when MI_DEBUG is not zero)
-#  ifndef Py_DEBUG
+   // mimalloc emits compiler warnings when Python is built on Windows
+   // in free-threaded mode.
+#  if !defined(Py_DEBUG) && !(defined(MS_WINDOWS) && defined(Py_GIL_DISABLED))
 #    include "internal/pycore_backoff.h"
 #  endif
 #endif


### PR DESCRIPTION
Add missing TEST_INTERNAL_C_API env var.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144490 -->
* Issue: gh-144490
<!-- /gh-issue-number -->
