### PR TITLE
gh-142518: Define lock-free and per-object lock

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -951,6 +951,16 @@ Glossary
       to locks exist such as queues, producer/consumer patterns, and
       thread-local state. See also :term:`deadlock`, and :term:`reentrant`.
 
+   lock-free
+      An operation that does not acquire any :term:`lock` and uses atomic CPU
+      instructions to ensure correctness. Lock-free operations can execute
+      concurrently without blocking each other and cannot be blocked by
+      operations that hold locks. In :term:`free-threaded <free threading>`
+      Python, built-in types like :class:`dict` and :class:`list` provide
+      lock-free read operations, which means other threads may observe
+      intermediate states during multi-step modifications even when those
+      modifications hold the :term:`per-object lock`.
+
    loader
       An object that loads a module.
       It must define the :meth:`!exec_module` and :meth:`!create_module` methods
@@ -1216,6 +1226,16 @@ Glossary
       :ref:`the difference between arguments and parameters
       <faq-argument-vs-parameter>`, the :class:`inspect.Parameter` class, the
       :ref:`function` section, and :pep:`362`.
+
+   per-object lock
+      A :term:`lock` associated with an individual object instance rather than
+      a global lock shared across all objects. In :term:`free-threaded
+      <free threading>` Python, built-in types like :class:`dict` and
+      :class:`list` use per-object locks to allow concurrent operations on
+      different objects while serializing operations on the same object.
+      Operations that hold the per-object lock prevent other locking operations
+      on the same object from proceeding, but do not block :term:`lock-free`
+      operations.
 
    path entry
       A single location on the :term:`import path` which the :term:`path

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1441,7 +1441,9 @@ application).
          list appear empty for the duration, and raises :exc:`ValueError` if it can
          detect that the list has been mutated during a sort.
 
-.. admonition:: Thread safety
+.. _thread-safety-list:
+
+.. rubric:: Thread safety for list objects
 
    Reading a single element from a :class:`list` is
    :term:`atomic <atomic operation>`:
@@ -1462,11 +1464,11 @@ application).
       lst.index(item)
       lst.count(item)
 
-   All of the above methods/operations are also lock-free. They do not block
-   concurrent modifications. Other operations that hold a lock will not block
-   these from observing intermediate states.
+   All of the above methods/operations are also :term:`lock-free`. They do not
+   block concurrent modifications. Other operations that hold a lock will not
+   block these from observing intermediate states.
 
-   All other operations from here on block using the per-object lock.
+   All other operations from here on block using the :term:`per-object lock`.
 
    Writing a single item via ``lst[i] = x`` is safe to call from multiple
    threads and will not corrupt the list.
@@ -1497,7 +1499,7 @@ application).
    Other threads cannot observe intermediate states during sorting, but the
    list appears empty for the duration of the sort.
 
-   The following operations may allow lock-free operations to observe
+   The following operations may allow :term:`lock-free` operations to observe
    intermediate states since they modify multiple elements in place:
 
    .. code-block::

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1464,9 +1464,10 @@ application).
       lst.index(item)
       lst.count(item)
 
-   All of the above methods/operations are also :term:`lock-free`. They do not
-   block concurrent modifications. Other operations that hold a lock will not
-   block these from observing intermediate states.
+   All of the above operations avoid acquiring :term:`per-object locks
+   <per-object lock>`. They do not block concurrent modifications. Other
+   operations that hold a lock will not block these from observing intermediate
+   states.
 
    All other operations from here on block using the :term:`per-object lock`.
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1484,8 +1484,8 @@ The following operations return new objects and appear
    x * lst        # repeats lst x times into a new list
    lst.copy()     # returns a shallow copy of the list
 
-Methods that only operate on a single elements with no shifting required are
-:term:`atomic <atomic operation>`:
+The following methods that only operate on a single element with no shifting
+required are :term:`atomic <atomic operation>`:
 
 .. code-block::
    :class: good


### PR DESCRIPTION
- Add definitions of lock-free and per-object lock to the glossary
- Cross-reference these from list thread safety notes
- Change admonition to rubric

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142518 -->
* Issue: gh-142518
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144548.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->