### PR TITLE
gh-144438: Fix false sharing between QSBR and tlbc_index

### DIFF
--- a/Include/internal/pycore_qsbr.h
+++ b/Include/internal/pycore_qsbr.h
@@ -83,8 +83,9 @@ struct _qsbr_shared {
     // Minimum observed read sequence of all QSBR thread states
     uint64_t rd_seq;
 
-    // Array of QSBR thread states.
+    // Array of QSBR thread states (aligned to 64 bytes).
     struct _qsbr_pad *array;
+    void *array_raw;   // raw allocation pointer (for free)
     Py_ssize_t size;
 
     // Freelist of unused _qsbr_thread_states (protected by mutex)

--- a/Include/internal/pycore_tstate.h
+++ b/Include/internal/pycore_tstate.h
@@ -102,6 +102,12 @@ typedef struct _PyThreadStateImpl {
 #if _Py_TIER2
     struct _PyJitTracerState *jit_tracer_state;
 #endif
+
+#ifdef Py_GIL_DISABLED
+    // gh-144438: Add padding to ensure that the fields above don't share a
+    // cache line with other allocations.
+    char __padding[64];
+#endif
 } _PyThreadStateImpl;
 
 #ifdef __cplusplus

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-06-21-45-52.gh-issue-144438.GI_uB1LR.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-06-21-45-52.gh-issue-144438.GI_uB1LR.rst
@@ -1,0 +1,2 @@
+Align the QSBR thread state array to a 64-byte cache line boundary to
+avoid false sharing in the free-threaded build.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-06-21-45-52.gh-issue-144438.GI_uB1LR.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-06-21-45-52.gh-issue-144438.GI_uB1LR.rst
@@ -1,2 +1,2 @@
 Align the QSBR thread state array to a 64-byte cache line boundary to
-avoid false sharing in the free-threaded build.
+avoid false sharing in the :term:`free-threaded build`.

--- a/Python/qsbr.c
+++ b/Python/qsbr.c
@@ -92,8 +92,8 @@ grow_thread_array(struct _qsbr_shared *shared)
     size_t alloc_size = (size_t)new_size * sizeof(struct _qsbr_pad) + alignment - 1;
     void *raw = PyMem_RawCalloc(1, alloc_size);
     if (raw == NULL) {
-return -1;
-}
+        return -1;
+    }
     struct _qsbr_pad *array = _Py_ALIGN_UP(raw, alignment);
 
     void *old_raw = shared->array_raw;

--- a/Python/qsbr.c
+++ b/Python/qsbr.c
@@ -88,12 +88,13 @@ grow_thread_array(struct _qsbr_shared *shared)
     // Overallocate by 63 bytes so we can align to a 64-byte boundary.
     // This avoids potential false sharing between the first entry and other
     // allocations.
-    size_t alloc_size = (size_t)new_size * sizeof(struct _qsbr_pad) + 63;
+    size_t alignment = 64;
+    size_t alloc_size = (size_t)new_size * sizeof(struct _qsbr_pad) + alignment - 1;
     void *raw = PyMem_RawCalloc(1, alloc_size);
     if (raw == NULL) {
-        return -1;
-    }
-    struct _qsbr_pad *array = _Py_ALIGN_UP(raw, 64);
+return -1;
+}
+    struct _qsbr_pad *array = _Py_ALIGN_UP(raw, alignment);
 
     void *old_raw = shared->array_raw;
     if (shared->array != NULL) {

--- a/Python/qsbr.c
+++ b/Python/qsbr.c
@@ -93,7 +93,7 @@ grow_thread_array(struct _qsbr_shared *shared)
     if (raw == NULL) {
         return -1;
     }
-    struct _qsbr_pad *array = (struct _qsbr_pad *)(((uintptr_t)raw + 63) & ~(uintptr_t)63);
+    struct _qsbr_pad *array = _Py_ALIGN_UP(raw, 64);
 
     void *old_raw = shared->array_raw;
     if (shared->array != NULL) {

--- a/Python/qsbr.c
+++ b/Python/qsbr.c
@@ -85,22 +85,28 @@ grow_thread_array(struct _qsbr_shared *shared)
         new_size = MIN_ARRAY_SIZE;
     }
 
-    struct _qsbr_pad *array = PyMem_RawCalloc(new_size, sizeof(*array));
-    if (array == NULL) {
+    // Overallocate by 63 bytes so we can align to a 64-byte boundary.
+    // This avoids potential false sharing between the first entry and other
+    // allocations.
+    size_t alloc_size = (size_t)new_size * sizeof(struct _qsbr_pad) + 63;
+    void *raw = PyMem_RawCalloc(1, alloc_size);
+    if (raw == NULL) {
         return -1;
     }
+    struct _qsbr_pad *array = (struct _qsbr_pad *)(((uintptr_t)raw + 63) & ~(uintptr_t)63);
 
-    struct _qsbr_pad *old = shared->array;
-    if (old != NULL) {
+    void *old_raw = shared->array_raw;
+    if (shared->array != NULL) {
         memcpy(array, shared->array, shared->size * sizeof(*array));
     }
 
     shared->array = array;
+    shared->array_raw = raw;
     shared->size = new_size;
     shared->freelist = NULL;
     initialize_new_array(shared);
 
-    PyMem_RawFree(old);
+    PyMem_RawFree(old_raw);
     return 0;
 }
 
@@ -257,8 +263,9 @@ void
 _Py_qsbr_fini(PyInterpreterState *interp)
 {
     struct _qsbr_shared *shared = &interp->qsbr;
-    PyMem_RawFree(shared->array);
+    PyMem_RawFree(shared->array_raw);
     shared->array = NULL;
+    shared->array_raw = NULL;
     shared->size = 0;
     shared->freelist = NULL;
 }


### PR DESCRIPTION
Align the QSBR thread state array to a 64-byte cache line boundary and add padding at the end of _PyThreadStateImpl. Depending on heap layout, the QSBR array could end up sharing a cache line with a thread's tlbc_index, causing QSBR quiescent state updates to contend with reads of tlbc_index in RESUME_CHECK. This is sensitive to earlier allocations during interpreter init and can appear or disappear with seemingly unrelated changes.

Either change alone is sufficient to fix the specific issue, but both are worthwhile to avoid similar problems in the future.

<!-- gh-issue-number: gh-144438 -->
* Issue: gh-144438
<!-- /gh-issue-number -->
