### PR TITLE
gh-143700: document `secrets.DEFAULT_ENTROPY` as an opaque value

### DIFF
--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -94,7 +94,7 @@ hard-to-guess URLs, and similar.
    bytes.  The text is Base64 encoded, so on average each byte results
    in approximately 1.3 characters.
 
-   If *nybtes* is not specified or ``None``, :const:`DEFAULT_ENTROPY`
+   If *nbytes* is not specified or ``None``, :const:`DEFAULT_ENTROPY`
    is used instead.
 
    .. doctest::

--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -66,7 +66,7 @@ hard-to-guess URLs, and similar.
 
    Return a random byte string containing *nbytes* number of bytes.
 
-   If *nybtes* is not specified or ``None``, :const:`DEFAULT_ENTROPY`
+   If *nbytes* is not specified or ``None``, :const:`DEFAULT_ENTROPY`
    is used instead.
 
    .. doctest::

--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -80,7 +80,7 @@ hard-to-guess URLs, and similar.
    Return a random text string, in hexadecimal.  The string has *nbytes*
    random bytes, each byte converted to two hex digits.
 
-   If *nybtes* is not specified or ``None``, :const:`DEFAULT_ENTROPY`
+   If *nbytes* is not specified or ``None``, :const:`DEFAULT_ENTROPY`
    is used instead.
 
    .. doctest::

--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -62,39 +62,44 @@ The :mod:`!secrets` module provides functions for generating secure
 tokens, suitable for applications such as password resets,
 hard-to-guess URLs, and similar.
 
-.. function:: token_bytes([nbytes=None])
+.. function:: token_bytes(nbytes=None)
 
    Return a random byte string containing *nbytes* number of bytes.
-   If *nbytes* is ``None`` or not supplied, a reasonable default is
-   used.
+
+   If *nybtes* is not specified or ``None``, :const:`DEFAULT_ENTROPY`
+   is used instead.
 
    .. doctest::
 
-      >>> token_bytes(16)  #doctest:+SKIP
+      >>> token_bytes(16)  # doctest: +SKIP
       b'\xebr\x17D*t\xae\xd4\xe3S\xb6\xe2\xebP1\x8b'
 
 
-.. function:: token_hex([nbytes=None])
+.. function:: token_hex(nbytes=None)
 
    Return a random text string, in hexadecimal.  The string has *nbytes*
-   random bytes, each byte converted to two hex digits.  If *nbytes* is
-   ``None`` or not supplied, a reasonable default is used.
+   random bytes, each byte converted to two hex digits.
+
+   If *nybtes* is not specified or ``None``, :const:`DEFAULT_ENTROPY`
+   is used instead.
 
    .. doctest::
 
-      >>> token_hex(16)  #doctest:+SKIP
+      >>> token_hex(16)  # doctest: +SKIP
       'f9bf78b9a18ce6d46a0cd2b0b86df9da'
 
-.. function:: token_urlsafe([nbytes=None])
+.. function:: token_urlsafe(nbytes=None)
 
    Return a random URL-safe text string, containing *nbytes* random
    bytes.  The text is Base64 encoded, so on average each byte results
-   in approximately 1.3 characters.  If *nbytes* is ``None`` or not
-   supplied, a reasonable default is used.
+   in approximately 1.3 characters.
+
+   If *nybtes* is not specified or ``None``, :const:`DEFAULT_ENTROPY`
+   is used instead.
 
    .. doctest::
 
-      >>> token_urlsafe(16)  #doctest:+SKIP
+      >>> token_urlsafe(16)  # doctest: +SKIP
       'Drmhze6EPcv0fN_81Bj-nA'
 
 
@@ -115,11 +120,13 @@ argument to the various ``token_*`` functions.  That argument is taken
 as the number of bytes of randomness to use.
 
 Otherwise, if no argument is provided, or if the argument is ``None``,
-the ``token_*`` functions will use a reasonable default instead.
+the ``token_*`` functions uses :const:`DEFAULT_ENTROPY` instead.
 
-.. note::
+.. data:: DEFAULT_ENTROPY
 
-   That default is subject to change at any time, including during
+   Default number of bytes of randomness used by the ``token_*`` functions.
+
+   The exact value is subject to change at any time, including during
    maintenance releases.
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143700 -->
* Issue: gh-143700
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144568.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->