### PR TITLE
gh-84116: Add missing backslash to `_SubParsersAction.add_parser` signature

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1896,7 +1896,7 @@ Subcommands
       the main parser.
 
 
-.. method:: _SubParsersAction.add_parser(name, *, help=None, aliases=None,
+.. method:: _SubParsersAction.add_parser(name, *, help=None, aliases=None, \
                                          deprecated=False, **kwargs)
 
    Create and return a new :class:`ArgumentParser` object for the


### PR DESCRIPTION
skip issue, skip news
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144572.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-84116 -->
* Issue: gh-84116
<!-- /gh-issue-number -->
