### PR TITLE
For `enum.bin`, update versionadded directive from 3.10 to 3.11

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -1053,7 +1053,7 @@ Utilities and Decorators
       >>> enum.bin(~10)   # ~10 is -11
       '0b1 0101'
 
-   .. versionadded:: 3.10
+   .. versionadded:: 3.11
 
 ---------------
 


### PR DESCRIPTION
skip news, skip issue

Correct versionadded
source: 
https://github.com/python/cpython/blob/3.10/Lib/enum.py
https://github.com/python/cpython/blob/3.11/Lib/enum.py#L132-L154

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144574.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->