### PR TITLE
gh-144411: Validate slotstate type in pickle.load_build()

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -1876,8 +1876,10 @@ class _Unpickler:
                     inst_dict[intern(k)] = v
                 else:
                     inst_dict[k] = v
-        if slotstate:
-            for k, v in slotstate.items():
+        if slotstate is not None:
+             if not isinstance(slotstate, dict):
+                raise UnpicklingError("slot state is not a dictionary")
+             for k, v in slotstate.items():
                 setattr(inst, k, v)
     dispatch[BUILD[0]] = load_build
 

--- a/Misc/NEWS.d/next/Library/2026-02-08-05-15-15.gh-issue-144411.5SLrNj.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-08-05-15-15.gh-issue-144411.5SLrNj.rst
@@ -1,0 +1,2 @@
+Fixed an inconsistency between the pure-Python and C pickle implementations
+when handling invalid slot state during unpickling.


### PR DESCRIPTION
- This fixes the `slotstate` issue for an object’s `__slots__` saved during pickling.
- This also fixes the difference in `slotstate` behavior in pickle.py and _pickle.c .
- Added the NEWS file.




<!-- gh-issue-number: gh-144411 -->
* Issue: gh-144411
<!-- /gh-issue-number -->
