### PR TITLE
gh-125053: Document that ob_mutex must only be used via critical section API

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -48,6 +48,22 @@ under :ref:`reference counting <countingrefs>`.
       Do not use this field directly; use :c:macro:`Py_TYPE` and
       :c:func:`Py_SET_TYPE` instead.
 
+   .. c:member:: PyMutex ob_mutex
+
+      A per-object lock, present only in the :term:`free-threaded <free threading>`
+      build (when :c:macro:`Py_GIL_DISABLED` is defined).
+
+      This field is **reserved for use by the critical section API**
+      (:c:macro:`Py_BEGIN_CRITICAL_SECTION` / :c:macro:`Py_END_CRITICAL_SECTION`).
+      Do **not** lock it directly with ``PyMutex_Lock``; doing so can cause
+      deadlocks.  If you need your own lock, add a separate :c:type:`PyMutex`
+      field to your object struct.
+
+      See :ref:`per-object-locks` in the free-threading extension guide for
+      details.
+
+      .. versionadded:: 3.13
+
 
 .. c:type:: PyVarObject
 

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -50,7 +50,7 @@ under :ref:`reference counting <countingrefs>`.
 
    .. c:member:: PyMutex ob_mutex
 
-      A per-object lock, present only in the :term:`free-threaded <free threading>`
+      A :ref:`per-object lock <per-object-locks>`, present only in the :term:`free-threaded <free threading>`
       build (when :c:macro:`Py_GIL_DISABLED` is defined).
 
       This field is **reserved for use by the critical section API**
@@ -58,9 +58,6 @@ under :ref:`reference counting <countingrefs>`.
       Do **not** lock it directly with ``PyMutex_Lock``; doing so can cause
       deadlocks.  If you need your own lock, add a separate :c:type:`PyMutex`
       field to your object struct.
-
-      See :ref:`per-object-locks` in the free-threading extension guide for
-      details.
 
       .. versionadded:: 3.13
 

--- a/Doc/howto/free-threading-extensions.rst
+++ b/Doc/howto/free-threading-extensions.rst
@@ -398,19 +398,15 @@ critical section API** (:c:macro:`Py_BEGIN_CRITICAL_SECTION` /
 
    Do **not** lock ``ob_mutex`` directly with ``PyMutex_Lock(&obj->ob_mutex)``.
    Mixing direct ``PyMutex_Lock`` calls with the critical section API on the
-   same mutex can cause deadlocks, because the critical section implementation
-   may suspend and release its locks when contention is detected.
+   same mutex can cause deadlocks.
 
 Even if your own code never uses critical sections on a particular object type,
 **CPython internals may use the critical section API on any Python object**.
-For example, the garbage collector or other interpreter internals may enter a
-critical section on your object.  If your code holds ``ob_mutex`` directly at
-that point, a deadlock can occur.
 
 If your extension type needs its own lock, add a separate :c:type:`PyMutex`
 field (or another synchronization primitive) to your object struct.
-:c:type:`PyMutex` is very lightweight — it is only one byte — so there is
-negligible cost to having an additional one.
+:c:type:`PyMutex` is very lightweight, so there is negligible cost to having
+an additional one.
 
 
 Building Extensions for the Free-Threaded Build

--- a/Doc/howto/free-threading-extensions.rst
+++ b/Doc/howto/free-threading-extensions.rst
@@ -410,28 +410,7 @@ that point, a deadlock can occur.
 If your extension type needs its own lock, add a separate :c:type:`PyMutex`
 field (or another synchronization primitive) to your object struct.
 :c:type:`PyMutex` is very lightweight — it is only one byte — so there is
-negligible cost to having an additional one::
-
-    /* WRONG — do not lock ob_mutex directly */
-    PyMutex_Lock(&obj->ob_mutex);
-    ...
-    PyMutex_Unlock(&obj->ob_mutex);
-
-    /* RIGHT — use critical sections for ob_mutex */
-    Py_BEGIN_CRITICAL_SECTION(obj);
-    ...
-    Py_END_CRITICAL_SECTION();
-
-    /* RIGHT — use your own mutex for your own state */
-    typedef struct {
-        PyObject_HEAD
-        PyMutex my_mutex;   /* separate lock for extension state */
-        int my_data;
-    } MyObject;
-
-    PyMutex_Lock(&self->my_mutex);
-    self->my_data++;
-    PyMutex_Unlock(&self->my_mutex);
+negligible cost to having an additional one.
 
 
 Building Extensions for the Free-Threaded Build


### PR DESCRIPTION
## Summary

- Add a new "Per-Object Locks (`ob_mutex`)" subsection to the free-threading extensions howto (`Doc/howto/free-threading-extensions.rst`) warning that `ob_mutex` is reserved for the critical section API and must not be locked directly with `PyMutex_Lock`
- Add an `ob_mutex` member entry under `PyObject` in the C API reference (`Doc/c-api/structures.rst`) with a cross-reference to the howto
- ~~Include code examples showing wrong (direct lock) vs. right (critical section or separate mutex) approaches~~

Closes #125053

## Test plan

- [x] `make html` in `Doc/` builds with no warnings
- [x] Cross-reference from `structures.html` to `free-threading-extensions.html#per-object-locks` renders correctly
- [x] All technical claims verified against C headers (`Include/object.h`, `Include/cpython/pylock.h`, `Include/internal/pycore_critical_section.h`)

<!-- gh-issue-number: gh-125053 -->
* Issue: gh-125053
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: 
* https://cpython-previews--144599.org.readthedocs.build/
* https://cpython-previews--144599.org.readthedocs.build/en/144599/c-api/structures.html#c.PyObject.ob_mutex
* https://cpython-previews--144599.org.readthedocs.build/en/144599/howto/free-threading-extensions.html#per-object-locks-ob-mutex

<!-- readthedocs-preview cpython-previews end -->