### PR TITLE
gh-144321: Fix named tuple bug when input is a non-sequence iterable

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8468,6 +8468,15 @@ class NamedTupleTests(BaseTestCase):
                 def name(self):
                     return __class__.__name__
 
+    def test_named_tuple_generator_input(self):
+        field_names = ["x", "y"]
+        field_values = [int, int]
+        Point = NamedTuple("Point", zip(field_names, field_values))
+        p = Point(1, 2)
+        self.assertEqual(p.x, 1)
+        self.assertEqual(p.y, 2)
+        self.assertEqual(repr(p),"Point(x=1, y=2)")
+
 
 class TypedDictTests(BaseTestCase):
     def test_basics_functional_syntax(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8468,7 +8468,7 @@ class NamedTupleTests(BaseTestCase):
                 def name(self):
                     return __class__.__name__
 
-    def test_named_tuple_generator_input(self):
+    def test_named_tuple_non_sequence_input(self):
         field_names = ["x", "y"]
         field_values = [int, int]
         Point = NamedTuple("Point", zip(field_names, field_values))

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3044,7 +3044,7 @@ def NamedTuple(typename, fields, /):
     """
     types = {n: _type_check(t, f"field {n} annotation must be a type")
              for n, t in fields}
-    field_names = [n for n, _ in fields]
+    field_names = list(types)
     nt = _make_nmtuple(typename, field_names, _make_eager_annotate(types), module=_caller())
     nt.__orig_bases__ = (NamedTuple,)
     return nt

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3044,8 +3044,7 @@ def NamedTuple(typename, fields, /):
     """
     types = {n: _type_check(t, f"field {n} annotation must be a type")
              for n, t in fields}
-    field_names = list(types)
-    nt = _make_nmtuple(typename, field_names, _make_eager_annotate(types), module=_caller())
+    nt = _make_nmtuple(typename, types, _make_eager_annotate(types), module=_caller())
     nt.__orig_bases__ = (NamedTuple,)
     return nt
 

--- a/Misc/NEWS.d/next/Library/2026-02-08-17-09-10.gh-issue-144321.w58PhQ.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-08-17-09-10.gh-issue-144321.w58PhQ.rst
@@ -1,0 +1,1 @@
+``NamedTuple`` function now works if the ``fields`` argument is a generator

--- a/Misc/NEWS.d/next/Library/2026-02-08-17-09-10.gh-issue-144321.w58PhQ.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-08-17-09-10.gh-issue-144321.w58PhQ.rst
@@ -1,2 +1,2 @@
-Fix :class:`typing.NamedTuple`` incorrectly
+Fix :class:`typing.NamedTuple` incorrectly
 inferring its fields when passing a generator.

--- a/Misc/NEWS.d/next/Library/2026-02-08-17-09-10.gh-issue-144321.w58PhQ.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-08-17-09-10.gh-issue-144321.w58PhQ.rst
@@ -1,2 +1,3 @@
-Fix :class:`typing.NamedTuple` incorrectly
-inferring its fields when passing a generator.
+The functional syntax for creating :class:`typing.NamedTuple`
+classes now supports passing any :term:`iterable` of fields and types.
+Previously, only sequences were supported.

--- a/Misc/NEWS.d/next/Library/2026-02-08-17-09-10.gh-issue-144321.w58PhQ.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-08-17-09-10.gh-issue-144321.w58PhQ.rst
@@ -1,1 +1,2 @@
-``NamedTuple`` function now works if the ``fields`` argument is a generator
+Fix :class:`typing.NamedTuple`` incorrectly
+inferring its fields when passing a generator.


### PR DESCRIPTION


<!-- gh-issue-number: gh-144321 -->
* Issue: gh-144321
<!-- /gh-issue-number -->
