### PR TITLE
Misc: remove unreachable second empty-heap check in heappushpop()

### DIFF
--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -281,11 +281,6 @@ _heapq_heappushpop_impl(PyObject *module, PyObject *heap, PyObject *item)
         return Py_NewRef(item);
     }
 
-    if (PyList_GET_SIZE(heap) == 0) {
-        PyErr_SetString(PyExc_IndexError, "index out of range");
-        return NULL;
-    }
-
     returnitem = PyList_GET_ITEM(heap, 0);
     PyListObject *list = _PyList_CAST(heap);
     FT_ATOMIC_STORE_PTR_RELAXED(list->ob_item[0], Py_NewRef(item));


### PR DESCRIPTION
The second `PyList_GET_SIZE(heap) == 0` check in `_heapq.heappushpop()` is unreachable and redundant. The heap size is already validated at entry, and remains stable under both the GIL and the `@critical_section heap lock` in no-GIL builds. So, remove the extra check to simplify the code.
