### PR TITLE
gh-137960: Add note about extended slicing in tutorial

### DIFF
--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -333,6 +333,10 @@ slicing::
    >>> word[42:]
    ''
 
+Some sequences also support extended slicing with a third "step" parameter:
+``s[i:j:k]``.  See :ref:`Common Sequence Operations <typesseq-common>` for
+details.
+
 Python strings cannot be changed --- they are :term:`immutable`.
 Therefore, assigning to an indexed position in the string results in an error::
 


### PR DESCRIPTION
## Summary

Adds a brief note about extended slicing (`s[i:j:k]`) to the tutorial's string slicing section, with a link to the full definition in Common Sequence Operations.

This follows [terryjreedy's suggestion](https://github.com/python/cpython/issues/137960#issuecomment-3149499498) on the issue:

> If we add anything to 'this section', the best place might between the end of the [i:j] discussion and the start of the next, "Python strings cannot be changed ... immutable."

The note is placed exactly at that location — after the out-of-range slice examples and before the immutability discussion. It keeps the tutorial beginner-friendly by not explaining negative steps inline, while pointing readers to the full reference.

## Test plan

- [x] `make -C Doc check` passes
- [x] `make -C Doc html` passes (no warnings)
- [x] Cross-reference to `:ref:`typesseq-common`` resolves correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-137960 -->
* Issue: gh-137960
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144605.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->