### PR TITLE
gh-140814: Fix call order in multiprocessing example

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -3238,8 +3238,8 @@ Safe importing of main module
            print('hello')
 
        if __name__ == '__main__':
-           freeze_support()
            set_start_method('spawn')
+           freeze_support()
            p = Process(target=foo)
            p.start()
 


### PR DESCRIPTION
## Summary

Swaps the order of `set_start_method()` and `freeze_support()` in the "Safe importing of main module" example in the multiprocessing docs.

`freeze_support()` internally calls `get_start_method()`, which sets `_actual_context` on the default context (`Lib/multiprocessing/context.py:240-244`). A subsequent `set_start_method('spawn')` then raises `RuntimeError('context has already been set')` because `_actual_context` is no longer `None` (`context.py:249`).

Calling `set_start_method()` first avoids this, since `freeze_support()` will then use the already-configured spawn context.

## Test plan

- [x] `make -C Doc check` passes
- [x] `make -C Doc html` passes (no warnings)
- [x] Verified against source: `Lib/multiprocessing/context.py` lines 144-150, 240-254


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-140814 -->
* Issue: gh-140814
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144606.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->