### PR TITLE
gh-137337: Clarify import statement namespace binding

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -762,7 +762,7 @@ steps:
 #. find a module, loading and initializing it if necessary
 #. define a name or names in the current namespace for the scope where
    the :keyword:`import` statement occurs, just as an assignment statement
-   would, including global, local, and nonlocal semantics.
+   would (including :keyword:`global` and :keyword:`nonlocal` semantics).
 
 When the statement contains multiple clauses (separated by
 commas) the two steps are carried out separately for each clause, just

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -760,8 +760,9 @@ The basic import statement (no :keyword:`from` clause) is executed in two
 steps:
 
 #. find a module, loading and initializing it if necessary
-#. define a name or names in the local namespace for the scope where
-   the :keyword:`import` statement occurs.
+#. define a name or names in the current namespace for the scope where
+   the :keyword:`import` statement occurs, just as an assignment statement
+   would, including global, local, and nonlocal semantics.
 
 When the statement contains multiple clauses (separated by
 commas) the two steps are carried out separately for each clause, just
@@ -806,7 +807,7 @@ The :keyword:`from` form uses a slightly more complex process:
    #. if not, attempt to import a submodule with that name and then
       check the imported module again for that attribute
    #. if the attribute is not found, :exc:`ImportError` is raised.
-   #. otherwise, a reference to that value is stored in the local namespace,
+   #. otherwise, a reference to that value is stored in the current namespace,
       using the name in the :keyword:`!as` clause if it is present,
       otherwise using the attribute name
 


### PR DESCRIPTION
## Summary

The import statement documentation says names are defined "in the local namespace," which is inaccurate when the imported name has been declared `global` or `nonlocal`:

```python
x = None
def f():
    global x
    import os as x  # Assigns to global namespace, not local
```

Updates two places in `Doc/reference/simple_stmts.rst`:
- The basic `import` description (step 2): "local namespace" -> "current namespace... just as an assignment statement would, including global, local, and nonlocal semantics"
- The `from ... import` description (step 2.d): "local namespace" -> "current namespace"

This follows the wording proposed by @nedbat and discussed with @serhiy-storchaka and @terryjreedy in the [issue thread](https://github.com/python/cpython/issues/137337).

## Test plan

- [x] `make -C Doc check` passes
- [x] `make -C Doc html` passes (no warnings)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-137337 -->
* Issue: gh-137337
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144607.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->