### PR TITLE
gh-143535: Dispatch on the second argument if generic method is instance-bindable

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -605,6 +605,10 @@ functools
   callables.
   (Contributed by Serhiy Storchaka in :gh:`140873`.)
 
+* :func:`~functools.singledispatchmethod` now dispatches on the second argument
+  if it wraps a regular method and is called as a class attribute.
+  (Contributed by Bartosz Sławecki in :gh:`143535`.)
+
 
 hashlib
 -------

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1063,10 +1063,7 @@ class _singledispatchmethod_get:
 
         # Dispatch on the second argument if a generic method turns into
         # a bound method on instance-level access. See GH-143535.
-        if obj is None and isinstance(func, FunctionType):
-            self._skip_bound_arg = True
-        else:
-            self._skip_bound_arg = False
+        self._skip_bound_arg = obj is None and isinstance(func, FunctionType)
 
         try:
             self.__module__ = func.__module__

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1100,8 +1100,7 @@ class _singledispatchmethod_get:
             method = self._dispatch(args[0].__class__)
         if hasattr(method, "__get__"):
             method = method.__get__(self._obj, self._cls)
-            if (self._skip_bound_arg
-                    and isinstance(method, MethodType)):
+            if self._skip_bound_arg and isinstance(method, MethodType):
                 args = args[1:]
         return method(*args, **kwargs)
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1100,10 +1100,9 @@ class _singledispatchmethod_get:
             method = self._dispatch(args[0].__class__)
         if hasattr(method, "__get__"):
             method = method.__get__(self._obj, self._cls)
-            if (
-                self._skip_bound_arg
-                and isinstance(method, MethodType)
-                and method.__self__ is self):
+            if (self._skip_bound_arg
+                    and isinstance(method, MethodType)
+                    and method.__self__ is self):
                 args = args[1:]
         return method(*args, **kwargs)
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1096,7 +1096,7 @@ class _singledispatchmethod_get:
                             '1 positional argument')
         if self._skip_bound_arg:
             method = self._dispatch(args[1].__class__)
-            if not isinstance(method, FunctionType):
+            if isinstance(method, MethodType):
                 args = args[1:]
         else:
             method = self._dispatch(args[0].__class__)

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1063,7 +1063,7 @@ class _singledispatchmethod_get:
 
         # Dispatch on the second argument if a generic method turns into
         # a bound method on instance-level access. See GH-143535.
-        self._skip_first_arg = obj is None and isinstance(func, FunctionType)
+        self._dispatch_arg_index = 1 if obj is None and isinstance(func, FunctionType) else 0
 
         try:
             self.__module__ = func.__module__
@@ -1093,8 +1093,7 @@ class _singledispatchmethod_get:
                                'singledispatchmethod method')
             raise TypeError(f'{funcname} requires at least '
                             '1 positional argument')
-        index = 1 if self._skip_first_arg else 0
-        method = self._dispatch(args[index].__class__)
+        method = self._dispatch(args[self._dispatch_arg_index].__class__)
 
         if hasattr(method, "__get__"):
             # If the method is a descriptor, it might be necessary
@@ -1102,11 +1101,11 @@ class _singledispatchmethod_get:
             # as it can be no longer expected after descriptor access.
             skip_bound_arg = False
             if isinstance(method, staticmethod):
-                skip_bound_arg = self._skip_first_arg
+                skip_bound_arg = self._dispatch_arg_index == 1
 
             method = method.__get__(self._obj, self._cls)
             if isinstance(method, MethodType):
-                skip_bound_arg = self._skip_first_arg
+                skip_bound_arg = self._dispatch_arg_index == 1
 
             if skip_bound_arg:
                 return method(*args[1:], **kwargs)

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1101,8 +1101,7 @@ class _singledispatchmethod_get:
         if hasattr(method, "__get__"):
             method = method.__get__(self._obj, self._cls)
             if (self._skip_bound_arg
-                    and isinstance(method, MethodType)
-                    and method.__self__ is self):
+                    and isinstance(method, MethodType)):
                 args = args[1:]
         return method(*args, **kwargs)
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 # import weakref  # Deferred to single_dispatch()
 from operator import itemgetter
 from reprlib import recursive_repr
-from types import FunctionType, GenericAlias, MethodType, MappingProxyType, UnionType
+from types import GenericAlias, MethodType, MappingProxyType, UnionType
 from _thread import RLock
 
 ################################################################################
@@ -1096,12 +1096,15 @@ class _singledispatchmethod_get:
                             '1 positional argument')
         if self._skip_bound_arg:
             method = self._dispatch(args[1].__class__)
-            if isinstance(method, FunctionType):
-                args = args[1:]
         else:
             method = self._dispatch(args[0].__class__)
         if hasattr(method, "__get__"):
             method = method.__get__(self._obj, self._cls)
+            if (
+                self._skip_bound_arg
+                and isinstance(method, MethodType)
+                and method.__self__ is self):
+                args = args[1:]
         return method(*args, **kwargs)
 
     def __getattr__(self, name):

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 # import weakref  # Deferred to single_dispatch()
 from operator import itemgetter
 from reprlib import recursive_repr
-from types import GenericAlias, MethodType, MappingProxyType, UnionType
+from types import FunctionType, GenericAlias, MethodType, MappingProxyType, UnionType
 from _thread import RLock
 
 ################################################################################

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1096,7 +1096,7 @@ class _singledispatchmethod_get:
                             '1 positional argument')
         if self._skip_bound_arg:
             method = self._dispatch(args[1].__class__)
-            if isinstance(method, MethodType):
+            if isinstance(method, FunctionType):
                 args = args[1:]
         else:
             method = self._dispatch(args[0].__class__)

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1093,10 +1093,8 @@ class _singledispatchmethod_get:
                                'singledispatchmethod method')
             raise TypeError(f'{funcname} requires at least '
                             '1 positional argument')
-        if self._skip_bound_arg:
-            method = self._dispatch(args[1].__class__)
-        else:
-            method = self._dispatch(args[0].__class__)
+        index = 1 if self._skip_bound_arg else 0
+        method = self._dispatch(args[index].__class__)
 
         if hasattr(method, "__get__"):
             # If the method is a descriptor, it might be necessary

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1103,7 +1103,7 @@ class _singledispatchmethod_get:
         if hasattr(method, "__get__"):
             method = method.__get__(self._obj, self._cls)
             if self._skip_bound_arg and isinstance(method, MethodType):
-                args = args[1:]
+                return method(*args[1:], **kwargs)
         return method(*args, **kwargs)
 
     def __getattr__(self, name):

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1063,7 +1063,7 @@ class _singledispatchmethod_get:
 
         # Dispatch on the second argument if a generic method turns into
         # a bound method on instance-level access. See GH-143535.
-        self._skip_bound_arg = obj is None and isinstance(func, FunctionType)
+        self._skip_first_arg = obj is None and isinstance(func, FunctionType)
 
         try:
             self.__module__ = func.__module__
@@ -1093,22 +1093,22 @@ class _singledispatchmethod_get:
                                'singledispatchmethod method')
             raise TypeError(f'{funcname} requires at least '
                             '1 positional argument')
-        index = 1 if self._skip_bound_arg else 0
+        index = 1 if self._skip_first_arg else 0
         method = self._dispatch(args[index].__class__)
 
         if hasattr(method, "__get__"):
             # If the method is a descriptor, it might be necessary
             # to drop the first argument before calling
             # as it can be no longer expected after descriptor access.
-            skip_first_arg = False
+            skip_bound_arg = False
             if isinstance(method, staticmethod):
-                skip_first_arg = self._skip_bound_arg
+                skip_bound_arg = self._skip_first_arg
 
             method = method.__get__(self._obj, self._cls)
             if isinstance(method, MethodType):
-                skip_first_arg = self._skip_bound_arg
+                skip_bound_arg = self._skip_first_arg
 
-            if skip_first_arg:
+            if skip_bound_arg:
                 return method(*args[1:], **kwargs)
         return method(*args, **kwargs)
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1060,12 +1060,14 @@ class _singledispatchmethod_get:
         # Set instance attributes which cannot be handled in __getattr__()
         # because they conflict with type descriptors.
         func = unbound.func
+
         # Dispatch on the second argument if a generic method turns into
-        # a bound method on instance-level access.
+        # a bound method on instance-level access. See GH-143535.
         if obj is None and isinstance(func, FunctionType):
             self._skip_bound_arg = True
         else:
             self._skip_bound_arg = False
+
         try:
             self.__module__ = func.__module__
         except AttributeError:

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 # import weakref  # Deferred to single_dispatch()
 from operator import itemgetter
 from reprlib import recursive_repr
-from types import GenericAlias, MethodType, MappingProxyType, UnionType
+from types import FunctionType, GenericAlias, MethodType, MappingProxyType, UnionType
 from _thread import RLock
 
 ################################################################################
@@ -1060,6 +1060,12 @@ class _singledispatchmethod_get:
         # Set instance attributes which cannot be handled in __getattr__()
         # because they conflict with type descriptors.
         func = unbound.func
+        # Dispatch on the second argument if a generic method turns into
+        # a bound method on instance-level access.
+        if obj is None and isinstance(func, FunctionType):
+            self._skip_bound_arg = True
+        else:
+            self._skip_bound_arg = False
         try:
             self.__module__ = func.__module__
         except AttributeError:
@@ -1088,7 +1094,12 @@ class _singledispatchmethod_get:
                                'singledispatchmethod method')
             raise TypeError(f'{funcname} requires at least '
                             '1 positional argument')
-        method = self._dispatch(args[0].__class__)
+        if self._skip_bound_arg:
+            method = self._dispatch(args[1].__class__)
+            if not isinstance(method, FunctionType):
+                args = args[1:]
+        else:
+            method = self._dispatch(args[0].__class__)
         if hasattr(method, "__get__"):
             method = method.__get__(self._obj, self._cls)
         return method(*args, **kwargs)

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1100,9 +1100,20 @@ class _singledispatchmethod_get:
             method = self._dispatch(args[1].__class__)
         else:
             method = self._dispatch(args[0].__class__)
+
         if hasattr(method, "__get__"):
+            # If the method is a descriptor, it might be necessary
+            # to drop the first argument before calling
+            # as it can be no longer expected after descriptor access.
+            skip_first_arg = False
+            if isinstance(method, staticmethod):
+                skip_first_arg = self._skip_bound_arg
+
             method = method.__get__(self._obj, self._cls)
-            if self._skip_bound_arg and isinstance(method, MethodType):
+            if isinstance(method, MethodType):
+                skip_first_arg = self._skip_bound_arg
+
+            if skip_first_arg:
                 return method(*args[1:], **kwargs)
         return method(*args, **kwargs)
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3023,7 +3023,7 @@ class TestSingleDispatch(unittest.TestCase):
 
             @generic.register
             @staticmethod
-            def special3(self, x: complex):
+            def special3(x: complex):
                 return "special3"
 
             def special4(self, x):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3047,7 +3047,6 @@ class TestSingleDispatch(unittest.TestCase):
 
             generic.register(D2, D2())
 
-
         self.assertEqual(C.generic(C(), "foo"), "generic")
         self.assertEqual(C.generic(C(), 1), "special1")
         self.assertEqual(C.generic(C(), 2.0), "special2")

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3042,7 +3042,9 @@ class TestSingleDispatch(unittest.TestCase):
                 def __get__(self, inst, owner):
                     # Different instance bound to the returned method
                     # doesn't cause it to receive the original instance
-                    # as a separate argument. Return a partial() to workaround.
+                    # as a separate argument.
+                    # To work around this, wrap the returned bound method
+                    # with `functools.partial`.
                     return C().special5
 
             generic.register(D2, D2())

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3005,6 +3005,56 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(A.static_func.__name__, 'static_func')
         self.assertEqual(A().static_func.__name__, 'static_func')
 
+    def test_method_classlevel_calls(self):
+        """Regression test for GH-144615."""
+        class C:
+            @functools.singledispatchmethod
+            def generic(self, x: object):
+                return "generic"
+
+            @generic.register
+            def special1(self, x: int):
+                return "special1"
+
+            @generic.register
+            @classmethod
+            def special2(self, x: float):
+                return "special2"
+
+            @generic.register
+            @staticmethod
+            def special3(self, x: complex):
+                return "special3"
+
+            def special4(self, x):
+                return "special4"
+
+            class D1:
+                def __get__(self, _, owner):
+                    return lambda inst, x: owner.special4(inst, x)
+
+            generic.register(D1, D1())
+
+            def special5(self, x):
+                return "special5"
+
+            class D2:
+                def __get__(self, inst, owner):
+                    # Different instance bound to the returned method
+                    # doesn't cause it to receive the original instance
+                    # as a separate argument. Return a partial() to workaround.
+                    return C().special5
+
+            generic.register(D2, D2())
+
+
+        self.assertEqual(C.generic(C(), "foo"), "generic")
+        self.assertEqual(C.generic(C(), 1), "special1")
+        self.assertEqual(C.generic(C(), 2.0), "special2")
+        self.assertEqual(C.generic(C(), 3j), "special3")
+        self.assertEqual(C.generic(C(), C.D1()), "special4")
+        self.assertEqual(C.generic(C(), C.D2()), "special5")
+
     def test_method_repr(self):
         class Callable:
             def __call__(self, *args):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3006,7 +3006,7 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(A().static_func.__name__, 'static_func')
 
     def test_method_classlevel_calls(self):
-        """Regression test for GH-144615."""
+        """Regression test for GH-143535."""
         class C:
             @functools.singledispatchmethod
             def generic(self, x: object):

--- a/Misc/NEWS.d/next/Library/2026-02-09-02-16-36.gh-issue-144615.s04x4n.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-09-02-16-36.gh-issue-144615.s04x4n.rst
@@ -1,0 +1,3 @@
+Methods directly decorated with :deco:`functools.singledispatchmethod` now
+dispatch on the second argument when called after being accessed as class
+attributes. Patch by Bartosz Sławecki.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Unbound methods (i.e. functions) become bound methods when regularly accessed as instance attributes. From the class level, the contract of Python is that the unbound method can be called like a function (the first argument to the call will be used as the conventional `self`) and the call will execute directly (no bound method in between). Following the contract, a natural expectation is that when generic methods are called as class attributes, the second argument will be used for dispatching, not the first (the conventional `self`).

To support descriptors like `classmethod` (that bind to something else than the instance), arguments are shifted by one even if `__get__` method returns a method that is bound to a different object than the original `self` (`_singledispatchmethod_get._obj`). If one wants to receive that `self` in an arbitrary bound method as a regular argument, the workaround is easy: return a `partial(bound method)` to hack the check.

This is a low risk bugfix. The patch is meant to fix the following program:

```py
class C:
   @singledispatchmethod
   def generic(self, x: object):
       return "generic"

   @generic.register
   def special(self, x: int):
       return "special"

assert C.generic(C(), 1) == "generic"  # should be "special"
```



<!-- gh-issue-number: gh-143535 -->
* Issue: gh-143535
<!-- /gh-issue-number -->
