### PR TITLE
gh-144623: Fix missing output uops in optimizer debug output

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-09-11-57-29.gh-issue-144623.QLDbZo.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-09-11-57-29.gh-issue-144623.QLDbZo.rst
@@ -1,0 +1,1 @@
+Fix missing output uops in JIT optimizer debug output.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-09-11-57-29.gh-issue-144623.QLDbZo.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-09-11-57-29.gh-issue-144623.QLDbZo.rst
@@ -1,1 +1,0 @@
-Fix missing output uops in JIT optimizer debug output.


### PR DESCRIPTION
Previously, `optimize_uops` used `DUMP_UOP` which only logged a single instruction at the `out_ptr`. However, since `optimize_uops` can emit multiple uops into the buffer in a single pass, this caused the debug log  to miss subsequent uops like this:
```
 stack_level 5
  24 abs: _BINARY_SLICE (0, target=24, operand0=0, operand1=0)
    locals=[<? at 0x101b58440>, <recorded type list>, <? at 0x101b58460>, <? at 0x101b58470>, <int at 0x101b584c0>, <? at 0x101b58490>]
    stack=[<? at 0x101b584a0>, <? at 0x101b584b0>, <recorded type list>, <? at 0x101b58460>, <? at 0x101b58470>]
  24 out: _GUARD_3OS_TYPE (0, target=24, operand0=0x101745988, operand1=0)
    locals=[<? at 0x101b58440>, <recorded type list>, <? at 0x101b58460>, <? at 0x101b58470>, <int at 0x101b584c0>, <? at 0x101b58490>]
    stack=[<? at 0x101b584a0>, <? at 0x101b584b0>, <list at 0x101b584d0>]
  25 out: _UNPACK_INDICES (0, target=24, operand0=0, operand1=0)
    locals=[<? at 0x101b58440>, <recorded type list>, <? at 0x101b58460>, <? at 0x101b58470>, <int at 0x101b584c0>, <? at 0x101b58490>]
    stack=[<? at 0x101b584a0>, <? at 0x101b584b0>, <list at 0x101b584d0>]
  26 out: _BINARY_SLICE_LIST (0, target=24, operand0=0, operand1=0)
    locals=[<? at 0x101b58440>, <recorded type list>, <? at 0x101b58460>, <? at 0x101b58470>, <int at 0x101b584c0>, <? at 0x101b58490>]
    stack=[<? at 0x101b584a0>, <? at 0x101b584b0>, <list at 0x101b584d0>]
```

<!-- gh-issue-number: gh-144623 -->
* Issue: gh-144623
<!-- /gh-issue-number -->
