### PR TITLE
gh-144618: Don't track `ClassVar` dataclass members as defaults

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -905,8 +905,8 @@ def _get_field(cls, a_name, a_type, default_kw_only):
         if not isinstance(default, Field):
             f.default = default
         else:
-            # Extremely weird case: the Field comes from __get__() of
-            # a descriptor.
+            # Exceptional case retained for backward compatibility:
+            # the Field comes from __get__() of a descriptor. See GH-144619.
             default._field_type = f._field_type
             default.name = f.name
             default.type = f.type

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -828,16 +828,11 @@ def _get_field(cls, a_name, a_type, default_kw_only):
     # default_kw_only is the value of kw_only to use if there isn't a field()
     # that defines it.
 
-    # If the default value isn't derived from Field, then it's only a
-    # normal default value.  Convert it to a Field().
-    default = getattr(cls, a_name, MISSING)
-    if isinstance(default, Field):
-        f = default
+    member = vars(cls).get(a_name, MISSING)
+    if isinstance(member, Field):
+        f = member
     else:
-        if isinstance(default, types.MemberDescriptorType):
-            # This is a field in __slots__, so it has no default value.
-            default = MISSING
-        f = field(default=default)
+        f = field()
 
     # Only at this point do we know the name and the type.  Set them.
     f.name = a_name
@@ -899,6 +894,17 @@ def _get_field(cls, a_name, a_type, default_kw_only):
 
     # kw_only validation and assignment.
     if f._field_type in (_FIELD, _FIELD_INITVAR):
+        # If the default value isn't derived from Field, then it's only a
+        # normal default value.
+        default = getattr(cls, a_name, MISSING)
+
+        # This is a field in __slots__, so it has no default value.
+        if isinstance(default, types.MemberDescriptorType):
+            default = MISSING
+
+        if not isinstance(default, Field):
+            f.default = default
+
         # For real and InitVar fields, if kw_only wasn't specified use the
         # default value.
         if f.kw_only is MISSING:
@@ -1072,6 +1078,14 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
         # field) exists and is of type 'Field', replace it with the
         # real default.  This is so that normal class introspection
         # sees a real default value, not a Field.
+
+        # Class variables cannot be removed from the class.
+        if f._field_type is _FIELD_CLASSVAR:
+            if f.default is not MISSING:
+                setattr(cls, f.name, f.default)
+            continue
+
+        # Regular fields can be set or removed as necessary.
         if isinstance(getattr(cls, f.name, None), Field):
             if f.default is MISSING:
                 # If there's no default, delete the class attribute.

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -904,6 +904,13 @@ def _get_field(cls, a_name, a_type, default_kw_only):
 
         if not isinstance(default, Field):
             f.default = default
+        else:
+            # Extremely weird case: the Field comes from __get__() of
+            # a descriptor.
+            default._field_type = f._field_type
+            default.name = f.name
+            default.type = f.type
+            f = default
 
         # For real and InitVar fields, if kw_only wasn't specified use the
         # default value.

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1085,7 +1085,7 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
                 setattr(cls, f.name, f.default)
             continue
 
-        # Regular fields can be set or removed as necessary.
+        # Other fields can be set or removed as necessary.
         if isinstance(getattr(cls, f.name, None), Field):
             if f.default is MISSING:
                 # If there's no default, delete the class attribute.

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -1496,6 +1496,25 @@ class TestCase(unittest.TestCase):
         d = D(4, 5)
         self.assertEqual((d.x, d.z), (4, 5))
 
+    def test_classvar_default_value_failing_descriptor(self):
+        class Kaboom:
+            def __get__(self, inst, owner):
+                raise RuntimeError("kaboom!")
+
+        @dataclass
+        class C:
+            kaboom: ClassVar[None] = Kaboom()
+
+        self.assertIsInstance(C.__dict__["kaboom"], Kaboom)
+
+    def test_classvar_member_isnt_tracked_or_removed(self):
+        @dataclass
+        class C:
+            x: ClassVar[int] = 1000
+
+        self.assertEqual(C.__dataclass_fields__['x'].default, MISSING)
+        self.assertEqual(C.x, 1000)
+
     def test_classvar_default_factory(self):
         # It's an error for a ClassVar to have a factory function.
         with self.assertRaisesRegex(TypeError,

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -1504,7 +1504,7 @@ class TestCase(unittest.TestCase):
 
         @dataclass
         class C:
-            kaboom: ClassVar[None] = Kaboom()
+            kaboom: ClassVar[Kaboom] = Kaboom()
 
         self.assertIsInstance(C.__dict__["kaboom"], Kaboom)
 

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -1514,7 +1514,7 @@ class TestCase(unittest.TestCase):
         class C:
             x: ClassVar[int] = 1000
 
-        self.assertEqual(C.__dataclass_fields__['x'].default, MISSING)
+        self.assertIs(C.__dataclass_fields__['x'].default, MISSING)
         self.assertEqual(C.x, 1000)
 
     def test_classvar_default_factory(self):

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -1497,6 +1497,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual((d.x, d.z), (4, 5))
 
     def test_classvar_default_value_failing_descriptor(self):
+        """Regression test for GH-144618."""
         class Kaboom:
             def __get__(self, inst, owner):
                 raise RuntimeError("kaboom!")
@@ -1508,6 +1509,7 @@ class TestCase(unittest.TestCase):
         self.assertIsInstance(C.__dict__["kaboom"], Kaboom)
 
     def test_classvar_member_isnt_tracked_or_removed(self):
+        """Regression test for GH-144618."""
         @dataclass
         class C:
             x: ClassVar[int] = 1000

--- a/Misc/NEWS.d/next/Library/2026-02-09-05-49-09.gh-issue-144618.raQvMb.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-09-05-49-09.gh-issue-144618.raQvMb.rst
@@ -1,0 +1,3 @@
+:deco:`dataclasses.dataclass` no longer triggers ``__get__`` of
+:data:`~typing.ClassVar` members nor tracks them as field defaults. Patch by
+Bartosz Sławecki.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

I haven't added code for cleaning up `ClassVar[Field] = dataclasses.field(default=MISSING)` from class members, because this is an incorrect use of the API.
Perhaps it should even fail, but that's out of scope of the issue.


<!-- gh-issue-number: gh-144618 -->
* Issue: gh-144618
<!-- /gh-issue-number -->
