### PR TITLE
gh-144490: Fix mimalloc debug build

### DIFF
--- a/Include/internal/mimalloc/mimalloc/types.h
+++ b/Include/internal/mimalloc/mimalloc/types.h
@@ -608,8 +608,8 @@ struct mi_heap_s {
 
 #if (MI_DEBUG)
 // use our own assertion to print without memory allocation
-mi_decl_noreturn mi_decl_cold mi_decl_throw
-void _mi_assert_fail(const char* assertion, const char* fname, unsigned int line, const char* func);
+mi_decl_noreturn mi_decl_cold
+void _mi_assert_fail(const char* assertion, const char* fname, unsigned int line, const char* func) mi_decl_throw;
 #define mi_assert(expr)     ((expr) ? (void)0 : _mi_assert_fail(#expr,__FILE__,__LINE__,__func__))
 #else
 #define mi_assert(x)

--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -19,7 +19,7 @@
    // mode (when MI_DEBUG is not zero)
    // mimalloc emits compiler warnings when Python is built on Windows
    // in free-threaded mode.
-#  if !defined(Py_DEBUG) && !(defined(MS_WINDOWS) && defined(Py_GIL_DISABLED))
+#  if !(defined(MS_WINDOWS) && defined(Py_GIL_DISABLED))
 #    include "internal/pycore_backoff.h"
 #    include "internal/pycore_cell.h"
 #  endif


### PR DESCRIPTION
Fix mimalloc C++ compilation error in debug builds.

The `_mi_assert_fail` declaration uses `mi_decl_throw`, which expands to `__THROW` (for `__GNUC__ `). In C, `__THROW` is `__attribute__((__nothrow__))` and works anywhere. In C++, `__THROW` is `noexcept(true)`, which must come after the parameter list.

  Before:
```
  // C:   __attribute__((__nothrow__)) void _mi_assert_fail(...);
  // C++: noexcept(true) void _mi_assert_fail(...);  <- Error, noexcept(...) must be after the params
```

After:
```
  // C:   void _mi_assert_fail(...) __attribute__((__nothrow__));
  // C++: void _mi_assert_fail(...) noexcept(true);
```

This fix also allows removing the `Py_DEBUG` guard in `test_cppext/extension.cpp`, so internal C API headers are now tested in debug builds too.

It’s possible this issue was introduced in #122587, though I haven’t verified it

Test:
```
$ ./configure --with-pydebug --disable-gil
$ make
$ ./python -m test test.test_cppext -u cpu=1
```

cc: @vstinner @colesbury @DinoV 

<!-- gh-issue-number: gh-144490 -->
* Issue: gh-144490
<!-- /gh-issue-number -->
