### PR TITLE
gh-144490: Fix test_cppext on Windows

### DIFF
--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -16,10 +16,9 @@
    // gh-135906: Check for compiler warnings in the internal C API
 #  include "internal/pycore_frame.h"
    // mimalloc emits many compiler warnings when Python is built in debug
-   // mode (when MI_DEBUG is not zero)
-   // mimalloc emits compiler warnings when Python is built on Windows
-   // in free-threaded mode.
-#  if !defined(Py_DEBUG) && !(defined(MS_WINDOWS) && defined(Py_GIL_DISABLED))
+   // mode (when MI_DEBUG is not zero).
+   // mimalloc emits compiler warnings when Python is built on Windows.
+#  if !defined(Py_DEBUG) && !defined(MS_WINDOWS)
 #    include "internal/pycore_backoff.h"
 #    include "internal/pycore_cell.h"
 #  endif


### PR DESCRIPTION
Don't include pycore_backoff.h and pycore_cell.h on Windows, since they emit C++ compiler warnings.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144490 -->
* Issue: gh-144490
<!-- /gh-issue-number -->
