### PR TITLE
Disable pip version check when upgrading certifi

### DIFF
--- a/Mac/BuildScript/resources/install_certificates.command
+++ b/Mac/BuildScript/resources/install_certificates.command
@@ -25,7 +25,8 @@ def main():
 
     print(" -- pip install --upgrade certifi")
     subprocess.check_call([sys.executable,
-        "-E", "-s", "-m", "pip", "install", "--upgrade", "certifi"])
+        "-E", "-s", "-m", "pip", "install", "--upgrade", "certifi",
+        "--disable-pip-version-check"])
 
     import certifi
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


This PR adds `--disable-pip-version-check` to the pip invocation that upgrades `certifi` in `Install Certificates.command`, to avoid warnings like this:

```
[notice] A new release of pip is available: 25.3 -> 26.0.1
[notice] To update, run: /Library/Frameworks/Python.framework/Versions/3.14/bin/python3.14 -m pip install --upgrade pip
```

Docs: https://pip.pypa.io/en/stable/cli/pip/#cmdoption-disable-pip-version-check

These sometimes [show up on GitHub Actions](https://github.com/python-pillow/Pillow/actions/runs/21798050860) as part of `actions/setup-python`, which I as an end user has little control over. And the funny thing is, that action had just upgraded pip right before calling `Install Certificates.command`. See https://github.com/python-pillow/Pillow/pull/9424#issuecomment-3870997581 for more details.

I think avoiding the warning in this script is okay. In normal use, the user double clicks the "Install Certificates.command" icon during installation, the default terminal upgrades certifi then terminates.

People will still see the warning later on regular pip invocations when they're in a normal terminal session, which is when they can actually do something about it.

(Let me know if this PR needs an issue or news.)