### PR TITLE
gh-142731: Prevent use-after-free in _PyObject_StoreInstanceAttribute with re-entrant __hash__

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -5361,6 +5361,22 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         with self.assertRaisesRegex(NotImplementedError, "BAR"):
             B().foo
 
+    def test_reentrant_hash_during_setattr_delattr(self):
+        class Evil(str):
+            def __hash__(self):
+                old_dict = target.__dict__
+                target.__dict__ = {}
+                del old_dict
+                return super().__hash__()
+        class Target:
+            pass
+        target = Target()
+        setattr(target, Evil("marker"), 123)
+        try:
+            delattr(target, Evil("marker"))
+        except AttributeError:
+            pass
+
 
 class DictProxyTests(unittest.TestCase):
     def setUp(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-09-23-18-55.gh-issue-142731.KYuPij.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-09-23-18-55.gh-issue-142731.KYuPij.rst
@@ -1,0 +1,3 @@
+Fix a potential use-after-free crash when setting or deleting instance
+attributes if a re-entrant ``__hash__`` implementation mutates the instance
+``__dict__`` during attribute handling.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -6983,7 +6983,10 @@ _PyObject_StoreInstanceAttribute(PyObject *obj, PyObject *name, PyObject *value)
             Py_DECREF(dict);
             return res;
         }
-        return store_instance_attr_dict(obj, dict, name, value);
+        Py_INCREF(dict);
+        int res = store_instance_attr_dict(obj, dict, name, value);
+        Py_DECREF(dict);
+        return res;
     }
 
 #ifdef Py_GIL_DISABLED
@@ -7012,7 +7015,10 @@ _PyObject_StoreInstanceAttribute(PyObject *obj, PyObject *name, PyObject *value)
             return res;
         }
     }
-    return store_instance_attr_dict(obj, dict, name, value);
+    Py_INCREF((PyObject *)dict);
+    int res = store_instance_attr_dict(obj, dict, name, value);
+    Py_DECREF((PyObject *)dict);
+    return res;
 #else
     return store_instance_attr_lock_held(obj, values, name, value);
 #endif


### PR DESCRIPTION
Fix a potential use-after-free when storing or deleting instance attributes if a re-entrant ``__hash__`` mutates the instance ``__dict__`` during attribute handling.

Temporarily INCREF the managed dict in the ``Py_GIL_DISABLED`` path to ensure it remains alive across the call to ``store_instance_attr_dict()``.

<!-- gh-issue-number: gh-142731 -->
* Issue: gh-142731
<!-- /gh-issue-number -->
