### PR TITLE
DOC: clarify and expand documentation about PYTHONUSERBASE and PYTHONNOUSERSITE

### DIFF
--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -64,7 +64,8 @@ When running under a :ref:`virtual environment <sys-path-init-virtual-environmen
 the ``pyvenv.cfg`` file in :data:`sys.prefix` is checked for site-specific
 configurations. If the ``include-system-site-packages`` key exists and is set to
 ``true`` (case-insensitive), the system-level prefixes will be searched for
-site-packages, otherwise they won't.
+site-packages, otherwise they won't.  If the system-level prefixes are not searched then
+the user site prefixes are also implicitly not searched for site-packages.
 
 .. index::
    single: # (hash); comment

--- a/Doc/library/sys_path_init.rst
+++ b/Doc/library/sys_path_init.rst
@@ -100,7 +100,7 @@ Please refer to :mod:`site`'s
 
 .. note::
 
-   There are many ways how "virtual environments" could be implemented.
+   There are other ways virtual environments" could be implemented.
    This documentation refers to implementations based on the ``pyvenv.cfg``
    mechanism, such as :mod:`venv`, that many virtual environment implementations
    follow.

--- a/Doc/library/sys_path_init.rst
+++ b/Doc/library/sys_path_init.rst
@@ -96,11 +96,10 @@ Please refer to :mod:`site`'s
 
 .. note::
 
-   There are other ways how "virtual environments" could be implemented, this
-   documentation refers implementations based on the ``pyvenv.cfg`` mechanism,
-   such as :mod:`venv`. Most virtual environment implementations follow the
-   model set by :mod:`venv`, but there may be exotic implementations that
-   diverge from it.
+   There are many ways how "virtual environments" could be implemented.
+   This documentation refers to implementations based on the ``pyvenv.cfg``
+   mechanism, such as :mod:`venv`, that many virtual environment implementations
+   follow.
 
 _pth files
 ----------

--- a/Doc/library/sys_path_init.rst
+++ b/Doc/library/sys_path_init.rst
@@ -100,7 +100,7 @@ Please refer to :mod:`site`'s
 
 .. note::
 
-   There are other ways virtual environments" could be implemented.
+   There are other ways "virtual environments" could be implemented.
    This documentation refers to implementations based on the ``pyvenv.cfg``
    mechanism, such as :mod:`venv`, that many virtual environment implementations
    follow.

--- a/Doc/library/sys_path_init.rst
+++ b/Doc/library/sys_path_init.rst
@@ -57,15 +57,19 @@ otherwise they are set to the same value as :data:`sys.base_prefix` and
 :data:`sys.base_exec_prefix`, respectively.
 This is used by :ref:`sys-path-init-virtual-environments`.
 
-Finally, the :mod:`site` module is processed and :file:`site-packages` directories
-are added to the module search path. A common way to customize the search path is
-to create :mod:`sitecustomize` or :mod:`usercustomize` modules as described in
-the :mod:`site` module documentation.
+Finally, the :mod:`site` module is processed and :file:`site-packages`
+directories are added to the module search path.  The :envvar:`PYTHONUSERBASE`
+environment variable controls where is searched for user site-packages and the
+:envvar:`PYTHONNOUSERSITE` environment variable prevents searching for user
+site-packages all together.  A common way to customize the search path is to
+create :mod:`sitecustomize` or :mod:`usercustomize` modules as described in the
+:mod:`site` module documentation.
 
 .. note::
 
-   Certain command line options may further affect path calculations.
-   See :option:`-E`, :option:`-I`, :option:`-s` and :option:`-S` for further details.
+   The command line options :option:`-E`, :option:`-P`, :option:`-I`,
+   :option:`-S` and :option:`-s` further affect path calculations, see their
+   documentation for details.
 
 .. versionchanged:: 3.14
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -941,8 +941,9 @@ conflict.
 
 .. envvar:: PYTHONNOUSERSITE
 
-   If this is set, Python won't add the :data:`user site-packages directory
-   <site.USER_SITE>` to :data:`sys.path`.
+   This is equivalent to the :option:`-s` option.  If this is set, Python won't
+   add the :data:`user site-packages directory <site.USER_SITE>` to
+   :data:`sys.path`.
 
    .. seealso::
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -957,6 +957,9 @@ conflict.
    and :ref:`installation paths <sysconfig-user-scheme>` for
    ``python -m pip install --user``.
 
+   To disable the user site-packages, see :envvar:`PYTHONNOUSERSITE` or the :option:`-s`
+   option.
+
    .. seealso::
 
       :pep:`370` -- Per user site-packages directory

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -18,7 +18,7 @@ sys.prefix and sys.exec_prefix are set to that directory and
 it is also checked for site-packages (sys.base_prefix and
 sys.base_exec_prefix will always be the "real" prefixes of the Python
 installation). If "pyvenv.cfg" (a bootstrap configuration file) contains
-the key "include-system-site-packages" set to anything other than "false"
+the key "include-system-site-packages" is set to  "true"
 (case-insensitive), the system-level prefixes will still also be
 searched for site-packages; otherwise they won't.
 

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -20,7 +20,9 @@ sys.base_exec_prefix will always be the "real" prefixes of the Python
 installation). If "pyvenv.cfg" (a bootstrap configuration file) contains
 the key "include-system-site-packages" is set to  "true"
 (case-insensitive), the system-level prefixes will still also be
-searched for site-packages; otherwise they won't.
+searched for site-packages; otherwise they won't.  If the system-level
+prefixes are not included then the user site prefixes are also implicitly
+not searched for site-packages.
 
 All of the resulting site-specific directories, if they exist, are
 appended to sys.path, and also inspected for path configuration


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

-->

I erred on this not needing an issue to say "the docs could be improved" as that is always a true statement ;). 

The changes are split up into individual commits for ease of review.  The primary changes are:

 - increased cross references
 - documenting the previously undocumented behavior that `include-system-site-packages` in `pyvenv.cfg` implicitly also controls user site-packages
 - an error in the `site.py` docstring (looks like it has always been wrong)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144637.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->