### PR TITLE
gh-144551: Update macOS installer to use OpenSSL 3.5.5

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -246,9 +246,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 3.5.4",
-              url="https://github.com/openssl/openssl/releases/download/openssl-3.5.4/openssl-3.5.4.tar.gz",
-              checksum="967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99",
+              name="OpenSSL 3.5.5",
+              url="https://github.com/openssl/openssl/releases/download/openssl-3.5.5/openssl-3.5.5.tar.gz",
+              checksum="b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89",
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2026-02-09-22-43-47.gh-issue-144551.VOfgfD.rst
+++ b/Misc/NEWS.d/next/macOS/2026-02-09-22-43-47.gh-issue-144551.VOfgfD.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use OpenSSL 3.5.5.


### PR DESCRIPTION


<!-- gh-issue-number: gh-144551 -->
* Issue: gh-144551
<!-- /gh-issue-number -->
