### PR TITLE
gh-124111: Update macOS installer to use Tcl/Tk 9.0.3

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -264,10 +264,10 @@ def library_recipes():
             tk_patches = ['backport_gh71383_fix.patch', 'tk868_on_10_8_10_9.patch', 'backport_gh110950_fix.patch']
 
         else:
-            tcl_tk_ver='9.0.2'
-            tcl_checksum='e074c6a8d9ba2cddf914ba97b6677a552d7a52a3ca102924389a05ccb249b520'
+            tcl_tk_ver='9.0.3'
+            tcl_checksum='2537ba0c86112c8c953f7c09d33f134dd45c0fb3a71f2d7f7691fd301d2c33a6'
 
-            tk_checksum='76fb852b2f167592fe8b41aa6549ce4e486dbf3b259a269646600e3894517c76'
+            tk_checksum='bf344efadb618babb7933f69275620f72454d1c8220130da93e3f7feb0efbf9b'
             tk_patches = []
 
 

--- a/Misc/NEWS.d/next/macOS/2026-02-09-23-01-49.gh-issue-124111.WmQG7S.rst
+++ b/Misc/NEWS.d/next/macOS/2026-02-09-23-01-49.gh-issue-124111.WmQG7S.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use Tcl/Tk 9.0.3.


### PR DESCRIPTION


<!-- gh-issue-number: gh-124111 -->
* Issue: gh-124111
<!-- /gh-issue-number -->
