### PR TITLE
gh-144648: Improve libproc usage in _remote_debugging

### DIFF
--- a/Misc/NEWS.d/next/macOS/2026-02-10-08-00-17.gh-issue-144648.KEuUXp.rst
+++ b/Misc/NEWS.d/next/macOS/2026-02-10-08-00-17.gh-issue-144648.KEuUXp.rst
@@ -1,0 +1,1 @@
+Allowed _remote_debugging to build on more OS versions by using proc_listpids() rather than proc_listallpids().

--- a/Modules/_remote_debugging/subprocess.c
+++ b/Modules/_remote_debugging/subprocess.c
@@ -273,6 +273,7 @@ done:
 
 #if defined(__APPLE__) && TARGET_OS_OSX
 
+#include <libproc.h>
 #include <sys/proc_info.h>
 
 static int
@@ -283,7 +284,7 @@ get_child_pids_platform(pid_t target_pid, int recursive, pid_array_t *result)
     pid_t *ppids = NULL;
 
     /* Get count of all PIDs */
-    int n_pids = proc_listallpids(NULL, 0);
+    int n_pids = proc_listpids(PROC_ALL_PIDS, 0, NULL, 0);
     if (n_pids <= 0) {
         PyErr_SetString(PyExc_OSError, "Failed to get process count");
         goto done;
@@ -298,7 +299,7 @@ get_child_pids_platform(pid_t target_pid, int recursive, pid_array_t *result)
     }
 
     /* Get actual PIDs */
-    int actual = proc_listallpids(pid_list, buffer_size * sizeof(pid_t));
+    int actual = proc_listpids(PROC_ALL_PIDS, 0, pid_list, buffer_size * sizeof(pid_t));
     if (actual <= 0) {
         PyErr_SetString(PyExc_OSError, "Failed to list PIDs");
         goto done;


### PR DESCRIPTION
Add a missing include and use `proc_listpids` rather than `proc_listallpids`, since it is functionally identical and more widely implemented.


<!-- gh-issue-number: gh-144648 -->
* Issue: gh-144648
<!-- /gh-issue-number -->
