### PR TITLE
gh-141563: Add missing cast to _PyDateTime_IMPORT()

### DIFF
--- a/Include/datetime.h
+++ b/Include/datetime.h
@@ -198,7 +198,7 @@ static PyDateTime_CAPI *PyDateTimeAPI = NULL;
 
 static inline PyDateTime_CAPI *
 _PyDateTime_IMPORT(void) {
-    PyDateTime_CAPI *val = _Py_atomic_load_ptr(&PyDateTimeAPI);
+    PyDateTime_CAPI *val = (PyDateTime_CAPI *)_Py_atomic_load_ptr(&PyDateTimeAPI);
     if (val == NULL) {
         PyDateTime_CAPI *capi = (PyDateTime_CAPI *)PyCapsule_Import(
             PyDateTime_CAPSULE_NAME, 0);

--- a/Lib/test/test_cext/extension.c
+++ b/Lib/test/test_cext/extension.c
@@ -11,6 +11,7 @@
 #endif
 
 #include "Python.h"
+#include "datetime.h"
 
 #ifdef TEST_INTERNAL_C_API
    // gh-135906: Check for compiler warnings in the internal C API.
@@ -50,8 +51,21 @@ _testcext_add(PyObject *Py_UNUSED(module), PyObject *args)
 }
 
 
+static PyObject *
+test_datetime(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
+{
+    PyDateTime_IMPORT;
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
+}
+
+
 static PyMethodDef _testcext_methods[] = {
     {"add", _testcext_add, METH_VARARGS, _testcext_add_doc},
+    {"test_datetime", test_datetime, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}  // sentinel
 };
 
@@ -65,11 +79,17 @@ _testcext_exec(
 #endif
     )
 {
+    PyObject *result;
+
 #ifdef __STDC_VERSION__
     if (PyModule_AddIntMacro(module, __STDC_VERSION__) < 0) {
         return -1;
     }
 #endif
+
+    result = PyObject_CallMethod(module, "test_datetime", "");
+    if (!result) return -1;
+    Py_DECREF(result);
 
     // test Py_BUILD_ASSERT() and Py_BUILD_ASSERT_EXPR()
     Py_BUILD_ASSERT(sizeof(int) == sizeof(unsigned int));

--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #include "Python.h"
+#include "datetime.h"
 
 #ifdef TEST_INTERNAL_C_API
    // gh-135906: Check for compiler warnings in the internal C API
@@ -228,11 +229,23 @@ test_virtual_object(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
     Py_RETURN_NONE;
 }
 
+static PyObject *
+test_datetime(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
+{
+    PyDateTime_IMPORT;
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
+}
+
 static PyMethodDef _testcppext_methods[] = {
     {"add", _testcppext_add, METH_VARARGS, _testcppext_add_doc},
     {"test_api_casts", test_api_casts, METH_NOARGS, _Py_NULL},
     {"test_unicode", test_unicode, METH_NOARGS, _Py_NULL},
     {"test_virtual_object", test_virtual_object, METH_NOARGS, _Py_NULL},
+    {"test_datetime", test_datetime, METH_NOARGS, _Py_NULL},
     // Note: _testcppext_exec currently runs all test functions directly.
     // When adding a new one, add a call there.
 
@@ -258,6 +271,10 @@ _testcppext_exec(PyObject *module)
     Py_DECREF(result);
 
     result = PyObject_CallMethod(module, "test_virtual_object", "");
+    if (!result) return -1;
+    Py_DECREF(result);
+
+    result = PyObject_CallMethod(module, "test_datetime", "");
     if (!result) return -1;
     Py_DECREF(result);
 


### PR DESCRIPTION
Fix compilation on C++.

Add test on PyDateTime_IMPORT in test_cext and test_cppext.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141563 -->
* Issue: gh-141563
<!-- /gh-issue-number -->
