### PR TITLE
gh-141563: Fix test_cext on Windows

### DIFF
--- a/Lib/test/test_cext/extension.c
+++ b/Lib/test/test_cext/extension.c
@@ -74,13 +74,7 @@ static PyMethodDef _testcext_methods[] = {
 
 
 static int
-_testcext_exec(
-#ifdef __STDC_VERSION__
-    PyObject *module
-#else
-    PyObject *Py_UNUSED(module)
-#endif
-    )
+_testcext_exec(PyObject *module)
 {
     PyObject *result;
 


### PR DESCRIPTION
The 'module' argument is now always needed to call the test_datetime method.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141563 -->
* Issue: gh-141563
<!-- /gh-issue-number -->
