### PR TITLE
gh-141563: Fix test_cppext on macOS

### DIFF
--- a/Lib/test/test_cext/setup.py
+++ b/Lib/test/test_cext/setup.py
@@ -118,7 +118,7 @@ def main():
             print(f"Add PCbuild directory: {pcbuild}")
 
     # Display information to help debugging
-    for env_name in ('CC', 'CFLAGS'):
+    for env_name in ('CC', 'CFLAGS', 'CPPFLAGS'):
         if env_name in os.environ:
             print(f"{env_name} env var: {os.environ[env_name]!r}")
         else:

--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -16,8 +16,9 @@
 #ifdef TEST_INTERNAL_C_API
    // gh-135906: Check for compiler warnings in the internal C API
 #  include "internal/pycore_frame.h"
-   // mimalloc emits compiler warnings when Python is built on Windows.
-#  if !defined(MS_WINDOWS)
+   // mimalloc emits compiler warnings when Python is built on Windows
+   // and macOS.
+#  if !defined(MS_WINDOWS) && !defined(__APPLE__)
 #    include "internal/pycore_backoff.h"
 #    include "internal/pycore_cell.h"
 #  endif

--- a/Lib/test/test_cppext/setup.py
+++ b/Lib/test/test_cppext/setup.py
@@ -101,7 +101,7 @@ def main():
             print(f"Add PCbuild directory: {pcbuild}")
 
     # Display information to help debugging
-    for env_name in ('CC', 'CFLAGS', 'CPPFLAGS'):
+    for env_name in ('CC', 'CXX', 'CFLAGS', 'CPPFLAGS', 'CXXFLAGS'):
         if env_name in os.environ:
             print(f"{env_name} env var: {os.environ[env_name]!r}")
         else:


### PR DESCRIPTION
Don't test internal header files including mimalloc on macOS since mimalloc emits compiler warnings:

  In file included from extension.cpp:21:
  In file included from Include/internal/pycore_backoff.h:15:
  In file included from Include/internal/pycore_interp_structs.h:15:
  In file included from Include/internal/pycore_tstate.h:14:
  In file included from Include/internal/pycore_mimalloc.h:43:
  Include/internal/mimalloc/mimalloc.h:464:85: error: defaulted
  function definitions are a C++11 extension
  [-Werror,-Wc++11-extensions]
    mi_stl_allocator() mi_attr_noexcept = default;
                                                                                      ^
  Include/internal/mimalloc/mimalloc.h:465:85: error: defaulted
  function definitions are a C++11 extension
  [-Werror,-Wc++11-extensions]
    mi_stl_allocator(const mi_stl_allocator&) mi_attr_noexcept = default;

Log also CXX and CXXFLAGS env vars in test_cppext. Log also CPPFLAGS in test_cext.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141563 -->
* Issue: gh-141563
<!-- /gh-issue-number -->
