### PR TITLE
gh-144694: Fix re.Match.group() doc claiming [1..99] range limit

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -1407,10 +1407,10 @@ when there is no match, you can test whether there was a match with a simple
    result is a single string; if there are multiple arguments, the result is a
    tuple with one item per argument. Without arguments, *group1* defaults to zero
    (the whole match is returned). If a *groupN* argument is zero, the corresponding
-   return value is the entire matching string; if it is in the inclusive range
-   [1..99], it is the string matching the corresponding parenthesized group.  If a
-   group number is negative or larger than the number of groups defined in the
-   pattern, an :exc:`IndexError` exception is raised. If a group is contained in a
+   return value is the entire matching string; if it is a positive integer, it is
+   the string matching the corresponding parenthesized group.  If a group number is
+   negative or larger than the number of groups defined in the pattern, an
+   :exc:`IndexError` exception is raised. If a group is contained in a
    part of the pattern that did not match, the corresponding result is ``None``.
    If a group is contained in a part of the pattern that matched multiple times,
    the last match is returned. ::


### PR DESCRIPTION
The documentation for `re.Match.group()` incorrectly states that numeric group arguments must be in the inclusive range `[1..99]`. This limit was removed in Python 3.5 (bpo-22437) when the number of capturing groups became dynamic.

Replace `[1..99]` with "a positive integer" since the next sentence already documents the `IndexError` for out-of-range values.

<!-- gh-issue-number: gh-144694 -->
* Issue: gh-144694

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144696.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->