### PR TITLE
[3.13] gh-143650: Fix importlib race condition on import failure (GH-143651)

### DIFF
--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -1364,6 +1364,14 @@ def _find_and_load(name, import_):
         # NOTE: because of this, initializing must be set *before*
         # putting the new module in sys.modules.
         _lock_unlock_module(name)
+    else:
+        # Verify the module is still in sys.modules. Another thread may have
+        # removed it (due to import failure) between our sys.modules.get()
+        # above and the _initializing check. If removed, we retry the import
+        # to preserve normal semantics: the caller gets the exception from
+        # the actual import failure rather than a synthetic error.
+        if sys.modules.get(name) is not module:
+            return _find_and_load(name, import_)
 
     if module is None:
         message = f'import of {name} halted; None in sys.modules'

--- a/Misc/NEWS.d/next/Core and Builtins/2026-01-10-10-58-36.gh-issue-143650.k8mR4x.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2026-01-10-10-58-36.gh-issue-143650.k8mR4x.rst
@@ -1,0 +1,2 @@
+Fix race condition in :mod:`importlib` where a thread could receive a stale
+module reference when another thread's import fails.

--- a/Python/import.c
+++ b/Python/import.c
@@ -252,12 +252,32 @@ PyImport_GetModule(PyObject *name)
     mod = import_get_module(tstate, name);
     if (mod != NULL && mod != Py_None) {
         if (import_ensure_initialized(tstate->interp, mod, name) < 0) {
+            goto error;
+        }
+        /* Verify the module is still in sys.modules. Another thread may have
+           removed it (due to import failure) between our import_get_module()
+           call and the _initializing check in import_ensure_initialized(). */
+        PyObject *mod_check = import_get_module(tstate, name);
+        if (mod_check != mod) {
+            Py_XDECREF(mod_check);
+            if (_PyErr_Occurred(tstate)) {
+                goto error;
+            }
+            /* The module was removed or replaced. Return NULL to report
+               "not found" rather than trying to keep up with racing
+               modifications to sys.modules; returning the new value would
+               require looping to redo the ensure_initialized check. */
             Py_DECREF(mod);
-            remove_importlib_frames(tstate);
             return NULL;
         }
+        Py_DECREF(mod_check);
     }
     return mod;
+
+error:
+    Py_DECREF(mod);
+    remove_importlib_frames(tstate);
+    return NULL;
 }
 
 /* Get the module object corresponding to a module name.
@@ -3779,6 +3799,27 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
     if (mod != NULL && mod != Py_None) {
         if (import_ensure_initialized(tstate->interp, mod, abs_name) < 0) {
             goto error;
+        }
+        /* Verify the module is still in sys.modules. Another thread may have
+           removed it (due to import failure) between our import_get_module()
+           call and the _initializing check in import_ensure_initialized().
+           If removed, we retry the import to preserve normal semantics: the
+           caller gets the exception from the actual import failure rather
+           than a synthetic error. */
+        PyObject *mod_check = import_get_module(tstate, abs_name);
+        if (mod_check != mod) {
+            Py_XDECREF(mod_check);
+            if (_PyErr_Occurred(tstate)) {
+                goto error;
+            }
+            Py_DECREF(mod);
+            mod = import_find_and_load(tstate, abs_name);
+            if (mod == NULL) {
+                goto error;
+            }
+        }
+        else {
+            Py_DECREF(mod_check);
         }
     }
     else {


### PR DESCRIPTION
Fix a race condition where a thread could receive a partially-initialized module when another thread's import fails. The race occurs when:

1. Thread 1 starts importing, adds module to sys.modules
2. Thread 2 sees the module in sys.modules via the fast path
3. Thread 1's import fails, removes module from sys.modules
4. Thread 2 returns a stale module reference not in sys.modules

The fix adds verification after the "skip lock" optimization in both Python and C code paths to check if the module is still in sys.modules. If the module was removed (due to import failure), we retry the import so the caller receives the actual exception from the import failure rather than a stale module reference.

cherry picked from ac8b5b6890006ee7254ea878866cb486ff835ecb

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- gh-issue-number: gh-143650 -->
* Issue: gh-143650
<!-- /gh-issue-number -->

Fixes #143650
