### PR TITLE
gh-144702: Use standard terminology in class pattern error message

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-11-11-28-25.gh-issue-144702.XjFumv.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-11-11-28-25.gh-issue-144702.XjFumv.rst
@@ -1,0 +1,2 @@
+Clarify the error message raised when a class pattern is used to match on a
+non-class object.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -531,7 +531,7 @@ _PyEval_MatchClass(PyThreadState *tstate, PyObject *subject, PyObject *type,
                    Py_ssize_t nargs, PyObject *kwargs)
 {
     if (!PyType_Check(type)) {
-        const char *e = "called match pattern must be a class";
+        const char *e = "class pattern must refer to a class";
         _PyErr_Format(tstate, PyExc_TypeError, e);
         return NULL;
     }


### PR DESCRIPTION
When trying to use a class pattern to match on a non-class object, we currently get the following error message:

    Traceback (most recent call last):
      File "/tmp/test.py", line 2, in <module>
        case len():
             ~~~^^
    TypeError: called match pattern must be a class

The terminology "called match pattern" here is a bit confusing. It's not used anywhere else as far as I can tell, and for a beginner, it might read like something is actually being called here.

The documentation consistently refers to these patterns as "class patterns":

* https://docs.python.org/3/reference/compound_stmts.html#class-patterns
* https://peps.python.org/pep-0635/#class-patterns
* https://docs.python.org/3/library/ast.html#ast.MatchClass
* https://docs.python.org/3/reference/datamodel.html#customizing-positional-arguments-in-class-pattern-matching

Here, we change this message to "class pattern must refer to a class".

<!-- gh-issue-number: gh-144702 -->
* Issue: gh-144702
<!-- /gh-issue-number -->
