### PR TITLE
[3.14] Docs: remove links of modules to themselves (GH-144695)

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1544,8 +1544,8 @@ mapping. It is not supported by :meth:`str.encode` (which only produces
    Restoration of the ``rot13`` alias.
 
 
-:mod:`encodings` --- Encodings package
---------------------------------------
+:mod:`!encodings` --- Encodings package
+---------------------------------------
 
 .. module:: encodings
    :synopsis: Encodings package
@@ -1604,8 +1604,8 @@ This module implements the following exception:
    Raised when a codec is invalid or incompatible.
 
 
-:mod:`encodings.idna` --- Internationalized Domain Names in Applications
-------------------------------------------------------------------------
+:mod:`!encodings.idna` --- Internationalized Domain Names in Applications
+-------------------------------------------------------------------------
 
 .. module:: encodings.idna
    :synopsis: Internationalized Domain Names implementation
@@ -1647,7 +1647,7 @@ When receiving host names from the wire (such as in reverse name lookup), no
 automatic conversion to Unicode is performed: applications wishing to present
 such host names to the user should decode them to Unicode.
 
-The module :mod:`encodings.idna` also implements the nameprep procedure, which
+The module :mod:`!encodings.idna` also implements the nameprep procedure, which
 performs certain normalizations on host names, to achieve case-insensitivity of
 international domain names, and to unify similar characters. The nameprep
 functions can be used directly if desired.
@@ -1670,8 +1670,8 @@ functions can be used directly if desired.
    Convert a label to Unicode, as specified in :rfc:`3490`.
 
 
-:mod:`encodings.mbcs` --- Windows ANSI codepage
------------------------------------------------
+:mod:`!encodings.mbcs` --- Windows ANSI codepage
+------------------------------------------------
 
 .. module:: encodings.mbcs
    :synopsis: Windows ANSI codepage
@@ -1688,8 +1688,8 @@ This module implements the ANSI codepage (CP_ACP).
    Support any error handler.
 
 
-:mod:`encodings.utf_8_sig` --- UTF-8 codec with BOM signature
--------------------------------------------------------------
+:mod:`!encodings.utf_8_sig` --- UTF-8 codec with BOM signature
+--------------------------------------------------------------
 
 .. module:: encodings.utf_8_sig
    :synopsis: UTF-8 codec with BOM signature

--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -1824,8 +1824,8 @@ The following table lists the predefined colors:
 +-------------------------+----------------------------+
 
 
-:mod:`curses.textpad` --- Text input widget for curses programs
-===============================================================
+:mod:`!curses.textpad` --- Text input widget for curses programs
+================================================================
 
 .. module:: curses.textpad
    :synopsis: Emacs-like input editing in a curses window.
@@ -1833,13 +1833,13 @@ The following table lists the predefined colors:
 .. sectionauthor:: Eric Raymond <esr@thyrsus.com>
 
 
-The :mod:`curses.textpad` module provides a :class:`Textbox` class that handles
+The :mod:`!curses.textpad` module provides a :class:`Textbox` class that handles
 elementary text editing in a curses window, supporting a set of keybindings
 resembling those of Emacs (thus, also of Netscape Navigator, BBedit 6.x,
 FrameMaker, and many other programs).  The module also provides a
 rectangle-drawing function useful for framing text boxes or for other purposes.
 
-The module :mod:`curses.textpad` defines the following function:
+The module :mod:`!curses.textpad` defines the following function:
 
 
 .. function:: rectangle(win, uly, ulx, lry, lrx)

--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -151,8 +151,8 @@ then prints out the contents of the database::
 
 The individual submodules are described in the following sections.
 
-:mod:`dbm.sqlite3` --- SQLite backend for dbm
----------------------------------------------
+:mod:`!dbm.sqlite3` --- SQLite backend for dbm
+----------------------------------------------
 
 .. module:: dbm.sqlite3
    :platform: All
@@ -166,7 +166,7 @@ The individual submodules are described in the following sections.
 
 This module uses the standard library :mod:`sqlite3` module to provide an
 SQLite backend for the :mod:`!dbm` module.
-The files created by :mod:`dbm.sqlite3` can thus be opened by :mod:`sqlite3`,
+The files created by :mod:`!dbm.sqlite3` can thus be opened by :mod:`sqlite3`,
 or any other SQLite browser, including the SQLite CLI.
 
 .. include:: ../includes/wasm-notavail.rst
@@ -202,8 +202,8 @@ or any other SQLite browser, including the SQLite CLI.
       Close the SQLite database.
 
 
-:mod:`dbm.gnu` --- GNU database manager
----------------------------------------
+:mod:`!dbm.gnu` --- GNU database manager
+----------------------------------------
 
 .. module:: dbm.gnu
    :platform: Unix
@@ -213,20 +213,20 @@ or any other SQLite browser, including the SQLite CLI.
 
 --------------
 
-The :mod:`dbm.gnu` module provides an interface to the :abbr:`GDBM (GNU dbm)`
+The :mod:`!dbm.gnu` module provides an interface to the :abbr:`GDBM (GNU dbm)`
 library, similar to the :mod:`dbm.ndbm` module, but with additional
 functionality like crash tolerance.
 
 .. note::
 
-   The file formats created by :mod:`dbm.gnu` and :mod:`dbm.ndbm` are incompatible
+   The file formats created by :mod:`!dbm.gnu` and :mod:`dbm.ndbm` are incompatible
    and can not be used interchangeably.
 
 .. include:: ../includes/wasm-mobile-notavail.rst
 
 .. exception:: error
 
-   Raised on :mod:`dbm.gnu`-specific errors, such as I/O errors. :exc:`KeyError` is
+   Raised on :mod:`!dbm.gnu`-specific errors, such as I/O errors. :exc:`KeyError` is
    raised for general mapping errors like specifying an incorrect key.
 
 
@@ -321,8 +321,8 @@ functionality like crash tolerance.
       unwritten data to be written to the disk.
 
 
-:mod:`dbm.ndbm` --- New Database Manager
-----------------------------------------
+:mod:`!dbm.ndbm` --- New Database Manager
+-----------------------------------------
 
 .. module:: dbm.ndbm
    :platform: Unix
@@ -332,14 +332,14 @@ functionality like crash tolerance.
 
 --------------
 
-The :mod:`dbm.ndbm` module provides an interface to the
+The :mod:`!dbm.ndbm` module provides an interface to the
 :abbr:`NDBM (New Database Manager)` library.
 This module can be used with the "classic" NDBM interface or the
 :abbr:`GDBM (GNU dbm)` compatibility interface.
 
 .. note::
 
-   The file formats created by :mod:`dbm.gnu` and :mod:`dbm.ndbm` are incompatible
+   The file formats created by :mod:`dbm.gnu` and :mod:`!dbm.ndbm` are incompatible
    and can not be used interchangeably.
 
 .. warning::
@@ -353,7 +353,7 @@ This module can be used with the "classic" NDBM interface or the
 
 .. exception:: error
 
-   Raised on :mod:`dbm.ndbm`-specific errors, such as I/O errors. :exc:`KeyError` is raised
+   Raised on :mod:`!dbm.ndbm`-specific errors, such as I/O errors. :exc:`KeyError` is raised
    for general mapping errors like specifying an incorrect key.
 
 
@@ -403,8 +403,8 @@ This module can be used with the "classic" NDBM interface or the
       Close the NDBM database.
 
 
-:mod:`dbm.dumb` --- Portable DBM implementation
------------------------------------------------
+:mod:`!dbm.dumb` --- Portable DBM implementation
+------------------------------------------------
 
 .. module:: dbm.dumb
    :synopsis: Portable implementation of the simple DBM interface.
@@ -415,14 +415,14 @@ This module can be used with the "classic" NDBM interface or the
 
 .. note::
 
-   The :mod:`dbm.dumb` module is intended as a last resort fallback for the
-   :mod:`!dbm` module when a more robust module is not available. The :mod:`dbm.dumb`
+   The :mod:`!dbm.dumb` module is intended as a last resort fallback for the
+   :mod:`!dbm` module when a more robust module is not available. The :mod:`!dbm.dumb`
    module is not written for speed and is not nearly as heavily used as the other
    database modules.
 
 --------------
 
-The :mod:`dbm.dumb` module provides a persistent :class:`dict`-like
+The :mod:`!dbm.dumb` module provides a persistent :class:`dict`-like
 interface which is written entirely in Python.
 Unlike other :mod:`!dbm` backends, such as :mod:`dbm.gnu`, no
 external library is required.
@@ -431,7 +431,7 @@ The :mod:`!dbm.dumb` module defines the following:
 
 .. exception:: error
 
-   Raised on :mod:`dbm.dumb`-specific errors, such as I/O errors.  :exc:`KeyError` is
+   Raised on :mod:`!dbm.dumb`-specific errors, such as I/O errors.  :exc:`KeyError` is
    raised for general mapping errors like specifying an incorrect key.
 
 

--- a/Doc/library/dialog.rst
+++ b/Doc/library/dialog.rst
@@ -1,8 +1,8 @@
 Tkinter Dialogs
 ===============
 
-:mod:`tkinter.simpledialog` --- Standard Tkinter input dialogs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:mod:`!tkinter.simpledialog` --- Standard Tkinter input dialogs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. module:: tkinter.simpledialog
    :platform: Tk
@@ -12,7 +12,7 @@ Tkinter Dialogs
 
 --------------
 
-The :mod:`tkinter.simpledialog` module contains convenience classes and
+The :mod:`!tkinter.simpledialog` module contains convenience classes and
 functions for creating simple modal dialogs to get a value from the user.
 
 
@@ -39,8 +39,8 @@ functions for creating simple modal dialogs to get a value from the user.
 
 
 
-:mod:`tkinter.filedialog` --- File selection dialogs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:mod:`!tkinter.filedialog` --- File selection dialogs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. module:: tkinter.filedialog
    :platform: Tk
@@ -50,7 +50,7 @@ functions for creating simple modal dialogs to get a value from the user.
 
 --------------
 
-The :mod:`tkinter.filedialog` module provides classes and factory functions for
+The :mod:`!tkinter.filedialog` module provides classes and factory functions for
 creating file/directory selection windows.
 
 Native Load/Save Dialogs
@@ -204,8 +204,8 @@ These do not emulate the native look-and-feel of the platform.
       directory. Confirmation is required if an already existing file is
       selected.
 
-:mod:`tkinter.commondialog` --- Dialog window templates
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:mod:`!tkinter.commondialog` --- Dialog window templates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. module:: tkinter.commondialog
    :platform: Tk
@@ -215,7 +215,7 @@ These do not emulate the native look-and-feel of the platform.
 
 --------------
 
-The :mod:`tkinter.commondialog` module provides the :class:`Dialog` class that
+The :mod:`!tkinter.commondialog` module provides the :class:`Dialog` class that
 is the base class for dialogs defined in other supporting modules.
 
 .. class:: Dialog(master=None, **options)

--- a/Doc/library/email.encoders.rst
+++ b/Doc/library/email.encoders.rst
@@ -25,7 +25,7 @@ is especially true for :mimetype:`image/\*` and :mimetype:`text/\*` type message
 containing binary data.
 
 The :mod:`email` package provides some convenient encoders in its
-:mod:`~email.encoders` module.  These encoders are actually used by the
+:mod:`!encoders` module.  These encoders are actually used by the
 :class:`~email.mime.audio.MIMEAudio` and :class:`~email.mime.image.MIMEImage`
 class constructors to provide default encodings.  All encoder functions take
 exactly one argument, the message object to encode.  They usually extract the

--- a/Doc/library/email.policy.rst
+++ b/Doc/library/email.policy.rst
@@ -602,7 +602,7 @@ The header objects and their attributes are described in
 
    This concrete :class:`Policy` is the backward compatibility policy.  It
    replicates the behavior of the email package in Python 3.2.  The
-   :mod:`~email.policy` module also defines an instance of this class,
+   :mod:`!policy` module also defines an instance of this class,
    :const:`compat32`, that is used as the default policy.  Thus the default
    behavior of the email package is to maintain compatibility with Python 3.2.
 

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -211,8 +211,8 @@ Functions
       in unexpected behavior. It's recommended to use the :class:`threading.Lock`
       or other synchronization primitives for thread-safe module reloading.
 
-:mod:`importlib.abc` -- Abstract base classes related to import
----------------------------------------------------------------
+:mod:`!importlib.abc` -- Abstract base classes related to import
+----------------------------------------------------------------
 
 .. module:: importlib.abc
     :synopsis: Abstract base classes related to import
@@ -222,7 +222,7 @@ Functions
 --------------
 
 
-The :mod:`importlib.abc` module contains all of the core abstract base classes
+The :mod:`!importlib.abc` module contains all of the core abstract base classes
 used by :keyword:`import`. Some subclasses of the core abstract base classes
 are also provided to help in implementing the core ABCs.
 
@@ -637,8 +637,8 @@ ABC hierarchy::
         itself does not end in ``__init__``.
 
 
-:mod:`importlib.machinery` -- Importers and path hooks
-------------------------------------------------------
+:mod:`!importlib.machinery` -- Importers and path hooks
+-------------------------------------------------------
 
 .. module:: importlib.machinery
     :synopsis: Importers and path hooks
@@ -1136,8 +1136,8 @@ find and load modules.
       Path to the ``.fwork`` file for the extension module.
 
 
-:mod:`importlib.util` -- Utility code for importers
----------------------------------------------------
+:mod:`!importlib.util` -- Utility code for importers
+----------------------------------------------------
 
 .. module:: importlib.util
     :synopsis: Utility code for importers

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -748,7 +748,7 @@ Command-line interface
 --------------
 
 The :mod:`!json` module can be invoked as a script via ``python -m json``
-to validate and pretty-print JSON objects. The :mod:`json.tool` submodule
+to validate and pretty-print JSON objects. The :mod:`!json.tool` submodule
 implements this interface.
 
 If the optional ``infile`` and ``outfile`` arguments are not

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -279,7 +279,7 @@ processes:
           p.join()
 
    Queues are thread and process safe.
-   Any object put into a :mod:`~multiprocessing` queue will be serialized.
+   Any object put into a :mod:`!multiprocessing` queue will be serialized.
 
 **Pipes**
 
@@ -1715,13 +1715,13 @@ inherited by child processes.
    attributes which allow one to use it to store and retrieve strings.
 
 
-The :mod:`multiprocessing.sharedctypes` module
-""""""""""""""""""""""""""""""""""""""""""""""
+The :mod:`!multiprocessing.sharedctypes` module
+"""""""""""""""""""""""""""""""""""""""""""""""
 
 .. module:: multiprocessing.sharedctypes
    :synopsis: Allocate ctypes objects from shared memory.
 
-The :mod:`multiprocessing.sharedctypes` module provides functions for allocating
+The :mod:`!multiprocessing.sharedctypes` module provides functions for allocating
 :mod:`ctypes` objects from shared memory which can be inherited by child
 processes.
 
@@ -2648,7 +2648,7 @@ Usually message passing between processes is done using queues or by using
 :class:`~Connection` objects returned by
 :func:`~multiprocessing.Pipe`.
 
-However, the :mod:`multiprocessing.connection` module allows some extra
+However, the :mod:`!multiprocessing.connection` module allows some extra
 flexibility.  It basically gives a high level message oriented API for dealing
 with sockets or Windows named pipes.  It also has support for *digest
 authentication* using the :mod:`hmac` module, and for polling
@@ -2955,18 +2955,18 @@ Below is an example session with logging turned on::
 For a full table of logging levels, see the :mod:`logging` module.
 
 
-The :mod:`multiprocessing.dummy` module
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The :mod:`!multiprocessing.dummy` module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. module:: multiprocessing.dummy
    :synopsis: Dumb wrapper around threading.
 
-:mod:`multiprocessing.dummy` replicates the API of :mod:`!multiprocessing` but is
+:mod:`!multiprocessing.dummy` replicates the API of :mod:`!multiprocessing` but is
 no more than a wrapper around the :mod:`threading` module.
 
 .. currentmodule:: multiprocessing.pool
 
-In particular, the ``Pool`` function provided by :mod:`multiprocessing.dummy`
+In particular, the ``Pool`` function provided by :mod:`!multiprocessing.dummy`
 returns an instance of :class:`ThreadPool`, which is a subclass of
 :class:`Pool` that supports all the same method calls but uses a pool of
 worker threads rather than worker processes.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1960,7 +1960,7 @@ Protocols
    :synopsis: pathlib types for static type checking
 
 
-The :mod:`pathlib.types` module provides types for static type checking.
+The :mod:`!pathlib.types` module provides types for static type checking.
 
 .. versionadded:: 3.14
 

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -1,7 +1,7 @@
 .. _debugger:
 
-:mod:`pdb` --- The Python Debugger
-==================================
+:mod:`!pdb` --- The Python Debugger
+===================================
 
 .. module:: pdb
    :synopsis: The Python debugger for interactive interpreters.
@@ -12,7 +12,7 @@
 
 --------------
 
-The module :mod:`pdb` defines an interactive source code debugger for Python
+The module :mod:`!pdb` defines an interactive source code debugger for Python
 programs.  It supports setting (conditional) breakpoints and single stepping at
 the source line level, inspection of stack frames, source code listing, and
 evaluation of arbitrary Python code in the context of any stack frame.  It also
@@ -82,7 +82,7 @@ Command-line interface
 
 .. program:: pdb
 
-You can also invoke :mod:`pdb` from the command line to debug other scripts.  For
+You can also invoke :mod:`!pdb` from the command line to debug other scripts.  For
 example::
 
    python -m pdb [-c command] (-m module | -p pid | pyfile) [args ...]

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -217,14 +217,14 @@ Invoked as a script, the :mod:`pstats` module is a statistics browser for
 reading and examining profile dumps.  It has a simple line-oriented interface
 (implemented using :mod:`cmd`) and interactive help.
 
-:mod:`profile` and :mod:`cProfile` Module Reference
-=======================================================
+:mod:`profile` and :mod:`!cProfile` Module Reference
+====================================================
 
 .. module:: cProfile
 .. module:: profile
    :synopsis: Python source profiler.
 
-Both the :mod:`profile` and :mod:`cProfile` modules provide the following
+Both the :mod:`profile` and :mod:`!cProfile` modules provide the following
 functions:
 
 .. function:: run(command, filename=None, sort=-1)
@@ -278,7 +278,7 @@ functions:
       print(s.getvalue())
 
    The :class:`Profile` class can also be used as a context manager (supported
-   only in :mod:`cProfile` module. see :ref:`typecontextmanager`)::
+   only in :mod:`!cProfile` module. see :ref:`typecontextmanager`)::
 
       import cProfile
 
@@ -292,11 +292,11 @@ functions:
 
    .. method:: enable()
 
-      Start collecting profiling data. Only in :mod:`cProfile`.
+      Start collecting profiling data. Only in :mod:`!cProfile`.
 
    .. method:: disable()
 
-      Stop collecting profiling data. Only in :mod:`cProfile`.
+      Stop collecting profiling data. Only in :mod:`!cProfile`.
 
    .. method:: create_stats()
 

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -683,7 +683,7 @@ values: the type, the quantifier, the name, and a tuple of children.  Children
 are simply additional content model descriptions.
 
 The values of the first two fields are constants defined in the
-:mod:`xml.parsers.expat.model` module.  These constants can be collected in two
+:mod:`!xml.parsers.expat.model` module.  These constants can be collected in two
 groups: the model type group and the quantifier group.
 
 The constants in the model type group are:
@@ -757,7 +757,7 @@ Expat error constants
 
 .. module:: xml.parsers.expat.errors
 
-The following constants are provided in the :mod:`xml.parsers.expat.errors`
+The following constants are provided in the :mod:`!xml.parsers.expat.errors`
 module.  These constants are useful in interpreting some of the attributes of
 the :exc:`ExpatError` exception objects raised when an error has occurred.
 Since for backwards compatibility reasons, the constants' value is the error

--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -130,28 +130,28 @@ directory precedes the :file:`foo` directory because :file:`bar.pth` comes
 alphabetically before :file:`foo.pth`; and :file:`spam` is omitted because it is
 not mentioned in either path configuration file.
 
-:mod:`sitecustomize`
---------------------
+:mod:`!sitecustomize`
+---------------------
 
 .. module:: sitecustomize
 
 After these path manipulations, an attempt is made to import a module named
-:mod:`sitecustomize`, which can perform arbitrary site-specific customizations.
+:mod:`!sitecustomize`, which can perform arbitrary site-specific customizations.
 It is typically created by a system administrator in the site-packages
 directory.  If this import fails with an :exc:`ImportError` or its subclass
 exception, and the exception's :attr:`~ImportError.name`
 attribute equals to ``'sitecustomize'``,
 it is silently ignored.  If Python is started without output streams available, as
 with :file:`pythonw.exe` on Windows (which is used by default to start IDLE),
-attempted output from :mod:`sitecustomize` is ignored.  Any other exception
+attempted output from :mod:`!sitecustomize` is ignored.  Any other exception
 causes a silent and perhaps mysterious failure of the process.
 
-:mod:`usercustomize`
---------------------
+:mod:`!usercustomize`
+---------------------
 
 .. module:: usercustomize
 
-After this, an attempt is made to import a module named :mod:`usercustomize`,
+After this, an attempt is made to import a module named :mod:`!usercustomize`,
 which can perform arbitrary user-specific customizations, if
 :data:`~site.ENABLE_USER_SITE` is true.  This file is intended to be created in the
 user site-packages directory (see below), which is part of ``sys.path`` unless
@@ -161,7 +161,7 @@ attribute equals to ``'usercustomize'``, it is silently ignored.
 
 Note that for some non-Unix systems, ``sys.prefix`` and ``sys.exec_prefix`` are
 empty, and the path manipulations are skipped; however the import of
-:mod:`sitecustomize` and :mod:`usercustomize` is still attempted.
+:mod:`sitecustomize` and :mod:`!usercustomize` is still attempted.
 
 .. currentmodule:: site
 

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -164,7 +164,7 @@ Running tests using the command-line interface
 
 The :mod:`!test` package can be run as a script to drive Python's regression
 test suite, thanks to the :option:`-m` option: :program:`python -m test`. Under
-the hood, it uses :mod:`test.regrtest`; the call :program:`python -m
+the hood, it uses :mod:`!test.regrtest`; the call :program:`python -m
 test.regrtest` used in previous Python versions still works.  Running the
 script by itself automatically starts running all regression tests in the
 :mod:`!test` package. It does this by finding all modules in the package whose
@@ -197,19 +197,19 @@ regression tests.
    :ref:`controlled using environment variables <using-on-controlling-color>`.
 
 
-:mod:`test.support` --- Utilities for the Python test suite
-===========================================================
+:mod:`!test.support` --- Utilities for the Python test suite
+============================================================
 
 .. module:: test.support
    :synopsis: Support for Python's regression test suite.
 
 
-The :mod:`test.support` module provides support for Python's regression
+The :mod:`!test.support` module provides support for Python's regression
 test suite.
 
 .. note::
 
-   :mod:`test.support` is not a public module.  It is documented here to help
+   :mod:`!test.support` is not a public module.  It is documented here to help
    Python developers write tests.  The API of this module is subject to change
    without backwards compatibility concerns between releases.
 
@@ -230,7 +230,7 @@ This module defines the following exceptions:
    function.
 
 
-The :mod:`test.support` module defines the following constants:
+The :mod:`!test.support` module defines the following constants:
 
 .. data:: verbose
 
@@ -363,7 +363,7 @@ The :mod:`test.support` module defines the following constants:
 
 .. data:: TEST_SUPPORT_DIR
 
-   Set to the top level directory that contains :mod:`test.support`.
+   Set to the top level directory that contains :mod:`!test.support`.
 
 
 .. data:: TEST_HOME_DIR
@@ -438,7 +438,7 @@ The :mod:`test.support` module defines the following constants:
    Used to test mixed type comparison.
 
 
-The :mod:`test.support` module defines the following functions:
+The :mod:`!test.support` module defines the following functions:
 
 .. function:: busy_retry(timeout, err_msg=None, /, *, error=True)
 
@@ -1043,7 +1043,7 @@ The :mod:`test.support` module defines the following functions:
    .. versionadded:: 3.11
 
 
-The :mod:`test.support` module defines the following classes:
+The :mod:`!test.support` module defines the following classes:
 
 
 .. class:: SuppressCrashReport()
@@ -1089,14 +1089,14 @@ The :mod:`test.support` module defines the following classes:
       Try to match a single stored value (*dv*) with a supplied value (*v*).
 
 
-:mod:`test.support.socket_helper` --- Utilities for socket tests
-================================================================
+:mod:`!test.support.socket_helper` --- Utilities for socket tests
+=================================================================
 
 .. module:: test.support.socket_helper
    :synopsis: Support for socket tests.
 
 
-The :mod:`test.support.socket_helper` module provides support for socket tests.
+The :mod:`!test.support.socket_helper` module provides support for socket tests.
 
 .. versionadded:: 3.9
 
@@ -1167,14 +1167,14 @@ The :mod:`test.support.socket_helper` module provides support for socket tests.
    exceptions.
 
 
-:mod:`test.support.script_helper` --- Utilities for the Python execution tests
-==============================================================================
+:mod:`!test.support.script_helper` --- Utilities for the Python execution tests
+===============================================================================
 
 .. module:: test.support.script_helper
    :synopsis: Support for Python's script execution tests.
 
 
-The :mod:`test.support.script_helper` module provides support for Python's
+The :mod:`!test.support.script_helper` module provides support for Python's
 script execution tests.
 
 .. function:: interpreter_requires_environment()
@@ -1278,13 +1278,13 @@ script execution tests.
    path and the archive name for the zip file.
 
 
-:mod:`test.support.bytecode_helper` --- Support tools for testing correct bytecode generation
-=============================================================================================
+:mod:`!test.support.bytecode_helper` --- Support tools for testing correct bytecode generation
+==============================================================================================
 
 .. module:: test.support.bytecode_helper
    :synopsis: Support tools for testing correct bytecode generation.
 
-The :mod:`test.support.bytecode_helper` module provides support for testing
+The :mod:`!test.support.bytecode_helper` module provides support for testing
 and inspecting bytecode generation.
 
 .. versionadded:: 3.9
@@ -1310,13 +1310,13 @@ The module defines the following class:
    Throws :exc:`AssertionError` if *opname* is found.
 
 
-:mod:`test.support.threading_helper` --- Utilities for threading tests
-======================================================================
+:mod:`!test.support.threading_helper` --- Utilities for threading tests
+=======================================================================
 
 .. module:: test.support.threading_helper
    :synopsis: Support for threading tests.
 
-The :mod:`test.support.threading_helper` module provides support for threading tests.
+The :mod:`!test.support.threading_helper` module provides support for threading tests.
 
 .. versionadded:: 3.10
 
@@ -1397,13 +1397,13 @@ The :mod:`test.support.threading_helper` module provides support for threading t
     finished.
 
 
-:mod:`test.support.os_helper` --- Utilities for os tests
-========================================================================
+:mod:`!test.support.os_helper` --- Utilities for os tests
+=========================================================
 
 .. module:: test.support.os_helper
    :synopsis: Support for os tests.
 
-The :mod:`test.support.os_helper` module provides support for os tests.
+The :mod:`!test.support.os_helper` module provides support for os tests.
 
 .. versionadded:: 3.10
 
@@ -1592,13 +1592,13 @@ The :mod:`test.support.os_helper` module provides support for os tests.
    wrapped with a wait loop that checks for the existence of the file.
 
 
-:mod:`test.support.import_helper` --- Utilities for import tests
-================================================================
+:mod:`!test.support.import_helper` --- Utilities for import tests
+=================================================================
 
 .. module:: test.support.import_helper
    :synopsis: Support for import tests.
 
-The :mod:`test.support.import_helper` module provides support for import tests.
+The :mod:`!test.support.import_helper` module provides support for import tests.
 
 .. versionadded:: 3.10
 
@@ -1706,13 +1706,13 @@ The :mod:`test.support.import_helper` module provides support for import tests.
    will be reverted at the end of the block.
 
 
-:mod:`test.support.warnings_helper` --- Utilities for warnings tests
-====================================================================
+:mod:`!test.support.warnings_helper` --- Utilities for warnings tests
+=====================================================================
 
 .. module:: test.support.warnings_helper
    :synopsis: Support for warnings tests.
 
-The :mod:`test.support.warnings_helper` module provides support for warnings tests.
+The :mod:`!test.support.warnings_helper` module provides support for warnings tests.
 
 .. versionadded:: 3.10
 

--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -2248,7 +2248,7 @@ Settings and special methods
    Set turtle mode ("standard", "logo" or "world") and perform reset.  If mode
    is not given, current mode is returned.
 
-   Mode "standard" is compatible with old :mod:`turtle`.  Mode "logo" is
+   Mode "standard" is compatible with old :mod:`!turtle`.  Mode "logo" is
    compatible with most Logo turtle graphics.  Mode "world" uses user-defined
    "world coordinates". **Attention**: in this mode angles appear distorted if
    ``x/y`` unit-ratio doesn't equal 1.
@@ -2689,7 +2689,7 @@ Screen and Turtle.
    Python script :file:`{filename}.py`.  It is intended to serve as a template
    for translation of the docstrings into different languages.
 
-If you (or your students) want to use :mod:`turtle` with online help in your
+If you (or your students) want to use :mod:`!turtle` with online help in your
 native language, you have to translate the docstrings and save the resulting
 file as e.g. :file:`turtle_docstringdict_german.py`.
 
@@ -2752,7 +2752,7 @@ Short explanation of selected entries:
   auto``.
 - If you set e.g. ``language = italian`` the docstringdict
   :file:`turtle_docstringdict_italian.py` will be loaded at import time (if
-  present on the import path, e.g. in the same directory as :mod:`turtle`).
+  present on the import path, e.g. in the same directory as :mod:`!turtle`).
 - The entries *exampleturtle* and *examplescreen* define the names of these
   objects as they occur in the docstrings.  The transformation of
   method-docstrings to function-docstrings will delete these names from the
@@ -2761,7 +2761,7 @@ Short explanation of selected entries:
   switch ("no subprocess").  This will prevent :func:`exitonclick` to enter the
   mainloop.
 
-There can be a :file:`turtle.cfg` file in the directory where :mod:`turtle` is
+There can be a :file:`turtle.cfg` file in the directory where :mod:`!turtle` is
 stored and an additional one in the current working directory.  The latter will
 override the settings of the first one.
 
@@ -2770,13 +2770,13 @@ study it as an example and see its effects when running the demos (preferably
 not from within the demo-viewer).
 
 
-:mod:`turtledemo` --- Demo scripts
-==================================
+:mod:`!turtledemo` --- Demo scripts
+===================================
 
 .. module:: turtledemo
    :synopsis: A viewer for example turtle scripts
 
-The :mod:`turtledemo` package includes a set of demo scripts.  These
+The :mod:`!turtledemo` package includes a set of demo scripts.  These
 scripts can be run and viewed using the supplied demo viewer as follows::
 
    python -m turtledemo
@@ -2785,11 +2785,11 @@ Alternatively, you can run the demo scripts individually.  For example, ::
 
    python -m turtledemo.bytedesign
 
-The :mod:`turtledemo` package directory contains:
+The :mod:`!turtledemo` package directory contains:
 
 - A demo viewer :file:`__main__.py` which can be used to view the sourcecode
   of the scripts and run them at the same time.
-- Multiple scripts demonstrating different features of the :mod:`turtle`
+- Multiple scripts demonstrating different features of the :mod:`!turtle`
   module.  Examples can be accessed via the Examples menu.  They can also
   be run standalone.
 - A :file:`turtle.cfg` file which serves as an example of how to write

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1539,13 +1539,13 @@ some point in the future.
 
 
 
-:mod:`urllib.response` --- Response classes used by urllib
-==========================================================
+:mod:`!urllib.response` --- Response classes used by urllib
+===========================================================
 
 .. module:: urllib.response
    :synopsis: Response classes used by urllib.
 
-The :mod:`urllib.response` module defines functions and classes which define a
+The :mod:`!urllib.response` module defines functions and classes which define a
 minimal file-like interface, including ``read()`` and ``readline()``.
 Functions defined by this module are used internally by the :mod:`!urllib.request` module.
 The typical response object is a :class:`urllib.response.addinfourl` instance:

--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -1,7 +1,7 @@
 .. _mod-weakref:
 
-:mod:`weakref` --- Weak references
-==================================
+:mod:`!weakref` --- Weak references
+===================================
 
 .. module:: weakref
    :synopsis: Support for weak references and weak dictionaries.
@@ -15,7 +15,7 @@
 
 --------------
 
-The :mod:`weakref` module allows the Python programmer to create :dfn:`weak
+The :mod:`!weakref` module allows the Python programmer to create :dfn:`weak
 references` to objects.
 
 .. When making changes to the examples in this file, be sure to update
@@ -39,7 +39,7 @@ associate a name with each.  If you used a Python dictionary to map names to
 images, or images to names, the image objects would remain alive just because
 they appeared as values or keys in the dictionaries.  The
 :class:`WeakKeyDictionary` and :class:`WeakValueDictionary` classes supplied by
-the :mod:`weakref` module are an alternative, using weak references to construct
+the :mod:`!weakref` module are an alternative, using weak references to construct
 mappings that don't keep objects alive solely because they appear in the mapping
 objects.  If, for example, an image object is a value in a
 :class:`WeakValueDictionary`, then when the last remaining references to that
@@ -63,7 +63,7 @@ remains alive until the object is collected.
 Most programs should find that using one of these weak container types
 or :class:`finalize` is all they need -- it's not usually necessary to
 create your own weak references directly.  The low-level machinery is
-exposed by the :mod:`weakref` module for the benefit of advanced uses.
+exposed by the :mod:`!weakref` module for the benefit of advanced uses.
 
 Not all objects can be weakly referenced. Objects which support weak references
 include class instances, functions written in Python (but not in C), instance methods,

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -40,8 +40,8 @@ to tutorials and other resources.
 .. XXX If you're just trying to write a web application...
 
 
-:mod:`wsgiref.util` -- WSGI environment utilities
--------------------------------------------------
+:mod:`!wsgiref.util` -- WSGI environment utilities
+--------------------------------------------------
 
 .. module:: wsgiref.util
    :synopsis: WSGI environment utilities.
@@ -149,7 +149,7 @@ in type annotations.
           httpd.serve_forever()
 
 
-In addition to the environment functions above, the :mod:`wsgiref.util` module
+In addition to the environment functions above, the :mod:`!wsgiref.util` module
 also provides these miscellaneous utilities:
 
 
@@ -189,8 +189,8 @@ also provides these miscellaneous utilities:
       Support for :meth:`~object.__getitem__` method has been removed.
 
 
-:mod:`wsgiref.headers` -- WSGI response header tools
-----------------------------------------------------
+:mod:`!wsgiref.headers` -- WSGI response header tools
+-----------------------------------------------------
 
 .. module:: wsgiref.headers
    :synopsis: WSGI response header tools.
@@ -273,8 +273,8 @@ manipulation of WSGI response headers using a mapping-like interface.
       *headers* parameter is optional.
 
 
-:mod:`wsgiref.simple_server` -- a simple WSGI HTTP server
----------------------------------------------------------
+:mod:`!wsgiref.simple_server` -- a simple WSGI HTTP server
+----------------------------------------------------------
 
 .. module:: wsgiref.simple_server
    :synopsis: A simple WSGI HTTP server.
@@ -315,7 +315,7 @@ request.  (E.g., using the :func:`shift_path_info` function from
    This function is a small but complete WSGI application that returns a text page
    containing the message "Hello world!" and a list of the key/value pairs provided
    in the *environ* parameter.  It's useful for verifying that a WSGI server (such
-   as :mod:`wsgiref.simple_server`) is able to run a simple WSGI application
+   as :mod:`!wsgiref.simple_server`) is able to run a simple WSGI application
    correctly.
 
    The *start_response* callable should follow the :class:`.StartResponse` protocol.
@@ -387,8 +387,8 @@ request.  (E.g., using the :func:`shift_path_info` function from
       interface.
 
 
-:mod:`wsgiref.validate` --- WSGI conformance checker
-----------------------------------------------------
+:mod:`!wsgiref.validate` --- WSGI conformance checker
+-----------------------------------------------------
 
 .. module:: wsgiref.validate
    :synopsis: WSGI conformance checker.
@@ -396,7 +396,7 @@ request.  (E.g., using the :func:`shift_path_info` function from
 
 When creating new WSGI application objects, frameworks, servers, or middleware,
 it can be useful to validate the new code's conformance using
-:mod:`wsgiref.validate`.  This module provides a function that creates WSGI
+:mod:`!wsgiref.validate`.  This module provides a function that creates WSGI
 application objects that validate communications between a WSGI server or
 gateway and a WSGI application object, to check both sides for protocol
 conformance.
@@ -455,8 +455,8 @@ Paste" library.
           httpd.serve_forever()
 
 
-:mod:`wsgiref.handlers` -- server/gateway base classes
-------------------------------------------------------
+:mod:`!wsgiref.handlers` -- server/gateway base classes
+-------------------------------------------------------
 
 .. module:: wsgiref.handlers
    :synopsis: WSGI server/gateway base classes.
@@ -627,7 +627,7 @@ input, output, and error streams.
 
       The default environment variables to be included in every request's WSGI
       environment.  By default, this is a copy of ``os.environ`` at the time that
-      :mod:`wsgiref.handlers` was imported, but subclasses can either create their own
+      :mod:`!wsgiref.handlers` was imported, but subclasses can either create their own
       at the class or instance level.  Note that the dictionary should be considered
       read-only, since the default value is shared between multiple classes and
       instances.
@@ -778,8 +778,8 @@ input, output, and error streams.
    .. versionadded:: 3.2
 
 
-:mod:`wsgiref.types` -- WSGI types for static type checking
------------------------------------------------------------
+:mod:`!wsgiref.types` -- WSGI types for static type checking
+------------------------------------------------------------
 
 .. module:: wsgiref.types
    :synopsis: WSGI types for static type checking

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -20,7 +20,7 @@ Python's interfaces for processing XML are grouped in the ``xml`` package.
    If you need to parse untrusted or unauthenticated data, see
    :ref:`xml-security`.
 
-It is important to note that modules in the :mod:`xml` package require that
+It is important to note that modules in the :mod:`!xml` package require that
 there be at least one SAX-compliant XML parser available. The Expat parser is
 included with Python, so the :mod:`xml.parsers.expat` module will always be
 available.


### PR DESCRIPTION
These changes were made with https://github.com/nedbat/linklint/commit/b101e827a45cab60c92e38490caa7d2b4f28c871:
```
% uv run ~/lab/linklint/linklint.py --fix --check=self  Doc/**/*.rst
... omitted 107 lines ...
Checked 529 file(s), found 107 issue(s).
```

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144705.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->