### PR TITLE
gh-141563: Enable test_cppext internal C API tests on macOS

### DIFF
--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -4,6 +4,7 @@ import os.path
 import shlex
 import shutil
 import subprocess
+import sys
 import unittest
 from test import support
 
@@ -26,9 +27,6 @@ SETUP = os.path.join(os.path.dirname(__file__), 'setup.py')
 @support.requires_resource('cpu')
 class BaseTests:
     TEST_INTERNAL_C_API = False
-
-    def test_build(self):
-        self.check_build('_testcppext')
 
     def check_build(self, extension_name, std=None, limited=False):
         venv_dir = 'env'
@@ -91,6 +89,9 @@ class BaseTests:
 
 
 class TestPublicCAPI(BaseTests, unittest.TestCase):
+    def test_build(self):
+        self.check_build('_testcppext')
+
     @support.requires_gil_enabled('incompatible with Free Threading')
     def test_build_limited_cpp03(self):
         self.check_build('_test_limited_cpp03ext', std='c++03', limited=True)
@@ -118,6 +119,13 @@ class TestPublicCAPI(BaseTests, unittest.TestCase):
 
 class TestInteralCAPI(BaseTests, unittest.TestCase):
     TEST_INTERNAL_C_API = True
+
+    def test_build(self):
+        kwargs = {}
+        if sys.platform == 'darwin':
+            # Old Apple clang++ default C++ std is gnu++98
+            kwargs['std'] = 'c++11'
+        self.check_build('_testcppext_internal', **kwargs)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -16,9 +16,8 @@
 #ifdef TEST_INTERNAL_C_API
    // gh-135906: Check for compiler warnings in the internal C API
 #  include "internal/pycore_frame.h"
-   // mimalloc emits compiler warnings when Python is built on Windows
-   // and macOS.
-#  if !defined(MS_WINDOWS) && !defined(__APPLE__)
+   // mimalloc emits compiler warnings on Windows.
+#  if !defined(MS_WINDOWS)
 #    include "internal/pycore_backoff.h"
 #    include "internal/pycore_cell.h"
 #  endif

--- a/Lib/test/test_cppext/setup.py
+++ b/Lib/test/test_cppext/setup.py
@@ -59,7 +59,7 @@ def main():
         else:
             cppflags.append(f'-std={std}')
 
-        if limited or (std != 'c++03'):
+        if limited or (std != 'c++03') and not internal:
             # See CPPFLAGS_PEDANTIC docstring
             cppflags.extend(CPPFLAGS_PEDANTIC)
 


### PR DESCRIPTION
Build the C API in C++11 mode on macOS.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141563 -->
* Issue: gh-141563
<!-- /gh-issue-number -->
