### PR TITLE
gh-144712 extern _Py_jit_entry in Modules/_testinternalcapi/interpreter.c

### DIFF
--- a/Modules/_testinternalcapi/interpreter.c
+++ b/Modules/_testinternalcapi/interpreter.c
@@ -21,7 +21,7 @@ stop_tracing_and_jit(PyThreadState *tstate, _PyInterpreterFrame *frame)
 }
 #endif
 
-_PyJitEntryFuncPtr _Py_jit_entry;
+extern _PyJitEntryFuncPtr _Py_jit_entry;
 
 #if _Py_TAIL_CALL_INTERP
 #include "test_targets.h"


### PR DESCRIPTION
Removes duplicate symbols in Python/ceval.o and Modules/_testinternalcapi/interpreter.o when the --enable-experimental-jit option is enabled. 

<!-- gh-issue-number: gh-144712 -->
* Issue: gh-144712
<!-- /gh-issue-number -->
