### PR TITLE
gh-106318: Fix incorrectly rendered code block in `str.isalnum()` docs

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2183,7 +2183,7 @@ expression support in the :mod:`re` module).
    Return ``True`` if all characters in the string are alphanumeric and there is at
    least one character, ``False`` otherwise.  A character ``c`` is alphanumeric if one
    of the following returns ``True``: ``c.isalpha()``, ``c.isdecimal()``,
-   ``c.isdigit()``, or ``c.isnumeric()``. For example::
+   ``c.isdigit()``, or ``c.isnumeric()``. For example:
 
    .. doctest::
 


### PR DESCRIPTION
WIP #106318 

Before

<img width="839" height="338" alt="image" src="https://github.com/user-attachments/assets/87ae7d73-616c-4b8a-95f4-c4c423b6badb" />

Now

<img width="845" height="315" alt="image" src="https://github.com/user-attachments/assets/40c1e809-99f4-4b4e-a8d4-9dd748cd26bf" />



<!-- gh-issue-number: gh-106318 -->
* Issue: gh-106318
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144718.org.readthedocs.build/en/144718/library/stdtypes.html#str.isalnum

<!-- readthedocs-preview cpython-previews end -->