### PR TITLE
gh-122622: Add sys._preexec hook for REPL

### DIFF
--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -146,6 +146,13 @@ def run_multiline_interactive_console(
             if maybe_run_command(statement):
                 continue
 
+            preexec = getattr(sys, "_preexec", None)
+            if callable(preexec):
+                try:
+                    preexec(statement)
+                except Exception:
+                    pass
+
             input_name = f"<python-input-{input_n}>"
             more = console.push(_strip_final_indent(statement), filename=input_name, _symbol="single")  # type: ignore[call-arg]
             assert not more

--- a/Lib/test/test_pyrepl/test_interact.py
+++ b/Lib/test/test_pyrepl/test_interact.py
@@ -1,8 +1,9 @@
 import contextlib
 import io
+import sys
 import warnings
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from textwrap import dedent
 
 from test.support import force_not_colorized
@@ -299,3 +300,53 @@ class TestWarnings(unittest.TestCase):
         count = sum("'return' in a 'finally' block" in str(w.message)
                     for w in caught)
         self.assertEqual(count, 1)
+
+
+class TestPreexecHook(unittest.TestCase):
+
+    def _run_interactive(self, statements, *, preexec=None):
+        from _pyrepl.simple_interact import run_multiline_interactive_console
+
+        console = InteractiveColoredConsole()
+        statement_iter = iter(statements)
+
+        def fake_multiline_input(more_lines, ps1, ps2):
+            try:
+                return next(statement_iter)
+            except StopIteration:
+                raise EOFError
+
+        patches = [
+            patch("_pyrepl.simple_interact.multiline_input", side_effect=fake_multiline_input),
+            patch("_pyrepl.simple_interact._get_reader"),
+            patch("_pyrepl.simple_interact.append_history_file"),
+            patch("_pyrepl.readline._setup"),
+        ]
+        if preexec is not None:
+            patches.append(patch.object(sys, "_preexec", preexec, create=True))
+
+        f = io.StringIO()
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            stack.enter_context(contextlib.redirect_stdout(f))
+            stack.enter_context(contextlib.redirect_stderr(f))
+            run_multiline_interactive_console(console)
+
+        return f.getvalue()
+
+    def test_preexec_called_with_statement(self):
+        preexec = MagicMock()
+        self._run_interactive(["x = 1"], preexec=preexec)
+        preexec.assert_called_once_with("x = 1")
+
+    def test_preexec_exception_does_not_break_repl(self):
+        def bad_preexec(cmd):
+            raise RuntimeError("hook error")
+
+        self._run_interactive(["x = 1", "y = 2"], preexec=bad_preexec)
+
+    def test_preexec_not_called_for_repl_commands(self):
+        preexec = MagicMock()
+        self._run_interactive(["clear"], preexec=preexec)
+        preexec.assert_not_called()

--- a/Misc/NEWS.d/next/Library/2026-02-12-21-34-57.gh-issue-122622.hlL1s9.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-12-21-34-57.gh-issue-122622.hlL1s9.rst
@@ -1,0 +1,3 @@
+Add ``sys._preexec`` hook that is called with the command line string
+before each statement is executed in the interactive REPL. This allows
+external tools to implement features such as shell integration.


### PR DESCRIPTION
See issue mentioned for background info: https://github.com/python/cpython/issues/122622  

Adding preexec hook will allow VS Code to enable [shell integration ](https://code.visualstudio.com/docs/terminal/shell-integration)for users on Windows! VS Code setting: `python.terminal.shellIntegration.enabled`

This also means we can also provide lsp completions in the REPL: https://code.visualstudio.com/updates/v1_101#_language-server-based-terminal-suggest 

 

Also planning to enable PY_REPL back since https://github.com/python/cpython/issues/126131 is resolved.

Thank you 

/cc @picnixz @Tyriar @brettcannon 


<!-- gh-issue-number: gh-122622 -->
* Issue: gh-122622
<!-- /gh-issue-number -->
