### PR TITLE
gh-142349: Fix build errors from PEP 810

### DIFF
--- a/Include/import.h
+++ b/Include/import.h
@@ -91,7 +91,7 @@ PyAPI_FUNC(int) PyImport_AppendInittab(
 typedef enum {
     PyImport_LAZY_NORMAL,
     PyImport_LAZY_ALL,
-    PyImport_LAZY_NONE,
+    PyImport_LAZY_NONE
 } PyImport_LazyImportsMode;
 
 #ifndef Py_LIMITED_API

--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -356,9 +356,9 @@ class TestCParser(unittest.TestCase):
         grammar_source = """
         start[mod_ty]: a[asdl_stmt_seq*]=import_from+ NEWLINE ENDMARKER { _PyAST_Module(a, NULL, p->arena)}
         import_from[stmt_ty]: ( a='from' !'import' c=simple_name 'import' d=import_as_names_from {
-                                _PyAST_ImportFrom(c->v.Name.id, d, 0, EXTRA) }
+                                _PyAST_ImportFrom(c->v.Name.id, d, 0, 0, EXTRA) }
                             | a='from' '.' 'import' c=import_as_names_from {
-                                _PyAST_ImportFrom(NULL, c, 1, EXTRA) }
+                                _PyAST_ImportFrom(NULL, c, 1, 0, EXTRA) }
                             )
         simple_name[expr_ty]: NAME
         import_as_names_from[asdl_alias_seq*]: a[asdl_alias_seq*]=','.import_as_name_from+ { a }


### PR DESCRIPTION
The PEP 810 commit added an is_lazy parameter to _PyAST_ImportFrom but did not update the test_peg_generator test that calls this function directly from a custom grammar. It also introduced a trailing comma in the PyImport_LazyImportsMode enum which is invalid under C++03 with -pedantic-errors, breaking test_cppext.

Pass 0 for the new is_lazy argument in the test grammar's _PyAST_ImportFrom calls, and remove the trailing comma from the enum definition to restore C++03 compatibility.


<!-- gh-issue-number: gh-142349 -->
* Issue: gh-142349
<!-- /gh-issue-number -->
