### PR TITLE
[3.13] gh-84424: Use numeric_changed for UCD.numeric (GH-19457)

### DIFF
--- a/Lib/test/test_unicodedata.py
+++ b/Lib/test/test_unicodedata.py
@@ -170,10 +170,14 @@ class UnicodeFunctionsTest(unittest.TestCase):
 
         # New in 4.1.0
         self.assertEqual(self.db.numeric('\U0001012A', None), None if self.old else 9000)
+        # Changed in 4.1.0
+        self.assertEqual(self.db.numeric('\u5793', None), 1e20 if self.old else None)
         # New in 5.0.0
         self.assertEqual(self.db.numeric('\u07c0', None), None if self.old else 0.0)
         # New in 5.1.0
         self.assertEqual(self.db.numeric('\ua627', None), None if self.old else 7.0)
+        # Changed in 5.2.0
+        self.assertEqual(self.db.numeric('\u09f6'), 3.0 if self.old else 3/16)
         # New in 6.0.0
         self.assertEqual(self.db.numeric('\u0b72', None), None if self.old else 0.25)
         # New in 12.0.0
@@ -569,9 +573,9 @@ class UnicodeFunctionsTest(unittest.TestCase):
 class Unicode_3_2_0_FunctionsTest(UnicodeFunctionsTest):
     db = unicodedata.ucd_3_2_0
     old = True
-    expectedchecksum = ('76b126d719d52ba11788a627d058163106da7d56'
+    expectedchecksum = ('4154d8d1232837e255edf3cdcbb5ab184d71f4a4'
                         if quicktest else
-                        '871389bdd96a709929496da7f9e59718daf61adb')
+                        'b678d38ffbf1f1de092b2af1ed155602909fcd8d')
 
 
 class UnicodeMiscTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2020-04-10-14-29-53.bpo-40243.85HRib.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-10-14-29-53.bpo-40243.85HRib.rst
@@ -1,0 +1,1 @@
+Fix :meth:`!unicodedata.ucd_3_2_0.numeric` for non-decimal values.

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -228,9 +228,9 @@ unicodedata_UCD_numeric_impl(PyObject *self, int chr,
             have_old = 1;
             rc = -1.0;
         }
-        else if (old->decimal_changed != 0xFF) {
+        else if (old->numeric_changed != 0.0) {
             have_old = 1;
-            rc = old->decimal_changed;
+            rc = old->numeric_changed;
         }
     }
 


### PR DESCRIPTION
This was causing ucd_3_2_0.numeric() to pick up only decimal changes between Unicode 3.2.0 and the current version. (cherry picked from commit 3e0322ff16f47caa3e273d453f007d3918b8ac80)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-84424 -->
* Issue: gh-84424
<!-- /gh-issue-number -->
