### PR TITLE
gh-142349: Fix refcount corruption in lazy import specialization

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1321,7 +1321,6 @@ specialize_load_global_lock_held(
     }
     if (value != NULL && PyLazyImport_CheckExact(value)) {
         SPECIALIZATION_FAIL(LOAD_GLOBAL, SPEC_FAIL_ATTR_MODULE_LAZY_VALUE);
-        Py_DECREF(value);
         goto fail;
     }
     PyInterpreterState *interp = _PyInterpreterState_GET();


### PR DESCRIPTION
 _PyDict_LookupIndexAndValue() returns a borrowed reference via _Py_dict_lookup(), but specialize_load_global_lock_held() called Py_DECREF(value) on it when bailing out for lazy imports. Each time the adaptive counter fired while a lazy import was still in globals, this stole one reference from the dict's object. With 8+ threads racing through LOAD_GLOBAL during concurrent lazy import resolution, enough triggers accumulated to drive the refcount to zero while the dict and other threads still referenced the object, causing use-after-free.

<!-- gh-issue-number: gh-142349 -->
* Issue: gh-142349
<!-- /gh-issue-number -->
