### PR TITLE
gh-144706: docs note about combining RLock and signal handlers

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -70,10 +70,9 @@ Besides, only the main thread of the main interpreter is allowed to set a new si
 
 .. warning::
 
-   Synchronization primitives such as :class:`threading.Lock` must not be shared
-   between signal handlers and other threads.
-   Because blocking synchronization calls can be interrupted by signals,
-   such sharing can lead to surprising dead locks.
+   Synchronization primitives such as :class:`threading.Lock` should not be used
+   within signal handlers.  Because blocking synchronization calls can be
+   interrupted by signals, such usage can lead to surprising dead locks.
 
 
 Module contents

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -71,7 +71,7 @@ Besides, only the main thread of the main interpreter is allowed to set a new si
 .. warning::
 
    Synchronization primitives such as :class:`threading.Lock` must not be shared
-   between between signal handlers and other threads.
+   between signal handlers and other threads.
    Because blocking synchronization calls can be interrupted by signals,
    such sharing can lead to surprising dead locks.
 

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -68,6 +68,13 @@ the synchronization primitives from the :mod:`threading` module instead.
 
 Besides, only the main thread of the main interpreter is allowed to set a new signal handler.
 
+.. warning::
+
+   Synchronization primitives such as :class:`threading.Lock` must not be shared
+   between between signal handlers and other threads.
+   Because blocking synchronization calls can be interrupted by signals,
+   such sharing can lead to surprising dead locks.
+
 
 Module contents
 ---------------

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -71,8 +71,7 @@ Besides, only the main thread of the main interpreter is allowed to set a new si
 .. warning::
 
    Synchronization primitives such as :class:`threading.Lock` should not be used
-   within signal handlers.  Because blocking synchronization calls can be
-   interrupted by signals, such usage can lead to surprising dead locks.
+   within signal handlers.  Doing so can lead to unexpected deadlocks.
 
 
 Module contents

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -840,6 +840,12 @@ the lock to an unlocked state and allows another thread blocked in
 must have a release in the thread that has acquired the lock. Failing to
 call release as many times the lock has been acquired can lead to deadlock.
 
+.. tip::
+
+   Because lock acquisition can be interrupted by signals, sharing reentrant
+   locks between :mod:`signal` handlers and the main thread can lead to
+   surprising behavior. Therefore, this is generally not recommended.
+
 
 .. class:: RLock()
 

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -13,6 +13,14 @@ level :mod:`_thread` module.
 
 .. include:: ../includes/wasm-notavail.rst
 
+.. warning::
+
+   Syncrhonization primitives must not be shared between between :mod:`signal`
+   handlers and the main thread.
+   Because blocking syncrhonizations calls can be interrupted by signals,
+   such sharing can lead to surprising dead locks.
+
+
 Introduction
 ------------
 
@@ -839,12 +847,6 @@ the lock to an unlocked state and allows another thread blocked in
 :meth:`~RLock.acquire`/:meth:`~RLock.release` must be used in pairs: each acquire
 must have a release in the thread that has acquired the lock. Failing to
 call release as many times the lock has been acquired can lead to deadlock.
-
-.. tip::
-
-   Because lock acquisition can be interrupted by signals, sharing reentrant
-   locks between :mod:`signal` handlers and the main thread can lead to
-   surprising behavior. Therefore, this is generally not recommended.
 
 
 .. class:: RLock()

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -13,14 +13,6 @@ level :mod:`_thread` module.
 
 .. include:: ../includes/wasm-notavail.rst
 
-.. warning::
-
-   Syncrhonization primitives must not be shared between between :mod:`signal`
-   handlers and the main thread.
-   Because blocking syncrhonizations calls can be interrupted by signals,
-   such sharing can lead to surprising dead locks.
-
-
 Introduction
 ------------
 


### PR DESCRIPTION
Document potentially surprising interplay or `threading.RLock` and `signal` as discussed in https://github.com/python/cpython/issues/144706#issuecomment-3887530820.

<!-- gh-issue-number: gh-144706 -->
* Issue: gh-144706
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144736.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->