### PR TITLE
gh-130821: Make error messages consistent in Modules/

### DIFF
--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -383,10 +383,14 @@ compute_abstract_methods(PyObject *self)
     }
     assert(PyList_Check(items));
     for (Py_ssize_t pos = 0; pos < PyList_GET_SIZE(items); pos++) {
+        PyObject *item = PyList_GET_ITEM(items, pos);
         PyObject *it = PySequence_Fast(
-                PyList_GET_ITEM(items, pos),
-                "items() returned non-iterable");
+                item,
+                NULL);
         if (!it) {
+            PyErr_Format(PyExc_TypeError,
+                         "items() must return an iterable, not %T",
+                         item);
             goto error;
         }
         if (PySequence_Fast_GET_SIZE(it) != 2) {

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -953,10 +953,9 @@ Reader_iternext_lock_held(PyObject *op)
         }
         if (!PyUnicode_Check(lineobj)) {
             PyErr_Format(module_state->error_obj,
-                         "iterator should return strings, "
-                         "not %.200s "
+                         "iterator must return str objects, not %T "
                          "(the file should be opened in text mode)",
-                         Py_TYPE(lineobj)->tp_name
+                         lineobj
                 );
             Py_DECREF(lineobj);
             return NULL;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2177,8 +2177,8 @@ checked_divmod(PyObject *a, PyObject *b)
     if (result != NULL) {
         if (!PyTuple_Check(result)) {
             PyErr_Format(PyExc_TypeError,
-                         "divmod() returned non-tuple (type %.200s)",
-                         Py_TYPE(result)->tp_name);
+                         "divmod() must return a tuple, not %T",
+                         result);
             Py_DECREF(result);
             return NULL;
         }

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -62,7 +62,9 @@ _bufferediobase_readinto_generic(PyObject *self, Py_buffer *buffer, char readint
 
     if (!PyBytes_Check(data)) {
         Py_DECREF(data);
-        PyErr_SetString(PyExc_TypeError, "read() should return bytes");
+        PyErr_Format(PyExc_TypeError,
+                     "read() must return a bytes object, not %T",
+                     data);
         return NULL;
     }
 
@@ -1717,7 +1719,9 @@ _bufferedreader_read_all(buffered *self)
         if (tmp == NULL)
             goto cleanup;
         if (tmp != Py_None && !PyBytes_Check(tmp)) {
-            PyErr_SetString(PyExc_TypeError, "readall() should return bytes");
+            PyErr_Format(PyExc_TypeError,
+                         "readall() must return a bytes object, not %T",
+                         tmp);
             goto cleanup;
         }
         if (current_size == 0) {
@@ -1747,7 +1751,9 @@ _bufferedreader_read_all(buffered *self)
         if (data == NULL)
             goto cleanup;
         if (data != Py_None && !PyBytes_Check(data)) {
-            PyErr_SetString(PyExc_TypeError, "read() should return bytes");
+            PyErr_Format(PyExc_TypeError,
+                         "read() must return a bytes object, not %T",
+                         data);
             goto cleanup;
         }
         if (data == Py_None || PyBytes_GET_SIZE(data) == 0) {

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -996,7 +996,9 @@ _io__RawIOBase_readall_impl(PyObject *self)
         }
         if (!PyBytes_Check(data)) {
             Py_DECREF(data);
-            PyErr_SetString(PyExc_TypeError, "read() should return bytes");
+            PyErr_Format(PyExc_TypeError,
+                         "read() must return a bytes object, not %T",
+                         data);
             PyBytesWriter_Discard(writer);
             return NULL;
         }

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -304,8 +304,8 @@ check_decoded(PyObject *decoded)
         return -1;
     if (!PyUnicode_Check(decoded)) {
         PyErr_Format(PyExc_TypeError,
-                     "decoder should return a string result, not '%.200s'",
-                     Py_TYPE(decoded)->tp_name);
+                     "decoder must return a str object, not %T",
+                     decoded);
         Py_DECREF(decoded);
         return -1;
     }
@@ -1718,8 +1718,8 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
         return NULL;
     if (b != text && !PyBytes_Check(b)) {
         PyErr_Format(PyExc_TypeError,
-                     "encoder should return a bytes object, not '%.200s'",
-                     Py_TYPE(b)->tp_name);
+                     "encoder must return a bytes object, not %T",
+                     b);
         Py_DECREF(b);
         return NULL;
     }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1302,8 +1302,8 @@ _Unpickler_ReadIntoFromFile(PickleState *state, UnpicklerObject *self, char *buf
         }
         if (!PyBytes_Check(data)) {
             PyErr_Format(PyExc_ValueError,
-                         "read() returned non-bytes object (%R)",
-                         Py_TYPE(data));
+                         "read() must return a bytes object, not %T",
+                         data);
             Py_DECREF(data);
             return -1;
         }


### PR DESCRIPTION
Update error messages in Modules/ directory to use consistent format with %T formatter for type names, similar to changes made in PR #130835 for Objects/ directory.

Changes:
- Modules/_abc.c: items() error message
- Modules/_datetimemodule.c: divmod() error message
- Modules/_pickle.c: read() error message
- Modules/_io/bufferedio.c: read() and readall() error messages
- Modules/_io/iobase.c: read() error message
- Modules/_io/textio.c: decoder and encoder error messages
- Modules/_csv.c: iterator error message



<!-- gh-issue-number: gh-130821 -->
* Issue: gh-130821
<!-- /gh-issue-number -->
