### PR TITLE
GH-144739: Skip test_pyexpat.MemoryProtectionTest based on expat compile-time version, not runtime

### DIFF
--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -1069,7 +1069,9 @@ class ExpansionProtectionTest(AttackProtectionTestBase, unittest.TestCase):
         self.assertIsNotNone(parser.Parse(payload, True))
 
 
-@unittest.skipIf(expat.version_info < (2, 7, 2), "requires Expat >= 2.7.2")
+@unittest.skipIf(not hasattr(expat.XMLParserType,
+                             "SetAllocTrackerMaximumAmplification"),
+                 "requires Python compiled with Expat >= 2.7.2")
 class MemoryProtectionTest(AttackProtectionTestBase, unittest.TestCase):
 
     # NOTE: with the default Expat configuration, the billion laughs protection

--- a/Misc/NEWS.d/next/Tests/2026-02-12-12-12-00.gh-issue-144739.-fx1tN.rst
+++ b/Misc/NEWS.d/next/Tests/2026-02-12-12-12-00.gh-issue-144739.-fx1tN.rst
@@ -1,0 +1,3 @@
+When Python was compiled with system expat older then 2.7.2 but tests run
+with newer expat, still skip
+:class:`test.test_pyexpat.MemoryProtectionTest`.

--- a/Misc/NEWS.d/next/Tests/2026-02-12-12-12-00.gh-issue-144739.-fx1tN.rst
+++ b/Misc/NEWS.d/next/Tests/2026-02-12-12-12-00.gh-issue-144739.-fx1tN.rst
@@ -1,3 +1,3 @@
 When Python was compiled with system expat older then 2.7.2 but tests run
 with newer expat, still skip
-:class:`test.test_pyexpat.MemoryProtectionTest`.
+:class:`!test.test_pyexpat.MemoryProtectionTest`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144739 -->
* Issue: gh-144739
<!-- /gh-issue-number -->
