### PR TITLE
Enable CPU tests on default ARM build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,11 +242,18 @@ jobs:
         # BOLT currently crashes during instrumentation on aarch64
         - os: ubuntu-24.04-arm
           bolt: true
+        include:
+        # Enable CPU-intensive tests on ARM (default build only)
+        - os: ubuntu-24.04-arm
+          bolt: false
+          free-threading: false
+          test-opts: '-u cpu'
     uses: ./.github/workflows/reusable-ubuntu.yml
     with:
       bolt-optimizations: ${{ matrix.bolt }}
       free-threading: ${{ matrix.free-threading }}
       os: ${{ matrix.os }}
+      test-opts: ${{ matrix.test-opts || '' }}
 
   build-ubuntu-ssltests-openssl:
     name: 'Ubuntu SSL tests with OpenSSL'

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -17,6 +17,11 @@ on:
          description: OS to run the job
          required: true
          type: string
+      test-opts:
+         description: Extra options to pass to the test runner via TESTOPTS
+         required: false
+         type: string
+         default: ''
 
 env:
   FORCE_COLOR: 1
@@ -111,4 +116,6 @@ jobs:
       run: sudo mount "$CPYTHON_RO_SRCDIR" -oremount,rw
     - name: Tests
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
-      run: xvfb-run make ci
+      run: xvfb-run make ci EXTRATESTOPTS="${TEST_OPTS}"
+      env:
+        TEST_OPTS: ${{ inputs.test-opts }}


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Some CPU-heavy tests are marked with the `cpu` resource and we don't run them on GitHub Actions because they're slow. This means we sometimes don't catch `cpu` failures until after they've been merged and run on the buildbots, which is a slow feedback cycle.

But how slow are the `cpu` tests?

Here's a recent GHA run, without any `cpu` ([🔒 Datadog](https://app.datadoghq.com/ci/build/AwAAAZxRZzA4U7C6vAAAABhBWnhSWnpBNEFBQjFweEdrVWNDYUNZTG8AAAAkMDE5YzUxNmQtZjY5OC00ODljLTk2MDktMTgxM2UzMmJkZWI3AAAAtg?query=ci_level%3Apipeline%20%40git.repository.id%3A%22github.com%2Fpython%2Fcpython%22%20%40ci.pipeline.name%3ATests&agg_m=%40duration&agg_m_source=base&agg_q=%40ci.pipeline.name&agg_q_source=base&agg_t=avg&buildId=AwAAAZxRZzA4U7C6vAAAABhBWnhSWnpBNEFBQjFweEdrVWNDYUNZTG8AAAAkMDE5YzUxNmQtZjY5OC00ODljLTk2MDktMTgxM2UzMmJkZWI3AAAAtg&cipipeline_explorer_sort=timestamp%2Cdesc&colorBy=meta%5B%27ci.job.name%27%5D&colorByAttr=meta%5B%27ci.job.name%27%5D&cols=%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name%2C%40git.branch%2C%40ci_stages&currentTab=trace&downstream_pipelines=false&filterCriticalPath=false&filterErrors=false&fromUser=false&graphType=flamegraph&index=cipipeline&mode=sliding&partial_retries=false&sort=time&span_id=14445622961154878684&spanViewType=metadata&tab=overview&top_n=10&top_o=top&trace_filters=critical_path&view=spans&viz=stream&x_missing=true&start=1770288833475&end=1770893633475&paused=false)):

<img width="1251" height="722" alt="image" src="https://github.com/user-attachments/assets/5bd17508-f1fc-4db5-9a87-e8f1658057da" />

The whole thing is around 31m, the slowest jobs are free-threading Windows arm64 (29.5m) and x64 (24.5m), with four others at 20-22m.

One of the fastest is the default `ubuntu-24.04-arm` at 9.5m.

(The `ubuntu-24.04` (x64) one is 13m.)

If we add `cpu` resources to just this job, it only takes an extra ~3 minutes (total around 12.5 mins), still ranking it among one of the fastest jobs on the CI:

https://github.com/python/cpython/actions/runs/21947082050/job/63387452394?pr=144743
