### PR TITLE
gh-117865: Speedup import of `inspect` module

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2117,7 +2117,6 @@ def _signature_strip_non_python_syntax(signature):
 
     lines = [l.encode('ascii') for l in signature.split('\n') if l]
     generator = iter(lines).__next__
-
     token_stream = tokenize.tokenize(generator)
 
     text = []
@@ -2154,7 +2153,9 @@ def _signature_fromstr(cls, obj, s, skip_bound_arg=True):
     and return a Signature based on it.
     """
     Parameter = cls._parameter_cls
+
     clean_signature, self_parameter = _signature_strip_non_python_syntax(s)
+
     program = "def foo" + clean_signature + ": pass"
 
     try:

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -145,7 +145,6 @@ __all__ = [
 import abc
 from annotationlib import Format, ForwardRef
 from annotationlib import get_annotations  # re-exported
-import ast
 import dis
 import collections.abc
 import enum
@@ -153,9 +152,7 @@ import importlib.machinery
 import itertools
 import linecache
 import os
-import re
 import sys
-import tokenize
 import token
 import types
 import functools
@@ -163,7 +160,7 @@ import builtins
 from keyword import iskeyword
 from operator import attrgetter
 from collections import namedtuple, OrderedDict
-from weakref import ref as make_weakref
+from _weakref import ref as make_weakref
 
 # Create constants for the compiler flags in Include/code.h
 # We try to get them from dis to avoid duplication
@@ -1089,6 +1086,8 @@ class BlockFinder:
         self.body_col0 = None
 
     def tokeneater(self, type, token, srowcol, erowcol, line):
+        import tokenize
+
         if not self.started and not self.indecorator:
             if type in (tokenize.INDENT, tokenize.COMMENT, tokenize.NL):
                 pass
@@ -1139,6 +1138,8 @@ class BlockFinder:
 def getblock(lines):
     """Extract the block of code at the top of the given list of lines."""
     blockfinder = BlockFinder()
+    import tokenize
+
     try:
         tokens = tokenize.generate_tokens(iter(lines).__next__)
         for _token in tokens:
@@ -1367,6 +1368,7 @@ def formatannotation(annotation, base_module=None, *, quote_annotation_strings=T
         def repl(match):
             text = match.group()
             return text.removeprefix('typing.')
+        import re
         return re.sub(r'[\w\.]+', repl, repr(annotation))
     if isinstance(annotation, types.GenericAlias):
         return str(annotation)
@@ -2116,6 +2118,8 @@ def _signature_strip_non_python_syntax(signature):
 
     lines = [l.encode('ascii') for l in signature.split('\n') if l]
     generator = iter(lines).__next__
+
+    import tokenize
     token_stream = tokenize.tokenize(generator)
 
     text = []
@@ -2151,10 +2155,10 @@ def _signature_fromstr(cls, obj, s, skip_bound_arg=True):
     """Private helper to parse content of '__text_signature__'
     and return a Signature based on it.
     """
+    import ast
+
     Parameter = cls._parameter_cls
-
     clean_signature, self_parameter = _signature_strip_non_python_syntax(s)
-
     program = "def foo" + clean_signature + ": pass"
 
     try:

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -163,6 +163,9 @@ from operator import attrgetter
 from collections import namedtuple, OrderedDict
 from _weakref import ref as make_weakref
 
+lazy import re
+lazy import tokenize
+
 # Create constants for the compiler flags in Include/code.h
 # We try to get them from dis to avoid duplication
 mod_dict = globals()
@@ -1087,8 +1090,6 @@ class BlockFinder:
         self.body_col0 = None
 
     def tokeneater(self, type, token, srowcol, erowcol, line):
-        import tokenize
-
         if not self.started and not self.indecorator:
             if type in (tokenize.INDENT, tokenize.COMMENT, tokenize.NL):
                 pass
@@ -1139,8 +1140,6 @@ class BlockFinder:
 def getblock(lines):
     """Extract the block of code at the top of the given list of lines."""
     blockfinder = BlockFinder()
-    import tokenize
-
     try:
         tokens = tokenize.generate_tokens(iter(lines).__next__)
         for _token in tokens:
@@ -1369,7 +1368,6 @@ def formatannotation(annotation, base_module=None, *, quote_annotation_strings=T
         def repl(match):
             text = match.group()
             return text.removeprefix('typing.')
-        import re
         return re.sub(r'[\w\.]+', repl, repr(annotation))
     if isinstance(annotation, types.GenericAlias):
         return str(annotation)
@@ -2120,7 +2118,6 @@ def _signature_strip_non_python_syntax(signature):
     lines = [l.encode('ascii') for l in signature.split('\n') if l]
     generator = iter(lines).__next__
 
-    import tokenize
     token_stream = tokenize.tokenize(generator)
 
     text = []

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -166,7 +166,7 @@ from _weakref import ref as make_weakref
 lazy import re
 lazy import tokenize
 
-# Create constants for the compiler flags in Include/code.h
+# Create constants for the compiler flags in Include/cpython/code.h
 # We try to get them from dis to avoid duplication
 mod_dict = globals()
 for k, v in dis.COMPILER_FLAG_NAMES.items():

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -145,6 +145,7 @@ __all__ = [
 import abc
 from annotationlib import Format, ForwardRef
 from annotationlib import get_annotations  # re-exported
+import ast
 import dis
 import collections.abc
 import enum
@@ -2155,8 +2156,6 @@ def _signature_fromstr(cls, obj, s, skip_bound_arg=True):
     """Private helper to parse content of '__text_signature__'
     and return a Signature based on it.
     """
-    import ast
-
     Parameter = cls._parameter_cls
     clean_signature, self_parameter = _signature_strip_non_python_syntax(s)
     program = "def foo" + clean_signature + ": pass"

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -153,7 +153,9 @@ import importlib.machinery
 import itertools
 import linecache
 import os
+lazy import re
 import sys
+lazy import tokenize
 import token
 import types
 import functools
@@ -162,9 +164,6 @@ from keyword import iskeyword
 from operator import attrgetter
 from collections import namedtuple, OrderedDict
 from _weakref import ref as make_weakref
-
-lazy import re
-lazy import tokenize
 
 # Create constants for the compiler flags in Include/cpython/code.h
 # We try to get them from dis to avoid duplication

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -173,6 +173,15 @@ class custom_descriptor:
         return self.func.__get__(instance, owner)
 
 
+class TestImportTime(unittest.TestCase):
+
+    @cpython_only
+    def test_lazy_import(self):
+        import_helper.ensure_lazy_imports(
+            "inspect", {"re", "tokenize"}
+        )
+
+
 class TestPredicates(IsTestBase):
 
     def test_excluding_predicates(self):

--- a/Misc/NEWS.d/next/Library/2026-02-12-17-56-17.gh-issue-117865.jE1ema.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-12-17-56-17.gh-issue-117865.jE1ema.rst
@@ -1,0 +1,1 @@
+Reduce the import time of :mod:`inspect` module by ~20%.


### PR DESCRIPTION
This is a revived version of #119526 (with Alex's blessing), using the new fancy lazy import machinery to defer imports of `re` and `tokenize` modules, for a ~20% speedup.

### Before

<img width="1345" height="1108" alt="image" src="https://github.com/user-attachments/assets/326a5ceb-d972-4412-bf6b-3a6f293fed97" />


```console
❯ hyperfine -w 5 "./python -c 'import inspect'"
Benchmark 1: ./python -c 'import inspect'
  Time (mean ± σ):      19.2 ms ±   1.9 ms    [User: 14.4 ms, System: 4.5 ms]
  Range (min … max):    16.3 ms …  23.4 ms    152 runs
```

### After 

<img width="1279" height="1033" alt="image" src="https://github.com/user-attachments/assets/df29f471-09e4-49f1-ac84-5845e5139fab" />

```console
❯ hyperfine -w 5 "./python -c 'import inspect'"
Benchmark 1: ./python -c 'import inspect'
  Time (mean ± σ):      16.4 ms ±   2.0 ms    [User: 12.3 ms, System: 3.9 ms]
  Range (min … max):    13.8 ms …  22.2 ms    191 runs
```

Part of #137855

<!-- gh-issue-number: gh-117865 -->
* Issue: gh-117865
<!-- /gh-issue-number -->
