### PR TITLE
[3.14] gh-144601: Use `_testmultiphase` instead of `_testsinglephase` in `test_importlib`

### DIFF
--- a/Lib/test/test_importlib/util.py
+++ b/Lib/test/test_importlib/util.py
@@ -15,7 +15,7 @@ import sys
 import tempfile
 import types
 
-_testsinglephase = import_helper.import_module("_testsinglephase")
+import_helper.import_module("_testmultiphase")
 
 
 BUILTINS = types.SimpleNamespace()


### PR DESCRIPTION
`test_importlib.util` is useful for subinterpreter tests, but they can't use it due to the import of `_testsinglephase` (which, you guessed it, is a single-phase extension). This problem is currently blocking the backport of GH-144602 (GH-144633).

On the main branch, this change was already made as part of GH-141785. As far as I can tell, nothing else from that PR needs to be backported to make this change.

<!-- gh-issue-number: gh-144601 -->
* Issue: gh-144601
<!-- /gh-issue-number -->
