### PR TITLE
gh-140009: Replace PyTuple_Pack with PyTuple_FromArray in _PyCode_ConstantKey

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -2967,17 +2967,22 @@ _PyCode_ConstantKey(PyObject *op)
     else if (PyBool_Check(op) || PyBytes_CheckExact(op)) {
         /* Make booleans different from integers 0 and 1.
          * Avoid BytesWarning from comparing bytes with strings. */
-        key = PyTuple_Pack(2, Py_TYPE(op), op);
+        PyObject *items[] = {(PyObject *)Py_TYPE(op), op};
+        key = PyTuple_FromArray(items, 2);
     }
     else if (PyFloat_CheckExact(op)) {
         double d = PyFloat_AS_DOUBLE(op);
         /* all we need is to make the tuple different in either the 0.0
          * or -0.0 case from all others, just to avoid the "coercion".
          */
-        if (d == 0.0 && copysign(1.0, d) < 0.0)
-            key = PyTuple_Pack(3, Py_TYPE(op), op, Py_None);
-        else
-            key = PyTuple_Pack(2, Py_TYPE(op), op);
+        if (d == 0.0 && copysign(1.0, d) < 0.0) {
+            PyObject *items[] = {(PyObject *)Py_TYPE(op), op, Py_None};
+            key = PyTuple_FromArray(items, 3);
+        }
+        else {
+            PyObject *items[] = {(PyObject *)Py_TYPE(op), op};
+            key = PyTuple_FromArray(items, 2);
+        }
     }
     else if (PyComplex_CheckExact(op)) {
         Py_complex z;
@@ -2992,16 +2997,20 @@ _PyCode_ConstantKey(PyObject *op)
         /* use True, False and None singleton as tags for the real and imag
          * sign, to make tuples different */
         if (real_negzero && imag_negzero) {
-            key = PyTuple_Pack(3, Py_TYPE(op), op, Py_True);
+            PyObject *items[] = {(PyObject *)Py_TYPE(op), op, Py_True};
+            key = PyTuple_FromArray(items, 3);
         }
         else if (imag_negzero) {
-            key = PyTuple_Pack(3, Py_TYPE(op), op, Py_False);
+            PyObject *items[] = {(PyObject *)Py_TYPE(op), op, Py_False};
+            key = PyTuple_FromArray(items, 3);
         }
         else if (real_negzero) {
-            key = PyTuple_Pack(3, Py_TYPE(op), op, Py_None);
+            PyObject *items[] = {(PyObject *)Py_TYPE(op), op, Py_None};
+            key = PyTuple_FromArray(items, 3);
         }
         else {
-            key = PyTuple_Pack(2, Py_TYPE(op), op);
+            PyObject *items[] = {(PyObject *)Py_TYPE(op), op};
+            key = PyTuple_FromArray(items, 2);
         }
     }
     else if (PyTuple_CheckExact(op)) {
@@ -3026,7 +3035,8 @@ _PyCode_ConstantKey(PyObject *op)
             PyTuple_SET_ITEM(tuple, i, item_key);
         }
 
-        key = PyTuple_Pack(2, tuple, op);
+        PyObject *items[] = {tuple, op};
+        key = PyTuple_FromArray(items, 2);
         Py_DECREF(tuple);
     }
     else if (PyFrozenSet_CheckExact(op)) {
@@ -3060,7 +3070,8 @@ _PyCode_ConstantKey(PyObject *op)
         if (set == NULL)
             return NULL;
 
-        key = PyTuple_Pack(2, set, op);
+        PyObject *items[] = {set, op};
+        key = PyTuple_FromArray(items, 2);
         Py_DECREF(set);
         return key;
     }
@@ -3091,7 +3102,8 @@ _PyCode_ConstantKey(PyObject *op)
             goto slice_exit;
         }
 
-        key = PyTuple_Pack(2, slice_key, op);
+        PyObject *items[] = {slice_key, op};
+        key = PyTuple_FromArray(items, 2);
         Py_DECREF(slice_key);
     slice_exit:
         Py_XDECREF(start_key);
@@ -3105,7 +3117,8 @@ _PyCode_ConstantKey(PyObject *op)
         if (obj_id == NULL)
             return NULL;
 
-        key = PyTuple_Pack(2, obj_id, op);
+        PyObject *items[] = {obj_id, op};
+        key = PyTuple_FromArray(items, 2);
         Py_DECREF(obj_id);
     }
     return key;


### PR DESCRIPTION
This PR replaces PyTuple_Pack calls with PyTuple_FromArray() in Objects/codeobject.c (_PyCode_ConstantKey).

Benchmark evidence will be added in a follow-up comment.

Part of #140009.


<!-- gh-issue-number: gh-140009 -->
* Issue: gh-140009
<!-- /gh-issue-number -->
