### PR TITLE
[3.10] Pin `setuptools==81` to avoid `pkg_resources` removal

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -150,7 +150,7 @@ venv:
 		echo "To recreate it, remove it first with \`make clean-venv'."; \
 	else \
 		$(PYTHON) -m venv $(VENVDIR); \
-		$(VENVDIR)/bin/python3 -m pip install -U pip setuptools; \
+		$(VENVDIR)/bin/python3 -m pip install -U pip setuptools<=81; \
 		$(VENVDIR)/bin/python3 -m pip install -r requirements.txt; \
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -150,7 +150,7 @@ venv:
 		echo "To recreate it, remove it first with \`make clean-venv'."; \
 	else \
 		$(PYTHON) -m venv $(VENVDIR); \
-		$(VENVDIR)/bin/python3 -m pip install -U pip setuptools<=81; \
+		$(VENVDIR)/bin/python3 -m pip install -U pip setuptools==81; \
 		$(VENVDIR)/bin/python3 -m pip install -r requirements.txt; \
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi


### PR DESCRIPTION
Python 3.10 docs is set to install sphinx==3.4.3 (requirements.txt) and latest setuptools (Docs/Makefile) . The latest setuptools (i.e. 82.0) removed `pkg_resources`, but sphinx<4.4.0 depends on it.

Pinning setuptools 81.0 solves this problem.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144781.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->