### PR TITLE
gh-84393: Re-enable posix_fadvise and f_allocate on AIX

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-04-07-05-09-34.bpo-40212.oPYeBs.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-07-05-09-34.bpo-40212.oPYeBs.rst
@@ -1,0 +1,1 @@
+Re-enable :func:`os.posix_fallocate` and :func:`os.posix_fadvise` on AIX.

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -9418,7 +9418,7 @@ exit:
 
 #endif /* (defined HAVE_TRUNCATE || defined MS_WINDOWS) */
 
-#if (defined(HAVE_POSIX_FALLOCATE) && !defined(POSIX_FADVISE_AIX_BUG) && !defined(__wasi__))
+#if (defined(HAVE_POSIX_FALLOCATE) && !defined(__wasi__))
 
 PyDoc_STRVAR(os_posix_fallocate__doc__,
 "posix_fallocate($module, fd, offset, length, /)\n"
@@ -9463,9 +9463,9 @@ exit:
     return return_value;
 }
 
-#endif /* (defined(HAVE_POSIX_FALLOCATE) && !defined(POSIX_FADVISE_AIX_BUG) && !defined(__wasi__)) */
+#endif /* (defined(HAVE_POSIX_FALLOCATE) && !defined(__wasi__)) */
 
-#if (defined(HAVE_POSIX_FADVISE) && !defined(POSIX_FADVISE_AIX_BUG))
+#if defined(HAVE_POSIX_FADVISE)
 
 PyDoc_STRVAR(os_posix_fadvise__doc__,
 "posix_fadvise($module, fd, offset, length, advice, /)\n"
@@ -9520,7 +9520,7 @@ exit:
     return return_value;
 }
 
-#endif /* (defined(HAVE_POSIX_FADVISE) && !defined(POSIX_FADVISE_AIX_BUG)) */
+#endif /* defined(HAVE_POSIX_FADVISE) */
 
 #if defined(MS_WINDOWS)
 
@@ -13611,4 +13611,4 @@ exit:
 #ifndef OS__EMSCRIPTEN_LOG_METHODDEF
     #define OS__EMSCRIPTEN_LOG_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_LOG_METHODDEF) */
-/*[clinic end generated code: output=5fd2aeb6ba9a5df8 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=89c21e2151ac7316 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -13376,19 +13376,9 @@ os_truncate_impl(PyObject *module, path_t *path, Py_off_t length)
 #endif /* HAVE_TRUNCATE || MS_WINDOWS */
 
 
-/* Issue #22396: On 32-bit AIX platform, the prototypes of os.posix_fadvise()
-   and os.posix_fallocate() in system headers are wrong if _LARGE_FILES is
-   defined, which is the case in Python on AIX. AIX bug report:
-   http://www-01.ibm.com/support/docview.wss?uid=isg1IV56170 */
-#if defined(_AIX) && defined(_LARGE_FILES) && !defined(__64BIT__)
-#  define POSIX_FADVISE_AIX_BUG
-#endif
-
-
 /* GH-111804: Due to posix_fallocate() not having consistent semantics across
    OSs, support was dropped in WASI preview2. */
-#if defined(HAVE_POSIX_FALLOCATE) && !defined(POSIX_FADVISE_AIX_BUG) && \
-    !defined(__wasi__)
+#if defined(HAVE_POSIX_FALLOCATE) && !defined(__wasi__)
 /*[clinic input]
 os.posix_fallocate
 
@@ -13426,10 +13416,10 @@ os_posix_fallocate_impl(PyObject *module, int fd, Py_off_t offset,
     errno = result;
     return posix_error();
 }
-#endif /* HAVE_POSIX_FALLOCATE) && !POSIX_FADVISE_AIX_BUG && !defined(__wasi__) */
+#endif /* HAVE_POSIX_FALLOCATE && !defined(__wasi__) */
 
 
-#if defined(HAVE_POSIX_FADVISE) && !defined(POSIX_FADVISE_AIX_BUG)
+#if defined(HAVE_POSIX_FADVISE)
 /*[clinic input]
 os.posix_fadvise
 
@@ -13473,7 +13463,7 @@ os_posix_fadvise_impl(PyObject *module, int fd, Py_off_t offset,
     errno = result;
     return posix_error();
 }
-#endif /* HAVE_POSIX_FADVISE && !POSIX_FADVISE_AIX_BUG */
+#endif /* HAVE_POSIX_FADVISE */
 
 
 #ifdef MS_WINDOWS


### PR DESCRIPTION
This is #19403 rebased on current main. (It was faster to recreate than to merge.)

This removes an outdated workaround, apparently needed around 2014-2016 for a (now) unsupported platform. (AIX is [unsupported](https://peps.python.org/pep-0011/#unsupported-platforms) by CPython; AIX 6 is EOL at IBM's side.)

cc @edelsohn @ayappanec as the [AIX experts](https://devguide.python.org/core-team/experts/index.html#platforms).


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-84393 -->
* Issue: gh-84393
<!-- /gh-issue-number -->
