### PR TITLE
gh-144759: Fix undefined behavior from NULL pointer arithmetic in lexer

### DIFF
--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -143,6 +143,22 @@ class TestInteractiveInterpreter(unittest.TestCase):
         output = kill_python(p)
         self.assertEqual(p.returncode, 0)
 
+    @cpython_only
+    def test_lexer_buffer_realloc_with_null_start(self):
+        # gh-144759: NULL pointer arithmetic in the lexer when start and
+        # multi_line_start are NULL (uninitialized in tok_mode_stack[0])
+        # and the lexer buffer is reallocated while parsing long input.
+        long_value = "a" * 2000
+        user_input = dedent(f"""\
+        x = f'{{{long_value!r}}}'
+        print(x)
+        """)
+        p = spawn_repl()
+        p.stdin.write(user_input)
+        output = kill_python(p)
+        self.assertEqual(p.returncode, 0)
+        self.assertIn(long_value, output)
+
     def test_close_stdin(self):
         user_input = dedent('''
             import os

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-13-12-00-00.gh-issue-144759.d3qYpe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-13-12-00-00.gh-issue-144759.d3qYpe.rst
@@ -1,4 +1,4 @@
 Fix undefined behavior in the lexer when ``start`` and ``multi_line_start``
-pointers are ``NULL`` in :c:func:`_PyLexer_remember_fstring_buffers` and
-:c:func:`_PyLexer_restore_fstring_buffers`. The ``NULL`` pointer arithmetic
+pointers are ``NULL`` in ``_PyLexer_remember_fstring_buffers()`` and
+``_PyLexer_restore_fstring_buffers()``. The ``NULL`` pointer arithmetic
 (``NULL - valid_pointer``) is now guarded with explicit ``NULL`` checks.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-13-12-00-00.gh-issue-144759.d3qYpe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-13-12-00-00.gh-issue-144759.d3qYpe.rst
@@ -1,0 +1,4 @@
+Fix undefined behavior in the lexer when ``start`` and ``multi_line_start``
+pointers are ``NULL`` in :c:func:`_PyLexer_remember_fstring_buffers` and
+:c:func:`_PyLexer_restore_fstring_buffers`. The ``NULL`` pointer arithmetic
+(``NULL - valid_pointer``) is now guarded with explicit ``NULL`` checks.

--- a/Parser/lexer/buffer.c
+++ b/Parser/lexer/buffer.c
@@ -13,8 +13,8 @@ _PyLexer_remember_fstring_buffers(struct tok_state *tok)
 
     for (index = tok->tok_mode_stack_index; index >= 0; --index) {
         mode = &(tok->tok_mode_stack[index]);
-        mode->start_offset = mode->start - tok->buf;
-        mode->multi_line_start_offset = mode->multi_line_start - tok->buf;
+        mode->start_offset = mode->start == NULL ? -1 : mode->start - tok->buf;
+        mode->multi_line_start_offset = mode->multi_line_start == NULL ? -1 : mode->multi_line_start - tok->buf;
     }
 }
 
@@ -27,8 +27,8 @@ _PyLexer_restore_fstring_buffers(struct tok_state *tok)
 
     for (index = tok->tok_mode_stack_index; index >= 0; --index) {
         mode = &(tok->tok_mode_stack[index]);
-        mode->start = tok->buf + mode->start_offset;
-        mode->multi_line_start = tok->buf + mode->multi_line_start_offset;
+        mode->start = mode->start_offset < 0 ? NULL : tok->buf + mode->start_offset;
+        mode->multi_line_start = mode->multi_line_start_offset < 0 ? NULL : tok->buf + mode->multi_line_start_offset;
     }
 }
 


### PR DESCRIPTION
Fix undefined behavior in `_PyLexer_remember_fstring_buffers` and `_PyLexer_restore_fstring_buffers` caused by performing pointer arithmetic on `NULL` pointers (`NULL - tok->buf`).

When `tok_mode_stack[0]` is initialized, the `start` and `multi_line_start` fields are not explicitly set and remain `NULL` (from `PyMem_Calloc`). Later, when the lexer buffer is reallocated, the remember/restore functions perform `NULL - valid_pointer` and `valid_pointer + negative_offset`, both of which are undefined behavior in C.

The fix adds explicit `NULL` checks: store `-1` as a sentinel offset when the pointer is `NULL`, and restore `NULL` when the offset is negative.

Detected with `--with-undefined-behavior-sanitizer`:
```
Parser/lexer/buffer.c:30:32: runtime error: pointer index expression with base 0x50300007f130 overflowed to 0xfffffddfffc38020
Parser/lexer/buffer.c:31:43: runtime error: pointer index expression with base 0x50300007f130 overflowed to 0xfffffddfffc38020
```

Fixes #144759

<!-- gh-issue-number: gh-144759 -->
* Issue: gh-144759
<!-- /gh-issue-number -->
