### PR TITLE
[3.13] gh-144551: Update CI to use latest OpenSSL versions (GH-144794)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,7 +293,8 @@ jobs:
         # Keep 1.1.1w in our list despite it being upstream EOL and otherwise
         # unsupported as it most resembles other 1.1.1-work-a-like ssl APIs
         # supported by important vendors such as AWS-LC.
-        openssl_ver: [1.1.1w, 3.0.18, 3.1.7, 3.2.6, 3.3.5]
+        openssl_ver: [1.1.1w, 3.0.19, 3.3.6, 3.4.4, 3.5.5, 3.6.1]
+        # See Tools/ssl/make_ssl_data.py for notes on adding a new version
     env:
       OPENSSL_VER: ${{ matrix.openssl_ver }}
       MULTISSL_DIR: ${{ github.workspace }}/multissl

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -44,13 +44,17 @@ log = logging.getLogger("multissl")
 
 OPENSSL_OLD_VERSIONS = [
     "1.1.1w",
+    "3.1.8",
+    "3.2.6",
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "3.0.18",
-    "3.1.7",
-    "3.2.6",
-    "3.3.5",
+    "3.0.19",
+    "3.3.6",
+    "3.4.4",
+    "3.5.5",
+    "3.6.1",
+    # See make_ssl_data.py for notes on adding a new version.
 ]
 
 LIBRESSL_OLD_VERSIONS = [


### PR DESCRIPTION
(cherry picked from commit b933ef92619db2a103a26c70e69b6d31978eb566)

<!-- gh-issue-number: gh-144551 -->
* Issue: gh-144551
<!-- /gh-issue-number -->
