### PR TITLE
gh-144551: Update OpenSSL version references in Mac/BuildScript/

### DIFF
--- a/Mac/BuildScript/README.rst
+++ b/Mac/BuildScript/README.rst
@@ -73,7 +73,7 @@ download them.
 
     - builds the following third-party libraries
 
-        * OpenSSL 3.0.x
+        * OpenSSL 3.5.x
         * Tcl/Tk 8.6.x
         * NCurses
         * SQLite

--- a/Mac/BuildScript/resources/ReadMe.rtf
+++ b/Mac/BuildScript/resources/ReadMe.rtf
@@ -19,7 +19,7 @@
 \f1\b \cf0 \ul \ulc0 Certificate verification and OpenSSL\
 
 \f0\b0 \ulnone \
-This package includes its own private copy of OpenSSL 3.0.   The trust certificates in system and user keychains managed by the 
+This package includes its own private copy of OpenSSL 3.5.   The trust certificates in system and user keychains managed by the 
 \f2\i Keychain Access 
 \f0\i0 application and the 
 \f2\i security


### PR DESCRIPTION


<!-- gh-issue-number: gh-144551 -->
* Issue: gh-144551
<!-- /gh-issue-number -->
