### PR TITLE
gh-144822: Remove an indirect double check in `codegen.c` through `co == NULL` and `Py_XDECREF(co);`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-14-16-47-39.gh-issue-144822.9TCaGe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-14-16-47-39.gh-issue-144822.9TCaGe.rst
@@ -1,2 +1,2 @@
-Slightly improved performance in `codegen.c` via removing an indirect double check through `Py_XDECREF(co);`.
+Slightly improve performance in `codegen.c` via removing an indirect double check through `Py_XDECREF(co);`.
 Contributed by Benedikt Johannes.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-14-16-47-39.gh-issue-144822.9TCaGe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-14-16-47-39.gh-issue-144822.9TCaGe.rst
@@ -1,2 +1,0 @@
-Remove an indirect double check in ``codegen.c`` through ``co == NULL`` and ``Py_XDECREF(co);``.
-Contributed by Benedikt Johannes.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-14-16-47-39.gh-issue-144822.9TCaGe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-14-16-47-39.gh-issue-144822.9TCaGe.rst
@@ -1,2 +1,3 @@
-Slightly improve performance in `codegen.c` via removing an indirect double check through `Py_XDECREF(co);`.
+Slightly improve performance in ``codegen.c`` via removing an indirect double check through ``Py_XDECREF(co);``.
 Contributed by Benedikt Johannes.
+

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-14-16-47-39.gh-issue-144822.9TCaGe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-14-16-47-39.gh-issue-144822.9TCaGe.rst
@@ -1,0 +1,2 @@
+Slightly improved performance in `codegen.c` via removing an indirect double check through `Py_XDECREF(co);`.
+Contributed by Benedikt Johannes.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-14-16-47-39.gh-issue-144822.9TCaGe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-14-16-47-39.gh-issue-144822.9TCaGe.rst
@@ -1,3 +1,2 @@
-Slightly improve performance in ``codegen.c`` via removing an indirect double check through ``Py_XDECREF(co);``.
+Remove an indirect double check in ``codegen.c`` through ``co == NULL`` and ``Py_XDECREF(co);``.
 Contributed by Benedikt Johannes.
-

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -1422,7 +1422,6 @@ codegen_function_body(compiler *c, stmt_ty s, int is_async, Py_ssize_t funcflags
     PyCodeObject *co = _PyCompile_OptimizeAndAssemble(c, 1);
     _PyCompile_ExitScope(c);
     if (co == NULL) {
-        Py_XDECREF(co);
         return ERROR;
     }
     int ret = codegen_make_closure(c, LOC(s), co, funcflags);


### PR DESCRIPTION
# Description of the problem

In `static int codegen_function_body(compiler *c, stmt_ty s, int is_async, Py_ssize_t funcflags, int firstlineno)` we use a check whether `co == NULL` in

    PyCodeObject *co = _PyCompile_OptimizeAndAssemble(c, 1);
    _PyCompile_ExitScope(c);
    if (co == NULL) {
        Py_XDECREF(co);
        return ERROR;
    }

and then use `Py_XDECREF(co);` which always returns a check failure in the case `co == NULL` which we already checked previously and for this reason never calls `Py_DECREF(co);` (which would anyway not work because it would cause errors) before we return the ERROR. Because of this, that condition check (which is triggered again) is unnecessary and just decreases performance slightly.

# Changes made

I've removed the unnecessary and performance consuming line for slightly increased performance and code readability.

# Additional information

This was not tested (and also not performance tested), but seems obvious to me from looking at the code that this is just an unnecessary statement.

Contributed by Benedikt Johannes.

<!-- gh-issue-number: gh-144822 -->
* Issue: gh-144822
<!-- /gh-issue-number -->
