### PR TITLE
docs: improve timeit autorange description

### DIFF
--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -145,13 +145,13 @@ The module defines three convenience functions and a public class:
 
    .. method:: Timer.autorange(callback=None, target_time=None)
 
-      Automatically determine how many times to call :meth:`.timeit`.
+      Call :meth:`.timeit` an automatically determined number of times.
 
-      This is a convenience function that calls :meth:`.timeit` repeatedly
-      so that the total time >= *Timer.target_time* seconds, returning the eventual
-      (number of loops, time taken for that number of loops). It calls
-      :meth:`.timeit` with increasing numbers from the sequence 1, 2, 5,
-      10, 20, 50, ... until the time taken is at least *target_time* seconds.
+      This is a convenience function that repeatedly calls :meth:`.timeit`
+      with an increasing amount of iterations from the sequence 1, 2, 5, 10,
+      20, 50, ... until the time taken is at least *target_time* seconds,
+      returning the eventual (number of loops, time taken for that number of
+      loops).
 
       If *callback* is given and is not ``None``, it will be called after
       each trial with two arguments: ``callback(number, time_taken)``.


### PR DESCRIPTION
It not only determines but actually runs timeit a number of times. Also be more concise; the original form said basically the same thing twice.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144825.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->