### PR TITLE
gh-130821: Add type information to error messages for remaining magic methods

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-15-02-03-53.gh-issue-130821.LuSpIZEC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-15-02-03-53.gh-issue-130821.LuSpIZEC.rst
@@ -1,0 +1,3 @@
+Add type information to error messages for ``__getnewargs__``,
+``__getnewargs_ex__``, ``__hash__``, and ``__init__`` when they return the wrong
+type. Error messages now use the format ``Type.__method__() must return ...``.

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -5705,8 +5705,8 @@
             if (!PyStackRef_IsNone(should_be_none)) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyErr_Format(PyExc_TypeError,
-                             "__init__() should return None, not '%.200s'",
-                             Py_TYPE(PyStackRef_AsPyObjectBorrow(should_be_none))->tp_name);
+                             "__init__() must return None, not %T",
+                             PyStackRef_AsPyObjectBorrow(should_be_none));
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 JUMP_TO_LABEL(error);
             }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7908,15 +7908,15 @@ _PyObject_GetNewArguments(PyObject *obj, PyObject **args, PyObject **kwargs)
         }
         if (!PyTuple_Check(newargs)) {
             PyErr_Format(PyExc_TypeError,
-                         "__getnewargs_ex__ should return a tuple, "
-                         "not '%.200s'", Py_TYPE(newargs)->tp_name);
+                         "%T.__getnewargs_ex__() must return a tuple, "
+                         "not %T", obj, newargs);
             Py_DECREF(newargs);
             return -1;
         }
         if (PyTuple_GET_SIZE(newargs) != 2) {
             PyErr_Format(PyExc_ValueError,
-                         "__getnewargs_ex__ should return a tuple of "
-                         "length 2, not %zd", PyTuple_GET_SIZE(newargs));
+                         "%T.__getnewargs_ex__() must return a tuple of "
+                         "length 2, not %zd", obj, PyTuple_GET_SIZE(newargs));
             Py_DECREF(newargs);
             return -1;
         }
@@ -7928,8 +7928,8 @@ _PyObject_GetNewArguments(PyObject *obj, PyObject **args, PyObject **kwargs)
         if (!PyTuple_Check(*args)) {
             PyErr_Format(PyExc_TypeError,
                          "first item of the tuple returned by "
-                         "__getnewargs_ex__ must be a tuple, not '%.200s'",
-                         Py_TYPE(*args)->tp_name);
+                         "%T.__getnewargs_ex__() must be a tuple, not %T",
+                         obj, *args);
             Py_CLEAR(*args);
             Py_CLEAR(*kwargs);
             return -1;
@@ -7937,8 +7937,8 @@ _PyObject_GetNewArguments(PyObject *obj, PyObject **args, PyObject **kwargs)
         if (!PyDict_Check(*kwargs)) {
             PyErr_Format(PyExc_TypeError,
                          "second item of the tuple returned by "
-                         "__getnewargs_ex__ must be a dict, not '%.200s'",
-                         Py_TYPE(*kwargs)->tp_name);
+                         "%T.__getnewargs_ex__() must be a dict, not %T",
+                         obj, *kwargs);
             Py_CLEAR(*args);
             Py_CLEAR(*kwargs);
             return -1;
@@ -7959,8 +7959,8 @@ _PyObject_GetNewArguments(PyObject *obj, PyObject **args, PyObject **kwargs)
         }
         if (!PyTuple_Check(*args)) {
             PyErr_Format(PyExc_TypeError,
-                         "__getnewargs__ should return a tuple, "
-                         "not '%.200s'", Py_TYPE(*args)->tp_name);
+                         "%T.__getnewargs__() must return a tuple, "
+                         "not %T", obj, *args);
             Py_CLEAR(*args);
             return -1;
         }
@@ -10713,9 +10713,10 @@ slot_tp_hash(PyObject *self)
         return PyObject_HashNotImplemented(self);
     }
     if (!PyLong_Check(res)) {
+        PyErr_Format(PyExc_TypeError,
+                     "%T.__hash__() must return an integer, not %T",
+                     self, res);
         Py_DECREF(res);
-        PyErr_SetString(PyExc_TypeError,
-                        "__hash__ method should return an integer");
         return -1;
     }
     /* Transform the PyLong `res` to a Py_hash_t `h`.  For an existing
@@ -10975,8 +10976,8 @@ slot_tp_init(PyObject *self, PyObject *args, PyObject *kwds)
         return -1;
     if (res != Py_None) {
         PyErr_Format(PyExc_TypeError,
-                     "__init__() should return None, not '%.200s'",
-                     Py_TYPE(res)->tp_name);
+                     "%T.__init__() must return None, not %T",
+                     self, res);
         Py_DECREF(res);
         return -1;
     }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -4251,8 +4251,8 @@ dummy_func(
         inst(EXIT_INIT_CHECK, (should_be_none -- )) {
             if (!PyStackRef_IsNone(should_be_none)) {
                 PyErr_Format(PyExc_TypeError,
-                    "__init__() should return None, not '%.200s'",
-                    Py_TYPE(PyStackRef_AsPyObjectBorrow(should_be_none))->tp_name);
+                    "__init__() must return None, not %T",
+                    PyStackRef_AsPyObjectBorrow(should_be_none));
                 ERROR_NO_POP();
             }
             DEAD(should_be_none);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -14376,8 +14376,8 @@
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyErr_Format(PyExc_TypeError,
-                             "__init__() should return None, not '%.200s'",
-                             Py_TYPE(PyStackRef_AsPyObjectBorrow(should_be_none))->tp_name);
+                             "__init__() must return None, not %T",
+                             PyStackRef_AsPyObjectBorrow(should_be_none));
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 SET_CURRENT_CACHED_VALUES(0);
                 JUMP_TO_ERROR();

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -5705,8 +5705,8 @@
             if (!PyStackRef_IsNone(should_be_none)) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyErr_Format(PyExc_TypeError,
-                             "__init__() should return None, not '%.200s'",
-                             Py_TYPE(PyStackRef_AsPyObjectBorrow(should_be_none))->tp_name);
+                             "__init__() must return None, not %T",
+                             PyStackRef_AsPyObjectBorrow(should_be_none));
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 JUMP_TO_LABEL(error);
             }


### PR DESCRIPTION
Follow-up to GH-130835 (merged). Fixes remaining inconsistent error messages for magic methods that return the wrong type in `Objects/typeobject.c` and `Python/bytecodes.c`.

## Changes

Updated error messages to use the consistent `%T.__method__() must return ...` format with `%T` type specifier:

| Method | Before | After |
|--------|--------|-------|
| `__getnewargs_ex__` | `__getnewargs_ex__ should return a tuple, not '%.200s'` | `%T.__getnewargs_ex__() must return a tuple, not %T` |
| `__getnewargs__` | `__getnewargs__ should return a tuple, not '%.200s'` | `%T.__getnewargs__() must return a tuple, not %T` |
| `__hash__` | `__hash__ method should return an integer` | `%T.__hash__() must return an integer, not %T` |
| `__init__` (typeobject.c) | `__init__() should return None, not '%.200s'` | `%T.__init__() must return None, not %T` |
| `__init__` (bytecodes.c) | `__init__() should return None, not '%.200s'` | `__init__() must return None, not %T` |

Also updated related messages for `__getnewargs_ex__` tuple length validation and sub-item type checks.

### Example output

```
>>> class Bad:
...     def __init__(self):
...         return 42
>>> Bad()
TypeError: Bad.__init__() must return None, not int

>>> class BadHash:
...     def __hash__(self):
...         return 'not an int'
>>> hash(BadHash())
TypeError: BadHash.__hash__() must return an integer, not str
```

### Files changed
- `Objects/typeobject.c` — Main error message updates
- `Python/bytecodes.c` — `EXIT_INIT_CHECK` instruction
- `Python/generated_cases.c.h` — Auto-generated from bytecodes.c
- `Python/executor_cases.c.h` — Auto-generated from bytecodes.c
- `Modules/_testinternalcapi/test_cases.c.h` — Auto-generated from bytecodes.c

<!-- gh-issue-number: gh-130821 -->
* Issue: gh-130821
