### PR TITLE
gh-144774: Fix data race in BaseException.__setstate__ in free-thread…

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1955,6 +1955,21 @@ class ExceptionTests(unittest.TestCase):
         self.assertGreater(len(output), 0)  # At minimum, should not hang
         self.assertIn(b"MemoryError", output)
 
+    def test_setstate_thread_safety(self):
+        import threading
+        import random
+        exc = Exception()
+        def worker():
+            for _ in range(100):
+                setattr(exc, "x", random.randint(0, 1000))
+                copy.copy(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertTrue(True)
 
 class NameErrorTests(unittest.TestCase):
     def test_name_error_has_name(self):

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -242,6 +242,9 @@ BaseException___setstate___impl(PyBaseExceptionObject *self, PyObject *state)
             PyErr_SetString(PyExc_TypeError, "state is not a dictionary");
             return NULL;
         }
+        PyCriticalSection cs;
+        PyThreadState *tstate = _PyThreadState_GET();
+        _PyCriticalSection_Begin(tstate, &cs, state);
         while (PyDict_Next(state, &i, &d_key, &d_value)) {
             Py_INCREF(d_key);
             Py_INCREF(d_value);
@@ -249,9 +252,11 @@ BaseException___setstate___impl(PyBaseExceptionObject *self, PyObject *state)
             Py_DECREF(d_value);
             Py_DECREF(d_key);
             if (res < 0) {
+                _PyCriticalSection_End(tstate, &cs);
                 return NULL;
             }
         }
+        _PyCriticalSection_End(tstate, &cs);
     }
     Py_RETURN_NONE;
 }

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -16,7 +16,7 @@
 
 #include "osdefs.h"               // SEP
 #include "clinic/exceptions.c.h"
-
+#include "pycore_critical_section.h"
 
 /*[clinic input]
 class BaseException "PyBaseExceptionObject *" "&PyExc_BaseException"
@@ -243,8 +243,7 @@ BaseException___setstate___impl(PyBaseExceptionObject *self, PyObject *state)
             return NULL;
         }
         PyCriticalSection cs;
-        PyThreadState *tstate = _PyThreadState_GET();
-        _PyCriticalSection_Begin(tstate, &cs, state);
+        PyCriticalSection_Begin(&cs, state);
         while (PyDict_Next(state, &i, &d_key, &d_value)) {
             Py_INCREF(d_key);
             Py_INCREF(d_value);
@@ -252,11 +251,11 @@ BaseException___setstate___impl(PyBaseExceptionObject *self, PyObject *state)
             Py_DECREF(d_value);
             Py_DECREF(d_key);
             if (res < 0) {
-                _PyCriticalSection_End(tstate, &cs);
+                PyCriticalSection_End(&cs);
                 return NULL;
             }
         }
-        _PyCriticalSection_End(tstate, &cs);
+        PyCriticalSection_End(&cs);
     }
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
This change ensures that the dictionary iteration happens under the appropriate critical section, preventing concurrent access during the operation.

This fixes the race condition reported in gh-144774.