### PR TITLE
gh-144190: Clarify get_type_hints() instance behavior in docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3353,8 +3353,8 @@ Introspection helpers
 
 .. function:: get_type_hints(obj, globalns=None, localns=None, include_extras=False)
 
-   Return a dictionary containing type hints for a function, method, module
-   or class object.
+   Return a dictionary containing type hints for a function, method, module,
+   class object, or other callable object.
 
    This is often the same as ``obj.__annotations__``, but this function makes
    the following changes to the annotations dictionary:
@@ -3395,6 +3395,13 @@ Introspection helpers
       :ref:`type aliases <type-aliases>` that include forward references,
       or with names imported under :data:`if TYPE_CHECKING <TYPE_CHECKING>`.
 
+   .. note::
+
+      Calling :func:`get_type_hints` on an instance is not supported.
+      To retrieve annotations for an instance, call
+      :func:`get_type_hints` on the instance's class instead
+      (for example, ``get_type_hints(type(obj))``).
+
    .. versionchanged:: 3.9
       Added ``include_extras`` parameter as part of :pep:`593`.
       See the documentation on :data:`Annotated` for more information.
@@ -3403,6 +3410,11 @@ Introspection helpers
       Previously, ``Optional[t]`` was added for function and method annotations
       if a default value equal to ``None`` was set.
       Now the annotation is returned unchanged.
+
+   .. versionchanged:: 3.14
+      Calling :func:`get_type_hints` on instances is no longer supported.
+      Some instances were accepted in earlier versions as an undocumented
+      implementation detail.
 
 .. function:: get_origin(tp)
 


### PR DESCRIPTION
## Summary

Document `typing.get_type_hints()` behavior for instance objects in Python 3.14+.

- Clarify that `get_type_hints()` is intended for modules, classes, and callables.
- Add an explicit note that calling `get_type_hints()` on instances is not supported.
- Recommend `get_type_hints(type(obj))` for instance use cases.
- Add a `versionchanged:: 3.14` note explaining that instance support in earlier versions was undocumented behavior.

## Why

Issue #144190 reported a regression when calling `get_type_hints(self)` in a dataclass `__init__`.  
Core-dev discussion confirmed this is intentional in 3.14 and should be documented.

## Testing

Docs-only change; no runtime behavior changed.


<!-- gh-issue-number: gh-144190 -->
* Issue: gh-144190
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144831.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->