### PR TITLE
docs: Add note recommending grid over pack in tkinter documentation

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -637,6 +637,11 @@ The Packer
 
 .. index:: single: packing (widgets)
 
+.. note::
+   For new code, using the :meth:`grid` geometry manager is recommended over
+   :meth:`pack`. While :meth:`pack` is equally powerful, :meth:`grid` is easier
+   to use and makes it less onerous to create layouts that look appealing.
+
 The packer is one of Tk's geometry-management mechanisms.    Geometry managers
 are used to specify the relative positioning of widgets within their container.
 In contrast to the more cumbersome *placer* (which is


### PR DESCRIPTION
## Summary

This PR adds a note at the beginning of the 'The Packer' section in the tkinter documentation to recommend using `grid` geometry manager over `pack` for new code.

## Background

As noted in [TkDocs](https://tkdocs.com/tutorial/concepts.html#geometry), while `pack` is equally powerful, `grid` is easier to use and makes it less onerous to create layouts that look appealing. The widespread use of `pack` in older code is a leading reason that many Tk user interfaces look terrible.

## Changes

- Added a `.. note::` directive at the beginning of 'The Packer' section
- The note recommends using `grid` for new code
- Maintains backward compatibility by keeping the existing pack documentation

## Issue

Fixes #93501

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144839.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->