### PR TITLE
gh-142349: Add CODEOWNERS for lazy imports

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -292,6 +292,12 @@ Python/jit.c                  @brandtbucher @savannahostrowski @diegorusso
 Tools/jit/                    @brandtbucher @savannahostrowski @diegorusso
 InternalDocs/jit.md           @brandtbucher @savannahostrowski @diegorusso @AA-Turner
 
+# Lazy imports (PEP 810)
+Objects/lazyimportobject.c                 @twouters @DinoV @pablogsal
+Include/internal/pycore_lazyimportobject.h @twouters @DinoV @pablogsal
+Lib/test/test_import/test_lazy_imports.py  @twouters @DinoV @pablogsal
+Lib/test/test_import/data/lazy_imports/    @twouters @DinoV @pablogsal
+
 # Micro-op / μop / Tier 2 Optimiser
 Python/optimizer.c            @markshannon @Fidget-Spinner
 Python/optimizer_analysis.c   @markshannon @tomasr8 @Fidget-Spinner @savannahostrowski


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142349 -->
* Issue: gh-142349
<!-- /gh-issue-number -->
