### PR TITLE
gh-144833: Fix use-after-free in SSL module when SSL_new() fails

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-02-15-00-00-00.gh-issue-144833.TUelo1.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-15-00-00-00.gh-issue-144833.TUelo1.rst
@@ -1,0 +1,3 @@
+Fixed a use-after-free in :mod:`ssl` when ``SSL_new()`` returns NULL in
+``newPySSLSocket()``. The error was reported via a dangling pointer after the
+object had already been freed.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -917,8 +917,8 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
     self->ssl = SSL_new(ctx);
     PySSL_END_ALLOW_THREADS(sslctx)
     if (self->ssl == NULL) {
+        _setSSLError(get_state_ctx(sslctx), NULL, 0, __FILE__, __LINE__);
         Py_DECREF(self);
-        _setSSLError(get_state_ctx(self), NULL, 0, __FILE__, __LINE__);
         return NULL;
     }
 


### PR DESCRIPTION
## Summary

Fix use-after-free and type confusion in `newPySSLSocket()` when `SSL_new()` returns NULL.

In `Modules/_ssl.c`, when `SSL_new()` fails, `Py_DECREF(self)` was called before `_setSSLError(get_state_ctx(self), ...)`, causing two bugs:

1. **Use-after-free**: `Py_DECREF(self)` frees the object, then `get_state_ctx(self)` dereferences freed memory.
2. **Type confusion**: `get_state_ctx()` expects `PySSLContext*` but receives `PySSLSocket*`.

### Fix

- Call `_setSSLError()` **before** `Py_DECREF(self)`
- Use `sslctx` (`PySSLContext*`) instead of `self` (`PySSLSocket*`) for `get_state_ctx()`

```c
// Before:
if (self->ssl == NULL) {
    Py_DECREF(self);
    _setSSLError(get_state_ctx(self), NULL, 0, __FILE__, __LINE__);
    return NULL;
}

// After:
if (self->ssl == NULL) {
    _setSSLError(get_state_ctx(sslctx), NULL, 0, __FILE__, __LINE__);
    Py_DECREF(self);
    return NULL;
}
```

Fixes gh-144833