### PR TITLE
gh-106318: Improve str.lower() docs

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2439,7 +2439,7 @@ expression support in the :mod:`re` module).
 
    Note that ``s.lower().islower()`` might be ``False`` if ``s``
    contains uncased characters or if the Unicode category of the resulting
-   character(s) is not "Lu" (Letter, uppercase), but e.g. "Lt" (Letter,
+   character(s) is not "Lu" (Letter, uppercase), but for instance "Lt" (Letter,
    titlecase).
 
    For example, see the word "Python" written in Punjabi, the most spoken

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2437,6 +2437,20 @@ expression support in the :mod:`re` module).
       >>> 'Lower Method Example'.lower()
       'lower method example'
 
+   Note that ``s.lower().islower()`` might be ``False`` if ``s``
+   contains uncased characters or if the Unicode category of the resulting
+   character(s) is not "Lu" (Letter, uppercase), but e.g. "Lt" (Letter,
+   titlecase).
+
+   For example, see the word "Python" written in Punjabi, the most spoken
+   language in Pakistan:
+
+   .. doctest::
+
+      >>> 'ازگر'.lower().islower()
+      False
+
+
    The lowercasing algorithm used is `described in section 3.13.2 'Default Case
    Conversion' of the Unicode Standard
    <https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-3/#G34078>`__.


### PR DESCRIPTION
WIP #106318 

This PR adds some details to `str.lower()` to make it similar to `str.upper()` proposed by #144638. 

<!-- gh-issue-number: gh-106318 -->
* Issue: gh-106318
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144848.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->