### PR TITLE
gh-61448: Fix inspect.formatargvalues for deleted arguments

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1385,6 +1385,16 @@ def formatannotationrelativeto(object):
     return _formatannotation
 
 
+class _Deleted:
+    """Sentinel for arguments that are no longer bound in the frame locals."""
+    __slots__ = ()
+    def __repr__(self):
+        return '<deleted>'
+
+_DELETED = _Deleted()
+del _Deleted
+
+
 def formatargvalues(args, varargs, varkw, locals,
                     formatarg=str,
                     formatvarargs=lambda name: '*' + name,
@@ -1398,14 +1408,14 @@ def formatargvalues(args, varargs, varkw, locals,
     argument is an optional function to format the sequence of arguments."""
     def convert(name, locals=locals,
                 formatarg=formatarg, formatvalue=formatvalue):
-        return formatarg(name) + formatvalue(locals[name])
+        return formatarg(name) + formatvalue(locals.get(name, _DELETED))
     specs = []
     for i in range(len(args)):
         specs.append(convert(args[i]))
     if varargs:
-        specs.append(formatvarargs(varargs) + formatvalue(locals[varargs]))
+        specs.append(formatvarargs(varargs) + formatvalue(locals.get(varargs, _DELETED)))
     if varkw:
-        specs.append(formatvarkw(varkw) + formatvalue(locals[varkw]))
+        specs.append(formatvarkw(varkw) + formatvalue(locals.get(varkw, _DELETED)))
     return '(' + ', '.join(specs) + ')'
 
 def _missing_arguments(f_name, argnames, pos, values):

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -585,6 +585,25 @@ class TestInterpreterStack(IsTestBase):
         self.assertEqual(inspect.formatargvalues(args, varargs, varkw, locals),
                          '(x=11, y=14)')
 
+    def test_formatargvalues_deleted_args(self):
+        # gh-61448: formatargvalues should not raise KeyError when
+        # argument names are no longer bound in the frame locals.
+        def fun(a, b, x, y):
+            del b, y
+            return inspect.currentframe()
+
+        result = inspect.formatargvalues(*inspect.getargvalues(fun(2, 4, 8, 16)))
+        self.assertEqual(result, '(a=2, b=<deleted>, x=8, y=<deleted>)')
+
+    def test_formatargvalues_deleted_varargs_varkw(self):
+        # gh-61448: formatargvalues should handle deleted *args and **kwargs.
+        def fun(a, *args, **kwargs):
+            del args, kwargs
+            return inspect.currentframe()
+
+        result = inspect.formatargvalues(*inspect.getargvalues(fun(1, 2, k=3)))
+        self.assertEqual(result, '(a=1, *args=<deleted>, **kwargs=<deleted>)')
+
     def test_previous_frame(self):
         args, varargs, varkw, locals = inspect.getargvalues(mod.fr.f_back)
         self.assertEqual(args, ['a', 'b', 'c', 'd', 'e', 'f'])

--- a/Misc/NEWS.d/next/Library/2026-02-15-22-53-30.gh-issue-61448.OmH86g.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-15-22-53-30.gh-issue-61448.OmH86g.rst
@@ -1,0 +1,3 @@
+Fix :func:`inspect.formatargvalues` to handle deleted arguments gracefully
+instead of raising :exc:`KeyError`. When an argument is no longer bound in
+the frame locals (e.g. after ``del``), it is now shown as ``<deleted>``.


### PR DESCRIPTION
Fix `inspect.formatargvalues()` to handle arguments that are no longer bound in the frame locals (e.g. after `del`) by showing them as `<deleted>` instead of raising `KeyError`.

## Changes

- Added a `_DELETED` sentinel object with `repr` of `<deleted>` in `Lib/inspect.py`
- Changed `formatargvalues()` to use `locals.get(name, _DELETED)` instead of `locals[name]` for regular arguments, `*args`, and `**kwargs`
- Added two tests: one for deleted regular arguments, one for deleted `*args`/`**kwargs`

## Reproducer (before fix)

```python
import inspect

def fun(x):
    del x
    return inspect.currentframe()

inspect.formatargvalues(*inspect.getargvalues(fun(10)))
# KeyError: 'x'
```

## After fix

```python
inspect.formatargvalues(*inspect.getargvalues(fun(10)))
# '(x=<deleted>)'
```

<!-- gh-issue-number: gh-61448 -->
* Issue: gh-61448

**Note:** This supersedes the stale PR #101318 which has been awaiting changes since August 2023 with merge conflicts.