### PR TITLE
gh-144873: Remove Overzealous `isinstance` Optimization

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -924,6 +924,25 @@ class UnionTests(unittest.TestCase):
         self.assertFalse(isinstance(CustomIsInstance(), CustomIsInstance))
         self.assertFalse(isinstance(CustomIsInstanceSubclass(), CustomIsInstance))
 
+    def test_custom_subclasscheck(self):
+        class CustomIsSubclassMeta(type):
+            def __subclasscheck__(cls, subcls):
+                return subcls is int
+
+        class CustomIsSubclass(metaclass=CustomIsSubclassMeta):
+            ...
+
+        class CustomIsSubclassSubclass(CustomIsSubclass):
+            ...
+
+        self.assertTrue(issubclass(int, CustomIsSubclass))
+        self.assertFalse(isinstance(4, CustomIsSubclass))
+        self.assertFalse(issubclass(CustomIsSubclass, CustomIsSubclass))
+        self.assertTrue(isinstance(CustomIsSubclass(), CustomIsSubclass))
+        self.assertFalse(issubclass(CustomIsSubclassSubclass, CustomIsSubclass))
+        self.assertTrue(isinstance(CustomIsSubclassSubclass(), CustomIsSubclass))
+
+
     def test_or_type_operator_with_TypeVar(self):
         TV = typing.TypeVar('T')
         self.assertEqual(TV | str, typing.Union[TV, str])

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -909,6 +909,21 @@ class UnionTests(unittest.TestCase):
         self.assertIsSubclass(int, x)
         self.assertRaises(ZeroDivisionError, issubclass, list, x)
 
+    def test_custom_instancecheck(self):
+        class CustomIsInstanceMeta(type):
+            def __instancecheck__(cls, instance):
+                return type(instance) is int
+
+        class CustomIsInstance(metaclass=CustomIsInstanceMeta):
+            ...
+
+        class CustomIsInstanceSubclass(CustomIsInstance):
+            ...
+
+        self.assertTrue(isinstance(5, CustomIsInstance))
+        self.assertFalse(isinstance(CustomIsInstance(), CustomIsInstance))
+        self.assertFalse(isinstance(CustomIsInstanceSubclass(), CustomIsInstance))
+
     def test_or_type_operator_with_TypeVar(self):
         TV = typing.TypeVar('T')
         self.assertEqual(TV | str, typing.Union[TV, str])

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -2638,11 +2638,6 @@ object_isinstance(PyObject *inst, PyObject *cls)
 static int
 object_recursive_isinstance(PyThreadState *tstate, PyObject *inst, PyObject *cls)
 {
-    /* Quick test for an exact match */
-    if (Py_IS_TYPE(inst, (PyTypeObject *)cls)) {
-        return 1;
-    }
-
     /* We know what type's __instancecheck__ does. */
     if (PyType_CheckExact(cls)) {
         return object_isinstance(inst, cls);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-144873: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Fixes #144873 by removing the optimisation.
There is also a test for this bug (which will fail on `main`) and a similar test for `issubclass`, which does not have the optimization.