### PR TITLE
gh-144846: make Element tag positional-only

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -879,7 +879,7 @@ Element Objects
    :noindex:
    :no-index:
 
-.. class:: Element(tag, attrib={}, **extra)
+.. class:: Element(tag, /, attrib={}, **extra)
 
    Element class.  This class defines the Element interface, and provides a
    reference implementation of this interface.
@@ -888,6 +888,9 @@ Element Objects
    bytestrings or Unicode strings.  *tag* is the element name.  *attrib* is
    an optional dictionary, containing element attributes.  *extra* contains
    additional attributes, given as keyword arguments.
+
+   .. versionchanged:: 3.15
+      *tag* is now a positional-only parameter.
 
 
    .. attribute:: tag

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -381,6 +381,22 @@ class ElementTreeTest(unittest.TestCase):
         self.serialize_check(element,
                 '<tag key="value"><subtag /><subtag /></tag>')
 
+    def test_positional_only_parameter(self):
+        # Test Element positional-only parameters (gh-144846).
+
+        # 'tag' is positional-only
+        with self.assertRaises(TypeError):
+            ET.Element(tag='fail')
+
+        # 'attrib' can be passed as keyword
+        e = ET.Element('e', attrib={'key': 'value'})
+        self.assertEqual(e.get('key'), 'value')
+
+        # 'tag' as kwarg becomes an XML attribute, not the element tag
+        e = ET.Element('e', tag='foo')
+        self.assertEqual(e.tag, 'e')
+        self.assertEqual(e.get('tag'), 'foo')
+
     def test_cdata(self):
         # Test CDATA handling (etc).
 

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -164,7 +164,7 @@ class Element:
 
     """
 
-    def __init__(self, tag, attrib={}, **extra):
+    def __init__(self, tag, /, attrib={}, **extra):
         if not isinstance(attrib, dict):
             raise TypeError("attrib must be dict, not %s" % (
                 attrib.__class__.__name__,))

--- a/Misc/NEWS.d/next/Library/2026-02-16-10-32-44.gh-issue-144846.4eda4bd2.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-16-10-32-44.gh-issue-144846.4eda4bd2.rst
@@ -1,0 +1,2 @@
+Made the *tag* parameter of :class:`xml.etree.ElementTree.Element`
+positional-only, matching the behavior of the C accelerator.


### PR DESCRIPTION
Make `tag` positional-only in `xml.etree.ElementTree.Element.__init__` to match the C accelerator.

The C implementation (`_elementtree.Element`) uses `PyArg_ParseTuple`, which inherently makes `tag` positional-only. The Python fallback used `def __init__(self, tag, attrib={}, **extra):` which allowed `tag` as a keyword argument. This inconsistency meant `Element(tag="foo")` worked only when the C accelerator was unavailable.

Same pattern as gh-144270 (`SubElement`).

Fix: add `/` after `tag` → `def __init__(self, tag, /, attrib={}, **extra):`

## Changes
- `Lib/xml/etree/ElementTree.py`: add `/` to `Element.__init__` signature
- `Lib/test/test_xml_etree.py`: add `test_element_init` covering positional-only enforcement, keyword attrib, and kwargs-as-XML-attributes parity
- `Doc/library/xml.etree.elementtree.rst`: update signature and add `versionchanged:: 3.15`


<!-- gh-issue-number: gh-144846 -->
* Issue: gh-144846
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144876.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->