### PR TITLE
gh-142349: Fix ast.unparse for lazy import statements

### DIFF
--- a/Lib/_ast_unparse.py
+++ b/Lib/_ast_unparse.py
@@ -239,11 +239,11 @@ class Unparser(NodeVisitor):
             self.traverse(node.value)
 
     def visit_Import(self, node):
-        self.fill("import ")
+        self.fill("lazy import " if node.is_lazy else "import ")
         self.interleave(lambda: self.write(", "), self.traverse, node.names)
 
     def visit_ImportFrom(self, node):
-        self.fill("from ")
+        self.fill("lazy from " if node.is_lazy else "from ")
         self.write("." * (node.level or 0))
         if node.module:
             self.write(node.module)


### PR DESCRIPTION
The unparser was not handling the `is_lazy` attribute on Import and
ImportFrom AST nodes, causing lazy imports to be unparsed as regular
imports. This broke the round-trip (parse → unparse → reparse) for
any file containing `lazy import` statements.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142349 -->
* Issue: gh-142349
<!-- /gh-issue-number -->
