### PR TITLE
[3.13] gh-129259: Fix AIX build failures caused by incorrect struct alignment

### DIFF
--- a/Include/internal/pycore_backoff.h
+++ b/Include/internal/pycore_backoff.h
@@ -14,6 +14,9 @@ extern "C" {
 #include <stdint.h>
 
 
+#ifdef _AIX
+#pragma pack(push, 1)
+#endif
 typedef struct {
     union {
         struct {
@@ -23,6 +26,9 @@ typedef struct {
         uint16_t as_counter;  // For printf("%#x", ...)
     };
 } _Py_BackoffCounter;
+#ifdef _AIX
+#pragma pack(pop)
+#endif
 
 
 /* 16-bit countdown counters using exponential backoff.

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -21,6 +21,9 @@ extern "C" {
  * 2**32 - 1, rather than INT_MAX.
  */
 
+#ifdef _AIX
+#pragma pack(push, 1)
+#endif
 typedef union {
     uint16_t cache;
     struct {
@@ -29,6 +32,9 @@ typedef union {
     } op;
     _Py_BackoffCounter counter;  // First cache entry of specializable op
 } _Py_CODEUNIT;
+#ifdef _AIX
+#pragma pack(pop)
+#endif
 
 #define _PyCode_CODE(CO) _Py_RVALUE((_Py_CODEUNIT *)(CO)->co_code_adaptive)
 #define _PyCode_NBYTES(CO) (Py_SIZE(CO) * (Py_ssize_t)sizeof(_Py_CODEUNIT))

--- a/Misc/NEWS.d/next/Build/2026-02-17-14-57-47.gh-issue-129259.aix8k3.rst
+++ b/Misc/NEWS.d/next/Build/2026-02-17-14-57-47.gh-issue-129259.aix8k3.rst
@@ -1,0 +1,2 @@
+Fix AIX build failures caused by incorrect struct alignment in ``_Py_CODEUNIT``
+and ``_Py_BackoffCounter`` by adding AIX-specific ``#pragma pack`` directives.


### PR DESCRIPTION
This PR fixes the AIX build failures mentioned in issue #129259.

**Note** In 3.14, the _Py_BackoffCounter bit field structure was replaced with a uint16_t

<!-- gh-issue-number: gh-129259 -->
* Issue: gh-129259
<!-- /gh-issue-number -->
