### PR TITLE
gh-141510: Change repr(frozendict) for empty dict

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1767,6 +1767,9 @@ class FrozenDictTests(unittest.TestCase):
         self.assertEqual(copy, frozendict({'x': 1}))
 
     def test_repr(self):
+        d = frozendict()
+        self.assertEqual(repr(d), "frozendict()")
+
         d = frozendict(x=1, y=2)
         self.assertEqual(repr(d), "frozendict({'x': 1, 'y': 2})")
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -7868,7 +7868,7 @@ static PyMethodDef frozendict_methods[] = {
 static PyObject *
 frozendict_repr(PyObject *self)
 {
-    PyDictObject *mp = (PyDictObject *)self;
+    PyDictObject *mp = _PyAnyDict_CAST(self);
     if (mp->ma_used == 0) {
         return PyUnicode_FromFormat("%s()", Py_TYPE(self)->tp_name);
     }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -7868,6 +7868,11 @@ static PyMethodDef frozendict_methods[] = {
 static PyObject *
 frozendict_repr(PyObject *self)
 {
+    PyDictObject *mp = (PyDictObject *)self;
+    if (mp->ma_used == 0) {
+        return PyUnicode_FromFormat("%s()", Py_TYPE(self)->tp_name);
+    }
+
     PyObject *repr = anydict_repr_impl(self);
     if (repr == NULL) {
         return NULL;


### PR DESCRIPTION
repr(frozendict()) returns "frozendict()" instead of "frozendict({})".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141510 -->
* Issue: gh-141510
<!-- /gh-issue-number -->
