### PR TITLE
gh-144748: Make EINTR retry paths honor PyThreadState_SetAsyncExc

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -22,6 +22,7 @@ import signal
 import textwrap
 import traceback
 import warnings
+import ctypes
 
 from unittest import mock
 from test import lock_tests
@@ -411,6 +412,39 @@ class ThreadTests(BaseTestCase):
         if t.finished:
             t.join()
         # else the thread is still running, and we have no way to kill it
+
+    @cpython_only
+    @unittest.skipIf(not hasattr(signal, "pthread_kill"), "requires pthread_kill (Unix only)")
+    def test_PyThreadState_SetAsyncExc_interrupts_sleep(self):
+        set_async_exc = ctypes.pythonapi.PyThreadState_SetAsyncExc
+        set_async_exc.argtypes = (ctypes.c_ulong, ctypes.py_object)
+
+        class AsyncExc(Exception):
+            pass
+
+        exception = ctypes.py_object(AsyncExc)
+        signal.signal(signal.SIGUSR1, lambda *_: None)
+        worker_started = threading.Event()
+        worker_finished = threading.Event()
+
+        def worker():
+            tid = threading.get_ident()
+            worker_started.set()
+            try:
+                time.sleep(10)  # blocked in EINTR retry path
+            except AsyncExc:
+                worker_finished.set()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        worker_started.wait()
+        time.sleep(0.2)
+        result = set_async_exc(t.ident, exception)
+        self.assertEqual(result, 1)
+        signal.pthread_kill(t.ident, signal.SIGUSR1)
+        worker_finished.wait(timeout=3)
+        self.assertTrue(worker_finished.is_set())
+        t.join(timeout=3)
 
     def test_limbo_cleanup(self):
         # Issue 7481: Failure to start thread should cleanup the limbo map.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-17-23-45-41.gh-issue-144748.Y3ZHWs.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-17-23-45-41.gh-issue-144748.Y3ZHWs.rst
@@ -1,0 +1,2 @@
+Fix PyThreadState_SetAsyncExc not interrupting threads blocked in EINTR
+retry paths such as time.sleep().

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -1050,6 +1050,15 @@ _PyEval_MakePendingCalls(PyThreadState *tstate)
         return res;
     }
 
+    /* Check for async exceptions (PyThreadState_SetAsyncExc) */
+    if (tstate->async_exc != NULL) {
+        PyObject *exc = tstate->async_exc;
+        tstate->async_exc = NULL;
+        PyErr_SetNone(exc);
+        Py_DECREF(exc);
+        return -1;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
Ensure that PyThreadState_SetAsyncExc interrupts threads blocked in EINTR retry paths (e.g., time.sleep()) by checking async exceptions in _PyEval_MakePendingCalls. Includes a regression test.

<!-- gh-issue-number: gh-144748 -->
* Issue: gh-144748
<!-- /gh-issue-number -->
