### PR TITLE
gh-141510: Fix `test_xpickle` failing with introduction of `frozendict`

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3167,6 +3167,7 @@ class AbstractPickleTests:
             'bytes': (3, 0),
             'BuiltinImporter': (3, 3),
             'str': (3, 4),  # not interoperable with Python < 3.4
+            'frozendict': (3, 15),
         }
         for t in builtins.__dict__.values():
             if isinstance(t, type) and not issubclass(t, BaseException):


### PR DESCRIPTION
Like https://github.com/python/cpython/issues/144878 just yesterday... we should start running this test somewhere.

<!-- gh-issue-number: gh-141510 -->
* Issue: gh-141510
<!-- /gh-issue-number -->
