### PR TITLE
gh-144837: use standard signature syntax in docs

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -149,7 +149,7 @@ The module defines the following type:
       Return the number of occurrences of *x* in the array.
 
 
-   .. method:: extend(iterable)
+   .. method:: extend(iterable, /)
 
       Append items from *iterable* to the end of the array.  If *iterable* is another
       array, it must have *exactly* the same type code; if not, :exc:`TypeError` will
@@ -206,7 +206,7 @@ The module defines the following type:
       values are treated as being relative to the end of the array.
 
 
-   .. method:: pop([i])
+   .. method:: pop(index=-1, /)
 
       Removes the item with the index *i* from the array and returns it. The optional
       argument defaults to ``-1``, so that by default the last item is removed and

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -513,7 +513,7 @@ or subtracting from an empty counter.
         .. versionadded:: 3.2
 
 
-    .. method:: extend(iterable)
+    .. method:: extend(iterable, /)
 
         Extend the right side of the deque by appending elements from the iterable
         argument.

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -21,7 +21,7 @@ of the methods of list objects:
    Add an item to the end of the list.  Similar to ``a[len(a):] = [x]``.
 
 
-.. method:: list.extend(iterable)
+.. method:: list.extend(iterable, /)
    :noindex:
 
    Extend the list by appending all the items from the iterable.  Similar to
@@ -43,7 +43,7 @@ of the methods of list objects:
    :exc:`ValueError` if there is no such item.
 
 
-.. method:: list.pop([i])
+.. method:: list.pop(index=-1, /)
    :noindex:
 
    Remove the item at the given position in the list, and return it.  If no index


### PR DESCRIPTION
This PR updates documentation method signatures to match standard signature conventions.

Changes:
- Use the positional-only marker `, /` for extend() where appropriate
- Change `pop([i])` to `pop(index=-1, /)`

Files updated:
- Doc/tutorial/datastructures.rst
- Doc/library/array.rst
- Doc/library/collections.rst

gh-144837


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144929.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->