### PR TITLE
Docs: Remove unnecessary entry from `nitpick_ignore`

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -227,10 +227,6 @@ nitpick_ignore = [
 # Temporary undocumented names.
 # In future this list must be empty.
 nitpick_ignore += [
-    # Do not error nit-picky mode builds when _SubParsersAction.add_parser cannot
-    # be resolved, as the method is currently undocumented. For context, see
-    # https://github.com/python/cpython/pull/103289.
-    ('py:meth', '_SubParsersAction.add_parser'),
     # Attributes/methods/etc. that definitely should be documented better,
     # but are deferred for now:
     ('py:attr', '__wrapped__'),


### PR DESCRIPTION
It was documented in https://github.com/python/cpython/commit/74db4404eaa9b4448b50ab7be7d50487dc0585fd.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144933.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->