### PR TITLE
gh-142731: fix re-entrant __hash__ UAF in setattr/delattr paths

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -643,6 +643,32 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         msg = r"^attribute name must be string, not 'int'$"
         self.assertRaisesRegex(TypeError, msg, delattr, sys, 1)
 
+    def test_delattr_reentrant_name_hash_does_not_crash(self):
+        code = dedent("""
+            import gc
+
+            class Victim:
+                pass
+
+            class Evil(str):
+                def __hash__(self):
+                    old = target.__dict__
+                    target.__dict__ = {}
+                    del old
+                    for _ in range(32):
+                        dict.fromkeys(range(4), 1)
+                    gc.collect()
+                    return hash(str(self))
+
+            for _ in range(2000):
+                target = Victim()
+                try:
+                    delattr(target, Evil("missing"))
+                except AttributeError:
+                    pass
+        """)
+        assert_python_ok("-c", code)
+
     def test_dir(self):
         # dir(wrong number of arguments)
         self.assertRaises(TypeError, dir, 42, 42)
@@ -1993,6 +2019,29 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         self.assertRaises(TypeError, setattr, sys, 'spam')
         msg = r"^attribute name must be string, not 'int'$"
         self.assertRaisesRegex(TypeError, msg, setattr, sys, 1, 'spam')
+
+    def test_setattr_reentrant_name_hash_does_not_crash(self):
+        code = dedent("""
+            import gc
+
+            class Victim:
+                pass
+
+            class Evil(str):
+                def __hash__(self):
+                    old = target.__dict__
+                    target.__dict__ = {}
+                    del old
+                    for _ in range(32):
+                        dict.fromkeys(range(4), 1)
+                    gc.collect()
+                    return hash(str(self))
+
+            for _ in range(2000):
+                target = Victim()
+                setattr(target, Evil("name"), 1)
+        """)
+        assert_python_ok("-c", code)
 
     # test_str(): see test_str.py and test_bytes.py for str() tests.
 

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4691,6 +4691,33 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         else:
             self.fail("Carlo Verre __delattr__ succeeded!")
 
+    def test_object_setattr_delattr_reentrant_name_hash_does_not_crash(self):
+        code = textwrap.dedent("""
+            import gc
+
+            class Victim:
+                pass
+
+            class Evil(str):
+                def __hash__(self):
+                    old = target.__dict__
+                    target.__dict__ = {}
+                    del old
+                    for _ in range(32):
+                        dict.fromkeys(range(4), 1)
+                    gc.collect()
+                    return hash(str(self))
+
+            for _ in range(2000):
+                target = Victim()
+                object.__setattr__(target, Evil("name"), 1)
+                try:
+                    object.__delattr__(target, Evil("missing"))
+                except AttributeError:
+                    pass
+        """)
+        assert_python_ok("-c", code)
+
     def test_carloverre_multi_inherit_valid(self):
         class A(type):
             def __setattr__(cls, key, value):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-17-20-30-00.gh-issue-142731.kM4pQ2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-17-20-30-00.gh-issue-142731.kM4pQ2.rst
@@ -1,0 +1,2 @@
+Fix a use-after-free in instance attribute setting/deletion when a str subclass
+attribute name has a re-entrant ``__hash__`` that replaces ``__dict__``.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -7108,6 +7108,8 @@ store_instance_attr_dict(PyObject *obj, PyDictObject *dict, PyObject *name, PyOb
 {
     PyDictValues *values = _PyObject_InlineValues(obj);
     int res;
+    // Keep the dict alive across potentially re-entrant hashing of 'name'.
+    Py_INCREF(dict);
     Py_BEGIN_CRITICAL_SECTION(dict);
     if (dict->ma_values == values) {
         res = store_instance_attr_lock_held(obj, values, name, value);
@@ -7116,6 +7118,7 @@ store_instance_attr_dict(PyObject *obj, PyDictObject *dict, PyObject *name, PyOb
         res = _PyDict_SetItem_LockHeld(dict, name, value);
     }
     Py_END_CRITICAL_SECTION();
+    Py_DECREF(dict);
     return res;
 }
 
@@ -7696,10 +7699,13 @@ _PyObjectDict_SetItem(PyTypeObject *tp, PyObject *obj, PyObject **dictptr,
         return -1;
     }
 
+    // Keep the dict alive across potentially re-entrant hashing of 'key'.
+    Py_INCREF(dict);
     Py_BEGIN_CRITICAL_SECTION(dict);
     res = _PyDict_SetItem_LockHeld((PyDictObject *)dict, key, value);
     ASSERT_CONSISTENT(dict);
     Py_END_CRITICAL_SECTION();
+    Py_DECREF(dict);
     return res;
 }
 


### PR DESCRIPTION
# Pull Request title
gh-142731: Fix re-entrant __hash__ UAF in setattr/delattr paths

## Summary

Fixes a use-after-free in dict attribute write/delete paths when `__hash__` is re-entered and mutates state during lookup.

### What changed
- Ensure key/object lifetime is protected across re-entrant hash/equality code paths in dict setattr/delattr operations.
- Add regression tests covering re-entrant `__hash__` behavior for both setattr and delattr flows.
- Add NEWS entry for gh-142731.

## Issue

- gh-142731

## Testing

- Added targeted regression tests.
- Existing tests in affected area pass locally.


issue #142731 