### PR TITLE
gh-141510: Fix frozendict.fromkeys() for subclasses

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1787,6 +1787,23 @@ class FrozenDictTests(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "unhashable type: 'list'"):
             hash(fd)
 
+    def test_fromkeys(self):
+        self.assertEqual(frozendict.fromkeys('abc'),
+                         frozendict(a=None, b=None, c=None))
+
+        # frozendict.fromkeys() must not call subclass constructor
+        class FrozenDictSubclass(frozendict):
+            def __new__(self):
+                raise ValueError("must not be called")
+
+        fd = FrozenDictSubclass.fromkeys("abc")
+        self.assertEqual(fd, frozendict(a=None, b=None, c=None))
+        self.assertEqual(type(fd), FrozenDictSubclass)
+
+        fd = FrozenDictSubclass.fromkeys(frozendict(x=1))
+        self.assertEqual(fd, frozendict(x=None))
+        self.assertEqual(type(fd), FrozenDictSubclass)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3285,10 +3285,17 @@ _PyDict_FromKeys(PyObject *cls, PyObject *iterable, PyObject *value)
     PyObject *d;
     int status;
 
-    d = _PyObject_CallNoArgs(cls);
-    if (d == NULL)
+    if (PyObject_IsSubclass(cls, (PyObject*)&PyFrozenDict_Type)) {
+        // Never call frozendict subclass constructor which would call
+        // arbitrary Python code.
+        d = frozendict_new(_PyType_CAST(cls), NULL, NULL);
+    }
+    else {
+        d = _PyObject_CallNoArgs(cls);
+    }
+    if (d == NULL) {
         return NULL;
-
+    }
 
     if (PyDict_CheckExact(d)) {
         if (PyDict_CheckExact(iterable)) {
@@ -3359,7 +3366,7 @@ _PyDict_FromKeys(PyObject *cls, PyObject *iterable, PyObject *value)
 dict_iter_exit:;
         Py_END_CRITICAL_SECTION();
     }
-    else if (PyFrozenDict_CheckExact(d)) {
+    else if (PyFrozenDict_Check(d)) {
         while ((key = PyIter_Next(it)) != NULL) {
             // anydict_setitem_take2 consumes a reference to key
             status = anydict_setitem_take2((PyDictObject *)d,
@@ -7994,6 +8001,8 @@ frozendict_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (d == NULL) {
         return NULL;
     }
+    assert(Py_REFCNT(d) == 1);
+
     PyFrozenDictObject *self = _PyFrozenDictObject_CAST(d);
     self->ma_hash = -1;
 


### PR DESCRIPTION
Don't call the constructor of the subclass, but frozendict constructor instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141510 -->
* Issue: gh-141510
<!-- /gh-issue-number -->
