### PR TITLE
gh-135573: Add tests for pickle opcodes with wrong types

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1484,6 +1484,29 @@ class AbstractUnpickleTests:
         # bad hashable dict key
         self.check_unpickling_error(CustomError, base + b'}c__main__\nBadKey1\n)\x81Nsb.')
 
+    def test_bad_types(self):
+        # APPEND
+        self.assertEqual(self.loads(b']Na.'), [None])
+        self.check_unpickling_error(AttributeError, b'NNa.')  # non-list
+        # APPENDS
+        self.assertEqual(self.loads(b'](Ne.'), [None])
+        self.check_unpickling_error(AttributeError, b'N(Ne.')  # non-list
+        self.check_unpickling_error(AttributeError, b'N(e.')
+        # SETITEM
+        self.assertEqual(self.loads(b'}NNs.'), {None: None})
+        self.check_unpickling_error(TypeError, b'NNNs.')  # non-dict
+        self.check_unpickling_error(TypeError, b'}]Ns.')  # non-hashable key
+        # SETITEMS
+        self.assertEqual(self.loads(b'}(NNu.'), {None: None})
+        self.check_unpickling_error(TypeError, b'N(NNu.')  # non-dict
+        self.assertEqual(self.loads(b'N(u.'), None)  # no validation for empty items
+        self.check_unpickling_error(TypeError, b'}(]Nu.')  # non-hashable key
+        # ADDITEMS
+        self.assertEqual(self.loads(b'\x8f(N\x90.'), {None})
+        self.check_unpickling_error(AttributeError, b'N(N\x90.')  # non-set
+        self.check_unpickling_error(AttributeError, b'N(\x90.')
+        self.check_unpickling_error(TypeError, b'\x8f(]\x90.')  # non-hashable element
+
     def test_bad_stack(self):
         badpickles = [
             b'.',                       # STOP

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6663,8 +6663,6 @@ do_append(PickleState *state, UnpicklerObject *self, Py_ssize_t x)
     len = Py_SIZE(self->stack);
     if (x > len || x <= self->stack->fence)
         return Pdata_stack_underflow(state, self->stack);
-    if (len == x)  /* nothing to do */
-        return 0;
 
     list = self->stack->data[x - 1];
 
@@ -6754,8 +6752,6 @@ do_setitems(PickleState *st, UnpicklerObject *self, Py_ssize_t x)
     len = Py_SIZE(self->stack);
     if (x > len || x <= self->stack->fence)
         return Pdata_stack_underflow(st, self->stack);
-    if (len == x)  /* nothing to do */
-        return 0;
     if ((len - x) % 2 != 0) {
         /* Corrupt or hostile pickle -- we never write one like this. */
         PyErr_SetString(st->UnpicklingError,
@@ -6807,8 +6803,6 @@ load_additems(PickleState *state, UnpicklerObject *self)
     len = Py_SIZE(self->stack);
     if (mark > len || mark <= self->stack->fence)
         return Pdata_stack_underflow(state, self->stack);
-    if (len == mark)  /* nothing to do */
-        return 0;
 
     set = self->stack->data[mark - 1];
 


### PR DESCRIPTION
Ensure that APPENDS and ADDITEMS raise error for wrong collection even with empty items.


<!-- gh-issue-number: gh-135573 -->
* Issue: gh-135573
<!-- /gh-issue-number -->
