### PR TITLE
[3.14] gh-140652: Fix a crash in _interpchannels.list_all() after closing a channel (GH-143743)

### DIFF
--- a/Lib/test/test__interpchannels.py
+++ b/Lib/test/test__interpchannels.py
@@ -382,6 +382,38 @@ class ChannelTests(TestBase):
         self.assertEqual(id3, int(id2) + 1)
         self.assertEqual(set(after) - set(before), {id1, id2, id3})
 
+    def test_channel_list_all_closed(self):
+        id1 = _channels.create()
+        id2 = _channels.create()
+        id3 = _channels.create()
+        before = _channels.list_all()
+        expected = [info for info in before if info[0] != id2]
+        _channels.close(id2, force=True)
+        after = _channels.list_all()
+        self.assertEqual(set(after), set(expected))
+        self.assertEqual(len(after), len(before) - 1)
+
+    def test_channel_list_all_destroyed(self):
+        id1 = _channels.create()
+        id2 = _channels.create()
+        id3 = _channels.create()
+        before = _channels.list_all()
+        expected = [info for info in before if info[0] != id2]
+        _channels.destroy(id2)
+        after = _channels.list_all()
+        self.assertEqual(set(after), set(expected))
+        self.assertEqual(len(after), len(before) - 1)
+
+    def test_channel_list_all_released(self):
+        id1 = _channels.create()
+        id2 = _channels.create()
+        id3 = _channels.create()
+        before = _channels.list_all()
+        _channels.release(id2, send=True, recv=True)
+        after = _channels.list_all()
+        self.assertEqual(set(after), set(before))
+        self.assertEqual(len(after), len(before))
+
     def test_ids_global(self):
         id1 = _interpreters.create()
         out = _run_output(id1, dedent("""

--- a/Lib/test/test_interpreters/test_channels.py
+++ b/Lib/test/test_interpreters/test_channels.py
@@ -47,6 +47,12 @@ class TestChannels(TestBase):
         after = set(channels.list_all())
         self.assertEqual(after, created)
 
+    def test_list_all_closed(self):
+        created = [channels.create() for _ in range(3)]
+        rch, sch = created.pop(1)
+        rch.close()
+        self.assertEqual(set(channels.list_all()), set(created))
+
     def test_shareable(self):
         interp = interpreters.create()
         rch, sch = channels.create()

--- a/Misc/NEWS.d/next/Library/2026-01-12-19-39-57.gh-issue-140652.HvM9Bl.rst
+++ b/Misc/NEWS.d/next/Library/2026-01-12-19-39-57.gh-issue-140652.HvM9Bl.rst
@@ -1,0 +1,1 @@
+Fix a crash in :func:`!_interpchannels.list_all` after closing a channel.

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -1644,14 +1644,16 @@ _channels_list_all(_channels *channels, int64_t *count)
     if (ids == NULL) {
         goto done;
     }
-    _channelref *ref = channels->head;
-    for (int64_t i=0; ref != NULL; ref = ref->next, i++) {
-        ids[i] = (struct channel_id_and_info){
-            .id = ref->cid,
-            .defaults = ref->chan->defaults,
-        };
+    int64_t i = 0;
+    for (_channelref *ref = channels->head; ref != NULL; ref = ref->next) {
+        if (ref->chan != NULL) {
+            ids[i++] = (struct channel_id_and_info){
+                .id = ref->cid,
+                .defaults = ref->chan->defaults,
+            };
+        }
     }
-    *count = channels->numopen;
+    *count = i;
 
     cids = ids;
 done:


### PR DESCRIPTION
(cherry picked from commit 3f50432e31c8e0d2e3ea8cbc2e472f7ee80e327a)


<!-- gh-issue-number: gh-140652 -->
* Issue: gh-140652
<!-- /gh-issue-number -->
