### PR TITLE
gh-142763: Fix race in ZoneInfo cache eviction

### DIFF
--- a/Lib/zoneinfo/_zoneinfo.py
+++ b/Lib/zoneinfo/_zoneinfo.py
@@ -47,7 +47,11 @@ class ZoneInfo(tzinfo):
         cls._strong_cache[key] = cls._strong_cache.pop(key, instance)
 
         if len(cls._strong_cache) > cls._strong_cache_size:
-            cls._strong_cache.popitem(last=False)
+            try:
+                cls._strong_cache.popitem(last=False)
+            except KeyError:
+                # another thread may have already emptied the cache
+                pass
 
         return instance
 

--- a/Misc/NEWS.d/next/Library/2025-12-18-00-00-00.gh-issue-142763.AJpZPVG5.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-18-00-00-00.gh-issue-142763.AJpZPVG5.rst
@@ -1,3 +1,2 @@
-Fix a race condition in :class:`zoneinfo.ZoneInfo` cache eviction that could
-raise :exc:`KeyError` when multiple threads create :class:`~zoneinfo.ZoneInfo`
-instances concurrently.
+Fix a race condition between :class:`zoneinfo.ZoneInfo` creation and
+:func:`zoneinfo.ZoneInfo.clear_cache` that could raise :exc:`KeyError`.

--- a/Misc/NEWS.d/next/Library/2025-12-18-00-00-00.gh-issue-142763.AJpZPVG5.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-18-00-00-00.gh-issue-142763.AJpZPVG5.rst
@@ -1,0 +1,3 @@
+Fix a race condition in :class:`zoneinfo.ZoneInfo` cache eviction that could
+raise :exc:`KeyError` when multiple threads create :class:`~zoneinfo.ZoneInfo`
+instances concurrently.


### PR DESCRIPTION
The cache may be cleared between the evaluation of the if statement and the call to `popitem`.

<!-- gh-issue-number: gh-142763 -->
* Issue: gh-142763
<!-- /gh-issue-number -->
