### PR TITLE
gh-144748: Document 3.12 and 3.14 changes to `PyErr_CheckSignals`

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -686,8 +686,9 @@ Signal Handling
    other pending signals may not have been handled yet: they will be on the
    next :c:func:`PyErr_CheckSignals()` invocation).
 
-   If the function is called from a non-main thread, or under a non-main
-   Python interpreter, it does nothing and returns ``0``.
+   This function may invoke the garbage collector or execute a :ref:`remote
+   debugger <remote-debugging>` script, regardless of the calling thread
+   or Python interpreter.
 
    This function can be called by long-running C code that wants to
    be interruptible by user requests (such as by pressing Ctrl-C).
@@ -695,6 +696,13 @@ Signal Handling
    .. note::
       The default Python signal handler for :c:macro:`!SIGINT` raises the
       :exc:`KeyboardInterrupt` exception.
+
+   .. versionchanged:: 3.12
+      This function may now invoke the garbage collector.
+
+   .. versionchanged:: 3.14
+      This function may now execute a remote debugger script, if remote
+      debugging is enabled.
 
 
 .. c:function:: void PyErr_SetInterrupt()

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -673,13 +673,17 @@ Signal Handling
       single: SIGINT (C macro)
       single: KeyboardInterrupt (built-in exception)
 
-
-
-   Handle external interruptions, such as signals (including :kbd:`Ctrl-C`),
-   or activating a debugger, whose processing has been delayed until it is safe
+   Handle external interruptions, such as signals or activating a debugger,
+   whose processing has been delayed until it is safe
    to run Python code and/or raise exceptions.
-   The function should be called by long-running C code frequently
-   enough so that the response appears immediate to humans.
+
+   For example, pressing :kbd:`Ctrl-C` causes a terminal to send the
+   :py:data:`signal.SIGINT` signal.
+   This function executes the corresponding Python signal handler, which,
+   by default, raises the :exc:`KeyboardInterrupt` exception.
+
+   :c:func:`!PyErr_CheckSignals` should be called by long-running C code
+   frequently enough so that the response appears immediate to humans.
 
    Handlers invoked by this function currently include:
 
@@ -702,10 +706,6 @@ Signal Handling
 
    If all handlers finish successfully, or there are no handlers to run,
    return ``0``.
-
-   .. note::
-      The default Python signal handler for :py:data:`signal.SIGINT` raises the
-      :exc:`KeyboardInterrupt` exception.
 
    .. versionchanged:: 3.12
       This function may now invoke the garbage collector.

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -703,6 +703,44 @@ Signal Handling
    .. versionchanged:: 3.14
       This function may now execute a remote debugger script, if remote
       debugging is enabled.
+   Handle external interruptions, such as signals (including :kbd:`Ctrl-C`),
+   or activating a debugger, whose processing has been delayed until it is safe
+   to run Python code and/or raise exceptions.
+   The function should be called by long-running C code frequently
+   enough so that the response appears immediate to humans.
+
+   Handlers invoked by this function currently include:
+
+   - Signal handlers, including Python functions registered using
+     the :mod:`signal` module.
+
+     Signal handlers are only run in the main thread of the main interpreter.
+
+     (This is where the function got the name: originally, signals
+     were the only way to interrupt the interpreter.)
+
+   - Running the garbage collector, if necessary.
+
+   - Execuing a pending :ref:`remote debugger <remote-debugging>` script.
+
+   If any handler raises an exception, immediately return ``-1`` with that
+   exception set.
+   Any remaining interruptions are left to be processed on the next
+   :c:func:`PyErr_CheckSignals()` invocation, if appropriate.
+
+   If all handlers finish successfully, or there are no handlers to run,
+   return ``0``.
+
+   .. note::
+      The default Python signal handler for :py:data:`signal.SIGINT` raises the
+      :exc:`KeyboardInterrupt` exception.
+
+   .. versionchanged:: 3.12
+      This function may now invoke the garbage collector.
+
+   .. versionchanged:: 3.14
+      This function may now execute a remote debugger script, if remote
+      debugging is enabled.
 
 
 .. c:function:: void PyErr_SetInterrupt()

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -673,36 +673,8 @@ Signal Handling
       single: SIGINT (C macro)
       single: KeyboardInterrupt (built-in exception)
 
-   This function interacts with Python's signal handling.
 
-   If the function is called from the main thread and under the main Python
-   interpreter, it checks whether a signal has been sent to the processes
-   and if so, invokes the corresponding signal handler.  If the :mod:`signal`
-   module is supported, this can invoke a signal handler written in Python.
 
-   The function attempts to handle all pending signals, and then returns ``0``.
-   However, if a Python signal handler raises an exception, the error
-   indicator is set and the function returns ``-1`` immediately (such that
-   other pending signals may not have been handled yet: they will be on the
-   next :c:func:`PyErr_CheckSignals()` invocation).
-
-   This function may invoke the garbage collector or execute a :ref:`remote
-   debugger <remote-debugging>` script, regardless of the calling thread
-   or Python interpreter.
-
-   This function can be called by long-running C code that wants to
-   be interruptible by user requests (such as by pressing Ctrl-C).
-
-   .. note::
-      The default Python signal handler for :c:macro:`!SIGINT` raises the
-      :exc:`KeyboardInterrupt` exception.
-
-   .. versionchanged:: 3.12
-      This function may now invoke the garbage collector.
-
-   .. versionchanged:: 3.14
-      This function may now execute a remote debugger script, if remote
-      debugging is enabled.
    Handle external interruptions, such as signals (including :kbd:`Ctrl-C`),
    or activating a debugger, whose processing has been delayed until it is safe
    to run Python code and/or raise exceptions.

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -697,7 +697,7 @@ Signal Handling
 
    - Running the garbage collector, if necessary.
 
-   - Execuing a pending :ref:`remote debugger <remote-debugging>` script.
+   - Executing a pending :ref:`remote debugger <remote-debugging>` script.
 
    If any handler raises an exception, immediately return ``-1`` with that
    exception set.


### PR DESCRIPTION
I'll need to remove the reference to the remote debugger in the 3.13 backport.

<!-- gh-issue-number: gh-144748 -->
* Issue: gh-144748
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144982.org.readthedocs.build/en/144982/c-api/exceptions.html#c.PyErr_CheckSignals

<!-- readthedocs-preview cpython-previews end -->