### PR TITLE
gh-144873: Document isinstance Edge Case

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -433,7 +433,9 @@ Object Protocol
 
    If *cls* has a :meth:`~type.__instancecheck__` method, it will be called to
    determine the subclass status as described in :pep:`3119`.  Otherwise, *inst*
-   is an instance of *cls* if its class is a subclass of *cls*.
+   is an instance of *cls* if its class is a subclass of *cls*. If *inst* is
+   an instance of *cls*, this will return ``1`` and will not call
+   :meth:`~type.__instancecheck__`.
 
    An instance *inst* can override what is considered its class by having a
    :attr:`~object.__class__` attribute.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2965,7 +2965,11 @@ ABCs.
 
    Return true if *instance* should be considered a (direct or indirect)
    instance of *class*. If defined, called to implement ``isinstance(instance,
-   class)``.
+   cls)``.
+
+   .. note::
+      If ``type(instance) is cls`` then ``isinstance(instance, cls)`` is
+      always ``True`` and ``__instancecheck__`` is not called.
 
 
 .. method:: type.__subclasscheck__(self, subclass)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Fixes #144873 and #79264 by describing the optimization where `type(instance) is cls` during `inistance(instance, cls)`. It describes that `__instancecheck__` is not called in this scenario.

<!-- gh-issue-number: gh-144873 -->
* Issue: gh-144873
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144997.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->