### PR TITLE
[3.13] Remove unused :platform: in module's docs (GH-144988)

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -4,7 +4,6 @@
 .. module:: curses
    :synopsis: An interface to the curses library, providing portable
               terminal handling.
-   :platform: Unix
 
 .. sectionauthor:: Moshe Zadka <moshez@zadka.site.co.il>
 .. sectionauthor:: Eric Raymond <esr@thyrsus.com>
@@ -22,6 +21,8 @@ designed to match the API of ncurses, an open-source curses library hosted on
 Linux and the BSD variants of Unix.
 
 .. include:: ../includes/wasm-mobile-notavail.rst
+
+.. availability:: Unix.
 
 .. note::
 

--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -155,7 +155,6 @@ The individual submodules are described in the following sections.
 ---------------------------------------------
 
 .. module:: dbm.sqlite3
-   :platform: All
    :synopsis: SQLite backend for dbm
 
 .. versionadded:: 3.13
@@ -206,7 +205,6 @@ or any other SQLite browser, including the SQLite CLI.
 ---------------------------------------
 
 .. module:: dbm.gnu
-   :platform: Unix
    :synopsis: GNU database manager
 
 **Source code:** :source:`Lib/dbm/gnu.py`
@@ -223,6 +221,8 @@ functionality like crash tolerance.
    and can not be used interchangeably.
 
 .. include:: ../includes/wasm-mobile-notavail.rst
+
+.. availability:: Unix.
 
 .. exception:: error
 
@@ -325,7 +325,6 @@ functionality like crash tolerance.
 ----------------------------------------
 
 .. module:: dbm.ndbm
-   :platform: Unix
    :synopsis: The New Database Manager
 
 **Source code:** :source:`Lib/dbm/ndbm.py`
@@ -350,6 +349,8 @@ This module can be used with the "classic" NDBM interface or the
    result in a hard crash (segmentation fault).
 
 .. include:: ../includes/wasm-mobile-notavail.rst
+
+.. availability:: Unix.
 
 .. exception:: error
 

--- a/Doc/library/dialog.rst
+++ b/Doc/library/dialog.rst
@@ -5,7 +5,6 @@ Tkinter Dialogs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. module:: tkinter.simpledialog
-   :platform: Tk
    :synopsis: Simple dialog windows
 
 **Source code:** :source:`Lib/tkinter/simpledialog.py`
@@ -43,7 +42,6 @@ functions for creating simple modal dialogs to get a value from the user.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. module:: tkinter.filedialog
-   :platform: Tk
    :synopsis: Dialog classes for file selection
 
 **Source code:** :source:`Lib/tkinter/filedialog.py`
@@ -208,7 +206,6 @@ These do not emulate the native look-and-feel of the platform.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. module:: tkinter.commondialog
-   :platform: Tk
    :synopsis: Tkinter base class for dialogs
 
 **Source code:** :source:`Lib/tkinter/commondialog.py`

--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -2,7 +2,6 @@
 ==========================================================
 
 .. module:: fcntl
-   :platform: Unix
    :synopsis: The fcntl() and ioctl() system calls.
 
 .. sectionauthor:: Jaap Vermeulen

--- a/Doc/library/grp.rst
+++ b/Doc/library/grp.rst
@@ -2,7 +2,6 @@
 ==================================
 
 .. module:: grp
-   :platform: Unix
    :synopsis: The group database (getgrnam() and friends).
 
 --------------

--- a/Doc/library/msvcrt.rst
+++ b/Doc/library/msvcrt.rst
@@ -2,7 +2,6 @@
 ===========================================================
 
 .. module:: msvcrt
-   :platform: Windows
    :synopsis: Miscellaneous useful routines from the MS VC++ runtime.
 
 .. sectionauthor:: Fred L. Drake, Jr. <fdrake@acm.org>

--- a/Doc/library/posix.rst
+++ b/Doc/library/posix.rst
@@ -2,7 +2,6 @@
 ====================================================
 
 .. module:: posix
-   :platform: Unix
    :synopsis: The most common POSIX system calls (normally used via module os).
 
 --------------

--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -2,7 +2,6 @@
 =========================================
 
 .. module:: pty
-   :platform: Unix
    :synopsis: Pseudo-Terminal Handling for Unix.
 
 .. moduleauthor:: Steen Lumholt

--- a/Doc/library/pwd.rst
+++ b/Doc/library/pwd.rst
@@ -2,7 +2,6 @@
 =====================================
 
 .. module:: pwd
-   :platform: Unix
    :synopsis: The password database (getpwnam() and friends).
 
 --------------

--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -2,7 +2,6 @@
 ===========================================
 
 .. module:: readline
-   :platform: Unix
    :synopsis: GNU readline support for Python.
 
 .. sectionauthor:: Skip Montanaro <skip.montanaro@gmail.com>
@@ -25,6 +24,8 @@ allowable constructs of that file, and the capabilities of the
 Readline library in general.
 
 .. include:: ../includes/wasm-mobile-notavail.rst
+
+.. availability:: Unix.
 
 .. note::
 

--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -2,7 +2,6 @@
 ===============================================
 
 .. module:: resource
-   :platform: Unix
    :synopsis: An interface to provide resource usage information on the current process.
 
 .. moduleauthor:: Jeremy Hylton <jeremy@alum.mit.edu>

--- a/Doc/library/syslog.rst
+++ b/Doc/library/syslog.rst
@@ -2,7 +2,6 @@
 ===============================================
 
 .. module:: syslog
-   :platform: Unix
    :synopsis: An interface to the Unix syslog library routines.
 
 --------------

--- a/Doc/library/termios.rst
+++ b/Doc/library/termios.rst
@@ -2,7 +2,6 @@
 ===========================================
 
 .. module:: termios
-   :platform: Unix
    :synopsis: POSIX style tty control.
 
 .. index::

--- a/Doc/library/tkinter.colorchooser.rst
+++ b/Doc/library/tkinter.colorchooser.rst
@@ -2,7 +2,6 @@
 ======================================================
 
 .. module:: tkinter.colorchooser
-   :platform: Tk
    :synopsis: Color choosing dialog
 
 **Source code:** :source:`Lib/tkinter/colorchooser.py`

--- a/Doc/library/tkinter.dnd.rst
+++ b/Doc/library/tkinter.dnd.rst
@@ -2,7 +2,6 @@
 =============================================
 
 .. module:: tkinter.dnd
-   :platform: Tk
    :synopsis: Tkinter drag-and-drop interface
 
 **Source code:** :source:`Lib/tkinter/dnd.py`

--- a/Doc/library/tkinter.font.rst
+++ b/Doc/library/tkinter.font.rst
@@ -2,7 +2,6 @@
 =============================================
 
 .. module:: tkinter.font
-   :platform: Tk
    :synopsis: Tkinter font-wrapping class
 
 **Source code:** :source:`Lib/tkinter/font.py`

--- a/Doc/library/tkinter.messagebox.rst
+++ b/Doc/library/tkinter.messagebox.rst
@@ -2,7 +2,6 @@
 ======================================================
 
 .. module:: tkinter.messagebox
-   :platform: Tk
    :synopsis: Various types of alert dialogs
 
 **Source code:** :source:`Lib/tkinter/messagebox.py`

--- a/Doc/library/tkinter.scrolledtext.rst
+++ b/Doc/library/tkinter.scrolledtext.rst
@@ -2,7 +2,6 @@
 =====================================================
 
 .. module:: tkinter.scrolledtext
-   :platform: Tk
    :synopsis: Text widget with a vertical scroll bar.
 
 .. sectionauthor:: Fred L. Drake, Jr. <fdrake@acm.org>

--- a/Doc/library/tty.rst
+++ b/Doc/library/tty.rst
@@ -2,7 +2,6 @@
 ==========================================
 
 .. module:: tty
-   :platform: Unix
    :synopsis: Utility functions that perform common terminal control operations.
 
 .. moduleauthor:: Steen Lumholt

--- a/Doc/library/winreg.rst
+++ b/Doc/library/winreg.rst
@@ -2,7 +2,6 @@
 ==========================================
 
 .. module:: winreg
-   :platform: Windows
    :synopsis: Routines and objects for manipulating the Windows registry.
 
 .. sectionauthor:: Mark Hammond <MarkH@ActiveState.com>

--- a/Doc/library/winsound.rst
+++ b/Doc/library/winsound.rst
@@ -2,7 +2,6 @@
 ========================================================
 
 .. module:: winsound
-   :platform: Windows
    :synopsis: Access to the sound-playing machinery for Windows.
 
 .. moduleauthor:: Toby Dickenson <htrd90@zepler.org>


### PR DESCRIPTION
It has not been outputted since Sphinx 1.1.
(cherry picked from commit 20caf1c08440684b618d2166022ae82b2db3b696)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--144998.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->