### PR TITLE
GH-144679: MSVC tailcall CI no longer needs to specify PlatformToolset

### DIFF
--- a/.github/workflows/tail-call.yml
+++ b/.github/workflows/tail-call.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Build
         shell: pwsh
         run: |
-          $env:PlatformToolset = "v145"
           ./PCbuild/build.bat --tail-call-interp ${{ matrix.build_flags }} -c Release -p ${{ matrix.architecture }}
       - name: Test
         if: matrix.run_tests


### PR DESCRIPTION
Because it is now used by default when VS2026 is available (https://github.com/python/cpython/pull/144680).

<!-- gh-issue-number: gh-144679 -->
* Issue: gh-144679
<!-- /gh-issue-number -->
