### PR TITLE
gh-145010: Fix Python.h compilation with -masm=intel

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -206,11 +206,11 @@ _Py_ThreadId(void)
 #elif defined(__MINGW32__) && defined(_M_ARM64)
     tid = __getReg(18);
 #elif defined(__i386__)
-    __asm__("movl %%gs:0, %0" : "=r" (tid));  // 32-bit always uses GS
+    __asm__("{movl %%gs:0, %0|mov %0, dword ptr gs:[0]}" : "=r" (tid));  // 32-bit always uses GS
 #elif defined(__MACH__) && defined(__x86_64__)
-    __asm__("movq %%gs:0, %0" : "=r" (tid));  // x86_64 macOSX uses GS
+    __asm__("{movq %%gs:0, %0|mov %0, qword ptr gs:[0]}" : "=r" (tid));  // x86_64 macOSX uses GS
 #elif defined(__x86_64__)
-   __asm__("movq %%fs:0, %0" : "=r" (tid));  // x86_64 Linux, BSD uses FS
+    __asm__("{movq %%fs:0, %0|mov %0, qword ptr fs:[0]}" : "=r" (tid));  // x86_64 Linux, BSD uses FS
 #elif defined(__arm__) && __ARM_ARCH >= 7
     __asm__ ("mrc p15, 0, %0, c13, c0, 3\nbic %0, %0, #3" : "=r" (tid));
 #elif defined(__aarch64__) && defined(__APPLE__)

--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -1,6 +1,7 @@
 # gh-91321: Build a basic C++ test extension to check that the Python C API is
 # compatible with C++ and does not emit C++ compiler warnings.
 import os.path
+import platform
 import shlex
 import shutil
 import subprocess
@@ -28,13 +29,16 @@ SETUP = os.path.join(os.path.dirname(__file__), 'setup.py')
 class BaseTests:
     TEST_INTERNAL_C_API = False
 
-    def check_build(self, extension_name, std=None, limited=False):
+    def check_build(self, extension_name, std=None, limited=False,
+                    extra_cflags=None):
         venv_dir = 'env'
         with support.setup_venv_with_pip_setuptools(venv_dir) as python_exe:
             self._check_build(extension_name, python_exe,
-                              std=std, limited=limited)
+                              std=std, limited=limited,
+                              extra_cflags=extra_cflags)
 
-    def _check_build(self, extension_name, python_exe, std, limited):
+    def _check_build(self, extension_name, python_exe, std, limited,
+                     extra_cflags=None):
         pkg_dir = 'pkg'
         os.mkdir(pkg_dir)
         shutil.copy(SETUP, os.path.join(pkg_dir, os.path.basename(SETUP)))
@@ -48,6 +52,8 @@ class BaseTests:
                 env['CPYTHON_TEST_LIMITED'] = '1'
             env['CPYTHON_TEST_EXT_NAME'] = extension_name
             env['TEST_INTERNAL_C_API'] = str(int(self.TEST_INTERNAL_C_API))
+            if extra_cflags:
+                env['CPYTHON_TEST_EXTRA_CFLAGS'] = extra_cflags
             if support.verbose:
                 print('Run:', ' '.join(map(shlex.quote, cmd)))
                 subprocess.run(cmd, check=True, env=env)
@@ -115,6 +121,14 @@ class TestPublicCAPI(BaseTests, unittest.TestCase):
     @unittest.skipIf(not support.MS_WINDOWS, "need Windows")
     def test_build_cpp14(self):
         self.check_build('_testcpp14ext', std='c++14')
+
+    # Test that headers compile with Intel asm syntax, which may conflict
+    # with inline assembly in free-threading headers that use AT&T syntax.
+    @unittest.skipIf(support.MS_WINDOWS, "MSVC doesn't support -masm=intel")
+    @unittest.skipUnless(platform.machine() in ('x86_64', 'i686', 'AMD64'),
+                         "x86-specific flag")
+    def test_build_intel_asm(self):
+        self.check_build('_testcppext_asm', extra_cflags='-masm=intel')
 
 
 class TestInteralCAPI(BaseTests, unittest.TestCase):

--- a/Lib/test/test_cppext/setup.py
+++ b/Lib/test/test_cppext/setup.py
@@ -86,6 +86,10 @@ def main():
     if internal:
         cppflags.append('-DTEST_INTERNAL_C_API=1')
 
+    extra_cflags = os.environ.get("CPYTHON_TEST_EXTRA_CFLAGS", "")
+    if extra_cflags:
+        cppflags.extend(shlex.split(extra_cflags))
+
     # On Windows, add PCbuild\amd64\ to include and library directories
     include_dirs = []
     library_dirs = []

--- a/Misc/NEWS.d/next/C_API/2026-02-19-18-39-11.gh-issue-145010.mKzjci.rst
+++ b/Misc/NEWS.d/next/C_API/2026-02-19-18-39-11.gh-issue-145010.mKzjci.rst
@@ -1,0 +1,2 @@
+Use GCC dialect alternatives for inline assembly in ``object.h`` so that the
+Python headers compile correctly with ``-masm=intel``.


### PR DESCRIPTION


<!-- gh-issue-number: gh-145010 -->
* Issue: gh-145010
<!-- /gh-issue-number -->
