### PR TITLE
gh-137165: Unify `datetime.strftime` behavior for unsupported non-zero-padded specifiers

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -284,6 +284,16 @@ def _wrap_strftime(object, format, timetuple):
                         push('{:04}'.format(year))
                         if ch == 'F':
                             push('-{:02}-{:02}'.format(*timetuple[1:3]))
+                elif ch == '-':
+                    if i < n:
+                        next_ch = format[i]
+                        i += 1
+                        if next_ch not in 'dmHIMSjUWVy':
+                            push('%%-' + next_ch)
+                        else:
+                           push('%-' + next_ch)
+                    else:
+                        push('%-')
                 else:
                     push('%')
                     push(ch)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -15,7 +15,6 @@ import sys
 import textwrap
 import unittest
 import warnings
-import platform
 
 from array import array
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -15,6 +15,7 @@ import sys
 import textwrap
 import unittest
 import warnings
+import platform
 
 from array import array
 
@@ -1588,6 +1589,11 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         self.assertEqual(t.strftime("m:%m d:%d y:%y"), "m:03 d:02 y:05")
         self.assertEqual(t.strftime(""), "") # SF bug #761337
         self.assertEqual(t.strftime('x'*1000), 'x'*1000) # SF bug #1556784
+
+        # unsupported %-format specifiers are passed through unchanged.
+        self.assertEqual(t.strftime("%-1"), "%-1")
+        self.assertEqual(t.strftime("%--"), "%--")
+        self.assertEqual(t.strftime("%-#"), "%-#")
 
         self.assertRaises(TypeError, t.strftime) # needs an arg
         self.assertRaises(TypeError, t.strftime, "one", "two") # too many args

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2003,6 +2003,20 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
             }
             continue;
         }
+        else if (ch == '-' && i < flen) {
+            Py_UCS4 next_ch = PyUnicode_READ_CHAR(format, i);
+            i++;
+
+             if (strchr("dmHIMSjUWVy", (int)next_ch) == NULL) {
+                replacement = PyUnicode_FromFormat("%%%%-%c", (char)next_ch);
+                if (replacement == NULL) {
+                    goto Error;
+                }
+            }
+            else {
+                continue;
+            }
+        }
         else {
             /* percent followed by something else */
             continue;


### PR DESCRIPTION
This PR unifies the behavior of `datetime.strftime` when encountering unsupported or invalid non-zero-padded specifiers across different platforms.

Previously, the behavior for invalid specifiers was inconsistent:
**Windows:** Raised a `ValueError`
**macOS/FreeBSD:** Could return partial strings or stripped characters (e.g., returning `#` instead of `%-#`).
**Linux:** Echoes the specifier back as-is (e.g., `%-#`).

The behavior is now unified to match Linux.

- Related PR: https://github.com/python/cpython/pull/139088

<!-- gh-issue-number: gh-137165 -->
* Issue: gh-137165
<!-- /gh-issue-number -->
