### PR TITLE
gh-145024: Improved wording for broken socket for socket.send

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1944,8 +1944,10 @@ to sockets.
    optional *flags* argument has the same meaning as for :meth:`recv` above.
    Returns the number of bytes sent. Applications are responsible for checking that
    all data has been sent; if only some of the data was transmitted, the
-   application needs to attempt delivery of the remaining data. For further
-   information on this topic, consult the :ref:`socket-howto`.
+   application needs to attempt delivery of the remaining data. Unlike :meth:`recv`,
+   this method will automatically raise an :exc:`OSError` in the case of a broken socket.
+   As such, there is no need to check the return value to determine if a socket is closed.
+   For further information on this topic, consult the :ref:`socket-howto`.
 
    .. versionchanged:: 3.5
       If the system call is interrupted and the signal handler does not raise


### PR DESCRIPTION
Add to docs for `socket.send` that it will raise an `OSError` if trying to send to a broken socket (instead of returning zero bytes as is the case for `socket.recv`)

<!-- gh-issue-number: gh-145024 -->
* Issue: gh-145024
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145025.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->