### PR TITLE
gh-144725: Relax over-strict alignment test on small arrays

### DIFF
--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4465,9 +4465,9 @@ class TestBufferProtocol(unittest.TestCase):
     @support.cpython_only
     @unittest.skipIf(_testcapi is None, "requires _testcapi")
     def test_array_alignment(self):
-        # gh-140557: pointer alignment of buffers including empty allocation
-        # should match the maximum array alignment.
-        align = max(struct.calcsize(fmt) for fmt in ARRAY)
+        # gh-140557: pointer alignment of empty buffers should be at least
+        # to `size_t`.
+        align = struct.calcsize("N")
         cases = [array.array(fmt) for fmt in ARRAY]
         # Empty arrays
         self.assertEqual(
@@ -4476,9 +4476,11 @@ class TestBufferProtocol(unittest.TestCase):
         )
         for case in cases:
             case.append(0)
-        # Allocated arrays
+        # Allocated arrays. The minimum alignment is now governed by regular
+        # allocator rules; aligned for any type that fits in the allocation.
         self.assertEqual(
-            [_testcapi.buffer_pointer_as_int(case) % align for case in cases],
+            [_testcapi.buffer_pointer_as_int(case) % case.itemsize
+             for case in cases],
             [0] * len(cases),
         )
 


### PR DESCRIPTION
This alignment test was introduced in gh-140557 with the intention of preventing empty-allocation optimisations from introducing odd-aligned pointers (as had previously been observed in such an optimisation for the empty `bytearray`, used in the Pickle v5 protocol).  The test was over-specified, however, and compared to the maximum platform alignment, even though the requirements on allocators in general is only that the allocation is aligned for all data types that would in the requested allocation.

This test could fail on 32-bit platforms using `mimalloc` for single-byte array elements (e.g. 'B'), as the tiny allocation region only enforced 4-byte alignment, not the 8-byte maximum platform alignment of the `double` type.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144725 -->
* Issue: gh-144725
<!-- /gh-issue-number -->
