### PR TITLE
gh-145028: Fix blake2 tests in test_hashlib when it is missing due to configure --without-builtin-hashlib-hashes

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -237,10 +237,9 @@ class HashLibTestCase(unittest.TestCase):
         for name in hashlib.algorithms_available:
             with self.subTest(name):
                 try:
-                    digest = hashlib.new(name, usedforsecurity=False)
-                    assert digest is not None
-                except ValueError as verr:
-                    self.skip_if_blake2_not_builtin(name, verr)
+                    _ = hashlib.new(name, usedforsecurity=False)
+                except ValueError as exc:
+                    self.skip_if_blake2_not_builtin(name, exc)
                     raise
 
     def test_usedforsecurity_true(self):
@@ -1102,8 +1101,8 @@ class HashLibTestCase(unittest.TestCase):
                 with self.subTest(name):
                     try:
                         self.do_test_threaded_hashing(constructor, is_shake=False)
-                    except ValueError as verr:
-                        self.skip_if_blake2_not_builtin(name, verr)
+                    except ValueError as exc:
+                        self.skip_if_blake2_not_builtin(name, exc)
                         raise
 
         if shake_128 := getattr(hashlib, 'shake_128', None):

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -242,7 +242,11 @@ class HashLibTestCase(unittest.TestCase):
                 except ValueError as verr:
                     # builtins may be absent if python built with
                     # a subset of --with-builtin-hashlib-hashes or none.
-                    self.skipTest(verr)
+                    if ("blake2" in name and
+                        "blake2" not in sysconfig.get_config_var("PY_BUILTIN_HASHLIB_HASHES").split(",")):
+                        self.skipTest(verr)
+                    else:
+                        raise
 
     def test_usedforsecurity_true(self):
         hashlib.new("sha256", usedforsecurity=True)

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -234,20 +234,14 @@ class HashLibTestCase(unittest.TestCase):
                             issubset(hashlib.algorithms_available))
         # all available algorithms must be loadable, bpo-47101
         self.assertNotIn("undefined", hashlib.algorithms_available)
-        algorithms_builtin = sysconfig.get_config_var("PY_BUILTIN_HASHLIB_HASHES").split(",")
         for name in hashlib.algorithms_available:
             with self.subTest(name):
                 try:
                     digest = hashlib.new(name, usedforsecurity=False)
                     assert digest is not None
                 except ValueError as verr:
-                    # builtins may be absent if python built with
-                    # a subset of --with-builtin-hashlib-hashes or none.
-                    if ("blake2" in name and
-                        "blake2" not in algorithms_builtin):
-                        self.skipTest(verr)
-                    else:
-                        raise
+                    self.skip_if_blake2_not_builtin(name, verr)
+                    raise
 
     def test_usedforsecurity_true(self):
         hashlib.new("sha256", usedforsecurity=True)
@@ -814,6 +808,12 @@ class HashLibTestCase(unittest.TestCase):
           "e718483d0ce769644e2e42c7bc15b4638e1f98b13b2044285632a803afa973eb"+
           "de0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b")
 
+    def skip_if_blake2_not_builtin(self, name, skip_reason):
+        # blake2 builtins may be absent if python built with
+        # a subset of --with-builtin-hashlib-hashes or none.
+        if "blake2" in name and "blake2" not in builtin_hashes:
+            self.skipTest(skip_reason)
+
     def check_blake2(self, constructor, salt_size, person_size, key_size,
                      digest_size, max_offset):
         self.assertEqual(constructor.SALT_SIZE, salt_size)
@@ -1096,13 +1096,16 @@ class HashLibTestCase(unittest.TestCase):
     def test_threaded_hashing_fast(self):
         # Same as test_threaded_hashing_slow() but only tests some functions
         # since otherwise test_hashlib.py becomes too slow during development.
-        algos = ['md5', 'sha1', 'sha256', 'sha3_256']
-        if _blake2:
-            algos.append('blake2s')
+        algos = ['md5', 'sha1', 'sha256', 'sha3_256', 'blake2s']
         for name in algos:
             if constructor := getattr(hashlib, name, None):
                 with self.subTest(name):
-                    self.do_test_threaded_hashing(constructor, is_shake=False)
+                    try:
+                        self.do_test_threaded_hashing(constructor, is_shake=False)
+                    except ValueError as verr:
+                        self.skip_if_blake2_not_builtin(name, verr)
+                        raise
+
         if shake_128 := getattr(hashlib, 'shake_128', None):
             self.do_test_threaded_hashing(shake_128, is_shake=True)
 

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -134,8 +134,11 @@ class HashLibTestCase(unittest.TestCase):
             algorithms.add(algorithm.lower())
 
         _blake2 = self._conditional_import_module('_blake2')
+        blake2_hashes = {'blake2b', 'blake2s'}
         if _blake2:
-            algorithms.update({'blake2b', 'blake2s'})
+            algorithms.update(blake2_hashes)
+        else:
+            algorithms.difference_update(blake2_hashes)
 
         self.constructors_to_test = {}
         for algorithm in algorithms:
@@ -232,7 +235,14 @@ class HashLibTestCase(unittest.TestCase):
         # all available algorithms must be loadable, bpo-47101
         self.assertNotIn("undefined", hashlib.algorithms_available)
         for name in hashlib.algorithms_available:
-            digest = hashlib.new(name, usedforsecurity=False)
+            with self.subTest(name):
+                try:
+                    digest = hashlib.new(name, usedforsecurity=False)
+                    assert digest is not None
+                except ValueError as verr:
+                    # builtins may be absent if python built with
+                    # a subset of --with-builtin-hashlib-hashes or none.
+                    self.skipTest(verr)
 
     def test_usedforsecurity_true(self):
         hashlib.new("sha256", usedforsecurity=True)
@@ -504,6 +514,7 @@ class HashLibTestCase(unittest.TestCase):
         self.assertEqual(h.hexdigest(), "e2d4535e3b613135c14f2fe4e026d7ad8d569db44901740beffa30d430acb038")
 
     @requires_resource('cpu')
+    @requires_blake2
     def test_blake2_update_over_4gb(self):
         # blake2s or blake2b doesn't matter based on how our C code is structured, this tests the
         # common loop macro logic.
@@ -1052,7 +1063,9 @@ class HashLibTestCase(unittest.TestCase):
         # for multithreaded operation. Currently, all cryptographic modules
         # have the same constant value (2048) but in the future it might not
         # be the case.
-        mods = ['_md5', '_sha1', '_sha2', '_sha3', '_blake2', '_hashlib']
+        mods = ['_md5', '_sha1', '_sha2', '_sha3', '_hashlib']
+        if _blake2:
+            mods.append('_blake2')
         gil_minsize = hashlib_helper.find_gil_minsize(mods)
         for cons in self.hash_constructors:
             # constructors belong to one of the above modules
@@ -1080,7 +1093,10 @@ class HashLibTestCase(unittest.TestCase):
     def test_threaded_hashing_fast(self):
         # Same as test_threaded_hashing_slow() but only tests some functions
         # since otherwise test_hashlib.py becomes too slow during development.
-        for name in ['md5', 'sha1', 'sha256', 'sha3_256', 'blake2s']:
+        algos = ['md5', 'sha1', 'sha256', 'sha3_256']
+        if _blake2:
+            algos.append('blake2s')
+        for name in algos:
             if constructor := getattr(hashlib, name, None):
                 with self.subTest(name):
                     self.do_test_threaded_hashing(constructor, is_shake=False)

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -234,6 +234,7 @@ class HashLibTestCase(unittest.TestCase):
                             issubset(hashlib.algorithms_available))
         # all available algorithms must be loadable, bpo-47101
         self.assertNotIn("undefined", hashlib.algorithms_available)
+        algorithms_builtin = sysconfig.get_config_var("PY_BUILTIN_HASHLIB_HASHES").split(",")
         for name in hashlib.algorithms_available:
             with self.subTest(name):
                 try:
@@ -243,7 +244,7 @@ class HashLibTestCase(unittest.TestCase):
                     # builtins may be absent if python built with
                     # a subset of --with-builtin-hashlib-hashes or none.
                     if ("blake2" in name and
-                        "blake2" not in sysconfig.get_config_var("PY_BUILTIN_HASHLIB_HASHES").split(",")):
+                        "blake2" not in algorithms_builtin):
                         self.skipTest(verr)
                     else:
                         raise
@@ -1067,9 +1068,7 @@ class HashLibTestCase(unittest.TestCase):
         # for multithreaded operation. Currently, all cryptographic modules
         # have the same constant value (2048) but in the future it might not
         # be the case.
-        mods = ['_md5', '_sha1', '_sha2', '_sha3', '_hashlib']
-        if _blake2:
-            mods.append('_blake2')
+        mods = ['_md5', '_sha1', '_sha2', '_sha3', '_blake2', '_hashlib']
         gil_minsize = hashlib_helper.find_gil_minsize(mods)
         for cons in self.hash_constructors:
             # constructors belong to one of the above modules


### PR DESCRIPTION
This PR addresses Issue #145028  tracking test_hashlib failure on cpython configured `--without-builtin-hashlib-hashes`

## Changes in test_hashlib.py
- Guard testing of blake2 with existing utils to verify its existence (`@require_blake2`)
- Remove blake2 variations from `algorithms` in constructor when _blake2 is None, as they may already be in that list through its initialization from `self.supported_hashnames`. 
- Add subtests in test_algorithms_available and skip if ValueError is raised, so it's easy to tell what exactly was skipped and why. 
- Add skip_if_blake2_not_builtin helper 


## Testing with fix on python without builtin blake2

```
python -m unittest Lib.test.test_hashlib.HashLibTestCase
...
----------------------------------------------------------------------
Ran 82 tests in 7.005s

OK (skipped=29)
```

Sample skips on test_algorithms_available

```
  test_algorithms_available (Lib.test.test_hashlib.HashLibTestCase.test_algorithms_available) [blake2b] ... skipped 'unsupported hash algorithm blake2b'
  test_algorithms_available (Lib.test.test_hashlib.HashLibTestCase.test_algorithms_available) [blake2s] ... skipped 'unsupported hash algorithm blake2s'
```

<!-- gh-issue-number: gh-145028 -->
* Issue: gh-145028
<!-- /gh-issue-number -->
