### PR TITLE
Fix errors in `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -295,10 +295,10 @@ Tools/jit/                    @brandtbucher @savannahostrowski @diegorusso
 InternalDocs/jit.md           @brandtbucher @savannahostrowski @diegorusso @AA-Turner
 
 # Lazy imports (PEP 810)
-Objects/lazyimportobject.c                  @twouters @DinoV @pablogsal
-Include/internal/pycore_lazyimportobject.h  @twouters @DinoV @pablogsal
-Lib/test/test_import/test_lazy_imports.py   @twouters @DinoV @pablogsal
-Lib/test/test_import/data/lazy_imports/     @twouters @DinoV @pablogsal
+Objects/lazyimportobject.c                  @yhg1s @DinoV @pablogsal
+Include/internal/pycore_lazyimportobject.h  @yhg1s @DinoV @pablogsal
+Lib/test/test_import/test_lazy_imports.py   @yhg1s @DinoV @pablogsal
+Lib/test/test_import/data/lazy_imports/     @yhg1s @DinoV @pablogsal
 
 # Micro-op / μop / Tier 2 Optimiser
 Python/optimizer.c            @markshannon @Fidget-Spinner


### PR DESCRIPTION
I noticed this yellow banner that notes four errors: 
<img width="1250" height="1022" alt="image" src="https://github.com/user-attachments/assets/05457efd-aac0-40a9-be83-a2c96200ffc9" />
