### PR TITLE
gh-145064: fix JIT tracing for non-function frames

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -4065,6 +4065,24 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertNotIn('_PyJit_TryInitializeTracing', stderr,
                          f"JIT tracer memory leak detected:\n{stderr}")
 
+    def test_145064(self):
+        # https://github.com/python/cpython/issues/145064
+        result = script_helper.run_python_until_end('-c', textwrap.dedent(f"""
+        SRC = '''
+        class A:
+            def __init__(self, x):
+                self.x = x
+
+        for i in range(8):
+            A(i)
+        '''
+
+        for _ in range({TIER2_THRESHOLD * 6}):
+            ns = {{}}
+            exec(SRC, ns, ns)
+        """), PYTHON_JIT="1", PYTHON_JIT_STRESS="1")
+        self.assertEqual(result[0].rc, 0, result)
+
 def global_identity(x):
     return x
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-21-18-10-00.gh-issue-145064.p8Nq2v.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-21-18-10-00.gh-issue-145064.p8Nq2v.rst
@@ -1,0 +1,1 @@
+Fix a JIT crash in ``_Py_uop_frame_new()`` when tracing starts from non-function frames (for example ``_Py_InitCleanup`` shims) by using the traced code object directly and only storing function metadata when available.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -146,7 +146,7 @@ _PyOptimizer_Optimize(
     assert(!interp->compiling);
     assert(_tstate->jit_tracer_state->initial_state.stack_depth >= 0);
 #ifndef Py_GIL_DISABLED
-    assert(_tstate->jit_tracer_state->initial_state.func != NULL);
+    assert(_tstate->jit_tracer_state->initial_state.code != NULL);
     interp->compiling = true;
     // The first executor in a chain and the MAX_CHAIN_DEPTH'th executor *must*
     // make progress in order to avoid infinite loops or excessively-long
@@ -1020,7 +1020,10 @@ _PyJit_TryInitializeTracing(
     tracer->initial_state.start_instr = start_instr;
     tracer->initial_state.close_loop_instr = close_loop_instr;
     tracer->initial_state.code = (PyCodeObject *)Py_NewRef(code);
-    tracer->initial_state.func = (PyFunctionObject *)Py_NewRef(func);
+    // Tracing can start in shim frames (e.g. _Py_InitCleanup), where
+    // frame->f_funcobj is not a PyFunctionObject.
+    tracer->initial_state.func = PyFunction_Check(func) ?
+        (PyFunctionObject *)Py_NewRef(func) : NULL;
     tracer->initial_state.executor = (_PyExecutorObject *)Py_XNewRef(current_executor);
     tracer->initial_state.exit = exit;
     tracer->initial_state.stack_depth = (int)(stack_pointer - _PyFrame_Stackbase(frame));

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -458,6 +458,8 @@ optimize_uops(
 {
     assert(!PyErr_Occurred());
     assert(tstate->jit_tracer_state != NULL);
+    PyCodeObject *co = tstate->jit_tracer_state->initial_state.code;
+    assert(co != NULL);
     PyFunctionObject *func = tstate->jit_tracer_state->initial_state.func;
 
     JitOptContext *ctx = &tstate->jit_tracer_state->opt_context;
@@ -473,11 +475,13 @@ optimize_uops(
     }
 
     _Py_uop_abstractcontext_init(ctx, dependencies);
-    _Py_UOpsAbstractFrame *frame = _Py_uop_frame_new(ctx, (PyCodeObject *)func->func_code, NULL, 0);
+    _Py_UOpsAbstractFrame *frame = _Py_uop_frame_new(ctx, co, NULL, 0);
     if (frame == NULL) {
         return 0;
     }
-    frame->func = func;
+    if (func != NULL) {
+        frame->func = func;
+    }
     ctx->curr_frame_depth++;
     ctx->frame = frame;
     _Py_uop_sym_set_stack_depth(ctx, curr_stacklen, frame->stack_pointer);


### PR DESCRIPTION
## Summary of Changes

- Fixed a JIT crash path for issue #145064 gh-145064 where tracing could start from non-function frames (for example init-cleanup shim frames), which could lead to invalid assumptions about function/code availability.
- Updated `/Users/aviralgarg/Everything/cpython/Python/optimizer.c`:
  - Store `initial_state.func` only when `frame->f_funcobj` is a real `PyFunctionObject`.
  - Assert `initial_state.code` (always required) instead of assuming `initial_state.func` is always present.
- Updated `/Users/aviralgarg/Everything/cpython/Python/optimizer_analysis.c`:
  - Use `initial_state.code` directly when creating the abstract frame.
  - Keep `frame->func` optional and null-safe.
- Added regression coverage in `/Users/aviralgarg/Everything/cpython/Lib/test/test_capi/test_opt.py`:
  - New test: `test_145064`.
- Added NEWS entry:
  - `/Users/aviralgarg/Everything/cpython/Misc/NEWS.d/next/Core_and_Builtins/2026-02-21-18-10-00.gh-issue-145064.p8Nq2v.rst`

## Testing Logs

### Local build and checks

- Build directory: `/tmp/cpython-build-145064`
- Rebuilt JIT-enabled debug interpreter multiple times:
  - `make -j8` (successful)
- Style/check run:
  - `make patchcheck` (completed; local output also noted expected environment state and prompted about test/refleak confirmation)

### Targeted regression tests

- New regression test run multiple times:
  - `./python.exe -m test -j1 -v test_capi.test_opt --match test_145064`
  - Result: `OK` (run repeatedly, all passes)

### Related JIT regression tests

- `./python.exe -m test -j1 -v test_capi.test_opt --match test_143026` → `OK`
- `./python.exe -m test -j1 -v test_capi.test_opt --match test_143092` → `OK`
- `./python.exe -m test -j1 -v test_capi.test_opt --match test_143183` → `OK`
- `./python.exe -m test -j1 -v test_capi.test_opt --match test_143358` → `OK`
- `./python.exe -m test -j1 -v test_capi.test_opt --match test_144068_daemon_thread_jit_cleanup` → `OK`
- `./python.exe -m test -j1 -v test_optimizer` → `OK`

### Reproduction-command stress validation (issue command)

- Command exercised repeatedly:
  - `PYTHON_JIT=1 ./python.exe -m mypy --no-incremental --strict -c "pass"`
- Post-fix stress runs:
  - Three batches of 25 runs each (75 total): `PASS batch=1`, `PASS batch=2`, `PASS batch=3`
  - Additional 25-run verification batch: `PASS:25`

### CI status observed after push

- Branch: `gh-145064-jit-co-null-uop-frame`
- Commit: `29faba9f94`
- GitHub Actions:
  - `Lint` workflow: `success`
  - `JIT` workflow: in progress during observation (no failures reported at the time)
