### PR TITLE
docs: fix description of `function` parameter of `shutil.register_archive_format` 

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -691,7 +691,7 @@ provided.  They rely on the :mod:`zipfile` and :mod:`tarfile` modules.
 
    Register an archiver for the format *name*.
 
-   *function* is the callable that will be used to unpack archives. The callable
+   *function* is the callable that will be used to create archives. The callable
    will receive the *base_name* of the file to create, followed by the
    *base_dir* (which defaults to :data:`os.curdir`) to start archiving from.
    Further arguments are passed as keyword arguments: *owner*, *group*,


### PR DESCRIPTION
Both [`register_archive_format`](https://docs.python.org/3.15/library/shutil.html#shutil.register_archive_format) and [`register_unpack_format`](https://docs.python.org/3.15/library/shutil.html#shutil.register_unpack_format) describe their *function* parameter as

> *function* is the callable that will be used to unpack archives.

The former should instead read:

> *function* is the callable that will be used to **create** archives.

The docstring of `register_archive_format` describes it correctly:

https://github.com/python/cpython/blob/c9380aebbe35973528392ff85f8914eb4c626d5b/Lib/shutil.py#L1160-L1164

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145087.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->