### PR TITLE
gh-122941: Fix test_launcher sporadic failures via py.ini isolation

### DIFF
--- a/Lib/test/test_launcher.py
+++ b/Lib/test/test_launcher.py
@@ -228,7 +228,7 @@ class RunPyMixin:
             **{k.upper(): v for k, v in (env or {}).items()},
         }
         if ini_dir := getattr(self, '_ini_dir', None):
-            env.setdefault("PYLAUNCHER_INIDIR", ini_dir)
+            env.setdefault("_PYLAUNCHER_INIDIR", ini_dir)
         if not argv:
             argv = [self.py_exe, *args]
         with subprocess.Popen(

--- a/Lib/test/test_launcher.py
+++ b/Lib/test/test_launcher.py
@@ -227,6 +227,8 @@ class RunPyMixin:
             "PYLAUNCHER_LIMIT_TO_COMPANY": "",
             **{k.upper(): v for k, v in (env or {}).items()},
         }
+        if ini_dir := getattr(self, '_ini_dir', None):
+            env.setdefault("PYLAUNCHER_INIDIR", ini_dir)
         if not argv:
             argv = [self.py_exe, *args]
         with subprocess.Popen(
@@ -262,11 +264,14 @@ class RunPyMixin:
         return data
 
     def py_ini(self, content):
-        local_appdata = os.environ.get("LOCALAPPDATA")
-        if not local_appdata:
-            raise unittest.SkipTest("LOCALAPPDATA environment variable is "
-                                    "missing or empty")
-        return PreservePyIni(Path(local_appdata) / "py.ini", content)
+        ini_dir = getattr(self, '_ini_dir', None)
+        if not ini_dir:
+            local_appdata = os.environ.get("LOCALAPPDATA")
+            if not local_appdata:
+                raise unittest.SkipTest("LOCALAPPDATA environment variable is "
+                                        "missing or empty")
+            ini_dir = local_appdata
+        return PreservePyIni(Path(ini_dir) / "py.ini", content)
 
     @contextlib.contextmanager
     def script(self, content, encoding="utf-8"):
@@ -302,6 +307,8 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
             p = subprocess.check_output("reg query HKCU\\Software\\Python /s")
             #print(p.decode('mbcs'))
 
+        cls._ini_dir = tempfile.mkdtemp()
+        cls.addClassCleanup(shutil.rmtree, cls._ini_dir, ignore_errors=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/PC/launcher2.c
+++ b/PC/launcher2.c
@@ -922,8 +922,8 @@ _readIni(const wchar_t *section, const wchar_t *settingName, wchar_t *buffer, in
 {
     wchar_t iniPath[MAXLEN];
     int n;
-    // Check for PYLAUNCHER_INIDIR override (used for test isolation)
-    DWORD len = GetEnvironmentVariableW(L"PYLAUNCHER_INIDIR", iniPath, MAXLEN);
+    // Check for _PYLAUNCHER_INIDIR override (used for test isolation)
+    DWORD len = GetEnvironmentVariableW(L"_PYLAUNCHER_INIDIR", iniPath, MAXLEN);
     if (len && len < MAXLEN) {
         if (join(iniPath, MAXLEN, L"py.ini")) {
             debug(L"# Reading from %s for %s/%s\n", iniPath, section, settingName);
@@ -933,7 +933,7 @@ _readIni(const wchar_t *section, const wchar_t *settingName, wchar_t *buffer, in
                 return n;
             }
         }
-        // When PYLAUNCHER_INIDIR is set, skip the default locations
+        // When _PYLAUNCHER_INIDIR is set, skip the default locations
         return 0;
     }
     if (SUCCEEDED(SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, iniPath)) &&

--- a/PC/launcher2.c
+++ b/PC/launcher2.c
@@ -922,6 +922,20 @@ _readIni(const wchar_t *section, const wchar_t *settingName, wchar_t *buffer, in
 {
     wchar_t iniPath[MAXLEN];
     int n;
+    // Check for PYLAUNCHER_INIDIR override (used for test isolation)
+    DWORD len = GetEnvironmentVariableW(L"PYLAUNCHER_INIDIR", iniPath, MAXLEN);
+    if (len && len < MAXLEN) {
+        if (join(iniPath, MAXLEN, L"py.ini")) {
+            debug(L"# Reading from %s for %s/%s\n", iniPath, section, settingName);
+            n = GetPrivateProfileStringW(section, settingName, NULL, buffer, bufferLength, iniPath);
+            if (n) {
+                debug(L"# Found %s in %s\n", settingName, iniPath);
+                return n;
+            }
+        }
+        // When PYLAUNCHER_INIDIR is set, skip the default locations
+        return 0;
+    }
     if (SUCCEEDED(SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, iniPath)) &&
         join(iniPath, MAXLEN, L"py.ini")) {
         debug(L"# Reading from %s for %s/%s\n", iniPath, section, settingName);


### PR DESCRIPTION
Note: this PR was authored with assistance from Claude Code Opus 4.6

The launcher reads py.ini from `%LOCALAPPDATA%` via `SHGetFolderPathW`, which is shared across all processes for a given user. When multiple test processes run concurrently on the same machine, one process's `py.ini` writes leak into another process's launcher invocations, causing assertions like `"PythonCore != PythonTestSuite"` to fail.

Add a `PYLAUNCHER_INIDIR` environment variable to the launcher that, when set, redirects `py.ini` lookup to the specified directory and skips the default locations. Update `test_launcher.py` to create an isolated temp directory per test class and pass it via `PYLAUNCHER_INIDIR`.

I verified this fix on my Windows buildbot worker that's currently failing due to this issue.

```
PCbuild\amd64\python3.15t_d.exe -m test test_launcher -v
```

with this PR, all tests pass:

```
== CPython 3.15.0a6+ free-threading build (heads/windows-test-launcher-isolation:a8427d8c434, Feb 21 2026, 20:23:53) [MSC v.1950 64 bit (AMD64)]
== Windows-2022Server-10.0.20348-SP0 little-endian
== Python build: free_threading debug
== cwd: C:\Users\Administrator\cpython\build\test_python_worker_10400æ
== CPU count: 16
== encodings: locale=cp1252 FS=utf-8
== resources: all test resources are disabled, use -u option to unskip tests

Using random seed: 3074267489
0:00:00 Run 1 test sequentially in a single process
0:00:00 [1/1] test_launcher
test_filter_to_company (test.test_launcher.TestLauncher.test_filter_to_company) ... ok
test_filter_to_company_and_tag (test.test_launcher.TestLauncher.test_filter_to_company_and_tag) ... ok
test_filter_to_company_with_default (test.test_launcher.TestLauncher.test_filter_to_company_with_default) ... ok
test_filter_to_tag (test.test_launcher.TestLauncher.test_filter_to_tag) ... ok
test_filter_with_single_install (test.test_launcher.TestLauncher.test_filter_with_single_install) ... ok
test_help_option (test.test_launcher.TestLauncher.test_help_option) ... ok
test_install (test.test_launcher.TestLauncher.test_install) ... ok
test_list (test.test_launcher.TestLauncher.test_list) ... ok
test_list_option (test.test_launcher.TestLauncher.test_list_option) ... ok
test_list_paths (test.test_launcher.TestLauncher.test_list_paths) ... ok
test_literal_shebang_absolute (test.test_launcher.TestLauncher.test_literal_shebang_absolute) ... ok
test_literal_shebang_command (test.test_launcher.TestLauncher.test_literal_shebang_command) ... ok
test_literal_shebang_invalid_template (test.test_launcher.TestLauncher.test_literal_shebang_invalid_template) ... ok
test_literal_shebang_quoted (test.test_launcher.TestLauncher.test_literal_shebang_quoted) ... ok
test_literal_shebang_quoted_escape (test.test_launcher.TestLauncher.test_literal_shebang_quoted_escape) ... ok
test_literal_shebang_relative (test.test_launcher.TestLauncher.test_literal_shebang_relative) ... ok
test_py2_default (test.test_launcher.TestLauncher.test_py2_default) ... ok
test_py2_default_env (test.test_launcher.TestLauncher.test_py2_default_env) ... ok
test_py2_shebang (test.test_launcher.TestLauncher.test_py2_shebang) ... ok
test_py2_shebang_nl (test.test_launcher.TestLauncher.test_py2_shebang_nl) ... ok
test_py3_default (test.test_launcher.TestLauncher.test_py3_default) ... ok
test_py3_default_env (test.test_launcher.TestLauncher.test_py3_default_env) ... ok
test_py3_shebang (test.test_launcher.TestLauncher.test_py3_shebang) ... ok
test_py3_shebang_nl (test.test_launcher.TestLauncher.test_py3_shebang_nl) ... ok
test_py_default (test.test_launcher.TestLauncher.test_py_default) ... ok
test_py_default_env (test.test_launcher.TestLauncher.test_py_default_env) ... ok
test_py_default_in_list (test.test_launcher.TestLauncher.test_py_default_in_list) ... ok
test_py_default_short_argv0 (test.test_launcher.TestLauncher.test_py_default_short_argv0) ... ok
test_py_handle_64_in_ini (test.test_launcher.TestLauncher.test_py_handle_64_in_ini) ... ok
test_py_shebang (test.test_launcher.TestLauncher.test_py_shebang) ... ok
test_py_shebang_invalid_bom (test.test_launcher.TestLauncher.test_py_shebang_invalid_bom) ... ok
test_py_shebang_nl (test.test_launcher.TestLauncher.test_py_shebang_nl) ... ok
test_py_shebang_short_argv0 (test.test_launcher.TestLauncher.test_py_shebang_short_argv0) ... ok
test_py_shebang_valid_bom (test.test_launcher.TestLauncher.test_py_shebang_valid_bom) ... ok
test_python_shebang (test.test_launcher.TestLauncher.test_python_shebang) ... ok
test_recursive_search_path (test.test_launcher.TestLauncher.test_recursive_search_path) ... ok
test_search_major_2 (test.test_launcher.TestLauncher.test_search_major_2) ... skipped 'requires at least one Python 2.x install'
test_search_major_3 (test.test_launcher.TestLauncher.test_search_major_3) ... ok
test_search_major_3_32 (test.test_launcher.TestLauncher.test_search_major_3_32) ... skipped 'requires at least one 32-bit Python 3.x install'
test_search_path (test.test_launcher.TestLauncher.test_search_path) ... ok
test_search_path_exe (test.test_launcher.TestLauncher.test_search_path_exe) ... ok
test_shebang_command_in_venv (test.test_launcher.TestLauncher.test_shebang_command_in_venv) ... ok
test_shebang_executable_extension (test.test_launcher.TestLauncher.test_shebang_executable_extension) ... ok
test_version (test.test_launcher.TestLauncher.test_version) ... ok
test_virtualenv_in_list (test.test_launcher.TestLauncher.test_virtualenv_in_list) ... ok
test_virtualenv_with_env (test.test_launcher.TestLauncher.test_virtualenv_with_env) ... ok

----------------------------------------------------------------------
Ran 46 tests in 1.353s

OK (skipped=2)
0:00:01 [1/1] test_launcher passed

== Tests result: SUCCESS ==

1 test OK.

Total duration: 1.6 sec
Total tests: run=46 skipped=2
Total test files: run=1/1
Result: SUCCESS
```

without it, 2 tests fail:

```
== CPython 3.15.0a6+ free-threading build (heads/main:c9380aebbe3, Feb 21 2026, 18:29:02) [MSC v.1950 64 bit (AMD64)]
== Windows-2022Server-10.0.20348-SP0 little-endian
== Python build: free_threading debug
== cwd: C:\Users\Administrator\cpython\build\test_python_worker_4368æ
== CPU count: 16
== encodings: locale=cp1252 FS=utf-8
== resources: all test resources are disabled, use -u option to unskip tests

Using random seed: 3866893247
0:00:00 Run 1 test sequentially in a single process
0:00:00 [1/1] test_launcher
test_filter_to_company (test.test_launcher.TestLauncher.test_filter_to_company) ... ok
test_filter_to_company_and_tag (test.test_launcher.TestLauncher.test_filter_to_company_and_tag) ... ok
test_filter_to_company_with_default (test.test_launcher.TestLauncher.test_filter_to_company_with_default) ... ok
test_filter_to_tag (test.test_launcher.TestLauncher.test_filter_to_tag) ... ok
test_filter_with_single_install (test.test_launcher.TestLauncher.test_filter_with_single_install) ... ok
test_help_option (test.test_launcher.TestLauncher.test_help_option) ... ok
test_install (test.test_launcher.TestLauncher.test_install) ... ok
test_list (test.test_launcher.TestLauncher.test_list) ... ok
test_list_option (test.test_launcher.TestLauncher.test_list_option) ... ok
test_list_paths (test.test_launcher.TestLauncher.test_list_paths) ... ok
test_literal_shebang_absolute (test.test_launcher.TestLauncher.test_literal_shebang_absolute) ... ok
test_literal_shebang_command (test.test_launcher.TestLauncher.test_literal_shebang_command) ... ok
test_literal_shebang_invalid_template (test.test_launcher.TestLauncher.test_literal_shebang_invalid_template) ... ok
test_literal_shebang_quoted (test.test_launcher.TestLauncher.test_literal_shebang_quoted) ... ok
test_literal_shebang_quoted_escape (test.test_launcher.TestLauncher.test_literal_shebang_quoted_escape) ... ok
test_literal_shebang_relative (test.test_launcher.TestLauncher.test_literal_shebang_relative) ... ok
test_py2_default (test.test_launcher.TestLauncher.test_py2_default) ... ok
test_py2_default_env (test.test_launcher.TestLauncher.test_py2_default_env) ... ok
test_py2_shebang (test.test_launcher.TestLauncher.test_py2_shebang) ... ok
test_py2_shebang_nl (test.test_launcher.TestLauncher.test_py2_shebang_nl) ... ok
test_py3_default (test.test_launcher.TestLauncher.test_py3_default) ... ok
test_py3_default_env (test.test_launcher.TestLauncher.test_py3_default_env) ... ok
test_py3_shebang (test.test_launcher.TestLauncher.test_py3_shebang) ... ok
test_py3_shebang_nl (test.test_launcher.TestLauncher.test_py3_shebang_nl) ... ok
test_py_default (test.test_launcher.TestLauncher.test_py_default) ... ok
test_py_default_env (test.test_launcher.TestLauncher.test_py_default_env) ... ok
test_py_default_in_list (test.test_launcher.TestLauncher.test_py_default_in_list) ... ok
test_py_default_short_argv0 (test.test_launcher.TestLauncher.test_py_default_short_argv0) ... ok
test_py_handle_64_in_ini (test.test_launcher.TestLauncher.test_py_handle_64_in_ini) ... ok
test_py_shebang (test.test_launcher.TestLauncher.test_py_shebang) ... ok
test_py_shebang_invalid_bom (test.test_launcher.TestLauncher.test_py_shebang_invalid_bom) ... ok
test_py_shebang_nl (test.test_launcher.TestLauncher.test_py_shebang_nl) ... ok
test_py_shebang_short_argv0 (test.test_launcher.TestLauncher.test_py_shebang_short_argv0) ... ok
test_py_shebang_valid_bom (test.test_launcher.TestLauncher.test_py_shebang_valid_bom) ... ok
test_python_shebang (test.test_launcher.TestLauncher.test_python_shebang) ... ok
test_recursive_search_path (test.test_launcher.TestLauncher.test_recursive_search_path) ... ok
test_search_major_2 (test.test_launcher.TestLauncher.test_search_major_2) ... FAIL
test_search_major_3 (test.test_launcher.TestLauncher.test_search_major_3) ... FAIL
test_search_major_3_32 (test.test_launcher.TestLauncher.test_search_major_3_32) ... skipped 'requires at least one 32-bit Python 3.x install'
test_search_path (test.test_launcher.TestLauncher.test_search_path) ... ok
test_search_path_exe (test.test_launcher.TestLauncher.test_search_path_exe) ... ok
test_shebang_command_in_venv (test.test_launcher.TestLauncher.test_shebang_command_in_venv) ... ok
test_shebang_executable_extension (test.test_launcher.TestLauncher.test_shebang_executable_extension) ... ok
test_version (test.test_launcher.TestLauncher.test_version) ... ok
test_virtualenv_in_list (test.test_launcher.TestLauncher.test_virtualenv_in_list) ... ok
test_virtualenv_with_env (test.test_launcher.TestLauncher.test_virtualenv_with_env) ... ok

======================================================================
FAIL: test_search_major_2 (test.test_launcher.TestLauncher.test_search_major_2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\Administrator\cpython\Lib\test\test_launcher.py", line 465, in test_search_major_2
    self.assertEqual("PythonCore", data["env.company"])
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 'PythonCore' != 'PythonTestSuite'
- PythonCore
+ PythonTestSuite


======================================================================
FAIL: test_search_major_3 (test.test_launcher.TestLauncher.test_search_major_3)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\Administrator\cpython\Lib\test\test_launcher.py", line 445, in test_search_major_3
    self.assertEqual("PythonCore", data["env.company"])
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 'PythonCore' != 'PythonTestSuite'
- PythonCore
+ PythonTestSuite


----------------------------------------------------------------------
Ran 46 tests in 1.302s

FAILED (failures=2, skipped=1)
test test_launcher failed
0:00:01 [1/1/1] test_launcher failed (2 failures)

== Tests result: FAILURE ==

1 test failed:
    test_launcher

Total duration: 1.5 sec
Total tests: run=46 failures=2 skipped=1
Total test files: run=1/1 failed=1
Result: FAILURE
```

<!-- gh-issue-number: gh-122941 -->
* Issue: gh-122941
<!-- /gh-issue-number -->
