### PR TITLE
gh-145092: fix discards const qualifier from pointer

### DIFF
--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -69,8 +69,8 @@ STRINGLIB(find_char)(const STRINGLIB_CHAR* s, Py_ssize_t n, STRINGLIB_CHAR ch)
            and UCS4 representations. */
         if (needle != 0) {
             do {
-                void *candidate = memchr(p, needle,
-                                         (e - p) * sizeof(STRINGLIB_CHAR));
+                const void *candidate = memchr(p, needle,
+                                               (e - p) * sizeof(STRINGLIB_CHAR));
                 if (candidate == NULL)
                     return -1;
                 s1 = p;

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -584,7 +584,7 @@ _Py_get_xoption(const PyWideStringList *xoptions, const wchar_t *name)
     for (Py_ssize_t i=0; i < xoptions->length; i++) {
         const wchar_t *option = xoptions->items[i];
         size_t len;
-        wchar_t *sep = wcschr(option, L'=');
+        const wchar_t *sep = wcschr(option, L'=');
         if (sep != NULL) {
             len = (sep - option);
         }
@@ -615,7 +615,7 @@ preconfig_init_utf8_mode(PyPreConfig *config, const _PyPreCmdline *cmdline)
     const wchar_t *xopt;
     xopt = _Py_get_xoption(&cmdline->xoptions, L"utf8");
     if (xopt) {
-        wchar_t *sep = wcschr(xopt, L'=');
+        const wchar_t *sep = wcschr(xopt, L'=');
         if (sep) {
             xopt = sep + 1;
             if (wcscmp(xopt, L"1") == 0) {


### PR DESCRIPTION
# Pull Request title 

- fixes #145092 
- fixes #145094
- fix discards const qualifier from pointer

# Description

Since glibc-2.43 and ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

wchar_t * pointer returns are only being used for comparisons so declare then as const, which matches the input variables.

<!-- gh-issue-number: gh-145092 -->
* Issue: gh-145092
<!-- /gh-issue-number -->
