### PR TITLE
gh-145092: fix discards const qualifier from pointer

### DIFF
--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -69,8 +69,8 @@ STRINGLIB(find_char)(const STRINGLIB_CHAR* s, Py_ssize_t n, STRINGLIB_CHAR ch)
            and UCS4 representations. */
         if (needle != 0) {
             do {
-                void *candidate = memchr(p, needle,
-                                         (e - p) * sizeof(STRINGLIB_CHAR));
+                const void *candidate = memchr(p, needle,
+                                               (e - p) * sizeof(STRINGLIB_CHAR));
                 if (candidate == NULL)
                     return -1;
                 s1 = p;


### PR DESCRIPTION
Since glibc-2.43 and ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

candidate * pointer returns are only being used for comparisons so declare them as const, which matches the input variables.


<!-- gh-issue-number: gh-145092 -->
* Issue: gh-145092
<!-- /gh-issue-number -->
