### PR TITLE
gh-145064:  Fix JIT assertion failure during CALL_ALLOC_AND_ENTER_INIT side exit

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-22-07-51-10.gh-issue-145064.iIMGKA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-22-07-51-10.gh-issue-145064.iIMGKA.rst
@@ -1,0 +1,1 @@
+Fix JIT optimizer assertion failure during ``CALL_ALLOC_AND_ENTER_INIT`` side exit.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -993,7 +993,7 @@ _PyJit_TryInitializeTracing(
         return 0;
     }
     PyObject *func = PyStackRef_AsPyObjectBorrow(frame->f_funcobj);
-    if (func == NULL) {
+    if (func == NULL || !PyFunction_Check(func)) {
         return 0;
     }
     PyCodeObject *code = _PyFrame_GetCode(frame);


### PR DESCRIPTION
When `CALL_ALLOC_AND_ENTER_INIT` creates an instance of a heap type (with `__slots__` and `tp_new == object.__new__`), it pushes a shim frame via `_PyFrame_PushTrampolineUnchecked`. This shim frame has `f_funcobj = Py_None`:
https://github.com/python/cpython/blob/2be2dd5fc219a5c252d72f351c85db14314bfca5/Include/internal/pycore_interpframe.h#L368

If a JIT trace runs out of buffer space exactly at this shim frame's `EXIT_INIT_CHECK` instruction, the `_EXIT_TRACE` terminator hands off to a `_COLD_EXIT` executor, which calls `_PyJit_TryInitializeTracing()` with the shim frame. The existing guard only checked `func == NULL`, but `Py_None` is not NULL, so control falls through  which casue assertion crash.

<!-- gh-issue-number: gh-145064 -->
* Issue: gh-145064
<!-- /gh-issue-number -->
