### PR TITLE
gh-145105: Fix crash in csv.reader with re-entrant iterator

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -553,6 +553,33 @@ class Test_Csv(unittest.TestCase):
                         self.assertEqual(row, rows[i])
 
 
+    def test_reader_reentrant_iterator(self):
+        # gh-145105: re-entering the reader from the iterator must not crash.
+        class ReentrantIter:
+            def __init__(self):
+                self.reader = None
+                self.n = 0
+            def __iter__(self):
+                return self
+            def __next__(self):
+                self.n += 1
+                if self.n == 1:
+                    try:
+                        next(self.reader)
+                    except StopIteration:
+                        pass
+                    return "a,b"
+                if self.n == 2:
+                    return "x"
+                raise StopIteration
+
+        it = ReentrantIter()
+        reader = csv.reader(it)
+        it.reader = reader
+        with self.assertRaises(csv.Error):
+            next(reader)
+
+
 class TestDialectRegistry(unittest.TestCase):
     def test_registry_badargs(self):
         self.assertRaises(TypeError, csv.list_dialects, None)

--- a/Misc/NEWS.d/next/Library/2026-02-22-00-00-00.gh-issue-145105.csv-reader-reentrant.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-22-00-00-00.gh-issue-145105.csv-reader-reentrant.rst
@@ -1,0 +1,2 @@
+Fix crash in :mod:`csv` reader when iterating with a re-entrant iterator
+that calls :func:`next` on the same reader from within ``__next__``.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -961,6 +961,12 @@ Reader_iternext_lock_held(PyObject *op)
             Py_DECREF(lineobj);
             return NULL;
         }
+        if (self->fields == NULL) {
+            PyErr_SetString(module_state->error_obj,
+                            "iterator has already advanced the reader");
+            Py_DECREF(lineobj);
+            return NULL;
+        }
         ++self->line_num;
         kind = PyUnicode_KIND(lineobj);
         data = PyUnicode_DATA(lineobj);


### PR DESCRIPTION
The fix adds a guard right after `PyIter_Next` returns: if
`self->fields` has been set to `NULL` by a re-entrant call, raise
`csv.Error` instead of continuing into `parse_process_char`.



<!-- gh-issue-number: gh-145105 -->
* Issue: gh-145105