### PR TITLE
GH-145110: fix arguments `Clean` and `CleanAll` for argument `-t` of `batch.bat` in case of PGO builds on Windows

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-02-22-13-35-20.gh-issue-145110.KgWofW.rst
+++ b/Misc/NEWS.d/next/Build/2026-02-22-13-35-20.gh-issue-145110.KgWofW.rst
@@ -1,0 +1,2 @@
+Fix targets "Clean" and "CLeanAll" in case of PGO builds on Windows. Patch by
+Chris Eibl.


### PR DESCRIPTION
In case of `Clean` or `CleanAll`, the
- the pgo_job must not be invoked
- and the target must not be switched to `Build`


<!-- gh-issue-number: gh-145110 -->
* Issue: gh-145110
<!-- /gh-issue-number -->
