### PR TITLE
gh-145113: Use {} instead of dict() in Tools/cases_generator/record_function_generator.py and Tools/peg_generator/pegen/first_sets.py

### DIFF
--- a/Tools/cases_generator/record_function_generator.py
+++ b/Tools/cases_generator/record_function_generator.py
@@ -62,7 +62,7 @@ def generate_recorder_functions(filenames: list[str], analysis: Analysis, out: C
     emitter = RecorderEmitter(out)
     func_count = 0
     nop = analysis.instructions["NOP"]
-    function_table: dict[str, int] = dict()
+    function_table: dict[str, int] = {}
     for name, uop in analysis.uops.items():
         if not uop.properties.records_value:
             continue
@@ -80,7 +80,7 @@ def generate_recorder_functions(filenames: list[str], analysis: Analysis, out: C
         out.emit("\n\n")
 
 def generate_recorder_tables(analysis: Analysis, out: CWriter) -> None:
-    record_function_indexes: dict[str, int] = dict()
+    record_function_indexes: dict[str, int] = {}
     record_table: dict[str, str] = {}
     index = 1
     for inst in analysis.instructions.values():

--- a/Tools/peg_generator/pegen/first_sets.py
+++ b/Tools/peg_generator/pegen/first_sets.py
@@ -35,7 +35,7 @@ class FirstSetCalculator(GrammarVisitor):
     def __init__(self, rules: dict[str, Rule]) -> None:
         self.rules = rules
         self.nullables = compute_nullables(rules)
-        self.first_sets: dict[str, set[str]] = dict()
+        self.first_sets: dict[str, set[str]] = {}
         self.in_process: set[str] = set()
 
     def calculate(self) -> dict[str, set[str]]:


### PR DESCRIPTION
# Use {} instead of dict() in Tools/cases_generator/record_function_generator.py and Tools/peg_generator/pegen/first_sets.py
I suggest that using {} instead of dict() in Tools/cases_generator/record_function_generator.py and Tools/peg_generator/pegen/first_sets.py should be a little bit better for performance and should be the same in terms of semantics, so I guess that changing this would be a nice and quick fix. 👍

<!-- gh-issue-number: gh-145113 -->
* Issue: gh-145113
<!-- /gh-issue-number -->
