### PR TITLE
gh-145117: Fix pprint.isreadable() returning True for inf/nan

### DIFF
--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -627,7 +627,10 @@ class PrettyPrinter:
         # Return triple (repr_string, isreadable, isrecursive).
         typ = type(object)
         if typ in _builtin_scalars:
-            return repr(object), True, False
+            rep = repr(object)
+            if typ is float and rep in ("inf", "-inf", "nan"):
+                return rep, False, False
+            return rep, True, False
 
         r = getattr(typ, "__repr__", None)
 

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -182,6 +182,14 @@ class QueryTestCase(unittest.TestCase):
             self.assertTrue(pp.isreadable(safe),
                             "expected isreadable for %r" % (safe,))
 
+    def test_isreadable_float_specials(self):
+        # inf, -inf, nan are not valid Python literals so isreadable should be False
+        for v in (float("inf"), float("-inf"), float("nan")):
+            self.assertFalse(pprint.isreadable(v),
+                             "expected not isreadable for %r" % (v,))
+            self.assertFalse(pprint.PrettyPrinter().isreadable(v),
+                             "expected not isreadable for %r" % (v,))
+
     def test_stdout_is_None(self):
         with contextlib.redirect_stdout(None):
             # smoke test - there is no output to check

--- a/Misc/NEWS.d/next/Library/2026-02-22-00-00-00.gh-issue-145117.pPrint.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-22-00-00-00.gh-issue-145117.pPrint.rst
@@ -1,0 +1,5 @@
+Fix :func:`pprint.isreadable` to return ``False`` for ``float('inf')``,
+``float('-inf')``, and ``float('nan')``. Their string representations
+(``inf``, ``-inf``, ``nan``) are not valid Python literals and cannot
+be reconstructed via :func:`eval`, violating the documented contract of
+:func:`~pprint.isreadable`.


### PR DESCRIPTION
## Problem

`pprint.isreadable()` returns `True` for `float('inf')`, `float('-inf')`, and `float('nan')`, but their `repr()` values are not valid Python literals — `eval()` raises `NameError`. The documented contract of `isreadable` is that the representation can be used to recreate the value via `eval()`.

## Reproducer

```python
import pprint
print(pprint.isreadable(float('inf')))  # True — but eval('inf') raises NameError
```

## Fix

In `Lib/pprint.py`, in `_safe_repr`, add a check for float specials and return `readable=False` for them.

<!-- gh-issue-number: gh-145117 -->
* Issue: gh-145117
<!-- /gh-issue-number -->
