### PR TITLE
[3.13] Add Savannah as `jit.yml` CODEOWNER (GH-145152)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # GitHub
 .github/**                    @ezio-melotti @hugovk @webknjaz
-.github/workflows/jit.yml.    @savannahostrowski
+.github/workflows/jit.yml    @savannahostrowski
 Tools/build/compute-changes.py              @AA-Turner @hugovk @webknjaz
 Lib/test/test_tools/test_compute_changes.py @AA-Turner @hugovk @webknjaz
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 
 # GitHub
 .github/**                    @ezio-melotti @hugovk @webknjaz
+.github/workflows/jit.yml.    @savannahostrowski
 Tools/build/compute-changes.py              @AA-Turner @hugovk @webknjaz
 Lib/test/test_tools/test_compute_changes.py @AA-Turner @hugovk @webknjaz
 
@@ -23,7 +24,7 @@ configure*                    @erlend-aasland @corona10
 **/*context*                  @1st1
 **/*genobject*                @markshannon
 **/*hamt*                     @1st1
-**/*jit*                      @brandtbucher
+**/*jit*                      @brandtbucher @savannahostrowski
 Python/perf_jit_trampoline.c  # Exclude the owners of "**/*jit*", above.
 Objects/set*                  @rhettinger
 Objects/dict*                 @methane @markshannon


### PR DESCRIPTION
Add Savannah for jit.yml CODEOWNER

(cherry picked from commit 6180e79ed2175f7b095807b78a5ea58b4da3de0b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Let me know if it's not okay to squeeze in adding myself to general JIT codeowners (I'm kind of surprised I'm not already but I guess I never backported to 3.13 in the first place).