### PR TITLE
`_struct.c`: Fix UB from integer overflow in `prepare_s`

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -552,6 +552,9 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         hugecount2 = '{}b{}H'.format(sys.maxsize//2, sys.maxsize//2)
         self.assertRaises(struct.error, struct.calcsize, hugecount2)
 
+        hugecount3 = '{}i{}q'.format(sys.maxsize // 4, sys.maxsize // 8)
+        self.assertRaises(struct.error, struct.calcsize, hugecount3)
+
     def test_trailing_counter(self):
         store = array.array('b', b' '*100)
 

--- a/Misc/NEWS.d/next/Library/2026-02-23-20-52-55.gh-issue-145158.vWJtxI.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-23-20-52-55.gh-issue-145158.vWJtxI.rst
@@ -1,0 +1,2 @@
+Avoid undefined behaviour from signed integer overflow when parsing format
+strings in the :mod:`struct` module.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1678,7 +1678,15 @@ prepare_s(PyStructObject *self)
             case 's': _Py_FALLTHROUGH;
             case 'p': len++; ncodes++; break;
             case 'x': break;
-            default: len += num; if (num) ncodes++; break;
+            default:
+                if (num > PY_SSIZE_T_MAX - len) {
+                    goto overflow;
+                }
+                len += num;
+                if (num) {
+                    ncodes++;
+                }
+                break;
         }
 
         itemsize = e->size;


### PR DESCRIPTION
Caught by OSS-Fuzz, see https://issues.oss-fuzz.com/issues/466669135.
```
stan@stanlaptop:~/dev/cpython{main}$ ./python -c 'import struct; struct.Struct("6107082938247334i9221070829382473344q")'
Modules/_struct.c:1681:26: runtime error: signed integer overflow: 6107082938247334 + 9221070829382473344 cannot be represented in type 'long int'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import struct; struct.Struct("6107082938247334i9221070829382473344q")
                   ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
struct.error: total struct size too long
```
Skipping news, since there shouldn't be any user-visible change, although I can add one if people prefer.