### PR TITLE
gh-145166: Fix crash in tzinfo.fromutc() when subclass __new__ returns non-datetime

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -1348,11 +1348,22 @@ class tzinfo:
         delta = dtoff - dtdst
         if delta:
             dt += delta
+            if not isinstance(dt, datetime):
+                raise TypeError(
+                    f"datetime arithmetic on a subclass returned non-datetime "
+                    f"(type {type(dt).__name__})"
+                )
             dtdst = dt.dst()
             if dtdst is None:
                 raise ValueError("fromutc(): dt.dst gave inconsistent "
                                  "results; cannot convert")
-        return dt + dtdst
+        result = dt + dtdst
+        if not isinstance(result, datetime):
+            raise TypeError(
+                f"datetime arithmetic on a subclass returned non-datetime "
+                f"(type {type(result).__name__})"
+            )
+        return result
 
     # Pickle support.
 
@@ -2063,6 +2074,11 @@ class datetime(date):
         offset = self.utcoffset()
         if offset:
             self -= offset
+            if not isinstance(self, datetime):
+                raise TypeError(
+                    f"datetime arithmetic on a subclass returned non-datetime "
+                    f"(type {type(self).__name__})"
+                )
         y, m, d = self.year, self.month, self.day
         hh, mm, ss = self.hour, self.minute, self.second
         return _build_struct_time(y, m, d, hh, mm, ss, 0)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -5133,6 +5133,68 @@ class TestDateTimeTZ(TestDateTime, TZInfoBase, unittest.TestCase):
             self.assertEqual(derived.tzname(), 'cookie')
         self.assertEqual(orig.__reduce__(), orig.__reduce_ex__(2))
 
+    def test_fromutc_subclass_new_returns_non_datetime(self):
+        call_count = 0
+
+        class EvilDatetime(self.theclass):
+            def __new__(cls, *args, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                if call_count > 1:
+                    return bytearray(b'\x00' * 200)
+                return super().__new__(cls, *args, **kwargs)
+
+        class SimpleTZ(tzinfo):
+            def utcoffset(self, dt): return timedelta(hours=1)
+            def dst(self, dt):       return timedelta(hours=1)
+            def tzname(self, dt):    return "Test"
+
+        tz = SimpleTZ()
+        dt = EvilDatetime(2000, 1, 1, 12, 0, 0, tzinfo=tz)
+        with self.assertRaises(TypeError):
+            tz.fromutc(dt)
+
+    def test_fromutc_subclass_new_returns_non_datetime_with_delta(self):
+        call_count = 0
+
+        class EvilDatetime(self.theclass):
+            def __new__(cls, *args, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                if call_count > 1:
+                    return bytearray(b'\x00' * 200)
+                return super().__new__(cls, *args, **kwargs)
+        class SimpleTZ(tzinfo):
+            def utcoffset(self, dt): return timedelta(hours=2)
+            def dst(self, dt):       return timedelta(hours=1)
+            def tzname(self, dt):    return "Test"
+
+        tz = SimpleTZ()
+        dt = EvilDatetime(2000, 1, 1, 12, 0, 0, tzinfo=tz)
+        with self.assertRaises(TypeError):
+            tz.fromutc(dt)
+
+    def test_utctimetuple_subclass_new_returns_non_datetime(self):
+        call_count = 0
+
+        class EvilDatetime(self.theclass):
+            def __new__(cls, *args, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                if call_count > 1:
+                    return bytearray(b'\x00' * 200)
+                return super().__new__(cls, *args, **kwargs)
+
+        class SimpleTZ(tzinfo):
+            def utcoffset(self, dt): return timedelta(hours=5)
+            def dst(self, dt):       return timedelta(0)
+            def tzname(self, dt):    return "Test"
+
+        tz = SimpleTZ()
+        dt = EvilDatetime(2000, 6, 15, 12, 0, 0, tzinfo=tz)
+        with self.assertRaises(TypeError):
+            dt.utctimetuple()
+
     def test_compat_unpickle(self):
         tests = [
             b'cdatetime\ndatetime\n'

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -5133,16 +5133,17 @@ class TestDateTimeTZ(TestDateTime, TZInfoBase, unittest.TestCase):
             self.assertEqual(derived.tzname(), 'cookie')
         self.assertEqual(orig.__reduce__(), orig.__reduce_ex__(2))
 
-    def test_fromutc_subclass_new_returns_non_datetime(self):
-        call_count = 0
-
+    def _make_evil_datetime_class(self):
         class EvilDatetime(self.theclass):
+            sabotage = False
             def __new__(cls, *args, **kwargs):
-                nonlocal call_count
-                call_count += 1
-                if call_count > 1:
+                if cls.sabotage:
                     return bytearray(b'\x00' * 200)
                 return super().__new__(cls, *args, **kwargs)
+        return EvilDatetime
+
+    def test_fromutc_subclass_new_returns_non_datetime(self):
+        EvilDatetime = self._make_evil_datetime_class()
 
         class SimpleTZ(tzinfo):
             def utcoffset(self, dt): return timedelta(hours=1)
@@ -5151,19 +5152,13 @@ class TestDateTimeTZ(TestDateTime, TZInfoBase, unittest.TestCase):
 
         tz = SimpleTZ()
         dt = EvilDatetime(2000, 1, 1, 12, 0, 0, tzinfo=tz)
+        EvilDatetime.sabotage = True
         with self.assertRaises(TypeError):
             tz.fromutc(dt)
 
     def test_fromutc_subclass_new_returns_non_datetime_with_delta(self):
-        call_count = 0
+        EvilDatetime = self._make_evil_datetime_class()
 
-        class EvilDatetime(self.theclass):
-            def __new__(cls, *args, **kwargs):
-                nonlocal call_count
-                call_count += 1
-                if call_count > 1:
-                    return bytearray(b'\x00' * 200)
-                return super().__new__(cls, *args, **kwargs)
         class SimpleTZ(tzinfo):
             def utcoffset(self, dt): return timedelta(hours=2)
             def dst(self, dt):       return timedelta(hours=1)
@@ -5171,19 +5166,12 @@ class TestDateTimeTZ(TestDateTime, TZInfoBase, unittest.TestCase):
 
         tz = SimpleTZ()
         dt = EvilDatetime(2000, 1, 1, 12, 0, 0, tzinfo=tz)
+        EvilDatetime.sabotage = True
         with self.assertRaises(TypeError):
             tz.fromutc(dt)
 
     def test_utctimetuple_subclass_new_returns_non_datetime(self):
-        call_count = 0
-
-        class EvilDatetime(self.theclass):
-            def __new__(cls, *args, **kwargs):
-                nonlocal call_count
-                call_count += 1
-                if call_count > 1:
-                    return bytearray(b'\x00' * 200)
-                return super().__new__(cls, *args, **kwargs)
+        EvilDatetime = self._make_evil_datetime_class()
 
         class SimpleTZ(tzinfo):
             def utcoffset(self, dt): return timedelta(hours=5)
@@ -5192,6 +5180,7 @@ class TestDateTimeTZ(TestDateTime, TZInfoBase, unittest.TestCase):
 
         tz = SimpleTZ()
         dt = EvilDatetime(2000, 6, 15, 12, 0, 0, tzinfo=tz)
+        EvilDatetime.sabotage = True
         with self.assertRaises(TypeError):
             dt.utctimetuple()
 

--- a/Misc/NEWS.d/next/Library/2026-02-24-19-14-43.gh-issue-145166.bG_Rp2.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-24-19-14-43.gh-issue-145166.bG_Rp2.rst
@@ -1,0 +1,4 @@
+Fix crash in :meth:`datetime.tzinfo.fromutc` and
+:meth:`datetime.datetime.utctimetuple` when a
+:class:`~datetime.datetime` subclass ``__new__`` returns a non-datetime
+object. A :exc:`TypeError` is now raised instead.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4168,7 +4168,6 @@ tzinfo_fromutc(PyObject *self, PyObject *dt)
     result = add_datetime_timedelta((PyDateTime_DateTime *)dt, delta, 1);
     if (result == NULL)
         goto Fail;
-
     Py_DECREF(dst);
     dst = call_dst(GET_DT_TZINFO(dt), result);
     if (dst == NULL)
@@ -6210,11 +6209,20 @@ add_datetime_timedelta(PyDateTime_DateTime *date, PyDateTime_Delta *delta,
         return NULL;
     }
 
-    return new_datetime_subclass_ex(year, month, day,
-                                    hour, minute, second, microsecond,
-                                    HASTZINFO(date) ? date->tzinfo : Py_None,
-                                    Py_TYPE(date));
-}
+    PyObject *result = new_datetime_subclass_ex(year, month, day,
+                                        hour, minute, second, microsecond,
+                                        HASTZINFO(date) ? date->tzinfo : Py_None,
+                                        Py_TYPE(date));
+        if (result != NULL && !PyDateTime_Check(result)) {
+            PyErr_Format(PyExc_TypeError,
+                        "datetime arithmetic on a subclass returned "
+                        "non-datetime (type %.200s)",
+                        Py_TYPE(result)->tp_name);
+            Py_DECREF(result);
+            return NULL;
+        }
+        return result;
+    }
 
 static PyObject *
 datetime_add(PyObject *left, PyObject *right)

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4168,6 +4168,7 @@ tzinfo_fromutc(PyObject *self, PyObject *dt)
     result = add_datetime_timedelta((PyDateTime_DateTime *)dt, delta, 1);
     if (result == NULL)
         goto Fail;
+
     Py_DECREF(dst);
     dst = call_dst(GET_DT_TZINFO(dt), result);
     if (dst == NULL)
@@ -6210,14 +6211,14 @@ add_datetime_timedelta(PyDateTime_DateTime *date, PyDateTime_Delta *delta,
     }
 
     PyObject *result = new_datetime_subclass_ex(year, month, day,
-                                        hour, minute, second, microsecond,
-                                        HASTZINFO(date) ? date->tzinfo : Py_None,
-                                        Py_TYPE(date));
-        if (result != NULL && !PyDateTime_Check(result)) {
-            PyErr_Format(PyExc_TypeError,
-                        "datetime arithmetic on a subclass returned "
-                        "non-datetime (type %.200s)",
-                        Py_TYPE(result)->tp_name);
+                                                hour, minute, second, microsecond,
+                                                HASTZINFO(date) ? date->tzinfo : Py_None,
+                                                Py_TYPE(date));
+    if (result != NULL && !PyDateTime_Check(result)) {
+        PyErr_Format(PyExc_TypeError,
+                     "datetime arithmetic on a subclass returned "
+                     "non-datetime (type %.200s)",
+                     Py_TYPE(result)->tp_name);
             Py_DECREF(result);
             return NULL;
         }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6215,10 +6215,10 @@ add_datetime_timedelta(PyDateTime_DateTime *date, PyDateTime_Delta *delta,
                                                 HASTZINFO(date) ? date->tzinfo : Py_None,
                                                 Py_TYPE(date));
     if (result != NULL && !PyDateTime_Check(result)) {
-        PyErr_Format(PyExc_TypeError,
-                     "datetime arithmetic on a subclass returned "
-                     "non-datetime (type %.200s)",
-                     Py_TYPE(result)->tp_name);
+            PyErr_Format(PyExc_TypeError,
+                        "datetime arithmetic on a subclass returned "
+                        "non-datetime (type %T)",
+                        result);
             Py_DECREF(result);
             return NULL;
         }


### PR DESCRIPTION
<!-- gh-145166 -->

### Problem
In `tzinfo_fromutc()`, the result of `add_datetime_timedelta()` is cast
to `PyDateTime_DateTime*` without a type check. If a `datetime` subclass
`__new__` returns a non-datetime object, the interpreter crashes with
`SIGABRT` due to out-of-bounds memory reads inside `normalize_y_m_d()`.

### Fix
- Added `PyDateTime_Check()` after both calls to `add_datetime_timedelta()`
  in `Modules/_datetimemodule.c` - raises `TypeError` instead of crashing
- Added equivalent `isinstance()` checks in `Lib/_pydatetime.py`
- Added regression test in `Lib/test/datetimetester.py`

### Testing
Regression test passes for both `TestDateTimeTZ_Pure` and `TestDateTimeTZ_Fast`.