### PR TITLE
gh-144942: Fix macOS dylib build by adding $(MODLIBS) and removing -undefined dy…

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1034,7 +1034,7 @@ libpython3.so:	libpython$(LDVERSION).so
 	$(BLDSHARED) $(NO_AS_NEEDED) -o $@ -Wl,-h$@ $^
 
 libpython$(LDVERSION).dylib: $(LIBRARY_OBJS)
-	 $(CC) -dynamiclib $(PY_CORE_LDFLAGS) -undefined dynamic_lookup -Wl,-install_name,$(prefix)/lib/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(DTRACE_OBJS) $(SHLIBS) $(LIBC) $(LIBM); \
+	 $(CC) -dynamiclib $(PY_CORE_LDFLAGS) -Wl,-install_name,$(prefix)/lib/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(MODLIBS) $(DTRACE_OBJS) $(SHLIBS) $(LIBC) $(LIBM); \
 
 
 libpython$(VERSION).sl: $(LIBRARY_OBJS)

--- a/Misc/NEWS.d/next/macOS/2026-02-25-07-20-00.gh-issue-144942.H7g6F5.rst
+++ b/Misc/NEWS.d/next/macOS/2026-02-25-07-20-00.gh-issue-144942.H7g6F5.rst
@@ -1,0 +1,1 @@
+Correctly link with $(MODLIBS) when building the macOS dylib and remove the -undefined dynamic_lookup linker flag.


### PR DESCRIPTION
PR Title
gh-144942: Add $(MODLIBS) to macOS dylib build and remove -undefined dynamic_lookup



PR Description
Summary
This PR fixes an issue where the macOS libpython.dylib was missing $(MODLIBS) in its link command. This caused modules built statically (e.g., via 

Modules/Setup.local
) to have their symbols omitted from the dynamic library, leading to runtime failures.

Additionally, this PR removes -undefined dynamic_lookup from the dylib link command. This ensures that any missing symbols are caught at build-time rather than resulting in null pointer dereferences or silent failures at runtime.

Changes
Updated 

Makefile.pre.in
 to include $(MODLIBS) when linking libpython$(LDVERSION).dylib.
Removed -undefined dynamic_lookup from the same link command to enforce symbol resolution at build-time.