### PR TITLE
gh-145187: Fix crash on invalid type parameter bound expression in conditional block

### DIFF
--- a/Lib/test/test_type_params.py
+++ b/Lib/test/test_type_params.py
@@ -152,6 +152,13 @@ class TypeParamsInvalidTest(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, r"\(MRO\) for bases object, Generic"):
             class My[X](object): ...
 
+    def test_compile_error_in_type_param_bound(self):
+        # This should not crash, see gh-145187
+        check_syntax_error(
+            self,
+            "if True:\n class h[l:{7for*()in 0}]:2"
+        )
+
 
 class TypeParamsNonlocalTest(unittest.TestCase):
     def test_nonlocal_disallowed_01(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-24-18-30-56.gh-issue-145187.YjPu1Z.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-24-18-30-56.gh-issue-145187.YjPu1Z.rst
@@ -1,0 +1,2 @@
+Fix compiler assertion fail when a type parameter bound contains an invalid
+expression in a conditional block.

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -1244,11 +1244,11 @@ codegen_type_param_bound_or_default(compiler *c, expr_ty e,
     ADDOP_LOAD_CONST_NEW(c, LOC(e), defaults);
     RETURN_IF_ERROR(codegen_setup_annotations_scope(c, LOC(e), key, name));
     if (allow_starred && e->kind == Starred_kind) {
-        VISIT(c, expr, e->v.Starred.value);
-        ADDOP_I(c, LOC(e), UNPACK_SEQUENCE, (Py_ssize_t)1);
+        VISIT_IN_SCOPE(c, expr, e->v.Starred.value);
+        ADDOP_I_IN_SCOPE(c, LOC(e), UNPACK_SEQUENCE, (Py_ssize_t)1);
     }
     else {
-        VISIT(c, expr, e);
+        VISIT_IN_SCOPE(c, expr, e);
     }
     ADDOP_IN_SCOPE(c, LOC(e), RETURN_VALUE);
     PyCodeObject *co = _PyCompile_OptimizeAndAssemble(c, 1);


### PR DESCRIPTION
found via oss-fuzz

<!-- gh-issue-number: gh-145187 -->
* Issue: gh-145187
<!-- /gh-issue-number -->
