### PR TITLE
gh-145200: Fix EVP_MAC_CTX leak in hashlib HMAC on init failure

### DIFF
--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -1024,6 +1024,14 @@ class OpenSSLConstructorTestCase(ThroughOpenSSLAPIMixin,
             ):
                 self.hmac_digest(b'key', b'msg', value)
 
+    def test_hmac_new_xof_digestmod(self):
+        # gh-145200: XOF digests (SHAKE) are not supported by HMAC.
+        # Verify that the error path does not leak the EVP_MAC_CTX.
+        for xof_name in ('shake_128', 'shake_256'):
+            with self.subTest(digestmod=xof_name):
+                with self.assertRaises(_hashlib.UnsupportedDigestmodError):
+                    self.hmac_new(b'key', digestmod=xof_name)
+
 
 class BuiltinConstructorTestCase(ThroughBuiltinAPIMixin,
                                  ExtensionConstructorTestCaseMixin,

--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -1024,13 +1024,12 @@ class OpenSSLConstructorTestCase(ThroughOpenSSLAPIMixin,
             ):
                 self.hmac_digest(b'key', b'msg', value)
 
-    def test_hmac_new_xof_digestmod(self):
+    @support.subTests("xof_name", ("shake_128", "shake_256"))
+    def test_hmac_new_xof_digestmod(self, xof_name):
         # gh-145200: XOF digests (SHAKE) are not supported by HMAC.
         # Verify that the error path does not leak the EVP_MAC_CTX.
-        for xof_name in ('shake_128', 'shake_256'):
-            with self.subTest(digestmod=xof_name):
-                with self.assertRaises(_hashlib.UnsupportedDigestmodError):
-                    self.hmac_new(b'key', digestmod=xof_name)
+        with self.assertRaises(_hashlib.UnsupportedDigestmodError):
+            self.hmac_new(b'key', digestmod=xof_name)
 
 
 class BuiltinConstructorTestCase(ThroughBuiltinAPIMixin,

--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -24,6 +24,7 @@ import random
 import unittest
 import warnings
 from _operator import _compare_digest as operator_compare_digest
+from test import support
 from test.support import _4G, bigmemtest
 from test.support import check_disallow_instantiation
 from test.support import hashlib_helper, import_helper

--- a/Misc/NEWS.d/next/Library/2026-02-25-10-00-00.gh-issue-145200.m_4PAtcI.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-25-10-00-00.gh-issue-145200.m_4PAtcI.rst
@@ -1,3 +1,2 @@
-Fix memory leak in :mod:`hashlib` HMAC when ``EVP_MAC_init()`` or
-``HMAC_Init_ex()`` fails (e.g., with an XOF digest such as SHAKE). The
-``EVP_MAC_CTX`` is now freed on the error path.
+Fix memory leak in :mod:`hashlib` HMAC when allocating
+or initializing the HMAC context fails.

--- a/Misc/NEWS.d/next/Library/2026-02-25-10-00-00.gh-issue-145200.m_4PAtcI.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-25-10-00-00.gh-issue-145200.m_4PAtcI.rst
@@ -1,0 +1,3 @@
+Fix memory leak in :mod:`hashlib` HMAC when ``EVP_MAC_init()`` or
+``HMAC_Init_ex()`` fails (e.g., with an XOF digest such as SHAKE). The
+``EVP_MAC_CTX`` is now freed on the error path.

--- a/Misc/NEWS.d/next/Library/2026-02-25-10-00-00.gh-issue-145200.m_4PAtcI.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-25-10-00-00.gh-issue-145200.m_4PAtcI.rst
@@ -1,2 +1,2 @@
-Fix memory leak in :mod:`hashlib` HMAC when allocating
-or initializing the HMAC context fails.
+:mod:`hashlib`: fix a memory leak when allocating
+or initializing an OpenSSL HMAC context fails.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -2103,6 +2103,7 @@ hashlib_HMAC_CTX_new_from_digestmod(_hashlibstate *state,
     PY_EVP_MD_free(md);
 #endif
     if (r == 0) {
+        hashlib_openssl_HMAC_CTX_free(ctx);
         if (is_xof) {
             /* use a better default error message if an XOF is used */
             raise_unsupported_algorithm_error(state, digestmod);


### PR DESCRIPTION
Free the `EVP_MAC_CTX` (or `HMAC_CTX`) when `EVP_MAC_init()` (or `HMAC_Init_ex()`) fails in `hashlib_HMAC_CTX_new_from_digestmod()`, preventing a memory leak on every failed call.

<!-- gh-issue-number: gh-145200 -->
* Issue: gh-145200
<!-- /gh-issue-number -->
