### PR TITLE
gh-145202: Fix segfault in unicodedata.iter_graphemes when cleared by GC

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-02-25-14-30-00.gh-issue-145202.xR3f9A.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-25-14-30-00.gh-issue-145202.xR3f9A.rst
@@ -1,0 +1,1 @@
+Fix a segmentation fault in :func:`unicodedata.iter_graphemes` when the iterator is deallocated after being cleared by the garbage collector.

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -1913,7 +1913,7 @@ Segment_dealloc(PyObject *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
-    Py_DECREF(((SegmentObject *)self)->string);
+    Py_XDECREF(((SegmentObject *)self)->string);
     tp->tp_free(self);
     Py_DECREF(tp);
 }
@@ -1989,7 +1989,7 @@ GBI_dealloc(PyObject *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
-    Py_DECREF(((GraphemeBreakIterator *)self)->iter.str);
+    Py_XDECREF(((GraphemeBreakIterator *)self)->iter.str);
     tp->tp_free(self);
     Py_DECREF(tp);
 }


### PR DESCRIPTION
This PR fixes a segmentation fault in `unicodedata.iter_graphemes` and its segment objects, which occurred when the objects were cleared by the garbage collector before being deallocated.

In [Modules/unicodedata.c](cci:7://file:///Users/gourijain/cpython/Modules/unicodedata.c:0:0-0:0), both `GraphemeBreakIterator` and `SegmentObject` have `tp_clear` implementations that set their string references to NULL. However, their deallocators were using `Py_DECREF` instead of `Py_XDECREF`. This led to a crash if a GC cycle (or interpreter shutdown) cleared the objects before they reached the deallocation path.

I've updated [GBI_dealloc](cci:1://file:///Users/gourijain/cpython/Modules/unicodedata.c:1986:0-1994:1) and [Segment_dealloc](cci:1://file:///Users/gourijain/cpython/Modules/unicodedata.c:1910:0-1918:1) to use `Py_XDECREF` to safely handle these NULL references.

Fixes gh-145202.
