### PR TITLE
gh-145204: Fix LSan leak in test_initconfig_get_api

### DIFF
--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1843,6 +1843,7 @@ static int test_initconfig_get_api(void)
     char **items;
     assert(PyInitConfig_GetStrList(config, "xoptions", &length, &items) == 0);
     assert(length == 0);
+    PyInitConfig_FreeStrList(length, items);
 
     char* xoptions[] = {"faulthandler"};
     assert(PyInitConfig_SetStrList(config, "xoptions",
@@ -1865,6 +1866,7 @@ static int test_initconfig_get_api(void)
                                    Py_ARRAY_LENGTH(paths), paths) == 0);
     assert(initconfig_getint(config, "module_search_paths_set") == 1);
 
+    PyInitConfig_Free(config);
     return 0;
 }
 


### PR DESCRIPTION
Fix LeakSanitizer-reported leak in Programs/_testembed test_initconfig_get_api.

The test now frees the initial empty xoptions list returned by
PyInitConfig_GetStrList() and releases the PyInitConfig created by
PyInitConfig_Create().

Reproducer:
  ASAN_OPTIONS=detect_leaks=1 ./Programs/_testembed test_initconfig_get_api

Tests:
  ./python -m test -j0 test_embed

<!-- gh-issue-number: gh-145204 -->
* Issue: gh-145204
<!-- /gh-issue-number -->
