### PR TITLE
Fix "lazy from (...) import (...)" tests

### DIFF
--- a/Lib/test/test_import/data/lazy_imports/global_filter_from.py
+++ b/Lib/test/test_import/data/lazy_imports/global_filter_from.py
@@ -1,11 +1,11 @@
-import importlib
+import sys
 
 def filter(module_name, imported_name, from_list):
     assert module_name == __name__
     assert imported_name == "test.test_import.data.lazy_imports.basic2"
-    assert from_list == ['f']
+    assert from_list == ('f',)
     return False
 
-importlib.set_lazy_imports(None, filter)
+sys.set_lazy_imports_filter(filter)
 
-lazy from import test.test_import.data.lazy_imports.basic2 import f
+lazy from test.test_import.data.lazy_imports.basic2 import f

--- a/Lib/test/test_import/data/lazy_imports/global_filter_from_true.py
+++ b/Lib/test/test_import/data/lazy_imports/global_filter_from_true.py
@@ -1,11 +1,12 @@
-import importlib
+import sys
 
 def filter(module_name, imported_name, from_list):
     assert module_name == __name__
     assert imported_name == "test.test_import.data.lazy_imports.basic2"
-    assert from_list == ['f']
+    assert from_list == ('f',)
     return True
 
-importlib.set_lazy_imports(None, filter)
+sys.set_lazy_imports("normal")
+sys.set_lazy_imports_filter(filter)
 
-lazy from import test.test_import.data.lazy_imports.basic2 import f
+lazy from test.test_import.data.lazy_imports.basic2 import f

--- a/Lib/test/test_import/test_lazy_imports.py
+++ b/Lib/test/test_import/test_lazy_imports.py
@@ -119,12 +119,12 @@ class GlobalLazyImportModeTests(unittest.TestCase):
 
     def test_global_filter_from(self):
         """Filter should work with 'from' imports."""
-        import test.test_import.data.lazy_imports.global_filter
+        import test.test_import.data.lazy_imports.global_filter_from
         self.assertIn("test.test_import.data.lazy_imports.basic2", sys.modules)
 
     def test_global_filter_from_true(self):
         """Filter returning True should allow lazy 'from' imports."""
-        import test.test_import.data.lazy_imports.global_filter_true
+        import test.test_import.data.lazy_imports.global_filter_from_true
         self.assertNotIn("test.test_import.data.lazy_imports.basic2", sys.modules)
 
 


### PR DESCRIPTION
Looks like `test_global_filter_from` and `test_global_filter_from_true` are importing the non-"from" version of the test data files, effectively skipping the tests for the "from" versions.

The data files seem to be written for an outdated version of the implementation, and contain a typo in the lazy import statement. Since they were not actually being tested, they went unnoticed and were never fixed and updated.