### PR TITLE
gh-145228: Increase performance of _config_dict_get_bool(PyObject *dict, const char *name, int *p_flag) by removing unused PY_DECREF(item)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-02-25-17-25-36.gh-issue-145228.bM5lo-.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-02-25-17-25-36.gh-issue-145228.bM5lo-.rst
@@ -1,0 +1,2 @@
+The function ``_config_dict_get_bool()`` in :file:`Python/interpconfig.c` has been optimized to avoid unnecessary reference count decrements on boolean results.
+Patch by Benedikt Johannes.

--- a/Python/interpconfig.c
+++ b/Python/interpconfig.c
@@ -115,7 +115,6 @@ _config_dict_get_bool(PyObject *dict, const char *name, int *p_flag)
         config_dict_invalid_type(name);
         return -1;
     }
-    Py_DECREF(item);
     *p_flag = flag;
     return 0;
 }


### PR DESCRIPTION
Fixes #145228

In `Python/interpconfig.c` we use `Py_DECREF(item);` in line 118 here

    static int
    _config_dict_get_bool(PyObject *dict, const char *name, int *p_flag)
    {
        PyObject *item;
        if (_config_dict_get(dict, name, &item) < 0) {
            return -1;
        }
        // For now we keep things strict, rather than using PyObject_IsTrue().
        int flag = item == Py_True;
        if (!flag && item != Py_False) {
            Py_DECREF(item);
            config_dict_invalid_type(name);
            return -1;
        }
        Py_DECREF(item);
        *p_flag = flag;
        return 0;
    }

while it's not necessary here

        Py_DECREF(item);
        *p_flag = flag;
        return 0;

because we use `if (!flag && item != Py_False)` and if this returns true, then we return and only in the other case we come to

        Py_DECREF(item);
        *p_flag = flag;
        return 0;

which then means that

a. `!flag` is false which means that `flag` is true which means that `item == PY_TRUE` which doesn't have to be decremented
b. `item == Py_FALSE` which doesn't have to be decremented
c. both

(This was not tested, but I'm pretty sure from looking at the code, but please correct me if I'm mistaken)

<!-- gh-issue-number: gh-145228 -->
* Issue: gh-145228
<!-- /gh-issue-number -->
