### PR TITLE
Fix bugs in `compute-changes.py` logic for CIFuzz

### DIFF
--- a/Parser/tokenizer/string_tokenizer.c
+++ b/Parser/tokenizer/string_tokenizer.c
@@ -105,7 +105,6 @@ decode_str(const char *input, int single, struct tok_state *tok, int preserve_cr
             return _PyTokenizer_error_ret(tok);
         str = PyBytes_AS_STRING(utf8);
     }
-// Touch a C file
     else if (!_PyTokenizer_ensure_utf8(str, tok, 1)) {
         return _PyTokenizer_error_ret(tok);
     }

--- a/Parser/tokenizer/string_tokenizer.c
+++ b/Parser/tokenizer/string_tokenizer.c
@@ -105,6 +105,7 @@ decode_str(const char *input, int single, struct tok_state *tok, int preserve_cr
             return _PyTokenizer_error_ret(tok);
         str = PyBytes_AS_STRING(utf8);
     }
+// Touch a C file
     else if (!_PyTokenizer_ensure_utf8(str, tok, 1)) {
         return _PyTokenizer_error_ret(tok);
     }

--- a/Tools/build/compute-changes.py
+++ b/Tools/build/compute-changes.py
@@ -68,7 +68,8 @@ LIBRARY_FUZZER_PATHS = frozenset({
     Path("Lib/encodings/"),
     Path("Modules/_codecsmodule.c"),
     Path("Modules/cjkcodecs/"),
-    Path("Modules/unicodedata*"),
+    Path("Modules/unicodedata.c"),
+    Path("Modules/unicodedata_db.h"),
     # difflib
     Path("Lib/difflib.py"),
     # email

--- a/Tools/build/compute-changes.py
+++ b/Tools/build/compute-changes.py
@@ -117,10 +117,10 @@ class Outputs:
 
 
 def compute_changes() -> None:
-    target_branch, head_ref = git_refs()
+    target_ref, head_ref = git_refs()
     if os.environ.get("GITHUB_EVENT_NAME", "") == "pull_request":
         # Getting changed files only makes sense on a pull request
-        files = get_changed_files(target_branch, head_ref)
+        files = get_changed_files(target_ref, head_ref)
         outputs = process_changed_files(files)
     else:
         # Otherwise, just run the tests
@@ -133,6 +133,7 @@ def compute_changes() -> None:
             run_wasi=True,
             run_windows_tests=True,
         )
+    target_branch = target_ref.removeprefix("origin/")
     outputs = process_target_branch(outputs, target_branch)
 
     if outputs.run_tests:


### PR DESCRIPTION
Fixes a typo, it isn't running when `unicodedata.c` is modified, e.g. [this run](https://github.com/python/cpython/actions/runs/22360458210/job/64712166595).

And, it also isn't setting `run_ci_fuzz=true` when it should be, see same run as above.

Testing this is a little messy.