### PR TITLE
gh-145242: Add early validation for target in Thread and Process

### DIFF
--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -79,7 +79,10 @@ class BaseProcess(object):
 
     def __init__(self, group=None, target=None, name=None, args=(), kwargs=None,
                  *, daemon=None):
-        assert group is None, 'group argument must be None for now'
+        if group is not None:
+            raise TypeError("group argument must be None for now")
+        if target is not None and not callable(target):
+            raise TypeError("target must be callable")
         count = next(_process_counter)
         self._identity = _current_process._identity + (count,)
         self._config = _current_process._config.copy()

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -326,6 +326,12 @@ class _TestProcess(BaseTestCase):
         self.assertEqual(current.ident, os.getpid())
         self.assertEqual(current.exitcode, None)
 
+    def test_invalid_args(self):
+        with self.assertRaisesRegex(TypeError, "group argument must be None"):
+            self.Process(group="not None")
+        with self.assertRaisesRegex(TypeError, "target must be callable"):
+            self.Process(target=123)
+
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_set_executable(self):
         if self.TYPE == 'threads':

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -151,6 +151,12 @@ class ThreadTests(BaseTestCase):
             thread = threading.Thread(target=func)
             self.assertEqual(thread.name, "Thread-5 (func)")
 
+    def test_invalid_args(self):
+        with self.assertRaisesRegex(TypeError, "group argument must be None"):
+            threading.Thread(group="not None")
+        with self.assertRaisesRegex(TypeError, "target must be callable"):
+            threading.Thread(target=123)
+
     def test_args_argument(self):
         # bpo-45735: Using list or tuple as *args* in constructor could
         # achieve the same effect.

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -901,7 +901,10 @@ class Thread:
         else to the thread.
 
         """
-        assert group is None, "group argument must be None for now"
+        if group is not None:
+            raise TypeError("group argument must be None for now")
+        if target is not None and not callable(target):
+            raise TypeError("target must be callable")
         if kwargs is None:
             kwargs = {}
         if name:

--- a/Misc/NEWS.d/next/Library/2026-02-25-14-30-00.gh-issue-145202.xR3f9A.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-25-14-30-00.gh-issue-145202.xR3f9A.rst
@@ -1,0 +1,1 @@
+Fix a segmentation fault in :func:`unicodedata.iter_graphemes` when the iterator is deallocated after being cleared by the garbage collector.

--- a/Misc/NEWS.d/next/Library/2026-02-26-09-30-00.gh-issue-145242.N7hA6L.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-26-09-30-00.gh-issue-145242.N7hA6L.rst
@@ -1,0 +1,1 @@
+Added early validation of the ``target`` argument in :class:`threading.Thread` and :class:`multiprocessing.Process` constructors. If ``target`` is not callable, a :exc:`TypeError` is now raised immediately in the calling thread, resulting in a clearer traceback. Optimized the validation of the reserved ``group`` argument by replacing internal assertions with :exc:`TypeError`.

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -1913,7 +1913,7 @@ Segment_dealloc(PyObject *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
-    Py_DECREF(((SegmentObject *)self)->string);
+    Py_XDECREF(((SegmentObject *)self)->string);
     tp->tp_free(self);
     Py_DECREF(tp);
 }
@@ -1989,7 +1989,7 @@ GBI_dealloc(PyObject *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
-    Py_DECREF(((GraphemeBreakIterator *)self)->iter.str);
+    Py_XDECREF(((GraphemeBreakIterator *)self)->iter.str);
     tp->tp_free(self);
     Py_DECREF(tp);
 }


### PR DESCRIPTION
his PR adds early validation for the 

target
 argument in the constructors of threading.Thread and multiprocessing.Process.

Changes
Early Validation: The 

target
 argument is now checked for callability within 

init
. If a non-callable 

target
 is provided (and it is not 

None
), a TypeError is raised immediately in the calling thread.
Improved Tracebacks: Previously, the validation would only fail deep within the library's internal 

_bootstrap
 or 

start()
 logic. By moving this check to the constructor, the resulting traceback now clearly points to the line where the 

Thread
 or 

Process
 object was instantiated, making it significantly easier for users to debug.
Group Argument Validation: Replaced internal assert group is None statements with explicit TypeError raises. This ensures consistent error reporting even when Python is run with optimizations (-O).
Unit Tests: Added 

test_invalid_args
 to both test_threading and test_multiprocessing to ensure correct behavior and prevent regressions.

<!-- gh-issue-number: gh-145242 -->
* Issue: gh-145242
<!-- /gh-issue-number -->
