### PR TITLE
Fix unlikely potential reference leak in _locale._getdefaultlocale

### DIFF
--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -567,7 +567,6 @@ _locale__getdefaultlocale_impl(PyObject *module)
     }
 
     /* cannot determine the language code (very unlikely) */
-    Py_INCREF(Py_None);
     return Py_BuildValue("Os", Py_None, encoding);
 }
 #endif


### PR DESCRIPTION
It occurs in a code which perhaps never executed.

The bug was here from the beginning, from 8f017a01f89d77392992ae623170cf252607d3ad.