### PR TITLE
gh-145259: Fix xml.dom.pulldom dropping events produced by parser.close()

### DIFF
--- a/Lib/test/test_pulldom.py
+++ b/Lib/test/test_pulldom.py
@@ -128,8 +128,13 @@ class PullDOMTestCase(unittest.TestCase):
         next(items) # Skip character data
         evt, node = next(items)
         self.assertEqual(node.tagName, "html")
-        with self.assertRaises(StopIteration):
-            next(items)
+        # Consume any remaining events (e.g. END_ELEMENT, END_DOCUMENT)
+        # that are now correctly delivered after the fix for parser.close()
+        remaining = list(items)
+        self.assertTrue(
+            any(evt == pulldom.END_DOCUMENT for evt, _ in remaining),
+            "Expected END_DOCUMENT in remaining events"
+        )
         items.clear()
         self.assertIsNone(items.parser)
         self.assertIsNone(items.stream)
@@ -144,9 +149,8 @@ class PullDOMTestCase(unittest.TestCase):
         else:
             self.fail("No comment was encountered")
 
-    @unittest.expectedFailure
     def test_end_document(self):
-        """PullDOM does not receive "end-document" events."""
+        """PullDOM receives end-document events."""
         items = pulldom.parseString(SMALL_SAMPLE)
         # Read all of the nodes up to and including </html>:
         for evt, node in items:

--- a/Lib/test/test_pulldom.py
+++ b/Lib/test/test_pulldom.py
@@ -128,8 +128,6 @@ class PullDOMTestCase(unittest.TestCase):
         next(items) # Skip character data
         evt, node = next(items)
         self.assertEqual(node.tagName, "html")
-        # Consume any remaining events (e.g. END_ELEMENT, END_DOCUMENT)
-        # that are now correctly delivered after the fix for parser.close()
         remaining = list(items)
         self.assertTrue(
             any(evt == pulldom.END_DOCUMENT for evt, _ in remaining),

--- a/Lib/xml/dom/pulldom.py
+++ b/Lib/xml/dom/pulldom.py
@@ -249,6 +249,8 @@ class DOMEventStream:
             buf = self.stream.read(self.bufsize)
             if not buf:
                 self.parser.close()
+                if self.pulldom.firstEvent[1]:
+                    break
                 return None
             self.parser.feed(buf)
         rc = self.pulldom.firstEvent[1][0]

--- a/Misc/NEWS.d/next/Library/2026-02-26-15-36-50.gh-issue-145259._SeM5N.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-26-15-36-50.gh-issue-145259._SeM5N.rst
@@ -1,0 +1,4 @@
+Fix :class:`xml.dom.pulldom.DOMEventStream` silently dropping SAX events
+produced by ``parser.close()`` at end-of-stream. When ``bufsize`` caused the
+final tag to be split across reads, ``END_ELEMENT`` and other trailing events
+were lost.


### PR DESCRIPTION
## Issue

When the input stream is exhausted, `getEvent()` calls `self.parser.close()` and immediately returns `None` without checking whether `close()` generated new events. SAX events emitted during `close()` (e.g. `END_ELEMENT` for the final tag) are silently lost.

## Reproducer

```python
import io
from xml.dom.pulldom import parse
events = list(parse(io.BytesIO(b'<a></a>'), bufsize=2))
print([e for e, _ in events])  # ['START_DOCUMENT', 'START_ELEMENT'] — END_ELEMENT missing
```

## Fix

In `Lib/xml/dom/pulldom.py`, after calling `self.parser.close()`, check if new events were produced before returning `None`:

```python
self.parser.close()
if self.pulldom.firstEvent[1]:
    break
return None
```

## Test updates

Two existing tests in `test_pulldom` needed adjustments since they were based on the previous behavior:
- `test_end_document` was marked `@expectedFailure` — it now passes as the `END_DOCUMENT` event is correctly delivered.
- `test_expandItem` expected `StopIteration` immediately after `</html>` — updated to account for the additional events (like `END_DOCUMENT`) that are now properly emitted.



<!-- gh-issue-number: gh-145259 -->
* Issue: gh-145259
<!-- /gh-issue-number -->
