### PR TITLE
gh-145260: fix ResourceContainer/ResourceHandle for Traversable changes

### DIFF
--- a/Lib/importlib/resources/simple.py
+++ b/Lib/importlib/resources/simple.py
@@ -55,6 +55,10 @@ class ResourceContainer(Traversable):
     def __init__(self, reader: SimpleReader):
         self.reader = reader
 
+    @property
+    def name(self):
+        return self.reader.name
+
     def is_dir(self):
         return True
 
@@ -62,7 +66,7 @@ class ResourceContainer(Traversable):
         return False
 
     def iterdir(self):
-        files = (ResourceHandle(self, name) for name in self.reader.resources)
+        files = (ResourceHandle(self, name) for name in self.reader.resources())
         dirs = map(ResourceContainer, self.reader.children())
         return itertools.chain(files, dirs)
 
@@ -85,13 +89,18 @@ class ResourceHandle(Traversable):
     def is_dir(self):
         return False
 
+    def iterdir(self):
+        return iter([])
+
     def open(self, mode='r', *args, **kwargs):
         stream = self.parent.reader.open_binary(self.name)
         if 'b' not in mode:
             stream = io.TextIOWrapper(stream, *args, **kwargs)
         return stream
 
-    def joinpath(self, name):
+    def joinpath(self, *descendants):
+        if not descendants:
+            return self
         raise RuntimeError("Cannot traverse into a resource")
 
 

--- a/Lib/importlib/resources/simple.py
+++ b/Lib/importlib/resources/simple.py
@@ -81,7 +81,11 @@ class ResourceHandle(Traversable):
 
     def __init__(self, parent: ResourceContainer, name: str):
         self.parent = parent
-        self.name = name  # type: ignore[misc]
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
 
     def is_file(self):
         return True

--- a/Misc/NEWS.d/next/Library/2026-02-26-15-46-50.gh-issue-145260.wmT5hp.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-26-15-46-50.gh-issue-145260.wmT5hp.rst
@@ -1,5 +1,5 @@
-Fix :class:`~importlib.resources.simple.ResourceContainer` and
-:class:`~importlib.resources.simple.ResourceHandle` being uninstantiable due
-to missing :attr:`name` property required by :class:`~importlib.resources.abc.Traversable`.
-Also fix ``ResourceContainer.iterdir()`` not calling ``resources()`` and
+Fix ``ResourceContainer`` and ``ResourceHandle`` in
+:mod:`importlib.resources.simple` being uninstantiable due to missing ``name``
+property required by :class:`~importlib.resources.abc.Traversable`. Also fix
+``ResourceContainer.iterdir()`` not calling ``resources()`` and
 ``ResourceHandle.joinpath`` signature mismatch with base class.

--- a/Misc/NEWS.d/next/Library/2026-02-26-15-46-50.gh-issue-145260.wmT5hp.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-26-15-46-50.gh-issue-145260.wmT5hp.rst
@@ -1,0 +1,5 @@
+Fix :class:`~importlib.resources.simple.ResourceContainer` and
+:class:`~importlib.resources.simple.ResourceHandle` being uninstantiable due
+to missing :attr:`name` property required by :class:`~importlib.resources.abc.Traversable`.
+Also fix ``ResourceContainer.iterdir()`` not calling ``resources()`` and
+``ResourceHandle.joinpath`` signature mismatch with base class.

--- a/Misc/NEWS.d/next/Library/2026-02-26-15-46-50.gh-issue-145260.wmT5hp.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-26-15-46-50.gh-issue-145260.wmT5hp.rst
@@ -1,5 +1,5 @@
 Fix ``ResourceContainer`` and ``ResourceHandle`` in
-:mod:`importlib.resources.simple` being uninstantiable due to missing ``name``
+``importlib.resources.simple`` being uninstantiable due to missing ``name``
 property required by :class:`~importlib.resources.abc.Traversable`. Also fix
 ``ResourceContainer.iterdir()`` not calling ``resources()`` and
 ``ResourceHandle.joinpath`` signature mismatch with base class.


### PR DESCRIPTION
## Problem

`ResourceContainer` and `ResourceHandle` cannot be instantiated because `Traversable` now requires `name` as an abstract property. Also, `iterdir()` accesses `self.reader.resources` without calling it, and `ResourceHandle.joinpath` has a signature mismatch.

## Reproducer

```python
from importlib.resources.simple import ResourceContainer, SimpleReader
import io

class R(SimpleReader):
    @property
    def package(self): return 'x'
    def children(self): return []
    def resources(self): return []
    def open_binary(self, r): return io.BytesIO(b'')

ResourceContainer(R())  # TypeError
```

## Fix

- Add `name` property to `ResourceContainer` and `ResourceHandle`
- Add `iterdir` to `ResourceHandle`
- Fix `self.reader.resources` → `self.reader.resources()` in `ResourceContainer.iterdir()`
- Fix `ResourceHandle.joinpath` to accept `*descendants`


<!-- gh-issue-number: gh-145260 -->
* Issue: gh-145260
<!-- /gh-issue-number -->
