### PR TITLE
gh-145227: Clarify os.remove() directory exception is platform-dependent

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2732,7 +2732,9 @@ features:
 .. function:: remove(path, *, dir_fd=None)
 
    Remove (delete) the file *path*.  If *path* is a directory, an
-   :exc:`OSError` is raised.  Use :func:`rmdir` to remove directories.
+   :exc:`OSError` is raised.  The exact exception type depends on the platform:
+   for example, :exc:`IsADirectoryError` or :exc:`PermissionError`.
+   Use :func:`rmdir` to remove directories.
    If the file does not exist, a :exc:`FileNotFoundError` is raised.
 
    This function can support :ref:`paths relative to directory descriptors

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2732,8 +2732,9 @@ features:
 .. function:: remove(path, *, dir_fd=None)
 
    Remove (delete) the file *path*.  If *path* is a directory, an
-   :exc:`OSError` is raised.  The exact exception type depends on the platform:
-   for example, :exc:`IsADirectoryError` or :exc:`PermissionError`.
+   :exc:`OSError` is raised.  The exact subclass depends on the platform:
+   for example, :exc:`IsADirectoryError` on Linux or :exc:`PermissionError`
+   on macOS.
    Use :func:`rmdir` to remove directories.
    If the file does not exist, a :exc:`FileNotFoundError` is raised.
 

--- a/Misc/NEWS.d/next/Documentation/2026-02-26-21-09-18.gh-issue-145227.yVAgmv.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-02-26-21-09-18.gh-issue-145227.yVAgmv.rst
@@ -1,2 +1,0 @@
-Clarify that the :exc:`OSError` subclass raised by :func:`os.remove` when the
-path is a directory is platform-dependent.

--- a/Misc/NEWS.d/next/Documentation/2026-02-26-21-09-18.gh-issue-145227.yVAgmv.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-02-26-21-09-18.gh-issue-145227.yVAgmv.rst
@@ -1,0 +1,2 @@
+Clarify that the :exc:`OSError` subclass raised by :func:`os.remove` when the
+path is a directory is platform-dependent.


### PR DESCRIPTION
The `OSError` subclass raised by `os.remove()` when the path is a directory depends on the platform and underlying errno:

- Linux: `unlink()` returns `EISDIR` → `IsADirectoryError`
- macOS: `unlink()` returns `EPERM` → `PermissionError`

The documentation previously stated only that `OSError` is raised, which is technically correct but can mislead users into catching a specific subclass that isn't portable. For example:

```python
try:
    os.remove(path)
except IsADirectoryError:
    os.rmdir(path)
```

This works on Linux but fails on macOS, where `PermissionError` is raised instead.

Updated the `os.remove()` docs to note that the exact subclass is platform-dependent, with `IsADirectoryError` and `PermissionError` as examples. No change needed for `os.unlink()` since its docs already defer to `os.remove()`.

<!-- gh-issue-number: gh-145227 -->
* Issue: gh-145227
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145265.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->