### PR TITLE
gh-144960: Clarify GC threshold1 formula in set_threshold docs

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -139,10 +139,11 @@ The :mod:`!gc` module provides the following functions:
    by 10% since the last collection and the net number of object allocations
    has not exceeded 40 times *threshold0*, the collection is not run.
 
-   The fraction of the old generation that is collected is **inversely** proportional
-   to *threshold1*. The larger *threshold1* is, the slower objects in the old generation
-   are collected.
-   For the default value of 10, 1% of the old generation is scanned during each collection.
+   The fraction of the old generation that is scanned during each collection is
+   ``1 / (10 * threshold1)``, making it **inversely** proportional to *threshold1*.
+   The larger *threshold1* is, the slower objects in the old generation are collected.
+   For the default value of 10, this means approximately 1% of the old generation is
+   scanned during each collection.
 
    *threshold2* is ignored.
 


### PR DESCRIPTION
## Summary
- Clarifies the `gc.set_threshold()` documentation for the `threshold1` parameter
- Shows the actual formula `1/(10 * threshold1)` instead of just stating "inversely proportional"
- Resolves the confusion noted in #144960 where "inversely proportional to threshold1" with a default of 10 would naively imply 10% (1/10), not the actual 1%
- The constant factor of 10 comes from the internal `SCAN_RATE_DIVISOR` in `Python/gc.c`

Fixes #144960

## Test plan
- [ ] Documentation renders correctly with `make -C Doc html`
- [ ] Formula matches the implementation in `Python/gc.c` (SCAN_RATE_DIVISOR = 10)

<!-- gh-issue-number: gh-144960 -->
* Issue: gh-144960
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145285.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->