### PR TITLE
Fix gen_colors docstring: function yields, not returns a list

### DIFF
--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -97,7 +97,7 @@ def unbracket(s: str, including_content: bool = False) -> str:
 
 
 def gen_colors(buffer: str) -> Iterator[ColorSpan]:
-    """Returns a list of index spans to color using the given color tag.
+    """Yield index spans to color using the given color tag.
 
     The input `buffer` should be a valid start of a Python code block, i.e.
     it cannot be a block starting in the middle of a multiline string.


### PR DESCRIPTION
## Summary
- Fix misleading docstring in `Lib/_pyrepl/utils.py::gen_colors()`
- The function is a generator (uses `yield`) with return type `Iterator[ColorSpan]`, but the docstring stated "Returns a list of index spans"
- Updated to "Yield index spans" to accurately describe the generator behavior

## Test plan
- [ ] Verify function behavior unchanged (docstring-only change)
- [ ] `python -m pytest Lib/test/test_pyrepl/` passes