### PR TITLE
Fix grammar: "allows to" → "allows using/blocking" in docs

### DIFF
--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -361,7 +361,7 @@ Barrier
 
    A barrier object.  Not thread-safe.
 
-   A barrier is a simple synchronization primitive that allows to block until
+   A barrier is a simple synchronization primitive that allows blocking until
    *parties* number of tasks are waiting on it.
    Tasks can wait on the :meth:`~Barrier.wait` method and would be blocked until
    the specified number of tasks end up waiting on :meth:`~Barrier.wait`.

--- a/Doc/library/hmac.rst
+++ b/Doc/library/hmac.rst
@@ -9,7 +9,7 @@
 --------------
 
 This module implements the HMAC algorithm as described by :rfc:`2104`.
-The interface allows to use any hash function with a *fixed* digest size.
+The interface allows using any hash function with a *fixed* digest size.
 In particular, extendable output functions such as SHAKE-128 or SHAKE-256
 cannot be used with HMAC.
 


### PR DESCRIPTION
## Summary
- Fix "allows to <verb>" grammar in two documentation files
- "Allows to" is grammatically incorrect; "allow" requires a gerund or object + infinitive
- `Doc/library/hmac.rst`: "allows to use" → "allows using"
- `Doc/library/asyncio-sync.rst`: "allows to block" → "allows blocking"

## Test plan
- [ ] Documentation builds without warnings

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145289.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->