### PR TITLE
Fix grammar in What's New 3.15: "allows to" → "allows distinguishing"

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1164,7 +1164,7 @@ urllib.parse
   :func:`~urllib.parse.urlparse` and :func:`~urllib.parse.urldefrag` functions.
   Add the *keep_empty* parameter to :func:`~urllib.parse.urlunsplit` and
   :func:`~urllib.parse.urlunparse` functions.
-  This allows to distinguish between empty and not defined URI components
+  This allows distinguishing between empty and not defined URI components
   and preserve empty components.
   (Contributed by Serhiy Storchaka in :gh:`67041`.)
 


### PR DESCRIPTION
## Summary
- Fix "allows to distinguish" → "allows distinguishing" in `Doc/whatsnew/3.15.rst`
- "Allows to <verb>" is grammatically incorrect in English; "allow" requires a gerund or object + infinitive

## Test plan
- [ ] Documentation builds without warnings

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145290.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->