### PR TITLE
Fix Latin abbreviations in http.cookiejar and optparse docs

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -26,7 +26,7 @@ introduced with RFC 2965.
 .. note::
 
    The various named parameters found in :mailheader:`Set-Cookie` and
-   :mailheader:`Set-Cookie2` headers (eg. ``domain`` and ``expires``) are
+   :mailheader:`Set-Cookie2` headers (e.g. ``domain`` and ``expires``) are
    conventionally referred to as :dfn:`attributes`.  To distinguish them from
    Python attributes, the documentation for this module uses the term
    :dfn:`cookie-attribute` instead.
@@ -574,7 +574,7 @@ both flags are set).
 
 .. attribute:: DefaultCookiePolicy.DomainStrictNoDots
 
-   When setting cookies, the 'host prefix' must not contain a dot (eg.
+   When setting cookies, the 'host prefix' must not contain a dot (e.g.
    ``www.foo.bar.com`` can't set a cookie for ``.bar.com``, because ``www.foo``
    contains a dot).
 
@@ -582,7 +582,7 @@ both flags are set).
 .. attribute:: DefaultCookiePolicy.DomainStrictNonDomain
 
    Cookies that did not explicitly specify a ``domain`` cookie-attribute can only
-   be returned to a domain equal to the domain that set the cookie (eg.
+   be returned to a domain equal to the domain that set the cookie (e.g.
    ``spam.example.com`` won't be returned cookies from ``example.com`` that had no
    ``domain`` cookie-attribute).
 
@@ -642,7 +642,7 @@ internal consistency, so you should know what you're doing if you do that.
 
 .. attribute:: Cookie.port
 
-   String representing a port or a set of ports (eg. '80', or '80,8080'), or
+   String representing a port or a set of ports (e.g. '80', or '80,8080'), or
    :const:`None`.
 
 
@@ -653,7 +653,7 @@ internal consistency, so you should know what you're doing if you do that.
 
 .. attribute:: Cookie.path
 
-   Cookie path (a string, eg. ``'/acme/rocket_launchers'``).
+   Cookie path (a string, e.g. ``'/acme/rocket_launchers'``).
 
 
 .. attribute:: Cookie.secure

--- a/Doc/library/optparse.rst
+++ b/Doc/library/optparse.rst
@@ -1770,13 +1770,13 @@ where
    you can access some other interesting data through its instance attributes:
 
    ``parser.largs``
-      the current list of leftover arguments, ie. arguments that have been
+      the current list of leftover arguments, i.e. arguments that have been
       consumed but are neither options nor option arguments. Feel free to modify
       ``parser.largs``, e.g. by adding more arguments to it.  (This list will
       become ``args``, the second return value of :meth:`~OptionParser.parse_args`.)
 
    ``parser.rargs``
-      the current list of remaining arguments, ie. with ``opt_str`` and
+      the current list of remaining arguments, i.e. with ``opt_str`` and
       ``value`` (if applicable) removed, and only the arguments following them
       still there.  Feel free to modify ``parser.rargs``, e.g. by consuming more
       arguments.


### PR DESCRIPTION
## Summary
- Fix "eg." → "e.g." (5 instances) in `Doc/library/http.cookiejar.rst`
- Fix "ie." → "i.e." (2 instances) in `Doc/library/optparse.rst`
- The Latin abbreviations "e.g." (exempli gratia) and "i.e." (id est) require periods after each letter per standard English typography

## Test plan
- [ ] Documentation builds without warnings

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145291.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->