### PR TITLE
gh-144338: Improve cmd.Cmd docs for emptyline() and do_EOF

### DIFF
--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -68,6 +68,8 @@ A :class:`Cmd` instance has the following methods:
    cursor to the left non-destructively, etc.).
 
    An end-of-file on input is passed back as the string ``'EOF'``.
+   To handle this gracefully, define a :meth:`!do_EOF` method in your subclass
+   (see :ref:`cmd-example` below).
 
    .. index::
       single: ? (question mark); in a command interpreter
@@ -117,7 +119,8 @@ A :class:`Cmd` instance has the following methods:
 .. method:: Cmd.emptyline()
 
    Method called when an empty line is entered in response to the prompt. If this
-   method is not overridden, it repeats the last nonempty command entered.
+   method is not overridden, it repeats the last nonempty command entered.  To
+   suppress this behavior, override with a method that does nothing (``pass``).
 
 
 .. method:: Cmd.default(line)
@@ -304,6 +307,16 @@ immediate playback::
             print('Thank you for using Turtle')
             self.close()
             bye()
+            return True
+
+        # ----- shell behavior -----
+        def emptyline(self):
+            'Do not repeat the last command on empty input'
+            pass
+        def do_EOF(self, arg):
+            'Exit on EOF (Ctrl-D):  EOF'
+            print()
+            self.close()
             return True
 
         # ----- record and playback -----


### PR DESCRIPTION
## Summary
Addresses #144338 by improving the `cmd.Cmd` documentation to make the `emptyline()` and `do_EOF` patterns more discoverable:

- Add a note to `cmdloop()` docs that `do_EOF` should be defined to handle Ctrl-D/EOF gracefully, with a cross-reference to the example
- Add a practical tip to `emptyline()` docs about overriding with `pass` to suppress the default repeat-last-command behavior
- Add `emptyline()` and `do_EOF()` methods to the existing TurtleShell example to demonstrate these common patterns

These are the two most commonly needed overrides that new `cmd.Cmd` users struggle to discover from the current documentation.

Closes #144338

## Test plan
- [ ] Documentation builds without warnings
- [ ] Example code in docs is syntactically correct

<!-- gh-issue-number: gh-144338 -->
* Issue: gh-144338
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145292.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->