### PR TITLE
Standardize spelling: "writeable" → "writable" in library docs

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -2348,7 +2348,7 @@ Data types
    .. method:: _CData.from_buffer(source[, offset])
 
       This method returns a ctypes instance that shares the buffer of the
-      *source* object.  The *source* object must support the writeable buffer
+      *source* object.  The *source* object must support the writable buffer
       interface.  The optional *offset* parameter specifies an offset into the
       source buffer in bytes; the default is zero.  If the source buffer is not
       large enough a :exc:`ValueError` is raised.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1704,7 +1704,7 @@ are always available.  They are listed here in alphabetical order.
       ``fdel`` corresponding to the constructor arguments.
 
    .. versionchanged:: 3.5
-      The docstrings of property objects are now writeable.
+      The docstrings of property objects are now writable.
 
    .. attribute:: __name__
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -789,7 +789,7 @@ than raw I/O does.
 
 .. class:: BufferedWriter(raw, buffer_size=DEFAULT_BUFFER_SIZE)
 
-   A buffered binary stream providing higher-level access to a writeable, non
+   A buffered binary stream providing higher-level access to a writable, non
    seekable :class:`RawIOBase` raw binary stream.  It inherits from
    :class:`BufferedIOBase`.
 
@@ -802,7 +802,7 @@ than raw I/O does.
    * when a :meth:`~IOBase.seek` is requested (for :class:`BufferedRandom` objects);
    * when the :class:`BufferedWriter` object is closed or destroyed.
 
-   The constructor creates a :class:`BufferedWriter` for the given writeable
+   The constructor creates a :class:`BufferedWriter` for the given writable
    *raw* stream.  If the *buffer_size* is not given, it defaults to
    :data:`DEFAULT_BUFFER_SIZE`.
 
@@ -840,11 +840,11 @@ than raw I/O does.
 .. class:: BufferedRWPair(reader, writer, buffer_size=DEFAULT_BUFFER_SIZE, /)
 
    A buffered binary stream providing higher-level access to two non seekable
-   :class:`RawIOBase` raw binary streams---one readable, the other writeable.
+   :class:`RawIOBase` raw binary streams---one readable, the other writable.
    It inherits from :class:`BufferedIOBase`.
 
    *reader* and *writer* are :class:`RawIOBase` objects that are readable and
-   writeable respectively.  If the *buffer_size* is omitted it defaults to
+   writable respectively.  If the *buffer_size* is omitted it defaults to
    :data:`DEFAULT_BUFFER_SIZE`.
 
    :class:`BufferedRWPair` implements all of :class:`BufferedIOBase`\'s methods

--- a/Doc/library/marshal.rst
+++ b/Doc/library/marshal.rst
@@ -78,7 +78,7 @@ The module defines these functions:
 .. function:: dump(value, file, version=version, /, *, allow_code=True)
 
    Write the value on the open file.  The value must be a supported type.  The
-   file must be a writeable :term:`binary file`.
+   file must be a writable :term:`binary file`.
 
    If the value has (or contains an object that has) an unsupported type, a
    :exc:`ValueError` exception is raised --- but garbage data will also be written

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -880,7 +880,7 @@ Constants
 
    Whether the OpenSSL library has built-in support not checking subject
    common name and :attr:`SSLContext.hostname_checks_common_name` is
-   writeable.
+   writable.
 
    .. versionadded:: 3.7
 

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -910,7 +910,7 @@ Reassigning them to new values is unsupported:
 
 .. attribute:: Popen.stdin
 
-   If the *stdin* argument was :data:`PIPE`, this attribute is a writeable
+   If the *stdin* argument was :data:`PIPE`, this attribute is a writable
    stream object as returned by :func:`open`. If the *encoding* or *errors*
    arguments were specified or the *text* or *universal_newlines* argument
    was ``True``, the stream is a text stream, otherwise it is a byte stream.

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -367,7 +367,7 @@ ZipFile objects
       Previously, a :exc:`RuntimeError` was raised.
 
    .. versionchanged:: 3.13
-      Added attributes :attr:`!name` and :attr:`!mode` for the writeable
+      Added attributes :attr:`!name` and :attr:`!mode` for the writable
       file-like object.
       The value of the :attr:`!mode` attribute for the readable file-like
       object was changed from ``'r'`` to ``'rb'``.


### PR DESCRIPTION
## Summary
- Standardize "writeable" → "writable" across 7 library documentation files
- Python's own `io` module uses "writable" (e.g. `IOBase.writable()`), and the codebase overwhelmingly prefers this spelling (33 vs 11 in docs, 55 vs 3 in source code)
- Affected files: `io.rst`, `marshal.rst`, `subprocess.rst`, `ssl.rst`, `ctypes.rst`, `functions.rst`, `zipfile.rst`

## Test plan
- [ ] Documentation builds without warnings
- [ ] No functional changes (spelling-only fix)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145294.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->