### PR TITLE
Update ocert.org URLs from HTTP to HTTPS in docs

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2256,7 +2256,7 @@ Basic customization
       This is intended to provide protection against a denial-of-service caused
       by carefully chosen inputs that exploit the worst case performance of a
       dict insertion, *O*\ (*n*\ :sup:`2`) complexity.  See
-      http://ocert.org/advisories/ocert-2011-003.html for details.
+      https://ocert.org/advisories/ocert-2011-003.html for details.
 
       Changing hash values affects the iteration order of sets.
       Python has never made guarantees about this ordering

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -390,7 +390,7 @@ Miscellaneous options
    Hash randomization is intended to provide protection against a
    denial-of-service caused by carefully chosen inputs that exploit the worst
    case performance of a dict construction, *O*\ (*n*\ :sup:`2`) complexity.  See
-   http://ocert.org/advisories/ocert-2011-003.html for details.
+   https://ocert.org/advisories/ocert-2011-003.html for details.
 
    :envvar:`PYTHONHASHSEED` allows you to set a fixed value for the hash
    seed secret.


### PR DESCRIPTION
## Summary
- Update 2 ocert.org advisory URLs from `http://` to `https://` in documentation
- The ocert.org site fully supports HTTPS (verified: returns HTTP 200)
- Affected files: `Doc/reference/datamodel.rst`, `Doc/using/cmdline.rst`
- Both reference the same hash collision DoS advisory (ocert-2011-003)

## Test plan
- [ ] `https://ocert.org/advisories/ocert-2011-003.html` returns HTTP 200 (verified)
- [ ] Documentation builds without warnings

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145295.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->