### PR TITLE
gh-145305: Update ocert.org URLs in docs from http to https

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2256,7 +2256,7 @@ Basic customization
       This is intended to provide protection against a denial-of-service caused
       by carefully chosen inputs that exploit the worst case performance of a
       dict insertion, *O*\ (*n*\ :sup:`2`) complexity.  See
-      http://ocert.org/advisories/ocert-2011-003.html for details.
+      https://ocert.org/advisories/ocert-2011-003.html for details.
 
       Changing hash values affects the iteration order of sets.
       Python has never made guarantees about this ordering

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -390,7 +390,7 @@ Miscellaneous options
    Hash randomization is intended to provide protection against a
    denial-of-service caused by carefully chosen inputs that exploit the worst
    case performance of a dict construction, *O*\ (*n*\ :sup:`2`) complexity.  See
-   http://ocert.org/advisories/ocert-2011-003.html for details.
+   https://ocert.org/advisories/ocert-2011-003.html for details.
 
    :envvar:`PYTHONHASHSEED` allows you to set a fixed value for the hash
    seed secret.


### PR DESCRIPTION
gh-issue-145305: update ocert.org URLs from http to https

## Summary

Two references to `http://ocert.org` in the documentation now use `https://` instead. The site supports HTTPS and these are long-lived documentation links that should use the secure scheme.

## Changes

- `Doc/reference/datamodel.rst`: updated ocert.org advisory link to HTTPS
- `Doc/using/cmdline.rst`: updated the same advisory link to HTTPS (hash randomization docs)

## Motivation

Both occurrences reference the same `ocert-2011-003` advisory about hash-flooding denial-of-service, used to explain `-R` / `PYTHONHASHSEED`. The current HTTP URL results in a redirect; using HTTPS directly is more correct and avoids the redirect.

Closes #145305

<!-- gh-issue-number: gh-145305 -->
* Issue: gh-145305
<!-- /gh-issue-number -->
