### PR TITLE
gh-145301: Fix double-free in hashlib and hmac module initialization

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-02-27-19-00-26.gh-issue-145301.2Wih4b.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-27-19-00-26.gh-issue-145301.2Wih4b.rst
@@ -1,0 +1,2 @@
+:mod:`hashlib`: fix a crash when the initialization of the underlying C
+extension module fails.

--- a/Misc/NEWS.d/next/Library/2026-02-28-00-55-00.gh-issue-145301.Lk2bRl.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-28-00-55-00.gh-issue-145301.Lk2bRl.rst
@@ -1,0 +1,2 @@
+:mod:`hmac`: fix a crash when the initialization of the underlying C
+extension module fails.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -268,7 +268,7 @@ py_hashentry_table_new(void) {
 
         if (h->py_alias != NULL) {
             if (_Py_hashtable_set(ht, (const void*)entry->py_alias, (void*)entry) < 0) {
-                PyMem_Free(entry);
+                /* entry is already in ht, will be freed by _Py_hashtable_destroy() */
                 goto error;
             }
             entry->refcnt++;

--- a/Modules/hmacmodule.c
+++ b/Modules/hmacmodule.c
@@ -1453,16 +1453,19 @@ py_hmac_hinfo_ht_new(void)
         assert(value->display_name == NULL);
         value->refcnt = 0;
 
-#define Py_HMAC_HINFO_LINK(KEY)                                 \
-        do {                                                    \
-            int rc = py_hmac_hinfo_ht_add(table, KEY, value);   \
-            if (rc < 0) {                                       \
-                PyMem_Free(value);                              \
-                goto error;                                     \
-            }                                                   \
-            else if (rc == 1) {                                 \
-                value->refcnt++;                                \
-            }                                                   \
+#define Py_HMAC_HINFO_LINK(KEY)                                     \
+        do {                                                        \
+            int rc = py_hmac_hinfo_ht_add(table, (KEY), value);     \
+            if (rc < 0) {                                           \
+                /* entry may already be in ht, freed upon exit */   \
+                if (value->refcnt == 0) {                           \
+                    PyMem_Free(value);                              \
+                }                                                   \
+                goto error;                                         \
+            }                                                       \
+            else if (rc == 1) {                                     \
+                value->refcnt++;                                    \
+            }                                                       \
         } while (0)
         Py_HMAC_HINFO_LINK(e->name);
         Py_HMAC_HINFO_LINK(e->hashlib_name);


### PR DESCRIPTION
Both `hashlib` and `hmac` modules have similar double-free bugs in their hashtable initialization code.

## Problem

### `hashlib`

In `py_hashentry_table_new()`, when `_Py_hashtable_set()` fails while adding an entry by its `py_alias` key (after successfully adding it by `py_name`), the code calls `PyMem_Free(entry)` before `goto error`. The error handler then calls `_Py_hashtable_destroy()` which frees the same entry again via `py_hashentry_t_destroy_value()`.

### `hmac`

In `py_hmac_hinfo_ht_new()`, the `Py_HMAC_HINFO_LINK` macro has the same issue. When `py_hmac_hinfo_ht_add()` fails for `hashlib_name` key (after successfully adding `name`), the code calls `PyMem_Free(value)` while the entry is already in the hashtable with `refcnt=1`.

## Solution

### `hashlib`

Remove the manual `PyMem_Free(entry)` call since the entry is already tracked by the hashtable under the `py_name` key and will be properly freed by `_Py_hashtable_destroy()`.

### `hmac`

Add a `refcnt` check before freeing: only call `PyMem_Free(value)` if `value->refcnt == 0` (meaning it was never added to the table). If `refcnt > 0`, the entry is already in the table and will be freed by `_Py_hashtable_destroy()`.

## Tests

No test added. I couldn't find a practical way to trigger this bug since it requires `_Py_hashtable_set()` to fail during module initialization. This type of bug is best caught by sanitizers rather than unit tests.

The fix can be verified by running the reproducer provided by the issue author:

**Build with ASan:**
```bash
mkdir build-asan && cd build-asan
../configure --with-pydebug --with-address-sanitizer --without-pymalloc
make -j$(nproc)
```

**Reproducer script (`uaf_asan.py`):**
```python
import subprocess
import sys

code = (
    "import sys, _testcapi\n"
    "if '_hashlib' in sys.modules:\n"
    "    del sys.modules['_hashlib']\n"
    "_testcapi.set_nomemory(40, 41)\n"
    "try:\n"
    "    import _hashlib\n"
    "except (MemoryError, ImportError):\n"
    "    pass\n"
    "finally:\n"
    "    _testcapi.remove_mem_hooks()\n"
)

result = subprocess.run(
    [sys.executable, '-c', code],
    capture_output=True, text=True, timeout=10
)

if result.returncode != 0:
    print(f"[*] CRASH confirmed (rc={result.returncode})")
    print(f"[*] {result.stderr.strip().split(chr(10))[-1]}")
else:
    print("[*] No crash (try different start values)")
```

**Before fix:**
```
$ ./build-asan/python uaf_asan.py
[*] CRASH confirmed (rc=-6)
[*] python: ../Include/internal/pycore_stackref.h:554: PyStackRef_FromPyObjectSteal: Assertion `obj != NULL' failed.
```

**After fix:** No crash.

<!-- gh-issue-number: gh-145301 -->
* Issue: gh-145301
<!-- /gh-issue-number -->
