### PR TITLE
GH-144533: Use wasmtime's --argv0 to auto-discover sysconfig in WASI builds

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-02-27-18-10-02.gh-issue-144533.21fk9L.rst
+++ b/Misc/NEWS.d/next/Build/2026-02-27-18-10-02.gh-issue-144533.21fk9L.rst
@@ -1,0 +1,1 @@
+Use wasmtime's ``--argv0`` to auto-discover sysconfig in WASI builds

--- a/Platforms/WASI/__main__.py
+++ b/Platforms/WASI/__main__.py
@@ -317,21 +317,8 @@ def configure_wasi_python(context, working_dir):
 
     wasi_build_dir = working_dir.relative_to(CHECKOUT)
 
-    python_build_dir = BUILD_DIR / "build"
-    lib_dirs = list(python_build_dir.glob("lib.*"))
-    assert len(lib_dirs) == 1, (
-        f"Expected a single lib.* directory in {python_build_dir}"
-    )
-    lib_dir = os.fsdecode(lib_dirs[0])
-    python_version = lib_dir.rpartition("-")[-1]
-    sysconfig_data_dir = (
-        f"{wasi_build_dir}/build/lib.wasi-wasm32-{python_version}"
-    )
-
-    # Use PYTHONPATH to include sysconfig data which must be anchored to the
-    # WASI guest's `/` directory.
     args = {
-        "PYTHONPATH": f"/{sysconfig_data_dir}",
+        "ARGV0": f"/{wasi_build_dir}/python.wasm",
         "PYTHON_WASM": working_dir / "python.wasm",
     }
     # Check dynamically for wasmtime in case it was specified manually via
@@ -421,8 +408,8 @@ def main():
     default_host_triple = config["targets"]["host-triple"]
     default_host_runner = (
         f"{WASMTIME_HOST_RUNNER_VAR} run "
-        # For setting PYTHONPATH to the sysconfig data directory.
-        "--env PYTHONPATH={PYTHONPATH} "
+        # Set argv0 so that getpath.py can auto-discover the sysconfig data directory
+        "--argv0 {ARGV0} "
         # Map the checkout to / to load the stdlib from /Lib.
         f"--dir {os.fsdecode(CHECKOUT)}::/ "
         # Flags involving --optimize, --codegen, --debug, --wasm, and --wasi can be kept


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144533 -->
* Issue: gh-144533
<!-- /gh-issue-number -->
