### PR TITLE
gh-145300: Add `__length_hint__` for `itertools.islice`

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1223,6 +1223,14 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(islice(range(10), 3, None, 2).__length_hint__(), 4)
         self.assertEqual(islice(range(10), 2, 2, 1).__length_hint__(), 0)
 
+        it = islice(iter(range(5)), None)
+        list(it)  # exhaust
+        self.assertEqual(it.__length_hint__(), 0)
+
+        it = islice(iter(range(5)), 3)
+        list(it)  # exhaust
+        self.assertEqual(it.__length_hint__(), 0)
+
     def test_takewhile(self):
         data = [1, 3, 5, 20, 2, 4, 6, 8]
         self.assertEqual(list(takewhile(underten, data)), [1, 3, 5])

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1213,6 +1213,16 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(list(islice(range(100), IntLike(10), IntLike(50), IntLike(5))),
                          list(range(10,50,5)))
 
+        # Test __length_hint__
+        self.assertEqual(islice(range(10), 1).__length_hint__(), 1)
+        self.assertEqual(islice(range(10), 1, 2).__length_hint__(), 1)
+        self.assertEqual(islice(range(10), 1, 2, 2).__length_hint__(), 1)
+        self.assertEqual(islice(range(10), 0, 4, 2).__length_hint__(), 2)
+        self.assertEqual(islice(range(10), 2, None, 1).__length_hint__(), 8)
+        self.assertEqual(islice(range(10), 2, None, 2).__length_hint__(), 4)
+        self.assertEqual(islice(range(10), 3, None, 2).__length_hint__(), 4)
+        self.assertEqual(islice(range(10), 2, 2, 1).__length_hint__(), 0)
+
     def test_takewhile(self):
         data = [1, 3, 5, 20, 2, 4, 6, 8]
         self.assertEqual(list(takewhile(underten, data)), [1, 3, 5])

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1231,6 +1231,17 @@ class TestBasicOps(unittest.TestCase):
         list(it)  # exhaust
         self.assertEqual(it.__length_hint__(), 0)
 
+        it = islice(iter(range(10)), 2, None, 2)
+        self.assertEqual(it.__length_hint__(), 4)  # indices 2, 4, 6, 8
+        next(it)  # yields 2
+        self.assertEqual(it.__length_hint__(), 3)  # indices 4, 6, 8
+        next(it)  # yields 4
+        self.assertEqual(it.__length_hint__(), 2)  # indices 6, 8
+        next(it)  # yields 6
+        self.assertEqual(it.__length_hint__(), 1)  # index 8
+        next(it)  # yields 8
+        self.assertEqual(it.__length_hint__(), 0)
+
     def test_takewhile(self):
         data = [1, 3, 5, 20, 2, 4, 6, 8]
         self.assertEqual(list(takewhile(underten, data)), [1, 3, 5])

--- a/Misc/NEWS.d/next/Library/2026-02-28-09-23-41.gh-issue-145300.JlCq0D.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-28-09-23-41.gh-issue-145300.JlCq0D.rst
@@ -1,0 +1,1 @@
+Add ``__length_hint__`` to :class:`itertools.islice`.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -1660,6 +1660,35 @@ empty:
     return NULL;
 }
 
+static PyObject *
+islice_length_hint(PyObject *op, PyObject *Py_UNUSED(dummy))
+{
+    isliceobject *lz = isliceobject_CAST(op);
+
+    if (lz->stop >= 0 && lz->stop <= lz->next) {
+        return PyLong_FromSsize_t(0);
+    }
+
+    Py_ssize_t remaining;
+    if (lz->stop == -1) {
+        Py_ssize_t hint = PyObject_LengthHint(lz->it, 0);
+        if (hint < 0) {
+            /* propagate exception */
+            return NULL;
+        }
+        remaining = hint - lz->next;
+    } else {
+        remaining = lz->stop - lz->next;
+    }
+
+    if (remaining <= 0) {
+        return PyLong_FromSsize_t(0);
+    }
+
+    Py_ssize_t steps = (remaining + lz->step - 1) / lz->step;
+    return PyLong_FromSsize_t(steps);
+}
+
 PyDoc_STRVAR(islice_doc,
 "islice(iterable, stop) --> islice object\n\
 islice(iterable, start, stop[, step]) --> islice object\n\
@@ -1671,6 +1700,11 @@ specified as another value, step determines how many values are\n\
 skipped between successive calls.  Works like a slice() on a list\n\
 but returns an iterator.");
 
+static PyMethodDef islice_methods[] = {
+    {"__length_hint__", islice_length_hint, METH_NOARGS, NULL},
+    {NULL, NULL},
+};
+
 static PyType_Slot islice_slots[] = {
     {Py_tp_dealloc, islice_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -1680,6 +1714,7 @@ static PyType_Slot islice_slots[] = {
     {Py_tp_iternext, islice_next},
     {Py_tp_new, islice_new},
     {Py_tp_free, PyObject_GC_Del},
+    {Py_tp_methods, islice_methods},
     {0, NULL},
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -1685,7 +1685,7 @@ islice_length_hint(PyObject *op, PyObject *Py_UNUSED(dummy))
         return PyLong_FromSsize_t(0);
     }
 
-    Py_ssize_t steps = (remaining + lz->step - 1) / lz->step;
+    Py_ssize_t steps = 1 + (remaining - 1) / lz->step;
     return PyLong_FromSsize_t(steps);
 }
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -1676,7 +1676,7 @@ islice_length_hint(PyObject *op, PyObject *Py_UNUSED(dummy))
             /* propagate exception */
             return NULL;
         }
-        remaining = hint - lz->next;
+        remaining = hint - (lz->next - lz->cnt);
     } else {
         remaining = lz->stop - lz->next;
     }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -1665,7 +1665,7 @@ islice_length_hint(PyObject *op, PyObject *Py_UNUSED(dummy))
 {
     isliceobject *lz = isliceobject_CAST(op);
 
-    if (lz->stop >= 0 && lz->stop <= lz->next) {
+    if (lz->it == NULL || (lz->stop >= 0 && lz->stop <= lz->next)) {
         return PyLong_FromSsize_t(0);
     }
 


### PR DESCRIPTION
## Summary

This PR addresses an issue I spotted on #145300, which mentioned that `itertools.islice` does not support `__length_hint__` currently. 

General philosophy is
- Early return 0 in all cases that make sense
- If `stop` is not set, we don't know the number of elements we will iterate over, so we use the underlying iterator's `__length_hint__` then do our calculations over that 
- Once we have a start, a stop and a step, or a start a length hint and a step, we can know how many iterations that will result in. 

Testing wise, I added a few unit tests but it's unclear to me if I should be adding more (there doesn't seem to be a ton of instances/examples for the other `itertools` tests), but feel free to request more. Just to gain confidence in the change myself, I also tried the following locally (it works):

```py
import itertools

for start in range(0, 100):
    for stop in range(0, 100):
        for step in range(1, 100):
            r = range(100)
            s = itertools.islice(r, start, stop, step)
            hint = s.__length_hint__()
            l = list(s)

            assert len(l) == hint
```

**Note** this is my first PR here; I read the contributor guidelines but I apologise in advance if anything I did not follow them (please do tell me!)

<!-- gh-issue-number: gh-145300 -->
* Issue: gh-145300
<!-- /gh-issue-number -->
