### PR TITLE
gh-61745: Clarify os.listdir behavior for empty path

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2380,6 +2380,8 @@ features:
    entries ``'.'`` and ``'..'`` even if they are present in the directory.
    If a file is removed from or added to the directory during the call of
    this function, whether a name for that file be included is unspecified.
+   *path* must refer to an existing directory. Passing ``''`` raises
+   :exc:`FileNotFoundError`; use ``'.'`` to list the current directory.
 
    *path* may be a :term:`path-like object`.  If *path* is of type ``bytes``
    (directly or indirectly through the :class:`PathLike` interface),


### PR DESCRIPTION
Fixes gh-61745.

Clarify the `os.listdir()` docs to explicitly state that passing an empty
string (`''`) raises `FileNotFoundError`, and that `'.'` should be used
for the current directory.

This change updates documentation only.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145338.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->