### PR TITLE
Use `reusable-docs.yml` in `documentation-links`

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -8,6 +8,7 @@ on:
       - opened
     paths:
     - 'Doc/**'
+    - '.github/workflows/documentation-links.sh'
     - '.github/workflows/reusable-docs.yml'
 
 concurrency:

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -8,7 +8,7 @@ on:
       - opened
     paths:
     - 'Doc/**'
-    - '.github/workflows/doc.yml'
+    - '.github/workflows/reusable-docs.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -9,7 +9,6 @@ on:
     paths:
     - 'Doc/**'
     - '.github/workflows/documentation-links.sh'
-    - '.github/workflows/reusable-docs.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -8,7 +8,7 @@ on:
       - opened
     paths:
     - 'Doc/**'
-    - '.github/workflows/documentation-links.sh'
+    - '.github/workflows/documentation-links.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## What is this?

Currently, the `documentation-links` refers to `doc.yml` which doesn't exist. 

~I suspect the correct file to reference is `reusable-docs.yml`, based on just looking at commit history for `doc.yml` and seeing 88d14da76f5.~  After some Git archeology, this turned out to be incorrect. 

Seems like `documentation-links.yml` was added in https://github.com/python/cpython/pull/103843 (back then, `doc.yml` did exist). My bet would be that `doc.yml` was copy-pasted to `documentation_links.yml` and this bit was not updated. In the meantime, `doc.yml` was renamed to `reusable-docs.yml`, which is what made me think that was the right new thing to run when changed.

**Note** I didn't add neither a GitHub Issue number nor a News entry as I don't think this warrants either, but feel free to tell me if I should.