### PR TITLE
 gh-139588: Docs: PDF: convert SVG to PDF using sphinxcontrib.rsvgconverter

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -44,6 +44,7 @@ extensions = [
 _OPTIONAL_EXTENSIONS = (
     'notfound.extension',
     'sphinxext.opengraph',
+    'sphinxcontrib.rsvgconverter',
 )
 for optional_ext in _OPTIONAL_EXTENSIONS:
     try:

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -13,6 +13,7 @@ blurb
 
 sphinxext-opengraph~=0.12.0
 sphinx-notfound-page~=1.0.0
+sphinxcontrib-svg2pdfconverter~=1.3.0
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

https://github.com/python/cpython/pull/133591 introduced an SVG into docs, which is not handled by LaTeX (used for PDF build) natively. This fixes the PDF build error. Uses [a recommended](https://nbsphinx.readthedocs.io/en/0.9.7/markdown-cells.html#SVG-support-for-LaTeX) approach.

(Better) alternative to https://github.com/python/cpython/pull/139635.

Render:

<img width="1196" height="1057" alt="Zrzut ekranu 2025-10-19 o 23 58 50" src="https://github.com/user-attachments/assets/fad54d81-7351-4d31-8ec8-f7e89335b96e" />

<!-- gh-issue-number: gh-139588 -->
* Issue: gh-139588
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145347.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->