### PR TITLE
gh-145351: use `--no-install-recommends`

### DIFF
--- a/.github/workflows/posix-deps-apt.sh
+++ b/.github/workflows/posix-deps-apt.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 apt-get update
 
-apt-get -yq install \
+apt-get -yq --no-install-recommends install \
     build-essential \
     pkg-config \
     ccache \
@@ -32,4 +32,4 @@ apt-get -yq install \
 # https://deb.sury.org/
 sudo add-apt-repository ppa:ondrej/php
 apt-get update
-apt-get -yq install libmpdec-dev
+apt-get -yq --no-install-recommends install libmpdec-dev

--- a/.github/workflows/regen-abidump.sh
+++ b/.github/workflows/regen-abidump.sh
@@ -2,7 +2,7 @@ set -ex
 
 export DEBIAN_FRONTEND=noninteractive
 ./.github/workflows/posix-deps-apt.sh
-apt-get install -yq abigail-tools python3
+apt-get install -yq --no-install-recommends abigail-tools python3
 export CFLAGS="-g3 -O0"
 ./configure --enable-shared && make
 make regen-abidump

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -92,7 +92,7 @@ jobs:
         restore-keys: |
           ubuntu-doc-
     - name: 'Install Dependencies'
-      run: sudo ./.github/workflows/posix-deps-apt.sh && sudo apt-get install wamerican
+      run: sudo ./.github/workflows/posix-deps-apt.sh && sudo apt-get install --no-install-recommends wamerican
     - name: 'Configure CPython'
       run: ./configure --with-pydebug
     - name: 'Build CPython'

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -47,7 +47,7 @@ jobs:
       if: ${{ fromJSON(inputs.bolt-optimizations) }}
       run: |
         sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh 19
-        sudo apt-get install bolt-19
+        sudo apt-get install --no-install-recommends bolt-19
         echo PATH="$(llvm-config-19 --bindir):$PATH" >> $GITHUB_ENV
     - name: Configure OpenSSL env vars
       run: |


### PR DESCRIPTION
## What is this PR?

Most details/context are available in gh-145351, but in short, local testing (through `docker run`)  showed that not installing recommended packages for build dependencies brings install time from ~51s down to ~25, which definitely sounds worth doing. 

**Note** As far as I know, GitHub Actions, for safety reasons, does not pick up changes from the PR's GHA configuration when there are some, and instead runs the version on the target branch, so I'm testing this change in my fork to validate that it works.
-> Result: I tested it in CI on my fork and the time in CI seems to be going down from 33s down to 21s, which is still worth it in my opinion.