### PR TITLE
gh-144475: Fix a heap buffer overflow in partial_repr

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -514,7 +514,7 @@ class TestPartial:
         self.assertEqual(alias.__args__, (int,))
         self.assertEqual(alias.__parameters__, ())
 
-    # Issue 144475
+    # GH-144475: Tests that the partial object does not change until repr finishes
     def test_repr_saftey_against_reentrant_mutation(self):
         g_partial = None
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -515,7 +515,7 @@ class TestPartial:
         self.assertEqual(alias.__parameters__, ())
 
     # GH-144475: Tests that the partial object does not change until repr finishes
-    def test_repr_saftey_against_reentrant_mutation(self):
+    def test_repr_safety_against_reentrant_mutation(self):
         g_partial = None
 
         class Function:

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -514,6 +514,58 @@ class TestPartial:
         self.assertEqual(alias.__args__, (int,))
         self.assertEqual(alias.__parameters__, ())
 
+    # Issue 144475
+    def test_repr_saftey_against_reentrant_mutation(self):
+        g_partial = None
+
+        class Function:
+            def __init__(self, name):
+                self.name = name
+
+            def __call__(self):
+                return None
+
+            def __repr__(self):
+                return f"Function({self.name})"
+
+        class EvilObject:
+            def __init__(self):
+                self.triggered = False
+
+            def __repr__(self):
+                if not self.triggered and g_partial is not None:
+                    self.triggered = True
+                    new_args_tuple = (None,)
+                    new_keywords_dict = {"keyword": None}
+                    new_tuple_state = (Function("new_function"), new_args_tuple, new_keywords_dict, None)
+                    g_partial.__setstate__(new_tuple_state)
+                    gc.collect()
+                return f"EvilObject"
+
+        trigger = EvilObject()
+        func = Function("old_function")
+
+        g_partial = functools.partial(func, None, trigger=trigger)
+        self.assertEqual(repr(g_partial),"functools.partial(Function(old_function), None, trigger=EvilObject)")
+
+        trigger.triggered = False
+        g_partial = functools.partial(func, trigger, arg=None)
+        self.assertEqual(repr(g_partial),"functools.partial(Function(old_function), EvilObject, arg=None)")
+
+
+        trigger.triggered = False
+        g_partial = functools.partial(func, trigger, None)
+        self.assertEqual(repr(g_partial),"functools.partial(Function(old_function), EvilObject, None)")
+
+        trigger.triggered = False
+        g_partial = functools.partial(func, trigger=trigger, arg=None)
+        self.assertEqual(repr(g_partial),"functools.partial(Function(old_function), trigger=EvilObject, arg=None)")
+
+        trigger.triggered = False
+        g_partial = functools.partial(func, trigger, None, None, None, None, arg=None)
+        self.assertEqual(repr(g_partial),"functools.partial(Function(old_function), EvilObject, None, None, None, None, arg=None)")
+
+
 
 @unittest.skipUnless(c_functools, 'requires the C _functools module')
 class TestPartialC(TestPartial, unittest.TestCase):

--- a/Misc/NEWS.d/next/C_API/2026-02-07-16-37-42.gh-issue-144475.8tFEXw.rst
+++ b/Misc/NEWS.d/next/C_API/2026-02-07-16-37-42.gh-issue-144475.8tFEXw.rst
@@ -1,3 +1,0 @@
-Calling :func:`repr` on :func:`functools.partial` will no longer
-use a mutated version of the arguments ``fn``, ``args``, or ``kw``
-when generating the string representation of the partial object.

--- a/Misc/NEWS.d/next/C_API/2026-02-07-16-37-42.gh-issue-144475.8tFEXw.rst
+++ b/Misc/NEWS.d/next/C_API/2026-02-07-16-37-42.gh-issue-144475.8tFEXw.rst
@@ -1,6 +1,3 @@
-Fixed a bug in :func:`functools.partial` when calling :func:`repr` on a partial
-object that could occur when the ``fn``, ``args``, or ``kw`` arguments are modified
-during a call to :func:`repr`. Now, calls to :func:`repr` will use the original
-arguments when generating the string representation of the partial object.
-Subsequent calls will use the updated arguments instead.
-
+Calling :func:`repr` on :func:`functools.partial` will no longer
+use a mutated version of the arguments ``fn``, ``args``, or ``kw``
+when generating the string representation of the partial object.

--- a/Misc/NEWS.d/next/C_API/2026-02-07-16-37-42.gh-issue-144475.8tFEXw.rst
+++ b/Misc/NEWS.d/next/C_API/2026-02-07-16-37-42.gh-issue-144475.8tFEXw.rst
@@ -1,0 +1,6 @@
+Fixed a bug in :func:`functools.partial` when calling :func:`repr` on a partial
+object that could occur when the ``fn``, ``args``, or ``kw`` arguments are modified
+during a call to :func:`repr`. Now, calls to :func:`repr` will use the original
+arguments when generating the string representation of the partial object.
+Subsequent calls will use the updated arguments instead.
+

--- a/Misc/NEWS.d/next/Library/2026-02-07-16-37-42.gh-issue-144475.8tFEXw.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-07-16-37-42.gh-issue-144475.8tFEXw.rst
@@ -1,0 +1,3 @@
+Calling :func:`repr` on :func:`functools.partial` is now safer
+when the partial object's internal attributes are replaced while
+the string representation is being generated.

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -688,6 +688,7 @@ partial_repr(PyObject *self)
 {
     partialobject *pto = partialobject_CAST(self);
     PyObject *result = NULL;
+    PyObject *fn, *args, *kw;
     PyObject *arglist;
     PyObject *mod;
     PyObject *name;
@@ -697,56 +698,65 @@ partial_repr(PyObject *self)
 
     status = Py_ReprEnter(self);
     if (status != 0) {
-        if (status < 0)
+        if (status < 0) {
             return NULL;
+        }
         return PyUnicode_FromString("...");
     }
+    /* Reference arguments in case they change */
+    fn = Py_NewRef(pto->fn);
+    args = Py_NewRef(pto->args);
+    kw = Py_NewRef(pto->kw);
+    assert(PyTuple_Check(args));
+    assert(PyDict_Check(kw));
 
     arglist = Py_GetConstant(Py_CONSTANT_EMPTY_STR);
-    if (arglist == NULL)
-        goto done;
+    if (arglist == NULL) {
+        goto arglist_error;
+    }
     /* Pack positional arguments */
-    assert(PyTuple_Check(pto->args));
-    n = PyTuple_GET_SIZE(pto->args);
+    n = PyTuple_GET_SIZE(args);
     for (i = 0; i < n; i++) {
         Py_SETREF(arglist, PyUnicode_FromFormat("%U, %R", arglist,
-                                        PyTuple_GET_ITEM(pto->args, i)));
-        if (arglist == NULL)
-            goto done;
+                                        PyTuple_GET_ITEM(args, i)));
+        if (arglist == NULL) {
+            goto arglist_error;
+        }
     }
     /* Pack keyword arguments */
-    assert (PyDict_Check(pto->kw));
-    for (i = 0; PyDict_Next(pto->kw, &i, &key, &value);) {
+    for (i = 0; PyDict_Next(kw, &i, &key, &value);) {
         /* Prevent key.__str__ from deleting the value. */
         Py_INCREF(value);
         Py_SETREF(arglist, PyUnicode_FromFormat("%U, %S=%R", arglist,
                                                 key, value));
         Py_DECREF(value);
-        if (arglist == NULL)
-            goto done;
+        if (arglist == NULL) {
+            goto arglist_error;
+        }
     }
 
     mod = PyType_GetModuleName(Py_TYPE(pto));
     if (mod == NULL) {
-        goto error;
+        goto mod_error;
     }
+
     name = PyType_GetQualName(Py_TYPE(pto));
     if (name == NULL) {
-        Py_DECREF(mod);
-        goto error;
+        goto name_error;
     }
-    result = PyUnicode_FromFormat("%S.%S(%R%U)", mod, name, pto->fn, arglist);
-    Py_DECREF(mod);
-    Py_DECREF(name);
-    Py_DECREF(arglist);
 
- done:
+    result = PyUnicode_FromFormat("%S.%S(%R%U)", mod, name, fn, arglist);
+    Py_DECREF(name);
+ name_error:
+    Py_DECREF(mod);
+ mod_error:
+    Py_DECREF(arglist);
+ arglist_error:
+    Py_DECREF(fn);
+    Py_DECREF(args);
+    Py_DECREF(kw);
     Py_ReprLeave(self);
     return result;
- error:
-    Py_DECREF(arglist);
-    Py_ReprLeave(self);
-    return NULL;
 }
 
 /* Pickle strategy:

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -689,9 +689,9 @@ partial_repr(PyObject *self)
     partialobject *pto = partialobject_CAST(self);
     PyObject *result = NULL;
     PyObject *fn, *args, *kw;
-    PyObject *arglist;
-    PyObject *mod;
-    PyObject *name;
+    PyObject *arglist = NULL;
+    PyObject *mod = NULL;
+    PyObject *name = NULL;
     Py_ssize_t i, n;
     PyObject *key, *value;
     int status;
@@ -712,7 +712,7 @@ partial_repr(PyObject *self)
 
     arglist = Py_GetConstant(Py_CONSTANT_EMPTY_STR);
     if (arglist == NULL) {
-        goto arglist_error;
+        goto done;
     }
     /* Pack positional arguments */
     n = PyTuple_GET_SIZE(args);
@@ -720,7 +720,7 @@ partial_repr(PyObject *self)
         Py_SETREF(arglist, PyUnicode_FromFormat("%U, %R", arglist,
                                         PyTuple_GET_ITEM(args, i)));
         if (arglist == NULL) {
-            goto arglist_error;
+            goto done;
         }
     }
     /* Pack keyword arguments */
@@ -731,27 +731,25 @@ partial_repr(PyObject *self)
                                                 key, value));
         Py_DECREF(value);
         if (arglist == NULL) {
-            goto arglist_error;
+            goto done;
         }
     }
 
     mod = PyType_GetModuleName(Py_TYPE(pto));
     if (mod == NULL) {
-        goto mod_error;
+        goto done;
     }
 
     name = PyType_GetQualName(Py_TYPE(pto));
     if (name == NULL) {
-        goto name_error;
+        goto done;
     }
 
     result = PyUnicode_FromFormat("%S.%S(%R%U)", mod, name, fn, arglist);
-    Py_DECREF(name);
- name_error:
-    Py_DECREF(mod);
- mod_error:
-    Py_DECREF(arglist);
- arglist_error:
+done:
+    Py_XDECREF(name);
+    Py_XDECREF(mod);
+    Py_XDECREF(arglist);
     Py_DECREF(fn);
     Py_DECREF(args);
     Py_DECREF(kw);

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -688,7 +688,6 @@ partial_repr(PyObject *self)
 {
     partialobject *pto = partialobject_CAST(self);
     PyObject *result = NULL;
-    PyObject *fn, *args, *kw;
     PyObject *arglist = NULL;
     PyObject *mod = NULL;
     PyObject *name = NULL;
@@ -704,9 +703,9 @@ partial_repr(PyObject *self)
         return PyUnicode_FromString("...");
     }
     /* Reference arguments in case they change */
-    fn = Py_NewRef(pto->fn);
-    args = Py_NewRef(pto->args);
-    kw = Py_NewRef(pto->kw);
+    PyObject *fn = Py_NewRef(pto->fn);
+    PyObject *args = Py_NewRef(pto->args);
+    PyObject *kw = Py_NewRef(pto->kw);
     assert(PyTuple_Check(args));
     assert(PyDict_Check(kw));
 


### PR DESCRIPTION
This is a cleaner version of PR https://github.com/python/cpython/pull/144571. I am not exactly sure what happened in https://github.com/python/cpython/pull/144571 so I would appreciate if anyone could tell me so I don't make the same mistake again.

Here are the changes I made:
-  I added an `args` and `kw`  local pointer so that both live long enough during the call to `repr` to prevent a segfault
- I added an `fn` local pointer so that `repr` uses its original state when generating its final representation.
- I got rid of the `error` goto and merged it with the `done` goto as I needed to decrement the reference count of `fn`, `args`, and `kw`, and I found that decrementing them in the `done` goto was the easiest. 
- I added a test based on @Qanux's original code. I extended it to also check for changes in the `fn` and `kw` arguments.

<!-- gh-issue-number: gh-144475 -->
* Issue: gh-144475
<!-- /gh-issue-number -->
