### PR TITLE
gh-144551: Update iOS builds to use OpenSSL 3.5.5

### DIFF
--- a/Apple/__main__.py
+++ b/Apple/__main__.py
@@ -316,7 +316,7 @@ def unpack_deps(
     for name_ver in [
         "BZip2-1.0.8-2",
         "libFFI-3.4.7-2",
-        "OpenSSL-3.0.19-1",
+        "OpenSSL-3.5.5-1",
         "XZ-5.6.4-2",
         "mpdecimal-4.0.0-2",
         "zstd-1.5.7-1",


### PR DESCRIPTION


<!-- gh-issue-number: gh-144551 -->
* Issue: gh-144551
<!-- /gh-issue-number -->
