### PR TITLE
gh-145369: document dataclass could possibly mutate provided field objects

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -254,6 +254,11 @@ Module contents
    used because ``None`` is a valid value for some parameters with
    a distinct meaning.  No code should directly use the :const:`MISSING` value.
 
+   :deco:`dataclass` is free to possibly mutate the provided field
+   objects. As such, do not use the same object for multiple fields
+   even if they share the same properties. If so, the updated class is
+   not ensured to be well-functioning.
+
    The parameters to :func:`!field` are:
 
    - *default*: If provided, this will be the default value for this


### PR DESCRIPTION
It is a suggestion to add to the docs a paragraph discouraging using the same field object for multiple fields as `dataclass` expect them to be *different*.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145369 -->
* Issue: gh-145369
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145387.org.readthedocs.build/

-> https://cpython-previews--145387.org.readthedocs.build/en/145387/library/dataclasses.html#dataclasses.field

<!-- readthedocs-preview cpython-previews end -->