### PR TITLE
gh-145335: Fix crash when passing -1 as fd in os.pathconf

### DIFF
--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -2781,7 +2781,7 @@ class TestInvalidFD(unittest.TestCase):
     @unittest.skipUnless(hasattr(os, 'pathconf'), 'test needs os.pathconf()')
     @unittest.skipIf(
         support.linked_to_musl(),
-        'musl pathconf ignores the file descriptor and returns a constant',
+        'musl fpathconf ignores the file descriptor and returns a constant',
         )
     def test_pathconf_negative_fd_uses_fd_semantics(self):
         with self.assertRaises(OSError) as ctx:

--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -2778,6 +2778,16 @@ class TestInvalidFD(unittest.TestCase):
         self.check(os.pathconf, "PC_NAME_MAX")
         self.check(os.fpathconf, "PC_NAME_MAX")
 
+    @unittest.skipUnless(hasattr(os, 'pathconf'), 'test needs os.pathconf()')
+    @unittest.skipIf(
+        support.linked_to_musl(),
+        'musl pathconf ignores the file descriptor and returns a constant',
+        )
+    def test_pathconf_negative_fd_uses_fd_semantics(self):
+        with self.assertRaises(OSError) as ctx:
+            os.pathconf(-1, 1)
+        self.assertEqual(ctx.exception.errno, errno.EBADF)
+
     @unittest.skipUnless(hasattr(os, 'ftruncate'), 'test needs os.ftruncate()')
     def test_ftruncate(self):
         self.check(os.truncate, 0)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-01-13-37-31.gh-issue-145335.e36kPJ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-01-13-37-31.gh-issue-145335.e36kPJ.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`os.pathconf` when called with ``-1`` as the path
+argument.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1280,6 +1280,8 @@ get_posix_state(PyObject *module)
  *     Contains a file descriptor if path.accept_fd was true
  *     and the caller provided a signed integer instead of any
  *     sort of string.
+ *   path.is_fd
+ *     True if path was provided as a file descriptor.
  *
  *     WARNING: if your "path" parameter is optional, and is
  *     unspecified, path_converter will never get called.
@@ -1332,6 +1334,7 @@ typedef struct {
     const wchar_t *wide;
     const char *narrow;
     int fd;
+    bool is_fd;
     int value_error;
     Py_ssize_t length;
     PyObject *object;
@@ -1341,7 +1344,7 @@ typedef struct {
 #define PATH_T_INITIALIZE(function_name, argument_name, nullable, nonstrict, \
                           make_wide, suppress_value_error, allow_fd) \
     {function_name, argument_name, nullable, nonstrict, make_wide, \
-     suppress_value_error, allow_fd, NULL, NULL, -1, 0, 0, NULL, NULL}
+     suppress_value_error, allow_fd, NULL, NULL, -1, false, 0, 0, NULL, NULL}
 #ifdef MS_WINDOWS
 #define PATH_T_INITIALIZE_P(function_name, argument_name, nullable, \
                             nonstrict, suppress_value_error, allow_fd) \
@@ -1475,6 +1478,7 @@ path_converter(PyObject *o, void *p)
         }
         path->wide = NULL;
         path->narrow = NULL;
+        path->is_fd = true;
         goto success_exit;
     }
     else {
@@ -1607,12 +1611,6 @@ follow_symlinks_specified(const char *function_name, int follow_symlinks)
 
     argument_unavailable_error(function_name, "follow_symlinks");
     return 1;
-}
-
-static bool
-path_is_fd(const path_t *path)
-{
-    return path->allow_fd && path->object != NULL && PyIndex_Check(path->object);
 }
 
 static int
@@ -14334,7 +14332,7 @@ os_pathconf_impl(PyObject *module, path_t *path, int name)
 
     errno = 0;
 #ifdef HAVE_FPATHCONF
-    if (path_is_fd(path)) {
+    if (path->is_fd) {
         limit = fpathconf(path->fd, name);
     }
     else

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1609,6 +1609,12 @@ follow_symlinks_specified(const char *function_name, int follow_symlinks)
     return 1;
 }
 
+static bool
+path_is_fd(const path_t *path)
+{
+    return path->allow_fd && path->object != NULL && PyIndex_Check(path->object);
+}
+
 static int
 path_and_dir_fd_invalid(const char *function_name, path_t *path, int dir_fd)
 {
@@ -14328,8 +14334,9 @@ os_pathconf_impl(PyObject *module, path_t *path, int name)
 
     errno = 0;
 #ifdef HAVE_FPATHCONF
-    if (path->fd != -1)
+    if (path_is_fd(path)) {
         limit = fpathconf(path->fd, name);
+    }
     else
 #endif
         limit = pathconf(path->narrow, name);


### PR DESCRIPTION
We currently test whether `path_t.fd` is -1 to decide if the argument should be treated as an fd or as a path, and then call `fpathconf()` or `pathconf()` according to it.

In the original issue, we passing -1 caused the code incorrectly treats the argument as a real path. But, `path->narrow` is NULL, so calling `pathconf()` on it will crash the interpreter.

This change adds a helper that checks whether the original argument is index-like to determine if it's an fd, so we can correctly the behavior and avoid the crash.

There are other `os` functions that accept `path_t` and may have the same issue. Since that is outside the scope of the original issue, I think we should fix those in a separate PR.

<!-- gh-issue-number: gh-145335 -->
* Issue: gh-145335
<!-- /gh-issue-number -->
