### PR TITLE
gh-142410: Soft-deprecate PyException_HEAD in C API docs

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -795,11 +795,15 @@ Exception Classes
 
 .. c:macro:: PyException_HEAD
 
-   This is a :term:`soft deprecated` macro including the base fields for an
-   exception object.
+   Include the base fields for an exception object.
 
-   This was included in Python's C API by mistake and is not designed for use
-   in extensions. For creating custom exception objects, use
+   .. deprecated:: 3.14
+      ``PyException_HEAD`` is an internal implementation detail that was not
+      intended to be exposed as  part of the python C API and is not designed
+      for use by third-party extensions.
+
+   The macro may be changed or removed in a future Python version.
+   Extensions authors should instead create exception class using
    :c:func:`PyErr_NewException` or otherwise create a class inheriting from
    :c:data:`PyExc_BaseException`.
 

--- a/Misc/NEWS.d/next/Documentation/2026-03-01-19-54-44.gh-issue-142410.8f-dkN.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-03-01-19-54-44.gh-issue-142410.8f-dkN.rst
@@ -1,0 +1,3 @@
+Soft-deprecate the ``PyException_HEAD`` macro in the C API documentation.
+The macro is an internal implementation detail and should not be used by
+third-party extensions.


### PR DESCRIPTION
- Soft-deprecated the PyException_HEAD macro in the C API documentation.

- No behavioral changes are introduced.

- Adds a NEWS entry.



<!-- gh-issue-number: gh-142410 -->
* Issue: gh-142410
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145391.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->