### PR TITLE
gh-144475: Fix use-after-free in functools.partial.__repr__()

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-03-02-02-30-00.gh-issue-144475.CfVOu8Hi.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-02-02-30-00.gh-issue-144475.CfVOu8Hi.rst
@@ -1,0 +1,6 @@
+Fix a heap-buffer-overflow in :func:`functools.partial.__repr__` where a
+user-defined :meth:`~object.__repr__` on an argument could mutate the
+:class:`~functools.partial` object via :meth:`~functools.partial.__setstate__`,
+freeing the args tuple while iteration was still in progress. The fix holds
+strong references to the ``args`` tuple, ``kw`` dict, and ``fn`` callable
+during formatting.

--- a/Misc/NEWS.d/next/Library/2026-03-02-02-30-00.gh-issue-144475.CfVOu8Hi.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-02-02-30-00.gh-issue-144475.CfVOu8Hi.rst
@@ -1,6 +1,5 @@
-Fix a heap-buffer-overflow in :func:`functools.partial.__repr__` where a
+Fix a heap-buffer-overflow in :func:`functools.partial` ``__repr__`` where a
 user-defined :meth:`~object.__repr__` on an argument could mutate the
-:class:`~functools.partial` object via :meth:`~functools.partial.__setstate__`,
-freeing the args tuple while iteration was still in progress. The fix holds
-strong references to the ``args`` tuple, ``kw`` dict, and ``fn`` callable
-during formatting.
+:class:`~functools.partial` object via ``__setstate__()``, freeing the args
+tuple while iteration was still in progress. The fix holds strong references
+to the ``args`` tuple, ``kw`` dict, and ``fn`` callable during formatting.

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -705,26 +705,39 @@ partial_repr(PyObject *self)
     arglist = Py_GetConstant(Py_CONSTANT_EMPTY_STR);
     if (arglist == NULL)
         goto done;
-    /* Pack positional arguments */
+    /* Pack positional arguments.
+     * Hold a strong reference to pto->args across the loop, because
+     * a user-defined __repr__ called via %R could mutate 'pto' (e.g.
+     * via __setstate__), freeing the original args tuple while we're
+     * still iterating over it.  See gh-144475. */
     assert(PyTuple_Check(pto->args));
-    n = PyTuple_GET_SIZE(pto->args);
+    PyObject *args = Py_NewRef(pto->args);
+    n = PyTuple_GET_SIZE(args);
     for (i = 0; i < n; i++) {
         Py_SETREF(arglist, PyUnicode_FromFormat("%U, %R", arglist,
-                                        PyTuple_GET_ITEM(pto->args, i)));
-        if (arglist == NULL)
+                                        PyTuple_GET_ITEM(args, i)));
+        if (arglist == NULL) {
+            Py_DECREF(args);
             goto done;
+        }
     }
-    /* Pack keyword arguments */
+    Py_DECREF(args);
+    /* Pack keyword arguments.
+     * Similarly, hold a strong reference to pto->kw.  See gh-144475. */
     assert (PyDict_Check(pto->kw));
-    for (i = 0; PyDict_Next(pto->kw, &i, &key, &value);) {
+    PyObject *kw = Py_NewRef(pto->kw);
+    for (i = 0; PyDict_Next(kw, &i, &key, &value);) {
         /* Prevent key.__str__ from deleting the value. */
         Py_INCREF(value);
         Py_SETREF(arglist, PyUnicode_FromFormat("%U, %S=%R", arglist,
                                                 key, value));
         Py_DECREF(value);
-        if (arglist == NULL)
+        if (arglist == NULL) {
+            Py_DECREF(kw);
             goto done;
+        }
     }
+    Py_DECREF(kw);
 
     mod = PyType_GetModuleName(Py_TYPE(pto));
     if (mod == NULL) {
@@ -735,7 +748,10 @@ partial_repr(PyObject *self)
         Py_DECREF(mod);
         goto error;
     }
-    result = PyUnicode_FromFormat("%S.%S(%R%U)", mod, name, pto->fn, arglist);
+    /* Hold a strong reference to pto->fn for the same reason as args/kw. */
+    PyObject *fn = Py_NewRef(pto->fn);
+    result = PyUnicode_FromFormat("%S.%S(%R%U)", mod, name, fn, arglist);
+    Py_DECREF(fn);
     Py_DECREF(mod);
     Py_DECREF(name);
     Py_DECREF(arglist);


### PR DESCRIPTION
## Summary

Fix a heap-buffer-overflow (use-after-free) in `functools.partial.__repr__()` where a user-defined `__repr__()` on an argument could mutate the partial object via `__setstate__()`, freeing the args tuple while `partial_repr()` was still iterating over it.

## Root Cause

`partial_repr()` captured the size of `pto->args` before the loop and accessed tuple items via borrowed references (`PyTuple_GET_ITEM`). If a `__repr__()` called during `%R` formatting invoked `pto.__setstate__()` with a new (smaller) args tuple, the original tuple was freed while iteration continued, causing an out-of-bounds read.

## Fix

Hold strong references (`Py_NewRef`) to `pto->args`, `pto->kw`, and `pto->fn` before iterating/using them. This ensures the underlying objects remain alive even if user code mutates the partial via `__setstate__()` during formatting.

The same pattern is applied to:
- **`pto->args`**: The positional arguments tuple iterated in the loop
- **`pto->kw`**: The keyword arguments dict iterated via `PyDict_Next`
- **`pto->fn`**: The callable whose `__repr__` is invoked via `%R`

## Reproducer (from the issue)

```python
import gc
from functools import partial

g_partial = None

class EvilObject:
    def __init__(self, name, is_trigger=False):
        self.name = name
        self.is_trigger = is_trigger
        self.triggered = False

    def __repr__(self):
        global g_partial
        if self.is_trigger and not self.triggered and g_partial is not None:
            self.triggered = True
            new_state = (lambda x: x, ("replaced",), {}, None)
            g_partial.__setstate__(new_state)
            gc.collect()
        return f"EvilObject({self.name})"

evil1 = EvilObject("trigger", is_trigger=True)
evil2 = EvilObject("victim1")
evil3 = EvilObject("victim2")

p = partial(lambda: None, evil1, evil2, evil3)
g_partial = p
del evil1, evil2, evil3

repr(p)  # heap-buffer-overflow without fix
```

Fixes #144475.

<!-- gh-issue-number: gh-144475 -->
* Issue: gh-144475
<!-- /gh-issue-number -->
