### PR TITLE
gh-91167: Fix cloned turtle pen not clearing completely

### DIFF
--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -671,6 +671,21 @@ class TestTurtle(unittest.TestCase):
         self.assertRaises(turtle.TurtleGraphicsError, self.turtle.dot, 0, (0, 257, 0))
         self.assertRaises(turtle.TurtleGraphicsError, self.turtle.dot, 0, 0, 257, 0)
 
+    def test_clone_clear_does_not_delete_source_items(self):
+        screen = self.turtle.screen
+        screen._delete.reset_mock()
+        screen._createline.side_effect = lambda: object()
+
+        self.turtle.circle(20)
+        clone = self.turtle.clone()
+        source_items = set(self.turtle.items)
+
+        clone.forward(50)
+        clone.clear()
+
+        deleted_items = {call.args[0] for call in screen._delete.call_args_list}
+        self.assertFalse(source_items & deleted_items)
+
 class TestModuleLevel(unittest.TestCase):
     def test_all_signatures(self):
         import inspect

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -2879,6 +2879,8 @@ class RawTurtle(TPen, TNavigator):
             q.turtle._item = [screen._createpoly() for item in
                               screen._shapes[self.turtle.shapeIndex]._data]
         q.currentLineItem = screen._createline()
+        q.currentLine = [q._position] if q._drawing else []
+        q.items = [q.currentLineItem]
         q._update()
         return q
 

--- a/Misc/NEWS.d/next/Library/2026-03-31-10-28-49.gh-issue-91167.CAf5BZ.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-31-10-28-49.gh-issue-91167.CAf5BZ.rst
@@ -1,0 +1,1 @@
+Fix cloned turtle clear not clearing source pen state.


### PR DESCRIPTION
When calling clear() on a cloned turtle, it incorrectly cleared the source
turtle's drawings instead of its own. 

The issue was in RawTurtle.clone(): after deepcopy(), the clone inherited
the source turtle's currentLine and items lists, causing the clone's
clear() to delete items owned by the source turtle.

Fix by reinitializing currentLine and items for the clone to track only
its own drawing state.

<!-- gh-issue-number: gh-91167 -->
* Issue: gh-91167
<!-- /gh-issue-number -->
