### PR TITLE
gh-145413: Fix nested attribute suggestions executing property code

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -378,6 +378,8 @@ Improved error messages
   name, the error message will suggest accessing it via that inner attribute:
 
   .. code-block:: python
+     from dataclasses import dataclass
+     from math import pi
 
      @dataclass
      class Circle:

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -378,6 +378,7 @@ Improved error messages
   name, the error message will suggest accessing it via that inner attribute:
 
   .. code-block:: python
+
      from dataclasses import dataclass
      from math import pi
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4401,17 +4401,23 @@ class SuggestionFormattingTestBase(SuggestionFormattingTestMixin):
     def test_getattr_nested_with_property(self):
         # Test that descriptors (including properties) are suggested in nested attributes
         class Inner:
+            def __init__(self):
+                self.access_counter = 0
             @property
             def computed(self):
+                self.access_counter += 1
                 return 42
 
         class Outer:
             def __init__(self):
                 self.inner = Inner()
 
-        actual = self.get_suggestion(Outer(), 'computed')
-        # Descriptors should not be suggested to avoid executing arbitrary code
+        obj = Outer()
+        actual = self.get_suggestion(obj, 'computed')
+        # Descriptors should be suggested
         self.assertIn("inner.computed", actual)
+        # Should not increment the access counter
+        self.assertEqual(obj.inner.access_counter, 0)
 
     def test_getattr_nested_no_suggestion_for_deep_nesting(self):
         # Test that deeply nested attributes (2+ levels) are not suggested

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -14,6 +14,7 @@ import tokenize
 import io
 import importlib.util
 import pathlib
+import inspect
 import _colorize
 
 from contextlib import suppress
@@ -1670,30 +1671,27 @@ def _check_for_nested_attribute(obj, wrong_name, attrs):
 
     Returns the first nested attribute suggestion found, or None.
     Limited to checking 20 attributes.
-    Only considers non-descriptor attributes to avoid executing arbitrary code.
     Skips lazy imports to avoid triggering module loading.
     """
     # Check for nested attributes (only one level deep)
     attrs_to_check = [x for x in attrs if not x.startswith('_')][:20]  # Limit number of attributes to check
     for attr_name in attrs_to_check:
-        with suppress(Exception):
-            # Check if attr_name is a descriptor - if so, skip it
-            attr_from_class = getattr(type(obj), attr_name, None)
-            if attr_from_class is not None and hasattr(attr_from_class, '__get__'):
-                continue  # Skip descriptors to avoid executing arbitrary code
-
+        with suppress(AttributeError):
+            attr_obj = inspect.getattr_static(obj, attr_name)
+                
+            try:
+                inspect.getattr_static(attr_obj, '__get__')
+                continue # Descriptor, skip it as we can't access its contents safely
+            except AttributeError:
+                pass
+            
             # Skip lazy imports to avoid triggering module loading
             if _is_lazy_import(obj, attr_name):
                 continue
 
-            # Safe to get the attribute since it's not a descriptor
-            attr_obj = getattr(obj, attr_name)
+            inspect.getattr_static(attr_obj, wrong_name)
 
-            # Check if the nested attribute exists and is not a descriptor
-            nested_attr_from_class = getattr(type(attr_obj), wrong_name, None)
-
-            if hasattr(attr_obj, wrong_name):
-                return f"{attr_name}.{wrong_name}"
+            return f"{attr_name}.{wrong_name}"
 
     return None
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1678,13 +1678,13 @@ def _check_for_nested_attribute(obj, wrong_name, attrs):
     for attr_name in attrs_to_check:
         with suppress(AttributeError):
             attr_obj = inspect.getattr_static(obj, attr_name)
-                
+
             try:
                 inspect.getattr_static(attr_obj, '__get__')
                 continue # Descriptor, skip it as we can't access its contents safely
             except AttributeError:
                 pass
-            
+
             # Skip lazy imports to avoid triggering module loading
             if _is_lazy_import(obj, attr_name):
                 continue

--- a/Misc/NEWS.d/next/Library/2026-03-02-13-35-14.gh-issue-145413.-x5Hpk.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-02-13-35-14.gh-issue-145413.-x5Hpk.rst
@@ -1,0 +1,1 @@
+Fixed nested properties being executed in error message suggestions


### PR DESCRIPTION
Updated the code of `_check_for_nested_attribute` to check properties without triggering their code. This approach will still suggest them

Changed a test case to look for side effects and changed some contradictory comments

Updated the news section code to include imports so the code can be tested out of the box


Example
```python
from dataclasses import dataclass
from math import pi

@dataclass
class Circle:
   radius: float
   @property
   def area(self) -> float:
      print("Property 'area' accessed")
      return pi * self.radius**2

class Container:
   def __init__(self, inner: Circle) -> None:
      self.inner = inner

circle = Circle(radius=4.0)
container = Container(circle)
print(container.area)
```

Output
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    print(container.area)
          ^^^^^^^^^^^^^^
AttributeError: 'Container' object has no attribute 'area'. Did you mean '.inner.area' instead of '.area'?
```

It doesn't reach the print statement at all


<!-- gh-issue-number: gh-145413 -->
* Issue: gh-145413
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145414.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->