### PR TITLE
gh-145376: Fix reference leaks in _collectionsmodule.c

### DIFF
--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -342,8 +342,10 @@ deque_append_lock_held(dequeobject *deque, PyObject *item, Py_ssize_t maxlen)
 {
     if (deque->rightindex == BLOCKLEN - 1) {
         block *b = newblock(deque);
-        if (b == NULL)
+        if (b == NULL) {
+            Py_DECREF(item);
             return -1;
+        }
         b->leftlink = deque->rightblock;
         CHECK_END(deque->rightblock->rightlink);
         deque->rightblock->rightlink = b;
@@ -389,8 +391,10 @@ deque_appendleft_lock_held(dequeobject *deque, PyObject *item,
 {
     if (deque->leftindex == 0) {
         block *b = newblock(deque);
-        if (b == NULL)
+        if (b == NULL) {
+            Py_DECREF(item);
             return -1;
+        }
         b->rightlink = deque->leftblock;
         CHECK_END(deque->leftblock->leftlink);
         deque->leftblock->leftlink = b;
@@ -564,7 +568,6 @@ deque_extendleft_impl(dequeobject *deque, PyObject *iterable)
     iternext = *Py_TYPE(it)->tp_iternext;
     while ((item = iternext(it)) != NULL) {
         if (deque_appendleft_lock_held(deque, item, maxlen) == -1) {
-            Py_DECREF(item);
             Py_DECREF(it);
             return NULL;
         }


### PR DESCRIPTION
Make `deque_append_lock_held` and `deque_appendleft_lock_held` consume the second argument (the methods already consumed the second argument, but not in the error path).

Issues found using Claude.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145376 -->
* Issue: gh-145376
<!-- /gh-issue-number -->
