### PR TITLE
gh-145376: Avoid reference leaks in failure path of _functoolsmodule.c method partial_new

### DIFF
--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -252,6 +252,11 @@ partial_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         }
         PyObject *item;
         PyObject *tot_args = PyTuple_New(tot_nargs);
+        if (tot_args == NULL) {
+            Py_DECREF(new_args);
+            Py_DECREF(pto);
+            return NULL;
+        }
         for (Py_ssize_t i = 0, j = 0; i < tot_nargs; i++) {
             if (i < npargs) {
                 item = PyTuple_GET_ITEM(pto_args, i);


### PR DESCRIPTION
Issue found using Claude.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145376 -->
* Issue: gh-145376
<!-- /gh-issue-number -->
