### PR TITLE
gh-142927: Move hotspots up flamegraph sidebar

### DIFF
--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph_template.html
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph_template.html
@@ -178,6 +178,51 @@
               </div>
             </section>
 
+            <!-- Hotspots Section -->
+            <section class="sidebar-section collapsible" id="hotspots-section">
+              <button class="section-header" onclick="toggleSection('hotspots-section')">
+                <h3 class="section-title">Hotspots</h3>
+                <svg class="section-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none">
+                  <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+              <div class="section-content">
+              <div class="hotspot" id="hotspot-1">
+                <div class="hotspot-rank hotspot-rank--1">1</div>
+                <div class="hotspot-info">
+                  <div class="hotspot-func" id="hotspot-func-1">--</div>
+                  <div class="hotspot-file" id="hotspot-file-1">--</div>
+                  <div class="hotspot-stats">
+                    <span class="hotspot-percent" id="hotspot-percent-1">--</span>
+                    <span id="hotspot-samples-1"></span>
+                  </div>
+                </div>
+              </div>
+              <div class="hotspot" id="hotspot-2">
+                <div class="hotspot-rank hotspot-rank--2">2</div>
+                <div class="hotspot-info">
+                  <div class="hotspot-func" id="hotspot-func-2">--</div>
+                  <div class="hotspot-file" id="hotspot-file-2">--</div>
+                  <div class="hotspot-stats">
+                    <span class="hotspot-percent" id="hotspot-percent-2">--</span>
+                    <span id="hotspot-samples-2"></span>
+                  </div>
+                </div>
+              </div>
+              <div class="hotspot" id="hotspot-3">
+                <div class="hotspot-rank hotspot-rank--3">3</div>
+                <div class="hotspot-info">
+                  <div class="hotspot-func" id="hotspot-func-3">--</div>
+                  <div class="hotspot-file" id="hotspot-file-3">--</div>
+                  <div class="hotspot-stats">
+                    <span class="hotspot-percent" id="hotspot-percent-3">--</span>
+                    <span id="hotspot-samples-3"></span>
+                  </div>
+                </div>
+              </div>
+              </div>
+            </section>
+
             <!-- Thread Stats Section (GIL/GC) -->
             <section class="sidebar-section thread-stats-section collapsible" id="thread-stats-bar" style="display: none;">
               <button class="section-header" onclick="toggleSection('thread-stats-bar')">
@@ -234,51 +279,6 @@
                     </div>
                   </div>
                 </div>
-              </div>
-            </section>
-
-            <!-- Hotspots Section -->
-            <section class="sidebar-section collapsible" id="hotspots-section">
-              <button class="section-header" onclick="toggleSection('hotspots-section')">
-                <h3 class="section-title">Hotspots</h3>
-                <svg class="section-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none">
-                  <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-              </button>
-              <div class="section-content">
-              <div class="hotspot" id="hotspot-1">
-                <div class="hotspot-rank hotspot-rank--1">1</div>
-                <div class="hotspot-info">
-                  <div class="hotspot-func" id="hotspot-func-1">--</div>
-                  <div class="hotspot-file" id="hotspot-file-1">--</div>
-                  <div class="hotspot-stats">
-                    <span class="hotspot-percent" id="hotspot-percent-1">--</span>
-                    <span id="hotspot-samples-1"></span>
-                  </div>
-                </div>
-              </div>
-              <div class="hotspot" id="hotspot-2">
-                <div class="hotspot-rank hotspot-rank--2">2</div>
-                <div class="hotspot-info">
-                  <div class="hotspot-func" id="hotspot-func-2">--</div>
-                  <div class="hotspot-file" id="hotspot-file-2">--</div>
-                  <div class="hotspot-stats">
-                    <span class="hotspot-percent" id="hotspot-percent-2">--</span>
-                    <span id="hotspot-samples-2"></span>
-                  </div>
-                </div>
-              </div>
-              <div class="hotspot" id="hotspot-3">
-                <div class="hotspot-rank hotspot-rank--3">3</div>
-                <div class="hotspot-info">
-                  <div class="hotspot-func" id="hotspot-func-3">--</div>
-                  <div class="hotspot-file" id="hotspot-file-3">--</div>
-                  <div class="hotspot-stats">
-                    <span class="hotspot-percent" id="hotspot-percent-3">--</span>
-                    <span id="hotspot-samples-3"></span>
-                  </div>
-                </div>
-              </div>
               </div>
             </section>
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Before and after:

<img width="578" height="1364" alt="image" src="https://github.com/user-attachments/assets/16e3a080-8041-4753-a174-7a606076d761" />

The issue says:

> * **Move hotspots to top of sidebar** — This is the most important info; currently buried below logo and stats

@pablogsal Is the above screenshot what you meant? Or even above "PROFILE SUMMARY", "VIEW MODE" or the logo?


<!-- gh-issue-number: gh-142927 -->
* Issue: gh-142927
<!-- /gh-issue-number -->
