### PR TITLE
Add `PyExc_OverflowError` to the list of possible exceptions in `fuzz_ast_literal_eval` fuzzer

### DIFF
--- a/Modules/_xxtestfuzz/fuzzer.c
+++ b/Modules/_xxtestfuzz/fuzzer.c
@@ -428,6 +428,7 @@ static int fuzz_ast_literal_eval(const char* data, size_t size) {
                             PyErr_ExceptionMatches(PyExc_TypeError) ||
                             PyErr_ExceptionMatches(PyExc_SyntaxError) ||
                             PyErr_ExceptionMatches(PyExc_MemoryError) ||
+                            PyErr_ExceptionMatches(PyExc_OverflowError) ||
                             PyErr_ExceptionMatches(PyExc_RecursionError))
     ) {
         PyErr_Clear();


### PR DESCRIPTION
This fixes the "bug" found in https://oss-fuzz.com/testcase-detail/5450638250278912.

```
>>> import ast
... data = open('/tmp/testcase', 'rb').read()
... ast.literal_eval(data[:data.index(0)].decode())
... 
<python-input-2>:2: ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/testcase'>
ResourceWarning: Enable tracemalloc to get the object allocation traceback
Traceback (most recent call last):
  File "<python-input-2>", line 3, in <module>
    ast.literal_eval(data[:data.index(0)].decode())
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/stan/dev/cpython/Lib/ast.py", line 64, in literal_eval
    return _convert_literal(node_or_string)
  File "/home/stan/dev/cpython/Lib/ast.py", line 108, in _convert_literal
    return left + right
           ~~~~~^~~~~~~
OverflowError: int too large to convert to float
```

<details>

<summary> With fuzzer </summary>

Currently:
```
$ ./python -c "
import _xxtestfuzz
data = open('/tmp/testcase', 'rb').read()
_xxtestfuzz.run(data)
"
<string>:3: ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/testcase'>
ResourceWarning: Enable tracemalloc to get the object allocation traceback
Traceback (most recent call last):
  File "/home/stan/dev/cpython/Lib/ast.py", line 64, in literal_eval
    return _convert_literal(node_or_string)
  File "/home/stan/dev/cpython/Lib/ast.py", line 108, in _convert_literal
    return left + right
           ~~~~~^~~~~~~
OverflowError: int too large to convert to float
Aborted (core dumped)
```
With fix:
```
$ ./python -c "
import _xxtestfuzz
data = open('/tmp/testcase', 'rb').read()
_xxtestfuzz.run(data)
"
<string>:3: ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/testcase'>
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

</details>