### PR TITLE
GH-145273: skip stdlib warning on module_search_paths_set

### DIFF
--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -773,8 +773,10 @@ elif not pythonpath_was_set:
 # SANITY CHECKS
 # ******************************************************************************
 
-# Warn if the standard library is missing
-if not stdlib_zip or not isfile(stdlib_zip):
+# Warn if the standard library is missing, unless pythonpath_was_set was set, as
+# that skips parts of the stdlib directories calculation — assume the provided
+# pythonpath is correct. This is how subinterpreters initialize the path for eg.
+if not pythonpath_was_set and (not stdlib_zip or not isfile(stdlib_zip)):
     home_hint = f"The Python 'home' directory was set to {home!r}, is this correct?"
     if not stdlib_dir or not isdir(stdlib_dir):
         hint = home_hint if home else f'sys.prefix is set to {prefix}, is this correct?'

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -776,7 +776,7 @@ elif not pythonpath_was_set:
 # Warn if the standard library is missing, unless pythonpath_was_set was set, as
 # that skips parts of the stdlib directories calculation — assume the provided
 # pythonpath is correct. This is how subinterpreters initialize the path for eg.
-if not pythonpath_was_set and (not stdlib_zip or not isfile(stdlib_zip)):
+if not py_setpath and not pythonpath_was_set and (not stdlib_zip or not isfile(stdlib_zip)):
     home_hint = f"The Python 'home' directory was set to {home!r}, is this correct?"
     if not stdlib_dir or not isdir(stdlib_dir):
         hint = home_hint if home else f'sys.prefix is set to {prefix}, is this correct?'


### PR DESCRIPTION
This should fix the buildbot failures, which run tests after installation.

<!-- gh-issue-number: gh-145273 -->
* Issue: gh-145273
<!-- /gh-issue-number -->
