### PR TITLE
[3.10] gh-145455: Constrain setuptools to a version with pkg_resources

### DIFF
--- a/Doc/constraints.txt
+++ b/Doc/constraints.txt
@@ -19,6 +19,7 @@ sphinxcontrib-htmlhelp<2.0.5
 sphinxcontrib-jsmath<1.1
 sphinxcontrib-qthelp<1.0.7
 sphinxcontrib-serializinghtml<1.1.10
+setuptools<82  # Setuptools with pkg_resources
 
 # Direct dependencies of Jinja2 (Jinja is a dependency of Sphinx, see above)
 MarkupSafe<2.2


### PR DESCRIPTION
Sphinx 3.4.3 needs this.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145455 -->
* Issue: gh-145455
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145456.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->