### PR TITLE
gh-145455: Show output of blurb & sphinx-build version commands

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -58,7 +58,7 @@ build:
 	@if [ -f  ../Misc/NEWS ] ; then \
 		echo "Using existing Misc/NEWS file"; \
 		cp ../Misc/NEWS build/NEWS; \
-	elif $(BLURB) help >/dev/null 2>&1 && $(SPHINXBUILD) --version >/dev/null 2>&1; then \
+	elif $(BLURB) --version && $(SPHINXBUILD) --version ; then \
 		if [ -d ../Misc/NEWS.d ]; then \
 			echo "Building NEWS from Misc/NEWS.d with blurb"; \
 			$(BLURB) merge -f build/NEWS; \


### PR DESCRIPTION
In gh-145455, an outdated dependency caused an import error that was not printed out	(`2>&1`); the message instead said that the tools are missing.

Don't redirect stderr, to show warnings and failures.

Also, switch `blurb` to output a version on a single line (`--version` rather than `help`), and, and don't redirect stdout either. This results in two version info lines being printed out. These get drowned in typical Sphinx output, and can be helpful when debugging.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145457.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->