### PR TITLE
gh-145458: use `self.skip_idle`

### DIFF
--- a/Lib/profiling/sampling/stack_collector.py
+++ b/Lib/profiling/sampling/stack_collector.py
@@ -19,9 +19,9 @@ class StackTraceCollector(Collector):
         self.sample_interval_usec = sample_interval_usec
         self.skip_idle = skip_idle
 
-    def collect(self, stack_frames, timestamps_us=None, skip_idle=False):
+    def collect(self, stack_frames, timestamps_us=None):
         weight = len(timestamps_us) if timestamps_us else 1
-        for frames, thread_id in self._iter_stacks(stack_frames, skip_idle=skip_idle):
+        for frames, thread_id in self._iter_stacks(stack_frames, skip_idle=self.skip_idle):
             self.process_frames(frames, thread_id, weight=weight)
 
     def process_frames(self, frames, thread_id, weight=1):
@@ -88,7 +88,7 @@ class FlamegraphCollector(StackTraceCollector):
         # Per-thread statistics
         self.per_thread_stats = {}  # {thread_id: {has_gil, on_cpu, gil_requested, unknown, has_exception, total, gc_samples}}
 
-    def collect(self, stack_frames, timestamps_us=None, skip_idle=False):
+    def collect(self, stack_frames, timestamps_us=None):
         """Override to track thread status statistics before processing frames."""
         # Weight is number of timestamps (samples with identical stack)
         weight = len(timestamps_us) if timestamps_us else 1
@@ -123,7 +123,7 @@ class FlamegraphCollector(StackTraceCollector):
                 self.per_thread_stats[thread_id][key] += value * weight
 
         # Call parent collect to process frames
-        super().collect(stack_frames, timestamps_us, skip_idle=skip_idle)
+        super().collect(stack_frames, timestamps_us)
 
     def set_stats(self, sample_interval_usec, duration_sec, sample_rate,
                   error_rate=None, missed_samples=None, mode=None):

--- a/Misc/NEWS.d/next/Library/2026-03-09-09-21-02.gh-issue-145458.mqQUFZ.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-09-21-02.gh-issue-145458.mqQUFZ.rst
@@ -1,2 +1,0 @@
-Use the instance ``skip_idle`` attribute instead of passing it as a parameter
-in ``StackCollector``.

--- a/Misc/NEWS.d/next/Library/2026-03-09-09-21-02.gh-issue-145458.mqQUFZ.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-09-21-02.gh-issue-145458.mqQUFZ.rst
@@ -1,2 +1,2 @@
 Use the instance ``skip_idle`` attribute instead of passing it as a parameter
-in :class:`profiling.sampling.stack_collector.StackCollector`.
+in ``StackCollector``.

--- a/Misc/NEWS.d/next/Library/2026-03-09-09-21-02.gh-issue-145458.mqQUFZ.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-09-21-02.gh-issue-145458.mqQUFZ.rst
@@ -1,0 +1,2 @@
+Use the instance ``skip_idle`` attribute instead of passing it as a parameter
+in :class:`profiling.sampling.stack_collector.StackCollector`.


### PR DESCRIPTION
More details are available in the issue (#145458) but long story short, today the `self.skip_idle` value is set in the constructor but never used (in favour of a function parameter). 

<!-- gh-issue-number: gh-145458 -->
* Issue: gh-145458
<!-- /gh-issue-number -->
