### PR TITLE
gh-145376: Fix refleak and null pointer deref in unusual error path of datetime module

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-03-03-19-42-51.gh-issue-145376.T7nY3q.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-03-19-42-51.gh-issue-145376.T7nY3q.rst
@@ -1,1 +1,0 @@
-Fix refleak and null pointer deref in unusual error path of :mod:`datetime`.

--- a/Misc/NEWS.d/next/Library/2026-03-03-19-42-51.gh-issue-145376.T7nY3q.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-03-19-42-51.gh-issue-145376.T7nY3q.rst
@@ -1,0 +1,1 @@
+Fix refleak and null pointer deref in unusual error path of :mod:`datetime`.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6908,8 +6908,8 @@ datetime_datetime_astimezone_impl(PyDateTime_DateTime *self,
         goto naive;
     }
     else if (!PyDelta_Check(offset)) {
-        PyErr_Format(PyExc_TypeError, "utcoffset() returned %.200s,"
-                     " expected timedelta or None", Py_TYPE(offset)->tp_name);
+        PyErr_Format(PyExc_TypeError, "utcoffset() returned %T,"
+                     " expected timedelta or None", offset);
         Py_DECREF(offset);
         return NULL;
     }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3822,9 +3822,26 @@ iso_calendar_date_new_impl(PyTypeObject *type, int year, int week,
         return NULL;
     }
 
-    PyTuple_SET_ITEM(self, 0, PyLong_FromLong(year));
-    PyTuple_SET_ITEM(self, 1, PyLong_FromLong(week));
-    PyTuple_SET_ITEM(self, 2, PyLong_FromLong(weekday));
+    PyObject *year_object = PyLong_FromLong(year);
+    if (year_object == NULL) {
+        Py_DECREF(self);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(self, 0, year_object);
+
+    PyObject *week_object = PyLong_FromLong(week);
+    if (week_object == NULL) {
+        Py_DECREF(self);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(self, 1, week_object);
+
+    PyObject *weekday_object = PyLong_FromLong(weekday);
+    if (weekday_object == NULL) {
+        Py_DECREF(self);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(self, 2, weekday_object);
 
     return (PyObject *)self;
 }
@@ -6891,9 +6908,9 @@ datetime_datetime_astimezone_impl(PyDateTime_DateTime *self,
         goto naive;
     }
     else if (!PyDelta_Check(offset)) {
-        Py_DECREF(offset);
         PyErr_Format(PyExc_TypeError, "utcoffset() returned %.200s,"
                      " expected timedelta or None", Py_TYPE(offset)->tp_name);
+        Py_DECREF(offset);
         return NULL;
     }
     /* result = self - offset */


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145376 -->
* Issue: gh-145376
<!-- /gh-issue-number -->
