### PR TITLE
gh-145376: Fix refleak in error path of time_tzset

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1170,6 +1170,7 @@ time_tzset(PyObject *self, PyObject *unused)
 
     /* Reset timezone, altzone, daylight and tzname */
     if (init_timezone(m) < 0) {
+        Py_DECREF(m);
          return NULL;
     }
     Py_DECREF(m);

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1171,7 +1171,7 @@ time_tzset(PyObject *self, PyObject *unused)
     /* Reset timezone, altzone, daylight and tzname */
     if (init_timezone(m) < 0) {
         Py_DECREF(m);
-         return NULL;
+        return NULL;
     }
     Py_DECREF(m);
     if (PyErr_Occurred())


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145376 -->
* Issue: gh-145376
<!-- /gh-issue-number -->
