### PR TITLE
Minor documentation fix: incorrect statement about argparse.ArgumentParser.add_argument()

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -739,9 +739,9 @@ By default, :mod:`!argparse` automatically handles the internal naming and
 display names of arguments, simplifying the process without requiring
 additional configuration.
 As such, you do not need to specify the dest_ and metavar_ parameters.
-The dest_ parameter defaults to the argument name with underscores ``_``
-replacing hyphens ``-`` . The metavar_ parameter defaults to the
-upper-cased name. For example::
+The dest_ parameter defaults to the argument name, with underscores ``_``
+replacing hyphens ``-`` if the argument is optional . The metavar_
+parameter defaults to the upper-cased name. For example::
 
    >>> parser = argparse.ArgumentParser(prog='PROG')
    >>> parser.add_argument('--foo-bar')

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -739,8 +739,8 @@ By default, :mod:`!argparse` automatically handles the internal naming and
 display names of arguments, simplifying the process without requiring
 additional configuration.
 As such, you do not need to specify the dest_ and metavar_ parameters.
-The dest_ parameter defaults to the argument name, with underscores ``_``
-replacing hyphens ``-`` if the argument is optional . The metavar_
+For optional arguments, the dest_ parameter defaults to the argument name, with underscores ``_``
+replacing hyphens ``-``. The metavar_
 parameter defaults to the upper-cased name. For example::
 
    >>> parser = argparse.ArgumentParser(prog='PROG')

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -739,9 +739,9 @@ By default, :mod:`!argparse` automatically handles the internal naming and
 display names of arguments, simplifying the process without requiring
 additional configuration.
 As such, you do not need to specify the dest_ and metavar_ parameters.
-For optional arguments, the dest_ parameter defaults to the argument name, with underscores ``_``
-replacing hyphens ``-``. The metavar_
-parameter defaults to the upper-cased name. For example::
+For optional arguments, the dest_ parameter defaults to the argument name, with
+underscores ``_`` replacing hyphens ``-``. The metavar_ parameter defaults to
+the upper-cased name. For example::
 
    >>> parser = argparse.ArgumentParser(prog='PROG')
    >>> parser.add_argument('--foo-bar')


### PR DESCRIPTION
The documentation for the name or flags argument of `argparse.ArgumentParser.add_argument()` said

> The dest parametre defaults to the argument name with underscores `_` replacing hyphens `-` .

However, this is not true for positional arguments, which retain their hyphens.  The documentation for the dest parameter correctly describes this behavior, but a user who only reads the name or flags documentation will be misled.

Thus, I added a qualification to the sentence to make clear that the hyphen relpacement only happens for optional arguments.

> The dest parameter defaults to the argument name, with underscores `_` replacing hyphens `-` if the argument is optional.

I'm hoping this change is trivial enough that I don't need to submit an issue first, but let me know if that's incorrect.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145479.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->