### PR TITLE
gh-145481: Optimize frozendict lookup in free threading

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1518,12 +1518,18 @@ dictkeys_generic_lookup_threadsafe(PyDictObject *mp, PyDictKeysObject* dk, PyObj
 Py_ssize_t
 _Py_dict_lookup_threadsafe(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr)
 {
+    ensure_shared_on_read(mp);
+
+    if (PyFrozenDict_CheckExact(mp)) {
+        Py_ssize_t ix = _Py_dict_lookup(mp, key, hash, value_addr);
+        Py_XNewRef(*value_addr);
+        return ix;
+    }
+
     PyDictKeysObject *dk;
     DictKeysKind kind;
     Py_ssize_t ix;
     PyObject *value;
-
-    ensure_shared_on_read(mp);
 
     dk = _Py_atomic_load_ptr(&mp->ma_keys);
     kind = dk->dk_kind;

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1280,7 +1280,10 @@ _Py_dict_lookup(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **valu
     DictKeysKind kind;
     Py_ssize_t ix;
 
-    _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(mp);
+    if (!PyFrozenDict_CheckExact(mp)) {
+        _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(mp);
+    }
+
 start:
     dk = mp->ma_keys;
     kind = dk->dk_kind;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145481 -->
* Issue: gh-145481
<!-- /gh-issue-number -->
