### PR TITLE
gh-145446: Add critical section in functools module for `PyDict_Next`

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-03-03-23-21-40.gh-issue-145446.0c-TJX.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-03-23-21-40.gh-issue-145446.0c-TJX.rst
@@ -1,0 +1,1 @@
+:mod:`functools` is now safer in free-threaded build when using keywords in func:`functools.partial`

--- a/Misc/NEWS.d/next/Library/2026-03-03-23-21-40.gh-issue-145446.0c-TJX.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-03-23-21-40.gh-issue-145446.0c-TJX.rst
@@ -1,1 +1,1 @@
-:mod:`functools` is now safer in free-threaded build when using keywords in func:`functools.partial`
+Now :mod:`functools` is safer in free-threaded build when using keywords in :func:`functools.partial`

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -194,13 +194,19 @@ partial_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     if (kw != NULL) {
         PyObject *key, *val;
         Py_ssize_t pos = 0;
+        Py_BEGIN_CRITICAL_SECTION(kw);
         while (PyDict_Next(kw, &pos, &key, &val)) {
             if (val == phold) {
                 PyErr_SetString(PyExc_TypeError,
                                 "Placeholder cannot be passed as a keyword argument");
+#ifdef Py_GIL_DISABLED
+                /* Need to release lock in case of error */
+                PyCriticalSection_End(&_py_cs);
+#endif
                 return NULL;
             }
         }
+        Py_END_CRITICAL_SECTION();
     }
 
     /* check wrapped function / object */
@@ -487,12 +493,15 @@ partial_vectorcall(PyObject *self, PyObject *const *args,
         /* Copy pto_keywords with overlapping call keywords merged
          * Note, tail is already coppied. */
         Py_ssize_t pos = 0, i = 0;
-        while (PyDict_Next(n_merges ? pto_kw_merged : pto->kw, &pos, &key, &val)) {
+        PyObject *keyword_dict = n_merges ? pto_kw_merged : pto->kw;
+        Py_BEGIN_CRITICAL_SECTION(keyword_dict);
+        while (PyDict_Next(keyword_dict, &pos, &key, &val)) {
             assert(i < pto_nkwds);
             PyTuple_SET_ITEM(tot_kwnames, i, Py_NewRef(key));
             stack[tot_nargs + i] = val;
             i++;
         }
+        Py_END_CRITICAL_SECTION();
         assert(i == pto_nkwds);
         Py_XDECREF(pto_kw_merged);
 
@@ -723,6 +732,7 @@ partial_repr(PyObject *self)
         }
     }
     /* Pack keyword arguments */
+    Py_BEGIN_CRITICAL_SECTION(kw);
     for (i = 0; PyDict_Next(kw, &i, &key, &value);) {
         /* Prevent key.__str__ from deleting the value. */
         Py_INCREF(value);
@@ -730,9 +740,14 @@ partial_repr(PyObject *self)
                                                 key, value));
         Py_DECREF(value);
         if (arglist == NULL) {
+#ifdef Py_GIL_DISABLED
+        /* Need to release lock in case of error */
+        PyCriticalSection_End(&_py_cs);
+#endif
             goto done;
         }
     }
+    Py_END_CRITICAL_SECTION();
 
     mod = PyType_GetModuleName(Py_TYPE(pto));
     if (mod == NULL) {
@@ -1247,10 +1262,12 @@ lru_cache_make_key(PyObject *kwd_mark, PyObject *args,
     }
     if (kwds_size) {
         PyTuple_SET_ITEM(key, key_pos++, Py_NewRef(kwd_mark));
+        Py_BEGIN_CRITICAL_SECTION(kwds);
         for (pos = 0; PyDict_Next(kwds, &pos, &keyword, &value);) {
             PyTuple_SET_ITEM(key, key_pos++, Py_NewRef(keyword));
             PyTuple_SET_ITEM(key, key_pos++, Py_NewRef(value));
         }
+        Py_END_CRITICAL_SECTION();
         assert(key_pos == PyTuple_GET_SIZE(args) + kwds_size * 2 + 1);
     }
     if (typed) {
@@ -1259,10 +1276,12 @@ lru_cache_make_key(PyObject *kwd_mark, PyObject *args,
             PyTuple_SET_ITEM(key, key_pos++, Py_NewRef(item));
         }
         if (kwds_size) {
+            Py_BEGIN_CRITICAL_SECTION(kwds);
             for (pos = 0; PyDict_Next(kwds, &pos, &keyword, &value);) {
                 PyObject *item = (PyObject *)Py_TYPE(value);
                 PyTuple_SET_ITEM(key, key_pos++, Py_NewRef(item));
             }
+            Py_END_CRITICAL_SECTION();
         }
     }
     assert(key_pos == key_size);

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -194,19 +194,20 @@ partial_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     if (kw != NULL) {
         PyObject *key, *val;
         Py_ssize_t pos = 0;
+        int error = 0;
         Py_BEGIN_CRITICAL_SECTION(kw);
         while (PyDict_Next(kw, &pos, &key, &val)) {
             if (val == phold) {
-                PyErr_SetString(PyExc_TypeError,
-                                "Placeholder cannot be passed as a keyword argument");
-#ifdef Py_GIL_DISABLED
-                /* Need to release lock in case of error */
-                PyCriticalSection_End(&_py_cs);
-#endif
-                return NULL;
+                error = 1;
+                break;
             }
         }
         Py_END_CRITICAL_SECTION();
+        if (error) {
+            PyErr_SetString(PyExc_TypeError,
+                            "Placeholder cannot be passed as a keyword argument");
+            return NULL;
+        }
     }
 
     /* check wrapped function / object */
@@ -732,6 +733,7 @@ partial_repr(PyObject *self)
         }
     }
     /* Pack keyword arguments */
+    int error = 0;
     Py_BEGIN_CRITICAL_SECTION(kw);
     for (i = 0; PyDict_Next(kw, &i, &key, &value);) {
         /* Prevent key.__str__ from deleting the value. */
@@ -740,14 +742,14 @@ partial_repr(PyObject *self)
                                                 key, value));
         Py_DECREF(value);
         if (arglist == NULL) {
-#ifdef Py_GIL_DISABLED
-        /* Need to release lock in case of error */
-        PyCriticalSection_End(&_py_cs);
-#endif
-            goto done;
+            error = 1;
+            break;
         }
     }
     Py_END_CRITICAL_SECTION();
+    if (error) {
+        goto done;
+    }
 
     mod = PyType_GetModuleName(Py_TYPE(pto));
     if (mod == NULL) {

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -194,19 +194,12 @@ partial_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     if (kw != NULL) {
         PyObject *key, *val;
         Py_ssize_t pos = 0;
-        int error = 0;
-        Py_BEGIN_CRITICAL_SECTION(kw);
         while (PyDict_Next(kw, &pos, &key, &val)) {
             if (val == phold) {
-                error = 1;
-                break;
+                PyErr_SetString(PyExc_TypeError,
+                                "Placeholder cannot be passed as a keyword argument");
+                return NULL;
             }
-        }
-        Py_END_CRITICAL_SECTION();
-        if (error) {
-            PyErr_SetString(PyExc_TypeError,
-                            "Placeholder cannot be passed as a keyword argument");
-            return NULL;
         }
     }
 
@@ -1264,12 +1257,10 @@ lru_cache_make_key(PyObject *kwd_mark, PyObject *args,
     }
     if (kwds_size) {
         PyTuple_SET_ITEM(key, key_pos++, Py_NewRef(kwd_mark));
-        Py_BEGIN_CRITICAL_SECTION(kwds);
         for (pos = 0; PyDict_Next(kwds, &pos, &keyword, &value);) {
             PyTuple_SET_ITEM(key, key_pos++, Py_NewRef(keyword));
             PyTuple_SET_ITEM(key, key_pos++, Py_NewRef(value));
         }
-        Py_END_CRITICAL_SECTION();
         assert(key_pos == PyTuple_GET_SIZE(args) + kwds_size * 2 + 1);
     }
     if (typed) {
@@ -1278,12 +1269,10 @@ lru_cache_make_key(PyObject *kwd_mark, PyObject *args,
             PyTuple_SET_ITEM(key, key_pos++, Py_NewRef(item));
         }
         if (kwds_size) {
-            Py_BEGIN_CRITICAL_SECTION(kwds);
             for (pos = 0; PyDict_Next(kwds, &pos, &keyword, &value);) {
                 PyObject *item = (PyObject *)Py_TYPE(value);
                 PyTuple_SET_ITEM(key, key_pos++, Py_NewRef(item));
             }
-            Py_END_CRITICAL_SECTION();
         }
     }
     assert(key_pos == key_size);


### PR DESCRIPTION
Added a critical section whenever `PyDict_Next` is called in `Module/_functoolsmodule.c` in the free-threaded build. 

Additionally, I had to manually remove the lock created by a critical section in case of an early return due to an error.

<!-- gh-issue-number: gh-145446 -->
* Issue: gh-145446
<!-- /gh-issue-number -->
