### PR TITLE
gh-144741: Fix test_frame_pointer_unwind for libpython

### DIFF
--- a/Misc/NEWS.d/next/Tests/2026-03-04-17-39-15.gh-issue-144741.0RHhBF.rst
+++ b/Misc/NEWS.d/next/Tests/2026-03-04-17-39-15.gh-issue-144741.0RHhBF.rst
@@ -1,0 +1,3 @@
+Fix ``test_frame_pointer_unwind`` when Python is built with
+:option:`--enable-shared`. Classify also libpython frames as ``"python"``.
+Patch by Victor Stinner.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -196,6 +196,10 @@ classify_address(uintptr_t addr, int jit_enabled, PyInterpreterState *interp)
         if (strncmp(base, "python", 6) == 0) {
             return "python";
         }
+        // Match "libpython3.15.so.1.0"
+        if (strncmp(base, "libpython", 9) == 0) {
+            return "python";
+        }
         return "other";
     }
 #ifdef _Py_JIT


### PR DESCRIPTION
Fix test_frame_pointer_unwind when Python is built with --enable-shared. Classify also libpython frames as "python".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144741 -->
* Issue: gh-144741
<!-- /gh-issue-number -->
