### PR TITLE
gh-145506: Fixes CVE-2026-2297 by ensuring SourcelessFileLoader uses io.open_code

### DIFF
--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -918,7 +918,7 @@ class FileLoader:
 
     def get_data(self, path):
         """Return the data from path as raw bytes."""
-        if isinstance(self, (SourceLoader, ExtensionFileLoader)):
+        if isinstance(self, (SourceLoader, SourcelessFileLoader, ExtensionFileLoader)):
             with _io.open_code(str(path)) as file:
                 return file.read()
         else:

--- a/Misc/NEWS.d/next/Security/2026-03-04-18-59-17.gh-issue-145506.6hwvEh.rst
+++ b/Misc/NEWS.d/next/Security/2026-03-04-18-59-17.gh-issue-145506.6hwvEh.rst
@@ -1,0 +1,2 @@
+Fixes :cve:`2026-2297` by ensuring that ``SourcelessFileLoader`` uses
+:func:`io.open_code` when opening ``.pyc`` files.


### PR DESCRIPTION


<!-- gh-issue-number: gh-145506 -->
* Issue: gh-145506
<!-- /gh-issue-number -->
