### PR TITLE
gh-145526: Update typing.rst for type alias assignment syntax

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -104,7 +104,7 @@ Type aliases are useful for simplifying complex type signatures. For example::
        ...
 
 The :keyword:`type` statement is new in Python 3.12. For backwards
-compatibility, type aliases can also be created through simple assignment::
+compatibility, type aliases can also be created through :ref:`augassign`::
 
    Vector = list[float]
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -104,7 +104,7 @@ Type aliases are useful for simplifying complex type signatures. For example::
        ...
 
 The :keyword:`type` statement is new in Python 3.12. For backwards
-compatibility, type aliases can also be created through :ref:`augassign`::
+compatibility, type aliases can also be created through :ref:`augmented assignment statement <augassign>`::
 
    Vector = list[float]
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -104,7 +104,7 @@ Type aliases are useful for simplifying complex type signatures. For example::
        ...
 
 The :keyword:`type` statement is new in Python 3.12. For backwards
-compatibility, type aliases can also be created through :ref:`augmented assignment statement <augassign>`::
+compatibility, type aliases can also be created through :ref:`assignment statement <assignment>`::
 
    Vector = list[float]
 


### PR DESCRIPTION
Fix: #145526

<!-- gh-issue-number: gh-145526 -->
* Issue: gh-145526
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145527.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->