### PR TITLE
gh-145335: Skip Emscripten for os.execve test

### DIFF
--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -2824,7 +2824,8 @@ class TestInvalidFD(unittest.TestCase):
                     func(*args)
                 self.assertEqual(ctx.exception.errno, errno.EBADF)
 
-        if hasattr(os, "execve") and os.execve in os.supports_fd and not support.is_emscripten:
+        if (hasattr(os, "execve") and os.execve in os.supports_fd
+            and support.has_subprocess_support):
             # glibc fails with EINVAL, musl fails with EBADF
             with self.assertRaises(OSError) as ctx:
                 os.execve(fd, [sys.executable, "-c", "pass"], os.environ)

--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -2824,7 +2824,7 @@ class TestInvalidFD(unittest.TestCase):
                     func(*args)
                 self.assertEqual(ctx.exception.errno, errno.EBADF)
 
-        if hasattr(os, "execve") and os.execve in os.supports_fd:
+        if hasattr(os, "execve") and os.execve in os.supports_fd and not support.is_emscripten:
             # glibc fails with EINVAL, musl fails with EBADF
             with self.assertRaises(OSError) as ctx:
                 os.execve(fd, [sys.executable, "-c", "pass"], os.environ)


### PR DESCRIPTION
Emscripten's os.execve always fails with ENOEXEC. As an alternative, we could add
ENOEXEC to the list of allowed return codes.


<!-- gh-issue-number: gh-145335 -->
* Issue: gh-145335
<!-- /gh-issue-number -->
