### PR TITLE
[3.13] gh-145301: Fix double-free in hashlib initialization (GH-145321)

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-02-27-19-00-26.gh-issue-145301.2Wih4b.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-27-19-00-26.gh-issue-145301.2Wih4b.rst
@@ -1,0 +1,2 @@
+:mod:`hashlib`: fix a crash when the initialization of the underlying C
+extension module fails.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -239,7 +239,7 @@ py_hashentry_table_new(void) {
 
         if (h->py_alias != NULL) {
             if (_Py_hashtable_set(ht, (const void*)entry->py_alias, (void*)entry) < 0) {
-                PyMem_Free(entry);
+                /* entry is already in ht, will be freed by _Py_hashtable_destroy() */
                 goto error;
             }
             entry->refcnt++;


### PR DESCRIPTION
(cherry picked from commit 6acaf659ef0fdee131bc02f0b58685da039b5855)


gh-145301: Fix double-free in hashlib and hmac initialization
