### PR TITLE
gh-145272: Fix data race when accessing func_code in PyFunctionObject

### DIFF
--- a/Include/cpython/funcobject.h
+++ b/Include/cpython/funcobject.h
@@ -95,6 +95,7 @@ static inline PyObject* PyFunction_GET_CODE(PyObject *func) {
     return op->func_code;
 #endif
 }
+#define PyFunction_GET_CODE(func) PyFunction_GET_CODE(_PyObject_CAST(func))
 static inline PyObject* PyFunction_GET_GLOBALS(PyObject *func) {
     return _PyFunction_CAST(func)->func_globals;
 }

--- a/Include/cpython/funcobject.h
+++ b/Include/cpython/funcobject.h
@@ -88,10 +88,13 @@ PyAPI_FUNC(int) PyFunction_SetAnnotations(PyObject *, PyObject *);
 /* Static inline functions for direct access to these values.
    Type checks are *not* done, so use with care. */
 static inline PyObject* PyFunction_GET_CODE(PyObject *func) {
-    return _PyFunction_CAST(func)->func_code;
+    PyFunctionObject *op = _PyFunction_CAST(func);
+#ifdef Py_GIL_DISABLED
+    return (PyObject *)_Py_atomic_load_ptr(&op->func_code);
+#else
+    return op->func_code;
+#endif
 }
-#define PyFunction_GET_CODE(func) PyFunction_GET_CODE(_PyObject_CAST(func))
-
 static inline PyObject* PyFunction_GET_GLOBALS(PyObject *func) {
     return _PyFunction_CAST(func)->func_globals;
 }

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-05-12-01-44.gh-issue-145272.MeSSbg.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-05-12-01-44.gh-issue-145272.MeSSbg.rst
@@ -1,0 +1,1 @@
+Fixing race condition in PyFunctionObject.func_code

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -631,7 +631,8 @@ func_get_code(PyObject *self, void *Py_UNUSED(ignored))
         return NULL;
     }
 
-    return Py_NewRef(op->func_code);
+    PyCodeObject *code = _Py_atomic_load_ptr(&op->func_code);
+    return Py_NewRef(code);
 }
 
 static int
@@ -664,7 +665,7 @@ func_set_code(PyObject *self, PyObject *value, void *Py_UNUSED(ignored))
         return -1;
     }
 
-    PyObject *func_code = PyFunction_GET_CODE(op);
+    PyCodeObject *func_code = _Py_atomic_load_ptr(&op->func_code);
     int old_flags = ((PyCodeObject *)func_code)->co_flags;
     int new_flags = ((PyCodeObject *)value)->co_flags;
     int mask = CO_GENERATOR | CO_COROUTINE | CO_ASYNC_GENERATOR;
@@ -679,7 +680,10 @@ func_set_code(PyObject *self, PyObject *value, void *Py_UNUSED(ignored))
 
     handle_func_event(PyFunction_EVENT_MODIFY_CODE, op, value);
     _PyFunction_ClearVersion(op);
-    Py_XSETREF(op->func_code, Py_NewRef(value));
+    PyCodeObject *new = (PyCodeObject *)Py_NewRef(value);
+    PyCodeObject *old =
+        (PyCodeObject *)_Py_atomic_exchange_ptr(&op->func_code, new);
+    Py_XDECREF(old);
     return 0;
 }
 

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -665,7 +665,7 @@ func_set_code(PyObject *self, PyObject *value, void *Py_UNUSED(ignored))
         return -1;
     }
 
-    PyCodeObject *func_code = _Py_atomic_load_ptr(&op->func_code);
+    PyCodeObject *func_code = (PyCodeObject *)PyFunction_GET_CODE(op);
     int old_flags = ((PyCodeObject *)func_code)->co_flags;
     int new_flags = ((PyCodeObject *)value)->co_flags;
     int mask = CO_GENERATOR | CO_COROUTINE | CO_ASYNC_GENERATOR;


### PR DESCRIPTION

- Fix a data race when accessing PyFunctionObject.func_code in free-threaded builds.

- This patch replaces the direct read with `_Py_atomic_load_ptr()` and updates the setter to use `_Py_atomic_exchange_ptr()` so that updates to `func_code` are performed atomically.

- The race was reproduced using `ThreadSanitizer` and verified to be fixed after this change.


* Issue: gh-145272
<!-- /gh-issue-number -->
