### PR TITLE
gh-145376: Fix reference leak in _lprof.c

### DIFF
--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -702,6 +702,7 @@ PyObject* get_cfunc_from_callable(PyObject* callable, PyObject* self_arg, PyObje
         if (PyCFunction_Check(meth)) {
             return (PyObject*)((PyCFunctionObject *)meth);
         }
+        Py_DECREF(meth);
     }
     return NULL;
 }
@@ -961,6 +962,8 @@ profiler_traverse(PyObject *op, visitproc visit, void *arg)
     ProfilerObject *self = ProfilerObject_CAST(op);
     Py_VISIT(Py_TYPE(op));
     Py_VISIT(self->externalTimer);
+    Py_VISIT(self->missing);
+
     return 0;
 }
 
@@ -979,6 +982,7 @@ profiler_dealloc(PyObject *op)
 
     flush_unmatched(self);
     clearEntries(self);
+    Py_XDECREF(self->missing);
     Py_XDECREF(self->externalTimer);
     PyTypeObject *tp = Py_TYPE(self);
     tp->tp_free(self);
@@ -1017,7 +1021,7 @@ profiler_init_impl(ProfilerObject *self, PyObject *timer, double timeunit,
     if (!monitoring) {
         return -1;
     }
-    self->missing = PyObject_GetAttrString(monitoring, "MISSING");
+    Py_XSETREF(self->missing, PyObject_GetAttrString(monitoring, "MISSING"));
     if (!self->missing) {
         Py_DECREF(monitoring);
         return -1;


### PR DESCRIPTION
Skipping news. This only affects cases where people manually replace the `sys.monitoring.MISSING` sentinel.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145376 -->
* Issue: gh-145376
<!-- /gh-issue-number -->
