### PR TITLE
Clarify logger creation example in logging HOWTO

### DIFF
--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -28,7 +28,7 @@ When to use logging
 ^^^^^^^^^^^^^^^^^^^
 
 You can access logging functionality by creating a logger via ``logger =
-getLogger(__name__)``, and then calling the logger's :meth:`~Logger.debug`,
+logging.getLogger(__name__)``, and then calling the logger's :meth:`~Logger.debug`,
 :meth:`~Logger.info`, :meth:`~Logger.warning`, :meth:`~Logger.error` and
 :meth:`~Logger.critical` methods. To determine when to use logging, and to see
 which logger methods to use when, see the table below. It states, for each of a


### PR DESCRIPTION
This PR clarifies the logger creation example in the Logging HOWTO.

The previous text used `getLogger(__name__)` without the module prefix,
which may confuse beginners. The example has been updated to
`logging.getLogger(__name__)` for clarity and consistency with later
examples in the document.

This is a small documentation clarification and does not change
functionality.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145540.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->