### PR TITLE
gh-139759: Add test_unclosed_interpreter_on_fork

### DIFF
--- a/Lib/test/test_interpreters/test_stress.py
+++ b/Lib/test/test_interpreters/test_stress.py
@@ -1,3 +1,4 @@
+import os
 import threading
 import unittest
 
@@ -82,6 +83,24 @@ class StressTests(TestBase):
         with self.assertRaises(InterpreterError):
             _testcapi.set_nomemory(0, 1)
             _interpreters.create()
+
+    @support.requires_fork()
+    def test_unclosed_interpreter_on_fork(self):
+        interp = interpreters.create()
+        interp.exec("pass")
+
+        fds = os.pipe()
+        pid = os.fork()
+
+        if pid == 0:
+            os.close(fds[0])
+            os.write(fds[1], b"OK")
+            os._exit(0)
+        else:
+            os.close(fds[1])
+            self.addCleanup(os.close, fds[0])
+            value = os.read(fds[0], 100)
+            self.assertEqual(value, b"OK")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a unit test which covers the issue raced in gh-139759 - forking when a subinterpreter is not properly closed creates a segfault in the child process.

Note, currently **this test will fail**. I provide it to emphasize the existing issue and as something to add to the testsuite once there is a proper fix.

The thread state handling is a bit intriguing to me, so I will propably not work on an actual fix. But maybe it is useful to someone actually picking up the issue.