### PR TITLE
gh-145546: unittest.util: fix `sorted_list_difference` tail deduplication

### DIFF
--- a/Lib/test/test_unittest/test_util.py
+++ b/Lib/test/test_unittest/test_util.py
@@ -26,6 +26,17 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(sorted_list_difference([2], [1, 1]), ([2], [1]))
         self.assertEqual(sorted_list_difference([1, 2], [1, 1]), ([2], []))
 
+    def test_sorted_list_difference_tail_deduplication(self):
+        # Tail deduplication when one list is exhausted before the other.
+        # These exercise the except-IndexError path in sorted_list_difference.
+        self.assertEqual(sorted_list_difference([], [0, 0]), ([], [0]))
+        self.assertEqual(sorted_list_difference([0, 0], []), ([0], []))
+        self.assertEqual(sorted_list_difference([], [1, 1, 2, 2]), ([], [1, 2]))
+        self.assertEqual(sorted_list_difference([1, 1, 2, 2], []), ([1, 2], []))
+        # One list exhausts mid-way, leaving duplicated tail in the other.
+        self.assertEqual(sorted_list_difference([1], [1, 2, 2, 3, 3]), ([], [2, 3]))
+        self.assertEqual(sorted_list_difference([1, 2, 2, 3, 3], [1]), ([2, 3], []))
+
     def test_unorderable_list_difference(self):
         self.assertEqual(unorderable_list_difference([], []), ([], []))
         self.assertEqual(unorderable_list_difference([1, 2], []), ([2, 1], []))

--- a/Lib/test/test_unittest/test_util.py
+++ b/Lib/test/test_unittest/test_util.py
@@ -37,6 +37,28 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(sorted_list_difference([1], [1, 2, 2, 3, 3]), ([], [2, 3]))
         self.assertEqual(sorted_list_difference([1, 2, 2, 3, 3], [1]), ([2, 3], []))
 
+    def test_sorted_list_difference_strings(self):
+        self.assertEqual(
+            sorted_list_difference(['a', 'b'], ['b', 'c']),
+            (['a'], ['c']))
+        self.assertEqual(
+            sorted_list_difference([], ['a', 'a', 'b']),
+            ([], ['a', 'b']))
+        self.assertEqual(
+            sorted_list_difference(['a', 'a', 'b'], []),
+            (['a', 'b'], []))
+
+    def test_sorted_list_difference_unhashable(self):
+        self.assertEqual(
+            sorted_list_difference([[1], [2]], [[2], [3]]),
+            ([[1]], [[3]]))
+        self.assertEqual(
+            sorted_list_difference([], [[0], [0]]),
+            ([], [[0]]))
+        self.assertEqual(
+            sorted_list_difference([[0], [0]], []),
+            ([[0]], []))
+
     def test_unorderable_list_difference(self):
         self.assertEqual(unorderable_list_difference([], []), ([], []))
         self.assertEqual(unorderable_list_difference([1, 2], []), ([2, 1], []))

--- a/Lib/unittest/util.py
+++ b/Lib/unittest/util.py
@@ -64,10 +64,7 @@ def strclass(cls):
     return "%s.%s" % (cls.__module__, cls.__qualname__)
 
 def _dedupe_sorted(lst):
-    """Remove consecutive duplicate elements from a sorted list.
-
-    Only requires that elements support equality comparison,
-    not hashing."""
+    """Remove consecutive duplicate elements from a sorted list."""
     result = []
     for item in lst:
         if not result or result[-1] != item:

--- a/Lib/unittest/util.py
+++ b/Lib/unittest/util.py
@@ -63,6 +63,17 @@ def safe_repr(obj, short=False):
 def strclass(cls):
     return "%s.%s" % (cls.__module__, cls.__qualname__)
 
+def _dedupe_sorted(lst):
+    """Remove consecutive duplicate elements from a sorted list.
+
+    Only requires that elements support equality comparison,
+    not hashing."""
+    result = []
+    for item in lst:
+        if not result or result[-1] != item:
+            result.append(item)
+    return result
+
 def sorted_list_difference(expected, actual):
     """Finds elements in only one or the other of two, sorted input lists.
 
@@ -98,8 +109,8 @@ def sorted_list_difference(expected, actual):
                     while actual[j] == a:
                         j += 1
         except IndexError:
-            missing.extend(dict.fromkeys(expected[i:]))
-            unexpected.extend(dict.fromkeys(actual[j:]))
+            missing.extend(_dedupe_sorted(expected[i:]))
+            unexpected.extend(_dedupe_sorted(actual[j:]))
             break
     return missing, unexpected
 

--- a/Lib/unittest/util.py
+++ b/Lib/unittest/util.py
@@ -98,8 +98,8 @@ def sorted_list_difference(expected, actual):
                     while actual[j] == a:
                         j += 1
         except IndexError:
-            missing.extend(expected[i:])
-            unexpected.extend(actual[j:])
+            missing.extend(dict.fromkeys(expected[i:]))
+            unexpected.extend(dict.fromkeys(actual[j:]))
             break
     return missing, unexpected
 

--- a/Misc/NEWS.d/next/Library/2026-03-05-14-13-10.gh-issue-145546.3tnlxx.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-05-14-13-10.gh-issue-145546.3tnlxx.rst
@@ -1,4 +1,4 @@
-Fix :func:`unittest.util.sorted_list_difference` to deduplicate remaining
+Fix ``unittest.util.sorted_list_difference()`` to deduplicate remaining
 elements when one input list is exhausted before the other. Previously,
 duplicates in the tail were included in the output despite the documented
 guarantee that "Duplicate elements in either input list are ignored."

--- a/Misc/NEWS.d/next/Library/2026-03-05-14-13-10.gh-issue-145546.3tnlxx.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-05-14-13-10.gh-issue-145546.3tnlxx.rst
@@ -1,0 +1,4 @@
+Fix :func:`unittest.util.sorted_list_difference` to deduplicate remaining
+elements when one input list is exhausted before the other. Previously,
+duplicates in the tail were included in the output despite the documented
+guarantee that "Duplicate elements in either input list are ignored."

--- a/Misc/NEWS.d/next/Library/2026-03-05-14-13-10.gh-issue-145546.3tnlxx.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-05-14-13-10.gh-issue-145546.3tnlxx.rst
@@ -1,4 +1,2 @@
 Fix ``unittest.util.sorted_list_difference()`` to deduplicate remaining
-elements when one input list is exhausted before the other. Previously,
-duplicates in the tail were included in the output despite the documented
-guarantee that "Duplicate elements in either input list are ignored."
+elements when one input list is exhausted before the other.


### PR DESCRIPTION
## Problem

`sorted_list_difference` doesn't deduplicate remaining elements when one list is exhausted. The `except IndexError` fallback uses `extend(expected[i:])` / `extend(actual[j:])` which includes duplicates.

## Reproducer

```python
from unittest.util import sorted_list_difference
print(sorted_list_difference([], [0, 0]))  # ([], [0, 0]) — expected ([], [0])
```

## Fix

Replace the raw extend(expected[i:]) / extend(actual[j:]) in the except IndexError fallback with a helper that removes consecutive duplicates. The helper only uses equality comparison (not hashing), matching the main loop's approach and preserving support for unhashable types like lists.

## Tests

- Tail deduplication with ints (empty list vs duplicates, mid-way exhaustion)
- String inputs with duplicated tails
- Unhashable types (lists of lists) to verify no hashing requirement is introduced


<!-- gh-issue-number: gh-145546 -->
* Issue: gh-145546
<!-- /gh-issue-number -->
