### PR TITLE
gh-116738: Make mmap.set_name thread-safe

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-06-01-36-20.gh-issue-116738.OWVWRx.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-06-01-36-20.gh-issue-116738.OWVWRx.rst
@@ -1,2 +1,2 @@
-Make :meth:`mmap.set_name` thread-safe on the :term:`free threaded <free
+Make :meth:`!mmap.mmap.set_name` thread-safe on the :term:`free threaded <free
 threading>` build.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-06-01-36-20.gh-issue-116738.OWVWRx.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-06-01-36-20.gh-issue-116738.OWVWRx.rst
@@ -1,0 +1,2 @@
+Make :meth:`mmap.set_name` thread-safe on the :term:`free threaded <free
+threading>` build.

--- a/Modules/clinic/mmapmodule.c.h
+++ b/Modules/clinic/mmapmodule.c.h
@@ -556,7 +556,9 @@ mmap_mmap_set_name(PyObject *self, PyObject *arg)
         PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = mmap_mmap_set_name_impl((mmap_object *)self, name);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -879,4 +881,4 @@ exit:
 #ifndef MMAP_MMAP_MADVISE_METHODDEF
     #define MMAP_MMAP_MADVISE_METHODDEF
 #endif /* !defined(MMAP_MMAP_MADVISE_METHODDEF) */
-/*[clinic end generated code: output=8389e3c8e3db3a78 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1122b93314aebc5c input=a9049054013a1b77]*/

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1122,6 +1122,7 @@ mmap_mmap_seek_impl(mmap_object *self, Py_ssize_t dist, int how)
 }
 
 /*[clinic input]
+@critical_section
 mmap.mmap.set_name
 
     name: str
@@ -1131,7 +1132,7 @@ mmap.mmap.set_name
 
 static PyObject *
 mmap_mmap_set_name_impl(mmap_object *self, const char *name)
-/*[clinic end generated code: output=1edaf4fd51277760 input=6c7dd91cad205f07]*/
+/*[clinic end generated code: output=1edaf4fd51277760 input=7c0e2a17ca6d1adc]*/
 {
 #if defined(MAP_ANONYMOUS) && defined(__linux__)
     const char *prefix = "cpython:mmap:";


### PR DESCRIPTION
`mmap.resize` may update the pointer to `data` and `size`, which is under the protection of a critical section.
 
In `mmap.set_name`, it uses `data` and `size` to annotate the mmap, but it does not have a critical section around it. So it may use an invalid `data` and `size` combination, which may have problems.

<!-- gh-issue-number: gh-116738 -->
* Issue: gh-116738
<!-- /gh-issue-number -->
