### PR TITLE
gh-145557: Check ctypes is available in test.test_external_inspection

### DIFF
--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -17,6 +17,7 @@ from test.support import (
     requires_gil_enabled,
     requires_remote_subprocess_debugging,
 )
+from test.support.import_helper import import_module
 from test.support.script_helper import make_script
 from test.support.socket_helper import find_unused_port
 
@@ -529,6 +530,10 @@ class TestGetStackTrace(RemoteInspectionTestBase):
         The remote debugging code must skip these uninitialized duplicate
         mappings and find the real PyRuntime. See gh-144563.
         """
+
+        # Skip the test if the _ctypes module is missing.
+        import_module("_ctypes")
+
         # Run the test in a subprocess to avoid side effects
         script = textwrap.dedent("""\
             import os


### PR DESCRIPTION
Currently TestGetStackTrace.test_self_trace_after_ctypes_import() will fail if
the ctypes extension is not built.  Make it match test.test_ctypes by skipping
the test in that case.



<!-- gh-issue-number: gh-145557 -->
* Issue: gh-145557
<!-- /gh-issue-number -->
