### PR TITLE
[3.11] Add `mkdir`s to fix 3.11 docs build

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -201,6 +201,7 @@ dist:
 .PHONY: dist-html
 dist-html:
 	# archive the HTML
+	mkdir -p dist
 	make html
 	cp -pPR build/html dist/python-$(DISTVERSION)-docs-html
 	tar -C dist -cf dist/python-$(DISTVERSION)-docs-html.tar python-$(DISTVERSION)-docs-html
@@ -212,6 +213,7 @@ dist-html:
 .PHONY: dist-text
 dist-text:
 	# archive the text build
+	mkdir -p dist
 	make text
 	cp -pPR build/text dist/python-$(DISTVERSION)-docs-text
 	tar -C dist -cf dist/python-$(DISTVERSION)-docs-text.tar python-$(DISTVERSION)-docs-text
@@ -223,6 +225,7 @@ dist-text:
 .PHONY: dist-pdf
 dist-pdf:
 	# archive the A4 latex
+	mkdir -p dist
 	rm -rf build/latex
 	make latex PAPER=a4
 	-sed -i 's/makeindex/makeindex -q/' build/latex/Makefile
@@ -241,6 +244,7 @@ dist-pdf:
 .PHONY: dist-epub
 dist-epub:
 	# copy the epub build
+	mkdir -p dist
 	rm -rf build/epub
 	make epub
 	cp -pPR build/epub/Python.epub dist/python-$(DISTVERSION)-docs.epub
@@ -248,6 +252,7 @@ dist-epub:
 .PHONY: dist-texinfo
 dist-texinfo:
 	# archive the texinfo build
+	mkdir -p dist
 	rm -rf build/texinfo
 	make texinfo
 	make info --directory=build/texinfo


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The 3.11 docs build is failing on the docsbuild server:

```
2026-03-05 20:41:52,084 DEBUG en/3.11: >>>> cp -pPR build/html dist/python-3.11.15-docs-html
2026-03-05 20:41:52,087 DEBUG en/3.11: >>>> cp: cannot create directory 'dist/python-3.11.15-docs-html': No such file or directory
```

It looks like 3.12+ are okay because of this refactor that didn't go into 3.10/11:

https://github.com/python/cpython/pull/124383

Pablo fixed 3.10 during the last release in https://github.com/python/cpython/commit/27c64549324915826947e6c7d479d16e95678cc6

So let's add those `mkdir` to 3.11 as well.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145571.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->