### PR TITLE
gh-145587: fix busy loop in multiprocessing.connection.wait on Windows

### DIFF
--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -1085,6 +1085,14 @@ if sys.platform == 'win32':
 
         Returns list of those objects in object_list which are ready/readable.
         '''
+        if not object_list:
+            if timeout is None:
+                while True:
+                    time.sleep(1e6)
+            elif timeout > 0:
+                time.sleep(timeout)
+            return []
+
         if timeout is None:
             timeout = INFINITE
         elif timeout < 0:

--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -1101,8 +1101,6 @@ if sys.platform == 'win32':
             timeout = 0
         else:
             timeout = int(timeout * 1000 + 0.5)
-
-        object_list = list(object_list)
         waithandle_to_obj = {}
         ov_list = []
         ready_objects = set()

--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -1085,6 +1085,8 @@ if sys.platform == 'win32':
 
         Returns list of those objects in object_list which are ready/readable.
         '''
+        object_list = list(object_list)
+
         if not object_list:
             if timeout is None:
                 while True:

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3892,11 +3892,14 @@ class _TestConnection(BaseTestCase):
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_wait_empty(self):
+        if self.TYPE != 'processes':
+            self.skipTest('test not appropriate for {}'.format(self.TYPE))
         # gh-145587: wait() with empty list should respect timeout
         timeout = 0.5
         start = time.monotonic()
         res = self.connection.wait([], timeout=timeout)
         duration = time.monotonic() - start
+
         self.assertEqual(res, [])
         self.assertGreaterEqual(duration, timeout - 0.1)
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3889,6 +3889,16 @@ class _TestConnection(BaseTestCase):
             self.assertTrue(b.closed)
             self.assertRaises(OSError, a.recv)
             self.assertRaises(OSError, b.recv)
+            
+    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    def test_wait_empty(self):
+        # gh-145587: wait() with empty list should respect timeout
+        timeout = 0.5
+        start = time.monotonic()
+        res = self.connection.wait([], timeout=timeout)
+        duration = time.monotonic() - start
+        self.assertEqual(res, [])
+        self.assertGreaterEqual(duration, timeout - 0.1)
 
 class _TestListener(BaseTestCase):
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3889,7 +3889,7 @@ class _TestConnection(BaseTestCase):
             self.assertTrue(b.closed)
             self.assertRaises(OSError, a.recv)
             self.assertRaises(OSError, b.recv)
-            
+
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_wait_empty(self):
         # gh-145587: wait() with empty list should respect timeout

--- a/Misc/NEWS.d/next/Library/2026-03-07-14-34-39.gh-issue-145587.flFQ5-.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-07-14-34-39.gh-issue-145587.flFQ5-.rst
@@ -1,1 +1,1 @@
-Resolved a performance regression in `multiprocessing.connection.wait` on Windows that caused infinite busy loops when called with no objects. The function now properly yields control to the OS to conserve CPU resources.
+Resolved a performance regression in ``multiprocessing.connection.wait`` on Windows that caused infinite busy loops when called with no objects. The function now properly yields control to the OS to conserve CPU resources.

--- a/Misc/NEWS.d/next/Library/2026-03-07-14-34-39.gh-issue-145587.flFQ5-.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-07-14-34-39.gh-issue-145587.flFQ5-.rst
@@ -1,0 +1,1 @@
+Resolved a performance regression in `multiprocessing.connection.wait` on Windows that caused infinite busy loops when called with no objects. The function now properly yields control to the OS to conserve CPU resources.

--- a/Misc/NEWS.d/next/Library/2026-03-07-14-34-39.gh-issue-145587.flFQ5-.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-07-14-34-39.gh-issue-145587.flFQ5-.rst
@@ -1,1 +1,1 @@
-Resolved a performance regression in ``multiprocessing.connection.wait`` on Windows that caused infinite busy loops when called with no objects. The function now properly yields control to the OS to conserve CPU resources.
+Resolved a performance regression in ``multiprocessing.connection.wait`` on Windows that caused infinite busy loops when called with no objects. The function now properly yields control to the OS to conserve CPU resources. Patch By Shrey Naithani


### PR DESCRIPTION
On Windows, `multiprocessing.connection.wait` returns immediately if the `object_list` is empty, regardless of the timeout.

This fix adds a check to make sure the function actually sleeps for the duration of the timeout, matching the Unix behavior and stopping the 100% CPU usage spike.

Verified locally:-
```python
import time
from multiprocessing.connection import wait
start = time.time()
wait([], 1.0) # took 0s before, now takes 1
print(time.time() - start)
```
Fixes #145587

<!-- gh-issue-number: gh-145587 -->
* Issue: gh-145587
<!-- /gh-issue-number -->
