### PR TITLE
gh-145602: Correct `_CallableGenericAlias` class and `typing.Callable` docstring

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -459,10 +459,10 @@ class Buffer(metaclass=ABCMeta):
 
 
 class _CallableGenericAlias(GenericAlias):
-    """ Represent `Callable[argtypes, resulttype]`.
+    """ Represent `Callable[paramtypes, returntype]`.
 
-    This sets ``__args__`` to a tuple containing the flattened ``argtypes``
-    followed by ``resulttype``.
+    This sets ``__args__`` to a tuple containing the flattened ``paramtypes``
+    followed by ``returntype``.
 
     Example: ``Callable[[int, str], float]`` sets ``__args__`` to
     ``(int, str, float)``.
@@ -473,13 +473,13 @@ class _CallableGenericAlias(GenericAlias):
     def __new__(cls, origin, args):
         if not (isinstance(args, tuple) and len(args) == 2):
             raise TypeError(
-                "Callable must be used as Callable[[arg, ...], result].")
-        t_args, t_result = args
-        if isinstance(t_args, (tuple, list)):
-            args = (*t_args, t_result)
-        elif not _is_param_expr(t_args):
+                "Callable must be used as Callable[[paramtype1, ...], returntype].")
+        t_params, t_return = args
+        if isinstance(t_params, (tuple, list)):
+            args = (*t_params, t_return)
+        elif not _is_param_expr(t_params):
             raise TypeError(f"Expected a list of types, an ellipsis, "
-                            f"ParamSpec, or Concatenate. Got {t_args}")
+                            f"ParamSpec, or Concatenate. Got {t_params}")
         return super().__new__(cls, origin, args)
 
     def __repr__(self):
@@ -508,9 +508,9 @@ class _CallableGenericAlias(GenericAlias):
 
         # args[0] occurs due to things like Z[[int, str, bool]] from PEP 612
         if not isinstance(new_args[0], (tuple, list)):
-            t_result = new_args[-1]
-            t_args = new_args[:-1]
-            new_args = (t_args, t_result)
+            t_params = new_args[:-1]
+            t_return = new_args[-1]
+            new_args = (t_params, t_return)
         return _CallableGenericAlias(Callable, tuple(new_args))
 
 def _is_param_expr(obj):

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -473,7 +473,7 @@ class _CallableGenericAlias(GenericAlias):
     def __new__(cls, origin, args):
         if not (isinstance(args, tuple) and len(args) == 2):
             raise TypeError(
-                "Callable must be used as Callable[[paramtype1, ...], returntype].")
+                "Callable must be used as Callable[[paramtype1, paramtype2, ...], returntype].")
         t_params, t_return = args
         if isinstance(t_params, (tuple, list)):
             args = (*t_params, t_return)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2831,15 +2831,15 @@ Callable = _CallableType(collections.abc.Callable, 2)
 Callable.__doc__ = \
     """Deprecated alias to collections.abc.Callable.
 
-    Callable[[int], str] signifies a function that takes a single
+    Callable[[int], str] signifies a function that has a single
     parameter of type int and returns a str.
 
-    The subscription syntax must always be used with exactly two
-    values: the argument list and the return type.
-    The argument list must be a list of types, a ParamSpec,
-    Concatenate or ellipsis. The return type must be a single type.
+    The type specification "[]" must have two objects, a parameter
+    type list and return type. The parameter type list must be a list
+    of types, ParamSpec, Concatenate or ellipsis "...".
+    The return type must be a single type.
 
-    There is no syntax to indicate optional or keyword arguments;
+    There is no syntax to indicate optional or keyword parameters;
     such function types are rarely used as callback types.
     """
 AbstractSet = _alias(collections.abc.Set, 1, name='AbstractSet')

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-06-17-19-11.gh-issue-145602.KC5SLP.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-06-17-19-11.gh-issue-145602.KC5SLP.rst
@@ -1,0 +1,1 @@
+Correct _CallableGenericAlias class and typing.Callable docstring


### PR DESCRIPTION
Fix: #145602
Related: #145577

<!-- gh-issue-number: gh-145602 -->
* Issue: gh-145602
<!-- /gh-issue-number -->
