### PR TITLE
Fix bug notifier for issues with no body text

### DIFF
--- a/.github/workflows/new-bugs-announce-notifier.yml
+++ b/.github/workflows/new-bugs-announce-notifier.yml
@@ -44,7 +44,7 @@ jobs:
                 // We need to truncate the body size, because the max size for
                 // the whole payload is 16kb. We want to be safe and assume that
                 // body can take up to ~8kb of space.
-                body   : issue.data.body.substring(0, 8000)
+                body   : (issue.data.body || "").substring(0, 8000)
               };
 
               const data = {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Possible fix for https://github.com/python/cpython/actions/runs/22773539894/job/66060786931


```
GET /repos/python/cpython/issues/145599 - 200 in 266ms
TypeError: Cannot read properties of null (reading 'substring')
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v8/dist/index.js:36187:16), <anonymous>:24:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
Error: Unhandled error: TypeError: Cannot read properties of null (reading 'substring')
```

The issue https://github.com/python/cpython/issues/145599 was created with no body, and we should always have at least a brief description. But something like this should let the notifier still process it if it happens again.