### PR TITLE
[3.14] gh-145566: Skip stop-the-world when reassigning `__class__` on newly created objects (gh-145567)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-05-19-10-56.gh-issue-145566.H4RupyYN.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-05-19-10-56.gh-issue-145566.H4RupyYN.rst
@@ -1,0 +1,2 @@
+In the free threading build, skip the stop-the-world pause when reassigning
+``__class__`` on a newly created object.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7164,9 +7164,9 @@ object_set_class(PyObject *self, PyObject *value, void *closure)
         return -1;
     }
 
-    int unique = _PyObject_IsUniquelyReferenced(self);
 #ifdef Py_GIL_DISABLED
     PyInterpreterState *interp = _PyInterpreterState_GET();
+    int unique = _PyObject_IsUniquelyReferenced(self);
     if (!unique) {
         _PyEval_StopTheWorld(interp);
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7120,7 +7120,11 @@ object_set_class_world_stopped(PyObject *self, PyTypeObject *newto)
 
             assert(_PyObject_GetManagedDict(self) == dict);
 
-            if (_PyDict_DetachFromObject(dict, self) < 0) {
+            int err;
+            Py_BEGIN_CRITICAL_SECTION(dict);
+            err = _PyDict_DetachFromObject(dict, self);
+            Py_END_CRITICAL_SECTION();
+            if (err < 0) {
                 return -1;
             }
 
@@ -7160,14 +7164,19 @@ object_set_class(PyObject *self, PyObject *value, void *closure)
         return -1;
     }
 
+    int unique = _PyObject_IsUniquelyReferenced(self);
 #ifdef Py_GIL_DISABLED
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    _PyEval_StopTheWorld(interp);
+    if (!unique) {
+        _PyEval_StopTheWorld(interp);
+    }
 #endif
     PyTypeObject *oldto = Py_TYPE(self);
     int res = object_set_class_world_stopped(self, newto);
 #ifdef Py_GIL_DISABLED
-    _PyEval_StartTheWorld(interp);
+    if (!unique) {
+        _PyEval_StartTheWorld(interp);
+    }
 #endif
     if (res == 0) {
         if (oldto->tp_flags & Py_TPFLAGS_HEAPTYPE) {


### PR DESCRIPTION
(cherry picked from commit 1d091a336e60b703a7d7ae4124f652eabe144f4e)

<!-- gh-issue-number: gh-145566 -->
* Issue: gh-145566
<!-- /gh-issue-number -->
