### PR TITLE
gh-145591: Move slicing note to subscription methods section

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -3223,21 +3223,6 @@ through the object's keys; for sequences, it should iterate through the values.
    .. versionadded:: 3.4
 
 
-.. index:: pair: object; slice
-
-.. note::
-
-   Slicing is done exclusively with the following three methods.  A call like ::
-
-      a[1:2] = b
-
-   is translated to ::
-
-      a[slice(1, 2, None)] = b
-
-   and so forth.  Missing slice items are always filled in with ``None``.
-
-
 .. method:: object.__getitem__(self, subscript)
 
    Called to implement *subscription*, that is, ``self[subscript]``.
@@ -3259,6 +3244,21 @@ through the object's keys; for sequences, it should iterate through the values.
    If *subscript* has an inappropriate value, :meth:`!__getitem__`
    should raise an :exc:`LookupError` or one of its subclasses
    (:exc:`IndexError` for sequences; :exc:`KeyError` for mappings).
+
+   .. index:: pair: object; slice
+
+   .. note::
+
+      Slicing is done exclusively with the following three methods.
+      A call like ::
+
+         a[1:2] = b
+
+      is translated to ::
+
+         a[slice(1, 2, None)] = b
+
+      and so forth. Missing slice items are always filled in with ``None``.
 
    .. note::
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -3249,7 +3249,8 @@ through the object's keys; for sequences, it should iterate through the values.
 
    .. note::
 
-      Slicing is done exclusively with the following three methods.
+      Slicing is handled by :meth:`!__getitem__`, :meth:`~object.__setitem__`,
+      and :meth:`~object.__delitem__`.
       A call like ::
 
          a[1:2] = b


### PR DESCRIPTION
This PR moves the slicing note out of the `object.__length_hint__` section and places it with the subscription protocol under `object.__getitem__`.

That keeps the slicing translation example (`a[1:2] = b` -> `a[slice(1, 2, None)] = b`) next to the relevant special methods (`__getitem__`, `__setitem__`, `__delitem__`).

Issue: https://github.com/python/cpython/issues/145591


<!-- gh-issue-number: gh-145591 -->
* Issue: gh-145591
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145606.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->