### PR TITLE
[REPRO] gh-145607: Reproduce flaky test_bz2.testDecompressorChunksMaxsize

### DIFF
--- a/Lib/test/test_bz2.py
+++ b/Lib/test/test_bz2.py
@@ -72,7 +72,9 @@ class BaseTest(unittest.TestCase):
     # simply use the bigger test data for all tests.
     test_size = 0
     BIG_TEXT = bytearray(128*1024)
-    for fname in glob.glob(os.path.join(glob.escape(os.path.dirname(__file__)), '*.py')):
+    _files = sorted(glob.glob(os.path.join(glob.escape(os.path.dirname(__file__)), '*.py')))
+    random.Random(555).shuffle(_files)
+    for fname in _files:
         with open(fname, 'rb') as fh:
             test_size += fh.readinto(memoryview(BIG_TEXT)[test_size:])
         if test_size > 128*1024:


### PR DESCRIPTION
Sort the glob results then shuffle with a fixed seed (555) so that the first bz2 block's compressed data extends into the last 64 bytes of BIG_DATA. The -64 truncation then yields an incomplete block, causing the assertFalse(bzd.needs_input) assertion to fail.


<!-- gh-issue-number: gh-145607 -->
* Issue: gh-145607
<!-- /gh-issue-number -->
