### PR TITLE
[3.13] gh-145376: Fix crashes in md5module.c (GH-145422)

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-03-06-20-17-45.gh-issue-145376.0F7HFq.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-06-20-17-45.gh-issue-145376.0F7HFq.rst
@@ -1,0 +1,1 @@
+Fix null pointer dereference in unusual error scenario in :mod:`hashlib`.

--- a/Modules/md5module.c
+++ b/Modules/md5module.c
@@ -84,7 +84,10 @@ MD5_traverse(PyObject *ptr, visitproc visit, void *arg)
 static void
 MD5_dealloc(MD5object *ptr)
 {
-    Hacl_Hash_MD5_free(ptr->hash_state);
+    if (ptr->hash_state != NULL) {
+        Hacl_Hash_MD5_free(ptr->hash_state);
+        ptr->hash_state == NULL;
+    }
     PyTypeObject *tp = Py_TYPE((PyObject*)ptr);
     PyObject_GC_UnTrack(ptr);
     PyObject_GC_Del(ptr);

--- a/Modules/md5module.c
+++ b/Modules/md5module.c
@@ -86,7 +86,7 @@ MD5_dealloc(MD5object *ptr)
 {
     if (ptr->hash_state != NULL) {
         Hacl_Hash_MD5_free(ptr->hash_state);
-        ptr->hash_state == NULL;
+        ptr->hash_state = NULL;
     }
     PyTypeObject *tp = Py_TYPE((PyObject*)ptr);
     PyObject_GC_UnTrack(ptr);


### PR DESCRIPTION
Fix a possible NULL pointer dereference in `md5module.c`.
This can only occur in error paths taken when the interpreter fails to allocate memory.

(cherry-picked from c1d77683213c400fca144692654845e6f5418981)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145376 -->
* Issue: gh-145376
<!-- /gh-issue-number -->
