### PR TITLE
Remove the `distutils-sig@python.org` email in 'Installing Python Modules'

### DIFF
--- a/Doc/installing/index.rst
+++ b/Doc/installing/index.rst
@@ -6,8 +6,6 @@
 Installing Python Modules
 *************************
 
-:Email: distutils-sig@python.org
-
 As a popular open source development project, Python has an active
 supporting community of contributors and users that also make their software
 available for other Python developers to use under open source license terms.


### PR DESCRIPTION
Per the [last post on the mailing list](https://mail.python.org/archives/list/distutils-sig@python.org/thread/TINMM5LQKQTTJDVGC224RMG7JGPXL4MQ/), it has been shut down since 2021.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145613.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->