### PR TITLE
gh-143526: tkinter.filedialog crashes when filetypes=None

### DIFF
--- a/Lib/tkinter/filedialog.py
+++ b/Lib/tkinter/filedialog.py
@@ -306,7 +306,8 @@ class _Dialog(commondialog.Dialog):
     def _fixoptions(self):
         try:
             # make sure "filetypes" is a tuple
-            self.options["filetypes"] = tuple(self.options["filetypes"])
+            if self.options.get("filetypes") is not None:
+                self.options["filetypes"] = tuple(self.options["filetypes"])
         except KeyError:
             pass
 

--- a/Misc/NEWS.d/next/Library/gh-143526.rst
+++ b/Misc/NEWS.d/next/Library/gh-143526.rst
@@ -1,0 +1,1 @@
+tkinter.filedialog.askopenfilename now correctly handles filetypes=None without raising a TypeError.


### PR DESCRIPTION
The filedialog was crashing with TypeError when filetypes=None was passed, despite the docs stating None is acceptable. This fix adds a guard to only convert to tuple if filetypes is not None.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143526 -->
* Issue: gh-143526
<!-- /gh-issue-number -->
