### PR TITLE
gh-145623: Fix crashes on uninitialized struct.Struct objects

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -836,6 +836,8 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         self.assertRaises(RuntimeError, S.unpack, spam)
         self.assertRaises(RuntimeError, S.unpack_from, spam)
         self.assertRaises(RuntimeError, getattr, S, 'format')
+        self.assertRaises(RuntimeError, S.__sizeof__)
+        self.assertRaises(RuntimeError, repr, S)
         self.assertEqual(S.size, -1)
 
 

--- a/Misc/NEWS.d/next/Library/2026-03-07-15-00-00.gh-issue-145623.2Y7LzT.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-07-15-00-00.gh-issue-145623.2Y7LzT.rst
@@ -1,0 +1,3 @@
+Fix crash in :mod:`struct` when calling :func:`repr` or
+``__sizeof__()`` on an uninitialized :class:`struct.Struct`
+object created via ``Struct.__new__()`` without calling ``__init__()``.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2382,6 +2382,7 @@ static PyObject *
 Struct___sizeof___impl(PyStructObject *self)
 /*[clinic end generated code: output=2d0d78900b4cdb4e input=faca5925c1f1ffd0]*/
 {
+    ENSURE_STRUCT_IS_READY(self);
     size_t size = _PyObject_SIZE(Py_TYPE(self)) + sizeof(formatcode);
     for (formatcode *code = self->s_codes; code->fmtdef != NULL; code++) {
         size += sizeof(formatcode);
@@ -2393,6 +2394,7 @@ static PyObject *
 s_repr(PyObject *op)
 {
     PyStructObject *self = PyStructObject_CAST(op);
+    ENSURE_STRUCT_IS_READY(self);
     PyObject* fmt = PyUnicode_FromStringAndSize(
         PyBytes_AS_STRING(self->s_format), PyBytes_GET_SIZE(self->s_format));
     if (fmt == NULL) {


### PR DESCRIPTION
Add `ENSURE_STRUCT_IS_READY()` checks to `Struct.__sizeof__()` and `Struct.__repr__()` to prevent crashes when called on uninitialized `Struct` objects.

<!-- gh-issue-number: gh-145623 -->
* Issue: gh-145623
<!-- /gh-issue-number -->
