### PR TITLE
[3.13] gh-145623: Fix crashes on uninitialized struct.Struct objects (gh-145624)

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -806,6 +806,8 @@ class StructTest(unittest.TestCase):
         self.assertRaises(RuntimeError, S.unpack, spam)
         self.assertRaises(RuntimeError, S.unpack_from, spam)
         self.assertRaises(RuntimeError, getattr, S, 'format')
+        self.assertRaises(RuntimeError, S.__sizeof__)
+        self.assertRaises(RuntimeError, repr, S)
         self.assertEqual(S.size, -1)
 
 

--- a/Misc/NEWS.d/next/Library/2026-03-07-15-00-00.gh-issue-145623.2Y7LzT.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-07-15-00-00.gh-issue-145623.2Y7LzT.rst
@@ -1,0 +1,3 @@
+Fix crash in :mod:`struct` when calling :func:`repr` or
+``__sizeof__()`` on an uninitialized :class:`struct.Struct`
+object created via ``Struct.__new__()`` without calling ``__init__()``.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2196,6 +2196,7 @@ PyDoc_STRVAR(s_sizeof__doc__,
 static PyObject *
 s_sizeof(PyStructObject *self, void *unused)
 {
+    ENSURE_STRUCT_IS_READY(self);
     size_t size = _PyObject_SIZE(Py_TYPE(self)) + sizeof(formatcode);
     for (formatcode *code = self->s_codes; code->fmtdef != NULL; code++) {
         size += sizeof(formatcode);
@@ -2206,6 +2207,7 @@ s_sizeof(PyStructObject *self, void *unused)
 static PyObject *
 s_repr(PyStructObject *self)
 {
+    ENSURE_STRUCT_IS_READY(self);
     PyObject* fmt = PyUnicode_FromStringAndSize(
         PyBytes_AS_STRING(self->s_format), PyBytes_GET_SIZE(self->s_format));
     if (fmt == NULL) {


### PR DESCRIPTION
  Backport of #145624 to 3.13.

  <!-- gh-issue-number: gh-145623 -->
  * Issue: gh-145623
  <!-- /gh-issue-number -->