### PR TITLE
gh-145410: Fix sysconfig.get_platform() on Windows when sys.version is truncated

### DIFF
--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -665,12 +665,14 @@ def get_platform():
 
     For other non-POSIX platforms, currently just returns :data:`sys.platform`."""
     if os.name == 'nt':
-        if 'amd64' in sys.version.lower():
+        import platform
+        machine = platform.machine()
+        if machine == 'AMD64':
             return 'win-amd64'
-        if '(arm)' in sys.version.lower():
-            return 'win-arm32'
-        if '(arm64)' in sys.version.lower():
+        if machine == 'ARM64':
             return 'win-arm64'
+        if machine == 'ARM' or machine.startswith('armv'):
+            return 'win-arm32'
         return sys.platform
 
     if os.name != "posix" or not hasattr(os, 'uname'):


### PR DESCRIPTION
Fixes #145410

The function was checking for 'amd64' in sys.version to detect 64-bit
Windows, but sys.version is truncated at a fixed width and may not
contain the architecture marker when the compiler version string is long.

Use platform.machine() instead, which reliably returns the machine
architecture on Windows regardless of the sys.version content.

<!-- gh-issue-number: gh-145410 -->
* Issue: gh-145410
<!-- /gh-issue-number -->
