### PR TITLE
gh-117961: Fix grammar production for multiplicative operators

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1567,7 +1567,7 @@ from the power operator, there are only two levels, one for multiplicative
 operators and one for additive operators:
 
 .. productionlist:: python-grammar
-   m_expr: `u_expr` | `m_expr` "*" `u_expr` | `m_expr` "@" `m_expr` |
+   m_expr: `u_expr` | `m_expr` "*" `u_expr` | `m_expr` "@" `u_expr` |
          : `m_expr` "//" `u_expr` | `m_expr` "/" `u_expr` |
          : `m_expr` "%" `u_expr`
    a_expr: `m_expr` | `a_expr` "+" `m_expr` | `a_expr` "-" `m_expr`


### PR DESCRIPTION
Fixes #117961

This PR corrects the grammar production for the multiplicative operator `@` (matmul) in the expressions documentation.

The right-hand operand of the `@` operator should be `u_expr` (unary expression), not `m_expr` (multiplicative expression), as per the grammar specification.

Changed line 1570 in Doc/reference/expressions.rst:
- Before: `m_expr` "@" `m_expr`
- After: `m_expr` "@" `u_expr`

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145636.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-117961 -->
* Issue: gh-117961
<!-- /gh-issue-number -->
