### PR TITLE
gh-145300: Document bytearray.extend() behavior when mutating during …

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1328,6 +1328,17 @@ Mutable sequence types also support the following methods:
    For the most part, this is the same as writing
    ``seq[len(seq):len(seq)] = iterable``.
 
+      .. note::
+
+         When extending a sequence with itself (e.g., ``seq.extend(seq)``),
+         the behavior differs between sequence types if the sequence mutates
+         during iteration:
+
+         * :class:`list` and :class:`array.array` pick up elements as they
+           are added, potentially leading to unbounded growth.
+         * :class:`bytearray` captures the sequence length at the start,
+           limiting the extension to at most doubling the original length.
+
 .. method:: bytearray.insert(index, value, /)
             list.insert(index, value, /)
    :no-contents-entry:


### PR DESCRIPTION
…iteration

Add a note to sequence.extend() documentation clarifying that bytearray behaves differently from list and array.array when extending a sequence with itself during iteration. bytearray captures the length at the start and can at most double the original length, while list and array.array pick up elements as they're added, potentially leading to unbounded growth.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145300 -->
* Issue: gh-145300
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145637.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->