### PR TITLE
Fix intermittent `test_ci_fuzz_stdlib` failures

### DIFF
--- a/Lib/test/test_tools/test_compute_changes.py
+++ b/Lib/test/test_tools/test_compute_changes.py
@@ -54,6 +54,8 @@ class TestProcessChangedFiles(unittest.TestCase):
                         f = p / "file"
                     elif p.is_file():
                         f = p
+                    else:
+                        self.fail(f"LIBRARY_FUZZER_PATHS contains an invalid entry: {p!r}")
                     result = process_changed_files({f})
                     self.assertTrue(result.run_ci_fuzz_stdlib)
                     self.assertTrue(is_fuzzable_library_file(f))

--- a/Tools/build/compute-changes.py
+++ b/Tools/build/compute-changes.py
@@ -90,7 +90,7 @@ LIBRARY_FUZZER_PATHS = frozenset({
     # tarfile
     Path("Lib/tarfile.py"),
     # tomllib
-    Path("Modules/tomllib/"),
+    Path("Lib/tomllib/"),
     # xml
     Path("Lib/xml/"),
     Path("Lib/_markupbase.py"),


### PR DESCRIPTION
`test_ci_fuzz_stdlib` fails randomly since https://github.com/python/cpython/pull/145232, [for example](https://github.com/python/cpython/actions/runs/22817216509/job/66184072974?pr=145597#step:19:526):

```
======================================================================
ERROR: test_ci_fuzz_stdlib (test.test_tools.test_compute_changes.TestProcessChangedFiles.test_ci_fuzz_stdlib) (p=PosixPath('Modules/tomllib'))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/cpython/cpython-ro-srcdir/Lib/test/test_tools/test_compute_changes.py", line 57, in test_ci_fuzz_stdlib
    result = process_changed_files({f})
                                    ^
UnboundLocalError: cannot access local variable 'f' where it is not associated with a value
```
in https://github.com/python/cpython/pull/145597.

Because the `LIBRARY_FUZZER_PATHS` is an unordered `frozenset` and contains an invalid entry `Modules\tomllib` (https://github.com/python/cpython/pull/143749), it can happen  that this is the first item when iterating.

Let's fail `test_ci_fuzz_stdlib` with an explicit error message if we detect an invalid entry.
