### PR TITLE
gh-145642: Match tutorial output to real interpreter output

### DIFF
--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -184,12 +184,11 @@ If you don't want characters prefaced by ``\`` to be interpreted as
 special characters, you can use *raw strings* by adding an ``r`` before
 the first quote::
 
-   >>> print('C:\some\name')  # here \n means newline, and \s means nothing!
-   <python-input-0>:1: SyntaxWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
-   C:\some
+   >>> print('C:\this\name')  # here \t means tab, \n means newline
+   C:      his
    ame
-   >>> print(r'C:\some\name')  # note the r before the quote
-   C:\some\name
+   >>> print(r'C:\this\name')  # note the r before the quote
+   C:\this\name
 
 There is one subtle aspect to raw strings: a raw string may not end in
 an odd number of ``\`` characters; see

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -184,7 +184,8 @@ If you don't want characters prefaced by ``\`` to be interpreted as
 special characters, you can use *raw strings* by adding an ``r`` before
 the first quote::
 
-   >>> print('C:\some\name')  # here \n means newline!
+   >>> print('C:\some\name')  # here \n means newline, and \s means nothing!
+   <python-input-0>:1: SyntaxWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
    C:\some
    ame
    >>> print(r'C:\some\name')  # note the r before the quote


### PR DESCRIPTION
Closes #145642.

This changeset updates the official tutorial to match real interpreter output for an example that demonstrates escape sequences, namely showing the generated `SyntaxWarning`.

<!-- gh-issue-number: gh-145642 -->
* Issue: gh-145642
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145643.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->