### PR TITLE
gh-145650: Add `logging.{Formatter,Filter}.__repr__`

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -797,6 +797,9 @@ class Filter(object):
         self.name = name
         self.nlen = len(name)
 
+    def __repr__(self):
+        return '<%s (%s)>' % (self.__class__.__name__, self.name)
+
     def filter(self, record):
         """
         Determine if the specified record is to be logged.
@@ -811,9 +814,6 @@ class Filter(object):
         elif record.name.find(self.name, 0, self.nlen) != 0:
             return False
         return (record.name[self.nlen] == ".")
-
-    def __repr__(self):
-        return '<%s (%s)>' % (self.__class__.__name__, self.name)
 
 class Filterer(object):
     """

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -622,6 +622,9 @@ class Formatter(object):
         self._fmt = self._style._fmt
         self.datefmt = datefmt
 
+    def __repr__(self):
+        return '<%s (%s)>' % (self.__class__.__name__, self._fmt)
+
     default_time_format = '%Y-%m-%d %H:%M:%S'
     default_msec_format = '%s,%03d'
 
@@ -808,6 +811,9 @@ class Filter(object):
         elif record.name.find(self.name, 0, self.nlen) != 0:
             return False
         return (record.name[self.nlen] == ".")
+
+    def __repr__(self):
+        return '<%s (%s)>' % (self.__class__.__name__, self.name)
 
 class Filterer(object):
     """

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4928,7 +4928,6 @@ class FormatterTest(unittest.TestCase, AssertErrorMessage):
                 # After PR gh-102412, precision (places) increases from 3 to 7
                 self.assertAlmostEqual(relativeCreated, offset_ns / 1e6, places=7)
 
-
     def test_formatter_repr(self):
         f = logging.Formatter('%(message)s')
         self.assertEqual(repr(f), '<Formatter (%(message)s)>')

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -404,6 +404,20 @@ class BasicFilterTest(BaseTest):
         r = logging.makeLogRecord({'name': 'spam.eggs'})
         self.assertTrue(f.filter(r))
 
+    def test_filter_repr(self):
+        f = logging.Filter('myapp')
+        self.assertEqual(repr(f), '<Filter (myapp)>')
+
+    def test_filter_repr_empty(self):
+        f = logging.Filter()
+        self.assertEqual(repr(f), '<Filter ()>')
+
+    def test_filter_repr_subclass(self):
+        class MyFilter(logging.Filter):
+            pass
+        f = MyFilter('myapp')
+        self.assertEqual(repr(f), '<MyFilter (myapp)>')
+
 #
 #   First, we define our levels. There can be as many as you want - the only
 #     limitations are that they should be integers, the lowest should be > 0 and
@@ -4913,6 +4927,21 @@ class FormatterTest(unittest.TestCase, AssertErrorMessage):
                 self.assertAlmostEqual(created, (start_ns + offset_ns) / 1e9, places=6)
                 # After PR gh-102412, precision (places) increases from 3 to 7
                 self.assertAlmostEqual(relativeCreated, offset_ns / 1e6, places=7)
+
+
+    def test_formatter_repr(self):
+        f = logging.Formatter('%(message)s')
+        self.assertEqual(repr(f), '<Formatter (%(message)s)>')
+
+    def test_formatter_repr_default(self):
+        f = logging.Formatter()
+        self.assertEqual(repr(f), '<Formatter (%(message)s)>')
+
+    def test_formatter_repr_subclass(self):
+        class MyFormatter(logging.Formatter):
+            pass
+        f = MyFormatter('%(message)s')
+        self.assertEqual(repr(f), '<MyFormatter (%(message)s)>')
 
 
 class TestBufferingFormatter(logging.BufferingFormatter):

--- a/Misc/NEWS.d/next/Library/2026-03-08-00-00-00.gh-issue-145650.LgRepr.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-08-00-00-00.gh-issue-145650.LgRepr.rst
@@ -1,3 +1,3 @@
-Add :func:`repr` support to :class:`logging.Formatter` and
+Add :meth:`~object.__repr__` support to :class:`logging.Formatter` and
 :class:`logging.Filter`, showing the format string and filter name
 respectively.

--- a/Misc/NEWS.d/next/Library/2026-03-08-00-00-00.gh-issue-145650.LgRepr.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-08-00-00-00.gh-issue-145650.LgRepr.rst
@@ -1,0 +1,3 @@
+Add :func:`repr` support to :class:`logging.Formatter` and
+:class:`logging.Filter`, showing the format string and filter name
+respectively.

--- a/Misc/NEWS.d/next/Library/2026-03-08-00-00-00.gh-issue-145651.HtRepr.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-08-00-00-00.gh-issue-145651.HtRepr.rst
@@ -1,3 +1,0 @@
-Add :func:`repr` support to :class:`http.client.HTTPConnection` and
-:class:`http.client.HTTPResponse`, showing host/port and status/reason
-respectively.

--- a/Misc/NEWS.d/next/Library/2026-03-08-00-00-00.gh-issue-145651.HtRepr.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-08-00-00-00.gh-issue-145651.HtRepr.rst
@@ -1,0 +1,3 @@
+Add :func:`repr` support to :class:`http.client.HTTPConnection` and
+:class:`http.client.HTTPResponse`, showing host/port and status/reason
+respectively.


### PR DESCRIPTION
Add informative `__repr__` implementations to `logging.Formatter` and `logging.Filter`, consistent with the existing repr style used by `Handler` and `StreamHandler`.

- `Formatter` now displays its format string: `<Formatter (%(message)s)>`
- `Filter` displays its filter name: `<Filter (myapp)>`

Closes #145650

<!-- gh-issue-number: gh-145650 -->
* Issue: gh-145650
<!-- /gh-issue-number -->
