### PR TITLE
gh-145238: Add native thread ID to logging record attributes

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1062,6 +1062,9 @@ the options available to you.
 |                |                         | of the logging call which resulted in the     |
 |                |                         | creation of this record.                      |
 +----------------+-------------------------+-----------------------------------------------+
+| nativeThreadId | ``%(nativeThreadId)d``  | Native thread ID (if available). See          |
+|                |                         | :func:`threading.get_native_id`.              |
++----------------+-------------------------+-----------------------------------------------+
 | thread         | ``%(thread)d``          | Thread ID (if available).                     |
 +----------------+-------------------------+-----------------------------------------------+
 | threadName     | ``%(threadName)s``      | Thread name (if available).                   |
@@ -1074,6 +1077,9 @@ the options available to you.
 
 .. versionchanged:: 3.12
    *taskName* was added.
+
+.. versionchanged:: 3.15
+   *nativeThreadId* was added.
 
 .. _logger-adapter:
 

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -350,9 +350,14 @@ class LogRecord(object):
         if logThreads:
             self.thread = threading.get_ident()
             self.threadName = threading.current_thread().name
+            if threading._HAVE_THREAD_NATIVE_ID:
+                self.nativeThreadId = threading.get_native_id()
+            else: # pragma: no cover
+                self.nativeThreadId = None
         else: # pragma: no cover
             self.thread = None
             self.threadName = None
+            self.nativeThreadId = None
         if not logMultiprocessing: # pragma: no cover
             self.processName = None
         else:

--- a/Misc/NEWS.d/next/Library/2026-03-08-00-00-00.gh-issue-145238.nThrId.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-08-00-00-00.gh-issue-145238.nThrId.rst
@@ -1,0 +1,3 @@
+Added ``nativeThreadId`` attribute to :class:`logging.LogRecord`, exposing
+the OS-native thread ID via :func:`threading.get_native_id`. This can be
+used in format strings as ``%(nativeThreadId)d``.


### PR DESCRIPTION
Fixes #145238.

Adds a `nativeThreadId` attribute to `LogRecord` that exposes the OS-native thread ID via `threading.get_native_id()`. This is useful for correlating log entries with system tools like `htop`, `strace`, and `perf` that display native thread IDs.

The attribute can be used in format strings as `%(nativeThreadId)d`.

On platforms where `get_native_id` is not available, the attribute is set to `None`.

This contribution was developed with AI assistance (Claude Code).

<!-- gh-issue-number: gh-145238 -->
* Issue: gh-145238
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145655.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->