### PR TITLE
gh-145492: Fix defaultdict __repr__ infinite recursion

### DIFF
--- a/Lib/test/test_defaultdict.py
+++ b/Lib/test/test_defaultdict.py
@@ -204,5 +204,20 @@ class TestDefaultDict(unittest.TestCase):
         self.assertEqual(test_dict[key], 2)
         self.assertEqual(count, 2)
 
+    def test_repr_recursive_factory(self):
+        # gh-145492: defaultdict.__repr__ should not cause infinite recursion
+        # when the factory's __repr__ calls repr() on the defaultdict.
+        class ProblematicFactory:
+            def __call__(self):
+                return {}
+            def __repr__(self):
+                repr(dd)
+                return "ProblematicFactory()"
+
+        dd = defaultdict(ProblematicFactory())
+        # Should not raise RecursionError
+        r = repr(dd)
+        self.assertIn('ProblematicFactory()', r)
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2026-03-09-00-00-00.gh-issue-145492.457Afc.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-00-00-00.gh-issue-145492.457Afc.rst
@@ -1,0 +1,2 @@
+Fix infinite recursion in :class:`collections.defaultdict` ``__repr__``
+when a ``defaultdict`` contains itself.

--- a/Misc/NEWS.d/next/Library/2026-03-09-00-00-00.gh-issue-145492.457Afc.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-00-00-00.gh-issue-145492.457Afc.rst
@@ -1,3 +1,3 @@
 Fix infinite recursion in :class:`collections.defaultdict` ``__repr__``
 when a ``defaultdict`` contains itself. Based on analysis by KowalskiThomas
-in :issue:`145492`.
+in :gh:`145492`.

--- a/Misc/NEWS.d/next/Library/2026-03-09-00-00-00.gh-issue-145492.457Afc.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-00-00-00.gh-issue-145492.457Afc.rst
@@ -1,2 +1,3 @@
 Fix infinite recursion in :class:`collections.defaultdict` ``__repr__``
-when a ``defaultdict`` contains itself.
+when a ``defaultdict`` contains itself. Based on analysis by KowalskiThomas
+in :issue:`145492`.

--- a/Misc/NEWS.d/next/Library/2026-03-09-16-16-09.gh-issue-145492.9BCFju.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-16-16-09.gh-issue-145492.9BCFju.rst
@@ -1,0 +1,2 @@
+Fix :class:`collections.defaultdict` ``__repr__`` entering infinite recursion
+when the default factory references the ``defaultdict`` instance.

--- a/Misc/NEWS.d/next/Library/2026-03-09-16-16-09.gh-issue-145492.9BCFju.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-16-16-09.gh-issue-145492.9BCFju.rst
@@ -1,2 +1,0 @@
-Fix :class:`collections.defaultdict` ``__repr__`` entering infinite recursion
-when the default factory references the ``defaultdict`` instance.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2385,9 +2385,10 @@ defdict_repr(PyObject *op)
             }
             defrepr = PyUnicode_FromString("...");
         }
-        else
+        else {
             defrepr = PyObject_Repr(dd->default_factory);
-        Py_ReprLeave(dd->default_factory);
+            Py_ReprLeave(dd->default_factory);
+        }
     }
     if (defrepr == NULL) {
         Py_DECREF(baserepr);


### PR DESCRIPTION
Fixes #145492.

## Summary

Fixed the recursion guard in `defdict_repr` so that `Py_ReprLeave` is only called when `Py_ReprEnter` successfully entered (returned 0). Previously, `Py_ReprLeave` was called unconditionally, including when `Py_ReprEnter` returned > 0 (recursion detected). Since `Py_ReprEnter` does not add a new entry when it detects recursion, calling `Py_ReprLeave` in that case incorrectly removed the entry from the outer (non-recursive) call, allowing subsequent recursive calls to bypass the guard and cause infinite recursion.

The fix is a 3-line change: move `Py_ReprLeave(dd->default_factory)` inside the `else` branch of the recursion check.

## Test plan

- Added `test_repr_recursive_factory` regression test that reproduces the infinite recursion scenario from the issue
- All existing `test_defaultdict` tests continue to pass (13/13)

This contribution was developed with AI assistance (Claude Code).

<!-- gh-issue-number: gh-145492 -->
* Issue: gh-145492
<!-- /gh-issue-number -->
