### PR TITLE
gh-145681: do not deallocate list buffer in `_PyList_AsTupleAndClear`

### DIFF
--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3260,7 +3260,6 @@ _PyList_AsTupleAndClear(PyListObject *self)
     Py_ssize_t size = Py_SIZE(self);
     Py_SET_SIZE(self, 0);
     ret = _PyTuple_FromArraySteal(items, size);
-    free_list_items(items, false);
     Py_END_CRITICAL_SECTION();
     return ret;
 }

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3260,6 +3260,7 @@ _PyList_AsTupleAndClear(PyListObject *self)
     Py_ssize_t size = Py_SIZE(self);
     self->ob_item = NULL;
     Py_SET_SIZE(self, 0);
+    self->allocated = 0;
     ret = _PyTuple_FromArraySteal(items, size);
     free_list_items(items, false);
     Py_END_CRITICAL_SECTION();

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3258,9 +3258,7 @@ _PyList_AsTupleAndClear(PyListObject *self)
     Py_BEGIN_CRITICAL_SECTION(self);
     PyObject **items = self->ob_item;
     Py_ssize_t size = Py_SIZE(self);
-    self->ob_item = NULL;
     Py_SET_SIZE(self, 0);
-    self->allocated = 0;
     ret = _PyTuple_FromArraySteal(items, size);
     free_list_items(items, false);
     Py_END_CRITICAL_SECTION();


### PR DESCRIPTION
## Description

This is a fix for gh-145681. 

**Note** I wanted to open this PR in my fork for the time being (until issue has been reviewed/triaged), but I accidentally opened it in the public CPython directly... Sorry about that. 