### PR TITLE
gh-145675: Raise `SyntaxError` when constants are used as an identifier

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -954,7 +954,7 @@ class AST_Tests(unittest.TestCase):
             ("None", b"N\xc2\xbane"),
         ]
         for constant in constants:
-            with self.assertRaisesRegex(ValueError,
+            with self.assertRaisesRegex(SyntaxError,
                 f"identifier field can't represent '{constant[0]}' constant"):
                 ast.parse(constant[1], mode="eval")
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-09-17-19-04.gh-issue-145675.9YPpYi.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-09-17-19-04.gh-issue-145675.9YPpYi.rst
@@ -1,0 +1,2 @@
+Raise :exc:`SyntaxError` when constants ``True``, ``False`` or ``None`` are
+used as an identifier after NFKC normalization.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -539,7 +539,7 @@ _PyPegen_new_identifier(Parser *p, const char *n)
     };
     for (int i = 0; forbidden[i] != NULL; i++) {
         if (_PyUnicode_EqualToASCIIString(id, forbidden[i])) {
-            PyErr_Format(PyExc_ValueError,
+            RAISE_SYNTAX_ERROR(
                          "identifier field can't represent '%s' constant",
                          forbidden[i]);
             Py_DECREF(id);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145675 -->
* Issue: gh-145675
<!-- /gh-issue-number -->
