### PR TITLE
gh-145704: Fix typo in `Doc/faq/programming.rst`

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1074,7 +1074,7 @@ Performance
 My program is too slow. How do I speed it up?
 ---------------------------------------------
 
-That's a tough one, in general.  First, here is list of things to
+That's a tough one, in general.  First, here is a list of things to
 remember before diving further:
 
 * Performance characteristics vary across Python implementations.  This FAQ


### PR DESCRIPTION
This fixes the typing issue ("Here is list" was missing the letter "a")


<!-- gh-issue-number: gh-145704 -->
* Issue: gh-145704
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145705.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->