### PR TITLE
gh-145703: Fix asyncio.BaseEventLoop low clock resolution

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -29,6 +29,7 @@ import traceback
 import sys
 import warnings
 import weakref
+import math
 
 try:
     import ssl
@@ -2022,7 +2023,10 @@ class BaseEventLoop(events.AbstractEventLoop):
         event_list = None
 
         # Handle 'later' callbacks that are ready.
-        end_time = self.time() + self._clock_resolution
+        now = self.time()
+        # If clock resolution is too small, make sure end_time has the minimal
+        # possible increment
+        end_time = now + max(self._clock_resolution, math.ulp(now))
         while self._scheduled:
             handle = self._scheduled[0]
             if handle._when >= end_time:

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -19,17 +19,17 @@ import concurrent.futures
 import errno
 import heapq
 import itertools
+import math
 import os
 import socket
 import stat
 import subprocess
+import sys
 import threading
 import time
 import traceback
-import sys
 import warnings
 import weakref
-import math
 
 try:
     import ssl
@@ -2024,8 +2024,8 @@ class BaseEventLoop(events.AbstractEventLoop):
 
         # Handle 'later' callbacks that are ready.
         now = self.time()
-        # If clock resolution is too small, make sure end_time has the minimal
-        # possible increment
+        # Ensure that `end_time` is strictly increasing
+        # when the clock resolution is too small.
         end_time = now + max(self._clock_resolution, math.ulp(now))
         while self._scheduled:
             handle = self._scheduled[0]

--- a/Misc/NEWS.d/next/Library/2026-03-09-19-59-05.gh-issue-145703.4EEP7J.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-19-59-05.gh-issue-145703.4EEP7J.rst
@@ -1,2 +1,2 @@
-:mod:`asyncio`: Make sure that :class:`~asyncio.BaseEventLoop` triggers
+:mod:`asyncio`: Make sure that :meth:`asyncio.loop.call_soon` triggers
 scheduled events on time when the clock resolution becomes too small.

--- a/Misc/NEWS.d/next/Library/2026-03-09-19-59-05.gh-issue-145703.4EEP7J.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-19-59-05.gh-issue-145703.4EEP7J.rst
@@ -1,2 +1,2 @@
-Make sure asyncio.BaseEventLoop triggers scheduled events on time when clock
-resolution is too small.
+:mod:`asyncio`: Make sure that :class:`~asyncio.BaseEventLoop` triggers
+scheduled events on time when the clock resolution becomes too small.

--- a/Misc/NEWS.d/next/Library/2026-03-09-19-59-05.gh-issue-145703.4EEP7J.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-19-59-05.gh-issue-145703.4EEP7J.rst
@@ -1,2 +1,3 @@
-:mod:`asyncio`: Make sure that :meth:`asyncio.loop.call_soon` triggers
-scheduled events on time when the clock resolution becomes too small.
+:mod:`asyncio`: Make sure that :meth:`asyncio.loop.call_at` and
+:meth:`asyncio.loop.loop.call_later` trigger scheduled events on time when
+the clock resolution becomes too small.

--- a/Misc/NEWS.d/next/Library/2026-03-09-19-59-05.gh-issue-145703.4EEP7J.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-19-59-05.gh-issue-145703.4EEP7J.rst
@@ -1,0 +1,2 @@
+Make sure asyncio.BaseEventLoop triggers scheduled events on time when clock
+resolution is too small.

--- a/Misc/NEWS.d/next/Library/2026-03-09-19-59-05.gh-issue-145703.4EEP7J.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-19-59-05.gh-issue-145703.4EEP7J.rst
@@ -1,3 +1,3 @@
-:mod:`asyncio`: Make sure that :meth:`asyncio.loop.call_at` and
-:meth:`asyncio.loop.loop.call_later` trigger scheduled events on time when
-the clock resolution becomes too small.
+:mod:`asyncio`: Make sure that :meth:`loop.call_at <asyncio.loop.call_at>` and
+:meth:`loop.call_later <asyncio.loop.call_later>` trigger scheduled events on
+time when the clock resolution becomes too small.


### PR DESCRIPTION
With this fix we make sure that even if the clock resolution becomes too small, the "next tick" will still be different from the current time, and the comparison remains valid.

Example: clock resolution = 1e-9, current uptime = 200 days (17280000 seconds). Floating point addition does not change the value, because the precision is too small. In this case the patch will use `math.ulp()`, which is the smallest possible increment that will modify the current value.

<!-- gh-issue-number: gh-145703 -->
* Issue: gh-145703
<!-- /gh-issue-number -->
