### PR TITLE
gh-145694: Update tutorial indentation guidance for PyREPL auto-indent

### DIFF
--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -532,10 +532,13 @@ This example introduces several new features.
   and ``!=`` (not equal to).
 
 * The *body* of the loop is *indented*: indentation is Python's way of grouping
-  statements.  At the interactive prompt, you have to type a tab or space(s) for
-  each indented line.  In practice you will prepare more complicated input
-  for Python with a text editor; all decent text editors have an auto-indent
-  facility.  When a compound statement is entered interactively, it must be
+  statements.  At the interactive prompt, the default REPL automatically
+  indents continuation lines after compound statement headers like ``if`` or
+  ``while``.  In the basic REPL (invoked with :envvar:`PYTHON_BASIC_REPL`)
+  or in older Python versions, you have to type a tab or space(s) for each
+  indented line manually.  In practice you will prepare more complicated
+  input for Python with a text editor; all decent text editors have an
+  auto-indent facility.  When a compound statement is entered interactively, it must be
   followed by a blank line to indicate completion (since the parser cannot
   guess when you have typed the last line).  Note that each line within a basic
   block must be indented by the same amount.


### PR DESCRIPTION
Fixes #145694

## Summary

The tutorial page "An Informal Introduction to Python" stated that users must manually type tabs/spaces for indentation at the interactive prompt. Since Python 3.13, the default PyREPL auto-indents after compound statement headers like `if` and `while`, making this guidance misleading.

Updated the text to mention that the default REPL auto-indents, while noting the basic REPL (`PYTHON_BASIC_REPL`) and older versions still require manual indentation.

## Test plan

- [x] Docs text is accurate for both default and basic REPL
- [x] References `PYTHON_BASIC_REPL` envvar correctly using `:envvar:` role

This contribution was developed with AI assistance (Claude Code).

<!-- gh-issue-number: gh-145694 -->
* Issue: gh-145694
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145725.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->