### PR TITLE
gh-145448: Fix REPL tab completion cursor position in pending wrap state

### DIFF
--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -675,7 +675,8 @@ class UnixConsole(Console):
             self.__move(x_coord, y)
             self.__write_code(self.ich1)
             self.__write(newline[x_pos])
-            self.posxy = x_coord + character_width, y
+            new_x = x_coord + character_width
+            self.posxy = min(new_x, self.width - 1), y
 
         # if it's a single character change in the middle of the line
         elif (
@@ -686,7 +687,8 @@ class UnixConsole(Console):
             character_width = wlen(newline[x_pos])
             self.__move(x_coord, y)
             self.__write(newline[x_pos])
-            self.posxy = x_coord + character_width, y
+            new_x = x_coord + character_width
+            self.posxy = min(new_x, self.width - 1), y
 
         # if this is the last character to fit in the line and we edit in the middle of the line
         elif (
@@ -713,7 +715,14 @@ class UnixConsole(Console):
             if wlen(oldline) > wlen(newline):
                 self.__write_code(self._el)
             self.__write(newline[x_pos:])
-            self.posxy = wlen(newline), y
+            # When writing reaches the last column, the terminal enters
+            # "pending wrap" state where the cursor physically stays at
+            # width-1. Record position accordingly so CUB calculations
+            # use the correct physical cursor position (gh-145448).
+            newline_width = wlen(newline)
+            if newline_width >= self.width:
+                newline_width = self.width - 1
+            self.posxy = newline_width, y
 
         if "\x1b" in newline:
             # ANSI escape characters are present, so we can't assume

--- a/Misc/NEWS.d/next/Library/2026-03-09-00-00-02.gh-issue-145448.repl-cursor.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-09-00-00-02.gh-issue-145448.repl-cursor.rst
@@ -1,0 +1,3 @@
+Fixed REPL tab completion cursor moving backward by one cell in terminals
+that correctly handle CUB (Cursor Backward) in pending wrap state, such as
+xterm and Ghostty.


### PR DESCRIPTION
Fixes #145448

## Summary

When the PyREPL's `__write_changed_line` writes to the last column of the terminal, the cursor enters "pending wrap" state - it physically stays at column `width-1` but `posxy` was recording `width`. This caused subsequent CUB (Cursor Backward) escape sequences to overshoot by one cell, moving the cursor one position too far left.

**Root cause:** In `unix_console.py`, three code paths in `__write_changed_line` set `posxy` to the full line width without accounting for pending wrap state. When the cursor is later moved back (e.g., to return to the input line after showing "[ complete but not unique ]"), the CUB count is calculated as `target_x - width` instead of `target_x - (width-1)`, producing one extra backward movement.

**Fix:** Cap `posxy[0]` at `self.width - 1` when writing reaches the terminal edge. This matches the physical cursor position in pending wrap state, so CUB calculations produce the correct count.

**Why Terminal.app isn't affected:** Terminal.app compensates by subtracting 1 from CUB in pending wrap state. xterm and Ghostty do not compensate, matching the spec more strictly.

## Test plan

- [x] All 244 `test_pyrepl` tests pass
- [x] NEWS entry added
- [x] Fix applied to all three `posxy` assignment paths in `__write_changed_line`

This contribution was developed with AI assistance (Claude Code).

<!-- gh-issue-number: gh-145448 -->
* Issue: gh-145448
<!-- /gh-issue-number -->
