### PR TITLE
gh-145607: Ensure BIG_DATA has two compressed blocks in test_bz2

### DIFF
--- a/Lib/test/test_bz2.py
+++ b/Lib/test/test_bz2.py
@@ -66,18 +66,28 @@ class BaseTest(unittest.TestCase):
     EMPTY_DATA = b'BZh9\x17rE8P\x90\x00\x00\x00\x00'
     BAD_DATA = b'this is not a valid bzip2 file'
 
-    # Some tests need more than one block of uncompressed data. Since one block
-    # is at least 100,000 bytes, we gather some data dynamically and compress it.
-    # Note that this assumes that compression works correctly, so we cannot
-    # simply use the bigger test data for all tests.
+    # Some tests need more than one block of data. The bz2 module does not
+    # support flushing a block during compression, so we must read in data until
+    # there are at least 2 blocks. Since different orderings of Python files may
+    # be compressed differently, we need to check the compression output for
+    # more than one bzip2 block header magic, a hex encoding of Pi
+    # (0x314159265359)
+    bz2_block_magic = bytes.fromhex('314159265359')
     test_size = 0
-    BIG_TEXT = bytearray(128*1024)
+    BIG_TEXT = b''
+    BIG_DATA = b''
+    compressor = BZ2Compressor(1)
     for fname in glob.glob(os.path.join(glob.escape(os.path.dirname(__file__)), '*.py')):
         with open(fname, 'rb') as fh:
-            test_size += fh.readinto(memoryview(BIG_TEXT)[test_size:])
-        if test_size > 128*1024:
+            data = fh.read()
+            BIG_DATA += compressor.compress(data)
+            BIG_TEXT += data
+        # TODO(emmatyping): if it is impossible for a block header to cross
+        # multiple outputs, we can just search the output of each compress call
+        # which should be more efficient
+        if BIG_DATA.count(bz2_block_magic) > 1:
+            BIG_DATA += compressor.flush()
             break
-    BIG_DATA = bz2.compress(BIG_TEXT, compresslevel=1)
 
     def setUp(self):
         fd, self.filename = tempfile.mkstemp()


### PR DESCRIPTION
The `BIG_DATA` variable in `test_bz2` will sometimes only have one block of compressed data instead of the two it is intended to contain due to the value depending on the order of listing files. To fix this, we stream in input data and check for multiple block header magic strings to ensure that there are at least 2 block headers.

This is an unfortunate hack, but the bz2 module doesn't expose flushing in calls to `BZ2Compressor.compress()` so we cannot directly generate two blocks. I'm also not certain if block headers can span the output to `.compress()`, so conservatively I have the code scan the entire set of data, which should only need to happen a few times at test setup time. There's probably a few ways to optimize this code, but I wanted to keep it simple to get it in before the alpha tomorrow. I specifically did not want to use BZ2File as I wanted the module setup code to be as minimal as possible in case the implementation is broken.

<!-- gh-issue-number: gh-145607 -->
* Issue: gh-145607
<!-- /gh-issue-number -->
