### PR TITLE
[3.13] gh-145548: Don't use VMADDR_CID_LOCAL from `socket`

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -568,7 +568,7 @@ class ThreadedVSOCKSocketStreamTest(unittest.TestCase, ThreadableTest):
         self.addCleanup(self.serv.close)
         cid = get_cid()
         if cid in (socket.VMADDR_CID_HOST, socket.VMADDR_CID_ANY):
-            cid = socket.VMADDR_CID_LOCAL
+            cid = VMADDR_CID_LOCAL
         try:
             self.serv.bind((cid, VSOCKPORT))
         except OSError as exc:


### PR DESCRIPTION
VMADDR_CID_LOCAL was added to `socket` in 3.14.
For 3.13, the test needs a local constant in setUp(), as in clientSetUp().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145548 -->
* Issue: gh-145548
<!-- /gh-issue-number -->
