### PR TITLE
[3.14] gh-139588: Docs: fix PDF build

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -88,6 +88,7 @@ htmlhelp: build
 	      "build/htmlhelp/pydoc.hhp project file."
 
 .PHONY: latex
+latex: _ensure-sphinxcontrib-svg2pdfconverter
 latex: BUILDER = latex
 latex: build
 	@echo "Build finished; the LaTeX files are in build/latex."
@@ -231,7 +232,7 @@ dist-text:
 	@echo "Build finished and archived!"
 
 .PHONY: dist-pdf
-dist-pdf:
+dist-pdf: _ensure-sphinxcontrib-svg2pdfconverter
 	# archive the A4 latex
 	@echo "Building LaTeX (A4 paper)..."
 	mkdir -p dist
@@ -291,6 +292,10 @@ _ensure-pre-commit:
 .PHONY: _ensure-sphinx-autobuild
 _ensure-sphinx-autobuild:
 	$(MAKE) _ensure-package PACKAGE=sphinx-autobuild
+
+.PHONY: _ensure-sphinxcontrib-svg2pdfconverter
+_ensure-sphinxcontrib-svg2pdfconverter:
+	$(MAKE) _ensure-package PACKAGE=sphinxcontrib-svg2pdfconverter
 
 .PHONY: check
 check: _ensure-pre-commit

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -88,9 +88,9 @@ htmlhelp: build
 	      "build/htmlhelp/pydoc.hhp project file."
 
 .PHONY: latex
-latex: _ensure-sphinxcontrib-svg2pdfconverter
 latex: BUILDER = latex
-latex: build
+latex: _ensure-sphinxcontrib-svg2pdfconverter
+	$(MAKE) build BUILDER=$(BUILDER)
 	@echo "Build finished; the LaTeX files are in build/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
 	      "run these through (pdf)latex."

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -45,6 +45,7 @@ _OPTIONAL_EXTENSIONS = (
     'linklint.ext',
     'notfound.extension',
     'sphinxext.opengraph',
+    'sphinxcontrib.rsvgconverter',
 )
 for optional_ext in _OPTIONAL_EXTENSIONS:
     try:


### PR DESCRIPTION
Partial cherry-pick from https://github.com/python/cpython/commit/fc03cdccc0e88fe60f1ea6d659da1f3764379520 commit. It wouldn't apply cleanly automatically, because `Doc/library/profiling.sampling.rst` is not on `3.14` branch.

Problematic docs line: https://github.com/python/cpython/blob/e765696ca0c3421bb5763e4b944d5c1bcca2e84a/Doc/library/datetime.rst#L161

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139588 -->
* Issue: gh-139588
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145741.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->