### PR TITLE
gh-61449: document present 0-padding option behavior for builtin numeric types

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -428,10 +428,12 @@ The *width* is a decimal integer defining the minimum total field width,
 including any prefixes, separators, and other formatting characters.
 If not specified, then the field width will be determined by the content.
 
-When no explicit alignment is given, preceding the *width* field by a zero
-(``'0'``) character enables sign-aware zero-padding for numeric types,
-excluding :class:`complex`.  This is equivalent to a *fill* character of
-``'0'`` with an *alignment* type of ``'='``.
+When no explicit *fill* character and/or alignment is given, preceding the
+*width* field by a zero (``'0'``) character enables sign-aware zero-padding for
+numeric types, excluding :class:`complex`.  This is equivalent to a *fill*
+character of ``'0'`` with an *alignment* type of ``'='``.  If *fill* character
+is specified, ``'0'`` option is ignored.  If alignment is explicitly specified,
+it's value take preference over provided by ``'0'`` option.
 
 .. versionchanged:: 3.10
    Preceding the *width* field by ``'0'`` no longer affects the default


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-61449 -->
* Issue: gh-61449
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145748.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->