### PR TITLE
`_struct.c`: Fix UB from integer overflow in `prepare_s`

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -555,6 +555,12 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         hugecount3 = '{}i{}q'.format(sys.maxsize // 4, sys.maxsize // 8)
         self.assertRaises(struct.error, struct.calcsize, hugecount3)
 
+        hugecount4 = '{}?s'.format(sys.maxsize)
+        self.assertRaises(struct.error, struct.calcsize, hugecount4)
+
+        hugecount5 = '{}?p'.format(sys.maxsize)
+        self.assertRaises(struct.error, struct.calcsize, hugecount5)
+
     def test_trailing_counter(self):
         store = array.array('b', b' '*100)
 

--- a/Misc/NEWS.d/next/Library/2026-03-10-14-13-12.gh-issue-145750.iQsTeX.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-10-14-13-12.gh-issue-145750.iQsTeX.rst
@@ -1,0 +1,3 @@
+Avoid undefined behaviour from signed integer overflow when parsing format
+strings in the :mod:`struct` module. Found by OSS Fuzz in
+:oss-fuzz:`488466741`.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1676,7 +1676,13 @@ prepare_s(PyStructObject *self)
 
         switch (c) {
             case 's': _Py_FALLTHROUGH;
-            case 'p': len++; ncodes++; break;
+            case 'p':
+                if (len == PY_SSIZE_T_MAX) {
+                    goto overflow;
+                }
+                len++;
+                ncodes++;
+                break;
             case 'x': break;
             default:
                 if (num > PY_SSIZE_T_MAX - len) {


### PR DESCRIPTION
Like https://github.com/python/cpython/pull/145158. I checked the remaining paths in `prepare_s` and there are no remaining possible cases for UB.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
