### PR TITLE
Support kitty keyboard protocol in Unix _pyrepl for VS Code terminal compatibility

### DIFF
--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -70,6 +70,8 @@ SIGWINCH_EVENT = "repaint"
 FIONREAD = getattr(termios, "FIONREAD", None)
 TIOCGWINSZ = getattr(termios, "TIOCGWINSZ", None)
 
+KITTY_KEYBOARD_FLAGS = 0b1 | 0b10 | 0b100 | 0b1000 | 0b10000
+
 # ------------ start of baudrate definitions ------------
 
 # Add (possibly) missing baudrates (check termios man page) to termios
@@ -377,12 +379,14 @@ class UnixConsole(Console):
             pass
 
         self.__enable_bracketed_paste()
+        self.__enable_kitty_keyboard()
 
     def restore(self):
         """
         Restore the console to the default state
         """
         self.__disable_bracketed_paste()
+        self.__disable_kitty_keyboard()
         self.__maybe_write_code(self._rmkx)
         self.flushoutput()
         self.__input_fd_set(self.__svtermstate)
@@ -597,6 +601,12 @@ class UnixConsole(Console):
 
     def __disable_bracketed_paste(self) -> None:
         os.write(self.output_fd, b"\x1b[?2004l")
+
+    def __enable_kitty_keyboard(self) -> None:
+        os.write(self.output_fd, f"\x1b[={KITTY_KEYBOARD_FLAGS};1u".encode("ascii"))
+
+    def __disable_kitty_keyboard(self) -> None:
+        os.write(self.output_fd, b"\x1b[<u")
 
     def __setup_movement(self):
         """

--- a/Lib/_pyrepl/unix_eventqueue.py
+++ b/Lib/_pyrepl/unix_eventqueue.py
@@ -18,6 +18,9 @@
 # CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from dataclasses import dataclass
+
+from .console import Event
 from .terminfo import TermInfo
 from .trace import trace
 from .base_eventqueue import BaseEventQueue
@@ -54,6 +57,95 @@ CTRL_ARROW_KEYCODES= {
     b'\033Oc': 'ctrl right',
 }
 
+KITTY_MOD_SHIFT = 0x01
+KITTY_MOD_ALT = 0x02
+KITTY_MOD_CTRL = 0x04
+KITTY_MOD_SUPER = 0x08
+KITTY_MOD_HYPER = 0x10
+KITTY_MOD_META = 0x20
+KITTY_MOD_CAPS_LOCK = 0x40
+KITTY_MOD_NUM_LOCK = 0x80
+
+KITTY_EVENT_PRESS = 1
+KITTY_EVENT_REPEAT = 2
+KITTY_EVENT_RELEASE = 3
+
+KITTY_CSI_FINAL_BYTES = frozenset(b"~uABCDEFHPQS")
+KITTY_FUNCTIONAL_TILDE_KEYS = {
+    2: "insert",
+    3: "delete",
+    5: "page up",
+    6: "page down",
+    7: "home",
+    8: "end",
+    11: "f1",
+    12: "f2",
+    13: "f3",
+    14: "f4",
+    15: "f5",
+    17: "f6",
+    18: "f7",
+    19: "f8",
+    20: "f9",
+    21: "f10",
+    23: "f11",
+    24: "f12",
+    57427: "begin",
+}
+KITTY_FUNCTIONAL_LETTER_KEYS = {
+    "A": "up",
+    "B": "down",
+    "C": "right",
+    "D": "left",
+    "E": "begin",
+    "F": "end",
+    "H": "home",
+    "P": "f1",
+    "Q": "f2",
+    "S": "f4",
+}
+KITTY_FUNCTIONAL_U_KEYS = {
+    9: "\t",
+    13: "\r",
+    27: "\033",
+    127: "backspace",
+    57358: "caps_lock",
+    57359: "scroll_lock",
+    57360: "num_lock",
+}
+KITTY_FUNCTIONAL_U_KEYS.update((57363 + i, f"f{i}") for i in range(13, 36))
+KITTY_IGNORED_FUNCTIONAL_U_KEYS = frozenset(range(57399, 57455))
+KITTY_CTRL_KEY_OVERRIDES = {
+    ord(" "): 0,
+    ord("2"): 0,
+    ord("@"): 0,
+    ord("3"): 27,
+    ord("["): 27,
+    ord("4"): 28,
+    ord("\\"): 28,
+    ord("5"): 29,
+    ord("]"): 29,
+    ord("6"): 30,
+    ord("^"): 30,
+    ord("7"): 31,
+    ord("-"): 31,
+    ord("_"): 31,
+    ord("/"): 31,
+    ord("8"): 127,
+    ord("?"): 127,
+}
+
+
+@dataclass(slots=True)
+class _KittyKeyEvent:
+    key_code: int
+    shifted_key: int | None = None
+    base_layout_key: int | None = None
+    text: str = ""
+    modifiers: int = 0
+    event_type: int = KITTY_EVENT_PRESS
+    key_name: str | None = None
+
 def get_terminal_keycodes(ti: TermInfo) -> dict[bytes, str]:
     """
     Generates a dictionary mapping terminal keycodes to human-readable names.
@@ -75,3 +167,199 @@ class EventQueue(BaseEventQueue):
             backspace = tcgetattr(fd)[6][VERASE]
             keycodes[backspace] = "backspace"
         BaseEventQueue.__init__(self, encoding, keycodes)
+        self._escape_buffer = bytearray()
+
+    def push(self, char: int | bytes) -> None:
+        assert isinstance(char, (int, bytes))
+        ord_char = char if isinstance(char, int) else ord(char)
+
+        if self.keymap is not self.compiled_keymap:
+            super().push(ord_char)
+            return
+
+        if self._escape_buffer:
+            self._escape_buffer.append(ord_char)
+            self._process_escape_buffer()
+            return
+
+        if ord_char == 0x1b:
+            self._escape_buffer.append(ord_char)
+            return
+
+        super().push(ord_char)
+
+    def _process_escape_buffer(self) -> None:
+        if len(self._escape_buffer) < 2:
+            return
+
+        if self._escape_buffer[1] != ord("["):
+            self._flush_escape_buffer()
+            return
+
+        final = self._escape_buffer[-1]
+        if len(self._escape_buffer) > 2 and 0x40 <= final <= 0x7E:
+            seq = bytes(self._escape_buffer)
+            self._escape_buffer.clear()
+            if final in KITTY_CSI_FINAL_BYTES and self._handle_kitty_sequence(seq):
+                return
+            self._push_bytes(seq)
+
+    def _flush_escape_buffer(self) -> None:
+        if self._escape_buffer:
+            self._push_bytes(bytes(self._escape_buffer))
+            self._escape_buffer.clear()
+
+    def _push_bytes(self, data: bytes) -> None:
+        for byte in data:
+            super().push(byte)
+
+    def _handle_kitty_sequence(self, seq: bytes) -> bool:
+        params = seq[2:-1].decode("ascii", "strict")
+        final = chr(seq[-1])
+
+        try:
+            if final == "u":
+                event = self._parse_kitty_u(params)
+            elif final == "~":
+                event = self._parse_kitty_tilde(params)
+            else:
+                event = self._parse_kitty_letter(params, final)
+        except ValueError:
+            return False
+
+        if event is None:
+            return False
+        return self._emit_kitty_event(event, seq)
+
+    def _parse_kitty_u(self, params: str) -> _KittyKeyEvent | None:
+        fields = params.split(";")
+        if not fields or not fields[0]:
+            raise ValueError
+
+        key_fields = fields[0].split(":")
+        key_code = int(key_fields[0])
+        shifted_key = int(key_fields[1]) if len(key_fields) > 1 and key_fields[1] else None
+        base_layout_key = int(key_fields[2]) if len(key_fields) > 2 and key_fields[2] else None
+
+        modifiers = 0
+        event_type = KITTY_EVENT_PRESS
+        if len(fields) > 1 and fields[1]:
+            modifier_fields = fields[1].split(":")
+            modifiers = self._decode_kitty_modifiers(modifier_fields[0])
+            if len(modifier_fields) > 1 and modifier_fields[1]:
+                event_type = int(modifier_fields[1])
+
+        text = ""
+        if len(fields) > 2 and fields[2]:
+            text = "".join(chr(int(cp)) for cp in fields[2].split(":") if cp)
+
+        key_name = KITTY_FUNCTIONAL_U_KEYS.get(key_code)
+        if key_name is None and key_code in KITTY_IGNORED_FUNCTIONAL_U_KEYS:
+            key_name = ""
+
+        return _KittyKeyEvent(
+            key_code=key_code,
+            shifted_key=shifted_key,
+            base_layout_key=base_layout_key,
+            text=text,
+            modifiers=modifiers,
+            event_type=event_type,
+            key_name=key_name,
+        )
+
+    def _parse_kitty_tilde(self, params: str) -> _KittyKeyEvent | None:
+        fields = params.split(";")
+        if not fields or not fields[0]:
+            raise ValueError
+        key_code = int(fields[0])
+        key_name = KITTY_FUNCTIONAL_TILDE_KEYS.get(key_code)
+        if key_name is None:
+            return None
+        modifiers = self._decode_kitty_modifiers(fields[1]) if len(fields) > 1 and fields[1] else 0
+        return _KittyKeyEvent(key_code=key_code, modifiers=modifiers, key_name=key_name)
+
+    def _parse_kitty_letter(self, params: str, final: str) -> _KittyKeyEvent | None:
+        key_name = KITTY_FUNCTIONAL_LETTER_KEYS.get(final)
+        if key_name is None:
+            return None
+        modifiers = 0
+        if params:
+            fields = params.split(";")
+            if fields[0] not in ("", "1"):
+                return None
+            if len(fields) > 1 and fields[1]:
+                modifiers = self._decode_kitty_modifiers(fields[1])
+        return _KittyKeyEvent(key_code=1, modifiers=modifiers, key_name=key_name)
+
+    def _decode_kitty_modifiers(self, value: str) -> int:
+        modifier_value = int(value)
+        return max(modifier_value - 1, 0)
+
+    def _emit_kitty_event(self, event: _KittyKeyEvent, raw: bytes) -> bool:
+        if event.event_type == KITTY_EVENT_RELEASE:
+            return True
+
+        keys = self._translate_kitty_event(event)
+        for key in keys:
+            self.insert(Event("key", key, raw))
+        return True
+
+    def _translate_kitty_event(self, event: _KittyKeyEvent) -> list[str]:
+        if event.key_name == "":
+            return []
+
+        modifiers = event.modifiers
+        key_name = event.key_name
+
+        if key_name in {"caps_lock", "scroll_lock", "num_lock"}:
+            return []
+
+        if key_name is not None:
+            if modifiers & KITTY_MOD_ALT:
+                return self._prefix_alt([key_name])
+            ctrl_key = self._maybe_ctrl_special_key(key_name, modifiers)
+            return [ctrl_key] if ctrl_key is not None else [key_name]
+
+        text = event.text
+        if not text:
+            text = self._kitty_key_text(event)
+        if not text:
+            return []
+
+        if modifiers & KITTY_MOD_CTRL:
+            text = self._apply_ctrl_to_text(text, event)
+        if modifiers & KITTY_MOD_ALT:
+            return self._prefix_alt(list(text))
+        return list(text)
+
+    def _maybe_ctrl_special_key(self, key_name: str, modifiers: int) -> str | None:
+        if not modifiers & KITTY_MOD_CTRL:
+            return None
+        if key_name in {"left", "right"}:
+            return f"ctrl {key_name}"
+        return None
+
+    def _kitty_key_text(self, event: _KittyKeyEvent) -> str:
+        codepoint = event.base_layout_key or event.key_code
+        if event.modifiers & KITTY_MOD_SHIFT and event.shifted_key is not None:
+            codepoint = event.shifted_key
+        try:
+            return chr(codepoint)
+        except ValueError:
+            return ""
+
+    def _apply_ctrl_to_text(self, text: str, event: _KittyKeyEvent) -> str:
+        codepoint = event.base_layout_key or event.key_code
+        if codepoint in KITTY_CTRL_KEY_OVERRIDES:
+            return chr(KITTY_CTRL_KEY_OVERRIDES[codepoint])
+
+        if not text:
+            return ""
+
+        char = text[0]
+        if "a" <= char <= "z" or "A" <= char <= "Z":
+            return chr(ord(char.upper()) & 0x1F)
+        return char
+
+    def _prefix_alt(self, keys: list[str]) -> list[str]:
+        return ["\033", *keys]

--- a/Lib/test/test_pyrepl/test_eventqueue.py
+++ b/Lib/test/test_pyrepl/test_eventqueue.py
@@ -196,3 +196,72 @@ class TestUnixEventQueue(EventQueueTestBase, unittest.TestCase):
 class TestWindowsEventQueue(EventQueueTestBase, unittest.TestCase):
     def make_eventqueue(self) -> base_eventqueue.BaseEventQueue:
         return windows_eventqueue.EventQueue("utf-8")
+
+
+@unittest.skipIf(support.MS_WINDOWS, "Unix-only kitty parser tests")
+class TestUnixKittyEventQueue(unittest.TestCase):
+    def make_eventqueue(self) -> base_eventqueue.BaseEventQueue:
+        ti = EmptyTermInfo("ansi")
+        return unix_eventqueue.EventQueue(self.file.fileno(), "utf-8", ti)
+
+    def setUp(self):
+        self.file = tempfile.TemporaryFile()
+
+    def tearDown(self) -> None:
+        self.file.close()
+
+    def push_sequence(self, sequence: bytes) -> list[Event]:
+        eq = self.make_eventqueue()
+        for byte in sequence:
+            eq.push(byte)
+        events = []
+        while not eq.empty():
+            events.append(eq.get())
+        return events
+
+    def assert_events(self, sequence: bytes, expected: list[str]) -> None:
+        events = self.push_sequence(sequence)
+        self.assertEqual([event.data for event in events], expected)
+
+    def test_kitty_unicode_key(self):
+        self.assert_events(b"\x1b[97u", ["a"])
+
+    def test_kitty_shifted_text(self):
+        self.assert_events(b"\x1b[97;2;65u", ["A"])
+
+    def test_kitty_ctrl_c(self):
+        self.assert_events(b"\x1b[99;5u", ["\x03"])
+
+    def test_kitty_ctrl_h(self):
+        self.assert_events(b"\x1b[104;5u", ["\x08"])
+
+    def test_kitty_alt_x(self):
+        self.assert_events(b"\x1b[120;3u", ["\033", "x"])
+
+    def test_kitty_alt_backspace(self):
+        self.assert_events(b"\x1b[127;3u", ["\033", "backspace"])
+
+    def test_kitty_ctrl_left(self):
+        self.assert_events(b"\x1b[1;5D", ["ctrl left"])
+
+    def test_kitty_functional_tilde(self):
+        self.assert_events(b"\x1b[15~", ["f5"])
+
+    def test_kitty_functional_unicode(self):
+        self.assert_events(b"\x1b[57383u", ["f20"])
+
+    def test_kitty_alternate_base_layout_for_ctrl(self):
+        self.assert_events(b"\x1b[1091::99;5u", ["\x03"])
+
+    def test_kitty_repeat_is_press(self):
+        self.assert_events(b"\x1b[99;5:2u", ["\x03"])
+
+    def test_kitty_release_is_ignored(self):
+        self.assert_events(b"\x1b[99;5:3u", [])
+
+    def test_kitty_malformed_sequence_falls_back(self):
+        self.assert_events(b"\x1b[xyz", ["\033", "[", "x", "y", "z"])
+
+    def test_kitty_sequence_then_legacy_sequence(self):
+        events = self.push_sequence(b"\x1b[99;5u\x1b[A")
+        self.assertEqual([event.data for event in events], ["\x03", "up"])

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -2004,6 +2004,7 @@ class TestMain(ReplTestCase):
 
         # Modern extensions not in standard terminfo - always use patterns
         safe_patterns.append(r'\x1b\[\?2004[hl]')  # bracketed paste mode
+        safe_patterns.append(r'\x1b\[[=<](?:\d+(?:;\d+)*)?u')  # kitty keyboard protocol
         safe_patterns.append(r'\x1b\[\?12[hl]')  # cursor blinking (may be separate)
         safe_patterns.append(r'\x1b\[\?[01]c')  # device attributes
 

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -102,6 +102,18 @@ handle_events_unix_console_height_3 = partial(
 @patch("os.write")
 @force_not_colorized_test_class
 class TestConsole(TestCase):
+    def test_prepare_enables_kitty_keyboard(self, _os_write):
+        console = UnixConsole(term="xterm")
+        console.prepare()
+        _os_write.assert_any_call(ANY, b"\x1b[=31;1u")
+        console.restore()
+
+    def test_restore_disables_kitty_keyboard(self, _os_write):
+        console = UnixConsole(term="xterm")
+        console.prepare()
+        console.restore()
+        _os_write.assert_any_call(ANY, b"\x1b[<u")
+
     def test_no_newline(self, _os_write):
         code = "1"
         events = code_to_events(code)


### PR DESCRIPTION
## Summary
VS Code 1.109 rolled out kitty keyboard protocol support in the integrated terminal via `terminal.integrated.enableKittyKeyboardProtocol`. In practice, this means Unix/macOS REPL users can start receiving kitty-coded key input in the integrated terminal, which currently breaks `_pyrepl` because it only understands legacy terminal input.

A similar distinction came up while discussing equivalent fixes in other REPL/line-editor projects: there are really two separate questions here.

1. Should the line editor actively enable kitty keyboard mode itself?
2. Should it defensively understand kitty `CSI u` input when the terminal is already sending it?

There is also an important subtlety here: `_pyrepl` can see kitty `CSI u` input even if the current Python process did not enable it itself. The terminal or PTY session can already be in kitty keyboard mode because of the terminal host, an earlier process, or a program that enabled it and failed to restore it cleanly.

This PR intentionally addresses both sides for Unix `_pyrepl`.

- `_pyrepl` benefits directly from kitty keyboard mode because it is an interactive line editor that wants more reliable key reporting and disambiguation.
- At the same time, this patch makes `_pyrepl` robust when kitty-coded input is already reaching Python in real-world VS Code terminal setups, even if Python was not the process that originally enabled the mode.

Concretely, this PR:
- enables kitty keyboard protocol when Unix `_pyrepl` prepares the terminal and restores the previous keyboard mode on exit
- parses kitty `CSI u`, `CSI ~`, and `CSI 1;...` key reports in `unix_eventqueue` and translates them into existing `_pyrepl` key events
- adds regression tests for kitty key parsing and updates REPL output sanitizing for the new terminal control sequences

## Tests
- `./python.exe -m test -j1 test_pyrepl.test_eventqueue test_pyrepl.test_unix_console`
- `./python.exe -m test -j1 test_pyrepl.test_pyrepl`
