### PR TITLE
gh-145492: Fix test_repr_recursive_factory reproducer

### DIFF
--- a/Lib/test/test_defaultdict.py
+++ b/Lib/test/test_defaultdict.py
@@ -211,13 +211,12 @@ class TestDefaultDict(unittest.TestCase):
             def __call__(self):
                 return {}
             def __repr__(self):
-                repr(dd)
-                return "ProblematicFactory()"
+                return f"ProblematicFactory for {repr(dd)}"
 
         dd = defaultdict(ProblematicFactory())
         # Should not raise RecursionError
         r = repr(dd)
-        self.assertIn('ProblematicFactory()', r)
+        self.assertIn('ProblematicFactory for', r)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The test's `ProblematicFactory.__repr__` called `repr(dd)` but discarded the result, returning a fixed string instead. This didn't properly exercise the infinite recursion path from the original issue where `repr(dd)` is embedded in the return value.

Changed to `return f"ProblematicFactory for {repr(dd)}"` to match the original reproducer from gh-145492.

Happy to close this if @KowalskiThomas wants to submit the fix-up instead.