### PR TITLE
Warn that overriding `__builtins__` for `eval` is not a security mechanism

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -606,7 +606,7 @@ are always available.  They are listed here in alphabetical order.
    .. warning::
 
       This function executes arbitrary code. Calling it with
-      user-supplied input may lead to security vulnerabilities.
+      user-supplied input will lead to security vulnerabilities.
 
    The *source* argument is parsed and evaluated as a Python expression
    (technically speaking, a condition list) using the *globals* and *locals*
@@ -672,7 +672,7 @@ are always available.  They are listed here in alphabetical order.
    .. warning::
 
       This function executes arbitrary code. Calling it with
-      user-supplied input may lead to security vulnerabilities.
+      user-supplied input will lead to security vulnerabilities.
 
    This function supports dynamic execution of Python code. *source* must be
    either a string or a code object.  If it is a string, the string is parsed as

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -615,8 +615,8 @@ are always available.  They are listed here in alphabetical order.
    reference to the dictionary of the built-in module :mod:`builtins` is
    inserted under that key before *source* is parsed.
    Overriding ``__builtins__`` can be used to restrict or change the available
-   names, but it is **not** a security mechanism, the executed code can
-   still access builtins.
+   names, but this is **not** a security mechanism: the executed code can
+   still access all builtins.
    If the *locals* mapping is omitted it defaults to the
    *globals* dictionary.  If both mappings are omitted, the source is
    executed with the *globals* and *locals* in the environment where
@@ -672,7 +672,7 @@ are always available.  They are listed here in alphabetical order.
    .. warning::
 
       This function executes arbitrary code. Calling it with
-      user-supplied input will lead to security vulnerabilities.
+      untrusted user-supplied input will lead to security vulnerabilities.
 
    This function supports dynamic execution of Python code. *source* must be
    either a string or a code object.  If it is a string, the string is parsed as
@@ -705,8 +705,8 @@ are always available.  They are listed here in alphabetical order.
    ``__builtins__``, a reference to the dictionary of the built-in module
    :mod:`builtins` is inserted under that key.
    Overriding ``__builtins__`` can be used to restrict or change the available
-   names, but it is **not** a security mechanism, the executed code can
-   still access builtins.
+   names, but is **not** a security mechanism: the executed code can
+   still access all builtins.
 
    The *closure* argument specifies a closure--a tuple of cellvars.
    It's only valid when the *object* is a code object containing

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -606,7 +606,7 @@ are always available.  They are listed here in alphabetical order.
    .. warning::
 
       This function executes arbitrary code. Calling it with
-      user-supplied input will lead to security vulnerabilities.
+      untrusted user-supplied input will lead to security vulnerabilities.
 
    The *source* argument is parsed and evaluated as a Python expression
    (technically speaking, a condition list) using the *globals* and *locals*

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -613,10 +613,11 @@ are always available.  They are listed here in alphabetical order.
    mappings as global and local namespace.  If the *globals* dictionary is
    present and does not contain a value for the key ``__builtins__``, a
    reference to the dictionary of the built-in module :mod:`builtins` is
-   inserted under that key before *source* is parsed.  That way you can
-   control what builtins are available to the executed code by inserting your
-   own ``__builtins__`` dictionary into *globals* before passing it to
-   :func:`eval`.  If the *locals* mapping is omitted it defaults to the
+   inserted under that key before *source* is parsed.
+   Overriding ``__builtins__`` can be used to restrict or change the available
+   names, but it is **not** a security mechanism, the executed code can
+   still access builtins.
+   If the *locals* mapping is omitted it defaults to the
    *globals* dictionary.  If both mappings are omitted, the source is
    executed with the *globals* and *locals* in the environment where
    :func:`eval` is called.  Note, *eval()* will only have access to the
@@ -702,9 +703,10 @@ are always available.  They are listed here in alphabetical order.
 
    If the *globals* dictionary does not contain a value for the key
    ``__builtins__``, a reference to the dictionary of the built-in module
-   :mod:`builtins` is inserted under that key.  That way you can control what
-   builtins are available to the executed code by inserting your own
-   ``__builtins__`` dictionary into *globals* before passing it to :func:`exec`.
+   :mod:`builtins` is inserted under that key.
+   Overriding ``__builtins__`` can be used to restrict or change the available
+   names, but it is **not** a security mechanism, the executed code can
+   still access builtins.
 
    The *closure* argument specifies a closure--a tuple of cellvars.
    It's only valid when the *object* is a code object containing

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -705,7 +705,7 @@ are always available.  They are listed here in alphabetical order.
    ``__builtins__``, a reference to the dictionary of the built-in module
    :mod:`builtins` is inserted under that key.
    Overriding ``__builtins__`` can be used to restrict or change the available
-   names, but is **not** a security mechanism: the executed code can
+   names, but this is **not** a security mechanism: the executed code can
    still access all builtins.
 
    The *closure* argument specifies a closure--a tuple of cellvars.


### PR DESCRIPTION
This misleads users as it gives the impression that the above warning can be ignored.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145773.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->