### PR TITLE
Add GitHub team for maintaining fuzzers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,6 +133,7 @@ Tools/check-c-api-docs/       @ZeroIntensity
 
 # Fuzzing
 Modules/_xxtestfuzz/                    @python/fuzzers
+Lib/test/test_xxtestfuzz.py             @python/fuzzers
 .github/workflows/reusable-cifuzz.yml   @python/fuzzers
 
 # Limited C API & Stable ABI

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -132,7 +132,8 @@ Tools/c-analyzer/             @ericsnowcurrently
 Tools/check-c-api-docs/       @ZeroIntensity
 
 # Fuzzing
-Modules/_xxtestfuzz/          @ammaraskar
+Modules/_xxtestfuzz/                    @python/fuzzers
+.github/workflows/reusable-cifuzz.yml   @python/fuzzers
 
 # Limited C API & Stable ABI
 Doc/c-api/stable.rst          @encukou


### PR DESCRIPTION
Instead of listing individuals, I've created a new GitHub team (@python/fuzzers) which has contributors to OSS-Fuzz fuzzers, harnesses, configuration, etc. This team also has write access to the `python/library-fuzzers` repository.