### PR TITLE
gh-145492: fix regression test for defaultdict factory repr

### DIFF
--- a/Lib/test/test_defaultdict.py
+++ b/Lib/test/test_defaultdict.py
@@ -212,12 +212,12 @@ class TestDefaultDict(unittest.TestCase):
                 return {}
             def __repr__(self):
                 repr(dd)
-                return "ProblematicFactory()"
+                return f"ProblematicFactory for {dd}"
 
         dd = defaultdict(ProblematicFactory())
         # Should not raise RecursionError
         r = repr(dd)
-        self.assertIn('ProblematicFactory()', r)
+        self.assertIn("ProblematicFactory for", r)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What is this PR?

This PR fixes the regression test introduced in #145761 and that did not properly reproduce the issue. 

Running the test without the `repr` changes now properly crashes.

```
% ./python.exe -m unittest test.test_defaultdict
..........E..
======================================================================
ERROR: test_repr_recursive_factory (test.test_defaultdict.TestDefaultDict.test_repr_recursive_factory)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/thomas.kowalski/Documents/cpython/Lib/test/test_defaultdict.py", line 219, in test_repr_recursive_factory
    r = repr(dd)
  File "/Users/thomas.kowalski/Documents/cpython/Lib/test/test_defaultdict.py", line 215, in __repr__
    return f"ProblematicFactory for {dd}"
                                    ^^^^
  File "/Users/thomas.kowalski/Documents/cpython/Lib/test/test_defaultdict.py", line 215, in __repr__
    return f"ProblematicFactory for {dd}"
                                    ^^^^
  File "/Users/thomas.kowalski/Documents/cpython/Lib/test/test_defaultdict.py", line 215, in __repr__
    return f"ProblematicFactory for {dd}"
                                    ^^^^
  [Previous line repeated 981 more times]
RecursionError: maximum recursion depth exceeded

----------------------------------------------------------------------
Ran 13 tests in 1.742s
```


gh-145492