### PR TITLE
[3.14] gh-145713: make bytearray.resize thread-safe on free-threading (#145714)

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -2770,6 +2770,22 @@ class FreeThreadingTest(unittest.TestCase):
             check([iter_next] + [iter_reduce] * 10, iter(ba))  # for tsan
             check([iter_next] + [iter_setstate] * 10, iter(ba))  # for tsan
 
+    @unittest.skipUnless(support.Py_GIL_DISABLED, 'this test can only possibly fail with GIL disabled')
+    @threading_helper.reap_threads
+    @threading_helper.requires_working_threading()
+    def test_free_threading_bytearray_resize(self):
+        def resize_stress(ba):
+            for _ in range(1000):
+                try:
+                    ba.resize(1000)
+                    ba.resize(1)
+                except (BufferError, ValueError):
+                    pass
+
+        ba = bytearray(100)
+        threads = [threading.Thread(target=resize_stress, args=(ba,)) for _ in range(4)]
+        with threading_helper.start_threads(threads):
+            pass
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-09-00-00-00.gh-issue-145713.KR6azvzI.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-09-00-00-00.gh-issue-145713.KR6azvzI.rst
@@ -1,0 +1,3 @@
+Make :meth:`bytearray.resize` thread-safe in the free-threaded build by
+using a critical section and calling the lock-held variant of the resize
+function.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -1552,6 +1552,7 @@ bytearray_removesuffix_impl(PyByteArrayObject *self, Py_buffer *suffix)
 
 
 /*[clinic input]
+@critical_section
 bytearray.resize
     size: Py_ssize_t
         New size to resize to.
@@ -1561,10 +1562,10 @@ Resize the internal buffer of bytearray to len.
 
 static PyObject *
 bytearray_resize_impl(PyByteArrayObject *self, Py_ssize_t size)
-/*[clinic end generated code: output=f73524922990b2d9 input=6c9a260ca7f72071]*/
+/*[clinic end generated code: output=f73524922990b2d9 input=116046316a2b5cfc]*/
 {
     Py_ssize_t start_size = PyByteArray_GET_SIZE(self);
-    int result = PyByteArray_Resize((PyObject *)self, size);
+    int result = bytearray_resize_lock_held((PyObject *)self, size);
     if (result < 0) {
         return NULL;
     }

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -625,7 +625,9 @@ bytearray_resize(PyObject *self, PyObject *arg)
         }
         size = ival;
     }
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = bytearray_resize_impl((PyByteArrayObject *)self, size);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -1796,4 +1798,4 @@ bytearray_sizeof(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl((PyByteArrayObject *)self);
 }
-/*[clinic end generated code: output=fdfe41139c91e409 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=bca62cf335d48127 input=a9049054013a1b77]*/


### PR DESCRIPTION
# Pull Request title

This is a backport to 3.14 for #145714.

(cherry picked from commit c3955e049fd5dbd3d92bc95fed4442964156293d)


<!-- gh-issue-number: gh-145713 -->
* Issue: gh-145713
<!-- /gh-issue-number -->
