### PR TITLE
gh-145801: Use gcc -fprofile-update=atomic for PGO builds

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-03-11-11-58-42.gh-issue-145801.iCXa3v.rst
+++ b/Misc/NEWS.d/next/Build/2026-03-11-11-58-42.gh-issue-145801.iCXa3v.rst
@@ -1,0 +1,4 @@
+When Python build is optimized by PGO, use GCC ``-fprofile-update=atomic``
+option to use atomic operations when updating profile information. This option
+reduces the risk of gcov Data Files (.gcda) corruption which can cause random
+GCC crashes. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Build/2026-03-11-11-58-42.gh-issue-145801.iCXa3v.rst
+++ b/Misc/NEWS.d/next/Build/2026-03-11-11-58-42.gh-issue-145801.iCXa3v.rst
@@ -1,4 +1,4 @@
-When Python build is optimized by PGO, use GCC ``-fprofile-update=atomic``
-option to use atomic operations when updating profile information. This option
-reduces the risk of gcov Data Files (.gcda) corruption which can cause random
-GCC crashes. Patch by Victor Stinner.
+When Python build is optimized with GCC using PGO, use
+``-fprofile-update=atomic`` option to use atomic operations when updating
+profile information. This option reduces the risk of gcov Data Files (.gcda)
+corruption which can cause random GCC crashes. Patch by Victor Stinner.

--- a/configure
+++ b/configure
@@ -9083,7 +9083,47 @@ case "$ac_cv_cc_name" in
     fi
     ;;
   gcc)
-    PGO_PROF_GEN_FLAG="-fprofile-generate -fprofile-update=atomic"
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -fprofile-update=atomic" >&5
+printf %s "checking whether C compiler accepts -fprofile-update=atomic... " >&6; }
+if test ${ax_cv_check_cflags___fprofile_update_atomic+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -fprofile-update=atomic"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___fprofile_update_atomic=yes
+else case e in #(
+  e) ax_cv_check_cflags___fprofile_update_atomic=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___fprofile_update_atomic" >&5
+printf "%s\n" "$ax_cv_check_cflags___fprofile_update_atomic" >&6; }
+if test "x$ax_cv_check_cflags___fprofile_update_atomic" = xyes
+then :
+  PGO_PROF_GEN_FLAG="-fprofile-generate -fprofile-update=atomic"
+else case e in #(
+  e) PGO_PROF_GEN_FLAG="-fprofile-generate" ;;
+esac
+fi
+
     PGO_PROF_USE_FLAG="-fprofile-use -fprofile-correction"
     LLVM_PROF_MERGER="true"
     LLVM_PROF_FILE=""

--- a/configure
+++ b/configure
@@ -9083,7 +9083,7 @@ case "$ac_cv_cc_name" in
     fi
     ;;
   gcc)
-    PGO_PROF_GEN_FLAG="-fprofile-generate"
+    PGO_PROF_GEN_FLAG="-fprofile-generate -fprofile-update=atomic"
     PGO_PROF_USE_FLAG="-fprofile-use -fprofile-correction"
     LLVM_PROF_MERGER="true"
     LLVM_PROF_FILE=""

--- a/configure.ac
+++ b/configure.ac
@@ -2084,7 +2084,7 @@ case "$ac_cv_cc_name" in
     fi
     ;;
   gcc)
-    PGO_PROF_GEN_FLAG="-fprofile-generate"
+    PGO_PROF_GEN_FLAG="-fprofile-generate -fprofile-update=atomic"
     PGO_PROF_USE_FLAG="-fprofile-use -fprofile-correction"
     LLVM_PROF_MERGER="true"
     LLVM_PROF_FILE=""

--- a/configure.ac
+++ b/configure.ac
@@ -2084,7 +2084,10 @@ case "$ac_cv_cc_name" in
     fi
     ;;
   gcc)
-    PGO_PROF_GEN_FLAG="-fprofile-generate -fprofile-update=atomic"
+    AX_CHECK_COMPILE_FLAG(
+        [-fprofile-update=atomic],
+        [PGO_PROF_GEN_FLAG="-fprofile-generate -fprofile-update=atomic"],
+        [PGO_PROF_GEN_FLAG="-fprofile-generate"])
     PGO_PROF_USE_FLAG="-fprofile-use -fprofile-correction"
     LLVM_PROF_MERGER="true"
     LLVM_PROF_FILE=""


### PR DESCRIPTION
When Python build is optimized by PGO, use GCC
-fprofile-update=atomic option to use atomic operations when updating profile information. This option reduces the risk of gcov Data Files (.gcda) corruption which can cause random GCC crashes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145801 -->
* Issue: gh-145801
<!-- /gh-issue-number -->
