### PR TITLE
gh-145792: Fix incorrect alloca allocation size in traceback.c

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -625,7 +625,7 @@ class TracebackCases(unittest.TestCase):
             str(inspect.signature(traceback.format_exception_only)),
             '(exc, /, value=<implicit>, *, show_group=False, **kwargs)')
 
-    def test_traceback_deep_recursion_alloca():
+    def test_traceback_deep_recursion_alloca(self):
 
         def recurse(n):
             if n == 0:

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -625,18 +625,6 @@ class TracebackCases(unittest.TestCase):
             str(inspect.signature(traceback.format_exception_only)),
             '(exc, /, value=<implicit>, *, show_group=False, **kwargs)')
 
-    def test_traceback_deep_recursion_alloca(self):
-
-        def recurse(n):
-            if n == 0:
-                raise RuntimeError("boom")
-            return recurse(n - 1)
-        try:
-            recurse(50)
-        except RuntimeError as exc:
-            tb = traceback.format_exception(exc)
-            assert any("RuntimeError" in line for line in tb)
-
 
 class PurePythonExceptionFormattingMixin:
     def get_exception(self, callable, slice_start=0, slice_end=-1):

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -632,7 +632,7 @@ class TracebackCases(unittest.TestCase):
                 raise RuntimeError("boom")
             return recurse(n - 1)
         try:
-            recurse(1000)
+            recurse(50)
         except RuntimeError as exc:
             tb = traceback.format_exception(exc)
             assert any("RuntimeError" in line for line in tb)

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -625,6 +625,18 @@ class TracebackCases(unittest.TestCase):
             str(inspect.signature(traceback.format_exception_only)),
             '(exc, /, value=<implicit>, *, show_group=False, **kwargs)')
 
+    def test_traceback_deep_recursion_alloca():
+
+        def recurse(n):
+            if n == 0:
+                raise RuntimeError("boom")
+            return recurse(n - 1)
+        try:
+            recurse(1000)
+        except RuntimeError as exc:
+            tb = traceback.format_exception(exc)
+            assert any("RuntimeError" in line for line in tb)
+
 
 class PurePythonExceptionFormattingMixin:
     def get_exception(self, callable, slice_start=0, slice_end=-1):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-11-19-09-47.gh-issue-145792.X5KUhc.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-11-19-09-47.gh-issue-145792.X5KUhc.rst
@@ -1,0 +1,2 @@
+Fix incorrect memory allocation in the VLA fallback macro in traceback.c
+when using alloca(), preventing potential out-of-bounds access.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-11-19-09-47.gh-issue-145792.X5KUhc.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-11-19-09-47.gh-issue-145792.X5KUhc.rst
@@ -1,2 +1,2 @@
-Fix incorrect memory allocation in the VLA fallback macro in traceback.c
-when using alloca(), preventing potential out-of-bounds access.
+Fix out-of-bounds access when invoking faulthandler on a CPython build
+compiled without support for VLAs.

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -41,7 +41,7 @@
 
 #if defined(__STDC_NO_VLA__) && (__STDC_NO_VLA__ == 1)
 /* Use alloca() for VLAs. */
-#  define VLA(type, name, size) type *name = alloca(size)
+#  define VLA(type, name, size) type *name = (type *)alloca(sizeof(type) * (size))
 #elif !defined(__STDC_NO_VLA__) || (__STDC_NO_VLA__ == 0)
 /* Use actual C VLAs.*/
 #  define VLA(type, name, size) type name[size]

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -41,7 +41,7 @@
 
 #if defined(__STDC_NO_VLA__) && (__STDC_NO_VLA__ == 1)
 /* Use alloca() for VLAs. */
-#  define VLA(type, name, size) type *name = (type *)alloca(sizeof(type) * (size))
+#  define VLA(type, name, size) type *name = alloca(sizeof(type) * (size))
 #elif !defined(__STDC_NO_VLA__) || (__STDC_NO_VLA__ == 0)
 /* Use actual C VLAs.*/
 #  define VLA(type, name, size) type name[size]


### PR DESCRIPTION
Fix incorrect memory allocation when using the VLA fallback macro in traceback.c with alloca(). The previous implementation allocated only size bytes instead of sizeof(type) * size, which could lead to out-of-bounds access.

A regression test and NEWS entry are included.


<!-- gh-issue-number: gh-145792 -->
* Issue: gh-145792
<!-- /gh-issue-number -->
