### PR TITLE
gh-140014: Wrap C API annotations in a paragraph.

### DIFF
--- a/Doc/tools/extensions/c_annotations.py
+++ b/Doc/tools/extensions/c_annotations.py
@@ -126,6 +126,14 @@ def add_annotations(app: Sphinx, doctree: nodes.document) -> None:
         name = par[0]["ids"][0].removeprefix("c.")
         objtype = par["objtype"]
 
+        annotations = []
+
+        # Return value annotation
+        if objtype == "function" and name in refcount_data:
+            entry = refcount_data[name]
+            if entry.result_type.endswith("Object*"):
+                annotations.append(_return_value_annotation(entry.result_refs))
+
         # Stable ABI annotation.
         if record := stable_abi_data.get(name):
             if ROLE_TO_OBJECT_TYPE[record.role] != objtype:
@@ -134,24 +142,19 @@ def add_annotations(app: Sphinx, doctree: nodes.document) -> None:
                     f"{ROLE_TO_OBJECT_TYPE[record.role]!r} != {objtype!r}"
                 )
                 raise ValueError(msg)
-            annotation = _stable_abi_annotation(record)
-            node.insert(0, annotation)
+            annotations.append(_stable_abi_annotation(record))
 
         # Unstable API annotation.
         if name.startswith("PyUnstable"):
-            annotation = _unstable_api_annotation()
-            node.insert(0, annotation)
+            annotations.append(_unstable_api_annotation())
 
-        # Return value annotation
-        if objtype != "function":
-            continue
-        if name not in refcount_data:
-            continue
-        entry = refcount_data[name]
-        if not entry.result_type.endswith("Object*"):
-            continue
-        annotation = _return_value_annotation(entry.result_refs)
-        node.insert(0, annotation)
+        if annotations:
+            para = nodes.paragraph(' ', ' ', classes=['c_annotations'])
+            for idx, annotation in enumerate(annotations):
+                if idx:
+                    para.append(nodes.Text(" "))
+                para.append(annotation)
+            node.insert(0, para)
 
 
 def _stable_abi_annotation(


### PR DESCRIPTION
It turns out putting `<emphasis>` directly in `<desc_content>` is not valid docutils. Sphinx doesn't detect this, though.

@m-aciek, are you able to test this with `rinohtype`?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-140014 -->
* Issue: gh-140014
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145838.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->