### PR TITLE
Docs: except with multiple exceptions parentheses not required

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -121,9 +121,9 @@ A :keyword:`try` statement may have more than one *except clause*, to specify
 handlers for different exceptions.  At most one handler will be executed.
 Handlers only handle exceptions that occur in the corresponding *try clause*,
 not in other handlers of the same :keyword:`!try` statement.  An *except clause*
-may name multiple exceptions as a parenthesized tuple, for example::
+may name multiple exceptions, for example::
 
-   ... except (RuntimeError, TypeError, NameError):
+   ... except RuntimeError, TypeError, NameError:
    ...     pass
 
 A class in an :keyword:`except` clause matches exceptions which are instances of the


### PR DESCRIPTION
As of PEP 758 the except statement doesn't require parentheses anymore for exception tuples.

See: https://peps.python.org/pep-0758/


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145848.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->