### PR TITLE
gh-145856: Fix plistlib.dumps() skipkeys behavior with mixed key types

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -388,16 +388,18 @@ class _PlistWriter(_DumbXMLWriter):
     def write_dict(self, d):
         if d:
             self.begin_element("dict")
-            if self._sort_keys:
-                items = sorted(d.items())
+            if self._skipkeys:
+                items = ((k, v) for k, v in d.items() if isinstance(k, str))
             else:
+                for k in d:
+                    if not isinstance(k, str):
+                        raise TypeError("keys must be strings")
                 items = d.items()
 
+            if self._sort_keys:
+                items = sorted(items)
+
             for key, value in items:
-                if not isinstance(key, str):
-                    if self._skipkeys:
-                        continue
-                    raise TypeError("keys must be strings")
                 self.simple_element("key", key)
                 self.write_value(value)
             self.end_element("dict")

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -962,6 +962,12 @@ class TestPlistlib(unittest.TestCase):
             expected = dt.astimezone(datetime.UTC).replace(tzinfo=None)
             self.assertEqual(parsed, expected)
 
+    def test_skipkeys_with_mixed_keys(self):
+        d = {1: "a", "z": "b", "a": "c"}
+        data = plistlib.dumps(d, skipkeys=True)
+        result = plistlib.loads(data)
+        self.assertEqual(result, {"a": "c", "z": "b"})
+
 
 class TestBinaryPlistlib(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2026-03-12-19-34-11.gh-issue-145856.A4t9mZ.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-12-19-34-11.gh-issue-145856.A4t9mZ.rst
@@ -1,0 +1,2 @@
+Fix plistlib.dumps() raising TypeError when skipkeys=True and a dictionary
+contains mixed key types.


### PR DESCRIPTION
When `skipkeys=True`, `plistlib.dumps()` attempted to sort dictionary keys before filtering non-string keys, 
causing a `TypeError` for mixed key types.

This change filters non-string keys first and then sorts the remaining items.

<!-- gh-issue-number: gh-145856 -->
* Issue: gh-145856
<!-- /gh-issue-number -->
