### PR TITLE
gh-145876: Fix AttributeError masked during dict unpacking

### DIFF
--- a/Lib/test/test_extcall.py
+++ b/Lib/test/test_extcall.py
@@ -334,6 +334,30 @@ What about willful misconduct?
       ...
     TypeError: dir() got multiple values for keyword argument 'b'
 
+AttributeError raised inside keys() or __getitem__() should not be masked
+(see https://github.com/python/cpython/issues/145876)
+
+    >>> class KeysRaisesAttributeError:
+    ...     def keys(self):
+    ...         raise AttributeError("error in keys")
+    ...     def __getitem__(self, key):
+    ...         return key
+    >>> def f(**kwargs): pass
+    >>> f(**KeysRaisesAttributeError())
+    Traceback (most recent call last):
+      ...
+    AttributeError: error in keys
+
+    >>> class GetitemRaisesAttributeError:
+    ...     def keys(self):
+    ...         return ['a', 'b']
+    ...     def __getitem__(self, key):
+    ...         raise AttributeError("error in __getitem__")
+    >>> f(**GetitemRaisesAttributeError())
+    Traceback (most recent call last):
+      ...
+    AttributeError: error in __getitem__
+
 Test a kwargs mapping with duplicated keys.
 
     >>> from collections.abc import Mapping

--- a/Lib/test/test_unpack_ex.py
+++ b/Lib/test/test_unpack_ex.py
@@ -134,6 +134,29 @@ Dict display element unpacking
     ...
     TypeError: 'list' object is not a mapping
 
+AttributeError raised inside keys() or __getitem__() should not be masked
+(see https://github.com/python/cpython/issues/145876)
+
+    >>> class KeysRaisesAttributeError:
+    ...     def keys(self):
+    ...         raise AttributeError("error in keys")
+    ...     def __getitem__(self, key):
+    ...         return key
+    >>> {**KeysRaisesAttributeError()}
+    Traceback (most recent call last):
+    ...
+    AttributeError: error in keys
+
+    >>> class GetitemRaisesAttributeError:
+    ...     def keys(self):
+    ...         return ['a', 'b']
+    ...     def __getitem__(self, key):
+    ...         raise AttributeError("error in __getitem__")
+    >>> {**GetitemRaisesAttributeError()}
+    Traceback (most recent call last):
+    ...
+    AttributeError: error in __getitem__
+
     >>> len(eval("{" + ", ".join("**{{{}: {}}}".format(i, i)
     ...                          for i in range(1000)) + "}"))
     1000

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-12-22-55-14.gh-issue-145876.9UDIk0.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-12-22-55-14.gh-issue-145876.9UDIk0.rst
@@ -1,0 +1,3 @@
+Fix :exc:`AttributeError` raised inside ``.keys()`` or ``.__getitem__()``
+being incorrectly masked as :exc:`TypeError` during ``{**mapping}`` and
+``f(**mapping)`` unpacking. Patched by Shamil Abdulaev.

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -5524,6 +5524,33 @@
             PyObject *callable_o = PyStackRef_AsPyObjectBorrow(callable);
             PyObject *dict_o = PyStackRef_AsPyObjectBorrow(dict);
             PyObject *update_o = PyStackRef_AsPyObjectBorrow(update);
+            if (!PyAnyDict_Check(update_o)) {
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                int has_keys = PyObject_HasAttrWithError(
+                    update_o, &_Py_ID(keys));
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                if (has_keys < 0) {
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    JUMP_TO_LABEL(error);
+                }
+                if (!has_keys) {
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    _PyErr_Format(tstate, PyExc_TypeError,
+                                  "Value after ** must be a mapping, not %.200s",
+                                  Py_TYPE(update_o)->tp_name);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    JUMP_TO_LABEL(error);
+                }
+            }
             _PyFrame_SetStackPointer(frame, stack_pointer);
             int err = _PyDict_MergeEx(dict_o, update_o, 2);
             stack_pointer = _PyFrame_GetStackPointer(frame);
@@ -5560,20 +5587,37 @@
             dict = stack_pointer[-2 - (oparg - 1)];
             PyObject *dict_o = PyStackRef_AsPyObjectBorrow(dict);
             PyObject *update_o = PyStackRef_AsPyObjectBorrow(update);
-            _PyFrame_SetStackPointer(frame, stack_pointer);
-            int err = PyDict_Update(dict_o, update_o);
-            stack_pointer = _PyFrame_GetStackPointer(frame);
-            if (err < 0) {
+            if (!PyAnyDict_Check(update_o)) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int matches = _PyErr_ExceptionMatches(tstate, PyExc_AttributeError);
+                int has_keys = PyObject_HasAttrWithError(
+                    update_o, &_Py_ID(keys));
                 stack_pointer = _PyFrame_GetStackPointer(frame);
-                if (matches) {
+                if (has_keys < 0) {
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    JUMP_TO_LABEL(error);
+                }
+                if (!has_keys) {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
                     _PyErr_Format(tstate, PyExc_TypeError,
                                   "'%.200s' object is not a mapping",
                                   Py_TYPE(update_o)->tp_name);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    JUMP_TO_LABEL(error);
                 }
+            }
+            _PyFrame_SetStackPointer(frame, stack_pointer);
+            int err = PyDict_Update(dict_o, update_o);
+            stack_pointer = _PyFrame_GetStackPointer(frame);
+            if (err < 0) {
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2240,14 +2240,23 @@ dummy_func(
             PyObject *dict_o = PyStackRef_AsPyObjectBorrow(dict);
             PyObject *update_o = PyStackRef_AsPyObjectBorrow(update);
 
-            int err = PyDict_Update(dict_o, update_o);
-            if (err < 0) {
-                int matches = _PyErr_ExceptionMatches(tstate, PyExc_AttributeError);
-                if (matches) {
+            if (!PyAnyDict_Check(update_o)) {
+                int has_keys = PyObject_HasAttrWithError(
+                    update_o, &_Py_ID(keys));
+                if (has_keys < 0) {
+                    PyStackRef_CLOSE(update);
+                    ERROR_IF(true);
+                }
+                if (!has_keys) {
                     _PyErr_Format(tstate, PyExc_TypeError,
                                     "'%.200s' object is not a mapping",
                                     Py_TYPE(update_o)->tp_name);
+                    PyStackRef_CLOSE(update);
+                    ERROR_IF(true);
                 }
+            }
+            int err = PyDict_Update(dict_o, update_o);
+            if (err < 0) {
                 PyStackRef_CLOSE(update);
                 ERROR_IF(true);
             }
@@ -2259,6 +2268,21 @@ dummy_func(
             PyObject *dict_o = PyStackRef_AsPyObjectBorrow(dict);
             PyObject *update_o = PyStackRef_AsPyObjectBorrow(update);
 
+            if (!PyAnyDict_Check(update_o)) {
+                int has_keys = PyObject_HasAttrWithError(
+                    update_o, &_Py_ID(keys));
+                if (has_keys < 0) {
+                    PyStackRef_CLOSE(update);
+                    ERROR_IF(true);
+                }
+                if (!has_keys) {
+                    _PyErr_Format(tstate, PyExc_TypeError,
+                                    "Value after ** must be a mapping, not %.200s",
+                                    Py_TYPE(update_o)->tp_name);
+                    PyStackRef_CLOSE(update);
+                    ERROR_IF(true);
+                }
+            }
             int err = _PyDict_MergeEx(dict_o, update_o, 2);
             if (err < 0) {
                 _PyEval_FormatKwargsError(tstate, callable_o, update_o);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3403,19 +3403,7 @@ _Py_Check_ArgsIterable(PyThreadState *tstate, PyObject *func, PyObject *args)
 void
 _PyEval_FormatKwargsError(PyThreadState *tstate, PyObject *func, PyObject *kwargs)
 {
-    /* _PyDict_MergeEx raises attribute
-     * error (percolated from an attempt
-     * to get 'keys' attribute) instead of
-     * a type error if its second argument
-     * is not a mapping.
-     */
-    if (_PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
-        _PyErr_Format(
-            tstate, PyExc_TypeError,
-            "Value after ** must be a mapping, not %.200s",
-            Py_TYPE(kwargs)->tp_name);
-    }
-    else if (_PyErr_ExceptionMatches(tstate, PyExc_KeyError)) {
+    if (_PyErr_ExceptionMatches(tstate, PyExc_KeyError)) {
         PyObject *exc = _PyErr_GetRaisedException(tstate);
         PyObject *args = PyException_GetArgs(exc);
         if (PyTuple_Check(args) && PyTuple_GET_SIZE(args) == 1) {

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -8745,6 +8745,39 @@
             dict = stack_pointer[-1 - (oparg - 1)];
             PyObject *dict_o = PyStackRef_AsPyObjectBorrow(dict);
             PyObject *update_o = PyStackRef_AsPyObjectBorrow(update);
+            if (!PyAnyDict_Check(update_o)) {
+                stack_pointer[0] = update;
+                stack_pointer += 1;
+                ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                int has_keys = PyObject_HasAttrWithError(
+                    update_o, &_Py_ID(keys));
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                if (has_keys < 0) {
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    SET_CURRENT_CACHED_VALUES(0);
+                    JUMP_TO_ERROR();
+                }
+                if (!has_keys) {
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    _PyErr_Format(tstate, PyExc_TypeError,
+                                  "'%.200s' object is not a mapping",
+                                  Py_TYPE(update_o)->tp_name);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    SET_CURRENT_CACHED_VALUES(0);
+                    JUMP_TO_ERROR();
+                }
+                stack_pointer += -1;
+            }
             stack_pointer[0] = update;
             stack_pointer += 1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -8752,16 +8785,6 @@
             int err = PyDict_Update(dict_o, update_o);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err < 0) {
-                _PyFrame_SetStackPointer(frame, stack_pointer);
-                int matches = _PyErr_ExceptionMatches(tstate, PyExc_AttributeError);
-                stack_pointer = _PyFrame_GetStackPointer(frame);
-                if (matches) {
-                    _PyFrame_SetStackPointer(frame, stack_pointer);
-                    _PyErr_Format(tstate, PyExc_TypeError,
-                                  "'%.200s' object is not a mapping",
-                                  Py_TYPE(update_o)->tp_name);
-                    stack_pointer = _PyFrame_GetStackPointer(frame);
-                }
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
@@ -8797,6 +8820,39 @@
             PyObject *callable_o = PyStackRef_AsPyObjectBorrow(callable);
             PyObject *dict_o = PyStackRef_AsPyObjectBorrow(dict);
             PyObject *update_o = PyStackRef_AsPyObjectBorrow(update);
+            if (!PyAnyDict_Check(update_o)) {
+                stack_pointer[0] = update;
+                stack_pointer += 1;
+                ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                int has_keys = PyObject_HasAttrWithError(
+                    update_o, &_Py_ID(keys));
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                if (has_keys < 0) {
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    SET_CURRENT_CACHED_VALUES(0);
+                    JUMP_TO_ERROR();
+                }
+                if (!has_keys) {
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    _PyErr_Format(tstate, PyExc_TypeError,
+                                  "Value after ** must be a mapping, not %.200s",
+                                  Py_TYPE(update_o)->tp_name);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    SET_CURRENT_CACHED_VALUES(0);
+                    JUMP_TO_ERROR();
+                }
+                stack_pointer += -1;
+            }
             stack_pointer[0] = update;
             stack_pointer += 1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -5524,6 +5524,33 @@
             PyObject *callable_o = PyStackRef_AsPyObjectBorrow(callable);
             PyObject *dict_o = PyStackRef_AsPyObjectBorrow(dict);
             PyObject *update_o = PyStackRef_AsPyObjectBorrow(update);
+            if (!PyAnyDict_Check(update_o)) {
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                int has_keys = PyObject_HasAttrWithError(
+                    update_o, &_Py_ID(keys));
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                if (has_keys < 0) {
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    JUMP_TO_LABEL(error);
+                }
+                if (!has_keys) {
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    _PyErr_Format(tstate, PyExc_TypeError,
+                                  "Value after ** must be a mapping, not %.200s",
+                                  Py_TYPE(update_o)->tp_name);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    JUMP_TO_LABEL(error);
+                }
+            }
             _PyFrame_SetStackPointer(frame, stack_pointer);
             int err = _PyDict_MergeEx(dict_o, update_o, 2);
             stack_pointer = _PyFrame_GetStackPointer(frame);
@@ -5560,20 +5587,37 @@
             dict = stack_pointer[-2 - (oparg - 1)];
             PyObject *dict_o = PyStackRef_AsPyObjectBorrow(dict);
             PyObject *update_o = PyStackRef_AsPyObjectBorrow(update);
-            _PyFrame_SetStackPointer(frame, stack_pointer);
-            int err = PyDict_Update(dict_o, update_o);
-            stack_pointer = _PyFrame_GetStackPointer(frame);
-            if (err < 0) {
+            if (!PyAnyDict_Check(update_o)) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int matches = _PyErr_ExceptionMatches(tstate, PyExc_AttributeError);
+                int has_keys = PyObject_HasAttrWithError(
+                    update_o, &_Py_ID(keys));
                 stack_pointer = _PyFrame_GetStackPointer(frame);
-                if (matches) {
+                if (has_keys < 0) {
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    JUMP_TO_LABEL(error);
+                }
+                if (!has_keys) {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
                     _PyErr_Format(tstate, PyExc_TypeError,
                                   "'%.200s' object is not a mapping",
                                   Py_TYPE(update_o)->tp_name);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
+                    stack_pointer += -1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(update);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    JUMP_TO_LABEL(error);
                 }
+            }
+            _PyFrame_SetStackPointer(frame, stack_pointer);
+            int err = PyDict_Update(dict_o, update_o);
+            stack_pointer = _PyFrame_GetStackPointer(frame);
+            if (err < 0) {
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);


### PR DESCRIPTION
## Summary

- Check `.keys` attribute existence before calling `PyDict_Update`/`_PyDict_MergeEx` in `DICT_UPDATE` and `DICT_MERGE` bytecodes
- Remove overly broad `AttributeError` catch that was masking real errors as `TypeError: 'X' object is not a mapping`

Closes #145876.

<!-- gh-issue-number: gh-145876 -->
* Issue: gh-145876
<!-- /gh-issue-number -->
