### PR TITLE
gh-145876: preserve AttributeError in dict unpacking

### DIFF
--- a/Lib/test/test_unpack_ex.py
+++ b/Lib/test/test_unpack_ex.py
@@ -134,6 +134,29 @@ Dict display element unpacking
     ...
     TypeError: 'list' object is not a mapping
 
+    >>> class MappingWithKeyErrors:
+    ...     def __init__(self, *, keys_error=None, getitem_error=None):
+    ...         self.keys_error = keys_error
+    ...         self.getitem_error = getitem_error
+    ...     def keys(self):
+    ...         if self.keys_error is not None:
+    ...             raise self.keys_error("error in keys")
+    ...         return [1, 2, 3]
+    ...     def __getitem__(self, key):
+    ...         if self.getitem_error is not None:
+    ...             raise self.getitem_error("error in __getitem__")
+    ...         return key * 2
+
+    >>> {**MappingWithKeyErrors(keys_error=AttributeError)}
+    Traceback (most recent call last):
+    ...
+    AttributeError: error in keys
+
+    >>> {**MappingWithKeyErrors(getitem_error=AttributeError)}
+    Traceback (most recent call last):
+    ...
+    AttributeError: error in __getitem__
+
     >>> len(eval("{" + ", ".join("**{{{}: {}}}".format(i, i)
     ...                          for i in range(1000)) + "}"))
     1000

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2244,9 +2244,24 @@ dummy_func(
             if (err < 0) {
                 int matches = _PyErr_ExceptionMatches(tstate, PyExc_AttributeError);
                 if (matches) {
-                    _PyErr_Format(tstate, PyExc_TypeError,
-                                    "'%.200s' object is not a mapping",
-                                    Py_TYPE(update_o)->tp_name);
+                    PyObject *exc = PyErr_GetRaisedException();
+                    PyObject *keys = NULL;
+                    int has_keys = PyObject_GetOptionalAttr(update_o, &_Py_ID(keys), &keys);
+
+                    if (has_keys < 0) {
+                        Py_XDECREF(keys);
+                        Py_DECREF(exc);
+                    }
+                    else if (has_keys == 0) {
+                        Py_DECREF(exc);
+                        _PyErr_Format(tstate, PyExc_TypeError,
+                                        "'%.200s' object is not a mapping",
+                                        Py_TYPE(update_o)->tp_name);
+                    }
+                    else {
+                        Py_DECREF(keys);
+                        PyErr_SetRaisedException(exc);
+                    }
                 }
                 PyStackRef_CLOSE(update);
                 ERROR_IF(true);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -5569,10 +5569,32 @@
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (matches) {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    _PyErr_Format(tstate, PyExc_TypeError,
-                                  "'%.200s' object is not a mapping",
-                                  Py_TYPE(update_o)->tp_name);
+                    PyObject *exc = PyErr_GetRaisedException();
                     stack_pointer = _PyFrame_GetStackPointer(frame);
+                    PyObject *keys = NULL;
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    int has_keys = PyObject_GetOptionalAttr(update_o, &_Py_ID(keys), &keys);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    if (has_keys < 0) {
+                        _PyFrame_SetStackPointer(frame, stack_pointer);
+                        Py_XDECREF(keys);
+                        Py_DECREF(exc);
+                        stack_pointer = _PyFrame_GetStackPointer(frame);
+                    }
+                    else if (has_keys == 0) {
+                        _PyFrame_SetStackPointer(frame, stack_pointer);
+                        Py_DECREF(exc);
+                        _PyErr_Format(tstate, PyExc_TypeError,
+                                      "'%.200s' object is not a mapping",
+                                      Py_TYPE(update_o)->tp_name);
+                        stack_pointer = _PyFrame_GetStackPointer(frame);
+                    }
+                    else {
+                        _PyFrame_SetStackPointer(frame, stack_pointer);
+                        Py_DECREF(keys);
+                        PyErr_SetRaisedException(exc);
+                        stack_pointer = _PyFrame_GetStackPointer(frame);
+                    }
                 }
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);


### PR DESCRIPTION
## Summary\n- preserve AttributeError raised from mapping methods during dict unpacking\n- keep TypeError for objects that are not mappings\n- add a regression test in test_unpack_ex\n\n## Testing\n- PCbuild\\build.bat -p x64 -c Release\n- PCbuild\\amd64\\python.exe -m test -v test_unpack_ex\n\nCloses #145876

<!-- gh-issue-number: gh-145876 -->
* Issue: gh-145876
<!-- /gh-issue-number -->
