### PR TITLE
GH-132042: Fix calculation of slotdef index in update_one_slot

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -11737,7 +11737,7 @@ update_one_slot(PyTypeObject *type, pytype_slotdef *p, pytype_slotdef **next_p,
         if (Py_IS_TYPE(descr, &PyWrapperDescr_Type) &&
             ((PyWrapperDescrObject *)descr)->d_base->name_strobj == p->name_strobj) {
             void **tptr;
-            size_t index = (p - slotdefs) / sizeof(slotdefs[0]);
+            size_t index = (p - slotdefs);
             if (slotdefs_name_counts[index] == 1) {
                 tptr = slotptr(type, p->offset);
             }


### PR DESCRIPTION
There is a fix for calculation of the slotdef index.
Thanks @eendebakpt 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-132042 -->
* Issue: gh-132042
<!-- /gh-issue-number -->
