### PR TITLE
gh-145886: Fix e.raw += e.raw typo in UnixConsole.getpending

### DIFF
--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -542,7 +542,7 @@ class UnixConsole(Console):
             while not self.event_queue.empty():
                 e2 = self.event_queue.get()
                 e.data += e2.data
-                e.raw += e.raw
+                e.raw += e2.raw
 
             amount = struct.unpack("i", ioctl(self.input_fd, FIONREAD, b"\0\0\0\0"))[0]
             trace("getpending({a})", a=amount)
@@ -566,7 +566,7 @@ class UnixConsole(Console):
             while not self.event_queue.empty():
                 e2 = self.event_queue.get()
                 e.data += e2.data
-                e.raw += e.raw
+                e.raw += e2.raw
 
             amount = 10000
             raw = self.__read(amount)

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -400,3 +400,30 @@ class TestUnixConsoleEIOHandling(TestCase):
             ),
             f"Expected EIO/ENXIO error message in stderr: {err}",
         )
+
+
+@unittest.skipIf(sys.platform == "win32", "No Unix console on Windows")
+class TestGetPending(TestCase):
+    def test_getpending_accumulates_raw_from_queued_events(self):
+        # gh-145886: getpending was adding e.raw to itself instead of e2.raw
+        console = UnixConsole.__new__(UnixConsole)
+        console.encoding = "utf-8"
+        console.input_fd = 0
+
+        ev1 = Event("key", "a", b"x")
+        ev2 = Event("key", "b", b"y")
+        queue = [ev1, ev2]
+
+        mock_eq = MagicMock()
+        mock_eq.empty = lambda: len(queue) == 0
+        mock_eq.get = lambda: queue.pop(0)
+        console.event_queue = mock_eq
+
+        # Mock __read to return empty bytes (no additional pending input)
+        console._UnixConsole__read = lambda n: b""
+
+        with patch("_pyrepl.unix_console.ioctl", return_value=b"\0\0\0\0"):
+            result = console.getpending()
+
+        self.assertEqual(result.data, "ab")
+        self.assertEqual(result.raw, b"xy")


### PR DESCRIPTION
Fix a copy-paste typo in both variants of `UnixConsole.getpending()` where `e.raw += e.raw` was used instead of `e.raw += e2.raw`.

The loop dequeues events as `e2` and accumulates their data into a combined event `e`. The `data` field was accumulated correctly (`e.data += e2.data`), but the `raw` field was adding itself to itself rather than accumulating from `e2`. Since `e.raw` starts as `b""`, the result of `b"" += b""` was always `b""`, so raw bytes from queued events were silently dropped.

This fixes the typo in both the `FIONREAD` and fallback code paths, and adds a test that verifies `getpending` correctly accumulates `raw` bytes from multiple queued events.

Fixes #145886

<!-- gh-issue-number: gh-145886 -->
* Issue: gh-145886
<!-- /gh-issue-number -->
