### PR TITLE
gh-145870: Fix Format.SOURCE reference in get_annotations docstring

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -919,7 +919,7 @@ def get_annotations(
     does not exist, the __annotate__ function is called. The
     FORWARDREF format uses __annotations__ if it exists and can be
     evaluated, and otherwise falls back to calling the __annotate__ function.
-    The SOURCE format tries __annotate__ first, and falls back to
+    The STRING format tries __annotate__ first, and falls back to
     using __annotations__, stringified using annotations_to_string().
 
     This function handles several details for you:


### PR DESCRIPTION
The `get_annotations()` docstring in `Lib/annotationlib.py` incorrectly refers to the `SOURCE` format on line 922. This format was renamed to `STRING` during PEP 749 development (see python/cpython#124412).

This change replaces `SOURCE` with `STRING` in the docstring to match the actual `Format` enum.

Fixes #145870

<!-- gh-issue-number: gh-145870 -->
* Issue: gh-145870
<!-- /gh-issue-number -->
