### PR TITLE
gh-145887: Use `write()` instead of `stream.write()` in `PrettyPrinter._pprint_frozendict`

### DIFF
--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -238,7 +238,7 @@ class PrettyPrinter:
     def _pprint_frozendict(self, object, stream, indent, allowance, context, level):
         write = stream.write
         cls = object.__class__
-        stream.write(cls.__name__ + '(')
+        write(cls.__name__ + '(')
         length = len(object)
         if length:
             self._pprint_dict(object, stream,


### PR DESCRIPTION
This trivial PR fixes a small error I introduced in https://github.com/python/cpython/pull/144908 by replacing `stream.write()` with `write()`  in `PrettyPrinter._pprint_frozendict`.


<!-- gh-issue-number: gh-145887 -->
* Issue: gh-145887
<!-- /gh-issue-number -->
