### PR TITLE
gh-129813: Document that PyBytesWriter_GetData() cannot fail

### DIFF
--- a/Doc/c-api/bytes.rst
+++ b/Doc/c-api/bytes.rst
@@ -371,12 +371,16 @@ Getters
 
    Get the writer size.
 
+   The function cannot fail.
+
 .. c:function:: void* PyBytesWriter_GetData(PyBytesWriter *writer)
 
    Get the writer data: start of the internal buffer.
 
    The pointer is valid until :c:func:`PyBytesWriter_Finish` or
    :c:func:`PyBytesWriter_Discard` is called on *writer*.
+
+   The function cannot fail.
 
 
 Low-level API

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -923,9 +923,6 @@ binascii_a2b_ascii85_impl(PyObject *module, Py_buffer *data, int foldspaces,
         return NULL;
     }
     unsigned char *bin_data = PyBytesWriter_GetData(writer);
-    if (bin_data == NULL) {
-        goto error;
-    }
 
     uint32_t leftchar = 0;
     int group_pos = 0;


### PR DESCRIPTION
Document that PyBytesWriter_GetData() and PyBytesWriter_GetSize() getter functions cannot fail

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129813 -->
* Issue: gh-129813
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145900.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->