### PR TITLE
logging: use new syntax to check if a handler is not already present in Logger.addHandler

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1682,7 +1682,7 @@ class Logger(Filterer):
         Add the specified handler to this logger.
         """
         with _lock:
-            if not (hdlr in self.handlers):
+            if hdlr not in self.handlers:
                 self.handlers.append(hdlr)
 
     def removeHandler(self, hdlr):


### PR DESCRIPTION
Use `x not in y` instead of `not (x in y)`