### PR TITLE
GH-145914: Fill newly created tuple with Py_None instead of NULL

### DIFF
--- a/Lib/test/test_capi/test_tuple.py
+++ b/Lib/test/test_capi/test_tuple.py
@@ -54,7 +54,6 @@ class CAPITest(unittest.TestCase):
         # Test PyTuple_New()
         tuple_new = _testlimitedcapi.tuple_new
         size = _testlimitedcapi.tuple_size
-        checknull = _testcapi._check_tuple_item_is_NULL
 
         tup1 = tuple_new(0)
         self.assertEqual(tup1, ())
@@ -66,7 +65,7 @@ class CAPITest(unittest.TestCase):
         self.assertIs(type(tup2), tuple)
         self.assertEqual(size(tup2), 1)
         self.assertIsNot(tup2, tup1)
-        self.assertTrue(checknull(tup2, 0))
+        self.assertIsNone(tup2[0])
         self._tracked(tup2)
 
         self.assertRaises(SystemError, tuple_new, -1)
@@ -299,7 +298,6 @@ class CAPITest(unittest.TestCase):
     def test__tuple_resize(self):
         # Test _PyTuple_Resize()
         resize = _testcapi._tuple_resize
-        checknull = _testcapi._check_tuple_item_is_NULL
 
         a = ()
         b = resize(a, 0, False)
@@ -308,8 +306,8 @@ class CAPITest(unittest.TestCase):
         b = resize(a, 2, False)
         self.assertEqual(len(a), 0)
         self.assertEqual(len(b), 2)
-        self.assertTrue(checknull(b, 0))
-        self.assertTrue(checknull(b, 1))
+        self.assertIsNone(b[0])
+        self.assertIsNone(b[1])
 
         a = ([1], [2], [3])
         b = resize(a, 3)
@@ -319,8 +317,8 @@ class CAPITest(unittest.TestCase):
         b = resize(a, 5)
         self.assertEqual(len(b), 5)
         self.assertEqual(b[:3], a)
-        self.assertTrue(checknull(b, 3))
-        self.assertTrue(checknull(b, 4))
+        self.assertIsNone(b[3])
+        self.assertIsNone(b[4])
 
         a = ()
         self.assertRaises(MemoryError, resize, a, PY_SSIZE_T_MAX)

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -1050,10 +1050,10 @@ _PyTuple_Resize(PyObject **pv, Py_ssize_t newsize)
         return -1;
     }
     _Py_NewReferenceNoTotal((PyObject *) sv);
-    /* Zero out items added by growing */
-    if (newsize > oldsize)
-        memset(&sv->ob_item[oldsize], 0,
-               sizeof(*sv->ob_item) * (newsize - oldsize));
+    /* Set items added by growing to Py_None */
+    for(i = oldsize; i < newsize;i++) {
+        sv->ob_item[i] = Py_None;
+    }
     *pv = (PyObject *) sv;
     _PyObject_GC_TRACK(sv);
     return 0;

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -83,7 +83,7 @@ PyTuple_New(Py_ssize_t size)
         return NULL;
     }
     for (Py_ssize_t i = 0; i < size; i++) {
-        op->ob_item[i] = NULL;
+        op->ob_item[i] = Py_None;
     }
     _PyObject_GC_TRACK(op);
     return (PyObject *) op;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -604,7 +604,7 @@ _PyEval_MatchClass(PyThreadState *tstate, PyObject *subject, PyObject *type,
         }
         if (match_self) {
             // Easy. Copy the subject itself, and move on to kwargs.
-            assert(PyTuple_GET_ITEM(attrs, 0) == NULL);
+            assert(PyTuple_GET_ITEM(attrs, 0) == Py_None);
             PyTuple_SET_ITEM(attrs, 0, Py_NewRef(subject));
         }
         else {
@@ -621,7 +621,7 @@ _PyEval_MatchClass(PyThreadState *tstate, PyObject *subject, PyObject *type,
                 if (attr == NULL) {
                     goto fail;
                 }
-                assert(PyTuple_GET_ITEM(attrs, i) == NULL);
+                assert(PyTuple_GET_ITEM(attrs, i) == Py_None);
                 PyTuple_SET_ITEM(attrs, i, attr);
             }
         }
@@ -634,7 +634,7 @@ _PyEval_MatchClass(PyThreadState *tstate, PyObject *subject, PyObject *type,
         if (attr == NULL) {
             goto fail;
         }
-        assert(PyTuple_GET_ITEM(attrs, nargs + i) == NULL);
+        assert(PyTuple_GET_ITEM(attrs, nargs + i) == Py_None);
         PyTuple_SET_ITEM(attrs, nargs + i, attr);
     }
     Py_XDECREF(seen);


### PR DESCRIPTION
Use Py_None instead of NULL in PyTuple_New. This ensures that the tuple is well constructed immediately after calling PyTuple_New.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145914 -->
* Issue: gh-145914
<!-- /gh-issue-number -->
