### PR TITLE
gh-146018: Disable over-aggressive optimization for _GUARD_CODE_VERSION

### DIFF
--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1747,9 +1747,10 @@ dummy_func(void) {
 
     op(_GUARD_CODE_VERSION, (version/2 -- )) {
         PyCodeObject *co = get_current_code_object(ctx);
-        if (co->co_version == version) {
-            _Py_BloomFilter_Add(dependencies, co);
-            REPLACE_OP(this_instr, _NOP, 0, 0);
+        if (co->co_version != version) {
+            // TODO:
+            // If we've previously guarded on this code version in a trace, we
+            // can avoid guarding it again.
         }
         else {
             ctx->done = true;

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1748,7 +1748,8 @@ dummy_func(void) {
     op(_GUARD_CODE_VERSION, (version/2 -- )) {
         PyCodeObject *co = get_current_code_object(ctx);
         if (co->co_version != version) {
-            // TODO:
+            _Py_BloomFilter_Add(dependencies, co);
+            // TODO gh-144651:
             // If we've previously guarded on this code version in a trace, we
             // can avoid guarding it again.
         }

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1747,7 +1747,7 @@ dummy_func(void) {
 
     op(_GUARD_CODE_VERSION, (version/2 -- )) {
         PyCodeObject *co = get_current_code_object(ctx);
-        if (co->co_version != version) {
+        if (co->co_version == version) {
             _Py_BloomFilter_Add(dependencies, co);
             // TODO gh-144651:
             // If we've previously guarded on this code version in a trace, we

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -4266,6 +4266,7 @@
             uint32_t version = (uint32_t)this_instr->operand0;
             PyCodeObject *co = get_current_code_object(ctx);
             if (co->co_version != version) {
+                _Py_BloomFilter_Add(dependencies, co);
             }
             else {
                 ctx->done = true;

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -4265,7 +4265,7 @@
         case _GUARD_CODE_VERSION: {
             uint32_t version = (uint32_t)this_instr->operand0;
             PyCodeObject *co = get_current_code_object(ctx);
-            if (co->co_version != version) {
+            if (co->co_version == version) {
                 _Py_BloomFilter_Add(dependencies, co);
             }
             else {

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -4265,9 +4265,7 @@
         case _GUARD_CODE_VERSION: {
             uint32_t version = (uint32_t)this_instr->operand0;
             PyCodeObject *co = get_current_code_object(ctx);
-            if (co->co_version == version) {
-                _Py_BloomFilter_Add(dependencies, co);
-                REPLACE_OP(this_instr, _NOP, 0, 0);
+            if (co->co_version != version) {
             }
             else {
                 ctx->done = true;


### PR DESCRIPTION
We still need the first check in the trace, the subsequent checks can be elided.

For now, let's just restore all checks for correctness reasons. We can come up with a smart way to track whether a code object has been checked in the future.

I don't know how to test this, as any assigning of code object on the function invalidates the function version. We'd need some indirect way of setting the code version?

Issue: https://github.com/python/cpython/issues/146018


<!-- gh-issue-number: gh-146018 -->
* Issue: gh-146018
<!-- /gh-issue-number -->
