### PR TITLE
Bump mypy to 1.19.1

### DIFF
--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -150,7 +150,7 @@ def setup_unraisable_hook() -> None:
     sys.unraisablehook = regrtest_unraisable_hook
 
 
-orig_threading_excepthook: Callable[..., None] | None = None
+orig_threading_excepthook: Callable[..., object] | None = None
 
 
 def regrtest_threading_excepthook(args) -> None:

--- a/Tools/clinic/libclinic/clanguage.py
+++ b/Tools/clinic/libclinic/clanguage.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Literal, Final
 from operator import attrgetter
 from collections.abc import Iterable
 
-import libclinic
+import libclinic.cpp
 from libclinic import (
     unspecified, fail, Sentinels, VersionTuple)
 from libclinic.codegen import CRenderData, TemplateDict, CodeGen

--- a/Tools/requirements-dev.txt
+++ b/Tools/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements file for external linters and checks we run on
 # Tools/clinic, Tools/cases_generator/, and Tools/peg_generator/ in CI
-mypy==1.17.1
+mypy==1.19.1
 
 # needed for peg_generator:
 types-psutil==7.0.0.20250801

--- a/Tools/requirements-dev.txt
+++ b/Tools/requirements-dev.txt
@@ -3,5 +3,5 @@
 mypy==1.19.1
 
 # needed for peg_generator:
-types-psutil==7.0.0.20250801
-types-setuptools==80.9.0.20250801
+types-psutil==7.2.2.20260130
+types-setuptools==82.0.0.20260210


### PR DESCRIPTION
Closes #145950

New mypy errors:
```
Lib/test/libregrtest/utils.py:174: error: Incompatible types in assignment (expression has type "Callable[[_ExceptHookArgs], object]", variable has type "Callable[..., None] | None")  [assignment]
        orig_threading_excepthook = threading.excepthook
                                    ^~~~~~~~~~~~~~~~~~~~
Tools/clinic/libclinic/clanguage.py:67: error: Module has no attribute "cpp" [attr-defined]
            self.cpp = libclinic.cpp.Monitor(filename)
                       ^~~~~~~~~~~~~
```

First error is due to the return type of `threading.excepthook` changing from `Any` to `object` in a [recent typeshed update](https://github.com/python/typeshed/pull/15023).

The second error is due to the `cpp` submodule never being explicitly imported in `clanguage`'s import graph, which can indeed lead to a runtime error:
```python
>>> import libclinic.clanguage
>>> libclinic.clanguage.CLanguage("foo")
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    libclinic.clanguage.CLanguage("foo")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/home/brian/Projects/open-contrib/cpython/Tools/clinic/libclinic/clanguage.py", line 67, in __init__
    self.cpp = libclinic.cpp.Monitor(filename)
               ^^^^^^^^^^^^^
AttributeError: module 'libclinic' has no attribute 'cpp'
```
It only works at the moment due to an implicit dependency on `libclinic.cli` being imported first, which imports `libclinic.cpp`.