### PR TITLE
gh-145961: Fix typos in configure.ac and pyconfig.h.in

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6412,7 +6412,7 @@ if test "$ac_cv_sizeof_wchar_t" -ge 2 \
           -a "$ac_cv_wchar_t_signed" = "no"
 then
   AC_DEFINE([HAVE_USABLE_WCHAR_T], [1],
-  [Define if you have a useable wchar_t type defined in wchar.h; useable
+  [Define if you have a usable wchar_t type defined in wchar.h; usable
    means wchar_t must be an unsigned type with at least 16 bits. (see
    Include/unicodeobject.h).])
   AC_MSG_RESULT([yes])
@@ -6502,7 +6502,7 @@ fi
 # Check for --with-platlibdir
 # /usr/$PLATLIBDIR/python$(VERSION)$(ABI_THREAD)
 AC_SUBST([PLATLIBDIR])
-PLATLIBDIR="lib"  # XXX: We should probably calculate the defauly from libdir, if defined.
+PLATLIBDIR="lib"  # XXX: We should probably calculate the default from libdir, if defined.
 AC_MSG_CHECKING([for --with-platlibdir])
 AC_ARG_WITH(
   [platlibdir],

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1599,7 +1599,7 @@
 /* Define to 1 if you have the 'unshare' function. */
 #undef HAVE_UNSHARE
 
-/* Define if you have a useable wchar_t type defined in wchar.h; useable means
+/* Define if you have a usable wchar_t type defined in wchar.h; usable means
    wchar_t must be an unsigned type with at least 16 bits. (see
    Include/unicodeobject.h). */
 #undef HAVE_USABLE_WCHAR_T


### PR DESCRIPTION
Fix typos in comments in `configure.ac` and `pyconfig.h.in`.

**Changes:**
- `configure.ac` line 6415: `useable` → `usable` (two occurrences on the same line)
- `configure.ac` line 6505: `defauly` → `default`
- `pyconfig.h.in` line 1602: `useable` → `usable` (two occurrences on the same line)

All changes are in comments only; no functional code is affected. The generated `configure` file is intentionally not modified.

Fixes gh-145961.