### PR TITLE
gh-145968: fix base64.b64decode altchars translation in specific cases

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -100,8 +100,13 @@ def b64decode(s, altchars=None, validate=_NOT_SPECIFIED, *, ignorechars=_NOT_SPE
                     break
             s = s.translate(bytes.maketrans(altchars, b'+/'))
         else:
-            trans = bytes.maketrans(altchars + bytes(set(b'+/') - set(altchars)),
-                                    b'+/' + bytes(set(altchars) - set(b'+/')))
+            trans_in = set(b'+/') - set(altchars)
+            if len(trans_in) == 2:
+                # we can't use the reqult of unordered sets here
+                trans = bytes.maketrans(altchars + b'+/', b'+/' + altchars)
+            else:
+                trans = bytes.maketrans(altchars + bytes(trans_in),
+                                        b'+/' + bytes(set(altchars) - set(b'+/')))
             s = s.translate(trans)
             ignorechars = ignorechars.translate(trans)
     if ignorechars is _NOT_SPECIFIED:

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -100,17 +100,8 @@ def b64decode(s, altchars=None, validate=_NOT_SPECIFIED, *, ignorechars=_NOT_SPE
                     break
             s = s.translate(bytes.maketrans(altchars, b'+/'))
         else:
-            altchars_out = (
-                altchars[0] if altchars[0] not in b'+/' else altchars[1],
-                altchars[1] if altchars[1] not in b'+/' else altchars[0],
-            )
-            trans_in = bytearray(altchars)
-            trans_out = bytearray(b'+/')
-            for b, b_out in zip(b'+/', altchars_out):
-                if b not in altchars:
-                    trans_in.append(b)
-                    trans_out.append(b_out)
-            trans = bytes.maketrans(trans_in, trans_out)
+            trans = bytes.maketrans(altchars + bytes(set(b'+/') - set(altchars)),
+                                    b'+/' + bytes(set(altchars) - set(b'+/')))
             s = s.translate(trans)
             ignorechars = ignorechars.translate(trans)
     if ignorechars is _NOT_SPECIFIED:

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -100,7 +100,17 @@ def b64decode(s, altchars=None, validate=_NOT_SPECIFIED, *, ignorechars=_NOT_SPE
                     break
             s = s.translate(bytes.maketrans(altchars, b'+/'))
         else:
-            trans = bytes.maketrans(b'+/' + altchars, altchars + b'+/')
+            altchars_out = (
+                altchars[0] if altchars[0] not in b'+/' else altchars[1],
+                altchars[1] if altchars[1] not in b'+/' else altchars[0],
+            )
+            trans_in = bytearray(altchars)
+            trans_out = bytearray(b'+/')
+            for b, b_out in zip(b'+/', altchars_out):
+                if b not in altchars:
+                    trans_in.append(b)
+                    trans_out.append(b_out)
+            trans = bytes.maketrans(trans_in, trans_out)
             s = s.translate(trans)
             ignorechars = ignorechars.translate(trans)
     if ignorechars is _NOT_SPECIFIED:

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -293,6 +293,13 @@ class BaseXYTestCase(unittest.TestCase):
             eq(base64.b64decode(data_str, altchars=altchars_str), res)
             eq(base64.b64decode(data, altchars=altchars, ignorechars=b'\n'), res)
 
+        eq(base64.b64decode(b'/----', altchars=b'-+', ignorechars=b'/'), b'\xfb\xef\xbe')
+        eq(base64.b64decode(b'/----', altchars=b'+-', ignorechars=b'/'), b'\xff\xff\xff')
+        eq(base64.b64decode(b'+----', altchars=b'-/', ignorechars=b'+'), b'\xfb\xef\xbe')
+        eq(base64.b64decode(b'+----', altchars=b'/-', ignorechars=b'+'), b'\xff\xff\xff')
+        eq(base64.b64decode(b'+/+/', altchars=b'/+', ignorechars=b''), b'\xff\xef\xfe')
+        eq(base64.b64decode(b'/+/+', altchars=b'+/', ignorechars=b''), b'\xff\xef\xfe')
+
         self.assertRaises(ValueError, base64.b64decode, b'', altchars=b'+')
         self.assertRaises(ValueError, base64.b64decode, b'', altchars=b'+/-')
         self.assertRaises(ValueError, base64.b64decode, '', altchars='+')

--- a/Misc/NEWS.d/next/Library/2026-03-15-10-17-51.gh-issue-145968.gZexry.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-15-10-17-51.gh-issue-145968.gZexry.rst
@@ -1,0 +1,2 @@
+Fix translation in :func:`base64.b64decode` when altchars overlaps with the
+standard ones.


### PR DESCRIPTION
When `altchars` overlaps with the standard ones, the translation does not always yield to the expected outcome.
This updates `bytes.maketrans` arguments to take those overlap cases into account.


<!-- gh-issue-number: gh-145968 -->
* Issue: gh-145968
<!-- /gh-issue-number -->
