### PR TITLE
Docs: a brief note in the sets tutorial about order

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -493,6 +493,9 @@ Curly braces or the :func:`set` function can be used to create sets.  Note: to
 create an empty set you have to use ``set()``, not ``{}``; the latter creates an
 empty dictionary, a data structure that we discuss in the next section.
 
+Because sets are unordered, iterating over them or printing them can
+produce the elements in a different order than you expect.
+
 Here is a brief demonstration::
 
    >>> basket = {'apple', 'orange', 'apple', 'pear', 'orange', 'banana'}


### PR DESCRIPTION
A learner didn't understand why when they tried the example, the output was different.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145984.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->