### PR TITLE
gh-145998: Remove duplicated "What's New in 3.15" entry

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1014,13 +1014,6 @@ symtable
   (Contributed by Yashp002 in :gh:`143504`.)
 
 
-symtable
---------
-
-* Add :meth:`symtable.Function.get_cells` and :meth:`symtable.Symbol.is_cell` methods.
-  (Contributed by Yashp002 in :gh:`143504`.)
-
-
 sys
 ---
 


### PR DESCRIPTION
Fix #145998 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--145994.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-145998 -->
* Issue: gh-145998
<!-- /gh-issue-number -->
