### PR TITLE
gh-145311: fix ensurepip and venv hang when stdin is a pipe

### DIFF
--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -84,7 +84,7 @@ runpy.run_module("pip", run_name="__main__", alter_sys=True)
     if sys.flags.isolated:
         # run code in isolated mode if currently running isolated
         cmd.insert(1, '-I')
-    return subprocess.run(cmd, check=True).returncode
+    return subprocess.run(cmd, stdin=subprocess.DEVNULL, check=True).returncode
 
 
 def version():

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -1,8 +1,10 @@
 import contextlib
 import os
 import os.path
+import subprocess
 import sys
 import tempfile
+import textwrap
 import test.support
 import unittest
 import unittest.mock
@@ -360,6 +362,51 @@ class TestUninstallationMainFunction(EnsurepipMixin, unittest.TestCase):
             self.run_pip.return_value = 2
             exit_code = ensurepip._uninstall._main([])
         self.assertEqual(exit_code, 2)
+
+
+class TestRunPip(unittest.TestCase):
+    def test_stdin_is_devnull(self):
+        mock_result = unittest.mock.MagicMock()
+        mock_result.returncode = 0
+        with unittest.mock.patch('ensurepip.subprocess.run',
+                                 return_value=mock_result) as mock_run:
+            ensurepip._run_pip(['install', 'pip'])
+        self.assertIs(mock_run.call_args.kwargs.get('stdin'), subprocess.DEVNULL)
+
+
+class TestRunPipStdinHang(unittest.TestCase):
+    """gh-145311: _run_pip must not hang when stdin is an open pipe."""
+
+    @test.support.requires_subprocess()
+    def test_run_pip_does_not_hang_on_piped_stdin(self):
+        # Spawn _run_pip in a child process whose stdin is an open pipe
+        # whose write end we never close — the condition that caused the hang.
+        script = textwrap.dedent("""\
+            import ensurepip, os
+            with ensurepip._get_pip_whl_path_ctx() as whl:
+                ensurepip._run_pip(["--version"], [os.fspath(whl)])
+            print("ok")
+        """)
+        r_fd, w_fd = os.pipe()
+        try:
+            with open(r_fd, "rb") as pipe_r:
+                result = subprocess.run(
+                    [sys.executable, "-c", script],
+                    stdin=pipe_r,
+                    capture_output=True,
+                    timeout=10,
+                    text=True,
+                )
+        except subprocess.TimeoutExpired:
+            self.fail(
+                "ensurepip._run_pip hung with an open pipe on stdin; "
+                "ensure subprocess.run(..., stdin=subprocess.DEVNULL, ...) "
+                "is used (gh-145311)"
+            )
+        finally:
+            os.close(w_fd)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("ok", result.stdout)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
+import textwrap
 from test.support import (captured_stdout, captured_stderr,
                           skip_if_broken_multiprocessing_synchronize, verbose,
                           requires_subprocess, is_android, is_apple_mobile,
@@ -253,6 +254,7 @@ class BasicTest(BaseTest):
                 exe_dir = os.path.normcase(os.path.dirname(cmd[0]))
                 expected_dir = os.path.normcase(os.path.dirname(expect_exe))
                 self.assertEqual(exe_dir, expected_dir)
+                self.assertIs(kwargs.get('stdin'), subprocess.DEVNULL)  # gh-145311
 
             fake_context = builder.ensure_directories(fake_env_dir)
             with patch('venv.subprocess.check_output', pip_cmd_checker):
@@ -1056,6 +1058,50 @@ class EnsurePipTest(BaseTest):
     def test_with_pip(self):
         self.do_test_with_pip(False)
         self.do_test_with_pip(True)
+
+
+class TestCallNewPythonStdinHang(unittest.TestCase):
+    """gh-145311: _call_new_python must not hang when stdin is an open pipe."""
+
+    @requires_subprocess()
+    def test_call_new_python_does_not_hang_on_piped_stdin(self):
+        # Spawn _call_new_python in a child process whose stdin is an open
+        # pipe whose write end we never close — the condition that caused the
+        # hang before kwargs['stdin'] = subprocess.DEVNULL was added.
+        #
+        # A minimal SimpleNamespace context is sufficient: _call_new_python
+        # only reads context.env_exec_cmd and context.env_dir.
+        script = textwrap.dedent("""\
+            import sys, tempfile, types, venv
+            with tempfile.TemporaryDirectory() as env_dir:
+                ctx = types.SimpleNamespace(
+                    env_exec_cmd=sys.executable,
+                    env_dir=env_dir,
+                )
+                builder = venv.EnvBuilder()
+                builder._call_new_python(ctx, "-c", "pass")
+            print("ok")
+        """)
+        r_fd, w_fd = os.pipe()
+        try:
+            with open(r_fd, "rb") as pipe_r:
+                result = subprocess.run(
+                    [sys.executable, "-c", script],
+                    stdin=pipe_r,
+                    capture_output=True,
+                    timeout=10,
+                    text=True,
+                )
+        except subprocess.TimeoutExpired:
+            self.fail(
+                "venv._call_new_python hung with an open pipe on stdin; "
+                "ensure kwargs['stdin'] = subprocess.DEVNULL is set "
+                "(gh-145311)"
+            )
+        finally:
+            os.close(w_fd)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("ok", result.stdout)
 
 
 if __name__ == "__main__":

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -444,6 +444,7 @@ class EnvBuilder:
         env.pop('PYTHONPATH', None)
         kwargs['cwd'] = context.env_dir
         kwargs['executable'] = context.env_exec_cmd
+        kwargs['stdin'] = subprocess.DEVNULL   # gh-145311
         subprocess.check_output(args, **kwargs)
 
     def _setup_pip(self, context):

--- a/Misc/NEWS.d/next/Library/2026-03-15-09-47-31.gh-issue-145311.tKxdj2.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-15-09-47-31.gh-issue-145311.tKxdj2.rst
@@ -1,0 +1,5 @@
+Fix :mod:`venv` and :mod:`ensurepip` hanging when stdin is connected to
+a pipe. :func:`subprocess.check_output` in
+:meth:`~venv.EnvBuilder._call_new_python` and :func:`subprocess.run` in
+:func:`ensurepip._run_pip` now pass ``stdin=subprocess.DEVNULL`` to
+prevent child processes from blocking on an inherited pipe descriptor.

--- a/Misc/NEWS.d/next/Library/2026-03-15-09-47-31.gh-issue-145311.tKxdj2.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-15-09-47-31.gh-issue-145311.tKxdj2.rst
@@ -1,5 +1,3 @@
 Fix :mod:`venv` and :mod:`ensurepip` hanging when stdin is connected to
-a pipe. :func:`subprocess.check_output` in
-:meth:`~venv.EnvBuilder._call_new_python` and :func:`subprocess.run` in
-:func:`ensurepip._run_pip` now pass ``stdin=subprocess.DEVNULL`` to
-prevent child processes from blocking on an inherited pipe descriptor.
+a pipe. Subprocess calls in both modules now pass ``stdin=subprocess.DEVNULL``
+to prevent child processes from blocking on an inherited pipe descriptor.


### PR DESCRIPTION
When a process spawns Python with an open pipe on stdin and never writes to it, `ensurepip._run_pip()` and `venv.EnvBuilder._call_new_python()` can hang indefinitely because the subprocess inherits the pipe and blocks waiting for input.

Fix: pass `stdin=subprocess.DEVNULL` to both calls.

Regression tests added for both code paths: a mock-based test that checks the kwarg is set, and an integration test that reproduces the hang condition with a real subprocess.

https://github.com/python/cpython/issues/145311

<!-- gh-issue-number: gh-145311 -->
* Issue: gh-145311
<!-- /gh-issue-number -->
