### PR TITLE
gh-142927: Show module names instead of file paths in flamegraph

### DIFF
--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph.css
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph.css
@@ -315,6 +315,12 @@ body.resizing-sidebar {
 }
 
 /* View Mode Section */
+.view-mode-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .view-mode-section .section-content {
   display: flex;
   flex-direction: column;
@@ -1067,7 +1073,8 @@ body.resizing-sidebar {
    -------------------------------------------------------------------------- */
 
 #toggle-invert .toggle-track.on,
-#toggle-elided .toggle-track.on {
+#toggle-elided .toggle-track.on,
+#toggle-path-display .toggle-track.on {
   background: #8e44ad;
   border-color: #8e44ad;
   box-shadow: 0 0 8px rgba(142, 68, 173, 0.3);

--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
@@ -64,6 +64,9 @@ function resolveStringIndices(node, table) {
   if (typeof resolved.funcname === 'number') {
     resolved.funcname = resolveString(resolved.funcname, table);
   }
+  if (typeof resolved.module_name === 'number') {
+    resolved.module_name = resolveString(resolved.module_name);
+  }
 
   if (Array.isArray(resolved.source)) {
     resolved.source = resolved.source.map(index =>
@@ -76,6 +79,11 @@ function resolveStringIndices(node, table) {
   }
 
   return resolved;
+}
+
+// Escape HTML special characters
+function escapeHtml(str) {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 function selectFlamegraphData() {
@@ -228,6 +236,7 @@ function setupLogos() {
 function updateStatusBar(nodeData, rootValue) {
   const funcname = resolveString(nodeData.funcname) || resolveString(nodeData.name) || "--";
   const filename = resolveString(nodeData.filename) || "";
+  const moduleName = resolveString(nodeData.module_name) || "";
   const lineno = nodeData.lineno;
   const timeMs = (nodeData.value / 1000).toFixed(2);
   const percent = rootValue > 0 ? ((nodeData.value / rootValue) * 100).toFixed(1) : "0.0";
@@ -249,8 +258,7 @@ function updateStatusBar(nodeData, rootValue) {
 
   const fileEl = document.getElementById('status-file');
   if (fileEl && filename && filename !== "~") {
-    const basename = filename.split('/').pop();
-    fileEl.textContent = lineno ? `${basename}:${lineno}` : basename;
+    fileEl.textContent = lineno ? `${moduleName}:${lineno}` : moduleName;
   }
 
   const funcEl = document.getElementById('status-func');
@@ -301,6 +309,7 @@ function createPythonTooltip(data) {
 
     const funcname = resolveString(d.data.funcname) || resolveString(d.data.name);
     const filename = resolveString(d.data.filename) || "";
+    const moduleName = escapeHtml(resolveString(d.data.module_name) || "");
     const isSpecialFrame = filename === "~";
 
     // Build source section
@@ -309,7 +318,7 @@ function createPythonTooltip(data) {
       const sourceLines = source
         .map((line) => {
           const isCurrent = line.startsWith("→");
-          const escaped = line.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+          const escaped = escapeHtml(line);
           return `<div class="tooltip-source-line${isCurrent ? ' current' : ''}">${escaped}</div>`;
         })
         .join("");
@@ -369,7 +378,7 @@ function createPythonTooltip(data) {
     }
 
     const fileLocationHTML = isSpecialFrame ? "" : `
-      <div class="tooltip-location">${filename}${d.data.lineno ? ":" + d.data.lineno : ""}</div>`;
+      <div class="tooltip-location">${moduleName}${d.data.lineno ? ":" + d.data.lineno : ""}</div>`;
 
     // Differential stats section
     let diffSection = "";
@@ -628,24 +637,24 @@ function updateSearchHighlight(searchTerm, searchInput) {
         const name = resolveString(d.data.name) || "";
         const funcname = resolveString(d.data.funcname) || "";
         const filename = resolveString(d.data.filename) || "";
+        const moduleName = resolveString(d.data.module_name) || "";
         const lineno = d.data.lineno;
         const term = searchTerm.toLowerCase();
 
-        // Check if search term looks like file:line pattern
+        // Check if search term looks like module:line pattern
         const fileLineMatch = term.match(/^(.+):(\d+)$/);
         let matches = false;
 
         if (fileLineMatch) {
-          // Exact file:line matching
           const searchFile = fileLineMatch[1];
           const searchLine = parseInt(fileLineMatch[2], 10);
-          const basename = filename.split('/').pop().toLowerCase();
-          matches = basename.includes(searchFile) && lineno === searchLine;
+          matches = moduleName.toLowerCase().includes(searchFile) && lineno === searchLine;
         } else {
           // Regular substring search
           matches =
             name.toLowerCase().includes(term) ||
             funcname.toLowerCase().includes(term) ||
+            moduleName.toLowerCase().includes(term) ||
             filename.toLowerCase().includes(term);
         }
 
@@ -1047,6 +1056,7 @@ function populateStats(data) {
 
     let filename = resolveString(node.filename);
     let funcname = resolveString(node.funcname);
+    let moduleName = resolveString(node.module_name);
 
     if (!filename || !funcname) {
       const nameStr = resolveString(node.name);
@@ -1061,6 +1071,7 @@ function populateStats(data) {
 
     filename = filename || 'unknown';
     funcname = funcname || 'unknown';
+    moduleName = moduleName || 'unknown';
 
     if (filename !== 'unknown' && funcname !== 'unknown' && node.value > 0) {
       let childrenValue = 0;
@@ -1077,12 +1088,14 @@ function populateStats(data) {
         existing.directPercent = (existing.directSamples / totalSamples) * 100;
         if (directSamples > existing.maxSingleSamples) {
           existing.filename = filename;
+          existing.module_name = moduleName;
           existing.lineno = node.lineno || '?';
           existing.maxSingleSamples = directSamples;
         }
       } else {
         functionMap.set(funcKey, {
           filename: filename,
+          module_name: moduleName,
           lineno: node.lineno || '?',
           funcname: funcname,
           directSamples,
@@ -1117,6 +1130,7 @@ function populateStats(data) {
       const h = hotSpots[i];
       const filename = h.filename || 'unknown';
       const lineno = h.lineno ?? '?';
+      const moduleName = h.module_name || 'unknown';
       const isSpecialFrame = filename === '~' && (lineno === 0 || lineno === '?');
 
       let funcDisplay = h.funcname || 'unknown';
@@ -1127,8 +1141,7 @@ function populateStats(data) {
         if (isSpecialFrame) {
           fileEl.textContent = '--';
         } else {
-          const basename = filename !== 'unknown' ? filename.split('/').pop() : 'unknown';
-          fileEl.textContent = `${basename}:${lineno}`;
+          fileEl.textContent = `${moduleName}:${lineno}`;
         }
       }
       if (percentEl) percentEl.textContent = `${h.directPercent.toFixed(1)}%`;
@@ -1144,8 +1157,9 @@ function populateStats(data) {
     if (card) {
       if (i < hotSpots.length && hotSpots[i]) {
         const h = hotSpots[i];
-        const basename = h.filename !== 'unknown' ? h.filename.split('/').pop() : '';
-        const searchTerm = basename && h.lineno !== '?' ? `${basename}:${h.lineno}` : h.funcname;
+        const moduleName = h.module_name || 'unknown';
+        const hasValidLocation = moduleName !== 'unknown' && h.lineno !== '?';
+        const searchTerm = hasValidLocation ? `${moduleName}:${h.lineno}` : h.funcname;
         card.dataset.searchterm = searchTerm;
         card.onclick = () => searchForHotspot(searchTerm);
         card.style.cursor = 'pointer';
@@ -1281,6 +1295,7 @@ function accumulateInvertedNode(parent, stackFrame, leaf, isDifferential) {
       self: 0,
       children: {},
       filename: stackFrame.filename,
+      module_name: stackFrame.module_name,
       lineno: stackFrame.lineno,
       funcname: stackFrame.funcname,
       source: stackFrame.source,

--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
@@ -65,11 +65,11 @@ function resolveStringIndices(node, table) {
   if (typeof resolved.funcname === 'number') {
     resolved.funcname = resolveString(resolved.funcname, table);
   }
-  if (typeof resolved.module_name === 'number') {
-    resolved.module_name = resolveString(resolved.module_name);
+  if (typeof resolved.module === 'number') {
+    resolved.module = resolveString(resolved.module, table);
   }
-  if (typeof resolved.name_module === 'number') {
-    resolved.name_module = resolveString(resolved.name_module);
+  if (typeof resolved.label === 'number') {
+    resolved.label = resolveString(resolved.label, table);
   }
 
   if (Array.isArray(resolved.source)) {
@@ -90,7 +90,7 @@ function escapeHtml(str) {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-// Get display path based on user preference (module name or basename)
+// Get display path based on user preference (module or full path)
 function getDisplayName(moduleName, filename) {
   if (useModuleNames) {
     return moduleName || filename;
@@ -248,7 +248,7 @@ function setupLogos() {
 function updateStatusBar(nodeData, rootValue) {
   const funcname = resolveString(nodeData.funcname) || resolveString(nodeData.name) || "--";
   const filename = resolveString(nodeData.filename) || "";
-  const moduleName = resolveString(nodeData.module_name) || "";
+  const moduleName = resolveString(nodeData.module) || "";
   const lineno = nodeData.lineno;
   const timeMs = (nodeData.value / 1000).toFixed(2);
   const percent = rootValue > 0 ? ((nodeData.value / rootValue) * 100).toFixed(1) : "0.0";
@@ -322,7 +322,7 @@ function createPythonTooltip(data) {
 
     const funcname = resolveString(d.data.funcname) || resolveString(d.data.name);
     const filename = resolveString(d.data.filename) || "";
-    const moduleName = resolveString(d.data.module_name) || "";
+    const moduleName = resolveString(d.data.module) || "";
     const displayName = escapeHtml(useModuleNames ? (moduleName || filename) : filename);
     const isSpecialFrame = filename === "~";
 
@@ -609,7 +609,7 @@ function createFlamegraph(tooltip, rootValue, data) {
     .minFrameSize(1)
     .tooltip(tooltip)
     .inverted(true)
-    .getName(d => resolveString(useModuleNames ? d.data.name_module : d.data.name) || resolveString(d.data.name) || '')
+    .getName(d => resolveString(useModuleNames ? d.data.label : d.data.name) || resolveString(d.data.name) || '')
     .setColorMapper(function (d) {
       if (d.depth === 0) return 'transparent';
 
@@ -652,7 +652,7 @@ function updateSearchHighlight(searchTerm, searchInput) {
         const name = resolveString(d.data.name) || "";
         const funcname = resolveString(d.data.funcname) || "";
         const filename = resolveString(d.data.filename) || "";
-        const moduleName = resolveString(d.data.module_name) || "";
+        const moduleName = resolveString(d.data.module) || "";
         const displayName = getDisplayName(moduleName, filename);
         const lineno = d.data.lineno;
         const term = searchTerm.toLowerCase();
@@ -1071,7 +1071,7 @@ function populateStats(data) {
 
     let filename = resolveString(node.filename);
     let funcname = resolveString(node.funcname);
-    let moduleName = resolveString(node.module_name);
+    let moduleName = resolveString(node.module);
 
     if (!filename || !funcname) {
       const nameStr = resolveString(node.name);
@@ -1103,14 +1103,14 @@ function populateStats(data) {
         existing.directPercent = (existing.directSamples / totalSamples) * 100;
         if (directSamples > existing.maxSingleSamples) {
           existing.filename = filename;
-          existing.module_name = moduleName;
+          existing.module = moduleName;
           existing.lineno = node.lineno || '?';
           existing.maxSingleSamples = directSamples;
         }
       } else {
         functionMap.set(funcKey, {
           filename: filename,
-          module_name: moduleName,
+          module: moduleName,
           lineno: node.lineno || '?',
           funcname: funcname,
           directSamples,
@@ -1145,7 +1145,7 @@ function populateStats(data) {
       const h = hotSpots[i];
       const filename = h.filename || 'unknown';
       const lineno = h.lineno ?? '?';
-      const moduleName = h.module_name || 'unknown';
+      const moduleName = h.module || 'unknown';
       const isSpecialFrame = filename === '~' && (lineno === 0 || lineno === '?');
 
       let funcDisplay = h.funcname || 'unknown';
@@ -1173,7 +1173,7 @@ function populateStats(data) {
     if (card) {
       if (i < hotSpots.length && hotSpots[i]) {
         const h = hotSpots[i];
-        const moduleName = h.module_name || 'unknown';
+        const moduleName = h.module || 'unknown';
         const filename = h.filename || 'unknown';
         const displayName = getDisplayName(moduleName, filename);
         const hasValidLocation = displayName !== 'unknown' && h.lineno !== '?';
@@ -1309,12 +1309,12 @@ function accumulateInvertedNode(parent, stackFrame, leaf, isDifferential) {
   if (!parent.children[key]) {
     const newNode = {
       name: stackFrame.name,
-      name_module: stackFrame.name_module,
+      label: stackFrame.label,
       value: 0,
       self: 0,
       children: {},
       filename: stackFrame.filename,
-      module_name: stackFrame.module_name,
+      module: stackFrame.module,
       lineno: stackFrame.lineno,
       funcname: stackFrame.funcname,
       source: stackFrame.source,
@@ -1409,7 +1409,7 @@ function generateInvertedFlamegraph(data) {
 
   const invertedRoot = {
     name: data.name,
-    name_module: data.name_module,
+    label: data.label,
     value: data.value,
     children: {},
     stats: data.stats,
@@ -1437,14 +1437,7 @@ function toggleInvert() {
 function togglePathDisplay() {
   useModuleNames = !useModuleNames;
   updateToggleUI('toggle-path-display', useModuleNames);
-  const dataToRender = isInverted ? invertedData : normalData;
-  const filteredData = currentThreadFilter !== 'all'
-    ? filterDataByThread(dataToRender, parseInt(currentThreadFilter))
-    : dataToRender;
-
-  const tooltip = createPythonTooltip(filteredData);
-  const chart = createFlamegraph(tooltip, filteredData.value);
-  renderFlamegraph(chart, filteredData);
+  updateFlamegraphView();
 }
 
 // ============================================================================

--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
@@ -95,7 +95,7 @@ function getDisplayName(moduleName, filename) {
   if (useModuleNames) {
     return moduleName || filename;
   }
-  return filename ? filename.split('/').pop() : filename;
+  return filename;
 }
 
 function selectFlamegraphData() {

--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
@@ -6,6 +6,7 @@ let normalData = null;
 let invertedData = null;
 let currentThreadFilter = 'all';
 let isInverted = false;
+let useModuleNames = true;
 
 // Heat colors are now defined in CSS variables (--heat-1 through --heat-8)
 // and automatically switch with theme changes - no JS color arrays needed!
@@ -67,6 +68,9 @@ function resolveStringIndices(node, table) {
   if (typeof resolved.module_name === 'number') {
     resolved.module_name = resolveString(resolved.module_name);
   }
+  if (typeof resolved.name_module === 'number') {
+    resolved.name_module = resolveString(resolved.name_module);
+  }
 
   if (Array.isArray(resolved.source)) {
     resolved.source = resolved.source.map(index =>
@@ -84,6 +88,14 @@ function resolveStringIndices(node, table) {
 // Escape HTML special characters
 function escapeHtml(str) {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// Get display path based on user preference (module name or basename)
+function getDisplayName(moduleName, filename) {
+  if (useModuleNames) {
+    return moduleName || filename;
+  }
+  return filename ? filename.split('/').pop() : filename;
 }
 
 function selectFlamegraphData() {
@@ -258,7 +270,8 @@ function updateStatusBar(nodeData, rootValue) {
 
   const fileEl = document.getElementById('status-file');
   if (fileEl && filename && filename !== "~") {
-    fileEl.textContent = lineno ? `${moduleName}:${lineno}` : moduleName;
+    const displayName = getDisplayName(moduleName, filename);
+    fileEl.textContent = lineno ? `${displayName}:${lineno}` : displayName;
   }
 
   const funcEl = document.getElementById('status-func');
@@ -309,7 +322,8 @@ function createPythonTooltip(data) {
 
     const funcname = resolveString(d.data.funcname) || resolveString(d.data.name);
     const filename = resolveString(d.data.filename) || "";
-    const moduleName = escapeHtml(resolveString(d.data.module_name) || "");
+    const moduleName = resolveString(d.data.module_name) || "";
+    const displayName = escapeHtml(useModuleNames ? (moduleName || filename) : filename);
     const isSpecialFrame = filename === "~";
 
     // Build source section
@@ -378,7 +392,7 @@ function createPythonTooltip(data) {
     }
 
     const fileLocationHTML = isSpecialFrame ? "" : `
-      <div class="tooltip-location">${moduleName}${d.data.lineno ? ":" + d.data.lineno : ""}</div>`;
+      <div class="tooltip-location">${displayName}${d.data.lineno ? ":" + d.data.lineno : ""}</div>`;
 
     // Differential stats section
     let diffSection = "";
@@ -595,6 +609,7 @@ function createFlamegraph(tooltip, rootValue, data) {
     .minFrameSize(1)
     .tooltip(tooltip)
     .inverted(true)
+    .getName(d => resolveString(useModuleNames ? d.data.name_module : d.data.name) || resolveString(d.data.name) || '')
     .setColorMapper(function (d) {
       if (d.depth === 0) return 'transparent';
 
@@ -638,24 +653,24 @@ function updateSearchHighlight(searchTerm, searchInput) {
         const funcname = resolveString(d.data.funcname) || "";
         const filename = resolveString(d.data.filename) || "";
         const moduleName = resolveString(d.data.module_name) || "";
+        const displayName = getDisplayName(moduleName, filename);
         const lineno = d.data.lineno;
         const term = searchTerm.toLowerCase();
 
-        // Check if search term looks like module:line pattern
+        // Check if search term looks like path:line pattern
         const fileLineMatch = term.match(/^(.+):(\d+)$/);
         let matches = false;
 
         if (fileLineMatch) {
           const searchFile = fileLineMatch[1];
           const searchLine = parseInt(fileLineMatch[2], 10);
-          matches = moduleName.toLowerCase().includes(searchFile) && lineno === searchLine;
+          matches = displayName.toLowerCase().includes(searchFile) && lineno === searchLine;
         } else {
           // Regular substring search
           matches =
             name.toLowerCase().includes(term) ||
             funcname.toLowerCase().includes(term) ||
-            moduleName.toLowerCase().includes(term) ||
-            filename.toLowerCase().includes(term);
+            displayName.toLowerCase().includes(term);
         }
 
         if (matches) {
@@ -1141,7 +1156,8 @@ function populateStats(data) {
         if (isSpecialFrame) {
           fileEl.textContent = '--';
         } else {
-          fileEl.textContent = `${moduleName}:${lineno}`;
+          const displayName = getDisplayName(moduleName, filename);
+          fileEl.textContent = `${displayName}:${lineno}`;
         }
       }
       if (percentEl) percentEl.textContent = `${h.directPercent.toFixed(1)}%`;
@@ -1158,8 +1174,10 @@ function populateStats(data) {
       if (i < hotSpots.length && hotSpots[i]) {
         const h = hotSpots[i];
         const moduleName = h.module_name || 'unknown';
-        const hasValidLocation = moduleName !== 'unknown' && h.lineno !== '?';
-        const searchTerm = hasValidLocation ? `${moduleName}:${h.lineno}` : h.funcname;
+        const filename = h.filename || 'unknown';
+        const displayName = getDisplayName(moduleName, filename);
+        const hasValidLocation = displayName !== 'unknown' && h.lineno !== '?';
+        const searchTerm = hasValidLocation ? `${displayName}:${h.lineno}` : h.funcname;
         card.dataset.searchterm = searchTerm;
         card.onclick = () => searchForHotspot(searchTerm);
         card.style.cursor = 'pointer';
@@ -1291,6 +1309,7 @@ function accumulateInvertedNode(parent, stackFrame, leaf, isDifferential) {
   if (!parent.children[key]) {
     const newNode = {
       name: stackFrame.name,
+      name_module: stackFrame.name_module,
       value: 0,
       self: 0,
       children: {},
@@ -1390,6 +1409,7 @@ function generateInvertedFlamegraph(data) {
 
   const invertedRoot = {
     name: data.name,
+    name_module: data.name_module,
     value: data.value,
     children: {},
     stats: data.stats,
@@ -1412,6 +1432,19 @@ function toggleInvert() {
   isInverted = !isInverted;
   updateToggleUI('toggle-invert', isInverted);
   updateFlamegraphView();
+}
+
+function togglePathDisplay() {
+  useModuleNames = !useModuleNames;
+  updateToggleUI('toggle-path-display', useModuleNames);
+  const dataToRender = isInverted ? invertedData : normalData;
+  const filteredData = currentThreadFilter !== 'all'
+    ? filterDataByThread(dataToRender, parseInt(currentThreadFilter))
+    : dataToRender;
+
+  const tooltip = createPythonTooltip(filteredData);
+  const chart = createFlamegraph(tooltip, filteredData.value);
+  renderFlamegraph(chart, filteredData);
 }
 
 // ============================================================================
@@ -1460,6 +1493,11 @@ function initFlamegraph() {
   const toggleInvertBtn = document.getElementById('toggle-invert');
   if (toggleInvertBtn) {
     toggleInvertBtn.addEventListener('click', toggleInvert);
+  }
+
+  const togglePathDisplayBtn = document.getElementById('toggle-path-display');
+  if (togglePathDisplayBtn) {
+    togglePathDisplayBtn.addEventListener('click', togglePathDisplay);
   }
 }
 

--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph_template.html
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph_template.html
@@ -117,6 +117,12 @@
                   <span class="toggle-label" data-text="Elided" title="Code paths that existed in baseline but are missing from current profile">Elided</span>
                 </div>
 
+                <div class="toggle-switch" id="toggle-path-display" title="Toggle between module names and full file paths" tabindex="0">
+                  <span class="toggle-label" data-text="Full Paths">Full Paths</span>
+                  <div class="toggle-track on"></div>
+                  <span class="toggle-label active" data-text="Module Names">Module Names</span>
+                </div>
+
                 <div class="toggle-switch" id="toggle-invert" title="Toggle between standard and inverted flamegraph view" tabindex="0">
                   <span class="toggle-label active" data-text="Flamegraph">Flamegraph</span>
                   <div class="toggle-track"></div>

--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph_template.html
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph_template.html
@@ -118,7 +118,7 @@
                 </div>
 
                 <div class="toggle-switch" id="toggle-path-display" title="Toggle between module names and full file paths" tabindex="0">
-                  <span class="toggle-label" data-text="Full Paths">Full Paths</span>
+                  <span class="toggle-label" data-text="File Paths">File Paths</span>
                   <div class="toggle-track on"></div>
                   <span class="toggle-label active" data-text="Module Names">Module Names</span>
                 </div>

--- a/Lib/profiling/sampling/heatmap_collector.py
+++ b/Lib/profiling/sampling/heatmap_collector.py
@@ -20,6 +20,7 @@ from ._format_utils import fmt
 from .collector import normalize_location, extract_lineno
 from .opcode_utils import get_opcode_info, format_opcode
 from .stack_collector import StackTraceCollector
+from .module_utils import extract_module_name, get_python_path_info
 
 
 # ============================================================================
@@ -47,126 +48,6 @@ class TreeNode:
     samples: int = 0
     count: int = 0
     children: Dict[str, 'TreeNode'] = field(default_factory=dict)
-
-
-# ============================================================================
-# Module Path Analysis
-# ============================================================================
-
-def get_python_path_info():
-    """Get information about Python installation paths for module extraction.
-
-    Returns:
-        dict: Dictionary containing stdlib path, site-packages paths, and sys.path entries.
-    """
-    info = {
-        'stdlib': None,
-        'site_packages': [],
-        'sys_path': []
-    }
-
-    # Get standard library path from os module location
-    try:
-        if hasattr(os, '__file__') and os.__file__:
-            info['stdlib'] = Path(os.__file__).parent
-    except (AttributeError, OSError):
-        pass  # Silently continue if we can't determine stdlib path
-
-    # Get site-packages directories
-    site_packages = []
-    try:
-        site_packages.extend(Path(p) for p in site.getsitepackages())
-    except (AttributeError, OSError):
-        pass  # Continue without site packages if unavailable
-
-    # Get user site-packages
-    try:
-        user_site = site.getusersitepackages()
-        if user_site and Path(user_site).exists():
-            site_packages.append(Path(user_site))
-    except (AttributeError, OSError):
-        pass  # Continue without user site packages
-
-    info['site_packages'] = site_packages
-    info['sys_path'] = [Path(p) for p in sys.path if p]
-
-    return info
-
-
-def extract_module_name(filename, path_info):
-    """Extract Python module name and type from file path.
-
-    Args:
-        filename: Path to the Python file
-        path_info: Dictionary from get_python_path_info()
-
-    Returns:
-        tuple: (module_name, module_type) where module_type is one of:
-               'stdlib', 'site-packages', 'project', or 'other'
-    """
-    if not filename:
-        return ('unknown', 'other')
-
-    try:
-        file_path = Path(filename)
-    except (ValueError, OSError):
-        return (str(filename), 'other')
-
-    # Check if it's in stdlib
-    if path_info['stdlib'] and _is_subpath(file_path, path_info['stdlib']):
-        try:
-            rel_path = file_path.relative_to(path_info['stdlib'])
-            return (_path_to_module(rel_path), 'stdlib')
-        except ValueError:
-            pass
-
-    # Check site-packages
-    for site_pkg in path_info['site_packages']:
-        if _is_subpath(file_path, site_pkg):
-            try:
-                rel_path = file_path.relative_to(site_pkg)
-                return (_path_to_module(rel_path), 'site-packages')
-            except ValueError:
-                continue
-
-    # Check other sys.path entries (project files)
-    if not str(file_path).startswith(('<', '[')):  # Skip special files
-        for path_entry in path_info['sys_path']:
-            if _is_subpath(file_path, path_entry):
-                try:
-                    rel_path = file_path.relative_to(path_entry)
-                    return (_path_to_module(rel_path), 'project')
-                except ValueError:
-                    continue
-
-    # Fallback: just use the filename
-    return (_path_to_module(file_path), 'other')
-
-
-def _is_subpath(file_path, parent_path):
-    try:
-        file_path.relative_to(parent_path)
-        return True
-    except (ValueError, OSError):
-        return False
-
-
-def _path_to_module(path):
-    if isinstance(path, str):
-        path = Path(path)
-
-    # Remove .py extension
-    if path.suffix == '.py':
-        path = path.with_suffix('')
-
-    # Convert path separators to dots
-    parts = path.parts
-
-    # Handle __init__ files - they represent the package itself
-    if parts and parts[-1] == '__init__':
-        parts = parts[:-1]
-
-    return '.'.join(parts) if parts else path.stem
 
 
 # ============================================================================

--- a/Lib/profiling/sampling/module_utils.py
+++ b/Lib/profiling/sampling/module_utils.py
@@ -112,8 +112,8 @@ def _path_to_module(path):
     if path.suffix == '.py':
         path = path.with_suffix('')
 
-    # Convert path separators to dots
-    parts = path.parts
+    # Convert path separators to dots, stripping root/drive (e.g. "/" or "C:\")
+    parts = [p for p in path.parts if p != path.root and p != path.drive]
 
     # Handle __init__ files - they represent the package itself
     if parts and parts[-1] == '__init__':

--- a/Lib/profiling/sampling/module_utils.py
+++ b/Lib/profiling/sampling/module_utils.py
@@ -1,0 +1,122 @@
+"""Utilities for extracting module names from file paths."""
+
+import os
+import site
+import sys
+from pathlib import Path
+
+
+def get_python_path_info():
+    """Get information about Python's search paths.
+
+    Returns:
+        dict: Dictionary containing stdlib path, site-packages paths, and sys.path entries.
+    """
+    info = {
+        'stdlib': None,
+        'site_packages': [],
+        'sys_path': []
+    }
+
+    # Get standard library path from os module location
+    try:
+        if hasattr(os, '__file__') and os.__file__:
+            info['stdlib'] = Path(os.__file__).parent
+    except (AttributeError, OSError):
+        pass  # Silently continue if we can't determine stdlib path
+
+    # Get site-packages directories
+    site_packages = []
+    try:
+        site_packages.extend(Path(p) for p in site.getsitepackages())
+    except (AttributeError, OSError):
+        pass  # Continue without site packages if unavailable
+
+    # Get user site-packages
+    try:
+        user_site = site.getusersitepackages()
+        if user_site and Path(user_site).exists():
+            site_packages.append(Path(user_site))
+    except (AttributeError, OSError):
+        pass  # Continue without user site packages
+
+    info['site_packages'] = site_packages
+    info['sys_path'] = [Path(p) for p in sys.path if p]
+
+    return info
+
+
+def extract_module_name(filename, path_info):
+    """Extract Python module name and type from file path.
+
+    Args:
+        filename: Path to the Python file
+        path_info: Dictionary from get_python_path_info()
+
+    Returns:
+        tuple: (module_name, module_type) where module_type is one of:
+               'stdlib', 'site-packages', 'project', or 'other'
+    """
+    if not filename:
+        return ('unknown', 'other')
+
+    try:
+        file_path = Path(filename)
+    except (ValueError, OSError):
+        return (str(filename), 'other')
+
+    # Check if it's in stdlib
+    if path_info['stdlib'] and _is_subpath(file_path, path_info['stdlib']):
+        try:
+            rel_path = file_path.relative_to(path_info['stdlib'])
+            return (_path_to_module(rel_path), 'stdlib')
+        except ValueError:
+            pass
+
+    # Check site-packages
+    for site_pkg in path_info['site_packages']:
+        if _is_subpath(file_path, site_pkg):
+            try:
+                rel_path = file_path.relative_to(site_pkg)
+                return (_path_to_module(rel_path), 'site-packages')
+            except ValueError:
+                continue
+
+    # Check other sys.path entries (project files)
+    if not str(file_path).startswith(('<', '[')):  # Skip special files
+        for path_entry in path_info['sys_path']:
+            if _is_subpath(file_path, path_entry):
+                try:
+                    rel_path = file_path.relative_to(path_entry)
+                    return (_path_to_module(rel_path), 'project')
+                except ValueError:
+                    continue
+
+    # Fallback: just use the filename
+    return (_path_to_module(file_path), 'other')
+
+
+def _is_subpath(file_path, parent_path):
+    try:
+        file_path.relative_to(parent_path)
+        return True
+    except (ValueError, OSError):
+        return False
+
+
+def _path_to_module(path):
+    if isinstance(path, str):
+        path = Path(path)
+
+    # Remove .py extension
+    if path.suffix == '.py':
+        path = path.with_suffix('')
+
+    # Convert path separators to dots
+    parts = path.parts
+
+    # Handle __init__ files - they represent the package itself
+    if parts and parts[-1] == '__init__':
+        parts = parts[:-1]
+
+    return '.'.join(parts) if parts else path.stem

--- a/Lib/profiling/sampling/module_utils.py
+++ b/Lib/profiling/sampling/module_utils.py
@@ -66,42 +66,22 @@ def extract_module_name(filename, path_info):
         return (str(filename), 'other')
 
     # Check if it's in stdlib
-    if path_info['stdlib'] and _is_subpath(file_path, path_info['stdlib']):
-        try:
-            rel_path = file_path.relative_to(path_info['stdlib'])
-            return (_path_to_module(rel_path), 'stdlib')
-        except ValueError:
-            pass
+    if path_info['stdlib'] and file_path.is_relative_to(path_info['stdlib']):
+        return (_path_to_module(file_path.relative_to(path_info['stdlib'])), 'stdlib')
 
     # Check site-packages
     for site_pkg in path_info['site_packages']:
-        if _is_subpath(file_path, site_pkg):
-            try:
-                rel_path = file_path.relative_to(site_pkg)
-                return (_path_to_module(rel_path), 'site-packages')
-            except ValueError:
-                continue
+        if file_path.is_relative_to(site_pkg):
+            return (_path_to_module(file_path.relative_to(site_pkg)), 'site-packages')
 
     # Check other sys.path entries (project files)
     if not str(file_path).startswith(('<', '[')):  # Skip special files
         for path_entry in path_info['sys_path']:
-            if _is_subpath(file_path, path_entry):
-                try:
-                    rel_path = file_path.relative_to(path_entry)
-                    return (_path_to_module(rel_path), 'project')
-                except ValueError:
-                    continue
+            if file_path.is_relative_to(path_entry):
+                return (_path_to_module(file_path.relative_to(path_entry)), 'project')
 
     # Fallback: just use the filename
     return (_path_to_module(file_path), 'other')
-
-
-def _is_subpath(file_path, parent_path):
-    try:
-        file_path.relative_to(parent_path)
-        return True
-    except (ValueError, OSError):
-        return False
 
 
 def _path_to_module(path):

--- a/Lib/profiling/sampling/stack_collector.py
+++ b/Lib/profiling/sampling/stack_collector.py
@@ -170,7 +170,23 @@ class FlamegraphCollector(StackTraceCollector):
 
     @staticmethod
     @functools.lru_cache(maxsize=None)
-    def _format_function_name(func, module_name):
+    def _format_function_name(func):
+        filename, lineno, funcname = func
+
+        # Special frames like <GC> and <native> should not show file:line
+        if filename == "~" and lineno == 0:
+            return funcname
+
+        if len(filename) > 50:
+            parts = filename.split("/")
+            if len(parts) > 2:
+                filename = f".../{'/'.join(parts[-2:])}"
+
+        return f"{funcname} ({filename}:{lineno})"
+
+    @staticmethod
+    @functools.lru_cache(maxsize=None)
+    def _format_module_name(func, module_name):
         filename, lineno, funcname = func
 
         # Special frames like <GC> and <native> should not show file:line
@@ -209,10 +225,12 @@ class FlamegraphCollector(StackTraceCollector):
                 module_name = self._get_module_name(func[0], path_info)
 
                 module_name_idx = self._string_table.intern(module_name)
-                name_idx = self._string_table.intern(self._format_function_name(func, module_name))
+                name_idx = self._string_table.intern(self._format_function_name(func))
+                name_module_idx = self._string_table.intern(self._format_module_name(func, module_name))
 
                 child_entry = {
                     "name": name_idx,
+                    "name_module": name_module_idx,
                     "value": samples,
                     "self": node.get("self", 0),
                     "children": [],

--- a/Lib/profiling/sampling/stack_collector.py
+++ b/Lib/profiling/sampling/stack_collector.py
@@ -12,6 +12,7 @@ from ._css_utils import get_combined_css
 from .collector import Collector, extract_lineno
 from .opcode_utils import get_opcode_mapping
 from .string_table import StringTable
+from .module_utils import extract_module_name, get_python_path_info
 
 
 class StackTraceCollector(Collector):
@@ -72,6 +73,7 @@ class FlamegraphCollector(StackTraceCollector):
         self._sample_count = 0  # Track actual number of samples (not thread traces)
         self._func_intern = {}
         self._string_table = StringTable()
+        self._module_cache = {}
         self._all_threads = set()
 
         # Thread status statistics (similar to LiveStatsCollector)
@@ -168,19 +170,21 @@ class FlamegraphCollector(StackTraceCollector):
 
     @staticmethod
     @functools.lru_cache(maxsize=None)
-    def _format_function_name(func):
+    def _format_function_name(func, module_name):
         filename, lineno, funcname = func
 
         # Special frames like <GC> and <native> should not show file:line
         if filename == "~" and lineno == 0:
             return funcname
 
-        if len(filename) > 50:
-            parts = filename.split("/")
-            if len(parts) > 2:
-                filename = f".../{'/'.join(parts[-2:])}"
+        return f"{funcname} ({module_name}:{lineno})"
 
-        return f"{funcname} ({filename}:{lineno})"
+    def _get_module_name(self, filename, path_info):
+        module_name = self._module_cache.get(filename)
+        if module_name is None:
+            module_name, _ = extract_module_name(filename, path_info)
+            self._module_cache[filename] = module_name
+        return module_name
 
     def _convert_to_flamegraph_format(self):
         if self._total_samples == 0:
@@ -192,7 +196,7 @@ class FlamegraphCollector(StackTraceCollector):
                 "strings": self._string_table.get_strings()
             }
 
-        def convert_children(children, min_samples):
+        def convert_children(children, min_samples, path_info):
             out = []
             for func, node in children.items():
                 samples = node["samples"]
@@ -202,7 +206,10 @@ class FlamegraphCollector(StackTraceCollector):
                 # Intern all string components for maximum efficiency
                 filename_idx = self._string_table.intern(func[0])
                 funcname_idx = self._string_table.intern(func[2])
-                name_idx = self._string_table.intern(self._format_function_name(func))
+                module_name = self._get_module_name(func[0], path_info)
+
+                module_name_idx = self._string_table.intern(module_name)
+                name_idx = self._string_table.intern(self._format_function_name(func, module_name))
 
                 child_entry = {
                     "name": name_idx,
@@ -210,6 +217,7 @@ class FlamegraphCollector(StackTraceCollector):
                     "self": node.get("self", 0),
                     "children": [],
                     "filename": filename_idx,
+                    "module_name": module_name_idx,
                     "lineno": func[1],
                     "funcname": funcname_idx,
                     "threads": sorted(list(node.get("threads", set()))),
@@ -228,7 +236,7 @@ class FlamegraphCollector(StackTraceCollector):
 
                 # Recurse
                 child_entry["children"] = convert_children(
-                    node["children"], min_samples
+                    node["children"], min_samples, path_info
                 )
                 out.append(child_entry)
 
@@ -239,8 +247,9 @@ class FlamegraphCollector(StackTraceCollector):
         # Filter out very small functions (less than 0.1% of total samples)
         total_samples = self._total_samples
         min_samples = max(1, int(total_samples * 0.001))
+        path_info = get_python_path_info()
 
-        root_children = convert_children(self._root["children"], min_samples)
+        root_children = convert_children(self._root["children"], min_samples, path_info)
         if not root_children:
             return {
                 "name": self._string_table.intern("No significant data"),

--- a/Lib/profiling/sampling/stack_collector.py
+++ b/Lib/profiling/sampling/stack_collector.py
@@ -224,18 +224,18 @@ class FlamegraphCollector(StackTraceCollector):
                 funcname_idx = self._string_table.intern(func[2])
                 module_name = self._get_module_name(func[0], path_info)
 
-                module_name_idx = self._string_table.intern(module_name)
+                module_idx = self._string_table.intern(module_name)
                 name_idx = self._string_table.intern(self._format_function_name(func))
-                name_module_idx = self._string_table.intern(self._format_module_name(func, module_name))
+                label_idx = self._string_table.intern(self._format_module_name(func, module_name))
 
                 child_entry = {
                     "name": name_idx,
-                    "name_module": name_module_idx,
+                    "label": label_idx,
                     "value": samples,
                     "self": node.get("self", 0),
                     "children": [],
                     "filename": filename_idx,
-                    "module_name": module_name_idx,
+                    "module": module_idx,
                     "lineno": func[1],
                     "funcname": funcname_idx,
                     "threads": sorted(list(node.get("threads", set()))),

--- a/Lib/profiling/sampling/stack_collector.py
+++ b/Lib/profiling/sampling/stack_collector.py
@@ -309,10 +309,11 @@ class FlamegraphCollector(StackTraceCollector):
         # If we only have one root child, make it the root to avoid redundant level
         if len(root_children) == 1:
             main_child = root_children[0]
-            # Update the name to indicate it's the program root
+            # Update name and label to indicate it's the program root
             old_name = self._string_table.get_string(main_child["name"])
-            new_name = f"Program Root: {old_name}"
-            main_child["name"] = self._string_table.intern(new_name)
+            main_child["name"] = self._string_table.intern(f"Program Root: {old_name}")
+            old_label = self._string_table.get_string(main_child["label"])
+            main_child["label"] = self._string_table.intern(f"Program Root: {old_label}")
             main_child["stats"] = {
                 **self.stats,
                 "thread_stats": thread_stats,
@@ -323,8 +324,10 @@ class FlamegraphCollector(StackTraceCollector):
             main_child["opcode_mapping"] = opcode_mapping
             return main_child
 
+        program_root_idx = self._string_table.intern("Program Root")
         return {
-            "name": self._string_table.intern("Program Root"),
+            "name": program_root_idx,
+            "label": program_root_idx,
             "value": total_samples,
             "children": root_children,
             "stats": {

--- a/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
@@ -435,14 +435,14 @@ class TestSampleProfilerComponents(unittest.TestCase):
         strings = data.get("strings", [])
         name = resolve_name(data, strings)
         self.assertTrue(name.startswith("Program Root: "))
-        self.assertIn("func2 (file:20)", name)
+        self.assertIn("func2 (file.py:20)", name)
         label = strings[data["label"]]
         self.assertTrue(label.startswith("Program Root: "))
         self.assertEqual(data["self"], 0)  # non-leaf: no self time
         children = data.get("children", [])
         self.assertEqual(len(children), 1)
         child = children[0]
-        self.assertIn("func1 (file:10)", resolve_name(child, strings))
+        self.assertIn("func1 (file.py:10)", resolve_name(child, strings))
         self.assertEqual(child["value"], 1)
         self.assertEqual(child["self"], 1)  # leaf: all time is self
 

--- a/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
@@ -436,6 +436,8 @@ class TestSampleProfilerComponents(unittest.TestCase):
         name = resolve_name(data, strings)
         self.assertTrue(name.startswith("Program Root: "))
         self.assertIn("func2 (file:20)", name)
+        label = strings[data["label"]]
+        self.assertTrue(label.startswith("Program Root: "))
         self.assertEqual(data["self"], 0)  # non-leaf: no self time
         children = data.get("children", [])
         self.assertEqual(len(children), 1)

--- a/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
@@ -435,12 +435,12 @@ class TestSampleProfilerComponents(unittest.TestCase):
         strings = data.get("strings", [])
         name = resolve_name(data, strings)
         self.assertTrue(name.startswith("Program Root: "))
-        self.assertIn("func2 (file.py:20)", name)
+        self.assertIn("func2 (file:20)", name)
         self.assertEqual(data["self"], 0)  # non-leaf: no self time
         children = data.get("children", [])
         self.assertEqual(len(children), 1)
         child = children[0]
-        self.assertIn("func1 (file.py:10)", resolve_name(child, strings))
+        self.assertIn("func1 (file:10)", resolve_name(child, strings))
         self.assertEqual(child["value"], 1)
         self.assertEqual(child["self"], 1)  # leaf: all time is self
 


### PR DESCRIPTION
Display module names instead of full file paths (`/home/user/project/pkg/mod.py` → `pkg.mod`) in flamegraph for readability.

<img width="2553" height="926" alt="image" src="https://github.com/user-attachments/assets/50f7d803-d03f-4dbf-8889-ec72984a4d99" />

CC: @pablogsal @lkollar 

The issue:
> Show module names instead of full file paths — /home/user/project/pkg/mod.py → pkg.mod for readability

<!-- gh-issue-number: gh-138122 -->
* Issue: gh-138122
<!-- /gh-issue-number -->

<!-- gh-issue-number: gh-142927 -->
* Issue: gh-142927
<!-- /gh-issue-number -->
