### PR TITLE
gh-146056: Fix TreeBuilder stack in xml.etree

### DIFF
--- a/Lib/test/test_xml_etree_c.py
+++ b/Lib/test/test_xml_etree_c.py
@@ -1,4 +1,5 @@
 # xml.etree test for cElementTree
+import gc
 import io
 import struct
 from test import support
@@ -202,6 +203,23 @@ class MiscTests(unittest.TestCase):
         root = cET.fromstring('<a></a>')
         iter_type = type(root.iter())
         support.check_disallow_instantiation(self, iter_type)
+
+    def test_tree_builder_stack(self):
+        builder = cET.TreeBuilder()
+        for x in range(10):
+            builder.start("a", {})
+        for x in range(10):
+            builder.end("a")
+        root = builder.close()
+
+        # Find the internal TreeBuilder stack list using gc.get_referrers()
+        for ref in gc.get_referrers(root[0]):
+            if isinstance(ref, list):
+                # Check that the list doesn't contain NULL items (gh-146056)
+                repr(ref)
+                break
+        else:
+            self.fail("failed to find TreeBuilder stack list")
 
 
 @unittest.skipUnless(cET, 'requires _elementtree')

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -2431,7 +2431,7 @@ treebuilder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         t->element_factory = NULL;
         t->comment_factory = NULL;
         t->pi_factory = NULL;
-        t->stack = PyList_New(20);
+        t->stack = PyList_New(0);
         if (!t->stack) {
             Py_DECREF(t->this);
             Py_DECREF(t->last);
@@ -2856,9 +2856,9 @@ treebuilder_handle_end(TreeBuilderObject* self, PyObject* tag)
 
     item = self->last;
     self->last = Py_NewRef(self->this);
-    Py_XSETREF(self->last_for_tail, self->last);
+    Py_XSETREF(self->last_for_tail, Py_NewRef(self->last));
     self->index--;
-    self->this = Py_NewRef(PyList_GET_ITEM(self->stack, self->index));
+    Py_SETREF(self->this, Py_NewRef(PyList_GET_ITEM(self->stack, self->index)));
     Py_DECREF(item);
 
     if (treebuilder_append_event(self, self->end_event_obj, self->last) < 0)


### PR DESCRIPTION
No longer create a stack of 20 items, but create an empty stack instead. It prevents crashes when the stack list is discovered by gc.get_referrers() or other functions.

Fix also reference counting in treebuilder_handle_end().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146056 -->
* Issue: gh-146056
<!-- /gh-issue-number -->
