### PR TITLE
Fix entry in `fuzz_pycompile.dict`

### DIFF
--- a/Modules/_xxtestfuzz/dictionaries/fuzz_pycompile.dict
+++ b/Modules/_xxtestfuzz/dictionaries/fuzz_pycompile.dict
@@ -54,7 +54,7 @@
 "  "
 "\\t"
 ":\\n  "
-"\\\n"
+"\\\\n"
 
 # type signatures and functions
 "-> "


### PR DESCRIPTION
It is invalid, see today's build for example: https://oss-fuzz-build-logs.storage.googleapis.com/log-3341d39d-23f7-43dc-aeae-2509072fc818.txt#:~:text=Step%20%2340%20%2D%20%22build%2Dcheck%2Dlibfuzzer%2Dundefined%2Dx86%5F64%22%3A%20ParseDictionaryFile%3A%20error%20in%20line%2057

I added it recently in https://github.com/python/cpython/commit/40095d526bd8ddbabee0603c2b502ed6807e5f4d.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
