### PR TITLE
gh-146075: Prevent crash in `functools.partial()` from malformed `str` subclass

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -565,7 +565,19 @@ class TestPartial:
         g_partial = functools.partial(func, trigger, None, None, None, None, arg=None)
         self.assertEqual(repr(g_partial),"functools.partial(Function(old_function), EvilObject, None, None, None, None, arg=None)")
 
+    def test_str_subclass_error(self):
+        class BadStr(str):
+            def __eq__(self, other):
+                raise RuntimeError
+            def __hash__(self):
+                return str.__hash__(self)
 
+        def f(**kwargs):
+            return kwargs
+
+        p = functools.partial(f, poison="")
+        with self.assertRaises(RuntimeError):
+            result = p(**{BadStr("poison"): "new_value"})
 
 @unittest.skipUnless(c_functools, 'requires the C _functools module')
 class TestPartialC(TestPartial, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2026-03-17-19-30-45.gh-issue-146075.85sCSh.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-17-19-30-45.gh-issue-146075.85sCSh.rst
@@ -1,1 +1,1 @@
-Errors when calling :func:`partial` with a malformed keyword will no longer crash the interpreter.
+Errors when calling :func:`functools.partial` with a malformed keyword will no longer crash the interpreter.

--- a/Misc/NEWS.d/next/Library/2026-03-17-19-30-45.gh-issue-146075.85sCSh.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-17-19-30-45.gh-issue-146075.85sCSh.rst
@@ -1,0 +1,1 @@
+Errors when calling :func:`partial` with a malformed keyword will no longer crash the interpreter.

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -457,7 +457,11 @@ partial_vectorcall(PyObject *self, PyObject *const *args,
         for (Py_ssize_t i = 0; i < nkwds; ++i) {
             key = PyTuple_GET_ITEM(kwnames, i);
             val = args[nargs + i];
-            if (PyDict_Contains(pto->kw, key)) {
+            int contains = PyDict_Contains(pto->kw, key);
+            if (contains < 0) {
+                goto error;
+            }
+            else if (contains == 1) {
                 if (pto_kw_merged == NULL) {
                     pto_kw_merged = PyDict_Copy(pto->kw);
                     if (pto_kw_merged == NULL) {


### PR DESCRIPTION
In `partial_vectorcall`, an error returned by `PyDict_Contains` was considered to be a truthy value. Now, the error is handled appropriately.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146075 -->
* Issue: gh-146075
<!-- /gh-issue-number -->
