### PR TITLE
gh-146086: Clarify sys.getsizeof() docstring regarding additional overhead

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2006,7 +2006,8 @@ sys_getsizeof(PyObject *self, PyObject *args, PyObject *kwds)
 PyDoc_STRVAR(getsizeof_doc,
 "getsizeof(object [, default]) -> int\n\
 \n\
-Return the size of object in bytes.");
+Return the size of object in bytes.\n\
+The result may include additional memory overhead (e.g., for the garbage collector).");
 
 /*[clinic input]
 sys.getrefcount -> Py_ssize_t


### PR DESCRIPTION
This change clarifies the short built-in documentation for `sys.getsizeof()`.

The full documentation already explains that `getsizeof()` calls `__sizeof__()` and may add additional overhead (e.g., for the garbage collector). However, this distinction is not visible from the short help output (`help()` / `pydoc`).

This change adds a short clarification to reduce potential confusion.

This is a documentation-only change and does not affect runtime behavior. No NEWS entry is needed.

<!-- gh-issue-number: gh-146086 -->
* Issue: gh-146086
<!-- /gh-issue-number -->
