### PR TITLE
gh-85332: Support cross-compiling for GNU/Hurd

### DIFF
--- a/configure
+++ b/configure
@@ -4149,6 +4149,9 @@ then
 	*-*-darwin*)
 		ac_sys_system=Darwin
 		;;
+	*-gnu)
+		ac_sys_system=GNU
+		;;
 	*-*-vxworks*)
 	    ac_sys_system=VxWorks
 	    ;;
@@ -4618,6 +4621,9 @@ if test "$cross_compiling" = yes; then
 		*)
 			_host_ident=$host_cpu
 		esac
+		;;
+	*-gnu)
+		_host_ident=$host_cpu
 		;;
 	*-*-cygwin*)
 		_host_ident=

--- a/configure.ac
+++ b/configure.ac
@@ -342,6 +342,9 @@ then
 	*-*-darwin*)
 		ac_sys_system=Darwin
 		;;
+	*-gnu)
+		ac_sys_system=GNU
+		;;
 	*-*-vxworks*)
 	    ac_sys_system=VxWorks
 	    ;;
@@ -779,6 +782,9 @@ if test "$cross_compiling" = yes; then
 		*)
 			_host_ident=$host_cpu
 		esac
+		;;
+	*-gnu)
+		_host_ident=$host_cpu
 		;;
 	*-*-cygwin*)
 		_host_ident=


### PR DESCRIPTION
Recognise *-gnu (after `*-linux*`) as GNU/Hurd for cross-compilation.


<!-- gh-issue-number: gh-85332 -->
* Issue: gh-85332
<!-- /gh-issue-number -->
