### PR TITLE
gh-145886: remove unused Event.raw field from _pyrepl

### DIFF
--- a/Lib/_pyrepl/base_eventqueue.py
+++ b/Lib/_pyrepl/base_eventqueue.py
@@ -54,13 +54,11 @@ class BaseEventQueue:
         """
         return not self.events
 
-    def flush_buf(self) -> bytearray:
+    def flush_buf(self) -> None:
         """
-        Flushes the buffer and returns its contents.
+        Flushes the buffer.
         """
-        old = self.buf
         self.buf = bytearray()
-        return old
 
     def insert(self, event: Event) -> None:
         """
@@ -98,7 +96,9 @@ class BaseEventQueue:
             trace('unrecognized escape sequence, propagating...')
             self.keymap = self.compiled_keymap
             self.insert(Event('key', '\033'))
-            for _c in self.flush_buf()[1:]:
+            remaining = self.buf[1:]
+            self.flush_buf()
+            for _c in remaining:
                 self.push(_c)
 
         else:

--- a/Lib/_pyrepl/base_eventqueue.py
+++ b/Lib/_pyrepl/base_eventqueue.py
@@ -87,7 +87,8 @@ class BaseEventQueue:
             if isinstance(k, dict):
                 self.keymap = k
             else:
-                self.insert(Event('key', k, bytes(self.flush_buf())))
+                self.flush_buf()
+                self.insert(Event('key', k))
                 self.keymap = self.compiled_keymap
 
         elif self.buf and self.buf[0] == 27:  # escape
@@ -96,7 +97,7 @@ class BaseEventQueue:
             # the docstring in keymap.py
             trace('unrecognized escape sequence, propagating...')
             self.keymap = self.compiled_keymap
-            self.insert(Event('key', '\033', b'\033'))
+            self.insert(Event('key', '\033'))
             for _c in self.flush_buf()[1:]:
                 self.push(_c)
 
@@ -106,5 +107,6 @@ class BaseEventQueue:
             except UnicodeError:
                 return
             else:
-                self.insert(Event('key', decoded, bytes(self.flush_buf())))
+                self.flush_buf()
+                self.insert(Event('key', decoded))
             self.keymap = self.compiled_keymap

--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
 class Event:
     evt: str
     data: str
-    raw: bytes = b""
 
 
 @dataclass

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -537,19 +537,16 @@ class UnixConsole(Console):
             Returns:
             - Event: Pending event from the event queue.
             """
-            e = Event("key", "", b"")
+            e = Event("key", "")
 
             while not self.event_queue.empty():
                 e2 = self.event_queue.get()
                 e.data += e2.data
-                e.raw += e.raw
 
             amount = struct.unpack("i", ioctl(self.input_fd, FIONREAD, b"\0\0\0\0"))[0]
             trace("getpending({a})", a=amount)
             raw = self.__read(amount)
-            data = str(raw, self.encoding, "replace")
-            e.data += data
-            e.raw += raw
+            e.data += str(raw, self.encoding, "replace")
             return e
 
     else:
@@ -561,18 +558,15 @@ class UnixConsole(Console):
             Returns:
             - Event: Pending event from the event queue.
             """
-            e = Event("key", "", b"")
+            e = Event("key", "")
 
             while not self.event_queue.empty():
                 e2 = self.event_queue.get()
                 e.data += e2.data
-                e.raw += e.raw
 
             amount = 10000
             raw = self.__read(amount)
-            data = str(raw, self.encoding, "replace")
-            e.data += data
-            e.raw += raw
+            e.data += str(raw, self.encoding, "replace")
             return e
 
     def clear(self):

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -524,7 +524,7 @@ class WindowsConsole(Console):
     def getpending(self) -> Event:
         """Return the characters that have been typed but not yet
         processed."""
-        e = Event("key", "", b"")
+        e = Event("key", "")
 
         while not self.event_queue.empty():
             e2 = self.event_queue.get()

--- a/Lib/test/test_pyrepl/support.py
+++ b/Lib/test/test_pyrepl/support.py
@@ -45,7 +45,7 @@ def more_lines(text: str, namespace: dict | None = None):
 
 def code_to_events(code: str):
     for c in code:
-        yield Event(evt="key", data=c, raw=bytearray(c.encode("utf-8")))
+        yield Event(evt="key", data=c)
 
 
 def clean_screen(reader: ReadlineAlikeReader) -> list[str]:

--- a/Lib/test/test_pyrepl/test_eventqueue.py
+++ b/Lib/test/test_pyrepl/test_eventqueue.py
@@ -41,7 +41,7 @@ class EventQueueTestBase:
     def test_flush_buf(self):
         eq = self.make_eventqueue()
         eq.buf.extend(b"test")
-        self.assertEqual(eq.flush_buf(), b"test")
+        eq.flush_buf()
         self.assertEqual(eq.buf, bytearray())
 
     def test_insert(self):

--- a/Lib/test/test_pyrepl/test_eventqueue.py
+++ b/Lib/test/test_pyrepl/test_eventqueue.py
@@ -28,14 +28,14 @@ class EventQueueTestBase:
 
     def test_get(self):
         eq = self.make_eventqueue()
-        event = Event("key", "a", b"a")
+        event = Event("key", "a")
         eq.insert(event)
         self.assertEqual(eq.get(), event)
 
     def test_empty(self):
         eq = self.make_eventqueue()
         self.assertTrue(eq.empty())
-        eq.insert(Event("key", "a", b"a"))
+        eq.insert(Event("key", "a"))
         self.assertFalse(eq.empty())
 
     def test_flush_buf(self):
@@ -46,7 +46,7 @@ class EventQueueTestBase:
 
     def test_insert(self):
         eq = self.make_eventqueue()
-        event = Event("key", "a", b"a")
+        event = Event("key", "a")
         eq.insert(event)
         self.assertEqual(eq.events[0], event)
 
@@ -152,10 +152,8 @@ class EventQueueTestBase:
         eq = self.make_eventqueue()
         eq.keymap = {}
 
-        def _event(evt, data, raw=None):
-            r = raw if raw is not None else data.encode(eq.encoding)
-            e = Event(evt, data, r)
-            return e
+        def _event(evt, data):
+            return Event(evt, data)
 
         def _push(keys):
             for k in keys:

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -175,7 +175,7 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="up"),
             ],
         )
 
@@ -193,7 +193,7 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
+                Event(evt="key", data="down"),
             ],
         )
 
@@ -205,7 +205,7 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events("11+11"),
             [
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
+                Event(evt="key", data="left"),
             ],
         )
 
@@ -217,7 +217,7 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events("11+11"),
             [
-                Event(evt="key", data="right", raw=bytearray(b"\x1bOC")),
+                Event(evt="key", data="right"),
             ],
         )
 
@@ -247,7 +247,7 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events("樂"),
             [
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
+                Event(evt="key", data="left"),
             ],
         )
 
@@ -259,8 +259,8 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events("樂"),
             [
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
-                Event(evt="key", data="right", raw=bytearray(b"\x1bOC")),
+                Event(evt="key", data="left"),
+                Event(evt="key", data="right"),
             ],
         )
 
@@ -283,7 +283,7 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="up"),
             ],
         )
 
@@ -306,9 +306,9 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="left"),
+                Event(evt="key", data="down"),
             ],
         )
 
@@ -324,9 +324,9 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events("' 可口可乐; 可口可樂'"),
             [
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
+                Event(evt="key", data="left"),
+                Event(evt="key", data="left"),
+                Event(evt="key", data="left"),
             ],
         )
 
@@ -353,8 +353,8 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="up"),
             ],
         )
 
@@ -385,10 +385,10 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="down"),
+                Event(evt="key", data="down"),
             ],
         )
 
@@ -413,8 +413,8 @@ class TestCursorPosition(TestCase):
 
         events = itertools.chain(
             code_to_events(code),
-            13 * [Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))],
-            [Event(evt="key", data="up", raw=bytearray(b"\x1bOA"))],
+            13 * [Event(evt="key", data="left")],
+            [Event(evt="key", data="up")],
         )
 
         reader, _ = handle_all_events(events)
@@ -439,7 +439,7 @@ class TestCursorPosition(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="up"),
             ],
         )
         reader, _ = handle_events_narrow_console(events)
@@ -486,7 +486,7 @@ class TestPyReplAutoindent(TestCase):
             code_to_events("def f():\n"),
             # add backspace to delete default auto-indent
             [
-                Event(evt="key", data="backspace", raw=bytearray(b"\x7f")),
+                Event(evt="key", data="backspace"),
             ],
             code_to_events(
                 "  pass\n"
@@ -513,7 +513,7 @@ class TestPyReplAutoindent(TestCase):
             code_to_events("def f():\n"),
             # add backspace to delete default auto-indent
             [
-                Event(evt="key", data="backspace", raw=bytearray(b"\x7f")),
+                Event(evt="key", data="backspace"),
             ],
             code_to_events(
                 "  pass\n"
@@ -546,21 +546,21 @@ class TestPyReplAutoindent(TestCase):
             ),
             [
                 # go to the end of the first line
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="\x05", raw=bytearray(b"\x1bO5")),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="\x05"),
                 # new line should be autoindented
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt="key", data="\n"),
             ],
             code_to_events(
                 "pass"
             ),
             [
                 # go to end of last line
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
-                Event(evt="key", data="\x05", raw=bytearray(b"\x1bO5")),
+                Event(evt="key", data="down"),
+                Event(evt="key", data="\x05"),
                 # double newline to terminate the block
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt="key", data="\n"),
+                Event(evt="key", data="\n"),
             ],
         )
 
@@ -672,24 +672,24 @@ class TestPyReplOutput(ScreenEqualMixin, TestCase):
         events = itertools.chain(
             code_to_events("def f():\n...\n\n"),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
-                Event(evt="key", data="backspace", raw=bytearray(b"\x08")),
-                Event(evt="key", data="g", raw=bytearray(b"g")),
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
-                Event(evt="key", data="backspace", raw=bytearray(b"\x08")),
-                Event(evt="key", data="delete", raw=bytearray(b"\x7F")),
-                Event(evt="key", data="right", raw=bytearray(b"g")),
-                Event(evt="key", data="backspace", raw=bytearray(b"\x08")),
-                Event(evt="key", data="p", raw=bytearray(b"p")),
-                Event(evt="key", data="a", raw=bytearray(b"a")),
-                Event(evt="key", data="s", raw=bytearray(b"s")),
-                Event(evt="key", data="s", raw=bytearray(b"s")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="left"),
+                Event(evt="key", data="left"),
+                Event(evt="key", data="left"),
+                Event(evt="key", data="backspace"),
+                Event(evt="key", data="g"),
+                Event(evt="key", data="down"),
+                Event(evt="key", data="backspace"),
+                Event(evt="key", data="delete"),
+                Event(evt="key", data="right"),
+                Event(evt="key", data="backspace"),
+                Event(evt="key", data="p"),
+                Event(evt="key", data="a"),
+                Event(evt="key", data="s"),
+                Event(evt="key", data="s"),
+                Event(evt="key", data="\n"),
+                Event(evt="key", data="\n"),
             ],
         )
         reader = self.prepare_reader(events)
@@ -707,12 +707,12 @@ class TestPyReplOutput(ScreenEqualMixin, TestCase):
         events = itertools.chain(
             code_to_events("1+1\n2+2\n"),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="\n"),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="\n"),
             ],
         )
 
@@ -736,11 +736,11 @@ class TestPyReplOutput(ScreenEqualMixin, TestCase):
         events = list(itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="\n"),
+                Event(evt="key", data="\n"),
             ]
         ))
 
@@ -757,11 +757,11 @@ class TestPyReplOutput(ScreenEqualMixin, TestCase):
         events = itertools.chain(
             code_to_events("1+1\n2+2\n"),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="\n"),
+                Event(evt="key", data="down"),
+                Event(evt="key", data="down"),
             ],
         )
 
@@ -775,10 +775,10 @@ class TestPyReplOutput(ScreenEqualMixin, TestCase):
         events = itertools.chain(
             code_to_events("1+1\n2+2\n3+3\n"),
             [
-                Event(evt="key", data="\x12", raw=bytearray(b"\x12")),
-                Event(evt="key", data="1", raw=bytearray(b"1")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt="key", data="\x12"),
+                Event(evt="key", data="1"),
+                Event(evt="key", data="\n"),
+                Event(evt="key", data="\n"),
             ],
         )
 
@@ -810,8 +810,8 @@ class TestPyReplOutput(ScreenEqualMixin, TestCase):
             code_to_events("import os\n"),
             code_to_events("imp"),
             [
-                Event(evt='key', data='page up', raw=bytearray(b'\x1b[5~')),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt='key', data='page up'),
+                Event(evt="key", data="\n"),
             ],
         )
 
@@ -829,8 +829,8 @@ class TestPyReplOutput(ScreenEqualMixin, TestCase):
         events = itertools.chain(
             code_to_events("import os\n"),
             [
-                Event(evt='key', data='page up', raw=bytearray(b'\x1b[5~')),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt='key', data='page up'),
+                Event(evt="key", data="\n"),
             ],
         )
 
@@ -901,9 +901,9 @@ class TestPyReplCompleter(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
+                Event(evt="key", data="down"),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="down"),
             ],
             code_to_events("\n"),
         )
@@ -1372,11 +1372,11 @@ class TestPasteEvent(TestCase):
 
         events = itertools.chain(
             [
-                Event(evt="key", data="f3", raw=bytearray(b"\x1bOR")),
+                Event(evt="key", data="f3"),
             ],
             code_to_events(code),
             [
-                Event(evt="key", data="f3", raw=bytearray(b"\x1bOR")),
+                Event(evt="key", data="f3"),
             ],
             code_to_events("\n"),
         )
@@ -1396,11 +1396,11 @@ class TestPasteEvent(TestCase):
 
         events = itertools.chain(
             [
-                Event(evt="key", data="f3", raw=bytearray(b"\x1bOR")),
+                Event(evt="key", data="f3"),
             ],
             code_to_events(code),
             [
-                Event(evt="key", data="f3", raw=bytearray(b"\x1bOR")),
+                Event(evt="key", data="f3"),
             ],
             code_to_events("\n"),
         )
@@ -2042,7 +2042,7 @@ class TestPyReplCtrlD(TestCase):
     def test_ctrl_d_empty_line(self):
         """Test that pressing Ctrl+D on empty line exits the program"""
         events = [
-            Event(evt="key", data="\x04", raw=bytearray(b"\x04")),  # Ctrl+D
+            Event(evt="key", data="\x04"),  # Ctrl+D
         ]
         reader = self.prepare_reader(events)
         with self.assertRaises(EOFError):
@@ -2053,7 +2053,7 @@ class TestPyReplCtrlD(TestCase):
         events = itertools.chain(
             code_to_events("def f():\n    pass\n"),  # Enter multiline mode with trailing newline
             [
-                Event(evt="key", data="\x04", raw=bytearray(b"\x04")),  # Ctrl+D
+                Event(evt="key", data="\x04"),  # Ctrl+D
             ],
         )
         reader, _ = handle_all_events(events)
@@ -2065,10 +2065,10 @@ class TestPyReplCtrlD(TestCase):
         events = itertools.chain(
             code_to_events("def f():\n    hello world"),  # Enter multiline mode
             [
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))
+                Event(evt="key", data="left")
             ] * 5,  # move cursor to 'w' in "world"
             [
-                Event(evt="key", data="\x04", raw=bytearray(b"\x04"))
+                Event(evt="key", data="\x04")
             ], # Ctrl+D should delete 'w'
         )
         reader, _ = handle_all_events(events)
@@ -2080,7 +2080,7 @@ class TestPyReplCtrlD(TestCase):
         events = itertools.chain(
             code_to_events("def f():\n    hello"),  # Enter multiline mode, no trailing newline
             [
-                Event(evt="key", data="\x04", raw=bytearray(b"\x04"))
+                Event(evt="key", data="\x04")
             ],  # Ctrl+D should be no-op
         )
         reader, _ = handle_all_events(events)
@@ -2091,8 +2091,8 @@ class TestPyReplCtrlD(TestCase):
         """Test that pressing Ctrl+D in single line mode deletes current character"""
         events = itertools.chain(
             code_to_events("hello"),
-            [Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))],  # move left
-            [Event(evt="key", data="\x04", raw=bytearray(b"\x04"))],    # Ctrl+D
+            [Event(evt="key", data="left")],  # move left
+            [Event(evt="key", data="\x04")],    # Ctrl+D
         )
         reader, _ = handle_all_events(events)
         self.assertEqual("hell", "".join(reader.buffer))
@@ -2101,7 +2101,7 @@ class TestPyReplCtrlD(TestCase):
         """Test that pressing Ctrl+D at end of single line without newline does nothing"""
         events = itertools.chain(
             code_to_events("hello"),  # cursor at end of line
-            [Event(evt="key", data="\x04", raw=bytearray(b"\x04"))],  # Ctrl+D
+            [Event(evt="key", data="\x04")],  # Ctrl+D
         )
         reader, _ = handle_all_events(events)
         self.assertEqual("hello", "".join(reader.buffer))

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -96,7 +96,7 @@ class TestReader(ScreenEqualMixin, TestCase):
         events = itertools.chain(
             code_to_events("aaa"),
             [
-                Event(evt="key", data="backspace", raw=bytearray(b"\x7f")),
+                Event(evt="key", data="backspace"),
             ],
         )
         reader, _ = handle_all_events(events)
@@ -106,7 +106,7 @@ class TestReader(ScreenEqualMixin, TestCase):
         events = itertools.chain(
             code_to_events(10 * "a"),
             [
-                Event(evt="key", data="backspace", raw=bytearray(b"\x7f")),
+                Event(evt="key", data="backspace"),
             ],
         )
         reader, _ = handle_events_narrow_console(events)
@@ -116,7 +116,7 @@ class TestReader(ScreenEqualMixin, TestCase):
         events = itertools.chain(
             code_to_events(11 * "a"),
             [
-                Event(evt="key", data="backspace", raw=bytearray(b"\x7f")),
+                Event(evt="key", data="backspace"),
             ],
         )
         reader, _ = handle_events_narrow_console(events)
@@ -170,8 +170,8 @@ class TestReader(ScreenEqualMixin, TestCase):
     def test_up_arrow_after_ctrl_r(self):
         events = iter(
             [
-                Event(evt="key", data="\x12", raw=bytearray(b"\x12")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="\x12"),
+                Event(evt="key", data="up"),
             ]
         )
 
@@ -190,19 +190,19 @@ class TestReader(ScreenEqualMixin, TestCase):
             code_to_events(code),
             [
                 # go to the end of the first line
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="\x05", raw=bytearray(b"\x1bO5")),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="\x05"),
                 # new lines in-block shouldn't terminate the block
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt="key", data="\n"),
+                Event(evt="key", data="\n"),
                 # end of line 2
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
-                Event(evt="key", data="\x05", raw=bytearray(b"\x1bO5")),
+                Event(evt="key", data="down"),
+                Event(evt="key", data="\x05"),
                 # a double new line in-block should terminate the block
                 # even if its followed by whitespace
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
-                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt="key", data="\n"),
+                Event(evt="key", data="\n"),
             ],
         )
 
@@ -243,9 +243,9 @@ class TestReader(ScreenEqualMixin, TestCase):
             code_to_events(code),
             [
                 # Two tabs for completion
-                Event(evt="key", data="\t", raw=bytearray(b"\t")),
-                Event(evt="key", data="\t", raw=bytearray(b"\t")),
-                Event(evt="key", data="\x03", raw=bytearray(b"\x03")),  # Ctrl-C
+                Event(evt="key", data="\t"),
+                Event(evt="key", data="\t"),
+                Event(evt="key", data="\x03"),  # Ctrl-C
             ],
         )
         console = prepare_console(events)
@@ -307,8 +307,8 @@ class TestReader(ScreenEqualMixin, TestCase):
             code_to_events(code),
             [
                 # Two tabs for completion
-                Event(evt="key", data="\t", raw=bytearray(b"\t")),
-                Event(evt="key", data="\t", raw=bytearray(b"\t")),
+                Event(evt="key", data="\t"),
+                Event(evt="key", data="\t"),
             ],
             code_to_events("a"),
         )
@@ -330,7 +330,7 @@ class TestReader(ScreenEqualMixin, TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="\t", raw=bytearray(b"\t")),
+                Event(evt="key", data="\t"),
             ],
             code_to_events("a"),
         )
@@ -413,7 +413,7 @@ class TestReaderInColor(ScreenEqualMixin, TestCase):
         expected_async = expected.format(a=async_msg, **colors)
         more_events = itertools.chain(
             code_to_events(code),
-            [Event(evt="key", data="up", raw=bytearray(b"\x1bOA"))] * 15,
+            [Event(evt="key", data="up")] * 15,
             code_to_events("async "),
         )
         reader, _ = handle_all_events(more_events)

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -142,7 +142,7 @@ class TestConsole(TestCase):
         code = "1"
         events = itertools.chain(
             code_to_events(code),
-            [Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))],
+            [Event(evt="key", data="left")],
         )
         _, con = handle_events_unix_console(events)
         _os_write.assert_any_call(ANY, TERM_CAPABILITIES["cub"] + b":1")
@@ -153,8 +153,8 @@ class TestConsole(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
-                Event(evt="key", data="right", raw=bytearray(b"\x1bOC")),
+                Event(evt="key", data="left"),
+                Event(evt="key", data="right"),
             ],
         )
         _, con = handle_events_unix_console(events)
@@ -166,7 +166,7 @@ class TestConsole(TestCase):
         code = "1\n2+3"
         events = itertools.chain(
             code_to_events(code),
-            [Event(evt="key", data="up", raw=bytearray(b"\x1bOA"))],
+            [Event(evt="key", data="up")],
         )
         _, con = handle_events_unix_console(events)
         _os_write.assert_any_call(ANY, TERM_CAPABILITIES["cuu"] + b":1")
@@ -177,8 +177,8 @@ class TestConsole(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="down"),
             ],
         )
         _, con = handle_events_unix_console(events)
@@ -189,7 +189,7 @@ class TestConsole(TestCase):
     def test_cursor_back_write(self, _os_write):
         events = itertools.chain(
             code_to_events("1"),
-            [Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))],
+            [Event(evt="key", data="left")],
             code_to_events("2"),
         )
         _, con = handle_events_unix_console(events)
@@ -209,7 +209,7 @@ class TestConsole(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="up"),
                 Event(evt="scroll", data=None),
             ],
         )
@@ -228,9 +228,9 @@ class TestConsole(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="up"),
                 Event(evt="scroll", data=None),
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
+                Event(evt="key", data="down"),
                 Event(evt="scroll", data=None),
             ],
         )

--- a/Lib/test/test_pyrepl/test_windows_console.py
+++ b/Lib/test/test_pyrepl/test_windows_console.py
@@ -596,7 +596,7 @@ class WindowsConsoleGetEventTests(TestCase):
     def test_backspace_vt(self):
         ir = self.get_input_record("\x7f")
         self.assertEqual(self.get_event([ir], vt_support=True),
-                         Event("key", "backspace", b"\x7f"))
+                         Event("key", "backspace"))
         self.assertEqual(self.mock.call_count, 1)
 
     def test_up_vt(self):

--- a/Lib/test/test_pyrepl/test_windows_console.py
+++ b/Lib/test/test_pyrepl/test_windows_console.py
@@ -183,7 +183,7 @@ class WindowsConsoleTests(TestCase):
         code = "1"
         events = itertools.chain(
             code_to_events(code),
-            [Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))],
+            [Event(evt="key", data="left")],
         )
         _, con = self.handle_events(events)
         con.out.write.assert_any_call(self.move_left())
@@ -194,8 +194,8 @@ class WindowsConsoleTests(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="left", raw=bytearray(b"\x1bOD")),
-                Event(evt="key", data="right", raw=bytearray(b"\x1bOC")),
+                Event(evt="key", data="left"),
+                Event(evt="key", data="right"),
             ],
         )
         _, con = self.handle_events(events)
@@ -207,7 +207,7 @@ class WindowsConsoleTests(TestCase):
         code = "1\n2+3"
         events = itertools.chain(
             code_to_events(code),
-            [Event(evt="key", data="up", raw=bytearray(b"\x1bOA"))],
+            [Event(evt="key", data="up")],
         )
         _, con = self.handle_events(events)
         con.out.write.assert_any_call(self.move_up())
@@ -218,8 +218,8 @@ class WindowsConsoleTests(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
+                Event(evt="key", data="up"),
+                Event(evt="key", data="down"),
             ],
         )
         _, con = self.handle_events(events)
@@ -230,7 +230,7 @@ class WindowsConsoleTests(TestCase):
     def test_cursor_back_write(self):
         events = itertools.chain(
             code_to_events("1"),
-            [Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))],
+            [Event(evt="key", data="left")],
             code_to_events("2"),
         )
         _, con = self.handle_events(events)
@@ -250,7 +250,7 @@ class WindowsConsoleTests(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="up"),
                 Event(evt="scroll", data=None),
             ],
         )
@@ -270,9 +270,9 @@ class WindowsConsoleTests(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="up"),
                 Event(evt="scroll", data=None),
-                Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
+                Event(evt="key", data="down"),
                 Event(evt="scroll", data=None),
             ],
         )
@@ -378,8 +378,8 @@ class WindowsConsoleTests(TestCase):
         events = itertools.chain(
             code_to_events(code),
             [
-                Event(evt="key", data='\x1a', raw=bytearray(b'\x1a')),
-                Event(evt="key", data='\x1a', raw=bytearray(b'\x1a')),
+                Event(evt="key", data='\x1a'),
+                Event(evt="key", data='\x1a'),
             ],
         )
         reader, con = self.handle_events_narrow(events)
@@ -602,7 +602,7 @@ class WindowsConsoleGetEventTests(TestCase):
     def test_up_vt(self):
         irs = [self.get_input_record(x) for x in "\x1b[A"]
         self.assertEqual(self.get_event(irs, vt_support=True),
-                         Event(evt='key', data='up', raw=bytearray(b'\x1b[A')))
+                         Event(evt='key', data='up'))
         self.assertEqual(self.mock.call_count, 3)
 
     # All tests above assume that there is always keyboard data to read,

--- a/Misc/NEWS.d/next/Library/2026-03-18-12-18-13.gh-issue-145886.AqtULx.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-18-12-18-13.gh-issue-145886.AqtULx.rst
@@ -1,0 +1,2 @@
+Remove unused ``Event.raw`` field from :mod:`_pyrepl`. The field was only
+written to and never read, and had a copy-paste bug in ``getpending()``.

--- a/Misc/NEWS.d/next/Library/2026-03-18-12-18-13.gh-issue-145886.AqtULx.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-18-12-18-13.gh-issue-145886.AqtULx.rst
@@ -1,2 +1,2 @@
-Remove unused ``Event.raw`` field from :mod:`_pyrepl`. The field was only
+Remove unused ``Event.raw`` field from ``_pyrepl``. The field was only
 written to and never read, and had a copy-paste bug in ``getpending()``.


### PR DESCRIPTION
While looking at the `getpending()` bug (`e.raw += e.raw` instead of `e2.raw`), I noticed `Event.raw` is never actually read anywhere -- only written to. So instead of just fixing the typo, this removes the dead field entirely.

Removed `raw: bytes = b""` from the `Event` dataclass along with all related assignments in `unix_console.py`, `windows_console.py`, and `base_eventqueue.py`. The `flush_buf()` calls are kept since they still need to clear the internal buffer, just no longer pass the result to `Event`.

Tests updated to match.

<!-- gh-issue-number: gh-145886 -->
* Issue: gh-145886
<!-- /gh-issue-number -->
