### PR TITLE
docs: fix f-string in ExceptionGroup example

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -549,9 +549,9 @@ caught like any other exception. ::
    >>> try:
    ...     f()
    ... except Exception as e:
-   ...     print(f'caught {type(e)}: e')
+   ...     print(f'caught {type(e)}: {e}')
    ...
-   caught <class 'ExceptionGroup'>: e
+   caught <class 'ExceptionGroup'>: there were problems (2 sub-exceptions)
    >>>
 
 By using ``except*`` instead of ``except``, we can selectively


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Example prints literal 'e' instead of the exception object

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146108.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->