### PR TITLE
gh-145254: Fix formatting of thread safety annotations

### DIFF
--- a/Doc/tools/extensions/c_annotations.py
+++ b/Doc/tools/extensions/c_annotations.py
@@ -308,27 +308,27 @@ def _unstable_api_annotation() -> nodes.admonition:
 def _threadsafety_annotation(level: str) -> nodes.emphasis:
     match level:
         case "incompatible":
-            display = sphinx_gettext("Not safe to call from multiple threads.")
+            display = sphinx_gettext("Not safe to call from multiple threads")
             reftarget = "threadsafety-level-incompatible"
         case "compatible":
             display = sphinx_gettext(
                 "Safe to call from multiple threads"
-                " with external synchronization only."
+                " with external synchronization only"
             )
             reftarget = "threadsafety-level-compatible"
         case "distinct":
             display = sphinx_gettext(
                 "Safe to call without external synchronization"
-                " on distinct objects."
+                " on distinct objects"
             )
             reftarget = "threadsafety-level-distinct"
         case "shared":
             display = sphinx_gettext(
-                "Safe for concurrent use on the same object."
+                "Safe for concurrent use on the same object"
             )
             reftarget = "threadsafety-level-shared"
         case "atomic":
-            display = sphinx_gettext("Atomic.")
+            display = sphinx_gettext("Atomic")
             reftarget = "threadsafety-level-atomic"
         case _:
             raise AssertionError(f"Unknown thread safety level {level!r}")
@@ -340,9 +340,11 @@ def _threadsafety_annotation(level: str) -> nodes.emphasis:
         reftype="ref",
         refexplicit="True",
     )
-    prefix = sphinx_gettext("Thread safety:") + " "
+    prefix = " " + sphinx_gettext("Thread safety:") + " "
     classes = ["threadsafety", f"threadsafety-{level}"]
-    return nodes.emphasis("", prefix, ref_node, classes=classes)
+    return nodes.emphasis(
+        "", prefix, ref_node, nodes.Text("."), classes=classes
+    )
 
 
 def _return_value_annotation(result_refs: int | None) -> nodes.emphasis:


### PR DESCRIPTION
- Add leading space so that the spacing between the previous annotation and the thread safety annotation looks correct.
- Remove trailing period from the link to the thread safety level.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145254 -->
* Issue: gh-145254
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146111.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->