### PR TITLE
[3.14] gh-146092: Fix error handling in _BINARY_OP_ADD_FLOAT opcode

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-18-16-57-56.gh-issue-146092.wCKFYS.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-18-16-57-56.gh-issue-146092.wCKFYS.rst
@@ -1,0 +1,2 @@
+Handle properly memory allocation failures on float operations in the
+bytecode opcodes. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-18-16-57-56.gh-issue-146092.wCKFYS.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-18-16-57-56.gh-issue-146092.wCKFYS.rst
@@ -1,2 +1,2 @@
-Handle properly memory allocation failures on float operations in the
-bytecode opcodes. Patch by Victor Stinner.
+Handle properly memory allocation failures on str and float opcodes. Patch by
+Victor Stinner.

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -139,7 +139,11 @@ _PyStackRef _PyFloat_FromDouble_ConsumeInputs(_PyStackRef left, _PyStackRef righ
 {
     PyStackRef_CLOSE_SPECIALIZED(left, _PyFloat_ExactDealloc);
     PyStackRef_CLOSE_SPECIALIZED(right, _PyFloat_ExactDealloc);
-    return PyStackRef_FromPyObjectSteal(PyFloat_FromDouble(value));
+    PyObject *obj = PyFloat_FromDouble(value);
+    if (obj == NULL) {
+        return PyStackRef_NULL;
+    }
+    return PyStackRef_FromPyObjectSteal(obj);
 }
 
 static PyObject *

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -796,7 +796,7 @@ dummy_func(
             Py_DECREF(right_o);
             if (temp == NULL) {
                 *target_local = PyStackRef_NULL;
-                ERROR_IF(1);
+                ERROR_IF(true);
             }
             *target_local = PyStackRef_FromPyObjectSteal(temp);
         #if TIER_ONE

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -794,7 +794,10 @@ dummy_func(
             PyObject *right_o = PyStackRef_AsPyObjectSteal(right);
             PyUnicode_Append(&temp, right_o);
             Py_DECREF(right_o);
-            ERROR_IF(temp == NULL);
+            if (temp == NULL) {
+                *target_local = PyStackRef_NULL;
+                ERROR_IF(1);
+            }
             *target_local = PyStackRef_FromPyObjectSteal(temp);
         #if TIER_ONE
             // The STORE_FAST is already done. This is done here in tier one,

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -793,9 +793,9 @@ dummy_func(
             PyObject *temp = PyStackRef_AsPyObjectSteal(*target_local);
             PyObject *right_o = PyStackRef_AsPyObjectSteal(right);
             PyUnicode_Append(&temp, right_o);
-            *target_local = PyStackRef_FromPyObjectSteal(temp);
             Py_DECREF(right_o);
-            ERROR_IF(PyStackRef_IsNull(*target_local));
+            ERROR_IF(temp == NULL);
+            *target_local = PyStackRef_FromPyObjectSteal(temp);
         #if TIER_ONE
             // The STORE_FAST is already done. This is done here in tier one,
             // and during trace projection in tier two:

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1134,6 +1134,7 @@
             Py_DECREF(right_o);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (temp == NULL) {
+                *target_local = PyStackRef_NULL;
                 JUMP_TO_ERROR();
             }
             *target_local = PyStackRef_FromPyObjectSteal(temp);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1131,14 +1131,12 @@
             assert(WITHIN_STACK_BOUNDS());
             _PyFrame_SetStackPointer(frame, stack_pointer);
             PyUnicode_Append(&temp, right_o);
-            stack_pointer = _PyFrame_GetStackPointer(frame);
-            *target_local = PyStackRef_FromPyObjectSteal(temp);
-            _PyFrame_SetStackPointer(frame, stack_pointer);
             Py_DECREF(right_o);
             stack_pointer = _PyFrame_GetStackPointer(frame);
-            if (PyStackRef_IsNull(*target_local)) {
+            if (temp == NULL) {
                 JUMP_TO_ERROR();
             }
+            *target_local = PyStackRef_FromPyObjectSteal(temp);
             #if TIER_ONE
 
             assert(next_instr->op.code == STORE_FAST);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -392,14 +392,12 @@
                 assert(WITHIN_STACK_BOUNDS());
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyUnicode_Append(&temp, right_o);
-                stack_pointer = _PyFrame_GetStackPointer(frame);
-                *target_local = PyStackRef_FromPyObjectSteal(temp);
-                _PyFrame_SetStackPointer(frame, stack_pointer);
                 Py_DECREF(right_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
-                if (PyStackRef_IsNull(*target_local)) {
+                if (temp == NULL) {
                     JUMP_TO_LABEL(error);
                 }
+                *target_local = PyStackRef_FromPyObjectSteal(temp);
                 #if TIER_ONE
 
                 assert(next_instr->op.code == STORE_FAST);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -395,6 +395,7 @@
                 Py_DECREF(right_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (temp == NULL) {
+                    *target_local = PyStackRef_NULL;
                     JUMP_TO_LABEL(error);
                 }
                 *target_local = PyStackRef_FromPyObjectSteal(temp);


### PR DESCRIPTION
Fix error handling in _PyFloat_FromDouble_ConsumeInputs() used by _BINARY_OP_ADD_FLOAT, _BINARY_OP_SUBTRACT_FLOAT and _BINARY_OP_MULTIPLY_FLOAT opcodes. PyStackRef_FromPyObjectSteal() must not be called with a NULL pointer.

Fix also _BINARY_OP_INPLACE_ADD_UNICODE opcode.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146092 -->
* Issue: gh-146092
<!-- /gh-issue-number -->
