### PR TITLE
[3.13] gh-142183: Cache one datachunk per tstate to prevent alloc/dealloc thrashing (GH-145789)

### DIFF
--- a/Doc/data/python3.13.abi
+++ b/Doc/data/python3.13.abi
@@ -1670,7 +1670,7 @@
     <elf-symbol name='_PyNotImplemented_Type' size='416' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyOS_ReadlineTState' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyParser_TokenNames' size='536' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='_PyRuntime' size='283400' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_PyRuntime' size='283408' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PySet_Dummy' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyUnion_Type' size='416' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyWeakref_CallableProxyType' size='416' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1688,7 +1688,7 @@
     <elf-symbol name='_Py_ctype_tolower' size='256' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_Py_ctype_toupper' size='256' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr address-size='64' path='./Modules/_abc.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_abc.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyType_SetFlags' filepath='./Include/internal/pycore_typeobject.h' line='232' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-2'/>
@@ -1703,7 +1703,7 @@
     </function-decl>
     <type-decl name='unsigned long int' size-in-bits='64' id='type-id-2'/>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_codecsmodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_codecsmodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyUnicode_EncodeUTF7' filepath='./Include/internal/pycore_unicodeobject.h' line='90' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-5'/>
@@ -1737,10 +1737,10 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_io/_iomodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_io/_iomodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='_PyIO_Module' type-id='type-id-9' visibility='default' filepath='./Modules/_io/_iomodule.h' line='143' column='1'/>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_io/bufferedio.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_io/bufferedio.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <typedef-decl name='_PyIO_State' type-id='type-id-10' filepath='./Modules/_io/_iomodule.h' line='35' column='1' id='type-id-11'/>
     <typedef-decl name='Py_off_t' type-id='type-id-12' filepath='./Modules/_io/_iomodule.h' line='109' column='1' id='type-id-13'/>
     <class-decl name='_io_state' size-in-bits='1024' is-struct='yes' visibility='default' filepath='./Modules/_io/_iomodule.h' line='145' column='1' id='type-id-10'>
@@ -1828,11 +1828,11 @@
       <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_io/bytesio.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_io/bytesio.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='bytesio_spec' type-id='type-id-16' visibility='default' filepath='./Modules/_io/_iomodule.h' line='17' column='1'/>
     <var-decl name='bytesiobuf_spec' type-id='type-id-16' visibility='default' filepath='./Modules/_io/_iomodule.h' line='18' column='1'/>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_io/fileio.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_io/fileio.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='fileio_spec' type-id='type-id-16' visibility='default' filepath='./Modules/_io/_iomodule.h' line='19' column='1'/>
     <function-decl name='_PyIOBase_finalize' filepath='./Modules/_io/_iomodule.h' line='48' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-4'/>
@@ -1844,14 +1844,14 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_io/iobase.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_io/iobase.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='iobase_spec' type-id='type-id-16' visibility='default' filepath='./Modules/_io/_iomodule.h' line='20' column='1'/>
     <var-decl name='rawiobase_spec' type-id='type-id-16' visibility='default' filepath='./Modules/_io/_iomodule.h' line='22' column='1'/>
     <function-decl name='_PyIO_trap_eintr' filepath='./Modules/_io/_iomodule.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_io/stringio.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_io/stringio.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='stringio_spec' type-id='type-id-16' visibility='default' filepath='./Modules/_io/_iomodule.h' line='23' column='1'/>
     <function-decl name='_PyIncrementalNewlineDecoder_decode' filepath='./Modules/_io/_iomodule.h' line='55' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-4'/>
@@ -1870,7 +1870,7 @@
       <return type-id='type-id-7'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_io/textio.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_io/textio.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyCodec_LookupTextEncoding' filepath='./Include/internal/pycore_codecs.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-6'/>
       <parameter type-id='type-id-6'/>
@@ -1898,7 +1898,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_localemodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_localemodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='gettext' filepath='/usr/include/libintl.h' line='39' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-6'/>
       <return type-id='type-id-17'/>
@@ -1940,7 +1940,7 @@
       <return type-id='type-id-21'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_sre/sre.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_sre/sre.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <qualified-type-def type-id='type-id-22' const='yes' id='type-id-23'/>
     <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-24'/>
     <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-25'/>
@@ -1957,7 +1957,7 @@
     </function-decl>
     <type-decl name='unsigned short int' size-in-bits='16' id='type-id-22'/>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_threadmodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_threadmodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyMutex_TryUnlock' filepath='./Include/internal/pycore_lock.h' line='69' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-26'/>
       <return type-id='type-id-5'/>
@@ -1974,7 +1974,7 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_tracemalloc.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_tracemalloc.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyTraceMalloc_IsTracing' filepath='./Include/internal/pycore_tracemalloc.h' line='135' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-5'/>
     </function-decl>
@@ -2001,13 +2001,13 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/_weakref.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/_weakref.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyWeakref_GetWeakrefCount' filepath='./Include/internal/pycore_weakref.h' line='122' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-4'/>
       <return type-id='type-id-7'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/atexitmodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/atexitmodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='PyUnstable_AtExit' mangled-name='PyUnstable_AtExit' filepath='./Modules/atexitmodule.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_AtExit'>
       <parameter type-id='type-id-28' name='interp' filepath='./Modules/atexitmodule.c' line='27' column='1'/>
       <parameter type-id='type-id-29' name='func' filepath='./Modules/atexitmodule.c' line='28' column='1'/>
@@ -2015,7 +2015,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/faulthandler.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/faulthandler.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <enum-decl name='__rlimit_resource' filepath='/usr/include/x86_64-linux-gnu/bits/resource.h' line='31' column='1' id='type-id-31'>
       <underlying-type type-id='type-id-32'/>
       <enumerator name='RLIMIT_CPU' value='0'/>
@@ -2100,7 +2100,7 @@
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/getbuildinfo.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/getbuildinfo.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <type-decl name='char' size-in-bits='8' id='type-id-53'/>
     <type-decl name='int' size-in-bits='32' id='type-id-5'/>
     <type-decl name='unsigned long int' size-in-bits='64' id='type-id-2'/>
@@ -2125,7 +2125,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/getpath.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/getpath.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_Py_wfopen' filepath='./Include/internal/pycore_fileutils.h' line='129' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-18'/>
       <parameter type-id='type-id-18'/>
@@ -2164,7 +2164,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/posixmodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/posixmodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-62' size-in-bits='1024' id='type-id-63'>
       <subrange length='16' type-id='type-id-2' id='type-id-64'/>
     </array-type-def>
@@ -3393,7 +3393,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/pwdmodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/pwdmodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='passwd' size-in-bits='384' is-struct='yes' visibility='default' filepath='/usr/include/pwd.h' line='49' column='1' id='type-id-188'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='pw_name' type-id='type-id-17' visibility='default' filepath='/usr/include/pwd.h' line='51' column='1'/>
@@ -3447,7 +3447,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/signalmodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/signalmodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <enum-decl name='__itimer_which' filepath='/usr/include/x86_64-linux-gnu/sys/time.h' line='114' column='1' id='type-id-193'>
       <underlying-type type-id='type-id-32'/>
       <enumerator name='ITIMER_REAL' value='0'/>
@@ -3558,7 +3558,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/symtablemodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/symtablemodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_Py_SymtableStringObjectFlags' filepath='./Include/internal/pycore_symtable.h' line='190' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-6'/>
       <parameter type-id='type-id-4'/>
@@ -3567,7 +3567,7 @@
       <return type-id='type-id-207'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Modules/timemodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Modules/timemodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='_PyTimeFraction' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-208' visibility='default' filepath='./Include/internal/pycore_time.h' line='310' column='1' id='type-id-209'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='numer' type-id='type-id-210' visibility='default' filepath='./Include/internal/pycore_time.h' line='311' column='1'/>
@@ -3653,7 +3653,7 @@
       <return type-id='type-id-21'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Python/dynload_shlib.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Python/dynload_shlib.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='256' id='type-id-225'>
       <subrange length='4' type-id='type-id-2' id='type-id-226'/>
     </array-type-def>
@@ -3675,12 +3675,12 @@
       <return type-id='type-id-17'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Python/getplatform.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Python/getplatform.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='Py_GetPlatform' mangled-name='Py_GetPlatform' filepath='./Python/getplatform.c' line='9' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetPlatform'>
       <return type-id='type-id-6'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='./Python/importdl.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Python/importdl.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <typedef-decl name='dl_funcptr' type-id='type-id-230' filepath='./Include/internal/pycore_importdl.h' line='132' column='1' id='type-id-231'/>
     <function-decl name='_PyImport_SwapPackageContext' filepath='./Include/internal/pycore_import.h' line='132' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-6'/>
@@ -3697,7 +3697,7 @@
       <return type-id='type-id-3'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='./Python/sysmodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='./Python/sysmodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyEval_SetSwitchInterval' filepath='./Include/internal/pycore_ceval.h' line='35' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-3'/>
@@ -3896,7 +3896,7 @@
       <return type-id='type-id-116'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Modules/config.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Modules/config.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='PyInit_atexit' mangled-name='PyInit_atexit' filepath='Modules/config.c' line='26' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit_atexit'>
       <return type-id='type-id-4'/>
     </function-decl>
@@ -3973,7 +3973,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Modules/gcmodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Modules/gcmodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <enum-decl name='_PyGC_Reason' naming-typedef-id='type-id-239' filepath='./Include/internal/pycore_gc.h' line='161' column='1' id='type-id-240'>
       <underlying-type type-id='type-id-32'/>
       <enumerator name='_Py_GC_REASON_HEAP' value='0'/>
@@ -4010,7 +4010,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Modules/main.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Modules/main.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <qualified-type-def type-id='type-id-241' const='yes' id='type-id-242'/>
     <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-243'/>
     <function-decl name='_PyImport_Fini2' filepath='./Include/internal/pycore_import.h' line='164' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4070,7 +4070,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/abstract.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/abstract.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <typedef-decl name='_Py_simple_func' type-id='type-id-246' filepath='./Include/internal/pycore_crossinterp.h' line='26' column='1' id='type-id-247'/>
     <pointer-type-def type-id='type-id-248' size-in-bits='64' id='type-id-249'/>
     <qualified-type-def type-id='type-id-250' const='yes' id='type-id-251'/>
@@ -4817,7 +4817,7 @@
       <return type-id='type-id-5'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/boolobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/boolobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='_Py_FalseStruct' type-id='type-id-248' mangled-name='_Py_FalseStruct' visibility='default' filepath='./Include/boolobject.h' line='17' column='1' elf-symbol-id='_Py_FalseStruct'/>
     <var-decl name='_Py_TrueStruct' type-id='type-id-248' mangled-name='_Py_TrueStruct' visibility='default' filepath='./Include/boolobject.h' line='18' column='1' elf-symbol-id='_Py_TrueStruct'/>
     <function-decl name='_PyArg_NoKwnames' filepath='./Include/internal/pycore_modsupport.h' line='15' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4855,7 +4855,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/bytearrayobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/bytearrayobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <qualified-type-def type-id='type-id-264' const='yes' id='type-id-265'/>
     <pointer-type-def type-id='type-id-265' size-in-bits='64' id='type-id-266'/>
     <qualified-type-def type-id='type-id-5' const='yes' id='type-id-267'/>
@@ -5175,35 +5175,35 @@
       <parameter type-id='type-id-21'/>
       <return type-id='type-id-30'/>
     </function-decl>
-    <function-decl name='PyByteArray_FromObject' mangled-name='PyByteArray_FromObject' filepath='Objects/bytearrayobject.c' line='83' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_FromObject'>
-      <parameter type-id='type-id-4' name='input' filepath='Objects/bytearrayobject.c' line='83' column='1'/>
+    <function-decl name='PyByteArray_FromObject' mangled-name='PyByteArray_FromObject' filepath='Objects/bytearrayobject.c' line='101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_FromObject'>
+      <parameter type-id='type-id-4' name='input' filepath='Objects/bytearrayobject.c' line='101' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyByteArray_FromStringAndSize' mangled-name='PyByteArray_FromStringAndSize' filepath='Objects/bytearrayobject.c' line='109' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_FromStringAndSize'>
-      <parameter type-id='type-id-6' name='bytes' filepath='Objects/bytearrayobject.c' line='109' column='1'/>
-      <parameter type-id='type-id-7' name='size' filepath='Objects/bytearrayobject.c' line='109' column='1'/>
+    <function-decl name='PyByteArray_FromStringAndSize' mangled-name='PyByteArray_FromStringAndSize' filepath='Objects/bytearrayobject.c' line='127' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_FromStringAndSize'>
+      <parameter type-id='type-id-6' name='bytes' filepath='Objects/bytearrayobject.c' line='127' column='1'/>
+      <parameter type-id='type-id-7' name='size' filepath='Objects/bytearrayobject.c' line='127' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyByteArray_Size' mangled-name='PyByteArray_Size' filepath='Objects/bytearrayobject.c' line='153' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_Size'>
-      <parameter type-id='type-id-4' name='self' filepath='Objects/bytearrayobject.c' line='153' column='1'/>
+    <function-decl name='PyByteArray_Size' mangled-name='PyByteArray_Size' filepath='Objects/bytearrayobject.c' line='171' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_Size'>
+      <parameter type-id='type-id-4' name='self' filepath='Objects/bytearrayobject.c' line='171' column='1'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='PyByteArray_AsString' mangled-name='PyByteArray_AsString' filepath='Objects/bytearrayobject.c' line='162' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_AsString'>
-      <parameter type-id='type-id-4' name='self' filepath='Objects/bytearrayobject.c' line='162' column='1'/>
+    <function-decl name='PyByteArray_AsString' mangled-name='PyByteArray_AsString' filepath='Objects/bytearrayobject.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_AsString'>
+      <parameter type-id='type-id-4' name='self' filepath='Objects/bytearrayobject.c' line='180' column='1'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='PyByteArray_Resize' mangled-name='PyByteArray_Resize' filepath='Objects/bytearrayobject.c' line='171' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_Resize'>
-      <parameter type-id='type-id-4' name='self' filepath='Objects/bytearrayobject.c' line='171' column='1'/>
-      <parameter type-id='type-id-7' name='requested_size' filepath='Objects/bytearrayobject.c' line='171' column='1'/>
+    <function-decl name='PyByteArray_Resize' mangled-name='PyByteArray_Resize' filepath='Objects/bytearrayobject.c' line='189' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_Resize'>
+      <parameter type-id='type-id-4' name='self' filepath='Objects/bytearrayobject.c' line='189' column='1'/>
+      <parameter type-id='type-id-7' name='requested_size' filepath='Objects/bytearrayobject.c' line='189' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyByteArray_Concat' mangled-name='PyByteArray_Concat' filepath='Objects/bytearrayobject.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_Concat'>
-      <parameter type-id='type-id-4' name='a' filepath='Objects/bytearrayobject.c' line='250' column='1'/>
-      <parameter type-id='type-id-4' name='b' filepath='Objects/bytearrayobject.c' line='250' column='1'/>
+    <function-decl name='PyByteArray_Concat' mangled-name='PyByteArray_Concat' filepath='Objects/bytearrayobject.c' line='268' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyByteArray_Concat'>
+      <parameter type-id='type-id-4' name='a' filepath='Objects/bytearrayobject.c' line='268' column='1'/>
+      <parameter type-id='type-id-4' name='b' filepath='Objects/bytearrayobject.c' line='268' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/bytes_methods.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/bytes_methods.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-55' size-in-bits='984' id='type-id-270'>
       <subrange length='123' type-id='type-id-2' id='type-id-271'/>
     </array-type-def>
@@ -5261,7 +5261,7 @@
       <return type-id='type-id-30'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/bytesobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/bytesobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-53' size-in-bits='4096' id='type-id-293'>
       <subrange length='512' type-id='type-id-2' id='type-id-294'/>
     </array-type-def>
@@ -5461,7 +5461,7 @@
       <return type-id='type-id-30'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/call.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/call.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='_Py_Identifier' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/cpython/object.h' line='38' column='1' id='type-id-300'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='string' type-id='type-id-6' visibility='default' filepath='./Include/cpython/object.h' line='39' column='1'/>
@@ -5480,7 +5480,7 @@
     </class-decl>
     <typedef-decl name='_Py_Identifier' type-id='type-id-300' filepath='./Include/cpython/object.h' line='47' column='1' id='type-id-303'/>
     <pointer-type-def type-id='type-id-303' size-in-bits='64' id='type-id-304'/>
-    <function-decl name='_PyObject_GetAttrId' mangled-name='_PyObject_GetAttrId' filepath='./Include/cpython/object.h' line='285' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GetAttrId'>
+    <function-decl name='_PyObject_GetAttrId' mangled-name='_PyObject_GetAttrId' filepath='./Include/cpython/object.h' line='295' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GetAttrId'>
       <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-304'/>
       <return type-id='type-id-4'/>
@@ -5665,7 +5665,7 @@
       <return type-id='type-id-7'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/capsule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/capsule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <typedef-decl name='PyCapsule_Destructor' type-id='type-id-307' filepath='./Include/pycapsule.h' line='23' column='1' id='type-id-308'/>
     <function-decl name='PyImport_ImportModule' mangled-name='PyImport_ImportModule' filepath='./Include/import.h' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModule'>
       <parameter type-id='type-id-6'/>
@@ -5740,7 +5740,7 @@
       <return type-id='type-id-3'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/cellobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/cellobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PyCell_Type' type-id='type-id-263' mangled-name='PyCell_Type' visibility='default' filepath='./Include/cpython/cellobject.h' line='16' column='1' elf-symbol-id='PyCell_Type'/>
     <function-decl name='PyObject_RichCompare' mangled-name='PyObject_RichCompare' filepath='./Include/object.h' line='566' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_RichCompare'>
       <parameter type-id='type-id-4'/>
@@ -5762,10 +5762,10 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/classobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/classobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PyMethod_Type' type-id='type-id-263' mangled-name='PyMethod_Type' visibility='default' filepath='./Include/cpython/classobject.h' line='20' column='1' elf-symbol-id='PyMethod_Type'/>
     <var-decl name='PyInstanceMethod_Type' type-id='type-id-263' mangled-name='PyInstanceMethod_Type' visibility='default' filepath='./Include/cpython/classobject.h' line='49' column='1' elf-symbol-id='PyInstanceMethod_Type'/>
-    <function-decl name='_PyType_LookupRef' mangled-name='_PyType_LookupRef' filepath='./Include/cpython/object.h' line='278' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_LookupRef'>
+    <function-decl name='_PyType_LookupRef' mangled-name='_PyType_LookupRef' filepath='./Include/cpython/object.h' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_LookupRef'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-4'/>
       <return type-id='type-id-4'/>
@@ -5818,7 +5818,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/codeobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/codeobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='_opaque' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/cpython/code.h' line='285' column='1' id='type-id-312'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='computed_line' type-id='type-id-5' visibility='default' filepath='./Include/cpython/code.h' line='286' column='1'/>
@@ -6023,7 +6023,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/complexobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/complexobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <pointer-type-def type-id='type-id-325' size-in-bits='64' id='type-id-326'/>
     <var-decl name='PyComplex_Type' type-id='type-id-263' mangled-name='PyComplex_Type' visibility='default' filepath='./Include/complexobject.h' line='11' column='1' elf-symbol-id='PyComplex_Type'/>
     <function-decl name='_Py_HashDouble' mangled-name='_Py_HashDouble' filepath='./Include/cpython/pyhash.h' line='30' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_HashDouble'>
@@ -6140,18 +6140,18 @@
       <return type-id='type-id-4'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/descrobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/descrobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <pointer-type-def type-id='type-id-328' size-in-bits='64' id='type-id-329'/>
-    <function-decl name='_PyObject_FunctionStr' mangled-name='_PyObject_FunctionStr' filepath='./Include/cpython/object.h' line='301' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_FunctionStr'>
+    <function-decl name='_PyObject_FunctionStr' mangled-name='_PyObject_FunctionStr' filepath='./Include/cpython/object.h' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_FunctionStr'>
       <parameter type-id='type-id-4'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyTrash_thread_deposit_object' mangled-name='_PyTrash_thread_deposit_object' filepath='./Include/cpython/object.h' line='468' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTrash_thread_deposit_object'>
+    <function-decl name='_PyTrash_thread_deposit_object' mangled-name='_PyTrash_thread_deposit_object' filepath='./Include/cpython/object.h' line='478' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTrash_thread_deposit_object'>
       <parameter type-id='type-id-27'/>
       <parameter type-id='type-id-4'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='_PyTrash_thread_destroy_chain' mangled-name='_PyTrash_thread_destroy_chain' filepath='./Include/cpython/object.h' line='469' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTrash_thread_destroy_chain'>
+    <function-decl name='_PyTrash_thread_destroy_chain' mangled-name='_PyTrash_thread_destroy_chain' filepath='./Include/cpython/object.h' line='479' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTrash_thread_destroy_chain'>
       <parameter type-id='type-id-27'/>
       <return type-id='type-id-3'/>
     </function-decl>
@@ -6282,8 +6282,8 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/dictobject.c' comp-dir-path='/src' language='LANG_C11'>
-    <function-decl name='_PyObject_AssertFailed' mangled-name='_PyObject_AssertFailed' filepath='./Include/cpython/object.h' line='408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_AssertFailed'>
+  <abi-instr address-size='64' path='Objects/dictobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
+    <function-decl name='_PyObject_AssertFailed' mangled-name='_PyObject_AssertFailed' filepath='./Include/cpython/object.h' line='418' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_AssertFailed'>
       <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-6'/>
       <parameter type-id='type-id-6'/>
@@ -6331,170 +6331,170 @@
     <function-decl name='PyInterpreterState_Get' mangled-name='PyInterpreterState_Get' filepath='./Include/pystate.h' line='26' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Get'>
       <return type-id='type-id-28'/>
     </function-decl>
-    <function-decl name='_PyDict_NewPresized' mangled-name='_PyDict_NewPresized' filepath='Objects/dictobject.c' line='2182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_NewPresized'>
-      <parameter type-id='type-id-7' name='minused' filepath='Objects/dictobject.c' line='2182' column='1'/>
+    <function-decl name='_PyDict_NewPresized' mangled-name='_PyDict_NewPresized' filepath='Objects/dictobject.c' line='2185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_NewPresized'>
+      <parameter type-id='type-id-7' name='minused' filepath='Objects/dictobject.c' line='2185' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyDict_GetItem_KnownHash' mangled-name='_PyDict_GetItem_KnownHash' filepath='Objects/dictobject.c' line='2310' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_GetItem_KnownHash'>
-      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='2310' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2310' column='1'/>
-      <parameter type-id='type-id-298' name='hash' filepath='Objects/dictobject.c' line='2310' column='1'/>
+    <function-decl name='_PyDict_GetItem_KnownHash' mangled-name='_PyDict_GetItem_KnownHash' filepath='Objects/dictobject.c' line='2313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_GetItem_KnownHash'>
+      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='2313' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2313' column='1'/>
+      <parameter type-id='type-id-298' name='hash' filepath='Objects/dictobject.c' line='2313' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyDict_GetItemRef_KnownHash_LockHeld' mangled-name='_PyDict_GetItemRef_KnownHash_LockHeld' filepath='Objects/dictobject.c' line='2336' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_GetItemRef_KnownHash_LockHeld'>
-      <parameter type-id='type-id-332' name='op' filepath='Objects/dictobject.c' line='2336' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2336' column='1'/>
-      <parameter type-id='type-id-298' name='hash' filepath='Objects/dictobject.c' line='2337' column='1'/>
-      <parameter type-id='type-id-235' name='result' filepath='Objects/dictobject.c' line='2337' column='1'/>
+    <function-decl name='_PyDict_GetItemRef_KnownHash_LockHeld' mangled-name='_PyDict_GetItemRef_KnownHash_LockHeld' filepath='Objects/dictobject.c' line='2339' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_GetItemRef_KnownHash_LockHeld'>
+      <parameter type-id='type-id-332' name='op' filepath='Objects/dictobject.c' line='2339' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2339' column='1'/>
+      <parameter type-id='type-id-298' name='hash' filepath='Objects/dictobject.c' line='2340' column='1'/>
+      <parameter type-id='type-id-235' name='result' filepath='Objects/dictobject.c' line='2340' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyDict_GetItemStringWithError' mangled-name='_PyDict_GetItemStringWithError' filepath='Objects/dictobject.c' line='2484' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_GetItemStringWithError'>
-      <parameter type-id='type-id-4' name='v' filepath='Objects/dictobject.c' line='2484' column='1'/>
-      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='2484' column='1'/>
+    <function-decl name='_PyDict_GetItemStringWithError' mangled-name='_PyDict_GetItemStringWithError' filepath='Objects/dictobject.c' line='2487' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_GetItemStringWithError'>
+      <parameter type-id='type-id-4' name='v' filepath='Objects/dictobject.c' line='2487' column='1'/>
+      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='2487' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyDict_LoadGlobal' mangled-name='_PyDict_LoadGlobal' filepath='Objects/dictobject.c' line='2509' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_LoadGlobal'>
-      <parameter type-id='type-id-332' name='globals' filepath='Objects/dictobject.c' line='2509' column='1'/>
-      <parameter type-id='type-id-332' name='builtins' filepath='Objects/dictobject.c' line='2509' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2509' column='1'/>
+    <function-decl name='_PyDict_LoadGlobal' mangled-name='_PyDict_LoadGlobal' filepath='Objects/dictobject.c' line='2512' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_LoadGlobal'>
+      <parameter type-id='type-id-332' name='globals' filepath='Objects/dictobject.c' line='2512' column='1'/>
+      <parameter type-id='type-id-332' name='builtins' filepath='Objects/dictobject.c' line='2512' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2512' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyDict_SetItem_Take2' mangled-name='_PyDict_SetItem_Take2' filepath='Objects/dictobject.c' line='2559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_SetItem_Take2'>
-      <parameter type-id='type-id-332' name='mp' filepath='Objects/dictobject.c' line='2559' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2559' column='1'/>
-      <parameter type-id='type-id-4' name='value' filepath='Objects/dictobject.c' line='2559' column='1'/>
+    <function-decl name='_PyDict_SetItem_Take2' mangled-name='_PyDict_SetItem_Take2' filepath='Objects/dictobject.c' line='2562' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_SetItem_Take2'>
+      <parameter type-id='type-id-332' name='mp' filepath='Objects/dictobject.c' line='2562' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2562' column='1'/>
+      <parameter type-id='type-id-4' name='value' filepath='Objects/dictobject.c' line='2562' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyDict_SetItem_KnownHash_LockHeld' mangled-name='_PyDict_SetItem_KnownHash_LockHeld' filepath='Objects/dictobject.c' line='2598' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_SetItem_KnownHash_LockHeld'>
-      <parameter type-id='type-id-332' name='mp' filepath='Objects/dictobject.c' line='2598' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2598' column='1'/>
-      <parameter type-id='type-id-4' name='value' filepath='Objects/dictobject.c' line='2598' column='1'/>
-      <parameter type-id='type-id-298' name='hash' filepath='Objects/dictobject.c' line='2599' column='1'/>
+    <function-decl name='_PyDict_SetItem_KnownHash_LockHeld' mangled-name='_PyDict_SetItem_KnownHash_LockHeld' filepath='Objects/dictobject.c' line='2601' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_SetItem_KnownHash_LockHeld'>
+      <parameter type-id='type-id-332' name='mp' filepath='Objects/dictobject.c' line='2601' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2601' column='1'/>
+      <parameter type-id='type-id-4' name='value' filepath='Objects/dictobject.c' line='2601' column='1'/>
+      <parameter type-id='type-id-298' name='hash' filepath='Objects/dictobject.c' line='2602' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyDict_SetItem_KnownHash' mangled-name='_PyDict_SetItem_KnownHash' filepath='Objects/dictobject.c' line='2610' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_SetItem_KnownHash'>
-      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='2610' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2610' column='1'/>
-      <parameter type-id='type-id-4' name='value' filepath='Objects/dictobject.c' line='2610' column='1'/>
-      <parameter type-id='type-id-298' name='hash' filepath='Objects/dictobject.c' line='2611' column='1'/>
+    <function-decl name='_PyDict_SetItem_KnownHash' mangled-name='_PyDict_SetItem_KnownHash' filepath='Objects/dictobject.c' line='2613' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_SetItem_KnownHash'>
+      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='2613' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2613' column='1'/>
+      <parameter type-id='type-id-4' name='value' filepath='Objects/dictobject.c' line='2613' column='1'/>
+      <parameter type-id='type-id-298' name='hash' filepath='Objects/dictobject.c' line='2614' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyDict_DelItem_KnownHash' mangled-name='_PyDict_DelItem_KnownHash' filepath='Objects/dictobject.c' line='2735' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_DelItem_KnownHash'>
-      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='2735' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2735' column='1'/>
-      <parameter type-id='type-id-298' name='hash' filepath='Objects/dictobject.c' line='2735' column='1'/>
+    <function-decl name='_PyDict_DelItem_KnownHash' mangled-name='_PyDict_DelItem_KnownHash' filepath='Objects/dictobject.c' line='2738' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_DelItem_KnownHash'>
+      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='2738' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2738' column='1'/>
+      <parameter type-id='type-id-298' name='hash' filepath='Objects/dictobject.c' line='2738' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyDict_DelItemIf' mangled-name='_PyDict_DelItemIf' filepath='Objects/dictobject.c' line='2790' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_DelItemIf'>
-      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='2790' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2790' column='1'/>
-      <parameter type-id='type-id-333' name='predicate' filepath='Objects/dictobject.c' line='2791' column='1'/>
-      <parameter type-id='type-id-30' name='arg' filepath='Objects/dictobject.c' line='2792' column='1'/>
+    <function-decl name='_PyDict_DelItemIf' mangled-name='_PyDict_DelItemIf' filepath='Objects/dictobject.c' line='2793' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_DelItemIf'>
+      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='2793' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='2793' column='1'/>
+      <parameter type-id='type-id-333' name='predicate' filepath='Objects/dictobject.c' line='2794' column='1'/>
+      <parameter type-id='type-id-30' name='arg' filepath='Objects/dictobject.c' line='2795' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyDict_Clear' mangled-name='PyDict_Clear' filepath='Objects/dictobject.c' line='2852' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_Clear'>
-      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='2852' column='1'/>
+    <function-decl name='PyDict_Clear' mangled-name='PyDict_Clear' filepath='Objects/dictobject.c' line='2868' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_Clear'>
+      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='2868' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='PyDict_PopString' mangled-name='PyDict_PopString' filepath='Objects/dictobject.c' line='3044' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_PopString'>
-      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='3044' column='1'/>
-      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='3044' column='1'/>
-      <parameter type-id='type-id-235' name='result' filepath='Objects/dictobject.c' line='3044' column='1'/>
+    <function-decl name='PyDict_PopString' mangled-name='PyDict_PopString' filepath='Objects/dictobject.c' line='3060' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_PopString'>
+      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='3060' column='1'/>
+      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='3060' column='1'/>
+      <parameter type-id='type-id-235' name='result' filepath='Objects/dictobject.c' line='3060' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyDict_Pop' mangled-name='_PyDict_Pop' filepath='Objects/dictobject.c' line='3061' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_Pop'>
-      <parameter type-id='type-id-4' name='dict' filepath='Objects/dictobject.c' line='3061' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='3061' column='1'/>
-      <parameter type-id='type-id-4' name='default_value' filepath='Objects/dictobject.c' line='3061' column='1'/>
+    <function-decl name='_PyDict_Pop' mangled-name='_PyDict_Pop' filepath='Objects/dictobject.c' line='3077' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_Pop'>
+      <parameter type-id='type-id-4' name='dict' filepath='Objects/dictobject.c' line='3077' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='3077' column='1'/>
+      <parameter type-id='type-id-4' name='default_value' filepath='Objects/dictobject.c' line='3077' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyDict_MergeFromSeq2' mangled-name='PyDict_MergeFromSeq2' filepath='Objects/dictobject.c' line='3723' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_MergeFromSeq2'>
-      <parameter type-id='type-id-4' name='d' filepath='Objects/dictobject.c' line='3723' column='1'/>
-      <parameter type-id='type-id-4' name='seq2' filepath='Objects/dictobject.c' line='3723' column='1'/>
-      <parameter type-id='type-id-5' name='override' filepath='Objects/dictobject.c' line='3723' column='1'/>
+    <function-decl name='PyDict_MergeFromSeq2' mangled-name='PyDict_MergeFromSeq2' filepath='Objects/dictobject.c' line='3739' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_MergeFromSeq2'>
+      <parameter type-id='type-id-4' name='d' filepath='Objects/dictobject.c' line='3739' column='1'/>
+      <parameter type-id='type-id-4' name='seq2' filepath='Objects/dictobject.c' line='3739' column='1'/>
+      <parameter type-id='type-id-5' name='override' filepath='Objects/dictobject.c' line='3739' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyDict_Merge' mangled-name='PyDict_Merge' filepath='Objects/dictobject.c' line='3942' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_Merge'>
-      <parameter type-id='type-id-4' name='a' filepath='Objects/dictobject.c' line='3942' column='1'/>
-      <parameter type-id='type-id-4' name='b' filepath='Objects/dictobject.c' line='3942' column='1'/>
-      <parameter type-id='type-id-5' name='override' filepath='Objects/dictobject.c' line='3942' column='1'/>
+    <function-decl name='PyDict_Merge' mangled-name='PyDict_Merge' filepath='Objects/dictobject.c' line='3958' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_Merge'>
+      <parameter type-id='type-id-4' name='a' filepath='Objects/dictobject.c' line='3958' column='1'/>
+      <parameter type-id='type-id-4' name='b' filepath='Objects/dictobject.c' line='3958' column='1'/>
+      <parameter type-id='type-id-5' name='override' filepath='Objects/dictobject.c' line='3958' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyDict_MergeEx' mangled-name='_PyDict_MergeEx' filepath='Objects/dictobject.c' line='3950' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_MergeEx'>
-      <parameter type-id='type-id-4' name='a' filepath='Objects/dictobject.c' line='3950' column='1'/>
-      <parameter type-id='type-id-4' name='b' filepath='Objects/dictobject.c' line='3950' column='1'/>
-      <parameter type-id='type-id-5' name='override' filepath='Objects/dictobject.c' line='3950' column='1'/>
+    <function-decl name='_PyDict_MergeEx' mangled-name='_PyDict_MergeEx' filepath='Objects/dictobject.c' line='3966' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_MergeEx'>
+      <parameter type-id='type-id-4' name='a' filepath='Objects/dictobject.c' line='3966' column='1'/>
+      <parameter type-id='type-id-4' name='b' filepath='Objects/dictobject.c' line='3966' column='1'/>
+      <parameter type-id='type-id-5' name='override' filepath='Objects/dictobject.c' line='3966' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyDict_SetDefaultRef' mangled-name='PyDict_SetDefaultRef' filepath='Objects/dictobject.c' line='4358' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_SetDefaultRef'>
-      <parameter type-id='type-id-4' name='d' filepath='Objects/dictobject.c' line='4358' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='4358' column='1'/>
-      <parameter type-id='type-id-4' name='default_value' filepath='Objects/dictobject.c' line='4358' column='1'/>
-      <parameter type-id='type-id-235' name='result' filepath='Objects/dictobject.c' line='4359' column='1'/>
+    <function-decl name='PyDict_SetDefaultRef' mangled-name='PyDict_SetDefaultRef' filepath='Objects/dictobject.c' line='4374' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_SetDefaultRef'>
+      <parameter type-id='type-id-4' name='d' filepath='Objects/dictobject.c' line='4374' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='4374' column='1'/>
+      <parameter type-id='type-id-4' name='default_value' filepath='Objects/dictobject.c' line='4374' column='1'/>
+      <parameter type-id='type-id-235' name='result' filepath='Objects/dictobject.c' line='4375' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyDict_SetDefault' mangled-name='PyDict_SetDefault' filepath='Objects/dictobject.c' line='4369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_SetDefault'>
-      <parameter type-id='type-id-4' name='d' filepath='Objects/dictobject.c' line='4369' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='4369' column='1'/>
-      <parameter type-id='type-id-4' name='defaultobj' filepath='Objects/dictobject.c' line='4369' column='1'/>
+    <function-decl name='PyDict_SetDefault' mangled-name='PyDict_SetDefault' filepath='Objects/dictobject.c' line='4385' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_SetDefault'>
+      <parameter type-id='type-id-4' name='d' filepath='Objects/dictobject.c' line='4385' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/dictobject.c' line='4385' column='1'/>
+      <parameter type-id='type-id-4' name='defaultobj' filepath='Objects/dictobject.c' line='4385' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyDict_SizeOf' mangled-name='_PyDict_SizeOf' filepath='Objects/dictobject.c' line='4595' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_SizeOf'>
-      <parameter type-id='type-id-332' name='mp' filepath='Objects/dictobject.c' line='4595' column='1'/>
+    <function-decl name='_PyDict_SizeOf' mangled-name='_PyDict_SizeOf' filepath='Objects/dictobject.c' line='4609' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyDict_SizeOf'>
+      <parameter type-id='type-id-332' name='mp' filepath='Objects/dictobject.c' line='4609' column='1'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='PyDict_ContainsString' mangled-name='PyDict_ContainsString' filepath='Objects/dictobject.c' line='4702' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_ContainsString'>
-      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='4702' column='1'/>
-      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='4702' column='1'/>
+    <function-decl name='PyDict_ContainsString' mangled-name='PyDict_ContainsString' filepath='Objects/dictobject.c' line='4716' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_ContainsString'>
+      <parameter type-id='type-id-4' name='op' filepath='Objects/dictobject.c' line='4716' column='1'/>
+      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='4716' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyDict_GetItemString' mangled-name='PyDict_GetItemString' filepath='Objects/dictobject.c' line='4904' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_GetItemString'>
-      <parameter type-id='type-id-4' name='v' filepath='Objects/dictobject.c' line='4904' column='1'/>
-      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='4904' column='1'/>
+    <function-decl name='PyDict_GetItemString' mangled-name='PyDict_GetItemString' filepath='Objects/dictobject.c' line='4918' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_GetItemString'>
+      <parameter type-id='type-id-4' name='v' filepath='Objects/dictobject.c' line='4918' column='1'/>
+      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='4918' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyDict_GetItemStringRef' mangled-name='PyDict_GetItemStringRef' filepath='Objects/dictobject.c' line='4922' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_GetItemStringRef'>
-      <parameter type-id='type-id-4' name='v' filepath='Objects/dictobject.c' line='4922' column='1'/>
-      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='4922' column='1'/>
-      <parameter type-id='type-id-235' name='result' filepath='Objects/dictobject.c' line='4922' column='1'/>
+    <function-decl name='PyDict_GetItemStringRef' mangled-name='PyDict_GetItemStringRef' filepath='Objects/dictobject.c' line='4936' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_GetItemStringRef'>
+      <parameter type-id='type-id-4' name='v' filepath='Objects/dictobject.c' line='4936' column='1'/>
+      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='4936' column='1'/>
+      <parameter type-id='type-id-235' name='result' filepath='Objects/dictobject.c' line='4936' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyDict_DelItemString' mangled-name='PyDict_DelItemString' filepath='Objects/dictobject.c' line='4969' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_DelItemString'>
-      <parameter type-id='type-id-4' name='v' filepath='Objects/dictobject.c' line='4969' column='1'/>
-      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='4969' column='1'/>
+    <function-decl name='PyDict_DelItemString' mangled-name='PyDict_DelItemString' filepath='Objects/dictobject.c' line='4983' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_DelItemString'>
+      <parameter type-id='type-id-4' name='v' filepath='Objects/dictobject.c' line='4983' column='1'/>
+      <parameter type-id='type-id-6' name='key' filepath='Objects/dictobject.c' line='4983' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyObject_VisitManagedDict' mangled-name='PyObject_VisitManagedDict' filepath='Objects/dictobject.c' line='7109' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_VisitManagedDict'>
-      <parameter type-id='type-id-4' name='obj' filepath='Objects/dictobject.c' line='7109' column='1'/>
-      <parameter type-id='type-id-334' name='visit' filepath='Objects/dictobject.c' line='7109' column='1'/>
-      <parameter type-id='type-id-30' name='arg' filepath='Objects/dictobject.c' line='7109' column='1'/>
+    <function-decl name='PyObject_VisitManagedDict' mangled-name='PyObject_VisitManagedDict' filepath='Objects/dictobject.c' line='7123' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_VisitManagedDict'>
+      <parameter type-id='type-id-4' name='obj' filepath='Objects/dictobject.c' line='7123' column='1'/>
+      <parameter type-id='type-id-334' name='visit' filepath='Objects/dictobject.c' line='7123' column='1'/>
+      <parameter type-id='type-id-30' name='arg' filepath='Objects/dictobject.c' line='7123' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyObject_SetManagedDict' mangled-name='_PyObject_SetManagedDict' filepath='Objects/dictobject.c' line='7147' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_SetManagedDict'>
-      <parameter type-id='type-id-4' name='obj' filepath='Objects/dictobject.c' line='7147' column='1'/>
-      <parameter type-id='type-id-4' name='new_dict' filepath='Objects/dictobject.c' line='7147' column='1'/>
+    <function-decl name='_PyObject_SetManagedDict' mangled-name='_PyObject_SetManagedDict' filepath='Objects/dictobject.c' line='7166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_SetManagedDict'>
+      <parameter type-id='type-id-4' name='obj' filepath='Objects/dictobject.c' line='7166' column='1'/>
+      <parameter type-id='type-id-4' name='new_dict' filepath='Objects/dictobject.c' line='7166' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyObject_ClearManagedDict' mangled-name='PyObject_ClearManagedDict' filepath='Objects/dictobject.c' line='7210' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_ClearManagedDict'>
-      <parameter type-id='type-id-4' name='obj' filepath='Objects/dictobject.c' line='7210' column='1'/>
+    <function-decl name='PyObject_ClearManagedDict' mangled-name='PyObject_ClearManagedDict' filepath='Objects/dictobject.c' line='7229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_ClearManagedDict'>
+      <parameter type-id='type-id-4' name='obj' filepath='Objects/dictobject.c' line='7229' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='PyDict_Watch' mangled-name='PyDict_Watch' filepath='Objects/dictobject.c' line='7396' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_Watch'>
-      <parameter type-id='type-id-5' name='watcher_id' filepath='Objects/dictobject.c' line='7396' column='1'/>
-      <parameter type-id='type-id-4' name='dict' filepath='Objects/dictobject.c' line='7396' column='1'/>
+    <function-decl name='PyDict_Watch' mangled-name='PyDict_Watch' filepath='Objects/dictobject.c' line='7415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_Watch'>
+      <parameter type-id='type-id-5' name='watcher_id' filepath='Objects/dictobject.c' line='7415' column='1'/>
+      <parameter type-id='type-id-4' name='dict' filepath='Objects/dictobject.c' line='7415' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyDict_Unwatch' mangled-name='PyDict_Unwatch' filepath='Objects/dictobject.c' line='7411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_Unwatch'>
-      <parameter type-id='type-id-5' name='watcher_id' filepath='Objects/dictobject.c' line='7411' column='1'/>
-      <parameter type-id='type-id-4' name='dict' filepath='Objects/dictobject.c' line='7411' column='1'/>
+    <function-decl name='PyDict_Unwatch' mangled-name='PyDict_Unwatch' filepath='Objects/dictobject.c' line='7430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_Unwatch'>
+      <parameter type-id='type-id-5' name='watcher_id' filepath='Objects/dictobject.c' line='7430' column='1'/>
+      <parameter type-id='type-id-4' name='dict' filepath='Objects/dictobject.c' line='7430' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyDict_AddWatcher' mangled-name='PyDict_AddWatcher' filepath='Objects/dictobject.c' line='7426' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_AddWatcher'>
-      <parameter type-id='type-id-335' name='callback' filepath='Objects/dictobject.c' line='7426' column='1'/>
+    <function-decl name='PyDict_AddWatcher' mangled-name='PyDict_AddWatcher' filepath='Objects/dictobject.c' line='7445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_AddWatcher'>
+      <parameter type-id='type-id-335' name='callback' filepath='Objects/dictobject.c' line='7445' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyDict_ClearWatcher' mangled-name='PyDict_ClearWatcher' filepath='Objects/dictobject.c' line='7443' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_ClearWatcher'>
-      <parameter type-id='type-id-5' name='watcher_id' filepath='Objects/dictobject.c' line='7443' column='1'/>
+    <function-decl name='PyDict_ClearWatcher' mangled-name='PyDict_ClearWatcher' filepath='Objects/dictobject.c' line='7462' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyDict_ClearWatcher'>
+      <parameter type-id='type-id-5' name='watcher_id' filepath='Objects/dictobject.c' line='7462' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-type size-in-bits='64' id='type-id-336'>
@@ -6503,11 +6503,11 @@
       <return type-id='type-id-5'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/enumobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/enumobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PyEnum_Type' type-id='type-id-263' mangled-name='PyEnum_Type' visibility='default' filepath='./Include/enumobject.h' line='10' column='1' elf-symbol-id='PyEnum_Type'/>
     <var-decl name='PyReversed_Type' type-id='type-id-263' mangled-name='PyReversed_Type' visibility='default' filepath='./Include/enumobject.h' line='11' column='1' elf-symbol-id='PyReversed_Type'/>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/exceptions.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/exceptions.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <qualified-type-def type-id='type-id-17' const='yes' id='type-id-337'/>
     <pointer-type-def type-id='type-id-337' size-in-bits='64' id='type-id-125'/>
     <var-decl name='PyExc_PythonFinalizationError' type-id='type-id-4' mangled-name='PyExc_PythonFinalizationError' visibility='default' filepath='./Include/cpython/pyerrors.h' line='130' column='1' elf-symbol-id='PyExc_PythonFinalizationError'/>
@@ -6848,7 +6848,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/fileobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/fileobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PyStdPrinter_Type' type-id='type-id-263' mangled-name='PyStdPrinter_Type' visibility='default' filepath='./Include/cpython/fileobject.h' line='10' column='1' elf-symbol-id='PyStdPrinter_Type'/>
     <function-decl name='_Py_write' mangled-name='_Py_write' filepath='./Include/internal/pycore_fileutils.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_write'>
       <parameter type-id='type-id-5'/>
@@ -6937,7 +6937,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/floatobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/floatobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='PyStructSequence_Field' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/structseq.h' line='10' column='1' id='type-id-339'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='name' type-id='type-id-6' visibility='default' filepath='./Include/structseq.h' line='11' column='1'/>
@@ -7005,11 +7005,6 @@
       <parameter type-id='type-id-6'/>
       <parameter type-id='type-id-245'/>
       <return type-id='type-id-170'/>
-    </function-decl>
-    <function-decl name='_PyLong_Lshift' mangled-name='_PyLong_Lshift' filepath='./Include/internal/pycore_long.h' line='111' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_Lshift'>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-21'/>
-      <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='_PyDebugAllocatorStats' filepath='./Include/internal/pycore_object.h' line='55' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-56'/>
@@ -7107,41 +7102,41 @@
       <parameter type-id='type-id-4' name='obj' filepath='Objects/floatobject.c' line='248' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='PyFloat_Pack2' mangled-name='PyFloat_Pack2' filepath='Objects/floatobject.c' line='2049' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack2'>
-      <parameter type-id='type-id-170' name='x' filepath='Objects/floatobject.c' line='2049' column='1'/>
-      <parameter type-id='type-id-17' name='data' filepath='Objects/floatobject.c' line='2049' column='1'/>
-      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2049' column='1'/>
+    <function-decl name='PyFloat_Pack2' mangled-name='PyFloat_Pack2' filepath='Objects/floatobject.c' line='2034' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack2'>
+      <parameter type-id='type-id-170' name='x' filepath='Objects/floatobject.c' line='2034' column='1'/>
+      <parameter type-id='type-id-17' name='data' filepath='Objects/floatobject.c' line='2034' column='1'/>
+      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2034' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyFloat_Pack4' mangled-name='PyFloat_Pack4' filepath='Objects/floatobject.c' line='2154' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack4'>
-      <parameter type-id='type-id-170' name='x' filepath='Objects/floatobject.c' line='2154' column='1'/>
-      <parameter type-id='type-id-17' name='data' filepath='Objects/floatobject.c' line='2154' column='1'/>
-      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2154' column='1'/>
+    <function-decl name='PyFloat_Pack4' mangled-name='PyFloat_Pack4' filepath='Objects/floatobject.c' line='2139' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack4'>
+      <parameter type-id='type-id-170' name='x' filepath='Objects/floatobject.c' line='2139' column='1'/>
+      <parameter type-id='type-id-17' name='data' filepath='Objects/floatobject.c' line='2139' column='1'/>
+      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2139' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyFloat_Pack8' mangled-name='PyFloat_Pack8' filepath='Objects/floatobject.c' line='2262' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack8'>
-      <parameter type-id='type-id-170' name='x' filepath='Objects/floatobject.c' line='2262' column='1'/>
-      <parameter type-id='type-id-17' name='data' filepath='Objects/floatobject.c' line='2262' column='1'/>
-      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2262' column='1'/>
+    <function-decl name='PyFloat_Pack8' mangled-name='PyFloat_Pack8' filepath='Objects/floatobject.c' line='2247' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack8'>
+      <parameter type-id='type-id-170' name='x' filepath='Objects/floatobject.c' line='2247' column='1'/>
+      <parameter type-id='type-id-17' name='data' filepath='Objects/floatobject.c' line='2247' column='1'/>
+      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2247' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyFloat_Unpack2' mangled-name='PyFloat_Unpack2' filepath='Objects/floatobject.c' line='2392' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack2'>
-      <parameter type-id='type-id-6' name='data' filepath='Objects/floatobject.c' line='2392' column='1'/>
-      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2392' column='1'/>
+    <function-decl name='PyFloat_Unpack2' mangled-name='PyFloat_Unpack2' filepath='Objects/floatobject.c' line='2377' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack2'>
+      <parameter type-id='type-id-6' name='data' filepath='Objects/floatobject.c' line='2377' column='1'/>
+      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2377' column='1'/>
       <return type-id='type-id-170'/>
     </function-decl>
-    <function-decl name='PyFloat_Unpack4' mangled-name='PyFloat_Unpack4' filepath='Objects/floatobject.c' line='2444' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack4'>
-      <parameter type-id='type-id-6' name='data' filepath='Objects/floatobject.c' line='2444' column='1'/>
-      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2444' column='1'/>
+    <function-decl name='PyFloat_Unpack4' mangled-name='PyFloat_Unpack4' filepath='Objects/floatobject.c' line='2429' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack4'>
+      <parameter type-id='type-id-6' name='data' filepath='Objects/floatobject.c' line='2429' column='1'/>
+      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2429' column='1'/>
       <return type-id='type-id-170'/>
     </function-decl>
-    <function-decl name='PyFloat_Unpack8' mangled-name='PyFloat_Unpack8' filepath='Objects/floatobject.c' line='2523' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack8'>
-      <parameter type-id='type-id-6' name='data' filepath='Objects/floatobject.c' line='2523' column='1'/>
-      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2523' column='1'/>
+    <function-decl name='PyFloat_Unpack8' mangled-name='PyFloat_Unpack8' filepath='Objects/floatobject.c' line='2508' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack8'>
+      <parameter type-id='type-id-6' name='data' filepath='Objects/floatobject.c' line='2508' column='1'/>
+      <parameter type-id='type-id-5' name='le' filepath='Objects/floatobject.c' line='2508' column='1'/>
       <return type-id='type-id-170'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/frameobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/frameobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='PyFrameConstructor' size-in-bits='512' is-struct='yes' naming-typedef-id='type-id-345' visibility='default' filepath='./Include/cpython/funcobject.h' line='21' column='1' id='type-id-346'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='fc_globals' type-id='type-id-4' visibility='default' filepath='./Include/cpython/funcobject.h' line='22' column='1'/>
@@ -7317,7 +7312,7 @@
     </function-decl>
     <type-decl name='bool' size-in-bits='8' id='type-id-349'/>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/funcobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/funcobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PyFunction_Type' type-id='type-id-263' mangled-name='PyFunction_Type' visibility='default' filepath='./Include/cpython/funcobject.h' line='65' column='1' elf-symbol-id='PyFunction_Type'/>
     <var-decl name='PyClassMethod_Type' type-id='type-id-263' mangled-name='PyClassMethod_Type' visibility='default' filepath='./Include/cpython/funcobject.h' line='125' column='1' elf-symbol-id='PyClassMethod_Type'/>
     <var-decl name='PyStaticMethod_Type' type-id='type-id-263' mangled-name='PyStaticMethod_Type' visibility='default' filepath='./Include/cpython/funcobject.h' line='126' column='1' elf-symbol-id='PyStaticMethod_Type'/>
@@ -7410,16 +7405,16 @@
       <parameter type-id='type-id-4' name='annotations' filepath='Objects/funcobject.c' line='555' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyClassMethod_New' mangled-name='PyClassMethod_New' filepath='Objects/funcobject.c' line='1345' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyClassMethod_New'>
-      <parameter type-id='type-id-4' name='callable' filepath='Objects/funcobject.c' line='1345' column='1'/>
+    <function-decl name='PyClassMethod_New' mangled-name='PyClassMethod_New' filepath='Objects/funcobject.c' line='1357' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyClassMethod_New'>
+      <parameter type-id='type-id-4' name='callable' filepath='Objects/funcobject.c' line='1357' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyStaticMethod_New' mangled-name='PyStaticMethod_New' filepath='Objects/funcobject.c' line='1539' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStaticMethod_New'>
-      <parameter type-id='type-id-4' name='callable' filepath='Objects/funcobject.c' line='1539' column='1'/>
+    <function-decl name='PyStaticMethod_New' mangled-name='PyStaticMethod_New' filepath='Objects/funcobject.c' line='1563' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStaticMethod_New'>
+      <parameter type-id='type-id-4' name='callable' filepath='Objects/funcobject.c' line='1563' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/genericaliasobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/genericaliasobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyUnicodeWriter_WriteASCIIString' mangled-name='_PyUnicodeWriter_WriteASCIIString' filepath='./Include/cpython/unicodeobject.h' line='539' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_WriteASCIIString'>
       <parameter type-id='type-id-327'/>
       <parameter type-id='type-id-6'/>
@@ -7430,6 +7425,11 @@
     <function-decl name='_Py_union_type_or' mangled-name='_Py_union_type_or' filepath='./Include/internal/pycore_unionobject.h' line='13' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_union_type_or'>
       <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-4'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='PyList_GetItemRef' mangled-name='PyList_GetItemRef' filepath='./Include/listobject.h' line='33' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyList_GetItemRef'>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-7'/>
       <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='PyList_SetSlice' mangled-name='PyList_SetSlice' filepath='./Include/listobject.h' line='40' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyList_SetSlice'>
@@ -7453,7 +7453,7 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/genobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/genobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='PyGenObject' size-in-bits='640' is-struct='yes' naming-typedef-id='type-id-351' visibility='default' filepath='./Include/cpython/genobject.h' line='31' column='1' id='type-id-352'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ob_base' type-id='type-id-353' visibility='default' filepath='./Include/cpython/genobject.h' line='33' column='1'/>
@@ -7542,7 +7542,7 @@
     <var-decl name='PyCoro_Type' type-id='type-id-263' mangled-name='PyCoro_Type' visibility='default' filepath='./Include/cpython/genobject.h' line='53' column='1' elf-symbol-id='PyCoro_Type'/>
     <var-decl name='PyAsyncGen_Type' type-id='type-id-263' mangled-name='PyAsyncGen_Type' visibility='default' filepath='./Include/cpython/genobject.h' line='66' column='1' elf-symbol-id='PyAsyncGen_Type'/>
     <var-decl name='_PyAsyncGenASend_Type' type-id='type-id-263' mangled-name='_PyAsyncGenASend_Type' visibility='default' filepath='./Include/cpython/genobject.h' line='67' column='1' elf-symbol-id='_PyAsyncGenASend_Type'/>
-    <function-decl name='PyObject_CallFinalizerFromDealloc' mangled-name='PyObject_CallFinalizerFromDealloc' filepath='./Include/cpython/object.h' line='289' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_CallFinalizerFromDealloc'>
+    <function-decl name='PyObject_CallFinalizerFromDealloc' mangled-name='PyObject_CallFinalizerFromDealloc' filepath='./Include/cpython/object.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_CallFinalizerFromDealloc'>
       <parameter type-id='type-id-4'/>
       <return type-id='type-id-5'/>
     </function-decl>
@@ -7648,7 +7648,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/iterobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/iterobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyObject_HasLen' filepath='./Include/internal/pycore_abstract.h' line='22' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-4'/>
       <return type-id='type-id-5'/>
@@ -7661,7 +7661,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/listobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/listobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyEval_SliceIndexNotNone' mangled-name='_PyEval_SliceIndexNotNone' filepath='./Include/cpython/ceval.h' line='25' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SliceIndexNotNone'>
       <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-8'/>
@@ -7697,11 +7697,6 @@
     <function-decl name='PyList_Size' mangled-name='PyList_Size' filepath='Objects/listobject.c' line='339' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyList_Size'>
       <parameter type-id='type-id-4' name='op' filepath='Objects/listobject.c' line='339' column='1'/>
       <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='PyList_GetItemRef' mangled-name='PyList_GetItemRef' filepath='Objects/listobject.c' line='436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyList_GetItemRef'>
-      <parameter type-id='type-id-4' name='op' filepath='Objects/listobject.c' line='436' column='1'/>
-      <parameter type-id='type-id-7' name='i' filepath='Objects/listobject.c' line='436' column='1'/>
-      <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='PyList_SetItem' mangled-name='PyList_SetItem' filepath='Objects/listobject.c' line='452' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyList_SetItem'>
       <parameter type-id='type-id-4' name='op' filepath='Objects/listobject.c' line='452' column='1'/>
@@ -7745,7 +7740,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/longobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/longobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-89' size-in-bits='2048' id='type-id-367'>
       <subrange length='256' type-id='type-id-2' id='type-id-69'/>
     </array-type-def>
@@ -7919,6 +7914,11 @@
       <parameter type-id='type-id-21' name='shiftby' filepath='Objects/longobject.c' line='5350' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
+    <function-decl name='_PyLong_Lshift' mangled-name='_PyLong_Lshift' filepath='Objects/longobject.c' line='5427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_Lshift'>
+      <parameter type-id='type-id-4' name='a' filepath='Objects/longobject.c' line='5427' column='1'/>
+      <parameter type-id='type-id-21' name='shiftby' filepath='Objects/longobject.c' line='5427' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
     <function-decl name='_PyLong_GCD' mangled-name='_PyLong_GCD' filepath='Objects/longobject.c' line='5629' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_GCD'>
       <parameter type-id='type-id-4' name='aarg' filepath='Objects/longobject.c' line='5629' column='1'/>
       <parameter type-id='type-id-4' name='barg' filepath='Objects/longobject.c' line='5629' column='1'/>
@@ -7941,7 +7941,7 @@
       <return type-id='type-id-7'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/memoryobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/memoryobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='_PyManagedBuffer_Type' type-id='type-id-263' visibility='default' filepath='./Include/internal/pycore_memoryobject.h' line='11' column='1'/>
     <var-decl name='PyMemoryView_Type' type-id='type-id-263' mangled-name='PyMemoryView_Type' visibility='default' filepath='./Include/memoryobject.h' line='9' column='1' elf-symbol-id='PyMemoryView_Type'/>
     <function-decl name='PyUnicode_AsASCIIString' mangled-name='PyUnicode_AsASCIIString' filepath='./Include/unicodeobject.h' line='631' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_AsASCIIString'>
@@ -7969,7 +7969,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/methodobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/methodobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PyCMethod_Type' type-id='type-id-263' mangled-name='PyCMethod_Type' visibility='default' filepath='./Include/cpython/methodobject.h' line='32' column='1' elf-symbol-id='PyCMethod_Type'/>
     <var-decl name='PyCFunction_Type' type-id='type-id-263' mangled-name='PyCFunction_Type' visibility='default' filepath='./Include/methodobject.h' line='14' column='1' elf-symbol-id='PyCFunction_Type'/>
     <function-decl name='PyCFunction_New' mangled-name='PyCFunction_New' filepath='Objects/methodobject.c' line='34' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCFunction_New'>
@@ -7996,7 +7996,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/moduleobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/moduleobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='PyModuleDef_Base' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/moduleobject.h' line='39' column='1' id='type-id-378'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ob_base' type-id='type-id-353' visibility='default' filepath='./Include/moduleobject.h' line='40' column='1'/>
@@ -8055,7 +8055,7 @@
     <pointer-type-def type-id='type-id-385' size-in-bits='64' id='type-id-383'/>
     <qualified-type-def type-id='type-id-387' const='yes' id='type-id-388'/>
     <pointer-type-def type-id='type-id-388' size-in-bits='64' id='type-id-18'/>
-    <function-decl name='_PyObject_GenericGetAttrWithDict' mangled-name='_PyObject_GenericGetAttrWithDict' filepath='./Include/cpython/object.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GenericGetAttrWithDict'>
+    <function-decl name='_PyObject_GenericGetAttrWithDict' mangled-name='_PyObject_GenericGetAttrWithDict' filepath='./Include/cpython/object.h' line='306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GenericGetAttrWithDict'>
       <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-4'/>
@@ -8189,7 +8189,7 @@
       <return type-id='type-id-4'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/namespaceobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/namespaceobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyArg_NoPositional' mangled-name='_PyArg_NoPositional' filepath='./Include/internal/pycore_modsupport.h' line='20' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_NoPositional'>
       <parameter type-id='type-id-6'/>
       <parameter type-id='type-id-4'/>
@@ -8201,12 +8201,12 @@
       <parameter type-id='type-id-4'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyNamespace_New' mangled-name='_PyNamespace_New' filepath='Objects/namespaceobject.c' line='302' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyNamespace_New'>
-      <parameter type-id='type-id-4' name='kwds' filepath='Objects/namespaceobject.c' line='302' column='1'/>
+    <function-decl name='_PyNamespace_New' mangled-name='_PyNamespace_New' filepath='Objects/namespaceobject.c' line='313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyNamespace_New'>
+      <parameter type-id='type-id-4' name='kwds' filepath='Objects/namespaceobject.c' line='313' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/object.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/object.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='192' id='type-id-95'>
       <subrange length='6' type-id='type-id-2' id='type-id-390'/>
     </array-type-def>
@@ -8619,7 +8619,7 @@
       <subrange length='80' type-id='type-id-2' id='type-id-415'/>
     </array-type-def>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/obmalloc.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/obmalloc.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-416' size-in-bits='14400' id='type-id-417'>
       <subrange length='75' type-id='type-id-2' id='type-id-418'/>
     </array-type-def>
@@ -9207,13 +9207,13 @@
       <parameter type-id='type-id-6'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='PyGILState_Check' mangled-name='PyGILState_Check' filepath='./Include/cpython/pystate.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Check'>
+    <function-decl name='PyGILState_Check' mangled-name='PyGILState_Check' filepath='./Include/cpython/pystate.h' line='255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Check'>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Head' mangled-name='PyInterpreterState_Head' filepath='./Include/cpython/pystate.h' line='263' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Head'>
+    <function-decl name='PyInterpreterState_Head' mangled-name='PyInterpreterState_Head' filepath='./Include/cpython/pystate.h' line='265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Head'>
       <return type-id='type-id-28'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Next' mangled-name='PyInterpreterState_Next' filepath='./Include/cpython/pystate.h' line='264' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Next'>
+    <function-decl name='PyInterpreterState_Next' mangled-name='PyInterpreterState_Next' filepath='./Include/cpython/pystate.h' line='266' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Next'>
       <parameter type-id='type-id-28'/>
       <return type-id='type-id-28'/>
     </function-decl>
@@ -9407,7 +9407,7 @@
       <return type-id='type-id-3'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/odictobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/odictobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PyODict_Type' type-id='type-id-263' mangled-name='PyODict_Type' visibility='default' filepath='./Include/cpython/odictobject.h' line='15' column='1' elf-symbol-id='PyODict_Type'/>
     <var-decl name='PyODictIter_Type' type-id='type-id-263' mangled-name='PyODictIter_Type' visibility='default' filepath='./Include/cpython/odictobject.h' line='16' column='1' elf-symbol-id='PyODictIter_Type'/>
     <var-decl name='PyODictKeys_Type' type-id='type-id-263' mangled-name='PyODictKeys_Type' visibility='default' filepath='./Include/cpython/odictobject.h' line='17' column='1' elf-symbol-id='PyODictKeys_Type'/>
@@ -9485,7 +9485,7 @@
       </data-member>
     </class-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/picklebufobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/picklebufobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PyPickleBuffer_Type' type-id='type-id-263' mangled-name='PyPickleBuffer_Type' visibility='default' filepath='./Include/cpython/picklebufobject.h' line='13' column='1' elf-symbol-id='PyPickleBuffer_Type'/>
     <function-decl name='PyPickleBuffer_FromObject' mangled-name='PyPickleBuffer_FromObject' filepath='Objects/picklebufobject.c' line='17' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyPickleBuffer_FromObject'>
       <parameter type-id='type-id-4' name='base' filepath='Objects/picklebufobject.c' line='17' column='1'/>
@@ -9500,7 +9500,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/rangeobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/rangeobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PySequence_IterSearch' filepath='./Include/internal/pycore_abstract.h' line='41' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-4'/>
@@ -9519,7 +9519,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/setobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/setobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-513' size-in-bits='1024' id='type-id-514'>
       <subrange length='8' type-id='type-id-2' id='type-id-515'/>
     </array-type-def>
@@ -9579,30 +9579,30 @@
     <var-decl name='PySet_Type' type-id='type-id-263' mangled-name='PySet_Type' visibility='default' filepath='./Include/setobject.h' line='9' column='1' elf-symbol-id='PySet_Type'/>
     <var-decl name='PyFrozenSet_Type' type-id='type-id-263' mangled-name='PyFrozenSet_Type' visibility='default' filepath='./Include/setobject.h' line='10' column='1' elf-symbol-id='PyFrozenSet_Type'/>
     <var-decl name='PySetIter_Type' type-id='type-id-263' mangled-name='PySetIter_Type' visibility='default' filepath='./Include/setobject.h' line='11' column='1' elf-symbol-id='PySetIter_Type'/>
-    <function-decl name='_PySet_Contains' mangled-name='_PySet_Contains' filepath='Objects/setobject.c' line='2174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PySet_Contains'>
-      <parameter type-id='type-id-520' name='so' filepath='Objects/setobject.c' line='2174' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/setobject.c' line='2174' column='1'/>
+    <function-decl name='_PySet_Contains' mangled-name='_PySet_Contains' filepath='Objects/setobject.c' line='2177' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PySet_Contains'>
+      <parameter type-id='type-id-520' name='so' filepath='Objects/setobject.c' line='2177' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/setobject.c' line='2177' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PySet_Size' mangled-name='PySet_Size' filepath='Objects/setobject.c' line='2610' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Size'>
-      <parameter type-id='type-id-4' name='anyset' filepath='Objects/setobject.c' line='2610' column='1'/>
+    <function-decl name='PySet_Size' mangled-name='PySet_Size' filepath='Objects/setobject.c' line='2613' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Size'>
+      <parameter type-id='type-id-4' name='anyset' filepath='Objects/setobject.c' line='2613' column='1'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='PySet_Clear' mangled-name='PySet_Clear' filepath='Objects/setobject.c' line='2620' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Clear'>
-      <parameter type-id='type-id-4' name='set' filepath='Objects/setobject.c' line='2620' column='1'/>
+    <function-decl name='PySet_Clear' mangled-name='PySet_Clear' filepath='Objects/setobject.c' line='2623' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Clear'>
+      <parameter type-id='type-id-4' name='set' filepath='Objects/setobject.c' line='2623' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PySet_Discard' mangled-name='PySet_Discard' filepath='Objects/setobject.c' line='2652' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Discard'>
-      <parameter type-id='type-id-4' name='set' filepath='Objects/setobject.c' line='2652' column='1'/>
-      <parameter type-id='type-id-4' name='key' filepath='Objects/setobject.c' line='2652' column='1'/>
+    <function-decl name='PySet_Discard' mangled-name='PySet_Discard' filepath='Objects/setobject.c' line='2655' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Discard'>
+      <parameter type-id='type-id-4' name='set' filepath='Objects/setobject.c' line='2655' column='1'/>
+      <parameter type-id='type-id-4' name='key' filepath='Objects/setobject.c' line='2655' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PySet_Pop' mangled-name='PySet_Pop' filepath='Objects/setobject.c' line='2716' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Pop'>
-      <parameter type-id='type-id-4' name='set' filepath='Objects/setobject.c' line='2716' column='1'/>
+    <function-decl name='PySet_Pop' mangled-name='PySet_Pop' filepath='Objects/setobject.c' line='2719' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Pop'>
+      <parameter type-id='type-id-4' name='set' filepath='Objects/setobject.c' line='2719' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/sliceobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/sliceobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='_Py_EllipsisObject' type-id='type-id-353' mangled-name='_Py_EllipsisObject' visibility='default' filepath='./Include/sliceobject.h' line='9' column='1' elf-symbol-id='_Py_EllipsisObject'/>
     <var-decl name='PySlice_Type' type-id='type-id-263' mangled-name='PySlice_Type' visibility='default' filepath='./Include/sliceobject.h' line='32' column='1' elf-symbol-id='PySlice_Type'/>
     <var-decl name='PyEllipsis_Type' type-id='type-id-263' mangled-name='PyEllipsis_Type' visibility='default' filepath='./Include/sliceobject.h' line='33' column='1' elf-symbol-id='PyEllipsis_Type'/>
@@ -9630,7 +9630,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/structseq.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/structseq.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='PyType_Slot' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-521' visibility='default' filepath='./Include/object.h' line='499' column='1' id='type-id-522'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='slot' type-id='type-id-5' visibility='default' filepath='./Include/object.h' line='500' column='1'/>
@@ -9675,27 +9675,27 @@
       <parameter type-id='type-id-7' name='index' filepath='Objects/structseq.c' line='98' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyStructSequence_InitType2' mangled-name='PyStructSequence_InitType2' filepath='Objects/structseq.c' line='677' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStructSequence_InitType2'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/structseq.c' line='677' column='1'/>
-      <parameter type-id='type-id-344' name='desc' filepath='Objects/structseq.c' line='677' column='1'/>
+    <function-decl name='PyStructSequence_InitType2' mangled-name='PyStructSequence_InitType2' filepath='Objects/structseq.c' line='678' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStructSequence_InitType2'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/structseq.c' line='678' column='1'/>
+      <parameter type-id='type-id-344' name='desc' filepath='Objects/structseq.c' line='678' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyStructSequence_InitType' mangled-name='PyStructSequence_InitType' filepath='Objects/structseq.c' line='711' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStructSequence_InitType'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/structseq.c' line='711' column='1'/>
-      <parameter type-id='type-id-344' name='desc' filepath='Objects/structseq.c' line='711' column='1'/>
+    <function-decl name='PyStructSequence_InitType' mangled-name='PyStructSequence_InitType' filepath='Objects/structseq.c' line='712' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStructSequence_InitType'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/structseq.c' line='712' column='1'/>
+      <parameter type-id='type-id-344' name='desc' filepath='Objects/structseq.c' line='712' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='_PyStructSequence_NewType' mangled-name='_PyStructSequence_NewType' filepath='Objects/structseq.c' line='749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyStructSequence_NewType'>
-      <parameter type-id='type-id-344' name='desc' filepath='Objects/structseq.c' line='749' column='1'/>
-      <parameter type-id='type-id-2' name='tp_flags' filepath='Objects/structseq.c' line='749' column='1'/>
+    <function-decl name='_PyStructSequence_NewType' mangled-name='_PyStructSequence_NewType' filepath='Objects/structseq.c' line='750' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyStructSequence_NewType'>
+      <parameter type-id='type-id-344' name='desc' filepath='Objects/structseq.c' line='750' column='1'/>
+      <parameter type-id='type-id-2' name='tp_flags' filepath='Objects/structseq.c' line='750' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='PyStructSequence_NewType' mangled-name='PyStructSequence_NewType' filepath='Objects/structseq.c' line='801' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStructSequence_NewType'>
-      <parameter type-id='type-id-344' name='desc' filepath='Objects/structseq.c' line='801' column='1'/>
+    <function-decl name='PyStructSequence_NewType' mangled-name='PyStructSequence_NewType' filepath='Objects/structseq.c' line='802' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStructSequence_NewType'>
+      <parameter type-id='type-id-344' name='desc' filepath='Objects/structseq.c' line='802' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/tupleobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/tupleobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyObject_GC_Resize' mangled-name='_PyObject_GC_Resize' filepath='./Include/objimpl.h' line='159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GC_Resize'>
       <parameter type-id='type-id-318'/>
       <parameter type-id='type-id-7'/>
@@ -9715,7 +9715,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/typeobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/typeobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='PyEval_GetGlobals' mangled-name='PyEval_GetGlobals' filepath='./Include/ceval.h' line='21' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetGlobals'>
       <return type-id='type-id-4'/>
     </function-decl>
@@ -9880,114 +9880,114 @@
       <parameter type-id='type-id-4' name='obj' filepath='Objects/typeobject.c' line='951' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyType_Modified' mangled-name='PyType_Modified' filepath='Objects/typeobject.c' line='1053' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_Modified'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='1053' column='1'/>
+    <function-decl name='PyType_Modified' mangled-name='PyType_Modified' filepath='Objects/typeobject.c' line='1054' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_Modified'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='1054' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='PyUnstable_Type_AssignVersionTag' mangled-name='PyUnstable_Type_AssignVersionTag' filepath='Objects/typeobject.c' line='1179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Type_AssignVersionTag'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='1179' column='1'/>
+    <function-decl name='PyUnstable_Type_AssignVersionTag' mangled-name='PyUnstable_Type_AssignVersionTag' filepath='Objects/typeobject.c' line='1189' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Type_AssignVersionTag'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='1189' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyType_GetFullyQualifiedName' mangled-name='PyType_GetFullyQualifiedName' filepath='Objects/typeobject.c' line='1399' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetFullyQualifiedName'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='1399' column='1'/>
+    <function-decl name='PyType_GetFullyQualifiedName' mangled-name='PyType_GetFullyQualifiedName' filepath='Objects/typeobject.c' line='1409' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetFullyQualifiedName'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='1409' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyType_GetFlags' mangled-name='PyType_GetFlags' filepath='Objects/typeobject.c' line='3415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetFlags'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='3415' column='1'/>
+    <function-decl name='PyType_GetFlags' mangled-name='PyType_GetFlags' filepath='Objects/typeobject.c' line='3425' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetFlags'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='3425' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyType_SUPPORTS_WEAKREFS' mangled-name='PyType_SUPPORTS_WEAKREFS' filepath='Objects/typeobject.c' line='3422' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_SUPPORTS_WEAKREFS'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='3422' column='1'/>
+    <function-decl name='PyType_SUPPORTS_WEAKREFS' mangled-name='PyType_SUPPORTS_WEAKREFS' filepath='Objects/typeobject.c' line='3432' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_SUPPORTS_WEAKREFS'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='3432' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyType_FromMetaclass' mangled-name='PyType_FromMetaclass' filepath='Objects/typeobject.c' line='4867' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_FromMetaclass'>
-      <parameter type-id='type-id-1' name='metaclass' filepath='Objects/typeobject.c' line='4867' column='1'/>
-      <parameter type-id='type-id-4' name='module' filepath='Objects/typeobject.c' line='4867' column='1'/>
-      <parameter type-id='type-id-525' name='spec' filepath='Objects/typeobject.c' line='4868' column='1'/>
-      <parameter type-id='type-id-4' name='bases_in' filepath='Objects/typeobject.c' line='4868' column='1'/>
+    <function-decl name='PyType_FromMetaclass' mangled-name='PyType_FromMetaclass' filepath='Objects/typeobject.c' line='4877' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_FromMetaclass'>
+      <parameter type-id='type-id-1' name='metaclass' filepath='Objects/typeobject.c' line='4877' column='1'/>
+      <parameter type-id='type-id-4' name='module' filepath='Objects/typeobject.c' line='4877' column='1'/>
+      <parameter type-id='type-id-525' name='spec' filepath='Objects/typeobject.c' line='4878' column='1'/>
+      <parameter type-id='type-id-4' name='bases_in' filepath='Objects/typeobject.c' line='4878' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyType_FromModuleAndSpec' mangled-name='PyType_FromModuleAndSpec' filepath='Objects/typeobject.c' line='4874' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_FromModuleAndSpec'>
-      <parameter type-id='type-id-4' name='module' filepath='Objects/typeobject.c' line='4874' column='1'/>
-      <parameter type-id='type-id-525' name='spec' filepath='Objects/typeobject.c' line='4874' column='1'/>
-      <parameter type-id='type-id-4' name='bases' filepath='Objects/typeobject.c' line='4874' column='1'/>
+    <function-decl name='PyType_FromModuleAndSpec' mangled-name='PyType_FromModuleAndSpec' filepath='Objects/typeobject.c' line='4884' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_FromModuleAndSpec'>
+      <parameter type-id='type-id-4' name='module' filepath='Objects/typeobject.c' line='4884' column='1'/>
+      <parameter type-id='type-id-525' name='spec' filepath='Objects/typeobject.c' line='4884' column='1'/>
+      <parameter type-id='type-id-4' name='bases' filepath='Objects/typeobject.c' line='4884' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyType_FromSpec' mangled-name='PyType_FromSpec' filepath='Objects/typeobject.c' line='4886' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_FromSpec'>
-      <parameter type-id='type-id-525' name='spec' filepath='Objects/typeobject.c' line='4886' column='1'/>
+    <function-decl name='PyType_FromSpec' mangled-name='PyType_FromSpec' filepath='Objects/typeobject.c' line='4896' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_FromSpec'>
+      <parameter type-id='type-id-525' name='spec' filepath='Objects/typeobject.c' line='4896' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyType_GetName' mangled-name='PyType_GetName' filepath='Objects/typeobject.c' line='4892' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetName'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='4892' column='1'/>
+    <function-decl name='PyType_GetName' mangled-name='PyType_GetName' filepath='Objects/typeobject.c' line='4902' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetName'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='4902' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyType_GetModuleName' mangled-name='PyType_GetModuleName' filepath='Objects/typeobject.c' line='4904' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModuleName'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='4904' column='1'/>
+    <function-decl name='PyType_GetModuleName' mangled-name='PyType_GetModuleName' filepath='Objects/typeobject.c' line='4914' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModuleName'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='4914' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyType_GetSlot' mangled-name='PyType_GetSlot' filepath='Objects/typeobject.c' line='4910' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetSlot'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='4910' column='1'/>
-      <parameter type-id='type-id-5' name='slot' filepath='Objects/typeobject.c' line='4910' column='1'/>
+    <function-decl name='PyType_GetSlot' mangled-name='PyType_GetSlot' filepath='Objects/typeobject.c' line='4920' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetSlot'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='4920' column='1'/>
+      <parameter type-id='type-id-5' name='slot' filepath='Objects/typeobject.c' line='4920' column='1'/>
       <return type-id='type-id-30'/>
     </function-decl>
-    <function-decl name='PyType_GetModule' mangled-name='PyType_GetModule' filepath='Objects/typeobject.c' line='4932' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModule'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='4932' column='1'/>
+    <function-decl name='PyType_GetModule' mangled-name='PyType_GetModule' filepath='Objects/typeobject.c' line='4942' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModule'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='4942' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyType_GetModuleState' mangled-name='PyType_GetModuleState' filepath='Objects/typeobject.c' line='4956' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModuleState'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='4956' column='1'/>
+    <function-decl name='PyType_GetModuleState' mangled-name='PyType_GetModuleState' filepath='Objects/typeobject.c' line='4966' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModuleState'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='4966' column='1'/>
       <return type-id='type-id-30'/>
     </function-decl>
-    <function-decl name='PyType_GetModuleByDef' mangled-name='PyType_GetModuleByDef' filepath='Objects/typeobject.c' line='5020' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModuleByDef'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='5020' column='1'/>
-      <parameter type-id='type-id-386' name='def' filepath='Objects/typeobject.c' line='5020' column='1'/>
+    <function-decl name='PyType_GetModuleByDef' mangled-name='PyType_GetModuleByDef' filepath='Objects/typeobject.c' line='5030' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModuleByDef'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='5030' column='1'/>
+      <parameter type-id='type-id-386' name='def' filepath='Objects/typeobject.c' line='5030' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyType_GetModuleByDef2' mangled-name='_PyType_GetModuleByDef2' filepath='Objects/typeobject.c' line='5033' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_GetModuleByDef2'>
-      <parameter type-id='type-id-1' name='left' filepath='Objects/typeobject.c' line='5033' column='1'/>
-      <parameter type-id='type-id-1' name='right' filepath='Objects/typeobject.c' line='5033' column='1'/>
-      <parameter type-id='type-id-386' name='def' filepath='Objects/typeobject.c' line='5034' column='1'/>
+    <function-decl name='_PyType_GetModuleByDef2' mangled-name='_PyType_GetModuleByDef2' filepath='Objects/typeobject.c' line='5043' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_GetModuleByDef2'>
+      <parameter type-id='type-id-1' name='left' filepath='Objects/typeobject.c' line='5043' column='1'/>
+      <parameter type-id='type-id-1' name='right' filepath='Objects/typeobject.c' line='5043' column='1'/>
+      <parameter type-id='type-id-386' name='def' filepath='Objects/typeobject.c' line='5044' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyType_GetModuleByDef3' mangled-name='_PyType_GetModuleByDef3' filepath='Objects/typeobject.c' line='5050' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_GetModuleByDef3'>
-      <parameter type-id='type-id-1' name='left' filepath='Objects/typeobject.c' line='5050' column='1'/>
-      <parameter type-id='type-id-1' name='right' filepath='Objects/typeobject.c' line='5050' column='1'/>
-      <parameter type-id='type-id-1' name='third' filepath='Objects/typeobject.c' line='5050' column='1'/>
-      <parameter type-id='type-id-386' name='def' filepath='Objects/typeobject.c' line='5051' column='1'/>
+    <function-decl name='_PyType_GetModuleByDef3' mangled-name='_PyType_GetModuleByDef3' filepath='Objects/typeobject.c' line='5060' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_GetModuleByDef3'>
+      <parameter type-id='type-id-1' name='left' filepath='Objects/typeobject.c' line='5060' column='1'/>
+      <parameter type-id='type-id-1' name='right' filepath='Objects/typeobject.c' line='5060' column='1'/>
+      <parameter type-id='type-id-1' name='third' filepath='Objects/typeobject.c' line='5060' column='1'/>
+      <parameter type-id='type-id-386' name='def' filepath='Objects/typeobject.c' line='5061' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyObject_GetTypeData' mangled-name='PyObject_GetTypeData' filepath='Objects/typeobject.c' line='5070' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetTypeData'>
-      <parameter type-id='type-id-4' name='obj' filepath='Objects/typeobject.c' line='5070' column='1'/>
-      <parameter type-id='type-id-1' name='cls' filepath='Objects/typeobject.c' line='5070' column='1'/>
+    <function-decl name='PyObject_GetTypeData' mangled-name='PyObject_GetTypeData' filepath='Objects/typeobject.c' line='5080' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetTypeData'>
+      <parameter type-id='type-id-4' name='obj' filepath='Objects/typeobject.c' line='5080' column='1'/>
+      <parameter type-id='type-id-1' name='cls' filepath='Objects/typeobject.c' line='5080' column='1'/>
       <return type-id='type-id-30'/>
     </function-decl>
-    <function-decl name='PyType_GetTypeDataSize' mangled-name='PyType_GetTypeDataSize' filepath='Objects/typeobject.c' line='5077' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetTypeDataSize'>
-      <parameter type-id='type-id-1' name='cls' filepath='Objects/typeobject.c' line='5077' column='1'/>
+    <function-decl name='PyType_GetTypeDataSize' mangled-name='PyType_GetTypeDataSize' filepath='Objects/typeobject.c' line='5087' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetTypeDataSize'>
+      <parameter type-id='type-id-1' name='cls' filepath='Objects/typeobject.c' line='5087' column='1'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='PyObject_GetItemData' mangled-name='PyObject_GetItemData' filepath='Objects/typeobject.c' line='5087' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetItemData'>
-      <parameter type-id='type-id-4' name='obj' filepath='Objects/typeobject.c' line='5087' column='1'/>
+    <function-decl name='PyObject_GetItemData' mangled-name='PyObject_GetItemData' filepath='Objects/typeobject.c' line='5097' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetItemData'>
+      <parameter type-id='type-id-4' name='obj' filepath='Objects/typeobject.c' line='5097' column='1'/>
       <return type-id='type-id-30'/>
     </function-decl>
-    <function-decl name='_PyType_Lookup' mangled-name='_PyType_Lookup' filepath='Objects/typeobject.c' line='5332' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_Lookup'>
-      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='5332' column='1'/>
-      <parameter type-id='type-id-4' name='name' filepath='Objects/typeobject.c' line='5332' column='1'/>
+    <function-decl name='_PyType_Lookup' mangled-name='_PyType_Lookup' filepath='Objects/typeobject.c' line='5342' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_Lookup'>
+      <parameter type-id='type-id-1' name='type' filepath='Objects/typeobject.c' line='5342' column='1'/>
+      <parameter type-id='type-id-4' name='name' filepath='Objects/typeobject.c' line='5342' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyStaticType_InitForExtension' mangled-name='_PyStaticType_InitForExtension' filepath='Objects/typeobject.c' line='8352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyStaticType_InitForExtension'>
-      <parameter type-id='type-id-28' name='interp' filepath='Objects/typeobject.c' line='8352' column='1'/>
-      <parameter type-id='type-id-1' name='self' filepath='Objects/typeobject.c' line='8352' column='1'/>
+    <function-decl name='_PyStaticType_InitForExtension' mangled-name='_PyStaticType_InitForExtension' filepath='Objects/typeobject.c' line='8356' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyStaticType_InitForExtension'>
+      <parameter type-id='type-id-28' name='interp' filepath='Objects/typeobject.c' line='8356' column='1'/>
+      <parameter type-id='type-id-1' name='self' filepath='Objects/typeobject.c' line='8356' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PySuper_Lookup' mangled-name='_PySuper_Lookup' filepath='Objects/typeobject.c' line='11315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PySuper_Lookup'>
-      <parameter type-id='type-id-1' name='su_type' filepath='Objects/typeobject.c' line='11315' column='1'/>
-      <parameter type-id='type-id-4' name='su_obj' filepath='Objects/typeobject.c' line='11315' column='1'/>
-      <parameter type-id='type-id-4' name='name' filepath='Objects/typeobject.c' line='11315' column='1'/>
-      <parameter type-id='type-id-175' name='method' filepath='Objects/typeobject.c' line='11315' column='1'/>
+    <function-decl name='_PySuper_Lookup' mangled-name='_PySuper_Lookup' filepath='Objects/typeobject.c' line='11319' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PySuper_Lookup'>
+      <parameter type-id='type-id-1' name='su_type' filepath='Objects/typeobject.c' line='11319' column='1'/>
+      <parameter type-id='type-id-4' name='su_obj' filepath='Objects/typeobject.c' line='11319' column='1'/>
+      <parameter type-id='type-id-4' name='name' filepath='Objects/typeobject.c' line='11319' column='1'/>
+      <parameter type-id='type-id-175' name='method' filepath='Objects/typeobject.c' line='11319' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/typevarobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/typevarobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyArg_UnpackKeywordsWithVararg' mangled-name='_PyArg_UnpackKeywordsWithVararg' filepath='./Include/internal/pycore_modsupport.h' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_UnpackKeywordsWithVararg'>
       <parameter type-id='type-id-255'/>
       <parameter type-id='type-id-7'/>
@@ -10005,7 +10005,7 @@
     <var-decl name='_PyNoDefault_Type' type-id='type-id-263' visibility='default' filepath='./Include/internal/pycore_typevarobject.h' line='21' column='1'/>
     <var-decl name='_Py_NoDefaultStruct' type-id='type-id-353' visibility='default' filepath='./Include/internal/pycore_typevarobject.h' line='22' column='1'/>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/unicodectype.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/unicodectype.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyUnicode_ToTitlecase' mangled-name='_PyUnicode_ToTitlecase' filepath='Objects/unicodectype.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicode_ToTitlecase'>
       <parameter type-id='type-id-256' name='ch' filepath='Objects/unicodectype.c' line='62' column='1'/>
       <return type-id='type-id-256'/>
@@ -10027,7 +10027,7 @@
       <return type-id='type-id-170'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/unicodeobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/unicodeobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-370' size-in-bits='1024' id='type-id-529'>
       <subrange length='128' type-id='type-id-2' id='type-id-530'/>
     </array-type-def>
@@ -10689,7 +10689,7 @@
       <enumerator name='_PyStatus_TYPE_EXIT' value='2'/>
     </enum-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/unionobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/unionobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='_PyUnion_Type' type-id='type-id-263' mangled-name='_PyUnion_Type' visibility='default' filepath='./Include/internal/pycore_unionobject.h' line='12' column='1' elf-symbol-id='_PyUnion_Type'/>
     <function-decl name='_Py_subs_parameters' filepath='./Include/internal/pycore_unionobject.h' line='18' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-4'/>
@@ -10703,7 +10703,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Objects/weakrefobject.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Objects/weakrefobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='_PyWeakReference' size-in-bits='512' is-struct='yes' visibility='default' filepath='./Include/cpython/weakrefobject.h' line='8' column='1' id='type-id-546'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ob_base' type-id='type-id-353' visibility='default' filepath='./Include/cpython/weakrefobject.h' line='9' column='1'/>
@@ -10759,7 +10759,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/action_helpers.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/action_helpers.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-549' size-in-bits='64' id='type-id-550'>
       <subrange length='1' type-id='type-id-2' id='type-id-428'/>
     </array-type-def>
@@ -11892,7 +11892,7 @@
       </data-member>
     </class-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/lexer/lexer.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/lexer/lexer.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_Py_FatalErrorFunc' mangled-name='_Py_FatalErrorFunc' filepath='./Include/cpython/pyerrors.h' line='124' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_FatalErrorFunc'>
       <parameter type-id='type-id-6'/>
       <parameter type-id='type-id-6'/>
@@ -11977,7 +11977,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/myreadline.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/myreadline.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <qualified-type-def type-id='type-id-56' restrict='yes' id='type-id-401'/>
     <pointer-type-def type-id='type-id-678' size-in-bits='64' id='type-id-26'/>
     <pointer-type-def type-id='type-id-679' size-in-bits='64' id='type-id-680'/>
@@ -12049,7 +12049,7 @@
       <return type-id='type-id-5'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/parser.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/parser.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='asdl_seq' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-683' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='28' column='1' id='type-id-684'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='size' type-id='type-id-7' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='29' column='1'/>
@@ -13346,7 +13346,7 @@
       <return type-id='type-id-30'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/peg_api.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/peg_api.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='PyCompilerFlags' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-738' visibility='default' filepath='./Include/cpython/compile.h' line='27' column='1' id='type-id-739'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='cf_flags' type-id='type-id-5' visibility='default' filepath='./Include/cpython/compile.h' line='28' column='1'/>
@@ -13385,7 +13385,7 @@
       <return type-id='type-id-573'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/pegen.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/pegen.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-740' size-in-bits='512' id='type-id-741'>
       <subrange length='8' type-id='type-id-2' id='type-id-515'/>
     </array-type-def>
@@ -13444,10 +13444,10 @@
     <array-type-def dimensions='1' type-id='type-id-766' size-in-bits='128' id='type-id-767'>
       <subrange length='1' type-id='type-id-2' id='type-id-428'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-768' size-in-bits='49152' id='type-id-769'>
+    <array-type-def dimensions='1' type-id='type-id-768' size-in-bits='65536' id='type-id-769'>
       <subrange length='128' type-id='type-id-2' id='type-id-530'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-770' size-in-bits='65536' id='type-id-771'>
+    <array-type-def dimensions='1' type-id='type-id-770' size-in-bits='49152' id='type-id-771'>
       <subrange length='128' type-id='type-id-2' id='type-id-530'/>
     </array-type-def>
     <array-type-def dimensions='1' type-id='type-id-772' size-in-bits='26880' id='type-id-773'>
@@ -14713,29 +14713,29 @@
         <var-decl name='tp_del' type-id='type-id-979' visibility='default' filepath='./Include/cpython/object.h' line='222' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3072'>
-        <var-decl name='tp_version_tag' type-id='type-id-99' visibility='default' filepath='./Include/cpython/object.h' line='225' column='1'/>
+        <var-decl name='tp_version_tag' type-id='type-id-99' visibility='default' filepath='./Include/cpython/object.h' line='227' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3136'>
-        <var-decl name='tp_finalize' type-id='type-id-979' visibility='default' filepath='./Include/cpython/object.h' line='227' column='1'/>
+        <var-decl name='tp_finalize' type-id='type-id-979' visibility='default' filepath='./Include/cpython/object.h' line='229' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3200'>
-        <var-decl name='tp_vectorcall' type-id='type-id-306' visibility='default' filepath='./Include/cpython/object.h' line='228' column='1'/>
+        <var-decl name='tp_vectorcall' type-id='type-id-306' visibility='default' filepath='./Include/cpython/object.h' line='230' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3264'>
-        <var-decl name='tp_watched' type-id='type-id-89' visibility='default' filepath='./Include/cpython/object.h' line='231' column='1'/>
+        <var-decl name='tp_watched' type-id='type-id-89' visibility='default' filepath='./Include/cpython/object.h' line='233' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3280'>
-        <var-decl name='tp_versions_used' type-id='type-id-443' visibility='default' filepath='./Include/cpython/object.h' line='232' column='1'/>
+        <var-decl name='tp_versions_used' type-id='type-id-443' visibility='default' filepath='./Include/cpython/object.h' line='240' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyType_WatchCallback' type-id='type-id-999' filepath='./Include/cpython/object.h' line='504' column='1' id='type-id-528'/>
-    <enum-decl name='PyRefTracerEvent' naming-typedef-id='type-id-1000' filepath='./Include/cpython/object.h' line='518' column='1' id='type-id-1001'>
+    <typedef-decl name='PyType_WatchCallback' type-id='type-id-999' filepath='./Include/cpython/object.h' line='514' column='1' id='type-id-528'/>
+    <enum-decl name='PyRefTracerEvent' naming-typedef-id='type-id-1000' filepath='./Include/cpython/object.h' line='528' column='1' id='type-id-1001'>
       <underlying-type type-id='type-id-32'/>
       <enumerator name='PyRefTracer_CREATE' value='0'/>
       <enumerator name='PyRefTracer_DESTROY' value='1'/>
     </enum-decl>
-    <typedef-decl name='PyRefTracerEvent' type-id='type-id-1001' filepath='./Include/cpython/object.h' line='521' column='1' id='type-id-1000'/>
-    <typedef-decl name='PyRefTracer' type-id='type-id-1002' filepath='./Include/cpython/object.h' line='523' column='1' id='type-id-402'/>
+    <typedef-decl name='PyRefTracerEvent' type-id='type-id-1001' filepath='./Include/cpython/object.h' line='531' column='1' id='type-id-1000'/>
+    <typedef-decl name='PyRefTracer' type-id='type-id-1002' filepath='./Include/cpython/object.h' line='533' column='1' id='type-id-402'/>
     <class-decl name='PyObjectArenaAllocator' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-501' visibility='default' filepath='./Include/cpython/objimpl.h' line='59' column='1' id='type-id-1003'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ctx' type-id='type-id-30' visibility='default' filepath='./Include/cpython/objimpl.h' line='61' column='1'/>
@@ -14819,7 +14819,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='_PyStackChunk' type-id='type-id-1016' filepath='./Include/cpython/pystate.h' line='57' column='1' id='type-id-1018'/>
-    <class-decl name='_ts' size-in-bits='2432' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='59' column='1' id='type-id-1019'>
+    <class-decl name='_ts' size-in-bits='2496' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='59' column='1' id='type-id-1019'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='prev' type-id='type-id-27' visibility='default' filepath='./Include/cpython/pystate.h' line='62' column='1'/>
       </data-member>
@@ -14943,6 +14943,9 @@
       <data-member access='public' layout-offset-in-bits='2368'>
         <var-decl name='threading_local_sentinel' type-id='type-id-4' visibility='default' filepath='./Include/cpython/pystate.h' line='202' column='1'/>
       </data-member>
+      <data-member access='public' layout-offset-in-bits='2432'>
+        <var-decl name='datastack_cached_chunk' type-id='type-id-1021' visibility='default' filepath='./Include/cpython/pystate.h' line='204' column='1'/>
+      </data-member>
     </class-decl>
     <class-decl name='__anonymous_struct__28' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='71' column='1' id='type-id-1020'>
       <data-member access='public' layout-offset-in-bits='0'>
@@ -14973,7 +14976,7 @@
         <var-decl name='finalized' type-id='type-id-99' visibility='default' filepath='./Include/cpython/pystate.h' line='92' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyFrameEvalFunction' type-id='type-id-1022' filepath='./Include/cpython/pystate.h' line='271' column='1' id='type-id-1023'/>
+    <typedef-decl name='_PyFrameEvalFunction' type-id='type-id-1022' filepath='./Include/cpython/pystate.h' line='273' column='1' id='type-id-1023'/>
     <class-decl name='_Py_tss_t' size-in-bits='64' is-struct='yes' visibility='default' filepath='./Include/cpython/pythread.h' line='35' column='1' id='type-id-1024'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_is_initialized' type-id='type-id-5' visibility='default' filepath='./Include/cpython/pythread.h' line='36' column='1'/>
@@ -17251,10 +17254,10 @@
         <var-decl name='identifiers' type-id='type-id-1172' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='774' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='315136'>
-        <var-decl name='ascii' type-id='type-id-769' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='778' column='1'/>
+        <var-decl name='ascii' type-id='type-id-771' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='778' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='364288'>
-        <var-decl name='latin1' type-id='type-id-771' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='782' column='1'/>
+        <var-decl name='latin1' type-id='type-id-769' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='782' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='__anonymous_struct__57' size-in-bits='9472' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='30' column='1' id='type-id-1171'>
@@ -19705,7 +19708,7 @@
         <var-decl name='_data' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='717' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__800' size-in-bits='384' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='775' column='1' id='type-id-768'>
+    <class-decl name='__anonymous_struct__800' size-in-bits='384' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='775' column='1' id='type-id-770'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_ascii' type-id='type-id-1028' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='776' column='1'/>
       </data-member>
@@ -19713,7 +19716,7 @@
         <var-decl name='_data' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='777' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__801' size-in-bits='512' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='779' column='1' id='type-id-770'>
+    <class-decl name='__anonymous_struct__801' size-in-bits='512' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='779' column='1' id='type-id-768'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_latin1' type-id='type-id-1031' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='780' column='1'/>
       </data-member>
@@ -19932,7 +19935,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='_rare_events' type-id='type-id-1232' filepath='./Include/internal/pycore_interp.h' line='85' column='1' id='type-id-1233'/>
-    <class-decl name='_is' size-in-bits='1559808' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_interp.h' line='94' column='1' id='type-id-1234'>
+    <class-decl name='_is' size-in-bits='1559872' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_interp.h' line='94' column='1' id='type-id-1234'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ceval' type-id='type-id-1109' visibility='default' filepath='./Include/internal/pycore_interp.h' line='99' column='1'/>
       </data-member>
@@ -20143,10 +20146,10 @@
       <data-member access='public' layout-offset-in-bits='1556992'>
         <var-decl name='_initial_thread' type-id='type-id-1245' visibility='default' filepath='./Include/internal/pycore_interp.h' line='276' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='1559680'>
+      <data-member access='public' layout-offset-in-bits='1559744'>
         <var-decl name='_interactive_src_count' type-id='type-id-7' visibility='default' filepath='./Include/internal/pycore_interp.h' line='277' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='1559744'>
+      <data-member access='public' layout-offset-in-bits='1559808'>
         <var-decl name='threads_preallocated' type-id='type-id-1246' visibility='default' filepath='./Include/internal/pycore_interp.h' line='279' column='1'/>
       </data-member>
     </class-decl>
@@ -20998,7 +21001,7 @@
         <var-decl name='tracer_data' type-id='type-id-30' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='200' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='pyruntimestate' size-in-bits='2267200' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='208' column='1' id='type-id-475'>
+    <class-decl name='pyruntimestate' size-in-bits='2267264' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='208' column='1' id='type-id-475'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='debug_offsets' type-id='type-id-1332' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='221' column='1'/>
       </data-member>
@@ -21275,17 +21278,17 @@
         <var-decl name='obj' type-id='type-id-499' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='74' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_PyThreadStateImpl' size-in-bits='2688' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_tstate.h' line='20' column='1' id='type-id-1349'>
+    <class-decl name='_PyThreadStateImpl' size-in-bits='2752' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_tstate.h' line='20' column='1' id='type-id-1349'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='base' type-id='type-id-1350' visibility='default' filepath='./Include/internal/pycore_tstate.h' line='22' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2432'>
+      <data-member access='public' layout-offset-in-bits='2496'>
         <var-decl name='asyncio_running_loop' type-id='type-id-4' visibility='default' filepath='./Include/internal/pycore_tstate.h' line='24' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2496'>
+      <data-member access='public' layout-offset-in-bits='2560'>
         <var-decl name='qsbr' type-id='type-id-507' visibility='default' filepath='./Include/internal/pycore_tstate.h' line='26' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2560'>
+      <data-member access='public' layout-offset-in-bits='2624'>
         <var-decl name='mem_free_queue' type-id='type-id-1247' visibility='default' filepath='./Include/internal/pycore_tstate.h' line='27' column='1'/>
       </data-member>
     </class-decl>
@@ -22618,7 +22621,7 @@
       <parameter type-id='type-id-321'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyType_Name' mangled-name='_PyType_Name' filepath='./Include/cpython/object.h' line='276' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_Name'>
+    <function-decl name='_PyType_Name' mangled-name='_PyType_Name' filepath='./Include/cpython/object.h' line='286' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_Name'>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-6'/>
     </function-decl>
@@ -23145,7 +23148,7 @@
       <return type-id='type-id-30'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/pegen_errors.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/pegen_errors.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyErr_ProgramDecodedTextObject' mangled-name='_PyErr_ProgramDecodedTextObject' filepath='./Include/internal/pycore_pyerrors.h' line='41' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_ProgramDecodedTextObject'>
       <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-5'/>
@@ -23207,7 +23210,7 @@
       <return type-id='type-id-7'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/string_parser.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/string_parser.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-258'/>
     <function-decl name='PyBytes_Size' mangled-name='PyBytes_Size' filepath='./Include/bytesobject.h' line='38' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyBytes_Size'>
       <parameter type-id='type-id-4'/>
@@ -23258,7 +23261,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/token.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/token.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-526' size-in-bits='4288' id='type-id-1521'>
       <subrange length='67' type-id='type-id-2' id='type-id-1522'/>
     </array-type-def>
@@ -23283,7 +23286,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/tokenizer/file_tokenizer.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/tokenizer/file_tokenizer.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <pointer-type-def type-id='type-id-1524' size-in-bits='64' id='type-id-1525'/>
     <pointer-type-def type-id='type-id-21' size-in-bits='64' id='type-id-57'/>
     <pointer-type-def type-id='type-id-1526' size-in-bits='64' id='type-id-1527'/>
@@ -23460,14 +23463,14 @@
       <return type-id='type-id-3'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/tokenizer/helpers.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/tokenizer/helpers.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='strcspn' filepath='/usr/include/string.h' line='293' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-6'/>
       <parameter type-id='type-id-6'/>
       <return type-id='type-id-21'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Parser/tokenizer/readline_tokenizer.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Parser/tokenizer/readline_tokenizer.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='PyUnicode_Decode' mangled-name='PyUnicode_Decode' filepath='./Include/unicodeobject.h' line='337' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_Decode'>
       <parameter type-id='type-id-6'/>
       <parameter type-id='type-id-7'/>
@@ -23476,7 +23479,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/Python-ast.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/Python-ast.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <typedef-decl name='_Py_once_fn_t' type-id='type-id-262' filepath='./Include/internal/pycore_lock.h' line='133' column='1' id='type-id-1528'/>
     <pointer-type-def type-id='type-id-953' size-in-bits='64' id='type-id-1529'/>
     <pointer-type-def type-id='type-id-1528' size-in-bits='64' id='type-id-1530'/>
@@ -23496,7 +23499,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/Python-tokenize.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/Python-tokenize.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='PyErr_SyntaxLocationObject' mangled-name='PyErr_SyntaxLocationObject' filepath='./Include/cpython/pyerrors.h' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SyntaxLocationObject'>
       <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-5'/>
@@ -23530,7 +23533,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/_warnings.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/_warnings.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyImport_GetModules' filepath='./Include/internal/pycore_import.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-28'/>
       <return type-id='type-id-4'/>
@@ -23598,7 +23601,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/assemble.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/assemble.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='_PyCodeConstructor' size-in-bits='896' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_code.h' line='243' column='1' id='type-id-1531'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='filename' type-id='type-id-4' visibility='default' filepath='./Include/internal/pycore_code.h' line='245' column='1'/>
@@ -23753,13 +23756,13 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/ast_opt.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/ast_opt.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyAST_GetDocString' filepath='./Include/internal/pycore_ast.h' line='921' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-605'/>
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/bltinmodule.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/bltinmodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <pointer-type-def type-id='type-id-813' size-in-bits='64' id='type-id-1543'/>
     <var-decl name='PyFilter_Type' type-id='type-id-263' mangled-name='PyFilter_Type' visibility='default' filepath='./Include/bltinmodule.h' line='7' column='1' elf-symbol-id='PyFilter_Type'/>
     <var-decl name='PyMap_Type' type-id='type-id-263' mangled-name='PyMap_Type' visibility='default' filepath='./Include/bltinmodule.h' line='8' column='1' elf-symbol-id='PyMap_Type'/>
@@ -23900,7 +23903,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/bootstrap_hash.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/bootstrap_hash.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_Py_fstat' mangled-name='_Py_fstat' filepath='./Include/internal/pycore_fileutils.h' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_fstat'>
       <parameter type-id='type-id-5'/>
       <parameter type-id='type-id-59'/>
@@ -23944,7 +23947,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/ceval.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/ceval.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-1544' size-in-bits='1664' id='type-id-1545'>
       <subrange length='26' type-id='type-id-2' id='type-id-880'/>
     </array-type-def>
@@ -24425,7 +24428,7 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/ceval_gil.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/ceval_gil.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <union-decl name='pthread_mutexattr_t' size-in-bits='32' naming-typedef-id='type-id-1551' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='32' column='1' id='type-id-1552'>
       <data-member access='public'>
         <var-decl name='__size' type-id='type-id-805' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='34' column='1'/>
@@ -24564,7 +24567,7 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/codecs.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/codecs.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='Py_hexdigits' type-id='type-id-6' mangled-name='Py_hexdigits' visibility='default' filepath='./Include/codecs.h' line='170' column='1' elf-symbol-id='Py_hexdigits'/>
     <function-decl name='PyStatus_Ok' mangled-name='PyStatus_Ok' filepath='./Include/cpython/initconfig.h' line='21' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Ok'>
       <return type-id='type-id-61'/>
@@ -24653,7 +24656,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/compile.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/compile.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-1560' size-in-bits='288' id='type-id-1561'>
       <subrange length='9' type-id='type-id-2' id='type-id-895'/>
     </array-type-def>
@@ -25164,7 +25167,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/context.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/context.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PyContext_Type' type-id='type-id-263' mangled-name='PyContext_Type' visibility='default' filepath='./Include/cpython/context.h' line='8' column='1' elf-symbol-id='PyContext_Type'/>
     <var-decl name='PyContextVar_Type' type-id='type-id-263' mangled-name='PyContextVar_Type' visibility='default' filepath='./Include/cpython/context.h' line='11' column='1' elf-symbol-id='PyContextVar_Type'/>
     <var-decl name='PyContextToken_Type' type-id='type-id-263' mangled-name='PyContextToken_Type' visibility='default' filepath='./Include/cpython/context.h' line='14' column='1' elf-symbol-id='PyContextToken_Type'/>
@@ -25253,7 +25256,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/critical_section.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/critical_section.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='PyCriticalSection' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1597'/>
     <class-decl name='PyCriticalSection2' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1598'/>
     <typedef-decl name='PyCriticalSection' type-id='type-id-1597' filepath='./Include/cpython/critical_section.h' line='70' column='1' id='type-id-1599'/>
@@ -25302,7 +25305,7 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/crossinterp.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/crossinterp.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='PyInterpreterConfig' size-in-bits='224' is-struct='yes' naming-typedef-id='type-id-1603' visibility='default' filepath='./Include/cpython/pylifecycle.h' line='44' column='1' id='type-id-1604'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='use_main_obmalloc' type-id='type-id-5' visibility='default' filepath='./Include/cpython/pylifecycle.h' line='46' column='1'/>
@@ -25409,21 +25412,21 @@
         <var-decl name='_error_override' type-id='type-id-1610' visibility='default' filepath='./Include/internal/pycore_crossinterp.h' line='308' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_sharednsitem' size-in-bits='128' is-struct='yes' visibility='default' filepath='Python/crossinterp.c' line='1100' column='1' id='type-id-1619'>
+    <class-decl name='_sharednsitem' size-in-bits='128' is-struct='yes' visibility='default' filepath='Python/crossinterp.c' line='1105' column='1' id='type-id-1619'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='name' type-id='type-id-6' visibility='default' filepath='Python/crossinterp.c' line='1101' column='1'/>
+        <var-decl name='name' type-id='type-id-6' visibility='default' filepath='Python/crossinterp.c' line='1106' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='data' type-id='type-id-1478' visibility='default' filepath='Python/crossinterp.c' line='1102' column='1'/>
+        <var-decl name='data' type-id='type-id-1478' visibility='default' filepath='Python/crossinterp.c' line='1107' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyXI_namespace_item' type-id='type-id-1619' filepath='Python/crossinterp.c' line='1108' column='1' id='type-id-1620'/>
-    <class-decl name='_sharedns' size-in-bits='128' is-struct='yes' visibility='default' filepath='Python/crossinterp.c' line='1228' column='1' id='type-id-1615'>
+    <typedef-decl name='_PyXI_namespace_item' type-id='type-id-1619' filepath='Python/crossinterp.c' line='1113' column='1' id='type-id-1620'/>
+    <class-decl name='_sharedns' size-in-bits='128' is-struct='yes' visibility='default' filepath='Python/crossinterp.c' line='1233' column='1' id='type-id-1615'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='len' type-id='type-id-7' visibility='default' filepath='Python/crossinterp.c' line='1229' column='1'/>
+        <var-decl name='len' type-id='type-id-7' visibility='default' filepath='Python/crossinterp.c' line='1234' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='items' type-id='type-id-1621' visibility='default' filepath='Python/crossinterp.c' line='1230' column='1'/>
+        <var-decl name='items' type-id='type-id-1621' visibility='default' filepath='Python/crossinterp.c' line='1235' column='1'/>
       </data-member>
     </class-decl>
     <pointer-type-def type-id='type-id-1603' size-in-bits='64' id='type-id-1622'/>
@@ -25571,76 +25574,76 @@
       <parameter type-id='type-id-1478' name='data' filepath='Python/crossinterp.c' line='330' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyXI_InitExcInfo' mangled-name='_PyXI_InitExcInfo' filepath='Python/crossinterp.c' line='926' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_InitExcInfo'>
-      <parameter type-id='type-id-1624' name='info' filepath='Python/crossinterp.c' line='926' column='1'/>
-      <parameter type-id='type-id-4' name='exc' filepath='Python/crossinterp.c' line='926' column='1'/>
+    <function-decl name='_PyXI_InitExcInfo' mangled-name='_PyXI_InitExcInfo' filepath='Python/crossinterp.c' line='931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_InitExcInfo'>
+      <parameter type-id='type-id-1624' name='info' filepath='Python/crossinterp.c' line='931' column='1'/>
+      <parameter type-id='type-id-4' name='exc' filepath='Python/crossinterp.c' line='931' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyXI_FormatExcInfo' mangled-name='_PyXI_FormatExcInfo' filepath='Python/crossinterp.c' line='948' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_FormatExcInfo'>
-      <parameter type-id='type-id-1624' name='info' filepath='Python/crossinterp.c' line='948' column='1'/>
+    <function-decl name='_PyXI_FormatExcInfo' mangled-name='_PyXI_FormatExcInfo' filepath='Python/crossinterp.c' line='953' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_FormatExcInfo'>
+      <parameter type-id='type-id-1624' name='info' filepath='Python/crossinterp.c' line='953' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyXI_ExcInfoAsObject' mangled-name='_PyXI_ExcInfoAsObject' filepath='Python/crossinterp.c' line='954' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_ExcInfoAsObject'>
-      <parameter type-id='type-id-1624' name='info' filepath='Python/crossinterp.c' line='954' column='1'/>
+    <function-decl name='_PyXI_ExcInfoAsObject' mangled-name='_PyXI_ExcInfoAsObject' filepath='Python/crossinterp.c' line='959' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_ExcInfoAsObject'>
+      <parameter type-id='type-id-1624' name='info' filepath='Python/crossinterp.c' line='959' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyXI_ClearExcInfo' mangled-name='_PyXI_ClearExcInfo' filepath='Python/crossinterp.c' line='960' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_ClearExcInfo'>
-      <parameter type-id='type-id-1624' name='info' filepath='Python/crossinterp.c' line='960' column='1'/>
+    <function-decl name='_PyXI_ClearExcInfo' mangled-name='_PyXI_ClearExcInfo' filepath='Python/crossinterp.c' line='965' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_ClearExcInfo'>
+      <parameter type-id='type-id-1624' name='info' filepath='Python/crossinterp.c' line='965' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='_PyXI_ApplyError' mangled-name='_PyXI_ApplyError' filepath='Python/crossinterp.c' line='1059' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_ApplyError'>
-      <parameter type-id='type-id-1618' name='error' filepath='Python/crossinterp.c' line='1059' column='1'/>
+    <function-decl name='_PyXI_ApplyError' mangled-name='_PyXI_ApplyError' filepath='Python/crossinterp.c' line='1064' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_ApplyError'>
+      <parameter type-id='type-id-1618' name='error' filepath='Python/crossinterp.c' line='1064' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyXI_FreeNamespace' mangled-name='_PyXI_FreeNamespace' filepath='Python/crossinterp.c' line='1401' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_FreeNamespace'>
-      <parameter type-id='type-id-1625' name='ns' filepath='Python/crossinterp.c' line='1401' column='1'/>
+    <function-decl name='_PyXI_FreeNamespace' mangled-name='_PyXI_FreeNamespace' filepath='Python/crossinterp.c' line='1406' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_FreeNamespace'>
+      <parameter type-id='type-id-1625' name='ns' filepath='Python/crossinterp.c' line='1406' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='_PyXI_NamespaceFromNames' mangled-name='_PyXI_NamespaceFromNames' filepath='Python/crossinterp.c' line='1426' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_NamespaceFromNames'>
-      <parameter type-id='type-id-4' name='names' filepath='Python/crossinterp.c' line='1426' column='1'/>
+    <function-decl name='_PyXI_NamespaceFromNames' mangled-name='_PyXI_NamespaceFromNames' filepath='Python/crossinterp.c' line='1431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_NamespaceFromNames'>
+      <parameter type-id='type-id-4' name='names' filepath='Python/crossinterp.c' line='1431' column='1'/>
       <return type-id='type-id-1625'/>
     </function-decl>
-    <function-decl name='_PyXI_FillNamespaceFromDict' mangled-name='_PyXI_FillNamespaceFromDict' filepath='Python/crossinterp.c' line='1454' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_FillNamespaceFromDict'>
-      <parameter type-id='type-id-1625' name='ns' filepath='Python/crossinterp.c' line='1454' column='1'/>
-      <parameter type-id='type-id-4' name='nsobj' filepath='Python/crossinterp.c' line='1454' column='1'/>
-      <parameter type-id='type-id-1626' name='session' filepath='Python/crossinterp.c' line='1455' column='1'/>
+    <function-decl name='_PyXI_FillNamespaceFromDict' mangled-name='_PyXI_FillNamespaceFromDict' filepath='Python/crossinterp.c' line='1459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_FillNamespaceFromDict'>
+      <parameter type-id='type-id-1625' name='ns' filepath='Python/crossinterp.c' line='1459' column='1'/>
+      <parameter type-id='type-id-4' name='nsobj' filepath='Python/crossinterp.c' line='1459' column='1'/>
+      <parameter type-id='type-id-1626' name='session' filepath='Python/crossinterp.c' line='1460' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyXI_ApplyNamespace' mangled-name='_PyXI_ApplyNamespace' filepath='Python/crossinterp.c' line='1516' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_ApplyNamespace'>
-      <parameter type-id='type-id-1625' name='ns' filepath='Python/crossinterp.c' line='1516' column='1'/>
-      <parameter type-id='type-id-4' name='nsobj' filepath='Python/crossinterp.c' line='1516' column='1'/>
-      <parameter type-id='type-id-4' name='dflt' filepath='Python/crossinterp.c' line='1516' column='1'/>
+    <function-decl name='_PyXI_ApplyNamespace' mangled-name='_PyXI_ApplyNamespace' filepath='Python/crossinterp.c' line='1521' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_ApplyNamespace'>
+      <parameter type-id='type-id-1625' name='ns' filepath='Python/crossinterp.c' line='1521' column='1'/>
+      <parameter type-id='type-id-4' name='nsobj' filepath='Python/crossinterp.c' line='1521' column='1'/>
+      <parameter type-id='type-id-4' name='dflt' filepath='Python/crossinterp.c' line='1521' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyXI_ApplyCapturedException' mangled-name='_PyXI_ApplyCapturedException' filepath='Python/crossinterp.c' line='1684' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_ApplyCapturedException'>
-      <parameter type-id='type-id-1626' name='session' filepath='Python/crossinterp.c' line='1684' column='1'/>
+    <function-decl name='_PyXI_ApplyCapturedException' mangled-name='_PyXI_ApplyCapturedException' filepath='Python/crossinterp.c' line='1689' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_ApplyCapturedException'>
+      <parameter type-id='type-id-1626' name='session' filepath='Python/crossinterp.c' line='1689' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyXI_HasCapturedException' mangled-name='_PyXI_HasCapturedException' filepath='Python/crossinterp.c' line='1695' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_HasCapturedException'>
-      <parameter type-id='type-id-1626' name='session' filepath='Python/crossinterp.c' line='1695' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='_PyXI_Enter' mangled-name='_PyXI_Enter' filepath='Python/crossinterp.c' line='1701' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_Enter'>
+    <function-decl name='_PyXI_HasCapturedException' mangled-name='_PyXI_HasCapturedException' filepath='Python/crossinterp.c' line='1701' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_HasCapturedException'>
       <parameter type-id='type-id-1626' name='session' filepath='Python/crossinterp.c' line='1701' column='1'/>
-      <parameter type-id='type-id-28' name='interp' filepath='Python/crossinterp.c' line='1702' column='1'/>
-      <parameter type-id='type-id-4' name='nsupdates' filepath='Python/crossinterp.c' line='1702' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyXI_Exit' mangled-name='_PyXI_Exit' filepath='Python/crossinterp.c' line='1770' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_Exit'>
-      <parameter type-id='type-id-1626' name='session' filepath='Python/crossinterp.c' line='1770' column='1'/>
+    <function-decl name='_PyXI_Enter' mangled-name='_PyXI_Enter' filepath='Python/crossinterp.c' line='1707' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_Enter'>
+      <parameter type-id='type-id-1626' name='session' filepath='Python/crossinterp.c' line='1707' column='1'/>
+      <parameter type-id='type-id-28' name='interp' filepath='Python/crossinterp.c' line='1708' column='1'/>
+      <parameter type-id='type-id-4' name='nsupdates' filepath='Python/crossinterp.c' line='1708' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='_PyXI_Exit' mangled-name='_PyXI_Exit' filepath='Python/crossinterp.c' line='1776' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_Exit'>
+      <parameter type-id='type-id-1626' name='session' filepath='Python/crossinterp.c' line='1776' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='_PyXI_NewInterpreter' mangled-name='_PyXI_NewInterpreter' filepath='Python/crossinterp.c' line='1830' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_NewInterpreter'>
-      <parameter type-id='type-id-1622' name='config' filepath='Python/crossinterp.c' line='1830' column='1'/>
-      <parameter type-id='type-id-168' name='maybe_whence' filepath='Python/crossinterp.c' line='1830' column='1'/>
-      <parameter type-id='type-id-1623' name='p_tstate' filepath='Python/crossinterp.c' line='1831' column='1'/>
-      <parameter type-id='type-id-1623' name='p_save_tstate' filepath='Python/crossinterp.c' line='1831' column='1'/>
+    <function-decl name='_PyXI_NewInterpreter' mangled-name='_PyXI_NewInterpreter' filepath='Python/crossinterp.c' line='1836' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_NewInterpreter'>
+      <parameter type-id='type-id-1622' name='config' filepath='Python/crossinterp.c' line='1836' column='1'/>
+      <parameter type-id='type-id-168' name='maybe_whence' filepath='Python/crossinterp.c' line='1836' column='1'/>
+      <parameter type-id='type-id-1623' name='p_tstate' filepath='Python/crossinterp.c' line='1837' column='1'/>
+      <parameter type-id='type-id-1623' name='p_save_tstate' filepath='Python/crossinterp.c' line='1837' column='1'/>
       <return type-id='type-id-28'/>
     </function-decl>
-    <function-decl name='_PyXI_EndInterpreter' mangled-name='_PyXI_EndInterpreter' filepath='Python/crossinterp.c' line='1877' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_EndInterpreter'>
-      <parameter type-id='type-id-28' name='interp' filepath='Python/crossinterp.c' line='1877' column='1'/>
-      <parameter type-id='type-id-27' name='tstate' filepath='Python/crossinterp.c' line='1878' column='1'/>
-      <parameter type-id='type-id-1623' name='p_save_tstate' filepath='Python/crossinterp.c' line='1878' column='1'/>
+    <function-decl name='_PyXI_EndInterpreter' mangled-name='_PyXI_EndInterpreter' filepath='Python/crossinterp.c' line='1883' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyXI_EndInterpreter'>
+      <parameter type-id='type-id-28' name='interp' filepath='Python/crossinterp.c' line='1883' column='1'/>
+      <parameter type-id='type-id-27' name='tstate' filepath='Python/crossinterp.c' line='1884' column='1'/>
+      <parameter type-id='type-id-1623' name='p_save_tstate' filepath='Python/crossinterp.c' line='1884' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
     <function-decl name='_PyCrossInterpreterData_Lookup' mangled-name='_PyCrossInterpreterData_Lookup' filepath='Python/crossinterp_data_lookup.h' line='15' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Lookup'>
@@ -25657,7 +25660,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/errors.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/errors.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_Py_fopen_obj' mangled-name='_Py_fopen_obj' filepath='./Include/cpython/fileutils.h' line='6' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_fopen_obj'>
       <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-6'/>
@@ -25737,37 +25740,37 @@
       <parameter type-id='type-id-4' name='dict' filepath='Python/errors.c' line='1295' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyErr_SyntaxLocation' mangled-name='PyErr_SyntaxLocation' filepath='Python/errors.c' line='1728' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SyntaxLocation'>
-      <parameter type-id='type-id-6' name='filename' filepath='Python/errors.c' line='1728' column='1'/>
-      <parameter type-id='type-id-5' name='lineno' filepath='Python/errors.c' line='1728' column='1'/>
+    <function-decl name='PyErr_SyntaxLocation' mangled-name='PyErr_SyntaxLocation' filepath='Python/errors.c' line='1726' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SyntaxLocation'>
+      <parameter type-id='type-id-6' name='filename' filepath='Python/errors.c' line='1726' column='1'/>
+      <parameter type-id='type-id-5' name='lineno' filepath='Python/errors.c' line='1726' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='PyErr_RangedSyntaxLocationObject' mangled-name='PyErr_RangedSyntaxLocationObject' filepath='Python/errors.c' line='1848' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_RangedSyntaxLocationObject'>
-      <parameter type-id='type-id-4' name='filename' filepath='Python/errors.c' line='1848' column='1'/>
-      <parameter type-id='type-id-5' name='lineno' filepath='Python/errors.c' line='1848' column='1'/>
-      <parameter type-id='type-id-5' name='col_offset' filepath='Python/errors.c' line='1848' column='1'/>
-      <parameter type-id='type-id-5' name='end_lineno' filepath='Python/errors.c' line='1849' column='1'/>
-      <parameter type-id='type-id-5' name='end_col_offset' filepath='Python/errors.c' line='1849' column='1'/>
+    <function-decl name='PyErr_RangedSyntaxLocationObject' mangled-name='PyErr_RangedSyntaxLocationObject' filepath='Python/errors.c' line='1846' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_RangedSyntaxLocationObject'>
+      <parameter type-id='type-id-4' name='filename' filepath='Python/errors.c' line='1846' column='1'/>
+      <parameter type-id='type-id-5' name='lineno' filepath='Python/errors.c' line='1846' column='1'/>
+      <parameter type-id='type-id-5' name='col_offset' filepath='Python/errors.c' line='1846' column='1'/>
+      <parameter type-id='type-id-5' name='end_lineno' filepath='Python/errors.c' line='1847' column='1'/>
+      <parameter type-id='type-id-5' name='end_col_offset' filepath='Python/errors.c' line='1847' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='PyErr_SyntaxLocationEx' mangled-name='PyErr_SyntaxLocationEx' filepath='Python/errors.c' line='1854' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SyntaxLocationEx'>
-      <parameter type-id='type-id-6' name='filename' filepath='Python/errors.c' line='1854' column='1'/>
-      <parameter type-id='type-id-5' name='lineno' filepath='Python/errors.c' line='1854' column='1'/>
-      <parameter type-id='type-id-5' name='col_offset' filepath='Python/errors.c' line='1854' column='1'/>
+    <function-decl name='PyErr_SyntaxLocationEx' mangled-name='PyErr_SyntaxLocationEx' filepath='Python/errors.c' line='1852' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SyntaxLocationEx'>
+      <parameter type-id='type-id-6' name='filename' filepath='Python/errors.c' line='1852' column='1'/>
+      <parameter type-id='type-id-5' name='lineno' filepath='Python/errors.c' line='1852' column='1'/>
+      <parameter type-id='type-id-5' name='col_offset' filepath='Python/errors.c' line='1852' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='PyErr_ProgramText' mangled-name='PyErr_ProgramText' filepath='Python/errors.c' line='1919' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_ProgramText'>
-      <parameter type-id='type-id-6' name='filename' filepath='Python/errors.c' line='1919' column='1'/>
-      <parameter type-id='type-id-5' name='lineno' filepath='Python/errors.c' line='1919' column='1'/>
+    <function-decl name='PyErr_ProgramText' mangled-name='PyErr_ProgramText' filepath='Python/errors.c' line='1917' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_ProgramText'>
+      <parameter type-id='type-id-6' name='filename' filepath='Python/errors.c' line='1917' column='1'/>
+      <parameter type-id='type-id-5' name='lineno' filepath='Python/errors.c' line='1917' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyTokenizer_FindEncodingFilename' filepath='Python/errors.c' line='1936' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyTokenizer_FindEncodingFilename' filepath='Python/errors.c' line='1934' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-5'/>
       <parameter type-id='type-id-4'/>
       <return type-id='type-id-17'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/fileutils.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/fileutils.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='__mbstate_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-1630' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='13' column='1' id='type-id-1631'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__count' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='15' column='1'/>
@@ -25892,7 +25895,7 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/flowgraph.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/flowgraph.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyCompile_EnsureArrayLargeEnough' filepath='./Include/internal/pycore_compile.h' line='68' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-5'/>
       <parameter type-id='type-id-259'/>
@@ -25902,7 +25905,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/formatter_unicode.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/formatter_unicode.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='lconv' size-in-bits='768' is-struct='yes' visibility='default' filepath='/usr/include/locale.h' line='51' column='1' id='type-id-1637'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='decimal_point' type-id='type-id-17' visibility='default' filepath='/usr/include/locale.h' line='55' column='1'/>
@@ -26021,7 +26024,7 @@
       <return type-id='type-id-1638'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/frame.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/frame.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-1639' size-in-bits='384' id='type-id-1640'>
       <subrange length='6' type-id='type-id-2' id='type-id-390'/>
     </array-type-def>
@@ -26042,7 +26045,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/frozen.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/frozen.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='_frozen' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/cpython/import.h' line='15' column='1' id='type-id-1643'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='name' type-id='type-id-6' visibility='default' filepath='./Include/cpython/import.h' line='16' column='1'/>
@@ -26075,7 +26078,7 @@
     <var-decl name='_PyImport_FrozenTest' type-id='type-id-1646' mangled-name='_PyImport_FrozenTest' visibility='default' filepath='./Include/internal/pycore_import.h' line='185' column='1' elf-symbol-id='_PyImport_FrozenTest'/>
     <var-decl name='_PyImport_FrozenAliases' type-id='type-id-1648' visibility='default' filepath='./Include/internal/pycore_import.h' line='187' column='1'/>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/frozenmain.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/frozenmain.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <pointer-type-def type-id='type-id-264' size-in-bits='64' id='type-id-60'/>
     <function-decl name='PyConfig_InitPythonConfig' mangled-name='PyConfig_InitPythonConfig' filepath='./Include/cpython/initconfig.h' line='239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_InitPythonConfig'>
       <parameter type-id='type-id-60'/>
@@ -26132,7 +26135,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/gc.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/gc.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <typedef-decl name='gcvisitobjects_t' type-id='type-id-333' filepath='./Include/cpython/objimpl.h' line='103' column='1' id='type-id-1649'/>
     <pointer-type-def type-id='type-id-210' size-in-bits='64' id='type-id-172'/>
     <function-decl name='PyTime_AsSecondsDouble' mangled-name='PyTime_AsSecondsDouble' filepath='./Include/cpython/pytime.h' line='14' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyTime_AsSecondsDouble'>
@@ -26186,14 +26189,14 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/gc_gil.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/gc_gil.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyObject_ClearFreeLists' filepath='./Include/internal/pycore_freelist.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-398'/>
       <parameter type-id='type-id-5'/>
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/getargs.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/getargs.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='PyThreadState_New' mangled-name='PyThreadState_New' filepath='./Include/pystate.h' line='48' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_New'>
       <parameter type-id='type-id-28'/>
       <return type-id='type-id-27'/>
@@ -26267,21 +26270,21 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/getcompiler.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/getcompiler.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='Py_GetCompiler' mangled-name='Py_GetCompiler' filepath='Python/getcompiler.c' line='24' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetCompiler'>
       <return type-id='type-id-6'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/getopt.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/getopt.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='_PyOS_opterr' type-id='type-id-5' visibility='default' filepath='./Include/internal/pycore_getopt.h' line='8' column='1'/>
     <var-decl name='_PyOS_optind' type-id='type-id-7' visibility='default' filepath='./Include/internal/pycore_getopt.h' line='9' column='1'/>
     <var-decl name='_PyOS_optarg' type-id='type-id-18' visibility='default' filepath='./Include/internal/pycore_getopt.h' line='10' column='1'/>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/getversion.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/getversion.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <qualified-type-def type-id='type-id-2' const='yes' id='type-id-1650'/>
     <var-decl name='Py_Version' type-id='type-id-1650' mangled-name='Py_Version' visibility='default' filepath='./Include/pylifecycle.h' line='64' column='1' elf-symbol-id='Py_Version'/>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/hamt.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/hamt.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='_PyHamt_Type' type-id='type-id-263' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='23' column='1'/>
     <var-decl name='_PyHamt_ArrayNode_Type' type-id='type-id-263' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='24' column='1'/>
     <var-decl name='_PyHamt_BitmapNode_Type' type-id='type-id-263' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='25' column='1'/>
@@ -26290,7 +26293,7 @@
     <var-decl name='_PyHamtValues_Type' type-id='type-id-263' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='28' column='1'/>
     <var-decl name='_PyHamtItems_Type' type-id='type-id-263' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='29' column='1'/>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/hashtable.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/hashtable.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <typedef-decl name='_Py_hashtable_foreach_func' type-id='type-id-1651' filepath='./Include/internal/pycore_hashtable.h' line='97' column='1' id='type-id-1652'/>
     <pointer-type-def type-id='type-id-1653' size-in-bits='64' id='type-id-1651'/>
     <function-decl name='_Py_hashtable_hash_ptr' mangled-name='_Py_hashtable_hash_ptr' filepath='Python/hashtable.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_hash_ptr'>
@@ -26334,7 +26337,7 @@
       <return type-id='type-id-5'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/import.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/import.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <enum-decl name='ext_module_kind' filepath='./Include/internal/pycore_importdl.h' line='18' column='1' id='type-id-1654'>
       <underlying-type type-id='type-id-32'/>
       <enumerator name='_Py_ext_module_kind_UNKNOWN' value='0'/>
@@ -26517,116 +26520,116 @@
       <parameter type-id='type-id-4' name='m' filepath='Python/import.c' line='186' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyImport_AddModuleRef' mangled-name='PyImport_AddModuleRef' filepath='Python/import.c' line='295' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AddModuleRef'>
-      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='295' column='1'/>
+    <function-decl name='PyImport_AddModuleRef' mangled-name='PyImport_AddModuleRef' filepath='Python/import.c' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AddModuleRef'>
+      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='315' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyImport_AddModuleObject' mangled-name='PyImport_AddModuleObject' filepath='Python/import.c' line='309' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AddModuleObject'>
-      <parameter type-id='type-id-4' name='name' filepath='Python/import.c' line='309' column='1'/>
+    <function-decl name='PyImport_AddModuleObject' mangled-name='PyImport_AddModuleObject' filepath='Python/import.c' line='329' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AddModuleObject'>
+      <parameter type-id='type-id-4' name='name' filepath='Python/import.c' line='329' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyImport_AddModule' mangled-name='PyImport_AddModule' filepath='Python/import.c' line='346' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AddModule'>
-      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='346' column='1'/>
+    <function-decl name='PyImport_AddModule' mangled-name='PyImport_AddModule' filepath='Python/import.c' line='366' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AddModule'>
+      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='366' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyState_FindModule' mangled-name='PyState_FindModule' filepath='Python/import.c' line='491' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_FindModule'>
-      <parameter type-id='type-id-386' name='module' filepath='Python/import.c' line='491' column='1'/>
+    <function-decl name='PyState_FindModule' mangled-name='PyState_FindModule' filepath='Python/import.c' line='511' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_FindModule'>
+      <parameter type-id='type-id-386' name='module' filepath='Python/import.c' line='511' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyState_AddModule' mangled-name='_PyState_AddModule' filepath='Python/import.c' line='506' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyState_AddModule'>
-      <parameter type-id='type-id-27' name='tstate' filepath='Python/import.c' line='506' column='1'/>
-      <parameter type-id='type-id-4' name='module' filepath='Python/import.c' line='506' column='1'/>
-      <parameter type-id='type-id-386' name='def' filepath='Python/import.c' line='506' column='1'/>
+    <function-decl name='_PyState_AddModule' mangled-name='_PyState_AddModule' filepath='Python/import.c' line='526' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyState_AddModule'>
+      <parameter type-id='type-id-27' name='tstate' filepath='Python/import.c' line='526' column='1'/>
+      <parameter type-id='type-id-4' name='module' filepath='Python/import.c' line='526' column='1'/>
+      <parameter type-id='type-id-386' name='def' filepath='Python/import.c' line='526' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyState_AddModule' mangled-name='PyState_AddModule' filepath='Python/import.c' line='524' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_AddModule'>
-      <parameter type-id='type-id-4' name='module' filepath='Python/import.c' line='524' column='1'/>
-      <parameter type-id='type-id-386' name='def' filepath='Python/import.c' line='524' column='1'/>
+    <function-decl name='PyState_AddModule' mangled-name='PyState_AddModule' filepath='Python/import.c' line='544' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_AddModule'>
+      <parameter type-id='type-id-4' name='module' filepath='Python/import.c' line='544' column='1'/>
+      <parameter type-id='type-id-386' name='def' filepath='Python/import.c' line='544' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyState_RemoveModule' mangled-name='PyState_RemoveModule' filepath='Python/import.c' line='554' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_RemoveModule'>
-      <parameter type-id='type-id-386' name='def' filepath='Python/import.c' line='554' column='1'/>
+    <function-decl name='PyState_RemoveModule' mangled-name='PyState_RemoveModule' filepath='Python/import.c' line='574' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_RemoveModule'>
+      <parameter type-id='type-id-386' name='def' filepath='Python/import.c' line='574' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='_PyImport_ClearExtension' mangled-name='_PyImport_ClearExtension' filepath='Python/import.c' line='827' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_ClearExtension'>
-      <parameter type-id='type-id-4' name='name' filepath='Python/import.c' line='827' column='1'/>
-      <parameter type-id='type-id-4' name='filename' filepath='Python/import.c' line='827' column='1'/>
+    <function-decl name='_PyImport_ClearExtension' mangled-name='_PyImport_ClearExtension' filepath='Python/import.c' line='847' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_ClearExtension'>
+      <parameter type-id='type-id-4' name='name' filepath='Python/import.c' line='847' column='1'/>
+      <parameter type-id='type-id-4' name='filename' filepath='Python/import.c' line='847' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyImport_ExtendInittab' mangled-name='PyImport_ExtendInittab' filepath='Python/import.c' line='2366' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExtendInittab'>
-      <parameter type-id='type-id-1224' name='newtab' filepath='Python/import.c' line='2366' column='1'/>
+    <function-decl name='PyImport_ExtendInittab' mangled-name='PyImport_ExtendInittab' filepath='Python/import.c' line='2401' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExtendInittab'>
+      <parameter type-id='type-id-1224' name='newtab' filepath='Python/import.c' line='2401' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyImport_AppendInittab' mangled-name='PyImport_AppendInittab' filepath='Python/import.c' line='2416' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AppendInittab'>
-      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='2416' column='1'/>
-      <parameter type-id='type-id-379' name='initfunc' filepath='Python/import.c' line='2416' column='1'/>
+    <function-decl name='PyImport_AppendInittab' mangled-name='PyImport_AppendInittab' filepath='Python/import.c' line='2451' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AppendInittab'>
+      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='2451' column='1'/>
+      <parameter type-id='type-id-379' name='initfunc' filepath='Python/import.c' line='2451' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyImport_GetMagicNumber' mangled-name='PyImport_GetMagicNumber' filepath='Python/import.c' line='2493' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetMagicNumber'>
+    <function-decl name='PyImport_GetMagicNumber' mangled-name='PyImport_GetMagicNumber' filepath='Python/import.c' line='2528' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetMagicNumber'>
       <return type-id='type-id-181'/>
     </function-decl>
-    <function-decl name='PyImport_GetMagicTag' mangled-name='PyImport_GetMagicTag' filepath='Python/import.c' line='2515' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetMagicTag'>
+    <function-decl name='PyImport_GetMagicTag' mangled-name='PyImport_GetMagicTag' filepath='Python/import.c' line='2550' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetMagicTag'>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='PyImport_ExecCodeModule' mangled-name='PyImport_ExecCodeModule' filepath='Python/import.c' line='2536' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModule'>
-      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='2536' column='1'/>
-      <parameter type-id='type-id-4' name='co' filepath='Python/import.c' line='2536' column='1'/>
+    <function-decl name='PyImport_ExecCodeModule' mangled-name='PyImport_ExecCodeModule' filepath='Python/import.c' line='2571' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModule'>
+      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='2571' column='1'/>
+      <parameter type-id='type-id-4' name='co' filepath='Python/import.c' line='2571' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyImport_ExecCodeModuleEx' mangled-name='PyImport_ExecCodeModuleEx' filepath='Python/import.c' line='2543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleEx'>
-      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='2543' column='1'/>
-      <parameter type-id='type-id-4' name='co' filepath='Python/import.c' line='2543' column='1'/>
-      <parameter type-id='type-id-6' name='pathname' filepath='Python/import.c' line='2543' column='1'/>
+    <function-decl name='PyImport_ExecCodeModuleEx' mangled-name='PyImport_ExecCodeModuleEx' filepath='Python/import.c' line='2578' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleEx'>
+      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='2578' column='1'/>
+      <parameter type-id='type-id-4' name='co' filepath='Python/import.c' line='2578' column='1'/>
+      <parameter type-id='type-id-6' name='pathname' filepath='Python/import.c' line='2578' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyImport_ExecCodeModuleWithPathnames' mangled-name='PyImport_ExecCodeModuleWithPathnames' filepath='Python/import.c' line='2550' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleWithPathnames'>
-      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='2550' column='1'/>
-      <parameter type-id='type-id-4' name='co' filepath='Python/import.c' line='2550' column='1'/>
-      <parameter type-id='type-id-6' name='pathname' filepath='Python/import.c' line='2551' column='1'/>
-      <parameter type-id='type-id-6' name='cpathname' filepath='Python/import.c' line='2552' column='1'/>
+    <function-decl name='PyImport_ExecCodeModuleWithPathnames' mangled-name='PyImport_ExecCodeModuleWithPathnames' filepath='Python/import.c' line='2585' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleWithPathnames'>
+      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='2585' column='1'/>
+      <parameter type-id='type-id-4' name='co' filepath='Python/import.c' line='2585' column='1'/>
+      <parameter type-id='type-id-6' name='pathname' filepath='Python/import.c' line='2586' column='1'/>
+      <parameter type-id='type-id-6' name='cpathname' filepath='Python/import.c' line='2587' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyImport_ExecCodeModuleObject' mangled-name='PyImport_ExecCodeModuleObject' filepath='Python/import.c' line='2652' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleObject'>
-      <parameter type-id='type-id-4' name='name' filepath='Python/import.c' line='2652' column='1'/>
-      <parameter type-id='type-id-4' name='co' filepath='Python/import.c' line='2652' column='1'/>
-      <parameter type-id='type-id-4' name='pathname' filepath='Python/import.c' line='2652' column='1'/>
-      <parameter type-id='type-id-4' name='cpathname' filepath='Python/import.c' line='2653' column='1'/>
+    <function-decl name='PyImport_ExecCodeModuleObject' mangled-name='PyImport_ExecCodeModuleObject' filepath='Python/import.c' line='2687' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleObject'>
+      <parameter type-id='type-id-4' name='name' filepath='Python/import.c' line='2687' column='1'/>
+      <parameter type-id='type-id-4' name='co' filepath='Python/import.c' line='2687' column='1'/>
+      <parameter type-id='type-id-4' name='pathname' filepath='Python/import.c' line='2687' column='1'/>
+      <parameter type-id='type-id-4' name='cpathname' filepath='Python/import.c' line='2688' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyImport_ImportFrozenModuleObject' mangled-name='PyImport_ImportFrozenModuleObject' filepath='Python/import.c' line='3021' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportFrozenModuleObject'>
-      <parameter type-id='type-id-4' name='name' filepath='Python/import.c' line='3021' column='1'/>
+    <function-decl name='PyImport_ImportFrozenModuleObject' mangled-name='PyImport_ImportFrozenModuleObject' filepath='Python/import.c' line='3056' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportFrozenModuleObject'>
+      <parameter type-id='type-id-4' name='name' filepath='Python/import.c' line='3056' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyImport_GetImporter' mangled-name='PyImport_GetImporter' filepath='Python/import.c' line='3341' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetImporter'>
-      <parameter type-id='type-id-4' name='path' filepath='Python/import.c' line='3341' column='1'/>
+    <function-decl name='PyImport_GetImporter' mangled-name='PyImport_GetImporter' filepath='Python/import.c' line='3376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetImporter'>
+      <parameter type-id='type-id-4' name='path' filepath='Python/import.c' line='3376' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyImport_ImportModuleNoBlock' mangled-name='PyImport_ImportModuleNoBlock' filepath='Python/import.c' line='3411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModuleNoBlock'>
-      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='3411' column='1'/>
+    <function-decl name='PyImport_ImportModuleNoBlock' mangled-name='PyImport_ImportModuleNoBlock' filepath='Python/import.c' line='3446' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModuleNoBlock'>
+      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='3446' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyImport_ImportModuleLevel' mangled-name='PyImport_ImportModuleLevel' filepath='Python/import.c' line='3876' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModuleLevel'>
-      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='3876' column='1'/>
-      <parameter type-id='type-id-4' name='globals' filepath='Python/import.c' line='3876' column='1'/>
-      <parameter type-id='type-id-4' name='locals' filepath='Python/import.c' line='3876' column='1'/>
-      <parameter type-id='type-id-4' name='fromlist' filepath='Python/import.c' line='3877' column='1'/>
-      <parameter type-id='type-id-5' name='level' filepath='Python/import.c' line='3877' column='1'/>
+    <function-decl name='PyImport_ImportModuleLevel' mangled-name='PyImport_ImportModuleLevel' filepath='Python/import.c' line='3932' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModuleLevel'>
+      <parameter type-id='type-id-6' name='name' filepath='Python/import.c' line='3932' column='1'/>
+      <parameter type-id='type-id-4' name='globals' filepath='Python/import.c' line='3932' column='1'/>
+      <parameter type-id='type-id-4' name='locals' filepath='Python/import.c' line='3932' column='1'/>
+      <parameter type-id='type-id-4' name='fromlist' filepath='Python/import.c' line='3933' column='1'/>
+      <parameter type-id='type-id-5' name='level' filepath='Python/import.c' line='3933' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyImport_ReloadModule' mangled-name='PyImport_ReloadModule' filepath='Python/import.c' line='3894' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ReloadModule'>
-      <parameter type-id='type-id-4' name='m' filepath='Python/import.c' line='3894' column='1'/>
+    <function-decl name='PyImport_ReloadModule' mangled-name='PyImport_ReloadModule' filepath='Python/import.c' line='3950' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ReloadModule'>
+      <parameter type-id='type-id-4' name='m' filepath='Python/import.c' line='3950' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyImport_GetModuleAttr' mangled-name='_PyImport_GetModuleAttr' filepath='Python/import.c' line='4202' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_GetModuleAttr'>
-      <parameter type-id='type-id-4' name='modname' filepath='Python/import.c' line='4202' column='1'/>
-      <parameter type-id='type-id-4' name='attrname' filepath='Python/import.c' line='4202' column='1'/>
+    <function-decl name='_PyImport_GetModuleAttr' mangled-name='_PyImport_GetModuleAttr' filepath='Python/import.c' line='4258' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_GetModuleAttr'>
+      <parameter type-id='type-id-4' name='modname' filepath='Python/import.c' line='4258' column='1'/>
+      <parameter type-id='type-id-4' name='attrname' filepath='Python/import.c' line='4258' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyInit__imp' mangled-name='PyInit__imp' filepath='Python/import.c' line='4873' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__imp'>
+    <function-decl name='PyInit__imp' mangled-name='PyInit__imp' filepath='Python/import.c' line='4929' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__imp'>
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/initconfig.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/initconfig.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='_PyArgv' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='69' column='1' id='type-id-241'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='argc' type-id='type-id-7' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='70' column='1'/>
@@ -26910,31 +26913,31 @@
       <parameter type-id='type-id-4' name='dict' filepath='Python/initconfig.c' line='1254' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyConfig_SetArgv' mangled-name='PyConfig_SetArgv' filepath='Python/initconfig.c' line='3003' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetArgv'>
-      <parameter type-id='type-id-60' name='config' filepath='Python/initconfig.c' line='3003' column='1'/>
-      <parameter type-id='type-id-7' name='argc' filepath='Python/initconfig.c' line='3003' column='1'/>
-      <parameter type-id='type-id-1669' name='argv' filepath='Python/initconfig.c' line='3003' column='1'/>
+    <function-decl name='PyConfig_SetArgv' mangled-name='PyConfig_SetArgv' filepath='Python/initconfig.c' line='3005' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetArgv'>
+      <parameter type-id='type-id-60' name='config' filepath='Python/initconfig.c' line='3005' column='1'/>
+      <parameter type-id='type-id-7' name='argc' filepath='Python/initconfig.c' line='3005' column='1'/>
+      <parameter type-id='type-id-1669' name='argv' filepath='Python/initconfig.c' line='3005' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='PyConfig_SetWideStringList' mangled-name='PyConfig_SetWideStringList' filepath='Python/initconfig.c' line='3015' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetWideStringList'>
-      <parameter type-id='type-id-60' name='config' filepath='Python/initconfig.c' line='3015' column='1'/>
-      <parameter type-id='type-id-1674' name='list' filepath='Python/initconfig.c' line='3015' column='1'/>
-      <parameter type-id='type-id-7' name='length' filepath='Python/initconfig.c' line='3016' column='1'/>
-      <parameter type-id='type-id-238' name='items' filepath='Python/initconfig.c' line='3016' column='1'/>
+    <function-decl name='PyConfig_SetWideStringList' mangled-name='PyConfig_SetWideStringList' filepath='Python/initconfig.c' line='3017' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetWideStringList'>
+      <parameter type-id='type-id-60' name='config' filepath='Python/initconfig.c' line='3017' column='1'/>
+      <parameter type-id='type-id-1674' name='list' filepath='Python/initconfig.c' line='3017' column='1'/>
+      <parameter type-id='type-id-7' name='length' filepath='Python/initconfig.c' line='3018' column='1'/>
+      <parameter type-id='type-id-238' name='items' filepath='Python/initconfig.c' line='3018' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='PyConfig_Read' mangled-name='PyConfig_Read' filepath='Python/initconfig.c' line='3099' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_Read'>
-      <parameter type-id='type-id-60' name='config' filepath='Python/initconfig.c' line='3099' column='1'/>
+    <function-decl name='PyConfig_Read' mangled-name='PyConfig_Read' filepath='Python/initconfig.c' line='3101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_Read'>
+      <parameter type-id='type-id-60' name='config' filepath='Python/initconfig.c' line='3101' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='_Py_GetConfigsAsDict' mangled-name='_Py_GetConfigsAsDict' filepath='Python/initconfig.c' line='3106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfigsAsDict'>
+    <function-decl name='_Py_GetConfigsAsDict' mangled-name='_Py_GetConfigsAsDict' filepath='Python/initconfig.c' line='3108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfigsAsDict'>
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/instruction_sequence.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/instruction_sequence.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='_PyInstructionSequence_Type' type-id='type-id-263' visibility='default' filepath='./Include/internal/pycore_instruction_sequence.h' line='67' column='1'/>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/instrumentation.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/instrumentation.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='_PyMonitoringState' size-in-bits='16' is-struct='yes' visibility='default' filepath='./Include/cpython/monitoring.h' line='37' column='1' id='type-id-1685'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='active' type-id='type-id-302' visibility='default' filepath='./Include/cpython/monitoring.h' line='38' column='1'/>
@@ -27064,7 +27067,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/interpconfig.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/interpconfig.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyInterpreterConfig_AsDict' mangled-name='_PyInterpreterConfig_AsDict' filepath='Python/interpconfig.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterConfig_AsDict'>
       <parameter type-id='type-id-1622' name='config' filepath='Python/interpconfig.c' line='54' column='1'/>
       <return type-id='type-id-4'/>
@@ -27085,7 +27088,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/intrinsics.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/intrinsics.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-1689' size-in-bits='1536' id='type-id-1690'>
       <subrange length='12' type-id='type-id-2' id='type-id-854'/>
     </array-type-def>
@@ -27192,7 +27195,7 @@
       <return type-id='type-id-4'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/legacy_tracing.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/legacy_tracing.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <typedef-decl name='_PyMonitoringEventSet' type-id='type-id-323' filepath='./Include/internal/pycore_instruments.h' line='16' column='1' id='type-id-1705'/>
     <pointer-type-def type-id='type-id-1705' size-in-bits='64' id='type-id-1706'/>
     <function-decl name='_PyMonitoring_RegisterCallback' filepath='./Include/internal/pycore_instruments.h' line='31' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -27219,7 +27222,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/lock.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/lock.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-53' size-in-bits='256' id='type-id-1707'>
       <subrange length='32' type-id='type-id-2' id='type-id-67'/>
     </array-type-def>
@@ -27369,7 +27372,7 @@
       <return type-id='type-id-3'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/marshal.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/marshal.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-482' size-in-bits='192' id='type-id-1721'>
       <subrange length='3' type-id='type-id-2' id='type-id-825'/>
     </array-type-def>
@@ -27439,44 +27442,44 @@
       <parameter type-id='type-id-401'/>
       <return type-id='type-id-21'/>
     </function-decl>
-    <function-decl name='PyMarshal_WriteLongToFile' mangled-name='PyMarshal_WriteLongToFile' filepath='Python/marshal.c' line='658' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_WriteLongToFile'>
-      <parameter type-id='type-id-181' name='x' filepath='Python/marshal.c' line='658' column='1'/>
-      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='658' column='1'/>
-      <parameter type-id='type-id-5' name='version' filepath='Python/marshal.c' line='658' column='1'/>
+    <function-decl name='PyMarshal_WriteLongToFile' mangled-name='PyMarshal_WriteLongToFile' filepath='Python/marshal.c' line='662' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_WriteLongToFile'>
+      <parameter type-id='type-id-181' name='x' filepath='Python/marshal.c' line='662' column='1'/>
+      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='662' column='1'/>
+      <parameter type-id='type-id-5' name='version' filepath='Python/marshal.c' line='662' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='PyMarshal_WriteObjectToFile' mangled-name='PyMarshal_WriteObjectToFile' filepath='Python/marshal.c' line='673' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_WriteObjectToFile'>
-      <parameter type-id='type-id-4' name='x' filepath='Python/marshal.c' line='673' column='1'/>
-      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='673' column='1'/>
-      <parameter type-id='type-id-5' name='version' filepath='Python/marshal.c' line='673' column='1'/>
+    <function-decl name='PyMarshal_WriteObjectToFile' mangled-name='PyMarshal_WriteObjectToFile' filepath='Python/marshal.c' line='677' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_WriteObjectToFile'>
+      <parameter type-id='type-id-4' name='x' filepath='Python/marshal.c' line='677' column='1'/>
+      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='677' column='1'/>
+      <parameter type-id='type-id-5' name='version' filepath='Python/marshal.c' line='677' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='PyMarshal_ReadShortFromFile' mangled-name='PyMarshal_ReadShortFromFile' filepath='Python/marshal.c' line='1572' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_ReadShortFromFile'>
-      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='1572' column='1'/>
+    <function-decl name='PyMarshal_ReadShortFromFile' mangled-name='PyMarshal_ReadShortFromFile' filepath='Python/marshal.c' line='1576' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_ReadShortFromFile'>
+      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='1576' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyMarshal_ReadLongFromFile' mangled-name='PyMarshal_ReadLongFromFile' filepath='Python/marshal.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_ReadLongFromFile'>
-      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='1588' column='1'/>
+    <function-decl name='PyMarshal_ReadLongFromFile' mangled-name='PyMarshal_ReadLongFromFile' filepath='Python/marshal.c' line='1592' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_ReadLongFromFile'>
+      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='1592' column='1'/>
       <return type-id='type-id-181'/>
     </function-decl>
-    <function-decl name='PyMarshal_ReadLastObjectFromFile' mangled-name='PyMarshal_ReadLastObjectFromFile' filepath='Python/marshal.c' line='1624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_ReadLastObjectFromFile'>
-      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='1624' column='1'/>
+    <function-decl name='PyMarshal_ReadLastObjectFromFile' mangled-name='PyMarshal_ReadLastObjectFromFile' filepath='Python/marshal.c' line='1628' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_ReadLastObjectFromFile'>
+      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='1628' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyMarshal_ReadObjectFromFile' mangled-name='PyMarshal_ReadObjectFromFile' filepath='Python/marshal.c' line='1649' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_ReadObjectFromFile'>
-      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='1649' column='1'/>
+    <function-decl name='PyMarshal_ReadObjectFromFile' mangled-name='PyMarshal_ReadObjectFromFile' filepath='Python/marshal.c' line='1653' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_ReadObjectFromFile'>
+      <parameter type-id='type-id-56' name='fp' filepath='Python/marshal.c' line='1653' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyMarshal_WriteObjectToString' mangled-name='PyMarshal_WriteObjectToString' filepath='Python/marshal.c' line='1745' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_WriteObjectToString'>
-      <parameter type-id='type-id-4' name='x' filepath='Python/marshal.c' line='1745' column='1'/>
-      <parameter type-id='type-id-5' name='version' filepath='Python/marshal.c' line='1745' column='1'/>
+    <function-decl name='PyMarshal_WriteObjectToString' mangled-name='PyMarshal_WriteObjectToString' filepath='Python/marshal.c' line='1749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_WriteObjectToString'>
+      <parameter type-id='type-id-4' name='x' filepath='Python/marshal.c' line='1749' column='1'/>
+      <parameter type-id='type-id-5' name='version' filepath='Python/marshal.c' line='1749' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyMarshal_Init' mangled-name='PyMarshal_Init' filepath='Python/marshal.c' line='1977' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_Init'>
+    <function-decl name='PyMarshal_Init' mangled-name='PyMarshal_Init' filepath='Python/marshal.c' line='1981' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMarshal_Init'>
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/modsupport.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/modsupport.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_Py_convert_optional_to_ssize_t' mangled-name='_Py_convert_optional_to_ssize_t' filepath='Python/modsupport.c' line='14' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_convert_optional_to_ssize_t'>
       <parameter type-id='type-id-4' name='obj' filepath='Python/modsupport.c' line='14' column='1'/>
       <parameter type-id='type-id-30' name='result' filepath='Python/modsupport.c' line='14' column='1'/>
@@ -27510,7 +27513,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/mysnprintf.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/mysnprintf.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='PyOS_vsnprintf' mangled-name='PyOS_vsnprintf' filepath='Python/mysnprintf.c' line='53' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_vsnprintf'>
       <parameter type-id='type-id-17' name='str' filepath='Python/mysnprintf.c' line='53' column='1'/>
       <parameter type-id='type-id-21' name='size' filepath='Python/mysnprintf.c' line='53' column='1'/>
@@ -27519,7 +27522,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/parking_lot.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/parking_lot.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='_PyRawMutex' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-1727' visibility='default' filepath='./Include/internal/pycore_lock.h' line='103' column='1' id='type-id-1728'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='v' type-id='type-id-426' visibility='default' filepath='./Include/internal/pycore_lock.h' line='104' column='1'/>
@@ -27570,7 +27573,7 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/pathconfig.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/pathconfig.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_Py_wreadlink' filepath='./Include/internal/pycore_fileutils.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-18'/>
       <parameter type-id='type-id-58'/>
@@ -27628,7 +27631,7 @@
       <return type-id='type-id-58'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/perf_jit_trampoline.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/perf_jit_trampoline.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <qualified-type-def type-id='type-id-219' restrict='yes' id='type-id-1732'/>
     <var-decl name='_Py_perfmap_jit_callbacks' type-id='type-id-1733' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='112' column='1'/>
     <function-decl name='gettimeofday' filepath='/usr/include/x86_64-linux-gnu/sys/time.h' line='67' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -27637,7 +27640,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/perf_trampoline.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/perf_trampoline.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='_Py_perfmap_callbacks' type-id='type-id-1733' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='111' column='1'/>
     <function-decl name='getppid' filepath='/usr/include/unistd.h' line='653' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-116'/>
@@ -27651,7 +27654,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/preconfig.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/preconfig.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <enum-decl name='PyMemAllocatorName' naming-typedef-id='type-id-1734' filepath='./Include/cpython/pymem.h' line='16' column='1' id='type-id-1735'>
       <underlying-type type-id='type-id-32'/>
       <enumerator name='PYMEM_ALLOCATOR_NOT_SET' value='0'/>
@@ -27724,7 +27727,7 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/pyctype.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/pyctype.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-370' size-in-bits='2048' id='type-id-1737'>
       <subrange length='256' type-id='type-id-2' id='type-id-69'/>
     </array-type-def>
@@ -27736,7 +27739,7 @@
     <var-decl name='_Py_ctype_tolower' type-id='type-id-1737' mangled-name='_Py_ctype_tolower' visibility='default' filepath='./Include/cpython/pyctype.h' line='29' column='1' elf-symbol-id='_Py_ctype_tolower'/>
     <var-decl name='_Py_ctype_toupper' type-id='type-id-1737' mangled-name='_Py_ctype_toupper' visibility='default' filepath='./Include/cpython/pyctype.h' line='30' column='1' elf-symbol-id='_Py_ctype_toupper'/>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/pyhash.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/pyhash.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-89' size-in-bits='128' id='type-id-1740'>
       <subrange length='16' type-id='type-id-2' id='type-id-64'/>
     </array-type-def>
@@ -27821,7 +27824,7 @@
       <return type-id='type-id-298'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/pylifecycle.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/pylifecycle.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='_PyPerf_Callbacks' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1733' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='94' column='1' id='type-id-1754'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='init_state' type-id='type-id-1104' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='96' column='1'/>
@@ -28450,45 +28453,45 @@
     <function-decl name='_Py_InitializeMain' mangled-name='_Py_InitializeMain' filepath='Python/pylifecycle.c' line='1491' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_InitializeMain'>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='Py_Finalize' mangled-name='Py_Finalize' filepath='Python/pylifecycle.c' line='2264' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Finalize'>
+    <function-decl name='Py_Finalize' mangled-name='Py_Finalize' filepath='Python/pylifecycle.c' line='2265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Finalize'>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='Py_NewInterpreter' mangled-name='Py_NewInterpreter' filepath='Python/pylifecycle.c' line='2407' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_NewInterpreter'>
+    <function-decl name='Py_NewInterpreter' mangled-name='Py_NewInterpreter' filepath='Python/pylifecycle.c' line='2408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_NewInterpreter'>
       <return type-id='type-id-27'/>
     </function-decl>
-    <function-decl name='Py_FatalError' mangled-name='Py_FatalError' filepath='Python/pylifecycle.c' line='3381' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_FatalError'>
-      <parameter type-id='type-id-6' name='msg' filepath='Python/pylifecycle.c' line='3381' column='1'/>
+    <function-decl name='Py_FatalError' mangled-name='Py_FatalError' filepath='Python/pylifecycle.c' line='3382' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_FatalError'>
+      <parameter type-id='type-id-6' name='msg' filepath='Python/pylifecycle.c' line='3382' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='_Py_FatalRefcountErrorFunc' mangled-name='_Py_FatalRefcountErrorFunc' filepath='Python/pylifecycle.c' line='3425' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_FatalRefcountErrorFunc'>
-      <parameter type-id='type-id-6' name='func' filepath='Python/pylifecycle.c' line='3425' column='1'/>
-      <parameter type-id='type-id-6' name='msg' filepath='Python/pylifecycle.c' line='3425' column='1'/>
+    <function-decl name='_Py_FatalRefcountErrorFunc' mangled-name='_Py_FatalRefcountErrorFunc' filepath='Python/pylifecycle.c' line='3426' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_FatalRefcountErrorFunc'>
+      <parameter type-id='type-id-6' name='func' filepath='Python/pylifecycle.c' line='3426' column='1'/>
+      <parameter type-id='type-id-6' name='msg' filepath='Python/pylifecycle.c' line='3426' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='Py_AtExit' mangled-name='Py_AtExit' filepath='Python/pylifecycle.c' line='3475' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_AtExit'>
-      <parameter type-id='type-id-230' name='func' filepath='Python/pylifecycle.c' line='3475' column='1'/>
+    <function-decl name='Py_AtExit' mangled-name='Py_AtExit' filepath='Python/pylifecycle.c' line='3476' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_AtExit'>
+      <parameter type-id='type-id-230' name='func' filepath='Python/pylifecycle.c' line='3476' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='Py_Exit' mangled-name='Py_Exit' filepath='Python/pylifecycle.c' line='3512' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Exit'>
-      <parameter type-id='type-id-5' name='sts' filepath='Python/pylifecycle.c' line='3512' column='1'/>
+    <function-decl name='Py_Exit' mangled-name='Py_Exit' filepath='Python/pylifecycle.c' line='3513' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Exit'>
+      <parameter type-id='type-id-5' name='sts' filepath='Python/pylifecycle.c' line='3513' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='Py_FdIsInteractive' mangled-name='Py_FdIsInteractive' filepath='Python/pylifecycle.c' line='3533' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_FdIsInteractive'>
-      <parameter type-id='type-id-56' name='fp' filepath='Python/pylifecycle.c' line='3533' column='1'/>
-      <parameter type-id='type-id-6' name='filename' filepath='Python/pylifecycle.c' line='3533' column='1'/>
+    <function-decl name='Py_FdIsInteractive' mangled-name='Py_FdIsInteractive' filepath='Python/pylifecycle.c' line='3534' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_FdIsInteractive'>
+      <parameter type-id='type-id-56' name='fp' filepath='Python/pylifecycle.c' line='3534' column='1'/>
+      <parameter type-id='type-id-6' name='filename' filepath='Python/pylifecycle.c' line='3534' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyOS_getsig' mangled-name='PyOS_getsig' filepath='Python/pylifecycle.c' line='3565' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_getsig'>
-      <parameter type-id='type-id-5' name='sig' filepath='Python/pylifecycle.c' line='3565' column='1'/>
+    <function-decl name='PyOS_getsig' mangled-name='PyOS_getsig' filepath='Python/pylifecycle.c' line='3566' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_getsig'>
+      <parameter type-id='type-id-5' name='sig' filepath='Python/pylifecycle.c' line='3566' column='1'/>
       <return type-id='type-id-1755'/>
     </function-decl>
-    <function-decl name='PyOS_setsig' mangled-name='PyOS_setsig' filepath='Python/pylifecycle.c' line='3604' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_setsig'>
-      <parameter type-id='type-id-5' name='sig' filepath='Python/pylifecycle.c' line='3604' column='1'/>
-      <parameter type-id='type-id-1755' name='handler' filepath='Python/pylifecycle.c' line='3604' column='1'/>
+    <function-decl name='PyOS_setsig' mangled-name='PyOS_setsig' filepath='Python/pylifecycle.c' line='3605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_setsig'>
+      <parameter type-id='type-id-5' name='sig' filepath='Python/pylifecycle.c' line='3605' column='1'/>
+      <parameter type-id='type-id-1755' name='handler' filepath='Python/pylifecycle.c' line='3605' column='1'/>
       <return type-id='type-id-1755'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/pystate.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/pystate.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <pointer-type-def type-id='type-id-1145' size-in-bits='64' id='type-id-1763'/>
     <pointer-type-def type-id='type-id-1336' size-in-bits='64' id='type-id-1764'/>
     <pointer-type-def type-id='type-id-1157' size-in-bits='64' id='type-id-1765'/>
@@ -28679,69 +28682,69 @@
       <parameter type-id='type-id-4' name='requested_id' filepath='Python/pystate.c' line='1383' column='1'/>
       <return type-id='type-id-28'/>
     </function-decl>
-    <function-decl name='_PyThreadState_Prealloc' mangled-name='_PyThreadState_Prealloc' filepath='Python/pystate.c' line='1634' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Prealloc'>
-      <parameter type-id='type-id-28' name='interp' filepath='Python/pystate.c' line='1634' column='1'/>
+    <function-decl name='_PyThreadState_Prealloc' mangled-name='_PyThreadState_Prealloc' filepath='Python/pystate.c' line='1635' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Prealloc'>
+      <parameter type-id='type-id-28' name='interp' filepath='Python/pystate.c' line='1635' column='1'/>
       <return type-id='type-id-27'/>
     </function-decl>
-    <function-decl name='_PyThreadState_Init' mangled-name='_PyThreadState_Init' filepath='Python/pystate.c' line='1642' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Init'>
-      <parameter type-id='type-id-27' name='tstate' filepath='Python/pystate.c' line='1642' column='1'/>
+    <function-decl name='_PyThreadState_Init' mangled-name='_PyThreadState_Init' filepath='Python/pystate.c' line='1643' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Init'>
+      <parameter type-id='type-id-27' name='tstate' filepath='Python/pystate.c' line='1643' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='PyThreadState_DeleteCurrent' mangled-name='PyThreadState_DeleteCurrent' filepath='Python/pystate.c' line='1874' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_DeleteCurrent'>
+    <function-decl name='PyThreadState_DeleteCurrent' mangled-name='PyThreadState_DeleteCurrent' filepath='Python/pystate.c' line='1880' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_DeleteCurrent'>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='_PyThreadState_GetDict' mangled-name='_PyThreadState_GetDict' filepath='Python/pystate.c' line='1951' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_GetDict'>
-      <parameter type-id='type-id-27' name='tstate' filepath='Python/pystate.c' line='1951' column='1'/>
+    <function-decl name='_PyThreadState_GetDict' mangled-name='_PyThreadState_GetDict' filepath='Python/pystate.c' line='1957' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_GetDict'>
+      <parameter type-id='type-id-27' name='tstate' filepath='Python/pystate.c' line='1957' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='PyThreadState_GetID' mangled-name='PyThreadState_GetID' filepath='Python/pystate.c' line='2000' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetID'>
-      <parameter type-id='type-id-27' name='tstate' filepath='Python/pystate.c' line='2000' column='1'/>
+    <function-decl name='PyThreadState_GetID' mangled-name='PyThreadState_GetID' filepath='Python/pystate.c' line='2006' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetID'>
+      <parameter type-id='type-id-27' name='tstate' filepath='Python/pystate.c' line='2006' column='1'/>
       <return type-id='type-id-106'/>
     </function-decl>
-    <function-decl name='PyThreadState_SetAsyncExc' mangled-name='PyThreadState_SetAsyncExc' filepath='Python/pystate.c' line='2381' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_SetAsyncExc'>
-      <parameter type-id='type-id-2' name='id' filepath='Python/pystate.c' line='2381' column='1'/>
-      <parameter type-id='type-id-4' name='exc' filepath='Python/pystate.c' line='2381' column='1'/>
+    <function-decl name='PyThreadState_SetAsyncExc' mangled-name='PyThreadState_SetAsyncExc' filepath='Python/pystate.c' line='2387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_SetAsyncExc'>
+      <parameter type-id='type-id-2' name='id' filepath='Python/pystate.c' line='2387' column='1'/>
+      <parameter type-id='type-id-4' name='exc' filepath='Python/pystate.c' line='2387' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='PyThreadState_GetUnchecked' mangled-name='PyThreadState_GetUnchecked' filepath='Python/pystate.c' line='2422' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetUnchecked'>
+    <function-decl name='PyThreadState_GetUnchecked' mangled-name='PyThreadState_GetUnchecked' filepath='Python/pystate.c' line='2428' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetUnchecked'>
       <return type-id='type-id-27'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Main' mangled-name='PyInterpreterState_Main' filepath='Python/pystate.c' line='2500' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Main'>
+    <function-decl name='PyInterpreterState_Main' mangled-name='PyInterpreterState_Main' filepath='Python/pystate.c' line='2506' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Main'>
       <return type-id='type-id-28'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_ThreadHead' mangled-name='PyInterpreterState_ThreadHead' filepath='Python/pystate.c' line='2511' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_ThreadHead'>
-      <parameter type-id='type-id-28' name='interp' filepath='Python/pystate.c' line='2511' column='1'/>
+    <function-decl name='PyInterpreterState_ThreadHead' mangled-name='PyInterpreterState_ThreadHead' filepath='Python/pystate.c' line='2517' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_ThreadHead'>
+      <parameter type-id='type-id-28' name='interp' filepath='Python/pystate.c' line='2517' column='1'/>
       <return type-id='type-id-27'/>
     </function-decl>
-    <function-decl name='PyThreadState_Next' mangled-name='PyThreadState_Next' filepath='Python/pystate.c' line='2516' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Next'>
-      <parameter type-id='type-id-27' name='tstate' filepath='Python/pystate.c' line='2516' column='1'/>
+    <function-decl name='PyThreadState_Next' mangled-name='PyThreadState_Next' filepath='Python/pystate.c' line='2522' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Next'>
+      <parameter type-id='type-id-27' name='tstate' filepath='Python/pystate.c' line='2522' column='1'/>
       <return type-id='type-id-27'/>
     </function-decl>
-    <function-decl name='_PyThread_CurrentFrames' mangled-name='_PyThread_CurrentFrames' filepath='Python/pystate.c' line='2531' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_CurrentFrames'>
+    <function-decl name='_PyThread_CurrentFrames' mangled-name='_PyThread_CurrentFrames' filepath='Python/pystate.c' line='2537' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_CurrentFrames'>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_GetEvalFrameFunc' mangled-name='_PyInterpreterState_GetEvalFrameFunc' filepath='Python/pystate.c' line='2861' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetEvalFrameFunc'>
-      <parameter type-id='type-id-28' name='interp' filepath='Python/pystate.c' line='2861' column='1'/>
+    <function-decl name='_PyInterpreterState_GetEvalFrameFunc' mangled-name='_PyInterpreterState_GetEvalFrameFunc' filepath='Python/pystate.c' line='2867' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetEvalFrameFunc'>
+      <parameter type-id='type-id-28' name='interp' filepath='Python/pystate.c' line='2867' column='1'/>
       <return type-id='type-id-1023'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_SetEvalFrameFunc' mangled-name='_PyInterpreterState_SetEvalFrameFunc' filepath='Python/pystate.c' line='2871' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetEvalFrameFunc'>
-      <parameter type-id='type-id-28' name='interp' filepath='Python/pystate.c' line='2871' column='1'/>
-      <parameter type-id='type-id-1023' name='eval_frame' filepath='Python/pystate.c' line='2872' column='1'/>
+    <function-decl name='_PyInterpreterState_SetEvalFrameFunc' mangled-name='_PyInterpreterState_SetEvalFrameFunc' filepath='Python/pystate.c' line='2877' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetEvalFrameFunc'>
+      <parameter type-id='type-id-28' name='interp' filepath='Python/pystate.c' line='2877' column='1'/>
+      <parameter type-id='type-id-1023' name='eval_frame' filepath='Python/pystate.c' line='2878' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_GetConfigCopy' mangled-name='_PyInterpreterState_GetConfigCopy' filepath='Python/pystate.c' line='2898' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfigCopy'>
-      <parameter type-id='type-id-60' name='config' filepath='Python/pystate.c' line='2898' column='1'/>
+    <function-decl name='_PyInterpreterState_GetConfigCopy' mangled-name='_PyInterpreterState_GetConfigCopy' filepath='Python/pystate.c' line='2904' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfigCopy'>
+      <parameter type-id='type-id-60' name='config' filepath='Python/pystate.c' line='2904' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/pystrcmp.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/pystrcmp.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='PyOS_mystricmp' mangled-name='PyOS_mystricmp' filepath='Python/pystrcmp.c' line='22' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_mystricmp'>
       <parameter type-id='type-id-6' name='s1' filepath='Python/pystrcmp.c' line='22' column='1'/>
       <parameter type-id='type-id-6' name='s2' filepath='Python/pystrcmp.c' line='22' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/pystrhex.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/pystrhex.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_Py_strhex' mangled-name='_Py_strhex' filepath='Python/pystrhex.c' line='145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_strhex'>
       <parameter type-id='type-id-6' name='argbuf' filepath='Python/pystrhex.c' line='145' column='1'/>
       <parameter type-id='type-id-253' name='arglen' filepath='Python/pystrhex.c' line='145' column='1'/>
@@ -28755,7 +28758,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/pythonrun.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/pythonrun.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyImport_GetImportlibExternalLoader' filepath='./Include/internal/pycore_import.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-28'/>
       <parameter type-id='type-id-6'/>
@@ -28952,7 +28955,7 @@
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/pytime.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/pytime.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <class-decl name='_Py_clock_info_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1767' visibility='default' filepath='./Include/internal/pycore_time.h' line='245' column='1' id='type-id-1768'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='implementation' type-id='type-id-6' visibility='default' filepath='./Include/internal/pycore_time.h' line='246' column='1'/>
@@ -29145,7 +29148,7 @@
       <return type-id='type-id-210'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/specialize.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/specialize.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyDictKeys_GetVersionForCurrentState' filepath='./Include/internal/pycore_dict.h' line='93' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-28'/>
       <parameter type-id='type-id-414'/>
@@ -29176,7 +29179,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/suggestions.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/suggestions.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_Py_UTF8_Edit_Cost' mangled-name='_Py_UTF8_Edit_Cost' filepath='Python/suggestions.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_UTF8_Edit_Cost'>
       <parameter type-id='type-id-4' name='a' filepath='Python/suggestions.c' line='180' column='1'/>
       <parameter type-id='type-id-4' name='b' filepath='Python/suggestions.c' line='180' column='1'/>
@@ -29184,10 +29187,10 @@
       <return type-id='type-id-7'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/symtable.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/symtable.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PySTEntry_Type' type-id='type-id-263' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='137' column='1'/>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/thread.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/thread.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <array-type-def dimensions='1' type-id='type-id-53' size-in-bits='448' id='type-id-1773'>
       <subrange length='56' type-id='type-id-2' id='type-id-1774'/>
     </array-type-def>
@@ -29388,7 +29391,7 @@
       <return type-id='type-id-30'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/traceback.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/traceback.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_PyObject_CallMethodFormat' filepath='./Include/internal/pycore_call.h' line='54' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-27'/>
       <parameter type-id='type-id-4'/>
@@ -29412,7 +29415,7 @@
       <return type-id='type-id-3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='Python/tracemalloc.c' comp-dir-path='/src' language='LANG_C11'>
+  <abi-instr address-size='64' path='Python/tracemalloc.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='PyTraceMalloc_Track' mangled-name='PyTraceMalloc_Track' filepath='Python/tracemalloc.c' line='1320' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyTraceMalloc_Track'>
       <parameter type-id='type-id-99' name='domain' filepath='Python/tracemalloc.c' line='1320' column='1'/>
       <parameter type-id='type-id-426' name='ptr' filepath='Python/tracemalloc.c' line='1320' column='1'/>

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -200,6 +200,8 @@ struct _ts {
        The PyThreadObject must hold the only reference to this value.
     */
     PyObject *threading_local_sentinel;
+
+    _PyStackChunk *datastack_cached_chunk;
 };
 
 #ifdef Py_DEBUG

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-11-00-13-59.gh-issue-142183.2iVhJH.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-11-00-13-59.gh-issue-142183.2iVhJH.rst
@@ -1,0 +1,1 @@
+Avoid a pathological case where repeated calls at a specific stack depth could be significantly slower.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1521,6 +1521,7 @@ init_threadstate(_PyThreadStateImpl *_tstate,
     tstate->datastack_chunk = NULL;
     tstate->datastack_top = NULL;
     tstate->datastack_limit = NULL;
+    tstate->datastack_cached_chunk = NULL;
     tstate->what_event = -1;
     tstate->previous_executor = NULL;
     tstate->dict_global_version = 0;
@@ -1654,6 +1655,11 @@ clear_datastack(PyThreadState *tstate)
         _PyStackChunk *prev = chunk->previous;
         _PyObject_VirtualFree(chunk, chunk->size);
         chunk = prev;
+    }
+    if (tstate->datastack_cached_chunk != NULL) {
+        _PyObject_VirtualFree(tstate->datastack_cached_chunk,
+                              tstate->datastack_cached_chunk->size);
+        tstate->datastack_cached_chunk = NULL;
     }
 }
 
@@ -2934,9 +2940,20 @@ push_chunk(PyThreadState *tstate, int size)
     while (allocate_size < (int)sizeof(PyObject*)*(size + MINIMUM_OVERHEAD)) {
         allocate_size *= 2;
     }
-    _PyStackChunk *new = allocate_chunk(allocate_size, tstate->datastack_chunk);
-    if (new == NULL) {
-        return NULL;
+    _PyStackChunk *new;
+    if (tstate->datastack_cached_chunk != NULL
+        && (size_t)allocate_size <= tstate->datastack_cached_chunk->size)
+    {
+        new = tstate->datastack_cached_chunk;
+        tstate->datastack_cached_chunk = NULL;
+        new->previous = tstate->datastack_chunk;
+        new->top = 0;
+    }
+    else {
+        new = allocate_chunk(allocate_size, tstate->datastack_chunk);
+        if (new == NULL) {
+            return NULL;
+        }
     }
     if (tstate->datastack_chunk) {
         tstate->datastack_chunk->top = tstate->datastack_top -
@@ -2972,12 +2989,17 @@ _PyThreadState_PopFrame(PyThreadState *tstate, _PyInterpreterFrame * frame)
     if (base == &tstate->datastack_chunk->data[0]) {
         _PyStackChunk *chunk = tstate->datastack_chunk;
         _PyStackChunk *previous = chunk->previous;
+        _PyStackChunk *cached = tstate->datastack_cached_chunk;
         // push_chunk ensures that the root chunk is never popped:
         assert(previous);
         tstate->datastack_top = &previous->data[previous->top];
         tstate->datastack_chunk = previous;
-        _PyObject_VirtualFree(chunk, chunk->size);
         tstate->datastack_limit = (PyObject **)(((char *)previous) + previous->size);
+        chunk->previous = NULL;
+        if (cached != NULL) {
+            _PyObject_VirtualFree(cached, cached->size);
+        }
+        tstate->datastack_cached_chunk = chunk;
     }
     else {
         assert(tstate->datastack_top);


### PR DESCRIPTION
Cache one datachunk per tstate to prevent alloc/dealloc thrashing when repeatedly hitting the same call depth at exactly the wrong boundary.

Move new _ts member to the end to not mess up remote debuggers' ideas of the struct's layout. (The struct is only created by the runtime, and the new field only used by the runtime, so it should be safe.)

(cherry picked from commit 706fd4ec08acbf1b1def3630017ebe55d224adfa) (cherry picked from commit 19cbcc0f85f30954293dbd92d718d5b81880b092)


<!-- gh-issue-number: gh-142183 -->
* Issue: gh-142183
<!-- /gh-issue-number -->
