### PR TITLE
gh-146139: Disable `socketpair` authentication on WASI

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -649,18 +649,22 @@ def _fallback_socketpair(family=AF_INET, type=SOCK_STREAM, proto=0):
     # Authenticating avoids using a connection from something else
     # able to connect to {host}:{port} instead of us.
     # We expect only AF_INET and AF_INET6 families.
-    try:
-        if (
-            ssock.getsockname() != csock.getpeername()
-            or csock.getsockname() != ssock.getpeername()
-        ):
-            raise ConnectionError("Unexpected peer connection")
-    except:
-        # getsockname() and getpeername() can fail
-        # if either socket isn't connected.
-        ssock.close()
-        csock.close()
-        raise
+    #
+    # Note that we skip this on WASI because on that platorm the client socket
+    # may not have finished connecting by the time we've reached this point.
+    if sys.platform != "wasi":
+        try:
+            if (
+                    ssock.getsockname() != csock.getpeername()
+                    or csock.getsockname() != ssock.getpeername()
+            ):
+                raise ConnectionError("Unexpected peer connection")
+        except:
+            # getsockname() and getpeername() can fail
+            # if either socket isn't connected.
+            ssock.close()
+            csock.close()
+            raise
 
     return (ssock, csock)
 

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -651,7 +651,7 @@ def _fallback_socketpair(family=AF_INET, type=SOCK_STREAM, proto=0):
     # We expect only AF_INET and AF_INET6 families.
     #
     # Note that we skip this on WASI because on that platorm the client socket
-    # may not have finished connecting by the time we've reached this point.
+    # may not have finished connecting by the time we've reached this point (gh-146139).
     if sys.platform != "wasi":
         try:
             if (


### PR DESCRIPTION
Calling `connect(2)` on a non-blocking socket on WASI may leave the socket in a "connecting" but not yet "connected" state.  In the former case, calling `getpeername(2)` on it will fail, leading to an unhandled exception in Python.


<!-- gh-issue-number: gh-146139 -->
* Issue: gh-146139
<!-- /gh-issue-number -->
