### PR TITLE
gh-146143: Fix the PyUnicodeWriter_WriteUCS4() signature

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1867,7 +1867,7 @@ object.
    On success, return ``0``.
    On error, set an exception, leave the writer unchanged, and return ``-1``.
 
-.. c:function:: int PyUnicodeWriter_WriteUCS4(PyUnicodeWriter *writer, Py_UCS4 *str, Py_ssize_t size)
+.. c:function:: int PyUnicodeWriter_WriteUCS4(PyUnicodeWriter *writer, const Py_UCS4 *str, Py_ssize_t size)
 
    Writer the UCS4 string *str* into *writer*.
 

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -496,7 +496,7 @@ PyAPI_FUNC(int) PyUnicodeWriter_WriteWideChar(
     Py_ssize_t size);
 PyAPI_FUNC(int) PyUnicodeWriter_WriteUCS4(
     PyUnicodeWriter *writer,
-    Py_UCS4 *str,
+    const Py_UCS4 *str,
     Py_ssize_t size);
 
 PyAPI_FUNC(int) PyUnicodeWriter_WriteStr(

--- a/Misc/NEWS.d/next/C_API/2026-03-18-23-44-29.gh-issue-146143.pwIrJq.rst
+++ b/Misc/NEWS.d/next/C_API/2026-03-18-23-44-29.gh-issue-146143.pwIrJq.rst
@@ -1,0 +1,2 @@
+:c:func:`PyUnicodeWriter_WriteUCS4` now accepts pointer to constant buffer
+of ``Py_UCS4``.

--- a/Misc/NEWS.d/next/C_API/2026-03-18-23-44-29.gh-issue-146143.pwIrJq.rst
+++ b/Misc/NEWS.d/next/C_API/2026-03-18-23-44-29.gh-issue-146143.pwIrJq.rst
@@ -1,2 +1,2 @@
-:c:func:`PyUnicodeWriter_WriteUCS4` now accepts pointer to constant buffer
+:c:func:`PyUnicodeWriter_WriteUCS4` now accepts a pointer to a constant buffer
 of ``Py_UCS4``.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -2224,7 +2224,7 @@ _PyUnicode_FromUCS4(const Py_UCS4 *u, Py_ssize_t size)
 
 int
 PyUnicodeWriter_WriteUCS4(PyUnicodeWriter *pub_writer,
-                          Py_UCS4 *str,
+                          const Py_UCS4 *str,
                           Py_ssize_t size)
 {
     _PyUnicodeWriter *writer = (_PyUnicodeWriter*)pub_writer;


### PR DESCRIPTION
It now accepts pointer to constant buffer of Py_UCS4.


<!-- gh-issue-number: gh-146143 -->
* Issue: gh-146143
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146144.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->