### PR TITLE
gh-145410: Add _sysconfig.get_platform() function

### DIFF
--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -665,12 +665,10 @@ def get_platform():
 
     For other non-POSIX platforms, currently just returns :data:`sys.platform`."""
     if os.name == 'nt':
-        if 'amd64' in sys.version.lower():
-            return 'win-amd64'
-        if '(arm)' in sys.version.lower():
-            return 'win-arm32'
-        if '(arm64)' in sys.version.lower():
-            return 'win-arm64'
+        import _sysconfig
+        platform = _sysconfig.get_platform()
+        if platform:
+            return platform
         return sys.platform
 
     if os.name != "posix" or not hasattr(os, 'uname'):

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -7,6 +7,7 @@ import subprocess
 import shutil
 import json
 import textwrap
+from unittest.mock import patch
 from copy import copy
 
 from test import support
@@ -247,19 +248,15 @@ class TestSysConfig(unittest.TestCase, VirtualEnvironmentMixin):
         self.assertIsInstance(actual_platform, str)
         self.assertTrue(actual_platform)
 
-        # windows XP, 32bits
+        # Windows
         os.name = 'nt'
-        sys.version = ('2.4.4 (#71, Oct 18 2006, 08:34:43) '
-                       '[MSC v.1310 32 bit (Intel)]')
-        sys.platform = 'win32'
-        self.assertEqual(get_platform(), 'win32')
-
-        # windows XP, amd64
-        os.name = 'nt'
-        sys.version = ('2.4.4 (#71, Oct 18 2006, 08:34:43) '
-                       '[MSC v.1310 32 bit (Amd64)]')
-        sys.platform = 'win32'
-        self.assertEqual(get_platform(), 'win-amd64')
+        with patch('_sysconfig.get_platform', create=True, return_value='win32'):
+            self.assertEqual(get_platform(), 'win32')
+        with patch('_sysconfig.get_platform', create=True, return_value='win-amd64'):
+            self.assertEqual(get_platform(), 'win-amd64')
+        sys.platform = 'test-plaform'
+        with patch('_sysconfig.get_platform', create=True, return_value=None):
+            self.assertEqual(get_platform(), 'test-plaform')
 
         # macbook
         os.name = 'posix'

--- a/Misc/NEWS.d/next/Library/2026-03-18-23-54-36.gh-issue-145410.NvLWj5.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-18-23-54-36.gh-issue-145410.NvLWj5.rst
@@ -1,0 +1,3 @@
+On Windows, :func:`sysconfig.get_platform` now gets the platform from the
+``_sysconfig`` module instead of parsing :data:`sys.version` string. Patch
+by Victor Stinner.

--- a/Modules/_sysconfig.c
+++ b/Modules/_sysconfig.c
@@ -81,11 +81,48 @@ _sysconfig_config_vars_impl(PyObject *module)
     return config;
 }
 
+#ifdef MS_WINDOWS
+/*[clinic input]
+_sysconfig.get_platform
+
+Return a string that identifies the current platform.
+[clinic start generated code]*/
+
+static PyObject *
+_sysconfig_get_platform_impl(PyObject *module)
+/*[clinic end generated code: output=4ecbbe2b77633f3e input=c0b43abda44f9a01]*/
+{
+#ifdef MS_WIN64
+#  if defined(_M_X64) || defined(_M_AMD64)
+#    define SYSCONFIG_PLATFORM "win-amd64"
+#  elif defined(_M_ARM64)
+#    define SYSCONFIG_PLATFORM "win-arm64"
+#  endif
+#endif
+
+#if defined(MS_WIN32) && !defined(MS_WIN64)
+#  if defined(_M_IX86)
+#    define SYSCONFIG_PLATFORM "win32"
+#  elif defined(_M_ARM)
+#    define SYSCONFIG_PLATFORM "win-arm32"
+#  endif
+#endif
+
+#ifdef SYSCONFIG_PLATFORM
+    return PyUnicode_FromString(SYSCONFIG_PLATFORM);
+#else
+    Py_RETURN_NONE;
+#endif
+}
+#endif  // MS_WINDOWS
+
+
 PyDoc_STRVAR(sysconfig__doc__,
 "A helper for the sysconfig module.");
 
 static struct PyMethodDef sysconfig_methods[] = {
     _SYSCONFIG_CONFIG_VARS_METHODDEF
+    _SYSCONFIG_GET_PLATFORM_METHODDEF
     {NULL, NULL}
 };
 

--- a/Modules/clinic/_sysconfig.c.h
+++ b/Modules/clinic/_sysconfig.c.h
@@ -19,4 +19,30 @@ _sysconfig_config_vars(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _sysconfig_config_vars_impl(module);
 }
-/*[clinic end generated code: output=25d395cf02eced1f input=a9049054013a1b77]*/
+
+#if defined(MS_WINDOWS)
+
+PyDoc_STRVAR(_sysconfig_get_platform__doc__,
+"get_platform($module, /)\n"
+"--\n"
+"\n"
+"Return a string that identifies the current platform.");
+
+#define _SYSCONFIG_GET_PLATFORM_METHODDEF    \
+    {"get_platform", (PyCFunction)_sysconfig_get_platform, METH_NOARGS, _sysconfig_get_platform__doc__},
+
+static PyObject *
+_sysconfig_get_platform_impl(PyObject *module);
+
+static PyObject *
+_sysconfig_get_platform(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return _sysconfig_get_platform_impl(module);
+}
+
+#endif /* defined(MS_WINDOWS) */
+
+#ifndef _SYSCONFIG_GET_PLATFORM_METHODDEF
+    #define _SYSCONFIG_GET_PLATFORM_METHODDEF
+#endif /* !defined(_SYSCONFIG_GET_PLATFORM_METHODDEF) */
+/*[clinic end generated code: output=558531e148f92320 input=a9049054013a1b77]*/


### PR DESCRIPTION
On Windows, sysconfig.get_platform() now gets the platform from the _sysconfig module instead of parsing sys.version string.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145410 -->
* Issue: gh-145410
<!-- /gh-issue-number -->
