### PR TITLE
gh-145410: Fix sysconfig.get_platform() for truncated sys.version on Windows

### DIFF
--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -665,12 +665,17 @@ def get_platform():
 
     For other non-POSIX platforms, currently just returns :data:`sys.platform`."""
     if os.name == 'nt':
+        # Check for architecture in sys.version first, then fall back to sys.maxsize
+        # which is reliable even when sys.version is truncated (e.g., clang builds on Windows)
         if 'amd64' in sys.version.lower():
             return 'win-amd64'
-        if '(arm)' in sys.version.lower():
-            return 'win-arm32'
+        if sys.maxsize > 2**32:
+            # 64-bit Windows where sys.version may be truncated
+            return 'win-amd64'
         if '(arm64)' in sys.version.lower():
             return 'win-arm64'
+        if '(arm)' in sys.version.lower():
+            return 'win-arm32'
         return sys.platform
 
     if os.name != "posix" or not hasattr(os, 'uname'):


### PR DESCRIPTION
## Bug Fix

On Windows, `sysconfig.get_platform()` checks for the string `'amd64'` in `sys.version` to detect 64-bit builds. However, `sys.version` can be truncated (e.g., ~100 characters on clang builds), causing `'amd64'` to be missing and returning `'win32'` incorrectly.

This causes problems when installing native packages via pip because `cp314-cp314-amd64` is not in the list of supported tags.

### The Fix

This PR adds `sys.maxsize > 2**32` as a fallback check, which is reliable even when `sys.version` is truncated. It also reorders the arm64 check before arm32 for proper precedence.

**Before:**
```python
if os.name == 'nt':
    if 'amd64' in sys.version.lower():
        return 'win-amd64'
    if '(arm)' in sys.version.lower():
        return 'win-arm32'
    if '(arm64)' in sys.version.lower():
        return 'win-arm64'
    return sys.platform
```

**After:**
```python
if os.name == 'nt':
    if 'amd64' in sys.version.lower():
        return 'win-amd64'
    if sys.maxsize > 2**32:
        # 64-bit Windows where sys.version may be truncated
        return 'win-amd64'
    if '(arm64)' in sys.version.lower():
        return 'win-arm64'
    if '(arm)' in sys.version.lower():
        return 'win-arm32'
    return sys.platform
```

Fixes: python/cpython#145410

---
*Submitted by automated agent*