### PR TITLE
gh-146091: Fix NULL check in termios.tcsetwinsize

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-03-18-16-58-17.gh-issue-146091.lBbo1L.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-18-16-58-17.gh-issue-146091.lBbo1L.rst
@@ -1,0 +1,3 @@
+Fix a bug in :func:`termios.tcsetwinsize` where passing a sequence that
+raises an exception in ``__getitem__`` would cause a :exc:`SystemError`
+instead of propagating the original exception.

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -500,19 +500,24 @@ termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz)
     PyObject *tmp_item;
     long winsz_0, winsz_1;
     tmp_item = PySequence_GetItem(winsz, 0);
+    if (tmp_item == NULL) {
+        return NULL;
+    }
     winsz_0 = PyLong_AsLong(tmp_item);
+    Py_DECREF(tmp_item);
     if (winsz_0 == -1 && PyErr_Occurred()) {
-        Py_XDECREF(tmp_item);
         return NULL;
     }
-    Py_XDECREF(tmp_item);
     tmp_item = PySequence_GetItem(winsz, 1);
-    winsz_1 = PyLong_AsLong(tmp_item);
-    if (winsz_1 == -1 && PyErr_Occurred()) {
-        Py_XDECREF(tmp_item);
+    if (tmp_item == NULL) {
         return NULL;
     }
-    Py_XDECREF(tmp_item);
+    winsz_1 = PyLong_AsLong(tmp_item);
+    Py_DECREF(tmp_item);
+    if (winsz_1 == -1 && PyErr_Occurred()) {
+        return NULL;
+    }
+
 
     termiosmodulestate *state = PyModule_GetState(module);
 


### PR DESCRIPTION
Fixes #146091

Add proper NULL checks for PySequence_GetItem results before passing
to PyLong_AsLong, this prevents SystemError when a BadSequence raises
TypeError in __getitem__, the issue was that PySequence_GetItem can return NULL, which when passed to PyLong_AsLong would cause an internal error instead of propagating
the original exception.


<!-- gh-issue-number: gh-146091 -->
* Issue: gh-146091
<!-- /gh-issue-number -->
