### PR TITLE
gh-81773: Avoid parsing sys.version string in sysconfig

### DIFF
--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -1,5 +1,6 @@
 """Access to Python's configuration information."""
 
+import _sysconfig
 import os
 import sys
 import threading
@@ -172,7 +173,7 @@ if _HAS_USER_BASE:
 _SCHEME_KEYS = ('stdlib', 'platstdlib', 'purelib', 'platlib', 'include',
                 'scripts', 'data')
 
-_PY_VERSION = sys.version.split()[0]
+_PY_VERSION = _sysconfig._PY_VERSION
 _PY_VERSION_SHORT = f'{sys.version_info[0]}.{sys.version_info[1]}'
 _PY_VERSION_SHORT_NO_DOT = f'{sys.version_info[0]}{sys.version_info[1]}'
 _BASE_PREFIX = os.path.normpath(sys.base_prefix)
@@ -385,7 +386,6 @@ def _init_non_posix(vars):
     """Initialize the module as appropriate for NT"""
     # set basic install directories
     import _winapi
-    import _sysconfig
     vars['LIBDEST'] = get_path('stdlib')
     vars['BINLIBDEST'] = get_path('platstdlib')
     vars['INCLUDEPY'] = get_path('include')
@@ -665,7 +665,6 @@ def get_platform():
 
     For other non-POSIX platforms, currently just returns :data:`sys.platform`."""
     if os.name == 'nt':
-        import _sysconfig
         platform = _sysconfig.get_platform()
         if platform:
             return platform

--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -173,6 +173,8 @@ if _HAS_USER_BASE:
 _SCHEME_KEYS = ('stdlib', 'platstdlib', 'purelib', 'platlib', 'include',
                 'scripts', 'data')
 
+_PY_VERSION_SHORT = f'{sys.version_info[0]}.{sys.version_info[1]}'
+_PY_VERSION_SHORT_NO_DOT = f'{sys.version_info[0]}{sys.version_info[1]}'
 _BASE_PREFIX = os.path.normpath(sys.base_prefix)
 _BASE_EXEC_PREFIX = os.path.normpath(sys.base_exec_prefix)
 # Mutex guarding initialization of _CONFIG_VARS.
@@ -321,8 +323,7 @@ def get_makefile_filename():
         return os.path.join(_PROJECT_BASE, "Makefile")
 
     if hasattr(sys, 'abiflags'):
-        py_version_short = f'{sys.version_info[0]}.{sys.version_info[1]}'
-        config_dir_name = f'config-{py_version_short}{sys.abiflags}'
+        config_dir_name = f'config-{_PY_VERSION_SHORT}{sys.abiflags}'
     else:
         config_dir_name = 'config'
 
@@ -405,7 +406,7 @@ def _init_non_posix(vars):
         vars['LIBRARY'] = os.path.basename(_safe_realpath(dllhandle))
         vars['LDLIBRARY'] = vars['LIBRARY']
     vars['EXE'] = '.exe'
-    vars['VERSION'] = vars['py_version_nodot']
+    vars['VERSION'] = _PY_VERSION_SHORT_NO_DOT
     vars['BINDIR'] = os.path.dirname(_safe_realpath(sys.executable))
     # No standard path exists on Windows for this, but we'll check
     # whether someone is imitating a POSIX-like layout
@@ -529,6 +530,8 @@ def _init_config_vars():
     # Distutils.
     _CONFIG_VARS['prefix'] = prefix
     _CONFIG_VARS['exec_prefix'] = exec_prefix
+    _CONFIG_VARS['py_version_short'] = _PY_VERSION_SHORT
+    _CONFIG_VARS['py_version_nodot'] = _PY_VERSION_SHORT_NO_DOT
     _CONFIG_VARS['installed_base'] = base_prefix
     _CONFIG_VARS['base'] = prefix
     _CONFIG_VARS['installed_platbase'] = base_exec_prefix
@@ -735,11 +738,11 @@ def get_platform():
 
 
 def get_python_version():
-    return get_config_var('py_version_short')
+    return _PY_VERSION_SHORT
 
 
 def _get_python_version_abi():
-    return get_config_var('py_version_short') + get_config_var('abi_thread')
+    return _PY_VERSION_SHORT + get_config_var("abi_thread")
 
 
 def expand_makefile_vars(s, vars):

--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -173,9 +173,6 @@ if _HAS_USER_BASE:
 _SCHEME_KEYS = ('stdlib', 'platstdlib', 'purelib', 'platlib', 'include',
                 'scripts', 'data')
 
-_PY_VERSION = _sysconfig.PY_VERSION
-_PY_VERSION_SHORT = f'{sys.version_info[0]}.{sys.version_info[1]}'
-_PY_VERSION_SHORT_NO_DOT = f'{sys.version_info[0]}{sys.version_info[1]}'
 _BASE_PREFIX = os.path.normpath(sys.base_prefix)
 _BASE_EXEC_PREFIX = os.path.normpath(sys.base_exec_prefix)
 # Mutex guarding initialization of _CONFIG_VARS.
@@ -324,7 +321,8 @@ def get_makefile_filename():
         return os.path.join(_PROJECT_BASE, "Makefile")
 
     if hasattr(sys, 'abiflags'):
-        config_dir_name = f'config-{_PY_VERSION_SHORT}{sys.abiflags}'
+        py_version_short = f'{sys.version_info[0]}.{sys.version_info[1]}'
+        config_dir_name = f'config-{py_version_short}{sys.abiflags}'
     else:
         config_dir_name = 'config'
 
@@ -390,9 +388,6 @@ def _init_non_posix(vars):
     vars['BINLIBDEST'] = get_path('platstdlib')
     vars['INCLUDEPY'] = get_path('include')
 
-    # Add EXT_SUFFIX, SOABI, Py_DEBUG, and Py_GIL_DISABLED
-    vars.update(_sysconfig.config_vars())
-
     # NOTE: ABIFLAGS is only an emulated value. It is not present during build
     #       on Windows. sys.abiflags is absent on Windows and vars['abiflags']
     #       is already widely used to calculate paths, so it should remain an
@@ -410,7 +405,7 @@ def _init_non_posix(vars):
         vars['LIBRARY'] = os.path.basename(_safe_realpath(dllhandle))
         vars['LDLIBRARY'] = vars['LIBRARY']
     vars['EXE'] = '.exe'
-    vars['VERSION'] = _PY_VERSION_SHORT_NO_DOT
+    vars['VERSION'] = vars['py_version_nodot']
     vars['BINDIR'] = os.path.dirname(_safe_realpath(sys.executable))
     # No standard path exists on Windows for this, but we'll check
     # whether someone is imitating a POSIX-like layout
@@ -505,6 +500,10 @@ def _init_config_vars():
     global _CONFIG_VARS
     _CONFIG_VARS = {}
 
+    # Add py_version, Py_DEBUG, and Py_GIL_DISABLED.
+    # On Windows, add also EXT_SUFFIX and SOABI.
+    _CONFIG_VARS.update(_sysconfig.config_vars())
+
     prefix = os.path.normpath(sys.prefix)
     exec_prefix = os.path.normpath(sys.exec_prefix)
     base_prefix = _BASE_PREFIX
@@ -530,9 +529,6 @@ def _init_config_vars():
     # Distutils.
     _CONFIG_VARS['prefix'] = prefix
     _CONFIG_VARS['exec_prefix'] = exec_prefix
-    _CONFIG_VARS['py_version'] = _PY_VERSION
-    _CONFIG_VARS['py_version_short'] = _PY_VERSION_SHORT
-    _CONFIG_VARS['py_version_nodot'] = _PY_VERSION_SHORT_NO_DOT
     _CONFIG_VARS['installed_base'] = base_prefix
     _CONFIG_VARS['base'] = prefix
     _CONFIG_VARS['installed_platbase'] = base_exec_prefix
@@ -739,11 +735,11 @@ def get_platform():
 
 
 def get_python_version():
-    return _PY_VERSION_SHORT
+    return get_config_var('py_version_short')
 
 
 def _get_python_version_abi():
-    return _PY_VERSION_SHORT + get_config_var("abi_thread")
+    return get_config_var('py_version_short') + get_config_var("abi_thread")
 
 
 def expand_makefile_vars(s, vars):

--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -739,7 +739,7 @@ def get_python_version():
 
 
 def _get_python_version_abi():
-    return get_config_var('py_version_short') + get_config_var("abi_thread")
+    return get_config_var('py_version_short') + get_config_var('abi_thread')
 
 
 def expand_makefile_vars(s, vars):

--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -173,7 +173,7 @@ if _HAS_USER_BASE:
 _SCHEME_KEYS = ('stdlib', 'platstdlib', 'purelib', 'platlib', 'include',
                 'scripts', 'data')
 
-_PY_VERSION = _sysconfig._PY_VERSION
+_PY_VERSION = _sysconfig.PY_VERSION
 _PY_VERSION_SHORT = f'{sys.version_info[0]}.{sys.version_info[1]}'
 _PY_VERSION_SHORT_NO_DOT = f'{sys.version_info[0]}{sys.version_info[1]}'
 _BASE_PREFIX = os.path.normpath(sys.base_prefix)

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -755,7 +755,7 @@ class TestSysConfig(unittest.TestCase, VirtualEnvironmentMixin):
         self.assertEqual(config_vars['py_version_short'],
                          f'{ver.major}.{ver.minor}')
         self.assertEqual(sysconfig.get_python_version(),
-                         config_vars['py_version_short'])
+                         f'{ver.major}.{ver.minor}')
 
         # Test py_version_nodot
         self.assertIsInstance(config_vars['py_version_nodot'], str)

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -743,11 +743,19 @@ class TestSysConfig(unittest.TestCase, VirtualEnvironmentMixin):
 
     def test_py_version(self):
         config_vars = sysconfig.get_config_vars()
-        py_version = config_vars['py_version']
-        self.assertIsInstance(py_version, str)
+        self.assertIsInstance(config_vars['py_version'], str)
         ver = sys.version_info
         version = f'{ver.major}.{ver.minor}.{ver.micro}'
-        self.assertStartsWith(py_version, version)
+        # py_version can be longer such as "3.15.0a7+" instead of "3.15.0"
+        self.assertStartsWith(config_vars['py_version'], version)
+
+        self.assertIsInstance(config_vars['py_version_short'], str)
+        self.assertEqual(config_vars['py_version_short'],
+                         f'{ver.major}.{ver.minor}')
+
+        self.assertIsInstance(config_vars['py_version_nodot'], str)
+        self.assertEqual(config_vars['py_version_nodot'],
+                         f'{ver.major}{ver.minor}')
 
 
 class MakefileTests(unittest.TestCase):

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -742,6 +742,7 @@ class TestSysConfig(unittest.TestCase, VirtualEnvironmentMixin):
         self.assertEqual(config_vars['platbase'], sys.exec_prefix)
 
     def test_py_version(self):
+        # Test py_version
         config_vars = sysconfig.get_config_vars()
         self.assertIsInstance(config_vars['py_version'], str)
         ver = sys.version_info
@@ -749,10 +750,14 @@ class TestSysConfig(unittest.TestCase, VirtualEnvironmentMixin):
         # py_version can be longer such as "3.15.0a7+" instead of "3.15.0"
         self.assertStartsWith(config_vars['py_version'], version)
 
+        # Test py_version_short and get_python_version()
         self.assertIsInstance(config_vars['py_version_short'], str)
         self.assertEqual(config_vars['py_version_short'],
                          f'{ver.major}.{ver.minor}')
+        self.assertEqual(sysconfig.get_python_version(),
+                         config_vars['py_version_short'])
 
+        # Test py_version_nodot
         self.assertIsInstance(config_vars['py_version_nodot'], str)
         self.assertEqual(config_vars['py_version_nodot'],
                          f'{ver.major}{ver.minor}')

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -741,6 +741,14 @@ class TestSysConfig(unittest.TestCase, VirtualEnvironmentMixin):
         self.assertEqual(config_vars['exec_prefix'], sys.exec_prefix)
         self.assertEqual(config_vars['platbase'], sys.exec_prefix)
 
+    def test_py_version(self):
+        config_vars = sysconfig.get_config_vars()
+        py_version = config_vars['py_version']
+        self.assertIsInstance(py_version, str)
+        ver = sys.version_info
+        version = f'{ver.major}.{ver.minor}.{ver.micro}'
+        self.assertStartsWith(py_version, version)
+
 
 class MakefileTests(unittest.TestCase):
 

--- a/Modules/_sysconfig.c
+++ b/Modules/_sysconfig.c
@@ -117,6 +117,14 @@ _sysconfig_get_platform_impl(PyObject *module)
 #endif  // MS_WINDOWS
 
 
+static int
+sysconfig_module_exec(PyObject *module)
+{
+    return PyModule_Add(module, "_PY_VERSION",
+                        PyUnicode_FromString(PY_VERSION));
+}
+
+
 PyDoc_STRVAR(sysconfig__doc__,
 "A helper for the sysconfig module.");
 
@@ -127,6 +135,7 @@ static struct PyMethodDef sysconfig_methods[] = {
 };
 
 static PyModuleDef_Slot sysconfig_slots[] = {
+    {Py_mod_exec, sysconfig_module_exec},
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL}

--- a/Modules/_sysconfig.c
+++ b/Modules/_sysconfig.c
@@ -120,7 +120,7 @@ _sysconfig_get_platform_impl(PyObject *module)
 static int
 sysconfig_module_exec(PyObject *module)
 {
-    return PyModule_Add(module, "_PY_VERSION",
+    return PyModule_Add(module, "PY_VERSION",
                         PyUnicode_FromString(PY_VERSION));
 }
 

--- a/Modules/_sysconfig.c
+++ b/Modules/_sysconfig.c
@@ -17,7 +17,13 @@ module _sysconfig
 
 #include "clinic/_sysconfig.c.h"
 
-#ifdef MS_WINDOWS
+
+#define py_version_short() \
+    (Py_STRINGIFY(PY_MAJOR_VERSION) "." Py_STRINGIFY(PY_MINOR_VERSION))
+#define py_version_nodot() \
+    (Py_STRINGIFY(PY_MAJOR_VERSION) Py_STRINGIFY(PY_MINOR_VERSION))
+
+
 static int
 add_string_value(PyObject *dict, const char *key, const char *str_value)
 {
@@ -29,7 +35,7 @@ add_string_value(PyObject *dict, const char *key, const char *str_value)
     Py_DECREF(value);
     return err;
 }
-#endif
+
 
 /*[clinic input]
 @permit_long_summary
@@ -47,14 +53,23 @@ _sysconfig_config_vars_impl(PyObject *module)
         return NULL;
     }
 
+    // Python version
+    if (add_string_value(config, "py_version", PY_VERSION) < 0) {
+        goto error;
+    }
+    if (add_string_value(config, "py_version_short", py_version_short()) < 0) {
+        goto error;
+    }
+    if (add_string_value(config, "py_version_nodot", py_version_nodot()) < 0) {
+        goto error;
+    }
+
 #ifdef MS_WINDOWS
     if (add_string_value(config, "EXT_SUFFIX", PYD_TAGGED_SUFFIX) < 0) {
-        Py_DECREF(config);
-        return NULL;
+        goto error;
     }
     if (add_string_value(config, "SOABI", PYD_SOABI) < 0) {
-        Py_DECREF(config);
-        return NULL;
+        goto error;
     }
 #endif
 
@@ -64,8 +79,7 @@ _sysconfig_config_vars_impl(PyObject *module)
     PyObject *py_gil_disabled = _PyLong_GetZero();
 #endif
     if (PyDict_SetItemString(config, "Py_GIL_DISABLED", py_gil_disabled) < 0) {
-        Py_DECREF(config);
-        return NULL;
+        goto error;
     }
 
 #ifdef Py_DEBUG
@@ -74,11 +88,14 @@ _sysconfig_config_vars_impl(PyObject *module)
     PyObject *py_debug = _PyLong_GetZero();
 #endif
     if (PyDict_SetItemString(config, "Py_DEBUG", py_debug) < 0) {
-        Py_DECREF(config);
-        return NULL;
+        goto error;
     }
 
     return config;
+
+error:
+    Py_DECREF(config);
+    return NULL;
 }
 
 #ifdef MS_WINDOWS
@@ -117,14 +134,6 @@ _sysconfig_get_platform_impl(PyObject *module)
 #endif  // MS_WINDOWS
 
 
-static int
-sysconfig_module_exec(PyObject *module)
-{
-    return PyModule_Add(module, "PY_VERSION",
-                        PyUnicode_FromString(PY_VERSION));
-}
-
-
 PyDoc_STRVAR(sysconfig__doc__,
 "A helper for the sysconfig module.");
 
@@ -135,7 +144,6 @@ static struct PyMethodDef sysconfig_methods[] = {
 };
 
 static PyModuleDef_Slot sysconfig_slots[] = {
-    {Py_mod_exec, sysconfig_module_exec},
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL}

--- a/Modules/_sysconfig.c
+++ b/Modules/_sysconfig.c
@@ -17,13 +17,6 @@ module _sysconfig
 
 #include "clinic/_sysconfig.c.h"
 
-
-#define py_version_short() \
-    (Py_STRINGIFY(PY_MAJOR_VERSION) "." Py_STRINGIFY(PY_MINOR_VERSION))
-#define py_version_nodot() \
-    (Py_STRINGIFY(PY_MAJOR_VERSION) Py_STRINGIFY(PY_MINOR_VERSION))
-
-
 static int
 add_string_value(PyObject *dict, const char *key, const char *str_value)
 {
@@ -35,7 +28,6 @@ add_string_value(PyObject *dict, const char *key, const char *str_value)
     Py_DECREF(value);
     return err;
 }
-
 
 /*[clinic input]
 @permit_long_summary
@@ -55,12 +47,6 @@ _sysconfig_config_vars_impl(PyObject *module)
 
     // Python version
     if (add_string_value(config, "py_version", PY_VERSION) < 0) {
-        goto error;
-    }
-    if (add_string_value(config, "py_version_short", py_version_short()) < 0) {
-        goto error;
-    }
-    if (add_string_value(config, "py_version_nodot", py_version_nodot()) < 0) {
         goto error;
     }
 


### PR DESCRIPTION
No longer parse sys.version string to create sysconfig._PY_VERSION. Add `_sysconfig.PY_VERSION` constant.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-81773 -->
* Issue: gh-81773
<!-- /gh-issue-number -->
