### PR TITLE
gh-145177: Put node version into emscripten/config.toml as well.

### DIFF
--- a/Platforms/emscripten/__main__.py
+++ b/Platforms/emscripten/__main__.py
@@ -418,14 +418,12 @@ def calculate_node_path():
     if node_version is None:
         node_version = load_config_toml()["node-version"]
 
-    res = subprocess.run(
+    subprocess.run(
         [
             "bash",
             "-c",
             f"source ~/.nvm/nvm.sh && nvm install {node_version}",
         ],
-        text=True,
-        capture_output=True,
         check=True,
     )
 
@@ -446,6 +444,10 @@ def calculate_node_path():
 def configure_emscripten_python(context, working_dir):
     """Configure the emscripten/host build."""
     validate_emsdk_version(context.emsdk_cache)
+    host_runner = context.host_runner
+    if host_runner is None:
+        host_runner = calculate_node_path()
+
     paths = context.build_paths
     config_site = os.fsdecode(EMSCRIPTEN_DIR / "config.site-wasm32-emscripten")
 
@@ -464,10 +466,6 @@ def configure_emscripten_python(context, working_dir):
     )
     if pydebug:
         sysconfig_data += "-pydebug"
-
-    host_runner = context.host_runner
-    if host_runner is None:
-        host_runner = calculate_node_path()
     pkg_config_path_dir = (paths["prefix_dir"] / "lib/pkgconfig/").resolve()
     env_additions = {
         "CONFIG_SITE": config_site,

--- a/Platforms/emscripten/__main__.py
+++ b/Platforms/emscripten/__main__.py
@@ -414,7 +414,7 @@ def make_mpdec(context, working_dir):
 
 
 def calculate_node_path():
-    node_version := os.environ.get("PYTHON_NODE_VERSION", None)
+    node_version = os.environ.get("PYTHON_NODE_VERSION", None)
     if node_version is None:
         node_version = load_config_toml()["node-version"]
 

--- a/Platforms/emscripten/__main__.py
+++ b/Platforms/emscripten/__main__.py
@@ -633,8 +633,6 @@ def add_cross_build_dir_option(subcommand):
 
 
 def main():
-    default_host_runner = "node"
-
     parser = argparse.ArgumentParser()
     subcommands = parser.add_subparsers(dest="subcommand")
 

--- a/Platforms/emscripten/__main__.py
+++ b/Platforms/emscripten/__main__.py
@@ -413,6 +413,35 @@ def make_mpdec(context, working_dir):
     write_library_config(prefix, "mpdec", mpdec_config, context.quiet)
 
 
+def calculate_node_path():
+    node_version := os.environ.get("PYTHON_NODE_VERSION", None)
+    if node_version is None:
+        node_version = load_config_toml()["node-version"]
+
+    res = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"source ~/.nvm/nvm.sh && nvm install {node_version}",
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    res = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"source ~/.nvm/nvm.sh && nvm which {node_version}",
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return res.stdout.strip()
+
+
 @subdir("host_dir", clean_ok=True)
 def configure_emscripten_python(context, working_dir):
     """Configure the emscripten/host build."""
@@ -437,17 +466,8 @@ def configure_emscripten_python(context, working_dir):
         sysconfig_data += "-pydebug"
 
     host_runner = context.host_runner
-    if node_version := os.environ.get("PYTHON_NODE_VERSION", None):
-        res = subprocess.run(
-            [
-                "bash",
-                "-c",
-                f"source ~/.nvm/nvm.sh && nvm which {node_version}",
-            ],
-            text=True,
-            capture_output=True,
-        )
-        host_runner = res.stdout.strip()
+    if host_runner is None:
+        host_runner = calculate_node_path()
     pkg_config_path_dir = (paths["prefix_dir"] / "lib/pkgconfig/").resolve()
     env_additions = {
         "CONFIG_SITE": config_site,
@@ -744,10 +764,10 @@ def main():
         subcommand.add_argument(
             "--host-runner",
             action="store",
-            default=default_host_runner,
+            default=None,
             dest="host_runner",
-            help="Command template for running the emscripten host"
-            f"`{default_host_runner}`)",
+            help="Command template for running the emscripten host "
+            "(default: use nvm to install the node version specified in config.toml)",
         )
 
     context = parser.parse_args()

--- a/Platforms/emscripten/config.toml
+++ b/Platforms/emscripten/config.toml
@@ -2,6 +2,7 @@
 # This allows for blanket copying of the Emscripten build code between supported
 # Python versions.
 emscripten-version = "4.0.12"
+node-version = "24"
 
 [libffi]
 url = "https://github.com/libffi/libffi/releases/download/v{version}/libffi-{version}.tar.gz"


### PR DESCRIPTION
This is the last bit of config that is in the buildbot config that we should move to the cpython repo.

<!-- gh-issue-number: gh-145177 -->
* Issue: gh-145177
<!-- /gh-issue-number -->
