### PR TITLE
gh-110067: Optimize nlargest/nsmallest and improve max-heap C docstrings

### DIFF
--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -480,6 +480,10 @@ def nsmallest(n, iterable, key=None):
     Equivalent to:  sorted(iterable, key=key)[:n]
     """
 
+    # Short-cut for n<=0 to avoid unnecessary work
+    if n <= 0:
+        return []
+
     # Short-cut for n==1 is to use min()
     if n == 1:
         it = iter(iterable)
@@ -539,6 +543,10 @@ def nlargest(n, iterable, key=None):
 
     Equivalent to:  sorted(iterable, key=key, reverse=True)[:n]
     """
+
+    # Short-cut for n<=0 to avoid unnecessary work
+    if n <= 0:
+        return []
 
     # Short-cut for n==1 is to use max()
     if n == 1:

--- a/Misc/NEWS.d/next/Library/2026-03-19-00-00-00.gh-issue-110067.RWJ5vA7m.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-19-00-00-00.gh-issue-110067.RWJ5vA7m.rst
@@ -1,0 +1,3 @@
+Add early return for ``n <= 0`` in :func:`heapq.nsmallest` and
+:func:`heapq.nlargest`, and improve docstrings for :func:`heapq.heappop_max`,
+:func:`heapq.heapreplace_max`, and :func:`heapq.heapify_max`.

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -424,7 +424,8 @@ siftdown_max(PyListObject *heap, Py_ssize_t startpos, Py_ssize_t pos)
     newitem = arr[pos];
     while (pos > startpos) {
         parentpos = (pos - 1) >> 1;
-        parent = Py_NewRef(arr[parentpos]);
+        parent = arr[parentpos];
+        Py_INCREF(parent);
         Py_INCREF(newitem);
         cmp = PyObject_RichCompareBool(parent, newitem, Py_LT);
         Py_DECREF(parent);
@@ -538,12 +539,12 @@ _heapq.heappop_max
     heap: object(subclass_of='&PyList_Type')
     /
 
-Maxheap variant of heappop.
+Pop the largest item off the max-heap, maintaining the heap invariant.
 [clinic start generated code]*/
 
 static PyObject *
 _heapq_heappop_max_impl(PyObject *module, PyObject *heap)
-/*[clinic end generated code: output=2f051195ab404b77 input=5d70c997798aec64]*/
+/*[clinic end generated code: output=2f051195ab404b77 input=edca3ff5d6aa11c6]*/
 {
     return heappop_internal(heap, siftup_max);
 }
@@ -556,12 +557,12 @@ _heapq.heapreplace_max
     item: object
     /
 
-Maxheap variant of heapreplace.
+Pop and return the largest item from the max-heap, and push the new item.
 [clinic start generated code]*/
 
 static PyObject *
 _heapq_heapreplace_max_impl(PyObject *module, PyObject *heap, PyObject *item)
-/*[clinic end generated code: output=8770778b5a9cbe9b input=fe70175356e4a649]*/
+/*[clinic end generated code: output=8770778b5a9cbe9b input=75b704b6f92beab9]*/
 {
     return heapreplace_internal(heap, item, siftup_max);
 }
@@ -573,12 +574,12 @@ _heapq.heapify_max
     heap: object(subclass_of='&PyList_Type')
     /
 
-Maxheap variant of heapify.
+Transform list into a max-heap, in-place, in O(len(heap)) time.
 [clinic start generated code]*/
 
 static PyObject *
 _heapq_heapify_max_impl(PyObject *module, PyObject *heap)
-/*[clinic end generated code: output=8401af3856529807 input=4eee63231e7d1573]*/
+/*[clinic end generated code: output=8401af3856529807 input=4e02ed8aa546fb8e]*/
 {
     return heapify_internal(heap, siftup_max);
 }

--- a/Modules/clinic/_heapqmodule.c.h
+++ b/Modules/clinic/_heapqmodule.c.h
@@ -226,7 +226,7 @@ PyDoc_STRVAR(_heapq_heappop_max__doc__,
 "heappop_max($module, heap, /)\n"
 "--\n"
 "\n"
-"Maxheap variant of heappop.");
+"Pop the largest item off the max-heap, maintaining the heap invariant.");
 
 #define _HEAPQ_HEAPPOP_MAX_METHODDEF    \
     {"heappop_max", (PyCFunction)_heapq_heappop_max, METH_O, _heapq_heappop_max__doc__},
@@ -257,7 +257,7 @@ PyDoc_STRVAR(_heapq_heapreplace_max__doc__,
 "heapreplace_max($module, heap, item, /)\n"
 "--\n"
 "\n"
-"Maxheap variant of heapreplace.");
+"Pop and return the largest item from the max-heap, and push the new item.");
 
 #define _HEAPQ_HEAPREPLACE_MAX_METHODDEF    \
     {"heapreplace_max", _PyCFunction_CAST(_heapq_heapreplace_max), METH_FASTCALL, _heapq_heapreplace_max__doc__},
@@ -293,7 +293,7 @@ PyDoc_STRVAR(_heapq_heapify_max__doc__,
 "heapify_max($module, heap, /)\n"
 "--\n"
 "\n"
-"Maxheap variant of heapify.");
+"Transform list into a max-heap, in-place, in O(len(heap)) time.");
 
 #define _HEAPQ_HEAPIFY_MAX_METHODDEF    \
     {"heapify_max", (PyCFunction)_heapq_heapify_max, METH_O, _heapq_heapify_max__doc__},
@@ -358,4 +358,4 @@ _heapq_heappushpop_max(PyObject *module, PyObject *const *args, Py_ssize_t nargs
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=e83d50002c29a96d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b1170d77557075f6 input=a9049054013a1b77]*/


### PR DESCRIPTION
## Summary

This PR makes three code-level improvements to the heapq module, following up on the max-heap public API added in Python 3.14 (gh-110067).

## Changes

### 1. Add `n <= 0` early return in `nsmallest()` and `nlargest()`

When called with `n=0` or a negative `n`, both functions previously took a wasteful code path through `iter()`, a `try/except` for `len()`, `zip(range(n))`, a list comprehension, and a `if not result` check—all to eventually return `[]`.

Adding `if n <= 0: return []` at the top short-circuits this immediately. This is consistent with how `n == 1` already has an early `min()`/`max()` shortcut.

### 2. Improve max-heap C function docstrings (argument clinic)

Three max-heap functions had minimal "Maxheap variant of X" docstrings, while their counterparts (`heappush_max`, `heappushpop_max`) had proper descriptions. This affected `help()` output for users.

| Function | Before | After |
|---|---|---|
| `heappop_max` | "Maxheap variant of heappop." | "Pop the largest item off the max-heap, maintaining the heap invariant." |
| `heapreplace_max` | "Maxheap variant of heapreplace." | "Pop and return the largest item from the max-heap, and push the new item." |
| `heapify_max` | "Maxheap variant of heapify." | "Transform list into a max-heap, in-place, in O(len(heap)) time." |

### 3. Consistent refcount pattern in `siftdown_max()`

`siftdown_max()` used `Py_NewRef()` mixed with a separate `Py_INCREF()`, while the min-heap `siftdown()` used consistent `Py_INCREF()` calls. Changed to match the established pattern for consistency.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146168.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->