### PR TITLE
gh-146044: Fix ctrl-w (unix-word-rubout) to use whitespace word boundaries

### DIFF
--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -169,7 +169,7 @@ class unix_word_rubout(KillCommand):
     def do(self) -> None:
         r = self.reader
         for i in range(r.get_arg()):
-            self.kill_range(r.bow(), r.pos)
+            self.kill_range(r.bow_whitespace(), r.pos)
 
 
 class kill_word(KillCommand):

--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -169,7 +169,7 @@ class unix_word_rubout(KillCommand):
     def do(self) -> None:
         r = self.reader
         for i in range(r.get_arg()):
-            self.kill_range(r.bow_whitespace(), r.pos)
+            self.kill_range(r.bow_ws(), r.pos)
 
 
 class kill_word(KillCommand):

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -423,7 +423,6 @@ class Reader:
 
         p defaults to self.pos; only whitespace is considered a word
         boundary, matching the behavior of unix-word-rubout in bash/readline.
-        See https://github.com/python/cpython/issues/146044
         """
         if p is None:
             p = self.pos

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -417,19 +417,20 @@ class Reader:
             p -= 1
         return p + 1
 
-    def bow_whitespace(self, p: int | None = None) -> int:
+    def bow_ws(self, p: int | None = None) -> int:
         """Return the 0-based index of the whitespace-delimited word break
         preceding p most immediately.
 
         p defaults to self.pos; only whitespace is considered a word
-        boundary, matching the behavior of unix-word-rubout in bash/readline."""
+        boundary, matching the behavior of unix-word-rubout in bash/readline.
+        See https://github.com/python/cpython/issues/146044"""
         if p is None:
             p = self.pos
         b = self.buffer
         p -= 1
-        while p >= 0 and b[p] in (" ", "\n"):
+        while p >= 0 and b[p] in " \n\t":
             p -= 1
-        while p >= 0 and b[p] not in (" ", "\n"):
+        while p >= 0 and b[p] not in " \n\t":
             p -= 1
         return p + 1
 

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -423,7 +423,8 @@ class Reader:
 
         p defaults to self.pos; only whitespace is considered a word
         boundary, matching the behavior of unix-word-rubout in bash/readline.
-        See https://github.com/python/cpython/issues/146044"""
+        See https://github.com/python/cpython/issues/146044
+        """
         if p is None:
             p = self.pos
         b = self.buffer

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -417,6 +417,22 @@ class Reader:
             p -= 1
         return p + 1
 
+    def bow_whitespace(self, p: int | None = None) -> int:
+        """Return the 0-based index of the whitespace-delimited word break
+        preceding p most immediately.
+
+        p defaults to self.pos; only whitespace is considered a word
+        boundary, matching the behavior of unix-word-rubout in bash/readline."""
+        if p is None:
+            p = self.pos
+        b = self.buffer
+        p -= 1
+        while p >= 0 and b[p] in (" ", "\n"):
+            p -= 1
+        while p >= 0 and b[p] not in (" ", "\n"):
+            p -= 1
+        return p + 1
+
     def eow(self, p: int | None = None) -> int:
         """Return the 0-based index of the word break following p most
         immediately.

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -558,3 +558,47 @@ class TestReaderInColor(ScreenEqualMixin, TestCase):
         reader, _ = handle_all_events(events)
         self.assert_screen_equal(reader, 'flag = "🏳️\\u200d🌈"', clean=True)
         self.assert_screen_equal(reader, 'flag {o}={z} {s}"🏳️\\u200d🌈"{z}'.format(**colors))
+
+
+class TestBowWhitespace(TestCase):
+    def test_bow_whitespace_stops_at_whitespace(self):
+        # GH#146044
+        # unix-word-rubout (ctrl-w) should use whitespace boundaries,
+        # not punctuation boundaries like bow() does
+        reader = prepare_reader(prepare_console())
+        reader.buffer = list("foo.bar baz")
+        reader.pos = len(reader.buffer)  # cursor at end
+
+        # bow_whitespace from end should jump to start of "baz"
+        result = reader.bow_whitespace()
+        self.assertEqual(result, 8)  # index of 'b' in "baz"
+
+    def test_bow_whitespace_includes_punctuation_in_word(self):
+        # GH#146044
+        reader = prepare_reader(prepare_console())
+        reader.buffer = list("foo.bar(baz) qux")
+        reader.pos = 12  # cursor after ")"
+
+        # bow_whitespace should treat "foo.bar(baz)" as one word
+        result = reader.bow_whitespace()
+        self.assertEqual(result, 0)
+
+    def test_bow_stops_at_punctuation(self):
+        # Verify existing bow() still uses syntax_table (punctuation boundary)
+        reader = prepare_reader(prepare_console())
+        reader.buffer = list("foo.bar baz")
+        reader.pos = len(reader.buffer)
+
+        result = reader.bow()
+        self.assertEqual(result, 8)  # same — "baz" is all word chars
+
+    def test_bow_vs_bow_whitespace_difference(self):
+        # The key difference: bow() stops at '.', bow_whitespace() does not
+        reader = prepare_reader(prepare_console())
+        reader.buffer = list("foo.bar")
+        reader.pos = len(reader.buffer)
+
+        # bow() stops at '.' → returns index of 'b' in "bar"
+        self.assertEqual(reader.bow(), 4)
+        # bow_whitespace() treats entire "foo.bar" as one word
+        self.assertEqual(reader.bow_whitespace(), 0)

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -367,8 +367,9 @@ class TestReader(ScreenEqualMixin, TestCase):
 
     def test_bow_ws_includes_punctuation_in_word(self):
         reader = prepare_reader(prepare_console([]))
-        reader.buffer = list("foo.bar(baz) qux")
-        reader.pos = 12
+        buf = "foo.bar(baz) qux"
+        reader.buffer = list(buf)
+        reader.pos = buf.index(")") + 1
         self.assertEqual(reader.bow_ws(), 0)
 
     def test_bow_vs_bow_ws(self):

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -565,7 +565,7 @@ class TestBowWhitespace(TestCase):
         # GH#146044
         # unix-word-rubout (ctrl-w) should use whitespace boundaries,
         # not punctuation boundaries like bow() does
-        reader = prepare_reader(prepare_console())
+        reader = prepare_reader(prepare_console([]))
         reader.buffer = list("foo.bar baz")
         reader.pos = len(reader.buffer)  # cursor at end
 
@@ -575,7 +575,7 @@ class TestBowWhitespace(TestCase):
 
     def test_bow_whitespace_includes_punctuation_in_word(self):
         # GH#146044
-        reader = prepare_reader(prepare_console())
+        reader = prepare_reader(prepare_console([]))
         reader.buffer = list("foo.bar(baz) qux")
         reader.pos = 12  # cursor after ")"
 
@@ -585,7 +585,7 @@ class TestBowWhitespace(TestCase):
 
     def test_bow_stops_at_punctuation(self):
         # Verify existing bow() still uses syntax_table (punctuation boundary)
-        reader = prepare_reader(prepare_console())
+        reader = prepare_reader(prepare_console([]))
         reader.buffer = list("foo.bar baz")
         reader.pos = len(reader.buffer)
 
@@ -594,7 +594,7 @@ class TestBowWhitespace(TestCase):
 
     def test_bow_vs_bow_whitespace_difference(self):
         # The key difference: bow() stops at '.', bow_whitespace() does not
-        reader = prepare_reader(prepare_console())
+        reader = prepare_reader(prepare_console([]))
         reader.buffer = list("foo.bar")
         reader.pos = len(reader.buffer)
 

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -586,5 +586,3 @@ class TestReaderInColor(ScreenEqualMixin, TestCase):
         reader, _ = handle_all_events(events)
         self.assert_screen_equal(reader, 'flag = "🏳️\\u200d🌈"', clean=True)
         self.assert_screen_equal(reader, 'flag {o}={z} {s}"🏳️\\u200d🌈"{z}'.format(**colors))
-
-

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -358,6 +358,34 @@ class TestReader(ScreenEqualMixin, TestCase):
         reader.setpos_from_xy(8, 0)
         self.assertEqual(reader.pos, 7)
 
+    def test_bow_ws_stops_at_whitespace(self):
+        # See https://github.com/python/cpython/issues/146044
+        reader = prepare_reader(prepare_console([]))
+        reader.buffer = list("foo.bar baz")
+        reader.pos = len(reader.buffer)
+        self.assertEqual(reader.bow_ws(), 8)
+
+    def test_bow_ws_includes_punctuation_in_word(self):
+        reader = prepare_reader(prepare_console([]))
+        reader.buffer = list("foo.bar(baz) qux")
+        reader.pos = 12
+        self.assertEqual(reader.bow_ws(), 0)
+
+    def test_bow_vs_bow_ws(self):
+        reader = prepare_reader(prepare_console([]))
+        reader.buffer = list("foo.bar")
+        reader.pos = len(reader.buffer)
+        # bow() stops at '.' so we return the index of 'b' in "bar"
+        self.assertEqual(reader.bow(), 4)
+        # bow_ws() treats entire "foo.bar" as one word
+        self.assertEqual(reader.bow_ws(), 0)
+
+    def test_bow_ws_with_tabs(self):
+        reader = prepare_reader(prepare_console([]))
+        reader.buffer = list("foo\tbar")
+        reader.pos = len(reader.buffer)
+        self.assertEqual(reader.bow_ws(), 4)
+
 @force_colorized_test_class
 class TestReaderInColor(ScreenEqualMixin, TestCase):
     def test_syntax_highlighting_basic(self):
@@ -560,45 +588,3 @@ class TestReaderInColor(ScreenEqualMixin, TestCase):
         self.assert_screen_equal(reader, 'flag {o}={z} {s}"🏳️\\u200d🌈"{z}'.format(**colors))
 
 
-class TestBowWhitespace(TestCase):
-    def test_bow_whitespace_stops_at_whitespace(self):
-        # GH#146044
-        # unix-word-rubout (ctrl-w) should use whitespace boundaries,
-        # not punctuation boundaries like bow() does
-        reader = prepare_reader(prepare_console([]))
-        reader.buffer = list("foo.bar baz")
-        reader.pos = len(reader.buffer)  # cursor at end
-
-        # bow_whitespace from end should jump to start of "baz"
-        result = reader.bow_whitespace()
-        self.assertEqual(result, 8)  # index of 'b' in "baz"
-
-    def test_bow_whitespace_includes_punctuation_in_word(self):
-        # GH#146044
-        reader = prepare_reader(prepare_console([]))
-        reader.buffer = list("foo.bar(baz) qux")
-        reader.pos = 12  # cursor after ")"
-
-        # bow_whitespace should treat "foo.bar(baz)" as one word
-        result = reader.bow_whitespace()
-        self.assertEqual(result, 0)
-
-    def test_bow_stops_at_punctuation(self):
-        # Verify existing bow() still uses syntax_table (punctuation boundary)
-        reader = prepare_reader(prepare_console([]))
-        reader.buffer = list("foo.bar baz")
-        reader.pos = len(reader.buffer)
-
-        result = reader.bow()
-        self.assertEqual(result, 8)  # same — "baz" is all word chars
-
-    def test_bow_vs_bow_whitespace_difference(self):
-        # The key difference: bow() stops at '.', bow_whitespace() does not
-        reader = prepare_reader(prepare_console([]))
-        reader.buffer = list("foo.bar")
-        reader.pos = len(reader.buffer)
-
-        # bow() stops at '.' → returns index of 'b' in "bar"
-        self.assertEqual(reader.bow(), 4)
-        # bow_whitespace() treats entire "foo.bar" as one word
-        self.assertEqual(reader.bow_whitespace(), 0)

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -359,7 +359,7 @@ class TestReader(ScreenEqualMixin, TestCase):
         self.assertEqual(reader.pos, 7)
 
     def test_bow_ws_stops_at_whitespace(self):
-        # See https://github.com/python/cpython/issues/146044
+        # See https://github.com/python/cpython/issues/146044.
         reader = prepare_reader(prepare_console([]))
         reader.buffer = list("foo.bar baz")
         reader.pos = len(reader.buffer)
@@ -383,6 +383,12 @@ class TestReader(ScreenEqualMixin, TestCase):
     def test_bow_ws_with_tabs(self):
         reader = prepare_reader(prepare_console([]))
         reader.buffer = list("foo\tbar")
+        reader.pos = len(reader.buffer)
+        self.assertEqual(reader.bow_ws(), 4)
+
+    def test_bow_ws_with_newlines(self):
+        reader = prepare_reader(prepare_console([]))
+        reader.buffer = list("foo\nbar")
         reader.pos = len(reader.buffer)
         self.assertEqual(reader.bow_ws(), 4)
 

--- a/Misc/NEWS.d/next/Library/2026-03-20-00-00-01.gh-issue-146044.WsCtrl.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-20-00-00-01.gh-issue-146044.WsCtrl.rst
@@ -1,3 +1,3 @@
 Fix ``unix-word-rubout`` (Ctrl-W) in the REPL to use whitespace-only word
-boundaries, matching bash/readline behavior. Previously it used
+boundaries, matching behavior of the basic REPL. Previously it used
 syntax-table boundaries which treated punctuation as word separators.

--- a/Misc/NEWS.d/next/Library/2026-03-20-00-00-01.gh-issue-146044.WsCtrl.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-20-00-00-01.gh-issue-146044.WsCtrl.rst
@@ -1,0 +1,3 @@
+Fix ``unix-word-rubout`` (Ctrl-W) in the REPL to use whitespace-only word
+boundaries, matching bash/readline behavior. Previously it used
+syntax-table boundaries which treated punctuation as word separators.


### PR DESCRIPTION
Fixes #146044

## Summary

The `unix-word-rubout` command (ctrl-w) was using `bow()` which treats
punctuation as word separators via the syntax table. This differs from
bash/readline's `unix-word-rubout` which uses only whitespace as boundaries.

## Changes

- **`reader.py`**: Add `bow_whitespace()` method — same as `bow()` but only
  considers spaces and newlines as word boundaries
- **`commands.py`**: `unix_word_rubout` now calls `bow_whitespace()` instead of `bow()`
- **`test_reader.py`**: Add `TestBowWhitespace` class with 4 tests verifying
  the whitespace-only behavior and the difference from `bow()`

## Example

With buffer `foo.bar baz` and cursor at end:
- **Before**: ctrl-w deletes `baz`, then `bar`, then `foo` (3 operations)
- **After**: ctrl-w deletes `baz`, then `foo.bar` (2 operations, matching bash)

The existing `bow()` method used by `backward-kill-word` (M-Backspace) is unchanged.

<!-- gh-issue-number: gh-146044 -->
* Issue: gh-146044
<!-- /gh-issue-number -->
