### PR TITLE
gh-146169: Prevent re-entrant Parse() calls in pyexpat

### DIFF
--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -276,6 +276,32 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(expat.ErrorString(cm.exception.code),
                           expat.errors.XML_ERROR_FINISHED)
 
+    def test_reentrant_parse_crash(self):
+        from xml.parsers import expat
+        p = expat.ParserCreate(encoding="utf-16")
+
+        def start(name, attrs):
+            def handler(data):
+                p.Parse(data, 0)
+            p.CharacterDataHandler = handler
+
+        p.StartElementHandler = start
+        data = b"\xff\xfe<\x00a\x00>\x00x\x00"
+        with self.assertRaises(RuntimeError) as cm:
+            for i in range(len(data)):
+                p.Parse(data[i:i+1], i == len(data) - 1)
+        self.assertEqual(str(cm.exception),
+                         "cannot call Parse() from within a handler")
+
+    def test_parse_normal(self):
+        from xml.parsers import expat
+        p = expat.ParserCreate()
+        data = "<root><child/></root>".encode('utf-8')
+        try:
+            p.Parse(data, 1)
+        except RuntimeError:
+            self.fail("Parse() raised RuntimeError during normal operation")
+
 class NamespaceSeparatorTest(unittest.TestCase):
     def test_legal(self):
         # Tests that make sure we get errors when the namespace_separator value

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -277,7 +277,6 @@ class ParseTest(unittest.TestCase):
                           expat.errors.XML_ERROR_FINISHED)
 
     def test_reentrant_parse_crash(self):
-        from xml.parsers import expat
         p = expat.ParserCreate(encoding="utf-16")
 
         def start(name, attrs):
@@ -294,7 +293,6 @@ class ParseTest(unittest.TestCase):
                          "cannot call Parse() from within a handler")
 
     def test_parse_normal(self):
-        from xml.parsers import expat
         p = expat.ParserCreate()
         data = "<root><child/></root>".encode('utf-8')
         try:

--- a/Misc/NEWS.d/next/Library/2026-03-19-10-30-20.gh-issue-146169.NXUmTH.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-19-10-30-20.gh-issue-146169.NXUmTH.rst
@@ -1,0 +1,9 @@
+.. gh-issue: 146169
+
+.. section: Library
+
+Prevent re-entrant calls to ``Parse()`` from within expat handlers,
+which
+could cause a crash. Now raises :exc:`RuntimeError` when such a
+call is
+attempted.

--- a/Misc/NEWS.d/next/Library/2026-03-19-10-30-20.gh-issue-146169.NXUmTH.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-19-10-30-20.gh-issue-146169.NXUmTH.rst
@@ -1,9 +1,0 @@
-.. gh-issue: 146169
-
-.. section: Library
-
-Prevent re-entrant calls to ``Parse()`` from within expat handlers,
-which
-could cause a crash. Now raises :exc:`RuntimeError` when such a
-call is
-attempted.

--- a/Misc/NEWS.d/next/Library/2026-03-19-11-15-00.gh-issue-146169.manual.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-19-11-15-00.gh-issue-146169.manual.rst
@@ -1,0 +1,3 @@
+Prevent re-entrant calls to ``Parse()`` from within expat handlers,
+which could cause a crash. Now raises :exc:`RuntimeError` when such a
+call is attempted.

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -857,6 +857,13 @@ pyexpat_xmlparser_Parse_impl(xmlparseobject *self, PyTypeObject *cls,
                              PyObject *data, int isfinal)
 /*[clinic end generated code: output=8faffe07fe1f862a input=053e0f047e55c05a]*/
 {
+
+    if (self->in_callback) {
+        PyErr_SetString(PyExc_RuntimeError,
+            "cannot call Parse() from within a handler");
+        return NULL;
+    }
+
     const char *s;
     Py_ssize_t slen;
     Py_buffer view;


### PR DESCRIPTION
Fixes #146169

Add a check in `Parse()` to prevent calls when `in_callback` is true,
as this violates expat's requirements and can cause crashes. Now raises
`RuntimeError` with a clear message.

Added tests to `test_pyexpat.py` to verify the fix:
- `test_reentrant_parse_crash`: Verifies re-entrant calls raise RuntimeError
- `test_parse_normal`: Ensures normal parsing still works


<!-- gh-issue-number: gh-146169 -->
* Issue: gh-146169
<!-- /gh-issue-number -->
