### PR TITLE
gh-145865: Fix CoverageResults.__init__ to copy the counts dict

### DIFF
--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -590,5 +590,32 @@ class TestTrace(unittest.TestCase):
         self.assertIn(f"{filename}({firstlineno + 4})", out[4])
 
 
+class TestCoverageResultsInit(unittest.TestCase):
+    def test_counts_dict_is_copied(self):
+        # gh-145865: CoverageResults.__init__ should copy the counts dict
+        from trace import CoverageResults
+
+        counts = {}
+        cr = CoverageResults(counts=counts)
+        cr.update(CoverageResults(counts={("file.py", 1): 5}))
+        self.assertEqual(counts, {})
+
+    def test_calledfuncs_dict_is_copied(self):
+        from trace import CoverageResults
+
+        calledfuncs = {}
+        cr = CoverageResults(calledfuncs=calledfuncs)
+        cr.update(CoverageResults(calledfuncs={("file.py", "mod", "func"): 1}))
+        self.assertEqual(calledfuncs, {})
+
+    def test_callers_dict_is_copied(self):
+        from trace import CoverageResults
+
+        callers = {}
+        cr = CoverageResults(callers=callers)
+        cr.update(CoverageResults(callers={(("a.py", "m", "f"), ("b.py", "m", "g")): 1}))
+        self.assertEqual(callers, {})
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -155,7 +155,7 @@ class CoverageResults:
         self.counts = counts
         if self.counts is None:
             self.counts = {}
-        self.counter = self.counts.copy() # map (filename, lineno) to count
+        self.counts = self.counts.copy()  # map (filename, lineno) to count
         self.calledfuncs = calledfuncs
         if self.calledfuncs is None:
             self.calledfuncs = {}

--- a/Misc/NEWS.d/next/Library/2026-03-20-00-00-00.gh-issue-145865.TrCpCo.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-20-00-00-00.gh-issue-145865.TrCpCo.rst
@@ -1,0 +1,3 @@
+Fix typo in :class:`trace.CoverageResults` where ``self.counter`` was
+assigned instead of ``self.counts``, causing the ``counts`` dict to not
+be copied and ``update()`` to mutate the caller's original dict.


### PR DESCRIPTION
Fixes #145865

## Summary

`CoverageResults.__init__` had a typo on line 158:
```python
self.counter = self.counts.copy()  # typo: creates dead attribute
```
should be:
```python
self.counts = self.counts.copy()  # matches calledfuncs/callers pattern
```

This caused `self.counts` to be an alias to the caller's dict, so
`update()` would mutate the original dict.

## Tests

Added `TestCoverageResultsInit` with 3 tests verifying that `counts`,
`calledfuncs`, and `callers` dicts are all properly copied.

## Changes from previous PR #146176

Removed unrelated pyrepl changes that were accidentally included.

<!-- gh-issue-number: gh-145865 -->
* Issue: gh-145865
<!-- /gh-issue-number -->
