### PR TITLE
Fix documentation typos and grammar errors

### DIFF
--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -66,7 +66,7 @@ Available make targets are:
   starts a local server, and automatically reloads the page in your browser
   when you make changes to reST files (Unix only).
 
-* "htmlhelp", which builds HTML files and a HTML Help project file usable to
+* "htmlhelp", which builds HTML files and an HTML Help project file usable to
   convert them into a single Compiled HTML (.chm) file -- these are popular
   under Microsoft Windows, but very handy on every platform.
 

--- a/Doc/deprecations/pending-removal-in-3.15.rst
+++ b/Doc/deprecations/pending-removal-in-3.15.rst
@@ -6,7 +6,7 @@ Pending removal in Python 3.15
   * Setting ``__cached__`` on a module while
     failing to set :attr:`__spec__.cached <importlib.machinery.ModuleSpec.cached>`
     is deprecated. In Python 3.15, ``__cached__`` will cease to be set or
-    taken into consideration by the import system or standard library. (:gh:`97879`)
+    be taken into consideration by the import system or standard library. (:gh:`97879`)
 
   * Setting :attr:`~module.__package__` on a module while
     failing to set :attr:`__spec__.parent <importlib.machinery.ModuleSpec.parent>`

--- a/Doc/deprecations/pending-removal-in-3.15.rst
+++ b/Doc/deprecations/pending-removal-in-3.15.rst
@@ -11,7 +11,7 @@ Pending removal in Python 3.15
   * Setting :attr:`~module.__package__` on a module while
     failing to set :attr:`__spec__.parent <importlib.machinery.ModuleSpec.parent>`
     is deprecated. In Python 3.15, :attr:`!__package__` will cease to be set or
-    taken into consideration by the import system or standard library. (:gh:`97879`)
+    be taken into consideration by the import system or standard library. (:gh:`97879`)
 
 * :mod:`ctypes`:
 

--- a/Doc/deprecations/pending-removal-in-3.15.rst
+++ b/Doc/deprecations/pending-removal-in-3.15.rst
@@ -6,12 +6,12 @@ Pending removal in Python 3.15
   * Setting ``__cached__`` on a module while
     failing to set :attr:`__spec__.cached <importlib.machinery.ModuleSpec.cached>`
     is deprecated. In Python 3.15, ``__cached__`` will cease to be set or
-    take into consideration by the import system or standard library. (:gh:`97879`)
+    taken into consideration by the import system or standard library. (:gh:`97879`)
 
   * Setting :attr:`~module.__package__` on a module while
     failing to set :attr:`__spec__.parent <importlib.machinery.ModuleSpec.parent>`
     is deprecated. In Python 3.15, :attr:`!__package__` will cease to be set or
-    take into consideration by the import system or standard library. (:gh:`97879`)
+    taken into consideration by the import system or standard library. (:gh:`97879`)
 
 * :mod:`ctypes`:
 

--- a/Doc/extending/first-extension-module.rst
+++ b/Doc/extending/first-extension-module.rst
@@ -670,7 +670,7 @@ on :py:attr:`sys.path`.
    ":c:type:`!PyFunctionDef`".
 .. [#why-pylongfromlong] The name :c:func:`PyLong_FromLong`
    might not seem obvious.
-   ``PyLong`` refers to a the Python :py:class:`int`, which was originally
+   ``PyLong`` refers to the Python :py:class:`int`, which was originally
    called ``long``; the ``FromLong`` refers to the C ``long`` (or ``long int``)
    type.
 .. [#why-pyunicodeasutf8] Here, ``PyUnicode`` refers to the original name of

--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -100,7 +100,7 @@ Data
 Sometimes you want to send data to a URL (often the URL will refer to a CGI
 (Common Gateway Interface) script or other web application). With HTTP,
 this is often done using what's known as a **POST** request. This is often what
-your browser does when you submit a HTML form that you filled in on the web. Not
+your browser does when you submit an HTML form that you filled in on the web. Not
 all POSTs have to come from forms: you can use a POST to transmit arbitrary data
 to your own application. In the common case of HTML forms, the data needs to be
 encoded in a standard way, and then passed to the Request object as the ``data``

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -487,7 +487,7 @@ Opening network connections
 
    Other arguments:
 
-   * *ssl*: if given and not false, a SSL/TLS transport is created
+   * *ssl*: if given and not false, an SSL/TLS transport is created
      (by default a plain TCP transport is created).  If *ssl* is
      a :class:`ssl.SSLContext` object, this context is used to create
      the transport; if *ssl* is :const:`True`, a default context returned

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -131,7 +131,7 @@ This module provides the following function:
 
 .. function:: parse_headers(fp)
 
-   Parse the headers from a file pointer *fp* representing a HTTP
+   Parse the headers from a file pointer *fp* representing an HTTP
    request/response. The file has to be a :class:`~io.BufferedIOBase` reader
    (i.e. not text) and must provide a valid :rfc:`5322` style header.
 
@@ -142,7 +142,7 @@ This module provides the following function:
    After returning, the file pointer *fp* is ready to read the HTTP body.
 
    .. note::
-      :meth:`parse_headers` does not parse the start-line of a HTTP message;
+      :meth:`parse_headers` does not parse the start-line of an HTTP message;
       it only parses the ``Name: value`` lines. The file has to be ready to
       read these field lines, so the first line should already be consumed
       before calling the function.
@@ -209,7 +209,7 @@ The following exceptions are raised as appropriate:
 
 .. exception:: BadStatusLine
 
-   A subclass of :exc:`HTTPException`.  Raised if a server responds with a HTTP
+   A subclass of :exc:`HTTPException`.  Raised if a server responds with an HTTP
    status code that we don't understand.
 
 
@@ -373,13 +373,13 @@ HTTPConnection Objects
    the CONNECT request.
 
    As HTTP/1.1 is used for HTTP CONNECT tunnelling request, `as per the RFC
-   <https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.6>`_, a HTTP ``Host:``
+   <https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.6>`_, an HTTP ``Host:``
    header must be provided, matching the authority-form of the request target
-   provided as the destination for the CONNECT request. If a HTTP ``Host:``
+   provided as the destination for the CONNECT request. If an HTTP ``Host:``
    header is not provided via the headers argument, one is generated and
    transmitted automatically.
 
-   For example, to tunnel through a HTTPS proxy server running locally on port
+   For example, to tunnel through an HTTPS proxy server running locally on port
    8080, we would pass the address of the proxy to the :class:`HTTPSConnection`
    constructor, and the address of the host that we eventually want to reach to
    the :meth:`~HTTPConnection.set_tunnel` method::

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -991,11 +991,11 @@ supports sending logging messages to a web server, using either ``GET`` or
 
    Returns a new instance of the :class:`HTTPHandler` class. The *host* can be
    of the form ``host:port``, should you need to use a specific port number.  If
-   no *method* is specified, ``GET`` is used. If *secure* is true, a HTTPS
+   no *method* is specified, ``GET`` is used. If *secure* is true, an HTTPS
    connection will be used. The *context* parameter may be set to a
    :class:`ssl.SSLContext` instance to configure the SSL settings used for the
    HTTPS connection. If *credentials* is specified, it should be a 2-tuple
-   consisting of userid and password, which will be placed in a HTTP
+   consisting of userid and password, which will be placed in an HTTP
    'Authorization' header using Basic authentication. If you specify
    credentials, you should also specify secure=True so that your userid and
    password are not passed in cleartext across the wire.

--- a/Doc/library/pydoc.rst
+++ b/Doc/library/pydoc.rst
@@ -64,7 +64,7 @@ module is the first line of its documentation string.
 
 You can also use :program:`pydoc` to start an HTTP server on the local machine
 that will serve documentation to visiting web browsers.  :program:`python -m pydoc -p 1234`
-will start a HTTP server on port 1234, allowing you to browse the
+will start an HTTP server on port 1234, allowing you to browse the
 documentation at ``http://localhost:1234/`` in your preferred web browser.
 Specifying ``0`` as the port number will select an arbitrary unused port.
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -47,7 +47,7 @@ Directory and files operations
    :func:`copyfileobj` will *not* guarantee that the destination stream has
    been flushed on completion of the copy. If you want to read from the
    destination at the completion of the copy operation (for example, reading
-   the contents of a temporary file that has been copied from a HTTP stream),
+   the contents of a temporary file that has been copied from an HTTP stream),
    you must ensure that you have called :func:`~io.IOBase.flush` or
    :func:`~io.IOBase.close` on the file-like object before attempting to read
    the destination file.

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -293,7 +293,7 @@ Exceptions
 .. exception:: SSLSyscallError
 
    A subclass of :exc:`SSLError` raised when a system error was encountered
-   while trying to fulfill an operation on a SSL socket.  Unfortunately,
+   while trying to fulfill an operation on an SSL socket.  Unfortunately,
    there is no easy way to inspect the original errno number.
 
    .. versionadded:: 3.3
@@ -1645,7 +1645,7 @@ to speed up repeated connections from the same clients.
    entry is a dict like the output of :meth:`SSLSocket.getpeercert`. Otherwise
    the method returns a list of DER-encoded certificates. The returned list
    does not contain certificates from *capath* unless a certificate was
-   requested and loaded by a SSL connection.
+   requested and loaded by an SSL connection.
 
    .. note::
       Certificates in a capath directory aren't loaded unless they have
@@ -2434,7 +2434,7 @@ should use the following idiom::
 Client-side operation
 ^^^^^^^^^^^^^^^^^^^^^
 
-This example creates a SSL context with the recommended security settings
+This example creates an SSL context with the recommended security settings
 for client sockets, including automatic certificate verification::
 
    >>> context = ssl.create_default_context()
@@ -2620,7 +2620,7 @@ thus several things you need to be aware of:
   and :meth:`SSLSocket.send` failures, and retry after another call to
   :func:`~select.select`.
 
-- Conversely, since the SSL layer has its own framing, a SSL socket may
+- Conversely, since the SSL layer has its own framing, an SSL socket may
   still have data available for reading without :func:`~select.select`
   being aware of it.  Therefore, you should first call
   :meth:`SSLSocket.recv` to drain any potentially available data, and then
@@ -2824,7 +2824,7 @@ validation and hostname checking, and try to choose reasonably secure
 protocol and cipher settings.
 
 For example, here is how you would use the :class:`smtplib.SMTP` class to
-create a trusted, secure connection to a SMTP server::
+create a trusted, secure connection to an SMTP server::
 
    >>> import ssl, smtplib
    >>> smtp = smtplib.SMTP("mail.python.org", port=587)
@@ -2893,7 +2893,7 @@ Cipher selection
 ''''''''''''''''
 
 If you have advanced security requirements, fine-tuning of the ciphers
-enabled when negotiating a SSL session is possible through the
+enabled when negotiating an SSL session is possible through the
 :meth:`SSLContext.set_ciphers` method.  Starting from Python 3.2.3, the
 ssl module disables certain weak ciphers by default, but you may want
 to further restrict the cipher choice. Be sure to read OpenSSL's documentation

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -2147,7 +2147,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    returned by the :func:`open` function.  Their parameters are chosen as
    follows:
 
-   * The encoding and error handling are is initialized from
+   * The encoding and error handling are initialized from
      :c:member:`PyConfig.stdio_encoding` and :c:member:`PyConfig.stdio_errors`.
 
      On Windows, UTF-8 is used for the console device.  Non-character

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -567,7 +567,7 @@ Example of Client Usage
        except Error as v:
            print("ERROR", v)
 
-To access an XML-RPC server through a HTTP proxy, you need to define a custom
+To access an XML-RPC server through an HTTP proxy, you need to define a custom
 transport.  The following example shows how::
 
    import http.client

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -369,7 +369,7 @@ General Options
      * :func:`!sys._stats_clear`: Clears the statistics.
      * :func:`!sys._stats_dump`: Dump statistics to file, and clears the statistics.
 
-   The statistics will be dumped to a arbitrary (probably unique) file in
+   The statistics will be dumped to an arbitrary (probably unique) file in
    ``/tmp/py_stats/`` (Unix) or ``C:\temp\py_stats\`` (Windows). If that
    directory does not exist, results will be printed on stderr.
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2188,7 +2188,7 @@ bdb
 ---
 
 * The basic debugger now has a :mod:`sys.monitoring`-based backend,
-  which can be selected via the passing ``'monitoring'``
+  which can be selected by passing ``'monitoring'``
   to the :class:`~bdb.Bdb` class's new *backend* parameter.
   (Contributed by Tian Gao in :gh:`124533`.)
 

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -1672,7 +1672,7 @@ The :class:`~unittest.mock.Mock` class has the following improvements:
 urllib.request
 --------------
 
-If a HTTP request has a file or iterable body (other than a
+If an HTTP request has a file or iterable body (other than a
 bytes object) but no ``Content-Length`` header, rather than
 throwing an error, :class:`AbstractHTTPHandler <urllib.request.HTTPHandler>`
 now falls back to use chunked transfer encoding.
@@ -2281,7 +2281,7 @@ Changes in the Python API
   :meth:`http.client.HTTPConnection.request` method, if no Content-Length
   header field has been specified and the request body is a file object,
   it is now sent with HTTP 1.1 chunked encoding. If a file object has to
-  be sent to a HTTP 1.0 server, the Content-Length value now has to be
+  be sent to an HTTP 1.0 server, the Content-Length value now has to be
   specified by the caller.
   (Contributed by Demian Brecht and Rolf Krahl with tweaks from
   Martin Panter in :issue:`12319`.)

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -907,7 +907,7 @@ for :func:`property`, :func:`classmethod`, and :func:`staticmethod`::
 io
 --
 
-In development mode (:option:`-X` ``env``) and in :ref:`debug build <debug-build>`, the
+In development mode (:option:`-X` ``dev``) and in :ref:`debug build <debug-build>`, the
 :class:`io.IOBase` finalizer now logs the exception if the ``close()`` method
 fails. The exception is ignored silently by default in release build.
 (Contributed by Victor Stinner in :issue:`18748`.)


### PR DESCRIPTION
## Summary

Fix 29 documentation errors across 16 files:

- **Article errors before vowel-sound acronyms** (22 instances): "a HTTP" → "an HTTP", "a HTTPS" → "an HTTPS", "a SSL" → "an SSL", "a HTML" → "an HTML", "a SMTP" → "an SMTP". English article choice depends on pronunciation, not spelling — these acronyms start with vowel sounds ("aitch", "ess").
- **"a arbitrary" → "an arbitrary"** in `Doc/using/configure.rst`
- **Wrong flag name**: "-X env" → "-X dev" in `Doc/whatsnew/3.8.rst` (the Python Development Mode flag is `-X dev`, not `-X env`)
- **Grammar error**: "are is initialized" → "are initialized" in `Doc/library/sys.rst`
- **Stray article**: "a the Python" → "the Python" in `Doc/extending/first-extension-module.rst`
- **Grammar error**: "via the passing" → "by passing" in `Doc/whatsnew/3.14.rst`
- **Grammar error**: "take into consideration" → "taken into consideration" in `Doc/deprecations/pending-removal-in-3.15.rst` (2 instances, consistent with the correct phrasing used in `pending-removal-in-3.16.rst` and `reference/datamodel.rst`)

### Files changed

| File | Fixes |
|------|-------|
| `Doc/library/ssl.rst` | 6 article fixes (SSL, SMTP) |
| `Doc/library/http.client.rst` | 6 article fixes (HTTP, HTTPS) |
| `Doc/whatsnew/3.6.rst` | 2 article fixes (HTTP) |
| `Doc/library/logging.handlers.rst` | 2 article fixes (HTTP, HTTPS) |
| `Doc/deprecations/pending-removal-in-3.15.rst` | 2 grammar fixes |
| `Doc/whatsnew/3.8.rst` | 1 wrong flag name fix |
| `Doc/library/sys.rst` | 1 grammar fix |
| `Doc/extending/first-extension-module.rst` | 1 typo fix |
| `Doc/whatsnew/3.14.rst` | 1 grammar fix |
| `Doc/using/configure.rst` | 1 article fix |
| `Doc/library/asyncio-eventloop.rst` | 1 article fix (SSL) |
| `Doc/library/xmlrpc.client.rst` | 1 article fix (HTTP) |
| `Doc/library/pydoc.rst` | 1 article fix (HTTP) |
| `Doc/library/shutil.rst` | 1 article fix (HTTP) |
| `Doc/howto/urllib2.rst` | 1 article fix (HTML) |
| `Doc/README.rst` | 1 article fix (HTML) |

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146187.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->