### PR TITLE
[3.14] gh-146056: Fix repr() for lists and tuples containing NULLs (GH-146129) (alt)

### DIFF
--- a/Doc/c-api/file.rst
+++ b/Doc/c-api/file.rst
@@ -123,9 +123,12 @@ the :mod:`io` APIs instead.
 
    Write object *obj* to file object *p*.  The only supported flag for *flags* is
    :c:macro:`Py_PRINT_RAW`; if given, the :func:`str` of the object is written
-   instead of the :func:`repr`.  Return ``0`` on success or ``-1`` on failure; the
-   appropriate exception will be set.
+   instead of the :func:`repr`.
 
+   If *obj* is ``NULL``, write the string ``"<NULL>"``.
+
+   Return ``0`` on success or ``-1`` on failure; the
+   appropriate exception will be set.
 
 .. c:function:: int PyFile_WriteString(const char *s, PyObject *p)
 

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -319,6 +319,8 @@ Object Protocol
    representation on success, ``NULL`` on failure.  This is the equivalent of the
    Python expression ``repr(o)``.  Called by the :func:`repr` built-in function.
 
+   If argument is ``NULL``, return the string ``'<NULL>'``.
+
    .. versionchanged:: 3.4
       This function now includes a debug assertion to help ensure that it
       does not silently discard an active exception.
@@ -333,6 +335,8 @@ Object Protocol
    a string similar to that returned by :c:func:`PyObject_Repr` in Python 2.
    Called by the :func:`ascii` built-in function.
 
+   If argument is ``NULL``, return the string ``'<NULL>'``.
+
    .. index:: string; PyObject_Str (C function)
 
 
@@ -342,6 +346,8 @@ Object Protocol
    representation on success, ``NULL`` on failure.  This is the equivalent of the
    Python expression ``str(o)``.  Called by the :func:`str` built-in function
    and, therefore, by the :func:`print` function.
+
+   If argument is ``NULL``, return the string ``'<NULL>'``.
 
    .. versionchanged:: 3.4
       This function now includes a debug assertion to help ensure that it
@@ -357,6 +363,8 @@ Object Protocol
    expression ``bytes(o)``, when *o* is not an integer.  Unlike ``bytes(o)``,
    a TypeError is raised when *o* is an integer instead of a zero-initialized
    bytes object.
+
+   If argument is ``NULL``, return the :class:`bytes` object ``b'<NULL>'``.
 
 
 .. c:function:: int PyObject_IsSubclass(PyObject *derived, PyObject *cls)

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1874,6 +1874,8 @@ object.
 
    Call :c:func:`PyObject_Repr` on *obj* and write the output into *writer*.
 
+   *obj* should not be ``NULL``.
+
    On success, return ``0``.
    On error, set an exception, leave the writer unchanged, and return ``-1``.
 

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -497,6 +497,14 @@ PyAPI_FUNC(int) PyUnicodeWriter_WriteStr(
 PyAPI_FUNC(int) PyUnicodeWriter_WriteRepr(
     PyUnicodeWriter *writer,
     PyObject *obj);
+
+PyAPI_FUNC(int) _PyUnicodeWriter_WriteReprTrue(
+    PyUnicodeWriter *writer,
+    PyObject *obj);
+#if defined(Py_BUILD_CORE) || defined(Py_BUILD_CORE_MODULE)
+#define PyUnicodeWriter_WriteRepr _PyUnicodeWriter_WriteReprTrue
+#endif
+
 PyAPI_FUNC(int) PyUnicodeWriter_WriteSubstring(
     PyUnicodeWriter *writer,
     PyObject *str,

--- a/Lib/test/test_capi/test_list.py
+++ b/Lib/test/test_capi/test_list.py
@@ -350,6 +350,10 @@ class CAPITest(unittest.TestCase):
         # CRASHES list_extend(NULL, [])
         # CRASHES list_extend([], NULL)
 
+    def test_uninitialized_list_repr(self):
+        lst = _testlimitedcapi.list_new(3)
+        self.assertEqual(repr(lst), '[<NULL>, <NULL>, <NULL>]')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_capi/test_tuple.py
+++ b/Lib/test/test_capi/test_tuple.py
@@ -292,6 +292,10 @@ class CAPITest(unittest.TestCase):
         self.assertEqual(tuple(my_iter()), (TAG, *range(10)))
         self.assertEqual(tuples, [])
 
+    def test_uninitialized_tuple_repr(self):
+        tup = _testlimitedcapi.tuple_new(3)
+        self.assertEqual(repr(tup), '(<NULL>, <NULL>, <NULL>)')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_capi/test_unicode.py
+++ b/Lib/test/test_capi/test_unicode.py
@@ -1765,6 +1765,14 @@ class PyUnicodeWriterTest(unittest.TestCase):
         self.assertEqual(writer.finish(),
                          "var=long value 'repr'")
 
+    def test_repr_null(self):
+        writer = self.create_writer(0)
+        writer.write_utf8(b'var=', -1)
+        # CRASHES writer.write_repr(NULL)
+        writer.write_repr_true(NULL)
+        self.assertEqual(writer.finish(),
+                         "var=<NULL>")
+
     def test_utf8(self):
         writer = self.create_writer(0)
         writer.write_utf8(b"ascii", -1)

--- a/Misc/NEWS.d/next/C_API/2026-03-18-20-18-59.gh-issue-146056.nnZIgp.rst
+++ b/Misc/NEWS.d/next/C_API/2026-03-18-20-18-59.gh-issue-146056.nnZIgp.rst
@@ -1,0 +1,1 @@
+:c:func:`PyUnicodeWriter_WriteRepr` now supports ``NULL`` argument.

--- a/Misc/NEWS.d/next/C_API/2026-03-18-20-18-59.gh-issue-146056.nnZIgp.rst
+++ b/Misc/NEWS.d/next/C_API/2026-03-18-20-18-59.gh-issue-146056.nnZIgp.rst
@@ -1,1 +1,0 @@
-:c:func:`PyUnicodeWriter_WriteRepr` now supports ``NULL`` argument.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-18-18-52-00.gh-issue-146056.r1tVSo.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-18-18-52-00.gh-issue-146056.r1tVSo.rst
@@ -1,0 +1,1 @@
+Fix :meth:`!list.__repr__` for lists containing ``NULL``\ s.

--- a/Modules/_testcapi/unicode.c
+++ b/Modules/_testcapi/unicode.c
@@ -443,8 +443,26 @@ writer_write_repr(PyObject *self_raw, PyObject *args)
     if (!PyArg_ParseTuple(args, "O", &obj)) {
         return NULL;
     }
+    NULLABLE(obj);
 
     if (PyUnicodeWriter_WriteRepr(self->writer, obj) < 0) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+
+static PyObject*
+writer_write_repr_true(PyObject *self_raw, PyObject *obj)
+{
+    WriterObject *self = (WriterObject *)self_raw;
+    if (writer_check(self) < 0) {
+        return NULL;
+    }
+
+    NULLABLE(obj);
+
+    if (_PyUnicodeWriter_WriteReprTrue(self->writer, obj) < 0) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -539,6 +557,7 @@ static PyMethodDef writer_methods[] = {
     {"write_ucs4", _PyCFunction_CAST(writer_write_ucs4), METH_VARARGS},
     {"write_str", _PyCFunction_CAST(writer_write_str), METH_VARARGS},
     {"write_repr", _PyCFunction_CAST(writer_write_repr), METH_VARARGS},
+    {"write_repr_true", _PyCFunction_CAST(writer_write_repr_true), METH_O},
     {"write_substring", _PyCFunction_CAST(writer_write_substring), METH_VARARGS},
     {"decodeutf8stateful", _PyCFunction_CAST(writer_decodeutf8stateful), METH_VARARGS},
     {"get_pointer", _PyCFunction_CAST(writer_get_pointer), METH_VARARGS},

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -595,7 +595,7 @@ list_repr_impl(PyListObject *v)
        so must refetch the list size on each iteration. */
     for (Py_ssize_t i = 0; i < Py_SIZE(v); ++i) {
         /* Hold a strong reference since repr(item) can mutate the list */
-        item = Py_NewRef(v->ob_item[i]);
+        item = Py_XNewRef(v->ob_item[i]);
 
         if (i > 0) {
             if (PyUnicodeWriter_WriteChar(writer, ',') < 0) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -13972,6 +13972,16 @@ PyUnicodeWriter_WriteStr(PyUnicodeWriter *writer, PyObject *obj)
     return res;
 }
 
+#undef PyUnicodeWriter_WriteRepr
+
+int
+_PyUnicodeWriter_WriteReprTrue(PyUnicodeWriter *writer, PyObject *obj)
+{
+    if (obj == NULL) {
+        return _PyUnicodeWriter_WriteASCIIString((_PyUnicodeWriter*)writer, "<NULL>", 6);
+    }
+    return PyUnicodeWriter_WriteRepr(writer, obj);
+}
 
 int
 PyUnicodeWriter_WriteRepr(PyUnicodeWriter *writer, PyObject *obj)


### PR DESCRIPTION
(cherry picked from commit 0f2246b1553f401da5ade47e0fd1c80ad7a8dfa5)

This is an alternative to #146155 which only fixes `PyUnicodeWriter_WriteRepr()` for internal use, leaving users with the broken variant.

<!-- gh-issue-number: gh-146056 -->
* Issue: gh-146056
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146204.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->