### PR TITLE
gh-146205: Check the errno with != 0 in close impls in select module

### DIFF
--- a/Lib/test/test_devpoll.py
+++ b/Lib/test/test_devpoll.py
@@ -2,6 +2,7 @@
 
 # Initial tests are copied as is from "test_poll.py"
 
+import errno
 import os
 import random
 import select
@@ -111,6 +112,15 @@ class DevPollTests(unittest.TestCase):
         self.assertRaises(ValueError, devpoll.poll)
         self.assertRaises(ValueError, devpoll.register, fd, select.POLLIN)
         self.assertRaises(ValueError, devpoll.unregister, fd)
+
+    def test_close_error(self):
+        # gh-146205: close() should raise OSError if underlying fd is invalid
+        devpoll = select.devpoll()
+        fd = devpoll.fileno()
+        os.close(fd)
+        with self.assertRaises(OSError) as cm:
+            devpoll.close()
+        self.assertEqual(cm.exception.errno, errno.EBADF)
 
     def test_fd_non_inheritable(self):
         devpoll = select.devpoll()

--- a/Lib/test/test_epoll.py
+++ b/Lib/test/test_epoll.py
@@ -259,6 +259,15 @@ class TestEPoll(unittest.TestCase):
         self.assertRaises(ValueError, epoll.register, fd, select.EPOLLIN)
         self.assertRaises(ValueError, epoll.unregister, fd)
 
+    def test_close_error(self):
+        # gh-146205: close() should raise OSError if underlying fd is invalid
+        epoll = select.epoll()
+        fd = epoll.fileno()
+        os.close(fd)
+        with self.assertRaises(OSError) as cm:
+            epoll.close()
+        self.assertEqual(cm.exception.errno, errno.EBADF)
+
     def test_fd_non_inheritable(self):
         epoll = select.epoll()
         self.addCleanup(epoll.close)

--- a/Lib/test/test_kqueue.py
+++ b/Lib/test/test_kqueue.py
@@ -254,6 +254,15 @@ class TestKQueue(unittest.TestCase):
         # operations must fail with ValueError("I/O operation on closed ...")
         self.assertRaises(ValueError, kqueue.control, None, 4)
 
+    def test_close_error(self):
+        # gh-146205: close() should raise OSError if underlying fd is invalid
+        kqueue = select.kqueue()
+        fd = kqueue.fileno()
+        os.close(fd)
+        with self.assertRaises(OSError) as cm:
+            kqueue.close()
+        self.assertEqual(cm.exception.errno, errno.EBADF)
+
     def test_fd_non_inheritable(self):
         kqueue = select.kqueue()
         self.addCleanup(kqueue.close)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-20-12-52-55.gh-issue-146205.M4yKdf.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-20-12-52-55.gh-issue-146205.M4yKdf.rst
@@ -1,0 +1,2 @@
+Fixed a bug where :meth:`select.epoll.close`, :meth:`select.kqueue.close`,
+and :meth:`select.devpoll.close` silently ignored errors.

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1118,8 +1118,9 @@ static PyObject *
 select_devpoll_close_impl(devpollObject *self)
 /*[clinic end generated code: output=26b355bd6429f21b input=408fde21a377ccfb]*/
 {
-    errno = devpoll_internal_close(self);
-    if (errno < 0) {
+    int err = devpoll_internal_close(self);
+    if (err != 0) {
+        errno = err;
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
@@ -1446,8 +1447,9 @@ static PyObject *
 select_epoll_close_impl(pyEpoll_Object *self)
 /*[clinic end generated code: output=ee2144c446a1a435 input=f626a769192e1dbe]*/
 {
-    errno = pyepoll_internal_close(self);
-    if (errno < 0) {
+    int err = pyepoll_internal_close(self);
+    if (err != 0) {
+        errno = err;
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
@@ -2263,8 +2265,9 @@ static PyObject *
 select_kqueue_close_impl(kqueue_queue_Object *self)
 /*[clinic end generated code: output=d1c7df0b407a4bc1 input=6d763c858b17b690]*/
 {
-    errno = kqueue_queue_internal_close(self);
-    if (errno < 0) {
+    int err = kqueue_queue_internal_close(self);
+    if (err != 0) {
+        errno = err;
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }


### PR DESCRIPTION
Also changed to set the `errno` to `err` only if `err != 0`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146205 -->
* Issue: gh-146205
<!-- /gh-issue-number -->
