### PR TITLE
[3.14] gh-146196: Fix Undefined Behavior in _PyUnicodeWriter_WriteASCIIString() (#146201)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-20-13-55-14.gh-issue-146196.Zg70Kb.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-20-13-55-14.gh-issue-146196.Zg70Kb.rst
@@ -1,0 +1,2 @@
+Fix potential Undefined Behavior in :c:func:`PyUnicodeWriter_WriteASCII` by
+adding a zero-length check. Patch by Shamil Abdulaev.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14054,6 +14054,10 @@ _PyUnicodeWriter_WriteASCIIString(_PyUnicodeWriter *writer,
     if (len == -1)
         len = strlen(ascii);
 
+    if (len == 0) {
+        return 0;
+    }
+
     assert(ucs1lib_find_max_char((const Py_UCS1*)ascii, (const Py_UCS1*)ascii + len) < 128);
 
     if (writer->buffer == NULL && !writer->overallocate) {


### PR DESCRIPTION
Avoid calling memcpy(data + writer->pos, NULL, 0)
which has an undefined behavior.


(cherry picked from commit cd10a2e65c25682095f6ee4a9b9a181938a50d2e)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146196 -->
* Issue: gh-146196
<!-- /gh-issue-number -->
