### PR TITLE
gh-146219: Document reusing a thread state across repeated foreign-thread calls

### DIFF
--- a/Doc/c-api/threads.rst
+++ b/Doc/c-api/threads.rst
@@ -257,20 +257,28 @@ exits::
 The equivalent with the :ref:`PyGILState API <gilstate>` keeps an *outer*
 :c:func:`PyGILState_Ensure` outstanding for the thread's lifetime, so
 nested Ensure/Release pairs never drop the internal nesting counter to
-zero::
+zero.
 
-   /* Thread startup: create and pin the state. */
+In thread startup, pin the state and immediately detach so the thread
+does not hold the GIL while off doing non-Python work.  Stash ``outer``
+and ``saved`` somewhere that survives for the thread's lifetime (for
+example, in thread-local storage)::
+
    PyGILState_STATE outer = PyGILState_Ensure();
-   PyThreadState *saved = PyEval_SaveThread();
+   PyThreadState *saved   = PyEval_SaveThread();
 
-   /* Per-call: the thread state already exists. */
+Each subsequent call into Python from this thread reuses the pinned
+state; the inner Release decrements the nesting counter but does not
+destroy the thread state because the outer Ensure is still
+outstanding::
+
    PyGILState_STATE inner = PyGILState_Ensure();
    result = CallSomeFunction();
    PyGILState_Release(inner);
 
-   /* ... many more calls ... */
+At thread shutdown, re-attach and drop the outer reference to destroy
+the thread state::
 
-   /* Thread shutdown: unpin and destroy the state. */
    PyEval_RestoreThread(saved);
    PyGILState_Release(outer);
 

--- a/Doc/c-api/threads.rst
+++ b/Doc/c-api/threads.rst
@@ -227,6 +227,61 @@ For example::
    If the interpreter finalized before ``PyThreadState_Swap`` was called, then
    ``interp`` will be a dangling pointer!
 
+Reusing a thread state across repeated calls
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Creating and destroying a :c:type:`PyThreadState` is not free, and is
+more expensive on a :term:`free-threaded build`.  If a non-Python thread
+calls into the interpreter many times, creating a fresh thread state on
+every entry and destroying it on every exit is a performance
+anti-pattern.  Instead, create the thread state once (when the native
+thread starts, or lazily on its first call into Python), attach and
+detach it around each call, and destroy it when the native thread
+exits::
+
+   /* Thread startup: create the state once. */
+   PyThreadState *tstate = PyThreadState_New(interp);
+
+   /* Per-call: attach, run Python, detach. */
+   PyEval_RestoreThread(tstate);
+   result = CallSomeFunction();
+   PyEval_SaveThread();
+
+   /* ... many more calls ... */
+
+   /* Thread shutdown: destroy the state once. */
+   PyEval_RestoreThread(tstate);
+   PyThreadState_Clear(tstate);
+   PyThreadState_DeleteCurrent();
+
+The equivalent with the :ref:`PyGILState API <gilstate>` keeps an *outer*
+:c:func:`PyGILState_Ensure` outstanding for the thread's lifetime, so
+nested Ensure/Release pairs never drop the internal nesting counter to
+zero::
+
+   /* Thread startup: create and pin the state. */
+   PyGILState_STATE outer = PyGILState_Ensure();
+   PyThreadState *saved = PyEval_SaveThread();
+
+   /* Per-call: the thread state already exists. */
+   PyGILState_STATE inner = PyGILState_Ensure();
+   result = CallSomeFunction();
+   PyGILState_Release(inner);
+
+   /* ... many more calls ... */
+
+   /* Thread shutdown: unpin and destroy the state. */
+   PyEval_RestoreThread(saved);
+   PyGILState_Release(outer);
+
+The embedding code must arrange for the shutdown sequence to run before
+the native thread exits, and before :c:func:`Py_FinalizeEx` is called.
+If interpreter finalization begins first, the shutdown
+:c:func:`PyEval_RestoreThread` call will hang the thread (see
+:c:func:`PyEval_RestoreThread` for details) rather than return.  If the
+native thread exits without running the shutdown sequence, the thread
+state is leaked for the remainder of the process.
+
 .. _gilstate:
 
 Legacy API

--- a/Doc/c-api/threads.rst
+++ b/Doc/c-api/threads.rst
@@ -242,6 +242,61 @@ a thread state that was previously attached for the current thread.
 .. seealso::
    :pep:`788`
 
+.. _c-api-reuse-thread-state:
+
+Reusing a thread state across repeated calls
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Creating and destroying a :c:type:`PyThreadState` is not free, and is more
+expensive on a :term:`free-threaded build`.  A foreign thread that calls into
+the interpreter many times -- for example a worker thread in a native thread
+pool -- should avoid creating a fresh thread state on every entry and
+destroying it on every exit.  Instead, set up one thread state when the thread
+starts (or lazily on its first call into Python), attach and detach it around
+each call, and tear it down once when the thread exits.
+
+Manage the thread state explicitly with :c:func:`PyThreadState_New`, attaching
+and detaching it with :c:func:`PyEval_RestoreThread` and
+:c:func:`PyEval_SaveThread`.  This happens in three distinct phases, at
+different points in the thread's life.
+
+When the thread starts, create one thread state for it.  ``interp`` is the
+target interpreter, captured by the code that created this thread while it held
+an attached thread state (for example via :c:func:`PyInterpreterState_Get`)::
+
+   PyThreadState *tstate = PyThreadState_New(interp);
+
+Then, on each call into Python -- which may happen many times over the thread's
+life -- attach the thread state, make the Python C API calls that require it,
+and detach again so the thread does not hold the GIL while off doing non-Python
+work::
+
+   PyEval_RestoreThread(tstate);
+   result = CallSomeFunction();  /* your Python C API calls go here */
+   PyEval_SaveThread();
+
+When the thread is finished calling into Python, destroy the thread state once::
+
+   PyEval_RestoreThread(tstate);
+   PyThreadState_Clear(tstate);
+   PyThreadState_DeleteCurrent();
+
+The general-purpose entry points for calling in from a foreign thread --
+:c:func:`PyThreadState_Ensure` and the older :c:func:`PyGILState_Ensure` -- do
+*not* guarantee a persistent thread state: their thread-state lifetime is
+deliberately implementation-defined, so a matched acquire/release pair may
+create and destroy a thread state each time.  Use :c:func:`PyThreadState_New`,
+as shown here, whenever you specifically want to reuse one thread state across
+calls.
+
+The code that created the foreign thread must arrange for the shutdown sequence
+to run before the thread exits, and before :c:func:`Py_FinalizeEx` is called.
+If interpreter finalization begins first, the shutdown
+:c:func:`PyEval_RestoreThread` call will hang the thread rather than return (see
+:ref:`cautions-regarding-runtime-finalization`).  If the thread exits without
+running the shutdown sequence, the thread state is leaked for the remainder of
+the process.
+
 .. _c-api-attach-detach:
 
 Attaching/detaching thread states

--- a/Doc/c-api/threads.rst
+++ b/Doc/c-api/threads.rst
@@ -249,7 +249,7 @@ Reusing a thread state across repeated calls
 
 Creating and destroying a :c:type:`PyThreadState` is not free, and is more
 expensive on a :term:`free-threaded build`.  A foreign thread that calls into
-the interpreter many times -- for example a worker thread in a native thread
+the interpreter many times -- for example, a worker thread in a native thread
 pool -- should avoid creating a fresh thread state on every entry and
 destroying it on every exit.  Instead, set up one thread state when the thread
 starts (or lazily on its first call into Python), attach and detach it around


### PR DESCRIPTION
Add a subsection under "Non-Python created threads" explaining the performance cost of creating/destroying a PyThreadState on every Ensure/Release cycle and showing how to keep one alive for the thread's lifetime instead.

(read them & see the issue for more details)

<!-- gh-issue-number: gh-146219 -->
* Issue: gh-146219
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146221.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->