### PR TITLE
gh-146227: Fix wrong type in _Py_atomic_load_uint16 in pyatomic_std.h

### DIFF
--- a/Include/cpython/pyatomic.h
+++ b/Include/cpython/pyatomic.h
@@ -72,8 +72,8 @@
 //   def _Py_atomic_load_ptr_acquire(obj):
 //       return obj  # acquire
 //
-//   def _Py_atomic_store_ptr_release(obj):
-//       return obj  # release
+//   def _Py_atomic_store_ptr_release(obj, value):
+//       obj = value  # release
 //
 //   def _Py_atomic_fence_seq_cst():
 //       # sequential consistency
@@ -531,6 +531,9 @@ _Py_atomic_store_int_release(int *obj, int value);
 
 static inline int
 _Py_atomic_load_int_acquire(const int *obj);
+
+static inline void
+_Py_atomic_store_uint_release(unsigned int *obj, unsigned int value);
 
 static inline void
 _Py_atomic_store_uint32_release(uint32_t *obj, uint32_t value);

--- a/Include/cpython/pyatomic_gcc.h
+++ b/Include/cpython/pyatomic_gcc.h
@@ -580,6 +580,10 @@ static inline void
 _Py_atomic_store_ssize_release(Py_ssize_t *obj, Py_ssize_t value)
 { __atomic_store_n(obj, value, __ATOMIC_RELEASE); }
 
+static inline void
+_Py_atomic_store_uint_release(unsigned int *obj, unsigned int value)
+{ __atomic_store_n(obj, value, __ATOMIC_RELEASE); }
+
 static inline int
 _Py_atomic_load_int_acquire(const int *obj)
 { return __atomic_load_n(obj, __ATOMIC_ACQUIRE); }

--- a/Include/cpython/pyatomic_msc.h
+++ b/Include/cpython/pyatomic_msc.h
@@ -972,12 +972,6 @@ _Py_atomic_store_ushort_relaxed(unsigned short *obj, unsigned short value)
 }
 
 static inline void
-_Py_atomic_store_uint_release(unsigned int *obj, unsigned int value)
-{
-    *(volatile unsigned int *)obj = value;
-}
-
-static inline void
 _Py_atomic_store_long_relaxed(long *obj, long value)
 {
     *(volatile long *)obj = value;
@@ -1076,6 +1070,19 @@ _Py_atomic_store_int8_release(int8_t *obj, int8_t value)
     __stlr8((unsigned __int8 volatile *)obj, (unsigned __int8)value);
 #else
 #  error "no implementation of _Py_atomic_store_int8_release"
+#endif
+}
+
+static inline void
+_Py_atomic_store_uint_release(unsigned int *obj, unsigned int value)
+{
+#if defined(_M_X64) || defined(_M_IX86)
+    *(volatile unsigned int *)obj = value;
+#elif defined(_M_ARM64)
+    _Py_atomic_ASSERT_ARG_TYPE(unsigned __int32);
+    __stlr32((unsigned __int32 volatile *)obj, (unsigned __int32)value);
+#else
+#  error "no implementation of _Py_atomic_store_uint_release"
 #endif
 }
 

--- a/Include/cpython/pyatomic_std.h
+++ b/Include/cpython/pyatomic_std.h
@@ -459,7 +459,7 @@ static inline uint16_t
 _Py_atomic_load_uint16(const uint16_t *obj)
 {
     _Py_USING_STD;
-    return atomic_load((const _Atomic(uint32_t)*)obj);
+    return atomic_load((const _Atomic(uint16_t)*)obj);
 }
 
 static inline uint32_t

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-20-13-07-33.gh-issue-146227.MqBPEo.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-20-13-07-33.gh-issue-146227.MqBPEo.rst
@@ -1,0 +1,3 @@
+Fix wrong type in ``_Py_atomic_load_uint16`` in the C11 atomics backend
+(``pyatomic_std.h``), which used a 32-bit atomic load instead of 16-bit.
+Found by Mohammed Zuhaib.


### PR DESCRIPTION
Also fix a few related issues in the pyatomic headers:

* Fix `_Py_atomic_store_uint_release` in pyatomic_msc.h to use `__stlr32` on ARM64 instead of a plain volatile store (which is only relaxed on ARM64).
* Add missing `_Py_atomic_store_uint_release` to pyatomic_gcc.h.
* Fix pseudo-code comment for `_Py_atomic_store_ptr_release` in pyatomic.h.


<!-- gh-issue-number: gh-146227 -->
* Issue: gh-146227
<!-- /gh-issue-number -->
