### PR TITLE
[3.13] gh-146227: Fix wrong type in _Py_atomic_load_uint16 in pyatomic_std.h (gh-146229)

### DIFF
--- a/Include/cpython/pyatomic.h
+++ b/Include/cpython/pyatomic.h
@@ -72,8 +72,8 @@
 //   def _Py_atomic_load_ptr_acquire(obj):
 //       return obj  # acquire
 //
-//   def _Py_atomic_store_ptr_release(obj):
-//       return obj  # release
+//   def _Py_atomic_store_ptr_release(obj, value):
+//       obj = value  # release
 //
 //   def _Py_atomic_fence_seq_cst():
 //       # sequential consistency

--- a/Include/cpython/pyatomic_std.h
+++ b/Include/cpython/pyatomic_std.h
@@ -459,7 +459,7 @@ static inline uint16_t
 _Py_atomic_load_uint16(const uint16_t *obj)
 {
     _Py_USING_STD;
-    return atomic_load((const _Atomic(uint32_t)*)obj);
+    return atomic_load((const _Atomic(uint16_t)*)obj);
 }
 
 static inline uint32_t

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-20-13-07-33.gh-issue-146227.MqBPEo.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-20-13-07-33.gh-issue-146227.MqBPEo.rst
@@ -1,0 +1,3 @@
+Fix wrong type in ``_Py_atomic_load_uint16`` in the C11 atomics backend
+(``pyatomic_std.h``), which used a 32-bit atomic load instead of 16-bit.
+Found by Mohammed Zuhaib.


### PR DESCRIPTION
Also fix a few related issues in the pyatomic headers:

* Fix pseudo-code comment for _Py_atomic_store_ptr_release in pyatomic.h. 

(cherry picked from commit 1eff27f2c0452b3114bcf139062c87c025842c3e)


<!-- gh-issue-number: gh-146227 -->
* Issue: gh-146227
<!-- /gh-issue-number -->
