### PR TITLE
gh-146245: Fix ref/buffer leaks in socketmodule.c on audit hook failure

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-03-21-00-00-00.gh-issue-146245.SockAud.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-21-00-00-00.gh-issue-146245.SockAud.rst
@@ -1,0 +1,3 @@
+Fix reference leak of ``idna`` and ``pstr`` in :func:`socket.getaddrinfo`
+and buffer leak in :meth:`socket.socket.sendto` when ``PySys_Audit``
+raises an exception.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -4808,6 +4808,7 @@ sock_sendto(PyObject *self, PyObject *args)
     }
 
     if (PySys_Audit("socket.sendto", "OO", s, addro) < 0) {
+        PyBuffer_Release(&pbuf);
         return NULL;
     }
 
@@ -6982,7 +6983,7 @@ socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
 
     if (PySys_Audit("socket.getaddrinfo", "OOiii",
                     hobj, pobj, family, socktype, protocol) < 0) {
-        return NULL;
+        goto err;
     }
 
     memset(&hints, 0, sizeof(hints));


### PR DESCRIPTION
Fixes #146245

## Summary

Two leak bugs in `socketmodule.c` when `PySys_Audit` raises:

### 1. `getaddrinfo` (line 6985)

`return NULL` skipped cleanup of `idna` and `pstr` refs. Changed to
`goto err` which properly calls `Py_XDECREF` on both.

### 2. `sock_sendto` (line 4811)

`return NULL` skipped `PyBuffer_Release(&pbuf)`. Added the release
before the return, matching the pattern used in adjacent error paths.

<!-- gh-issue-number: gh-146245 -->
* Issue: gh-146245
<!-- /gh-issue-number -->
