### PR TITLE
gh-146250: Fix memory leak in re-initialization of `SyntaxError`

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1956,7 +1956,6 @@ class ExceptionTests(unittest.TestCase):
 
     # gh-146250: memory leak with re-initialization of SyntaxError
     def test_syntax_error_memory_leak(self):
-        # Test crashes with ASan
         e = SyntaxError("msg", ("file.py", 1, 2, "txt", 2, 3))
         e.__init__("new_msg", ("new_file.py", 2, 3, "new_txt", 3, 4))
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1954,11 +1954,6 @@ class ExceptionTests(unittest.TestCase):
         self.assertGreater(len(output), 0)  # At minimum, should not hang
         self.assertIn(b"MemoryError", output)
 
-    # gh-146250: memory leak with re-initialization of SyntaxError
-    def test_syntax_error_memory_leak(self):
-        e = SyntaxError("msg", ("file.py", 1, 2, "txt", 2, 3))
-        e.__init__("new_msg", ("new_file.py", 2, 3, "new_txt", 3, 4))
-
 
 class NameErrorTests(unittest.TestCase):
     def test_name_error_has_name(self):
@@ -2565,6 +2560,11 @@ class SyntaxErrorTests(unittest.TestCase):
 
         args = ("bad.py", 1, 2, "abcdefg", 1)
         self.assertRaises(TypeError, SyntaxError, "bad bad", args)
+
+    def test_syntax_error_memory_leak(self):
+        # gh-146250: memory leak with re-initialization of SyntaxError
+        e = SyntaxError("msg", ("file.py", 1, 2, "txt", 2, 3))
+        e.__init__("new_msg", ("new_file.py", 2, 3, "new_txt", 3, 4))
 
 
 class TestInvalidExceptionMatcher(unittest.TestCase):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1954,6 +1954,12 @@ class ExceptionTests(unittest.TestCase):
         self.assertGreater(len(output), 0)  # At minimum, should not hang
         self.assertIn(b"MemoryError", output)
 
+    # gh-146250: memory leak with re-initialization of SyntaxError
+    def test_syntax_error_memory_leak(self):
+        # Test crashes with ASan
+        e = SyntaxError("msg", ("file.py", 1, 2, "txt", 2, 3))
+        e.__init__("new_msg", ("new_file.py", 2, 3, "new_txt", 3, 4))
+
 
 class NameErrorTests(unittest.TestCase):
     def test_name_error_has_name(self):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2565,6 +2565,25 @@ class SyntaxErrorTests(unittest.TestCase):
         # gh-146250: memory leak with re-initialization of SyntaxError
         e = SyntaxError("msg", ("file.py", 1, 2, "txt", 2, 3))
         e.__init__("new_msg", ("new_file.py", 2, 3, "new_txt", 3, 4))
+        self.assertEqual(e.msg, "new_msg")
+        self.assertEqual(e.args, ("new_msg", ("new_file.py", 2, 3, "new_txt", 3, 4)))
+        self.assertEqual(e.filename, "new_file.py")
+        self.assertEqual(e.lineno, 2)
+        self.assertEqual(e.offset, 3)
+        self.assertEqual(e.text, "new_txt")
+        self.assertEqual(e.end_lineno, 3)
+        self.assertEqual(e.end_offset, 4)
+
+        e = SyntaxError("msg", ("file.py", 1, 2, "txt", 2, 3))
+        e.__init__("new_msg", ("new_file.py", 2, 3, "new_txt"))
+        self.assertEqual(e.msg, "new_msg")
+        self.assertEqual(e.args, ("new_msg", ("new_file.py", 2, 3, "new_txt")))
+        self.assertEqual(e.filename, "new_file.py")
+        self.assertEqual(e.lineno, 2)
+        self.assertEqual(e.offset, 3)
+        self.assertEqual(e.text, "new_txt")
+        self.assertIsNone(e.end_lineno)
+        self.assertIsNone(e.end_offset)
 
 
 class TestInvalidExceptionMatcher(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-21-11-55-16.gh-issue-146250.ahl3O2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-21-11-55-16.gh-issue-146250.ahl3O2.rst
@@ -1,0 +1,1 @@
+Fixed a memory leak in :class:`SyntaxError` when re-initializing it.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-21-11-55-16.gh-issue-146250.ahl3O2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-21-11-55-16.gh-issue-146250.ahl3O2.rst
@@ -1,1 +1,1 @@
-Fixed a memory leak in :class:`SyntaxError` when re-initializing it.
+Fixed a memory leak in :exc:`SyntaxError` when re-initializing it.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2802,29 +2802,25 @@ SyntaxError_init(PyObject *op, PyObject *args, PyObject *kwds)
             return -1;
         }
 
-        Py_XDECREF(self->filename);
-        Py_XDECREF(self->lineno);
-        Py_XDECREF(self->offset);
-        Py_XDECREF(self->text);
-        Py_XSETREF(self->end_lineno, NULL);
-        Py_XSETREF(self->end_offset, NULL);
-        Py_XDECREF(self->metadata);
-
+        PyObject *filename, *lineno, *offset, *text;
+        PyObject *end_lineno = NULL;
+        PyObject *end_offset = NULL;
+        PyObject *metadata = NULL;
         if (!PyArg_ParseTuple(info, "OOOO|OOO",
-                              &self->filename, &self->lineno,
-                              &self->offset, &self->text,
-                              &self->end_lineno, &self->end_offset, &self->metadata)) {
+                              &filename, &lineno,
+                              &offset, &text,
+                              &end_lineno, &end_offset, &metadata)) {
             Py_DECREF(info);
             return -1;
         }
 
-        Py_INCREF(self->filename);
-        Py_INCREF(self->lineno);
-        Py_INCREF(self->offset);
-        Py_INCREF(self->text);
-        Py_XINCREF(self->end_lineno);
-        Py_XINCREF(self->end_offset);
-        Py_XINCREF(self->metadata);
+        Py_XSETREF(self->filename, Py_NewRef(filename));
+        Py_XSETREF(self->lineno, Py_NewRef(lineno));
+        Py_XSETREF(self->offset, Py_NewRef(offset));
+        Py_XSETREF(self->text, Py_XNewRef(text));
+        Py_XSETREF(self->end_lineno, Py_XNewRef(end_lineno));
+        Py_XSETREF(self->end_offset, Py_XNewRef(end_offset));
+        Py_XSETREF(self->metadata, Py_XNewRef(metadata));
         Py_DECREF(info);
 
         if (self->end_lineno != NULL && self->end_offset == NULL) {

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2802,8 +2802,14 @@ SyntaxError_init(PyObject *op, PyObject *args, PyObject *kwds)
             return -1;
         }
 
-        self->end_lineno = NULL;
-        self->end_offset = NULL;
+        Py_XDECREF(self->filename);
+        Py_XDECREF(self->lineno);
+        Py_XDECREF(self->offset);
+        Py_XDECREF(self->text);
+        Py_XSETREF(self->end_lineno, NULL);
+        Py_XSETREF(self->end_offset, NULL);
+        Py_XDECREF(self->metadata);
+
         if (!PyArg_ParseTuple(info, "OOOO|OOO",
                               &self->filename, &self->lineno,
                               &self->offset, &self->text,

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2817,7 +2817,7 @@ SyntaxError_init(PyObject *op, PyObject *args, PyObject *kwds)
         Py_XSETREF(self->filename, Py_NewRef(filename));
         Py_XSETREF(self->lineno, Py_NewRef(lineno));
         Py_XSETREF(self->offset, Py_NewRef(offset));
-        Py_XSETREF(self->text, Py_XNewRef(text));
+        Py_XSETREF(self->text, Py_NewRef(text));
         Py_XSETREF(self->end_lineno, Py_XNewRef(end_lineno));
         Py_XSETREF(self->end_offset, Py_XNewRef(end_offset));
         Py_XSETREF(self->metadata, Py_XNewRef(metadata));


### PR DESCRIPTION
Added `Py_XDECREF`/`Py_XSETREF` to avoid a memory leak when calling `SyntaxError.__init__`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146250 -->
* Issue: gh-146250
<!-- /gh-issue-number -->
