### PR TITLE
Docs: Use !r in __repr__ example

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1754,7 +1754,7 @@ are always available.  They are listed here in alphabetical order.
             self.age = age
 
          def __repr__(self):
-            return f"Person('{self.name}', {self.age})"
+            return f"Person({self.name!r}, {self.age!r})"
 
 
 .. function:: reversed(object, /)


### PR DESCRIPTION
Use `!r` in the `__repr__` example in the `repr()`  docs mainly avoid manual quoting and to help steer users away from patterns that lead security and correctness issues.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146273.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->