### PR TITLE
gh-146065: Fix NULL dereference in FutureIter_am_send

### DIFF
--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -756,7 +756,7 @@ class BaseFutureTests:
             f.__init__(loop=self.loop)
 
     def test_futureiter_send_after_throw_no_crash(self):
-        fut = self._new_future()
+        fut = self._new_future(loop=self.loop)
         it = fut.__await__()
         next(it)
         with self.assertRaises(RuntimeError):

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -756,7 +756,7 @@ class BaseFutureTests:
             f.__init__(loop=self.loop)
 
     def test_futureiter_send_after_throw_no_crash(self):
-        async def exploit():
+        async def run_test():
             loop = asyncio.get_event_loop()
             fut = loop.create_future()
             it = fut.__await__()
@@ -767,7 +767,7 @@ class BaseFutureTests:
                 pass
             with self.assertRaises(StopIteration):
                 it.send(None)
-        asyncio.run(exploit())
+        asyncio.run(run_test())
 
 
 @unittest.skipUnless(hasattr(futures, '_CFuture'),

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -756,18 +756,13 @@ class BaseFutureTests:
             f.__init__(loop=self.loop)
 
     def test_futureiter_send_after_throw_no_crash(self):
-        async def run_test():
-            loop = asyncio.get_event_loop()
-            fut = loop.create_future()
-            it = fut.__await__()
-            it.__next__()
-            try:
-                it.throw(RuntimeError)
-            except RuntimeError:
-                pass
-            with self.assertRaises(StopIteration):
-                it.send(None)
-        asyncio.run(run_test())
+        fut = self._new_future()
+        it = fut.__await__()
+        next(it)
+        with self.assertRaises(RuntimeError):
+            it.throw(RuntimeError)
+        with self.assertRaises(StopIteration):
+            it.send(None)
 
 
 @unittest.skipUnless(hasattr(futures, '_CFuture'),

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -755,6 +755,21 @@ class BaseFutureTests:
         with self.assertRaises(RuntimeError, msg="is already initialized"):
             f.__init__(loop=self.loop)
 
+    def test_futureiter_send_after_throw_no_crash(self):
+        async def exploit():
+            loop = asyncio.get_event_loop()
+            fut = loop.create_future()
+            it = fut.__await__()
+            it.__next__()
+            try:
+                it.throw(RuntimeError)
+            except RuntimeError:
+                pass
+            with self.assertRaises(StopIteration):
+                it.send(None)
+        asyncio.run(exploit())
+
+
 @unittest.skipUnless(hasattr(futures, '_CFuture'),
                      'requires the C _asyncio module')
 class CFutureTests(BaseFutureTests, test_utils.TestCase):

--- a/Misc/NEWS.d/next/Library/2026-03-23-00-04-13.gh-issue-146065.FIdn8D.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-23-00-04-13.gh-issue-146065.FIdn8D.rst
@@ -1,0 +1,2 @@
+Fix a NULL pointer dereference in asyncio.Future iterator when send() is
+called after throw() or close(), which previously could cause a crash.

--- a/Misc/NEWS.d/next/Library/2026-03-23-00-04-13.gh-issue-146065.FIdn8D.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-23-00-04-13.gh-issue-146065.FIdn8D.rst
@@ -1,2 +1,2 @@
-Fix a NULL pointer dereference in asyncio.Future iterator when send() is
-called after throw() or close(), which previously could cause a crash.
+Fix a crash in asyncio.Future iterator when send() is
+called after throw() or close().

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1872,6 +1872,11 @@ FutureIter_am_send(PyObject *op,
                    PyObject **result)
 {
     futureiterobject *it = (futureiterobject*)op;
+    if (it->future == NULL) {
+        PyErr_SetNone(PyExc_StopIteration);
+        *result = NULL;
+        return PYGEN_RETURN;
+    }
     /* arg is unused, see the comment on FutureIter_send for clarification */
     PySendResult res;
     Py_BEGIN_CRITICAL_SECTION(it->future);

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1875,7 +1875,7 @@ FutureIter_am_send(PyObject *op,
     if (it->future == NULL) {
         PyErr_SetNone(PyExc_StopIteration);
         *result = NULL;
-        return PYGEN_RETURN;
+        return PYGEN_ERROR;
     }
     /* arg is unused, see the comment on FutureIter_send for clarification */
     PySendResult res;


### PR DESCRIPTION
After throw() or close(), it->future can be NULL. A subsequent send() call would dereference it and crash. This adds a NULL check and raises StopIteration instead.

<!-- gh-issue-number: gh-146065 -->
* Issue: gh-146065
<!-- /gh-issue-number -->
