### PR TITLE
gh-144540: Eliminate `_MAKE_HEAP_FUNCTION` for owned references

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1352,7 +1352,7 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertNotIn("_MAKE_HEAP_SAFE", uops)
         self.assertIn("_YIELD_VALUE", uops)
 
-    def test_make_heap_safe_not_optimized_for_owned(self):
+    def test_make_heap_safe_optimized_owned(self):
         def returns_owned(x):
             return x + 1
         def testfunc(n):
@@ -1364,7 +1364,7 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertEqual(res, TIER2_THRESHOLD)
         self.assertIsNotNone(ex)
         uops = get_opnames(ex)
-        self.assertIn("_MAKE_HEAP_SAFE", uops)
+        self.assertNotIn("_MAKE_HEAP_SAFE", uops)
         self.assertIn("_RETURN_VALUE", uops)
 
     def test_for_iter(self):

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -90,7 +90,7 @@ dummy_func(void) {
 
     op(_MAKE_HEAP_SAFE, (value -- value)) {
         // eliminate _MAKE_HEAP_SAFE when we *know* the value is immortal
-        if (sym_is_immortal(PyJitRef_Unwrap(value))) {
+        if (sym_is_immortal(PyJitRef_Unwrap(value)) || !PyJitRef_IsBorrowed(value)) {
             ADD_OP(_NOP, 0, 0);
         }
         value = PyJitRef_StripBorrowInfo(value);

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1322,7 +1322,7 @@
         case _MAKE_HEAP_SAFE: {
             JitOptRef value;
             value = stack_pointer[-1];
-            if (sym_is_immortal(PyJitRef_Unwrap(value))) {
+            if (sym_is_immortal(PyJitRef_Unwrap(value)) || !PyJitRef_IsBorrowed(value)) {
                 ADD_OP(_NOP, 0, 0);
             }
             value = PyJitRef_StripBorrowInfo(value);


### PR DESCRIPTION
If the reference of the returned object is not borrowed, we remove the `_MAKE_HEAP_FUNCTION`. Hence I ended up changing the `test_make_heap_safe_optimized_owned` test to test that `_MAKE_HEAP_FUNCTION` is no longer in the trace as the value returned is not a borrowed reference.

Also, for a "return of a return", given the inner function returns a borrowed reference, the double `_MAKE_HEAP_FUNCTION` is reduced to just 1 :)
```c
  44 OPTIMIZED: _MAKE_HEAP_SAFE_r11 (0, target=3, operand0=0, operand1=0)
  45 OPTIMIZED: _RETURN_VALUE_r11 (0, target=3, operand0=0, operand1=0)
  46 OPTIMIZED: _CHECK_VALIDITY_r11 (0, jump_target=71, operand0=0, operand1=0)
  47 OPTIMIZED: _SET_IP_r11 (0, target=10, operand0=0x1b5f9947d24, operand1=0)
  48 OPTIMIZED: _RETURN_VALUE_r11 (0, target=10, operand0=0, operand1=0)
  ```

I hope I didn't misunderstand the issue...

<!-- gh-issue-number: gh-144540 -->
* Issue: gh-144540
<!-- /gh-issue-number -->
