### PR TITLE
gh-146325: Use `test.support.requires_fork` in test_fastpath_cache_cleared_in_forked_child

### DIFF
--- a/Lib/test/test_importlib/metadata/test_zip.py
+++ b/Lib/test/test_importlib/metadata/test_zip.py
@@ -3,7 +3,7 @@ import os
 import sys
 import unittest
 
-from test.support import warnings_helper
+from test.support import requires_fork, warnings_helper
 
 from importlib.metadata import (
     FastPath,
@@ -53,6 +53,7 @@ class TestZip(fixtures.ZipFixtures, unittest.TestCase):
         assert len(dists) == 1
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @requires_fork()
     @unittest.skipUnless(
         hasattr(os, 'register_at_fork')
         and 'fork' in multiprocessing.get_all_start_methods(),


### PR DESCRIPTION
Tests that need fork have to call test.support.requires_fork() to rule out platforms that have `os.fork()` but where it should not be called


<!-- gh-issue-number: gh-146325 -->
* Issue: gh-146325
<!-- /gh-issue-number -->
