### PR TITLE
gh-146202: Create tmp_dir in regrtest worker

### DIFF
--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -452,12 +452,6 @@ def get_temp_dir(tmp_dir: StrPath | None = None) -> StrPath:
                         f"unexpectedly returned {tmp_dir!r} on WASI"
                     )
                 tmp_dir = os.path.join(tmp_dir, 'build')
-
-                # When get_temp_dir() is called in a worker process,
-                # get_temp_dir() path is different than in the parent process
-                # which is not a WASI process. So the parent does not create
-                # the same "tmp_dir" than the test worker process.
-                os.makedirs(tmp_dir, exist_ok=True)
         else:
             tmp_dir = tempfile.gettempdir()
 

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -127,6 +127,9 @@ def main() -> NoReturn:
     worker_json = sys.argv[1]
 
     tmp_dir = get_temp_dir()
+    # get_temp_dir() can be different in the worker and the parent process.
+    # For example, if --tempdir option is used.
+    os.makedirs(tmp_dir, exist_ok=True)
     work_dir = get_work_dir(tmp_dir, worker=True)
 
     with exit_timeout():

--- a/Misc/NEWS.d/next/Tests/2026-03-24-00-15-58.gh-issue-146202.LgH6Bj.rst
+++ b/Misc/NEWS.d/next/Tests/2026-03-24-00-15-58.gh-issue-146202.LgH6Bj.rst
@@ -1,0 +1,3 @@
+Fix a race condition in regrtest: make sure that the temporary directory is
+created in the worker process. Previously, temp_cwd() could fail on Windows if
+the "build" directory was not created.  Patch by Victor Stinner.


### PR DESCRIPTION
Create tmp_dir in libregrtest.worker since the directory can be different than --tempdir directory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146202 -->
* Issue: gh-146202
<!-- /gh-issue-number -->
