### PR TITLE
gh-146355: Fix `main_module` ref leak in `_PyRun_SimpleStringFlagsWithName`

### DIFF
--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -554,32 +554,39 @@ PyRun_SimpleFileExFlags(FILE *fp, const char *filename, int closeit,
 
 int
 _PyRun_SimpleStringFlagsWithName(const char *command, const char* name, PyCompilerFlags *flags) {
+    int ret = -1;
+
     PyObject *main_module = PyImport_AddModuleRef("__main__");
     if (main_module == NULL) {
-        return -1;
+        return ret;
     }
     PyObject *dict = PyModule_GetDict(main_module);  // borrowed ref
 
+    PyObject *the_name = NULL;
     PyObject *res = NULL;
     if (name == NULL) {
         res = PyRun_StringFlags(command, Py_file_input, dict, dict, flags);
     } else {
-        PyObject* the_name = PyUnicode_FromString(name);
-        if (!the_name) {
+        the_name = PyUnicode_FromString(name);
+        if (the_name == NULL) {
             PyErr_Print();
-            return -1;
+            goto done;
         }
         res = _PyRun_StringFlagsWithName(command, the_name, Py_file_input, dict, dict, flags, 0);
-        Py_DECREF(the_name);
     }
-    Py_DECREF(main_module);
     if (res == NULL) {
         PyErr_Print();
-        return -1;
+        goto done;
     }
 
-    Py_DECREF(res);
-    return 0;
+    ret = 0;
+
+  done:
+    Py_DECREF(main_module);
+    Py_XDECREF(the_name);
+    Py_XDECREF(res);
+
+    return ret;
 }
 
 int

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -554,39 +554,33 @@ PyRun_SimpleFileExFlags(FILE *fp, const char *filename, int closeit,
 
 int
 _PyRun_SimpleStringFlagsWithName(const char *command, const char* name, PyCompilerFlags *flags) {
-    int ret = -1;
-
     PyObject *main_module = PyImport_AddModuleRef("__main__");
     if (main_module == NULL) {
-        return ret;
+        return -1;
     }
     PyObject *dict = PyModule_GetDict(main_module);  // borrowed ref
 
-    PyObject *the_name = NULL;
     PyObject *res = NULL;
     if (name == NULL) {
         res = PyRun_StringFlags(command, Py_file_input, dict, dict, flags);
     } else {
-        the_name = PyUnicode_FromString(name);
-        if (the_name == NULL) {
+        PyObject* the_name = PyUnicode_FromString(name);
+        if (!the_name) {
             PyErr_Print();
-            goto done;
+            Py_DECREF(main_module);
+            return -1;
         }
         res = _PyRun_StringFlagsWithName(command, the_name, Py_file_input, dict, dict, flags, 0);
+        Py_DECREF(the_name);
     }
+    Py_DECREF(main_module);
     if (res == NULL) {
         PyErr_Print();
-        goto done;
+        return -1;
     }
 
-    ret = 0;
-
-  done:
-    Py_DECREF(main_module);
-    Py_XDECREF(the_name);
-    Py_XDECREF(res);
-
-    return ret;
+    Py_DECREF(res);
+    return 0;
 }
 
 int


### PR DESCRIPTION
# gh-146355: Fix `main_module` ref leak in `_PyRun_SimpleStringFlagsWithName`

This is a sub-issue for #146102 and original gist details can be found [here](https://gist.github.com/devdanzin/86eda5ca53243ef667773991312c2e74)

When `the_name` is NULL we'll fail to call `Py_DECREF` on `main_module`. I used the same goto pattern as `_PyRun_SimpleFileObject` to fix this.

I omitted a new test entry as we have indirect coverage of functionality in `test_embed.py`. Not sure if it makes sense for the scope of fixing the ref leak to include the additional code for a test in test_run.py (which has a TODO for this function). 