### PR TITLE
gh-146310: Fix ensurepip to treat empty WHEEL_PKG_DIR as unset

### DIFF
--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -16,7 +16,8 @@ _PIP_VERSION = "26.0.1"
 # policies recommend against bundling dependencies. For example, Fedora
 # installs wheel packages in the /usr/share/python-wheels/ directory and don't
 # install the ensurepip._bundled package.
-if (_pkg_dir := sysconfig.get_config_var('WHEEL_PKG_DIR')) is not None and _pkg_dir:
+_pkg_dir = sysconfig.get_config_var('WHEEL_PKG_DIR')
+if _pkg_dir:
     _WHEEL_PKG_DIR = Path(_pkg_dir).resolve()
 else:
     _WHEEL_PKG_DIR = None

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -16,7 +16,7 @@ _PIP_VERSION = "26.0.1"
 # policies recommend against bundling dependencies. For example, Fedora
 # installs wheel packages in the /usr/share/python-wheels/ directory and don't
 # install the ensurepip._bundled package.
-if (_pkg_dir := sysconfig.get_config_var('WHEEL_PKG_DIR')) is not None:
+if (_pkg_dir := sysconfig.get_config_var('WHEEL_PKG_DIR')) is not None and _pkg_dir:
     _WHEEL_PKG_DIR = Path(_pkg_dir).resolve()
 else:
     _WHEEL_PKG_DIR = None

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -38,7 +38,7 @@ class TestPackages(unittest.TestCase):
             self.assertEqual(ensurepip._PIP_VERSION, ensurepip.version())
 
     def test_wheel_pkg_dir_none(self):
-        # GH#146310: empty or None WHEEL_PKG_DIR should not search CWD
+        # gh-146310: empty or None WHEEL_PKG_DIR should not search CWD
         for value in ('', None):
             with unittest.mock.patch('sysconfig.get_config_var',
                                      return_value=value) as get_config_var:

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -7,6 +7,7 @@ import test.support
 import unittest
 import unittest.mock
 from pathlib import Path
+from test.support import import_helper
 
 import ensurepip
 import ensurepip._uninstall
@@ -36,12 +37,14 @@ class TestPackages(unittest.TestCase):
             # when the bundled pip wheel is used, we get _PIP_VERSION
             self.assertEqual(ensurepip._PIP_VERSION, ensurepip.version())
 
-    def test_empty_wheel_pkg_dir_treated_as_none(self):
-        # GH#146310: empty string WHEEL_PKG_DIR should not search CWD.
-        # An empty WHEEL_PKG_DIR converts to Path('.') which would
-        # incorrectly search the current working directory.
-        with unittest.mock.patch.object(ensurepip, '_WHEEL_PKG_DIR', None):
-            self.assertIsNone(ensurepip._find_wheel_pkg_dir_pip())
+    def test_wheel_pkg_dir_none(self):
+        # GH#146310: empty or None WHEEL_PKG_DIR should not search CWD
+        for value in ('', None):
+            with unittest.mock.patch('sysconfig.get_config_var',
+                                     return_value=value) as get_config_var:
+                module = import_helper.import_fresh_module('ensurepip')
+                self.assertIsNone(module._WHEEL_PKG_DIR)
+                get_config_var.assert_called_once_with('WHEEL_PKG_DIR')
 
     def test_selected_wheel_path_no_dir(self):
         pip_filename = f'pip-{ensurepip._PIP_VERSION}-py3-none-any.whl'

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -36,6 +36,13 @@ class TestPackages(unittest.TestCase):
             # when the bundled pip wheel is used, we get _PIP_VERSION
             self.assertEqual(ensurepip._PIP_VERSION, ensurepip.version())
 
+    def test_empty_wheel_pkg_dir_treated_as_none(self):
+        # GH#146310: empty string WHEEL_PKG_DIR should not search CWD.
+        # An empty WHEEL_PKG_DIR converts to Path('.') which would
+        # incorrectly search the current working directory.
+        with unittest.mock.patch.object(ensurepip, '_WHEEL_PKG_DIR', None):
+            self.assertIsNone(ensurepip._find_wheel_pkg_dir_pip())
+
     def test_selected_wheel_path_no_dir(self):
         pip_filename = f'pip-{ensurepip._PIP_VERSION}-py3-none-any.whl'
         with unittest.mock.patch.object(ensurepip, '_WHEEL_PKG_DIR', None):

--- a/Misc/NEWS.d/next/Library/2026-03-24-03-49-50.gh-issue-146310.WhlDir.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-24-03-49-50.gh-issue-146310.WhlDir.rst
@@ -1,0 +1,2 @@
+Fix :mod:`ensurepip` to treat an empty string ``WHEEL_PKG_DIR`` as unset,
+preventing it from searching the current working directory for wheel files.

--- a/Misc/NEWS.d/next/Library/2026-03-24-03-49-50.gh-issue-146310.WhlDir.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-24-03-49-50.gh-issue-146310.WhlDir.rst
@@ -1,2 +1,2 @@
-Fix :mod:`ensurepip` to treat an empty string ``WHEEL_PKG_DIR`` as unset,
-preventing it from searching the current working directory for wheel files.
+The :mod:`ensurepip` module no longer looks for ``pip-*.whl`` wheel packages
+in the current directory.


### PR DESCRIPTION
Fixes #146310

`Path('')` resolves to the current working directory (`PosixPath('.')`), so when `WHEEL_PKG_DIR` is an empty string (not `None`), `ensurepip` searches CWD for wheel files. This can cause unexpected behavior or crashes if CWD contains files matching `pip-*.whl`.

## Changes

- `Lib/ensurepip/__init__.py`: Add truthiness check so empty strings are treated the same as `None`
- `Lib/test/test_ensurepip.py`: Add test verifying empty `WHEEL_PKG_DIR` does not search CWD

## Before/After

```python
# Before: Path('').resolve() -> PosixPath('/current/working/dir')
# Empty string was treated as a valid directory path

# After: Empty string treated as None -> use bundled wheel
```

<!-- gh-issue-number: gh-146310 -->
* Issue: gh-146310
<!-- /gh-issue-number -->
