### PR TITLE
gh-146369: Ensure `PYTHON_LAZY_IMPORTS=none` overrides `__lazy_modules__`

### DIFF
--- a/Lib/test/test_lazy_import/__init__.py
+++ b/Lib/test/test_lazy_import/__init__.py
@@ -1088,6 +1088,49 @@ class CommandLineAndEnvVarTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
         self.assertIn("EAGER", result.stdout)
 
+    def test_cli_lazy_imports_none_disables_dunder_lazy_modules(self):
+        """-X lazy_imports=none should override __lazy_modules__."""
+        code = textwrap.dedent("""
+            import sys
+            __lazy_modules__ = ["json"]
+            import json
+            if 'json' in sys.modules:
+                print("EAGER")
+            else:
+                print("LAZY")
+        """)
+        result = subprocess.run(
+            [sys.executable, "-X", "lazy_imports=none", "-c", code],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+        self.assertIn("EAGER", result.stdout)
+
+    def test_env_var_lazy_imports_none_disables_dunder_lazy_modules(self):
+        """PYTHON_LAZY_IMPORTS=none should override __lazy_modules__."""
+        code = textwrap.dedent("""
+            import sys
+            __lazy_modules__ = ["json"]
+            import json
+            if 'json' in sys.modules:
+                print("EAGER")
+            else:
+                print("LAZY")
+        """)
+        import os
+
+        env = os.environ.copy()
+        env["PYTHON_LAZY_IMPORTS"] = "none"
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+        self.assertIn("EAGER", result.stdout)
+
     def test_cli_overrides_env_var(self):
         """Command-line option should take precedence over environment variable."""
         # PEP 810: -X lazy_imports takes precedence over PYTHON_LAZY_IMPORTS

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-24-13-06-52.gh-issue-146369.6wDI6S.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-24-13-06-52.gh-issue-146369.6wDI6S.rst
@@ -1,0 +1,2 @@
+Ensure ``-X lazy_imports=none``` and ``PYTHON_LAZY_IMPORTS=none``` override
+``__lazy_modules__``. Patch by Hugo van Kemenade.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3086,7 +3086,7 @@ _PyEval_LazyImportName(PyThreadState *tstate, PyObject *builtins,
             break;
     }
 
-    if (!lazy) {
+    if (!lazy && PyImport_GetLazyImportsMode() != PyImport_LAZY_NONE) {
         // See if __lazy_modules__ forces this to be lazy.
         lazy = check_lazy_import_compatibility(tstate, globals, name, level);
         if (lazy < 0) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

When a regular import is in `__lazy_modules__`, `_PyEval_LazyImportName` is called with `lazy = 0`, because this is a regular import with no `lazy` keyword. 

The switch statement also sets it to zero, because we've set either `PYTHON_LAZY_IMPORTS=none` or `-X lazy_imports=none`.

However, the first `if` statement checks `!lazy` (true) and then checks if the import is in `__lazy_modules__`. Well, it is, so we treat it as lazy.

Instead, we should skip this `if` statement if we've set either `PYTHON_LAZY_IMPORTS=none` or `-X lazy_imports=none`. These should override regular imports using the backwards compatibility dunder, just like they override the `lazy` keyword.

With the fix, the override still works for eager:

```console
❯ hyperfine --warmup 10 --runs 20 \
   "./python.exe lazy-eager.py" \
   "PYTHON_LAZY_IMPORTS=normal ./python.exe lazy-eager.py" \
   "PYTHON_LAZY_IMPORTS=none   ./python.exe lazy-eager.py" \
   "PYTHON_LAZY_IMPORTS=all    ./python.exe lazy-eager.py" \
   "./python.exe -X lazy_imports=normal lazy-eager.py" \
   "./python.exe -X lazy_imports=none   lazy-eager.py" \
   "./python.exe -X lazy_imports=all    lazy-eager.py"
Benchmark 1: ./python.exe lazy-eager.py
  Time (mean ± σ):      16.8 ms ±   0.4 ms    [User: 13.2 ms, System: 2.9 ms]
  Range (min … max):    16.0 ms …  17.4 ms    20 runs

Benchmark 2: PYTHON_LAZY_IMPORTS=normal ./python.exe lazy-eager.py
  Time (mean ± σ):      16.9 ms ±   0.6 ms    [User: 13.2 ms, System: 3.0 ms]
  Range (min … max):    15.6 ms …  17.8 ms    20 runs

Benchmark 3: PYTHON_LAZY_IMPORTS=none   ./python.exe lazy-eager.py
  Time (mean ± σ):     137.4 ms ±   4.2 ms    [User: 120.4 ms, System: 15.2 ms]
  Range (min … max):   133.9 ms … 153.4 ms    20 runs

Benchmark 4: PYTHON_LAZY_IMPORTS=all    ./python.exe lazy-eager.py
  Time (mean ± σ):      17.1 ms ±   0.6 ms    [User: 13.4 ms, System: 3.0 ms]
  Range (min … max):    16.0 ms …  18.1 ms    20 runs

Benchmark 5: ./python.exe -X lazy_imports=normal lazy-eager.py
  Time (mean ± σ):      16.7 ms ±   0.4 ms    [User: 13.2 ms, System: 2.9 ms]
  Range (min … max):    15.9 ms …  17.6 ms    20 runs

Benchmark 6: ./python.exe -X lazy_imports=none   lazy-eager.py
  Time (mean ± σ):     139.1 ms ±   3.9 ms    [User: 121.9 ms, System: 15.2 ms]
  Range (min … max):   134.9 ms … 153.4 ms    20 runs

Benchmark 7: ./python.exe -X lazy_imports=all    lazy-eager.py
  Time (mean ± σ):      17.0 ms ±   0.5 ms    [User: 13.3 ms, System: 3.0 ms]
  Range (min … max):    16.0 ms …  18.3 ms    20 runs

Summary
  ./python.exe -X lazy_imports=normal lazy-eager.py ran
    1.01 ± 0.03 times faster than ./python.exe lazy-eager.py
    1.01 ± 0.05 times faster than PYTHON_LAZY_IMPORTS=normal ./python.exe lazy-eager.py
    1.02 ± 0.04 times faster than ./python.exe -X lazy_imports=all    lazy-eager.py
    1.02 ± 0.05 times faster than PYTHON_LAZY_IMPORTS=all    ./python.exe lazy-eager.py
    8.23 ± 0.33 times faster than PYTHON_LAZY_IMPORTS=none   ./python.exe lazy-eager.py
    8.33 ± 0.31 times faster than ./python.exe -X lazy_imports=none   lazy-eager.py
```

And now also for the dunder (compare the issue):

```console
❯ hyperfine --warmup 10 --runs 20 \
   "./python.exe lazy-dunder.py" \
   "PYTHON_LAZY_IMPORTS=normal ./python.exe lazy-dunder.py" \
   "PYTHON_LAZY_IMPORTS=none   ./python.exe lazy-dunder.py" \
   "PYTHON_LAZY_IMPORTS=all    ./python.exe lazy-dunder.py" \
   "./python.exe -X lazy_imports=normal lazy-dunder.py" \
   "./python.exe -X lazy_imports=none   lazy-dunder.py" \
   "./python.exe -X lazy_imports=all    lazy-dunder.py"
Benchmark 1: ./python.exe lazy-dunder.py
  Time (mean ± σ):      17.4 ms ±   0.5 ms    [User: 13.6 ms, System: 3.0 ms]
  Range (min … max):    16.4 ms …  18.3 ms    20 runs

Benchmark 2: PYTHON_LAZY_IMPORTS=normal ./python.exe lazy-dunder.py
  Time (mean ± σ):      18.2 ms ±   2.1 ms    [User: 13.9 ms, System: 3.1 ms]
  Range (min … max):    16.6 ms …  25.7 ms    20 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 3: PYTHON_LAZY_IMPORTS=none   ./python.exe lazy-dunder.py
  Time (mean ± σ):     138.9 ms ±   1.8 ms    [User: 121.8 ms, System: 15.4 ms]
  Range (min … max):   134.9 ms … 141.6 ms    20 runs

Benchmark 4: PYTHON_LAZY_IMPORTS=all    ./python.exe lazy-dunder.py
  Time (mean ± σ):      17.7 ms ±   0.5 ms    [User: 13.7 ms, System: 3.1 ms]
  Range (min … max):    16.9 ms …  18.7 ms    20 runs

Benchmark 5: ./python.exe -X lazy_imports=normal lazy-dunder.py
  Time (mean ± σ):      17.3 ms ±   0.5 ms    [User: 13.5 ms, System: 3.0 ms]
  Range (min … max):    16.5 ms …  18.3 ms    20 runs

Benchmark 6: ./python.exe -X lazy_imports=none   lazy-dunder.py
  Time (mean ± σ):     138.6 ms ±   4.4 ms    [User: 121.1 ms, System: 15.5 ms]
  Range (min … max):   130.6 ms … 154.4 ms    20 runs

Benchmark 7: ./python.exe -X lazy_imports=all    lazy-dunder.py
  Time (mean ± σ):      18.1 ms ±   0.7 ms    [User: 14.0 ms, System: 3.1 ms]
  Range (min … max):    17.0 ms …  19.1 ms    20 runs

Summary
  ./python.exe -X lazy_imports=normal lazy-dunder.py ran
    1.01 ± 0.04 times faster than ./python.exe lazy-dunder.py
    1.02 ± 0.04 times faster than PYTHON_LAZY_IMPORTS=all    ./python.exe lazy-dunder.py
    1.04 ± 0.05 times faster than ./python.exe -X lazy_imports=all    lazy-dunder.py
    1.05 ± 0.12 times faster than PYTHON_LAZY_IMPORTS=normal ./python.exe lazy-dunder.py
    8.00 ± 0.34 times faster than ./python.exe -X lazy_imports=none   lazy-dunder.py
    8.02 ± 0.26 times faster than PYTHON_LAZY_IMPORTS=none   ./python.exe lazy-dunder.py
```


<!-- gh-issue-number: gh-146369 -->
* Issue: gh-146369
<!-- /gh-issue-number -->
