### PR TITLE
`_pyrepl/pager.py`: call `less` with `--clear-screen`

### DIFF
--- a/Lib/_pyrepl/pager.py
+++ b/Lib/_pyrepl/pager.py
@@ -138,7 +138,7 @@ def pipe_pager(text: str, cmd: str, title: str = '') -> None:
         '.'
         '?e (END):?pB %pB\\%..'
         ' (press h for help or q to quit)')
-    env['LESS'] = '-RmPm{0}$PM{0}$'.format(prompt_string)
+    env['LESS'] = '-RcmPm{0}$PM{0}$'.format(prompt_string)
     proc = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE,
                             errors='backslashreplace', env=env)
     assert proc.stdin is not None


### PR DESCRIPTION
Since this is only a cosmetic change, I don't think it qualifies for a news entry.

Currently, text is written bottom-to-top, resulting in odd placement for `copyright()`:

<img width="1644" height="835" alt="Screenshot From 2026-03-24 15-30-53" src="https://github.com/user-attachments/assets/341948c4-272f-4e9f-bf80-95bf62f819e5" />

This patch fixes that:

<img width="1652" height="899" alt="image" src="https://github.com/user-attachments/assets/2f6b54a5-c77d-4380-81c4-88906fa8d362" />

By passing [`--clear-screen` (`-c`)](https://man7.org/linux/man-pages/man1/less.1.html#:~:text=%2Dc%20or%20%2D%2Dclear%2Dscreen) to `less`, which "causes full screen repaints to be painted from the top line down."
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
