### PR TITLE
gh-146386:`modsupport.c` Missing `va_end` in `_abiinfo_raise`

### DIFF
--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -688,9 +688,12 @@ static int _abiinfo_raise(const char *module_name, const char *format, ...)
     va_list vargs;
     va_start(vargs, format);
     if (_PyUnicodeWriter_FormatV(writer, format, vargs) < 0) {
+        va_end(vargs);
         PyUnicodeWriter_Discard(writer);
         return -1;
     }
+
+    va_end(vargs);
     PyObject *message = PyUnicodeWriter_Finish(writer);
     if (!message) {
         return -1;


### PR DESCRIPTION
### modsupport.c: Missing va_end in _abiinfo_raise

`va_start(vargs, format)` at line 689 but `va_end(vargs)` never called on any path. UB per C99 7.15.1.

This is a sub-issue of https://github.com/python/cpython/issues/146102 with original [gist details](https://gist.github.com/devdanzin/d1a6ab9f62970be0cae139366ce3c482)

`va_end` was added at the two exit points.

<!-- gh-issue-number: gh-146386 -->
* Issue: gh-146386
<!-- /gh-issue-number -->
