### PR TITLE
gh-146388: Add null check for `sym_new(ctx)` in `make_bottom`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-26-11-18-45.gh-issue-146388.O0u1c3.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-26-11-18-45.gh-issue-146388.O0u1c3.rst
@@ -1,1 +1,1 @@
-Add a null check for :func:`sym_new(ctx)` in :func:`make_bottom`
+Adds a null check to handle when the JIT optimizer runs out of space when dealing with contradictions in :func:`make_bottom`

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-26-11-18-45.gh-issue-146388.O0u1c3.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-26-11-18-45.gh-issue-146388.O0u1c3.rst
@@ -1,1 +1,1 @@
-Adds a null check to handle when the JIT optimizer runs out of space when dealing with contradictions in :func:`make_bottom`
+Adds a null check to handle when the JIT optimizer runs out of space when dealing with contradictions in `make_bottom`

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-26-11-18-45.gh-issue-146388.O0u1c3.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-26-11-18-45.gh-issue-146388.O0u1c3.rst
@@ -1,1 +1,1 @@
-Adds a null check to handle when the JIT optimizer runs out of space when dealing with contradictions in `make_bottom`
+Adds a null check to handle when the JIT optimizer runs out of space when dealing with contradictions in ``make_bottom``.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-26-11-18-45.gh-issue-146388.O0u1c3.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-26-11-18-45.gh-issue-146388.O0u1c3.rst
@@ -1,0 +1,1 @@
+Add a null check for :func:`sym_new(ctx)` in :func:`make_bottom`

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -1684,6 +1684,9 @@ static JitOptSymbol *
 make_bottom(JitOptContext *ctx)
 {
     JitOptSymbol *sym = sym_new(ctx);
+    if (res == NULL) {
+        return out_of_space_ref(ctx);
+    }
     sym->tag = JIT_SYM_BOTTOM_TAG;
     return sym;
 }

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -1684,7 +1684,7 @@ static JitOptSymbol *
 make_bottom(JitOptContext *ctx)
 {
     JitOptSymbol *sym = sym_new(ctx);
-    if (res == NULL) {
+    if (sym == NULL) {
         return out_of_space_ref(ctx);
     }
     sym->tag = JIT_SYM_BOTTOM_TAG;

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -1685,7 +1685,7 @@ make_bottom(JitOptContext *ctx)
 {
     JitOptSymbol *sym = sym_new(ctx);
     if (sym == NULL) {
-        return out_of_space_ref(ctx);
+        return out_of_space(ctx);
     }
     sym->tag = JIT_SYM_BOTTOM_TAG;
     return sym;


### PR DESCRIPTION
# optimizer_symbols.c: make_bottom NULL deref when arena full

`sym_new(ctx)` at line 1535 can return NULL when the type arena is full. Result immediately dereferenced without check. Every other `sym_new` call site checks for NULL.

This is a sub-issue of https://github.com/python/cpython/issues/146102 with [gist details](https://gist.github.com/devdanzin/14a5663604e1d7fb930d121b4e0c8d25)

<!-- gh-issue-number: gh-146388 -->
* Issue: gh-146388
<!-- /gh-issue-number -->
