### PR TITLE
GH-139922: update 3.15 whatsnew: Windows 64-bit binaries now use the tail-calling interpreter

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1943,6 +1943,15 @@ Build changes
   and :option:`-X dev <-X>` is passed to the Python or Python is built in :ref:`debug mode <debug-build>`.
   (Contributed by Donghee Na in :gh:`141770`.)
 
+* The official Windows 64-bit binaries on python.org__ are now using the
+  tail-calling interpreter since Python 3.15.0a8.
+  (Contributed by Ken Jin, Brandt Bucher and Chris Eibl in :gh:`143068`.
+  Special thanks go to Steve Dower for his assistance with the integration in the
+  Windows release build process and to the MSVC team including Hulon Jenkins
+  for ``msvc::musttail``.)
+
+  __ https://www.python.org/downloads/windows/
+
 
 Porting to Python 3.15
 ======================

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1276,18 +1276,6 @@ zlib
 Optimizations
 =============
 
-* Builds using Visual Studio 2026 (MSVC 18) may now use the new
-  :ref:`tail-calling interpreter <whatsnew314-tail-call-interpreter>`.
-  Results on Visual Studio 18.1.1 report between
-  `15-20% <https://github.com/faster-cpython/ideas/blob/main/results/5800X-msvc.pgo2-vs-msvc.pgo.tc.svg>`__
-  speedup on the geometric mean of pyperformance on Windows x86-64 over
-  the switch-case interpreter on an AMD Ryzen 7 5800X. We have
-  observed speedups ranging from 14% for large pure-Python libraries
-  to 40% for long-running small pure-Python scripts on Windows.
-  This was made possible by a new feature introduced in MSVC 18.
-  (Contributed by Chris Eibl, Ken Jin, and Brandt Bucher in :gh:`143068`.
-  Special thanks to the MSVC team including Hulon Jenkins.)
-
 * ``mimalloc`` is now used as the default allocator for
   for raw memory allocations such as via :c:func:`PyMem_RawMalloc`
   for better performance on :term:`free-threaded builds <free-threaded build>`.
@@ -1946,12 +1934,18 @@ Build changes
 
 .. _whatsnew315-windows-tail-calling-interpreter:
 
-* The official Windows 64-bit binaries on python.org__ now use the new
+* 64-bit builds using Visual Studio 2026 (MSVC 18) may now use the new
   :ref:`tail-calling interpreter <whatsnew314-tail-call-interpreter>`.
-  (Contributed by Ken Jin, Brandt Bucher and Chris Eibl in :gh:`139922`.
-  Special thanks go to Steve Dower for his assistance with the integration in the
-  Windows release build process and to the MSVC team including Hulon Jenkins
-  for ``msvc::musttail``.)
+  Results on Visual Studio 18.1.1 report between
+  `15-20% <https://github.com/faster-cpython/ideas/blob/main/results/5800X-msvc.pgo2-vs-msvc.pgo.tc.svg>`__
+  speedup on the geometric mean of pyperformance on Windows x86-64 over
+  the switch-case interpreter on an AMD Ryzen 7 5800X. We have
+  observed speedups ranging from 14% for large pure-Python libraries
+  to 40% for long-running small pure-Python scripts on Windows.
+  This was made possible by a new feature introduced in MSVC 18,
+  which the official Windows 64-bit binaries on python.org__ now use.
+  (Contributed by Chris Eibl, Ken Jin, and Brandt Bucher in :gh:`143068`.
+  Special thanks to the MSVC team including Hulon Jenkins.)
 
   __ https://www.python.org/downloads/windows/
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -84,7 +84,8 @@ Summary -- Release highlights
   <whatsnew315-pybyteswriter>`
 * :ref:`The JIT compiler has been significantly upgraded <whatsnew315-jit>`
 * :ref:`Improved error messages <whatsnew315-improved-error-messages>`
-
+* :ref:`The official Windows 64-bit binaries now use the tail-calling interpreter
+  <whatsnew315-windows-tail-calling-interpreter>`
 
 New features
 ============
@@ -1942,6 +1943,8 @@ Build changes
   Annotations are visible in ``/proc/<pid>/maps`` if the kernel supports the feature
   and :option:`-X dev <-X>` is passed to the Python or Python is built in :ref:`debug mode <debug-build>`.
   (Contributed by Donghee Na in :gh:`141770`.)
+
+.. _whatsnew315-windows-tail-calling-interpreter:
 
 * The official Windows 64-bit binaries on python.org__ now use the new
   :ref:`tail-calling interpreter <whatsnew314-tail-call-interpreter>`.

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1945,7 +1945,7 @@ Build changes
   This was made possible by a new feature introduced in MSVC 18,
   which the official Windows 64-bit binaries on python.org__ now use.
   (Contributed by Chris Eibl, Ken Jin, and Brandt Bucher in :gh:`143068`.
-  Special thanks to the MSVC team including Hulon Jenkins.)
+  Special thanks to Steve Dower, and the MSVC team including Hulon Jenkins.)
 
   __ https://www.python.org/downloads/windows/
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1945,7 +1945,7 @@ Build changes
 
 * The official Windows 64-bit binaries on python.org__ are now using the new
   :ref:`tail-calling interpreter <whatsnew314-tail-call-interpreter>` since Python 3.15.0a8.
-  (Contributed by Ken Jin, Brandt Bucher and Chris Eibl in :gh:`143068`.
+  (Contributed by Ken Jin, Brandt Bucher and Chris Eibl in :gh:`139922`.
   Special thanks go to Steve Dower for his assistance with the integration in the
   Windows release build process and to the MSVC team including Hulon Jenkins
   for ``msvc::musttail``.)

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1944,7 +1944,7 @@ Build changes
   (Contributed by Donghee Na in :gh:`141770`.)
 
 * The official Windows 64-bit binaries on python.org__ are now using the new
-  :ref:`tail-calling interpreter <whatsnew314-tail-call-interpreter>` since Python 3.15.0a8.
+  :ref:`tail-calling interpreter <whatsnew314-tail-call-interpreter>`.
   (Contributed by Ken Jin, Brandt Bucher and Chris Eibl in :gh:`139922`.
   Special thanks go to Steve Dower for his assistance with the integration in the
   Windows release build process and to the MSVC team including Hulon Jenkins

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1943,8 +1943,8 @@ Build changes
   and :option:`-X dev <-X>` is passed to the Python or Python is built in :ref:`debug mode <debug-build>`.
   (Contributed by Donghee Na in :gh:`141770`.)
 
-* The official Windows 64-bit binaries on python.org__ are now using the
-  tail-calling interpreter since Python 3.15.0a8.
+* The official Windows 64-bit binaries on python.org__ are now using the new
+  :ref:`tail-calling interpreter <whatsnew314-tail-call-interpreter>` since Python 3.15.0a8.
   (Contributed by Ken Jin, Brandt Bucher and Chris Eibl in :gh:`143068`.
   Special thanks go to Steve Dower for his assistance with the integration in the
   Windows release build process and to the MSVC team including Hulon Jenkins

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1943,7 +1943,7 @@ Build changes
   and :option:`-X dev <-X>` is passed to the Python or Python is built in :ref:`debug mode <debug-build>`.
   (Contributed by Donghee Na in :gh:`141770`.)
 
-* The official Windows 64-bit binaries on python.org__ are now using the new
+* The official Windows 64-bit binaries on python.org__ now use the new
   :ref:`tail-calling interpreter <whatsnew314-tail-call-interpreter>`.
   (Contributed by Ken Jin, Brandt Bucher and Chris Eibl in :gh:`139922`.
   Special thanks go to Steve Dower for his assistance with the integration in the


### PR DESCRIPTION


<!-- gh-issue-number: gh-139922 -->
* Issue: gh-139922
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146391.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->