### PR TITLE
gh-146333: Fix quadratic regex backtracking in configparser option parsing

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -613,7 +613,9 @@ class RawConfigParser(MutableMapping):
         \]                                 # ]
         """
     _OPT_TMPL = r"""
-        (?P<option>.*?)                    # very permissive!
+        (?P<option>                        # very permissive!
+            (?:(?!{delim})\S)*             # non-delimiter non-whitespace
+            (?:\s+(?:(?!{delim})\S)+)*)    # optionally more words
         \s*(?P<vi>{delim})\s*              # any number of space/tab,
                                            # followed by any of the
                                            # allowed delimiters,
@@ -621,7 +623,9 @@ class RawConfigParser(MutableMapping):
         (?P<value>.*)$                     # everything up to eol
         """
     _OPT_NV_TMPL = r"""
-        (?P<option>.*?)                    # very permissive!
+        (?P<option>                        # very permissive!
+            (?:(?!{delim})\S)*             # non-delimiter non-whitespace
+            (?:\s+(?:(?!{delim})\S)+)*)    # optionally more words
         \s*(?:                             # any number of space/tab,
         (?P<vi>{delim})\s*                 # optionally followed by
                                            # any of the allowed
@@ -1144,26 +1148,6 @@ class RawConfigParser(MutableMapping):
     def _handle_option(self, st, line, fpname):
         # an option line?
         st.indent_level = st.cur_indent_level
-
-        # Fast path: if no delimiter is present, skip the regex to avoid
-        # quadratic backtracking (gh-146333). When allow_no_value is True,
-        # treat the whole line as an option name with no value.
-        if not any(d in line.clean for d in self._delimiters):
-            if self._allow_no_value:
-                st.optname = self.optionxform(line.clean.strip())
-                if not st.optname:
-                    st.errors.append(ParsingError(fpname, st.lineno, line))
-                    return
-                if (self._strict and
-                    (st.sectname, st.optname) in st.elements_added):
-                    raise DuplicateOptionError(st.sectname, st.optname,
-                                            fpname, st.lineno)
-                st.elements_added.add((st.sectname, st.optname))
-                st.cursect[st.optname] = None
-                return
-            else:
-                st.errors.append(ParsingError(fpname, st.lineno, line))
-                return
 
         mo = self._optcre.match(line.clean)
         if not mo:

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -1145,6 +1145,26 @@ class RawConfigParser(MutableMapping):
         # an option line?
         st.indent_level = st.cur_indent_level
 
+        # Fast path: if no delimiter is present, skip the regex to avoid
+        # quadratic backtracking (gh-146333). When allow_no_value is True,
+        # treat the whole line as an option name with no value.
+        if not any(d in line.clean for d in self._delimiters):
+            if self._allow_no_value:
+                st.optname = self.optionxform(line.clean.strip())
+                if not st.optname:
+                    st.errors.append(ParsingError(fpname, st.lineno, line))
+                    return
+                if (self._strict and
+                    (st.sectname, st.optname) in st.elements_added):
+                    raise DuplicateOptionError(st.sectname, st.optname,
+                                            fpname, st.lineno)
+                st.elements_added.add((st.sectname, st.optname))
+                st.cursect[st.optname] = None
+                return
+            else:
+                st.errors.append(ParsingError(fpname, st.lineno, line))
+                return
+
         mo = self._optcre.match(line.clean)
         if not mo:
             # a non-fatal parsing error occurred. set up the

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -2270,6 +2270,26 @@ class InvalidInputTestCase(unittest.TestCase):
         output.close()
 
 
+class ReDoSTestCase(unittest.TestCase):
+    """Regression tests for quadratic regex backtracking (gh-146333)."""
+
+    def test_option_regex_does_not_backtrack(self):
+        # A line with many spaces between non-delimiter characters
+        # should be parsed in linear time, not quadratic.
+        parser = configparser.RawConfigParser()
+        content = "[section]\n" + "x" + " " * 40000 + "y" + "\n"
+        # This should complete almost instantly. Before the fix,
+        # it would take over a minute due to catastrophic backtracking.
+        with self.assertRaises(configparser.ParsingError):
+            parser.read_string(content)
+
+    def test_option_regex_no_value_does_not_backtrack(self):
+        parser = configparser.RawConfigParser(allow_no_value=True)
+        content = "[section]\n" + "x" + " " * 40000 + "y" + "\n"
+        parser.read_string(content)
+        self.assertTrue(parser.has_option("section", "x" + " " * 40000 + "y"))
+
+
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
         support.check__all__(self, configparser, not_exported={"Error"})

--- a/Misc/NEWS.d/next/Security/2026-03-25-00-51-03.gh-issue-146333.LqdL__bn.rst
+++ b/Misc/NEWS.d/next/Security/2026-03-25-00-51-03.gh-issue-146333.LqdL__bn.rst
@@ -1,0 +1,3 @@
+Fix quadratic backtracking in :class:`configparser.RawConfigParser` option
+parsing regexes (``OPTCRE`` and ``OPTCRE_NV``). A crafted configuration line
+with many whitespace characters could cause excessive CPU usage.


### PR DESCRIPTION
The `_OPT_TMPL` and `_OPT_NV_TMPL` regexes have quadratic backtracking when a line contains many spaces between non-delimiter characters. The lazy `.*?` in the option group and the `\s*` before the delimiter overlap on whitespace, so the engine tries every possible split point.

The fix removes `\s*` before the delimiter. This is safe because the option name is already stripped via `.rstrip()` in `_handle_option` (line 1160), and the value is stripped via `.strip()` (line 1169).

Before: `x` + 40000 spaces + `y` takes ~86 seconds
After: ~0.004 seconds

<!-- gh-issue-number: gh-146333 -->
* Issue: gh-146333
<!-- /gh-issue-number -->
