### PR TITLE
gh-146362: Document co_exceptiontable in code objects

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1545,6 +1545,11 @@ Special read-only attributes
    * - .. attribute:: codeobject.co_stacksize
      - The required stack size of the code object
 
+   * - .. attribute:: codeobject.co_exceptiontable
+     - A bytes object containing the exception handling table of the code object
+
+       .. versionadded:: 3.11
+
    * - .. attribute:: codeobject.co_flags
      - An :class:`integer <int>` encoding a number of flags for the
        interpreter.


### PR DESCRIPTION
Fixes gh-146362.

Add documentation for `co_exceptiontable` in the code object attributes section of the data model.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146405.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->