### PR TITLE
gh-146410: Add --pythoninfo option to regrtest

### DIFF
--- a/Android/android.py
+++ b/Android/android.py
@@ -628,7 +628,8 @@ async def gradle_task(context):
             # Randomization is disabled because order-dependent failures are
             # much less likely to pass on a rerun in single-process mode.
             "-m", "test",
-            f"--{context.ci_mode}-ci", "--single-process", "--no-randomize"
+            f"--{context.ci_mode}-ci", "--single-process", "--no-randomize",
+            "--pythoninfo",
         ]
 
     if not any(arg in context.args for arg in ["-c", "-m"]):

--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -393,6 +393,8 @@ def _create_parser():
                        help='remove old test_python_* directories')
     group.add_argument('--bisect', action='store_true',
                        help='if some tests fail, run test.bisect_cmd on them')
+    group.add_argument('--pythoninfo', action='store_true',
+                       help="run python -m test.pythoninfo before tests")
     group.add_argument('--dont-add-python-opts', dest='_add_python_opts',
                        action='store_false',
                        help="internal option, don't use it")

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -26,7 +26,7 @@ from .utils import (
     strip_py_suffix, count, format_duration,
     printlist, get_temp_dir, get_work_dir, exit_timeout,
     display_header, cleanup_temp_dir, print_warning,
-    is_cross_compiled, get_host_runner,
+    is_cross_compiled, get_host_runner, display_title,
     EXIT_TIMEOUT)
 
 
@@ -126,6 +126,7 @@ class Regrtest:
         self.coverage: bool = ns.trace
         self.coverage_dir: StrPath | None = ns.coverdir
         self._tmp_dir: StrPath | None = ns.tempdir
+        self.pythoninfo: bool = ns.pythoninfo
 
         # Randomize
         self.randomize: bool = ns.randomize
@@ -322,9 +323,7 @@ class Regrtest:
         title = f"Bisect {test}"
         if progress:
             title = f"{title} ({progress})"
-        print(title)
-        print("#" * len(title))
-        print()
+        display_title(title)
 
         cmd = runtests.create_python_cmd()
         cmd.extend([
@@ -345,9 +344,7 @@ class Regrtest:
         exitcode = proc.returncode
 
         title = f"{title}: exit code {exitcode}"
-        print(title)
-        print("#" * len(title))
-        print(flush=True)
+        display_title(title)
 
         if exitcode:
             print(f"Bisect failed with exit code {exitcode}")
@@ -752,6 +749,15 @@ class Regrtest:
             )
         return self._tmp_dir
 
+    def run_pythoninfo(self):
+        from test import pythoninfo
+        try:
+            pythoninfo.main()
+        except SystemExit:
+            # Ignore non-zero exit code on purpose
+            pass
+        print()
+
     def main(self, tests: TestList | None = None) -> NoReturn:
         if self.want_add_python_opts:
             self._add_python_opts()
@@ -764,6 +770,9 @@ class Regrtest:
 
         if self.want_wait:
             input("Press any key to continue...")
+
+        if self.pythoninfo:
+            self.run_pythoninfo()
 
         setup_test_dir(self.test_dir)
         selected, tests = self.find_tests(tests)

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -746,3 +746,9 @@ def _sanitize_xml_replace(regs):
 
 def sanitize_xml(text: str) -> str:
     return ILLEGAL_XML_CHARS_RE.sub(_sanitize_xml_replace, text)
+
+
+def display_title(title):
+    print(title)
+    print("#" * len(title))
+    print(flush=True)

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -1103,9 +1103,9 @@ def collect_info(info):
 
 
 def dump_info(info, file=None):
-    title = "Python debug information"
+    title = "Python build information"
     print(title)
-    print("=" * len(title))
+    print("#" * len(title))
     print()
 
     infos = info.get_infos()

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -571,6 +571,13 @@ class ParseArgsTestCase(unittest.TestCase):
         self.assertEqual(regrtest.num_workers, 0)
         self.assertTrue(regrtest.single_process)
 
+    def test_pythoninfo(self):
+        ns = self.parse_args([])
+        self.assertFalse(ns.pythoninfo)
+
+        ns = self.parse_args(['--pythoninfo'])
+        self.assertTrue(ns.pythoninfo)
+
 
 @dataclasses.dataclass(slots=True)
 class Rerun:
@@ -2426,6 +2433,11 @@ class ArgsTestCase(BaseTestCase):
         tests = output.strip().split()
         self.assertNotIn('test_re', tests)
         self.assertEqual(len(tests), len(pgo_tests) - 1)
+
+    def test_pythoninfo(self):
+        testname = self.create_test()
+        output = self.run_tests('--pythoninfo', testname)
+        self.assertIn("Python build information", output)
 
 
 class TestUtils(unittest.TestCase):


### PR DESCRIPTION
* Android now runs tests with --pythoninfo to dump build information.
* Add display_title() function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146410 -->
* Issue: gh-146410
<!-- /gh-issue-number -->
