### PR TITLE
gh-145633: Fix struct.pack('f') on s390x

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -365,7 +365,7 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             (got,) = struct.unpack(code, got)
             self.assertEqual(got, expectedback)
 
-    def check_705836(self, format, reverse_format):
+    def test_705836(self):
         # SF bug 705836.  "<f" and ">f" had a severe rounding bug, where a carry
         # from the low-order discarded bits could propagate into the exponent
         # field, causing the result to be wrong by a factor of 2.
@@ -376,33 +376,42 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
                 delta /= 2.0
             smaller = base - delta
             # Packing this rounds away a solid string of trailing 1 bits.
-            packed = struct.pack(format, smaller)
-            unpacked = struct.unpack(format, packed)[0]
+            packed = struct.pack("<f", smaller)
+            unpacked = struct.unpack("<f", packed)[0]
             # This failed at base = 2, 4, and 32, with unpacked = 1, 2, and
             # 16, respectively.
             self.assertEqual(base, unpacked)
-
-            bigpacked = struct.pack(reverse_format, smaller)
+            bigpacked = struct.pack(">f", smaller)
             self.assertEqual(bigpacked, string_reverse(packed))
-            unpacked = struct.unpack(reverse_format, bigpacked)[0]
+            unpacked = struct.unpack(">f", bigpacked)[0]
             self.assertEqual(base, unpacked)
 
         # Largest finite IEEE single.
         big = (1 << 24) - 1
         big = math.ldexp(big, 127 - 23)
-        packed = struct.pack(format, big)
-        unpacked = struct.unpack(format, packed)[0]
+        packed = struct.pack(">f", big)
+        unpacked = struct.unpack(">f", packed)[0]
         self.assertEqual(big, unpacked)
 
         # The same, but tack on a 1 bit so it rounds up to infinity.
         big = (1 << 25) - 1
         big = math.ldexp(big, 127 - 24)
-        self.assertRaises(OverflowError, struct.pack, format, big)
+        self.assertRaises(OverflowError, struct.pack, ">f", big)
+        self.assertRaises(OverflowError, struct.pack, "<f", big)
+        # same for native format, see gh-145633
+        self.assertRaises(OverflowError, struct.pack, "f", big)
 
-    def test_705836(self):
-        self.check_705836("<f", ">f")
-        self.check_705836(">f", "<f")
-        self.check_705836("f", "<f" if sys.byteorder == "big" else ">f")
+        # And for half-floats
+        big = (1 << 11) - 1
+        big = math.ldexp(big, 15 - 10)
+        packed = struct.pack(">e", big)
+        unpacked = struct.unpack(">e", packed)[0]
+        self.assertEqual(big, unpacked)
+        big = (1 << 12) - 1
+        big = math.ldexp(big, 15 - 11)
+        self.assertRaises(OverflowError, struct.pack, ">e", big)
+        self.assertRaises(OverflowError, struct.pack, "<e", big)
+        self.assertRaises(OverflowError, struct.pack, "e", big)
 
     def test_1530559(self):
         for code, byteorder in iter_integer_formats():
@@ -1206,20 +1215,6 @@ class UnpackIteratorTest(unittest.TestCase):
 
         for formatcode, bits, f in format_bits_float__doubleRoundingError_list:
             self.assertEqual(bits, struct.pack(formatcode, f))
-
-    def test_float_round_trip(self):
-        for format in ("f", "<f", ">f", "d", "<d", ">d"):
-            with self.subTest(format=format):
-                f = struct.unpack(format, struct.pack(format, 1.5))[0]
-                self.assertEqual(f, 1.5)
-                f = struct.unpack(format, struct.pack(format, NAN))[0]
-                self.assertTrue(math.isnan(f), f)
-                f = struct.unpack(format, struct.pack(format, INF))[0]
-                self.assertTrue(math.isinf(f), f)
-                self.assertEqual(math.copysign(1.0, f), 1.0)
-                f = struct.unpack(format, struct.pack(format, -INF))[0]
-                self.assertTrue(math.isinf(f), f)
-                self.assertEqual(math.copysign(1.0, f), -1.0)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -365,7 +365,7 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             (got,) = struct.unpack(code, got)
             self.assertEqual(got, expectedback)
 
-    def test_705836(self):
+    def check_705836(self, format, reverse_format):
         # SF bug 705836.  "<f" and ">f" had a severe rounding bug, where a carry
         # from the low-order discarded bits could propagate into the exponent
         # field, causing the result to be wrong by a factor of 2.
@@ -376,27 +376,33 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
                 delta /= 2.0
             smaller = base - delta
             # Packing this rounds away a solid string of trailing 1 bits.
-            packed = struct.pack("<f", smaller)
-            unpacked = struct.unpack("<f", packed)[0]
+            packed = struct.pack(format, smaller)
+            unpacked = struct.unpack(format, packed)[0]
             # This failed at base = 2, 4, and 32, with unpacked = 1, 2, and
             # 16, respectively.
             self.assertEqual(base, unpacked)
-            bigpacked = struct.pack(">f", smaller)
+
+            bigpacked = struct.pack(reverse_format, smaller)
             self.assertEqual(bigpacked, string_reverse(packed))
-            unpacked = struct.unpack(">f", bigpacked)[0]
+            unpacked = struct.unpack(reverse_format, bigpacked)[0]
             self.assertEqual(base, unpacked)
 
         # Largest finite IEEE single.
         big = (1 << 24) - 1
         big = math.ldexp(big, 127 - 23)
-        packed = struct.pack(">f", big)
-        unpacked = struct.unpack(">f", packed)[0]
+        packed = struct.pack(format, big)
+        unpacked = struct.unpack(format, packed)[0]
         self.assertEqual(big, unpacked)
 
         # The same, but tack on a 1 bit so it rounds up to infinity.
         big = (1 << 25) - 1
         big = math.ldexp(big, 127 - 24)
-        self.assertRaises(OverflowError, struct.pack, ">f", big)
+        self.assertRaises(OverflowError, struct.pack, format, big)
+
+    def test_705836(self):
+        self.check_705836("<f", ">f")
+        self.check_705836(">f", "<f")
+        self.check_705836("f", "<f" if sys.byteorder == "big" else ">f")
 
     def test_1530559(self):
         for code, byteorder in iter_integer_formats():
@@ -1200,6 +1206,20 @@ class UnpackIteratorTest(unittest.TestCase):
 
         for formatcode, bits, f in format_bits_float__doubleRoundingError_list:
             self.assertEqual(bits, struct.pack(formatcode, f))
+
+    def test_float_round_trip(self):
+        for format in ("f", "<f", ">f", "d", "<d", ">d"):
+            with self.subTest(format=format):
+                f = struct.unpack(format, struct.pack(format, 1.5))[0]
+                self.assertEqual(f, 1.5)
+                f = struct.unpack(format, struct.pack(format, NAN))[0]
+                self.assertTrue(math.isnan(f), f)
+                f = struct.unpack(format, struct.pack(format, INF))[0]
+                self.assertTrue(math.isinf(f), f)
+                self.assertEqual(math.copysign(1.0, f), 1.0)
+                f = struct.unpack(format, struct.pack(format, -INF))[0]
+                self.assertTrue(math.isinf(f), f)
+                self.assertEqual(math.copysign(1.0, f), -1.0)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -1031,6 +1031,24 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         self.assertRaises(RuntimeError, repr, S)
         self.assertEqual(S.size, -1)
 
+    def test_float_round_trip(self):
+        for format in (
+            "f", "<f", ">f",
+            "d", "<d", ">d",
+            "e", "<e", ">e",
+        ):
+            with self.subTest(format=format):
+                f = struct.unpack(format, struct.pack(format, 1.5))[0]
+                self.assertEqual(f, 1.5)
+                f = struct.unpack(format, struct.pack(format, NAN))[0]
+                self.assertTrue(math.isnan(f), f)
+                f = struct.unpack(format, struct.pack(format, INF))[0]
+                self.assertTrue(math.isinf(f), f)
+                self.assertEqual(math.copysign(1.0, f), 1.0)
+                f = struct.unpack(format, struct.pack(format, -INF))[0]
+                self.assertTrue(math.isinf(f), f)
+                self.assertEqual(math.copysign(1.0, f), -1.0)
+
 
 class UnpackIteratorTest(unittest.TestCase):
     """

--- a/Misc/NEWS.d/next/Library/2026-03-26-11-04-42.gh-issue-145633.RWjlaX.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-26-11-04-42.gh-issue-145633.RWjlaX.rst
@@ -1,0 +1,2 @@
+Fix ``struct.pack('f', float)``: use :c:func:`PyFloat_Pack4` to raise
+:exc:`OverflowError`. Patch by Sergey B Kirpichev and Victor Stinner.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -763,14 +763,13 @@ np_halffloat(_structmodulestate *state, char *p, PyObject *v, const formatdef *f
 static int
 np_float(_structmodulestate *state, char *p, PyObject *v, const formatdef *f)
 {
-    float x = (float)PyFloat_AsDouble(v);
+    double x = PyFloat_AsDouble(v);
     if (x == -1 && PyErr_Occurred()) {
         PyErr_SetString(state->StructError,
                         "required argument is not a float");
         return -1;
     }
-    memcpy(p, &x, sizeof x);
-    return 0;
+    return PyFloat_Pack4(x, p, PY_LITTLE_ENDIAN);
 }
 
 static int


### PR DESCRIPTION
Use PyFloat_Pack4() to raise OverflowError.

Add more tests on packing/unpacking floats.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145633 -->
* Issue: gh-145633
<!-- /gh-issue-number -->
