### PR TITLE
gh-146381: Fold frozendict(key=const, ...) calls to LOAD_CONST

### DIFF
--- a/Include/internal/pycore_opcode_utils.h
+++ b/Include/internal/pycore_opcode_utils.h
@@ -75,7 +75,8 @@ extern "C" {
 #define CONSTANT_BUILTIN_ANY 4
 #define CONSTANT_BUILTIN_LIST 5
 #define CONSTANT_BUILTIN_SET 6
-#define NUM_COMMON_CONSTANTS 7
+#define CONSTANT_BUILTIN_FROZENDICT 7
+#define NUM_COMMON_CONSTANTS 8
 
 /* Values used in the oparg for RESUME */
 #define RESUME_AT_FUNC_START 0

--- a/Lib/opcode.py
+++ b/Lib/opcode.py
@@ -41,7 +41,7 @@ _intrinsic_2_descs = _opcode.get_intrinsic2_descs()
 _special_method_names = _opcode.get_special_method_names()
 _common_constants = [builtins.AssertionError, builtins.NotImplementedError,
                      builtins.tuple, builtins.all, builtins.any, builtins.list,
-                     builtins.set]
+                     builtins.set, builtins.frozendict]
 _nb_ops = _opcode.get_nb_ops()
 
 hascompare = [opmap["COMPARE_OP"]]

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -241,6 +241,29 @@ class TestTranforms(BytecodeTestCase):
         self.assertTrue(g(4))
         self.check_lnotab(g)
 
+    def test_constant_folding_frozendict_call(self):
+        # frozendict(key=const, ...) should be folded to LOAD_CONST
+        # with a runtime guard (fallback CALL_KW path still exists)
+        def f():
+            return frozendict(x=1, y=2)
+
+        code = f.__code__
+        self.assertInBytecode(code, 'LOAD_CONST', frozendict(x=1, y=2))
+        self.assertInBytecode(code, 'LOAD_COMMON_CONSTANT', 7)
+        result = f()
+        self.assertEqual(result, frozendict(x=1, y=2))
+        self.assertIsInstance(result, frozendict)
+
+    def test_constant_folding_frozendict_call_shadowed(self):
+        # When frozendict is shadowed, the fallback path should be used
+        def f():
+            frozendict = dict
+            return frozendict(x=1, y=2)
+
+        result = f()
+        self.assertEqual(result, {'x': 1, 'y': 2})
+        self.assertIsInstance(result, dict)
+
     def test_constant_folding_small_int(self):
         tests = [
             ('(0, )[0]', 0),

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-25-23-07-44.gh-issue-146381.t80WOO.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-25-23-07-44.gh-issue-146381.t80WOO.rst
@@ -1,0 +1,2 @@
+Fold frozendict(key=const, ...) calls to LOAD_CONST in codegen. Patch by
+Donghee Na.

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -4128,6 +4128,66 @@ codegen_validate_keywords(compiler *c, asdl_keyword_seq *keywords)
     return SUCCESS;
 }
 
+/* Try to fold frozendict(key=const, ...) into LOAD_CONST with a runtime guard.
+   Called after the function has been loaded onto the stack.
+   Return 1 if optimization was emitted, 0 if not, -1 on error. */
+static int
+maybe_optimize_frozendict_call(compiler *c, expr_ty e, jump_target_label end)
+{
+    expr_ty func = e->v.Call.func;
+    asdl_expr_seq *args = e->v.Call.args;
+    asdl_keyword_seq *kwds = e->v.Call.keywords;
+
+    if (func->kind != Name_kind ||
+        !_PyUnicode_EqualToASCIIString(func->v.Name.id, "frozendict") ||
+        asdl_seq_LEN(args) != 0)
+    {
+        return 0;
+    }
+
+    /* All keywords must have names (no **kwargs) and constant values */
+    Py_ssize_t nkwds = asdl_seq_LEN(kwds);
+    for (Py_ssize_t i = 0; i < nkwds; i++) {
+        keyword_ty kw = asdl_seq_GET(kwds, i);
+        if (kw->arg == NULL || kw->value->kind != Constant_kind) {
+            return 0;
+        }
+    }
+
+    /* Build the frozendict at compile time */
+    PyObject *dict = PyDict_New();
+    if (dict == NULL) {
+        return -1;
+    }
+    for (Py_ssize_t i = 0; i < nkwds; i++) {
+        keyword_ty kw = asdl_seq_GET(kwds, i);
+        if (PyDict_SetItem(dict, kw->arg, kw->value->v.Constant.value) < 0) {
+            Py_DECREF(dict);
+            return -1;
+        }
+    }
+    PyObject *fd = PyFrozenDict_New(dict);
+    Py_DECREF(dict);
+    if (fd == NULL) {
+        return -1;
+    }
+
+    location loc = LOC(func);
+    NEW_JUMP_TARGET_LABEL(c, skip_optimization);
+
+    ADDOP_I(c, loc, COPY, 1);
+    ADDOP_I(c, loc, LOAD_COMMON_CONSTANT, CONSTANT_BUILTIN_FROZENDICT);
+    ADDOP_COMPARE(c, loc, Is);
+    ADDOP_JUMP(c, loc, POP_JUMP_IF_FALSE, skip_optimization);
+    ADDOP(c, loc, POP_TOP);
+    ADDOP_LOAD_CONST(c, LOC(e), fd);
+    Py_DECREF(fd);
+    ADDOP_JUMP(c, loc, JUMP, end);
+
+    USE_LABEL(c, skip_optimization);
+    return 1;
+}
+
 static int
 codegen_call(compiler *c, expr_ty e)
 {
@@ -4143,6 +4203,7 @@ codegen_call(compiler *c, expr_ty e)
     RETURN_IF_ERROR(check_caller(c, e->v.Call.func));
     VISIT(c, expr, e->v.Call.func);
     RETURN_IF_ERROR(maybe_optimize_function_call(c, e, skip_normal_call));
+    RETURN_IF_ERROR(maybe_optimize_frozendict_call(c, e, skip_normal_call));
     location loc = LOC(e->v.Call.func);
     ADDOP(c, loc, PUSH_NULL);
     loc = LOC(e);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -887,6 +887,7 @@ pycore_init_builtins(PyThreadState *tstate)
     interp->common_consts[CONSTANT_BUILTIN_ANY] = any;
     interp->common_consts[CONSTANT_BUILTIN_LIST] = (PyObject*)&PyList_Type;
     interp->common_consts[CONSTANT_BUILTIN_SET] = (PyObject*)&PySet_Type;
+    interp->common_consts[CONSTANT_BUILTIN_FROZENDICT] = (PyObject*)&PyFrozenDict_Type;
 
     for (int i=0; i < NUM_COMMON_CONSTANTS; i++) {
         assert(interp->common_consts[i] != NULL);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
This PR folds `frozendict` calls into `LOAD_CONST` at compile time.

This is a prerequisite for JIT constant folding of frozendict lookups. Without this, `frozendict` compiles to CALL_KW, which the JIT cannot recognize as a constant. With this change, it becomes LOAD_CONST frozendict(...), enabling the JIT to promote it and fold subscript operations like d['x'] at optimization time.

Without codegen-level folding like this, supporting frozendict constants in the JIT would likely require introducing a new literal syntax (e.g., <1: 3, 5: 6>) at the language level, and it might need a PEP for this change.

cc @vstinner 

<!-- gh-issue-number: gh-146381 -->
* Issue: gh-146381
<!-- /gh-issue-number -->

