### PR TITLE
gh-146396: Improve tarfile docs with extractfile() example and clarify TarInfo.size

### DIFF
--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -810,7 +810,7 @@ A ``TarInfo`` object has the following public data attributes:
 .. attribute:: TarInfo.size
    :type: int
 
-   Size in bytes.
+   Size of the archived file's data in bytes.
 
 
 .. attribute:: TarInfo.mtime
@@ -1386,6 +1386,17 @@ a generator function instead of a list::
    tar = tarfile.open("sample.tar.gz")
    tar.extractall(members=py_files(tar))
    tar.close()
+
+How to read the content of a specific archive member into memory::
+
+   import tarfile
+
+   with tarfile.open("sample.tar.gz") as tar:
+       for member in tar:
+           f = tar.extractfile(member)
+           if f is not None:
+               content = f.read()
+               break
 
 How to read a gzip compressed tar archive and display some member information::
 


### PR DESCRIPTION
Closes #146396

### Summary

Improve the tarfile documentation by clarifying the meaning of `TarInfo.size` and adding a practical example for reading file contents directly into memory.

### Changes

* Clarified that `TarInfo.size` refers to the size of the archived file’s data (excluding header information)
* Added an example demonstrating how to use `TarFile.extractfile()` to read file contents without extracting to disk

### Motivation

The current documentation does not clearly explain how to read file data from a tar archive in memory. This change improves usability and helps developers discover the intended high-level API without relying on internal details.


<!-- gh-issue-number: gh-146396 -->
* Issue: gh-146396
<!-- /gh-issue-number -->
