### PR TITLE
Fix typo in 3.14 What's New tail call interpreter docs

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -454,7 +454,7 @@ on x86-64 and AArch64 architectures.
 However, a future release of GCC is expected to support this as well.
 
 This feature is opt-in for now. Enabling profile-guided optimization is highly
-recommendeded when using the new interpreter as it is the only configuration
+recommended when using the new interpreter as it is the only configuration
 that has been tested and validated for improved performance.
 For further information, see :option:`--with-tail-call-interp`.
 


### PR DESCRIPTION
Fix typo in **A new type of interpreter** section of Python 3.14 What's New docs.

Unclear if an issue number is required for this?

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146425.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->