### PR TITLE
gh-146442: Fix various bugs in compiler pipeline from bug report

### DIFF
--- a/Python/assemble.c
+++ b/Python/assemble.c
@@ -418,6 +418,7 @@ assemble_emit_instr(struct assembler *a, instruction *instr)
     int size = instr_size(instr);
     if (a->a_offset + size >= len / (int)sizeof(_Py_CODEUNIT)) {
         if (len > PY_SSIZE_T_MAX / 2) {
+            PyErr_NoMemory();
             return ERROR;
         }
         RETURN_IF_ERROR(_PyBytes_Resize(&a->a_bytecode, len * 2));

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -798,6 +798,9 @@ codegen_deferred_annotations_body(compiler *c, location loc,
         if (!mangled) {
             return ERROR;
         }
+        // NOTE: ref of mangled can be leaked on ADDOP* and VISIT macros due to early returns
+        // fixing would require an overhaul of these macros 
+
         PyObject *cond_index = PyList_GET_ITEM(conditional_annotation_indices, i);
         assert(PyLong_CheckExact(cond_index));
         long idx = PyLong_AS_LONG(cond_index);

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -667,8 +667,8 @@ codegen_unwind_fblock_stack(compiler *c, location *ploc,
     _PyCompile_PopFBlock(c, top->fb_type, top->fb_block);
     RETURN_IF_ERROR(codegen_unwind_fblock(c, ploc, &copy, preserve_tos));
     RETURN_IF_ERROR(codegen_unwind_fblock_stack(c, ploc, preserve_tos, loop));
-    _PyCompile_PushFBlock(c, copy.fb_loc, copy.fb_type, copy.fb_block,
-                          copy.fb_exit, copy.fb_datum);
+    RETURN_IF_ERROR(_PyCompile_PushFBlock(c, copy.fb_loc, copy.fb_type, copy.fb_block,
+                          copy.fb_exit, copy.fb_datum));
     return SUCCESS;
 }
 
@@ -715,10 +715,14 @@ codegen_setup_annotations_scope(compiler *c, location loc,
 
     // if .format > VALUE_WITH_FAKE_GLOBALS: raise NotImplementedError
     PyObject *value_with_fake_globals = PyLong_FromLong(_Py_ANNOTATE_FORMAT_VALUE_WITH_FAKE_GLOBALS);
+    if (value_with_fake_globals == NULL) {
+        return ERROR;
+    }
+
     assert(!SYMTABLE_ENTRY(c)->ste_has_docstring);
     _Py_DECLARE_STR(format, ".format");
     ADDOP_I(c, loc, LOAD_FAST, 0);
-    ADDOP_LOAD_CONST(c, loc, value_with_fake_globals);
+    ADDOP_LOAD_CONST_NEW(c, loc, value_with_fake_globals); // macro handles decref of value_with_fake_globals
     ADDOP_I(c, loc, COMPARE_OP, (Py_GT << 5) | compare_masks[Py_GT]);
     NEW_JUMP_TARGET_LABEL(c, body);
     ADDOP_JUMP(c, loc, POP_JUMP_IF_FALSE, body);
@@ -816,7 +820,7 @@ codegen_deferred_annotations_body(compiler *c, location loc,
 
         VISIT(c, expr, st->v.AnnAssign.annotation);
         ADDOP_I(c, LOC(st), COPY, 2);
-        ADDOP_LOAD_CONST_NEW(c, LOC(st), mangled);
+        ADDOP_LOAD_CONST_NEW(c, LOC(st), mangled); // macro handles decref of mangle
         // stack now contains <annos> <name> <annos> <value>
         ADDOP(c, loc, STORE_SUBSCR);
         // stack now contains <annos>
@@ -3279,7 +3283,11 @@ codegen_nameop(compiler *c, location loc,
     }
 
     int scope = _PyST_GetScope(SYMTABLE_ENTRY(c), mangled);
-    RETURN_IF_ERROR(scope);
+    if (scope == -1) {
+        Py_DECREF(mangled);
+        return ERROR;
+    }
+
     _PyCompile_optype optype;
     Py_ssize_t arg = 0;
     if (_PyCompile_ResolveNameop(c, mangled, scope, &optype, &arg) < 0) {

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -722,7 +722,7 @@ codegen_setup_annotations_scope(compiler *c, location loc,
     assert(!SYMTABLE_ENTRY(c)->ste_has_docstring);
     _Py_DECLARE_STR(format, ".format");
     ADDOP_I(c, loc, LOAD_FAST, 0);
-    ADDOP_LOAD_CONST_NEW(c, loc, value_with_fake_globals); // macro handles decref of value_with_fake_globals
+    ADDOP_LOAD_CONST_NEW(c, loc, value_with_fake_globals);
     ADDOP_I(c, loc, COMPARE_OP, (Py_GT << 5) | compare_masks[Py_GT]);
     NEW_JUMP_TARGET_LABEL(c, body);
     ADDOP_JUMP(c, loc, POP_JUMP_IF_FALSE, body);
@@ -823,7 +823,7 @@ codegen_deferred_annotations_body(compiler *c, location loc,
 
         VISIT(c, expr, st->v.AnnAssign.annotation);
         ADDOP_I(c, LOC(st), COPY, 2);
-        ADDOP_LOAD_CONST_NEW(c, LOC(st), mangled); // macro handles decref of mangle
+        ADDOP_LOAD_CONST_NEW(c, LOC(st), mangled);
         // stack now contains <annos> <name> <annos> <value>
         ADDOP(c, loc, STORE_SUBSCR);
         // stack now contains <annos>
@@ -3287,8 +3287,7 @@ codegen_nameop(compiler *c, location loc,
 
     int scope = _PyST_GetScope(SYMTABLE_ENTRY(c), mangled);
     if (scope == -1) {
-        Py_DECREF(mangled);
-        return ERROR;
+        goto error;
     }
 
     _PyCompile_optype optype;

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -799,7 +799,7 @@ codegen_deferred_annotations_body(compiler *c, location loc,
             return ERROR;
         }
         // NOTE: ref of mangled can be leaked on ADDOP* and VISIT macros due to early returns
-        // fixing would require an overhaul of these macros 
+        // fixing would require an overhaul of these macros
 
         PyObject *cond_index = PyList_GET_ITEM(conditional_annotation_indices, i);
         assert(PyLong_CheckExact(cond_index));

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1100,18 +1100,22 @@ _PyCompile_TweakInlinedComprehensionScopes(compiler *c, location loc,
                 assert(orig == NULL || orig == Py_True || orig == Py_False);
                 if (orig != Py_True) {
                     if (PyDict_SetItem(c->u->u_metadata.u_fasthidden, k, Py_True) < 0) {
+                        Py_XDECREF(orig);
                         return ERROR;
                     }
                     if (state->fast_hidden == NULL) {
                         state->fast_hidden = PySet_New(NULL);
                         if (state->fast_hidden == NULL) {
+                            Py_XDECREF(orig);
                             return ERROR;
                         }
                     }
                     if (PySet_Add(state->fast_hidden, k) < 0) {
+                        Py_XDECREF(orig);
                         return ERROR;
                     }
                 }
+                Py_XDECREF(orig);
             }
         }
     }


### PR DESCRIPTION
# Compiler Pipeline (codegen + compile + symtable + flowgraph + assemble) | 6 FIX

## codegen.c (6,632 lines) — 4 FIX
1. **NULL deref + ref leak in `codegen_setup_annotations_scope` (line 716-720)**: `PyLong_FromLong` result not NULL-checked, passed to `ADDOP_LOAD_CONST` which dereferences it. Also never DECREF'd even on success.
2. **Ref leak of `mangled` in `codegen_nameop` (line 3280)**: `RETURN_IF_ERROR(scope)` early-returns without DECREF'ing `mangled` from `_PyCompile_MaybeMangle`.
3. **Unchecked `_PyCompile_PushFBlock` in `codegen_unwind_fblock_stack` (line 669)**: Return value silently discarded, error lost, frame block stack left inconsistent.

## compile.c (1,772 lines) — 1 FIX
1. **Ref leak of `orig` in `_PyCompile_TweakInlinedComprehensionScopes` (line 1096-1114)**: `PyDict_GetItemRef` returns new ref in `orig`, never DECREF'd on any path (success or error). Leaks on every inlined comprehension.

## assemble.c (802 lines) — 1 FIX
1. **`assemble_emit_instr` returns ERROR without exception (line 420-421)**: Bytecode overflow check returns ERROR without `PyErr_NoMemory()` → SystemError.

## symtable.c (3,355 lines) — 0 FIX (clean)
## flowgraph.c (4,088 lines) — 0 FIX (clean)

## Did not fix
1. **Ref leak of `mangled` in `codegen_deferred_annotations_body` (line 792-818)**
    - I do not see a simple way to fix this without overhauling the macros (ADDOP* & VISIT) that can early return


<!-- gh-issue-number: gh-146102 -->
* Issue: gh-146102
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-146442 -->
* Issue: gh-146442
<!-- /gh-issue-number -->
