### PR TITLE
gh-146446: Miscellaneous improvements to iOS XCframework build script

### DIFF
--- a/Apple/__main__.py
+++ b/Apple/__main__.py
@@ -380,7 +380,11 @@ def configure_host_python(
     with group(f"Downloading dependencies ({host})"):
         if not prefix_dir.exists():
             prefix_dir.mkdir()
-            cache_dir = context.cache_dir or CROSS_BUILD_DIR / "downloads"
+            cache_dir = (
+                Path(context.cache_dir).resolve()
+                if context.cache_dir
+                else CROSS_BUILD_DIR / "downloads"
+            )
             unpack_deps(context.platform, host, prefix_dir, cache_dir)
         else:
             print("Dependencies already installed")
@@ -993,6 +997,7 @@ def parse_args() -> argparse.Namespace:
     for cmd in [configure_host, build, ci]:
         cmd.add_argument(
             "--cache-dir",
+            default=os.environ.get("CACHE_DIR"),
             help="The directory to store cached downloads.",
         )
 

--- a/Apple/__main__.py
+++ b/Apple/__main__.py
@@ -175,25 +175,24 @@ def all_host_triples(platform: str) -> list[str]:
 
 def clean(context: argparse.Namespace, target: str | None = None) -> None:
     """The implementation of the "clean" command."""
+    if target is None:
+        target = context.host
+
     # If we're explicitly targeting the build, there's no platform or
     # distribution artefacts. If we're cleaning tests, we keep all built
     # artefacts. Otherwise, the built artefacts must be dirty, so we remove
     # them.
-    if target is None:
-        target = context.host
-
-    paths = []
+    if target not in {"build", "test"}:
+        paths = ["dist", context.platform] + list(HOSTS[context.platform])
+    else:
+        paths = []
 
     if target in {"all", "build"}:
         paths.append("build")
 
-    if target in {"all", "hosts", "package"}:
-        paths.append("dist")
-        paths.extend(list(HOSTS[context.platform]))
-        paths.append(context.platform)
-        if target != "package":
-            paths.extend(all_host_triples(context.platform))
-    elif target not in {"build", "test"}:
+    if target in {"all", "hosts"}:
+        paths.extend(all_host_triples(context.platform))
+    elif target not in {"build", "test", "package"}:
         paths.append(target)
 
     if target in {"all", "hosts", "test"}:

--- a/Apple/__main__.py
+++ b/Apple/__main__.py
@@ -832,7 +832,7 @@ def test(context: argparse.Namespace, host: str | None = None) -> None:  # noqa:
             + [
                 "--",
                 "test",
-                f"--{context.ci_mode}-ci",
+                f"--{context.ci_mode or 'fast'}-ci",
                 "--single-process",
                 "--no-randomize",
                 # Timeout handling requires subprocesses; explicitly setting

--- a/Apple/__main__.py
+++ b/Apple/__main__.py
@@ -381,7 +381,8 @@ def configure_host_python(
     with group(f"Downloading dependencies ({host})"):
         if not prefix_dir.exists():
             prefix_dir.mkdir()
-            unpack_deps(context.platform, host, prefix_dir, context.cache_dir)
+            cache_dir = context.cache_dir or CROSS_BUILD_DIR / "downloads"
+            unpack_deps(context.platform, host, prefix_dir, cache_dir)
         else:
             print("Dependencies already installed")
 
@@ -898,7 +899,7 @@ def parse_args() -> argparse.Namespace:
     configure_build = subcommands.add_parser(
         "configure-build", help="Run `configure` for the build Python"
     )
-    subcommands.add_parser(
+    make_build = subcommands.add_parser(
         "make-build", help="Run `make` for the build Python"
     )
     configure_host = subcommands.add_parser(
@@ -954,6 +955,31 @@ def parse_args() -> argparse.Namespace:
             ),
         )
 
+    # --cross-build-dir argument
+    for cmd in [
+        clean,
+        configure_build,
+        make_build,
+        configure_host,
+        make_host,
+        build,
+        package,
+        test,
+        ci,
+    ]:
+        cmd.add_argument(
+            "--cross-build-dir",
+            action="store",
+            default=os.environ.get("CROSS_BUILD_DIR"),
+            dest="cross_build_dir",
+            type=Path,
+            help=(
+                "Path to the cross-build directory "
+                f"(default: {CROSS_BUILD_DIR}). Can also be set "
+                "with the CROSS_BUILD_DIR environment variable."
+            ),
+        )
+
     # --clean option
     for cmd in [configure_build, configure_host, build, package, test, ci]:
         cmd.add_argument(
@@ -968,7 +994,6 @@ def parse_args() -> argparse.Namespace:
     for cmd in [configure_host, build, ci]:
         cmd.add_argument(
             "--cache-dir",
-            default="./cross-build/downloads",
             help="The directory to store cached downloads.",
         )
 
@@ -1035,6 +1060,12 @@ def main() -> None:
 
     # Process command line arguments
     context = parse_args()
+
+    # Set the CROSS_BUILD_DIR if an argument was provided
+    if context.cross_build_dir:
+        global CROSS_BUILD_DIR
+        CROSS_BUILD_DIR = context.cross_build_dir.resolve()
+
     dispatch: dict[str, Callable] = {
         "clean": clean,
         "configure-build": configure_build_python,

--- a/Apple/__main__.py
+++ b/Apple/__main__.py
@@ -173,23 +173,27 @@ def all_host_triples(platform: str) -> list[str]:
     return triples
 
 
-def clean(context: argparse.Namespace, target: str = "all") -> None:
+def clean(context: argparse.Namespace, target: str | None = None) -> None:
     """The implementation of the "clean" command."""
     # If we're explicitly targeting the build, there's no platform or
     # distribution artefacts. If we're cleaning tests, we keep all built
     # artefacts. Otherwise, the built artefacts must be dirty, so we remove
     # them.
-    if target not in {"build", "test"}:
-        paths = ["dist", context.platform] + list(HOSTS[context.platform])
-    else:
-        paths = []
+    if target is None:
+        target = context.host
+
+    paths = []
 
     if target in {"all", "build"}:
         paths.append("build")
 
-    if target in {"all", "hosts"}:
-        paths.extend(all_host_triples(context.platform))
-    elif target not in {"build", "test", "package"}:
+    if target in {"all", "hosts", "package"}:
+        paths.append("dist")
+        paths.extend(list(HOSTS[context.platform]))
+        paths.append(context.platform)
+        if target != "package":
+            paths.extend(all_host_triples(context.platform))
+    elif target not in {"build", "test"}:
         paths.append(target)
 
     if target in {"all", "hosts", "test"}:

--- a/Misc/NEWS.d/next/Build/2026-03-26-12-48-42.gh-issue-146446.0GyMu4.rst
+++ b/Misc/NEWS.d/next/Build/2026-03-26-12-48-42.gh-issue-146446.0GyMu4.rst
@@ -1,0 +1,2 @@
+The clean target for the Apple/iOS XCframework build script is now more
+selective when targeting a single architecture.


### PR DESCRIPTION
Three improvements to the Apple/iOS XCframework build script:

1. Honor the target that is selected for a clean target unless it's specifically overridden
2. Ensures a valid fallback value if `--slow-ci` or `--fast-ci` isn't specified to the `test` command
3. Allows for the location of the `cross-build` folder to be customised. This makes it easier to maintain multiple versions of iOS.

<!-- gh-issue-number: gh-146446 -->
* Issue: gh-146446
<!-- /gh-issue-number -->
