### PR TITLE
gh-146453: fix `_PyType_LookupByVersion` for types with fixed pre-defined version tags

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -3017,6 +3017,20 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertNotIn("_LOAD_ATTR_METHOD_NO_DICT", uops)
         self.assertNotIn("_LOAD_ATTR_METHOD_LAZY_DICT", uops)
 
+    def test_cached_attributes_fixed_version_tag(self):
+        def f(n):
+            c = 1
+            x = 0
+            for _ in range(n):
+                x += c.bit_length()
+            return x
+
+        res, ex = self._run_with_optimizer(f, TIER2_THRESHOLD)
+        self.assertIsNotNone(ex)
+        self.assertEqual(res, TIER2_THRESHOLD)
+        uops = get_opnames(ex)
+        self.assertNotIn("_LOAD_ATTR_METHOD_NO_DICT", uops)
+
     def test_store_fast_refcount_elimination(self):
         def foo(x):
             # Since x is known to be

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1349,6 +1349,35 @@ _PyType_LookupByVersion(unsigned int version)
 #ifdef Py_GIL_DISABLED
     return NULL;
 #else
+    switch (version) {
+        case _Py_TYPE_VERSION_INT:
+            return &PyLong_Type;
+        case _Py_TYPE_VERSION_FLOAT:
+            return &PyFloat_Type;
+        case _Py_TYPE_VERSION_LIST:
+            return &PyList_Type;
+        case _Py_TYPE_VERSION_TUPLE:
+            return &PyTuple_Type;
+        case _Py_TYPE_VERSION_STR:
+            return &PyUnicode_Type;
+        case _Py_TYPE_VERSION_SET:
+            return &PySet_Type;
+        case _Py_TYPE_VERSION_FROZEN_SET:
+            return &PyFrozenSet_Type;
+        case _Py_TYPE_VERSION_DICT:
+            return &PyDict_Type;
+        case _Py_TYPE_VERSION_BYTEARRAY:
+            return &PyByteArray_Type;
+        case _Py_TYPE_VERSION_BYTES:
+            return &PyBytes_Type;
+        case _Py_TYPE_VERSION_COMPLEX:
+            return &PyComplex_Type;
+        case _Py_TYPE_VERSION_FROZENDICT:
+            return &PyFrozenDict_Type;
+        default:
+            break;
+    }
+
     PyInterpreterState *interp = _PyInterpreterState_GET();
     PyTypeObject **slot =
         interp->types.type_version_cache


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146453 -->
* Issue: gh-146453
<!-- /gh-issue-number -->

Without the fix on current main branch, the added test fails:
```console
./python -m test test_capi.test_opt -m test_cached_attributes_fixed_version_tag -v   
== CPython 3.15.0a7+ (heads/type-version-dirty:eeacb3eab0b, Mar 26 2026, 14:11:52) [Clang 21.1.8 (++20251221032922+2078da43e25a-1~exp1~2025
1221153059.70)]                                                                                                                            == Linux-6.6.87.2-microsoft-standard-WSL2-x86_64-with-glibc2.39 little-endian
== Python build: debug JIT
== cwd: /home/realkumaraditya/cpython/build/test_python_worker_37285æ
== CPU count: 12
== encodings: locale=UTF-8 FS=utf-8
== resources: all test resources are disabled, use -u option to unskip tests

Using random seed: 1734361391
0:00:00 load avg: 1.83 Run 1 test sequentially in a single process
0:00:00 load avg: 1.83 [1/1] test_capi.test_opt
test_cached_attributes_fixed_version_tag (test.test_capi.test_opt.TestUopsOptimization.test_cached_attributes_fixed_version_tag) ... FAIL

======================================================================
FAIL: test_cached_attributes_fixed_version_tag (test.test_capi.test_opt.TestUopsOptimization.test_cached_attributes_fixed_version_tag)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/realkumaraditya/cpython/Lib/test/test_capi/test_opt.py", line 3032, in test_cached_attributes_fixed_version_tag
    self.assertNotIn("_LOAD_ATTR_METHOD_NO_DICT", uops)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: '_LOAD_ATTR_METHOD_NO_DICT' unexpectedly found in ['_START_EXECUTOR', '_MAKE_WARM', '_SET_IP', '_CHECK_PERIODIC', '_CHECK_V
ALIDITY', '_ITER_CHECK_RANGE', '_GUARD_NOT_EXHAUSTED_RANGE', '_ITER_NEXT_RANGE', '_SET_IP', '_SWAP_FAST_3', '_SPILL_OR_RELOAD', '_POP_TOP', '_CHECK_VALIDITY', '_LOAD_FAST_BORROW_2', '_LOAD_FAST_BORROW_1', '_GUARD_TYPE_VERSION', '_LOAD_ATTR_METHOD_NO_DICT', '_SET_IP', '_SPILL_OR_RELOAD', '_CALL_METHOD_DESCRIPTOR_NOARGS', '_TIER2_RESUME_CHECK', '_CHECK_VALIDITY', '_GUARD_TOS_INT', '_GUARD_NOS_INT', '_BINARY_OP_ADD_INT', '_POP_TOP_INT', '_POP_TOP_NOP', '_SWAP_FAST_2', '_POP_TOP_INT', '_JUMP_TO_TOP', '_DEOPT', '_ERROR_POP_N', '_DEOPT', '_EXIT_TRACE', '_EXIT_TRACE', '_ERROR_POP_N', '_DEOPT', '_EXIT_TRACE', '_EXIT_TRACE', '_ERROR_POP_N', '_HANDLE_PENDING_AND_DEOPT', '_DEOPT', '_EXIT_TRACE', '_EXIT_TRACE']                                                                                                                              
----------------------------------------------------------------------
Ran 1 test in 0.006s

FAILED (failures=1)
test test_capi.test_opt failed
0:00:00 load avg: 1.83 [1/1/1] test_capi.test_opt failed (1 failure)

== Tests result: FAILURE ==

1 test failed:
    test_capi.test_opt

Total duration: 108 ms
Total tests: run=1 (filtered) failures=1
Total test files: run=1/1 (filtered) failed=1
Result: FAILURE

```
