### PR TITLE
gh-146458: Fix repl height and width tracking on resize

### DIFF
--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -644,6 +644,7 @@ class Reader:
 
     def refresh(self) -> None:
         """Recalculate and refresh the screen."""
+        self.console.height, self.console.width = self.console.getheightwidth()
         # this call sets up self.cxy, so call it first.
         self.screen = self.calc_screen()
         self.console.refresh(self.screen, self.cxy)

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -776,7 +776,6 @@ class UnixConsole(Console):
         self.__write_code(self._cup, y - self.__offset, x)
 
     def __sigwinch(self, signum, frame):
-        self.height, self.width = self.getheightwidth()
         self.event_queue.insert(Event("resize", None))
 
     def __hide_cursor(self):

--- a/Lib/test/test_pyrepl/support.py
+++ b/Lib/test/test_pyrepl/support.py
@@ -88,6 +88,8 @@ def prepare_console(events: Iterable[Event], **kwargs) -> MagicMock | Console:
     console.get_event.side_effect = events
     console.height = 100
     console.width = 80
+    console.getheightwidth = MagicMock(side_effect=lambda: (console.height, console.width))
+
     for key, val in kwargs.items():
         setattr(console, key, val)
     return console

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -228,6 +228,7 @@ class TestReader(ScreenEqualMixin, TestCase):
             console.get_event.side_effect = events
             console.height = 100
             console.width = 80
+            console.getheightwidth = MagicMock(side_effect=lambda: (console.height, console.width))
             console.input_hook = input_hook
             return console
 

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -250,8 +250,7 @@ class TestConsole(TestCase):
         events = itertools.chain(code_to_events(code))
         reader, console = handle_events_short_unix_console(events)
 
-        console.height = 2
-        console.getheightwidth = MagicMock(lambda _: (2, 80))
+        console.getheightwidth = MagicMock(side_effect=lambda: (2, 80))
 
         def same_reader(_):
             return reader
@@ -286,8 +285,7 @@ class TestConsole(TestCase):
         events = itertools.chain(code_to_events(code))
         reader, console = handle_events_unix_console_height_3(events)
 
-        console.height = 1
-        console.getheightwidth = MagicMock(lambda _: (1, 80))
+        console.getheightwidth = MagicMock(side_effect=lambda: (1, 80))
 
         def same_reader(_):
             return reader

--- a/Lib/test/test_pyrepl/test_windows_console.py
+++ b/Lib/test/test_pyrepl/test_windows_console.py
@@ -129,9 +129,7 @@ class WindowsConsoleTests(TestCase):
         events = code_to_events(code)
         reader, console = self.handle_events_narrow(events)
 
-        console.height = 20
-        console.width = 80
-        console.getheightwidth = MagicMock(lambda _: (20, 80))
+        console.getheightwidth = MagicMock(side_effect=lambda: (20, 80))
 
         def same_reader(_):
             return reader
@@ -157,9 +155,7 @@ class WindowsConsoleTests(TestCase):
         events = code_to_events(code)
         reader, console = self.handle_events(events)
 
-        console.height = 20
-        console.width = 4
-        console.getheightwidth = MagicMock(lambda _: (20, 4))
+        console.getheightwidth = MagicMock(side_effect=lambda: (20, 4))
 
         def same_reader(_):
             return reader
@@ -292,8 +288,7 @@ class WindowsConsoleTests(TestCase):
         events = itertools.chain(code_to_events(code))
         reader, console = self.handle_events_short(events)
 
-        console.height = 2
-        console.getheightwidth = MagicMock(lambda _: (2, 80))
+        console.getheightwidth = MagicMock(side_effect=lambda: (2, 80))
 
         def same_reader(_):
             return reader
@@ -330,8 +325,7 @@ class WindowsConsoleTests(TestCase):
         events = itertools.chain(code_to_events(code))
         reader, console = self.handle_events_height_3(events)
 
-        console.height = 1
-        console.getheightwidth = MagicMock(lambda _: (1, 80))
+        console.getheightwidth = MagicMock(side_effect=lambda: (1, 80))
 
         def same_reader(_):
             return reader

--- a/Misc/NEWS.d/next/Windows/2026-03-27-22-06-10.gh-issue-146458.fYj0UQ.rst
+++ b/Misc/NEWS.d/next/Windows/2026-03-27-22-06-10.gh-issue-146458.fYj0UQ.rst
@@ -1,1 +1,1 @@
-Fix incorrect REPL height and width tracking on console window resize
+Fix incorrect REPL height and width tracking on console window resize on Windows.

--- a/Misc/NEWS.d/next/Windows/2026-03-27-22-06-10.gh-issue-146458.fYj0UQ.rst
+++ b/Misc/NEWS.d/next/Windows/2026-03-27-22-06-10.gh-issue-146458.fYj0UQ.rst
@@ -1,0 +1,1 @@
+Fix incorrect REPL height and width tracking on console window resize


### PR DESCRIPTION
On windows, the resize event should be triggering an update in the console height and width, however this is not happening.

I noticed the Unix console didn't have this problem, it was updating fine. My suggestion to fixing this is taking the resizing logic from both console implementations and let it at the reader level, that way it will update both (Unix and windows).

After adding this change, the resizing was happening:

https://github.com/user-attachments/assets/6df6e1a2-45af-4a1b-af2c-1b019ac9a2db

The tests then started failing as the Magic Mocks to `getheightwidth` weren't actually returning a tuple with the height and width, so I changed it by adding the `side_effect` keyword and sending a lambda with the values. With that addition, the tests are actually testing if the resize is happening, if you comment out the height and width resizing logic, they will fail.


<!-- gh-issue-number: gh-146458 -->
* Issue: gh-146458
<!-- /gh-issue-number -->
