### PR TITLE
gh-146475: Block Apple LLVM 21 from passing JIT tool version check

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-03-26-23-40-21.gh-issue-146475.F9KMLP.rst
+++ b/Misc/NEWS.d/next/Build/2026-03-26-23-40-21.gh-issue-146475.F9KMLP.rst
@@ -1,0 +1,2 @@
+Block Apple LLVM 21 from passing the JIT tool version check, as the JIT is
+incompatible with it.

--- a/Tools/jit/_llvm.py
+++ b/Tools/jit/_llvm.py
@@ -59,7 +59,7 @@ async def _check_tool_version(
     name: str, llvm_version: str, *, echo: bool = False
 ) -> bool:
     output = await _run(name, ["--version"], echo=echo)
-    _llvm_version_pattern = re.compile(rf"version\s+{llvm_version}\.\d+\.\d+\S*\s+")
+    _llvm_version_pattern = re.compile(rf"(?<!Apple )LLVM version\s+{llvm_version}\.\d+\.\d+\S*\s+")
     return bool(output and _llvm_version_pattern.search(output))
 
 


### PR DESCRIPTION
Fixes #146475

The JIT is incompatible with Apple LLVM 21, but the tool version 
check was passing it through. This change blocks Apple LLVM 21 
from passing the check.

<!-- gh-issue-number: gh-146475 -->
* Issue: gh-146475
<!-- /gh-issue-number -->
