### PR TITLE
fix: pin 10 unpinned action(s)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -512,7 +512,7 @@ jobs:
     - name: Install dependencies
       run: sudo ./.github/workflows/posix-deps-apt.sh
     - name: Set up GCC-10 for ASAN
-      uses: egor-tensin/setup-gcc@v2
+      uses: egor-tensin/setup-gcc@a2861a8b8538f49cf2850980acccf6b05a1b2ae4 # v2
       with:
         version: 10
     - name: Configure OpenSSL env vars

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: readthedocs/actions/preview@v1
+      - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1
         with:
           project-slug: "cpython-previews"
           single-version: "true"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,4 +22,4 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: j178/prek-action@v1
+      - uses: j178/prek-action@0bb87d7f00b0c99306c8bcb8b8beba1eb581c037 # v1

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check there's no DO-NOT-MERGE
-        uses: mheap/github-action-required-labels@v5
+        uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
         with:
           mode: exactly
           count: 0
@@ -33,7 +33,7 @@ jobs:
     steps:
       # Check that the PR is not awaiting changes from the author due to previous review.
       - name: Check there's no required changes
-        uses: mheap/github-action-required-labels@v5
+        uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
         with:
           mode: exactly
           count: 0
@@ -42,7 +42,7 @@ jobs:
             awaiting change review
       - id: is-feature
         name: Check whether this PR is a feature (contains a "type-feature" label)
-        uses: mheap/github-action-required-labels@v5
+        uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
         with:
           mode: exactly
           count: 1
@@ -53,7 +53,7 @@ jobs:
       - id: awaiting-merge
         if: steps.is-feature.outputs.status == 'success'
         name: Check for complete review
-        uses: mheap/github-action-required-labels@v5
+        uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
         with:
           mode: exactly
           count: 1

--- a/.github/workflows/reusable-cifuzz.yml
+++ b/.github/workflows/reusable-cifuzz.yml
@@ -21,12 +21,12 @@ jobs:
     steps:
       - name: Build fuzzers (${{ inputs.sanitizer }})
         id: build
-        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@51fea8a581a325b79f2af174b9f7c04333c283c0 # master
         with:
           oss-fuzz-project-name: ${{ inputs.oss-fuzz-project-name }}
           sanitizer: ${{ inputs.sanitizer }}
       - name: Run fuzzers (${{ inputs.sanitizer }})
-        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@51fea8a581a325b79f2af174b9f7c04333c283c0 # master
         with:
           fuzz-seconds: 600
           oss-fuzz-project-name: ${{ inputs.oss-fuzz-project-name }}

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -21,7 +21,7 @@ jobs:
         persist-credentials: false
     # No problem resolver registered as one doesn't currently exist for Clang.
     - name: "Install wasmtime"
-      uses: bytecodealliance/actions/wasmtime/setup@v1
+      uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1
       with:
         version: ${{ env.WASMTIME_VERSION }}
     - name: "Read WASI SDK version"


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/build.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/documentation-links.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/lint.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/require-pr-label.yml` | Pinned 4 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/reusable-cifuzz.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/reusable-wasi.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-006 | high | `.github/workflows/jit.yml` | Curl-Pipe-Bash Remote Code Execution |
| RGS-006 | high | `.github/workflows/jit.yml` | Curl-Pipe-Bash Remote Code Execution |
| RGS-006 | high | `.github/workflows/reusable-ubuntu.yml` | Curl-Pipe-Bash Remote Code Execution |
| RGS-006 | high | `.github/workflows/tail-call.yml` | Curl-Pipe-Bash Remote Code Execution |
| RGS-005 | medium | `.github/workflows/documentation-links.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)


Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.