### PR TITLE
gh-146498: Ensure binary content is correctly processed in multi-arch iOS XCframeworks

### DIFF
--- a/Apple/testbed/Python.xcframework/build/utils.sh
+++ b/Apple/testbed/Python.xcframework/build/utils.sh
@@ -42,11 +42,11 @@ install_stdlib() {
     # If the XCframework has a shared lib folder, then it's a full framework.
     # Copy both the common and slice-specific part of the lib directory.
     # Otherwise, it's a single-arch framework; use the "full" lib folder.
+    # Don't include any libpython symlink; that can't be included at runtime
     if [ -d "$PROJECT_DIR/$PYTHON_XCFRAMEWORK_PATH/lib" ]; then
-        rsync -au --delete "$PROJECT_DIR/$PYTHON_XCFRAMEWORK_PATH/lib/" "$CODESIGNING_FOLDER_PATH/python/lib/"
-        rsync -au "$PROJECT_DIR/$PYTHON_XCFRAMEWORK_PATH/$SLICE_FOLDER/lib-$ARCHS/" "$CODESIGNING_FOLDER_PATH/python/lib/"
+        rsync -au --delete "$PROJECT_DIR/$PYTHON_XCFRAMEWORK_PATH/lib/" "$CODESIGNING_FOLDER_PATH/python/lib/" --exclude 'libpython*.dylib'
+        rsync -au "$PROJECT_DIR/$PYTHON_XCFRAMEWORK_PATH/$SLICE_FOLDER/lib-$ARCHS/" "$CODESIGNING_FOLDER_PATH/python/lib/" --exclude 'libpython*.dylib'
     else
-        # A single-arch framework will have a libpython symlink; that can't be included at runtime
         rsync -au --delete "$PROJECT_DIR/$PYTHON_XCFRAMEWORK_PATH/$SLICE_FOLDER/lib/" "$CODESIGNING_FOLDER_PATH/python/lib/" --exclude 'libpython*.dylib'
     fi
 }
@@ -140,7 +140,7 @@ install_python() {
     shift
 
     install_stdlib $PYTHON_XCFRAMEWORK_PATH
-    PYTHON_VER=$(ls -1 "$CODESIGNING_FOLDER_PATH/python/lib")
+    PYTHON_VER=$(ls -1 "$CODESIGNING_FOLDER_PATH/python/lib" | grep -E "^python3\.\d+$")
     echo "Install Python $PYTHON_VER standard library extension modules..."
     process_dylibs $PYTHON_XCFRAMEWORK_PATH python/lib/$PYTHON_VER/lib-dynload
 

--- a/Misc/NEWS.d/next/Build/2026-03-27-06-55-10.gh-issue-146498.uOiCab.rst
+++ b/Misc/NEWS.d/next/Build/2026-03-27-06-55-10.gh-issue-146498.uOiCab.rst
@@ -1,0 +1,3 @@
+The iOS XCframework build script now ensures libpython isn't included in
+installed app content, and is more robust in identifying standard library
+binary content that requires processing.


### PR DESCRIPTION
Modifies the iOS XCframework processing script so that:

1. The libpython dylib is explicitly excluded from being copied, no matter whether the framework is thin or multi-arch
2. The identification mechanism that looks for the standard library is more robust to additional content in the folder.

<!-- gh-issue-number: gh-146498 -->
* Issue: gh-146498
<!-- /gh-issue-number -->
