### PR TITLE
gh-138580: revert PR 138811

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -848,8 +848,7 @@ Constants
 
    The :mod:`!math` module consists mostly of thin wrappers around the platform C
    math library functions.  Behavior in exceptional cases follows Annex F of
-   the C99 standard, if :attr:`sys.float_info.iec_60559` is true.
-   The current implementation will raise
+   the C99 standard where appropriate.  The current implementation will raise
    :exc:`ValueError` for invalid operations like ``sqrt(-1.0)`` or ``log(0.0)``
    (where C99 Annex F recommends signaling invalid operation or divide-by-zero),
    and :exc:`OverflowError` for results that overflow (for example,

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -694,16 +694,15 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    A :term:`named tuple` holding information about the float type. It
    contains low level information about the precision and internal
    representation.  The values correspond to the various floating-point
-   constants defined by C implementation and in the standard header file
-   :file:`float.h` for the 'C' programming language; see Annex F and section
-   5.2.4.2.2 of the 1999 ISO/IEC C standard [C99]_, 'Characteristics of
-   floating types', for details.
+   constants defined in the standard header file :file:`float.h` for the 'C'
+   programming language; see section 5.2.4.2.2 of the 1999 ISO/IEC C standard
+   [C99]_, 'Characteristics of floating types', for details.
 
    .. list-table:: Attributes of the :data:`!float_info` :term:`named tuple`
       :header-rows: 1
 
       * - attribute
-        - C macro
+        - float.h macro
         - explanation
 
       * - .. attribute:: float_info.epsilon
@@ -771,12 +770,6 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
           All other values for :c:macro:`!FLT_ROUNDS` characterize
           implementation-defined rounding behavior.
-
-      * - .. attribute:: float_info.iec_60559
-        - :c:macro:`!__STDC_IEC_559__`
-        - A boolean, indicating support the IEC 60559 floating-point standard.
-          If true, the :class:`float` type characteristics and behavior matches
-          the IEC 60559 double format.
 
    The attribute :attr:`sys.float_info.dig` needs further explanation.  If
    ``s`` is any string representing a decimal number with at most

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1028,11 +1028,6 @@ sys
 * Add :data:`sys.abi_info` namespace to improve access to ABI information.
   (Contributed by Klaus Zimmermann in :gh:`137476`.)
 
-* Add :data:`sys.float_info.iec_60559 <sys.float_info>`: a boolean flag,
-  indicating support the IEC 60559 floating-point standard (as specified by the
-  Annex F of C99).
-  (Contributed by Sergey B Kirpichev in :gh:`138580`.)
-
 
 tarfile
 -------

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -641,7 +641,7 @@ class SysModuleTest(unittest.TestCase):
         self.assertIsInstance(sys.exec_prefix, str)
         self.assertIsInstance(sys.base_exec_prefix, str)
         self.assertIsInstance(sys.executable, str)
-        self.assertEqual(len(sys.float_info), 12)
+        self.assertEqual(len(sys.float_info), 11)
         self.assertEqual(sys.float_info.radix, 2)
         self.assertEqual(len(sys.int_info), 4)
         self.assertTrue(sys.int_info.bits_per_digit % 5 == 0)

--- a/Misc/NEWS.d/next/Library/2025-09-12-07-30-13.gh-issue-138580.Qr_fSH.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-12-07-30-13.gh-issue-138580.Qr_fSH.rst
@@ -1,3 +1,0 @@
-Add :data:`sys.float_info.iec_60559 <sys.float_info>`: a boolean flag,
-indicating support the IEC 60559 floating-point standard (as specified by the
-Annex F of C99).  Patch by Sergey B Kirpichev.

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -68,8 +68,6 @@ static PyStructSequence_Field floatinfo_fields[] = {
     {"radix",           "FLT_RADIX -- radix of exponent"},
     {"rounds",          "FLT_ROUNDS -- rounding mode used for arithmetic "
                     "operations"},
-    {"iec_60559",   "test if implementation supports the IEC 60559 "
-                    "floating-point standard"},
     {0}
 };
 
@@ -77,7 +75,7 @@ static PyStructSequence_Desc floatinfo_desc = {
     "sys.float_info",           /* name */
     floatinfo__doc__,           /* doc */
     floatinfo_fields,           /* fields */
-    12
+    11
 };
 
 PyObject *
@@ -115,11 +113,6 @@ PyFloat_GetInfo(void)
     SetDblFlag(DBL_EPSILON);
     SetIntFlag(FLT_RADIX);
     SetIntFlag(FLT_ROUNDS);
-#ifdef __STDC_IEC_559__
-    SetFlag(PyBool_FromLong(1));
-#else
-    SetFlag(PyBool_FromLong(0));
-#endif
 #undef SetIntFlag
 #undef SetDblFlag
 #undef SetFlag


### PR DESCRIPTION
This reverts commit 68c7fad757f3a99fca257d11ce61adb78128a66c.

It looks like on practice the `__STDC_IEC_559__` doesn't indicate conformance to the standard. It can't be used to filter out tests or to give some promises in documentation.  See discussion in the reverted PR thread:
https://github.com/python/cpython/pull/138811#issuecomment-4117692418

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-138580 -->
* Issue: gh-138580
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146501.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->