### PR TITLE
gh-145629: Expand block inlining to enable LOAD_FAST_BORROW optimization for return ternary expressions

### DIFF
--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1129,6 +1129,14 @@ class TestMarkingVariablesAsUnKnown(BytecodeTestCase):
             print(ExecError)
         self.assertInBytecode(f, "LOAD_FAST_BORROW", "self")
 
+    def test_ternary_expression_uses_load_fast_borrow(self):
+        def f(a, b):
+            return a if a < b else b
+
+        self.assertNotInBytecode(f, "LOAD_FAST")
+        self.assertInBytecode(f, "LOAD_FAST_BORROW", "a")
+        self.assertInBytecode(f, "LOAD_FAST_BORROW", "b")
+
 class DirectCfgOptimizerTests(CfgOptimizationTestCase):
 
     def cfg_optimization_test(self, insts, expected_insts,

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-27-04-16-08.gh-issue-145629.eLFhwn.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-27-04-16-08.gh-issue-145629.eLFhwn.rst
@@ -1,0 +1,1 @@
+Fix missed ``LOAD_FAST_BORROW`` optimization for ternary expressions by improving basic block inlining during the compiler's control flow graph optimization phase.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1218,6 +1218,7 @@ basicblock_has_no_lineno(basicblock *b) {
 /* If this block ends with an unconditional jump to a small exit block or
  * a block that has no line numbers (and no fallthrough), then
  * remove the jump and extend this block with the target.
+ * Also handles the case where a block falls through to a small exit block.
  * Returns 1 if extended, 0 if no change, and -1 on error.
  */
 static int
@@ -1227,6 +1228,15 @@ basicblock_inline_small_or_no_lineno_blocks(basicblock *bb) {
         return 0;
     }
     if (!IS_UNCONDITIONAL_JUMP_OPCODE(last->i_opcode)) {
+        // If the block ends with a fallthrough to a small exit block, inline it.
+        if (BB_HAS_FALLTHROUGH(bb) && bb->b_next != NULL && !is_jump(last)) {
+            basicblock *next = bb->b_next;
+            if (basicblock_exits_scope(next) && next->b_iused <= MAX_COPY_SIZE) {
+                RETURN_IF_ERROR(basicblock_append_instructions(bb, next));
+                next->b_predecessors--;
+                return 1;
+            }
+        }
         return 0;
     }
     basicblock *target = last->i_target;


### PR DESCRIPTION
In existing CFG optimization logic, for equivalent conditional code, ternary expressions do not get the `LOAD_FAST` optimization applied, unlike standard `if/else` statements:

```python
# Ternary Expression
def f(a, b):
    return a if a < b else b

# if/else
def g(a, b):
    if a < b:
        return a
    else:
        return b
```

The return in the `if/else` branch is successfully optimized to `LOAD_FAST_BORROW`, whereas the `else` branch in the ternary expression can only generate a standard `LOAD_FAST`.

Before being passed to `optimize_load_fast` (the entry point for the reference checking phase), the control flow graphs of the two structures exhibit subtle differences:

For **`if/else`**, its `else` branch naturally belongs to a single basic block, containing both the reference being loaded and the return instruction that consumes that reference:
```text
Block A (jump here from if failure):
    LOAD_FAST          1 (b)
    RETURN_VALUE
```
Because the local reference is consumed directly within this basic block, `optimize_load_fast` can determine that the safety constraint is satisfied and convert it into a prioritized `LOAD_FAST_BORROW`.

However, for a **trinary expression**, due to the structural characteristics of the AST, the code generator produces the following CFG, which prevents `optimize_load_fast` from performing the optimization: 
```text
Block A (evaluation of the else branch expression):
    LOAD_FAST          1 (b)
    || 
    \/
Block B (small exit return block):
    RETURN_VALUE
```

So this PR extends the inlining capabilities of `basicblock_inline_small_or_no_lineno_blocks`:
- When a basic block is connected to the next block via **Fallthrough** and **no conditional jump instructions** block the path, if the target block is an extremely small exit block (e.g., containing only `RETURN_VALUE`), we can still safely copy it directly and inline it at the end of the underlying block.



<!-- gh-issue-number: gh-145629 -->
* Issue: gh-145629
<!-- /gh-issue-number -->
