### PR TITLE
gh-52008: document that absolute paths can break use_errno=True in ct…

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1532,8 +1532,8 @@ way is to instantiate :py:class:`CDLL` or one of its subclasses:
       of the library than the one already linked into the process, the two
       instances have *separate* :data:`errno` variables and ctypes will swap the
       wrong one.  To avoid this, load the library by its unqualified name (e.g.
-      ``CDLL('libc.so.6')`` or use :func:`ctypes.util.find_library` to obtain
-      a name that the linker can resolve to the already-loaded instance.
+      ``CDLL('libc.so.6')``) or use :func:`!find_library` to obtain a name that
+      the linker can resolve to the already-loaded instance.
 
    The *use_last_error* parameter, when set to true, enables the same mechanism for
    the Windows error code which is managed by the :func:`GetLastError` and

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1524,6 +1524,17 @@ way is to instantiate :py:class:`CDLL` or one of its subclasses:
    copy, and the function :func:`ctypes.set_errno` changes the ctypes private copy
    to a new value and returns the former value.
 
+   .. note::
+
+      On some platforms (notably Linux), loading a library by absolute path (e.g.
+      ``CDLL('/lib/libc.so.6')``) may cause ``use_errno=True`` to malfunction.
+      If the absolute path resolves to a different :manpage:`dlopen(3)` instance
+      of the library than the one already linked into the process, the two
+      instances have *separate* :data:`errno` variables and ctypes will swap the
+      wrong one.  To avoid this, load the library by its unqualified name (e.g.
+      ``CDLL('libc.so.6')`` or use :func:`ctypes.util.find_library` to obtain
+      a name that the linker can resolve to the already-loaded instance.
+
    The *use_last_error* parameter, when set to true, enables the same mechanism for
    the Windows error code which is managed by the :func:`GetLastError` and
    :func:`!SetLastError` Windows API functions; :func:`ctypes.get_last_error` and

--- a/Misc/NEWS.d/next/Documentation/2026-03-26-00-00-00.gh-issue-52008.y2n4w9.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-03-26-00-00-00.gh-issue-52008.y2n4w9.rst
@@ -1,0 +1,4 @@
+Add a note to :class:`ctypes.CDLL` documenting that loading a shared library
+via an absolute path can silently break ``use_errno=True`` on Linux, because
+:manpage:`dlopen(3)` may return a separate library instance with its own
+:data:`errno` variable.


### PR DESCRIPTION
 Loading a shared library via an absolute path (e.g. `CDLL('/lib/libc.so.6')`)
  can cause `use_errno=True` to silently malfunction on Linux: `dlopen` may
  return a separate instance of the library with its own `errno` variable, so
  ctypes swaps the wrong one and `get_errno()` always returns 0.

  Adds a `.. note::` block to the `use_errno` parameter docs in
  `Doc/library/ctypes.rst` warning about this and recommending the use of an
  unqualified name or `ctypes.util.find_library` instead.

  Fixes gh-52008

  - Base: python/cpython:main
  - Head: Das-Chinmay:fix-ctypes-use-errno-docs

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146504.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->