### PR TITLE
gh-72088: clarify inspect.ismethod returns False for class-level access

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -425,6 +425,11 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
 
    Return ``True`` if the object is a bound method written in Python.
 
+   Note that accessing a method through the class (rather than an instance)
+   returns a plain :term:`function`, not a bound method, so :func:`ismethod`
+   will return ``False`` in that case.  See :ref:`instance-methods` in the
+   language reference for details.
+
 
 .. function:: ispackage(object)
 


### PR DESCRIPTION
 `inspect.ismethod()` returns `False` when a method is accessed through the
  class rather than an instance (because the result is a plain function, not a
  bound method). This trips up users coming from Python 2, where unbound methods
  existed. The current one-liner docstring gives no hint of this behaviour.

  Adds a short note and a cross-reference to the `instance-methods` section of
  the language reference so readers can understand why.

  Fixes issue gh-72088

  - Base: python/cpython:main
  - Head: Das-Chinmay:fix-inspect-ismethod-docs

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146505.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->