### PR TITLE
[3.14] Fix possible memory leak in OrderedDict popitem (GH-145247)

### DIFF
--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1168,8 +1168,10 @@ OrderedDict_popitem_impl(PyODictObject *self, int last)
     node = last ? _odict_LAST(self) : _odict_FIRST(self);
     key = Py_NewRef(_odictnode_KEY(node));
     value = _odict_popkey_hash((PyObject *)self, key, NULL, _odictnode_HASH(node));
-    if (value == NULL)
+    if (value == NULL) {
+        Py_DECREF(key);
         return NULL;
+    }
     item = PyTuple_Pack(2, key, value);
     Py_DECREF(key);
     Py_DECREF(value);


### PR DESCRIPTION
Was observed working on https://github.com/python/cpython/pull/145884

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145247 -->
* Issue: gh-145247
<!-- /gh-issue-number -->
