### PR TITLE
[3.13] gh-145616: Detect Android sysconfig ABI correctly on 32-bit ARM Android on 64-bit ARM kernel (GH-145617)

### DIFF
--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -644,11 +644,15 @@ def get_platform():
             release = get_config_var("ANDROID_API_LEVEL")
 
             # Wheel tags use the ABI names from Android's own tools.
+            # When Python is running on 32-bit ARM Android on a 64-bit ARM kernel,
+            # 'os.uname().machine' is 'armv8l'. Such devices run the same userspace
+            # code as 'armv7l' devices.
             machine = {
                 "x86_64": "x86_64",
                 "i686": "x86",
                 "aarch64": "arm64_v8a",
                 "armv7l": "armeabi_v7a",
+                "armv8l": "armeabi_v7a",
             }[machine]
         else:
             # At least on Linux/Intel, 'machine' is the processor --

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -377,6 +377,7 @@ class TestSysConfig(unittest.TestCase):
             'i686': 'x86',
             'aarch64': 'arm64_v8a',
             'armv7l': 'armeabi_v7a',
+            'armv8l': 'armeabi_v7a',
         }.items():
             with self.subTest(machine):
                 self._set_uname(('Linux', 'localhost', '3.18.91+',
@@ -589,6 +590,7 @@ class TestSysConfig(unittest.TestCase):
             "i686": "i686-linux-android",
             "aarch64": "aarch64-linux-android",
             "armv7l": "arm-linux-androideabi",
+            "armv8l": "arm-linux-androideabi",
         }[machine]
         self.assertTrue(suffix.endswith(f"-{expected_triplet}.so"),
                         f"{machine=}, {suffix=}")

--- a/Misc/NEWS.d/next/Library/2026-03-07-02-44-52.gh-issue-145616.x8Mf23.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-07-02-44-52.gh-issue-145616.x8Mf23.rst
@@ -1,0 +1,1 @@
+Detect Android sysconfig ABI correctly on 32-bit ARM Android on 64-bit ARM kernel


### PR DESCRIPTION
When Python is running on 32-bit ARM Android on a 64-bit ARM kernel, `os.uname().machine` is `armv8l`. Such devices run the same userspace code as `armv7l` devices, so apply the same `armeabi_v7a` Android ABI to them, which works.
(cherry picked from commit 3a2b81e919103c0be3bc60a47aaa74d34fea6e9e)

Co-authored-by: Robert Kirkman <31490854+robertkirkman@users.noreply.github.com>

<!-- gh-issue-number: gh-145616 -->
* Issue: gh-145616
<!-- /gh-issue-number -->
