### PR TITLE
gh-146536: docs: Clarify that PyMutex is not re-entrant

### DIFF
--- a/Doc/c-api/synchronization.rst
+++ b/Doc/c-api/synchronization.rst
@@ -24,6 +24,13 @@ The C-API provides a basic mutual exclusion lock.
       considered unstable.  The size may change in future Python releases
       without a deprecation period.
 
+   .. note::
+
+      A :c:type:`!PyMutex` is **not** re-entrant (recursive). If a thread
+      that already holds the lock attempts to acquire it again, the thread
+      will deadlock. Use :c:func:`Py_BEGIN_CRITICAL_SECTION` instead if
+      re-entrancy is required.
+
    .. versionadded:: 3.13
 
 .. c:function:: void PyMutex_Lock(PyMutex *m)
@@ -32,12 +39,20 @@ The C-API provides a basic mutual exclusion lock.
    thread will block until the mutex is unlocked.  While blocked, the thread
    will temporarily detach the :term:`thread state <attached thread state>` if one exists.
 
+   .. warning::
+
+      This function will deadlock if the calling thread already holds the lock.
+      :c:type:`!PyMutex` is not re-entrant. For re-entrant locking, use
+      :c:func:`Py_BEGIN_CRITICAL_SECTION` instead.
+
    .. versionadded:: 3.13
 
 .. c:function:: void PyMutex_Unlock(PyMutex *m)
 
-   Unlock mutex *m*. The mutex must be locked --- otherwise, the function will
-   issue a fatal error.
+   Unlock mutex *m*. The mutex must be locked by the calling thread ---
+   otherwise, the function will issue a fatal error. Unlocking a mutex from
+   a different thread than the one that locked it results in undefined
+   behavior.
 
    .. versionadded:: 3.13
 

--- a/Doc/c-api/synchronization.rst
+++ b/Doc/c-api/synchronization.rst
@@ -35,15 +35,9 @@ The C-API provides a basic mutual exclusion lock.
 
 .. c:function:: void PyMutex_Lock(PyMutex *m)
 
-   Lock mutex *m*.  If another thread has already locked it, the calling
-   thread will block until the mutex is unlocked.  While blocked, the thread
+   Lock mutex *m*. If the mutex is already locked, the calling
+   thread will block until the mutex is unlocked. While blocked, the thread
    will temporarily detach the :term:`thread state <attached thread state>` if one exists.
-
-   .. warning::
-
-      This function will deadlock if the calling thread already holds the lock.
-      :c:type:`!PyMutex` is not re-entrant. For re-entrant locking, use
-      :c:func:`Py_BEGIN_CRITICAL_SECTION` instead.
 
    .. versionadded:: 3.13
 
@@ -51,8 +45,8 @@ The C-API provides a basic mutual exclusion lock.
 
    Unlock mutex *m*. The mutex must be locked by the calling thread ---
    otherwise, the function will issue a fatal error. Unlocking a mutex from
-   a different thread than the one that locked it results in undefined
-   behavior.
+   a different thread than the one that locked it also results in a fatal
+   error.
 
    .. versionadded:: 3.13
 


### PR DESCRIPTION
## Summary

This PR clarifies the documentation for :c:type:`PyMutex` to explicitly state that it is **not** re-entrant (recursive).

## Changes

- Add note to :c:type:`PyMutex` type documentation explaining that it will deadlock if a thread attempts to acquire a lock it already holds
- Add warning to :c:func:`PyMutex_Lock` about deadlock behavior on re-entry
- Clarify :c:func:`PyMutex_Unlock` must be called by the same thread that acquired the lock

## Background

The original issue reported confusion about whether PyMutex supports re-entrant locking. Since PyMutex occupies only one byte and uses atomic operations without tracking thread ownership, it cannot support re-entrancy. This documentation update makes this limitation explicit and suggests using :c:func:`Py_BEGIN_CRITICAL_SECTION` as an alternative for re-entrant locking scenarios.

Fixes #146536

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146543.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-146536 -->
* Issue: gh-146536
<!-- /gh-issue-number -->
