### PR TITLE
[3.13] Throw informative SystemError rather than plain Exception when ctypes version consistency assertion fails before 3.15 deprecation (GH-146549)

### DIFF
--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -18,7 +18,7 @@ from _ctypes import SIZEOF_TIME_T
 from struct import calcsize as _calcsize
 
 if __version__ != _ctypes_version:
-    raise Exception("Version number mismatch", __version__, _ctypes_version)
+    raise SystemError("Version number mismatch", __version__, _ctypes_version)
 
 if _os.name == "nt":
     from _ctypes import FormatError

--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -18,7 +18,9 @@ from _ctypes import SIZEOF_TIME_T
 from struct import calcsize as _calcsize
 
 if __version__ != _ctypes_version:
-    raise SystemError("Version number mismatch", __version__, _ctypes_version)
+    raise SystemError(
+        f"ctypes version mismatch: Python={__version__}, _ctypes={_ctypes_version}"
+    )
 
 if _os.name == "nt":
     from _ctypes import FormatError


### PR DESCRIPTION
See #146549.

<!-- gh-issue-number: gh-146549 -->
* Issue: gh-146549
<!-- /gh-issue-number -->
