### PR TITLE
gh-146553: Fix infinite loop in typing.get_type_hints() on circular __wrapped__

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6842,7 +6842,7 @@ class GetTypeHintsTests(BaseTestCase):
         # not loop forever.
         def f(x: int) -> str: ...
         f.__wrapped__ = f
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, 'wrapper loop'):
             get_type_hints(f)
 
     def test_get_type_hints_wrapped_cycle_mutual(self):
@@ -6852,18 +6852,8 @@ class GetTypeHintsTests(BaseTestCase):
         def b(): ...
         a.__wrapped__ = b
         b.__wrapped__ = a
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, 'wrapper loop'):
             get_type_hints(a)
-
-    def test_get_type_hints_wrapped_chain_no_cycle(self):
-        # gh-146553: a valid (non-cyclic) __wrapped__ chain must still work.
-        def inner(x: int) -> str: ...
-        def middle(x: int) -> str: ...
-        middle.__wrapped__ = inner
-        def outer(x: int) -> str: ...
-        outer.__wrapped__ = middle
-        # No cycle — should return the annotations without raising.
-        self.assertEqual(get_type_hints(outer), {'x': int, 'return': str})
 
     def test_get_type_hints_annotated(self):
         def foobar(x: List['X']): ...

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6837,6 +6837,34 @@ class GetTypeHintsTests(BaseTestCase):
         self.assertEqual(gth(ForRefExample.func), expects)
         self.assertEqual(gth(ForRefExample.nested), expects)
 
+    def test_get_type_hints_wrapped_cycle_self(self):
+        # gh-146553: __wrapped__ self-reference must raise ValueError,
+        # not loop forever.
+        def f(x: int) -> str: ...
+        f.__wrapped__ = f
+        with self.assertRaises(ValueError):
+            get_type_hints(f)
+
+    def test_get_type_hints_wrapped_cycle_mutual(self):
+        # gh-146553: mutual __wrapped__ cycle (a -> b -> a) must raise
+        # ValueError, not loop forever.
+        def a(): ...
+        def b(): ...
+        a.__wrapped__ = b
+        b.__wrapped__ = a
+        with self.assertRaises(ValueError):
+            get_type_hints(a)
+
+    def test_get_type_hints_wrapped_chain_no_cycle(self):
+        # gh-146553: a valid (non-cyclic) __wrapped__ chain must still work.
+        def inner(x: int) -> str: ...
+        def middle(x: int) -> str: ...
+        middle.__wrapped__ = inner
+        def outer(x: int) -> str: ...
+        outer.__wrapped__ = middle
+        # No cycle — should return the annotations without raising.
+        self.assertEqual(get_type_hints(outer), {'x': int, 'return': str})
+
     def test_get_type_hints_annotated(self):
         def foobar(x: List['X']): ...
         X = Annotated[int, (1, 10)]

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1972,6 +1972,7 @@ def _lazy_load_getattr_static():
 
 _cleanups.append(_lazy_load_getattr_static.cache_clear)
 
+
 def _pickle_psargs(psargs):
     return ParamSpecArgs, (psargs.__origin__,)
 
@@ -2483,20 +2484,9 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False,
         if isinstance(obj, types.ModuleType):
             globalns = obj.__dict__
         else:
-            nsobj = obj
             # Find globalns for the unwrapped object.
-            # Use an id-based visited set to detect and break on cycles in the
-            # __wrapped__ chain (e.g. f.__wrapped__ = f), matching the behavior
-            # of inspect.unwrap().
-            _seen_ids = {id(nsobj)}
-            while hasattr(nsobj, '__wrapped__'):
-                nsobj = nsobj.__wrapped__
-                _nsobj_id = id(nsobj)
-                if _nsobj_id in _seen_ids:
-                    raise ValueError(
-                        f'wrapper loop when unwrapping {obj!r}'
-                    )
-                _seen_ids.add(_nsobj_id)
+            import inspect
+            nsobj = inspect.unwrap(obj)
             globalns = getattr(nsobj, '__globals__', {})
         if localns is None:
             localns = globalns

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2485,8 +2485,18 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False,
         else:
             nsobj = obj
             # Find globalns for the unwrapped object.
+            # Use an id-based visited set to detect and break on cycles in the
+            # __wrapped__ chain (e.g. f.__wrapped__ = f), matching the behavior
+            # of inspect.unwrap().
+            _seen_ids = {id(nsobj)}
             while hasattr(nsobj, '__wrapped__'):
                 nsobj = nsobj.__wrapped__
+                _nsobj_id = id(nsobj)
+                if _nsobj_id in _seen_ids:
+                    raise ValueError(
+                        f'wrapper loop when unwrapping {obj!r}'
+                    )
+                _seen_ids.add(_nsobj_id)
             globalns = getattr(nsobj, '__globals__', {})
         if localns is None:
             localns = globalns

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1973,6 +1973,17 @@ def _lazy_load_getattr_static():
 _cleanups.append(_lazy_load_getattr_static.cache_clear)
 
 
+@functools.cache
+def _lazy_load_unwrap():
+    # Import unwrap lazily so as not to slow down the import of typing.py
+    # Cache the result so we don't slow down get_type_hints() unnecessarily
+    from inspect import unwrap
+    return unwrap
+
+
+_cleanups.append(_lazy_load_unwrap.cache_clear)
+
+
 def _pickle_psargs(psargs):
     return ParamSpecArgs, (psargs.__origin__,)
 
@@ -2485,8 +2496,7 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False,
             globalns = obj.__dict__
         else:
             # Find globalns for the unwrapped object.
-            import inspect
-            nsobj = inspect.unwrap(obj)
+            nsobj = _lazy_load_unwrap()(obj)
             globalns = getattr(nsobj, '__globals__', {})
         if localns is None:
             localns = globalns

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -172,6 +172,16 @@ class _LazyAnnotationLib:
 _lazy_annotationlib = _LazyAnnotationLib()
 
 
+class _LazyInspect:
+    def __getattr__(self, attr):
+        global _lazy_inspect
+        import inspect
+        _lazy_inspect = inspect
+        return getattr(inspect, attr)
+
+_lazy_inspect = _LazyInspect()
+
+
 def _type_convert(arg, module=None, *, allow_special_forms=False, owner=None):
     """For converting None to type(None), and strings to ForwardRef."""
     if arg is None:
@@ -1962,28 +1972,6 @@ _PROTO_ALLOWLIST = {
 }
 
 
-@functools.cache
-def _lazy_load_getattr_static():
-    # Import getattr_static lazily so as not to slow down the import of typing.py
-    # Cache the result so we don't slow down _ProtocolMeta.__instancecheck__ unnecessarily
-    from inspect import getattr_static
-    return getattr_static
-
-
-_cleanups.append(_lazy_load_getattr_static.cache_clear)
-
-
-@functools.cache
-def _lazy_load_unwrap():
-    # Import unwrap lazily so as not to slow down the import of typing.py
-    # Cache the result so we don't slow down get_type_hints() unnecessarily
-    from inspect import unwrap
-    return unwrap
-
-
-_cleanups.append(_lazy_load_unwrap.cache_clear)
-
-
 def _pickle_psargs(psargs):
     return ParamSpecArgs, (psargs.__origin__,)
 
@@ -2116,7 +2104,7 @@ class _ProtocolMeta(ABCMeta):
         if _abc_instancecheck(cls, instance):
             return True
 
-        getattr_static = _lazy_load_getattr_static()
+        getattr_static = _lazy_inspect.getattr_static
         for attr in cls.__protocol_attrs__:
             try:
                 val = getattr_static(instance, attr)
@@ -2496,7 +2484,7 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False,
             globalns = obj.__dict__
         else:
             # Find globalns for the unwrapped object.
-            nsobj = _lazy_load_unwrap()(obj)
+            nsobj = _lazy_inspect.unwrap(obj)
             globalns = getattr(nsobj, '__globals__', {})
         if localns is None:
             localns = globalns

--- a/Misc/NEWS.d/next/Library/2026-03-28-11-43-25.gh-issue-146553.mXaWza.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-28-11-43-25.gh-issue-146553.mXaWza.rst
@@ -1,0 +1,4 @@
+Fix :func:`typing.get_type_hints` hanging indefinitely when a callable has a
+circular ``__wrapped__`` chain (e.g. ``f.__wrapped__ = f``). A
+:exc:`ValueError` is now raised on cycle detection, matching the behavior of
+:func:`inspect.unwrap`.


### PR DESCRIPTION
https://github.com/python/cpython/issues/146553

<!-- gh-issue-number: gh-146553 -->
* Issue: gh-146553
<!-- /gh-issue-number -->
