### PR TITLE
gh-139922: always run MSVC 64-bit tail-calling CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,8 @@ jobs:
           # Skip Win32 on free-threaded builds
           - { arch: Win32, free-threading: true }
         include:
+          # msvc::musttail is currently only supported on x64,
+          # and only supported on 3.15+.
           - { arch: x64, free-threading: false, interpreter: tail-call }
           - { arch: x64, free-threading: true,  interpreter: tail-call }
     uses: ./.github/workflows/reusable-windows.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,13 +165,19 @@ jobs:
         free-threading:
           - false
           - true
+        interpreter:
+          - regular
         exclude:
           # Skip Win32 on free-threaded builds
           - { arch: Win32, free-threading: true }
+        include:
+          - { arch: x64, free-threading: false, interpreter: tail-call }
+          - { arch: x64, free-threading: true,  interpreter: tail-call }
     uses: ./.github/workflows/reusable-windows.yml
     with:
       arch: ${{ matrix.arch }}
       free-threading: ${{ matrix.free-threading }}
+      interpreter: ${{ matrix.interpreter }}
 
   build-windows-msi:
     # ${{ '' } is a hack to nest jobs under the same sidebar category.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
           - false
           - true
         interpreter:
-          - regular
+          - switch-case
         exclude:
           # Skip Win32 on free-threaded builds
           - { arch: Win32, free-threading: true }

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -13,10 +13,9 @@ on:
         type: boolean
         default: false
       interpreter:
-        description: Which interpreter to build
-        required: false
+        description: Which interpreter to build (switch-case or tail-call)
+        required: true
         type: string
-        default: switch-case
 
 env:
   FORCE_COLOR: 1

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: boolean
         default: false
+      interpreter:
+        description: Which interpreter to build
+        required: false
+        type: string
+        default: regular
 
 env:
   FORCE_COLOR: 1
@@ -20,7 +25,7 @@ env:
 
 jobs:
   build:
-    name: Build and test (${{ inputs.arch }})
+    name: Build and test (${{ inputs.arch }}, ${{ inputs.interpreter }})
     runs-on: ${{ inputs.arch == 'arm64' && 'windows-11-arm' || 'windows-2025-vs2026' }}
     timeout-minutes: 60
     env:
@@ -33,9 +38,12 @@ jobs:
       if: inputs.arch != 'Win32'
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
+      # msvc::musttail is not supported for debug builds, so we have to
+      # switch to release.
       run: >-
         .\\PCbuild\\build.bat
-        -e -d -v
+        -e -v
+        ${{ inputs.interpreter == 'regular' && '-d' || '--tail-call-interp -c Release' }}
         -p "${ARCH}"
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
       shell: bash
@@ -45,6 +53,7 @@ jobs:
       run: >-
         .\\PCbuild\\rt.bat
         -p "${ARCH}"
-        -d -q --fast-ci
+        -q --fast-ci
+        ${{ inputs.interpreter == 'regular' && '-d' || '' }}
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
       shell: bash

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -16,7 +16,7 @@ on:
         description: Which interpreter to build
         required: false
         type: string
-        default: regular
+        default: switch-case
 
 env:
   FORCE_COLOR: 1
@@ -43,7 +43,7 @@ jobs:
       run: >-
         .\\PCbuild\\build.bat
         -e -v
-        ${{ inputs.interpreter == 'regular' && '-d' || '--tail-call-interp -c Release' }}
+        ${{ inputs.interpreter == 'switch-case' && '-d' || '--tail-call-interp -c Release' }}
         -p "${ARCH}"
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
       shell: bash
@@ -54,6 +54,6 @@ jobs:
         .\\PCbuild\\rt.bat
         -p "${ARCH}"
         -q --fast-ci
-        ${{ inputs.interpreter == 'regular' && '-d' || '' }}
+        ${{ inputs.interpreter == 'switch-case' && '-d' || '' }}
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
       shell: bash

--- a/.github/workflows/tail-call.yml
+++ b/.github/workflows/tail-call.yml
@@ -23,41 +23,6 @@ env:
   LLVM_VERSION: 21
 
 jobs:
-  windows:
-    name: ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-pc-windows-msvc/msvc
-            architecture: x64
-            runner: windows-2025-vs2026
-            build_flags: ""
-            run_tests: true
-          - target: x86_64-pc-windows-msvc/msvc-free-threading
-            architecture: x64
-            runner: windows-2025-vs2026
-            build_flags: --disable-gil
-            run_tests: false
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-      - name: Build
-        shell: pwsh
-        run: |
-          ./PCbuild/build.bat --tail-call-interp ${{ matrix.build_flags }} -c Release -p ${{ matrix.architecture }}
-      - name: Test
-        if: matrix.run_tests
-        shell: pwsh
-        run: |
-          ./PCbuild/rt.bat -p ${{ matrix.architecture }} -q --multiprocess 0 --timeout 4500 --verbose2 --verbose3
-
   macos:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
And not only for the paths in 
https://github.com/python/cpython/blob/578d726d467dee14abe52a7790aca36e4cb9f70c/.github/workflows/tail-call.yml#L4-L9



<!-- gh-issue-number: gh-139922 -->
* Issue: gh-139922
<!-- /gh-issue-number -->
