### PR TITLE
CYGWIN: fix "defined but not used" warnings on mimalloc

### DIFF
--- a/Objects/mimalloc/prim/unix/prim.c
+++ b/Objects/mimalloc/prim/unix/prim.c
@@ -77,7 +77,7 @@ static int mi_prim_access(const char *fpath, int mode) {
   return syscall(SYS_access,fpath,mode);
 }
 
-#elif !defined(__APPLE__) && !defined(_AIX) && !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__sun) && !defined(__NetBSD__) // avoid unused warnings
+#elif !defined(__APPLE__) && !defined(_AIX) && !defined(__CYGWIN__) && !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__sun) && !defined(__NetBSD__) // avoid unused warnings
 
 static int mi_prim_open(const char* fpath, int open_flags) {
   return open(fpath,open_flags);


### PR DESCRIPTION
Compiling under CYGWIN prints these warning messages:
```
In file included from ../cpython/Objects/mimalloc/prim/prim.c:22,
                 from ../cpython/Objects/mimalloc/static.c:37,
                 from ../cpython/Objects/obmalloc.c:23:
../cpython/Objects/mimalloc/prim/unix/prim.c:91:12: warning: ‘mi_prim_access’ defined but not used [-Wunused-function]
   91 | static int mi_prim_access(const char *fpath, int mode) {
      |            ^~~~~~~~~~~~~~
../cpython/Objects/mimalloc/prim/unix/prim.c:88:12: warning: ‘mi_prim_close’ defined but not used [-Wunused-function]
   88 | static int mi_prim_close(int fd) {
      |            ^~~~~~~~~~~~~
../cpython/Objects/mimalloc/prim/unix/prim.c:85:16: warning: ‘mi_prim_read’ defined but not used [-Wunused-function]
   85 | static ssize_t mi_prim_read(int fd, void* buf, size_t bufsize) {
      |                ^~~~~~~~~~~~
../cpython/Objects/mimalloc/prim/unix/prim.c:82:12: warning: ‘mi_prim_open’ defined but not used [-Wunused-function]
   82 | static int mi_prim_open(const char* fpath, int open_flags) {
      |            ^~~~~~~~~~~~
```
Looking into the code of `Objects/mimalloc/prim/unix/prim.c`, there is already a conditional block to avoid the generation of such warnings.
Unfortunately, CYGWIN is missing in this list.
However, adding it is very easy and the change is self-explanatory, as you can see.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
