### PR TITLE
gh-143263: relax `test_ctx_mgr_rollback_if_commit_failed` for SQLite 3.45+

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1905,12 +1905,24 @@ class MultiprocessTests(unittest.TestCase):
         unlink(TESTFN)
 
     def test_ctx_mgr_rollback_if_commit_failed(self):
-        # bpo-27334: ctx manager does not rollback if commit fails
+        # Ensure that context manager does not rollback if commit fails.
+        # See https://github.com/python/cpython/issues/71521.
+
+        wait_messages = ["database is locked"]
+        if sqlite.sqlite_version_info >= (3, 45):
+            # Around SQLite 3.45 or later, a read-only transaction plus
+            # a user-defined function do not block concurrent writers,
+            # so we allow the parent process to send "no error".
+            #
+            # See https://github.com/python/cpython/issues/143263.
+            wait_messages.append("no error")
+
         SCRIPT = f"""if 1:
             import sqlite3
             def wait():
                 print("started")
-                assert "database is locked" in input()
+                line = input()
+                assert any(message in line for message in {wait_messages})
 
             cx = sqlite3.connect("{TESTFN}", timeout={self.CONNECTION_TIMEOUT})
             cx.create_function("wait", 0, wait)
@@ -1921,11 +1933,11 @@ class MultiprocessTests(unittest.TestCase):
                 cx.executescript('''
                     -- start a transaction and wait for parent
                     begin transaction;
-                    select * from t;
+                    insert into t values("ok");
                     select wait();
                     rollback;
 
-                    -- start a new transaction; would fail if parent holds lock
+                    -- start a new transaction; may fail if parent holds lock
                     begin transaction;
                     select * from t;
                     rollback;
@@ -1948,7 +1960,7 @@ class MultiprocessTests(unittest.TestCase):
         self.assertEqual("started", proc.stdout.readline().strip())
 
         cx = sqlite.connect(TESTFN, timeout=self.CONNECTION_TIMEOUT)
-        try:  # context manager should correctly release the db lock
+        try:  # context manager should correctly release the db lock (if any)
             with cx:
                 cx.execute("insert into t values('test')")
         except sqlite.OperationalError as exc:

--- a/Misc/NEWS.d/next/Tests/2026-03-28-14-53-17.gh-issue-143263.TINPJr.rst
+++ b/Misc/NEWS.d/next/Tests/2026-03-28-14-53-17.gh-issue-143263.TINPJr.rst
@@ -1,0 +1,2 @@
+Relax conditions in ``test_ctx_mgr_rollback_if_commit_failed`` to make the
+test pass with SQLite 3.45 and later. Patch by Bénédikt Tran.


### PR DESCRIPTION
By re-reading the test I'm actually skeptical on my fix so I'll first create a draft for now.

@erlend-aasland you wrote the original test but I am not exactly sure why this is a regression test for the original issue where the DB was locked after failing to rollback. If the original issue does not happen with the latest SQLite versions, maybe we should just guard the test for _old_ SQLite versions and skip it for more recent versions? I don't have an SQLite version I can test at hand though.

@BwL1289 can you check if the original issue (#71521) is still reproducible with recent SQLite versions please?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143263 -->
* Issue: gh-143263
<!-- /gh-issue-number -->
