### PR TITLE
gh-146579: _zstd: Fix decompression options dict error message

### DIFF
--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -101,7 +101,7 @@ _zstd_set_d_parameters(ZstdDecompressor *self, PyObject *options)
         /* Check key type */
         if (Py_TYPE(key) == mod_state->CParameter_type) {
             PyErr_SetString(PyExc_TypeError,
-                "compression options dictionary key must not be a "
+                "decompression options dictionary key must not be a "
                 "CompressionParameter attribute");
             return -1;
         }


### PR DESCRIPTION
## Summary

Fix the `TypeError` string in `_zstd_set_d_parameters`: it incorrectly said
`compression options dictionary` when validating decompression option keys.

## Test plan

- No behavior change beyond the error text; optional manual check by passing an
  invalid key type to decompression options.

<!-- gh-issue-number: gh-146579 -->
* Issue: gh-146579
<!-- /gh-issue-number -->
