### PR TITLE
gh-146581: Use ZipFile.extractall() in shutil for secure ZIP extraction

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1313,13 +1313,10 @@ def _unpack_zipfile(filename, extract_dir, **kwargs):
     """Unpack zip `filename` to `extract_dir`
     """
     import zipfile  # late import for breaking circular dependency
-
     if not zipfile.is_zipfile(filename):
         raise ReadError("%s is not a zip file" % filename)
-
     with zipfile.ZipFile(filename) as zf:
         zf.extractall(extract_dir)
-
 
 def _unpack_tarfile(filename, extract_dir, *, filter=None):
     """Unpack tar/tar.gz/tar.bz2/tar.xz/tar.zst `filename` to `extract_dir`

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1309,7 +1309,7 @@ def _ensure_directory(path):
     if not os.path.isdir(dirname):
         os.makedirs(dirname)
 
-def _unpack_zipfile(filename, extract_dir):
+def _unpack_zipfile(filename, extract_dir, **kwargs):
     """Unpack zip `filename` to `extract_dir`
     """
     import zipfile  # late import for breaking circular dependency
@@ -1317,27 +1317,9 @@ def _unpack_zipfile(filename, extract_dir):
     if not zipfile.is_zipfile(filename):
         raise ReadError("%s is not a zip file" % filename)
 
-    zip = zipfile.ZipFile(filename)
-    try:
-        for info in zip.infolist():
-            name = info.filename
+    with zipfile.ZipFile(filename) as zf:
+        zf.extractall(extract_dir)
 
-            # don't extract absolute paths or ones with .. in them
-            if name.startswith('/') or '..' in name:
-                continue
-
-            targetpath = os.path.join(extract_dir, *name.split('/'))
-            if not targetpath:
-                continue
-
-            _ensure_directory(targetpath)
-            if not name.endswith('/'):
-                # file
-                with zip.open(name, 'r') as source, \
-                        open(targetpath, 'wb') as target:
-                    copyfileobj(source, target)
-    finally:
-        zip.close()
 
 def _unpack_tarfile(filename, extract_dir, *, filter=None):
     """Unpack tar/tar.gz/tar.bz2/tar.xz/tar.zst `filename` to `extract_dir`
@@ -1668,3 +1650,4 @@ def __getattr__(name):
         )
         return RuntimeError
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1647,4 +1647,3 @@ def __getattr__(name):
         )
         return RuntimeError
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1309,7 +1309,7 @@ def _ensure_directory(path):
     if not os.path.isdir(dirname):
         os.makedirs(dirname)
 
-def _unpack_zipfile(filename, extract_dir, **kwargs):
+def _unpack_zipfile(filename, extract_dir):
     """Unpack zip `filename` to `extract_dir`
     """
     import zipfile  # late import for breaking circular dependency

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -3523,3 +3523,38 @@ class PublicAPITests(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+class TestShutilZipTraversal(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.extract_dir = os.path.join(self.tmp_dir, "extract")
+        os.mkdir(self.extract_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    @unittest.skipUnless(sys.platform == 'win32', 'Windows-specific traversal test')
+    @support.requires_zlib()
+    def test_unpack_zipfile_traversal_windows_drive(self):
+        # Create a ZIP file with a drive-prefixed path
+        zip_path = os.path.join(self.tmp_dir, "test.zip")
+        with zipfile.ZipFile(zip_path, 'w') as zf:
+            # zipfile.extractall() should sanitize this to 'D/traversal.txt'
+            # relative to extract_dir.
+            zf.writestr("D:/traversal.txt", "found you")
+
+        # Prior to the fix, this might have attempted to write to D:/traversal.txt
+        # With the fix (using extractall()), it's safely joined.
+        shutil.unpack_archive(zip_path, self.extract_dir)
+
+        # Check that it didn't go to D:/
+        self.assertFalse(os.path.exists("D:/traversal.txt"))
+
+        # Check where it actually went
+        found = False
+        for root, dirs, files in os.walk(self.extract_dir):
+            if "traversal.txt" in files:
+                found = True
+                break
+        self.assertTrue(found, "Extracted file not found within extract_dir")
+

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -3519,20 +3519,15 @@ class PublicAPITests(unittest.TestCase):
         self.assertEqual(set(shutil.__all__), set(target_api))
         with self.assertWarns(DeprecationWarning):
             from shutil import ExecError  # noqa: F401
-
-
 if __name__ == '__main__':
     unittest.main()
-
 class TestShutilZipTraversal(unittest.TestCase):
     def setUp(self):
         self.tmp_dir = tempfile.mkdtemp()
         self.extract_dir = os.path.join(self.tmp_dir, "extract")
         os.mkdir(self.extract_dir)
-
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)
-
     @unittest.skipUnless(sys.platform == 'win32', 'Windows-specific traversal test')
     @support.requires_zlib()
     def test_unpack_zipfile_traversal_windows_drive(self):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -3536,25 +3536,15 @@ class TestShutilZipTraversal(unittest.TestCase):
     @unittest.skipUnless(sys.platform == 'win32', 'Windows-specific traversal test')
     @support.requires_zlib()
     def test_unpack_zipfile_traversal_windows_drive(self):
-        # Create a ZIP file with a drive-prefixed path
+        # Create a ZIP file with a drive prefixed path
         zip_path = os.path.join(self.tmp_dir, "test.zip")
         with zipfile.ZipFile(zip_path, 'w') as zf:
-            # zipfile.extractall() should sanitize this to 'D/traversal.txt'
-            # relative to extract_dir.
             zf.writestr("D:/traversal.txt", "found you")
-
-        # Prior to the fix, this might have attempted to write to D:/traversal.txt
-        # With the fix (using extractall()), it's safely joined.
         shutil.unpack_archive(zip_path, self.extract_dir)
-
-        # Check that it didn't go to D:/
         self.assertFalse(os.path.exists("D:/traversal.txt"))
-
-        # Check where it actually went
         found = False
         for root, dirs, files in os.walk(self.extract_dir):
             if "traversal.txt" in files:
                 found = True
                 break
         self.assertTrue(found, "Extracted file not found within extract_dir")
-

--- a/Misc/NEWS.d/next/Security/2026-03-29-08-14-09.gh-issue-146581.81t9a4.rst
+++ b/Misc/NEWS.d/next/Security/2026-03-29-08-14-09.gh-issue-146581.81t9a4.rst
@@ -1,0 +1,1 @@
+Fix a directory traversal vulnerability in shutil.unpack_archive for ZIP files on Windows by refactoring _unpack_zipfile to use zipfile.ZipFile.extractall. This leverages the built in, hardened path sanitization in the zipfile module to safely handle drive prefixed paths. Patch by Shrey Naithani.


### PR DESCRIPTION
This PR refactors `shutil._unpack_zipfile` to use `zipfile.ZipFile.extractall()` instead of a manual extraction loop. This resolves a directory traversal vulnerability on Windows where archives containing drive prefixed paths for example`D:/file.txt` could write files outside the intended destination directory.

### Changes Made
- Replaced manual path joining and validation with `ZipFile.extractall()`, which leverages the `zipfile` module
- Updated the `_unpack_zipfile` signature to accept `**kwargs`. This ensures compatibility with the `filter` argument, preventing `TypeError` while allowing future filter support for ZIP files.
- This change brings ZIP extraction in line with how `shutil` handles TAR files, which already uses `extractall()`.

### Regression Test
Added a new test case `test_unpack_zipfile_traversal_windows_drive` to `Lib/test/test_shutil.py`. This test specifically verifies that a ZIP file containing a drive prefixed path is safely sanitized and extracted within the intended `extract_dir` on Windows.

### Linked Issue
#146581 

<!-- gh-issue-number: gh-146581 -->
* Issue: gh-146581
<!-- /gh-issue-number -->
