### PR TITLE
gh-146589: Fix raw buffer merge in UnixConsole.getpending()

### DIFF
--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -542,7 +542,7 @@ class UnixConsole(Console):
             while not self.event_queue.empty():
                 e2 = self.event_queue.get()
                 e.data += e2.data
-                e.raw += e.raw
+                e.raw += e2.raw
 
             amount = struct.unpack("i", ioctl(self.input_fd, FIONREAD, b"\0\0\0\0"))[0]
             trace("getpending({a})", a=amount)


### PR DESCRIPTION
## Summary

Fixes gh-146589.

When `getpending()` merges consecutive events from the queue, `e.raw` was
updated with `e.raw += e.raw` instead of appending the second event's bytes.
Use `e.raw += e2.raw`, consistent with `e.data += e2.data`.

## Test plan

- Exercise pyrepl on Unix with pending input coalescing (manual), or run
  relevant `_pyrepl` tests if present.