### PR TITLE
gh-146448: fix t-string parser truncating expression at != with format spec

### DIFF
--- a/Lib/test/test_tstring.py
+++ b/Lib/test/test_tstring.py
@@ -287,5 +287,14 @@ class TestTString(unittest.TestCase, TStringBaseCase):
         )
         self.assertEqual(fstring(t), "\n        Hello,\n        Python\n        ")
 
+    def test_not_equal_with_format_spec(self):
+        # gh-146448: != in expression with format spec should not be
+        # confused with the ! conversion specifier
+        t = t"{0!=0:}"
+        self.assertTStringEqual(t, ("", ""), [(False, "0!=0")])
+
+        t = t"{0!=0:s}"
+        self.assertTStringEqual(t, ("", ""), [(False, "0!=0", None, "s")])
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-03-30-00-00-00.gh-issue-146448.5fce3b.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-03-30-00-00-00.gh-issue-146448.5fce3b.rst
@@ -1,0 +1,2 @@
+Fix template string parser incorrectly truncating the ``Interpolation.str``
+attribute when the expression contains ``!=`` followed by a format spec.

--- a/Parser/lexer/lexer.c
+++ b/Parser/lexer/lexer.c
@@ -1250,8 +1250,17 @@ tok_get_normal_mode(struct tok_state *tok, tokenizer_mode* current_tok, struct t
         goto again; /* Read next line */
     }
 
-    /* Punctuation character */
-    int is_punctuation = (c == ':' || c == '}' || c == '!' || c == '{');
+    /* Punctuation character.
+     * '!' is only treated as f-string/t-string punctuation (conversion
+     * specifier) when not followed by '=' (which would make it '!='). */
+    int is_punctuation = (c == ':' || c == '}' || c == '{');
+    if (c == '!') {
+        int ahead = tok_nextc(tok);
+        tok_backup(tok, ahead);
+        if (ahead != '=') {
+            is_punctuation = 1;
+        }
+    }
     if (is_punctuation && INSIDE_FSTRING(tok) && INSIDE_FSTRING_EXPR(current_tok)) {
         /* This code block gets executed before the curly_bracket_depth is incremented
          * by the `{` case, so for ensuring that we are on the 0th level, we need


### PR DESCRIPTION
Fixes #146448.

The lexer treats `!` inside f-string/t-string expressions as a conversion specifier marker, which causes the expression text to be truncated at `!`. For `!=`, this incorrectly sets `Interpolation.str` to just the part before `!` (e.g. `t'{0!=0:}'` produces `str='0'` instead of `str='0!=0'`). The bug only triggers when a format spec follows (`:`) because without it, the expression end is determined by `}` instead.

The fix peeks at the character following `!` using `tok_nextc`/`tok_backup` and only treats it as f-string punctuation when it's not followed by `=`.

<!-- gh-issue-number: gh-146448 -->
* Issue: gh-146448
<!-- /gh-issue-number -->