### PR TITLE
gh-146615: Fix format specifiers in error messages for consistency and correctness

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2244,7 +2244,7 @@ enter_task(_PyThreadStateImpl *ts, PyObject *loop, PyObject *task)
             PyExc_RuntimeError,
             "Cannot enter into task %R while another " \
             "task %R is being executed.",
-            task, ts->asyncio_running_task, NULL);
+            task, ts->asyncio_running_task);
         return -1;
     }
 
@@ -2265,7 +2265,7 @@ leave_task(_PyThreadStateImpl *ts, PyObject *loop, PyObject *task)
             PyExc_RuntimeError,
             "Invalid attempt to leave task %R while " \
             "task %R is entered.",
-            task, ts->asyncio_running_task ? ts->asyncio_running_task : Py_None, NULL);
+            task, ts->asyncio_running_task ? ts->asyncio_running_task : Py_None);
         return -1;
     }
     Py_CLEAR(ts->asyncio_running_task);
@@ -2328,7 +2328,7 @@ _asyncio_Task___init___impl(TaskObj *self, PyObject *coro, PyObject *loop,
         self->task_log_destroy_pending = 0;
         PyErr_Format(PyExc_TypeError,
                      "a coroutine was expected, got %R",
-                     coro, NULL);
+                     coro);
         return -1;
     }
 

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -212,7 +212,7 @@ parse_task_name(
             set_exception_cause(unwinder, PyExc_RuntimeError, "Task name PyLong parsing failed");
             return NULL;
         }
-        return PyUnicode_FromFormat("Task-%d", res);
+        return PyUnicode_FromFormat("Task-%ld", res);
     }
 
     if(!(GET_MEMBER(unsigned long, type_obj, unwinder->debug_offsets.type_object.tp_flags) & Py_TPFLAGS_UNICODE_SUBCLASS)) {

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -592,7 +592,7 @@ fill_and_set_sslerror(_sslmodulestate *state,
     }
     else {
         if (PyUnicodeWriter_Format(
-                writer, "unknown error (0x%x)", errcode) < 0) {
+                writer, "unknown error (0x%lx)", errcode) < 0) {
             goto fail;
         }
     }
@@ -4059,7 +4059,7 @@ set_min_max_proto_version(PySSLContext *self, PyObject *arg, int what)
             break;
         default:
             PyErr_Format(PyExc_ValueError,
-                     "Unsupported TLS/SSL version 0x%x", v);
+                     "Unsupported TLS/SSL version 0x%lx", v);
             return -1;
     }
 
@@ -4093,7 +4093,7 @@ set_min_max_proto_version(PySSLContext *self, PyObject *arg, int what)
     }
     if (result == 0) {
         PyErr_Format(PyExc_ValueError,
-                     "Unsupported protocol version 0x%x", v);
+                     "Unsupported protocol version 0x%lx", v);
         return -1;
     }
     return 0;

--- a/Modules/_testcapi/watchers.c
+++ b/Modules/_testcapi/watchers.c
@@ -364,7 +364,7 @@ add_code_watcher(PyObject *self, PyObject *which_watcher)
         watcher_id = PyCode_AddWatcher(error_code_event_handler);
     }
     else {
-        PyErr_Format(PyExc_ValueError, "invalid watcher %d", which_l);
+        PyErr_Format(PyExc_ValueError, "invalid watcher %ld", which_l);
         return NULL;
     }
     if (watcher_id < 0) {
@@ -673,7 +673,7 @@ add_context_watcher(PyObject *self, PyObject *which_watcher)
     assert(PyLong_Check(which_watcher));
     long which_l = PyLong_AsLong(which_watcher);
     if (which_l < 0 || which_l >= (long)Py_ARRAY_LENGTH(callbacks)) {
-        PyErr_Format(PyExc_ValueError, "invalid watcher %d", which_l);
+        PyErr_Format(PyExc_ValueError, "invalid watcher %ld", which_l);
         return NULL;
     }
     int watcher_id = PyContext_AddWatcher(callbacks[which_l]);

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -116,8 +116,8 @@ test_sizeof_c_types(PyObject *self, PyObject *Py_UNUSED(ignored))
     do { \
         if (EXPECTED != sizeof(TYPE)) { \
             PyErr_Format(get_testerror(self),               \
-                         "sizeof(%s) = %u instead of %u",   \
-                         #TYPE, sizeof(TYPE), EXPECTED);    \
+                         "sizeof(%s) = %zu instead of %u",   \
+                         #TYPE, sizeof(TYPE), (unsigned)(EXPECTED));    \
             return (PyObject*)NULL; \
         } \
     } while (0)

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -417,14 +417,14 @@ test_bswap(PyObject *self, PyObject *Py_UNUSED(args))
     uint16_t u16 = _Py_bswap16(UINT16_C(0x3412));
     if (u16 != UINT16_C(0x1234)) {
         PyErr_Format(PyExc_AssertionError,
-                     "_Py_bswap16(0x3412) returns %u", u16);
+                     "_Py_bswap16(0x3412) returns %d", u16);
         return NULL;
     }
 
     uint32_t u32 = _Py_bswap32(UINT32_C(0x78563412));
     if (u32 != UINT32_C(0x12345678)) {
         PyErr_Format(PyExc_AssertionError,
-                     "_Py_bswap32(0x78563412) returns %lu", u32);
+                     "_Py_bswap32(0x78563412) returns %u", u32);
         return NULL;
     }
 
@@ -711,7 +711,7 @@ check_bytes_find(const char *haystack0, const char *needle0,
                                         needle0, len_needle, offset);
     if (result_1 != expected) {
         PyErr_Format(PyExc_AssertionError,
-                    "Incorrect result_1: '%s' in '%s' (offset=%zd)",
+                    "Incorrect result_1: '%s' in '%s' (offset=%d)",
                     needle0, haystack0, offset);
         return -1;
     }
@@ -735,7 +735,7 @@ check_bytes_find(const char *haystack0, const char *needle0,
     PyMem_Free(needle);
     if (result_2 != expected) {
         PyErr_Format(PyExc_AssertionError,
-                    "Incorrect result_2: '%s' in '%s' (offset=%zd)",
+                    "Incorrect result_2: '%s' in '%s' (offset=%d)",
                     needle0, haystack0, offset);
         return -1;
     }
@@ -1158,7 +1158,7 @@ get_interp_settings(PyObject *self, PyObject *args)
     }
     else {
         PyErr_Format(PyExc_NotImplementedError,
-                     "%zd", interpid);
+                     "%d", interpid);
         return NULL;
     }
     assert(interp != NULL);

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -991,7 +991,7 @@ load_data(zoneinfo_state *state, PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
     }
 
     if (!PyTuple_CheckExact(data_tuple)) {
-        PyErr_Format(PyExc_TypeError, "Invalid data result type: %r",
+        PyErr_Format(PyExc_TypeError, "Invalid data result type: %R",
                      data_tuple);
         goto error;
     }

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -74,7 +74,7 @@ zstd_contentsize_converter(PyObject *size, unsigned long long *p)
             if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
                 PyErr_Format(PyExc_ValueError,
                              "size argument should be a positive int less "
-                             "than %ull", ZSTD_CONTENTSIZE_ERROR);
+                             "than %llu", ZSTD_CONTENTSIZE_ERROR);
                 return 0;
             }
             return 0;
@@ -83,7 +83,7 @@ zstd_contentsize_converter(PyObject *size, unsigned long long *p)
             *p = ZSTD_CONTENTSIZE_ERROR;
             PyErr_Format(PyExc_ValueError,
                          "size argument should be a positive int less "
-                         "than %ull", ZSTD_CONTENTSIZE_ERROR);
+                         "than %llu", ZSTD_CONTENTSIZE_ERROR);
             return 0;
         }
         *p = pledged_size;

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -1350,7 +1350,7 @@ binascii_a2b_base85_impl(PyObject *module, Py_buffer *data,
                 state = get_binascii_state(module);
                 if (state != NULL) {
                     PyErr_Format(state->Error,
-                                 "Base85 overflow in hunk starting at byte %d",
+                                 "Base85 overflow in hunk starting at byte %zd",
                                  (data->len - ascii_len) / 5 * 5);
                 }
                 goto error;
@@ -1361,7 +1361,7 @@ binascii_a2b_base85_impl(PyObject *module, Py_buffer *data,
         else {
             state = get_binascii_state(module);
             if (state != NULL) {
-                PyErr_Format(state->Error, "bad Base85 character at position %d",
+                PyErr_Format(state->Error, "bad Base85 character at position %zd",
                              data->len - ascii_len);
             }
             goto error;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3357,8 +3357,7 @@ sock_setsockopt(PyObject *self, PyObject *args)
     arglen = PyTuple_Size(args);
     if (arglen == 3 && optval == Py_None) {
         PyErr_Format(PyExc_TypeError,
-                     "setsockopt() requires 4 arguments when the third argument is None",
-                     arglen);
+                     "setsockopt() requires 4 arguments when the third argument is None");
         return NULL;
     }
     if (arglen == 4 && optval != Py_None) {

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -150,7 +150,7 @@ method_get(PyObject *self, PyObject *obj, PyObject *type)
         } else {
             PyErr_Format(PyExc_TypeError,
                         "descriptor '%V' needs a type, not '%s', as arg 2",
-                        descr_name((PyDescrObject *)descr),
+                        descr_name((PyDescrObject *)descr), "?",
                         Py_TYPE(type)->tp_name);
             return NULL;
         }
@@ -1610,7 +1610,7 @@ property_set_name(PyObject *self, PyObject *args) {
     if (PyTuple_GET_SIZE(args) != 2) {
         PyErr_Format(
                 PyExc_TypeError,
-                "__set_name__() takes 2 positional arguments but %d were given",
+                "__set_name__() takes 2 positional arguments but %zd were given",
                 PyTuple_GET_SIZE(args));
         return NULL;
     }

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -148,7 +148,7 @@ enumerate_vectorcall(PyObject *type, PyObject *const *args,
     }
 
     PyErr_Format(PyExc_TypeError,
-        "enumerate() takes at most 2 arguments (%d given)", nargs + nkwargs);
+        "enumerate() takes at most 2 arguments (%zd given)", nargs + nkwargs);
     return NULL;
 }
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -935,7 +935,7 @@ BaseExceptionGroup_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         if (!PyExceptionInstance_Check(exc)) {
             PyErr_Format(
                 PyExc_ValueError,
-                "Item %d of second argument (exceptions) is not an exception",
+                "Item %zd of second argument (exceptions) is not an exception",
                 i);
             goto error;
         }
@@ -1714,7 +1714,7 @@ PyUnstable_Exc_PrepReraiseStar(PyObject *orig, PyObject *excs)
         PyObject *exc = PyList_GET_ITEM(excs, i);
         if (exc == NULL || !(PyExceptionInstance_Check(exc) || Py_IsNone(exc))) {
             PyErr_Format(PyExc_TypeError,
-                         "item %d of excs is not an exception", i);
+                         "item %zd of excs is not an exception", i);
             return NULL;
         }
     }

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -657,7 +657,7 @@ func_set_code(PyObject *self, PyObject *value, void *Py_UNUSED(ignored))
     if (nclosure != nfree) {
         PyErr_Format(PyExc_ValueError,
                      "%U() requires a code object with %zd free vars,"
-                     " not %zd",
+                     " not %d",
                      op->func_name,
                      nclosure, nfree);
         return -1;
@@ -1044,7 +1044,7 @@ func_new_impl(PyTypeObject *type, PyCodeObject *code, PyObject *globals,
     nclosure = closure == Py_None ? 0 : PyTuple_GET_SIZE(closure);
     if (code->co_nfreevars != nclosure)
         return PyErr_Format(PyExc_ValueError,
-                            "%U requires closure of length %zd, not %zd",
+                            "%U requires closure of length %d, not %zd",
                             code->co_name, code->co_nfreevars, nclosure);
     if (nclosure) {
         Py_ssize_t i;

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -2472,7 +2472,7 @@ ptr_from_tuple(const Py_buffer *view, PyObject *tup)
 
     if (nindices > view->ndim) {
         PyErr_Format(PyExc_TypeError,
-                     "cannot index %zd-dimension view with %zd-element tuple",
+                     "cannot index %d-dimension view with %zd-element tuple",
                      view->ndim, nindices);
         return NULL;
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5184,28 +5184,28 @@ check_basicsize_includes_size_and_offsets(PyTypeObject* type)
 
     if (type->tp_base && type->tp_base->tp_basicsize > type->tp_basicsize) {
         PyErr_Format(PyExc_TypeError,
-                     "tp_basicsize for type '%s' (%d) is too small for base '%s' (%d)",
+                     "tp_basicsize for type '%s' (%zd) is too small for base '%s' (%zd)",
                      type->tp_name, type->tp_basicsize,
                      type->tp_base->tp_name, type->tp_base->tp_basicsize);
         return 0;
     }
     if (type->tp_weaklistoffset + (Py_ssize_t)sizeof(PyObject*) > max) {
         PyErr_Format(PyExc_TypeError,
-                     "weaklist offset %d is out of bounds for type '%s' (tp_basicsize = %d)",
+                     "weaklist offset %zd is out of bounds for type '%s' (tp_basicsize = %zd)",
                      type->tp_weaklistoffset,
                      type->tp_name, type->tp_basicsize);
         return 0;
     }
     if (type->tp_dictoffset + (Py_ssize_t)sizeof(PyObject*) > max) {
         PyErr_Format(PyExc_TypeError,
-                     "dict offset %d is out of bounds for type '%s' (tp_basicsize = %d)",
+                     "dict offset %zd is out of bounds for type '%s' (tp_basicsize = %zd)",
                      type->tp_dictoffset,
                      type->tp_name, type->tp_basicsize);
         return 0;
     }
     if (type->tp_vectorcall_offset + (Py_ssize_t)sizeof(vectorcallfunc*) > max) {
         PyErr_Format(PyExc_TypeError,
-                     "vectorcall offset %d is out of bounds for type '%s' (tp_basicsize = %d)",
+                     "vectorcall offset %zd is out of bounds for type '%s' (tp_basicsize = %zd)",
                      type->tp_vectorcall_offset,
                      type->tp_name, type->tp_basicsize);
         return 0;

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -818,7 +818,7 @@ typevar_typing_prepare_subst_impl(typevarobject *self, PyObject *alias,
     }
     Py_DECREF(params);
     PyErr_Format(PyExc_TypeError,
-                 "Too few arguments for %S; actual %d, expected at least %d",
+                 "Too few arguments for %S; actual %zd, expected at least %zd",
                  alias, args_len, i + 1);
     return NULL;
 }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8350,7 +8350,7 @@ charmap_decode_mapping(const char *s,
                 goto Undefined;
             if (value < 0 || value > MAX_UNICODE) {
                 PyErr_Format(PyExc_TypeError,
-                             "character mapping must be in range(0x%x)",
+                             "character mapping must be in range(0x%lx)",
                              (unsigned long)MAX_UNICODE + 1);
                 goto onError;
             }
@@ -9141,8 +9141,8 @@ charmaptranslate_lookup(Py_UCS4 c, PyObject *mapping, PyObject **result, Py_UCS4
         long value = PyLong_AsLong(x);
         if (value < 0 || value > MAX_UNICODE) {
             PyErr_Format(PyExc_ValueError,
-                         "character mapping must be in range(0x%x)",
-                         MAX_UNICODE+1);
+                         "character mapping must be in range(0x%lx)",
+                         (unsigned long)MAX_UNICODE + 1);
             Py_DECREF(x);
             return -1;
         }

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -61,7 +61,7 @@ union_hash(PyObject *self)
         }
         // The unhashable values somehow became hashable again. Still raise
         // an error.
-        PyErr_Format(PyExc_TypeError, "union contains %d unhashable elements", n);
+        PyErr_Format(PyExc_TypeError, "union contains %zd unhashable elements", n);
         return -1;
     }
     return PyObject_Hash(alias->hashable_args);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1607,7 +1607,7 @@ check:
         // ValueError: map() argument 3 is shorter than arguments 1-2
         const char* plural = i == 1 ? " " : "s 1-";
         PyErr_Format(PyExc_ValueError,
-                     "map() argument %d is shorter than argument%s%d",
+                     "map() argument %zd is shorter than argument%s%zd",
                      i + 1, plural, i);
         goto exit_no_result;
     }
@@ -1618,7 +1618,7 @@ check:
             Py_DECREF(val);
             const char* plural = i == 1 ? " " : "s 1-";
             PyErr_Format(PyExc_ValueError,
-                         "map() argument %d is longer than argument%s%d",
+                         "map() argument %zd is longer than argument%s%zd",
                          i + 1, plural, i);
             goto exit_no_result;
         }
@@ -3307,7 +3307,7 @@ check:
         // ValueError: zip() argument 3 is shorter than arguments 1-2
         const char* plural = i == 1 ? " " : "s 1-";
         return PyErr_Format(PyExc_ValueError,
-                            "zip() argument %d is shorter than argument%s%d",
+                            "zip() argument %zd is shorter than argument%s%zd",
                             i + 1, plural, i);
     }
     for (i = 1; i < tuplesize; i++) {
@@ -3317,7 +3317,7 @@ check:
             Py_DECREF(item);
             const char* plural = i == 1 ? " " : "s 1-";
             return PyErr_Format(PyExc_ValueError,
-                                "zip() argument %d is longer than argument%s%d",
+                                "zip() argument %zd is longer than argument%s%zd",
                                 i + 1, plural, i);
         }
         if (PyErr_Occurred()) {

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -602,7 +602,7 @@ _PyEval_MatchClass(PyThreadState *tstate, PyObject *subject, PyObject *type,
         if (allowed < nargs) {
             const char *plural = (allowed == 1) ? "" : "s";
             _PyErr_Format(tstate, PyExc_TypeError,
-                          "%s() accepts %d positional sub-pattern%s (%d given)",
+                          "%s() accepts %zd positional sub-pattern%s (%zd given)",
                           ((PyTypeObject*)type)->tp_name,
                           allowed, plural, nargs);
             goto fail;
@@ -1555,7 +1555,7 @@ format_missing(PyThreadState *tstate, const char *kind,
     if (name_str == NULL)
         return;
     _PyErr_Format(tstate, PyExc_TypeError,
-                  "%U() missing %i required %s argument%s: %U",
+                  "%U() missing %zi required %s argument%s: %U",
                   qualname,
                   len,
                   kind,

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -455,7 +455,7 @@ _PyBytes_GetXIDataWrapped(PyThreadState *tstate,
         return NULL;
     }
     if (size < sizeof(_PyBytes_data_t)) {
-        PyErr_Format(PyExc_ValueError, "expected size >= %d, got %d",
+        PyErr_Format(PyExc_ValueError, "expected size >= %zu, got %zu",
                      sizeof(_PyBytes_data_t), size);
         return NULL;
     }

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2423,7 +2423,7 @@ vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
             if (i < pos) {
                 Py_ssize_t min = Py_MIN(pos, parser->min);
                 PyErr_Format(PyExc_TypeError,
-                             "%.200s%s takes %s %d positional argument%s"
+                             "%.200s%s takes %s %zd positional argument%s"
                              " (%zd given)",
                              (parser->fname == NULL) ? "function" : parser->fname,
                              (parser->fname == NULL) ? "" : "()",
@@ -2435,7 +2435,7 @@ vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
             else {
                 keyword = PyTuple_GET_ITEM(kwtuple, i - pos);
                 PyErr_Format(PyExc_TypeError,  "%.200s%s missing required "
-                             "argument '%U' (pos %d)",
+                             "argument '%U' (pos %zd)",
                              (parser->fname == NULL) ? "function" : parser->fname,
                              (parser->fname == NULL) ? "" : "()",
                              keyword, i+1);
@@ -2476,7 +2476,7 @@ vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
                 /* arg present in tuple and in dict */
                 PyErr_Format(PyExc_TypeError,
                              "argument for %.200s%s given by name ('%U') "
-                             "and position (%d)",
+                             "and position (%zd)",
                              (parser->fname == NULL) ? "function" : parser->fname,
                              (parser->fname == NULL) ? "" : "()",
                              keyword, i+1);

--- a/Python/interpconfig.c
+++ b/Python/interpconfig.c
@@ -208,7 +208,7 @@ interp_config_from_dict(PyObject *origdict, PyInterpreterConfig *config,
     }
     else if (unused > 0) {
         PyErr_Format(PyExc_ValueError,
-                     "config dict has %d extra items (%R)", unused, dict);
+                     "config dict has %zd extra items (%R)", unused, dict);
         goto error;
     }
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1382,11 +1382,11 @@ get_interactive_filename(PyObject *filename, Py_ssize_t count)
         if (middle == NULL) {
             return NULL;
         }
-        result = PyUnicode_FromFormat("<%U-%d>", middle, count);
+        result = PyUnicode_FromFormat("<%U-%zd>", middle, count);
         Py_DECREF(middle);
     } else {
         result = PyUnicode_FromFormat(
-            "%U-%d", filename, count);
+            "%U-%zd", filename, count);
     }
     return result;
 


### PR DESCRIPTION
There are 2 kinds of errors.

There are ~8 real mistakes.
Comply with C99 for va_list: https://en.cppreference.com/w/c/variadic/va_arg.html
Most of the changes are `%d` <-> `%ld` for `int` and `Py_ssize_t`.


<!-- gh-issue-number: gh-146615 -->
* Issue: gh-146615
<!-- /gh-issue-number -->
