### PR TITLE
[3.10] Docs: add standard-imghdr for compatibility with Python 3.13+

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -10,6 +10,8 @@ sphinx==3.4.3
 docutils==0.17.1
 # Jinja version is pinned to a version compatible with Sphinx version <4.5.
 jinja2==3.0.3
+# Sphinx 3.4.3 uses imghdr which was removed from stdlib in Python 3.11
+standard-imghdr==3.13.0; python_version>3.10
 
 blurb
 

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -11,7 +11,7 @@ docutils==0.17.1
 # Jinja version is pinned to a version compatible with Sphinx version <4.5.
 jinja2==3.0.3
 # Sphinx 3.4.3 uses imghdr which was removed from stdlib in Python 3.11
-standard-imghdr==3.13.0; python_version>3.10
+standard-imghdr==3.13.0; python_version>'3.10'
 
 blurb
 

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -10,8 +10,8 @@ sphinx==3.4.3
 docutils==0.17.1
 # Jinja version is pinned to a version compatible with Sphinx version <4.5.
 jinja2==3.0.3
-# Sphinx 3.4.3 uses imghdr which was removed from stdlib in Python 3.11
-standard-imghdr==3.13.0; python_version>'3.10'
+# Sphinx 3.4.3 uses imghdr which was removed from stdlib in Python 3.13
+standard-imghdr==3.13.0; python_version>'3.12'
 
 blurb
 


### PR DESCRIPTION
To keep `Doc/requirements.txt` self-contained for building with recent Python versions.

We pin docs on 3.10 branch to Sphinx 3.4.3, which uses `imghdr` which in turn was removed from stdlib in Python 3.13.

https://pypi.org/project/standard-imghdr/ is drop-in replacement for the `imghdr`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--146623.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->