### PR TITLE
gh-146444: Don't package as part of iOS 'build hosts' target

### DIFF
--- a/Platforms/Apple/.ruff.toml
+++ b/Platforms/Apple/.ruff.toml
@@ -1,8 +1,5 @@
 extend = "../../.ruff.toml"  # Inherit the project-wide settings
 
-# iOS buildbot worker uses Python 3.9
-target-version = "py39"
-
 [format]
 preview = true
 docstring-code-format = true

--- a/Platforms/Apple/__main__.py
+++ b/Platforms/Apple/__main__.py
@@ -771,7 +771,7 @@ def build(context: argparse.Namespace, host: str | None = None) -> None:
         ]:
             step(context, host=step_host)
 
-    if host in {"all", "hosts"}:
+    if host == "all":
         package(context)
 
 

--- a/Platforms/Apple/__main__.py
+++ b/Platforms/Apple/__main__.py
@@ -52,10 +52,9 @@ from datetime import datetime, timezone
 from os.path import basename, relpath
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import Union
 
 EnvironmentT = dict[str, str]
-ArgsT = Sequence[Union[str, Path]]
+ArgsT = Sequence[str | Path]
 
 SCRIPT_NAME = Path(__file__).name
 PYTHON_DIR = Path(__file__).resolve().parent.parent.parent

--- a/Platforms/Apple/testbed/__main__.py
+++ b/Platforms/Apple/testbed/__main__.py
@@ -7,7 +7,6 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Union
 
 TEST_SLICES = {
     "iOS": "ios-arm64_x86_64-simulator",
@@ -263,7 +262,7 @@ def update_test_plan(testbed_path, platform, args):
 
 def run_testbed(
     platform: str,
-    simulator: Union[str, None],
+    simulator: str | None,
     args: list[str],
     verbose: bool = False,
 ):


### PR DESCRIPTION
Modify the `Platforms/Apple build iOS hosts` target to *not* build the package. The package target is still run on a `build all`.

Also reverts the Python3.9 compatibility fixes from #146624, as the iOS buildbot is now on Python 3.12



<!-- gh-issue-number: gh-146444 -->
* Issue: gh-146444
<!-- /gh-issue-number -->
