### PR TITLE
gh-146632: make `traceback` handle illformed `ModuleNotFoundError`

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -5456,5 +5456,17 @@ class TestLazyImportSuggestions(unittest.TestCase):
         self.assertNotIn(b"BAR_MODULE_LOADED", stdout)
 
 
+class TestNoCrashInTracebackException(unittest.TestCase):
+    def test_module_not_found_error_with_bad_name(self):
+        exc = ModuleNotFoundError(name=NotImplemented)
+        try:
+            te = traceback.TracebackException.from_exception(exc)
+        except Exception as e:
+            self.fail(f"TracebackException raised unexpected exception: {e!r}")
+        else:
+            msg = "".join(te.format())
+            self.assertEqual(msg, "ModuleNotFoundError\n")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1907,26 +1907,29 @@ def _find_incompatible_extension_module(module_name):
     import importlib.machinery
     import importlib.resources.readers
 
-    if not module_name or not importlib.machinery.EXTENSION_SUFFIXES:
+    if not isinstance(module_name, str) or not importlib.machinery.EXTENSION_SUFFIXES:
         return
 
     # We assume the last extension is untagged (eg. .so, .pyd)!
     # tests.test_traceback.MiscTest.test_find_incompatible_extension_modules
     # tests that assumption.
-    untagged_suffix = importlib.machinery.EXTENSION_SUFFIXES[-1]
-    # On Windows the debug tag is part of the module file stem, instead of the
-    # extension (eg. foo_d.pyd), so let's remove it and just look for .pyd.
-    if os.name == 'nt':
-        untagged_suffix = untagged_suffix.removeprefix('_d')
+    try:
+        untagged_suffix = importlib.machinery.EXTENSION_SUFFIXES[-1]
+        # On Windows the debug tag is part of the module file stem, instead of the
+        # extension (eg. foo_d.pyd), so let's remove it and just look for .pyd.
+        if os.name == 'nt':
+            untagged_suffix = untagged_suffix.removeprefix('_d')
 
-    parent, _, child = module_name.rpartition('.')
-    if parent:
-        traversable = importlib.resources.files(parent)
-    else:
-        traversable = importlib.resources.readers.MultiplexedPath(
-            *map(pathlib.Path, filter(os.path.isdir, sys.path))
-        )
+        parent, _, child = module_name.rpartition('.')
+        if parent:
+            traversable = importlib.resources.files(parent)
+        else:
+            traversable = importlib.resources.readers.MultiplexedPath(
+                *map(pathlib.Path, filter(os.path.isdir, sys.path))
+            )
 
-    for entry in traversable.iterdir():
-        if entry.name.startswith(child + '.') and entry.name.endswith(untagged_suffix):
-            return entry.name
+        for entry in traversable.iterdir():
+            if entry.name.startswith(child + '.') and entry.name.endswith(untagged_suffix):
+                return entry.name
+    except Exception:
+        return

--- a/Misc/NEWS.d/next/Library/2026-03-30-21-11-02.gh-issue-146632.cDa6Yp.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-30-21-11-02.gh-issue-146632.cDa6Yp.rst
@@ -1,0 +1,1 @@
+Add type check and use try-except to fix traceback crash


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146632 -->
* Issue: gh-146632
<!-- /gh-issue-number -->
