### PR TITLE
gh-146656: properly raise `NotImplementedError` instead of `NotImplemented` in `test_discover`

### DIFF
--- a/Lib/test/test_importlib/test_discover.py
+++ b/Lib/test/test_importlib/test_discover.py
@@ -11,7 +11,7 @@ class DiscoverableFinder:
         self._discovered_values = discover
 
     def find_spec(self, fullname, path=None, target=None):
-        raise NotImplemented
+        raise NotImplementedError
 
     def discover(self, parent=None):
         yield from self._discovered_values

--- a/Lib/test/test_importlib/test_discover.py
+++ b/Lib/test/test_importlib/test_discover.py
@@ -11,7 +11,7 @@ class DiscoverableFinder:
         self._discovered_values = discover
 
     def find_spec(self, fullname, path=None, target=None):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def discover(self, parent=None):
         yield from self._discovered_values

--- a/Lib/test/test_importlib/test_discover.py
+++ b/Lib/test/test_importlib/test_discover.py
@@ -11,7 +11,7 @@ class DiscoverableFinder:
         self._discovered_values = discover
 
     def find_spec(self, fullname, path=None, target=None):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def discover(self, parent=None):
         yield from self._discovered_values


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

In [docs](https://docs.python.org/3.15/library/exceptions.html#NotImplementedError):
> NotImplementedError and NotImplemented are not interchangeable

<!-- gh-issue-number: gh-146656 -->
* Issue: gh-146656
<!-- /gh-issue-number -->
