### PR TITLE
[3.13] gh-146615: Fix format specifiers in Objects/ directory (GH-146620) 

### DIFF
--- a/Parser/lexer/lexer.c
+++ b/Parser/lexer/lexer.c
@@ -1106,7 +1106,7 @@ tok_get_normal_mode(struct tok_state *tok, tokenizer_mode* current_tok, struct t
                     tokenizer_mode *the_current_tok = TOK_GET_MODE(tok);
                     if (the_current_tok->f_string_quote == quote &&
                         the_current_tok->f_string_quote_size == quote_size) {
-                        return MAKE_TOKEN(_PyTokenizer_syntaxerror(tok, "f-string: expecting '}'", start));
+                        return MAKE_TOKEN(_PyTokenizer_syntaxerror(tok, "f-string: expecting '}'"));
                     }
                 }
 

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2203,7 +2203,7 @@ vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
             else {
                 keyword = PyTuple_GET_ITEM(kwtuple, i - pos);
                 PyErr_Format(PyExc_TypeError,  "%.200s%s missing required "
-                             "argument '%U' (pos %zd)",
+                             "argument '%U' (pos %d)",
                              (parser->fname == NULL) ? "function" : parser->fname,
                              (parser->fname == NULL) ? "" : "()",
                              keyword, i+1);
@@ -2244,7 +2244,7 @@ vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
                 /* arg present in tuple and in dict */
                 PyErr_Format(PyExc_TypeError,
                              "argument for %.200s%s given by name ('%U') "
-                             "and position (%zd)",
+                             "and position (%d)",
                              (parser->fname == NULL) ? "function" : parser->fname,
                              (parser->fname == NULL) ? "" : "()",
                              keyword, i+1);


### PR DESCRIPTION
I found a new error specific to 3.13.

https://github.com/python/cpython/blob/fc1c6446ce80b547de6214ed4970b061695f94b8/Parser/lexer/lexer.c#L1107-L1110

```diff
-      return MAKE_TOKEN(_PyTokenizer_syntaxerror(tok, "f-string: expecting '}'", start));
+      return MAKE_TOKEN(_PyTokenizer_syntaxerror(tok, "f-string: expecting '}'")); 
```

This is fixed by https://github.com/python/cpython/commit/60202609a2c2d0971aadfa4729ba30b50e89c6ea in 3.14.

<!-- gh-issue-number: gh-146615 -->
* Issue: gh-146615
<!-- /gh-issue-number -->
