### PR TITLE
gh-143930: Fix typo in NEWS entry

### DIFF
--- a/Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst
+++ b/Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst
@@ -1,1 +1,1 @@
-Reject leading dashes in URLs passed to :func:`webbrowser.open`
+Reject leading dashes in URLs passed to :func:`webbrowser.open`.


### PR DESCRIPTION
We do always include a "." at the end of the Whats New statement in the release notes (see

[gh-143935](https://github.com/python/cpython/issues/143935): Fixed a bug in the folding of comments when flattening an email message using a modern email policy. Comments consisting of a very long sequence of non-foldable characters could trigger a forced line wrap that omitted the required leading space on the continuation line, causing the remainder of the comment to be interpreted as a new header field. This enabled header injection with carefully crafted inputs.

[gh-143925](https://github.com/python/cpython/issues/143925): Reject control characters in data: URL media types.

[gh-143919](https://github.com/python/cpython/issues/143919): Reject control characters in [http.cookies.Morsel](https://docs.python.org/release/3.14.3/library/http.cookies.html#http.cookies.Morsel) fields and values.

[gh-143916](https://github.com/python/cpython/issues/143916): Reject C0 control characters within wsgiref.headers.Headers fields, values, and parameters.

)

And Benedikt Tran said that it's not necessary to open up an issue for just fixing a typo, but I don't know whether formating of the title is correct now because of the missing issue

<!-- gh-issue-number: gh-143930 -->
* Issue: gh-143930
<!-- /gh-issue-number -->
