### PR TITLE
gh-147960: Avoid memory leak in _tuple_shared() on allocation failure

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-01-08-16-14.gh-issue-147960.iUeF5e.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-01-08-16-14.gh-issue-147960.iUeF5e.rst
@@ -1,0 +1,1 @@
+Fix a memory leak in ``_tuple_shared()`` when allocation of the internal items array fails.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-01-08-16-14.gh-issue-147960.iUeF5e.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-01-08-16-14.gh-issue-147960.iUeF5e.rst
@@ -1,1 +1,0 @@
-Fix a memory leak in ``_tuple_shared()`` when allocation of the internal items array fails.

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -657,6 +657,7 @@ _tuple_shared(PyThreadState *tstate, PyObject *obj, xidata_fallback_t fallback,
     shared->items = (_PyXIData_t **) PyMem_Calloc(shared->len, sizeof(_PyXIData_t *));
     if (shared->items == NULL) {
         PyErr_NoMemory();
+        PyMem_RawFree(shared);
         return -1;
     }
 


### PR DESCRIPTION
Fix a memory leak in _tuple_shared() when allocating the items array fails.

If PyMem_Calloc() for shared->items fails, the previously allocated
`shared` structure was not freed before returning, resulting in a leak.

Add the missing PyMem_RawFree(shared) on the error path.

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-147960 -->
* Issue: gh-147960
<!-- /gh-issue-number -->
