### PR TITLE
gh-146613: Fix re-entrant use-after-free in itertools._grouper

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -757,7 +757,7 @@ class TestBasicOps(unittest.TestCase):
     def test_grouper_reentrant_eq_does_not_crash(self):
         # regression test for gh-146613
         grouper_iter = None
-        
+
         class Key:
             __hash__ = None
 

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -754,6 +754,40 @@ class TestBasicOps(unittest.TestCase):
         next(g)
         next(g)  # must pass with address sanitizer
 
+    def test_grouper_reentrant_eq_does_not_crash(self):
+            # regression test for gh-146613
+            grouper_iter = None
+            class Key:
+                __hash__ = None
+
+                def __init__(self, do_advance):
+                    self.do_advance = do_advance
+                    self.payload = bytearray(256)
+
+                def __eq__(self, other):
+                    nonlocal grouper_iter
+                    if self.do_advance:
+                        self.do_advance = False
+                        if grouper_iter is not None:
+                            try:
+                                next(grouper_iter)
+                            except StopIteration:
+                                pass
+                        for _ in range(50):
+                            bytearray(256)
+                        return NotImplemented
+                    return True
+
+            def keyfunc(element):
+                if element == 0:
+                    return Key(do_advance=True)
+                return Key(do_advance=False)
+
+            g = itertools.groupby(range(4), keyfunc)
+            key, grouper_iter = next(g)
+            items = list(grouper_iter)
+            self.assertEqual(len(items), 1)
+
     def test_filter(self):
         self.assertEqual(list(filter(isEven, range(6))), [0,2,4])
         self.assertEqual(list(filter(None, [0,1,0,2,0])), [1,2])

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -755,38 +755,36 @@ class TestBasicOps(unittest.TestCase):
         next(g)  # must pass with address sanitizer
 
     def test_grouper_reentrant_eq_does_not_crash(self):
-            # regression test for gh-146613
-            grouper_iter = None
-            class Key:
-                __hash__ = None
+        # regression test for gh-146613
+        grouper_iter = None
+        
+        class Key:
+            __hash__ = None
 
-                def __init__(self, do_advance):
-                    self.do_advance = do_advance
-                    self.payload = bytearray(256)
+            def __init__(self, do_advance):
+                self.do_advance = do_advance
 
-                def __eq__(self, other):
-                    nonlocal grouper_iter
-                    if self.do_advance:
-                        self.do_advance = False
-                        if grouper_iter is not None:
-                            try:
-                                next(grouper_iter)
-                            except StopIteration:
-                                pass
-                        for _ in range(50):
-                            bytearray(256)
-                        return NotImplemented
-                    return True
+            def __eq__(self, other):
+                nonlocal grouper_iter
+                if self.do_advance:
+                    self.do_advance = False
+                    if grouper_iter is not None:
+                        try:
+                            next(grouper_iter)
+                        except StopIteration:
+                            pass
+                    return NotImplemented
+                return True
 
-            def keyfunc(element):
-                if element == 0:
-                    return Key(do_advance=True)
-                return Key(do_advance=False)
+        def keyfunc(element):
+            if element == 0:
+                return Key(do_advance=True)
+            return Key(do_advance=False)
 
-            g = itertools.groupby(range(4), keyfunc)
-            key, grouper_iter = next(g)
-            items = list(grouper_iter)
-            self.assertEqual(len(items), 1)
+        g = itertools.groupby(range(4), keyfunc)
+        key, grouper_iter = next(g)
+        items = list(grouper_iter)
+        self.assertEqual(len(items), 1)
 
     def test_filter(self):
         self.assertEqual(list(filter(isEven, range(6))), [0,2,4])

--- a/Misc/NEWS.d/next/Library/2026-04-01-11-05-36.gh-issue-146613.GzjUFK.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-01-11-05-36.gh-issue-146613.GzjUFK.rst
@@ -1,4 +1,3 @@
 :mod:`itertools`: Fix re-entrant use-after-free in ``itertools.groupby()``
 that could lead to a segmentation fault when a user-defined ``__eq__``
-re-enters the grouper iterator. The same pattern was previously fixed
-in gh-143543.
+re-enters the grouper iterator.

--- a/Misc/NEWS.d/next/Library/2026-04-01-11-05-36.gh-issue-146613.GzjUFK.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-01-11-05-36.gh-issue-146613.GzjUFK.rst
@@ -1,0 +1,4 @@
+:mod:`itertools`: Fix re-entrant use-after-free in ``_grouper.__next__``
+that could lead to a segmentation fault when a user-defined ``__eq__``
+re-enters the grouper iterator. The same pattern was previously fixed
+in ``groupby.__next__`` (gh-143543).

--- a/Misc/NEWS.d/next/Library/2026-04-01-11-05-36.gh-issue-146613.GzjUFK.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-01-11-05-36.gh-issue-146613.GzjUFK.rst
@@ -1,3 +1,2 @@
-:mod:`itertools`: Fix re-entrant use-after-free in ``itertools.groupby()``
-that could lead to a segmentation fault when a user-defined ``__eq__``
-re-enters the grouper iterator.
+:mod:`itertools`: Fix a crash in :func:`itertools.groupby` when
+the grouper iterator is concurrently mutated.

--- a/Misc/NEWS.d/next/Library/2026-04-01-11-05-36.gh-issue-146613.GzjUFK.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-01-11-05-36.gh-issue-146613.GzjUFK.rst
@@ -1,4 +1,4 @@
-:mod:`itertools`: Fix re-entrant use-after-free in ``_grouper.__next__``
+:mod:`itertools`: Fix re-entrant use-after-free in ``itertools.groupby()``
 that could lead to a segmentation fault when a user-defined ``__eq__``
 re-enters the grouper iterator. The same pattern was previously fixed
-in ``groupby.__next__`` (gh-143543).
+in gh-143543.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -682,11 +682,8 @@ _grouper_next(PyObject *op)
        mutating gbo->currkey while we are comparing them.
        Take local snapshots and hold strong references so INCREF/DECREF
        apply to the same objects even under re-entrancy. */
-    PyObject *tgtkey = igo->tgtkey;
-    PyObject *currkey = gbo->currkey;
-
-    Py_INCREF(tgtkey);
-    Py_INCREF(currkey);
+    PyObject *tgtkey = Py_NewRef(igo->tgtkey);
+    PyObject *currkey = Py_NewRef(gbo->currkey);
     rcmp = PyObject_RichCompareBool(tgtkey, currkey, Py_EQ);
     Py_DECREF(tgtkey);
     Py_DECREF(currkey);

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -678,7 +678,19 @@ _grouper_next(PyObject *op)
     }
 
     assert(gbo->currkey != NULL);
-    rcmp = PyObject_RichCompareBool(igo->tgtkey, gbo->currkey, Py_EQ);
+    /* A user-defined __eq__ can re-enter the grouper and advance the iterator,
+       mutating gbo->currkey while we are comparing them.
+       Take local snapshots and hold strong references so INCREF/DECREF
+       apply to the same objects even under re-entrancy. */
+    PyObject *tgtkey = igo->tgtkey;
+    PyObject *currkey = gbo->currkey;
+
+    Py_INCREF(tgtkey);
+    Py_INCREF(currkey);
+    rcmp = PyObject_RichCompareBool(tgtkey, currkey, Py_EQ);
+    Py_DECREF(tgtkey);
+    Py_DECREF(currkey);
+
     if (rcmp <= 0)
         /* got any error or current group is end */
         return NULL;


### PR DESCRIPTION
Closes gh-146613

The same pattern was fixed in `groupby.__next__` (gh-143543 / a91b5c3), but `_grouper_next` (the inner group iterator returned by `groupby`) was missed.

A user-defined `__eq__` can re-enter the grouper during `PyObject_RichCompareBool`, causing `Py_XSETREF` to free `currkey` while it is still being used.

Fixed by taking strong references (`Py_INCREF` / `Py_DECREF`) to `tgtkey` and `currkey` before the comparison, exactly as done in `groupby_next`.

Added regression test `test_grouper_reentrant_eq_does_not_crash`.