### PR TITLE
gh-146642: Clarify -W regex requires at least two characters

### DIFF
--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -159,9 +159,9 @@ the disposition of the match.  Each entry is a tuple of the form (*action*,
 
 * *message* is a string containing a regular expression that the start of
   the warning message must match, case-insensitively.  In :option:`-W` and
-  :envvar:`PYTHONWARNINGS`, if *message* starts and ends with a forward slash
-  (``/``), it specifies a regular expression as above;
-  otherwise it is a literal string that the start of the
+  :envvar:`PYTHONWARNINGS`, if *message* is at least two characters long and
+  starts and ends with a forward slash (``/``), it specifies a regular
+  expression as above; otherwise it is a literal string that the start of the
   warning message must match (case-insensitively), ignoring any whitespace at
   the start or end of *message*.
 
@@ -170,9 +170,9 @@ the disposition of the match.  Each entry is a tuple of the form (*action*,
 
 * *module* is a string containing a regular expression that the start of the
   fully qualified module name must match, case-sensitively.  In :option:`-W` and
-  :envvar:`PYTHONWARNINGS`, if *module* starts and ends with a forward slash
-  (``/``), it specifies a regular expression as above;
-  otherwise it is a literal string that the
+  :envvar:`PYTHONWARNINGS`, if *module* is at least two characters long and
+  starts and ends with a forward slash (``/``), it specifies a regular
+  expression as above; otherwise it is a literal string that the
   fully qualified module name must be equal to (case-sensitively), ignoring any
   whitespace at the start or end of *module*.
 

--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -159,9 +159,10 @@ the disposition of the match.  Each entry is a tuple of the form (*action*,
 
 * *message* is a string containing a regular expression that the start of
   the warning message must match, case-insensitively.  In :option:`-W` and
-  :envvar:`PYTHONWARNINGS`, if *message* is at least two characters long and
-  starts and ends with a forward slash (``/``), it specifies a regular
-  expression as above; otherwise it is a literal string that the start of the
+  :envvar:`PYTHONWARNINGS`, if *message* starts and ends with a forward
+  slash (``/``), it specifies a regular expression as above (a single ``/``
+  on its own is treated as a literal string); otherwise it is a literal
+  string that the start of the
   warning message must match (case-insensitively), ignoring any whitespace at
   the start or end of *message*.
 
@@ -170,9 +171,10 @@ the disposition of the match.  Each entry is a tuple of the form (*action*,
 
 * *module* is a string containing a regular expression that the start of the
   fully qualified module name must match, case-sensitively.  In :option:`-W` and
-  :envvar:`PYTHONWARNINGS`, if *module* is at least two characters long and
-  starts and ends with a forward slash (``/``), it specifies a regular
-  expression as above; otherwise it is a literal string that the
+  :envvar:`PYTHONWARNINGS`, if *module* starts and ends with a forward
+  slash (``/``), it specifies a regular expression as above (a single ``/``
+  on its own is treated as a literal string); otherwise it is a literal
+  string that the
   fully qualified module name must be equal to (case-sensitively), ignoring any
   whitespace at the start or end of *module*.
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -481,9 +481,9 @@ Miscellaneous options
 
    The *message* field must match the start of the warning message;
    this match is case-insensitive.
-   If it is at least two characters long and starts and ends with a forward
-   slash (``/``), it specifies a regular expression, otherwise it specifies a
-   literal string.
+   If it starts and ends with a forward slash (``/``), it specifies a regular
+   expression (a single ``/`` on its own is treated as a literal string),
+   otherwise it specifies a literal string.
 
    The *category* field matches the warning category
    (ex: ``DeprecationWarning``). This must be a class name; the match test
@@ -492,10 +492,11 @@ Miscellaneous options
 
    The *module* field matches the (fully qualified) module name; this match is
    case-sensitive.
-   If it is at least two characters long and starts and ends with a forward
-   slash (``/``), it specifies a regular expression that the start of the fully
-   qualified module name must match, otherwise it specifies a literal string
-   that the fully qualified module name must be equal to.
+   If it starts and ends with a forward slash (``/``), it specifies a regular
+   expression (a single ``/`` on its own is treated as a literal string) that
+   the start of the fully qualified module name must match, otherwise it
+   specifies a literal string that the fully qualified module name must be
+   equal to.
 
    The *lineno* field matches the line number, where zero matches all line
    numbers and is thus equivalent to an omitted line number.

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -481,8 +481,9 @@ Miscellaneous options
 
    The *message* field must match the start of the warning message;
    this match is case-insensitive.
-   If it starts and ends with a forward slash (``/``), it specifies
-   a regular expression, otherwise it specifies a literal string.
+   If it is at least two characters long and starts and ends with a forward
+   slash (``/``), it specifies a regular expression, otherwise it specifies a
+   literal string.
 
    The *category* field matches the warning category
    (ex: ``DeprecationWarning``). This must be a class name; the match test
@@ -491,10 +492,10 @@ Miscellaneous options
 
    The *module* field matches the (fully qualified) module name; this match is
    case-sensitive.
-   If it starts and ends with a forward slash (``/``), it specifies
-   a regular expression that the start of the fully qualified module name
-   must match, otherwise it specifies a literal string that the fully
-   qualified module name must be equal to.
+   If it is at least two characters long and starts and ends with a forward
+   slash (``/``), it specifies a regular expression that the start of the fully
+   qualified module name must match, otherwise it specifies a literal string
+   that the fully qualified module name must be equal to.
 
    The *lineno* field matches the line number, where zero matches all line
    numbers and is thus equivalent to an omitted line number.


### PR DESCRIPTION
Closes #146642.

The documentation for the `-W` option's *message* and *module* fields says that a value "starts and ends with a forward slash (`/`)" is treated as a regular expression. However, the implementation in `Lib/_py_warnings.py` (`_setoption()`, lines 372 and 377) requires `len(value) >= 2`, so a bare `/` is treated as a literal string, not a regex.

This PR updates the docs in both `Doc/using/cmdline.rst` and `Doc/library/warnings.rst` to mention the minimum length requirement, matching the actual behavior.

## Changes
- `Doc/using/cmdline.rst`: Add "at least two characters long" qualifier for both *message* and *module* regex detection
- `Doc/library/warnings.rst`: Same clarification for both *message* and *module* fields

<!-- gh-issue-number: gh-146642 -->
* Issue: gh-146642
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--147969.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->