### PR TITLE
gh-147965: Add shutdown() to multiprocessing.Queue excluded methods

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -932,7 +932,8 @@ For an example of the usage of queues for interprocess communication see
    standard library's :mod:`queue` module are raised to signal timeouts.
 
    :class:`Queue` implements all the methods of :class:`queue.Queue` except for
-   :meth:`~queue.Queue.task_done` and :meth:`~queue.Queue.join`.
+   :meth:`~queue.Queue.task_done`, :meth:`~queue.Queue.join`, and
+   :meth:`~queue.Queue.shutdown`.
 
    .. method:: qsize()
 


### PR DESCRIPTION
Closes #147965.

The `multiprocessing.Queue` documentation states it implements all methods of `queue.Queue` except for `task_done()` and `join()`. Since `queue.Queue.shutdown()` was added in Python 3.13, and `multiprocessing.Queue` does not implement it either, this PR adds `shutdown()` to the list of excluded methods.

## Changes
- `Doc/library/multiprocessing.rst`: Add `shutdown()` to the list of `queue.Queue` methods not implemented by `multiprocessing.Queue`

<!-- gh-issue-number: gh-147965 -->
* Issue: gh-147965
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--147970.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->