### PR TITLE
GH-113425: Add example for default_namespace in ElementTree docs

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -365,8 +365,26 @@ These two approaches both output::
      |--> Gunther
      |--> Commander Clement
 
+Serializing XML with Default Namespace
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. _elementtree-xpath:
+When serializing XML that contains a default namespace, ElementTree will by
+default add a generated prefix (such as ``ns0``) instead of preserving the
+default namespace. For example::
+
+   >>> root = ET.fromstring("<doc xmlns='http://example.com'><p>text</p></doc>")
+   >>> print(ET.tostring(root, encoding='unicode'))
+   <ns0:doc xmlns:ns0="http://example.com"><ns0:p>text</ns0:p></ns0:doc>
+
+To preserve the default namespace during serialization, use the
+*default_namespace* parameter with :func:`tostring` or :meth:`ElementTree.write`::
+
+   >>> root = ET.fromstring("<doc xmlns='http://example.com'><p>text</p></doc>")
+   >>> print(ET.tostring(root, encoding='unicode', default_namespace='http://example.com'))
+   <doc xmlns="http://example.com"><p>text</p></doc>
+
+.. versionadded:: 3.8
+   The *default_namespace* parameter.
 
 XPath support
 -------------


### PR DESCRIPTION
## Summary

Adds an example to the ElementTree documentation showing how to use the `default_namespace` parameter to preserve default namespaces during XML serialization.

## Problem

When serializing XML that contains a default namespace, ElementTree adds a generated `ns0:` prefix instead of preserving the default namespace. This behavior is documented but lacks a clear example showing the workaround.

## Solution

Added a new subsection "Serializing XML with Default Namespace" in the Tutorial section with:
- Example showing the problem (ns0 prefix appearing)
- Example showing the solution (using `default_namespace` parameter)

## Issue

Fixes #113425

## Checklist

- [x] Documentation changes in [Doc/library/xml.etree.elementtree.rst](cci:7://file:///c:/Users/rohit/Music/cpython/Doc/library/xml.etree.elementtree.rst:0:0-0:0)
- [x] Includes code examples with expected output
- [x] References the relevant parameter `default_namespace` added in 3.8

<!-- gh-issue-number: gh-113425 -->
* Issue: gh-113425
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--147976.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->