### PR TITLE
gh-125895: Render 404 page correctly on `docs.python.org`

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -572,6 +572,17 @@ refcount_file = 'data/refcounts.dat'
 stable_abi_file = 'data/stable_abi.dat'
 threadsafety_file = 'data/threadsafety.dat'
 
+# Options for notfound.extension
+# -------------------------------
+
+if not os.getenv("READTHEDOCS"):
+    if language_code:
+        notfound_urls_prefix = (
+            f'/{language_code.replace("_", "-").lower()}/{version}/'
+        )
+    else:
+        notfound_urls_prefix = f'/{version}/'
+
 # Options for sphinxext-opengraph
 # -------------------------------
 


### PR DESCRIPTION
With https://github.com/python/psf-salt/pull/637, nginx will serve the per-version 404.html page. However, it will render without styling/JS since `sphinx-notfound-page` defaults to referencing static assets under `/en/latest/`, this fixes that.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125895 -->
* Issue: gh-125895
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--147984.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->