### PR TITLE
gh-146444: Remove legacy iOS folder

### DIFF
--- a/iOS/Resources/bin/arm64-apple-ios-ar
+++ b/iOS/Resources/bin/arm64-apple-ios-ar
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} ar "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-clang
+++ b/iOS/Resources/bin/arm64-apple-ios-clang
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} clang -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET} "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-clang++
+++ b/iOS/Resources/bin/arm64-apple-ios-clang++
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} clang++ -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET} "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-cpp
+++ b/iOS/Resources/bin/arm64-apple-ios-cpp
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} clang -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET} -E "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-ar
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-ar
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} ar "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-clang
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-clang
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-clang++
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-clang++
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-cpp
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-cpp
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator -E "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-strip
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-strip
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} strip -arch arm64 "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-strip
+++ b/iOS/Resources/bin/arm64-apple-ios-strip
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} strip -arch arm64 "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-ar
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-ar
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} ar "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-clang
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-clang
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target x86_64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-clang++
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-clang++
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target x86_64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-cpp
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-cpp
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target x86_64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator -E "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-strip
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-strip
@@ -1,2 +1,0 @@
-#!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} strip -arch x86_64 "$@"


### PR DESCRIPTION
With the transition to the new Platforms folder complete, and the builbots using the Platforms/Apple script, we can remove the legacy iOS folder.

Fixes #146444.

<!-- gh-issue-number: gh-146444 -->
* Issue: gh-146444
<!-- /gh-issue-number -->
