### PR TITLE
gh-146646: Document that glob functions suppress OSError

### DIFF
--- a/Doc/library/glob.rst
+++ b/Doc/library/glob.rst
@@ -83,6 +83,11 @@ The :mod:`!glob` module defines the following functions:
       This function may return duplicate path names if *pathname*
       contains multiple "``**``" patterns and *recursive* is true.
 
+   .. note::
+      Any :exc:`OSError` exceptions raised from scanning the filesystem are
+      suppressed. This includes :exc:`PermissionError` when accessing
+      directories without read permission.
+
    .. versionchanged:: 3.5
       Support for recursive globs using "``**``".
 
@@ -105,6 +110,11 @@ The :mod:`!glob` module defines the following functions:
    .. note::
       This function may return duplicate path names if *pathname*
       contains multiple "``**``" patterns and *recursive* is true.
+
+   .. note::
+      Any :exc:`OSError` exceptions raised from scanning the filesystem are
+      suppressed. This includes :exc:`PermissionError` when accessing
+      directories without read permission.
 
    .. versionchanged:: 3.5
       Support for recursive globs using "``**``".

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1351,6 +1351,11 @@ Reading directories
    ``False``, this method follows symlinks except when expanding "``**``"
    wildcards. Set *recurse_symlinks* to ``True`` to always follow symlinks.
 
+   .. note::
+      Any :exc:`OSError` exceptions raised from scanning the filesystem are
+      suppressed. This includes :exc:`PermissionError` when accessing
+      directories without read permission.
+
    .. audit-event:: pathlib.Path.glob self,pattern pathlib.Path.glob
 
    .. versionchanged:: 3.12
@@ -1379,6 +1384,11 @@ Reading directories
 
    .. seealso::
       :ref:`pathlib-pattern-language` and :meth:`Path.glob` documentation.
+
+   .. note::
+      Any :exc:`OSError` exceptions raised from scanning the filesystem are
+      suppressed. This includes :exc:`PermissionError` when accessing
+      directories without read permission.
 
    .. audit-event:: pathlib.Path.rglob self,pattern pathlib.Path.rglob
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1382,13 +1382,13 @@ Reading directories
       The paths are returned in no particular order.
       If you need a specific order, sort the results.
 
-   .. seealso::
-      :ref:`pathlib-pattern-language` and :meth:`Path.glob` documentation.
-
    .. note::
       Any :exc:`OSError` exceptions raised from scanning the filesystem are
       suppressed. This includes :exc:`PermissionError` when accessing
       directories without read permission.
+
+   .. seealso::
+      :ref:`pathlib-pattern-language` and :meth:`Path.glob` documentation.
 
    .. audit-event:: pathlib.Path.rglob self,pattern pathlib.Path.rglob
 

--- a/Misc/NEWS.d/next/Documentation/2026-04-02-07-20-00.gh-issue-146646.GlobDoc1.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-04-02-07-20-00.gh-issue-146646.GlobDoc1.rst
@@ -1,0 +1,3 @@
+Document that :func:`glob.glob`, :func:`glob.iglob`,
+:meth:`pathlib.Path.glob`, and :meth:`pathlib.Path.rglob` silently suppress
+:exc:`OSError` exceptions raised from scanning the filesystem.


### PR DESCRIPTION
## Summary

- Add notes to `glob.glob()` and `glob.iglob()` documentation that `OSError` exceptions raised from scanning the filesystem are silently suppressed
- This includes `PermissionError` when accessing directories without read permission
- The `pathlib.Path.glob()` docs already document this behavior (added in 3.13 via a `versionchanged` note), but the `glob` module docs did not mention it

As @vstinner noted in the issue, the `glob` module ignores all `OSError` errors (not just access errors) — for example, `_iterdir()` wraps its scanner in `except OSError: return`.

<!-- gh-issue-number: gh-146646 -->
* Issue: gh-146646
<!-- /gh-issue-number -->

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--147996.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->