### PR TITLE
GH-126910: Increase default stack size for linux platforms without working HAVE_PTHREAD_GETATTR_NP

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -60,7 +60,7 @@ _Py_ReachedRecursionLimitWithMargin(PyThreadState *tstate, int margin_count)
 #elif defined(__hppa__) || defined(__powerpc64__)
 #  define Py_C_STACK_SIZE 2000000
 #else
-#  define Py_C_STACK_SIZE 4000000
+#  define Py_C_STACK_SIZE 5000000
 #endif
 
 #if defined(__EMSCRIPTEN__)


### PR DESCRIPTION
This is an attempt to fix the CentOS no-gil buildbot with perf profiling.


<!-- gh-issue-number: gh-126910 -->
* Issue: gh-126910
<!-- /gh-issue-number -->
