### PR TITLE
gh-142518: add thread safety annotations for tuple C-API

### DIFF
--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -80,11 +80,9 @@ Tuple Objects
    :c:func:`Py_NewRef(PyTuple_GetItem(...)) <Py_NewRef>`
    or :c:func:`PySequence_GetItem`.
 
-
 .. c:function:: PyObject* PyTuple_GET_ITEM(PyObject *p, Py_ssize_t pos)
 
    Like :c:func:`PyTuple_GetItem`, but does no checking of its arguments.
-
 
 .. c:function:: PyObject* PyTuple_GetSlice(PyObject *p, Py_ssize_t low, Py_ssize_t high)
 
@@ -99,7 +97,8 @@ Tuple Objects
 
    Insert a reference to object *o* at position *pos* of the tuple pointed to by
    *p*.  Return ``0`` on success.  If *pos* is out of bounds, return ``-1``
-   and set an :exc:`IndexError` exception.
+   and set an :exc:`IndexError` exception. This function should only be used to fill in brand new tuples;
+   using it on an existing tuples is thread-unsafe.
 
    .. note::
 
@@ -110,7 +109,7 @@ Tuple Objects
 .. c:function:: void PyTuple_SET_ITEM(PyObject *p, Py_ssize_t pos, PyObject *o)
 
    Like :c:func:`PyTuple_SetItem`, but does no error checking, and should *only* be
-   used to fill in brand new tuples.
+   used to fill in brand new tuples. Using it on an existing tuple is thread-unsafe.
 
    Bounds checking is performed as an assertion if Python is built in
    :ref:`debug mode <debug-build>` or :option:`with assertions <--with-assertions>`.
@@ -121,12 +120,6 @@ Tuple Objects
       :c:func:`PyTuple_SetItem`, does *not* discard a reference to any item that
       is being replaced; any reference in the tuple at position *pos* will be
       leaked.
-
-   .. warning::
-
-      This macro should *only* be used on tuples that are newly created.
-      Using this macro on a tuple that is already in use (or in other words, has
-      a refcount > 1) could lead to undefined behavior.
 
 
 .. c:function:: int _PyTuple_Resize(PyObject **p, Py_ssize_t newsize)
@@ -141,6 +134,11 @@ Tuple Objects
    this function. If the object referenced by ``*p`` is replaced, the original
    ``*p`` is destroyed.  On failure, returns ``-1`` and sets ``*p`` to ``NULL``, and
    raises :exc:`MemoryError` or :exc:`SystemError`.
+
+   .. note::
+
+      In the :term:`free-threaded build`, this function must only be used on
+      tuples that are not yet visible to other threads.
 
 
 .. _struct-sequence-objects:
@@ -236,10 +234,11 @@ type.
 .. c:function:: PyObject* PyStructSequence_GetItem(PyObject *p, Py_ssize_t pos)
 
    Return the object at position *pos* in the struct sequence pointed to by *p*.
+   The returned reference is borrowed from the struct sequence *p*
+   (that is: it is only valid as long as you hold a reference to *p*).
 
    Bounds checking is performed as an assertion if Python is built in
    :ref:`debug mode <debug-build>` or :option:`with assertions <--with-assertions>`.
-
 
 .. c:function:: PyObject* PyStructSequence_GET_ITEM(PyObject *p, Py_ssize_t pos)
 

--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -100,7 +100,7 @@ Tuple Objects
    Insert a reference to object *o* at position *pos* of the tuple pointed to by
    *p*.  Return ``0`` on success.  If *pos* is out of bounds, return ``-1``
    and set an :exc:`IndexError` exception. This function should only be used to fill in brand new tuples;
-   using it on an existing tuples is thread-unsafe.
+   using it on an existing tuple is thread-unsafe.
 
    .. note::
 

--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -80,9 +80,11 @@ Tuple Objects
    :c:func:`Py_NewRef(PyTuple_GetItem(...)) <Py_NewRef>`
    or :c:func:`PySequence_GetItem`.
 
+
 .. c:function:: PyObject* PyTuple_GET_ITEM(PyObject *p, Py_ssize_t pos)
 
    Like :c:func:`PyTuple_GetItem`, but does no checking of its arguments.
+
 
 .. c:function:: PyObject* PyTuple_GetSlice(PyObject *p, Py_ssize_t low, Py_ssize_t high)
 
@@ -109,7 +111,7 @@ Tuple Objects
 .. c:function:: void PyTuple_SET_ITEM(PyObject *p, Py_ssize_t pos, PyObject *o)
 
    Like :c:func:`PyTuple_SetItem`, but does no error checking, and should *only* be
-   used to fill in brand new tuples. Using it on an existing tuple is thread-unsafe.
+   used to fill in brand new tuples, using it on an existing tuple is thread-unsafe.
 
    Bounds checking is performed as an assertion if Python is built in
    :ref:`debug mode <debug-build>` or :option:`with assertions <--with-assertions>`.
@@ -120,6 +122,12 @@ Tuple Objects
       :c:func:`PyTuple_SetItem`, does *not* discard a reference to any item that
       is being replaced; any reference in the tuple at position *pos* will be
       leaked.
+
+   .. warning::
+
+      This macro should *only* be used on tuples that are newly created.
+      Using this macro on a tuple that is already in use (or in other words, has
+      a refcount > 1) could lead to undefined behavior.
 
 
 .. c:function:: int _PyTuple_Resize(PyObject **p, Py_ssize_t newsize)
@@ -134,11 +142,6 @@ Tuple Objects
    this function. If the object referenced by ``*p`` is replaced, the original
    ``*p`` is destroyed.  On failure, returns ``-1`` and sets ``*p`` to ``NULL``, and
    raises :exc:`MemoryError` or :exc:`SystemError`.
-
-   .. note::
-
-      In the :term:`free-threaded build`, this function must only be used on
-      tuples that are not yet visible to other threads.
 
 
 .. _struct-sequence-objects:
@@ -239,6 +242,7 @@ type.
 
    Bounds checking is performed as an assertion if Python is built in
    :ref:`debug mode <debug-build>` or :option:`with assertions <--with-assertions>`.
+
 
 .. c:function:: PyObject* PyStructSequence_GET_ITEM(PyObject *p, Py_ssize_t pos)
 

--- a/Doc/data/threadsafety.dat
+++ b/Doc/data/threadsafety.dat
@@ -156,8 +156,6 @@ PyCapsule_Import:compatible:
 
 # Tuple objects
 
-PyTuple_CheckExact:atomic:
-
 # Creation - pure allocation, no shared state
 PyTuple_New:atomic:
 PyTuple_FromArray:atomic:

--- a/Doc/data/threadsafety.dat
+++ b/Doc/data/threadsafety.dat
@@ -172,13 +172,11 @@ PyTuple_GET_SIZE:atomic:
 PyTuple_GetItem:compatible:
 PyTuple_GET_ITEM:compatible:
 
-# Slice - creates a new tuple from an immutable source
+# Slice - creates a new tuple from an existing tuple
 PyTuple_GetSlice:atomic:
 
 # SetItem - only usable on tuples with refcount 1
 PyTuple_SetItem:compatible:
-
-# SET_ITEM - no synchronization; only for filling in brand new tuples
 PyTuple_SET_ITEM:compatible:
 
 # Resize - only usable on tuples with refcount 1

--- a/Doc/data/threadsafety.dat
+++ b/Doc/data/threadsafety.dat
@@ -182,7 +182,7 @@ PyTuple_SetItem:compatible:
 PyTuple_SET_ITEM:compatible:
 
 # Resize - only usable on tuples with refcount 1
-_PyTuple_Resize:distinct:
+_PyTuple_Resize:compatible:
 
 # Struct Sequence objects
 

--- a/Doc/data/threadsafety.dat
+++ b/Doc/data/threadsafety.dat
@@ -153,3 +153,52 @@ PyCapsule_SetContext:distinct:
 # Import - looks up a capsule from a module attribute and
 # calls PyCapsule_GetPointer; may call arbitrary code
 PyCapsule_Import:compatible:
+
+# Tuple objects
+
+PyTuple_CheckExact:atomic:
+
+# Creation - pure allocation, no shared state
+PyTuple_New:atomic:
+PyTuple_FromArray:atomic:
+PyTuple_Pack:atomic:
+
+# Size - tuples are immutable so size never changes
+PyTuple_Size:atomic:
+PyTuple_GET_SIZE:atomic:
+
+# Borrowed-reference lookups - tuples are immutable so items
+# never change, however the tuple must be kept alive while using the borrowed reference
+PyTuple_GetItem:compatible:
+PyTuple_GET_ITEM:compatible:
+
+# Slice - creates a new tuple from an immutable source
+PyTuple_GetSlice:atomic:
+
+# SetItem - only usable on tuples with refcount 1
+PyTuple_SetItem:compatible:
+
+# SET_ITEM - no synchronization; only for filling in brand new tuples
+PyTuple_SET_ITEM:compatible:
+
+# Resize - only usable on tuples with refcount 1
+_PyTuple_Resize:distinct:
+
+# Struct Sequence objects
+
+# Creation
+PyStructSequence_NewType:atomic:
+PyStructSequence_New:atomic:
+
+# Initialization - modifies the type object in place
+PyStructSequence_InitType:distinct:
+PyStructSequence_InitType2:distinct:
+
+# Borrowed-reference lookups - same as tuple items
+PyStructSequence_GetItem:compatible:
+PyStructSequence_GET_ITEM:compatible:
+
+# SetItem - only for filling in brand new instances
+PyStructSequence_SetItem:compatible:
+PyStructSequence_SET_ITEM:compatible:
+


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142518 -->
* Issue: gh-142518
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148012.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->