### PR TITLE
gh-147965: Document that multiprocessing.Queue does not implement shutdown()

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -921,6 +921,10 @@ For an example of the usage of queues for interprocess communication see
 
 .. class:: Queue([maxsize])
 
+   .. note::
+      Unlike :class:`queue.Queue`, :class:`multiprocessing.Queue` does not
+      implement the :meth:`~queue.Queue.shutdown` method.
+
    Returns a process shared queue implemented using a pipe and a few
    locks/semaphores.  When a process first puts an item on the queue a feeder
    thread is started which transfers objects from a buffer into the pipe.


### PR DESCRIPTION
Added a note to the multiprocessing documentation to clarify that Queue lacks the shutdown() method, as requested in gh-147965.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148034.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->