### PR TITLE
gh-145098: Use `macos-15-intel` instead of unstable `macos-26-intel`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,16 +206,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-26 is Apple Silicon, macos-26-intel is Intel.
-        # macos-26-intel only runs tests against the GIL-enabled CPython.
+        # macos-26 is Apple Silicon, macos-15-intel is Intel.
+        # macos-15-intel only runs tests against the GIL-enabled CPython.
         os:
         - macos-26
-        - macos-26-intel
+        - macos-15-intel
         free-threading:
         - false
         - true
         exclude:
-        - os: macos-26-intel
+        - os: macos-15-intel
           free-threading: true
     uses: ./.github/workflows/reusable-macos.yml
     with:

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -52,15 +52,15 @@ jobs:
           --prefix=/opt/python-dev \
           --with-openssl="$(brew --prefix openssl@3.5)"
     - name: Build CPython
-      if : ${{ inputs.free-threading || inputs.os != 'macos-26-intel' }}
+      if : ${{ inputs.free-threading || inputs.os != 'macos-15-intel' }}
       run: gmake -j8
     - name: Build CPython for compiler warning check
-      if : ${{ !inputs.free-threading && inputs.os == 'macos-26-intel' }}
+      if : ${{ !inputs.free-threading && inputs.os == 'macos-15-intel' }}
       run: set -o pipefail; gmake -j8 --output-sync 2>&1 | tee compiler_output_macos.txt
     - name: Display build info
       run: make pythoninfo
     - name: Check compiler warnings
-      if : ${{ !inputs.free-threading && inputs.os == 'macos-26-intel' }}
+      if : ${{ !inputs.free-threading && inputs.os == 'macos-15-intel' }}
       run: >-
         python3 Tools/build/check_warnings.py
         --compiler-output-file-path=compiler_output_macos.txt


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The `macos-26-intel` appears to be unstable, with unexplained hangs:

- https://github.com/python/cpython/issues/145098#issuecomment-4181191543
- https://github.com/python/cpython/issues/145098#issuecomment-4182143629

This seems unrelated to the Tk hangs (https://github.com/python/cpython/issues/146531) because it also happens when skipping the Tk test on `macos-26-intel`:

- https://github.com/python/cpython/pull/148032
- https://github.com/python/cpython/actions/runs/23944426082/job/69837525233?pr=148032

This PR changes the main tests from `macos-26-intel` to `macos-15-intel`.

It doesn't change it in `jit.yml` or `tail-call.yml` as they seem okay.

<!-- gh-issue-number: gh-145098 -->
* Issue: gh-145098
<!-- /gh-issue-number -->
