### PR TITLE
[3.13] gh-143930: Tweak the exception message and increase test coverage (GH-146476)

### DIFF
--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -1,3 +1,4 @@
+import io
 import os
 import re
 import shlex
@@ -55,6 +56,14 @@ class CommandTestMixin:
             popen_args.pop(popen_args.index(option))
         self.assertEqual(popen_args, arguments)
 
+    def test_reject_dash_prefixes(self):
+        browser = self.browser_class(name=CMD_NAME)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"^Invalid URL \(leading dash disallowed\): '--key=val http.*'$"
+        ):
+            browser.open(f"--key=val {URL}")
+
 
 class GenericBrowserCommandTest(CommandTestMixin, unittest.TestCase):
 
@@ -64,11 +73,6 @@ class GenericBrowserCommandTest(CommandTestMixin, unittest.TestCase):
         self._test('open',
                    options=[],
                    arguments=[URL])
-
-    def test_reject_dash_prefixes(self):
-        browser = self.browser_class(name=CMD_NAME)
-        with self.assertRaises(ValueError):
-            browser.open(f"--key=val {URL}")
 
 
 class BackgroundBrowserCommandTest(CommandTestMixin, unittest.TestCase):
@@ -304,6 +308,72 @@ class IOSBrowserTest(unittest.TestCase):
 
     def test_open_new_tab(self):
         self._test('open_new_tab')
+
+
+class MockPopenPipe:
+    def __init__(self, cmd, mode):
+        self.cmd = cmd
+        self.mode = mode
+        self.pipe = io.StringIO()
+        self._closed = False
+
+    def write(self, buf):
+        self.pipe.write(buf)
+
+    def close(self):
+        self._closed = True
+        return None
+
+
+@unittest.skipUnless(sys.platform == "darwin", "macOS specific test")
+@requires_subprocess()
+class MacOSXOSAScriptTest(unittest.TestCase):
+    def setUp(self):
+        # Ensure that 'BROWSER' is not set to 'open' or something else.
+        # See: https://github.com/python/cpython/issues/131254.
+        env = self.enterContext(os_helper.EnvironmentVarGuard())
+        env.unset("BROWSER")
+
+        support.patch(self, os, "popen", self.mock_popen)
+        self.browser = webbrowser.MacOSXOSAScript("default")
+
+    def mock_popen(self, cmd, mode):
+        self.popen_pipe = MockPopenPipe(cmd, mode)
+        return self.popen_pipe
+
+    def test_default(self):
+        browser = webbrowser.get()
+        assert isinstance(browser, webbrowser.MacOSXOSAScript)
+        self.assertEqual(browser.name, "default")
+
+    def test_default_open(self):
+        url = "https://python.org"
+        self.browser.open(url)
+        self.assertTrue(self.popen_pipe._closed)
+        self.assertEqual(self.popen_pipe.cmd, "osascript")
+        script = self.popen_pipe.pipe.getvalue()
+        self.assertEqual(script.strip(), f'open location "{url}"')
+
+    def test_url_quote(self):
+        self.browser.open('https://python.org/"quote"')
+        script = self.popen_pipe.pipe.getvalue()
+        self.assertEqual(
+            script.strip(), 'open location "https://python.org/%22quote%22"'
+        )
+
+    def test_explicit_browser(self):
+        browser = webbrowser.MacOSXOSAScript("safari")
+        browser.open("https://python.org")
+        script = self.popen_pipe.pipe.getvalue()
+        self.assertIn('tell application "safari"', script)
+        self.assertIn('open location "https://python.org"', script)
+
+    def test_reject_dash_prefixes(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"^Invalid URL \(leading dash disallowed\): '--key=val http.*'$"
+        ):
+            self.browser.open(f"--key=val {URL}")
 
 
 class BrowserRegistrationTest(unittest.TestCase):

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -168,7 +168,7 @@ class BaseBrowser:
     def _check_url(url):
         """Ensures that the URL is safe to pass to subprocesses as a parameter"""
         if url and url.lstrip().startswith("-"):
-            raise ValueError(f"Invalid URL: {url}")
+            raise ValueError(f"Invalid URL (leading dash disallowed): {url!r}")
 
 
 class GenericBrowser(BaseBrowser):

--- a/Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst
+++ b/Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst
@@ -1,1 +1,1 @@
-Reject leading dashes in URLs passed to :func:`webbrowser.open`
+Reject leading dashes in URLs passed to :func:`webbrowser.open`.


### PR DESCRIPTION
(cherry picked from commit 3681d47a440865aead912a054d4599087b4270dd)

Includes the MacOSXOSAScriptTest backport, because why not.

<!-- gh-issue-number: gh-143930 -->
* Issue: gh-143930
<!-- /gh-issue-number -->
