### PR TITLE
gh-144766: Fix flaky test_trampoline_works_with_forks

### DIFF
--- a/Lib/test/test_perf_profiler.py
+++ b/Lib/test/test_perf_profiler.py
@@ -118,9 +118,12 @@ class TestPerfTrampoline(unittest.TestCase):
                     if pid == 0:
                         print(os.getpid())
                         baz_fork()
+                        os._exit(0)
                     else:
                         _, status = os.waitpid(-1, 0)
-                        sys.exit(status)
+                        if os.WIFSIGNALED(status):
+                            sys.exit(1)
+                        sys.exit(os.WEXITSTATUS(status))
 
                 def bar():
                     foo()

--- a/Lib/test/test_perf_profiler.py
+++ b/Lib/test/test_perf_profiler.py
@@ -116,7 +116,7 @@ class TestPerfTrampoline(unittest.TestCase):
                 def foo():
                     pid = os.fork()
                     if pid == 0:
-                        print(os.getpid())
+                        print(os.getpid(), flush=True)
                         baz_fork()
                         os._exit(0)
                     else:

--- a/Misc/NEWS.d/next/Tests/2026-04-04-00-00-00.gh-issue-144766.Yk3mPq.rst
+++ b/Misc/NEWS.d/next/Tests/2026-04-04-00-00-00.gh-issue-144766.Yk3mPq.rst
@@ -1,0 +1,4 @@
+Fix flaky :func:`test_trampoline_works_with_forks` by using ``os._exit(0)``
+in the fork child to avoid fragile Python finalization, and by flushing
+stdout before exit. Also fix the parent's wait status handling to use
+``os.WEXITSTATUS()``.

--- a/Misc/NEWS.d/next/Tests/2026-04-04-00-00-00.gh-issue-144766.Yk3mPq.rst
+++ b/Misc/NEWS.d/next/Tests/2026-04-04-00-00-00.gh-issue-144766.Yk3mPq.rst
@@ -1,4 +1,0 @@
-Fix flaky :func:`test_trampoline_works_with_forks` by using ``os._exit(0)``
-in the fork child to avoid fragile Python finalization, and by flushing
-stdout before exit. Also fix the parent's wait status handling to use
-``os.WEXITSTATUS()``.


### PR DESCRIPTION
## Summary

`test_trampoline_works_with_forks` intermittently fails on macOS CI because the fork child runs full Python finalization instead of calling `os._exit(0)`. Perf trampoline finalization in a forked child is fragile: it unmaps executable memory and unregisters code watchers while code objects are being destroyed, which can crash intermittently.

The newer test in the same file (`test_trampoline_works_after_fork_with_many_code_objects`, added in gh-144766) already uses `os._exit(0)` in the child for exactly this reason. This applies the same pattern to the older test.

Also fixes the parent's wait status handling: `os.waitpid` returns a raw 16-bit wait status, not an exit code. The old code passed this raw status to `sys.exit()`, which could produce incorrect exit codes. Now uses `os.WEXITSTATUS()` to extract the actual exit code and `os.WIFSIGNALED()` to detect signal deaths.

## Changes

- `Lib/test/test_perf_profiler.py`: Add `os._exit(0)` in fork child, fix wait status handling in parent

Discovered while testing #148050 (unrelated multiprocessing change that was blocked by this flaky test on macOS CI).

<claude>