### PR TITLE
[3.14] gh-146541: Allow building the Android testbed for 32-bit targets (GH-146542)

### DIFF
--- a/Android/android.py
+++ b/Android/android.py
@@ -34,7 +34,12 @@ ENV_SCRIPT = ANDROID_DIR / "android-env.sh"
 TESTBED_DIR = ANDROID_DIR / "testbed"
 CROSS_BUILD_DIR = PYTHON_DIR / "cross-build"
 
-HOSTS = ["aarch64-linux-android", "x86_64-linux-android"]
+HOSTS = [
+    "aarch64-linux-android",
+    "arm-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android",
+]
 APP_ID = "org.python.testbed"
 DECODE_ARGS = ("UTF-8", "backslashreplace")
 
@@ -209,7 +214,7 @@ def unpack_deps(host, prefix_dir):
     os.chdir(prefix_dir)
     deps_url = "https://github.com/beeware/cpython-android-source-deps/releases/download"
     for name_ver in ["bzip2-1.0.8-3", "libffi-3.4.4-3", "openssl-3.0.19-1",
-                     "sqlite-3.50.4-0", "xz-5.4.6-1", "zstd-1.5.7-1"]:
+                     "sqlite-3.50.4-0", "xz-5.4.6-1", "zstd-1.5.7-2"]:
         filename = f"{name_ver}-{host}.tar.gz"
         download(f"{deps_url}/{name_ver}/{filename}")
         shutil.unpack_archive(filename)

--- a/Android/testbed/app/build.gradle.kts
+++ b/Android/testbed/app/build.gradle.kts
@@ -15,6 +15,8 @@ val inSourceTree = (
 
 val KNOWN_ABIS = mapOf(
     "aarch64-linux-android" to "arm64-v8a",
+    "arm-linux-androideabi" to "armeabi-v7a",
+    "i686-linux-android" to "x86",
     "x86_64-linux-android" to "x86_64",
 )
 

--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -701,12 +701,16 @@ def get_platform():
         # When Python is running on 32-bit ARM Android on a 64-bit ARM kernel,
         # 'os.uname().machine' is 'armv8l'. Such devices run the same userspace
         # code as 'armv7l' devices.
+        # During the build process of the Android testbed when targeting 32-bit ARM,
+        # '_PYTHON_HOST_PLATFORM' is 'arm-linux-androideabi', so 'machine' becomes
+        # 'arm'.
         machine = {
-            "x86_64": "x86_64",
-            "i686": "x86",
             "aarch64": "arm64_v8a",
+            "arm": "armeabi_v7a",
             "armv7l": "armeabi_v7a",
             "armv8l": "armeabi_v7a",
+            "i686": "x86",
+            "x86_64": "x86_64",
         }[machine]
     elif osname == "linux":
         # At least on Linux/Intel, 'machine' is the processor --

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -375,11 +375,12 @@ class TestSysConfig(unittest.TestCase, VirtualEnvironmentMixin):
         sys.platform = 'android'
         get_config_vars()['ANDROID_API_LEVEL'] = 9
         for machine, abi in {
-            'x86_64': 'x86_64',
-            'i686': 'x86',
             'aarch64': 'arm64_v8a',
+            'arm': 'armeabi_v7a',
             'armv7l': 'armeabi_v7a',
             'armv8l': 'armeabi_v7a',
+            'i686': 'x86',
+            'x86_64': 'x86_64',
         }.items():
             with self.subTest(machine):
                 self._set_uname(('Linux', 'localhost', '3.18.91+',
@@ -584,11 +585,12 @@ class TestSysConfig(unittest.TestCase, VirtualEnvironmentMixin):
         machine = platform.machine()
         suffix = sysconfig.get_config_var('EXT_SUFFIX')
         expected_triplet = {
-            "x86_64": "x86_64-linux-android",
-            "i686": "i686-linux-android",
             "aarch64": "aarch64-linux-android",
+            "arm": "arm-linux-androideabi",
             "armv7l": "arm-linux-androideabi",
             "armv8l": "arm-linux-androideabi",
+            "i686": "i686-linux-android",
+            "x86_64": "x86_64-linux-android",
         }[machine]
         self.assertEndsWith(suffix, f"-{expected_triplet}.so")
 

--- a/Misc/NEWS.d/next/Build/2026-03-28-02-48-51.gh-issue-146541.k-zlM6.rst
+++ b/Misc/NEWS.d/next/Build/2026-03-28-02-48-51.gh-issue-146541.k-zlM6.rst
@@ -1,0 +1,1 @@
+The Android testbed can now be built for 32-bit ARM and x86 targets.


### PR DESCRIPTION
Allows building the Android testbed for 32-bit targets, adding the target triplets 
`arm-linux-androideabi` and `i686-linux-android`.
(cherry picked from commit 848bbe9ff21ae0a3ee412cc25843835ace4f75df)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146541 -->
* Issue: gh-146541
<!-- /gh-issue-number -->
