### PR TITLE
gh-131798: relax GUARD_CALLABLE checks for self type checks

### DIFF
--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1323,11 +1323,11 @@ dummy_func(void) {
         PyObject *callable_o = sym_get_const(ctx, callable);
         if (callable_o && sym_matches_type(callable, &PyMethodDescr_Type)) {
             int total_args = oparg;
-            if (!sym_is_null(self_or_null)) {
+            if (sym_is_not_null(self_or_null)) {
                 total_args++;
             }
             PyTypeObject *self_type = NULL;
-            if (!sym_is_null(self_or_null)) {
+            if (sym_is_not_null(self_or_null)) {
                 self_type = sym_get_type(self_or_null);
             }
             else {
@@ -1349,11 +1349,11 @@ dummy_func(void) {
         PyObject *callable_o = sym_get_const(ctx, callable);
         if (callable_o && sym_matches_type(callable, &PyMethodDescr_Type)) {
             int total_args = oparg;
-            if (!sym_is_null(self_or_null)) {
+            if (sym_is_not_null(self_or_null)) {
                 total_args++;
             }
             PyTypeObject *self_type = NULL;
-            if (!sym_is_null(self_or_null)) {
+            if (sym_is_not_null(self_or_null)) {
                 self_type = sym_get_type(self_or_null);
             }
             else {
@@ -1375,11 +1375,11 @@ dummy_func(void) {
         PyObject *callable_o = sym_get_const(ctx, callable);
         if (callable_o && sym_matches_type(callable, &PyMethodDescr_Type)) {
             int total_args = oparg;
-            if (!sym_is_null(self_or_null)) {
+            if (sym_is_not_null(self_or_null)) {
                 total_args++;
             }
             PyTypeObject *self_type = NULL;
-            if (!sym_is_null(self_or_null)) {
+            if (sym_is_not_null(self_or_null)) {
                 self_type = sym_get_type(self_or_null);
             }
             else {
@@ -1434,11 +1434,11 @@ dummy_func(void) {
         PyObject *callable_o = sym_get_const(ctx, callable);
         if (callable_o && sym_matches_type(callable, &PyMethodDescr_Type)) {
             int total_args = oparg;
-            if (!sym_is_null(self_or_null)) {
+            if (sym_is_not_null(self_or_null)) {
                 total_args++;
             }
             PyTypeObject *self_type = NULL;
-            if (!sym_is_null(self_or_null)) {
+            if (sym_is_not_null(self_or_null)) {
                 self_type = sym_get_type(self_or_null);
             }
             else {

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1326,16 +1326,17 @@ dummy_func(void) {
             if (!sym_is_null(self_or_null)) {
                 total_args++;
             }
-            PyObject *self = NULL;
+            PyTypeObject *self_type = NULL;
             if (!sym_is_null(self_or_null)) {
-                self = sym_get_const(ctx, self_or_null);
-            } else {
-                self = sym_get_const(ctx, args[0]);
+                self_type = sym_get_type(self_or_null);
+            }
+            else {
+                self_type = sym_get_type(args[0]);
             }
             PyTypeObject *d_type = ((PyMethodDescrObject *)callable_o)->d_common.d_type;
             if (total_args == 2 &&
                 ((PyMethodDescrObject *)callable_o)->d_method->ml_flags == METH_O &&
-                self && Py_IS_TYPE(self, d_type)) {
+                self_type == d_type) {
                 ADD_OP(_NOP, 0, 0);
             }
         }
@@ -1351,16 +1352,17 @@ dummy_func(void) {
             if (!sym_is_null(self_or_null)) {
                 total_args++;
             }
-            PyObject *self = NULL;
+            PyTypeObject *self_type = NULL;
             if (!sym_is_null(self_or_null)) {
-                self = sym_get_const(ctx, self_or_null);
-            } else {
-                self = sym_get_const(ctx, args[0]);
+                self_type = sym_get_type(self_or_null);
+            }
+            else {
+                self_type = sym_get_type(args[0]);
             }
             PyTypeObject *d_type = ((PyMethodDescrObject *)callable_o)->d_common.d_type;
             if (total_args != 0 &&
                 ((PyMethodDescrObject *)callable_o)->d_method->ml_flags == (METH_FASTCALL|METH_KEYWORDS) &&
-                self && Py_IS_TYPE(self, d_type)) {
+                self_type == d_type) {
                 ADD_OP(_NOP, 0, 0);
             }
         }
@@ -1376,16 +1378,17 @@ dummy_func(void) {
             if (!sym_is_null(self_or_null)) {
                 total_args++;
             }
-            PyObject *self = NULL;
+            PyTypeObject *self_type = NULL;
             if (!sym_is_null(self_or_null)) {
-                self = sym_get_const(ctx, self_or_null);
-            } else {
-                self = sym_get_const(ctx, args[0]);
+                self_type = sym_get_type(self_or_null);
+            }
+            else {
+                self_type = sym_get_type(args[0]);
             }
             PyTypeObject *d_type = ((PyMethodDescrObject *)callable_o)->d_common.d_type;
             if (total_args == 1 &&
                 ((PyMethodDescrObject *)callable_o)->d_method->ml_flags == METH_NOARGS &&
-                self && Py_IS_TYPE(self, d_type)) {
+                self_type == d_type) {
                 ADD_OP(_NOP, 0, 0);
             }
         }
@@ -1434,16 +1437,17 @@ dummy_func(void) {
             if (!sym_is_null(self_or_null)) {
                 total_args++;
             }
-            PyObject *self = NULL;
+            PyTypeObject *self_type = NULL;
             if (!sym_is_null(self_or_null)) {
-                self = sym_get_const(ctx, self_or_null);
-            } else {
-                self = sym_get_const(ctx, args[0]);
+                self_type = sym_get_type(self_or_null);
+            }
+            else {
+                self_type = sym_get_type(args[0]);
             }
             PyTypeObject *d_type = ((PyMethodDescrObject *)callable_o)->d_common.d_type;
             if (total_args != 0 &&
                 ((PyMethodDescrObject *)callable_o)->d_method->ml_flags == METH_FASTCALL &&
-                self && Py_IS_TYPE(self, d_type)) {
+                self_type == d_type) {
                 ADD_OP(_NOP, 0, 0);
             }
         }

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -4074,11 +4074,11 @@
             PyObject *callable_o = sym_get_const(ctx, callable);
             if (callable_o && sym_matches_type(callable, &PyMethodDescr_Type)) {
                 int total_args = oparg;
-                if (!sym_is_null(self_or_null)) {
+                if (sym_is_not_null(self_or_null)) {
                     total_args++;
                 }
                 PyTypeObject *self_type = NULL;
-                if (!sym_is_null(self_or_null)) {
+                if (sym_is_not_null(self_or_null)) {
                     self_type = sym_get_type(self_or_null);
                 }
                 else {
@@ -4165,11 +4165,11 @@
             PyObject *callable_o = sym_get_const(ctx, callable);
             if (callable_o && sym_matches_type(callable, &PyMethodDescr_Type)) {
                 int total_args = oparg;
-                if (!sym_is_null(self_or_null)) {
+                if (sym_is_not_null(self_or_null)) {
                     total_args++;
                 }
                 PyTypeObject *self_type = NULL;
-                if (!sym_is_null(self_or_null)) {
+                if (sym_is_not_null(self_or_null)) {
                     self_type = sym_get_type(self_or_null);
                 }
                 else {
@@ -4229,11 +4229,11 @@
             PyObject *callable_o = sym_get_const(ctx, callable);
             if (callable_o && sym_matches_type(callable, &PyMethodDescr_Type)) {
                 int total_args = oparg;
-                if (!sym_is_null(self_or_null)) {
+                if (sym_is_not_null(self_or_null)) {
                     total_args++;
                 }
                 PyTypeObject *self_type = NULL;
-                if (!sym_is_null(self_or_null)) {
+                if (sym_is_not_null(self_or_null)) {
                     self_type = sym_get_type(self_or_null);
                 }
                 else {
@@ -4293,11 +4293,11 @@
             PyObject *callable_o = sym_get_const(ctx, callable);
             if (callable_o && sym_matches_type(callable, &PyMethodDescr_Type)) {
                 int total_args = oparg;
-                if (!sym_is_null(self_or_null)) {
+                if (sym_is_not_null(self_or_null)) {
                     total_args++;
                 }
                 PyTypeObject *self_type = NULL;
-                if (!sym_is_null(self_or_null)) {
+                if (sym_is_not_null(self_or_null)) {
                     self_type = sym_get_type(self_or_null);
                 }
                 else {

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -4077,16 +4077,17 @@
                 if (!sym_is_null(self_or_null)) {
                     total_args++;
                 }
-                PyObject *self = NULL;
+                PyTypeObject *self_type = NULL;
                 if (!sym_is_null(self_or_null)) {
-                    self = sym_get_const(ctx, self_or_null);
-                } else {
-                    self = sym_get_const(ctx, args[0]);
+                    self_type = sym_get_type(self_or_null);
+                }
+                else {
+                    self_type = sym_get_type(args[0]);
                 }
                 PyTypeObject *d_type = ((PyMethodDescrObject *)callable_o)->d_common.d_type;
                 if (total_args == 2 &&
                     ((PyMethodDescrObject *)callable_o)->d_method->ml_flags == METH_O &&
-                    self && Py_IS_TYPE(self, d_type)) {
+                    self_type == d_type) {
                     ADD_OP(_NOP, 0, 0);
                 }
             }
@@ -4167,16 +4168,17 @@
                 if (!sym_is_null(self_or_null)) {
                     total_args++;
                 }
-                PyObject *self = NULL;
+                PyTypeObject *self_type = NULL;
                 if (!sym_is_null(self_or_null)) {
-                    self = sym_get_const(ctx, self_or_null);
-                } else {
-                    self = sym_get_const(ctx, args[0]);
+                    self_type = sym_get_type(self_or_null);
+                }
+                else {
+                    self_type = sym_get_type(args[0]);
                 }
                 PyTypeObject *d_type = ((PyMethodDescrObject *)callable_o)->d_common.d_type;
                 if (total_args != 0 &&
                     ((PyMethodDescrObject *)callable_o)->d_method->ml_flags == (METH_FASTCALL|METH_KEYWORDS) &&
-                    self && Py_IS_TYPE(self, d_type)) {
+                    self_type == d_type) {
                     ADD_OP(_NOP, 0, 0);
                 }
             }
@@ -4230,16 +4232,17 @@
                 if (!sym_is_null(self_or_null)) {
                     total_args++;
                 }
-                PyObject *self = NULL;
+                PyTypeObject *self_type = NULL;
                 if (!sym_is_null(self_or_null)) {
-                    self = sym_get_const(ctx, self_or_null);
-                } else {
-                    self = sym_get_const(ctx, args[0]);
+                    self_type = sym_get_type(self_or_null);
+                }
+                else {
+                    self_type = sym_get_type(args[0]);
                 }
                 PyTypeObject *d_type = ((PyMethodDescrObject *)callable_o)->d_common.d_type;
                 if (total_args == 1 &&
                     ((PyMethodDescrObject *)callable_o)->d_method->ml_flags == METH_NOARGS &&
-                    self && Py_IS_TYPE(self, d_type)) {
+                    self_type == d_type) {
                     ADD_OP(_NOP, 0, 0);
                 }
             }
@@ -4293,16 +4296,17 @@
                 if (!sym_is_null(self_or_null)) {
                     total_args++;
                 }
-                PyObject *self = NULL;
+                PyTypeObject *self_type = NULL;
                 if (!sym_is_null(self_or_null)) {
-                    self = sym_get_const(ctx, self_or_null);
-                } else {
-                    self = sym_get_const(ctx, args[0]);
+                    self_type = sym_get_type(self_or_null);
+                }
+                else {
+                    self_type = sym_get_type(args[0]);
                 }
                 PyTypeObject *d_type = ((PyMethodDescrObject *)callable_o)->d_common.d_type;
                 if (total_args != 0 &&
                     ((PyMethodDescrObject *)callable_o)->d_method->ml_flags == METH_FASTCALL &&
-                    self && Py_IS_TYPE(self, d_type)) {
+                    self_type == d_type) {
                     ADD_OP(_NOP, 0, 0);
                 }
             }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The checks were overly defensive as it required self to be constant which isn't necessary, we only care about its type so this PR relaxes it. 

<!-- gh-issue-number: gh-131798 -->
* Issue: gh-131798
<!-- /gh-issue-number -->
