### PR TITLE
gh-148067: Fix typo in asyncio event loop docs: 'signals' -> 'signal'

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -2055,7 +2055,7 @@ Wait until a file descriptor received some data using the
 Set signal handlers for SIGINT and SIGTERM
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-(This ``signals`` example only works on Unix.)
+(This ``signal`` example only works on Unix.)
 
 Register handlers for signals :const:`~signal.SIGINT` and :const:`~signal.SIGTERM`
 using the :meth:`loop.add_signal_handler` method::


### PR DESCRIPTION
Fix a small typo in the asyncio event loop documentation.

The "Set signal handlers for SIGINT and SIGTERM" example section says:
> (This `signals` example only works on Unix.)

It should be `signal` (referring to the `signal` module), not `signals`.

Closes #148067

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148073.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-148067 -->
* Issue: gh-148067
<!-- /gh-issue-number -->
