### PR TITLE
gh-148074: Fix `typeobject.c` missing error return

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -9345,6 +9345,7 @@ type_ready_post_checks(PyTypeObject *type)
             PyErr_Format(PyExc_SystemError,
                          "type %s has a tp_dictoffset that is too small",
                          type->tp_name);
+            return -1;
         }
     }
     return 0;


### PR DESCRIPTION
> At line 9314-9320, `PyErr_Format` sets a `SystemError` for invalid `tp_dictoffset` but falls through to `return 0` (success). Type finishes initialization with invalid offset and pending exception. Requires C extension to trigger.

I think we can skip-news

<!-- gh-issue-number: gh-148074 -->
* Issue: gh-148074
<!-- /gh-issue-number -->
