### PR TITLE
[3.13] gh-145098: Use `macos-15-intel` instead of unstable `macos-26-intel` (GH-148038)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,16 +246,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-26 is Apple Silicon, macos-26-intel is Intel.
-        # macos-26-intel only runs tests against the GIL-enabled CPython.
+        # macos-26 is Apple Silicon, macos-15-intel is Intel.
+        # macos-15-intel only runs tests against the GIL-enabled CPython.
         os:
         - macos-26
-        - macos-26-intel
+        - macos-15-intel
         free-threading:
         - false
         - true
         exclude:
-        - os: macos-26-intel
+        - os: macos-15-intel
           free-threading: true
     uses: ./.github/workflows/reusable-macos.yml
     with:


### PR DESCRIPTION


(cherry picked from commit cb76ab3819f778e55a3f49ddb1f681ee20978eda)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145098 -->
* Issue: gh-145098
<!-- /gh-issue-number -->
