### PR TITLE
Docs: Standardize documentation authors

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -73,7 +73,7 @@ manpages_url = 'https://manpages.debian.org/{path}'
 # General substitutions.
 project = 'Python'
 copyright = "2001 Python Software Foundation"
-doc_authors = 'Python documentation authors'
+_doc_authors = 'Python documentation authors'
 
 # We look for the Include/patchlevel.h file in the current Python source tree
 # and replace the values accordingly.
@@ -363,67 +363,73 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-    ('c-api/index', 'c-api.tex', 'The Python/C API', doc_authors, 'manual'),
+    ('c-api/index', 'c-api.tex', 'The Python/C API', _doc_authors, 'manual'),
     (
         'extending/index',
         'extending.tex',
         'Extending and Embedding Python',
-        doc_authors,
+        _doc_authors,
         'manual',
     ),
     (
         'installing/index',
         'installing.tex',
         'Installing Python Modules',
-        doc_authors,
+        _doc_authors,
         'manual',
     ),
     (
         'library/index',
         'library.tex',
         'The Python Library Reference',
-        doc_authors,
+        _doc_authors,
         'manual',
     ),
     (
         'reference/index',
         'reference.tex',
         'The Python Language Reference',
-        doc_authors,
+        _doc_authors,
         'manual',
     ),
     (
         'tutorial/index',
         'tutorial.tex',
         'Python Tutorial',
-        doc_authors,
+        _doc_authors,
         'manual',
     ),
     (
         'using/index',
         'using.tex',
         'Python Setup and Usage',
-        doc_authors,
+        _doc_authors,
         'manual',
     ),
     (
         'faq/index',
         'faq.tex',
         'Python Frequently Asked Questions',
-        doc_authors,
+        _doc_authors,
         'manual',
     ),
     (
         'whatsnew/' + version,
         'whatsnew.tex',
         'What\'s New in Python',
-        doc_authors,
+        _doc_authors,
         'howto',
     ),
 ]
 # Collect all HOWTOs individually
 latex_documents.extend(
-    ('howto/' + fn[:-4], 'howto-' + fn[:-4] + '.tex', '', doc_authors, 'howto')
+    (
+        'howto/' + fn[:-4],
+        'howto-' + fn[:-4] + '.tex',
+        '',
+        _doc_authors,
+        'howto',
+    )
     for fn in os.listdir('howto')
     if fn.endswith('.rst') and fn != 'index.rst'
 )
@@ -434,7 +440,7 @@ latex_appendices = ['glossary', 'about', 'license', 'copyright']
 # Options for Epub output
 # -----------------------
 
-epub_author = doc_authors
+epub_author = _doc_authors
 epub_publisher = 'Python Software Foundation'
 epub_exclude_files = (
     'index.xhtml',

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -73,6 +73,7 @@ manpages_url = 'https://manpages.debian.org/{path}'
 # General substitutions.
 project = 'Python'
 copyright = "2001 Python Software Foundation"
+doc_authors = 'Python documentation authors'
 
 # We look for the Include/patchlevel.h file in the current Python source tree
 # and replace the values accordingly.
@@ -361,69 +362,68 @@ latex_elements = {
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
-_stdauthor = 'The Python development team'
 latex_documents = [
-    ('c-api/index', 'c-api.tex', 'The Python/C API', _stdauthor, 'manual'),
+    ('c-api/index', 'c-api.tex', 'The Python/C API', doc_authors, 'manual'),
     (
         'extending/index',
         'extending.tex',
         'Extending and Embedding Python',
-        _stdauthor,
+        doc_authors,
         'manual',
     ),
     (
         'installing/index',
         'installing.tex',
         'Installing Python Modules',
-        _stdauthor,
+        doc_authors,
         'manual',
     ),
     (
         'library/index',
         'library.tex',
         'The Python Library Reference',
-        _stdauthor,
+        doc_authors,
         'manual',
     ),
     (
         'reference/index',
         'reference.tex',
         'The Python Language Reference',
-        _stdauthor,
+        doc_authors,
         'manual',
     ),
     (
         'tutorial/index',
         'tutorial.tex',
         'Python Tutorial',
-        _stdauthor,
+        doc_authors,
         'manual',
     ),
     (
         'using/index',
         'using.tex',
         'Python Setup and Usage',
-        _stdauthor,
+        doc_authors,
         'manual',
     ),
     (
         'faq/index',
         'faq.tex',
         'Python Frequently Asked Questions',
-        _stdauthor,
+        doc_authors,
         'manual',
     ),
     (
         'whatsnew/' + version,
         'whatsnew.tex',
         'What\'s New in Python',
-        'A. M. Kuchling',
+        doc_authors,
         'howto',
     ),
 ]
 # Collect all HOWTOs individually
 latex_documents.extend(
-    ('howto/' + fn[:-4], 'howto-' + fn[:-4] + '.tex', '', _stdauthor, 'howto')
+    ('howto/' + fn[:-4], 'howto-' + fn[:-4] + '.tex', '', doc_authors, 'howto')
     for fn in os.listdir('howto')
     if fn.endswith('.rst') and fn != 'index.rst'
 )
@@ -435,7 +435,7 @@ latex_appendices = ['glossary', 'about', 'license', 'copyright']
 # -----------------------
 
 epub_author = 'Python Documentation Authors'
-epub_publisher = 'Python Software Foundation'
+epub_publisher = doc_authors
 epub_exclude_files = (
     'index.xhtml',
     'download.xhtml',

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -434,8 +434,8 @@ latex_appendices = ['glossary', 'about', 'license', 'copyright']
 # Options for Epub output
 # -----------------------
 
-epub_author = 'Python Documentation Authors'
-epub_publisher = doc_authors
+epub_author = doc_authors
+epub_publisher = 'Python Software Foundation'
 epub_exclude_files = (
     'index.xhtml',
     'download.xhtml',


### PR DESCRIPTION
Also, change the author of the What's New documents from A. M. Kuchling to 'Python documentation authors,' CC @akuchling.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148102.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->