### PR TITLE
[3.14] Add `permissions: {}` to all reusable workflows (#148114)

### DIFF
--- a/.github/workflows/reusable-cifuzz.yml
+++ b/.github/workflows/reusable-cifuzz.yml
@@ -13,6 +13,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   cifuzz:
     name: ${{ inputs.oss-fuzz-project-name }} (${{ inputs.sanitizer }})

--- a/.github/workflows/reusable-context.yml
+++ b/.github/workflows/reusable-context.yml
@@ -54,6 +54,8 @@ on:  # yamllint disable-line rule:truthy
         description: Whether to run the Windows tests
         value: ${{ jobs.compute-changes.outputs.run-windows-tests }}  # bool
 
+permissions: {}
+
 jobs:
   compute-changes:
     name: Create context from changed files

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -4,8 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/reusable-emscripten.yml
+++ b/.github/workflows/reusable-emscripten.yml
@@ -3,6 +3,8 @@ name: Reusable Emscripten
 on:
   workflow_call:
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
 

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -12,6 +12,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
 

--- a/.github/workflows/reusable-san.yml
+++ b/.github/workflows/reusable-san.yml
@@ -12,6 +12,8 @@ on:
         type: boolean
         default: false
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
 

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -18,6 +18,8 @@ on:
          required: true
          type: string
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
 

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -3,6 +3,8 @@ name: Reusable WASI
 on:
   workflow_call:
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
 

--- a/.github/workflows/reusable-windows-msi.yml
+++ b/.github/workflows/reusable-windows-msi.yml
@@ -8,8 +8,7 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   FORCE_COLOR: 1

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -13,6 +13,8 @@ on:
         type: boolean
         default: false
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
   IncludeUwp: >-


### PR DESCRIPTION
Add permissions: {} to all reusable workflows

(cherry picked from commit 1f36a510a2a16e8ff15572f44090c7db43bb7935)