### PR TITLE
gh-148119: Refactor `get_type_attr_as_size` to improve error handling in `structseq.c`

### DIFF
--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -38,7 +38,6 @@ get_type_attr_as_size(PyTypeObject *tp, PyObject *name)
                      name, tp->tp_name);
         return -1;
     }
-
     return PyLong_AsSsize_t(v);
 }
 

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -28,13 +28,23 @@ static Py_ssize_t
 get_type_attr_as_size(PyTypeObject *tp, PyObject *name)
 {
     PyObject *v = PyDict_GetItemWithError(_PyType_GetDict(tp), name);
-    if (v == NULL && !PyErr_Occurred()) {
+
+    if (v == NULL) {
+        if (PyErr_Occurred()) {
+            return -1;
+        }
         PyErr_Format(PyExc_TypeError,
                      "Missed attribute '%U' of type %s",
                      name, tp->tp_name);
         return -1;
     }
-    return PyLong_AsSsize_t(v);
+
+    Py_ssize_t result = PyLong_AsSsize_t(v);
+    if (result == -1 && PyErr_Occurred()) {
+        return -1;
+    }
+
+    return result;
 }
 
 #define VISIBLE_SIZE(op) Py_SIZE(op)

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -39,12 +39,7 @@ get_type_attr_as_size(PyTypeObject *tp, PyObject *name)
         return -1;
     }
 
-    Py_ssize_t result = PyLong_AsSsize_t(v);
-    if (result == -1 && PyErr_Occurred()) {
-        return -1;
-    }
-
-    return result;
+    return PyLong_AsSsize_t(v);
 }
 
 #define VISIBLE_SIZE(op) Py_SIZE(op)


### PR DESCRIPTION
Please add skip-news label

<!-- gh-issue-number: gh-148119 -->
* Issue: gh-148119
<!-- /gh-issue-number -->
