### PR TITLE
Silence `unused-variable` warnings in `optimizer_cases.c.h`

### DIFF
--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -2124,18 +2124,21 @@ dummy_func(void) {
     }
 
     op(_GUARD_CODE_VERSION_RETURN_VALUE, (version/2 -- )) {
+        (void)version;
         if (ctx->frame->caller) {
             REPLACE_OP(this_instr, _NOP, 0, 0);
         }
     }
 
     op(_GUARD_CODE_VERSION_YIELD_VALUE, (version/2 -- )) {
+        (void)version;
         if (ctx->frame->caller) {
             REPLACE_OP(this_instr, _NOP, 0, 0);
         }
     }
 
     op(_GUARD_CODE_VERSION_RETURN_GENERATOR, (version/2 -- )) {
+        (void)version;
         if (ctx->frame->caller) {
             REPLACE_OP(this_instr, _NOP, 0, 0);
         }

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -5092,6 +5092,7 @@
 
         case _GUARD_CODE_VERSION_YIELD_VALUE: {
             uint32_t version = (uint32_t)this_instr->operand0;
+            (void)version;
             if (ctx->frame->caller) {
                 REPLACE_OP(this_instr, _NOP, 0, 0);
             }
@@ -5100,6 +5101,7 @@
 
         case _GUARD_CODE_VERSION_RETURN_VALUE: {
             uint32_t version = (uint32_t)this_instr->operand0;
+            (void)version;
             if (ctx->frame->caller) {
                 REPLACE_OP(this_instr, _NOP, 0, 0);
             }
@@ -5108,6 +5110,7 @@
 
         case _GUARD_CODE_VERSION_RETURN_GENERATOR: {
             uint32_t version = (uint32_t)this_instr->operand0;
+            (void)version;
             if (ctx->frame->caller) {
                 REPLACE_OP(this_instr, _NOP, 0, 0);
             }


### PR DESCRIPTION
I saw some warnings in this [JIT CI run](https://github.com/python/cpython/actions/runs/24003603050/job/70003576787?pr=148126):
```
77
Python/optimizer_cases.c.h:5094:22: warning: unused variable 'version' [-Wunused-variable]
 5094 |             uint32_t version = (uint32_t)this_instr->operand0;
      |                      ^~~~~~~
Python/optimizer_cases.c.h:5102:22: warning: unused variable 'version' [-Wunused-variable]
 5102 |             uint32_t version = (uint32_t)this_instr->operand0;
      |                      ^~~~~~~
Python/optimizer_cases.c.h:5110:22: warning: unused variable 'version' [-Wunused-variable]
 5110 |             uint32_t version = (uint32_t)this_instr->operand0;
      |                      ^~~~~~~
```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
