### PR TITLE
[3.11] gh-145098: Use `macos-15-intel` instead of unstable `macos-26-…intel` in `{jit,tail-call}.yml` (GH-148126)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,7 @@ on:
     - 'main'
     - '3.*'
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-reusable

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,7 @@ name: Lint
 
 on: [push, pull_request, workflow_dispatch]
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   FORCE_COLOR: 1

--- a/.github/workflows/new-bugs-announce-notifier.yml
+++ b/.github/workflows/new-bugs-announce-notifier.yml
@@ -5,12 +5,13 @@ on:
     types:
       - opened
 
-permissions:
-  issues: read
+permissions: {}
 
 jobs:
   notify-new-bugs-announce:
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
     timeout-minutes: 10
     steps:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -4,15 +4,15 @@ on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, synchronize]
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   label:
     name: DO-NOT-MERGE / unresolved review
     if: github.repository_owner == 'python'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: [
           "macos-26",  # Apple Silicon
-          "macos-26-intel",  # Intel
+          "macos-15-intel",  # Intel
         ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,14 +4,14 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   stale:
     if: github.repository_owner == 'python'
-
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/verify-ensurepip-wheels.yml
+++ b/.github/workflows/verify-ensurepip-wheels.yml
@@ -13,8 +13,7 @@ on:
       - '.github/workflows/verify-ensurepip-wheels.yml'
       - 'Tools/scripts/verify_ensurepip_wheels.py'
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/verify-expat.yml
+++ b/.github/workflows/verify-expat.yml
@@ -11,8 +11,7 @@ on:
       - 'Modules/expat/**'
       - '.github/workflows/verify-expat.yml'
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION


(cherry picked from commit bce96a181350f348560fe0623361f39a6d5c6361)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145098 -->
* Issue: gh-145098
<!-- /gh-issue-number -->
