### PR TITLE
[3.10] gh-145098: Add `permissions: {}` to all workflows (GH-148126)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,7 @@ on:
     - 'main'
     - '3.*'
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,8 @@ on:
 permissions:
   pull-requests: write
 
+permissions: {}
+
 jobs:
   stale:
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,15 +4,15 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
-permissions:
-  pull-requests: write
-
 permissions: {}
 
 jobs:
   stale:
-
+    if: github.repository_owner == 'python'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    timeout-minutes: 10
 
     steps:
     - name: "Check PRs"

--- a/.github/workflows/verify-ensurepip-wheels.yml
+++ b/.github/workflows/verify-ensurepip-wheels.yml
@@ -13,8 +13,7 @@ on:
       - '.github/workflows/verify-ensurepip-wheels.yml'
       - 'Tools/scripts/verify_ensurepip_wheels.py'
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/verify-expat.yml
+++ b/.github/workflows/verify-expat.yml
@@ -11,8 +11,7 @@ on:
       - 'Modules/expat/**'
       - '.github/workflows/verify-expat.yml'
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
(cherry picked from commit bce96a181350f348560fe0623361f39a6d5c6361)

No `macos-26-intel` -> `macos-15-intel` needed here, only explicit `permissions: {}`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145098 -->
* Issue: gh-145098
<!-- /gh-issue-number -->
