### PR TITLE
gh-97032: avoid test_squeezer crash on macOS buildbots (gh-115508)

### DIFF
--- a/Lib/idlelib/idle_test/test_squeezer.py
+++ b/Lib/idlelib/idle_test/test_squeezer.py
@@ -170,6 +170,7 @@ class SqueezerTest(unittest.TestCase):
 
     def test_write_stdout(self):
         """Test Squeezer's overriding of the EditorWindow's write() method."""
+        requires('gui')
         editwin = self.make_mock_editor_window()
 
         for text in ['', 'TEXT']:


### PR DESCRIPTION
This is a forward-port from 3.10 to 'main'.  The same bug exists in newer version.

avoid test_squeezer crash on macOS buildbots


<!-- gh-issue-number: gh-97032 -->
* Issue: gh-97032
<!-- /gh-issue-number -->
