### PR TITLE
Note out-of-date obmalloc comments

### DIFF
--- a/Include/internal/pycore_obmalloc.h
+++ b/Include/internal/pycore_obmalloc.h
@@ -16,9 +16,9 @@ typedef unsigned int pymem_uint;  /* assuming >= 16 bits */
 
 /* NOTE: the following overviews were in the initial checkin, in 1998. In
  * 2026, they're still helpful, but some details have changed. For example,
- * we now use 32 size clesses 16 bytes apart, and an arena is generally at
- * last 1MB. Use sys._debugmallocstats() to see exact current details for
- * the specific version of CPython is use.
+ * we now use 32 size classes 16 bytes apart, and an arena is generally at
+ * least 1MB. Use sys._debugmallocstats() to see exact current details for
+ * the specific version of CPython used.
  */
 
 /* An object allocator for Python.

--- a/Include/internal/pycore_obmalloc.h
+++ b/Include/internal/pycore_obmalloc.h
@@ -14,6 +14,12 @@ typedef unsigned int pymem_uint;  /* assuming >= 16 bits */
 #undef  uint
 #define uint pymem_uint
 
+/* NOTE: the following overviews were in the initial checkin, in 1998. In
+ * 2026, they're still helpful, but some details have changed. For example,
+ * we now use 32 size clesses 16 bytes apart, and an arena is generally at
+ * last 1MB. Use sys._debugmallocstats() to see exact current details for
+ * the specific version of CPython is use.
+ */
 
 /* An object allocator for Python.
 


### PR DESCRIPTION
Vladimir's original overviews, from 1998, are still good, but going on 30 years later details have changed. Note that, but rather than try to keep up with moving targets in a different file, point to sys._debugmallocstats() as the sure way to discover precise current details.

No code changes, just added a block comment.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
