### PR TITLE
gh-148153: Do not use assert for parameter validation in base64

### DIFF
--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -69,9 +69,6 @@ POST request.
    after at most every *wrapcol* characters.
    If *wrapcol* is zero (default), do not insert any newlines.
 
-   May assert or raise a :exc:`ValueError` if the length of *altchars* is not 2.  Raises a
-   :exc:`TypeError` if *altchars* is not a :term:`bytes-like object`.
-
    .. versionchanged:: 3.15
       Added the *padded* and *wrapcol* parameters.
 

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -237,7 +237,6 @@ def b32decode(s, casefold=False, map01=None, *, padded=True, ignorechars=b''):
     # either L (el) or I (eye).
     if map01 is not None:
         map01 = _bytes_from_decode_data(map01)
-        assert len(map01) == 1, repr(map01)
         s = s.translate(bytes.maketrans(b'01', b'O' + map01))
     if casefold:
         s = s.upper()

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -607,6 +607,11 @@ class BaseXYTestCase(unittest.TestCase):
         self.assertRaises(binascii.Error, base64.b32decode, b'M1O23456')
         self.assertRaises(binascii.Error, base64.b32decode, b'ML023456')
         self.assertRaises(binascii.Error, base64.b32decode, b'MI023456')
+        self.assertRaises(ValueError, base64.b32decode, b'', map01=b'')
+        self.assertRaises(ValueError, base64.b32decode, b'', map01=b'LI')
+        self.assertRaises(TypeError, base64.b32decode, b'', map01=0)
+        eq(base64.b32decode(b'MLO23456', map01=None), res_L)
+        self.assertRaises(binascii.Error, base64.b32decode, b'M1023456', map01=None)
 
         data = b'M1023456'
         data_str = data.decode('ascii')

--- a/Misc/NEWS.d/next/Library/2026-04-06-11-20-24.gh-issue-148153.ZtsuTl.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-06-11-20-24.gh-issue-148153.ZtsuTl.rst
@@ -1,0 +1,2 @@
+:func:`base64.b32encode` now always raises :exc:`ValueError` instead of
+:exc:`AssertionError` for the value of *map01* with invalid length.


### PR DESCRIPTION
base64.b32encode() now always raises ValueError instead of AssertionError for the value of map01 with invalid length.


<!-- gh-issue-number: gh-148153 -->
* Issue: gh-148153
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148154.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->