### PR TITLE
 gh-148157: Check for `_PyPegen_add_type_comment_to_arg` fail in `_PyPegen_name_default_pair`

### DIFF
--- a/Lib/test/test_type_comments.py
+++ b/Lib/test/test_type_comments.py
@@ -398,6 +398,9 @@ class TypeCommentTests(unittest.TestCase):
         with self.assertRaises(UnicodeDecodeError):
             _testcapi.Py_CompileStringExFlags(
                 b"a=1 # type: \x80", "<test>", 256, flags)
+        with self.assertRaises(UnicodeDecodeError):
+            _testcapi.Py_CompileStringExFlags(
+                b"def a(f=8, #type: \x80\n\x80", "<test>", 256, flags)
 
     def test_func_type_input(self):
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-06-11-15-46.gh-issue-148157.JFnZDn.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-06-11-15-46.gh-issue-148157.JFnZDn.rst
@@ -1,2 +1,2 @@
 Fix an unlikely crash when parsing an invalid type comments for function
-parameters.
+parameters. Found by OSS Fuzz in :oss-fuzz:`492782951`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-06-11-15-46.gh-issue-148157.JFnZDn.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-06-11-15-46.gh-issue-148157.JFnZDn.rst
@@ -1,0 +1,2 @@
+Fix an unlikely crash when parsing an invalid type comments for function
+parameters.

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -435,6 +435,9 @@ _PyPegen_name_default_pair(Parser *p, arg_ty arg, expr_ty value, Token *tc)
         return NULL;
     }
     a->arg = _PyPegen_add_type_comment_to_arg(p, arg, tc);
+    if (!a->arg) {
+        return NULL;
+    }
     a->value = value;
     return a;
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148157 -->
* Issue: gh-148157
<!-- /gh-issue-number -->
