### PR TITLE
gh-140279: Stale workflow needs 'actions: write' to update its own cache

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,7 @@ jobs:
     if: github.repository_owner == 'python'
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       pull-requests: write
     timeout-minutes: 10
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Looking at the last three stale runs:

* https://github.com/python/cpython/actions/runs/24013745584/job/70029433814
* https://github.com/python/cpython/actions/runs/24021719127/job/70051782660
* https://github.com/python/cpython/actions/runs/24031392929/job/70080736928

They all process the same batch:

```
Processing the batch of issues  #1  containing  100  issues...
::group::[#37883] Issue #37883
[#37883] Issue #37883
##[debug]state: mark 37883 as processed
...
::group::[#13536] Pull request #13536
[#13536] Pull request #13536
##[debug]state: mark 13536 as processed
Warning: No more operations left! Exiting...
Warning: If you think that not enough issues were processed you could try to increase the quantity related to the  operations-per-run (​[https://github.com/actions/stale#operations-per-run​)](https://github.com/actions/stale#operations-per-run%E2%80%8B))  option which is currently set to  120
Statistics:
Processed items: 2498
├── Processed issues: 2446
└── Processed PRs   : 52
Fetched items: 2600
Fetched items events: 47
Fetched items comments: 47
Operations performed: 120
```

This is because it fails to update its own cache:

```
state: persisting info about 2561 issue(s)
##[debug]remove cache "_state"
Warning: Error delete _state: [403] Resource not accessible by integration - https://docs.github.com/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key
##[debug]Cache service version: v2
##[debug]Checking zstd --quiet --version
##[debug]1.5.7
##[debug]zstd version: 1.5.7
##[debug]implicitDescendants 'false'
##[debug]followSymbolicLinks 'true'
##[debug]implicitDescendants 'false'
##[debug]matchDirectories 'true'
##[debug]omitBrokenSymbolicLinks 'true'
##[debug]excludeHiddenFiles 'false'
##[debug]Search path '/tmp/56acbeaa-1fef-4c79-8f84-7565e560fb03'
##[debug]Matched: ../../../../../tmp/56acbeaa-1fef-4c79-8f84-7565e560fb03
##[debug]Cache Paths:
##[debug]["../../../../../tmp/56acbeaa-1fef-4c79-8f84-7565e560fb03"]
##[debug]Archive Path: /home/runner/work/_temp/182ce2b9-beec-48f1-8a39-01885e86ce30/cache.tzst
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/cpython/cpython --files-from manifest.txt --use-compress-program zstdmt
/usr/bin/tar -tf /home/runner/work/_temp/182ce2b9-beec-48f1-8a39-01885e86ce30/cache.tzst -P --use-compress-program unzstd
../../../../../tmp/56acbeaa-1fef-4c79-8f84-7565e560fb03/
../../../../../tmp/56acbeaa-1fef-4c79-8f84-7565e560fb03/state.txt
##[debug]File Size: 5712
##[debug]Reserving Cache
##[debug][Request] CreateCacheEntry https://results-receiver.actions.githubusercontent.com/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry
##[debug][Response] - 409
##[debug]Headers: {
##[debug]  "content-length": "98",
##[debug]  "content-type": "application/json",
##[debug]  "date": "Mon, 06 Apr 2026 12:15:29 GMT",
##[debug]  "x-github-backend": "Kubernetes",
##[debug]  "x-github-request-id": "C440:1E9CFA:222389D:28AADDD:69D3A3E0"
##[debug]}
##[debug]Body: {
##[debug]  "code": "already_exists",
##[debug]  "msg": "cache entry with the same key, version, and scope already exists"
##[debug]}
##[debug]Failed to reserve cache: Error: Failed to CreateCacheEntry: Received non-retryable error: Failed request: (409) Conflict: cache entry with the same key, version, and scope already exists
Failed to save: Unable to reserve cache with key _state, another job may be creating this cache.
```

According to https://github.com/actions/stale/issues/1133#issuecomment-2885467488 it needs `actions: write` to update the cache.

Then the next run should be able to process the next batch.

<!-- gh-issue-number: gh-140279 -->
* Issue: gh-140279
<!-- /gh-issue-number -->
