### PR TITLE
gh-101178: Fix UB in `binascii.b2a_ascii85`

### DIFF
--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -1240,7 +1240,7 @@ binascii_b2a_ascii85_impl(PyObject *module, Py_buffer *data, int foldspaces,
 
     /* Encode all full-length chunks. */
     for (; bin_len >= 4; bin_len -= 4, bin_data += 4) {
-        uint32_t leftchar = (bin_data[0] << 24) | (bin_data[1] << 16) |
+        uint32_t leftchar = ((uint32_t)bin_data[0] << 24) | (bin_data[1] << 16) |
                             (bin_data[2] << 8)  |  bin_data[3];
         if (leftchar == BASE85_A85_Z) {
             *ascii_data++ = 'z';
@@ -1481,7 +1481,7 @@ binascii_b2a_base85_impl(PyObject *module, Py_buffer *data, int pad,
 
     /* Encode all full-length chunks. */
     for (; bin_len >= 4; bin_len -= 4, bin_data += 4) {
-        uint32_t leftchar = (bin_data[0] << 24) | (bin_data[1] << 16) |
+        uint32_t leftchar = ((uint32_t)bin_data[0] << 24) | (bin_data[1] << 16) |
                             (bin_data[2] << 8)  |  bin_data[3];
 
         ascii_data[4] = table_b2a[leftchar % 85];


### PR DESCRIPTION
Spotted when running the test:
```
$ ./python -m test test_binascii
Using random seed: 2254522381
0:00:00 load avg: 0.43 Run 1 test sequentially in a single process
0:00:00 load avg: 0.43 [1/1] test_binascii
Modules/binascii.c:1243:42: runtime error: left shift of 129 by 24 places cannot be represented in type 'int'
Modules/binascii.c:1484:42: runtime error: left shift of 130 by 24 places cannot be represented in type 'int'
0:00:00 load avg: 0.43 [1/1] test_binascii passed

== Tests result: SUCCESS ==

1 test OK.

Total duration: 89 ms
Total tests: run=197 skipped=17
Total test files: run=1/1
Result: SUCCESS
```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101178 -->
* Issue: gh-101178
<!-- /gh-issue-number -->
