### PR TITLE
gh-130472: Use fancycompleter in import completions

### DIFF
--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -72,7 +72,7 @@ class ModuleCompleter:
         self._curr_sys_path: list[str] = sys.path[:]
         self._stdlib_path = os.path.dirname(importlib.__path__[0])
 
-    def get_completions(self, line: str) -> tuple[list[str], list[Any], CompletionAction | None] | None:
+    def get_completions(self, line: str) -> tuple[list[str], list[object], CompletionAction | None] | None:
         """Return the next possible import completions for 'line'.
 
         For attributes completion, if the module to complete from is not
@@ -89,7 +89,7 @@ class ModuleCompleter:
             # no completions are available
             return [], [], None
 
-    def complete(self, from_name: str | None, name: str | None) -> tuple[list[str], list[Any], CompletionAction | None]:
+    def complete(self, from_name: str | None, name: str | None) -> tuple[list[str], list[object], CompletionAction | None]:
         if from_name is None:
             # import x.y.z<tab>
             assert name is not None
@@ -181,7 +181,7 @@ class ModuleCompleter:
         return (isinstance(module_info.module_finder, FileFinder)
                 and module_info.module_finder.path == self._stdlib_path)
 
-    def find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[Any], CompletionAction | None]:
+    def find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[object], CompletionAction | None]:
         """Find all attributes of module 'path' that start with 'prefix'."""
         attributes, values, action = self._find_attributes(path, prefix)
         # Filter out invalid attribute names
@@ -194,7 +194,7 @@ class ModuleCompleter:
                 filtered_values.append(val)
         return filtered_names, filtered_values, action
 
-    def _find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[Any], CompletionAction | None]:
+    def _find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[object], CompletionAction | None]:
         path = self._resolve_relative_path(path)  # type: ignore[assignment]
         if path is None:
             return [], [], None

--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -72,7 +72,7 @@ class ModuleCompleter:
         self._curr_sys_path: list[str] = sys.path[:]
         self._stdlib_path = os.path.dirname(importlib.__path__[0])
 
-    def get_completions(self, line: str) -> tuple[list[str], list[object], CompletionAction | None] | None:
+    def get_completions(self, line: str) -> tuple[list[str], list[Any], CompletionAction | None] | None:
         """Return the next possible import completions for 'line'.
 
         For attributes completion, if the module to complete from is not
@@ -89,7 +89,7 @@ class ModuleCompleter:
             # no completions are available
             return [], [], None
 
-    def complete(self, from_name: str | None, name: str | None) -> tuple[list[str], list[object], CompletionAction | None]:
+    def complete(self, from_name: str | None, name: str | None) -> tuple[list[str], list[Any], CompletionAction | None]:
         if from_name is None:
             # import x.y.z<tab>
             assert name is not None
@@ -180,7 +180,7 @@ class ModuleCompleter:
         return (isinstance(module_info.module_finder, FileFinder)
                 and module_info.module_finder.path == self._stdlib_path)
 
-    def find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[object], CompletionAction | None]:
+    def find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[Any], CompletionAction | None]:
         """Find all attributes of module 'path' that start with 'prefix'."""
         attributes, values, action = self._find_attributes(path, prefix)
         # Filter out invalid attribute names
@@ -193,7 +193,7 @@ class ModuleCompleter:
                 filtered_values.append(val)
         return filtered_names, filtered_values, action
 
-    def _find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[object], CompletionAction | None]:
+    def _find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[Any], CompletionAction | None]:
         path = self._resolve_relative_path(path)  # type: ignore[assignment]
         if path is None:
             return [], [], None

--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import chain
 from tokenize import TokenInfo
+from .fancycompleter import safe_getattr
 
 TYPE_CHECKING = False
 
@@ -71,7 +72,7 @@ class ModuleCompleter:
         self._curr_sys_path: list[str] = sys.path[:]
         self._stdlib_path = os.path.dirname(importlib.__path__[0])
 
-    def get_completions(self, line: str) -> tuple[list[str], CompletionAction | None] | None:
+    def get_completions(self, line: str) -> tuple[list[str], list[Any], CompletionAction | None] | None:
         """Return the next possible import completions for 'line'.
 
         For attributes completion, if the module to complete from is not
@@ -86,26 +87,40 @@ class ModuleCompleter:
         except Exception:
             # Some unexpected error occurred, make it look like
             # no completions are available
-            return [], None
+            return [], [], None
 
-    def complete(self, from_name: str | None, name: str | None) -> tuple[list[str], CompletionAction | None]:
+    def complete(self, from_name: str | None, name: str | None) -> tuple[list[str], list[Any], CompletionAction | None]:
         if from_name is None:
             # import x.y.z<tab>
             assert name is not None
             path, prefix = self.get_path_and_prefix(name)
             modules = self.find_modules(path, prefix)
-            return [self.format_completion(path, module) for module in modules], None
+            names = [self.format_completion(path, module) for module in modules]
+            # These are always modules, use dummy values to get the right color
+            values = [sys] * len(names)
+            return names, values, None
 
         if name is None:
             # from x.y.z<tab>
             path, prefix = self.get_path_and_prefix(from_name)
             modules = self.find_modules(path, prefix)
-            return [self.format_completion(path, module) for module in modules], None
+            names = [self.format_completion(path, module) for module in modules]
+            # These are always modules, use dummy values to get the right color
+            values = [sys] * len(names)
+            return names, values, None
 
         # from x.y import z<tab>
         submodules = self.find_modules(from_name, name)
-        attributes, action = self.find_attributes(from_name, name)
-        return sorted({*submodules, *attributes}), action
+        attr_names, attr_values, action = self.find_attributes(from_name, name)
+        all_names = sorted({*submodules, *attr_names})
+        # Build values list matching the sorted order:
+        # submodules use `sys` as a dummy value so they get the 'module' color,
+        # attributes use their actual value.
+        submodule_set = set(submodules)
+        attr_map = dict(zip(attr_names, attr_values))
+        all_values = [attr_map.get(n) if n not in submodule_set else sys
+                      for n in all_names]
+        return all_names, all_values, action
 
     def find_modules(self, path: str, prefix: str) -> list[str]:
         """Find all modules under 'path' that start with 'prefix'."""
@@ -166,31 +181,43 @@ class ModuleCompleter:
         return (isinstance(module_info.module_finder, FileFinder)
                 and module_info.module_finder.path == self._stdlib_path)
 
-    def find_attributes(self, path: str, prefix: str) -> tuple[list[str], CompletionAction | None]:
+    def find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[Any], CompletionAction | None]:
         """Find all attributes of module 'path' that start with 'prefix'."""
-        attributes, action = self._find_attributes(path, prefix)
+        attributes, values, action = self._find_attributes(path, prefix)
         # Filter out invalid attribute names
         # (for example those containing dashes that cannot be imported with 'import')
-        return [attr for attr in attributes if attr.isidentifier()], action
+        filtered_names = []
+        filtered_values = []
+        for attr, val in zip(attributes, values):
+            if attr.isidentifier():
+                filtered_names.append(attr)
+                filtered_values.append(val)
+        return filtered_names, filtered_values, action
 
-    def _find_attributes(self, path: str, prefix: str) -> tuple[list[str], CompletionAction | None]:
+    def _find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[Any], CompletionAction | None]:
         path = self._resolve_relative_path(path)  # type: ignore[assignment]
         if path is None:
-            return [], None
+            return [], [], None
 
         imported_module = sys.modules.get(path)
         if not imported_module:
             if path in self._failed_imports:  # Do not propose to import again
-                return [], None
+                return [], [], None
             imported_module = self._maybe_import_module(path)
         if not imported_module:
-            return [], self._get_import_completion_action(path)
+            return [], [], self._get_import_completion_action(path)
         try:
             module_attributes = dir(imported_module)
         except Exception:
             module_attributes = []
-        return [attr_name for attr_name in module_attributes
-                if self.is_suggestion_match(attr_name, prefix)], None
+        names = []
+        values = []
+        for attr_name in module_attributes:
+            if not self.is_suggestion_match(attr_name, prefix):
+                continue
+            names.append(attr_name)
+            values.append(safe_getattr(imported_module, attr_name))
+        return names, values, None
 
     def is_suggestion_match(self, module_name: str, prefix: str) -> bool:
         if prefix:

--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -118,8 +118,7 @@ class ModuleCompleter:
         # attributes use their actual value.
         submodule_set = set(submodules)
         attr_map = dict(zip(attr_names, attr_values))
-        all_values = [attr_map.get(n) if n not in submodule_set else sys
-                      for n in all_names]
+        all_values = [attr_map[n] if n in attr_map else sys for n in all_names]
         return all_names, all_values, action
 
     def find_modules(self, path: str, prefix: str) -> list[str]:

--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -72,24 +72,35 @@ class ModuleCompleter:
         self._curr_sys_path: list[str] = sys.path[:]
         self._stdlib_path = os.path.dirname(importlib.__path__[0])
 
-    def get_completions(self, line: str) -> tuple[list[str], list[Any], CompletionAction | None] | None:
+    def get_completions(
+        self, line: str, *, include_values: bool = True
+    ) -> tuple[list[str], list[Any], CompletionAction | None] | None:
         """Return the next possible import completions for 'line'.
 
         For attributes completion, if the module to complete from is not
         imported, also return an action (prompt + callback to run if the
         user press TAB again) to import the module.
+
+        If *include_values* is false, the returned values list is empty and
+        attribute values are not resolved.
         """
         result = ImportParser(line).parse()
         if not result:
             return None
         try:
-            return self.complete(*result)
+            return self.complete(*result, include_values=include_values)
         except Exception:
             # Some unexpected error occurred, make it look like
             # no completions are available
             return [], [], None
 
-    def complete(self, from_name: str | None, name: str | None) -> tuple[list[str], list[Any], CompletionAction | None]:
+    def complete(
+        self,
+        from_name: str | None,
+        name: str | None,
+        *,
+        include_values: bool = True,
+    ) -> tuple[list[str], list[Any], CompletionAction | None]:
         if from_name is None:
             # import x.y.z<tab>
             assert name is not None
@@ -97,7 +108,7 @@ class ModuleCompleter:
             modules = self.find_modules(path, prefix)
             names = [self.format_completion(path, module) for module in modules]
             # These are always modules, use dummy values to get the right color
-            values = [sys] * len(names)
+            values = [sys] * len(names) if include_values else []
             return names, values, None
 
         if name is None:
@@ -106,18 +117,22 @@ class ModuleCompleter:
             modules = self.find_modules(path, prefix)
             names = [self.format_completion(path, module) for module in modules]
             # These are always modules, use dummy values to get the right color
-            values = [sys] * len(names)
+            values = [sys] * len(names) if include_values else []
             return names, values, None
 
         # from x.y import z<tab>
         submodules = self.find_modules(from_name, name)
-        attr_names, attr_values, action = self.find_attributes(from_name, name)
+        attr_names, attr_module, action = self._find_attributes(from_name, name)
         all_names = sorted({*submodules, *attr_names})
+        if not include_values:
+            return all_names, [], action
+
         # Build values list matching the sorted order:
         # submodules use `sys` as a dummy value so they get the 'module' color,
         # attributes use their actual value.
-        submodule_set = set(submodules)
-        attr_map = dict(zip(attr_names, attr_values))
+        attr_map = {}
+        if attr_module is not None:
+            attr_map = {n: safe_getattr(attr_module, n) for n in attr_names}
         all_values = [attr_map[n] if n in attr_map else sys for n in all_names]
         return all_names, all_values, action
 
@@ -180,43 +195,43 @@ class ModuleCompleter:
         return (isinstance(module_info.module_finder, FileFinder)
                 and module_info.module_finder.path == self._stdlib_path)
 
-    def find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[Any], CompletionAction | None]:
+    def find_attributes(
+        self, path: str, prefix: str
+    ) -> tuple[list[str], list[Any], CompletionAction | None]:
         """Find all attributes of module 'path' that start with 'prefix'."""
-        attributes, values, action = self._find_attributes(path, prefix)
-        # Filter out invalid attribute names
-        # (for example those containing dashes that cannot be imported with 'import')
-        filtered_names = []
-        filtered_values = []
-        for attr, val in zip(attributes, values):
-            if attr.isidentifier():
-                filtered_names.append(attr)
-                filtered_values.append(val)
-        return filtered_names, filtered_values, action
+        attributes, module, action = self._find_attributes(path, prefix)
+        if module is not None:
+            values = [safe_getattr(module, attr) for attr in attributes]
+        else:
+            values = []
+        return attributes, values, action
 
-    def _find_attributes(self, path: str, prefix: str) -> tuple[list[str], list[Any], CompletionAction | None]:
+    def _find_attributes(
+        self, path: str, prefix: str
+    ) -> tuple[list[str], ModuleType | None, CompletionAction | None]:
         path = self._resolve_relative_path(path)  # type: ignore[assignment]
         if path is None:
-            return [], [], None
+            return [], None, None
 
         imported_module = sys.modules.get(path)
         if not imported_module:
             if path in self._failed_imports:  # Do not propose to import again
-                return [], [], None
+                return [], None, None
             imported_module = self._maybe_import_module(path)
         if not imported_module:
-            return [], [], self._get_import_completion_action(path)
+            return [], None, self._get_import_completion_action(path)
         try:
             module_attributes = dir(imported_module)
         except Exception:
             module_attributes = []
-        names = []
-        values = []
-        for attr_name in module_attributes:
-            if not self.is_suggestion_match(attr_name, prefix):
-                continue
-            names.append(attr_name)
-            values.append(safe_getattr(imported_module, attr_name))
-        return names, values, None
+        # Filter out invalid attribute names, such as dashes that cannot be
+        # imported with 'import'.
+        names = [
+            attr_name for attr_name in module_attributes
+            if (self.is_suggestion_match(attr_name, prefix)
+                and attr_name.isidentifier())
+        ]
+        return names, imported_module, None
 
     def is_suggestion_match(self, module_name: str, prefix: str) -> bool:
         if prefix:

--- a/Lib/_pyrepl/fancycompleter.py
+++ b/Lib/_pyrepl/fancycompleter.py
@@ -8,6 +8,12 @@ import rlcompleter
 import keyword
 import types
 
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from typing import Any
+    from _colorize import Theme
+
 
 def safe_getattr(obj, name):
     # Mirror rlcompleter's safeguards so completion does not
@@ -21,13 +27,13 @@ def safe_getattr(obj, name):
     return getattr(obj, name, None)
 
 
-def colorize_matches(names, values, theme):
+def colorize_matches(names: list[str], values: list[Any], theme: Theme) -> list[str]:
     return [
         _color_for_obj(name, obj, theme)
         for name, obj in zip(names, values)
     ]
 
-def _color_for_obj(name, value, theme):
+def _color_for_obj(name: str, value: Any, theme: Theme) -> str:
     t = type(value)
     color = _color_by_type(t, theme)
     return f"{color}{name}{ANSIColors.RESET}"

--- a/Lib/_pyrepl/fancycompleter.py
+++ b/Lib/_pyrepl/fancycompleter.py
@@ -8,6 +8,19 @@ import rlcompleter
 import keyword
 import types
 
+
+def safe_getattr(obj, name):
+    # Mirror rlcompleter's safeguards so completion does not
+    # call properties or reify lazy module attributes.
+    if isinstance(getattr(type(obj), name, None), property):
+        return None
+    if (isinstance(obj, types.ModuleType)
+        and isinstance(obj.__dict__.get(name), types.LazyImportType)
+    ):
+        return obj.__dict__.get(name)
+    return getattr(obj, name, None)
+
+
 class Completer(rlcompleter.Completer):
     """
     When doing something like a.b.<tab>, keep the full a.b.attr completion
@@ -143,21 +156,7 @@ class Completer(rlcompleter.Completer):
                     word[:n] == attr
                     and not (noprefix and word[:n+1] == noprefix)
                 ):
-                    # Mirror rlcompleter's safeguards so completion does not
-                    # call properties or reify lazy module attributes.
-                    if isinstance(getattr(type(thisobject), word, None), property):
-                        value = None
-                    elif (
-                        isinstance(thisobject, types.ModuleType)
-                        and isinstance(
-                            thisobject.__dict__.get(word),
-                            types.LazyImportType,
-                        )
-                    ):
-                        value = thisobject.__dict__.get(word)
-                    else:
-                        value = getattr(thisobject, word, None)
-
+                    value = safe_getattr(thisobject, word)
                     names.append(word)
                     values.append(value)
             if names or not noprefix:

--- a/Lib/_pyrepl/fancycompleter.py
+++ b/Lib/_pyrepl/fancycompleter.py
@@ -21,6 +21,27 @@ def safe_getattr(obj, name):
     return getattr(obj, name, None)
 
 
+def colorize_matches(names, values, theme):
+    return [
+        _color_for_obj(name, obj, theme)
+        for name, obj in zip(names, values)
+    ]
+
+def _color_for_obj(name, value, theme):
+    t = type(value)
+    color = _color_by_type(t, theme)
+    return f"{color}{name}{ANSIColors.RESET}"
+
+
+def _color_by_type(t, theme):
+    typename = t.__name__
+    # this is needed e.g. to turn method-wrapper into method_wrapper,
+    # because if we want _colorize.FancyCompleter to be "dataclassable"
+    # our keys need to be valid identifiers.
+    typename = typename.replace('-', '_').replace('.', '_')
+    return getattr(theme.fancycompleter, typename, ANSIColors.RESET)
+
+
 class Completer(rlcompleter.Completer):
     """
     When doing something like a.b.<tab>, keep the full a.b.attr completion
@@ -169,23 +190,7 @@ class Completer(rlcompleter.Completer):
         return expr, attr, names, values
 
     def colorize_matches(self, names, values):
-        return [
-            self._color_for_obj(name, obj)
-            for name, obj in zip(names, values)
-        ]
-
-    def _color_for_obj(self, name, value):
-        t = type(value)
-        color = self._color_by_type(t)
-        return f"{color}{name}{ANSIColors.RESET}"
-
-    def _color_by_type(self, t):
-        typename = t.__name__
-        # this is needed e.g. to turn method-wrapper into method_wrapper,
-        # because if we want _colorize.FancyCompleter to be "dataclassable"
-        # our keys need to be valid identifiers.
-        typename = typename.replace('-', '_').replace('.', '_')
-        return getattr(self.theme.fancycompleter, typename, ANSIColors.RESET)
+        return colorize_matches(names, values, self.theme)
 
 
 def commonprefix(names):

--- a/Lib/_pyrepl/fancycompleter.py
+++ b/Lib/_pyrepl/fancycompleter.py
@@ -3,6 +3,8 @@
 #
 #                        All Rights Reserved
 """Colorful tab completion for Python prompt"""
+from __future__ import annotations
+
 from _colorize import ANSIColors, get_colors, get_theme
 import rlcompleter
 import keyword

--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -175,7 +175,7 @@ class ReadlineAlikeReader(historical_reader.HistoricalReader, CompletingReader):
         if result is None:
             return None
         names, values, action = result
-        if len(names) > 1 and self.config.colorize_completions:
+        if self.config.colorize_completions:
             names = self.config.colorize_completions(names, values)
         return names, action
 

--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -104,7 +104,7 @@ class ReadlineConfig:
     readline_completer: Completer | None = None
     completer_delims: frozenset[str] = frozenset(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?")
     module_completer: ModuleCompleter = field(default_factory=make_default_module_completer)
-    colorize_completions: Callable[[list[str], list[object]], list[str]] | None = None
+    colorize_completions: Callable[[list[str], list[Any]], list[str]] | None = None
 
 @dataclass(kw_only=True)
 class ReadlineAlikeReader(historical_reader.HistoricalReader, CompletingReader):
@@ -623,9 +623,10 @@ def _setup(namespace: Mapping[str, Any]) -> None:
     completer_cls = RLCompleter if use_basic_completer else FancyCompleter
     completer = completer_cls(namespace)
     _wrapper.config.readline_completer = completer.complete
-    if getattr(completer, 'use_colors', False):
+    if isinstance(completer, FancyCompleter) and completer.use_colors:
+        theme = completer.theme
         def _colorize(names: list[str], values: list[object]) -> list[str]:
-            return colorize_matches(names, values, completer.theme)
+            return colorize_matches(names, values, theme)
         _wrapper.config.colorize_completions = _colorize
     _wrapper.config.module_completer = ModuleCompleter(namespace)
 

--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -40,7 +40,7 @@ from . import commands, historical_reader
 from .completing_reader import CompletingReader, stripcolor
 from .console import Console as ConsoleType
 from ._module_completer import ModuleCompleter, make_default_module_completer
-from .fancycompleter import Completer as FancyCompleter
+from .fancycompleter import Completer as FancyCompleter, colorize_matches
 
 Console: type[ConsoleType]
 _error: tuple[type[Exception], ...] | type[Exception]
@@ -104,6 +104,7 @@ class ReadlineConfig:
     readline_completer: Completer | None = None
     completer_delims: frozenset[str] = frozenset(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?")
     module_completer: ModuleCompleter = field(default_factory=make_default_module_completer)
+    colorize_completions: Callable[[list[str], list[object]], list[str]] | None = None
 
 @dataclass(kw_only=True)
 class ReadlineAlikeReader(historical_reader.HistoricalReader, CompletingReader):
@@ -169,8 +170,14 @@ class ReadlineAlikeReader(historical_reader.HistoricalReader, CompletingReader):
         return result, None
 
     def get_module_completions(self) -> tuple[list[str], CompletionAction | None] | None:
-        line = self.get_line()
-        return self.config.module_completer.get_completions(line)
+        line = stripcolor(self.get_line())
+        result = self.config.module_completer.get_completions(line)
+        if result is None:
+            return None
+        names, values, action = result
+        if len(names) > 1 and self.config.colorize_completions:
+            names = self.config.colorize_completions(names, values)
+        return names, action
 
     def get_trimmed_history(self, maxlength: int) -> list[str]:
         if maxlength >= 0:
@@ -609,13 +616,18 @@ def _setup(namespace: Mapping[str, Any]) -> None:
     # set up namespace in rlcompleter, which requires it to be a bona fide dict
     if not isinstance(namespace, dict):
         namespace = dict(namespace)
-    _wrapper.config.module_completer = ModuleCompleter(namespace)
     use_basic_completer = (
         not sys.flags.ignore_environment
         and os.getenv("PYTHON_BASIC_COMPLETER")
     )
     completer_cls = RLCompleter if use_basic_completer else FancyCompleter
-    _wrapper.config.readline_completer = completer_cls(namespace).complete
+    completer = completer_cls(namespace)
+    _wrapper.config.readline_completer = completer.complete
+    if getattr(completer, 'use_colors', False):
+        def _colorize(names: list[str], values: list[object]) -> list[str]:
+            return colorize_matches(names, values, completer.theme)
+        _wrapper.config.colorize_completions = _colorize
+    _wrapper.config.module_completer = ModuleCompleter(namespace)
 
     # this is not really what readline.c does.  Better than nothing I guess
     import builtins

--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -171,12 +171,15 @@ class ReadlineAlikeReader(historical_reader.HistoricalReader, CompletingReader):
 
     def get_module_completions(self) -> tuple[list[str], CompletionAction | None] | None:
         line = stripcolor(self.get_line())
-        result = self.config.module_completer.get_completions(line)
+        colorize_completions = self.config.colorize_completions
+        result = self.config.module_completer.get_completions(
+            line, include_values=bool(colorize_completions)
+        )
         if result is None:
             return None
         names, values, action = result
-        if self.config.colorize_completions:
-            names = self.config.colorize_completions(names, values)
+        if colorize_completions:
+            names = colorize_completions(names, values)
         return names, action
 
     def get_trimmed_history(self, maxlength: int) -> list[str]:

--- a/Lib/test/test_pyrepl/test_fancycompleter.py
+++ b/Lib/test/test_pyrepl/test_fancycompleter.py
@@ -167,7 +167,7 @@ class FancyCompleterTests(unittest.TestCase):
         self.assertEqual(compl.global_matches('foobaz'), ['foobazzz'])
         self.assertEqual(compl.global_matches('nothing'), [])
 
-    def test_large_color_sort_prefix_is_stripped(self):
+    def test_colorized_match_is_stripped(self):
         theme = get_theme()
         match = _color_for_obj('spam', 1, theme)
         self.assertEqual(stripcolor(match), 'spam')

--- a/Lib/test/test_pyrepl/test_fancycompleter.py
+++ b/Lib/test/test_pyrepl/test_fancycompleter.py
@@ -5,7 +5,7 @@ import unittest
 
 from _colorize import ANSIColors, get_theme
 from _pyrepl.completing_reader import stripcolor
-from _pyrepl.fancycompleter import Completer, commonprefix
+from _pyrepl.fancycompleter import Completer, commonprefix, _color_for_obj
 from test.support.import_helper import ready_to_import
 
 class MockPatch:
@@ -167,9 +167,9 @@ class FancyCompleterTests(unittest.TestCase):
         self.assertEqual(compl.global_matches('foobaz'), ['foobazzz'])
         self.assertEqual(compl.global_matches('nothing'), [])
 
-    def test_colorized_match_is_stripped(self):
-        compl = Completer({'a': 42}, use_colors=True)
-        match = compl._color_for_obj('spam', 1)
+    def test_large_color_sort_prefix_is_stripped(self):
+        theme = get_theme()
+        match = _color_for_obj('spam', 1, theme)
         self.assertEqual(stripcolor(match), 'spam')
 
     def test_complete_with_indexer(self):

--- a/Lib/test/test_pyrepl/test_fancycompleter.py
+++ b/Lib/test/test_pyrepl/test_fancycompleter.py
@@ -1,11 +1,17 @@
 import importlib
+import inspect
 import os
 import types
 import unittest
 
 from _colorize import ANSIColors, get_theme
 from _pyrepl.completing_reader import stripcolor
-from _pyrepl.fancycompleter import Completer, commonprefix, _color_for_obj
+from _pyrepl.fancycompleter import (
+    Completer,
+    colorize_matches,
+    commonprefix,
+    _color_for_obj,
+)
 from test.support.import_helper import ready_to_import
 
 class MockPatch:
@@ -35,6 +41,11 @@ class FancyCompleterTests(unittest.TestCase):
         self.assertEqual(commonprefix(['isalpha', 'isdigit', 'foo']), '')
         self.assertEqual(commonprefix(['isalpha', 'isdigit']), 'is')
         self.assertEqual(commonprefix([]), '')
+
+    def test_colorize_matches_signature(self):
+        signature = inspect.signature(colorize_matches)
+
+        self.assertEqual(list(signature.parameters), ["names", "values", "theme"])
 
     def test_complete_attribute(self):
         compl = Completer({'a': None}, use_colors=False)

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1629,7 +1629,7 @@ class TestPyReplModuleCompleter(TestCase):
                         result = completer.get_completions(code)
                         self.assertEqual(result is None, expected is None)
                         if result:
-                            compl, act = result
+                            compl, _values, act = result
                             self.assertEqual(compl, expected[0])
                             self.assertEqual(act is None, expected[1] is None)
                             if act:

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -35,6 +35,7 @@ from .support import (
     multiline_input,
     code_to_events,
 )
+from _colorize import ANSIColors, get_theme
 from _pyrepl.console import Event
 from _pyrepl.completing_reader import stripcolor
 from _pyrepl._module_completer import (
@@ -42,7 +43,7 @@ from _pyrepl._module_completer import (
     ModuleCompleter,
     HARDCODED_SUBMODULES,
 )
-from _pyrepl.fancycompleter import Completer as FancyCompleter
+from _pyrepl.fancycompleter import Completer as FancyCompleter, colorize_matches
 import _pyrepl.readline as pyrepl_readline
 from _pyrepl.readline import (
     ReadlineAlikeReader,
@@ -1642,38 +1643,37 @@ class TestPyReplModuleCompleter(TestCase):
                         self.assertSetEqual(new_imports, expected_imports)
 
     def test_colorize_import_completions(self) -> None:
-        from _colorize import get_theme
-        from _pyrepl.fancycompleter import colorize_matches
-        from _pyrepl.completing_reader import stripcolor
-
         theme = get_theme()
+        type_color = theme.fancycompleter.type
+        module_color = theme.fancycompleter.module
+        R = ANSIColors.RESET
+
         colorize = lambda names, values: colorize_matches(names, values, theme)
         config = ReadlineConfig(colorize_completions=colorize)
-
         reader = ReadlineAlikeReader(
             console=FakeConsole(events=[]),
             config=config,
         )
 
-        # Multiple completions should be colorized (contain ANSI codes)
-        reader.buffer = list("from collections import d")
+        # "from collections import de" -> defaultdict (type) and deque (type)
+        reader.buffer = list("from collections import de")
         reader.pos = len(reader.buffer)
-        result = reader.get_module_completions()
-        self.assertIsNotNone(result)
-        names, action = result
-        self.assertTrue(len(names) > 1)
-        # Colorized names contain ANSI escape sequences
-        self.assertTrue(any(name != stripcolor(name) for name in names
-                            if name.strip()))
+        names, action = reader.get_module_completions()
+        self.assertEqual(names, [
+            f"{type_color}defaultdict{R}",
+            f"{type_color}deque{R}",
+        ])
+        self.assertIsNone(action)
 
-        # Single completion should NOT be colorized
-        reader.buffer = list("from collections import Order")
+        # "from importlib.m" has submodule completions colored as modules
+        reader.buffer = list("from importlib.m")
         reader.pos = len(reader.buffer)
-        result = reader.get_module_completions()
-        self.assertIsNotNone(result)
-        names, action = result
-        self.assertEqual(len(names), 1)
-        self.assertEqual(names[0], stripcolor(names[0]))
+        names, action = reader.get_module_completions()
+        self.assertEqual(names, [
+            f"{module_color}importlib.machinery{R}",
+            f"{module_color}importlib.metadata{R}",
+        ])
+        self.assertIsNone(action)
 
 
 # Audit hook used to check for stdlib modules import side-effects

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1641,6 +1641,40 @@ class TestPyReplModuleCompleter(TestCase):
                         new_imports = sys.modules.keys() - _imported
                         self.assertSetEqual(new_imports, expected_imports)
 
+    def test_colorize_import_completions(self) -> None:
+        from _colorize import get_theme
+        from _pyrepl.fancycompleter import colorize_matches
+        from _pyrepl.completing_reader import stripcolor
+
+        theme = get_theme()
+        colorize = lambda names, values: colorize_matches(names, values, theme)
+        config = ReadlineConfig(colorize_completions=colorize)
+
+        reader = ReadlineAlikeReader(
+            console=FakeConsole(events=[]),
+            config=config,
+        )
+
+        # Multiple completions should be colorized (contain ANSI codes)
+        reader.buffer = list("from collections import d")
+        reader.pos = len(reader.buffer)
+        result = reader.get_module_completions()
+        self.assertIsNotNone(result)
+        names, action = result
+        self.assertTrue(len(names) > 1)
+        # Colorized names contain ANSI escape sequences
+        self.assertTrue(any(name != stripcolor(name) for name in names
+                            if name.strip()))
+
+        # Single completion should NOT be colorized
+        reader.buffer = list("from collections import Order")
+        reader.pos = len(reader.buffer)
+        result = reader.get_module_completions()
+        self.assertIsNotNone(result)
+        names, action = result
+        self.assertEqual(len(names), 1)
+        self.assertEqual(names[0], stripcolor(names[0]))
+
 
 # Audit hook used to check for stdlib modules import side-effects
 # Defined globally to avoid adding one hook per test run (refleak)

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1028,6 +1028,8 @@ class TestPyReplReadlineSetup(TestCase):
         class FakeFancyCompleter:
             def __init__(self, namespace):
                 self.namespace = namespace
+                self.use_colors = Mock()
+                self.theme = Mock()
 
             def complete(self, text, state):
                 return None
@@ -1672,6 +1674,17 @@ class TestPyReplModuleCompleter(TestCase):
         self.assertEqual(names, [
             f"{module_color}importlib.machinery{R}",
             f"{module_color}importlib.metadata{R}",
+        ])
+        self.assertIsNone(action)
+
+        # Make sure attributes take precedence over submodules when both exist
+        # Here we're using `unittest.main` which happens to be both a module and an attribute
+        reader.buffer = list("from unittest import m")
+        reader.pos = len(reader.buffer)
+        names, action = reader.get_module_completions()
+        self.assertEqual(names, [
+            f"{type_color}main{R}",  # Ensure that `main` is colored as an attribute (class in this case)
+            f"{module_color}mock{R}",
         ])
         self.assertIsNone(action)
 

--- a/Misc/NEWS.d/next/Library/2026-04-08-21-39-01.gh-issue-130472.4Bk6qH.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-08-21-39-01.gh-issue-130472.4Bk6qH.rst
@@ -1,0 +1,1 @@
+Integrate fancycompleter with import completions.


### PR DESCRIPTION
<img width="1914" height="168" alt="image" src="https://github.com/user-attachments/assets/6cdf9a1e-8c06-432b-8d07-a4d12a4df654" />

Now that https://github.com/python/cpython/pull/130473 has been merged, let's use it for import completions as well.
This is my first stab at this. First, I did a bit of refactoring and extracted the getattr and colorize logic from `FancyCompleter` into reusable functions since I needed those for module completions. I also modified `ModuleCompleter` to return attribute values in addition to names (for modules, it just returns the `sys` module as a dummy value, this is just to get the color right). Then I just needed to extend `get_module_completions` to do the colorization.

@loic-simon would love if you have some spare time to have a look :)


<!-- gh-issue-number: gh-130472 -->
* Issue: gh-130472
<!-- /gh-issue-number -->
