### PR TITLE
GH-148189: Fix miscalculation of  type-specific free list memory use

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-08-02-49-07.gh-issue-148189.0KpXID.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-08-02-49-07.gh-issue-148189.0KpXID.rst
@@ -1,0 +1,1 @@
+Repaired undercount of bytes in type-specific free lists reported by sys._debugmallocstats(). For types that participate in cyclic garbage collection, it was missing two pointers used by GC.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -443,7 +443,7 @@ _PyDict_DebugMallocStats(FILE *out)
 {
     _PyDebugAllocatorStats(out, "free PyDictObject",
                            _Py_FREELIST_SIZE(dicts),
-                           sizeof(PyDictObject));
+                           _PyType_PreHeaderSize(&PyDict_Type) + sizeof(PyDictObject));
     _PyDebugAllocatorStats(out, "free PyDictKeysObject",
                            _Py_FREELIST_SIZE(dictkeys),
                            sizeof(PyDictKeysObject));

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -234,7 +234,7 @@ _PyList_DebugMallocStats(FILE *out)
     _PyDebugAllocatorStats(out,
                            "free PyListObject",
                             _Py_FREELIST_SIZE(lists),
-                           sizeof(PyListObject));
+                           _PyType_PreHeaderSize(&PyList_Type) + sizeof(PyListObject));
 }
 
 PyObject *

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -1274,6 +1274,7 @@ _PyTuple_DebugMallocStats(FILE *out)
         PyOS_snprintf(buf, sizeof(buf),
                       "free %d-sized PyTupleObject", len);
         _PyDebugAllocatorStats(out, buf, _Py_FREELIST_SIZE(tuples[i]),
-                               _PyObject_VAR_SIZE(&PyTuple_Type, len));
+                                /* If you would like, you could remove the _PyType_PreHeaderSize(&PyTuple_Type) + to make it so that the freelist entries actual memory is calculated */
+                               _PyType_PreHeaderSize(&PyTuple_Type) + _PyObject_VAR_SIZE(&PyTuple_Type, len));
     }
 }

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -1274,7 +1274,6 @@ _PyTuple_DebugMallocStats(FILE *out)
         PyOS_snprintf(buf, sizeof(buf),
                       "free %d-sized PyTupleObject", len);
         _PyDebugAllocatorStats(out, buf, _Py_FREELIST_SIZE(tuples[i]),
-                                /* If you would like, you could remove the _PyType_PreHeaderSize(&PyTuple_Type) + to make it so that the freelist entries actual memory is calculated */
-                               _PyType_PreHeaderSize(&PyTuple_Type) + _PyObject_VAR_SIZE(&PyTuple_Type, len));
+                               _PyObject_VAR_SIZE(&PyTuple_Type, len));
     }
 }

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -1274,6 +1274,6 @@ _PyTuple_DebugMallocStats(FILE *out)
         PyOS_snprintf(buf, sizeof(buf),
                       "free %d-sized PyTupleObject", len);
         _PyDebugAllocatorStats(out, buf, _Py_FREELIST_SIZE(tuples[i]),
-                               _PyObject_VAR_SIZE(&PyTuple_Type, len));
+                               _PyType_PreHeaderSize(&PyTuple_Type) + _PyObject_VAR_SIZE(&PyTuple_Type, len));
     }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
# Fixing calculation of bytes in type-specific free lists

GH-148189: Fix miscalculation of  type-specific free list memory use