### PR TITLE
gh-146121: Clarify security model of pkgutil.getdata; revert checks

### DIFF
--- a/Doc/library/pkgutil.rst
+++ b/Doc/library/pkgutil.rst
@@ -191,7 +191,7 @@ support.
 
    .. seealso::
 
-      The :mod:`importlib.resources` module provides structures access to
+      The :mod:`importlib.resources` module provides structured access to
       module resources.
 
 .. function:: resolve_name(name)

--- a/Doc/library/pkgutil.rst
+++ b/Doc/library/pkgutil.rst
@@ -151,11 +151,15 @@ support.
    :meth:`get_data <importlib.abc.ResourceLoader.get_data>` API.  The
    *package* argument should be the name of a package, in standard module format
    (``foo.bar``).  The *resource* argument should be in the form of a relative
-   filename, using ``/`` as the path separator.  The parent directory name
-   ``..`` is not allowed, and nor is a rooted name (starting with a ``/``).
+   filename, using ``/`` as the path separator.
 
    The function returns a binary string that is the contents of the specified
    resource.
+
+   This function uses the :term:`loader` method
+   :func:`~importlib.abc.FileLoader.get_data`
+   to support modules installed in the filesystem, but also in zip files,
+   databases, or elsewhere.
 
    For packages located in the filesystem, which have already been imported,
    this is the rough equivalent of::
@@ -163,12 +167,32 @@ support.
       d = os.path.dirname(sys.modules[package].__file__)
       data = open(os.path.join(d, resource), 'rb').read()
 
+   Like the :func:`open` function, :func:`!get_data` can follow parent
+   directories (``../``) and absolute paths (starting with ``/`` or ``C:/``,
+   for example).
+   It can open compilation/installation artifacts like ``.py`` and ``.pyc``
+   files or files with :func:`reserved filenames <os.path.isreserved>`.
+   To be compatible with non-filesystem loaders, avoid using these features.
+
+   .. warning::
+
+      This function is intended for trusted input.
+      It does not verify that *resource* "belongs" to *package*.
+
+   If you use a user-provided *resource* path, consider verifying it.
+   For example, require an alphanumeric filename with a known extension, or
+   install and check a list of known resources.
+
    If the package cannot be located or loaded, or it uses a :term:`loader`
    which does not support :meth:`get_data <importlib.abc.ResourceLoader.get_data>`,
    then ``None`` is returned.  In particular, the :term:`loader` for
    :term:`namespace packages <namespace package>` does not support
    :meth:`get_data <importlib.abc.ResourceLoader.get_data>`.
 
+   .. seealso::
+
+      The :mod:`importlib.resources` module provides structures access to
+      module resources.
 
 .. function:: resolve_name(name)
 

--- a/Lib/pkgutil.py
+++ b/Lib/pkgutil.py
@@ -393,9 +393,6 @@ def get_data(package, resource):
     # signature - an os.path format "filename" starting with the dirname of
     # the package's __file__
     parts = resource.split('/')
-    if os.path.isabs(resource) or '..' in parts:
-        raise ValueError("resource must be a relative path with no "
-                         "parent directory components")
     parts.insert(0, os.path.dirname(mod.__file__))
     resource_name = os.path.join(*parts)
     return loader.get_data(resource_name)

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -61,25 +61,6 @@ class PkgutilTests(unittest.TestCase):
 
         del sys.modules[pkg]
 
-    def test_getdata_path_traversal(self):
-        pkg = 'test_getdata_traversal'
-
-        # Make a package with some resources
-        package_dir = os.path.join(self.dirname, pkg)
-        os.mkdir(package_dir)
-        # Empty init.py
-        f = open(os.path.join(package_dir, '__init__.py'), "wb")
-        f.close()
-
-        with self.assertRaises(ValueError):
-            pkgutil.get_data(pkg, '../../../etc/passwd')
-        with self.assertRaises(ValueError):
-            pkgutil.get_data(pkg, 'sub/../../../etc/passwd')
-        with self.assertRaises(ValueError):
-            pkgutil.get_data(pkg, os.path.abspath('/etc/passwd'))
-
-        del sys.modules[pkg]
-
     def test_getdata_zipfile(self):
         zip = 'test_getdata_zipfile.zip'
         pkg = 'test_getdata_zipfile'

--- a/Misc/NEWS.d/next/Security/2026-03-16-18-07-00.gh-issue-146121.vRbdro.rst
+++ b/Misc/NEWS.d/next/Security/2026-03-16-18-07-00.gh-issue-146121.vRbdro.rst
@@ -1,3 +1,0 @@
-:func:`pkgutil.get_data` now raises rejects *resource* arguments containing the
-parent directory components or that is an absolute path.
-This addresses :cve:`2026-3479`.


### PR DESCRIPTION
`pkgutil.getdata` has the same security model as `open()`. The documented limitations ensure compatibility with non-filesystem loaders; Python doesn't check that.

Revert the incomplete checks added in bcdf231946b1da8bdfbab4c05539bb0cc964a1c7


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146121 -->
* Issue: gh-146121
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148197.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->