### PR TITLE
gh-148208: Fix recursion depth leak in `PyObject_Print`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-07-20-21-44.gh-issue-148208.JAxpDU.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-07-20-21-44.gh-issue-148208.JAxpDU.rst
@@ -1,1 +1,1 @@
-Fix recursion depth leak in :c:func:`PyObject_Print
+Fix recursion depth leak in :c:func:`PyObject_Print`

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-07-20-21-44.gh-issue-148208.JAxpDU.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-07-20-21-44.gh-issue-148208.JAxpDU.rst
@@ -1,0 +1,1 @@
+Fix recursion depth leak in :c:func:`PyObject_Print

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -688,6 +688,8 @@ PyObject_Print(PyObject *op, FILE *fp, int flags)
             ret = -1;
         }
     }
+
+    _Py_LeaveRecursiveCall();
     return ret;
 }
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-148208 -->
* Issue: gh-148208
<!-- /gh-issue-number -->
