### PR TITLE
gh-148223: Avoid unnecessary NotShareableError in XIData FULL_FALLBACK

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-07-00-00-00.gh-issue-148223.Rk4xPe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-07-00-00-00.gh-issue-148223.Rk4xPe.rst
@@ -1,0 +1,4 @@
+Avoid unnecessary ``NotShareableError`` creation in
+``_PyObject_GetXIData()`` when falling back to pickle for types not in the
+XIData registry.  This speeds up cross-interpreter transfers of mutable
+types such as ``list`` and ``dict``.

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -536,25 +536,54 @@ _PyObject_GetXIData(PyThreadState *tstate,
         case _PyXIDATA_XIDATA_ONLY:
             return _get_xidata(tstate, obj, fallback, xidata);
         case _PyXIDATA_FULL_FALLBACK:
-            if (_get_xidata(tstate, obj, fallback, xidata) == 0) {
-                return 0;
+        {
+            // Check the type registry first to avoid unnecessary exception
+            // creation when falling back to pickle for unregistered types.
+            dlcontext_t ctx;
+            if (get_lookup_context(tstate, &ctx) < 0) {
+                return -1;
             }
-            PyObject *exc = _PyErr_GetRaisedException(tstate);
+            _PyXIData_getdata_t getdata = lookup_getdata(&ctx, obj);
+            if (getdata.basic != NULL || getdata.fallback != NULL) {
+                // Type is in the registry.  Use the normal path which may
+                // still fail (e.g. a tuple with non-shareable elements).
+                if (_get_xidata(tstate, obj, fallback, xidata) == 0) {
+                    return 0;
+                }
+                // Save the exception to restore if all fallbacks fail.
+                PyObject *exc = _PyErr_GetRaisedException(tstate);
+                if (PyFunction_Check(obj)) {
+                    if (_PyFunction_GetXIData(tstate, obj, xidata) == 0) {
+                        Py_DECREF(exc);
+                        return 0;
+                    }
+                    _PyErr_Clear(tstate);
+                }
+                if (_PyPickle_GetXIData(tstate, obj, xidata) == 0) {
+                    Py_DECREF(exc);
+                    return 0;
+                }
+                _PyErr_SetRaisedException(tstate, exc);
+                return -1;
+            }
+            // Type is NOT in the registry.  Skip _get_xidata() entirely
+            // to avoid creating and discarding a NotShareableError.
             if (PyFunction_Check(obj)) {
                 if (_PyFunction_GetXIData(tstate, obj, xidata) == 0) {
-                    Py_DECREF(exc);
                     return 0;
                 }
                 _PyErr_Clear(tstate);
             }
             // We could try _PyMarshal_GetXIData() but we won't for now.
             if (_PyPickle_GetXIData(tstate, obj, xidata) == 0) {
-                Py_DECREF(exc);
                 return 0;
             }
-            // Raise the original exception.
-            _PyErr_SetRaisedException(tstate, exc);
+            // All fallbacks failed.  Raise the same NotShareableError
+            // as the non-optimized path would.
+            _PyErr_Clear(tstate);
+            _set_xid_lookup_failure(tstate, obj, NULL, NULL);
             return -1;
+        }
         default:
 #ifdef Py_DEBUG
             Py_FatalError("unsupported xidata fallback option");


### PR DESCRIPTION
<!-- gh-issue-number: gh-148223 -->
* Issue: gh-148223
<!-- /gh-issue-number -->

## Summary

Avoid unnecessary `NotShareableError` creation in `_PyObject_GetXIData()` on the `FULL_FALLBACK` path.

For types not present in the XIData registry, the previous code always called `_get_xidata()`, which raised `NotShareableError` before falling back to function/pickle handling.  When pickle fallback succeeded, that exception was immediately discarded.  This change adds a registry pre-check so unregistered types can skip `_get_xidata()` and go straight to the fallback path.

Follow-up to gh-148072 / GH-148125 (pickle cache).

## Changes

- restructure the `FULL_FALLBACK` branch in `Python/crossinterp.c`
- probe the XIData registry with `lookup_getdata()` before calling `_get_xidata()`
- keep the existing path for registered types
- skip unnecessary exception creation for unregistered types
- preserve the previous `NotShareableError` behavior on total failure

## Behavior

This is intended as a performance-only change.

- registered types still follow the existing path
- unregistered types use the same fallback chain as before
- on failure, the same final `NotShareableError` is raised as in the non-optimized path

## Benchmarks

Baseline is `upstream/main` (after GH-148125). `identity(x)` round-trip, `max_workers=1`, Apple M2.

| Data | Before | After | Speedup |
|------|--------|-------|---------|
| `list(100)` | 0.14ms | 0.06ms | 2.3x |
| `dict(100)` | 0.20ms | 0.08ms | 2.5x |
| `list(10000)` | 3.45ms | 0.53ms | 6.5x |
| `dict(10000)` | 10.66ms | 2.52ms | 4.2x |

## Test plan

- [x] `./python -m test test_interpreters` — 172 tests passed
- [x] `./python -m test test_concurrent_futures` — 380 tests passed (including `test_interpreter_pool`)