### PR TITLE
gh-148241: Fix json serialization for str subclasses

### DIFF
--- a/Lib/test/test_json/test_dump.py
+++ b/Lib/test/test_json/test_dump.py
@@ -77,6 +77,44 @@ class TestDump:
         d[1337] = "true.dat"
         self.assertEqual(self.dumps(d, sort_keys=True), '{"1337": "true.dat"}')
 
+    def test_dumps_str_subclass(self):
+        # Don't call obj.__str__() on str subclasses
+
+        # str subclass which returns a different string on str(obj)
+        class StrSubclass(str):
+            def __str__(self):
+                return "StrSubclass"
+
+        obj = StrSubclass('ascii')
+        self.assertEqual(self.dumps(obj),
+                         '"ascii"')
+        self.assertEqual(self.dumps([obj]),
+                         '["ascii"]')
+        self.assertEqual(self.dumps({'key': obj}),
+                         '{"key": "ascii"}')
+
+        obj = StrSubclass('escape\n')
+        self.assertEqual(self.dumps(obj),
+                         '"escape\\n"')
+        self.assertEqual(self.dumps([obj]),
+                         '["escape\\n"]')
+        self.assertEqual(self.dumps({'key': obj}),
+                         '{"key": "escape\\n"}')
+
+        obj = StrSubclass('nonascii:é')
+        self.assertEqual(self.dumps(obj, ensure_ascii=False),
+                         '"nonascii:é"')
+        self.assertEqual(self.dumps([obj], ensure_ascii=False),
+                         '["nonascii:é"]')
+        self.assertEqual(self.dumps({'key': obj}, ensure_ascii=False),
+                         '{"key": "nonascii:é"}')
+        self.assertEqual(self.dumps(obj),
+                         '"nonascii:\\u00e9"')
+        self.assertEqual(self.dumps([obj]),
+                         '["nonascii:\\u00e9"]')
+        self.assertEqual(self.dumps({'key': obj}),
+                         '{"key": "nonascii:\\u00e9"}')
+
 
 class TestPyDump(TestDump, PyTest): pass
 

--- a/Lib/test/test_json/test_dump.py
+++ b/Lib/test/test_json/test_dump.py
@@ -86,20 +86,14 @@ class TestDump:
                 return "StrSubclass"
 
         obj = StrSubclass('ascii')
-        self.assertEqual(self.dumps(obj),
-                         '"ascii"')
-        self.assertEqual(self.dumps([obj]),
-                         '["ascii"]')
-        self.assertEqual(self.dumps({'key': obj}),
-                         '{"key": "ascii"}')
+        self.assertEqual(self.dumps(obj), '"ascii"')
+        self.assertEqual(self.dumps([obj]), '["ascii"]')
+        self.assertEqual(self.dumps({'key': obj}), '{"key": "ascii"}')
 
         obj = StrSubclass('escape\n')
-        self.assertEqual(self.dumps(obj),
-                         '"escape\\n"')
-        self.assertEqual(self.dumps([obj]),
-                         '["escape\\n"]')
-        self.assertEqual(self.dumps({'key': obj}),
-                         '{"key": "escape\\n"}')
+        self.assertEqual(self.dumps(obj), '"escape\\n"')
+        self.assertEqual(self.dumps([obj]), '["escape\\n"]')
+        self.assertEqual(self.dumps({'key': obj}), '{"key": "escape\\n"}')
 
         obj = StrSubclass('nonascii:é')
         self.assertEqual(self.dumps(obj, ensure_ascii=False),
@@ -108,10 +102,8 @@ class TestDump:
                          '["nonascii:é"]')
         self.assertEqual(self.dumps({'key': obj}, ensure_ascii=False),
                          '{"key": "nonascii:é"}')
-        self.assertEqual(self.dumps(obj),
-                         '"nonascii:\\u00e9"')
-        self.assertEqual(self.dumps([obj]),
-                         '["nonascii:\\u00e9"]')
+        self.assertEqual(self.dumps(obj), '"nonascii:\\u00e9"')
+        self.assertEqual(self.dumps([obj]), '["nonascii:\\u00e9"]')
         self.assertEqual(self.dumps({'key': obj}),
                          '{"key": "nonascii:\\u00e9"}')
 

--- a/Lib/test/test_json/test_encode_basestring_ascii.py
+++ b/Lib/test/test_json/test_encode_basestring_ascii.py
@@ -3,6 +3,11 @@ from test.test_json import PyTest, CTest
 from test.support import bigaddrspacetest
 
 
+# str subclass which returns a different string on str(obj)
+class StrSubclass(str):
+    def __str__(self):
+        return "StrSubclass"
+
 CASES = [
     ('/\\"\ucafe\ubabe\uab98\ufcde\ubcda\uef4a\x08\x0c\n\r\t`1~!@#$%^&*()_+-=[]{}|;:\',./<>?', '"/\\\\\\"\\ucafe\\ubabe\\uab98\\ufcde\\ubcda\\uef4a\\b\\f\\n\\r\\t`1~!@#$%^&*()_+-=[]{}|;:\',./<>?"'),
     ('\u0123\u4567\u89ab\ucdef\uabcd\uef4a', '"\\u0123\\u4567\\u89ab\\ucdef\\uabcd\\uef4a"'),
@@ -14,6 +19,8 @@ CASES = [
     ('\U0001d120', '"\\ud834\\udd20"'),
     ('\u03b1\u03a9', '"\\u03b1\\u03a9"'),
     ("`1~!@#$%^&*()_+-={':[,]}|;.</>?", '"`1~!@#$%^&*()_+-={\':[,]}|;.</>?"'),
+    # Don't call obj.__str__() on str subclasses
+    (StrSubclass('ascii'), '"ascii"'),
 ]
 
 class TestEncodeBasestringAscii:

--- a/Lib/test/test_json/test_enum.py
+++ b/Lib/test/test_json/test_enum.py
@@ -31,6 +31,9 @@ class WeirdNum(float, Enum):
     neg_inf = NEG_INF
     nan = NAN
 
+class StringEnum(str, Enum):
+    COLOR = "color"
+
 class TestEnum:
 
     def test_floats(self):
@@ -115,6 +118,12 @@ class TestEnum:
         self.assertEqual(nd['i'], INF)
         self.assertEqual(nd['j'], NEG_INF)
         self.assertTrue(isnan(nd['n']))
+
+    def test_str_enum(self):
+        obj = StringEnum.COLOR
+        self.assertEqual(self.dumps(obj), '"color"')
+        self.assertEqual(self.dumps([obj]), '["color"]')
+        self.assertEqual(self.dumps({'key': obj}), '{"key": "color"}')
 
 class TestPyEnum(TestEnum, PyTest): pass
 class TestCEnum(TestEnum, CTest): pass

--- a/Misc/NEWS.d/next/Library/2026-04-08-14-19-17.gh-issue-148241.fO_QT4.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-08-14-19-17.gh-issue-148241.fO_QT4.rst
@@ -1,0 +1,2 @@
+:mod:`json`: Fix serialization: no longer call ``str(obj)`` on :class:`str`
+subclasses. Patch by Victor Stinner.

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -258,7 +258,10 @@ write_escaped_ascii(PyUnicodeWriter *writer, PyObject *pystr)
         if (PyUnicodeWriter_WriteChar(writer, '"') < 0) {
             return -1;
         }
-        if (PyUnicodeWriter_WriteStr(writer, pystr) < 0) {
+        // gh-148241: Avoid PyUnicodeWriter_WriteStr() which calls str(obj)
+        // on str subclasses
+        assert(PyUnicode_IS_ASCII(pystr));
+        if (PyUnicodeWriter_WriteASCII(writer, input, input_chars) < 0) {
             return -1;
         }
         return PyUnicodeWriter_WriteChar(writer, '"');
@@ -399,7 +402,9 @@ write_escaped_unicode(PyUnicodeWriter *writer, PyObject *pystr)
         if (PyUnicodeWriter_WriteChar(writer, '"') < 0) {
             return -1;
         }
-        if (PyUnicodeWriter_WriteStr(writer, pystr) < 0) {
+        // gh-148241: Avoid PyUnicodeWriter_WriteStr() which calls str(obj)
+        // on str subclasses
+        if (_PyUnicodeWriter_WriteStr((_PyUnicodeWriter*)writer, pystr) < 0) {
             return -1;
         }
         return PyUnicodeWriter_WriteChar(writer, '"');


### PR DESCRIPTION
Fix json serialization: no longer call str(obj) on str subclasses.

Replace PyUnicodeWriter_WriteStr() with PyUnicodeWriter_WriteASCII() and private _PyUnicodeWriter_WriteStr().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148241 -->
* Issue: gh-148241
<!-- /gh-issue-number -->
