### PR TITLE
gh-148254: Use singular "sec" in timeit verbose output

### DIFF
--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -309,7 +309,7 @@ class TestTimeit(unittest.TestCase):
     def test_main_verbose(self):
         s = self.run_main(switches=['-v'])
         self.assertEqual(s, dedent("""\
-                1 loop -> 1 secs
+                1 loop -> 1 sec
 
                 raw times: 1 sec, 1 sec, 1 sec, 1 sec, 1 sec
 
@@ -319,19 +319,19 @@ class TestTimeit(unittest.TestCase):
     def test_main_very_verbose(self):
         s = self.run_main(seconds_per_increment=0.000_030, switches=['-vv'])
         self.assertEqual(s, dedent("""\
-                1 loop -> 3e-05 secs
-                2 loops -> 6e-05 secs
-                5 loops -> 0.00015 secs
-                10 loops -> 0.0003 secs
-                20 loops -> 0.0006 secs
-                50 loops -> 0.0015 secs
-                100 loops -> 0.003 secs
-                200 loops -> 0.006 secs
-                500 loops -> 0.015 secs
-                1000 loops -> 0.03 secs
-                2000 loops -> 0.06 secs
-                5000 loops -> 0.15 secs
-                10000 loops -> 0.3 secs
+                1 loop -> 3e-05 sec
+                2 loops -> 6e-05 sec
+                5 loops -> 0.00015 sec
+                10 loops -> 0.0003 sec
+                20 loops -> 0.0006 sec
+                50 loops -> 0.0015 sec
+                100 loops -> 0.003 sec
+                200 loops -> 0.006 sec
+                500 loops -> 0.015 sec
+                1000 loops -> 0.03 sec
+                2000 loops -> 0.06 sec
+                5000 loops -> 0.15 sec
+                10000 loops -> 0.3 sec
 
                 raw times: 300 msec, 300 msec, 300 msec, 300 msec, 300 msec
 
@@ -429,7 +429,7 @@ class TestTimeitColor(unittest.TestCase):
         s = self.run_main(switches=["-v"])
         self.assertEqual(
             s,
-            f"1 loop {t.punctuation}-> {t.timing}1 secs{t.reset}\n\n"
+            f"1 loop {t.punctuation}-> {t.timing}1 sec{t.reset}\n\n"
             "raw times: "
             f"{t.timing}1 sec{t.punctuation}, "
             f"{t.timing}1 sec{t.punctuation}, "

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -343,7 +343,7 @@ def main(args=None, *, _wrap_timer=None):
                 print(
                     f"{number} loop{s} "
                     f"{theme.punctuation}-> "
-                    f"{theme.timing}{time_taken:.{precision}g} secs{reset}"
+                    f"{theme.timing}{time_taken:.{precision}g} sec{reset}"
                 )
 
         try:

--- a/Misc/NEWS.d/next/Library/2026-04-09-12-42-42.gh-issue-148254.Xt7vKs.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-09-12-42-42.gh-issue-148254.Xt7vKs.rst
@@ -1,0 +1,2 @@
+Use singular "sec" instead of "secs" in :mod:`timeit` verbose output for
+consistency with other time units.


### PR DESCRIPTION
Change "secs" to "sec" in the verbose callback of timeit.main() for consistency with other time units (nsec, usec, msec, sec) used elsewhere in the module output.

<!-- gh-issue-number: gh-148254 -->
* Issue: gh-148254
<!-- /gh-issue-number -->
