### PR TITLE
[3.14] gh-148254: Use singular "sec" in timeit verbose output (GH-148290)

### DIFF
--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -302,7 +302,7 @@ class TestTimeit(unittest.TestCase):
     def test_main_verbose(self):
         s = self.run_main(switches=['-v'])
         self.assertEqual(s, dedent("""\
-                1 loop -> 1 secs
+                1 loop -> 1 sec
 
                 raw times: 1 sec, 1 sec, 1 sec, 1 sec, 1 sec
 
@@ -312,19 +312,19 @@ class TestTimeit(unittest.TestCase):
     def test_main_very_verbose(self):
         s = self.run_main(seconds_per_increment=0.000_030, switches=['-vv'])
         self.assertEqual(s, dedent("""\
-                1 loop -> 3e-05 secs
-                2 loops -> 6e-05 secs
-                5 loops -> 0.00015 secs
-                10 loops -> 0.0003 secs
-                20 loops -> 0.0006 secs
-                50 loops -> 0.0015 secs
-                100 loops -> 0.003 secs
-                200 loops -> 0.006 secs
-                500 loops -> 0.015 secs
-                1000 loops -> 0.03 secs
-                2000 loops -> 0.06 secs
-                5000 loops -> 0.15 secs
-                10000 loops -> 0.3 secs
+                1 loop -> 3e-05 sec
+                2 loops -> 6e-05 sec
+                5 loops -> 0.00015 sec
+                10 loops -> 0.0003 sec
+                20 loops -> 0.0006 sec
+                50 loops -> 0.0015 sec
+                100 loops -> 0.003 sec
+                200 loops -> 0.006 sec
+                500 loops -> 0.015 sec
+                1000 loops -> 0.03 sec
+                2000 loops -> 0.06 sec
+                5000 loops -> 0.15 sec
+                10000 loops -> 0.3 sec
 
                 raw times: 300 msec, 300 msec, 300 msec, 300 msec, 300 msec
 

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -319,7 +319,7 @@ def main(args=None, *, _wrap_timer=None):
         callback = None
         if verbose:
             def callback(number, time_taken):
-                msg = "{num} loop{s} -> {secs:.{prec}g} secs"
+                msg = "{num} loop{s} -> {secs:.{prec}g} sec"
                 plural = (number != 1)
                 print(msg.format(num=number, s='s' if plural else '',
                                  secs=time_taken, prec=precision))

--- a/Misc/NEWS.d/next/Library/2026-04-09-12-42-42.gh-issue-148254.Xt7vKs.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-09-12-42-42.gh-issue-148254.Xt7vKs.rst
@@ -1,0 +1,2 @@
+Use singular "sec" instead of "secs" in :mod:`timeit` verbose output for
+consistency with other time units.


### PR DESCRIPTION


(cherry picked from commit d8c56581560ed139d261dd14acd73597e40cf88b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148254 -->
* Issue: gh-148254
<!-- /gh-issue-number -->
