### PR TITLE
gh-139423: Fix plistlib to preserve carriage returns in XML plist round-trips

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -164,11 +164,10 @@ def _escape(text):
     if m is not None:
         raise ValueError("strings can't contain control characters; "
                          "use bytes instead")
-    text = text.replace("\r\n", "\n")       # convert DOS line endings
-    text = text.replace("\r", "\n")         # convert Mac line endings
     text = text.replace("&", "&amp;")       # escape '&'
     text = text.replace("<", "&lt;")        # escape '<'
     text = text.replace(">", "&gt;")        # escape '>'
+    text = text.replace("\r", "&#13;")      # preserve CR via character reference
     return text
 
 class _PlistParser:

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -818,12 +818,25 @@ class TestPlistlib(unittest.TestCase):
             if i >= 32 or c in "\r\n\t":
                 # \r, \n and \t are the only legal control chars in XML
                 data = plistlib.dumps(testString, fmt=plistlib.FMT_XML)
-                if c != "\r":
-                    self.assertEqual(plistlib.loads(data), testString)
+                self.assertEqual(plistlib.loads(data), testString)
             else:
                 with self.assertRaises(ValueError):
                     plistlib.dumps(testString, fmt=plistlib.FMT_XML)
             plistlib.dumps(testString, fmt=plistlib.FMT_BINARY)
+
+    def test_cr_newline_roundtrip(self):
+        # gh-139423: Carriage returns should survive XML plist round-trip.
+        test_cases = [
+            "hello\rworld",        # standalone CR
+            "hello\r\nworld",      # CRLF
+            "a\rb\nc\r\nd",        # mixed newlines
+            "\r",                   # bare CR
+            "\r\n",                 # bare CRLF
+        ]
+        for s in test_cases:
+            with self.subTest(s=s):
+                data = plistlib.dumps(s, fmt=plistlib.FMT_XML)
+                self.assertEqual(plistlib.loads(data), s)
 
     def test_non_bmp_characters(self):
         pl = {'python': '\U0001f40d'}

--- a/Misc/NEWS.d/next/Library/2026-04-09-14-30-00.gh-issue-139423.UD0SN_qTKdI.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-09-14-30-00.gh-issue-139423.UD0SN_qTKdI.rst
@@ -1,0 +1,4 @@
+Fixed :mod:`plistlib` to preserve carriage return characters (``\r``) during
+XML plist round-trips. Previously, ``\r`` and ``\r\n`` were normalized to
+``\n`` during serialization, causing data corruption. Carriage returns are now
+encoded as ``&#13;`` XML character references, which the XML parser preserves.


### PR DESCRIPTION
plistlib's _escape() function was normalizing \r\n to \n and \r to \n during XML plist serialization. When the plist was loaded back, the original carriage return characters were lost because expat also normalizes newlines in XML character data.

Fix by encoding \r as the XML character reference &#13; instead of converting it to \n. Character references are not subject to XML newline normalization, so expat correctly decodes &#13; back to \r, preserving the original data during round-trips.

<!-- gh-issue-number: gh-139423 -->
* Issue: gh-139423
<!-- /gh-issue-number -->
