### PR TITLE
[3.14]: gh-148284: Move stackref buffer to per-eval loop, and don't override PGO data.

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-09-20-02-06.gh-issue-148284.DTBhaX.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-09-20-02-06.gh-issue-148284.DTBhaX.rst
@@ -1,0 +1,1 @@
+Reduce C stack usage in the Python interpreter on recent versions of Clang.

--- a/Modules/_testcapi/vectorcall.c
+++ b/Modules/_testcapi/vectorcall.c
@@ -98,7 +98,15 @@ _testcapi_pyobject_vectorcall_impl(PyObject *module, PyObject *func,
         PyErr_SetString(PyExc_TypeError, "kwnames must be None or a tuple");
         return NULL;
     }
-    return PyObject_Vectorcall(func, stack, nargs, kwnames);
+    PyObject *res;
+    // The CPython interpreter does not guarantee that vectorcalls are
+    // checked for recursion limit. It's thus up to the C extension themselves to check.
+    if (Py_EnterRecursiveCall("in _testcapi.pyobject_vectorcall")) {
+        return NULL;
+    }
+    res = PyObject_Vectorcall(func, stack, nargs, kwnames);
+    Py_LeaveRecursiveCall();
+    return res;
 }
 
 static PyObject *

--- a/Modules/_testcapi/vectorcall.c
+++ b/Modules/_testcapi/vectorcall.c
@@ -98,15 +98,7 @@ _testcapi_pyobject_vectorcall_impl(PyObject *module, PyObject *func,
         PyErr_SetString(PyExc_TypeError, "kwnames must be None or a tuple");
         return NULL;
     }
-    PyObject *res;
-    // The CPython interpreter does not guarantee that vectorcalls are
-    // checked for recursion limit. It's thus up to the C extension themselves to check.
-    if (Py_EnterRecursiveCall("in _testcapi.pyobject_vectorcall")) {
-        return NULL;
-    }
-    res = PyObject_Vectorcall(func, stack, nargs, kwnames);
-    Py_LeaveRecursiveCall();
-    return res;
+    return PyObject_Vectorcall(func, stack, nargs, kwnames);
 }
 
 static PyObject *

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1168,6 +1168,13 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int 
         return NULL;
     }
 
+    /* +1 because vectorcall might use -1 to write self */
+    /* gh-138115: This must not be in individual cases for
+       non-tail-call interpreters, as it results in excessive
+       stack usage in some compilers.
+    */
+    PyObject *STACKREF_SCRATCH[MAX_STACKREF_SCRATCH+1];
+
     /* Local "register" variables.
      * These are cached values from the frame and code object.  */
     _Py_CODEUNIT *next_instr;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1142,14 +1142,26 @@ typedef struct {
 } _PyEntryFrame;
 
 /* gh-148284: *Do not* mark this function as _Py_HOT_FUNCTION.
- * On certain compilers (Clang-22 and above), this overrides PGO information
+ * On certain compilers (Clang), this overrides PGO information
  * leading possibly to miss-optimization and over-inlining.
+ * On GCC, _Py_HOT_FUNCTION is ignored when PGO is enabled.
  */
 PyObject* DONT_SLP_VECTORIZE
 _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int throwflag)
 {
     _Py_EnsureTstateNotNULL(tstate);
     CALL_STAT_INC(pyeval_calls);
+
+    /* +1 because vectorcall might use -1 to write self */
+    /* gh-138115: This must not be in individual cases for
+       non-tail-call interpreters, as it results in excessive
+       stack usage in some compilers.
+       This must also be placed before any branches to avoid
+       interaction with other optimization passes.
+    */
+#if !Py_TAIL_CALL_INTERP
+    PyObject *STACKREF_SCRATCH[MAX_STACKREF_SCRATCH+1];
+#endif
 
 #if USE_COMPUTED_GOTOS && !Py_TAIL_CALL_INTERP
 /* Import the static jump table */
@@ -1172,14 +1184,6 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int 
         return NULL;
     }
 
-    /* +1 because vectorcall might use -1 to write self */
-    /* gh-138115: This must not be in individual cases for
-       non-tail-call interpreters, as it results in excessive
-       stack usage in some compilers.
-    */
-#if !Py_TAIL_CALL_INTERP
-    PyObject *STACKREF_SCRATCH[MAX_STACKREF_SCRATCH+1];
-#endif
 
     /* Local "register" variables.
      * These are cached values from the frame and code object.  */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1149,9 +1149,6 @@ typedef struct {
 PyObject* DONT_SLP_VECTORIZE
 _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int throwflag)
 {
-    _Py_EnsureTstateNotNULL(tstate);
-    CALL_STAT_INC(pyeval_calls);
-
     /* +1 because vectorcall might use -1 to write self */
     /* gh-138115: This must not be in individual cases for
        non-tail-call interpreters, as it results in excessive
@@ -1162,6 +1159,10 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int 
 #if !Py_TAIL_CALL_INTERP
     PyObject *STACKREF_SCRATCH[MAX_STACKREF_SCRATCH+1];
 #endif
+
+    _Py_EnsureTstateNotNULL(tstate);
+    CALL_STAT_INC(pyeval_calls);
+
 
 #if USE_COMPUTED_GOTOS && !Py_TAIL_CALL_INTERP
 /* Import the static jump table */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1141,7 +1141,11 @@ typedef struct {
     _PyStackRef stack[1];
 } _PyEntryFrame;
 
-PyObject* _Py_HOT_FUNCTION DONT_SLP_VECTORIZE
+/* gh-148284: *Do not* mark this function as _Py_HOT_FUNCTION.
+ * On certain compilers (Clang-22 and above), this overrides PGO information
+ * leading possibly to miss-optimization and over-inlining.
+ */
+PyObject* DONT_SLP_VECTORIZE
 _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int throwflag)
 {
     _Py_EnsureTstateNotNULL(tstate);
@@ -1173,7 +1177,9 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int 
        non-tail-call interpreters, as it results in excessive
        stack usage in some compilers.
     */
+#if !Py_TAIL_CALL_INTERP
     PyObject *STACKREF_SCRATCH[MAX_STACKREF_SCRATCH+1];
+#endif
 
     /* Local "register" variables.
      * These are cached values from the frame and code object.  */

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -427,9 +427,16 @@ do { \
 /* How much scratch space to give stackref to PyObject* conversion. */
 #define MAX_STACKREF_SCRATCH 10
 
+#if Py_TAIL_CALL_INTERP
+#define STACKREFS_TO_PYOBJECTS(ARGS, ARG_COUNT, NAME) \
+    /* +1 because vectorcall might use -1 to write self */ \
+    PyObject *NAME##_temp[MAX_STACKREF_SCRATCH+1]; \
+    PyObject **NAME = _PyObjectArray_FromStackRefArray(ARGS, ARG_COUNT, NAME##_temp + 1);
+#else
 #define STACKREFS_TO_PYOBJECTS(ARGS, ARG_COUNT, NAME) \
     PyObject **NAME##_temp = (PyObject **)&STACKREF_SCRATCH; \
     PyObject **NAME = _PyObjectArray_FromStackRefArray(ARGS, ARG_COUNT, NAME##_temp + 1);
+#endif
 
 #define STACKREFS_TO_PYOBJECTS_CLEANUP(NAME) \
     /* +1 because we +1 previously */ \

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -428,8 +428,7 @@ do { \
 #define MAX_STACKREF_SCRATCH 10
 
 #define STACKREFS_TO_PYOBJECTS(ARGS, ARG_COUNT, NAME) \
-    /* +1 because vectorcall might use -1 to write self */ \
-    PyObject *NAME##_temp[MAX_STACKREF_SCRATCH+1]; \
+    PyObject **NAME##_temp = (PyObject **)&STACKREF_SCRATCH; \
     PyObject **NAME = _PyObjectArray_FromStackRefArray(ARGS, ARG_COUNT, NAME##_temp + 1);
 
 #define STACKREFS_TO_PYOBJECTS_CLEANUP(NAME) \


### PR DESCRIPTION


<!-- gh-issue-number: gh-148284 -->
* Issue: gh-148284
<!-- /gh-issue-number -->
