### PR TITLE
gh-148306: Fix dis.distb() crash when traceback is None

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -145,9 +145,12 @@ def distb(tb=None, *, file=None, show_caches=False, adaptive=False, show_offsets
                 tb = sys.last_exc.__traceback__
             else:
                 tb = sys.last_traceback
+
+            while tb.tb_next: tb = tb.tb_next
         except AttributeError:
             raise RuntimeError("no last traceback to disassemble") from None
-        while tb.tb_next: tb = tb.tb_next
+
+
     disassemble(tb.tb_frame.f_code, tb.tb_lasti, file=file, show_caches=show_caches, adaptive=adaptive, show_offsets=show_offsets, show_positions=show_positions)
 
 # The inspect module interrogates this dictionary to build its

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -2478,6 +2478,16 @@ class TestDisTraceback(DisTestBase):
         with self.assertRaises(RuntimeError):
             dis.distb()
 
+    def test_distb_syntax_error(self):
+        try:
+            compile("???", "", "exec")
+        except SyntaxError as e:
+            sys.last_exc = e
+            sys.last_exc.__traceback__ = None
+
+        with self.assertRaises(RuntimeError):
+            dis.distb()
+
     def test_distb_last_traceback(self):
         self.maxDiff = None
         # We need to have an existing last traceback in `sys`:


### PR DESCRIPTION
## Summary

Prevent `dis.distb()` from failing with `AttributeError` when the last exception has no traceback.

## Bug
In the REPL, a `SyntaxError` raised  does not always have a traceback attached. As a result, `dis.distb()` may attempt to access `tb.tb_next` where `tb` is `None`, leading to:

```
AttributeError: 'NoneType' object has no attribute 'tb_next'
```

## Fix
Wrap the traceback traversal (`while tb.tb_next`) in the `try` block so that cases where the traceback is `None` are handled gracefully.

Also add a regression test simulating REPL state for a `SyntaxError` that has no traceback.

---


This is my first contribution to CPython. I’d really appreciate any feedback. Thanks!

<!-- gh-issue-number: gh-148306 -->
* Issue: gh-148306
<!-- /gh-issue-number -->
