### PR TITLE
gh-146450: Ensure Android gradle build uses custom cross-build dir

### DIFF
--- a/Android/android.py
+++ b/Android/android.py
@@ -398,10 +398,15 @@ def setup_testbed():
 def build_testbed(context):
     setup_sdk()
     setup_testbed()
+
+    # Ensure that CROSS_BUILD_DIR is in the Gradle environment, regardless
+    # of whether it was set by environment variable or `--cross-build-dir`.
+    env = os.environ.copy()
+    env["CROSS_BUILD_DIR"] = CROSS_BUILD_DIR
     run(
         [gradlew, "--console", "plain", "packageDebug", "packageDebugAndroidTest"],
         cwd=TESTBED_DIR,
-        env={}
+        env=env,
     )
 
 

--- a/Android/android.py
+++ b/Android/android.py
@@ -393,23 +393,6 @@ def setup_testbed():
         os.chmod(out_path, 0o755)
 
 
-# run_testbed will build the app automatically, but it's useful to have this as
-# a separate command to allow running the app outside of this script.
-def build_testbed(context):
-    setup_sdk()
-    setup_testbed()
-
-    # Ensure that CROSS_BUILD_DIR is in the Gradle environment, regardless
-    # of whether it was set by environment variable or `--cross-build-dir`.
-    env = os.environ.copy()
-    env["CROSS_BUILD_DIR"] = CROSS_BUILD_DIR
-    run(
-        [gradlew, "--console", "plain", "packageDebug", "packageDebugAndroidTest"],
-        cwd=TESTBED_DIR,
-        env=env,
-    )
-
-
 # Work around a bug involving sys.exit and TaskGroups
 # (https://github.com/python/cpython/issues/101515).
 def exit(*args):
@@ -883,50 +866,6 @@ def parse_args():
     def add_parser(*args, **kwargs):
         parser = subcommands.add_parser(*args, **kwargs)
         parser.add_argument(
-            "-v", "--verbose", action="count", default=0,
-            help="Show verbose output. Use twice to be even more verbose.")
-        return parser
-
-    # Subcommands
-    build = add_parser(
-        "build",
-        help="Run configure and make for the selected target"
-    )
-    configure_build = add_parser(
-        "configure-build", help="Run `configure` for the build Python")
-    make_build = add_parser(
-        "make-build", help="Run `make` for the build Python")
-    configure_host = add_parser(
-        "configure-host", help="Run `configure` for Android")
-    make_host = add_parser(
-        "make-host", help="Run `make` for Android")
-
-    clean = add_parser(
-        "clean",
-        help="Delete build directories for the selected target"
-    )
-
-    build_testbed = add_parser("build-testbed", help="Build the testbed app")
-    test = add_parser("test", help="Run the testbed app")
-    package = add_parser("package", help="Make a release package")
-    ci = add_parser("ci", help="Run build, package and test")
-    env = add_parser("env", help="Print environment variables")
-
-    # Common arguments
-    # --cross-build-dir argument
-    for cmd in [
-        clean,
-        configure_build,
-        make_build,
-        configure_host,
-        make_host,
-        build,
-        package,
-        build_testbed,
-        test,
-        ci,
-    ]:
-        cmd.add_argument(
             "--cross-build-dir",
             action="store",
             default=os.environ.get("CROSS_BUILD_DIR"),
@@ -938,7 +877,36 @@ def parse_args():
                 "with the CROSS_BUILD_DIR environment variable."
             ),
         )
+        parser.add_argument(
+            "-v", "--verbose", action="count", default=0,
+            help="Show verbose output. Use twice to be even more verbose.")
+        return parser
 
+    # Subcommands
+    build = add_parser(
+        "build",
+        help="Run configure and make for the selected target"
+    )
+    configure_build = add_parser(
+        "configure-build", help="Run `configure` for the build Python")
+    add_parser(
+        "make-build", help="Run `make` for the build Python")
+    configure_host = add_parser(
+        "configure-host", help="Run `configure` for Android")
+    make_host = add_parser(
+        "make-host", help="Run `make` for Android")
+
+    clean = add_parser(
+        "clean",
+        help="Delete build directories for the selected target"
+    )
+
+    test = add_parser("test", help="Run the testbed app")
+    package = add_parser("package", help="Make a release package")
+    ci = add_parser("ci", help="Run build, package and test")
+    env = add_parser("env", help="Print environment variables")
+
+    # Common arguments
     # --cache-dir option
     for cmd in [configure_host, build, ci]:
         cmd.add_argument(
@@ -1043,7 +1011,6 @@ def main():
         "make-host": make_host_python,
         "build": build_targets,
         "clean": clean_targets,
-        "build-testbed": build_testbed,
         "test": run_testbed,
         "package": package,
         "ci": ci,

--- a/Android/android.py
+++ b/Android/android.py
@@ -401,6 +401,7 @@ def build_testbed(context):
     run(
         [gradlew, "--console", "plain", "packageDebug", "packageDebugAndroidTest"],
         cwd=TESTBED_DIR,
+        env={}
     )
 
 
@@ -644,6 +645,10 @@ async def gradle_task(context):
     else:
         task_prefix = "connected"
         env["ANDROID_SERIAL"] = context.connected
+
+    # Ensure that CROSS_BUILD_DIR is in the Gradle environment, regardless
+    # of whether it was set by environment variable or `--cross-build-dir`.
+    env["CROSS_BUILD_DIR"] = CROSS_BUILD_DIR
 
     if context.ci_mode:
         context.args[0:0] = [

--- a/Android/android.py
+++ b/Android/android.py
@@ -906,7 +906,7 @@ def parse_args():
         help="Delete build directories for the selected target"
     )
 
-    add_parser("build-testbed", help="Build the testbed app")
+    build_testbed = add_parser("build-testbed", help="Build the testbed app")
     test = add_parser("test", help="Run the testbed app")
     package = add_parser("package", help="Make a release package")
     ci = add_parser("ci", help="Run build, package and test")
@@ -922,6 +922,7 @@ def parse_args():
         make_host,
         build,
         package,
+        build_testbed,
         test,
         ci,
     ]:

--- a/Android/testbed/app/build.gradle.kts
+++ b/Android/testbed/app/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 val ANDROID_DIR = file("../..")
 val PYTHON_DIR = ANDROID_DIR.parentFile!!
 val PYTHON_CROSS_DIR = file(System.getenv("CROSS_BUILD_DIR") ?: "$PYTHON_DIR/cross-build")
-)
 val inSourceTree = (
     ANDROID_DIR.name == "Android" && file("$PYTHON_DIR/pyconfig.h.in").exists()
 )

--- a/Android/testbed/app/build.gradle.kts
+++ b/Android/testbed/app/build.gradle.kts
@@ -8,9 +8,7 @@ plugins {
 
 val ANDROID_DIR = file("../..")
 val PYTHON_DIR = ANDROID_DIR.parentFile!!
-val CROSS_BUILD_DIR = System.getenv("CROSS_BUILD_DIR") ?: "cross-build"
-val PYTHON_CROSS_DIR = file(
-    if ((File(CROSS_BUILD_DIR)).isAbsolute) CROSS_BUILD_DIR else "$PYTHON_DIR/$CROSS_BUILD_DIR"
+val PYTHON_CROSS_DIR = file(System.getenv("CROSS_BUILD_DIR") ?: "$PYTHON_DIR/cross-build")
 )
 val inSourceTree = (
     ANDROID_DIR.name == "Android" && file("$PYTHON_DIR/pyconfig.h.in").exists()

--- a/Android/testbed/app/build.gradle.kts
+++ b/Android/testbed/app/build.gradle.kts
@@ -8,8 +8,9 @@ plugins {
 
 val ANDROID_DIR = file("../..")
 val PYTHON_DIR = ANDROID_DIR.parentFile!!
+val CROSS_BUILD_DIR = System.getenv("CROSS_BUILD_DIR") ?: "cross-build"
 val PYTHON_CROSS_DIR = file(
-    "$PYTHON_DIR/" + (System.getenv("CROSS_BUILD_DIR") ?: "cross-build")
+    if ((File(CROSS_BUILD_DIR)).isAbsolute) CROSS_BUILD_DIR else "$PYTHON_DIR/$CROSS_BUILD_DIR"
 )
 val inSourceTree = (
     ANDROID_DIR.name == "Android" && file("$PYTHON_DIR/pyconfig.h.in").exists()

--- a/Android/testbed/app/build.gradle.kts
+++ b/Android/testbed/app/build.gradle.kts
@@ -8,7 +8,9 @@ plugins {
 
 val ANDROID_DIR = file("../..")
 val PYTHON_DIR = ANDROID_DIR.parentFile!!
-val PYTHON_CROSS_DIR = file("$PYTHON_DIR/cross-build")
+val PYTHON_CROSS_DIR = file(
+    "$PYTHON_DIR/" + (System.getenv("CROSS_BUILD_DIR") ?: "cross-build")
+)
 val inSourceTree = (
     ANDROID_DIR.name == "Android" && file("$PYTHON_DIR/pyconfig.h.in").exists()
 )


### PR DESCRIPTION
#146450 introduced the ability to customise the `cross-build` directory (to aid with maintaining multiple Python version backports). The build script honors this setting, but doesn't guarantee that the gradle environment will also use the setting.
