### PR TITLE
gh-148321: use --quit-if-one-screen option for the pager (new REPL)

### DIFF
--- a/Lib/_pyrepl/pager.py
+++ b/Lib/_pyrepl/pager.py
@@ -138,7 +138,7 @@ def pipe_pager(text: str, cmd: str, title: str = '') -> None:
         '.'
         '?e (END):?pB %pB\\%..'
         ' (press h for help or q to quit)')
-    env['LESS'] = '-F-RmPm{0}$PM{0}$'.format(prompt_string)
+    env['LESS'] = '-FRmPm{0}$PM{0}$'.format(prompt_string)
     proc = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE,
                             errors='backslashreplace', env=env)
     assert proc.stdin is not None

--- a/Lib/_pyrepl/pager.py
+++ b/Lib/_pyrepl/pager.py
@@ -138,7 +138,7 @@ def pipe_pager(text: str, cmd: str, title: str = '') -> None:
         '.'
         '?e (END):?pB %pB\\%..'
         ' (press h for help or q to quit)')
-    env['LESS'] = '-RcmPm{0}$PM{0}$'.format(prompt_string)
+    env['LESS'] = '-F-RmPm{0}$PM{0}$'.format(prompt_string)
     proc = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE,
                             errors='backslashreplace', env=env)
     assert proc.stdin is not None


### PR DESCRIPTION
Currently, by passing --clear-screen (-c) to the pager --- small texts (like few-sentences docstrings) are shown at top of the screen, just as big texts.

I believe it would be better to show this inline instead, not clearing last session commands with output and so on.  BTW, this is the default for git commands (e.g. git-log) and in the IPython.  Of course, we loose on this way ability to use pager for search, but terminal emulators usually have similar capability on its own.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148321 -->
* Issue: gh-148321
<!-- /gh-issue-number -->
