### PR TITLE
[3.14] gh-148284: Block inlining of gigantic functions in ceval.c for clang 22

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -126,6 +126,8 @@ PY_CORE_CFLAGS=	$(PY_STDMODULE_CFLAGS) -DPy_BUILD_CORE
 PY_CORE_LDFLAGS=$(PY_LDFLAGS) $(PY_LDFLAGS_NODIST)
 # Strict or non-strict aliasing flags used to compile dtoa.c, see above
 CFLAGS_ALIASING=@CFLAGS_ALIASING@
+# Compilation flags only for ceval.c.
+CFLAGS_CEVAL=@CFLAGS_CEVAL@
 
 
 # Machine-dependent subdirectories
@@ -3141,6 +3143,9 @@ regen-jit:
 # https://bugs.llvm.org//show_bug.cgi?id=31928
 Python/dtoa.o: Python/dtoa.c
 	$(CC) -c $(PY_CORE_CFLAGS) $(CFLAGS_ALIASING) -o $@ $<
+
+Python/ceval.o: Python/ceval.c
+	$(CC) -c $(PY_CORE_CFLAGS) $(CFLAGS_CEVAL) -o $@ $<
 
 # Run reindent on the library
 .PHONY: reindent

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-10-09-21-40.gh-issue-148284.6xMH49.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-10-09-21-40.gh-issue-148284.6xMH49.rst
@@ -1,0 +1,1 @@
+Fix high stack consumption in Python's interpreter loop on Clang 22 by setting function limits for inlining.

--- a/configure
+++ b/configure
@@ -826,6 +826,7 @@ OPENSSL_LDFLAGS
 OPENSSL_LIBS
 OPENSSL_INCLUDES
 ENSUREPIP
+CFLAGS_CEVAL
 SRCDIRS
 THREADHEADERS
 PANEL_LIBS
@@ -30048,6 +30049,53 @@ if test "$have_glibc_memmove_bug" = yes; then
 printf "%s\n" "#define HAVE_GLIBC_MEMMOVE_BUG 1" >>confdefs.h
 
 fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we need to manually block large inlining in ceval.c" >&5
+printf %s "checking if we need to manually block large inlining in ceval.c... " >&6; }
+if test "$cross_compiling" = yes
+then :
+  block_huge_inlining_in_ceval=undefined
+else case e in #(
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+void foo(void *p, void *q) { memmove(p, q, 19); }
+int main(void) {
+// See gh-148284:
+// Clang 22 seems to have interactions with inlining and the stackref buffer
+// which cause 40kB of stack usage on x86-64 in buggy versions of _PyEval_EvalFrameDefault
+// in computed goto interpreter. The normal usage seen is normally 1-2kB.
+#if defined(__clang__) && (__clang_major__ == 22)
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+_ACEOF
+if ac_fn_c_try_run "$LINENO"
+then :
+  block_huge_inlining_in_ceval=no
+else case e in #(
+  e) block_huge_inlining_in_ceval=yes ;;
+esac
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext ;;
+esac
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $block_huge_inlining_in_ceval" >&5
+printf "%s\n" "$block_huge_inlining_in_ceval" >&6; }
+
+if test "$block_huge_inlining_in_ceval" = yes && test "$ac_cv_computed_gotos" = yes; then
+    // This number should be tuned to follow the C stack consumption
+    // in _PyEval_EvalFrameDefault on computed goto interpreter.
+    CFLAGS_CEVAL="-finline-max-stacksize=512"
+else
+    CFLAGS_CEVAL=""
+fi
+
 
 if test "$ac_cv_gcc_asm_for_x87" = yes; then
     # Some versions of gcc miscompile inline asm:

--- a/configure
+++ b/configure
@@ -30059,7 +30059,6 @@ else case e in #(
   e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-void foo(void *p, void *q) { memmove(p, q, 19); }
 int main(void) {
 // See gh-148284:
 // Clang 22 seems to have interactions with inlining and the stackref buffer

--- a/configure.ac
+++ b/configure.ac
@@ -7246,7 +7246,6 @@ fi
 
 AC_MSG_CHECKING([if we need to manually block large inlining in ceval.c])
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
-void foo(void *p, void *q) { memmove(p, q, 19); }
 int main(void) {
 // See gh-148284:
 // Clang 22 seems to have interactions with inlining and the stackref buffer

--- a/configure.ac
+++ b/configure.ac
@@ -7244,6 +7244,35 @@ if test "$have_glibc_memmove_bug" = yes; then
      for memmove and bcopy.])
 fi
 
+AC_MSG_CHECKING([if we need to manually block large inlining in ceval.c])
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
+void foo(void *p, void *q) { memmove(p, q, 19); }
+int main(void) {
+// See gh-148284:
+// Clang 22 seems to have interactions with inlining and the stackref buffer
+// which cause 40kB of stack usage on x86-64 in buggy versions of _PyEval_EvalFrameDefault
+// in computed goto interpreter. The normal usage seen is normally 1-2kB.
+#if defined(__clang__) && (__clang_major__ == 22)
+    return 1;
+#else
+    return 0;
+#endif
+}
+]])],
+[block_huge_inlining_in_ceval=no],
+[block_huge_inlining_in_ceval=yes],
+[block_huge_inlining_in_ceval=undefined])
+AC_MSG_RESULT([$block_huge_inlining_in_ceval])
+
+if test "$block_huge_inlining_in_ceval" = yes && test "$ac_cv_computed_gotos" = yes; then
+    // This number should be tuned to follow the C stack consumption
+    // in _PyEval_EvalFrameDefault on computed goto interpreter.
+    CFLAGS_CEVAL="-finline-max-stacksize=512"
+else
+    CFLAGS_CEVAL=""
+fi
+AC_SUBST([CFLAGS_CEVAL])
+
 if test "$ac_cv_gcc_asm_for_x87" = yes; then
     # Some versions of gcc miscompile inline asm:
     # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46491


### PR DESCRIPTION
It seems that on clang-22, the inliner is too aggressive on _PyEval_EvalFrameDefault when on computed goto interpreter. Together with some strange interaction with the stackref buffer, the function requires 40kB of stack space (!!!) versus the usual 1-2kB normally used.

This sets the inline limit to functions of max 512B stack space (1/4th of normal) allowed to be inlined in `ceval.c`. I checked the dissasembly and the new function uses about 2kB of stack.

This will need a forward-port to 3.15 too.

<!-- gh-issue-number: gh-148284 -->
* Issue: gh-148284
<!-- /gh-issue-number -->
