### PR TITLE
gh-148284: Block inlining of gigantic functions in ceval.c for clang 22

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -1574,6 +1574,12 @@ Compiler flags
 
    .. versionadded:: 3.7
 
+.. envvar:: CFLAGS_CEVAL
+
+   Flags used to compile ``Python/ceval.c``.
+
+   .. versionadded:: 3.14.5
+
 .. envvar:: CCSHARED
 
    Compiler flags used to build a shared library.

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -130,6 +130,8 @@ CONFIGURE_EXE_LDFLAGS=@EXE_LDFLAGS@
 PY_CORE_EXE_LDFLAGS:= $(if $(CONFIGURE_EXE_LDFLAGS), $(CONFIGURE_EXE_LDFLAGS) $(PY_LDFLAGS_NODIST), $(PY_CORE_LDFLAGS))
 # Strict or non-strict aliasing flags used to compile dtoa.c, see above
 CFLAGS_ALIASING=@CFLAGS_ALIASING@
+# Compilation flags only for ceval.c.
+CFLAGS_CEVAL=@CFLAGS_CEVAL@
 
 
 # Machine-dependent subdirectories
@@ -3202,6 +3204,9 @@ regen-jit:
 # https://bugs.llvm.org//show_bug.cgi?id=31928
 Python/dtoa.o: Python/dtoa.c
 	$(CC) -c $(PY_CORE_CFLAGS) $(CFLAGS_ALIASING) -o $@ $<
+
+Python/ceval.o: Python/ceval.c
+	$(CC) -c $(PY_CORE_CFLAGS) $(CFLAGS_CEVAL) -o $@ $<
 
 # Run reindent on the library
 .PHONY: reindent

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-10-09-21-40.gh-issue-148284.6xMH49.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-10-09-21-40.gh-issue-148284.6xMH49.rst
@@ -1,0 +1,1 @@
+Fix high stack consumption in Python's interpreter loop on Clang 22 by setting function limits for inlining.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-10-09-21-40.gh-issue-148284.6xMH49.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-10-09-21-40.gh-issue-148284.6xMH49.rst
@@ -1,1 +1,0 @@
-Fix high stack consumption in Python's interpreter loop on Clang 22 by setting function limits for inlining.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-10-14-20-54.gh-issue-148284.HKs-S_.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-10-14-20-54.gh-issue-148284.HKs-S_.rst
@@ -1,0 +1,1 @@
+Fix high stack consumption in Python's interpreter loop on Clang 22 by setting function limits for inlining when building with computed gotos.

--- a/configure
+++ b/configure
@@ -829,6 +829,7 @@ OPENSSL_LDFLAGS
 OPENSSL_LIBS
 OPENSSL_INCLUDES
 ENSUREPIP
+CFLAGS_CEVAL
 SRCDIRS
 THREADHEADERS
 PANEL_LIBS
@@ -30357,6 +30358,53 @@ if test "$have_glibc_memmove_bug" = yes; then
 printf "%s\n" "#define HAVE_GLIBC_MEMMOVE_BUG 1" >>confdefs.h
 
 fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we need to manually block large inlining in ceval.c" >&5
+printf %s "checking if we need to manually block large inlining in ceval.c... " >&6; }
+if test "$cross_compiling" = yes
+then :
+  block_huge_inlining_in_ceval=undefined
+else case e in #(
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+void foo(void *p, void *q) { memmove(p, q, 19); }
+int main(void) {
+// See gh-148284:
+// Clang 22 seems to have interactions with inlining and the stackref buffer
+// which cause 40kB of stack usage on x86-64 in buggy versions of _PyEval_EvalFrameDefault
+// in computed goto interpreter. The normal usage seen is normally 1-2kB.
+#if defined(__clang__) && (__clang_major__ == 22)
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+_ACEOF
+if ac_fn_c_try_run "$LINENO"
+then :
+  block_huge_inlining_in_ceval=no
+else case e in #(
+  e) block_huge_inlining_in_ceval=yes ;;
+esac
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext ;;
+esac
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $block_huge_inlining_in_ceval" >&5
+printf "%s\n" "$block_huge_inlining_in_ceval" >&6; }
+
+if test "$block_huge_inlining_in_ceval" = yes && test "$ac_cv_computed_gotos" = yes; then
+    // This number should be tuned to follow the C stack consumption
+    // in _PyEval_EvalFrameDefault on computed goto interpreter.
+    CFLAGS_CEVAL="-finline-max-stacksize=512"
+else
+    CFLAGS_CEVAL=""
+fi
+
 
 if test "$ac_cv_gcc_asm_for_x87" = yes; then
     # Some versions of gcc miscompile inline asm:

--- a/configure
+++ b/configure
@@ -30368,7 +30368,6 @@ else case e in #(
   e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-void foo(void *p, void *q) { memmove(p, q, 19); }
 int main(void) {
 // See gh-148284:
 // Clang 22 seems to have interactions with inlining and the stackref buffer

--- a/configure
+++ b/configure
@@ -30369,10 +30369,10 @@ else case e in #(
 /* end confdefs.h.  */
 
 int main(void) {
-// See gh-148284:
-// Clang 22 seems to have interactions with inlining and the stackref buffer
-// which cause 40kB of stack usage on x86-64 in buggy versions of _PyEval_EvalFrameDefault
-// in computed goto interpreter. The normal usage seen is normally 1-2kB.
+// See gh-148284: Clang 22 seems to have interactions with inlining
+// and the stackref buffer which cause 40 kB of stack usage on x86-64
+// in buggy versions of _PyEval_EvalFrameDefault() in computed goto
+// interpreter. The normal usage seen is normally 1-2 kB.
 #if defined(__clang__) && (__clang_major__ == 22)
     return 1;
 #else
@@ -30397,11 +30397,11 @@ fi
 printf "%s\n" "$block_huge_inlining_in_ceval" >&6; }
 
 if test "$block_huge_inlining_in_ceval" = yes && test "$ac_cv_computed_gotos" = yes; then
-    // This number should be tuned to follow the C stack consumption
-    // in _PyEval_EvalFrameDefault on computed goto interpreter.
-    CFLAGS_CEVAL="-finline-max-stacksize=512"
-else
-    CFLAGS_CEVAL=""
+    # gh-148284: Suppress inlining of functions whose stack size exceeds
+    # 512 bytes. This number should be tuned to follow the C stack
+    # consumption in _PyEval_EvalFrameDefault() on computed goto
+    # interpreter.
+    CFLAGS_CEVAL="$CFLAGS_CEVAL -finline-max-stacksize=512"
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -7371,6 +7371,35 @@ if test "$have_glibc_memmove_bug" = yes; then
      for memmove and bcopy.])
 fi
 
+AC_MSG_CHECKING([if we need to manually block large inlining in ceval.c])
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
+void foo(void *p, void *q) { memmove(p, q, 19); }
+int main(void) {
+// See gh-148284:
+// Clang 22 seems to have interactions with inlining and the stackref buffer
+// which cause 40kB of stack usage on x86-64 in buggy versions of _PyEval_EvalFrameDefault
+// in computed goto interpreter. The normal usage seen is normally 1-2kB.
+#if defined(__clang__) && (__clang_major__ == 22)
+    return 1;
+#else
+    return 0;
+#endif
+}
+]])],
+[block_huge_inlining_in_ceval=no],
+[block_huge_inlining_in_ceval=yes],
+[block_huge_inlining_in_ceval=undefined])
+AC_MSG_RESULT([$block_huge_inlining_in_ceval])
+
+if test "$block_huge_inlining_in_ceval" = yes && test "$ac_cv_computed_gotos" = yes; then
+    // This number should be tuned to follow the C stack consumption
+    // in _PyEval_EvalFrameDefault on computed goto interpreter.
+    CFLAGS_CEVAL="-finline-max-stacksize=512"
+else
+    CFLAGS_CEVAL=""
+fi
+AC_SUBST([CFLAGS_CEVAL])
+
 if test "$ac_cv_gcc_asm_for_x87" = yes; then
     # Some versions of gcc miscompile inline asm:
     # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46491

--- a/configure.ac
+++ b/configure.ac
@@ -7374,10 +7374,10 @@ fi
 AC_MSG_CHECKING([if we need to manually block large inlining in ceval.c])
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 int main(void) {
-// See gh-148284:
-// Clang 22 seems to have interactions with inlining and the stackref buffer
-// which cause 40kB of stack usage on x86-64 in buggy versions of _PyEval_EvalFrameDefault
-// in computed goto interpreter. The normal usage seen is normally 1-2kB.
+// See gh-148284: Clang 22 seems to have interactions with inlining
+// and the stackref buffer which cause 40 kB of stack usage on x86-64
+// in buggy versions of _PyEval_EvalFrameDefault() in computed goto
+// interpreter. The normal usage seen is normally 1-2 kB.
 #if defined(__clang__) && (__clang_major__ == 22)
     return 1;
 #else
@@ -7391,11 +7391,11 @@ int main(void) {
 AC_MSG_RESULT([$block_huge_inlining_in_ceval])
 
 if test "$block_huge_inlining_in_ceval" = yes && test "$ac_cv_computed_gotos" = yes; then
-    // This number should be tuned to follow the C stack consumption
-    // in _PyEval_EvalFrameDefault on computed goto interpreter.
-    CFLAGS_CEVAL="-finline-max-stacksize=512"
-else
-    CFLAGS_CEVAL=""
+    # gh-148284: Suppress inlining of functions whose stack size exceeds
+    # 512 bytes. This number should be tuned to follow the C stack
+    # consumption in _PyEval_EvalFrameDefault() on computed goto
+    # interpreter.
+    CFLAGS_CEVAL="$CFLAGS_CEVAL -finline-max-stacksize=512"
 fi
 AC_SUBST([CFLAGS_CEVAL])
 

--- a/configure.ac
+++ b/configure.ac
@@ -7373,7 +7373,6 @@ fi
 
 AC_MSG_CHECKING([if we need to manually block large inlining in ceval.c])
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
-void foo(void *p, void *q) { memmove(p, q, 19); }
 int main(void) {
 // See gh-148284:
 // Clang 22 seems to have interactions with inlining and the stackref buffer


### PR DESCRIPTION
It seems that on clang-22, the inliner is too aggressive on _PyEval_EvalFrameDefault when on computed goto interpreter. Together with some strange interaction with the stackref buffer, the function requires 40kB of stack space (!!!) versus the usual 1-2kB normally used.

This sets the inline limit to functions of max 512B stack space (1/4th of normal) allowed to be inlined in `ceval.c`. I checked the dissasembly and the new function uses about 2kB of stack.


<!-- gh-issue-number: gh-148284 -->
* Issue: gh-148284
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148334.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->