### PR TITLE
tests: use errno.EBADF instead of hardcoded number in _close_file()

### DIFF
--- a/Lib/test/test_interpreters/utils.py
+++ b/Lib/test/test_interpreters/utils.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 import contextlib
+import errno
 import json
 import logging
 import os
@@ -51,7 +52,7 @@ def _close_file(file):
         else:
             os.close(file)
     except OSError as exc:
-        if exc.errno != 9:
+        if exc.errno != errno.EBADF:
             raise  # re-raise
         # It was closed already.
 


### PR DESCRIPTION
Replace the hardcoded `9` check in `Lib/test/test_interpreters/utils.py` with `errno.EBADF`.

Using `errno.EBADF` makes the helper portable across platforms with different errno numbering while preserving the intended behavior.

Didn't create an issue for that as I think it could count as trivial