### PR TITLE
InternalDocs: Correct struct path for latin1 singletons in `string_interning.md`

### DIFF
--- a/InternalDocs/string_interning.md
+++ b/InternalDocs/string_interning.md
@@ -16,8 +16,8 @@ dynamic interning.
 
 The 256 possible one-character latin-1 strings, which can be retrieved with
 `_Py_LATIN1_CHR(c)`, are stored in statically allocated arrays,
-`_PyRuntime.static_objects.strings.ascii` and
-`_PyRuntime.static_objects.strings.latin1`.
+`_PyRuntime.static_objects.singletons.strings.ascii` and
+`_PyRuntime.static_objects.singletons.strings.latin1`.
 
 Longer singleton strings are marked in C source with `_Py_ID` (if the string
 is a valid C identifier fragment) or `_Py_STR` (if it needs a separate


### PR DESCRIPTION
I can technically add my usual "Found by OSS-Fuzz in [testcase #6425123073884160](https://oss-fuzz.com/testcase-detail/6425123073884160)," since without it finding a bug in itself I would have never found this docs bug ;-)
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
