### PR TITLE
GH-146475: Strip CFI directives from JIT stencils to allow using Apple LLVM 21

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-04-10-20-57-30.gh-issue-146475.SWxwGM.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-10-20-57-30.gh-issue-146475.SWxwGM.rst
@@ -1,1 +1,1 @@
-Strip CFI directives from JIT stencils to fix build failures with Apple LLVM 21.
+Use ``-fno-unwind-tables`` for JIT stencils to fix build failures with Apple LLVM 21.

--- a/Misc/NEWS.d/next/Build/2026-04-10-20-57-30.gh-issue-146475.SWxwGM.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-10-20-57-30.gh-issue-146475.SWxwGM.rst
@@ -1,0 +1,1 @@
+Strip CFI directives from JIT stencil assembly to fix build failures with Apple LLVM 21.

--- a/Misc/NEWS.d/next/Build/2026-04-10-20-57-30.gh-issue-146475.SWxwGM.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-10-20-57-30.gh-issue-146475.SWxwGM.rst
@@ -1,1 +1,1 @@
-Strip CFI directives from JIT stencil assembly to fix build failures with Apple LLVM 21.
+Strip CFI directives from JIT stencils to fix build failures with Apple LLVM 21.

--- a/Misc/NEWS.d/next/Build/2026-04-10-20-57-30.gh-issue-146475.SWxwGM.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-10-20-57-30.gh-issue-146475.SWxwGM.rst
@@ -1,1 +1,1 @@
-Use ``-fno-unwind-tables`` for JIT stencils to fix build failures with Apple LLVM 21.
+Strip CFI directives from JIT stencils to fix build failures with Apple LLVM 21.

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -252,10 +252,9 @@ class Optimizer:
         continue_symbol = rf"\b{re.escape(self.symbol_prefix)}_JIT_CONTINUE\b"
         continue_label = f"{self.label_prefix}_JIT_CONTINUE"
         text = re.sub(continue_symbol, continue_label, text)
-        # Strip CFI directives. JIT stencils are compiled with
+        # Strip CFI directives as JIT stencils are compiled with
         # -fno-asynchronous-unwind-tables and don't use DWARF CFI unwind
-        # tables (.eh_frame).
-        # The optimizer's dead code elimination can remove blocks containing
+        # tables (.eh_frame). The optimizer can remove blocks containing
         # .cfi_endproc while keeping the corresponding .cfi_startproc,
         # producing unbalanced CFI frames that some assemblers reject:
         text = re.sub(r"^\s*\.cfi_\w+[^\n]*$", "", text, flags=re.MULTILINE)

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -251,7 +251,14 @@ class Optimizer:
         # references to a local _JIT_CONTINUE label (which we will add later):
         continue_symbol = rf"\b{re.escape(self.symbol_prefix)}_JIT_CONTINUE\b"
         continue_label = f"{self.label_prefix}_JIT_CONTINUE"
-        return re.sub(continue_symbol, continue_label, text)
+        text = re.sub(continue_symbol, continue_label, text)
+        # Strip CFI directives as JIT stencils are compiled with
+        # -fno-asynchronous-unwind-tables. The optimizer can remove
+        # blocks containing .cfi_endproc while keeping the corresponding
+        # .cfi_startproc, producing unbalanced CFI frames that some
+        # assemblers reject (e.g. Apple LLVM 21):
+        text = re.sub(r"^\s*\.cfi_\w+[^\n]*$", "", text, flags=re.MULTILINE)
+        return text
 
     def _parse_instruction(self, line: str) -> Instruction:
         target = None

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -251,7 +251,15 @@ class Optimizer:
         # references to a local _JIT_CONTINUE label (which we will add later):
         continue_symbol = rf"\b{re.escape(self.symbol_prefix)}_JIT_CONTINUE\b"
         continue_label = f"{self.label_prefix}_JIT_CONTINUE"
-        return re.sub(continue_symbol, continue_label, text)
+        text = re.sub(continue_symbol, continue_label, text)
+        # Strip CFI directives. JIT stencils are compiled with
+        # -fno-asynchronous-unwind-tables and don't use DWARF CFI unwind
+        # tables (.eh_frame).
+        # The optimizer's dead code elimination can remove blocks containing
+        # .cfi_endproc while keeping the corresponding .cfi_startproc,
+        # producing unbalanced CFI frames that some assemblers reject:
+        text = re.sub(r"^\s*\.cfi_\w+[^\n]*$", "", text, flags=re.MULTILINE)
+        return text
 
     def _parse_instruction(self, line: str) -> Instruction:
         target = None

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -253,10 +253,10 @@ class Optimizer:
         continue_label = f"{self.label_prefix}_JIT_CONTINUE"
         text = re.sub(continue_symbol, continue_label, text)
         # Strip CFI directives as JIT stencils are compiled with
-        # -fno-asynchronous-unwind-tables and don't use DWARF CFI unwind
-        # tables (.eh_frame). The optimizer can remove blocks containing
-        # .cfi_endproc while keeping the corresponding .cfi_startproc,
-        # producing unbalanced CFI frames that some assemblers reject:
+        # -fno-asynchronous-unwind-tables. The optimizer can remove blocks
+        # containing .cfi_endproc while keeping the corresponding
+        # .cfi_startproc, producing unbalanced CFI frames that some
+        # assemblers reject:
         text = re.sub(r"^\s*\.cfi_\w+[^\n]*$", "", text, flags=re.MULTILINE)
         return text
 

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -251,14 +251,7 @@ class Optimizer:
         # references to a local _JIT_CONTINUE label (which we will add later):
         continue_symbol = rf"\b{re.escape(self.symbol_prefix)}_JIT_CONTINUE\b"
         continue_label = f"{self.label_prefix}_JIT_CONTINUE"
-        text = re.sub(continue_symbol, continue_label, text)
-        # Strip CFI directives as JIT stencils are compiled with
-        # -fno-asynchronous-unwind-tables. The optimizer can remove blocks
-        # containing .cfi_endproc while keeping the corresponding
-        # .cfi_startproc, producing unbalanced CFI frames that some
-        # assemblers reject:
-        text = re.sub(r"^\s*\.cfi_\w+[^\n]*$", "", text, flags=re.MULTILINE)
-        return text
+        return re.sub(continue_symbol, continue_label, text)
 
     def _parse_instruction(self, line: str) -> Instruction:
         target = None

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -163,10 +163,11 @@ class _Target(typing.Generic[_S, _R]):
             # __FILE__ macro and assert failure messages) for reproducibility:
             f"-ffile-prefix-map={CPYTHON}=.",
             f"-ffile-prefix-map={tempdir}=.",
-            # This debug info isn't necessary, and bloats out the JIT'ed code.
-            # We *may* be able to re-enable this, process it, and JIT it for a
-            # nicer debugging experience... but that needs a lot more research:
-            "-fno-asynchronous-unwind-tables",
+            # Don't emit unwind tables or CFI directives. JIT stencils are
+            # not standard functions and their unwind info is not usable at
+            # runtime. The optimizer can produce unbalanced CFI directives
+            # that some assemblers reject (e.g. Apple LLVM 21):
+            "-fno-unwind-tables",
             # Don't call built-in functions that we can't find or patch:
             "-fno-builtin",
             # Don't call stack-smashing canaries that we can't find or patch:

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -163,7 +163,7 @@ class _Target(typing.Generic[_S, _R]):
             # __FILE__ macro and assert failure messages) for reproducibility:
             f"-ffile-prefix-map={CPYTHON}=.",
             f"-ffile-prefix-map={tempdir}=.",
-            # Don't emit CFI directives. The optimizer can produce unbalanced 
+            # Don't emit CFI directives. The optimizer can produce unbalanced
             # CFI directives that some assemblers reject (e.g. Apple LLVM 21):
             "-fno-unwind-tables",
             # Don't call built-in functions that we can't find or patch:

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -163,10 +163,8 @@ class _Target(typing.Generic[_S, _R]):
             # __FILE__ macro and assert failure messages) for reproducibility:
             f"-ffile-prefix-map={CPYTHON}=.",
             f"-ffile-prefix-map={tempdir}=.",
-            # Don't emit unwind tables or CFI directives. JIT stencils are
-            # not standard functions and their unwind info is not usable at
-            # runtime. The optimizer can produce unbalanced CFI directives
-            # that some assemblers reject (e.g. Apple LLVM 21):
+            # Don't emit CFI directives. The optimizer can produce unbalanced 
+            # CFI directives that some assemblers reject (e.g. Apple LLVM 21):
             "-fno-unwind-tables",
             # Don't call built-in functions that we can't find or patch:
             "-fno-builtin",

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -163,9 +163,10 @@ class _Target(typing.Generic[_S, _R]):
             # __FILE__ macro and assert failure messages) for reproducibility:
             f"-ffile-prefix-map={CPYTHON}=.",
             f"-ffile-prefix-map={tempdir}=.",
-            # Don't emit CFI directives. The optimizer can produce unbalanced
-            # CFI directives that some assemblers reject (e.g. Apple LLVM 21):
-            "-fno-unwind-tables",
+            # This debug info isn't necessary, and bloats out the JIT'ed code.
+            # We *may* be able to re-enable this, process it, and JIT it for a
+            # nicer debugging experience... but that needs a lot more research:
+            "-fno-asynchronous-unwind-tables",
             # Don't call built-in functions that we can't find or patch:
             "-fno-builtin",
             # Don't call stack-smashing canaries that we can't find or patch:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

After poking around at this a bit, it seems like Apple LLVM 21 is stricter about validating CFI frame nesting. In debug builds, `.cfi_endproc` directives can end up in blocks that the optimizer removes as unreachable, leaving unbalanced `.cfi_startproc` directives that the assembler rejects (and so you'll get something like this https://github.com/python/cpython/pull/146478#issuecomment-4186915528 while building).

Since JIT stencils are already compiled with `-fno-asynchronous-unwind-tables`, I believe the CFI directives are unused and so they can be stripped out. I also tried  changing the flag to `-fno-unwind-tables` instead to just prevent us from emitting the directives in the first place but it seems like that's a bigger change as we'd have to handle `SHT_X86_64_UNWIND` sections on x86_64 Linux (https://github.com/python/cpython/actions/runs/24265500635/job/70859484777?pr=148364)? I'm not totally sure why that is. We could go that route but wanted to solicit opinions first before going down that road.

This is an alternative to #146478 that tries to fix the root cause rather than blocking Apple LLVM 21.

<!-- gh-issue-number: gh-146475 -->
* Issue: gh-146475
<!-- /gh-issue-number -->
