### PR TITLE
gh-148320: document that `import sys.monitoring` raises `ModuleNotFoundError`

### DIFF
--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -11,8 +11,8 @@
 .. note::
 
     :mod:`!sys.monitoring` is a namespace within the :mod:`sys` module,
-    not an independent module, and ``import sys.monitoring`` will fail
-    with a :py:exc:`ModuleNotFoundError`. Instead, simply ``import sys``
+    not an independent module, and ``import sys.monitoring`` would fail
+    with a :exc:`ModuleNotFoundError`. Instead, simply ``import sys``
     and then use ``sys.monitoring``.
 
 

--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -11,9 +11,9 @@
 .. note::
 
     :mod:`!sys.monitoring` is a namespace within the :mod:`sys` module,
-    not an independent module, so there is no need to
-    ``import sys.monitoring``, simply ``import sys`` and then use
-    ``sys.monitoring``.
+    not an independent module, and ``import sys.monitoring`` will fail
+    with a :exception:`ModuleNotFoundError`. Instead, simply
+    ``import sys`` and then use ``sys.monitoring``.
 
 
 This namespace provides access to the functions and constants necessary to

--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -12,8 +12,8 @@
 
     :mod:`!sys.monitoring` is a namespace within the :mod:`sys` module,
     not an independent module, and ``import sys.monitoring`` will fail
-    with a :py:exception:`ModuleNotFoundError`. Instead, simply
-    ``import sys`` and then use ``sys.monitoring``.
+    with a :py:exc:`ModuleNotFoundError`. Instead, simply ``import sys``
+    and then use ``sys.monitoring``.
 
 
 This namespace provides access to the functions and constants necessary to

--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -12,7 +12,7 @@
 
     :mod:`!sys.monitoring` is a namespace within the :mod:`sys` module,
     not an independent module, and ``import sys.monitoring`` will fail
-    with a :exception:`ModuleNotFoundError`. Instead, simply
+    with a :py:exception:`ModuleNotFoundError`. Instead, simply
     ``import sys`` and then use ``sys.monitoring``.
 
 


### PR DESCRIPTION
Closes #148320.

<!-- gh-issue-number: gh-148320 -->
* Issue: gh-148320
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148365.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->