### PR TITLE
gh-137855: Improve import time of dataclasses by lazy importing  `re` and `copy` modules

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1,4 +1,4 @@
-import re
+lazy import re
 import sys
 lazy import copy
 import types
@@ -217,9 +217,8 @@ _PARAMS = '__dataclass_params__'
 _POST_INIT_NAME = '__post_init__'
 
 # String regex that string annotations for ClassVar or InitVar must match.
-# Allows "identifier.identifier[" or "identifier[".
-# https://bugs.python.org/issue33453 for details.
-_MODULE_IDENTIFIER_RE = re.compile(r'^(?:\s*(\w+)\s*\.)?\s*(\w+)')
+# This regular expression is compiled on demand so that 're' module can be imported lazily
+_MODULE_IDENTIFIER_RE = None
 
 # Atomic immutable types which don't require any recursive handling and for which deepcopy
 # returns the same object. We can provide a fast-path for these types in asdict and astuple.
@@ -803,6 +802,13 @@ def _is_type(annotation, cls, a_module, a_type, is_type_predicate):
     # correct global and local namespaces.  However that would involve
     # a eval() penalty for every single field of every dataclass
     # that's defined.  It was judged not worth it.
+
+    # String regex that string annotations for ClassVar or InitVar must match.
+    # Allows "identifier.identifier[" or "identifier[".
+    # https://bugs.python.org/issue33453 for details.
+    global _MODULE_IDENTIFIER_RE
+    if _MODULE_IDENTIFIER_RE is None:
+        _MODULE_IDENTIFIER_RE = re.compile(r'^(?:\s*(\w+)\s*\.)?\s*(\w+)')
 
     match = _MODULE_IDENTIFIER_RE.match(annotation)
     if match:

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -805,7 +805,7 @@ def _is_type(annotation, cls, a_module, a_type, is_type_predicate):
 
     # String regex that string annotations for ClassVar or InitVar must match.
     # Allows "identifier.identifier[" or "identifier[".
-    # https://bugs.python.org/issue33453 for details.
+    # https://github.com/python/cpython/issues/77634 for details.
     global _MODULE_IDENTIFIER_RE
     if _MODULE_IDENTIFIER_RE is None:
         _MODULE_IDENTIFIER_RE = re.compile(r'^(?:\s*(\w+)\s*\.)?\s*(\w+)')

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1,6 +1,4 @@
-lazy import re
 import sys
-lazy import copy
 import types
 import inspect
 import keyword
@@ -8,6 +6,8 @@ import itertools
 import annotationlib
 import abc
 from reprlib import recursive_repr
+lazy import copy
+lazy import re
 
 
 __all__ = ['dataclass',

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -808,12 +808,12 @@ def _is_type(annotation, cls, a_module, a_type, is_type_predicate):
     # https://github.com/python/cpython/issues/77634 for details.
     global _MODULE_IDENTIFIER_RE
     if _MODULE_IDENTIFIER_RE is None:
-        _MODULE_IDENTIFIER_RE = re.compile(r'^(?:\s*(\w+)\s*\.)?\s*(\w+)')
+        _MODULE_IDENTIFIER_RE = re.compile(r'(?:\s*(\w+)\s*\.)?\s*(\w+)')
 
-    match = _MODULE_IDENTIFIER_RE.match(annotation)
+    match = _MODULE_IDENTIFIER_RE.prefixmatch(annotation)
     if match:
         ns = None
-        module_name = match.group(1)
+        module_name = match[1]
         if not module_name:
             # No module name, assume the class's module did
             # "from dataclasses import InitVar".

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1,6 +1,6 @@
 import re
 import sys
-import copy
+lazy import copy
 import types
 import inspect
 import keyword

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -823,7 +823,7 @@ def _is_type(annotation, cls, a_module, a_type, is_type_predicate):
             module = sys.modules.get(cls.__module__)
             if module and module.__dict__.get(module_name) is a_module:
                 ns = sys.modules.get(a_type.__module__).__dict__
-        if ns and is_type_predicate(ns.get(match.group(2)), a_module):
+        if ns and is_type_predicate(ns.get(match[2]), a_module):
             return True
     return False
 

--- a/Misc/NEWS.d/next/Library/2026-04-11-12-32-38.gh-issue-137855.tsVny_.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-11-12-32-38.gh-issue-137855.tsVny_.rst
@@ -1,0 +1,2 @@
+Improve import time of :mod:`dataclasses` module by lazy importing :mod:`re`
+and :mod:`copy` modules.


### PR DESCRIPTION
Split from #144387 as requested by @hugovk (tagging for review :-)  This is a relatively minor win, the bigger win will come from lazy importing inspect in #144387

See below for tuna-visualized outputs from `./python -X importtime -c "import dataclasses"`
(the absolute import numbers are not representative as I was running a debug python build)

## Before
<img width="1792" height="1128" alt="image" src="https://github.com/user-attachments/assets/772dc221-7a4a-432a-8476-1e0eaed96f66" />

## After

<img width="1792" height="833" alt="image" src="https://github.com/user-attachments/assets/dc68daf0-2cd5-4a48-8b5e-8a8dfb5fb32a" />


<!-- gh-issue-number: gh-137855 -->
* Issue: gh-137855
<!-- /gh-issue-number -->
