### PR TITLE
gh-148406: Fix annotations of _colorize.FancyCompleter

### DIFF
--- a/Lib/_colorize.py
+++ b/Lib/_colorize.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 import sys
 
@@ -202,25 +203,25 @@ class Difflib(ThemeSection):
 @dataclass(frozen=True, kw_only=True)
 class FancyCompleter(ThemeSection):
     # functions and methods
-    function: str = ANSIColors.BOLD_BLUE
-    builtin_function_or_method: str = ANSIColors.BOLD_BLUE
-    method: str = ANSIColors.BOLD_CYAN
-    method_wrapper: str = ANSIColors.BOLD_CYAN
-    wrapper_descriptor: str = ANSIColors.BOLD_CYAN
-    method_descriptor: str = ANSIColors.BOLD_CYAN
+    function: builtins.str = ANSIColors.BOLD_BLUE
+    builtin_function_or_method: builtins.str = ANSIColors.BOLD_BLUE
+    method: builtins.str = ANSIColors.BOLD_CYAN
+    method_wrapper: builtins.str = ANSIColors.BOLD_CYAN
+    wrapper_descriptor: builtins.str = ANSIColors.BOLD_CYAN
+    method_descriptor: builtins.str = ANSIColors.BOLD_CYAN
 
     # numbers
-    int: str = ANSIColors.BOLD_YELLOW
-    float: str = ANSIColors.BOLD_YELLOW
-    complex: str = ANSIColors.BOLD_YELLOW
-    bool: str = ANSIColors.BOLD_YELLOW
+    int: builtins.str = ANSIColors.BOLD_YELLOW
+    float: builtins.str = ANSIColors.BOLD_YELLOW
+    complex: builtins.str = ANSIColors.BOLD_YELLOW
+    bool: builtins.str = ANSIColors.BOLD_YELLOW
 
     # others
-    type: str = ANSIColors.BOLD_MAGENTA
-    module: str = ANSIColors.CYAN
-    NoneType: str = ANSIColors.GREY
-    bytes: str = ANSIColors.BOLD_GREEN
-    str: str = ANSIColors.BOLD_GREEN
+    type: builtins.str = ANSIColors.BOLD_MAGENTA
+    module: builtins.str = ANSIColors.CYAN
+    NoneType: builtins.str = ANSIColors.GREY
+    bytes: builtins.str = ANSIColors.BOLD_GREEN
+    str: builtins.str = ANSIColors.BOLD_GREEN
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -5,6 +5,7 @@ import sys
 import unittest
 import unittest.mock
 import _colorize
+from test.support import cpython_only, import_helper
 from test.support.os_helper import EnvironmentVarGuard
 
 
@@ -20,6 +21,15 @@ def supports_virtual_terminal():
         return unittest.mock.patch("nt._supports_virtual_terminal", return_value=True)
     else:
         return contextlib.nullcontext()
+
+
+class TestImportTime(unittest.TestCase):
+
+    @cpython_only
+    def test_lazy_import(self):
+        import_helper.ensure_lazy_imports(
+            "_colorize", {"re", "copy"}
+        )
 
 
 class TestTheme(unittest.TestCase):

--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -28,7 +28,7 @@ class TestImportTime(unittest.TestCase):
     @cpython_only
     def test_lazy_import(self):
         import_helper.ensure_lazy_imports(
-            "_colorize", {"re", "copy"}
+            "_colorize", {"copy", "re"}
         )
 
 


### PR DESCRIPTION
Fixes #148406, using an approach suggested in the issue. 

### Test plan

#### Before 

```python
>>> import _colorize, pprint
>>> pprint.pprint(_colorize.FancyCompleter.__annotations__)
{'NoneType': '\x1b[1;32m',
 'bool': '\x1b[1;32m',
 'builtin_function_or_method': '\x1b[1;32m',
 'bytes': '\x1b[1;32m',
 'complex': '\x1b[1;32m',
 'float': '\x1b[1;32m',
 'function': '\x1b[1;32m',
 'int': '\x1b[1;32m',
 'method': '\x1b[1;32m',
 'method_descriptor': '\x1b[1;32m',
 'method_wrapper': '\x1b[1;32m',
 'module': '\x1b[1;32m',
 'str': '\x1b[1;32m',
 'type': '\x1b[1;32m',
 'wrapper_descriptor': '\x1b[1;32m'}
```

#### After 
```python
>>> from _colorize import FancyCompleter
>>> from pprint import pprint
>>> pprint(FancyCompleter.__annotations__)
{'NoneType': <class 'str'>,
 'bool': <class 'str'>,
 'builtin_function_or_method': <class 'str'>,
 'bytes': <class 'str'>,
 'complex': <class 'str'>,
 'float': <class 'str'>,
 'function': <class 'str'>,
 'int': <class 'str'>,
 'method': <class 'str'>,
 'method_descriptor': <class 'str'>,
 'method_wrapper': <class 'str'>,
 'module': <class 'str'>,
 'str': <class 'str'>,
 'type': <class 'str'>,
 'wrapper_descriptor': <class 'str'>}
```

Also added a regression tests to ensure that `re` module is not imported during `_colorize` import.
We've just made `re` import lazy in `dataclasses` (#148379), but because of the bug resolved here, it ended up being imported (because the annotations were strings, which was triggering the path that uses the `re` module). 



<!-- gh-issue-number: gh-148406 -->
* Issue: gh-148406
<!-- /gh-issue-number -->
