### PR TITLE
gh-148418: Fix a possible reference leak in a corrupted `TYPE_CODE` marshal stream

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-12-10-40-57.gh-issue-148418.ggA1LZ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-12-10-40-57.gh-issue-148418.ggA1LZ.rst
@@ -1,1 +1,1 @@
-Fix a possible reference leak in a corrupted ``TYPE_CODE`` marshal stream
+Fix a possible reference leak in a corrupted ``TYPE_CODE`` marshal stream.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-12-10-40-57.gh-issue-148418.ggA1LZ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-12-10-40-57.gh-issue-148418.ggA1LZ.rst
@@ -1,0 +1,1 @@
+Fix a possible reference leak in a corrupted ``TYPE_CODE`` marshal stream

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1599,7 +1599,7 @@ r_object(RFILE *p)
                 goto code_error;
             firstlineno = (int)r_long(p);
             if (firstlineno == -1 && PyErr_Occurred())
-                break;
+                goto code_error;
             linetable = r_object(p);
             if (linetable == NULL)
                 goto code_error;


### PR DESCRIPTION


<!-- gh-issue-number: gh-148418 -->
* Issue: gh-148418
<!-- /gh-issue-number -->
