### PR TITLE
gh-148427: Fix bare except in expatreader.external_entity_ref()

### DIFF
--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -1057,60 +1057,51 @@ class ExpatReaderTest(XmlTestBase):
 
     def test_external_entity_ref_keyboard_interrupt(self):
         # gh-148427: KeyboardInterrupt must propagate, not be swallowed
-        class KBHandler(handler.ContentHandler):
-            def startElement(self, name, attrs):
-                if name == 'entity':
-                    raise KeyboardInterrupt('test')
+        eh = mock.Mock()
+        eh.startElement.side_effect = KeyboardInterrupt('test')
 
         parser = create_parser()
         parser.setFeature(feature_external_ges, True)
         parser.setEntityResolver(self.TestEntityResolver())
-        parser.setContentHandler(KBHandler())
+        parser.setContentHandler(eh)
 
+        parser.feed('<!DOCTYPE doc [\n')
+        parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
+        parser.feed(']>\n')
         with self.assertRaises(KeyboardInterrupt):
-            parser.feed('<!DOCTYPE doc [\n')
-            parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
-            parser.feed(']>\n')
             parser.feed('<doc>&test;</doc>')
-            parser.close()
 
     def test_external_entity_ref_system_exit(self):
         # gh-148427: SystemExit must propagate, not be swallowed
-        class ExitHandler(handler.ContentHandler):
-            def startElement(self, name, attrs):
-                if name == 'entity':
-                    raise SystemExit(42)
+        eh = mock.Mock()
+        eh.startElement.side_effect = SystemExit(42)
 
         parser = create_parser()
         parser.setFeature(feature_external_ges, True)
         parser.setEntityResolver(self.TestEntityResolver())
-        parser.setContentHandler(ExitHandler())
+        parser.setContentHandler(eh)
 
+        parser.feed('<!DOCTYPE doc [\n')
+        parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
+        parser.feed(']>\n')
         with self.assertRaises(SystemExit):
-            parser.feed('<!DOCTYPE doc [\n')
-            parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
-            parser.feed(']>\n')
             parser.feed('<doc>&test;</doc>')
-            parser.close()
 
     def test_external_entity_ref_stack_cleanup(self):
         # gh-148427: _entity_stack must be cleaned up after errors
-        class ErrorHandler(handler.ContentHandler):
-            def startElement(self, name, attrs):
-                if name == 'entity':
-                    raise ValueError('test error')
+        eh = mock.Mock()
+        eh.startElement.side_effect = ValueError('test error')
 
         parser = create_parser()
         parser.setFeature(feature_external_ges, True)
         parser.setEntityResolver(self.TestEntityResolver())
-        parser.setContentHandler(ErrorHandler())
+        parser.setContentHandler(eh)
 
+        parser.feed('<!DOCTYPE doc [\n')
+        parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
+        parser.feed(']>\n')
         with self.assertRaises(SAXParseException):
-            parser.feed('<!DOCTYPE doc [\n')
-            parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
-            parser.feed(']>\n')
             parser.feed('<doc>&test;</doc>')
-            parser.close()
 
         self.assertEqual(len(parser._entity_stack), 0)
 

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -25,6 +25,7 @@ import sys
 from urllib.error import URLError
 import urllib.request
 from test.support import os_helper
+from test import support
 from test.support import findfile, check__all__
 from test.support.os_helper import FakePath, TESTFN
 
@@ -1055,64 +1056,32 @@ class ExpatReaderTest(XmlTestBase):
         self.assertEqual(result.getvalue(), start +
                          b"<doc></doc>")
 
-    def test_external_entity_ref_keyboard_interrupt(self):
-        # gh-148427: KeyboardInterrupt must propagate, not be swallowed
+    @support.subTests("exc_type", [KeyboardInterrupt, SystemExit, ValueError])
+    def test_external_entity_parser_with_exceptions(self, exc_type):
+        # gh-148427: BaseException subclasses must propagate, not be swallowed
         def raise_on_entity(name, attrs):
             if name == 'entity':
-                raise KeyboardInterrupt('test')
-        eh = mock.Mock()
-        eh.startElement.side_effect = raise_on_entity
+                raise exc_type("test")
+
+        handler = mock.Mock()
+        handler.startElement = raise_on_entity
 
         parser = create_parser()
         parser.setFeature(feature_external_ges, True)
         parser.setEntityResolver(self.TestEntityResolver())
-        parser.setContentHandler(eh)
+        parser.setContentHandler(handler)
 
         parser.feed('<!DOCTYPE doc [\n')
         parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
         parser.feed(']>\n')
-        with self.assertRaises(KeyboardInterrupt):
-            parser.feed('<doc>&test;</doc>')
+        trigger = '<doc>&test;</doc>'
 
-    def test_external_entity_ref_system_exit(self):
-        # gh-148427: SystemExit must propagate, not be swallowed
-        def raise_on_entity(name, attrs):
-            if name == 'entity':
-                raise SystemExit(42)
-        eh = mock.Mock()
-        eh.startElement.side_effect = raise_on_entity
-
-        parser = create_parser()
-        parser.setFeature(feature_external_ges, True)
-        parser.setEntityResolver(self.TestEntityResolver())
-        parser.setContentHandler(eh)
-
-        parser.feed('<!DOCTYPE doc [\n')
-        parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
-        parser.feed(']>\n')
-        with self.assertRaises(SystemExit):
-            parser.feed('<doc>&test;</doc>')
-
-    def test_external_entity_ref_stack_cleanup(self):
-        # gh-148427: _entity_stack must be cleaned up after errors
-        def raise_on_entity(name, attrs):
-            if name == 'entity':
-                raise ValueError('test error')
-        eh = mock.Mock()
-        eh.startElement.side_effect = raise_on_entity
-
-        parser = create_parser()
-        parser.setFeature(feature_external_ges, True)
-        parser.setEntityResolver(self.TestEntityResolver())
-        parser.setContentHandler(eh)
-
-        parser.feed('<!DOCTYPE doc [\n')
-        parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
-        parser.feed(']>\n')
-        with self.assertRaises(SAXParseException):
-            parser.feed('<doc>&test;</doc>')
-
-        self.assertEqual(len(parser._entity_stack), 0)
+        if issubclass(exc_type, Exception):
+            self.assertRaises(SAXParseException, parser.feed, trigger)
+            self.assertEqual(len(parser._entity_stack), 0)
+        else:
+            with self.assertRaisesRegex(exc_type, "test"):
+                parser.feed(trigger)
 
     # ===== Attributes support
 

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -1078,7 +1078,6 @@ class ExpatReaderTest(XmlTestBase):
 
         if issubclass(exc_type, Exception):
             self.assertRaises(SAXParseException, parser.feed, trigger)
-            self.assertEqual(len(parser._entity_stack), 0)
         else:
             with self.assertRaisesRegex(exc_type, "test"):
                 parser.feed(trigger)

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -1055,6 +1055,65 @@ class ExpatReaderTest(XmlTestBase):
         self.assertEqual(result.getvalue(), start +
                          b"<doc></doc>")
 
+    def test_external_entity_ref_keyboard_interrupt(self):
+        # gh-148427: KeyboardInterrupt must propagate, not be swallowed
+        class KBHandler(handler.ContentHandler):
+            def startElement(self, name, attrs):
+                if name == 'entity':
+                    raise KeyboardInterrupt('test')
+
+        parser = create_parser()
+        parser.setFeature(feature_external_ges, True)
+        parser.setEntityResolver(self.TestEntityResolver())
+        parser.setContentHandler(KBHandler())
+
+        with self.assertRaises(KeyboardInterrupt):
+            parser.feed('<!DOCTYPE doc [\n')
+            parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
+            parser.feed(']>\n')
+            parser.feed('<doc>&test;</doc>')
+            parser.close()
+
+    def test_external_entity_ref_system_exit(self):
+        # gh-148427: SystemExit must propagate, not be swallowed
+        class ExitHandler(handler.ContentHandler):
+            def startElement(self, name, attrs):
+                if name == 'entity':
+                    raise SystemExit(42)
+
+        parser = create_parser()
+        parser.setFeature(feature_external_ges, True)
+        parser.setEntityResolver(self.TestEntityResolver())
+        parser.setContentHandler(ExitHandler())
+
+        with self.assertRaises(SystemExit):
+            parser.feed('<!DOCTYPE doc [\n')
+            parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
+            parser.feed(']>\n')
+            parser.feed('<doc>&test;</doc>')
+            parser.close()
+
+    def test_external_entity_ref_stack_cleanup(self):
+        # gh-148427: _entity_stack must be cleaned up after errors
+        class ErrorHandler(handler.ContentHandler):
+            def startElement(self, name, attrs):
+                if name == 'entity':
+                    raise ValueError('test error')
+
+        parser = create_parser()
+        parser.setFeature(feature_external_ges, True)
+        parser.setEntityResolver(self.TestEntityResolver())
+        parser.setContentHandler(ErrorHandler())
+
+        with self.assertRaises(SAXParseException):
+            parser.feed('<!DOCTYPE doc [\n')
+            parser.feed('  <!ENTITY test SYSTEM "whatever">\n')
+            parser.feed(']>\n')
+            parser.feed('<doc>&test;</doc>')
+            parser.close()
+
+        self.assertEqual(len(parser._entity_stack), 0)
+
     # ===== Attributes support
 
     class AttrGatherer(ContentHandler):

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -1057,8 +1057,11 @@ class ExpatReaderTest(XmlTestBase):
 
     def test_external_entity_ref_keyboard_interrupt(self):
         # gh-148427: KeyboardInterrupt must propagate, not be swallowed
+        def raise_on_entity(name, attrs):
+            if name == 'entity':
+                raise KeyboardInterrupt('test')
         eh = mock.Mock()
-        eh.startElement.side_effect = KeyboardInterrupt('test')
+        eh.startElement.side_effect = raise_on_entity
 
         parser = create_parser()
         parser.setFeature(feature_external_ges, True)
@@ -1073,8 +1076,11 @@ class ExpatReaderTest(XmlTestBase):
 
     def test_external_entity_ref_system_exit(self):
         # gh-148427: SystemExit must propagate, not be swallowed
+        def raise_on_entity(name, attrs):
+            if name == 'entity':
+                raise SystemExit(42)
         eh = mock.Mock()
-        eh.startElement.side_effect = SystemExit(42)
+        eh.startElement.side_effect = raise_on_entity
 
         parser = create_parser()
         parser.setFeature(feature_external_ges, True)
@@ -1089,8 +1095,11 @@ class ExpatReaderTest(XmlTestBase):
 
     def test_external_entity_ref_stack_cleanup(self):
         # gh-148427: _entity_stack must be cleaned up after errors
+        def raise_on_entity(name, attrs):
+            if name == 'entity':
+                raise ValueError('test error')
         eh = mock.Mock()
-        eh.startElement.side_effect = ValueError('test error')
+        eh.startElement.side_effect = raise_on_entity
 
         parser = create_parser()
         parser.setFeature(feature_external_ges, True)

--- a/Lib/xml/sax/expatreader.py
+++ b/Lib/xml/sax/expatreader.py
@@ -424,11 +424,11 @@ class ExpatParser(xmlreader.IncrementalParser, xmlreader.Locator):
 
         try:
             xmlreader.IncrementalParser.parse(self, source)
-        except:
-            return 0  # FIXME: save error info here?
-
-        (self._parser, self._source) = self._entity_stack[-1]
-        del self._entity_stack[-1]
+        except Exception:
+            return 0
+        finally:
+            (self._parser, self._source) = self._entity_stack[-1]
+            del self._entity_stack[-1]
         return 1
 
     def skipped_entity_handler(self, name, is_pe):

--- a/Lib/xml/sax/expatreader.py
+++ b/Lib/xml/sax/expatreader.py
@@ -425,7 +425,7 @@ class ExpatParser(xmlreader.IncrementalParser, xmlreader.Locator):
         try:
             xmlreader.IncrementalParser.parse(self, source)
         except Exception:
-            return 0
+            return 0  # FIXME: save error info here?
         finally:
             (self._parser, self._source) = self._entity_stack[-1]
             del self._entity_stack[-1]

--- a/Lib/xml/sax/expatreader.py
+++ b/Lib/xml/sax/expatreader.py
@@ -426,9 +426,9 @@ class ExpatParser(xmlreader.IncrementalParser, xmlreader.Locator):
             xmlreader.IncrementalParser.parse(self, source)
         except Exception:
             return 0  # FIXME: save error info here?
-        finally:
-            (self._parser, self._source) = self._entity_stack[-1]
-            del self._entity_stack[-1]
+
+        (self._parser, self._source) = self._entity_stack[-1]
+        del self._entity_stack[-1]
         return 1
 
     def skipped_entity_handler(self, name, is_pe):

--- a/Misc/NEWS.d/next/Library/2026-04-12-09-52-14.gh-issue-148427.xR7v3m.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-12-09-52-14.gh-issue-148427.xR7v3m.rst
@@ -1,4 +1,3 @@
-Fix bare ``except`` clause in :mod:`xml.sax` expatreader's external entity
-handler that silently swallowed :exc:`KeyboardInterrupt` and
-:exc:`SystemExit`. Also fix entity parser stack leak on errors by moving
-cleanup into a ``finally`` clause.
+Fix bare ``except`` clause in :mod:`xml.sax` Expat's external entity
+handler that silently swallowed :exc:`BaseException` instances such
+as :exc:`KeyboardInterrupt`.

--- a/Misc/NEWS.d/next/Library/2026-04-12-09-52-14.gh-issue-148427.xR7v3m.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-12-09-52-14.gh-issue-148427.xR7v3m.rst
@@ -1,0 +1,4 @@
+Fix bare ``except`` clause in :mod:`xml.sax` expatreader's external entity
+handler that silently swallowed :exc:`KeyboardInterrupt` and
+:exc:`SystemExit`. Also fix entity parser stack leak on errors by moving
+cleanup into a ``finally`` clause.


### PR DESCRIPTION
`ExpatParser.external_entity_ref()` uses a bare `except:` that silently swallows `KeyboardInterrupt` and `SystemExit` during external entity parsing. It also leaks the `_entity_stack` on errors since the cleanup code only runs on the success path.

This changes `except:` to `except Exception:` and moves the stack cleanup into a `finally` block.

I verified in pyexpat.c that the C layer handles Python exception propagation correctly — `call_with_frame()` calls `XML_StopParser()` on callback failure, and `get_parse_result()` checks `PyErr_Occurred()` before inspecting the return value, so letting `KeyboardInterrupt` through is safe.

<!-- gh-issue-number: gh-148427 -->
* Issue: gh-148427
<!-- /gh-issue-number -->