### PR TITLE
gh-148259: make `list.remove` atomic for non-trivial `__eq__` comparison

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2812,17 +2812,17 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
     def test_remove_with_clear_assume_missing(self):
         # gh-126033: Check that a concurrent clear() for an assumed-to-be
         # missing element does not make the interpreter crash.
-        self.do_test_remove_with_clear(raises=True)
+        self.do_test_remove_with_clear(existing=False)
 
     def test_remove_with_clear_assume_existing(self):
         # gh-126033: Check that a concurrent clear() for an assumed-to-be
         # existing element raises RuntimeError but does not crash.
-        self.do_test_remove_with_clear(raises=False)
+        self.do_test_remove_with_clear(existing=True)
 
-    def do_test_remove_with_clear(self, *, raises):
+    def do_test_remove_with_clear(self, *, existing):
         # 'del root[:]' mutates the children list in-place, while
         # 'root.clear()' replaces self._children with a new list.  When
-        # raises=False (element "found"), the in-place mutation is detected
+        # existing=True (element "found"), the in-place mutation is detected
         # by list.remove and raises RuntimeError, whereas root.clear() is
         # invisible to list.remove (the old list is unchanged).
 
@@ -2832,12 +2832,12 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
         class X(E):
             def __eq__(self, o):
                 del root[:]
-                return not raises
+                return existing
 
         class Y(E):
             def __eq__(self, o):
                 root.clear()
-                return not raises
+                return existing
 
         self.assertIs(E.__eq__, object.__eq__)
 
@@ -2846,12 +2846,14 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
             self.enterContext(self.subTest(side_effect=side_effect))
 
             # X uses 'del root[:]' which mutates the list in-place; this is
-            # detected by list.remove when raises=False (element "found").
+            # detected by list.remove (pure Python implementation) when existing=False.
+            # The C implementation does not detect this mutation and silently
+            # returns None.
             # Y uses 'root.clear()' which swaps out self._children; the old
             # list that list.remove is iterating is untouched, so no error.
-            if raises:
+            if not existing:
                 get_checker_context = lambda: self.assertRaises(ValueError)
-            elif Z is X:
+            elif Z is X and is_python_implementation():
                 get_checker_context = lambda: self.assertRaises(RuntimeError)
             else:
                 get_checker_context = nullcontext
@@ -2890,7 +2892,7 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
                 g.assert_not_called()
 
             # Test removing root[1] (of type R) from [U(), R()].
-            if is_python_implementation() and raises and Z is Y:
+            if is_python_implementation() and not existing and Z is Y:
                 # In pure Python, using root.clear() sets the children
                 # list to [] without calling list.clear().
                 #
@@ -2915,25 +2917,32 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
     def test_remove_with_mutate_root_assume_missing(self):
         # gh-126033: Check that a concurrent mutation for an assumed-to-be
         # missing element does not make the interpreter crash.
-        self.do_test_remove_with_mutate_root(raises=True)
+        self.do_test_remove_with_mutate_root(existing=False)
 
     def test_remove_with_mutate_root_assume_existing(self):
         # gh-126033: Check that a concurrent mutation for an assumed-to-be
-        # existing element raises RuntimeError.
-        self.do_test_remove_with_mutate_root(raises=False)
+        # existing element raises RuntimeError when using the pure Python
+        # implementation; the C implementation silently returns None).
+        self.do_test_remove_with_mutate_root(existing=True)
 
-    def do_test_remove_with_mutate_root(self, *, raises):
+    def do_test_remove_with_mutate_root(self, *, existing):
         E = ET.Element
 
         class Z(E):
             def __eq__(self, o):
                 del root[0]
-                return not raises
+                return existing
 
-        if raises:
+        if not existing:
             get_checker_context = lambda: self.assertRaises(ValueError)
-        else:
+        elif is_python_implementation():
+            # The Python implementation is based on list.remove, which raises
+            # RuntimeError if the list is mutated during the __eq__ comparison.
             get_checker_context = lambda: self.assertRaises(RuntimeError)
+        else:
+            # The C implementation does not detect in-place mutations during
+            # remove and silently returns None.
+            get_checker_context = nullcontext
 
         # test removing R() from [U(), V()]
         cases = self.cases_for_remove_missing_with_mutations(E, Z)

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2816,15 +2816,15 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
 
     def test_remove_with_clear_assume_existing(self):
         # gh-126033: Check that a concurrent clear() for an assumed-to-be
-        # existing element does not make the interpreter crash.
+        # existing element raises RuntimeError but does not crash.
         self.do_test_remove_with_clear(raises=False)
 
     def do_test_remove_with_clear(self, *, raises):
-
-        # Until the discrepency between "del root[:]" and "root.clear()" is
-        # resolved, we need to keep two tests. Previously, using "del root[:]"
-        # did not crash with the reproducer of gh-126033 while "root.clear()"
-        # did.
+        # 'del root[:]' mutates the children list in-place, while
+        # 'root.clear()' replaces self._children with a new list.  When
+        # raises=False (element "found"), the in-place mutation is detected
+        # by list.remove and raises RuntimeError, whereas root.clear() is
+        # invisible to list.remove (the old list is unchanged).
 
         class E(ET.Element):
             """Local class to be able to mock E.__eq__ for introspection."""
@@ -2839,15 +2839,22 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
                 root.clear()
                 return not raises
 
-        if raises:
-            get_checker_context = lambda: self.assertRaises(ValueError)
-        else:
-            get_checker_context = nullcontext
-
         self.assertIs(E.__eq__, object.__eq__)
 
+        get_checker_context = nullcontext
         for Z, side_effect in [(X, 'del root[:]'), (Y, 'root.clear()')]:
             self.enterContext(self.subTest(side_effect=side_effect))
+
+            # X uses 'del root[:]' which mutates the list in-place; this is
+            # detected by list.remove when raises=False (element "found").
+            # Y uses 'root.clear()' which swaps out self._children; the old
+            # list that list.remove is iterating is untouched, so no error.
+            if raises:
+                get_checker_context = lambda: self.assertRaises(ValueError)
+            elif Z is X:
+                get_checker_context = lambda: self.assertRaises(RuntimeError)
+            else:
+                get_checker_context = nullcontext
 
             # test removing R() from [U()]
             for R, U, description in [
@@ -2883,7 +2890,6 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
                 g.assert_not_called()
 
             # Test removing root[1] (of type R) from [U(), R()].
-            is_special = is_python_implementation() and raises and Z is Y
             if is_python_implementation() and raises and Z is Y:
                 # In pure Python, using root.clear() sets the children
                 # list to [] without calling list.clear().
@@ -2913,7 +2919,7 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
 
     def test_remove_with_mutate_root_assume_existing(self):
         # gh-126033: Check that a concurrent mutation for an assumed-to-be
-        # existing element does not make the interpreter crash.
+        # existing element raises RuntimeError.
         self.do_test_remove_with_mutate_root(raises=False)
 
     def do_test_remove_with_mutate_root(self, *, raises):
@@ -2927,7 +2933,7 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
         if raises:
             get_checker_context = lambda: self.assertRaises(ValueError)
         else:
-            get_checker_context = nullcontext
+            get_checker_context = lambda: self.assertRaises(RuntimeError)
 
         # test removing R() from [U(), V()]
         cases = self.cases_for_remove_missing_with_mutations(E, Z)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-13-20-51-34.gh-issue-148259.76UyK8x8.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-13-20-51-34.gh-issue-148259.76UyK8x8.rst
@@ -1,0 +1,4 @@
+:meth:`list.remove` now raises :exc:`RuntimeError` if the list is mutated
+during the ``__eq__`` rich comparison and a matching element was found. This
+prevents silent data corruption where the wrong element could be removed from
+a list under concurrent mutation.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3390,6 +3390,11 @@ list_remove_impl(PyListObject *self, PyObject *value)
         int cmp = PyObject_RichCompareBool(obj, value, Py_EQ);
         Py_DECREF(obj);
         if (cmp > 0) {
+            if (i >= Py_SIZE(self) || self->ob_item[i] != obj) {
+                PyErr_SetString(PyExc_RuntimeError,
+                                "list mutated during remove");
+                return NULL;
+            }
             if (list_ass_slice_lock_held(self, i, i+1, NULL) == 0)
                 Py_RETURN_NONE;
             return NULL;


### PR DESCRIPTION
## What is this PR?

This PR addresses the bug reported in #148259 where calling rich comparison may result in releasing the GIL which may result in `list.remove` removing the wrong item from the `list`. 

The PR also updates the tests added for #126033. 

<!-- gh-issue-number: gh-148259 -->
* Issue: gh-148259
<!-- /gh-issue-number -->
