### PR TITLE
fix: properly set exception in remote debugging

### DIFF
--- a/Modules/_remote_debugging/object_reading.c
+++ b/Modules/_remote_debugging/object_reading.c
@@ -196,6 +196,8 @@ read_py_long(
 
     // Validate size: reject garbage (negative or unreasonably large)
     if (size < 0 || size > MAX_LONG_DIGITS) {
+        PyErr_Format(PyExc_RuntimeError,
+            "Invalid PyLong size (%zd) at 0x%lx", size, address);
         set_exception_cause(unwinder, PyExc_RuntimeError,
             "Invalid PyLong size (corrupted remote memory)");
         return -1;


### PR DESCRIPTION
# What is this PR?

~I'm working on the Python Profiler at Datadog and while looking at how Tachyon is implemented, I noticed that I believe this error path is missing a call to `PyErr_Format`. This probably rarely happens (need to read corrupt memory) but I still think it's worth fixing.~ Closing this as I didn't open an issue first. 