### PR TITLE
gh-148444: Use "zero of any numeric type" instead of "numeric zero of all types"

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -2048,7 +2048,7 @@ Boolean operations
 
 In the context of Boolean operations, and also when expressions are used by
 control flow statements, the following values are interpreted as false:
-``False``, ``None``, numeric zero of all types, and empty strings and containers
+``False``, ``None``, zero of any numeric type, and empty strings and containers
 (including strings, tuples, lists, dictionaries, sets and frozensets).  All
 other values are interpreted as true.  User-defined objects can customize their
 truth value by providing a :meth:`~object.__bool__` method.


### PR DESCRIPTION
This makes the wording of the "Boolean operations" section consistent with the "Truth Value Testing" section.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148444 -->
* Issue: gh-148444
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148455.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->