### PR TITLE
gh-148323: release the GIL in `bytes.join` when operands are immutable

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -629,14 +629,20 @@ class BaseBytesTest:
         self.assertEqual(dot_join([b"ab", memoryview(b"cd")]), b"ab.:cd")
         self.assertEqual(dot_join([bytearray(b"ab"), b"cd"]), b"ab.:cd")
         self.assertEqual(dot_join([b"ab", bytearray(b"cd")]), b"ab.:cd")
-        # Stress it with many items
-        seq = [b"abc"] * 100000
-        expected = b"abc" + b".:abc" * 99999
+        # Stress it with many items or many views on immutable bytes
+        N = 0x100000  # threshold for releasing the GIL in join()
+        seq = [b"abc"] * N
+        expected = b"abc" + b".:abc" * (N - 1)
+        self.assertGreater(len(expected), N)
         self.assertEqual(dot_join(seq), expected)
+        views = list(map(memoryview, seq))
+        self.assertEqual(dot_join(views), expected)
         # Stress test with empty separator
-        seq = [b"abc"] * 100000
-        expected = b"abc" * 100000
+        expected = b"abc" * N
+        self.assertGreater(len(expected), N)
         self.assertEqual(self.type2test(b"").join(seq), expected)
+        views = list(map(memoryview, seq))
+        self.assertEqual(self.type2test(b"").join(views), expected)
         self.assertRaises(TypeError, self.type2test(b" ").join, None)
         # Error handling and cleanup when some item in the middle of the
         # sequence has the wrong type.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-12-17-36-12.gh-issue-148323.HicoJQ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-12-17-36-12.gh-issue-148323.HicoJQ.rst
@@ -1,0 +1,3 @@
+Improve performance of :meth:`bytes.join` when the operands are known to be
+buffer views on :class:`bytes` objects (but not subclasses thereof) by
+releasing the GIL during the concatenation. Patch by Bénédikt Tran.

--- a/Objects/stringlib/join.h
+++ b/Objects/stringlib/join.h
@@ -18,7 +18,7 @@ STRINGLIB(bytes_join)(PyObject *sep, PyObject *iterable)
     Py_buffer *buffers = NULL;
 #define NB_STATIC_BUFFERS 10
     Py_buffer static_buffers[NB_STATIC_BUFFERS];
-#define GIL_THRESHOLD 1048576 // 0x100000
+#define GIL_THRESHOLD 1048576
     int drop_gil = 1;
     PyThreadState *save = NULL;
 

--- a/Objects/stringlib/join.h
+++ b/Objects/stringlib/join.h
@@ -81,7 +81,8 @@ STRINGLIB(bytes_join)(PyObject *sep, PyObject *iterable)
              * races anyway, but this is a conservative approach that avoids
              * changing the behaviour of that data race.
              */
-            if (!PyBytes_CheckExact(buffers[i].obj)) {
+            PyObject *bufobj = buffers[i].obj;
+            if (!bufobj || !PyBytes_CheckExact(bufobj)) {
                 drop_gil = 0;
             }
         }

--- a/Objects/stringlib/join.h
+++ b/Objects/stringlib/join.h
@@ -18,7 +18,7 @@ STRINGLIB(bytes_join)(PyObject *sep, PyObject *iterable)
     Py_buffer *buffers = NULL;
 #define NB_STATIC_BUFFERS 10
     Py_buffer static_buffers[NB_STATIC_BUFFERS];
-#define GIL_THRESHOLD 1048576
+#define GIL_THRESHOLD 1048576 // 0x100000
     int drop_gil = 1;
     PyThreadState *save = NULL;
 
@@ -81,7 +81,9 @@ STRINGLIB(bytes_join)(PyObject *sep, PyObject *iterable)
              * races anyway, but this is a conservative approach that avoids
              * changing the behaviour of that data race.
              */
-            drop_gil = 0;
+            if (!PyBytes_CheckExact(buffers[i].obj)) {
+                drop_gil = 0;
+            }
         }
         nbufs = i + 1;  /* for error cleanup */
         itemlen = buffers[i].len;


### PR DESCRIPTION


<!-- gh-issue-number: gh-148323 -->
* Issue: gh-148323
<!-- /gh-issue-number -->
