### PR TITLE
gh-148186: Improve `assertCountEqual` description in docs.

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1223,9 +1223,9 @@ Test cases
    | :meth:`assertNotRegex(s, r)           | ``not r.search(s)``            | 3.2          |
    | <TestCase.assertNotRegex>`            |                                |              |
    +---------------------------------------+--------------------------------+--------------+
-   | :meth:`assertCountEqual(a, b)         | *a* and *b* have the same      | 3.2          |
-   | <TestCase.assertCountEqual>`          | elements in the same number,   |              |
-   |                                       | regardless of their order.     |              |
+   | :meth:`assertCountEqual(a, b)         | *a* contains the same elements | 3.2          |
+   | <TestCase.assertCountEqual>`          | as *b*, regardless of their    |              |
+   |                                       | order.                         |              |
    +---------------------------------------+--------------------------------+--------------+
    | :meth:`assertStartsWith(a, b)         | ``a.startswith(b)``            | 3.14         |
    | <TestCase.assertStartsWith>`          |                                |              |


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Little changes to `assertCountEqual` description in docs due #148186 issue.


<!-- gh-issue-number: gh-148186 -->
* Issue: gh-148186
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148463.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->