### PR TITLE
gh-148474: Fix _Py_hexlify_simd compilation with older clang

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-04-12-22-54-16.gh-issue-148474.ouIO8R.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-12-22-54-16.gh-issue-148474.ouIO8R.rst
@@ -1,0 +1,1 @@
+Fixed compilation of _Py_hexlify_simd with older clang versions.

--- a/Misc/NEWS.d/next/Build/2026-04-12-22-54-16.gh-issue-148474.ouIO8R.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-12-22-54-16.gh-issue-148474.ouIO8R.rst
@@ -1,1 +1,1 @@
-Fixed compilation of _Py_hexlify_simd with older clang versions.
+Fixed compilation of :file:`Python/pystrhex.c` with older clang versions.

--- a/Python/pystrhex.c
+++ b/Python/pystrhex.c
@@ -67,8 +67,8 @@ _Py_hexlify_simd(const unsigned char *src, Py_UCS1 *dst, Py_ssize_t len)
     const v16u8 mask_0f = v16u8_splat(0x0f);
     const v16u8 ascii_0 = v16u8_splat('0');
     const v16u8 offset = v16u8_splat('a' - '0' - 10);  /* 0x27 */
-    const v16s8 nine = v16s8_splat(9);
     const v16u8 four = v16u8_splat(4);
+    const v16s8 nine = v16s8_splat(9);
 
     Py_ssize_t i = 0;
 

--- a/Python/pystrhex.c
+++ b/Python/pystrhex.c
@@ -68,6 +68,7 @@ _Py_hexlify_simd(const unsigned char *src, Py_UCS1 *dst, Py_ssize_t len)
     const v16u8 ascii_0 = v16u8_splat('0');
     const v16u8 offset = v16u8_splat('a' - '0' - 10);  /* 0x27 */
     const v16s8 nine = v16s8_splat(9);
+    const v16u8 four = v16u8_splat(4);
 
     Py_ssize_t i = 0;
 
@@ -78,7 +79,7 @@ _Py_hexlify_simd(const unsigned char *src, Py_UCS1 *dst, Py_ssize_t len)
         memcpy(&data, src + i, 16);
 
         /* Extract high and low nibbles using vector operators */
-        v16u8 hi = (data >> 4) & mask_0f;
+        v16u8 hi = (data >> four) & mask_0f;
         v16u8 lo = data & mask_0f;
 
         /* Compare > 9 using signed comparison for efficient codegen.


### PR DESCRIPTION
Apple clang prior to around Xcode 9 does not automatically generate a vector from a scalar shift operator RHS in this case. Doing it explicitly works with all versions and arguably also makes it clearer what is actually happening.


<!-- gh-issue-number: gh-148474 -->
* Issue: gh-148474
<!-- /gh-issue-number -->
