### PR TITLE
gh-148483: Use Py_GCC_ATTRIBUTE(unused) for stop_tracing label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.cover
 *.iml
 *.o
+*.o.tmp
 *.lto
 *.a
 *.so

--- a/Misc/NEWS.d/next/Build/2026-04-13-02-36-13.gh-issue-148483.gLe1h8.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-13-02-36-13.gh-issue-148483.gLe1h8.rst
@@ -1,1 +1,1 @@
-Use Py_GCC_ATTRIBUTE(unused) for stop_tracing label
+Use ``Py_GCC_ATTRIBUTE(unused)`` for stop_tracing label.

--- a/Misc/NEWS.d/next/Build/2026-04-13-02-36-13.gh-issue-148483.gLe1h8.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-13-02-36-13.gh-issue-148483.gLe1h8.rst
@@ -1,0 +1,1 @@
+Use Py_GCC_ATTRIBUTE(unused) for stop_tracing label

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -12943,6 +12943,7 @@ JUMP_TO_LABEL(error);
             DISPATCH();
         }
 
+        Py_GCC_ATTRIBUTE((unused)) 
         LABEL(stop_tracing)
         {
             #if _Py_TIER2

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -12943,7 +12943,7 @@ JUMP_TO_LABEL(error);
             DISPATCH();
         }
 
-        #if _Py_TAIL_CALL_INTERP
+        #if _Py_TAIL_CALL_INTERP && !defined(_Py_TIER2)
         Py_GCC_ATTRIBUTE((unused))
         #endif
         LABEL(stop_tracing)

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -12944,7 +12944,7 @@ JUMP_TO_LABEL(error);
         }
 
         #if _Py_TAIL_CALL_INTERP
-        Py_GCC_ATTRIBUTE((unused)) 
+        Py_GCC_ATTRIBUTE((unused))
         #endif
         LABEL(stop_tracing)
         {

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -12943,7 +12943,9 @@ JUMP_TO_LABEL(error);
             DISPATCH();
         }
 
+        #if _Py_TAIL_CALL_INTERP
         Py_GCC_ATTRIBUTE((unused)) 
+        #endif
         LABEL(stop_tracing)
         {
             #if _Py_TIER2

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -12941,7 +12941,7 @@ JUMP_TO_LABEL(error);
         }
 
         #if _Py_TAIL_CALL_INTERP
-        Py_GCC_ATTRIBUTE((unused)) 
+        Py_GCC_ATTRIBUTE((unused))
         #endif
         LABEL(stop_tracing)
         {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -12940,7 +12940,7 @@ JUMP_TO_LABEL(error);
             DISPATCH();
         }
 
-        #if _Py_TAIL_CALL_INTERP
+        #if _Py_TAIL_CALL_INTERP && !defined(_Py_TIER2)
         Py_GCC_ATTRIBUTE((unused))
         #endif
         LABEL(stop_tracing)

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -12940,7 +12940,9 @@ JUMP_TO_LABEL(error);
             DISPATCH();
         }
 
+        #if _Py_TAIL_CALL_INTERP
         Py_GCC_ATTRIBUTE((unused)) 
+        #endif
         LABEL(stop_tracing)
         {
             #if _Py_TIER2

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -12940,6 +12940,7 @@ JUMP_TO_LABEL(error);
             DISPATCH();
         }
 
+        Py_GCC_ATTRIBUTE((unused)) 
         LABEL(stop_tracing)
         {
             #if _Py_TIER2

--- a/Tools/cases_generator/tier1_generator.py
+++ b/Tools/cases_generator/tier1_generator.py
@@ -204,7 +204,9 @@ def generate_tier1_labels(
     # Emit tail-callable labels as function defintions
     for name, label in analysis.labels.items():
         if name == 'stop_tracing':
+            emitter.emit("#if _Py_TAIL_CALL_INTERP\n")
             emitter.emit("Py_GCC_ATTRIBUTE((unused)) \n")
+            emitter.emit("#endif\n")
         emitter.emit(f"LABEL({name})\n")
         storage = Storage(Stack(), [], [], 0, False)
         if label.spilled:

--- a/Tools/cases_generator/tier1_generator.py
+++ b/Tools/cases_generator/tier1_generator.py
@@ -205,7 +205,7 @@ def generate_tier1_labels(
     for name, label in analysis.labels.items():
         if name == 'stop_tracing':
             emitter.emit("#if _Py_TAIL_CALL_INTERP\n")
-            emitter.emit("Py_GCC_ATTRIBUTE((unused)) \n")
+            emitter.emit("Py_GCC_ATTRIBUTE((unused))\n")
             emitter.emit("#endif\n")
         emitter.emit(f"LABEL({name})\n")
         storage = Storage(Stack(), [], [], 0, False)

--- a/Tools/cases_generator/tier1_generator.py
+++ b/Tools/cases_generator/tier1_generator.py
@@ -204,7 +204,7 @@ def generate_tier1_labels(
     # Emit tail-callable labels as function defintions
     for name, label in analysis.labels.items():
         if name == 'stop_tracing':
-            emitter.emit("#if _Py_TAIL_CALL_INTERP\n")
+            emitter.emit("#if _Py_TAIL_CALL_INTERP && !defined(_Py_TIER2)\n")
             emitter.emit("Py_GCC_ATTRIBUTE((unused))\n")
             emitter.emit("#endif\n")
         emitter.emit(f"LABEL({name})\n")

--- a/Tools/cases_generator/tier1_generator.py
+++ b/Tools/cases_generator/tier1_generator.py
@@ -203,6 +203,8 @@ def generate_tier1_labels(
     emitter.emit("\n")
     # Emit tail-callable labels as function defintions
     for name, label in analysis.labels.items():
+        if name == 'stop_tracing':
+            emitter.emit("Py_GCC_ATTRIBUTE((unused)) \n")
         emitter.emit(f"LABEL({name})\n")
         storage = Storage(Stack(), [], [], 0, False)
         if label.spilled:


### PR DESCRIPTION
To silence the following warnings:

* `Python/generated_cases.c.h:12943:9: warning: unused function '_TAIL_CALL_stop_tracing' [-Wunused-function]` and 
* `./Modules/_testinternalcapi/test_cases.c.h:12946:9: warning: unused function '_TAIL_CALL_stop_tracing' [-Wunused-function]`


<!-- gh-issue-number: gh-148483 -->
* Issue: gh-148483
<!-- /gh-issue-number -->
