### PR TITLE
Minor improvement to statistics.pdf()

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -145,6 +145,7 @@ from operator import itemgetter
 from collections import Counter, namedtuple, defaultdict
 
 _SQRT2 = sqrt(2.0)
+_SQRT2PI = sqrt(tau)
 _random = random
 
 ## Exceptions ##############################################################
@@ -1257,11 +1258,11 @@ class NormalDist:
 
     def pdf(self, x):
         "Probability density function.  P(x <= X < x+dx) / dx"
-        variance = self._sigma * self._sigma
-        if not variance:
+        sigma = self._sigma
+        if not sigma:
             raise StatisticsError('pdf() not defined when sigma is zero')
-        diff = x - self._mu
-        return exp(diff * diff / (-2.0 * variance)) / sqrt(tau * variance)
+        z = (x - self._mu) / sigma
+        return exp(-0.5 * z * z) / (_SQRT2PI * sigma)
 
     def cdf(self, x):
         "Cumulative distribution function.  P(X <= x)"


### PR DESCRIPTION
The current code squares `sigma` and then takes the square root of the result. The unnecessary round-trip increases overflow/underflow risks, costs a little time, and loses a tiny bit of numerical accuracy.

Avoid the round trip by normalizing the data first.

```
% python3.15 -m timeit -s 'from statistics import NormalDist as ND' -s 'iq=ND(100,15)' 'iq.pdf(121.1)'
2000000 loops, best of 5: 121 nsec per loop

% python3.15 -m timeit -s 'from statistics import NormalDist as ND' -s 'iq=ND(100,15)' 'iq.pdf2(121.1)'
5000000 loops, best of 5: 99.5 nsec per loop
```

This also makes the error message slightly more accurate. Formerly, a subnormal sigma could underflow the variance to zero and the message would report that sigma itself was zero.