### PR TITLE
Fix "encodings" typo in argparse.FileType documentation

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1970,7 +1970,7 @@ FileType objects
       run and then use the :keyword:`with`-statement to manage the files.
 
    .. versionchanged:: 3.4
-      Added the *encodings* and *errors* parameters.
+      Added the *encoding* and *errors* parameters.
 
    .. deprecated:: 3.14
 


### PR DESCRIPTION
Fix a typo in argparse.FileType documentation.

The parameter name is `encoding`, not `encodings`, to match the actual API.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148502.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->