### PR TITLE
[3.11] gh-148395: Fix a possible UAF in `{LZMA,BZ2}Decompressor` (GH-148396)

### DIFF
--- a/Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst
+++ b/Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst
@@ -1,0 +1,5 @@
+Fix a dangling input pointer in :class:`lzma.LZMADecompressor`,
+:class:`bz2.BZ2Decompressor`, and internal :class:`!zlib._ZlibDecompressor`
+when memory allocation fails with :exc:`MemoryError`, which could let a
+subsequent :meth:`!decompress` call read or write through a stale pointer to
+the already-released caller buffer.

--- a/Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst
+++ b/Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst
@@ -1,5 +1,5 @@
 Fix a dangling input pointer in :class:`lzma.LZMADecompressor`,
-:class:`bz2.BZ2Decompressor`, and internal :class:`!zlib._ZlibDecompressor`
+and :class:`bz2.BZ2Decompressor`
 when memory allocation fails with :exc:`MemoryError`, which could let a
 subsequent :meth:`!decompress` call read or write through a stale pointer to
 the already-released caller buffer.

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -595,6 +595,7 @@ decompress(BZ2Decompressor *d, char *data, size_t len, Py_ssize_t max_length)
     return result;
 
 error:
+    bzs->next_in = NULL;
     Py_XDECREF(result);
     return NULL;
 }

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -1105,6 +1105,7 @@ decompress(Decompressor *d, uint8_t *data, size_t len, Py_ssize_t max_length)
     return result;
 
 error:
+    lzs->next_in = NULL;
     Py_XDECREF(result);
     return NULL;
 }


### PR DESCRIPTION
Fix dangling input pointer after `MemoryError` in `{_lzma,_bz2}Decompressor.decompress()`
(cherry picked from commit 8fc66aef6d7b3ae58f43f5c66f9366cc8cbbfcd2)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148395 -->
* Issue: gh-148395
<!-- /gh-issue-number -->
