### PR TITLE
gh-143955: Prevent schema drift false-positives in asyncio tools tests

### DIFF
--- a/Lib/test/test_asyncio/test_tools.py
+++ b/Lib/test/test_asyncio/test_tools.py
@@ -2,13 +2,27 @@ import unittest
 
 from asyncio import tools
 
-from collections import namedtuple
+import _remote_debugging
 
-LocationInfo = namedtuple('LocationInfo', ['lineno', 'end_lineno', 'col_offset', 'end_col_offset'], defaults=[None]*4)
-FrameInfo = namedtuple('FrameInfo', ['funcname', 'filename', 'location'])
-CoroInfo = namedtuple('CoroInfo', ['call_stack', 'task_name'])
-TaskInfo = namedtuple('TaskInfo', ['task_id', 'task_name', 'coroutine_stack', 'awaited_by'])
-AwaitedInfo = namedtuple('AwaitedInfo', ['thread_id', 'awaited_by'])
+
+def LocationInfo(lineno, end_lineno=None, col_offset=None, end_col_offset=None):
+    return _remote_debugging.LocationInfo((lineno, end_lineno, col_offset, end_col_offset))
+
+
+def FrameInfo(funcname, filename, location, opcode=None):
+    return _remote_debugging.FrameInfo((filename, location, funcname, opcode))
+
+
+def CoroInfo(call_stack, task_name):
+    return _remote_debugging.CoroInfo((call_stack, task_name))
+
+
+def TaskInfo(task_id, task_name, coroutine_stack, awaited_by):
+    return _remote_debugging.TaskInfo((task_id, task_name, coroutine_stack, awaited_by))
+
+
+def AwaitedInfo(thread_id, awaited_by):
+    return _remote_debugging.AwaitedInfo((thread_id, awaited_by))
 
 
 # mock output of get_all_awaited_by function.


### PR DESCRIPTION
Replace namedtuple reimplementations with factory helpers that wrap the real _remote_debugging structseq types. This prevents silent drift between test stubs and production structs, as previously occurred in gh-142394 (see gh-143952).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143955 -->
* Issue: gh-143955
<!-- /gh-issue-number -->
