### PR TITLE
gh-148508: Add resilience to SSL preauth tests on iOS

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5566,15 +5566,20 @@ class TestPreHandshakeClose(unittest.TestCase):
             return  # Expect the full test setup to always work on Linux.
         if (isinstance(err, ConnectionResetError) or
             (isinstance(err, OSError) and err.errno == errno.EINVAL) or
-            re.search('wrong.version.number', str(getattr(err, "reason", "")), re.I)):
+            re.search('wrong.version.number', str(getattr(err, "reason", "")), re.I) or
+            re.search('record.layer.failure', str(getattr(err, "reason", "")), re.I)
+        ):
             # On Windows the TCP RST leads to a ConnectionResetError
             # (ECONNRESET) which Linux doesn't appear to surface to userspace.
             # If wrap_socket() winds up on the "if connected:" path and doing
-            # the actual wrapping... we get an SSLError from OpenSSL. Typically
-            # WRONG_VERSION_NUMBER. While appropriate, neither is the scenario
-            # we're specifically trying to test. The way this test is written
-            # is known to work on Linux. We'll skip it anywhere else that it
-            # does not present as doing so.
+            # the actual wrapping... we get an SSLError from OpenSSL. This is
+            # typically WRONG_VERSION_NUMBER. The same happens on iOS, but
+            # RECORD_LAYER_FAILURE is the error.
+            #
+            # While appropriate, neither is the scenario we're specifically
+            # trying to test. The way this test is written is known to work on
+            # Linux. We'll skip it anywhere else that it does not present as
+            # doing so.
             try:
                 self.skipTest(f"Could not recreate conditions on {sys.platform}:"
                               f" {err=}")

--- a/Misc/NEWS.d/next/Library/2026-04-14-09-04-35.gh-issue-148508.-GiXml.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-14-09-04-35.gh-issue-148508.-GiXml.rst
@@ -1,0 +1,2 @@
+An intermittent timing error when running SSL tests on iOS has been
+resolved.


### PR DESCRIPTION
The `test_ssl.TestPreHandshakeClose.test_preauth_data_to_tls_server` test fails intermittently on the iOS buildbot because an SSL error doesn't raise the expected TLS handshake error. 

This test already has an escape clause that allows a skip under certain error conditions (raising a ConnectionError, an OSError, or an SSL error with "wrong version number"). Running locally, I reliably hit the OSError handling case; the buildbot also hits the OSError case *most* of the time, but sometimes it raises SSLError with "[SSL: RECORD_LAYER_FAILURE] record layer failure". 

This adds a check for "record layer failure" as an additional failure mode that will be accepted.
 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148508 -->
* Issue: gh-148508
<!-- /gh-issue-number -->
