### PR TITLE
Fix comma and make explanation better for readability

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -201,8 +201,8 @@ Running and stopping the loop
 
    The *timeout* parameter specifies the amount of time
    (in :class:`float` seconds) the executor will be given to finish joining.
-   With the default, ``None``,
-   the executor is allowed an unlimited amount of time.
+   With the default ``None``,
+   the executor is allowed unlimited time.
 
    If the *timeout* is reached, a :exc:`RuntimeWarning` is emitted
    and the default executor is terminated


### PR DESCRIPTION
The documentation for loop.shutdown_default_executor(timeout=None) method was a little off in terms of readability:
```
With the default, ``None``,
the executor is allowed an unlimited amount of time.
```

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148538.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->