### PR TITLE
gh-148047: Revert "GH-148047: Check early whether tail-calling is possible for MSVC builds on Windows (#148036)"

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-04-03-20-09-46.gh-issue-148047.HE6iGK.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-03-20-09-46.gh-issue-148047.HE6iGK.rst
@@ -1,2 +1,0 @@
-Fail fast with an explicit and clear error message if tail-calling is not
-possible for MSVC builds on Windows. Patch by Chris Eibl.

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -749,13 +749,4 @@
   <Target Name="_DeletePyBuildDirTxt" BeforeTargets="PrepareForBuild">
     <Delete Files="$(OutDir)pybuilddir.txt" />
   </Target>
-
-  <Target Name="_CheckTailCalling" BeforeTargets="PrepareForBuild" Condition="'$(UseTailCallInterp)' == 'true' and $(PlatformToolset) != 'ClangCL'">
-    <Error Text="MSVC supports tail-calling only for x64."
-           Condition="$(Platform) != 'x64'" />
-    <Error Text="Platform toolset >= v145 is required for tail-calling."
-           Condition="$(PlatformToolset.Replace('v', '0')) &lt; '145'" />
-    <Error Text="MSVC requires optimization to be enabled for tail-calling."
-           Condition="$(Configuration) == 'Debug'" />
-  </Target>
 </Project>


### PR DESCRIPTION


<!-- gh-issue-number: gh-148047 -->
* Issue: gh-148047
<!-- /gh-issue-number -->
