### PR TITLE
docs: fix multiple 'exampele' typos in email parser tests

### DIFF
--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2285,11 +2285,11 @@ class TestParser(TestParserMixin, TestEmailBase):
     def test_get_group_mixed_list(self):
         group = self._test_get_x(parser.get_group,
             ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
-                '(foo) Roger <ping@exampele.com>, x@test.example.com;'),
+                '(foo) Roger <ping@example.com>, x@test.example.com;'),
             ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
-                '(foo) Roger <ping@exampele.com>, x@test.example.com;'),
+                '(foo) Roger <ping@example.com>, x@test.example.com;'),
             ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
-                ' Roger <ping@exampele.com>, x@test.example.com;'),
+                ' Roger <ping@example.com>, x@test.example.com;'),
             [],
             '')
         self.assertEqual(group.token_type, 'group')
@@ -2306,11 +2306,11 @@ class TestParser(TestParserMixin, TestEmailBase):
     def test_get_group_one_invalid(self):
         group = self._test_get_x(parser.get_group,
             ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
-                '(foo) Roger ping@exampele.com, x@test.example.com;'),
+                '(foo) Roger ping@example.com, x@test.example.com;'),
             ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
-                '(foo) Roger ping@exampele.com, x@test.example.com;'),
+                '(foo) Roger ping@example.com, x@test.example.com;'),
             ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
-                ' Roger ping@exampele.com, x@test.example.com;'),
+                ' Roger ping@example.com, x@test.example.com;'),
             [errors.InvalidHeaderDefect,   # non-angle addr makes local part invalid
              errors.InvalidHeaderDefect],   # and its not obs-local either: no dots.
             '')


### PR DESCRIPTION
Fixed multiple occurrences in `test_email` where `example.com` was misspelled as `exampele.com`.

This is a trivial typo fix in the test suite to ensure consistency across email parser test cases. No issue number is required for this change.