### PR TITLE
[3.13] gh-72406: Document argument ordering in argparse help output (GH-148534)

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1888,6 +1888,9 @@ Argument groups
    Note that any arguments not in your user-defined groups will end up back
    in the usual "positional arguments" and "optional arguments" sections.
 
+   Within each argument group, arguments are displayed in help output in the
+   order in which they are added.
+
    .. versionchanged:: 3.11
     Calling :meth:`add_argument_group` on an argument group is deprecated.
     This feature was never supported and does not always work correctly.


### PR DESCRIPTION
(cherry picked from commit 4286227308ee8dafc867062df4cad73af2a84696)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148567.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->