### PR TITLE
gh-121946: Use clang-20 for TSan build

### DIFF
--- a/.github/workflows/reusable-san.yml
+++ b/.github/workflows/reusable-san.yml
@@ -40,17 +40,15 @@ jobs:
         # Install clang
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
+        sudo ./llvm.sh 20
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100
+        sudo update-alternatives --set clang /usr/bin/clang-20
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 100
+        sudo update-alternatives --set clang++ /usr/bin/clang++-20
 
         if [ "${SANITIZER}" = "TSan" ]; then
-          sudo ./llvm.sh 17  # gh-121946: llvm-18 package is temporarily broken
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 100
-          sudo update-alternatives --set clang /usr/bin/clang-17
-          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 100
-          sudo update-alternatives --set clang++ /usr/bin/clang++-17
           # Reduce ASLR to avoid TSan crashing
           sudo sysctl -w vm.mmap_rnd_bits=28
-        else
-          sudo ./llvm.sh 20
         fi
 
     - name: Sanitizer option setup


### PR DESCRIPTION
Almost 2 years ago, we switched to clang-17 because of broken apt packaging. That's been fixed for a while now. I think we can use clang-20 for all our sanitizer tests.

<!-- gh-issue-number: gh-121946 -->
* Issue: gh-121946
<!-- /gh-issue-number -->
