### PR TITLE
gh-148575: Use the right entry to read the set of file descriptors on CYGWIN

### DIFF
--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -63,7 +63,7 @@
 # endif
 #endif
 
-#if defined(__FreeBSD__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__DragonFly__)
+#if defined(__CYGWIN__) || defined(__FreeBSD__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__DragonFly__)
 # define FD_DIR "/dev/fd"
 #else
 # define FD_DIR "/proc/self/fd"


### PR DESCRIPTION
This patch fixes issue #148575.


<!-- gh-issue-number: gh-148575 -->
* Issue: gh-148575
<!-- /gh-issue-number -->
