### PR TITLE
gh-137335: remove a mktemp use in multiprocessing.connection to avoid security scanner noise

### DIFF
--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -16,7 +16,6 @@ import os
 import sys
 import socket
 import struct
-import tempfile
 import time
 
 
@@ -77,7 +76,11 @@ def arbitrary_address(family):
     if family == 'AF_INET':
         return ('localhost', 0)
     elif family == 'AF_UNIX':
-        return tempfile.mktemp(prefix='sock-', dir=util.get_temp_dir())
+        # NOTE: util.get_temp_dir() is a 0o700 per-process directory. A
+        # mktemp-style ToC vs ToU concern is not important; bind() surfaces
+        # the extremely unlikely collision as EADDRINUSE.
+        return os.path.join(util.get_temp_dir(),
+                            f'sock-{os.urandom(6).hex()}')
     elif family == 'AF_PIPE':
         return (r'\\.\pipe\pyc-%d-%d-%s' %
                 (os.getpid(), next(_mmap_counter), os.urandom(8).hex()))


### PR DESCRIPTION
This is not a security issue given it is a random filename in a mode 0o700 mkdtemp directory, but naive automated scanners that don't do code analysis flag it regardless.  (https://github.com/python/cpython/security/code-scanning/190)

Followon to #137389 which fixed a bunch of others.

<!-- gh-issue-number: gh-137335 -->
* Issue: gh-137335
<!-- /gh-issue-number -->
