### PR TITLE
gh-148588: Document `__lazy_modules__`

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1124,9 +1124,9 @@ the following writable attributes:
 
 .. attribute:: module.__lazy_modules__
 
-   An :term:`iterable` of fully qualified module name strings.  When defined
+   A container of fully qualified module name strings.  When defined
    at module scope, any regular :keyword:`import` statement in that module whose
-   target module name appears in this iterable is treated as a
+   target module name appears in this container is treated as a
    :ref:`lazy import <lazy-imports>`, as if the :keyword:`lazy` keyword had
    been used.  Imports inside functions, class bodies, or
    :keyword:`try`/:keyword:`except`/:keyword:`finally` blocks are unaffected.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -926,6 +926,7 @@ Attribute assignment updates the module's namespace dictionary, e.g.,
    single: __doc__ (module attribute)
    single: __annotations__ (module attribute)
    single: __annotate__ (module attribute)
+   single: __lazy_modules__ (module attribute)
    pair: module; namespace
 
 .. _import-mod-attrs:
@@ -1120,6 +1121,19 @@ the following writable attributes:
    no annotations. See also: :attr:`~object.__annotate__` attributes.
 
    .. versionadded:: 3.14
+
+.. attribute:: module.__lazy_modules__
+
+   An optional sequence of absolute module name strings.  When defined at
+   module scope, any regular :keyword:`import` statement in that module whose
+   target module name appears in this sequence is treated as a
+   :ref:`lazy import <lazy-imports>`, as if the :keyword:`lazy` keyword had
+   been used.  Imports inside functions, class bodies, or
+   :keyword:`try`/:keyword:`except`/:keyword:`finally` blocks are unaffected.
+
+   See :ref:`lazy-modules-compat` for details and examples.
+
+   .. versionadded:: 3.15
 
 Module dictionaries
 ^^^^^^^^^^^^^^^^^^^

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1124,7 +1124,7 @@ the following writable attributes:
 
 .. attribute:: module.__lazy_modules__
 
-   An optional :term:`iterable` of fully qualified module name strings.  When defined
+   An :term:`iterable` of fully qualified module name strings.  When defined
    at module scope, any regular :keyword:`import` statement in that module whose
    target module name appears in this iterable is treated as a
    :ref:`lazy import <lazy-imports>`, as if the :keyword:`lazy` keyword had

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1124,7 +1124,8 @@ the following writable attributes:
 
 .. attribute:: module.__lazy_modules__
 
-   A container of fully qualified module name strings.  When defined
+   A container (an object implementing :meth:`~object.__contains__`) of fully
+   qualified module name strings.  When defined
    at module scope, any regular :keyword:`import` statement in that module whose
    target module name appears in this container is treated as a
    :ref:`lazy import <lazy-imports>`, as if the :keyword:`lazy` keyword had

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1124,9 +1124,9 @@ the following writable attributes:
 
 .. attribute:: module.__lazy_modules__
 
-   An optional sequence of absolute module name strings.  When defined at
-   module scope, any regular :keyword:`import` statement in that module whose
-   target module name appears in this sequence is treated as a
+   An optional :term:`iterable` of absolute module name strings.  When defined
+   at module scope, any regular :keyword:`import` statement in that module whose
+   target module name appears in this iterable is treated as a
    :ref:`lazy import <lazy-imports>`, as if the :keyword:`lazy` keyword had
    been used.  Imports inside functions, class bodies, or
    :keyword:`try`/:keyword:`except`/:keyword:`finally` blocks are unaffected.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1124,7 +1124,7 @@ the following writable attributes:
 
 .. attribute:: module.__lazy_modules__
 
-   An optional :term:`iterable` of absolute module name strings.  When defined
+   An optional :term:`iterable` of fully qualified module name strings.  When defined
    at module scope, any regular :keyword:`import` statement in that module whose
    target module name appears in this iterable is treated as a
    :ref:`lazy import <lazy-imports>`, as if the :keyword:`lazy` keyword had

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -948,9 +948,7 @@ Python versions older than 3.15 while using lazy imports in 3.15+::
    import pathlib  # loaded lazily
 
 Relative imports are resolved to their absolute name before the lookup, so
-the sequence must always contain fully qualified module names.  For
-``from``-style imports, the name to list is the module being imported
-*from* (the base module, left of the ``import`` keyword), not the names
+:attr:`!__lazy_modules__` must always contain fully qualified module names.  For
 imported from it::
 
    # In mypackage/mymodule.py

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -948,7 +948,9 @@ Python versions older than 3.15 while using lazy imports in 3.15+::
    import pathlib  # loaded lazily
 
 Relative imports are resolved to their absolute name before the lookup, so
-:attr:`!__lazy_modules__` must always contain fully qualified module names.  For
+:attr:`!__lazy_modules__` must always contain fully qualified module names.
+For ``from``-style imports, the name to list is the module being imported
+*from* (the base module, left of the ``import`` keyword), not the names
 imported from it::
 
    # In mypackage/mymodule.py

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -922,8 +922,8 @@ See :pep:`810` for the full specification of lazy imports.
 
 .. _lazy-modules-compat:
 
-Compatibility mode via ``__lazy_modules__``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Compatibility via ``__lazy_modules__``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. index::
    single: __lazy_modules__
@@ -938,7 +938,7 @@ container of fully qualified module name strings.  Any regular (non-``lazy``)
 
 This provides a way to enable lazy loading for specific dependencies without
 changing individual ``import`` statements. This is useful when supporting
-Python versions older than 3.15 while leveraging lazy imports on 3.15+::
+Python versions older than 3.15 while using lazy imports in 3.15+::
 
    __lazy_modules__ = ["json", "pathlib"]
 

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -948,13 +948,17 @@ Python versions older than 3.15 while leveraging lazy imports on 3.15+::
    import pathlib  # loaded lazily
 
 Relative imports are resolved to their absolute name before the lookup, so
-the sequence must always contain fully qualified module names::
+the sequence must always contain fully qualified module names.  For
+``from``-style imports, the name to list is the module being imported
+*from* (the base module, left of the ``import`` keyword), not the names
+imported from it::
 
    # In mypackage/mymodule.py
-   __lazy_modules__ = ["mypackage"]
+   __lazy_modules__ = ["mypackage", "mypackage.sub.utils"]
 
-   from . import utils  # loaded lazily: resolves to mypackage
-   import json          # loaded eagerly (not in __lazy_modules__)
+   from . import helper         # loaded lazily: . resolves to mypackage
+   from .sub.utils import func  # loaded lazily: .sub.utils resolves to mypackage.sub.utils
+   import json                  # loaded eagerly (not in __lazy_modules__)
 
 Imports inside functions, class bodies, or
 :keyword:`try`/:keyword:`except`/:keyword:`finally` blocks are always eager,

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -931,7 +931,7 @@ Compatibility mode via ``__lazy_modules__``
 As an alternative to using the :keyword:`lazy` keyword, a module can opt
 into lazy loading for specific imports by defining a module-level
 :attr:`~module.__lazy_modules__` variable.  When present, it must be an
-:term:`iterable` of absolute module name strings.  Any regular (non-``lazy``)
+:term:`iterable` of fully qualified module name strings.  Any regular (non-``lazy``)
 :keyword:`import` statement at module scope whose target appears in
 :attr:`!__lazy_modules__` is treated as a lazy import, exactly as if the
 :keyword:`lazy` keyword had been used.
@@ -948,7 +948,7 @@ Python versions older than 3.15 while leveraging lazy imports on 3.15+::
    import pathlib  # loaded lazily
 
 Relative imports are resolved to their absolute name before the lookup, so
-the sequence must always contain absolute module names.
+the sequence must always contain fully qualified module names.
 
 Imports inside functions, class bodies, or
 :keyword:`try`/:keyword:`except`/:keyword:`finally` blocks are always eager,

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -920,6 +920,46 @@ See :pep:`810` for the full specification of lazy imports.
 
 .. versionadded:: 3.15
 
+.. _lazy-modules-compat:
+
+Compatibility mode via ``__lazy_modules__``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index::
+   single: __lazy_modules__
+
+As an alternative to using the :keyword:`lazy` keyword, a module can opt
+into lazy loading for specific imports by defining a module-level
+:attr:`~module.__lazy_modules__` variable.  When present, it must be a
+sequence of absolute module name strings.  Any regular (non-``lazy``)
+:keyword:`import` statement at module scope whose target appears in
+:attr:`!__lazy_modules__` is treated as a lazy import, exactly as if the
+:keyword:`lazy` keyword had been used.
+
+This provides a way to enable lazy loading for specific dependencies without
+changing individual ``import`` statements — useful when migrating existing
+code or when the imports are generated programmatically::
+
+   __lazy_modules__ = ["json", "pathlib"]
+
+   import json     # loaded lazily (name is in __lazy_modules__)
+   import os       # loaded eagerly (name not in __lazy_modules__)
+
+   import pathlib  # loaded lazily
+
+Relative imports are resolved to their absolute name before the lookup, so
+the sequence must always contain absolute module names.
+
+Imports inside functions, class bodies, or
+:keyword:`try`/:keyword:`except`/:keyword:`finally` blocks are always eager,
+regardless of :attr:`!__lazy_modules__`.
+
+Setting ``-X lazy_imports=none`` (or the :envvar:`PYTHON_LAZY_IMPORTS`
+environment variable to ``none``) overrides :attr:`!__lazy_modules__` and
+forces all imports to be eager.
+
+.. versionadded:: 3.15
+
 .. _future:
 
 Future statements

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -938,8 +938,7 @@ sequence of absolute module name strings.  Any regular (non-``lazy``)
 
 This provides a way to enable lazy loading for specific dependencies without
 changing individual ``import`` statements. This is useful when supporting
-Python versions older than 3.15 while leveraging lazy imports on 3.15+, or
-when the imports are generated programmatically::
+Python versions older than 3.15 while leveraging lazy imports on 3.15+::
 
    __lazy_modules__ = ["json", "pathlib"]
 

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -931,7 +931,8 @@ Compatibility mode via ``__lazy_modules__``
 As an alternative to using the :keyword:`lazy` keyword, a module can opt
 into lazy loading for specific imports by defining a module-level
 :attr:`~module.__lazy_modules__` variable.  When present, it must be a
-container of fully qualified module name strings.  Any regular (non-``lazy``)
+container (an object implementing :meth:`~object.__contains__`) of fully
+qualified module name strings.  Any regular (non-``lazy``)
 :keyword:`import` statement at module scope whose target appears in
 :attr:`!__lazy_modules__` is treated as a lazy import, exactly as if the
 :keyword:`lazy` keyword had been used.

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -931,8 +931,7 @@ Compatibility mode via ``__lazy_modules__``
 As an alternative to using the :keyword:`lazy` keyword, a module can opt
 into lazy loading for specific imports by defining a module-level
 :attr:`~module.__lazy_modules__` variable.  When present, it must be a
-container (an object implementing :meth:`~object.__contains__`) of fully
-qualified module name strings.  Any regular (non-``lazy``)
+container of fully qualified module name strings.  Any regular (non-``lazy``)
 :keyword:`import` statement at module scope whose target appears in
 :attr:`!__lazy_modules__` is treated as a lazy import, exactly as if the
 :keyword:`lazy` keyword had been used.

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -937,9 +937,9 @@ sequence of absolute module name strings.  Any regular (non-``lazy``)
 :keyword:`lazy` keyword had been used.
 
 This provides a way to enable lazy loading for specific dependencies without
-changing individual ``import`` statements — useful when supporting Python
-versions older than 3.15 while leveraging lazy imports on 3.15+, or when
-the imports are generated programmatically::
+changing individual ``import`` statements. This is useful when supporting
+Python versions older than 3.15 while leveraging lazy imports on 3.15+, or
+when the imports are generated programmatically::
 
    __lazy_modules__ = ["json", "pathlib"]
 

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -949,9 +949,9 @@ Python versions older than 3.15 while using lazy imports in 3.15+::
 
 Relative imports are resolved to their absolute name before the lookup, so
 :attr:`!__lazy_modules__` must always contain fully qualified module names.
-For ``from``-style imports, the name to list is the module being imported
-*from* (the base module, left of the ``import`` keyword), not the names
-imported from it::
+
+For ``from``-style imports, the relevant name is the module following
+``from``, not the names of its members::
 
    # In mypackage/mymodule.py
    __lazy_modules__ = ["mypackage", "mypackage.sub.utils"]

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -948,7 +948,13 @@ Python versions older than 3.15 while leveraging lazy imports on 3.15+::
    import pathlib  # loaded lazily
 
 Relative imports are resolved to their absolute name before the lookup, so
-the sequence must always contain fully qualified module names.
+the sequence must always contain fully qualified module names::
+
+   # In mypackage/mymodule.py
+   __lazy_modules__ = ["mypackage"]
+
+   from . import utils  # loaded lazily: resolves to mypackage
+   import json          # loaded eagerly (not in __lazy_modules__)
 
 Imports inside functions, class bodies, or
 :keyword:`try`/:keyword:`except`/:keyword:`finally` blocks are always eager,

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -937,8 +937,9 @@ sequence of absolute module name strings.  Any regular (non-``lazy``)
 :keyword:`lazy` keyword had been used.
 
 This provides a way to enable lazy loading for specific dependencies without
-changing individual ``import`` statements — useful when migrating existing
-code or when the imports are generated programmatically::
+changing individual ``import`` statements — useful when supporting Python
+versions older than 3.15 while leveraging lazy imports on 3.15+, or when
+the imports are generated programmatically::
 
    __lazy_modules__ = ["json", "pathlib"]
 

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -930,8 +930,8 @@ Compatibility mode via ``__lazy_modules__``
 
 As an alternative to using the :keyword:`lazy` keyword, a module can opt
 into lazy loading for specific imports by defining a module-level
-:attr:`~module.__lazy_modules__` variable.  When present, it must be a
-sequence of absolute module name strings.  Any regular (non-``lazy``)
+:attr:`~module.__lazy_modules__` variable.  When present, it must be an
+:term:`iterable` of absolute module name strings.  Any regular (non-``lazy``)
 :keyword:`import` statement at module scope whose target appears in
 :attr:`!__lazy_modules__` is treated as a lazy import, exactly as if the
 :keyword:`lazy` keyword had been used.

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -930,8 +930,8 @@ Compatibility mode via ``__lazy_modules__``
 
 As an alternative to using the :keyword:`lazy` keyword, a module can opt
 into lazy loading for specific imports by defining a module-level
-:attr:`~module.__lazy_modules__` variable.  When present, it must be an
-:term:`iterable` of fully qualified module name strings.  Any regular (non-``lazy``)
+:attr:`~module.__lazy_modules__` variable.  When present, it must be a
+container of fully qualified module name strings.  Any regular (non-``lazy``)
 :keyword:`import` statement at module scope whose target appears in
 :attr:`!__lazy_modules__` is treated as a lazy import, exactly as if the
 :keyword:`lazy` keyword had been used.

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -182,6 +182,17 @@ function, class body, or ``try``/``except``/``finally`` block raises a
 (``lazy from module import *`` and ``lazy from __future__ import ...`` both
 raise :exc:`SyntaxError`).
 
+For code that cannot use the ``lazy`` keyword directly — for example, when
+migrating a large existing codebase — a module can define
+:attr:`~module.__lazy_modules__` as a sequence of absolute module name
+strings.  Regular ``import`` statements for those modules are then treated
+as lazy, with the same semantics as the ``lazy`` keyword::
+
+   __lazy_modules__ = ["json", "pathlib"]
+
+   import json     # lazy
+   import os       # still eager
+
 .. seealso:: :pep:`810` for the full specification and rationale.
 
 (Contributed by Pablo Galindo Salgado and Dino Viehland in :gh:`142349`.)

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -185,8 +185,8 @@ raise :exc:`SyntaxError`).
 For code that cannot use the ``lazy`` keyword directly (for example, when
 supporting Python versions older than 3.15 while still leveraging lazy
 imports on 3.15+), a module can define
-:attr:`~module.__lazy_modules__` as an :term:`iterable` of fully qualified module
-name strings.  Regular ``import`` statements for those modules are then treated
+:attr:`~module.__lazy_modules__` as a container (an object implementing
+:meth:`~object.__contains__`) of fully qualified module name strings.  Regular ``import`` statements for those modules are then treated
 as lazy, with the same semantics as the ``lazy`` keyword::
 
    __lazy_modules__ = ["json", "pathlib"]

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -185,7 +185,7 @@ raise :exc:`SyntaxError`).
 For code that cannot use the ``lazy`` keyword directly (for example, when
 supporting Python versions older than 3.15 while still leveraging lazy
 imports on 3.15+), a module can define
-:attr:`~module.__lazy_modules__` as an :term:`iterable` of absolute module
+:attr:`~module.__lazy_modules__` as an :term:`iterable` of fully qualified module
 name strings.  Regular ``import`` statements for those modules are then treated
 as lazy, with the same semantics as the ``lazy`` keyword::
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -185,8 +185,8 @@ raise :exc:`SyntaxError`).
 For code that cannot use the ``lazy`` keyword directly (for example, when
 supporting Python versions older than 3.15 while still leveraging lazy
 imports on 3.15+), a module can define
-:attr:`~module.__lazy_modules__` as a sequence of absolute module name
-strings.  Regular ``import`` statements for those modules are then treated
+:attr:`~module.__lazy_modules__` as an :term:`iterable` of absolute module
+name strings.  Regular ``import`` statements for those modules are then treated
 as lazy, with the same semantics as the ``lazy`` keyword::
 
    __lazy_modules__ = ["json", "pathlib"]

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -185,8 +185,8 @@ raise :exc:`SyntaxError`).
 For code that cannot use the ``lazy`` keyword directly (for example, when
 supporting Python versions older than 3.15 while still leveraging lazy
 imports on 3.15+), a module can define
-:attr:`~module.__lazy_modules__` as a container (an object implementing
-:meth:`~object.__contains__`) of fully qualified module name strings.  Regular ``import`` statements for those modules are then treated
+:attr:`~module.__lazy_modules__` as a container of fully qualified module
+name strings.  Regular ``import`` statements for those modules are then treated
 as lazy, with the same semantics as the ``lazy`` keyword::
 
    __lazy_modules__ = ["json", "pathlib"]

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -182,9 +182,9 @@ function, class body, or ``try``/``except``/``finally`` block raises a
 (``lazy from module import *`` and ``lazy from __future__ import ...`` both
 raise :exc:`SyntaxError`).
 
-For code that cannot use the ``lazy`` keyword directly — for example, when
+For code that cannot use the ``lazy`` keyword directly (for example, when
 supporting Python versions older than 3.15 while still leveraging lazy
-imports on 3.15+ — a module can define
+imports on 3.15+), a module can define
 :attr:`~module.__lazy_modules__` as a sequence of absolute module name
 strings.  Regular ``import`` statements for those modules are then treated
 as lazy, with the same semantics as the ``lazy`` keyword::

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -183,7 +183,7 @@ function, class body, or ``try``/``except``/``finally`` block raises a
 raise :exc:`SyntaxError`).
 
 For code that cannot use the ``lazy`` keyword directly (for example, when
-supporting Python versions older than 3.15 while still leveraging lazy
+supporting Python versions older than 3.15 while still using lazy
 imports on 3.15+), a module can define
 :attr:`~module.__lazy_modules__` as a container of fully qualified module
 name strings.  Regular ``import`` statements for those modules are then treated

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -183,7 +183,8 @@ function, class body, or ``try``/``except``/``finally`` block raises a
 raise :exc:`SyntaxError`).
 
 For code that cannot use the ``lazy`` keyword directly — for example, when
-migrating a large existing codebase — a module can define
+supporting Python versions older than 3.15 while still leveraging lazy
+imports on 3.15+ — a module can define
 :attr:`~module.__lazy_modules__` as a sequence of absolute module name
 strings.  Regular ``import`` statements for those modules are then treated
 as lazy, with the same semantics as the ``lazy`` keyword::

--- a/Misc/NEWS.d/3.15.0a8.rst
+++ b/Misc/NEWS.d/3.15.0a8.rst
@@ -185,8 +185,8 @@ dealing with contradictions in ``make_bottom``.
 .. nonce: 6wDI6S
 .. section: Core and Builtins
 
-Ensure ``-X lazy_imports=none``` and ``PYTHON_LAZY_IMPORTS=none``` override
-:attr:`module.__lazy_modules__`. Patch by Hugo van Kemenade.
+Ensure ``-X lazy_imports=none`` and ``PYTHON_LAZY_IMPORTS=none`` override
+:attr:`~module.__lazy_modules__`. Patch by Hugo van Kemenade.
 
 ..
 

--- a/Misc/NEWS.d/3.15.0a8.rst
+++ b/Misc/NEWS.d/3.15.0a8.rst
@@ -186,7 +186,7 @@ dealing with contradictions in ``make_bottom``.
 .. section: Core and Builtins
 
 Ensure ``-X lazy_imports=none``` and ``PYTHON_LAZY_IMPORTS=none``` override
-``__lazy_modules__``. Patch by Hugo van Kemenade.
+:attr:`module.__lazy_modules__`. Patch by Hugo van Kemenade.
 
 ..
 

--- a/Misc/NEWS.d/next/Documentation/2026-04-15-00-06-40.gh-issue-148588.gC7AEZ.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-04-15-00-06-40.gh-issue-148588.gC7AEZ.rst
@@ -1,3 +1,0 @@
-Document :attr:`module.__lazy_modules__`, the compatibility-mode mechanism
-for opting specific imports into lazy loading without the :keyword:`lazy`
-keyword, in the language reference and the "What's New in Python 3.15" page.

--- a/Misc/NEWS.d/next/Documentation/2026-04-15-00-06-40.gh-issue-148588.gC7AEZ.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-04-15-00-06-40.gh-issue-148588.gC7AEZ.rst
@@ -1,0 +1,3 @@
+Document :attr:`module.__lazy_modules__`, the compatibility-mode mechanism
+for opting specific imports into lazy loading without the :keyword:`lazy`
+keyword, in the language reference and the "What's New in Python 3.15" page.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

I'll need some info here, cc @pablogsal @Yhg1s

The PEP reads as if `__lazy_modules__` must implement `__contains__`. The actual implementation supports _any_ iterable, because it uses the classic [membership test](https://docs.python.org/3/reference/expressions.html#in).

Question: Is it an implementation detail of CPython to support objects beyond containers in `__lazy_modules__`, and non-containers *aren't* supported, or do we support any iterable for `__lazy_modules__`?

Right now I can assign a generator or an old-style `__getitem__`-based sequence to `__lazy_modules__` and CPython will walk it to check membership. Question is whether it's just a CPython thing.

**EDIT:** ...Hmmm now that I think about it, this makes no sense: a `__lazy_modules__` generator will be empty after the first `import`, rendering all subsequent imports eager. I believe we shouldn't support anything beyond containers. Maybe we could even do this at the runtime level, but maybe if you put a generator to `__lazy_modules__` you deserve anything that happens to you.


<!-- gh-issue-number: gh-148588 -->
* Issue: gh-148588
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148590.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->