### PR TITLE
gh-148592: Inaccuracies in expression_stmt documentation

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -321,7 +321,7 @@ Parenthesized forms
 A parenthesized form is an optional expression list enclosed in parentheses:
 
 .. productionlist:: python-grammar
-   parenth_form: "(" [`starred_expression`] ")"
+   parenth_form: "(" [`flexible_expression_list`] ")"
 
 A parenthesized expression list yields whatever that expression list yields: if
 the list contains at least one comma, it yields a tuple; otherwise, it yields
@@ -628,7 +628,7 @@ Yield expressions
 .. productionlist:: python-grammar
    yield_atom: "(" `yield_expression` ")"
    yield_from: "yield" "from" `expression`
-   yield_expression: "yield" `yield_list` | `yield_from`
+   yield_expression: "yield" [`yield_list` | `yield_from`]
 
 The yield expression is used when defining a :term:`generator` function
 or an :term:`asynchronous generator` function and

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -48,7 +48,7 @@ expression statements are allowed and occasionally useful.  The syntax for an
 expression statement is:
 
 .. productionlist:: python-grammar
-   expression_stmt: `starred_expression`
+   expression_stmt: `starred_expression_list`
 
 An expression statement evaluates the expression list (which may be a single
 expression).
@@ -84,7 +84,7 @@ Assignment statements are used to (re)bind names to values and to modify
 attributes or items of mutable objects:
 
 .. productionlist:: python-grammar
-   assignment_stmt: (`target_list` "=")+ (`starred_expression` | `yield_expression`)
+   assignment_stmt: (`target_list` "=")+ (`starred_expression_list` | `yield_expression`)
    target_list: `target` ("," `target`)* [","]
    target: `identifier`
          : | "(" [`target_list`] ")"
@@ -275,7 +275,7 @@ Augmented assignment is the combination, in a single statement, of a binary
 operation and an assignment statement:
 
 .. productionlist:: python-grammar
-   augmented_assignment_stmt: `augtarget` `augop` (`expression_list` | `yield_expression`)
+   augmented_assignment_stmt: `augtarget` `augop` (`starred_expression_list` | `yield_expression`)
    augtarget: `identifier` | `attributeref` | `subscription`
    augop: "+=" | "-=" | "*=" | "@=" | "/=" | "//=" | "%=" | "**="
         : | ">>=" | "<<=" | "&=" | "^=" | "|="
@@ -324,7 +324,7 @@ statement, of a variable or attribute annotation and an optional assignment stat
 
 .. productionlist:: python-grammar
    annotated_assignment_stmt: `augtarget` ":" `expression`
-                            : ["=" (`starred_expression` | `yield_expression`)]
+                            : ["=" (`starred_expression_list` | `yield_expression`)]
 
 The difference from normal :ref:`assignment` is that only a single target is allowed.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148592 -->
* Issue: gh-148592
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148593.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->