### PR TITLE
gh-148292: Update SSLSocket.read() for OpenSSL 4

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -1037,6 +1037,7 @@ class SSLSocket(socket):
             self.server_hostname = context._encode_hostname(server_hostname)
             self.do_handshake_on_connect = do_handshake_on_connect
             self.suppress_ragged_eofs = suppress_ragged_eofs
+            self._got_eof = False
 
             # See if we are connected
             try:
@@ -1149,19 +1150,28 @@ class SSLSocket(socket):
         self._checkClosed()
         if self._sslobj is None:
             raise ValueError("Read on closed or unwrapped SSL socket.")
+        if self._got_eof:
+            # gh-148292: On OpenSSL 4, calling SSL_read_ex() again after
+            # SSL_ERROR_EOF fails with "A failure in the SSL library occurred"
+            if buffer is not None:
+                return 0
+            else:
+                return b''
+
         try:
             if buffer is not None:
                 return self._sslobj.read(len, buffer)
             else:
                 return self._sslobj.read(len)
         except SSLError as x:
-            if x.args[0] == SSL_ERROR_EOF and self.suppress_ragged_eofs:
-                if buffer is not None:
-                    return 0
-                else:
-                    return b''
-            else:
-                raise
+            if x.args[0] == SSL_ERROR_EOF:
+                self._got_eof = True
+                if self.suppress_ragged_eofs:
+                    if buffer is not None:
+                        return 0
+                    else:
+                        return b''
+            raise
 
     def write(self, data):
         """Write DATA to the underlying SSL channel.  Returns

--- a/Misc/NEWS.d/next/Library/2026-04-15-11-47-30.gh-issue-148292.sT3JZE.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-15-11-47-30.gh-issue-148292.sT3JZE.rst
@@ -1,0 +1,2 @@
+Update :meth:`ssl.SSLSocket.read` for OpenSSL 4: no longer call
+``SSL_read_ex()`` after ``SSL_ERROR_EOF``. Patch by Victor Stinner.


### PR DESCRIPTION
Add _got_eof attribute to avoid calling SSL_read_ex() again after SSL_ERROR_EOF.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148292 -->
* Issue: gh-148292
<!-- /gh-issue-number -->
