### PR TITLE
gh-131798: Fix `_ITER_CHECK_RANGE`  type in the JIT

### DIFF
--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1468,11 +1468,11 @@ dummy_func(void) {
     }
 
     op(_ITER_CHECK_RANGE, (iter, null_or_index -- iter, null_or_index)) {
-        if (sym_matches_type(iter, &PyRange_Type)) {
+        if (sym_matches_type(iter, &PyRangeIter_Type)) {
             ADD_OP(_NOP, 0, 0);
         }
         else {
-            sym_set_type(iter, &PyRange_Type);
+            sym_set_type(iter, &PyRangeIter_Type);
         }
     }
 

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -3543,11 +3543,11 @@
         case _ITER_CHECK_RANGE: {
             JitOptRef iter;
             iter = stack_pointer[-2];
-            if (sym_matches_type(iter, &PyRange_Type)) {
+            if (sym_matches_type(iter, &PyRangeIter_Type)) {
                 ADD_OP(_NOP, 0, 0);
             }
             else {
-                sym_set_type(iter, &PyRange_Type);
+                sym_set_type(iter, &PyRangeIter_Type);
             }
             break;
         }


### PR DESCRIPTION
See https://github.com/python/cpython/pull/144583#discussion_r3082970929

<!-- gh-issue-number: gh-131798 -->
* Issue: gh-131798
<!-- /gh-issue-number -->
