### PR TITLE
gh-69605: fix PyREPL completions inserted for import statements with spaces

### DIFF
--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -11,9 +11,9 @@ from importlib.machinery import FileFinder
 from io import StringIO
 from contextlib import contextmanager
 from dataclasses import dataclass
-from itertools import chain, takewhile
+from itertools import chain
 from tokenize import TokenInfo
-from .trace import trace
+
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:

--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -11,9 +11,9 @@ from importlib.machinery import FileFinder
 from io import StringIO
 from contextlib import contextmanager
 from dataclasses import dataclass
-from itertools import chain
+from itertools import chain, takewhile
 from tokenize import TokenInfo
-
+from .trace import trace
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
@@ -82,7 +82,9 @@ class ModuleCompleter:
         if not result:
             return None
         try:
-            return self.complete(*result)
+            names, action = self.complete(*result)
+            names = [self._remove_separated_words(line, c) for c in names]
+            return names, action
         except Exception:
             # Some unexpected error occurred, make it look like
             # no completions are available
@@ -299,6 +301,26 @@ class ModuleCompleter:
                 return f"[ error during import: {exc} ]"
 
         return (prompt, _do_import)
+
+    def _remove_separated_words(self, line: str, completion: str) -> str:
+        """Remove completion parts imputed as separate words.
+
+        Needed because the completer insert any completion provided
+        by replacing the stem (eg. word) currently imputed, if any.
+
+        Examples:
+            - 'import foo.', 'foo.bar'    -> 'foo.bar'
+            - 'import foo  .', 'foo.bar'  -> '.bar'
+            - 'from foo import ', 'bar'   -> 'bar'
+            - 'import x.x .x.', 'x.x.x.x' -> '.x.x'
+        """
+        last_word = line.split(" ")[-1]
+        if not last_word:
+            return completion
+        index = completion.rfind(last_word)
+        if index > 0:
+            return completion[index:]
+        return completion
 
 
 class ImportParser:

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1176,6 +1176,12 @@ class TestPyReplModuleCompleter(TestCase):
             ("from importlib import res\t\n", "from importlib import resources"),
             ("from importlib.res\t import a\t\n", "from importlib.resources import abc"),
             ("from __phello__ import s\t\n", "from __phello__ import spam"),  # frozen module
+            ("import importlib .res\t\n", "import importlib .resources"),
+            ("import importlib. res\t\n", "import importlib. resources"),
+            ("import importlib . res\t\n", "import importlib . resources"),
+            ("import importlib  .metadata.\t\n", "import importlib  .metadata.diagnose"),
+            ("import importlib .metadata   .\t\n", "import importlib .metadata   .diagnose"),
+            ("from importlib .resources .a\t\n", "from importlib .resources .abc"),
         )
         for code, expected in cases:
             with self.subTest(code=code):
@@ -1564,8 +1570,13 @@ class TestPyReplModuleCompleter(TestCase):
             ('import a.b.c, foo.bar, ', (None, '')),
             ('from foo', ('foo', None)),
             ('from a.', ('a.', None)),
+            ('from a .', ('a.', None)),
+            ('from a   .', ('a.', None)),
+            ('from a .', ('a.', None)),
             ('from a.b', ('a.b', None)),
             ('from a.b.', ('a.b.', None)),
+            ('from a. b.', ('a.b.', None)),
+            ('from a  .  b  .', ('a.b.', None)),
             ('from a.b.c', ('a.b.c', None)),
             ('from foo import ', ('foo', '')),
             ('from foo import a', ('foo', 'a')),

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-15-21-55-45.gh-issue-69605.NwoP6l.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-15-21-55-45.gh-issue-69605.NwoP6l.rst
@@ -1,0 +1,2 @@
+Fix :term:`REPL` completions inserted incorrectly when there was spaces in
+import statements.


### PR DESCRIPTION
Re: https://github.com/python/cpython/pull/148445#issuecomment-4232818165

> Note: I juste found an existing bug (on main) while testing things 😅 
>
> ```pycon
>>>> from math .<tab>
>>>> from math .ath.integer  # instead of `from math .integer` (valid syntax!)
>```

Turn out the import parser already handled these cases well, the issue was that the REPL only replaces the last entered word when inserting a suggestion, but inserted the whole import dotted name

So I added an additional step in `ModuleCompleter.get_completions` to reduce the completions to the portion to insert only

cc @tomasr8 

<!-- gh-issue-number: gh-69605 -->
* Issue: gh-69605
<!-- /gh-issue-number -->
