### PR TITLE
gh-148659: Export some internal functions for the JIT (PEP-523)

### DIFF
--- a/Include/internal/pycore_abstract.h
+++ b/Include/internal/pycore_abstract.h
@@ -16,10 +16,11 @@ _PyIndex_Check(PyObject *obj)
     return (tp_as_number != NULL && tp_as_number->nb_index != NULL);
 }
 
-PyObject *_PyNumber_PowerNoMod(PyObject *lhs, PyObject *rhs);
-PyObject *_PyNumber_InPlacePowerNoMod(PyObject *lhs, PyObject *rhs);
+// Exported for external JIT support
+PyAPI_FUNC(PyObject *) _PyNumber_PowerNoMod(PyObject *lhs, PyObject *rhs);
+PyAPI_FUNC(PyObject *) _PyNumber_InPlacePowerNoMod(PyObject *lhs, PyObject *rhs);
 
-extern int _PyObject_HasLen(PyObject *o);
+PyAPI_FUNC(int) _PyObject_HasLen(PyObject *o);
 
 /* === Sequence protocol ================================================ */
 

--- a/Include/internal/pycore_call.h
+++ b/Include/internal/pycore_call.h
@@ -166,7 +166,8 @@ _PyStack_UnpackDict(PyThreadState *tstate,
     PyObject *const *args, Py_ssize_t nargs,
     PyObject *kwargs, PyObject **p_kwnames);
 
-extern void _PyStack_UnpackDict_Free(
+// Exported for external JIT support
+PyAPI_FUNC(void) _PyStack_UnpackDict_Free(
     PyObject *const *stack,
     Py_ssize_t nargs,
     PyObject *kwnames);

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -31,7 +31,8 @@ PyAPI_FUNC(int) _PyDict_SetItem_KnownHash(PyObject *mp, PyObject *key,
 PyAPI_FUNC(int) _PyDict_DelItem_KnownHash(PyObject *mp, PyObject *key,
                                           Py_hash_t hash);
 
-extern int _PyDict_DelItem_KnownHash_LockHeld(PyObject *mp, PyObject *key,
+// Exported for external JIT support
+PyAPI_FUNC(int) _PyDict_DelItem_KnownHash_LockHeld(PyObject *mp, PyObject *key,
                                               Py_hash_t hash);
 
 extern int _PyDict_Contains_KnownHash(PyObject *, PyObject *, Py_hash_t);
@@ -93,8 +94,9 @@ extern PyObject *_PyDict_Or(PyObject *self, PyObject *other);
 extern PyObject *_PyDict_IOr(PyObject *self, PyObject *other);
 
 /* Gets a version number unique to the current state of the keys of dict, if possible.
- * Returns the version number, or zero if it was not possible to get a version number. */
-extern uint32_t _PyDictKeys_GetVersionForCurrentState(
+ * Returns the version number, or zero if it was not possible to get a version number.
+ * Exported for external JIT support */
+PyAPI_FUNC(uint32_t) _PyDictKeys_GetVersionForCurrentState(
         PyInterpreterState *interp, PyDictKeysObject *dictkeys);
 
 /* Gets a version number unique to the current state of the keys of dict, if possible.
@@ -104,8 +106,9 @@ extern uint32_t _PyDictKeys_GetVersionForCurrentState(
  *
  * The caller must hold the per-object lock on dict.
  *
- * Returns the version number, or zero if it was not possible to get a version number. */
-extern uint32_t _PyDict_GetKeysVersionForCurrentState(
+ * Returns the version number, or zero if it was not possible to get a version number.
+ * Exported for external JIT support */
+PyAPI_FUNC(uint32_t) _PyDict_GetKeysVersionForCurrentState(
         PyInterpreterState *interp, PyDictObject *dict);
 
 extern size_t _PyDict_KeysSize(PyDictKeysObject *keys);
@@ -114,16 +117,18 @@ extern void _PyDictKeys_DecRef(PyDictKeysObject *keys);
 
 /* _Py_dict_lookup() returns index of entry which can be used like DK_ENTRIES(dk)[index].
  * -1 when no entry found, -3 when compare raises error.
+ * Exported for external JIT support
  */
-extern Py_ssize_t _Py_dict_lookup(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
+PyAPI_FUNC(Py_ssize_t) _Py_dict_lookup(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
 extern Py_ssize_t _Py_dict_lookup_threadsafe(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
 extern Py_ssize_t _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject *key, Py_hash_t hash, _PyStackRef *value_addr);
 
 extern int _PyDict_GetMethodStackRef(PyDictObject *dict, PyObject *name, _PyStackRef *method);
 
-extern Py_ssize_t _PyDict_LookupIndexAndValue(PyDictObject *, PyObject *, PyObject **);
-extern Py_ssize_t _PyDict_LookupIndex(PyDictObject *, PyObject *);
-extern Py_ssize_t _PyDictKeys_StringLookup(PyDictKeysObject* dictkeys, PyObject *key);
+// Exported for external JIT support
+PyAPI_FUNC(Py_ssize_t) _PyDict_LookupIndexAndValue(PyDictObject *, PyObject *, PyObject **);
+PyAPI_FUNC(Py_ssize_t) _PyDict_LookupIndex(PyDictObject *, PyObject *);
+PyAPI_FUNC(Py_ssize_t) _PyDictKeys_StringLookup(PyDictKeysObject* dictkeys, PyObject *key);
 
 /* Look up a string key in an all unicode dict keys, assign the keys object a version, and
  * store it in version.
@@ -132,9 +137,11 @@ extern Py_ssize_t _PyDictKeys_StringLookup(PyDictKeysObject* dictkeys, PyObject 
  * strings.
  *
  * Returns DKIX_EMPTY if the key is not present.
+ *
+ * Exported for external JIT support
  */
-extern Py_ssize_t _PyDictKeys_StringLookupAndVersion(PyDictKeysObject* dictkeys, PyObject *key, uint32_t *version);
-extern Py_ssize_t _PyDictKeys_StringLookupSplit(PyDictKeysObject* dictkeys, PyObject *key);
+PyAPI_FUNC(Py_ssize_t) _PyDictKeys_StringLookupAndVersion(PyDictKeysObject* dictkeys, PyObject *key, uint32_t *version);
+PyAPI_FUNC(Py_ssize_t) _PyDictKeys_StringLookupSplit(PyDictKeysObject* dictkeys, PyObject *key);
 PyAPI_FUNC(PyObject *)_PyDict_LoadGlobal(PyDictObject *, PyDictObject *, PyObject *);
 PyAPI_FUNC(void) _PyDict_LoadGlobalStackRef(PyDictObject *, PyDictObject *, PyObject *, _PyStackRef *);
 
@@ -144,7 +151,8 @@ extern PyObject *_PyDict_LoadBuiltinsFromGlobals(PyObject *globals);
 /* Consumes references to key and value */
 PyAPI_FUNC(int) _PyDict_SetItem_Take2(PyDictObject *op, PyObject *key, PyObject *value);
 PyAPI_FUNC(int) _PyDict_SetItem_Take2_KnownHash(PyDictObject *op, PyObject *key, PyObject *value, Py_hash_t hash);
-extern int _PyDict_SetItem_LockHeld(PyDictObject *dict, PyObject *name, PyObject *value);
+// Exported for external JIT support
+PyAPI_FUNC(int) _PyDict_SetItem_LockHeld(PyDictObject *dict, PyObject *name, PyObject *value);
 // Export for '_asyncio' shared extension
 PyAPI_FUNC(int) _PyDict_SetItem_KnownHash_LockHeld(PyDictObject *mp, PyObject *key,
                                                    PyObject *value, Py_hash_t hash);
@@ -328,6 +336,10 @@ _PyDictValues_AddToInsertionOrder(PyDictValues *values, Py_ssize_t ix)
     array[size] = (uint8_t)ix;
     values->size = size+1;
 }
+
+// Exported for external JIT support
+PyAPI_FUNC(void)
+_PyDict_InsertSplitValue(PyDictObject *mp, PyObject *key, PyObject *value, Py_ssize_t ix);
 
 static inline size_t
 shared_keys_usable_size(PyDictKeysObject *keys)

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -38,7 +38,8 @@ struct _frame {
     PyObject *_f_frame_data[1];
 };
 
-extern PyFrameObject* _PyFrame_New_NoTrack(PyCodeObject *code);
+// Exported for external JIT support
+PyAPI_FUNC(PyFrameObject *) _PyFrame_New_NoTrack(PyCodeObject *code);
 
 
 /* other API */

--- a/Include/internal/pycore_function.h
+++ b/Include/internal/pycore_function.h
@@ -27,7 +27,8 @@ _PyFunction_IsVersionValid(uint32_t version)
     return version >= FUNC_VERSION_FIRST_VALID;
 }
 
-extern uint32_t _PyFunction_GetVersionForCurrentState(PyFunctionObject *func);
+// Exported for external JIT support
+PyAPI_FUNC(uint32_t) _PyFunction_GetVersionForCurrentState(PyFunctionObject *func);
 PyAPI_FUNC(void) _PyFunction_SetVersion(PyFunctionObject *func, uint32_t version);
 void _PyFunction_ClearCodeByVersion(uint32_t version);
 

--- a/Include/internal/pycore_interpframe.h
+++ b/Include/internal/pycore_interpframe.h
@@ -302,7 +302,8 @@ _PyFrame_GetFrameObject(_PyInterpreterFrame *frame)
     return _PyFrame_MakeAndSetFrameObject(frame);
 }
 
-void
+// Exported for external JIT support
+PyAPI_FUNC(void)
 _PyFrame_ClearLocals(_PyInterpreterFrame *frame);
 
 /* Clears all references in the frame.
@@ -313,8 +314,10 @@ _PyFrame_ClearLocals(_PyInterpreterFrame *frame);
  * in the frame.
  * take should  be set to 1 for heap allocated
  * frames like the ones in generators and coroutines.
+ *
+ * Exported for external JIT support
  */
-void
+ PyAPI_FUNC(void)
 _PyFrame_ClearExceptCode(_PyInterpreterFrame * frame);
 
 int
@@ -338,7 +341,8 @@ _PyThreadState_HasStackSpace(PyThreadState *tstate, int size)
         size < tstate->datastack_limit - tstate->datastack_top;
 }
 
-extern _PyInterpreterFrame *
+// Exported for external JIT support
+PyAPI_FUNC(_PyInterpreterFrame *)
 _PyThreadState_PushFrame(PyThreadState *tstate, size_t size);
 
 PyAPI_FUNC(void) _PyThreadState_PopFrame(PyThreadState *tstate, _PyInterpreterFrame *frame);

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -879,14 +879,16 @@ PyAPI_FUNC(PyObject *) _PyType_NewManagedObject(PyTypeObject *type);
 extern PyTypeObject* _PyType_CalculateMetaclass(PyTypeObject *, PyObject *);
 extern PyObject* _PyType_GetDocFromInternalDoc(const char *, const char *);
 extern PyObject* _PyType_GetTextSignatureFromInternalDoc(const char *, const char *, int);
-extern int _PyObject_SetAttributeErrorContext(PyObject *v, PyObject* name);
+// Exported for external JIT support
+PyAPI_FUNC(int) _PyObject_SetAttributeErrorContext(PyObject *v, PyObject* name);
 
 void _PyObject_InitInlineValues(PyObject *obj, PyTypeObject *tp);
 extern int _PyObject_StoreInstanceAttribute(PyObject *obj,
                                             PyObject *name, PyObject *value);
 extern bool _PyObject_TryGetInstanceAttribute(PyObject *obj, PyObject *name,
                                               PyObject **attr);
-extern PyObject *_PyType_LookupRefAndVersion(PyTypeObject *, PyObject *,
+// Exported for external JIT support
+PyAPI_FUNC(PyObject *) _PyType_LookupRefAndVersion(PyTypeObject *, PyObject *,
                                              unsigned int *);
 
 // Internal API to look for a name through the MRO.
@@ -910,7 +912,9 @@ PyAPI_FUNC(_PyStackRef) _PyObject_GetAttrStackRef(PyObject *obj, PyObject *name)
 // deferred reference counting.
 //
 // Returns 1 if the value was cached or 0 otherwise.
-extern int _PyType_CacheInitForSpecialization(PyHeapTypeObject *type,
+//
+// Exported for external JIT support
+PyAPI_FUNC(int) _PyType_CacheInitForSpecialization(PyHeapTypeObject *type,
                                               PyObject *init,
                                               unsigned int tp_version);
 

--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -170,7 +170,8 @@ extern PyObject* _PyErr_FormatFromCauseTstate(
     const char *format,
     ...);
 
-extern PyObject* _PyExc_CreateExceptionGroup(
+// Exported for external JIT support
+PyAPI_FUNC(PyObject *) _PyExc_CreateExceptionGroup(
     const char *msg,
     PyObject *excs);
 
@@ -181,7 +182,8 @@ extern PyObject* _PyExc_PrepReraiseStar(
 extern int _PyErr_CheckSignalsTstate(PyThreadState *tstate);
 
 extern void _Py_DumpExtensionModules(int fd, PyInterpreterState *interp);
-extern PyObject* _Py_CalculateSuggestions(PyObject *dir, PyObject *name);
+// Exported for external JIT support
+PyAPI_FUNC(PyObject *) _Py_CalculateSuggestions(PyObject *dir, PyObject *name);
 extern PyObject* _Py_Offer_Suggestions(PyObject* exception);
 
 // Export for '_testinternalcapi' shared extension

--- a/Include/internal/pycore_traceback.h
+++ b/Include/internal/pycore_traceback.h
@@ -85,7 +85,8 @@ extern void _Py_DumpHexadecimal(
     uintptr_t value,
     Py_ssize_t width);
 
-extern PyObject* _PyTraceBack_FromFrame(
+// Exported for external JIT support
+PyAPI_FUNC(PyObject *) _PyTraceBack_FromFrame(
     PyObject *tb_next,
     PyFrameObject *frame);
 

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -60,7 +60,8 @@ extern void _PyStaticType_FiniBuiltin(
 extern void _PyStaticType_ClearWeakRefs(
     PyInterpreterState *interp,
     PyTypeObject *type);
-extern managed_static_type_state * _PyStaticType_GetState(
+// Exported for external JIT support
+PyAPI_FUNC(managed_static_type_state *) _PyStaticType_GetState(
     PyInterpreterState *interp,
     PyTypeObject *type);
 
@@ -156,8 +157,9 @@ typedef int (*_py_validate_type)(PyTypeObject *);
 // It will verify the ``ty`` through user-defined validation function ``validate``,
 // and if the validation is passed, it will set the ``tp_version`` as valid
 // tp_version_tag from the ``ty``.
-extern int _PyType_Validate(PyTypeObject *ty, _py_validate_type validate, unsigned int *tp_version);
-extern int _PyType_CacheGetItemForSpecialization(PyHeapTypeObject *ht, PyObject *descriptor, uint32_t tp_version);
+// Exported for external JIT support
+int _PyType_Validate(PyTypeObject *ty, _py_validate_type validate, unsigned int *tp_version);
+int _PyType_CacheGetItemForSpecialization(PyHeapTypeObject *ht, PyObject *descriptor, uint32_t tp_version);
 
 // Precalculates count of non-unique slots and fills wrapperbase.name_count.
 extern int _PyType_InitSlotDefs(PyInterpreterState *interp);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1910,8 +1910,8 @@ insert_split_key(PyDictKeysObject *keys, PyObject *key, Py_hash_t hash)
     return ix;
 }
 
-static void
-insert_split_value(PyDictObject *mp, PyObject *key, PyObject *value, Py_ssize_t ix)
+void
+_PyDict_InsertSplitValue(PyDictObject *mp, PyObject *key, PyObject *value, Py_ssize_t ix)
 {
     assert(can_modify_dict(mp));
     assert(PyUnicode_CheckExact(key));
@@ -1951,7 +1951,7 @@ insertdict(PyDictObject *mp,
     if (_PyDict_HasSplitTable(mp) && PyUnicode_CheckExact(key)) {
         ix = insert_split_key(mp->ma_keys, key, hash);
         if (ix != DKIX_EMPTY) {
-            insert_split_value(mp, key, value, ix);
+            _PyDict_InsertSplitValue(mp, key, value, ix);
             Py_DECREF(key);
             Py_DECREF(value);
             return 0;
@@ -4714,7 +4714,7 @@ dict_setdefault_ref_lock_held(PyObject *d, PyObject *key, PyObject *default_valu
             PyObject *value = mp->ma_values->values[ix];
             int already_present = value != NULL;
             if (!already_present) {
-                insert_split_value(mp, key, default_value, ix);
+                _PyDict_InsertSplitValue(mp, key, default_value, ix);
                 value = default_value;
             }
             if (result) {


### PR DESCRIPTION
These are various functions which are key for implementing a JIT built on PEP 523 built on top of the unstable API.

<!-- gh-issue-number: gh-148659 -->
* Issue: gh-148659
<!-- /gh-issue-number -->
