### PR TITLE
docs: remove stray spaces in documentation

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -4170,7 +4170,7 @@ The script, when run, should produce output like this:
     2025-07-09 06:47:33,783 DEBUG     Another single line
     2025-07-09 06:47:33,783 DEBUG     Multiple lines:\nfool me ...\ncan't get fooled again
 
-Escaping behaviour can't be the stdlib default , as it would break backwards
+Escaping behaviour can't be the stdlib default, as it would break backwards
 compatibility.
 
 .. patterns-to-avoid:

--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -10,8 +10,8 @@ The :mod:`!readline` module defines a number of functions to facilitate
 completion and reading/writing of history files from the Python interpreter.
 This module can be used directly, or via the :mod:`rlcompleter` module, which
 supports completion of Python identifiers at the interactive prompt.  Settings
-made using  this module affect the behaviour of both the interpreter's
-interactive prompt  and the prompts offered by the built-in :func:`input`
+made using this module affect the behaviour of both the interpreter's
+interactive prompt and the prompts offered by the built-in :func:`input`
 function.
 
 Readline keybindings may be configured via an initialization file, typically

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -720,7 +720,7 @@ breaking intraclass method calls.  For example::
 
 The above example would work even if ``MappingSubclass`` were to introduce a
 ``__update`` identifier since it is replaced with ``_Mapping__update`` in the
-``Mapping`` class  and ``_MappingSubclass__update`` in the ``MappingSubclass``
+``Mapping`` class and ``_MappingSubclass__update`` in the ``MappingSubclass``
 class respectively.
 
 Note that the mangling rules are designed mostly to avoid accidents; it still is


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Remove stray spaces in three documentation files:

- `Doc/library/readline.rst`
- `Doc/tutorial/classes.rst`
- `Doc/howto/logging-cookbook.rst`

This is a documentation-only cleanup with no behavioral changes.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148635.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->