### PR TITLE
gh-148638: Parse `PYTHON_LLTRACE`/`PYTHON_OPT_DEBUG` as integer

### DIFF
--- a/Python/ceval.h
+++ b/Python/ceval.h
@@ -298,7 +298,7 @@ maybe_lltrace_resume_frame(_PyInterpreterFrame *frame, PyObject *globals)
         // Can also be controlled by environment variable
         char *python_lltrace = Py_GETENV("PYTHON_LLTRACE");
         if (python_lltrace != NULL && *python_lltrace >= '0') {
-            lltrace = *python_lltrace - '0';  // TODO: Parse an int and all that
+            lltrace = atoi(python_lltrace);
         }
     }
     if (lltrace >= 5) {

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -625,7 +625,7 @@ _PyJit_translate_single_bytecode_to_trace(
     char *python_lltrace = Py_GETENV("PYTHON_LLTRACE");
     int lltrace = 0;
     if (python_lltrace != NULL && *python_lltrace >= '0') {
-        lltrace = *python_lltrace - '0';  // TODO: Parse an int and all that
+        lltrace = atoi(python_lltrace);
     }
 #endif
     _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate;
@@ -1033,7 +1033,7 @@ _PyJit_TryInitializeTracing(
     char *python_lltrace = Py_GETENV("PYTHON_LLTRACE");
     int lltrace = 0;
     if (python_lltrace != NULL && *python_lltrace >= '0') {
-        lltrace = *python_lltrace - '0';  // TODO: Parse an int and all that
+        lltrace = atoi(python_lltrace);
     }
     DPRINTF(2,
         "Tracing %s (%s:%d) at byte offset %d at chain depth %d\n",
@@ -1433,7 +1433,7 @@ make_executor_from_uops(_PyThreadStateImpl *tstate, _PyUOpInstruction *buffer, i
     char *python_lltrace = Py_GETENV("PYTHON_LLTRACE");
     int lltrace = 0;
     if (python_lltrace != NULL && *python_lltrace >= '0') {
-        lltrace = *python_lltrace - '0';  // TODO: Parse an int and all that
+        lltrace = atoi(python_lltrace);
     }
     if (lltrace >= 2) {
         printf("Optimized trace (length %d):\n", length);

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -47,7 +47,7 @@
         char *uop_debug = Py_GETENV(DEBUG_ENV);
         int lltrace = 0;
         if (uop_debug != NULL && *uop_debug >= '0') {
-            lltrace = *uop_debug - '0';  // TODO: Parse an int and all that
+            lltrace = atoi(uop_debug);
         }
         return lltrace;
     }

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -65,7 +65,7 @@ static inline int get_lltrace(void) {
     char *uop_debug = Py_GETENV("PYTHON_OPT_DEBUG");
     int lltrace = 0;
     if (uop_debug != NULL && *uop_debug >= '0') {
-        lltrace = *uop_debug - '0';  // TODO: Parse an int and all that
+        lltrace = atoi(uop_debug);
     }
     return lltrace;
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Parse the `PYTHON_LLTRACE` and `PYTHON_OPT_DEBUG` environment variables as integers using `atoi()` instead of only reading the first character.

## Example
Before: `PYTHON_LLTRACE=10` was interpreted as `1`
After: `PYTHON_LLTRACE=10` is correctly interpreted as `10`


<!-- gh-issue-number: gh-148638 -->
* Issue: gh-148638
<!-- /gh-issue-number -->
