### PR TITLE
gh-148644: propagate PGO job exit code in PCbuild/build.bat

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-04-17-21-45-32.gh-issue-148644.vwkknh.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-17-21-45-32.gh-issue-148644.vwkknh.rst
@@ -1,0 +1,1 @@
+Errors during the PGO training job on Windows are no longer ignored, and a non-zero return code will cause the build to fail.

--- a/PCbuild/build.bat
+++ b/PCbuild/build.bat
@@ -170,14 +170,18 @@ if "%do_pgo%"=="true" (
     del /s "%dir%\*.pgc"
     del /s "%dir%\..\Lib\*.pyc"
     set conf=PGUpdate
-    if "%clean%"=="false" (
-        echo on
-        call "%dir%\..\python.bat" %pgo_job%
-        @echo off
-        call :Kill
-        set target=Build
-    )
+    if "%clean%"=="false" goto :RunPgoJob
 )
+goto :Build
+
+:RunPgoJob
+echo on
+call "%dir%\..\python.bat" %pgo_job%
+@echo off
+set pgo_errorlevel=%ERRORLEVEL%
+call :Kill
+if %pgo_errorlevel% NEQ 0 exit /B %pgo_errorlevel%
+set target=Build
 goto :Build
 
 :Kill


### PR DESCRIPTION
Replace the `if "%clean%"=="false" (...)` block with a `goto :RunPgoJob` so the job runs outside any parenthesized block, where `%ERRORLEVEL%` is not subject to eager evaluation.

Save the exit code before `call :Kill` resets it, then propagate it if non-zero.

<!-- gh-issue-number: gh-148644 -->
* Issue: gh-148644
<!-- /gh-issue-number -->
