### PR TITLE
[3.13] gh-148535: Don't use gcc -fprofile-update=atomic flag on i686 (#148554)

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-04-14-15-20-29.gh-issue-148535.JjKiaa.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-14-15-20-29.gh-issue-148535.JjKiaa.rst
@@ -1,0 +1,6 @@
+No longer use the ``gcc -fprofile-update=atomic`` flag on i686. The flag has
+been added to fix a random GCC internal error on PGO build (:gh:`145801`)
+caused by corruption of profile data (.gcda files). The problem is that it
+makes the PGO build way slower (up to 47x slower) on i686. Since the GCC
+internal error was not seen on i686 so far, don't use
+``-fprofile-update=atomic`` on i686 anymore. Patch by Victor Stinner.

--- a/configure
+++ b/configure
@@ -8990,7 +8990,55 @@ case "$CC_BASENAME" in
         fi
         ;;
       *)
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -fprofile-update=atomic" >&5
+        # Check for 32-bit x86 ISA
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for i686" >&5
+printf %s "checking for i686... " >&6; }
+if test ${ac_cv_i686+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+                    #ifdef __i386__
+                    #  error "i386"
+                    #endif
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ac_cv_i686=no
+else $as_nop
+  ac_cv_i686=yes
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_i686" >&5
+printf "%s\n" "$ac_cv_i686" >&6; }
+
+        PGO_PROF_GEN_FLAG="-fprofile-generate"
+
+        # Use -fprofile-update=atomic to fix a random GCC internal error on PGO
+        # build (gh-145801) caused by corruption of profile data (.gcda files).
+        #
+        # gh-148535: On i686, using -fprofile-update=atomic makes the PGO build
+        # way slower (up to 47x slower). So far, the GCC internal error on PGO
+        # build was not seen on i686, so don't use this flag on i686.
+        if test "x$ac_cv_i686" = xno
+then :
+
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -fprofile-update=atomic" >&5
 printf %s "checking whether C compiler accepts -fprofile-update=atomic... " >&6; }
 if test ${ax_cv_check_cflags___fprofile_update_atomic+y}
 then :
@@ -9023,9 +9071,12 @@ fi
 printf "%s\n" "$ax_cv_check_cflags___fprofile_update_atomic" >&6; }
 if test "x$ax_cv_check_cflags___fprofile_update_atomic" = xyes
 then :
-  PGO_PROF_GEN_FLAG="-fprofile-generate -fprofile-update=atomic"
+  PGO_PROF_GEN_FLAG="$PGO_PROF_GEN_FLAG -fprofile-update=atomic"
 else $as_nop
-  PGO_PROF_GEN_FLAG="-fprofile-generate"
+  :
+fi
+
+
 fi
 
         PGO_PROF_USE_FLAG="-fprofile-use -fprofile-correction"

--- a/configure.ac
+++ b/configure.ac
@@ -2137,10 +2137,32 @@ case "$CC_BASENAME" in
         fi
         ;;
       *)
-        AX_CHECK_COMPILE_FLAG(
-            [-fprofile-update=atomic],
-            [PGO_PROF_GEN_FLAG="-fprofile-generate -fprofile-update=atomic"],
-            [PGO_PROF_GEN_FLAG="-fprofile-generate"])
+        # Check for 32-bit x86 ISA
+        AC_CACHE_CHECK([for i686], [ac_cv_i686], [
+            AC_COMPILE_IFELSE([
+                AC_LANG_PROGRAM([
+                    #ifdef __i386__
+                    #  error "i386"
+                    #endif
+                ], [])
+            ],[ac_cv_i686=no],[ac_cv_i686=yes])
+        ])
+
+        PGO_PROF_GEN_FLAG="-fprofile-generate"
+
+        # Use -fprofile-update=atomic to fix a random GCC internal error on PGO
+        # build (gh-145801) caused by corruption of profile data (.gcda files).
+        #
+        # gh-148535: On i686, using -fprofile-update=atomic makes the PGO build
+        # way slower (up to 47x slower). So far, the GCC internal error on PGO
+        # build was not seen on i686, so don't use this flag on i686.
+        AS_VAR_IF([ac_cv_i686], [no], [
+            AX_CHECK_COMPILE_FLAG(
+                [-fprofile-update=atomic],
+                [PGO_PROF_GEN_FLAG="$PGO_PROF_GEN_FLAG -fprofile-update=atomic"],
+                [])
+        ])
+
         PGO_PROF_USE_FLAG="-fprofile-use -fprofile-correction"
         LLVM_PROF_MERGER="true"
         LLVM_PROF_FILE=""


### PR DESCRIPTION
The -fprofile-update=atomic flag was added to fix a random GCC internal error on PGO build (gh-145801) caused by corruption of profile data (.gcda files). The problem is that it makes the PGO build way slower (up to 47x slower) on i686. Since the GCC internal error was not seen on i686 so far, don't use -fprofile-update=atomic on i686.

(cherry picked from commit 2faceeec5c0fb06498a9654d429180ac4610c65a)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148535 -->
* Issue: gh-148535
<!-- /gh-issue-number -->
