### PR TITLE
gh-148651: Fix Py_DECREF(value) leak in _zstd decompressor options

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-04-16-13-30-00.gh-issue-148651.ZsTdLk.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-16-13-30-00.gh-issue-148651.ZsTdLk.rst
@@ -1,0 +1,2 @@
+Fix reference leak in :class:`compression.zstd.ZstdDecompressor` when an
+invalid option key is passed.

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -111,6 +111,7 @@ _zstd_set_d_parameters(ZstdDecompressor *self, PyObject *options)
         int key_v = PyLong_AsInt(key);
         Py_DECREF(key);
         if (key_v == -1 && PyErr_Occurred()) {
+            Py_DECREF(value);
             return -1;
         }
 


### PR DESCRIPTION
Fixes #148651 with DecRef proposed in the original report.

`Modules/_zstd/decompressor.c` line 113 is missing `Py_DECREF(value)` before the early `return -1` when `PyLong_AsInt(key)` fails. The identical code in `Modules/_zstd/compressor.c` line 158 has the fix.                      
                                                                                                    
Confirmed with refcount test from the original report: before fix, 100 error triggers leak 100 refs; after fix, 0 leaked.                                                                                               

<!-- gh-issue-number: gh-148651 -->
* Issue: gh-148651
<!-- /gh-issue-number -->
