### PR TITLE
gh-113093: add parameter 'mode' in shelve.open

### DIFF
--- a/Doc/library/shelve.rst
+++ b/Doc/library/shelve.rst
@@ -18,7 +18,7 @@ lots of shared  sub-objects.  The keys are ordinary strings.
 
 
 .. function:: open(filename, flag='c', protocol=None, writeback=False, *, \
-                   serializer=None, deserializer=None)
+                   mode=0o666, serializer=None, deserializer=None)
 
    Open a persistent dictionary.  The filename specified is the base filename for
    the underlying database.  As a side-effect, an extension may be added to the
@@ -41,6 +41,9 @@ lots of shared  sub-objects.  The keys are ordinary strings.
    very slow since all accessed entries are written back (there is no way to
    determine which accessed entries are mutable, nor which ones were actually
    mutated).
+
+   The optional *mode* parameter controls the file mode (permissions) when creating
+   a new shelf. It has the same interpretation as the *mode* parameter of :func:`dbm.open`.
 
    By default, :mod:`!shelve` uses :func:`pickle.dumps` and :func:`pickle.loads`
    for serializing and deserializing. This can be changed by supplying
@@ -67,6 +70,9 @@ lots of shared  sub-objects.  The keys are ordinary strings.
    .. versionchanged:: 3.15
       Accepts custom *serializer* and *deserializer* functions in place of
       :func:`pickle.dumps` and :func:`pickle.loads`.
+
+   .. versionchanged:: next
+      Accepts *mode* to control file mode, behavior is the same as in :func:`dbm.open`.
 
    .. note::
 
@@ -209,19 +215,22 @@ Restrictions
 
 
 .. class:: DbfilenameShelf(filename, flag='c', protocol=None, \
-                           writeback=False, *, serializer=None, \
+                           writeback=False, *, mode=0o666, serializer=None \
                            deserializer=None)
 
    A subclass of :class:`Shelf` which accepts a *filename* instead of a dict-like
    object.  The underlying file will be opened using :func:`dbm.open`.  By
    default, the file will be created and opened for both read and write.  The
    optional *flag* parameter has the same interpretation as for the
-   :func:`.open` function.  The optional *protocol*, *writeback*, *serializer*
+   :func:`.open` function.  The optional *mode*, *protocol*, *writeback*, *serializer*
    and *deserializer* parameters have the same interpretation as in
    :func:`~shelve.open`.
 
    .. versionchanged:: 3.15
       Added the *serializer* and *deserializer* parameters.
+
+   .. versionchanged:: next
+      Added the *mode* parameter.
 
 
 .. _shelve-example:

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -151,6 +151,12 @@ mimetypes
   :meth:`mimetypes.MimeTypes.add_type`.
   Undotted extensions now raise a :exc:`ValueError`.
 
+shelve
+------
+
+* Add suport for custom mode in :func:`shelve.open`.
+  (Contributed by Guilherme Crocetti in :gh:`113093`.)
+
 shutil
 ------
 

--- a/Lib/shelve.py
+++ b/Lib/shelve.py
@@ -236,9 +236,9 @@ class DbfilenameShelf(Shelf):
     """
 
     def __init__(self, filename, flag='c', protocol=None, writeback=False, *,
-                 serializer=None, deserializer=None):
+                 mode=0o666, serializer=None, deserializer=None):
         import dbm
-        Shelf.__init__(self, dbm.open(filename, flag), protocol, writeback,
+        Shelf.__init__(self, dbm.open(filename, flag, mode), protocol, writeback,
                        serializer=serializer, deserializer=deserializer)
 
     def clear(self):
@@ -249,7 +249,7 @@ class DbfilenameShelf(Shelf):
         self.dict.clear()
 
 def open(filename, flag='c', protocol=None, writeback=False, *,
-         serializer=None, deserializer=None):
+         mode=0o666, serializer=None, deserializer=None):
     """Open a persistent dictionary for reading and writing.
 
     The filename parameter is the base filename for the underlying
@@ -257,10 +257,12 @@ def open(filename, flag='c', protocol=None, writeback=False, *,
     filename and more than one file may be created.  The optional flag
     parameter has the same interpretation as the flag parameter of
     dbm.open(). The optional protocol parameter specifies the
-    version of the pickle protocol.
+    version of the pickle protocol. The optional mode parameter is
+    passed to dbm.open() and controls the file mode when creating a
+    new shelf, set to 0666 by default.
 
     See the module's __doc__ string for an overview of the interface.
     """
 
-    return DbfilenameShelf(filename, flag, protocol, writeback,
+    return DbfilenameShelf(filename, flag, protocol, writeback, mode=mode,
                            serializer=serializer, deserializer=deserializer)

--- a/Lib/test/test_shelve.py
+++ b/Lib/test/test_shelve.py
@@ -5,6 +5,7 @@ import shelve
 import pickle
 import os
 
+from unittest import mock
 from test.support import import_helper, os_helper, subTests
 from collections.abc import MutableMapping
 from test.test_dbm import dbm_iterator
@@ -46,6 +47,12 @@ class byteskeydict(MutableMapping):
 class TestCase(unittest.TestCase):
     dirname = os_helper.TESTFN
     fn = os.path.join(os_helper.TESTFN, "shelftemp.db")
+
+    @mock.patch("dbm.open", autospec=True)
+    def test_open_calls_dbm_as_expected(self, dbm_open):
+        shelf_open_mode = 0o433
+        shelve.open(filename=self.fn, mode=shelf_open_mode)
+        dbm_open.assert_called_once_with(self.fn, 'c', shelf_open_mode)
 
     def test_close(self):
         d1 = {}

--- a/Misc/NEWS.d/next/Library/2026-04-17-10-42-00.gh-issue-113093.KzsNvW.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-17-10-42-00.gh-issue-113093.KzsNvW.rst
@@ -1,0 +1,2 @@
+Add parameter *mode* in :func:`shelve.open`.
+Patch by Guilherme Crocetti.


### PR DESCRIPTION
add parameter 'mode' in shelve.open, letting users control file's type and access permissions

issue [#113093](https://github.com/python/cpython/issues/113093)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-113093: Summary of the changes made
```

Where: gh-113093 refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148662.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->