### PR TITLE
gh-148663: Document that IllegalMonthError inherits from both ValueError and IndexError

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -580,8 +580,11 @@ The :mod:`!calendar` module defines the following exceptions:
 
 .. exception:: IllegalMonthError(month)
 
-   A subclass of :exc:`ValueError`,
+   A subclass of both :exc:`ValueError` and :exc:`IndexError`,
    raised when the given month number is outside of the range 1-12 (inclusive).
+   The :exc:`IndexError` base class is preserved for backwards compatibility
+   with code that caught :exc:`IndexError` for bad month numbers prior to
+   Python 3.13.
 
    .. attribute:: month
 

--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -580,8 +580,16 @@ The :mod:`!calendar` module defines the following exceptions:
 
 .. exception:: IllegalMonthError(month)
 
-   A subclass of :exc:`ValueError`,
+   A subclass of both :exc:`ValueError` and :exc:`IndexError`,
    raised when the given month number is outside of the range 1-12 (inclusive).
+   The :exc:`IndexError` base class is preserved for backwards compatibility
+   with code that caught :exc:`IndexError` for bad month numbers prior to
+   Python 3.13.
+
+   .. versionchanged:: 3.12
+      :exc:`IllegalMonthError` is now also a subclass of
+      :exc:`ValueError`. Newer code should avoid catching
+      :exc:`IndexError`.
 
    .. attribute:: month
 

--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -580,11 +580,8 @@ The :mod:`!calendar` module defines the following exceptions:
 
 .. exception:: IllegalMonthError(month)
 
-   A subclass of both :exc:`ValueError` and :exc:`IndexError`,
+   A subclass of :exc:`ValueError` and :exc:`IndexError`,
    raised when the given month number is outside of the range 1-12 (inclusive).
-   The :exc:`IndexError` base class is preserved for backwards compatibility
-   with code that caught :exc:`IndexError` for bad month numbers prior to
-   Python 3.13.
 
    .. versionchanged:: 3.12
       :exc:`IllegalMonthError` is now also a subclass of

--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -585,7 +585,7 @@ The :mod:`!calendar` module defines the following exceptions:
 
    .. versionchanged:: 3.12
       :exc:`IllegalMonthError` is now also a subclass of
-      :exc:`ValueError`. Newer code should avoid catching
+      :exc:`ValueError`. New code should avoid catching
       :exc:`IndexError`.
 
    .. attribute:: month

--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -495,11 +495,16 @@ class OutputTestCase(unittest.TestCase):
             calendar.TextCalendar().formatmonth(0, 2),
             result_0_02_text
         )
+        
     def test_formatmonth_with_invalid_month(self):
         with self.assertRaises(calendar.IllegalMonthError):
             calendar.TextCalendar().formatmonth(2017, 13)
         with self.assertRaises(calendar.IllegalMonthError):
             calendar.TextCalendar().formatmonth(2017, -1)
+
+    def test_illegal_month_error_bases(self):
+        self.assertIsSubclass(calendar.IllegalMonthError, ValueError)
+        self.assertIsSubclass(calendar.IllegalMonthError, IndexError)
 
     def test_formatmonthname_with_year(self):
         self.assertEqual(

--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -495,7 +495,7 @@ class OutputTestCase(unittest.TestCase):
             calendar.TextCalendar().formatmonth(0, 2),
             result_0_02_text
         )
-        
+
     def test_formatmonth_with_invalid_month(self):
         with self.assertRaises(calendar.IllegalMonthError):
             calendar.TextCalendar().formatmonth(2017, 13)

--- a/Misc/NEWS.d/next/Documentation/2026-04-17-02-28-55.gh-issue-148663.MHIbRB.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-04-17-02-28-55.gh-issue-148663.MHIbRB.rst
@@ -1,0 +1,2 @@
+Document that :class:`calendar.IllegalMonthError` is a subclass of both
+:exc:`ValueError` and :exc:`IndexError` since Python 3.12.

--- a/Misc/NEWS.d/next/Documentation/2026-04-17-02-28-55.gh-issue-148663.MHIbRB.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-04-17-02-28-55.gh-issue-148663.MHIbRB.rst
@@ -1,0 +1,5 @@
+Document that :class:`calendar.IllegalMonthError` inherits from both
+:exc:`ValueError` and :exc:`IndexError`, preserving :exc:`IndexError` for
+backwards compatibility with code that caught it for bad month numbers prior
+to Python 3.13.
+###########################################################################


### PR DESCRIPTION
The documentation for `calendar.IllegalMonthError` describes it only as "a subclass of `ValueError`", but the source code defines it as:

```python
class IllegalMonthError(ValueError, IndexError):
```

The `IndexError` base class is intentional for backwards compatibility (see the source comment in `Lib/calendar.py`), but this is not mentioned in the docs. Users catching `IndexError` for bad month numbers won't know their code still works after Python 3.13.

<!-- gh-issue-number: gh-148663 -->
* Issue: gh-148663
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148664.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->