### PR TITLE
gh-148402: add missing stacklevel to warnings.warn() in subprocess.Popen

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -912,7 +912,8 @@ class Popen:
         else:
             # POSIX
             if pass_fds and not close_fds:
-                warnings.warn("pass_fds overriding close_fds.", RuntimeWarning)
+                warnings.warn("pass_fds overriding close_fds.",
+                              RuntimeWarning, stacklevel=2)
                 close_fds = True
             if startupinfo is not None:
                 raise ValueError("startupinfo is only supported on Windows "
@@ -1567,7 +1568,8 @@ class Popen:
                 if handle_list:
                     if not close_fds:
                         warnings.warn("startupinfo.lpAttributeList['handle_list'] "
-                                      "overriding close_fds", RuntimeWarning)
+                                      "overriding close_fds", RuntimeWarning,
+                                      stacklevel=3)
 
                     # When using the handle_list we always request to inherit
                     # handles but the only handles that will be inherited are

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -913,7 +913,8 @@ class Popen:
             # POSIX
             if pass_fds and not close_fds:
                 warnings.warn("pass_fds overriding close_fds.",
-                              RuntimeWarning, stacklevel=2)
+                              RuntimeWarning,
+                              skip_file_prefixes=(__file__,))
                 close_fds = True
             if startupinfo is not None:
                 raise ValueError("startupinfo is only supported on Windows "
@@ -1569,7 +1570,7 @@ class Popen:
                     if not close_fds:
                         warnings.warn("startupinfo.lpAttributeList['handle_list'] "
                                       "overriding close_fds", RuntimeWarning,
-                                      stacklevel=3)
+                                      skip_file_prefixes=(__file__,))
 
                     # When using the handle_list we always request to inherit
                     # handles but the only handles that will be inherited are

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -3176,19 +3176,7 @@ class POSIXProcessTestCase(BaseTestCase):
                         ZERO_RETURN_CMD,
                         close_fds=False, pass_fds=(fd, )))
             self.assertIn('overriding close_fds', str(context.warning))
-
-    def test_pass_fds_overriding_close_fds_warning_location(self):
-        # Verify the warning points to the caller, not subprocess.py.
-        r, w = os.pipe()
-        self.addCleanup(os.close, r)
-        self.addCleanup(os.close, w)
-        os.set_inheritable(r, True)
-        with self.assertWarns(RuntimeWarning) as cm:
-            p = subprocess.Popen(
-                ZERO_RETURN_CMD,
-                close_fds=False, pass_fds=(r,))
-            p.wait()
-        self.assertEqual(cm.filename, __file__)
+            self.assertEqual(context.filename, __file__)
 
     def test_pass_fds_inheritable(self):
         script = support.findfile("fd_status.py", subdir="subprocessdata")

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -3177,6 +3177,19 @@ class POSIXProcessTestCase(BaseTestCase):
                         close_fds=False, pass_fds=(fd, )))
             self.assertIn('overriding close_fds', str(context.warning))
 
+    def test_pass_fds_overriding_close_fds_warning_location(self):
+        # Verify the warning points to the caller, not subprocess.py.
+        r, w = os.pipe()
+        self.addCleanup(os.close, r)
+        self.addCleanup(os.close, w)
+        os.set_inheritable(r, True)
+        with self.assertWarns(RuntimeWarning) as cm:
+            p = subprocess.Popen(
+                ZERO_RETURN_CMD,
+                close_fds=False, pass_fds=(r,))
+            p.wait()
+        self.assertEqual(cm.filename, __file__)
+
     def test_pass_fds_inheritable(self):
         script = support.findfile("fd_status.py", subdir="subprocessdata")
 
@@ -3762,8 +3775,7 @@ class Win32ProcessTestCase(BaseTestCase):
         self.assertIn(b"OSError", stderr)
 
         # Check for a warning due to using handle_list and close_fds=False
-        with warnings_helper.check_warnings((".*overriding close_fds",
-                                             RuntimeWarning)):
+        with self.assertWarns(RuntimeWarning) as cm:
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.lpAttributeList = {"handle_list": handles[:]}
             p = subprocess.Popen([sys.executable, "-c",
@@ -3772,6 +3784,8 @@ class Win32ProcessTestCase(BaseTestCase):
                                  startupinfo=startupinfo, close_fds=False)
             stdout, stderr = p.communicate()
             self.assertEqual(p.returncode, 0)
+        self.assertIn('overriding close_fds', str(cm.warning))
+        self.assertEqual(cm.filename, __file__)
 
     def test_empty_attribute_list(self):
         startupinfo = subprocess.STARTUPINFO()

--- a/Misc/NEWS.d/next/Library/2026-04-11-14-28-56.gh-issue-148402.zey6m1.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-11-14-28-56.gh-issue-148402.zey6m1.rst
@@ -1,0 +1,2 @@
+Warnings emitted by :class:`subprocess.Popen` now correctly report the
+caller's source location instead of a line inside :mod:`subprocess`.


### PR DESCRIPTION
## Summary

Add `stacklevel` to two `warnings.warn()` calls in `subprocess.Popen` so
that warnings point to the caller's code instead of `subprocess` internals.

### Changes

| Location | Warning | stacklevel | Reason |
|----------|---------|------------|--------|
| `__init__` (POSIX) | `pass_fds overriding close_fds` | 2 | `caller → __init__ → warn` |
| `_execute_child` (Windows) | `handle_list overriding close_fds` | 3 | `caller → __init__ → _execute_child → warn` |

### Tests

- New `test_pass_fds_overriding_close_fds_warning_location` in `POSIXProcessTestCase`: calls `Popen()` directly and asserts `cm.filename == __file__`.
- Enhanced `test_close_fds_with_stdio` in `Win32ProcessTestCase`: switched from `check_warnings` to `assertWarns`, added `cm.filename == __file__` assertion.

_Supersedes #148400 which was accidentally closed during a force push._

<!-- gh-issue-number: gh-148402 -->