### PR TITLE
gh-148680: Replace internal names with type_reprs of objects in string representations of ForwardRef

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -269,15 +269,10 @@ class ForwardRef:
             names = self.__extra_names__
 
             if names:
-                # identifiers can be replaced directly
-                if resolved_str.isidentifier():
-                    if (name_obj := names.get(resolved_str, _sentinel)) is not _sentinel:
-                        resolved_str = type_repr(name_obj)
-                else:
-                    visitor = _ExtraNameFixer(names)
-                    ast_expr = ast.parse(resolved_str, mode="eval").body
-                    node = visitor.visit(ast_expr)
-                    resolved_str = ast.unparse(node)
+                visitor = _ExtraNameFixer(names)
+                ast_expr = ast.parse(resolved_str, mode="eval").body
+                node = visitor.visit(ast_expr)
+                resolved_str = ast.unparse(node)
 
             self.__resolved_str_cache__ = resolved_str
 

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -271,7 +271,7 @@ class ForwardRef:
             if names:
                 # identifiers can be replaced directly
                 if resolved_str.isidentifier():
-                    if (name_obj := names.get(resolved_str), _sentinel) is not _sentinel:
+                    if (name_obj := names.get(resolved_str, _sentinel)) is not _sentinel:
                         resolved_str = type_repr(name_obj)
                 else:
                     visitor = _ExtraNameFixer(names)

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -260,7 +260,8 @@ class ForwardRef:
 
     @property
     def __resolved_forward_str__(self):
-        # __forward_arg__ but with __extra_names__ resolved as strings
+        # __forward_arg__ with any names from __extra_names__ replaced
+        # with the type_repr of the value they represent
         resolved_str = self.__forward_arg__
         names = self.__extra_names__
 

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -113,7 +113,7 @@ class ForwardRef:
         """
         match format:
             case Format.STRING:
-                return self.__forward_arg__
+                return self.__resolved_forward_str__
             case Format.VALUE:
                 is_forwardref_format = False
             case Format.FORWARDREF:
@@ -259,6 +259,25 @@ class ForwardRef:
         )
 
     @property
+    def __resolved_forward_str__(self):
+        # __forward_arg__ but with __extra_names__ resolved as strings
+        resolved_str = self.__forward_arg__
+        names = self.__extra_names__
+
+        if names:
+            # identifiers can be replaced directly
+            if resolved_str.isidentifier():
+                if (name_obj := names.get(resolved_str), _sentinel) is not _sentinel:
+                    resolved_str = type_repr(name_obj)
+            else:
+                visitor = _ExtraNameFixer(names)
+                ast_expr = ast.parse(resolved_str, mode="eval").body
+                node = visitor.visit(ast_expr)
+                resolved_str = ast.unparse(node)
+
+        return resolved_str
+
+    @property
     def __forward_code__(self):
         if self.__code__ is not None:
             return self.__code__
@@ -321,7 +340,7 @@ class ForwardRef:
             extra.append(", is_class=True")
         if self.__owner__ is not None:
             extra.append(f", owner={self.__owner__!r}")
-        return f"ForwardRef({self.__forward_arg__!r}{''.join(extra)})"
+        return f"ForwardRef({self.__resolved_forward_str__!r}{''.join(extra)})"
 
 
 _Template = type(t"")
@@ -1163,3 +1182,16 @@ def _get_dunder_annotations(obj):
     if not isinstance(ann, dict):
         raise ValueError(f"{obj!r}.__annotations__ is neither a dict nor None")
     return ann
+
+
+class _ExtraNameFixer(ast.NodeTransformer):
+    """Fixer for __extra_names__ items in ForwardRef __repr__ and string evaluation"""
+    def __init__(self, extra_names):
+        self.extra_names = extra_names
+
+    def visit_Name(self, node: ast.Name):
+        if (new_name := self.extra_names.get(node.id, _sentinel)) is not _sentinel:
+            new_node = ast.Name(id=type_repr(new_name))
+            ast.copy_location(node, new_node)
+            node = new_node
+        return node

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -1198,7 +1198,5 @@ class _ExtraNameFixer(ast.NodeTransformer):
 
     def visit_Name(self, node: ast.Name):
         if (new_name := self.extra_names.get(node.id, _sentinel)) is not _sentinel:
-            new_node = ast.Name(id=type_repr(new_name))
-            ast.copy_location(node, new_node)
-            node = new_node
+            node = ast.Name(id=type_repr(new_name))
         return node

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -47,6 +47,7 @@ _SLOTS = (
     "__cell__",
     "__owner__",
     "__stringifier_dict__",
+    "__resolved_str_cache__",
 )
 
 
@@ -94,6 +95,7 @@ class ForwardRef:
         # value later.
         self.__code__ = None
         self.__ast_node__ = None
+        self.__resolved_str_cache__ = None
 
     def __init_subclass__(cls, /, *args, **kwds):
         raise TypeError("Cannot subclass ForwardRef")
@@ -113,7 +115,7 @@ class ForwardRef:
         """
         match format:
             case Format.STRING:
-                return self.__resolved_forward_str__
+                return self.__resolved_str__
             case Format.VALUE:
                 is_forwardref_format = False
             case Format.FORWARDREF:
@@ -259,24 +261,27 @@ class ForwardRef:
         )
 
     @property
-    def __resolved_forward_str__(self):
+    def __resolved_str__(self):
         # __forward_arg__ with any names from __extra_names__ replaced
         # with the type_repr of the value they represent
-        resolved_str = self.__forward_arg__
-        names = self.__extra_names__
+        if self.__resolved_str_cache__ is None:
+            resolved_str = self.__forward_arg__
+            names = self.__extra_names__
 
-        if names:
-            # identifiers can be replaced directly
-            if resolved_str.isidentifier():
-                if (name_obj := names.get(resolved_str), _sentinel) is not _sentinel:
-                    resolved_str = type_repr(name_obj)
-            else:
-                visitor = _ExtraNameFixer(names)
-                ast_expr = ast.parse(resolved_str, mode="eval").body
-                node = visitor.visit(ast_expr)
-                resolved_str = ast.unparse(node)
+            if names:
+                # identifiers can be replaced directly
+                if resolved_str.isidentifier():
+                    if (name_obj := names.get(resolved_str), _sentinel) is not _sentinel:
+                        resolved_str = type_repr(name_obj)
+                else:
+                    visitor = _ExtraNameFixer(names)
+                    ast_expr = ast.parse(resolved_str, mode="eval").body
+                    node = visitor.visit(ast_expr)
+                    resolved_str = ast.unparse(node)
 
-        return resolved_str
+            self.__resolved_str_cache__ = resolved_str
+
+        return self.__resolved_str_cache__
 
     @property
     def __forward_code__(self):
@@ -341,7 +346,7 @@ class ForwardRef:
             extra.append(", is_class=True")
         if self.__owner__ is not None:
             extra.append(f", owner={self.__owner__!r}")
-        return f"ForwardRef({self.__resolved_forward_str__!r}{''.join(extra)})"
+        return f"ForwardRef({self.__resolved_str__!r}{''.join(extra)})"
 
 
 _Template = type(t"")
@@ -377,6 +382,7 @@ class _Stringifier:
         self.__cell__ = cell
         self.__owner__ = owner
         self.__stringifier_dict__ = stringifier_dict
+        self.__resolved_str_cache__ = None  # Needed for ForwardRef
 
     def __convert_to_ast(self, other):
         if isinstance(other, _Stringifier):

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -2058,7 +2058,11 @@ class TestForwardRefClass(unittest.TestCase):
         def f(a: ref | str): ...
 
         fr = get_annotations(f, format=Format.FORWARDREF)['a']
+        # Test the cache is not populated before access
+        self.assertIsNone(fr.__resolved_str_cache__)
+
         self.assertEqual(fr.evaluate(format=Format.STRING), "ref | str")
+        self.assertEqual(fr.__resolved_str_cache__, "ref | str")
 
     def test_evaluate_forwardref_format(self):
         fr = ForwardRef("undef")

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1961,6 +1961,11 @@ class TestForwardRefClass(unittest.TestCase):
             "typing.List[ForwardRef('int', owner='class')]",
         )
 
+    def test_forward_repr_extra_names(self):
+        fr = ForwardRef("__annotationlib_name_1__")
+        fr.__extra_names__ = {"__annotationlib_name_1__": list[str]}
+        self.assertEqual(repr(fr), "ForwardRef('list[str]')")
+
     def test_forward_recursion_actually(self):
         def namespace1():
             a = ForwardRef("A")
@@ -2036,6 +2041,20 @@ class TestForwardRefClass(unittest.TestCase):
     def test_evaluate_string_format(self):
         fr = ForwardRef("set[Any]")
         self.assertEqual(fr.evaluate(format=Format.STRING), "set[Any]")
+
+    def test_evaluate_string_format_extra_names(self):
+        # Test that internal extra_names are replaced when evaluating as strings
+
+        # As identifier
+        fr = ForwardRef("__annotationlib_name_1__")
+        fr.__extra_names__ = {"__annotationlib_name_1__": str}
+        self.assertEqual(fr.evaluate(format=Format.STRING), "str")
+
+        # Via AST visitor
+        def f(a: ref | str): ...
+
+        fr = get_annotations(f, format=Format.FORWARDREF)['a']
+        self.assertEqual(fr.evaluate(format=Format.STRING), "ref | str")
 
     def test_evaluate_forwardref_format(self):
         fr = ForwardRef("undef")

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1962,9 +1962,13 @@ class TestForwardRefClass(unittest.TestCase):
         )
 
     def test_forward_repr_extra_names(self):
-        fr = ForwardRef("__annotationlib_name_1__")
-        fr.__extra_names__ = {"__annotationlib_name_1__": list[str]}
-        self.assertEqual(repr(fr), "ForwardRef('list[str]')")
+        def f(a: undefined | str): ...
+
+        annos = get_annotations(f, format=Format.FORWARDREF)
+
+        self.assertRegex(
+            repr(annos['a']), r"ForwardRef\('undefined \| str'.*\)"
+        )
 
     def test_forward_recursion_actually(self):
         def namespace1():

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -2048,21 +2048,14 @@ class TestForwardRefClass(unittest.TestCase):
 
     def test_evaluate_string_format_extra_names(self):
         # Test that internal extra_names are replaced when evaluating as strings
-
-        # As identifier
-        fr = ForwardRef("__annotationlib_name_1__")
-        fr.__extra_names__ = {"__annotationlib_name_1__": str}
-        self.assertEqual(fr.evaluate(format=Format.STRING), "str")
-
-        # Via AST visitor
-        def f(a: ref | str): ...
+        def f(a: unknown | str | int | list[str] | tuple[int, ...]): ...
 
         fr = get_annotations(f, format=Format.FORWARDREF)['a']
         # Test the cache is not populated before access
         self.assertIsNone(fr.__resolved_str_cache__)
 
-        self.assertEqual(fr.evaluate(format=Format.STRING), "ref | str")
-        self.assertEqual(fr.__resolved_str_cache__, "ref | str")
+        self.assertEqual(fr.evaluate(format=Format.STRING), "unknown | str | int | list[str] | tuple[int, ...]")
+        self.assertEqual(fr.__resolved_str_cache__, "unknown | str | int | list[str] | tuple[int, ...]")
 
     def test_evaluate_forwardref_format(self):
         fr = ForwardRef("undef")

--- a/Misc/NEWS.d/next/Library/2026-04-23-07-38-04.gh-issue-148680.___ePl.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-23-07-38-04.gh-issue-148680.___ePl.rst
@@ -1,0 +1,1 @@
+``ForwardRef``s that contain internal names to represent known objects now show the ``type_repr`` of the object rather than the internal ``__annotationlib_name_x__`` name when evaluated as strings.

--- a/Misc/NEWS.d/next/Library/2026-04-23-07-38-04.gh-issue-148680.___ePl.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-23-07-38-04.gh-issue-148680.___ePl.rst
@@ -1,1 +1,1 @@
-``ForwardRef``s that contain internal names to represent known objects now show the ``type_repr`` of the object rather than the internal ``__annotationlib_name_x__`` name when evaluated as strings.
+``ForwardRef`` objects that contain internal names to represent known objects now show the ``type_repr`` of the known object rather than the internal ``__annotationlib_name_x__`` name when evaluated as strings.


### PR DESCRIPTION
This adds a new `ForwardRef.__resolved_forward_str__` attribute which takes the `__forward_arg__` and replaces any internal `__annotationlib_name_x__` names with the `type_repr` of the object they represent.

Before:
```python
ForwardRef('ref | __annotationlib_name_1__', is_class=True, owner=<class '__main__.Example'>)
ref | __annotationlib_name_1__
```

After:
```python
ForwardRef('ref | str', is_class=True, owner=<class '__main__.Example'>)
ref | str
```

This approach replaces the extra_names with their `type_repr` when the forwardref is evaluated to a string. I'm fairly sure that trying to get the original names as they are in the source would be both slower and significantly more complicated.

This logic is largely based on something I already have for my `reannotate` library.

<!-- gh-issue-number: gh-148680 -->
* Issue: gh-148680
<!-- /gh-issue-number -->
