### PR TITLE
gh-148688: Fix _BlocksOutputBuffer_Finish() double free

### DIFF
--- a/Include/internal/pycore_blocks_output_buffer.h
+++ b/Include/internal/pycore_blocks_output_buffer.h
@@ -242,9 +242,12 @@ static inline PyObject *
 _BlocksOutputBuffer_Finish(_BlocksOutputBuffer *buffer,
                            const Py_ssize_t avail_out)
 {
+    PyObject *obj;
     assert(buffer->writer != NULL);
-    return PyBytesWriter_FinishWithSize(buffer->writer,
-                                        buffer->allocated - avail_out);
+    obj = PyBytesWriter_FinishWithSize(buffer->writer,
+                                       buffer->allocated - avail_out);
+    buffer->writer = NULL;
+    return obj;
 }
 
 /* Clean up the buffer when an error occurred. */

--- a/Misc/NEWS.d/next/Library/2026-04-17-16-31-58.gh-issue-148688.vVugFn.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-17-16-31-58.gh-issue-148688.vVugFn.rst
@@ -1,0 +1,2 @@
+Fix a double free in :mod:`bz2` on memory allocation failure. Patch by
+Victor Stinner.

--- a/Misc/NEWS.d/next/Library/2026-04-17-16-31-58.gh-issue-148688.vVugFn.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-17-16-31-58.gh-issue-148688.vVugFn.rst
@@ -1,2 +1,2 @@
-Fix a double free in :mod:`bz2` on memory allocation failure. Patch by
-Victor Stinner.
+:mod:`bz2`, :mod:`lzma`, :mod:`zlib`: Fix a double free in on memory allocation
+failure. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Library/2026-04-17-16-31-58.gh-issue-148688.vVugFn.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-17-16-31-58.gh-issue-148688.vVugFn.rst
@@ -1,2 +1,2 @@
 :mod:`bz2`, :mod:`compression.zstd`, :mod:`lzma`, :mod:`zlib`: Fix a double
-free in on memory allocation failure. Patch by Victor Stinner.
+free on memory allocation failure. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Library/2026-04-17-16-31-58.gh-issue-148688.vVugFn.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-17-16-31-58.gh-issue-148688.vVugFn.rst
@@ -1,2 +1,2 @@
-:mod:`bz2`, :mod:`lzma`, :mod:`zlib`: Fix a double free in on memory allocation
-failure. Patch by Victor Stinner.
+:mod:`bz2`, :mod:`compression.zstd`, :mod:`lzma`, :mod:`zlib`: Fix a double
+free in on memory allocation failure. Patch by Victor Stinner.


### PR DESCRIPTION
If _BlocksOutputBuffer_Finish() fails (memory allocation failure), PyBytesWriter_Discard() is called on the writer. Then if _BlocksOutputBuffer_OnError() is called, it calls again PyBytesWriter_Discard() causing a double free.

Fix _BlocksOutputBuffer_Finish() by setting buffer->writer to NULL, so _BlocksOutputBuffer_OnError() does nothing instead of calling PyBytesWriter_Discard() again.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148688 -->
* Issue: gh-148688
<!-- /gh-issue-number -->
