### PR TITLE
GH-148560: Don't emit unwind info for JIT stencils

### DIFF
--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -90,6 +90,7 @@ _PATCH_FUNCS = {
     "R_AARCH64_MOVW_UABS_G1_NC": "patch_aarch64_16b",
     "R_AARCH64_MOVW_UABS_G2_NC": "patch_aarch64_16c",
     "R_AARCH64_MOVW_UABS_G3": "patch_aarch64_16d",
+    "R_AARCH64_PREL32": "patch_32r",
     # x86_64-unknown-linux-gnu:
     "R_X86_64_64": "patch_64",
     "R_X86_64_GOTPCRELX": "patch_x86_64_32rx",

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -90,7 +90,6 @@ _PATCH_FUNCS = {
     "R_AARCH64_MOVW_UABS_G1_NC": "patch_aarch64_16b",
     "R_AARCH64_MOVW_UABS_G2_NC": "patch_aarch64_16c",
     "R_AARCH64_MOVW_UABS_G3": "patch_aarch64_16d",
-    "R_AARCH64_PREL32": "patch_32r",
     # x86_64-unknown-linux-gnu:
     "R_X86_64_64": "patch_64",
     "R_X86_64_GOTPCRELX": "patch_x86_64_32rx",

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -166,6 +166,7 @@ class _Target(typing.Generic[_S, _R]):
             # This debug info isn't necessary, and bloats out the JIT'ed code.
             # We *may* be able to re-enable this, process it, and JIT it for a
             # nicer debugging experience... but that needs a lot more research:
+            "-fno-asynchronous-unwind-tables",
             "-fno-unwind-tables",
             # Don't call built-in functions that we can't find or patch:
             "-fno-builtin",
@@ -435,7 +436,6 @@ class _ELF(
                 "SHT_NULL",
                 "SHT_STRTAB",
                 "SHT_SYMTAB",
-                "SHT_X86_64_UNWIND",
             }, section_type
 
     def _handle_relocation(

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -166,7 +166,7 @@ class _Target(typing.Generic[_S, _R]):
             # This debug info isn't necessary, and bloats out the JIT'ed code.
             # We *may* be able to re-enable this, process it, and JIT it for a
             # nicer debugging experience... but that needs a lot more research:
-            "-fno-asynchronous-unwind-tables",
+            "-fno-unwind-tables",
             # Don't call built-in functions that we can't find or patch:
             "-fno-builtin",
             # Don't call stack-smashing canaries that we can't find or patch:
@@ -435,6 +435,7 @@ class _ELF(
                 "SHT_NULL",
                 "SHT_STRTAB",
                 "SHT_SYMTAB",
+                "SHT_X86_64_UNWIND",
             }, section_type
 
     def _handle_relocation(


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

In practice, `-fno-unwind-tables` alone doesn't suppress all unwind-table emission across platform targets (Windows still emits SEH unwind info), so we need both flags to make every platform happy. Verified that with this combo, we no longer see .cfi frame errors on macOS (where this was originally reported to be a problem).

<!-- gh-issue-number: gh-148560 -->
* Issue: gh-148560
<!-- /gh-issue-number -->
