### PR TITLE
gh-86178: Refactor WSGIEnvironment to use TypedDict

### DIFF
--- a/Lib/wsgiref/types.py
+++ b/Lib/wsgiref/types.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Iterable, Iterator
 from types import TracebackType
-from typing import Any, Protocol, TypeAlias
+from typing import Any, Literal, NotRequired, Protocol, TypeAlias, TypedDict
 
 __all__ = [
     "StartResponse",
@@ -26,7 +26,29 @@ class StartResponse(Protocol):
         /,
     ) -> Callable[[bytes], object]: ...
 
-WSGIEnvironment: TypeAlias = dict[str, Any]
+WSGIEnvironment = TypedDict(
+    "WSGIEnvironment",
+    {
+        "REQUEST_METHOD": str,
+        "SCRIPT_NAME": NotRequired[str],
+        "PATH_INFO": NotRequired[str],
+        "QUERY_STRING": NotRequired[str],
+        "CONTENT_TYPE": NotRequired[str],
+        "CONTENT_LENGTH": NotRequired[str],
+        "SERVER_NAME": str,
+        "SERVER_PORT": str,
+        "SERVER_PROTOCOL": str,
+        "wsgi.version": tuple[Literal[1], Literal[0]],
+        "wsgi.url_scheme": str,
+        "wsgi.input": "InputStream",
+        "wsgi.errors": "ErrorStream",
+        "wsgi.multithread": Any,
+        "wsgi.multiprocess": Any,
+        "wsgi.run_once": Any,
+        "wsgi.file_wrapper": NotRequired["FileWrapper"],
+    },
+    extra_items=Any,
+)
 WSGIApplication: TypeAlias = Callable[[WSGIEnvironment, StartResponse],
     Iterable[bytes]]
 

--- a/Misc/NEWS.d/next/Library/2026-04-20-18-24-36.gh-issue-86178.5gTefv.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-20-18-24-36.gh-issue-86178.5gTefv.rst
@@ -1,0 +1,1 @@
+Add the CGI and WSGI variables specified in :pep:`3333` to :data:`wsgiref.types.WSGIEnvironment`.


### PR DESCRIPTION
As mentioned in https://github.com/python/cpython/pull/32335#issuecomment-1089027120, this PR makes WSGIEnvironment use TypedDict. It has items for the CGI variables and WSGI variables specified in [PEP 3333](https://peps.python.org/pep-3333/#environ-variables). `wsgi.multithread`, `wsgi.multiprocess`, and `wsgi.run_once` are typed as `Any` because they are only specified as being evaluable as true or false, not explicitly as `bool`. In addition, since according to the PEP `environ` is valid with arbitrary extra items, so `extra_items=Any` is set.

According to PEP 3333, a server or gateway should provide as many CGI variables as possible. This includes variables beginning with `HTTP_*`, other variables specified in [RFC 3875](https://datatracker.ietf.org/doc/html/rfc3875), and mod_ssl variables. If these were to be included in WSGIEnvironment, they would all need to be `NotRequired[str]`, as described in the PEP. Including them could provide some help with IDE/editor autocompletion and inferring types, but there are too many of them, and it is unclear how much to include, so I have not added them for now.

<!-- gh-issue-number: gh-86178 -->
* Issue: gh-86178
<!-- /gh-issue-number -->
