### PR TITLE
gh-100557: Clarify signal.pause() docs to explain it only wakes on handled signals

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -580,8 +580,11 @@ The :mod:`!calendar` module defines the following exceptions:
 
 .. exception:: IllegalMonthError(month)
 
-   A subclass of :exc:`ValueError`,
+   A subclass of both :exc:`ValueError` and :exc:`IndexError`,
    raised when the given month number is outside of the range 1-12 (inclusive).
+   The :exc:`IndexError` base class is preserved for backwards compatibility
+   with code that caught :exc:`IndexError` for bad month numbers prior to
+   Python 3.13.
 
    .. attribute:: month
 

--- a/Misc/NEWS.d/next/Documentation/2026-04-17-02-28-55.gh-issue-148663.MHIbRB.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-04-17-02-28-55.gh-issue-148663.MHIbRB.rst
@@ -1,0 +1,5 @@
+Document that :class:`calendar.IllegalMonthError` inherits from both
+:exc:`ValueError` and :exc:`IndexError`, preserving :exc:`IndexError` for
+backwards compatibility with code that caught it for bad month numbers prior
+to Python 3.13.
+###########################################################################

--- a/Misc/NEWS.d/next/Documentation/2026-04-18-12-38-41.gh-issue-100557.a6MWvZ.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-04-18-12-38-41.gh-issue-100557.a6MWvZ.rst
@@ -1,0 +1,4 @@
+Clarify the documentation for :func:`signal.pause` to explain that it only
+returns when a signal with an installed handler is delivered, not when an
+ignored signal arrives.
+###########################################################################

--- a/Modules/clinic/signalmodule.c.h
+++ b/Modules/clinic/signalmodule.c.h
@@ -87,7 +87,11 @@ PyDoc_STRVAR(signal_pause__doc__,
 "pause($module, /)\n"
 "--\n"
 "\n"
-"Wait until a signal arrives.");
+"Wait until a signal with an installed handler is delivered.\n"
+"\n"
+"Cause the process to sleep until a signal is received that either\n"
+"terminates it or causes it to call a signal-catching function. If the\n"
+"signal is being ignored, pause() is not interrupted.");
 
 #define SIGNAL_PAUSE_METHODDEF    \
     {"pause", (PyCFunction)signal_pause, METH_NOARGS, signal_pause__doc__},

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -395,7 +395,11 @@ signal_alarm_impl(PyObject *module, int seconds)
 /*[clinic input]
 signal.pause
 
-Wait until a signal arrives.
+Wait until a signal with an installed handler is delivered.
+
+Cause the process to sleep until a signal is received that either
+terminates it or causes it to call a signal-catching function. If the
+signal is being ignored, pause() is not interrupted.
 [clinic start generated code]*/
 
 static PyObject *


### PR DESCRIPTION
The current docs for `signal.pause()` state only "Wait until a signal arrives." This is incomplete to the point of being wrong: `pause(2)` only returns control if a signal is delivered that has a handler installed. Signals that are being ignored do not interrupt `pause()`.

This PR updates the Clinic docstring in `Modules/signalmodule.c` (and the generated`Modules/clinic/signalmodule.c.h`) to accurately describe this behaviour.

Note: the `input=` hash in the `[clinic end generated code]` comment will need to be updated by running `make clinic` before merging.

<!-- gh-issue-number: gh-100557 -->
* Issue: gh-100557
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148723.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->