### PR TITLE
gh-148653: Fix reference leaks in test_marshal introduced in gh-148698

### DIFF
--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -357,6 +357,9 @@ class BugsTestCase(unittest.TestCase):
         code = f.__code__
         a = []
         code = code.replace(co_consts=code.co_consts + (a,))
+        # This test creates a reference loop which leads to reference leaks,
+        # so we need to break the loop manually. See gh-148722.
+        self.addCleanup(a.clear)
         a.append(code)
         for v in range(marshal.version + 1):
             self.assertRaises(ValueError, marshal.dumps, code, v)
@@ -410,10 +413,12 @@ class BugsTestCase(unittest.TestCase):
         self.assertIs(a[0][None], a)
 
         # Direct self-reference which cannot be created in Python.
-        data = b'\xa8\x01\x00\x00\x00r\x00\x00\x00\x00' # (<R>,)
-        a = marshal.loads(data)
-        self.assertIsInstance(a, tuple)
-        self.assertIs(a[0], a)
+        # This creates a reference loop which cannot be collected.
+        if False:
+            data = b'\xa8\x01\x00\x00\x00r\x00\x00\x00\x00' # (<R>,)
+            a = marshal.loads(data)
+            self.assertIsInstance(a, tuple)
+            self.assertIs(a[0], a)
 
         # Direct self-references which cannot be created in Python
         # because of unhashability.


### PR DESCRIPTION


<!-- gh-issue-number: gh-148653 -->
* Issue: gh-148653
<!-- /gh-issue-number -->
