### PR TITLE
gh-148735: Fix a UAF in `Element.findtext()`

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -3258,6 +3258,16 @@ class BadElementPathTest(ElementTestCase, unittest.TestCase):
                 e.extend([ET.Element('bar')])
                 e.findtext(cls(e, 'x'))
 
+    def test_findtext_with_mutating_non_none_text(self):
+        for cls in [MutationDeleteElementPath, MutationClearElementPath]:
+            with self.subTest(cls):
+                e = ET.Element('foo')
+                child = ET.Element('bar')
+                child.text = str(object())
+                e.append(child)
+                del child
+                repr(e.findtext(cls(e, 'x')))
+
     def test_findtext_with_error(self):
         e = ET.Element('foo')
         e.extend([ET.Element('bar')])

--- a/Misc/NEWS.d/next/Library/2026-04-18-21-39-15.gh-issue-148735.siw6DG.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-18-21-39-15.gh-issue-148735.siw6DG.rst
@@ -1,0 +1,4 @@
+:mod:`xml.etree.ElementTree`: Fix a use-after-free in
+:meth:`Element.findtext <xml.etree.ElementTree.Element.findtext>` when the
+tag to find implements an :meth:`~object.__eq__` method that drops every
+other reference to a matching element.

--- a/Misc/NEWS.d/next/Library/2026-04-18-21-39-15.gh-issue-148735.siw6DG.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-18-21-39-15.gh-issue-148735.siw6DG.rst
@@ -1,4 +1,3 @@
 :mod:`xml.etree.ElementTree`: Fix a use-after-free in
 :meth:`Element.findtext <xml.etree.ElementTree.Element.findtext>` when the
-tag to find implements an :meth:`~object.__eq__` method that drops every
-other reference to a matching element.
+element tree is mutated concurrently during the search.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1347,12 +1347,12 @@ _elementtree_Element_findtext_impl(ElementObject *self, PyTypeObject *cls,
         int rc = PyObject_RichCompareBool(tag, path, Py_EQ);
         Py_DECREF(tag);
         if (rc > 0) {
-            PyObject *text = element_get_text((ElementObject *)item);
+            PyObject *text = Py_XNewRef(element_get_text((ElementObject *)item));
             Py_DECREF(item);
             if (text == Py_None) {
+                Py_DECREF(text);
                 return Py_GetConstant(Py_CONSTANT_EMPTY_STR);
             }
-            Py_XINCREF(text);
             return text;
         }
         Py_DECREF(item);

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -572,7 +572,7 @@ element_get_attrib(ElementObject* self)
 LOCAL(PyObject*)
 element_get_text(ElementObject* self)
 {
-    /* return borrowed reference to text attribute */
+    /* return new reference to text attribute */
 
     PyObject *res = self->text;
 
@@ -587,13 +587,13 @@ element_get_text(ElementObject* self)
         }
     }
 
-    return res;
+    return Py_NewRef(res);
 }
 
 LOCAL(PyObject*)
 element_get_tail(ElementObject* self)
 {
-    /* return borrowed reference to text attribute */
+    /* return new reference to tail attribute */
 
     PyObject *res = self->tail;
 
@@ -608,7 +608,7 @@ element_get_tail(ElementObject* self)
         }
     }
 
-    return res;
+    return Py_NewRef(res);
 }
 
 static PyObject*
@@ -1347,7 +1347,7 @@ _elementtree_Element_findtext_impl(ElementObject *self, PyTypeObject *cls,
         int rc = PyObject_RichCompareBool(tag, path, Py_EQ);
         Py_DECREF(tag);
         if (rc > 0) {
-            PyObject *text = Py_XNewRef(element_get_text((ElementObject *)item));
+            PyObject *text = element_get_text((ElementObject *)item);
             Py_DECREF(item);
             if (text == Py_None) {
                 Py_DECREF(text);
@@ -2055,16 +2055,14 @@ static PyObject*
 element_text_getter(PyObject *op, void *closure)
 {
     ElementObject *self = _Element_CAST(op);
-    PyObject *res = element_get_text(self);
-    return Py_XNewRef(res);
+    return element_get_text(self);
 }
 
 static PyObject*
 element_tail_getter(PyObject *op, void *closure)
 {
     ElementObject *self = _Element_CAST(op);
-    PyObject *res = element_get_tail(self);
-    return Py_XNewRef(res);
+    return element_get_tail(self);
 }
 
 static PyObject*
@@ -2307,16 +2305,14 @@ elementiter_next(PyObject *op)
         continue;
 
 gettext:
+        Py_DECREF(elem);
         if (!text) {
-            Py_DECREF(elem);
             return NULL;
         }
         if (text == Py_None) {
-            Py_DECREF(elem);
+            Py_DECREF(text);
         }
         else {
-            Py_INCREF(text);
-            Py_DECREF(elem);
             rc = PyObject_IsTrue(text);
             if (rc > 0)
                 return text;


### PR DESCRIPTION
This was a regression introduced by c57623c221d46daeaedfbf2b32d041fde0c882de.

https://github.com/python/cpython/blob/ae55e9c053a79d90e619733f36b5806d7f9306c7/Modules/_elementtree.c#L575-L575

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148735 -->
* Issue: gh-148735
<!-- /gh-issue-number -->
