### PR TITLE
gh-148596: Fix callback return handling for subclassed ctypes types

### DIFF
--- a/Lib/test/test_ctypes/test_callbacks.py
+++ b/Lib/test/test_ctypes/test_callbacks.py
@@ -328,6 +328,17 @@ class SampleCallbacksTestCase(unittest.TestCase):
                              f"of ctypes callback function {func!r}")
             self.assertIsNone(cm.unraisable.object)
 
+    def test_callback_return_subclass(self):
+        class MyInt(ctypes.c_int):
+            pass
+
+        @ctypes.CFUNCTYPE(MyInt, MyInt)
+        def identity(x):
+            return x
+
+        result = identity(MyInt(42))
+        assert isinstance(result, MyInt)
+        assert result.value == 42
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2026-04-19-07-56-51.gh-issue-148596.SKckm9.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-19-07-56-51.gh-issue-148596.SKckm9.rst
@@ -1,0 +1,5 @@
+Fix ctypes callback return handling for subclassed simple types.
+
+Returning a ctypes instance (e.g. a subclass of c_int) from a CFUNCTYPE
+callback no longer raises an unraisable TypeError or leaves the result
+buffer uninitialized.

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -239,7 +239,19 @@ static void _CallPythonObject(ctypes_state *st,
            be the result.  EXCEPT when restype is py_object - Python
            itself knows how to manage the refcount of these objects.
         */
-        PyObject *keep = setfunc(mem, result, restype->size);
+        PyObject *value = result;   /* borrowed */
+        PyObject *unwrapped = NULL; /* new ref if created */
+        if (value != NULL && PyObject_TypeCheck(value, st->PyCData_Type)) {
+            unwrapped = PyObject_GetAttrString(value, "value");
+            if (unwrapped != NULL) {
+                value = unwrapped;
+            } else {
+                /* fallback: clear error and keep original */
+                PyErr_Clear();
+            }
+        }
+
+        PyObject *keep = setfunc(mem, value, restype->size);
 
         if (keep == NULL) {
             /* Could not convert callback result. */


### PR DESCRIPTION
## PR Summary: Fix handling of callback return values in `ctypes`

Fixes the handling of callback return values in `ctypes` when a callback returns an instance of a **subclass of a simple ctypes type** (e.g., a subclass of `c_int`).

**Closes:** gh-148596

---

### Problem
When a Python callback created with `CFUNCTYPE` returns an instance of a subclassed simple `ctypes` type, the return value is passed directly to the corresponding `setfunc` in `_ctypes`.

**Example Scenario:**
```python
class MyInt(ctypes.c_int):
    pass
```

**The Issue:**
1. `setfunc` expects a **native Python value** (such as `int` or `float`).
2. It does **not** accept `ctypes` instances.
3. This results in an internal `TypeError`, reported as an **unraisable exception**.
4. The C result buffer remains uninitialized, leading the caller to observe **undefined or garbage values**.

---

### Cause
In `Modules/_ctypes/callbacks.c::_CallPythonObject`, the callback return value is written into the C result buffer via:

```c
setfunc(mem, result, restype->size);
```

Unlike argument handling—which uses `ConvParam()` in `callproc.c` to unwrap `ctypes` instances into underlying Python values—this callback return path lacks the unwrapping step. This creates an inconsistency between how arguments and return values are processed.

---

### Solution
The fix ensures that `ctypes` instances are unwrapped by accessing their `.value` attribute before being passed to `setfunc`.

**Key Improvements:**
* **Correct Conversion:** Subclassed `ctypes` simple types are converted to native Python values.
* **Compatibility:** `setfunc` receives input it can process.
* **Stability:** The result buffer is properly initialized.
* **Consistency:** Native Python return values remain unaffected, preserving existing behavior.

---

### Behavior After Fix
```python
import ctypes

class MyInt(ctypes.c_int):
    pass

@ctypes.CFUNCTYPE(MyInt, MyInt)
def identity(x):
    # Now correctly unwraps the MyInt instance
    return x

result = identity(MyInt(42))

assert isinstance(result, MyInt)
assert result.value == 42
```

---

### Implementation Details
* **Tests:** Added a regression test to `test_ctypes` to verify that callbacks can safely return subclassed simple `ctypes` types.
* **Alignment:** This change aligns callback return value handling with standard argument conversion logic.