### PR TITLE
Fix typos in asyncio, ctypes, and importlib documentation

### DIFF
--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -304,7 +304,7 @@ generator can occur in an unexpected order::
       try:
           yield 2
       finally:
-          await asyncio.sleep(0.1) # immitate some async work
+          await asyncio.sleep(0.1) # imitate some async work
           work_done = True
 
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1735,7 +1735,7 @@ If wrapping a shared library with :mod:`!ctypes`, consider determining the
 shared library name at development time, and hardcoding it into the wrapper
 module instead of using :func:`!find_library` to locate the library
 at runtime.
-Also consider addding a configuration option or environment variable to let
+Also consider adding a configuration option or environment variable to let
 users select a library to use, and then perhaps use :func:`!find_library`
 as a default or fallback.
 

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -286,7 +286,7 @@ ABC hierarchy::
          This method can potentially yield a very large number of objects, and
          it may carry out IO operations when computing these values.
 
-         Because of this, it will generaly be desirable to compute the result
+         Because of this, it will generally be desirable to compute the result
          values on-the-fly, as they are needed. As such, the returned object is
          only guaranteed to be an :class:`iterable <collections.abc.Iterable>`,
          instead of a :class:`list` or other
@@ -340,7 +340,7 @@ ABC hierarchy::
          This method can potentially yield a very large number of objects, and
          it may carry out IO operations when computing these values.
 
-         Because of this, it will generaly be desirable to compute the result
+         Because of this, it will generally be desirable to compute the result
          values on-the-fly, as they are needed. As such, the returned object is
          only guaranteed to be an :class:`iterable <collections.abc.Iterable>`,
          instead of a :class:`list` or other


### PR DESCRIPTION
Fix typos in `asyncio`, `ctypes`, and `importlib` documentation.
Since it's a typo fix, I think issue number is not needed.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148747.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->