### PR TITLE
Enable keyboard navigation for Python docs

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -271,6 +271,7 @@ html_theme_options = {
     'collapsiblesidebar': True,
     'issues_url': '/bugs.html',
     'license_url': '/license.html',
+    'navigation_with_keys': True,  # Inherited from basic theme
     'root_include_title': False,  # We use the version switcher instead.
 }
 

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -269,6 +269,7 @@ html_theme_options = {
     'collapsiblesidebar': True,
     'issues_url': '/bugs.html',
     'license_url': '/license.html',
+    'navigation_with_keys': True,  # Inherited from basic theme
     'root_include_title': False,  # We use the version switcher instead.
 }
 

--- a/Misc/NEWS.d/next/Documentation/2026-04-19-11-37-35.gh-issue-148751.xe4KBl.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-04-19-11-37-35.gh-issue-148751.xe4KBl.rst
@@ -1,0 +1,1 @@
+Enable keyboard navigation for Python docs


### PR DESCRIPTION
You can test how it works before this change by opening JavaScript console with F12 and setting
````javascript
DOCUMENTATION_OPTIONS.NAVIGATION_WITH_KEYS = true
````
then make sure the focus is in the main are and press Left on the keyboard.

The option is documented here https://www.sphinx-doc.org/en/master/usage/theming.html#:~:text=navigation%5Fwith%5Fkeys



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148751.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->