### PR TITLE
gh-148758: Fix dynamic loading file extensions for CYGWIN

### DIFF
--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -38,6 +38,8 @@
 
 const char *_PyImport_DynLoadFiletab[] = {
 #ifdef __CYGWIN__
+    "." SOABI ".dll",
+    ".abi" PYTHON_ABI_STRING ".dll",
     ".dll",
 #else  /* !__CYGWIN__ */
     "." SOABI ".so",

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -39,7 +39,6 @@
 const char *_PyImport_DynLoadFiletab[] = {
 #ifdef __CYGWIN__
     "." SOABI ".dll",
-    ".abi" PYTHON_ABI_STRING ".dll",
     ".dll",
 #else  /* !__CYGWIN__ */
     "." SOABI ".so",


### PR DESCRIPTION
This patch fixes issue #148758.

After applying the patch, this will be the result on the console:
```
Checked 115 modules (37 built-in, 77 shared, 1 n/a on cygwin-3.6.7-x86_64, 0 disabled, 0 missing, 0 failed on import)
```

<!-- gh-issue-number: gh-148758 -->
* Issue: gh-148758
<!-- /gh-issue-number -->
