### PR TITLE
gh-100557: Clarify signal.pause() docs to explain it only wakes on handled signals

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -419,8 +419,9 @@ The :mod:`!signal` module defines the following functions:
 
 .. function:: pause()
 
-   Cause the process to sleep until a signal is received; the appropriate handler
-   will then be called.  Returns nothing.
+   Cause the process to sleep until a signal with an installed handler is
+   delivered; the handler will then be called.  Signals that are ignored or
+   set to the default action do not wake the process.  Returns nothing.
 
    .. availability:: Unix.
 

--- a/Misc/NEWS.d/next/Documentation/2026-04-18-12-38-41.gh-issue-100557.a6MWvZ.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-04-18-12-38-41.gh-issue-100557.a6MWvZ.rst
@@ -1,0 +1,4 @@
+Clarify the documentation for :func:`signal.pause` to explain that it only
+returns when a signal with an installed handler is delivered, not when an
+ignored signal arrives.
+###########################################################################


### PR DESCRIPTION
The docs for `signal.pause()` say it sleeps "until a signal is received", which is ambiguous. Signals that are ignored or set to the default action do not wake the process, only signals with an installed handler do this.

This clarifies the content in `Doc/library/signal.rst` accordingly.

The C docstring in `signalmodule.c` is intentionally left unchanged as it is the short manpage description and the online docs are the appropriate place for this level of detail.

Fixes #100557


<!-- gh-issue-number: gh-100557 -->
* Issue: gh-100557
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148760.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->