### PR TITLE
Use `soft-deprecated` in more places

### DIFF
--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -258,7 +258,9 @@ readonly, format
 
    .. c:macro:: PyBUF_WRITEABLE
 
-      This is a :term:`soft deprecated` alias to :c:macro:`PyBUF_WRITABLE`.
+      This is an alias to :c:macro:`PyBUF_WRITABLE`.
+
+      .. soft-deprecated:: 3.13
 
    .. c:macro:: PyBUF_FORMAT
 

--- a/Doc/c-api/code.rst
+++ b/Doc/c-api/code.rst
@@ -212,13 +212,15 @@ bound into a function.
 
 .. c:function:: PyObject *PyCode_Optimize(PyObject *code, PyObject *consts, PyObject *names, PyObject *lnotab_obj)
 
-   This is a :term:`soft deprecated` function that does nothing.
+   This is a function that does nothing.
 
    Prior to Python 3.10, this function would perform basic optimizations to a
    code object.
 
    .. versionchanged:: 3.10
       This function now does nothing.
+
+   .. soft-deprecated:: 3.13
 
 
 .. _c_codeobject_flags:

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -140,13 +140,15 @@ found in the dictionary of type objects.
 
 .. c:macro:: PyDescr_COMMON
 
-   This is a :term:`soft deprecated` macro including the common fields for a
+   This is a macro including the common fields for a
    descriptor object.
 
    This was included in Python's C API by mistake; do not use it in extensions.
    For creating custom descriptor objects, create a class implementing the
    descriptor protocol (:c:member:`~PyTypeObject.tp_descr_get` and
    :c:member:`~PyTypeObject.tp_descr_set`).
+
+   .. soft-deprecated:: 3.15
 
 
 Built-in descriptors

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -818,13 +818,15 @@ Exception Classes
 
 .. c:macro:: PyException_HEAD
 
-   This is a :term:`soft deprecated` macro including the base fields for an
+   This is a macro including the base fields for an
    exception object.
 
    This was included in Python's C API by mistake and is not designed for use
    in extensions. For creating custom exception objects, use
    :c:func:`PyErr_NewException` or otherwise create a class inheriting from
    :c:data:`PyExc_BaseException`.
+
+   .. soft-deprecated:: 3.15
 
 
 Exception Objects

--- a/Doc/c-api/gen.rst
+++ b/Doc/c-api/gen.rst
@@ -90,7 +90,9 @@ Deprecated API
 
 .. c:macro:: PyAsyncGenASend_CheckExact(op)
 
-   This is a :term:`soft deprecated` API that was included in Python's C API
+   This is an API that was included in Python's C API
    by mistake.
 
    It is solely here for completeness; do not use this API.
+
+   .. soft-deprecated:: 3.14

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -587,10 +587,10 @@ have been standardized in C11 (or previous standards).
 
 .. c:macro:: Py_MEMCPY(dest, src, n)
 
-   This is a :term:`soft deprecated` alias to :c:func:`!memcpy`.
-   Use :c:func:`!memcpy` directly instead.
+   This is an alias to :c:func:`!memcpy`.
 
    .. soft-deprecated:: 3.14
+      Use :c:func:`!memcpy` directly instead.
 
 .. c:macro:: Py_UNICODE_SIZE
 
@@ -611,8 +611,7 @@ have been standardized in C11 (or previous standards).
 
 .. c:macro:: Py_VA_COPY
 
-   This is a :term:`soft deprecated` alias to the C99-standard ``va_copy``
-   function.
+   This is an alias to the C99-standard ``va_copy`` function.
 
    Historically, this would use a compiler-specific method to copy a ``va_list``.
 

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -858,9 +858,8 @@ The :c:type:`PyLongWriter` API can be used to import an integer.
 Deprecated API
 ^^^^^^^^^^^^^^
 
-.. soft-deprecated:: 3.14
-   These macros describe parameters of the internal representation of
-   :c:type:`PyLongObject` instances.
+These macros are :term:`soft deprecated`. They describe parameters
+of the internal representation of :c:type:`PyLongObject` instances.
 
 Use :c:func:`PyLong_GetNativeLayout` instead, along with :c:func:`PyLong_Export`
 to read integer data or :c:type:`PyLongWriter` to write it.

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -858,8 +858,9 @@ The :c:type:`PyLongWriter` API can be used to import an integer.
 Deprecated API
 ^^^^^^^^^^^^^^
 
-These macros are :term:`soft deprecated`. They describe parameters
-of the internal representation of :c:type:`PyLongObject` instances.
+.. soft-deprecated:: 3.14
+   These macros describe parameters of the internal representation of
+   :c:type:`PyLongObject` instances.
 
 Use :c:func:`PyLong_GetNativeLayout` instead, along with :c:func:`PyLong_Export`
 to read integer data or :c:type:`PyLongWriter` to write it.

--- a/Doc/c-api/set.rst
+++ b/Doc/c-api/set.rst
@@ -201,7 +201,7 @@ Deprecated API
 
 .. c:macro:: PySet_MINSIZE
 
-   A :term:`soft deprecated` constant representing the size of an internal
+   A constant representing the size of an internal
    preallocated table inside :c:type:`PySetObject` instances.
 
    This is documented solely for completeness, as there are no guarantees
@@ -211,3 +211,5 @@ Deprecated API
    :c:macro:`!PySet_MINSIZE` can be replaced with a small constant like ``8``.
 
    If looking for the size of a set, use :c:func:`PySet_Size` instead.
+
+   .. soft-deprecated:: 3.14

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1391,8 +1391,8 @@ and :c:data:`PyType_Type` effectively act as defaults.)
 
       .. versionchanged:: 3.9
 
-      Renamed to the current name, without the leading underscore.
-      The old provisional name is :term:`soft deprecated`.
+         Renamed to the current name, without the leading underscore.
+         The old provisional name is :term:`soft deprecated`.
 
       .. versionchanged:: 3.12
 
@@ -1501,10 +1501,12 @@ and :c:data:`PyType_Type` effectively act as defaults.)
 
    .. c:macro:: Py_TPFLAGS_HAVE_VERSION_TAG
 
-      This is a :term:`soft deprecated` macro that does nothing.
+      This macro does nothing.
       Historically, this would indicate that the
       :c:member:`~PyTypeObject.tp_version_tag` field was available and
       initialized.
+
+      .. soft-deprecated:: 3.13
 
 
    .. c:macro:: Py_TPFLAGS_INLINE_VALUES

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -3190,8 +3190,8 @@ Arrays and pointers
    Equivalent to ``type * length``, where *type* is a
    :mod:`!ctypes` data type and *length* an integer.
 
-   This function is :term:`soft deprecated` in favor of multiplication.
-   There are no plans to remove it.
+   .. soft-deprecated:: 3.14
+      In favor of multiplication.
 
 
 .. class:: _Pointer

--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -55,7 +55,7 @@ the information :func:`init` sets up.
       Added support for *url* being a :term:`path-like object`.
 
    .. soft-deprecated:: 3.13
-      Passing a file path instead of URL is :term:`soft deprecated`.
+      Passing a file path instead of URL.
       Use :func:`guess_file_type` for this.
 
 


### PR DESCRIPTION
Some features were missed in https://github.com/python/cpython/commit/e9bbf8617dff942360b5d800769c00440dc93bac.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148769.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->