### PR TITLE
gh-148773: Fix undefined behaviour in `write()` call

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-19-20-22-00.gh-issue-148773.LBukI9.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-19-20-22-00.gh-issue-148773.LBukI9.rst
@@ -1,0 +1,4 @@
+Fixes a bug in :func:`print` which could result in a hangup signal (``SIGHUP``)
+being sent to the user session under certain circumstances when printing an
+empty string to unbuffered stdout, e.g. if ``python3 -u`` is used or the
+:envvar:`PYTHONUNBUFFERED` environment variable is set.

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1970,8 +1970,8 @@ _Py_write_impl(int fd, const void *buf, size_t count, int gil_held)
                 c /= 2;
             } while (c > 0);
 #else
-            /* only call write() if there is something to write.
-             * writing 0 bytes to not a regular file is undefined behaviour. */
+            /* Only call write() if there is something to write as
+             * writing 0 bytes to a non-regular file is an undefined behaviour. */
             if (count > 0) {
                 n = write(fd, buf, count);
             }
@@ -2000,8 +2000,8 @@ _Py_write_impl(int fd, const void *buf, size_t count, int gil_held)
                 c /= 2;
             } while (c > 0);
 #else
-            /* only call write() if there is something to write.
-             * writing 0 bytes to not a regular file is undefined behaviour. */
+            /* Only call write() if there is something to write as
+             * writing 0 bytes to a non-regular file is an undefined behaviour. */
             if (count > 0) {
                 n = write(fd, buf, count);
             }

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1923,7 +1923,7 @@ _Py_read(int fd, void *buf, size_t count)
 static Py_ssize_t
 _Py_write_impl(int fd, const void *buf, size_t count, int gil_held)
 {
-    Py_ssize_t n;
+    Py_ssize_t n = 0;
     int err;
     int async_err = 0;
 
@@ -1970,7 +1970,11 @@ _Py_write_impl(int fd, const void *buf, size_t count, int gil_held)
                 c /= 2;
             } while (c > 0);
 #else
-            n = write(fd, buf, count);
+            /* only call write() if there is something to write.
+             * writing 0 bytes to not a regular file is undefined behaviour. */
+            if (count > 0) {
+                n = write(fd, buf, count);
+            }
 #endif
             /* save/restore errno because PyErr_CheckSignals()
              * and PyErr_SetFromErrno() can modify it */
@@ -1996,7 +2000,11 @@ _Py_write_impl(int fd, const void *buf, size_t count, int gil_held)
                 c /= 2;
             } while (c > 0);
 #else
-            n = write(fd, buf, count);
+            /* only call write() if there is something to write.
+             * writing 0 bytes to not a regular file is undefined behaviour. */
+            if (count > 0) {
+                n = write(fd, buf, count);
+            }
 #endif
             err = errno;
         } while (n < 0 && err == EINTR);


### PR DESCRIPTION
`write()`ing zero bytes to not a regular file (e.g. stdout) is undefined behaviour and can generate a SIGHUP under certain circumstances, e.g. on AIX when running with unbuffered stdout within sudo, screen, tmux:

    $ sudo python3 -u -c 'print(""); print("foo")'
    Hangup

Python's `print()` implementation in this case calls `write()` twice:

    # truss python3 -u -c 'print("")'
    [...]
    kwrite(1, 0x08001000A001B910, 0)                = 0

    kwrite(1, "\n", 1)                              = 1

However, the first `write()` is undefined behaviour.

    ssize_t write(int fildes, const void *buf, size_t nbyte);

    The write() function shall attempt to write nbyte bytes from the buffer
    pointed to by buf to the file associated with the open file descriptor,
    fildes.

    Before any action described below is taken, and if nbyte is zero and the
    file is a regular file, the write() function may detect and return errors as
    described below. In the absence of errors, or if error detection is not
    performed, the write() function shall return zero and have no other results.
    If nbyte is zero and the file is not a regular file, the results are
    unspecified.

https://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148773 -->
* Issue: gh-148773
<!-- /gh-issue-number -->
