### PR TITLE
gh-148762: speed up SRE_AT_BEGINNING_LINE regexes

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-04-19-23-29-38.gh-issue-148762.HSCJka.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-19-23-29-38.gh-issue-148762.HSCJka.rst
@@ -1,0 +1,2 @@
+Multiline regexes starting with a caret, such as ``re.compile("^foo",
+re.MULTILINE)``, now run significantly faster.

--- a/Modules/_sre/sre_lib.h
+++ b/Modules/_sre/sre_lib.h
@@ -1855,6 +1855,18 @@ SRE(search)(SRE_STATE* state, SRE_CODE* pattern)
             return 0;
         }
         while (status == 0 && ptr < end) {
+            if (pattern[0] == SRE_OP_AT &&
+                pattern[1] == SRE_AT_BEGINNING_LINE &&
+                !SRE_IS_LINEBREAK((int) ptr[-1]))
+            {
+                /* fast-forward to the next newline character */
+                while (ptr < end && !SRE_IS_LINEBREAK((int) *ptr)) {
+                    ptr++;
+                }
+                if (ptr >= end) {
+                    return 0;
+                }
+            }
             ptr++;
             RESET_CAPTURE_GROUP();
             TRACE(("|%p|%p|SEARCH\n", pattern, ptr));


### PR DESCRIPTION
`SRE(search)` lacks a fast-forward for multiline regexes like

```python
re.compile("^foo", re.MULTILINE)
```

even though it has a fast prefix scan for regexes like `foo`.

The current implementation does a character-by-character loop that calls
`SRE(match)` each iteration, leading to a lot of overhead.

This commit ensures `SRE(match)` is only called right after a newline
character, leading to a ~10x speedup in a representative benchmark.



<!-- gh-issue-number: gh-148762 -->
* Issue: gh-148762
<!-- /gh-issue-number -->
