### PR TITLE
gh-148783: Respect caller-specified socket proto

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-04-20-00-20-01.gh-issue-148783.ZRKJt4.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-20-00-20-01.gh-issue-148783.ZRKJt4.rst
@@ -1,0 +1,2 @@
+Fix :class:`socket.socket` to respect caller-specified proto over
+auto-detection, which is not supported on platforms such as macOS.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -5746,8 +5746,8 @@ sock_initobj_impl(PySocketSockObject *self, int family, int type, int proto,
 #else
             type = SOCK_STREAM;
 #endif
-#ifdef SO_PROTOCOL
             if (proto == -1) {
+#ifdef SO_PROTOCOL
                 int tmp;
                 socklen_t slen = sizeof(tmp);
                 if (getsockopt(fd, SOL_SOCKET, SO_PROTOCOL,
@@ -5758,10 +5758,10 @@ sock_initobj_impl(PySocketSockObject *self, int family, int type, int proto,
                     set_error();
                     return -1;
                 }
-            }
 #else
             proto = 0;
 #endif
+            }
         }
     }
     else {


### PR DESCRIPTION
This limits socket proto detection to only when `proto == -1`, so that proto explicitly passed in as argument is always respected, instead of being set to zero when `SO_PROTOCOL` is not supported (e.g. macOS).

I believe this is inline with the spirit of original commit https://github.com/python/cpython/commit/b6e43af669f61a37a29d8ff0785455108e6bc29d that introduced this detection, which states:
> The auto-detection can be overruled
by passing in family, type, and proto explicitly.

<!-- gh-issue-number: gh-148783 -->
* Issue: gh-148783
<!-- /gh-issue-number -->
