### PR TITLE
gh-148798: Fix crash in _interpreters.create() on non-UTF-8 string in config

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -117,17 +117,12 @@ class CreateTests(TestBase):
         # GH-126221: Passing an invalid Unicode character used to cause a SystemError
         self.assertRaises(UnicodeEncodeError, _interpreters.create, '\udc80')
 
-        # A config object with a surrogate in a string field must raise, not crash.
-        class BadConfig:
-            use_main_obmalloc = False
-            allow_fork = False
-            allow_exec = False
-            allow_threads = False
-            allow_daemon_threads = False
-            check_multi_interp_extensions = False
-            own_gil = True
-            gil = 'own\udc80'
-        self.assertRaises(UnicodeEncodeError, _interpreters.create, BadConfig())
+    def test_config_with_surrogate_str_field(self):
+        # gh-148798: a config whose string field contains an unpaired
+        # surrogate used to crash the interpreter. It must raise instead.
+        config = _interpreters.new_config()
+        config.gil = 'own\udc80'
+        self.assertRaises(UnicodeEncodeError, _interpreters.create, config)
 
     def test_in_thread(self):
         lock = threading.Lock()

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -117,6 +117,18 @@ class CreateTests(TestBase):
         # GH-126221: Passing an invalid Unicode character used to cause a SystemError
         self.assertRaises(UnicodeEncodeError, _interpreters.create, '\udc80')
 
+        # A config object with a surrogate in a string field must raise, not crash.
+        class BadConfig:
+            use_main_obmalloc = False
+            allow_fork = False
+            allow_exec = False
+            allow_threads = False
+            allow_daemon_threads = False
+            check_multi_interp_extensions = False
+            own_gil = True
+            gil = 'own\udc80'
+        self.assertRaises(UnicodeEncodeError, _interpreters.create, BadConfig())
+
     def test_in_thread(self):
         lock = threading.Lock()
         interp = None

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-20-01-45-00.gh-issue-148798.interpconfig.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-20-01-45-00.gh-issue-148798.interpconfig.rst
@@ -1,5 +1,4 @@
-Fix a crash in :func:`!_interpreters.create` when a config object passes a
-string with an unpaired surrogate as a value (for example ``gil``). The
-internal helper ``_config_dict_copy_str`` now checks the return of
-:c:func:`PyUnicode_AsUTF8` before copying, turning the segfault into a
-:exc:`UnicodeEncodeError`.
+Fix a crash in :func:`!_interpreters.create` when a config value contains
+a string with an unpaired surrogate. :c:func:`PyUnicode_AsUTF8` returned
+``NULL`` and the result was passed to :c:func:`!strncpy`, dereferencing
+it. The caller now propagates the :exc:`UnicodeEncodeError` instead.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-20-01-45-00.gh-issue-148798.interpconfig.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-20-01-45-00.gh-issue-148798.interpconfig.rst
@@ -1,0 +1,5 @@
+Fix a crash in :func:`!_interpreters.create` when a config object passes a
+string with an unpaired surrogate as a value (for example ``gil``). The
+internal helper ``_config_dict_copy_str`` now checks the return of
+:c:func:`PyUnicode_AsUTF8` before copying, turning the segfault into a
+:exc:`UnicodeEncodeError`.

--- a/Python/interpconfig.c
+++ b/Python/interpconfig.c
@@ -133,7 +133,12 @@ _config_dict_copy_str(PyObject *dict, const char *name,
         config_dict_invalid_type(name);
         return -1;
     }
-    strncpy(buf, PyUnicode_AsUTF8(item), bufsize-1);
+    const char *utf8 = PyUnicode_AsUTF8(item);
+    if (utf8 == NULL) {
+        Py_DECREF(item);
+        return -1;
+    }
+    strncpy(buf, utf8, bufsize-1);
     buf[bufsize-1] = '\0';
     Py_DECREF(item);
     return 0;


### PR DESCRIPTION
`_config_dict_copy_str` (`Python/interpconfig.c`) passed the result of
`PyUnicode_AsUTF8()` straight to `strncpy()`. When the string can't be
UTF-8 encoded — e.g. it contains an unpaired surrogate — `PyUnicode_AsUTF8`
returns `NULL` and sets `UnicodeEncodeError`, and `strncpy` then
dereferences `NULL`, segfaulting the interpreter.

Lone surrogates are reachable from pure Python (`'\udc80'`, `chr(0xDC80)`)
and also show up via `surrogateescape` when non-UTF-8 filenames / env
vars / argv get forwarded into a config dict.

Fix: check the return of `PyUnicode_AsUTF8` and propagate the error,
mirroring the pattern already used at `Modules/_interpretersmodule.c:425`.

Regression test lives next to the existing gh-126221 case in
`CreateTests.test_in_main`.

<!-- issue-number: gh-148798 -->
- Issue: https://github.com/python/cpython/issues/148798