### PR TITLE
gh-148808: Add boundary check to asyncio.AbstractEventLoop.sock_recvf…

### DIFF
--- a/Lib/test/test_asyncio/test_sock_lowlevel.py
+++ b/Lib/test/test_asyncio/test_sock_lowlevel.py
@@ -427,6 +427,27 @@ class BaseSockTestsMixin:
             self.loop.run_until_complete(
                 self._basetest_datagram_recvfrom_into(server_address))
 
+    async def _basetest_datagram_recvfrom_into_wrong_size(self, server_address):
+        # Call sock_sendto() with a size larger than the buffer
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.setblocking(False)
+
+            buf = bytearray(5000)
+            data = b'\x01' * 4096
+            wrong_size = len(buf) + 1
+            await self.loop.sock_sendto(sock, data, server_address)
+            with self.assertRaises(ValueError):
+                await self.loop.sock_recvfrom_into(
+                    sock, buf, wrong_size)
+
+            size, addr = await self.loop.sock_recvfrom_into(sock, buf)
+            self.assertEqual(buf[:size], data)
+
+    def test_recvfrom_into_wrong_size(self):
+        with test_utils.run_udp_echo_server() as server_address:
+            self.loop.run_until_complete(
+                self._basetest_datagram_recvfrom_into_wrong_size(server_address))
+
     async def _basetest_datagram_sendto_blocking(self, server_address):
         # Sad path, sock.sendto() raises BlockingIOError
         # This involves patching sock.sendto() to raise BlockingIOError but

--- a/Misc/NEWS.d/next/Security/2026-04-20-15-31-37.gh-issue-148808._Z8JL0.rst
+++ b/Misc/NEWS.d/next/Security/2026-04-20-15-31-37.gh-issue-148808._Z8JL0.rst
@@ -1,0 +1,2 @@
+Added buffer boundary check comparing ``nbytes`` parameter to
+:meth:`asyncio.AbstractEventLoop.sock_recvfrom_into`.

--- a/Misc/NEWS.d/next/Security/2026-04-20-15-31-37.gh-issue-148808._Z8JL0.rst
+++ b/Misc/NEWS.d/next/Security/2026-04-20-15-31-37.gh-issue-148808._Z8JL0.rst
@@ -1,3 +1,3 @@
 Added buffer boundary check when using ``nbytes`` parameter with
-:meth:`~asyncio.AbstractEventLoop.sock_recvfrom_into`. Only
+:meth:`!asyncio.AbstractEventLoop.sock_recvfrom_into`. Only
 relevant for Windows and the :class:`asyncio.ProactorEventLoop`.

--- a/Misc/NEWS.d/next/Security/2026-04-20-15-31-37.gh-issue-148808._Z8JL0.rst
+++ b/Misc/NEWS.d/next/Security/2026-04-20-15-31-37.gh-issue-148808._Z8JL0.rst
@@ -1,3 +1,3 @@
 Added buffer boundary check when using ``nbytes`` parameter with
-:meth:`asyncio.AbstractEventLoop.sock_recvfrom_into`. Only
+:meth:`~asyncio.AbstractEventLoop.sock_recvfrom_into`. Only
 relevant for Windows and the :class:`asyncio.ProactorEventLoop`.

--- a/Misc/NEWS.d/next/Security/2026-04-20-15-31-37.gh-issue-148808._Z8JL0.rst
+++ b/Misc/NEWS.d/next/Security/2026-04-20-15-31-37.gh-issue-148808._Z8JL0.rst
@@ -1,2 +1,3 @@
-Added buffer boundary check comparing ``nbytes`` parameter to
-:meth:`asyncio.AbstractEventLoop.sock_recvfrom_into`.
+Added buffer boundary check when using ``nbytes`` parameter with
+:meth:`asyncio.AbstractEventLoop.sock_recvfrom_into`. Only
+relevant for Windows and the :class:`asyncio.ProactorEventLoop`.

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -1910,6 +1910,11 @@ _overlapped_Overlapped_WSARecvFromInto_impl(OverlappedObject *self,
     }
 #endif
 
+    if (bufobj->len < (Py_ssize_t)size) {
+        PyErr_SetString(PyExc_ValueError, "nbytes is greater than the length of the buffer");
+        return NULL;
+    }
+
     wsabuf.buf = bufobj->buf;
     wsabuf.len = size;
 


### PR DESCRIPTION
Originally authored by @GGAutomaton and @vstinner. cc @python/asyncio for a review.

<!-- gh-issue-number: gh-148808 -->
* Issue: gh-148808
<!-- /gh-issue-number -->
