### PR TITLE
gh-148600: Add OpenSSL 4.0.0 support to test configurations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,6 +283,7 @@ jobs:
           - { name: openssl, version: 3.4.4 }
           - { name: openssl, version: 3.5.5 }
           - { name: openssl, version: 3.6.1 }
+          - { name: openssl, version: 4.0.0 }
           ## AWS-LC
           - { name: aws-lc, version: 1.68.0 }
     env:

--- a/Misc/NEWS.d/next/Tests/2026-04-21-12-33-14.gh-issue-148600.vnTb3t.rst
+++ b/Misc/NEWS.d/next/Tests/2026-04-21-12-33-14.gh-issue-148600.vnTb3t.rst
@@ -1,0 +1,1 @@
+Add OpenSSL 4.0.0 support to test configurations

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -171,11 +171,11 @@ static void _PySSLFixErrno(void) {
 #  define OPENSSL_NO_SSL3
 #  define OPENSSL_NO_TLS1
 #  define OPENSSL_NO_TLS1_1
-#  define OPENSSL_NO_TLS1_2
+// #  define OPENSSL_NO_TLS1_2
 #  define OPENSSL_NO_SSL3_METHOD
 #  define OPENSSL_NO_TLS1_METHOD
 #  define OPENSSL_NO_TLS1_1_METHOD
-#  define OPENSSL_NO_TLS1_2_METHOD
+// #  define OPENSSL_NO_TLS1_2_METHOD
 #endif
 
 /* OpenSSL API 1.1.0+ does not include version methods */

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -54,6 +54,7 @@ OPENSSL_RECENT_VERSIONS = [
     "3.4.4",
     "3.5.5",
     "3.6.1",
+    "4.0.0",
     # See make_ssl_data.py for notes on adding a new version.
 ]
 


### PR DESCRIPTION
Building off of 70eb56be427aac3fc45342024dbcfef632accc3a:

- Add OpenSSL 4.0.0 to the build matrix in build.yml
- Add "4.0.0" to the OpenSSL versions list in multissltests.py

<!-- gh-issue-number: gh-148600 -->
* Issue: gh-148600
<!-- /gh-issue-number -->
