### PR TITLE
Allow breaking cross-reference of tokens in a `productionlist`

### DIFF
--- a/Doc/tools/extensions/grammar_snippet.py
+++ b/Doc/tools/extensions/grammar_snippet.py
@@ -144,7 +144,13 @@ class GrammarSnippetBase(SphinxDirective):
                         location=location,
                     )
                 case 'rule_ref':
-                    production_node += token_xrefs(content, group_name)
+                    if content.startswith('`!'):
+                        token = content[2:-1]
+                        production_node += nodes.literal(
+                            token, token, classes=['xref']
+                        )
+                    else:
+                        production_node += token_xrefs(content, group_name)
                 case 'single_quoted' | 'double_quoted':
                     production_node += snippet_string_node('', content)
                 case 'text':


### PR DESCRIPTION
Before:

<img width="1008" height="296" alt="image" src="https://github.com/user-attachments/assets/7df18690-00fd-4484-9a96-5db7f3410f57" />

After:

<img width="1008" height="296" alt="image" src="https://github.com/user-attachments/assets/4a31ff00-d763-4c60-88eb-04ea0e8cfd1f" />
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148845.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->