### PR TITLE
gh-119670: Add `force` keyword only argument to `shlex.quote`

### DIFF
--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -44,11 +44,14 @@ The :mod:`!shlex` module defines the following functions:
    .. versionadded:: 3.8
 
 
-.. function:: quote(s)
+.. function:: quote(s, *, force=False)
 
    Return a shell-escaped version of the string *s*.  The returned value is a
    string that can safely be used as one token in a shell command line, for
    cases where you cannot use a list.
+
+   If *force* is :const:`True` then *s* will be quoted even if it is already
+   safe for a shell without being quoted.
 
    .. _shlex-quote-warning:
 
@@ -91,7 +94,22 @@ The :mod:`!shlex` module defines the following functions:
       >>> command
       ['ls', '-l', 'somefile; rm -rf ~']
 
+   The *force* keyword can be used to produce consistent behavior when
+   escaping multiple strings:
+
+      >>> from shlex import quote
+      >>> filenames = ['my first file', 'file2', 'file 3']
+      >>> filenames_some_escaped = [quote(f, force=False) for f in filenames]
+      >>> filenames_some_escaped
+      ["'my first file'", 'file2', "'file 3'"]
+      >>> filenames_all_escaped = [quote(f, force=True) for f in filenames]
+      >>> filenames_all_escaped
+      ["'my first file'", "'file2'", "'file 3'"]
+
    .. versionadded:: 3.3
+
+   .. versionchanged:: next
+      The *force* keyword was added.
 
 The :mod:`!shlex` module defines the following class:
 

--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -50,8 +50,8 @@ The :mod:`!shlex` module defines the following functions:
    string that can safely be used as one token in a shell command line, for
    cases where you cannot use a list.
 
-   If *force* is :const:`True` then *s* will be quoted even if it is already
-   safe for a shell without being quoted.
+   If *force* is :const:`True`, then *s* is unconditionally quoted,
+   even if it is already safe for a shell without being quoted.
 
    .. _shlex-quote-warning:
 

--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -99,7 +99,7 @@ The :mod:`!shlex` module defines the following functions:
 
       >>> from shlex import quote
       >>> filenames = ['my first file', 'file2', 'file 3']
-      >>> filenames_some_escaped = [quote(f, force=False) for f in filenames]
+      >>> filenames_some_escaped = [quote(f) for f in filenames]
       >>> filenames_some_escaped
       ["'my first file'", 'file2', "'file 3'"]
       >>> filenames_all_escaped = [quote(f, force=True) for f in filenames]

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -2271,14 +2271,6 @@ New deprecations
     Hugo van Kemenade in :gh:`148100`.)
 
 
-* :mod:`shlex`:
-
-  * Add keyword-only parameter *force* to :func:`shlex.quote` to force quoting
-    a string, even if it is already safe for a shell without being quoted.
-
-    (Contributed by Jay Berry in :gh:`148846`.)
-
-
 * :mod:`struct`:
 
   * Calling ``Struct.__new__()`` without a required argument is now

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -2271,6 +2271,15 @@ New deprecations
     Hugo van Kemenade in :gh:`148100`.)
 
 
+* :mod:`shlex`:
+
+  * :func:`shlex.quote` has a new keyword-only parameter *force* that ensures
+    a string will always be quoted, even if it is already safe for a shell
+    without being quoted.
+
+    (Contributed by Jay Berry in :gh:`148846`.)
+
+
 * :mod:`struct`:
 
   * Calling ``Struct.__new__()`` without a required argument is now

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -2273,9 +2273,8 @@ New deprecations
 
 * :mod:`shlex`:
 
-  * :func:`shlex.quote` has a new keyword-only parameter *force* that ensures
-    a string will always be quoted, even if it is already safe for a shell
-    without being quoted.
+  * Add keyword-only parameter *force* to :func:`shlex.quote` to force quoting
+    a string, even if it is already safe for a shell without being quoted.
 
     (Contributed by Jay Berry in :gh:`148846`.)
 

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -109,6 +109,13 @@ os
   process via a pidfd.  Available on Linux 5.6+.
   (Contributed by Maurycy Pawłowski-Wieroński in :gh:`149464`.)
 
+shlex
+-----
+
+* Add keyword-only parameter *force* to :func:`shlex.quote` to force quoting
+  a string, even if it is already safe for a shell without being quoted.
+  (Contributed by Jay Berry in :gh:`148846`.)
+
 xml
 ---
 

--- a/Lib/shlex.py
+++ b/Lib/shlex.py
@@ -334,8 +334,7 @@ def quote(s, *, force=False):
                   b'ABCDEFGHIJKLMNOPQRSTUVWXYZ_'
                   b'abcdefghijklmnopqrstuvwxyz')
     if (not force
-        and s.isascii() and not s.encode().translate(None, delete=safe_chars)
-    ):
+        and s.isascii() and not s.encode().translate(None, delete=safe_chars)):
         # No quoting is needed if we're not forcing quoting
         # and `s` is an ASCII string consisting only of `safe_chars`
         return s

--- a/Lib/shlex.py
+++ b/Lib/shlex.py
@@ -317,8 +317,12 @@ def join(split_command):
     return ' '.join(quote(arg) for arg in split_command)
 
 
-def quote(s):
-    """Return a shell-escaped version of the string *s*."""
+def quote(s, force=False):
+    """Return a shell-escaped version of the string *s*.
+
+    If *force* is *True* then *s* will be quoted even if it is
+    already safe for a shell without being quoted.
+    """
     if not s:
         return "''"
 
@@ -329,8 +333,11 @@ def quote(s):
     safe_chars = (b'%+,-./0123456789:=@'
                   b'ABCDEFGHIJKLMNOPQRSTUVWXYZ_'
                   b'abcdefghijklmnopqrstuvwxyz')
-    # No quoting is needed if `s` is an ASCII string consisting only of `safe_chars`
-    if s.isascii() and not s.encode().translate(None, delete=safe_chars):
+    if (not force
+        and s.isascii() and not s.encode().translate(None, delete=safe_chars)
+    ):
+        # No quoting is needed if we're not forcing quoting
+        # and `s` is an ASCII string consisting only of `safe_chars`
         return s
 
     # use single quotes, and put single quotes into double quotes

--- a/Lib/shlex.py
+++ b/Lib/shlex.py
@@ -335,8 +335,8 @@ def quote(s, *, force=False):
                   b'abcdefghijklmnopqrstuvwxyz')
     if (not force
         and s.isascii() and not s.encode().translate(None, delete=safe_chars)):
-        # No quoting is needed if we're not forcing quoting
-        # and `s` is an ASCII string consisting only of `safe_chars`
+        # No quoting is needed if we are not forcing quoting
+        # and `s` is an ASCII string consisting only of `safe_chars`.
         return s
 
     # use single quotes, and put single quotes into double quotes

--- a/Lib/shlex.py
+++ b/Lib/shlex.py
@@ -317,7 +317,7 @@ def join(split_command):
     return ' '.join(quote(arg) for arg in split_command)
 
 
-def quote(s, force=False):
+def quote(s, *, force=False):
     """Return a shell-escaped version of the string *s*.
 
     If *force* is *True* then *s* will be quoted even if it is

--- a/Lib/shlex.py
+++ b/Lib/shlex.py
@@ -320,8 +320,8 @@ def join(split_command):
 def quote(s, *, force=False):
     """Return a shell-escaped version of the string *s*.
 
-    If *force* is *True* then *s* will be quoted even if it is
-    already safe for a shell without being quoted.
+    If *force* is *True*, then *s* is unconditionally quoted,
+    even if it is already safe for a shell without being quoted.
     """
     if not s:
         return "''"

--- a/Lib/shlex.py
+++ b/Lib/shlex.py
@@ -333,10 +333,10 @@ def quote(s, *, force=False):
     safe_chars = (b'%+,-./0123456789:=@'
                   b'ABCDEFGHIJKLMNOPQRSTUVWXYZ_'
                   b'abcdefghijklmnopqrstuvwxyz')
+    # No quoting is needed if we are not forcing quoting
+    # and `s` is an ASCII string consisting only of `safe_chars`.
     if (not force
         and s.isascii() and not s.encode().translate(None, delete=safe_chars)):
-        # No quoting is needed if we are not forcing quoting
-        # and `s` is an ASCII string consisting only of `safe_chars`.
         return s
 
     # use single quotes, and put single quotes into double quotes

--- a/Lib/test/test_shlex.py
+++ b/Lib/test/test_shlex.py
@@ -341,7 +341,6 @@ class ShlexTest(unittest.TestCase):
                              "'test%s'\"'\"'name'\"'\"''" % u)
         self.assertRaises(TypeError, shlex.quote, 42)
         self.assertRaises(TypeError, shlex.quote, b"abc")
-        # self.assertRaises(TypeError, shlex.quote, None)
 
     def testForceQuote(self):
         self.assertEqual(shlex.quote("spam"), "spam")

--- a/Lib/test/test_shlex.py
+++ b/Lib/test/test_shlex.py
@@ -344,7 +344,6 @@ class ShlexTest(unittest.TestCase):
         # self.assertRaises(TypeError, shlex.quote, None)
 
     def testForceQuote(self):
-        # ensure default `force` behavior does not unnecessarily quote strings
         self.assertEqual(shlex.quote("spam"), "spam")
         self.assertEqual(shlex.quote("spam", force=False), "spam")
         self.assertEqual(shlex.quote("spam", force=True), "'spam'")

--- a/Lib/test/test_shlex.py
+++ b/Lib/test/test_shlex.py
@@ -348,6 +348,7 @@ class ShlexTest(unittest.TestCase):
         self.assertEqual(shlex.quote("spam", force=True), "'spam'")
         self.assertEqual(shlex.quote("spam eggs", force=False), "'spam eggs'")
         self.assertEqual(shlex.quote("spam eggs", force=True), "'spam eggs'")
+        self.assertEqual(shlex.quote("two's-complement", force=False), "'two'\"'\"'s-complement'")
 
     def testJoin(self):
         for split_command, command in [

--- a/Lib/test/test_shlex.py
+++ b/Lib/test/test_shlex.py
@@ -341,6 +341,28 @@ class ShlexTest(unittest.TestCase):
                              "'test%s'\"'\"'name'\"'\"''" % u)
         self.assertRaises(TypeError, shlex.quote, 42)
         self.assertRaises(TypeError, shlex.quote, b"abc")
+        # self.assertRaises(TypeError, shlex.quote, None)
+
+    def testForceQuote(self):
+        # ensure default `force` behavior does not unnecessarily quote strings
+        self.assertEqual(shlex.quote("no-quotes-needed"),
+                                     "no-quotes-needed")
+
+        # ensure `force=False` does not unnecessarily quote strings
+        self.assertEqual(shlex.quote("no-quotes-needed", force=False),
+                                     "no-quotes-needed")
+
+        # ensure `force=True` does quote strings that
+        # would not be quoted if using `force=False`
+        self.assertEqual(shlex.quote("no-quotes-needed", force=True),
+                                     "'no-quotes-needed'")
+
+        # ensure `force` does not affect outcome for strings that
+        # need quoting anyways
+        self.assertEqual(shlex.quote("quotes needed", force=False),
+                                     "'quotes needed'")
+        self.assertEqual(shlex.quote("quotes needed", force=True),
+                                     "'quotes needed'")
 
     def testJoin(self):
         for split_command, command in [

--- a/Lib/test/test_shlex.py
+++ b/Lib/test/test_shlex.py
@@ -345,24 +345,11 @@ class ShlexTest(unittest.TestCase):
 
     def testForceQuote(self):
         # ensure default `force` behavior does not unnecessarily quote strings
-        self.assertEqual(shlex.quote("no-quotes-needed"),
-                                     "no-quotes-needed")
-
-        # ensure `force=False` does not unnecessarily quote strings
-        self.assertEqual(shlex.quote("no-quotes-needed", force=False),
-                                     "no-quotes-needed")
-
-        # ensure `force=True` does quote strings that
-        # would not be quoted if using `force=False`
-        self.assertEqual(shlex.quote("no-quotes-needed", force=True),
-                                     "'no-quotes-needed'")
-
-        # ensure `force` does not affect outcome for strings that
-        # need quoting anyways
-        self.assertEqual(shlex.quote("quotes needed", force=False),
-                                     "'quotes needed'")
-        self.assertEqual(shlex.quote("quotes needed", force=True),
-                                     "'quotes needed'")
+        self.assertEqual(shlex.quote("spam"), "spam")
+        self.assertEqual(shlex.quote("spam", force=False), "spam")
+        self.assertEqual(shlex.quote("spam", force=True), "'spam'")
+        self.assertEqual(shlex.quote("spam eggs", force=False), "'spam eggs'")
+        self.assertEqual(shlex.quote("spam eggs", force=True), "'spam eggs'")
 
     def testJoin(self):
         for split_command, command in [

--- a/Misc/NEWS.d/next/Library/2026-04-21-06-30-59.gh-issue-119670.pMWZfY.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-21-06-30-59.gh-issue-119670.pMWZfY.rst
@@ -1,3 +1,2 @@
-Add *force* keyword only argument to :func:`shlex.quote` to always quote the
-string passed to it, even if it is already safe for a shell without being
-quoted.
+Add keyword-only parameter *force* to :func:`shlex.quote` to force quoting
+a string, even if it is already safe for a shell without being quoted.

--- a/Misc/NEWS.d/next/Library/2026-04-21-06-30-59.gh-issue-119670.pMWZfY.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-21-06-30-59.gh-issue-119670.pMWZfY.rst
@@ -1,0 +1,3 @@
+Add *force* keyword only argument to :func:`shlex.quote` to always quote the
+string passed to it, even if it is already safe for a shell without being
+quoted.


### PR DESCRIPTION
Closes #119670
Supersedes my out-of-date PR #119674 

We use `force` instead of `always` as a word more consistent with other programming jargon (like in `rm -f` the `f` is for 'force') [as discussed](https://github.com/python/cpython/pull/119674#pullrequestreview-2288530013)

Commits

- ddbe3a55a264e5f560b0aebdbfdcd1cf1b01f706: Add base implementation.
- 0e722d6818f30bf5c411e4a1af601d5aca04ce9f: Make `shlex.quote`'s kwargs kwargs-only. Backwards compatible. There are [propositions](https://github.com/python/cpython/issues/90630) to add a single-quote-double-quote switch, which I'm ambivalent about, but to future-proof against hiccups of people passing `force` as a positional and it ending up being used as the wrong kwarg, we make the kwargs kwargs-only, eg like `json.loads`.
- fd4af184f3254a1137c832fb85ed4aa71fe83ba9: Add tests. I've tried to be pretty thorough. Their purposes are commented on.
- 78b6f3b7d6bb2ad3a4fbd5807f083b464b916890: Update docs. Contains explanation and examples.
- 762999d9e35f13f12f596c976fd4961aec5d88f1: Add blurb entry.
- 2a301a5b3535bde40a94b5c956541d55a96af36c: Add whatsnew entry.

As [mentioned](https://github.com/python/cpython/pull/119674#issuecomment-4284837869) I'm also going to open ~~an issue~~ a [discussion](https://discuss.python.org/t/107055) thread about `shlex.quote` returning `"''"` for falsey non-str data. This PR and that discussion seem independent of each other, that is this PR doesn't need to be held back until that discussion is addressed.


<!-- gh-issue-number: gh-119670 -->
* Issue: gh-119670
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148846.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->