### PR TITLE
gh-148820: Fix `_PyRawMutex` use-after-free on spurious semaphore wakeup

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-21-14-36-44.gh-issue-148820.XhOGhA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-21-14-36-44.gh-issue-148820.XhOGhA.rst
@@ -1,0 +1,5 @@
+Fix a race in :c:type:`!_PyRawMutex` on the free-threaded build where a
+``Py_PARK_INTR`` return from ``_PySemaphore_Wait`` could let the waiter
+destroy its semaphore before the unlocking thread's
+``_PySemaphore_Wakeup`` completed, causing a fatal ``ReleaseSemaphore``
+error.

--- a/Python/lock.c
+++ b/Python/lock.c
@@ -248,7 +248,16 @@ _PyRawMutex_LockSlow(_PyRawMutex *m)
 
         // Wait for us to be woken up. Note that we still have to lock the
         // mutex ourselves: it is NOT handed off to us.
-        _PySemaphore_Wait(&waiter.sema, -1);
+        //
+        // Loop until we observe an actual wakeup. A return of Py_PARK_INTR
+        // could otherwise let us exit _PySemaphore_Wait and destroy
+        // `waiter.sema` while _PyRawMutex_UnlockSlow's matching
+        // _PySemaphore_Wakeup is still pending, since the unlocker has
+        // already CAS-removed us from the waiter list without any handshake.
+        int res;
+        do {
+            res = _PySemaphore_Wait(&waiter.sema, -1);
+        } while (res != Py_PARK_OK);
     }
 
     _PySemaphore_Destroy(&waiter.sema);

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -61,7 +61,9 @@ _PySemaphore_Init(_PySemaphore *sema)
         NULL    //  unnamed
     );
     if (!sema->platform_sem) {
-        Py_FatalError("parking_lot: CreateSemaphore failed");
+        _Py_FatalErrorFormat(__func__,
+            "parking_lot: CreateSemaphore failed (error: %u)",
+            GetLastError());
     }
 #elif defined(_Py_USE_SEMAPHORES)
     if (sem_init(&sema->platform_sem, /*pshared=*/0, /*value=*/0) < 0) {
@@ -141,8 +143,8 @@ _PySemaphore_Wait(_PySemaphore *sema, PyTime_t timeout)
     }
     else {
         _Py_FatalErrorFormat(__func__,
-            "unexpected error from semaphore: %u (error: %u)",
-            wait, GetLastError());
+            "unexpected error from semaphore: %u (error: %u, handle: %p)",
+            wait, GetLastError(), sema->platform_sem);
     }
 #elif defined(_Py_USE_SEMAPHORES)
     int err;
@@ -230,7 +232,9 @@ _PySemaphore_Wakeup(_PySemaphore *sema)
 {
 #if defined(MS_WINDOWS)
     if (!ReleaseSemaphore(sema->platform_sem, 1, NULL)) {
-        Py_FatalError("parking_lot: ReleaseSemaphore failed");
+        _Py_FatalErrorFormat(__func__,
+            "parking_lot: ReleaseSemaphore failed (error: %u, handle: %p)",
+            GetLastError(), sema->platform_sem);
     }
 #elif defined(_Py_USE_SEMAPHORES)
     int err = sem_post(&sema->platform_sem);


### PR DESCRIPTION
`_PyRawMutex_UnlockSlow` CAS-removes the waiter from the list and then calls `_PySemaphore_Wakeup`, with no handshake (unlike parking_lot's `wait_entry.is_unparking` protocol). If the waiter's `_PySemaphore_Wait` returns for any reason other than the matching Wakeup — e.g. `Py_PARK_INTR` from `sigint_event` on the main thread on Windows, or `EINTR` on POSIX — the waiter can exit the wait, re-acquire the mutex (already CAS-unlocked by the unlocker), break out of the loop, and call `_PySemaphore_Destroy` on the stack-allocated semaphore before the unlocker's `_PySemaphore_Wakeup` runs. That Wakeup then hits a closed handle, producing `Fatal Python error: _PySemaphore_Wakeup: parking_lot: ReleaseSemaphore failed` (Win32 `ERROR_INVALID_HANDLE`).

Observed on free-threaded 3.14 on Windows with `coverage run` + trio + `signal.raise_signal(SIGINT)` from a non-main thread. Parking-lot's `_PyParkingLot_Park` is not affected because its bucket-locked `is_unparking` handshake already ensures the parker waits for the unparker's Wakeup before destroying the semaphore.

## Fix

Loop in `_PyRawMutex_LockSlow` until `_PySemaphore_Wait` returns `Py_PARK_OK`. `Py_PARK_OK` is only returned when a matching post was observed on all backends (`WAIT_OBJECT_0` / `sem_wait` success / `sema->counter > 0`), so looping until OK guarantees the unlocker's pending Wakeup has fired before we destroy the semaphore. Deferring SIGINT until the unlock completes is acceptable in practice: `_PyRawMutex` protects only short critical sections (principally parking-lot bucket locks), so ctrl-C is delivered near-immediately.

Also include `GetLastError()` and the `HANDLE` value in the Windows fatal messages in `_PySemaphore_Init`, `_PySemaphore_Wait`, and `_PySemaphore_Wakeup` — these were key in identifying the bug as a use-after-free (error 6 = `ERROR_INVALID_HANDLE`) rather than a double-release.

The `_PySemaphore_Wakeup` API signature is intentionally left unchanged to preserve the ability to backport this fix.

Based on analysis and patch by @colesbury in https://gist.github.com/colesbury/3e4c6180e3eb4b3b9fd07b26f3196e12 / https://gist.github.com/colesbury/f9f0c5cf1a00f2c946e80795fcc245d7.

## Verification

Stress harness (16 workers × 100 iterations × `coverage run` of the trio SIGINT-from-thread reproducer) showed ~0.19% crash rate on the unpatched baseline and 0% with the loop.

<!-- gh-issue-number: gh-148820 -->
* Issue: gh-148820
<!-- /gh-issue-number -->