### PR TITLE
gh-148850: Fix memory sanitizer false positive in os.getrandom

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -553,7 +553,7 @@ extern "C" {
 #    if !defined(_Py_MEMORY_SANITIZER)
 #      define _Py_MEMORY_SANITIZER
 #      define _Py_NO_SANITIZE_MEMORY __attribute__((no_sanitize_memory))
-#      define _Py_MSAN_UNPOISON(p, sz)  (__msan_unpoison(p, sz))
+#      define _Py_MSAN_UNPOISON(PTR, SIZE)  (__msan_unpoison(PTR, SIZE))
 #    endif
 #  endif
 #  if __has_feature(address_sanitizer)

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -553,6 +553,7 @@ extern "C" {
 #    if !defined(_Py_MEMORY_SANITIZER)
 #      define _Py_MEMORY_SANITIZER
 #      define _Py_NO_SANITIZE_MEMORY __attribute__((no_sanitize_memory))
+#      define _Py_MSAN_UNPOISON(p, sz)  (__msan_unpoison(p, sz))
 #    endif
 #  endif
 #  if __has_feature(address_sanitizer)
@@ -590,6 +591,9 @@ extern "C" {
 #endif
 #ifndef _Py_NO_SANITIZE_MEMORY
 #  define _Py_NO_SANITIZE_MEMORY
+#endif
+#ifndef _Py_MSAN_UNPOISON
+#  define _Py_MSAN_UNPOISON
 #endif
 
 /* AIX has __bool__ redefined in it's system header file. */

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -593,7 +593,7 @@ extern "C" {
 #  define _Py_NO_SANITIZE_MEMORY
 #endif
 #ifndef _Py_MSAN_UNPOISON
-#  define _Py_MSAN_UNPOISON
+#  define _Py_MSAN_UNPOISON(PTR, SIZE)
 #endif
 
 /* AIX has __bool__ redefined in it's system header file. */

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-21-19-29-29.gh-issue-148850.MSH0J_.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-21-19-29-29.gh-issue-148850.MSH0J_.rst
@@ -1,0 +1,1 @@
+Fix the memory sanitizer false positive in :func:`os.getrandom`.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -17195,6 +17195,10 @@ os_getrandom_impl(PyObject *module, Py_ssize_t size, int flags)
         goto error;
     }
 
+#ifdef _Py_MEMORY_SANITIZER
+    __msan_unpoison(data, size);
+#endif
+
     return PyBytesWriter_FinishWithSize(writer, n);
 
 error:

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -17195,9 +17195,7 @@ os_getrandom_impl(PyObject *module, Py_ssize_t size, int flags)
         goto error;
     }
 
-#ifdef _Py_MEMORY_SANITIZER
-    __msan_unpoison(data, size);
-#endif
+    _Py_MSAN_UNPOISON(data, size);
 
     return PyBytesWriter_FinishWithSize(writer, n);
 


### PR DESCRIPTION
This marks the memory filled by the `getrandom` syscall as having been initialized when `os.getrandom()` is called. Without this, accessing this memory will cause a false positive when the memory sanitizer is enabled.

<!-- gh-issue-number: gh-148850 -->
* Issue: gh-148850
<!-- /gh-issue-number -->
