### PR TITLE
gh-148488: Clarify that both / and \ slashes are accepted in py -V:company/tag

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -162,7 +162,7 @@ omitted in cases where the tag refers to an official release and starts with
    $> py -V:3-arm64 ...
 
 Runtimes from other distributors may require the *company* to be included as
-well. This should be separated from the tag by a slash, and may be a prefix.
+well. This should be separated from the tag by a slash (either ``/`` or ``\\``, both are accepted on Windows), and may be a prefix.
 Specifying the company is optional when it is ``PythonCore``, and specifying the
 tag is optional (but not the slash) when you want the latest release from a
 specific company.


### PR DESCRIPTION
Good day

This PR addresses issue #148488, which reported that the documentation for ``py -V`` was confusing regarding which slash characters are accepted as separators between company and tag.

## Changes

In ``Doc/using/windows.rst``, the sentence:

    This should be separated from the tag by a slash, and may be a prefix.

was updated to:

    This should be separated from the tag by a slash (either ``/`` or ``\\``, both are accepted on Windows), and may be a prefix.

This makes it clear that both forward slash ``/`` and backslash ``\\`` are accepted as separators on Windows (as the underlying implementation handles both), resolving the confusion noted in the issue where the example used ``\\`` but the text only mentioned "slash".

## Verification

- Documentation builds cleanly with Sphinx (no warnings related to this change)
- The change is minimal and targeted, affecting only one sentence
- Both example entries (``Distributor\\1.0`` and ``distrib/``) already exist in the file, confirming both slash types are intended to be demonstrated

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
Jah-yee

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148856.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-148488 -->
* Issue: gh-148488
<!-- /gh-issue-number -->
