### PR TITLE
gh-148883: Docs: clarify grammar in Counter dictionary methods note

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -326,7 +326,7 @@ For example::
         .. versionadded:: 3.10
 
     The usual dictionary methods are available for :class:`Counter` objects
-    except for two which work differently for counters.
+    except for these two which work differently for counters:
 
     .. method:: fromkeys(iterable)
 


### PR DESCRIPTION
Small grammar/punctuation tweak in the `collections.Counter` docs so the sentence reads as an introduction to the two methods that immediately follow it.

Before:
> The usual dictionary methods are available for `Counter` objects except for two which work differently for counters.

After:
> The usual dictionary methods are available for `Counter` objects except for these two which work differently for counters:

The following `fromkeys` and `update` entries are what "these two" refers to, so ending with a colon (and adding "these") makes the list connection explicit.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148882.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-148883 -->
* Issue: gh-148883
<!-- /gh-issue-number -->
