### PR TITLE
gh-148907: fix performance regression in `PyType_GetModuleByDef` on free-threading

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5878,7 +5878,13 @@ PyType_GetModuleByToken_DuringGC(PyTypeObject *type, const void *token)
 PyObject *
 PyType_GetModuleByToken(PyTypeObject *type, const void *token)
 {
-    PyObject *mod = PyType_GetModuleByToken_DuringGC(type, token);
+    return Py_XNewRef(PyType_GetModuleByDef(type, (PyModuleDef *)token));
+}
+
+PyObject *
+PyType_GetModuleByDef(PyTypeObject *type, PyModuleDef *def)
+{
+    PyObject *mod = PyType_GetModuleByToken_DuringGC(type, def);
     if (!mod) {
         PyErr_Format(
             PyExc_TypeError,
@@ -5886,14 +5892,6 @@ PyType_GetModuleByToken(PyTypeObject *type, const void *token)
             type->tp_name);
         return NULL;
     }
-    return Py_NewRef(mod);
-}
-
-PyObject *
-PyType_GetModuleByDef(PyTypeObject *type, PyModuleDef *def)
-{
-    PyObject *mod = PyType_GetModuleByToken(type, def);
-    Py_XDECREF(mod);  // return borrowed ref
     return mod;
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148907 -->
* Issue: gh-148907
<!-- /gh-issue-number -->

On this PR:
```console
❯ ./python.exe Tools/ftscalingbench/ftscalingbench.py --threads=10 thread_local_read
Running benchmarks with 10 threads
thread_local_read          4.7x faster

```