### PR TITLE
gh-148891: prevent crash in HAMT

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-23-08-36-47.gh-issue-148891.AMMHow.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-23-08-36-47.gh-issue-148891.AMMHow.rst
@@ -1,0 +1,6 @@
+Fix a crash in :func:`contextvars.Context.run` where a re-entrant GC
+invocation (triggered by ``_PyHamt_Assoc`` or ``_PyHamt_Without``
+allocating nodes) could free the current HAMT while it was still being
+traversed.  The fix holds a strong reference to the old ``ctx_vars``
+across the hazardous call in ``contextvar_set`` and ``contextvar_del``.
+

--- a/Python/context.c
+++ b/Python/context.c
@@ -791,8 +791,16 @@ contextvar_set(PyContextVar *var, PyObject *val)
         return -1;
     }
 
+    // gh-148891: _PyHamt_Assoc can allocate HAMT nodes, which may trigger
+    // GC.  A weakref callback or finalizer could then re-enter
+    // contextvar_set, replacing ctx->ctx_vars via Py_SETREF and freeing
+    // the old HAMT while _PyHamt_Assoc is still traversing it.
+    // Prevent this by holding a strong reference to the current vars.
+    PyHamtObject *old_vars = ctx->ctx_vars;
+    Py_INCREF(old_vars);
     PyHamtObject *new_vars = _PyHamt_Assoc(
-        ctx->ctx_vars, (PyObject *)var, val);
+        old_vars, (PyObject *)var, val);
+    Py_DECREF(old_vars);
     if (new_vars == NULL) {
         return -1;
     }
@@ -819,8 +827,12 @@ contextvar_del(PyContextVar *var)
         return -1;
     }
 
+    // gh-148891: same borrowed-reference hazard as contextvar_set:
+    // _PyHamt_Without allocates nodes, which may trigger GC re-entrancy.
     PyHamtObject *vars = ctx->ctx_vars;
+    Py_INCREF(vars);
     PyHamtObject *new_vars = _PyHamt_Without(vars, (PyObject *)var);
+    Py_DECREF(vars);
     if (new_vars == NULL) {
         return -1;
     }


### PR DESCRIPTION
## What is this PR?

Fixes #148891.

`_PyHamt_Assoc` allocates HAMT nodes, which can trigger GC. A weakref callback or finaliser fired during GC could re-enter `contextvar_set`, replacing `ctx->ctx_vars` via `Py_SETREF` and freeing the old HAMT while `_PyHamt_Assoc` was still traversing it, causing a use-after-free.

The proposed fix is to hold a strong reference to `ctx->ctx_vars` during the `_PyHamt_Assoc` call, so that a re-entrant free cannot affect the HAMT being traversed.

<!-- gh-issue-number: gh-148891 -->
* Issue: gh-148891
<!-- /gh-issue-number -->
