### PR TITLE
docs: remove dead link to Michele Simionato's website (gh-148938)

### DIFF
--- a/Doc/howto/mro.rst
+++ b/Doc/howto/mro.rst
@@ -10,7 +10,7 @@ The Python 2.3 Method Resolution Order
    The Method Resolution Order discussed here was *introduced* in Python 2.3,
    but it is still used in later versions -- including Python 3.
 
-By `Michele Simionato <https://www.phyast.pitt.edu/~micheles/>`__.
+By Michele Simionato.
 
 :Abstract:
 


### PR DESCRIPTION
Good day

I noticed that the link to Michele Simionato's website in `Doc/howto/mro.rst` is no longer accessible. This PR removes the dead hyperlink while preserving the attribution.

Fixes #148909.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithRoof

<!-- gh-issue-number: gh-148909 -->
* Issue: gh-148909
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148938.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->