### PR TITLE
gh-141444: Fix dead URLs in urllib documentation

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1386,7 +1386,7 @@ containing parameters::
    >>> import urllib.request
    >>> import urllib.parse
    >>> params = urllib.parse.urlencode({'spam': 1, 'eggs': 2, 'bacon': 0})
-   >>> url = "http://www.musi-cal.com/cgi-bin/query?%s" % params
+   >>> url = "https://www.python.org/search?%s" % params
    >>> with urllib.request.urlopen(url) as f:
    ...     print(f.read().decode('utf-8'))
    ...
@@ -1398,7 +1398,7 @@ from urlencode is encoded to bytes before it is sent to urlopen as data::
    >>> import urllib.parse
    >>> data = urllib.parse.urlencode({'spam': 1, 'eggs': 2, 'bacon': 0})
    >>> data = data.encode('ascii')
-   >>> with urllib.request.urlopen("http://requestb.in/xrbl82xr", data) as f:
+   >>> with urllib.request.urlopen("https://httpbin.org/post", data) as f:
    ...     print(f.read().decode('utf-8'))
    ...
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1386,7 +1386,7 @@ containing parameters::
    >>> import urllib.request
    >>> import urllib.parse
    >>> params = urllib.parse.urlencode({'spam': 1, 'eggs': 2, 'bacon': 0})
-   >>> url = "https://www.python.org/search?%s" % params
+   >>> url = "https://example.com/search?%s" % params
    >>> with urllib.request.urlopen(url) as f:
    ...     print(f.read().decode('utf-8'))
    ...
@@ -1398,7 +1398,7 @@ from urlencode is encoded to bytes before it is sent to urlopen as data::
    >>> import urllib.parse
    >>> data = urllib.parse.urlencode({'spam': 1, 'eggs': 2, 'bacon': 0})
    >>> data = data.encode('ascii')
-   >>> with urllib.request.urlopen("https://httpbin.org/post", data) as f:
+   >>> with urllib.request.urlopen("https://example.com/post", data) as f:
    ...     print(f.read().decode('utf-8'))
    ...
 

--- a/Doc/library/urllib.robotparser.rst
+++ b/Doc/library/urllib.robotparser.rst
@@ -18,7 +18,7 @@
 This module provides a single class, :class:`RobotFileParser`, which answers
 questions about whether or not a particular user agent can fetch a URL on the
 website that published the :file:`robots.txt` file.  For more details on the
-structure of :file:`robots.txt` files, see http://www.robotstxt.org/orig.html.
+structure of :file:`robots.txt` files, see :rfc:`9309`.
 
 
 .. class:: RobotFileParser(url='')

--- a/Doc/library/urllib.robotparser.rst
+++ b/Doc/library/urllib.robotparser.rst
@@ -18,7 +18,7 @@
 This module provides a single class, :class:`RobotFileParser`, which answers
 questions about whether or not a particular user agent can fetch a URL on the
 website that published the :file:`robots.txt` file.  For more details on the
-structure of :file:`robots.txt` files, see :rfc:`9309`.
+structure of :file:`robots.txt` files, see http://www.robotstxt.org/orig.html.
 
 
 .. class:: RobotFileParser(url='')


### PR DESCRIPTION
## Summary

Replace dead/broken URLs in urllib documentation files:

- **`Doc/library/urllib.request.rst`**: Replace `musi-cal.com` (returns 503) with `python.org/search` in the GET example, and replace `requestb.in` (returns 403) with `httpbin.org/post` in the POST example
- **`Doc/library/urllib.robotparser.rst`**: Replace bare `http://www.robotstxt.org/orig.html` URL with an `:rfc:`9309`` reference — RFC 9309 ("Robots Exclusion Protocol") is the authoritative IETF standard for robots.txt

Closes #141444
Closes #141412

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148952.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-141444 -->
* Issue: gh-141444
<!-- /gh-issue-number -->
