### PR TITLE
gh-148957: Fix build failure from missing `jit_got_size` stats wiring

### DIFF
--- a/Include/cpython/pystats.h
+++ b/Include/cpython/pystats.h
@@ -163,6 +163,7 @@ typedef struct _optimization_stats {
     uint64_t jit_code_size;
     uint64_t jit_trampoline_size;
     uint64_t jit_data_size;
+    uint64_t jit_got_size;
     uint64_t jit_padding_size;
     uint64_t jit_freed_memory_size;
     uint64_t trace_total_memory_hist[_Py_UOP_HIST_SIZE];

--- a/Misc/NEWS.d/next/Build/2026-04-24-14-03-23.gh-issue-148957.G2Ztk1.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-24-14-03-23.gh-issue-148957.G2Ztk1.rst
@@ -1,0 +1,1 @@
+Fix a build failure caused by missing ``jit_got_size`` stats wiring.

--- a/Python/pystats.c
+++ b/Python/pystats.c
@@ -327,6 +327,7 @@ print_optimization_stats(FILE *out, OptimizationStats *stats)
     fprintf(out, "JIT code size: %" PRIu64 "\n", stats->jit_code_size);
     fprintf(out, "JIT trampoline size: %" PRIu64 "\n", stats->jit_trampoline_size);
     fprintf(out, "JIT data size: %" PRIu64 "\n", stats->jit_data_size);
+    fprintf(out, "JIT GOT size: %" PRIu64 "\n", stats->jit_got_size);
     fprintf(out, "JIT padding size: %" PRIu64 "\n", stats->jit_padding_size);
     fprintf(out, "JIT freed memory size: %" PRIu64 "\n", stats->jit_freed_memory_size);
 
@@ -480,6 +481,7 @@ merge_optimization_stats(OptimizationStats *dest, const OptimizationStats *src)
     dest->jit_code_size += src->jit_code_size;
     dest->jit_trampoline_size += src->jit_trampoline_size;
     dest->jit_data_size += src->jit_data_size;
+    dest->jit_got_size += src->jit_got_size;
     dest->jit_padding_size += src->jit_padding_size;
     dest->jit_freed_memory_size += src->jit_freed_memory_size;
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-148957 -->
* Issue: gh-148957
<!-- /gh-issue-number -->
