### PR TITLE
gh-148961 : Use parsed-literal for the slot column legend in c-api/typeobj.rst

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -169,19 +169,19 @@ Quick Reference
 
    **"D"**:  default (if slot is set to ``NULL``)
 
-   .. code-block:: none
+   .. parsed-literal::
 
-      X - PyType_Ready sets this value if it is NULL
-      ~ - PyType_Ready always sets this value (it should be NULL)
-      ? - PyType_Ready may set this value depending on other slots
+      X - :c:func:`PyType_Ready` sets this value if it is ``NULL``
+      ~ - :c:func:`PyType_Ready` always sets this value (it should be ``NULL``)
+      ? - :c:func:`PyType_Ready` may set this value depending on other slots
 
       Also see the inheritance column ("I").
 
    **"I"**:  inheritance
 
-   .. code-block:: none
+   .. parsed-literal::
 
-      X - type slot is inherited via *PyType_Ready* if defined with a *NULL* value
+      X - type slot is inherited via :c:func:`PyType_Ready` if defined with a ``NULL`` value
       % - the slots of the sub-struct are inherited individually
       G - inherited, but only in combination with other slots; see the slot's description
       ? - it's complicated; see the slot's description


### PR DESCRIPTION
The two small legends under the `PyTypeObject` "Quick Reference" table in
`Doc/c-api/typeobj.rst` explain what each character in the `"D"` (default)
and `"I"` (inheritance) columns means. They were wrapped in
`.. code-block:: none`, so reST inline markup inside them was rendered
verbatim:
- `*PyType_Ready*` and `*NULL*` showed literal asterisks.
- `PyType_Ready` was plain text instead of a cross-reference link.
- `NULL` was plain text instead of the ``NULL`` inline literal used
  throughout the rest of the page.

##  Before:

<img width="1898" height="836" alt="image" src="https://github.com/user-attachments/assets/6ee67997-ff72-4045-856e-11b1820a2513" />

## After:
<img width="1678" height="1064" alt="Clipboard_Screenshot_1777045193" src="https://github.com/user-attachments/assets/cab80ea2-6777-498c-98de-c5909e4d2416" />


* Issue: gh-148961



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148962.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->