### PR TITLE
Fix example code for islice

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -473,7 +473,7 @@ loops that truncate the stream.
    Roughly equivalent to::
 
       def islice(iterable, *args):
-          # islice('ABCDEFG', 2) → A B
+          # islice('ABCDEFG', 0, 2) → A B
           # islice('ABCDEFG', 2, 4) → C D
           # islice('ABCDEFG', 2, None) → C D E F G
           # islice('ABCDEFG', 0, None, 2) → A C E G


### PR DESCRIPTION
As far as I can tell, `islice('ABCDEFG', 2)` should result in `C D E F G`, which is the same as a later example. I suspect the original author meant to use `islice('ABCDEFG', 0, 2)`.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148966.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->