### PR TITLE
gh-127550 Fix ElementTree write  newline handling

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -4312,9 +4312,9 @@ class IOTest(unittest.TestCase):
 
         tree.write(TESTFN, encoding='ISO-8859-1')
         with open(TESTFN, 'rb') as f:
-            self.assertEqual(f.read(), convlinesep(
+            self.assertEqual(f.read(),
                              b'''<?xml version='1.0' encoding='ISO-8859-1'?>\n'''
-                             b'''<site>\xf8</site>'''))
+                             b'''<site>\xf8</site>''')
 
     def test_write_to_filename_as_unicode(self):
         self.addCleanup(os_helper.unlink, TESTFN)
@@ -4356,6 +4356,25 @@ class IOTest(unittest.TestCase):
             self.assertFalse(f.closed)
         with open(TESTFN, 'rb') as f:
             self.assertEqual(f.read(), b'''<site>&#248;</site>''')
+
+    def test_write_with_and_without_context_manager_same_output(self):
+        self.addCleanup(os_helper.unlink, TESTFN)
+        testfn2 = TESTFN + '2'
+        self.addCleanup(os_helper.unlink, testfn2)
+
+        tree = ET.ElementTree(ET.XML('''<site>\x0a</site>'''))
+        tree.write(TESTFN, encoding='utf-8')
+        with open(TESTFN, 'rb') as f:
+            output_without_context_manager = f.read()
+
+        with open(testfn2, 'wb') as f:
+            tree.write(f, encoding='utf-8')
+            self.assertFalse(f.closed)
+        with open(testfn2, 'rb') as f:
+            output_with_context_manager = f.read()
+
+        self.assertEqual(output_without_context_manager,
+                         output_with_context_manager)
 
     def test_write_to_binary_file_with_encoding(self):
         self.addCleanup(os_helper.unlink, TESTFN)

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -756,7 +756,7 @@ def _get_writer(file_or_filename, encoding):
         if encoding.lower() == "unicode":
             encoding="utf-8"
         with open(file_or_filename, "w", encoding=encoding,
-                  errors="xmlcharrefreplace") as file:
+                  errors="xmlcharrefreplace", newline="\n") as file:
             yield file.write, encoding
     else:
         # file_or_filename is a file-like object


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
gh-127550: Fix ElementTree.write to ensure newline consistency between standalone and context manager use

## Summary

Ensure consistent newline handling in `ElementTree.write()` when writing
to a filename versus a file-like object.

## Relevant code in `Lib/xml/etree/ElementTree.py`

Function: `_get_writer(file_or_filename, encoding)`

Removing `newline="\n"` from the first code block caused multiple test
failures in `Lib/test/test_xml_etree.py`. In contrast, adding
`newline="\n"` to the second block resulted in only one failing test.

### Writer for file-like objects

```python
file = io.TextIOWrapper(
    file,
    encoding=encoding,
    errors="xmlcharrefreplace",
    newline="\n",
)
```
### Writer for file or filename
```python
   with open(file_or_filename, "w", encoding=encoding,
                  errors="xmlcharrefreplace", newline="\n") as file:
```
## Changes

Added `newline="\n"` to the `open()` call for filename-based writing,
instead of removing it from the `TextIOWrapper` path, to ensure consistent
behavior between file-like objects and filenames.

This change improves consistency between the two code paths.

## Rationale

According to the XML specification, XML parsers normalize line endings.
The sequences `\r\n`, `\r`, and `\n` are all normalized to `\n` during parsing.
Therefore, differences in newline handling at write time do not affect
parsed XML content, but consistency in output behavior is desirable.

## Tests

- Fixed one failing test case in `Lib/test/test_xml_etree.py`  
- Added a new regression test in `Lib/test/test_xml_etree.py`

