### PR TITLE
fix: programs/_freeze_module in _freeze_module.c

### DIFF
--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -182,7 +182,7 @@ decode_unicode_with_escapes(Parser *parser, const char *s, size_t len, Token *t)
             w_len = PyUnicode_GET_LENGTH(w);
             for (i = 0; i < w_len; i++) {
                 Py_UCS4 chr = PyUnicode_READ(kind, data, i);
-                sprintf(p, "\\U%08x", chr);
+                snprintf(p, 11, "\\U%08x", chr);
                 p += 10;
             }
             /* Should be impossible to overflow */

--- a/Programs/_freeze_module.c
+++ b/Programs/_freeze_module.c
@@ -126,7 +126,7 @@ compile_and_marshal(const char *name, const char *text)
     if (filename == NULL) {
         return PyErr_NoMemory();
     }
-    sprintf(filename, "<frozen %s>", name);
+    snprintf(filename, strlen(name) + 10, "<frozen %s>", name);
     PyObject *code = Py_CompileStringExFlags(text, filename,
                                              Py_file_input, NULL, 0);
     free(filename);
@@ -153,7 +153,7 @@ get_varname(const char *name, const char *prefix)
     if (varname == NULL) {
         return NULL;
     }
-    (void)strcpy(varname, prefix);
+    memcpy(varname, prefix, n);
     for (size_t i = 0; name[i] != '\0'; i++) {
         if (name[i] == '.') {
             varname[n++] = '_';


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `Programs/_freeze_module.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `Programs/_freeze_module.c:129` |
| **CWE** | CWE-120 |

**Description**: Programs/_freeze_module.c:129 uses sprintf(filename, "<frozen %s>", name) where 'name' is the module name argument. If 'name' exceeds the fixed-size filename buffer minus the 9-character surrounding literal '<frozen >', the buffer overflows. Parser/string_parser.c:185 uses sprintf(p, "\\U%08x", chr) where 'p' points into a string buffer whose remaining capacity is not validated before the write. Both calls use the unsafe sprintf() function which performs no bounds checking on the destination buffer.

## Changes
- `Programs/_freeze_module.c`
- `Parser/string_parser.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
