### PR TITLE
gh-148981: Add color to `ast.dump`

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2480,7 +2480,7 @@ and classes for traversing abstract syntax trees:
       node = YourTransformer().visit(node)
 
 
-.. function:: dump(node, annotate_fields=True, include_attributes=False, *, indent=None, show_empty=False)
+.. function:: dump(node, annotate_fields=True, include_attributes=False, *, color=True, indent=None, show_empty=False)
 
    Return a formatted dump of the tree in *node*.  This is mainly useful for
    debugging purposes.  If *annotate_fields* is true (by default),
@@ -2489,6 +2489,11 @@ and classes for traversing abstract syntax trees:
    omitting unambiguous field names.  Attributes such as line
    numbers and column offsets are not dumped by default.  If this is wanted,
    *include_attributes* can be set to true.
+
+   If *color* is ``True`` (the default), output will be syntax highlighted using
+   ANSI escape sequences, if the *stream* and :ref:`environment variables
+   <using-on-controlling-color>` permit.
+   If ``False``, colored output is always disabled.
 
    If *indent* is a non-negative integer or string, then the tree will be
    pretty-printed with that indent level.  An indent level
@@ -2526,6 +2531,9 @@ and classes for traversing abstract syntax trees:
 
    .. versionchanged:: 3.15
       Omit optional ``Load()`` values by default.
+
+   .. versionchanged:: next
+      Added the *color* parameter.
 
 
 .. _ast-compiler-flags:

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2490,9 +2490,8 @@ and classes for traversing abstract syntax trees:
    numbers and column offsets are not dumped by default.  If this is wanted,
    *include_attributes* can be set to true.
 
-   If *color* is ``True``, output will be syntax highlighted using
-   ANSI escape sequences, if the *stream* and :ref:`environment variables
-   <using-on-controlling-color>` permit.
+   If *color* is ``True``, the returned string is syntax highlighted using
+   ANSI escape sequences.
    If ``False`` (the default), colored output is always disabled.
 
    If *indent* is a non-negative integer or string, then the tree will be

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2591,6 +2591,10 @@ Command-line usage
 
 .. versionadded:: 3.9
 
+.. versionchanged:: next
+   The output is now syntax highlighted by default. This can be
+   :ref:`controlled using environment variables <using-on-controlling-color>`.
+
 The :mod:`!ast` module can be executed as a script from the command line.
 It is as simple as:
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2480,7 +2480,7 @@ and classes for traversing abstract syntax trees:
       node = YourTransformer().visit(node)
 
 
-.. function:: dump(node, annotate_fields=True, include_attributes=False, *, color=True, indent=None, show_empty=False)
+.. function:: dump(node, annotate_fields=True, include_attributes=False, *, color=False, indent=None, show_empty=False)
 
    Return a formatted dump of the tree in *node*.  This is mainly useful for
    debugging purposes.  If *annotate_fields* is true (by default),
@@ -2490,10 +2490,10 @@ and classes for traversing abstract syntax trees:
    numbers and column offsets are not dumped by default.  If this is wanted,
    *include_attributes* can be set to true.
 
-   If *color* is ``True`` (the default), output will be syntax highlighted using
+   If *color* is ``True``, output will be syntax highlighted using
    ANSI escape sequences, if the *stream* and :ref:`environment variables
    <using-on-controlling-color>` permit.
-   If ``False``, colored output is always disabled.
+   If ``False`` (the default), colored output is always disabled.
 
    If *indent* is a non-negative integer or string, then the tree will be
    pretty-printed with that indent level.  An indent level

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -696,9 +696,9 @@ ast
 ---
 
 * Add *color* parameter to :func:`~ast.dump`.
-  If ``True`` (the default), output is highlighted in color, when the stream
+  If ``True``, output is highlighted in color, when the stream
   and :ref:`environment variables <using-on-controlling-color>` permit.
-  If ``False``, colored output is always disabled.
+  If ``False`` (the default), colored output is always disabled.
   (Contributed by Stan Ulbrych in :gh:`148981`.)
 
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -692,6 +692,16 @@ array
   (Contributed by Sergey B Kirpichev in :gh:`146238`.)
 
 
+ast
+---
+
+* Add *color* parameter to :func:`~ast.dump`.
+  If ``True`` (the default), output is highlighted in color, when the stream
+  and :ref:`environment variables <using-on-controlling-color>` permit.
+  If ``False``, colored output is always disabled.
+  (Contributed by Stan Ulbrych in :gh:`148981`.)
+
+
 base64
 ------
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -701,6 +701,10 @@ ast
   If ``False`` (the default), colored output is always disabled.
   (Contributed by Stan Ulbrych in :gh:`148981`.)
 
+* The :ref:`command-line <ast-cli>` output is now syntax highlighted by default.
+  This can be :ref:`controlled using environment variables <using-on-controlling-color>`.
+  (Contributed by Stan Ulbrych in :gh:`148981`.)
+
 
 base64
 ------

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -696,8 +696,8 @@ ast
 ---
 
 * Add *color* parameter to :func:`~ast.dump`.
-  If ``True``, output is highlighted in color, when the stream
-  and :ref:`environment variables <using-on-controlling-color>` permit.
+  If ``True``, the returned string is syntax highlighted using ANSI escape
+  sequences.
   If ``False`` (the default), colored output is always disabled.
   (Contributed by Stan Ulbrych in :gh:`148981`.)
 

--- a/Lib/_colorize.py
+++ b/Lib/_colorize.py
@@ -193,6 +193,7 @@ class Argparse(ThemeSection):
 class Ast(ThemeSection):
     node: str = ANSIColors.CYAN
     field: str = ANSIColors.BLUE
+    attribute: str = ANSIColors.GREY
     string: str = ANSIColors.GREEN
     number: str = ANSIColors.YELLOW
     keyword: str = ANSIColors.BOLD_BLUE

--- a/Lib/_colorize.py
+++ b/Lib/_colorize.py
@@ -190,6 +190,16 @@ class Argparse(ThemeSection):
 
 
 @dataclass(frozen=True, kw_only=True)
+class Ast(ThemeSection):
+    node: str = ANSIColors.CYAN
+    field: str = ANSIColors.BLUE
+    string: str = ANSIColors.GREEN
+    number: str = ANSIColors.YELLOW
+    keyword: str = ANSIColors.BOLD_BLUE
+    reset: str = ANSIColors.RESET
+
+
+@dataclass(frozen=True, kw_only=True)
 class Difflib(ThemeSection):
     """A 'git diff'-like theme for `difflib.unified_diff`."""
     added: str = ANSIColors.GREEN
@@ -405,6 +415,7 @@ class Theme:
     below.
     """
     argparse: Argparse = field(default_factory=Argparse)
+    ast: Ast = field(default_factory=Ast)
     difflib: Difflib = field(default_factory=Difflib)
     fancycompleter: FancyCompleter = field(default_factory=FancyCompleter)
     http_server: HttpServer = field(default_factory=HttpServer)
@@ -418,6 +429,7 @@ class Theme:
         self,
         *,
         argparse: Argparse | None = None,
+        ast: Ast | None = None,
         difflib: Difflib | None = None,
         fancycompleter: FancyCompleter | None = None,
         http_server: HttpServer | None = None,
@@ -434,6 +446,7 @@ class Theme:
         """
         return type(self)(
             argparse=argparse or self.argparse,
+            ast=ast or self.ast,
             difflib=difflib or self.difflib,
             fancycompleter=fancycompleter or self.fancycompleter,
             http_server=http_server or self.http_server,
@@ -454,6 +467,7 @@ class Theme:
         """
         return cls(
             argparse=Argparse.no_colors(),
+            ast=Ast.no_colors(),
             difflib=Difflib.no_colors(),
             fancycompleter=FancyCompleter.no_colors(),
             http_server=HttpServer.no_colors(),

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -134,10 +134,12 @@ def dump(
     level. None (the default) selects the single line representation.
     If show_empty is False, then empty lists and fields that are None
     will be omitted from the output for better readability.
-    If color is true, the result will be syntax highlighted
-    using ANSI escape sequences if the stream and environment variables permit.
+    If color is true, the returned string is syntax highlighted using ANSI
+    escape sequences.
     If color is false (the default), colored output is always disabled.
     """
+    theme = get_theme(force_color=color, force_no_color=not color).ast
+
     def _format(node, level=0):
         if indent is not None:
             level += 1
@@ -166,13 +168,13 @@ def dump(
                         field_type = cls._field_types.get(name, object)
                         if getattr(field_type, '__origin__', ...) is list:
                             if not keywords:
-                                args_buffer.append(repr(value))
+                                args_buffer.append(_format(value, level)[0])
                             continue
                     elif isinstance(value, Load):
                         field_type = cls._field_types.get(name, object)
                         if field_type is expr_context:
                             if not keywords:
-                                args_buffer.append(repr(value))
+                                args_buffer.append(_format(value, level)[0])
                             continue
                     if not keywords:
                         args.extend(args_buffer)
@@ -180,7 +182,7 @@ def dump(
                 value, simple = _format(value, level)
                 allsimple = allsimple and simple
                 if keywords:
-                    args.append('%s=%s' % (name, value))
+                    args.append(f'{theme.field}{name}{theme.reset}={value}')
                 else:
                     args.append(value)
             if include_attributes and node._attributes:
@@ -193,52 +195,28 @@ def dump(
                         continue
                     value, simple = _format(value, level)
                     allsimple = allsimple and simple
-                    args.append('%s=%s' % (name, value))
+                    args.append(f'{theme.attribute}{name}{theme.reset}={value}')
+            cls_name = f'{theme.node}{cls.__name__}{theme.reset}'
             if allsimple and len(args) <= 3:
-                return '%s(%s)' % (node.__class__.__name__, ', '.join(args)), not args
-            return '%s(%s%s)' % (node.__class__.__name__, prefix, sep.join(args)), False
+                return f'{cls_name}({", ".join(args)})', not args
+            return f'{cls_name}({prefix}{sep.join(args)})', False
         elif isinstance(node, list):
             if not node:
                 return '[]', True
-            return '[%s%s]' % (prefix, sep.join(_format(x, level)[0] for x in node)), False
+            return f'[{prefix}{sep.join(_format(x, level)[0] for x in node)}]', False
+        if isinstance(node, bool) or node is None or node is Ellipsis:
+            return f'{theme.keyword}{node!r}{theme.reset}', True
+        if isinstance(node, (int, float, complex)):
+            return f'{theme.number}{node!r}{theme.reset}', True
+        if isinstance(node, (str, bytes)):
+            return f'{theme.string}{node!r}{theme.reset}', True
         return repr(node), True
 
     if not isinstance(node, AST):
         raise TypeError('expected AST, got %r' % node.__class__.__name__)
     if indent is not None and not isinstance(indent, str):
         indent = ' ' * indent
-    output = _format(node)[0]
-    if color:
-        if can_colorize(file=sys.stdout):
-            output = _colorize_dump(output, get_theme(tty_file=sys.stdout).ast)
-    return output
-
-
-_color_pattern = None
-
-def _colorize_dump(output, theme):
-    global _color_pattern
-    if _color_pattern is None:
-        _color_pattern = re.compile(r"""
-            (?P<string>[bB]?'(?:\\.|[^'\\])*'|[bB]?"(?:\\.|[^"\\])*") |
-            (?P<keyword>\b(?:None|True|False|Ellipsis)\b)             |
-            (?P<node>[A-Za-z_]\w*)(?=\()                              |
-            (?P<field>[a-z_]\w*)(?==)                                 |
-            (?P<number>-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?[jJ]?)
-        """, re.VERBOSE)
-
-    color_map = {
-        "node": theme.node,
-        "field": theme.field,
-        "string": theme.string,
-        "number": theme.number,
-        "keyword": theme.keyword,
-    }
-
-    def replace(match):
-        return f"{color_map[match.lastgroup]}{match.group()}{theme.reset}"
-
-    return _color_pattern.sub(replace, output)
+    return _format(node)[0]
 
 
 def copy_location(new_node, old_node):
@@ -721,7 +699,8 @@ def main(args=None):
 
     tree = parse(source, name, args.mode, type_comments=args.no_type_comments,
                  feature_version=feature_version, optimize=args.optimize)
-    print(dump(tree, include_attributes=args.include_attributes, color=True,
+    print(dump(tree, include_attributes=args.include_attributes,
+               color=can_colorize(file=sys.stdout),
                indent=args.indent, show_empty=args.show_empty))
 
 if __name__ == '__main__':

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -21,8 +21,6 @@ that work tightly with the python syntax (template engines for example).
 :license: Python License.
 """
 from _ast import *
-lazy import re
-lazy import sys
 lazy from _colorize import can_colorize, get_theme
 
 
@@ -352,6 +350,8 @@ def _splitlines_no_ff(source, maxlines=None):
     """
     global _line_pattern
     if _line_pattern is None:
+        # lazily computed to speedup import time of `ast`
+        import re
         _line_pattern = re.compile(r"(.*?(?:\r\n|\n|\r|$))")
 
     lines = []
@@ -653,6 +653,7 @@ def unparse(ast_obj):
 
 def main(args=None):
     import argparse
+    import sys
 
     parser = argparse.ArgumentParser(color=True)
     parser.add_argument('infile', nargs='?', default='-',

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -173,7 +173,7 @@ def dump(
                         field_type = cls._field_types.get(name, object)
                         if getattr(field_type, '__origin__', ...) is list:
                             if not keywords:
-                                args_buffer.append('[]')
+                                args_buffer.append(repr(value))
                             continue
                     elif isinstance(value, Load):
                         field_type = cls._field_types.get(name, object)

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -142,7 +142,7 @@ def dump(
     If show_empty is False, then empty lists and fields that are None
     will be omitted from the output for better readability.
     """
-    theme = get_theme(force_color=color, force_no_color=not color).ast
+    t = get_theme(force_color=color, force_no_color=not color).ast
 
     def _format(node, level=0):
         if indent is not None:
@@ -179,8 +179,8 @@ def dump(
                         if field_type is expr_context:
                             if not keywords:
                                 args_buffer.append(
-                                    f'{theme.node}{type(value).__name__}'
-                                    f'{theme.reset}()')
+                                    f'{t.node}{type(value).__name__}'
+                                    f'{t.reset}()')
                             continue
                     if not keywords:
                         args.extend(args_buffer)
@@ -188,7 +188,7 @@ def dump(
                 value, simple = _format(value, level)
                 allsimple = allsimple and simple
                 if keywords:
-                    args.append(f'{theme.field}{name}{theme.reset}={value}')
+                    args.append(f'{t.field}{name}{t.reset}={value}')
                 else:
                     args.append(value)
             if include_attributes and node._attributes:
@@ -201,8 +201,8 @@ def dump(
                         continue
                     value, simple = _format(value, level)
                     allsimple = allsimple and simple
-                    args.append(f'{theme.attribute}{name}{theme.reset}={value}')
-            cls_name = f'{theme.node}{cls.__name__}{theme.reset}'
+                    args.append(f'{t.attribute}{name}{t.reset}={value}')
+            cls_name = f'{t.node}{cls.__name__}{t.reset}'
             if allsimple and len(args) <= 3:
                 return f'{cls_name}({", ".join(args)})', not args
             return f'{cls_name}({prefix}{sep.join(args)})', False
@@ -211,11 +211,11 @@ def dump(
                 return '[]', True
             return '[%s%s]' % (prefix, sep.join(_format(x, level)[0] for x in node)), False
         if isinstance(node, bool) or node is None or node is Ellipsis:
-            return f'{theme.keyword}{node!r}{theme.reset}', True
+            return f'{t.keyword}{node!r}{t.reset}', True
         if isinstance(node, (int, float, complex)):
-            return f'{theme.number}{node!r}{theme.reset}', True
+            return f'{t.number}{node!r}{t.reset}', True
         if isinstance(node, (str, bytes)):
-            return f'{theme.string}{node!r}{theme.reset}', True
+            return f'{t.string}{node!r}{t.reset}', True
         return repr(node), True
 
     if not isinstance(node, AST):
@@ -663,7 +663,7 @@ def main(args=None):
     import argparse
     import sys
 
-    parser = argparse.ArgumentParser(color=True)
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('infile', nargs='?', default='-',
                         help='the file to parse; defaults to stdin')
     parser.add_argument('-m', '--mode', default='exec',
@@ -682,7 +682,7 @@ def main(args=None):
                              '(for example, 3.10)')
     parser.add_argument('-O', '--optimize',
                         type=int, default=-1, metavar='LEVEL',
-                        help='optimization level for parser (default -1)')
+                        help='optimization level for parser')
     parser.add_argument('--show-empty', default=False, action='store_true',
                         help='show empty lists and fields in dump output')
     args = parser.parse_args(args)

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -122,19 +122,26 @@ def dump(
 ):
     """
     Return a formatted dump of the tree in node.  This is mainly useful for
-    debugging purposes.  If annotate_fields is true (by default),
+    debugging purposes.
+
+    If annotate_fields is true (by default),
     the returned string will show the names and the values for fields.
     If annotate_fields is false, the result string will be more compact by
-    omitting unambiguous field names.  Attributes such as line
-    numbers and column offsets are not dumped by default.  If this is wanted,
-    include_attributes can be set to true.  If indent is a non-negative
-    integer or string, then the tree will be pretty-printed with that indent
-    level. None (the default) selects the single line representation.
-    If show_empty is False, then empty lists and fields that are None
-    will be omitted from the output for better readability.
+    omitting unambiguous field names.
+
+    Attributes such as line numbers and column offsets are not dumped by default.
+    If this is wanted, include_attributes can be set to true.
+
     If color is true, the returned string is syntax highlighted using ANSI
     escape sequences.
     If color is false (the default), colored output is always disabled.
+
+    If indent is a non-negative
+    integer or string, then the tree will be pretty-printed with that indent
+    level. None (the default) selects the single line representation.
+
+    If show_empty is False, then empty lists and fields that are None
+    will be omitted from the output for better readability.
     """
     theme = get_theme(force_color=color, force_no_color=not color).ast
 
@@ -166,13 +173,15 @@ def dump(
                         field_type = cls._field_types.get(name, object)
                         if getattr(field_type, '__origin__', ...) is list:
                             if not keywords:
-                                args_buffer.append(_format(value, level)[0])
+                                args_buffer.append('[]')
                             continue
                     elif isinstance(value, Load):
                         field_type = cls._field_types.get(name, object)
                         if field_type is expr_context:
                             if not keywords:
-                                args_buffer.append(_format(value, level)[0])
+                                args_buffer.append(
+                                    f'{theme.node}{type(value).__name__}'
+                                    f'{theme.reset}()')
                             continue
                     if not keywords:
                         args.extend(args_buffer)

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -120,7 +120,7 @@ def _convert_literal(node):
 def dump(
     node, annotate_fields=True, include_attributes=False,
     *,
-    color=True, indent=None, show_empty=False,
+    color=False, indent=None, show_empty=False,
 ):
     """
     Return a formatted dump of the tree in node.  This is mainly useful for
@@ -134,9 +134,9 @@ def dump(
     level. None (the default) selects the single line representation.
     If show_empty is False, then empty lists and fields that are None
     will be omitted from the output for better readability.
-    If color is true (the default), the result will be syntax highlighted
+    If color is true, the result will be syntax highlighted
     using ANSI escape sequences if the stream and environment variables permit.
-    If color is false, colored output is always disabled.
+    If color is false (the default), colored output is always disabled.
     """
     def _format(node, level=0):
         if indent is not None:
@@ -721,7 +721,7 @@ def main(args=None):
 
     tree = parse(source, name, args.mode, type_comments=args.no_type_comments,
                  feature_version=feature_version, optimize=args.optimize)
-    print(dump(tree, include_attributes=args.include_attributes,
+    print(dump(tree, include_attributes=args.include_attributes, color=True,
                indent=args.indent, show_empty=args.show_empty))
 
 if __name__ == '__main__':

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -124,21 +124,20 @@ def dump(
     Return a formatted dump of the tree in node.  This is mainly useful for
     debugging purposes.
 
-    If annotate_fields is true (by default),
-    the returned string will show the names and the values for fields.
-    If annotate_fields is false, the result string will be more compact by
-    omitting unambiguous field names.
+    If annotate_fields is true (by default), the returned string will show the
+    names and the values for fields. If annotate_fields is false, the result
+    string will be more compact by omitting unambiguous field names.
 
     Attributes such as line numbers and column offsets are not dumped by default.
     If this is wanted, include_attributes can be set to true.
 
     If color is true, the returned string is syntax highlighted using ANSI
-    escape sequences.
-    If color is false (the default), colored output is always disabled.
+    escape sequences. If color is false (the default), colored output is always
+    disabled.
 
-    If indent is a non-negative
-    integer or string, then the tree will be pretty-printed with that indent
-    level. None (the default) selects the single line representation.
+    If indent is a non-negative integer or string, then the tree will be
+    pretty-printed with that indent level. If indent is None (the default),
+    the tree is dumped on a single line.
 
     If show_empty is False, then empty lists and fields that are None
     will be omitted from the output for better readability.
@@ -210,7 +209,7 @@ def dump(
         elif isinstance(node, list):
             if not node:
                 return '[]', True
-            return f'[{prefix}{sep.join(_format(x, level)[0] for x in node)}]', False
+            return '[%s%s]' % (prefix, sep.join(_format(x, level)[0] for x in node)), False
         if isinstance(node, bool) or node is None or node is Ellipsis:
             return f'{theme.keyword}{node!r}{theme.reset}', True
         if isinstance(node, (int, float, complex)):

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -21,6 +21,9 @@ that work tightly with the python syntax (template engines for example).
 :license: Python License.
 """
 from _ast import *
+lazy import re
+lazy import sys
+lazy from _colorize import can_colorize, get_theme
 
 
 def parse(source, filename='<unknown>', mode='exec', *,
@@ -117,7 +120,7 @@ def _convert_literal(node):
 def dump(
     node, annotate_fields=True, include_attributes=False,
     *,
-    indent=None, show_empty=False,
+    color=True, indent=None, show_empty=False,
 ):
     """
     Return a formatted dump of the tree in node.  This is mainly useful for
@@ -131,6 +134,9 @@ def dump(
     level. None (the default) selects the single line representation.
     If show_empty is False, then empty lists and fields that are None
     will be omitted from the output for better readability.
+    If color is true (the default), the result will be syntax highlighted
+    using ANSI escape sequences if the stream and environment variables permit.
+    If color is false, colored output is always disabled.
     """
     def _format(node, level=0):
         if indent is not None:
@@ -201,7 +207,38 @@ def dump(
         raise TypeError('expected AST, got %r' % node.__class__.__name__)
     if indent is not None and not isinstance(indent, str):
         indent = ' ' * indent
-    return _format(node)[0]
+    output = _format(node)[0]
+    if color:
+        if can_colorize(file=sys.stdout):
+            output = _colorize_dump(output, get_theme(tty_file=sys.stdout).ast)
+    return output
+
+
+_color_pattern = None
+
+def _colorize_dump(output, theme):
+    global _color_pattern
+    if _color_pattern is None:
+        _color_pattern = re.compile(r"""
+            (?P<string>[bB]?'(?:\\.|[^'\\])*'|[bB]?"(?:\\.|[^"\\])*") |
+            (?P<keyword>\b(?:None|True|False|Ellipsis)\b)             |
+            (?P<node>[A-Za-z_]\w*)(?=\()                              |
+            (?P<field>[a-z_]\w*)(?==)                                 |
+            (?P<number>-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?[jJ]?)
+        """, re.VERBOSE)
+
+    color_map = {
+        "node": theme.node,
+        "field": theme.field,
+        "string": theme.string,
+        "number": theme.number,
+        "keyword": theme.keyword,
+    }
+
+    def replace(match):
+        return f"{color_map[match.lastgroup]}{match.group()}{theme.reset}"
+
+    return _color_pattern.sub(replace, output)
 
 
 def copy_location(new_node, old_node):
@@ -337,8 +374,6 @@ def _splitlines_no_ff(source, maxlines=None):
     """
     global _line_pattern
     if _line_pattern is None:
-        # lazily computed to speedup import time of `ast`
-        import re
         _line_pattern = re.compile(r"(.*?(?:\r\n|\n|\r|$))")
 
     lines = []
@@ -640,7 +675,6 @@ def unparse(ast_obj):
 
 def main(args=None):
     import argparse
-    import sys
 
     parser = argparse.ArgumentParser(color=True)
     parser.add_argument('infile', nargs='?', default='-',

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -1450,6 +1450,7 @@ class CopyTests(unittest.TestCase):
             node.__replace__(**{object(): "y"})
 
 
+@support.force_not_colorized_test_class
 class ASTHelpers_Test(unittest.TestCase):
     maxDiff = None
 
@@ -1704,6 +1705,16 @@ Module(
             empty="Module(body=[Import(names=[alias(name='_ast', asname='ast')], is_lazy=0), ImportFrom(module='module', names=[alias(name='sub')], level=0, is_lazy=0)])",
             full="Module(body=[Import(names=[alias(name='_ast', asname='ast')], is_lazy=0), ImportFrom(module='module', names=[alias(name='sub')], level=0, is_lazy=0)], type_ignores=[])",
         )
+
+    def test_dump_with_color(self):
+        node = ast.parse("x = 1")
+
+        with support.force_color(True):
+            self.assertNotIn("\x1b[", ast.dump(node, color=False))
+            self.assertIn("\x1b[", ast.dump(node, color=True))
+
+        with support.force_color(False):
+            self.assertNotIn("\x1b[", ast.dump(node, color=True))
 
     def test_copy_location(self):
         src = ast.parse('1 + 1', mode='eval')
@@ -3415,6 +3426,7 @@ class ModuleStateTests(unittest.TestCase):
         self.assertEqual(res, 0)
 
 
+@support.force_not_colorized_test_class
 class CommandLineTests(unittest.TestCase):
     def setUp(self):
         self.filename = tempfile.mktemp()
@@ -3674,6 +3686,7 @@ class CommandLineTests(unittest.TestCase):
         self.check_output(source, expect, '--show-empty')
 
 
+@support.force_not_colorized_test_class
 class ASTOptimizationTests(unittest.TestCase):
     def wrap_expr(self, expr):
         return ast.Module(body=[ast.Expr(value=expr)])

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -1450,7 +1450,6 @@ class CopyTests(unittest.TestCase):
             node.__replace__(**{object(): "y"})
 
 
-@support.force_not_colorized_test_class
 class ASTHelpers_Test(unittest.TestCase):
     maxDiff = None
 
@@ -1708,13 +1707,8 @@ Module(
 
     def test_dump_with_color(self):
         node = ast.parse("x = 1")
-
-        with support.force_color(True):
-            self.assertNotIn("\x1b[", ast.dump(node, color=False))
-            self.assertIn("\x1b[", ast.dump(node, color=True))
-
-        with support.force_color(False):
-            self.assertNotIn("\x1b[", ast.dump(node, color=True))
+        self.assertNotIn("\x1b[", ast.dump(node, color=False))
+        self.assertIn("\x1b[", ast.dump(node, color=True))
 
     def test_copy_location(self):
         src = ast.parse('1 + 1', mode='eval')

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -1707,8 +1707,13 @@ Module(
 
     def test_dump_with_color(self):
         node = ast.parse("x = 1")
+        self.assertNotIn("\x1b[", ast.dump(node))
         self.assertNotIn("\x1b[", ast.dump(node, color=False))
         self.assertIn("\x1b[", ast.dump(node, color=True))
+
+        node = ast.Constant(value="\x1b[31m")
+        self.assertEqual(ast.dump(node), "Constant(value='\\x1b[31m')")
+        self.assertIn("'\\x1b[31m'", ast.dump(node, color=True))
 
     def test_copy_location(self):
         src = ast.parse('1 + 1', mode='eval')

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -3680,7 +3680,6 @@ class CommandLineTests(unittest.TestCase):
         self.check_output(source, expect, '--show-empty')
 
 
-@support.force_not_colorized_test_class
 class ASTOptimizationTests(unittest.TestCase):
     def wrap_expr(self, expr):
         return ast.Module(body=[ast.Expr(value=expr)])

--- a/Misc/NEWS.d/next/Library/2026-04-25-12-50-46.gh-issue-148981.YMM4Y9.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-25-12-50-46.gh-issue-148981.YMM4Y9.rst
@@ -1,0 +1,1 @@
+Add *color* parameter to :func:`ast.dump`.


### PR DESCRIPTION
For example, `echo 'def f(): x = f"{1_0}"; y = True' | ./python -m ast`:
<table>
<tr>
<th>Before
<th>After
<tr>
<td valign=top><img width="1476" height="622" alt="image" src="https://github.com/user-attachments/assets/ee47458a-996f-4114-9aa4-0551b638eb6d" />
<td valign=top><img width="1347" height="622" alt="image" src="https://github.com/user-attachments/assets/f372f35a-17ea-41fe-acd1-146675c604a8" />
<tr>
</table>
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148981 -->
* Issue: gh-148981
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--148982.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->