### PR TITLE
gh-149021: Fix AIX build by dropping `-e` from `SHELL` in Makefile

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -18,6 +18,12 @@
 #
 # See also the section "Build instructions" in the README file.
 
+# Run in POSIX-conforming mode. Among other things this guarantees that the
+# shell is invoked with -e (so complex recipes fail on the first error),
+# which avoids relying on SHELL = /bin/sh -e -- AIX make interprets that as
+# a literal path and fails to find an executable named "/bin/sh -e".
+.POSIX:
+
 # === Variables set by makesetup ===
 
 MODBUILT_NAMES=    _MODBUILT_NAMES_
@@ -61,8 +67,10 @@ DSYMUTIL_PATH=  @DSYMUTIL_PATH@
 
 GNULD=		@GNULD@
 
-# Shell used by make (some versions default to the login shell, which is bad)
-SHELL=		/bin/sh -e
+# Shell used by make (some versions default to the login shell, which is bad).
+# The shell is invoked with -e via the .POSIX: special target above, which
+# applies under POSIX make implementations and to GNU make in POSIX mode.
+SHELL=		/bin/sh
 
 # Use this to make a link between python$(VERSION) and python in $(BINDIR)
 LN=		@LN@

--- a/Misc/NEWS.d/next/Build/2026-04-26-12-00-00.gh-issue-149021.vo85dd.rst
+++ b/Misc/NEWS.d/next/Build/2026-04-26-12-00-00.gh-issue-149021.vo85dd.rst
@@ -1,0 +1,6 @@
+Fix build on AIX by no longer setting ``SHELL = /bin/sh -e`` in the
+top-level :file:`Makefile`.  AIX :program:`make` interprets ``SHELL`` as a
+literal executable path, so the embedded ``-e`` flag caused
+:samp:`/bin/sh -e: not found`.  The makefile now sets ``SHELL = /bin/sh``
+and declares the ``.POSIX:`` special target, which causes both POSIX
+:program:`make` and GNU :program:`make` to invoke the shell with ``-e``.


### PR DESCRIPTION
On AIX, ``make(1)`` treats the value of ``SHELL`` as a literal executable
path rather than a command line. Since gh-100220 the top-level Makefile
sets ``SHELL = /bin/sh -e`` to make complex recipes fail-fast under GNU
make, but AIX then tries to ``execve("/bin/sh -e", ...)`` and the build
aborts immediately:

```
$ make
/bin/sh -e: not found
make: 1254-004 The error code from the last command is 1.
```

POSIX requires ``make`` to invoke the shell with ``-e`` by default; GNU
make does the same once a ``.POSIX:`` special target is declared (it sets
``.SHELLFLAGS = -ec``). This PR:

- adds ``.POSIX:`` as the first non-comment line in ``Makefile.pre.in``;
- restores ``SHELL = /bin/sh`` so the value is a valid path on AIX;
- keeps the original fail-fast guarantee from gh-100220 on both POSIX and
  GNU make.

Verified locally with GNU Make 4.3 that a multi-command recipe
(``echo a; false; echo b``) aborts after ``false`` with ``.POSIX:`` set,
matching the prior ``SHELL = /bin/sh -e`` behavior.

<!-- gh-issue-number: gh-149021 -->
* Issue: gh-149021
<!-- /gh-issue-number -->