### PR TITLE
gh-149029: Update SQLite to 3.53.0 for binary releases

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -359,9 +359,9 @@ def library_recipes():
                   ),
           ),
           dict(
-              name="SQLite 3.50.4",
-              url="https://www.sqlite.org/2025/sqlite-autoconf-3500400.tar.gz",
-              checksum="a3db587a1b92ee5ddac2f66b3edb41b26f9c867275782d46c3a088977d6a5b18",
+              name="SQLite 3.53.0",
+              url="https://www.sqlite.org/2026/sqlite-autoconf-3530000.tar.gz",
+              checksum="60c4b08c6729761e488d185e0d52411da10b14c72b53ada6936dc5eea225cefe",
               extra_cflags=('-Os '
                             '-DSQLITE_ENABLE_FTS5 '
                             '-DSQLITE_ENABLE_FTS4 '

--- a/Misc/NEWS.d/next/Windows/2026-04-26-23-14-45.gh-issue-149029.oPTXP4.rst
+++ b/Misc/NEWS.d/next/Windows/2026-04-26-23-14-45.gh-issue-149029.oPTXP4.rst
@@ -1,0 +1,1 @@
+Update Windows installer to ship with SQLite 3.53.0.

--- a/Misc/NEWS.d/next/macOS/2026-04-26-23-15-09.gh-issue-149029.Lsx--T.rst
+++ b/Misc/NEWS.d/next/macOS/2026-04-26-23-15-09.gh-issue-149029.Lsx--T.rst
@@ -1,0 +1,1 @@
+Update macOS installer to ship with SQLite version 3.53.0.

--- a/Misc/externals.spdx.json
+++ b/Misc/externals.spdx.json
@@ -91,21 +91,21 @@
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "fb5ab81f27612b0a7b4861ba655906c76dc85ee969e7a4905d2075aff931e8d0"
+          "checksumValue": "PENDING"
         }
       ],
-      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/sqlite-3.50.4.0.tar.gz",
+      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/sqlite-3.53.0.0.tar.gz",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:sqlite:sqlite:3.50.4.0:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:sqlite:sqlite:3.53.0.0:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
       "licenseConcluded": "NOASSERTION",
       "name": "sqlite",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "3.50.4.0"
+      "versionInfo": "3.53.0.0"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-tcl-core",

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -56,7 +56,7 @@ set libraries=%libraries%                                       bzip2-1.0.8
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.4.4
 if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-3.5.5
 set libraries=%libraries%                                       mpdecimal-4.0.0
-set libraries=%libraries%                                       sqlite-3.50.4.0
+set libraries=%libraries%                                       sqlite-3.53.0.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.15.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.15.0
 set libraries=%libraries%                                       xz-5.8.1.1

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -75,7 +75,7 @@
   <Import Project="$(ExternalProps)" Condition="$(ExternalProps) != '' and Exists('$(ExternalProps)')" />
 
   <PropertyGroup>
-    <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.50.4.0\</sqlite3Dir>
+    <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.53.0.0\</sqlite3Dir>
     <bz2Dir Condition="$(bz2Dir) == ''">$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
     <lzmaDir Condition="$(lzmaDir) == ''">$(ExternalsDir)xz-5.8.1.1\</lzmaDir>
     <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.4\</libffiDir>

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -237,7 +237,7 @@ _ssl
     again when building.
 
 _sqlite3
-    Wraps SQLite 3.50.4, which is itself built by sqlite3.vcxproj
+    Wraps SQLite 3.53.0, which is itself built by sqlite3.vcxproj
     Homepage:
         https://www.sqlite.org/
 

--- a/Platforms/Android/__main__.py
+++ b/Platforms/Android/__main__.py
@@ -217,7 +217,7 @@ def unpack_deps(host, prefix_dir, cache_dir):
     os.chdir(prefix_dir)
     deps_url = "https://github.com/beeware/cpython-android-source-deps/releases/download"
     for name_ver in ["bzip2-1.0.8-3", "libffi-3.4.4-3", "openssl-3.5.5-0",
-                     "sqlite-3.50.4-0", "xz-5.4.6-1", "zstd-1.5.7-2"]:
+                     "sqlite-3.53.0-0", "xz-5.4.6-1", "zstd-1.5.7-2"]:
         filename = f"{name_ver}-{host}.tar.gz"
         out_path = download(f"{deps_url}/{name_ver}/{filename}", cache_dir)
         shutil.unpack_archive(out_path)


### PR DESCRIPTION
Fixes #149029. Copied from #137135.

Someone, maybe @gpshead, needs to push the source to cpython-source-deps.

Someone, maybe @mhsmith, needs to push a build on beeware.

<!-- gh-issue-number: gh-149029 -->
* Issue: gh-149029
<!-- /gh-issue-number -->
