### PR TITLE
gh-149015: avoid iterate-and-delete issue in `Bdb.clear_all_file_breaks`

### DIFF
--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -747,7 +747,7 @@ class Bdb:
             return 'There are no breakpoints in %s' % filename
         for line in self.breaks[filename]:
             blist = Breakpoint.bplist[filename, line]
-            for bp in blist:
+            for bp in blist[:]:
                 bp.deleteMe()
         del self.breaks[filename]
         return None

--- a/Lib/test/test_bdb.py
+++ b/Lib/test/test_bdb.py
@@ -1232,6 +1232,23 @@ class IssuesTestCase(BaseTestCase):
 
 
 class TestRegressions(unittest.TestCase):
+    def test_clear_all_file_breaks_with_multiple_bps_same_line(self):
+        """Regression test: gh-149015.
+        clear_all_file_breaks must remove all breakpoints even when
+        multiple breakpoints share the same (file, line)."""
+        dbg = Bdb()
+        src = canonic(__file__)
+        dbg.set_break(src, 10)
+        dbg.set_break(src, 10)
+        dbg.set_break(src, 10)
+        self.assertEqual(len(Breakpoint.bplist[(src, 10)]), 3)
+        dbg.clear_all_file_breaks(src)
+        self.assertNotIn((src, 10), Breakpoint.bplist)
+        for bp in list(Breakpoint.bpbynumber):
+            if bp is not None:
+                bp.deleteMe()
+
+
     def test_format_stack_entry_no_lineno(self):
         # See gh-101517
         self.assertIn('Warning: lineno is None',

--- a/Misc/NEWS.d/next/Library.rst
+++ b/Misc/NEWS.d/next/Library.rst
@@ -1,0 +1,4 @@
+bdb: Fix :meth:`bdb.Bdb.clear_all_file_breaks` to not skip breakpoints when multiple
+breakpoints share the same file and line. Patch by Aman Sachan.
+
+.. bpo-149015.


### PR DESCRIPTION
Fix for gh-149015: bdb.Bdb.clear_all_file_breaks() skips breakpoints when multiple share the same (filename, line).

Root cause: iterating a list directly while deleteMe() removes items from that same list causes the loop to skip every other element. For N breakpoints at the same (file, line), floor(N/2) orphans remain.

Fix: one-character change - add slice copy to avoid mutating during iteration:
- for bp in blist:
+ for bp in blist[:]:

This matches the existing defensive pattern already used in clear_break() (same file, same class).

Files:
- Lib/bdb.py - the one-character fix
- Lib/test/test_bdb.py - regression test
- Misc/NEWS.d/next/Library.rst - news entry

Closes #149015