### PR TITLE
gh-149046: fix: correctly handle `str` subclasses in `StringIO`

### DIFF
--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -967,6 +967,25 @@ class CStringIOTest(PyStringIOTest):
         memio.close()
         self.assertRaises(ValueError, memio.__setstate__, ("closed", "", 0, None))
 
+    def test_write_str_subclass(self):
+        # Writing a str subclass should use the subclass's unicode data
+        # directly, not call __str__ on it (which may return a different
+        # value).  gh-149047
+        class MyStr(str):
+            def __str__(self):
+                return "WRONG"
+
+        s = MyStr("correct")
+        memio = self.ioclass()
+        memio.write(s)
+        self.assertEqual(memio.getvalue(), "correct")
+
+        # Also test the fast path where pos == string_size (STATE_ACCUMULATING)
+        memio2 = self.ioclass()
+        memio2.write(MyStr("hello "))
+        memio2.write(MyStr("world"))
+        self.assertEqual(memio2.getvalue(), "hello world")
+
 
 class CStringIOPickleTest(PyStringIOPickleTest):
     UnsupportedOperation = io.UnsupportedOperation

--- a/Misc/NEWS.d/next/Library/2026-04-27-11-12-00.gh-issue-149046.74shDd.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-27-11-12-00.gh-issue-149046.74shDd.rst
@@ -1,0 +1,2 @@
+:mod:`io`: Fix :class:`io.StringIO` serialization: no longer call ``str(obj)`` on :class:`str`
+subclasses. Patch by Thomas Kowalski.

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -225,7 +225,7 @@ write_str(stringio *self, PyObject *obj)
 
     if (self->state == STATE_ACCUMULATING) {
         if (self->string_size == self->pos) {
-            if (PyUnicodeWriter_WriteStr(self->writer, decoded))
+            if (_PyUnicodeWriter_WriteStr((_PyUnicodeWriter*)self->writer, decoded))
                 goto fail;
             goto success;
         }

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -225,6 +225,8 @@ write_str(stringio *self, PyObject *obj)
 
     if (self->state == STATE_ACCUMULATING) {
         if (self->string_size == self->pos) {
+            // gh-149046: Avoid PyUnicodeWriter_WriteStr() which calls str(obj)
+            // on str subclasses
             if (_PyUnicodeWriter_WriteStr((_PyUnicodeWriter*)self->writer, decoded))
                 goto fail;
             goto success;


### PR DESCRIPTION
## What is this PR?

This PR is, in a way, a follow-up from #148241. 

This other PR fixed a breaking change in behaviour where classes inheriting `str` would have `__str__` called on them when instead of using the "underlying" `str` itself. The PR fixed the problem for JSON serialisation, but seemingly missed some other call sites, including `StringIO`.  This seems to affect Python 3.14+ (but works as expected on 3.13).

This is a reproducer.

```py
import io

class StrSubclass(str):
    def __str__(self):
        return "WRONG_VALUE"

obj = StrSubclass("correct_value")

buf = io.StringIO()
buf.write(obj)
value = buf.getvalue()
assert value == "correct_value", f"got {value!r}"
```

... gives `AssertionError: got 'WRONG_VALUE'`



<!-- gh-issue-number: gh-149046 -->
* Issue: gh-149046
<!-- /gh-issue-number -->
