### PR TITLE
Un-skip previously-broken `test_get_type_hints_modules_forwardref`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -14,7 +14,7 @@ import pickle
 import re
 import sys
 import warnings
-from unittest import TestCase, main, skip
+from unittest import TestCase, main
 from unittest.mock import patch
 from copy import copy, deepcopy
 
@@ -6796,11 +6796,7 @@ class GetTypeHintsTests(BaseTestCase):
         self.assertEqual(gth(ann_module2), {})
         self.assertEqual(gth(ann_module3), {})
 
-    @skip("known bug")
     def test_get_type_hints_modules_forwardref(self):
-        # FIXME: This currently exposes a bug in typing. Cached forward references
-        # don't account for the case where there are multiple types of the same
-        # name coming from different modules in the same program.
         mgc_hints = {'default_a': Optional[mod_generics_cache.A],
                      'default_b': Optional[mod_generics_cache.B]}
         self.assertEqual(gth(mod_generics_cache), mgc_hints)


### PR DESCRIPTION
## What is this PR?

This PR removes the `skip` decorator on a test that used to be broken but that was "accidentally fixed" by a previous change. 

I don't think this warrants a news entry nor a dedicated issue so leaving it like that unless a reviewer thinks it should be otherwise.