### PR TITLE
[3.14] Un-skip previously-broken `test_get_type_hints_modules_forward_ref`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -13,7 +13,7 @@ import os
 import pickle
 import re
 import sys
-from unittest import TestCase, main, skip
+from unittest import TestCase, main
 from unittest.mock import patch
 from copy import copy, deepcopy
 
@@ -6686,11 +6686,7 @@ class GetTypeHintsTests(BaseTestCase):
         self.assertEqual(gth(ann_module2), {})
         self.assertEqual(gth(ann_module3), {})
 
-    @skip("known bug")
     def test_get_type_hints_modules_forwardref(self):
-        # FIXME: This currently exposes a bug in typing. Cached forward references
-        # don't account for the case where there are multiple types of the same
-        # name coming from different modules in the same program.
         mgc_hints = {'default_a': Optional[mod_generics_cache.A],
                      'default_b': Optional[mod_generics_cache.B]}
         self.assertEqual(gth(mod_generics_cache), mgc_hints)


### PR DESCRIPTION
This is a backport to 3.14 for #149048.