### PR TITLE
gh-149056: properly pass `array_hook` to `json.loads`

### DIFF
--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -306,7 +306,7 @@ def load(fp, *, cls=None, object_hook=None, parse_float=None,
         cls=cls, object_hook=object_hook,
         parse_float=parse_float, parse_int=parse_int,
         parse_constant=parse_constant, object_pairs_hook=object_pairs_hook,
-        array_hook=None, **kw)
+        array_hook=array_hook, **kw)
 
 
 def loads(s, *, cls=None, object_hook=None, parse_float=None,

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -87,6 +87,13 @@ class TestDecode:
 
         self.assertEqual(self.loads('[]', array_hook=tuple), ())
 
+    def test_load_array_hook(self):
+        # json.load must forward array_hook to loads
+        fp = StringIO('[10, 20, 30]')
+        result = self.json.load(fp, array_hook=tuple)
+        self.assertEqual(result, (10, 20, 30))
+        self.assertEqual(type(result), tuple)
+
     def test_decoder_optimizations(self):
         # Several optimizations were made that skip over calls to
         # the whitespace regex, so this test is designed to try and

--- a/Misc/NEWS.d/next/Library/2026-04-29-08-10-17.gh-issue-149056.jnaD4W.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-29-08-10-17.gh-issue-149056.jnaD4W.rst
@@ -1,0 +1,2 @@
+Fix :func:`json.load` not forwarding the *array_hook* argument to
+:func:`json.loads`. Patch by Thomas Kowalski.


### PR DESCRIPTION
## What is this PR?

This PR fixes the issue reported in #149056 where the `array_hook` parameter isn't properly being forwarded to `json.loads` by `json.load`.

<!-- gh-issue-number: gh-149056 -->
* Issue: gh-149056
<!-- /gh-issue-number -->
