### PR TITLE
gh-148998: Remove outdated Python wiki links from documentation

### DIFF
--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -25,9 +25,7 @@ extensible in C or C++.  It is also usable as an extension language for
 applications that need a programmable interface. Finally, Python is portable:
 it runs on many Unix variants including Linux and macOS, and on Windows.
 
-To find out more, start with :ref:`tutorial-index`.  The `Beginner's Guide to
-Python <https://wiki.python.org/moin/BeginnersGuide>`_ links to other
-introductory tutorials and resources for learning Python.
+To find out more, start with :ref:`tutorial-index`.
 
 
 What is the Python Software Foundation?
@@ -200,9 +198,6 @@ I've never programmed before. Is there a Python tutorial?
 There are numerous tutorials and books available.  The standard documentation
 includes :ref:`tutorial-index`.
 
-Consult `the Beginner's Guide <https://wiki.python.org/moin/BeginnersGuide>`_ to
-find information for beginning Python programmers, including lists of tutorials.
-
 
 Is there a newsgroup or mailing list devoted to Python?
 -------------------------------------------------------
@@ -261,10 +256,9 @@ written in 1991 and is now quite outdated.
 Are there any books on Python?
 ------------------------------
 
-Yes, there are many, and more are being published.  See the python.org wiki at
-https://wiki.python.org/moin/PythonBooks for a list.
+Yes, there are many, and more are being published.
 
-You can also search online bookstores for "Python" and filter out the Monty
+You can search online bookstores for "Python" and filter out the Monty
 Python references; or perhaps search for "Python" and "language".
 
 
@@ -439,9 +433,7 @@ There are also good IDEs for Python.  IDLE is a cross-platform IDE for Python
 that is written in Python using Tkinter.
 Emacs users will be happy to know that there is a very good Python mode for
 Emacs.  All of these programming environments provide syntax highlighting,
-auto-indenting, and access to the interactive interpreter while coding.  Consult
-`the Python wiki <https://wiki.python.org/moin/PythonEditors>`_ for a full list
-of Python editing environments.
+auto-indenting, and access to the interactive interpreter while coding.
 
 If you want to discuss Python's use in education, you may be interested in
 joining `the edu-sig mailing list

--- a/Doc/faq/gui.rst
+++ b/Doc/faq/gui.rst
@@ -25,12 +25,8 @@ For more info about Tk, including pointers to the source, see the
 `Tcl/Tk home page <https://www.tcl.tk>`_.  Tcl/Tk is fully portable to the
 macOS, Windows, and Unix platforms.
 
-Depending on what platform(s) you are aiming at, there are also several
-alternatives. A `list of cross-platform
-<https://wiki.python.org/moin/GuiProgramming#Cross-Platform_Frameworks>`_ and
-`platform-specific
-<https://wiki.python.org/moin/GuiProgramming#Platform-specific_Frameworks>`_ GUI
-frameworks can be found on the python wiki.
+Depending on what platform(s) you are aiming at, there are several
+alternatives.
 
 Tkinter questions
 =================

--- a/Doc/faq/installed.rst
+++ b/Doc/faq/installed.rst
@@ -10,9 +10,6 @@ It's used in some high schools and colleges as an introductory programming
 language because Python is easy to learn, but it's also used by professional
 software developers at places such as Google, NASA, and Lucasfilm Ltd.
 
-If you wish to learn more about Python, start with the `Beginner's Guide to
-Python <https://wiki.python.org/moin/BeginnersGuide>`_.
-
 
 Why is Python installed on my machine?
 --------------------------------------

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -591,19 +591,11 @@ See the chapters titled :ref:`internet` and :ref:`netdata` in the Library
 Reference Manual.  Python has many modules that will help you build server-side
 and client-side web systems.
 
-.. XXX check if wiki page is still up to date
-
-A summary of available frameworks is maintained by Paul Boddie at
-https://wiki.python.org/moin/WebProgramming\ .
-
 
 What module should I use to help with generating HTML?
 ------------------------------------------------------
 
 .. XXX add modern template languages
-
-You can find a collection of useful links on the `Web Programming wiki page
-<https://wiki.python.org/moin/WebProgramming>`_.
 
 
 How do I send mail from a Python script?
@@ -692,9 +684,7 @@ Interfaces to disk-based hashes such as :mod:`DBM <dbm.ndbm>` and :mod:`GDBM
 :mod:`sqlite3` module, which provides a lightweight disk-based relational
 database.
 
-Support for most relational databases is available.  See the
-`DatabaseProgramming wiki page
-<https://wiki.python.org/moin/DatabaseProgramming>`_ for details.
+Support for most relational databases is available.
 
 
 How do you implement persistent objects in Python?

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1123,10 +1123,6 @@ faster than when interpreted.  If you are confident in your C programming
 skills, you can also :ref:`write a C extension module <extending-index>`
 yourself.
 
-.. seealso::
-   The wiki page devoted to `performance tips
-   <https://wiki.python.org/moin/PythonSpeed/PerformanceTips>`_.
-
 
 .. _efficient_string_concatenation:
 

--- a/Doc/howto/gdb_helpers.rst
+++ b/Doc/howto/gdb_helpers.rst
@@ -28,8 +28,7 @@ of CPython that are written in C can use this document to learn how to use the
 
    This document assumes that you are familiar with the basics of GDB and the
    CPython C API. It consolidates guidance from the
-   `devguide <https://devguide.python.org>`_  and the
-   `Python wiki <https://wiki.python.org/moin/DebuggingWithGdb>`_.
+   `devguide <https://devguide.python.org>`_.
 
 
 Prerequisites

--- a/Doc/library/tk.rst
+++ b/Doc/library/tk.rst
@@ -25,8 +25,7 @@ bundled with Python. Although its standard documentation is weak, good
 material is available, which includes: references, tutorials, a book and
 others. :mod:`tkinter` is also famous for having an outdated look and feel,
 which has been vastly improved in Tk 8.5. Nevertheless, there are many other
-GUI libraries that you could be interested in. The Python wiki lists several
-alternative `GUI frameworks and tools <https://wiki.python.org/moin/GuiProgramming>`_.
+GUI libraries that you could be interested in.
 
 .. toctree::
 

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -54,10 +54,6 @@ test runner
       Third-party unittest framework with a lighter-weight syntax for writing
       tests.  For example, ``assert func(10) == 42``.
 
-   `The Python Testing Tools Taxonomy <https://wiki.python.org/moin/PythonTestingToolsTaxonomy>`_
-      An extensive list of Python testing tools including functional testing
-      frameworks and mock object libraries.
-
    `Testing in Python Mailing List <http://lists.idyll.org/listinfo/testing-in-python>`_
       A special-interest-group for discussion of testing, and testing tools,
       in Python.

--- a/Doc/tools/templates/indexsidebar.html
+++ b/Doc/tools/templates/indexsidebar.html
@@ -10,8 +10,6 @@
 <ul>
   {# XXX: many of these should probably be merged in the main docs #}
   <li><a href="https://peps.python.org/">{% trans %}PEP index{% endtrans %}</a></li>
-  <li><a href="https://wiki.python.org/moin/BeginnersGuide">{% trans %}Beginner's guide{% endtrans %}</a></li>
-  <li><a href="https://wiki.python.org/moin/PythonBooks">{% trans %}Book list{% endtrans %}</a></li>
   <li><a href="https://www.python.org/doc/av/">{% trans %}Audio/visual talks{% endtrans %}</a></li>
   <li><a href="https://devguide.python.org/">{% trans %}Python developer’s guide{% endtrans %}</a></li>
 </ul>

--- a/Doc/using/editors.rst
+++ b/Doc/using/editors.rst
@@ -20,8 +20,3 @@ For more information see the :ref:`IDLE docs <idle>`.
 
 Other Editors and IDEs
 ======================
-
-Python's community wiki has information submitted by the community on Editors and IDEs.
-Please go to `Python Editors <https://wiki.python.org/moin/PythonEditors>`_ and
-`Integrated Development Environments <https://wiki.python.org/moin/IntegratedDevelopmentEnvironments>`_
-for a comprehensive list.

--- a/Doc/whatsnew/2.4.rst
+++ b/Doc/whatsnew/2.4.rst
@@ -338,9 +338,6 @@ returned.
       wrote patches implementing function decorators, but the one that was actually
       checked in was patch #979728, written by Mark Russell.
 
-   https://wiki.python.org/moin/PythonDecoratorLibrary
-      This Wiki page contains several examples of decorators.
-
 .. ======================================================================
 
 

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -833,8 +833,7 @@ functools
   >>> # locale-aware sort order
   >>> sorted(iterable, key=cmp_to_key(locale.strcoll)) # doctest: +SKIP
 
-  For sorting examples and a brief sorting tutorial, see the `Sorting HowTo
-  <https://wiki.python.org/moin/HowTo/Sorting/>`_ tutorial.
+  For sorting examples and a brief sorting tutorial, see the :ref:`sortinghowto`.
 
   (Contributed by Raymond Hettinger.)
 


### PR DESCRIPTION
Remove outdated wiki.python.org references from the documentation.

The Python wiki is being archived, so this PR removes obsolete wiki links from FAQs, HOWTOs, library docs, What’s New entries, and the docs sidebar.

Also replaces the old wiki Sorting HOWTO link with the existing internal :ref:`sortinghowto` reference.

<!-- gh-issue-number: gh-148998 -->
* Issue: gh-148998
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--149067.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->