### PR TITLE
gh-148093: Raise `binascii.Error` from `binascii.a2b_uu` on empty input

### DIFF
--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -1307,6 +1307,10 @@ class BinASCIITest(unittest.TestCase):
         self.assertRaises(binascii.Error, binascii.a2b_uu, b"\xff\x00")
         self.assertRaises(binascii.Error, binascii.a2b_uu, b"!!!!")
         self.assertRaises(binascii.Error, binascii.b2a_uu, 46*b"!")
+        self.assertRaises(binascii.Error, binascii.a2b_uu,
+                          self.type2test(b""))
+        self.assertRaises(binascii.Error, binascii.a2b_uu,
+                          self.type2test(b"#86)C")[:0])
 
         # Issue #7701 (crash on a pydebug build)
         self.assertEqual(binascii.b2a_uu(b'x'), b'!>   \n')
@@ -1522,6 +1526,9 @@ class BinASCIITest(unittest.TestCase):
                 binascii.crc_hqx(empty, 0)
                 continue
             f = getattr(binascii, func)
+            if func == 'a2b_uu':
+                self.assertRaises(binascii.Error, f, empty)
+                continue
             try:
                 f(empty)
             except Exception as err:

--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -1306,11 +1306,11 @@ class BinASCIITest(unittest.TestCase):
         self.assertEqual(binascii.a2b_uu(b"\xff"), b"\x00"*31)
         self.assertRaises(binascii.Error, binascii.a2b_uu, b"\xff\x00")
         self.assertRaises(binascii.Error, binascii.a2b_uu, b"!!!!")
-        self.assertRaises(binascii.Error, binascii.b2a_uu, 46*b"!")
         self.assertRaises(binascii.Error, binascii.a2b_uu,
                           self.type2test(b""))
         self.assertRaises(binascii.Error, binascii.a2b_uu,
                           self.type2test(b"#86)C")[:0])
+        self.assertRaises(binascii.Error, binascii.b2a_uu, 46*b"!")
 
         # Issue #7701 (crash on a pydebug build)
         self.assertEqual(binascii.b2a_uu(b'x'), b'!>   \n')

--- a/Misc/NEWS.d/next/Library/2026-04-27-22-34-09.gh-issue-148093.9pWceM.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-27-22-34-09.gh-issue-148093.9pWceM.rst
@@ -1,0 +1,1 @@
+Fix :func:`binascii.a2b_uu` reading past the end of an empty input buffer.

--- a/Misc/NEWS.d/next/Library/2026-04-27-22-34-09.gh-issue-148093.9pWceM.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-27-22-34-09.gh-issue-148093.9pWceM.rst
@@ -1,1 +1,2 @@
-Fix :func:`binascii.a2b_uu` reading past the end of an empty input buffer.
+Fix :func:`binascii.a2b_uu` reading past the end of an empty input buffer. Now
+it raises :exc:`binascii.Error`, instead of reading past the buffer end.

--- a/Misc/NEWS.d/next/Library/2026-04-27-22-34-09.gh-issue-148093.9pWceM.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-27-22-34-09.gh-issue-148093.9pWceM.rst
@@ -1,2 +1,2 @@
-Fix :func:`binascii.a2b_uu` reading past the end of an empty input buffer. Now
-it raises :exc:`binascii.Error`, instead of reading past the buffer end.
+Fix an out-of-bounds read of one byte in :func:`binascii.a2b_uu`. Raise
+:exc:`binascii.Error`, instead of reading past the buffer end.

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -508,6 +508,14 @@ binascii_a2b_uu_impl(PyObject *module, Py_buffer *data)
     assert(ascii_len >= 0);
 
     /* First byte: binary data length (in bytes) */
+    if (ascii_len == 0) {
+        state = get_binascii_state(module);
+        if (state == NULL) {
+            return NULL;
+        }
+        PyErr_SetString(state->Error, "Empty string");
+        return NULL;
+    }
     bin_len = (*ascii_data++ - ' ') & 077;
     ascii_len--;
 

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -513,7 +513,7 @@ binascii_a2b_uu_impl(PyObject *module, Py_buffer *data)
         if (state == NULL) {
             return NULL;
         }
-        PyErr_SetString(state->Error, "Empty string");
+        PyErr_SetString(state->Error, "Missing length byte");
         return NULL;
     }
     bin_len = (*ascii_data++ - ' ') & 077;


### PR DESCRIPTION
Right now, `binascii.a2b_uu` with empty data reads one byte past the end of the input buffer. Per [the discussion](https://github.com/python/cpython/issues/148093#issuecomment-4187537469), it should raise `binascii.Error`. 

Resolves #148093

<!-- gh-issue-number: gh-148093 -->
* Issue: gh-148093
<!-- /gh-issue-number -->
