### PR TITLE
gh-149078: test_socket: verify runtime kernel support for UDPLite

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -170,6 +170,22 @@ def _have_socket_vsock():
     return (cid is not None)
 
 
+def _have_socket_udplite():
+    """Check whether UDPLITE sockets are supported on this host."""
+    if not hasattr(socket, "IPPROTO_UDPLITE"):
+        return False
+    # Older Android versions block UDPLITE with SELinux.
+    if support.is_android and platform.android_ver().api_level < 29:
+        return False
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDPLITE)
+    except (AttributeError, OSError):
+        return False
+    else:
+        s.close()
+    return True
+
+
 def _have_socket_bluetooth():
     """Check whether AF_BLUETOOTH sockets are supported on this host."""
     try:
@@ -247,10 +263,7 @@ HAVE_SOCKET_QIPCRTR = _have_socket_qipcrtr()
 
 HAVE_SOCKET_VSOCK = _have_socket_vsock()
 
-# Older Android versions block UDPLITE with SELinux.
-HAVE_SOCKET_UDPLITE = (
-    hasattr(socket, "IPPROTO_UDPLITE")
-    and not (support.is_android and platform.android_ver().api_level < 29))
+HAVE_SOCKET_UDPLITE = _have_socket_udplite()
 
 HAVE_SOCKET_BLUETOOTH = _have_socket_bluetooth()
 

--- a/Misc/NEWS.d/next/Tests/2026-04-28-01-08-05.gh-issue-149078.cQNQRp.rst
+++ b/Misc/NEWS.d/next/Tests/2026-04-28-01-08-05.gh-issue-149078.cQNQRp.rst
@@ -1,0 +1,3 @@
+This change adds a _have_socket_udplite() helper that performs a runtime
+check by attempting to create a UDPLite socket, aligning its behavior with
+other optional protocols like RDS or AF_ALG.


### PR DESCRIPTION
The test suite previously only checked for the existence of the `socket.IPPROTO_UDPLITE` constant. This caused test failures on systems where the constant is defined in headers (and thus present in the interpreter) but the protocol is not supported or enabled in the running kernel (e.g., restricted build environments).

This change adds a `_have_socket_udplite()` helper that performs a runtime check by attempting to create a `UDPLite` socket, aligning its behaviour with other optional protocols like `RDS` or `AF_ALG`.

Fixes: https://github.com/python/cpython/issues/149078

<!-- gh-issue-number: gh-149078 -->
* Issue: gh-149078
<!-- /gh-issue-number -->
