### PR TITLE
gh-149083: Convert dataclasses.MISSING and dataclasses.KW_ONLY to sentinels

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -178,17 +178,12 @@ class _HAS_DEFAULT_FACTORY_CLASS:
         return '<factory>'
 _HAS_DEFAULT_FACTORY = _HAS_DEFAULT_FACTORY_CLASS()
 
-# A sentinel object to detect if a parameter is supplied or not.  Use
-# a class to give it a better repr.
-class _MISSING_TYPE:
-    pass
-MISSING = _MISSING_TYPE()
+# A sentinel object to detect if a parameter is supplied or not.
+MISSING = sentinel("MISSING")
 
 # A sentinel object to indicate that following fields are keyword-only by
-# default.  Use a class to give it a better repr.
-class _KW_ONLY_TYPE:
-    pass
-KW_ONLY = _KW_ONLY_TYPE()
+# default.
+KW_ONLY = sentinel("KW_ONLY")
 
 # Since most per-field metadata will be unused, create an empty
 # read-only dictionary that can be shared among all fields.

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -995,7 +995,7 @@ class TestCase(unittest.TestCase):
         self.assertNotIn('x', D.__dict__)
 
     def test_missing_repr(self):
-        self.assertIn('MISSING_TYPE object', repr(MISSING))
+        self.assertEqual(repr(MISSING), 'MISSING')
 
     def test_dont_include_other_annotations(self):
         @dataclass

--- a/Misc/NEWS.d/next/Library/2026-04-27-20-15-54.gh-issue-149083.BdrpU8.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-27-20-15-54.gh-issue-149083.BdrpU8.rst
@@ -1,0 +1,2 @@
+:data:`dataclasses.MISSING` and :data:`dataclasses.KW_ONLY` are now
+instances of :class:`sentinel`.


### PR DESCRIPTION
There were comments claiming these were implemented as custom classes to give a nicer
repr(), but the repr() wasn't all that nice:

```
>>> repr(dataclasses.MISSING)
'<dataclasses._MISSING_TYPE object at 0x1005e7e00>'
>>> repr(dataclasses.KW_ONLY)
'<dataclasses._KW_ONLY_TYPE object at 0x100884050>'
```

Sentinels are conceptually the right tool for these, so let's use them.

This does change the repr() of these two objects.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149083 -->
* Issue: gh-149083
<!-- /gh-issue-number -->
