### PR TITLE
gh-148909: Fix URL in author attribution for MRO documentation

### DIFF
--- a/Doc/howto/mro.rst
+++ b/Doc/howto/mro.rst
@@ -10,7 +10,7 @@ The Python 2.3 Method Resolution Order
    The Method Resolution Order discussed here was *introduced* in Python 2.3,
    but it is still used in later versions -- including Python 3.
 
-By `Michele Simionato <https://www.phyast.pitt.edu/~micheles/>`__.
+By `Michele Simionato <http://www.phyast.pitt.edu/~micheles/>`__.
 
 :Abstract:
 

--- a/Doc/howto/mro.rst
+++ b/Doc/howto/mro.rst
@@ -10,7 +10,7 @@ The Python 2.3 Method Resolution Order
    The Method Resolution Order discussed here was *introduced* in Python 2.3,
    but it is still used in later versions -- including Python 3.
 
-By `Michele Simionato <http://www.phyast.pitt.edu/~micheles/>`__.
+By `Michele Simionato <https://github.com/micheles>`__.
 
 :Abstract:
 


### PR DESCRIPTION
The author attribution URL in the MRO documentation currently fails to load because the host website does not support TLS (HTTPS). According to [Wayback Machine records](https://web.archive.org/web/*/http://www.phyast.pitt.edu/~micheles/*), the site has only ever supported HTTP. This PR updates the URL to ensure it remains accessible.

<!-- gh-issue-number: gh-148909 -->
* Issue: gh-148909
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--149092.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->