### PR TITLE
gh-148292: Update ssl._SSLSocket for OpenSSL 4

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5032,6 +5032,9 @@ class ThreadedTests(unittest.TestCase):
                         raise cm.exc_value
 
     def test_got_eof(self):
+        # gh-148292: Test that _ssl._SSLSocket behaves the same on all OpenSSL
+        # versions on calling methods after EOF (after the first SSLEOFError).
+
         server = TestEOFServer()
         server.start()
         if not server.listening.wait(support.SHORT_TIMEOUT):
@@ -5071,9 +5074,14 @@ class ThreadedTests(unittest.TestCase):
                 sslsock.do_handshake()
 
             self.assertEqual(sslsock.pending(), 0)
-            with self.assertRaises(OSError) as cm:
+            try:
                 sslsock.shutdown(socket.SHUT_WR)
-            self.assertEqual(cm.exception.errno, errno.ENOTCONN)
+            except OSError as exc:
+                self.assertEqual(exc.errno, errno.ENOTCONN)
+            else:
+                # On Windows and on OpenSSL 1.1.1, shutdown() doesn't
+                # raise an error
+                pass
 
         server.join()
 

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5066,9 +5066,8 @@ class ThreadedTests(unittest.TestCase):
                 sslobj.read(1024)
             if hasattr(sslobj, 'sendfile'):
                 with open(__file__, "rb") as fp:
-                    fd = fp.fileno()
                     with self.assertRaises(ssl.SSLEOFError):
-                        sslobj.sendfile(fd, 0, 1)
+                        sslobj.sendfile(fp.fileno(), 0, 1)
             with self.assertRaises(ssl.SSLEOFError):
                 sslobj.write(b'client2\n')
             with self.assertRaises(ssl.SSLEOFError):

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2854,6 +2854,7 @@ class TestEOFServer(threading.Thread):
         context.load_cert_chain(CERTFILE)
         server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with server_sock:
+            server_sock.settimeout(support.SHORT_TIMEOUT)
             server_sock.bind((HOST, 0))
             server_sock.listen(5)
 
@@ -2864,10 +2865,9 @@ class TestEOFServer(threading.Thread):
             sslconn = context.wrap_socket(sock, server_side=True)
             with sslconn:
                 request = b''
-                while True:
-                    chunk = sslconn.recv(1024)
+                while chunk := sslconn.recv(1024):
                     request += chunk
-                    if b'\n' in request:
+                    if b'\n' in chunk:
                         break
 
                 sslconn.sendall(b'server\n')
@@ -5039,6 +5039,7 @@ class ThreadedTests(unittest.TestCase):
         server.start()
         if not server.listening.wait(support.SHORT_TIMEOUT):
             raise RuntimeError("server took too long")
+        self.addCleanup(server.join)
 
         context = ssl.create_default_context(cafile=CERTFILE)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -5082,8 +5083,6 @@ class ThreadedTests(unittest.TestCase):
                 # On Windows and on OpenSSL 1.1.1, shutdown() doesn't
                 # raise an error
                 pass
-
-        server.join()
 
 
 @unittest.skipUnless(has_tls_version('TLSv1_3') and ssl.HAS_PHA,

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5060,10 +5060,11 @@ class ThreadedTests(unittest.TestCase):
                 # The _SSLSocket remembers the previous EOF error
                 # and raises again SSLEOFError
                 sslobj.read(1024)
-            with open(__file__, "rb") as fp:
-                fd = fp.fileno()
-                with self.assertRaises(ssl.SSLEOFError):
-                    sslobj.sendfile(fd, 0, 1)
+            if hasattr(sslobj, 'sendfile'):
+                with open(__file__, "rb") as fp:
+                    fd = fp.fileno()
+                    with self.assertRaises(ssl.SSLEOFError):
+                        sslobj.sendfile(fd, 0, 1)
             with self.assertRaises(ssl.SSLEOFError):
                 sslobj.write(b'client2\n')
 

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2843,6 +2843,36 @@ class ThreadedEchoServer(threading.Thread):
     def stop(self):
         self.active = False
 
+class TestEOFServer(threading.Thread):
+    def __init__(self):
+        super().__init__()
+        self.listening = threading.Event()
+        self.address = None
+
+    def run(self):
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context.load_cert_chain(CERTFILE)
+        server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        with server_sock:
+            server_sock.bind((HOST, 0))
+            server_sock.listen(5)
+
+            self.address = server_sock.getsockname()
+            self.listening.set()
+
+            sock, addr = server_sock.accept()
+            sslconn = context.wrap_socket(sock, server_side=True)
+            with sslconn:
+                request = b''
+                while True:
+                    chunk = sslconn.recv(1024)
+                    request += chunk
+                    if b'\n' in request:
+                        break
+
+                sslconn.sendall(b'server\n')
+                sslconn.shutdown(socket.SHUT_WR)
+
 class AsyncoreEchoServer(threading.Thread):
 
     # this one's based on asyncore.dispatcher
@@ -5000,6 +5030,44 @@ class ThreadedTests(unittest.TestCase):
                     thread.join()
                     if cm.exc_value is not None:
                         raise cm.exc_value
+
+    def test_got_eof(self):
+        server = TestEOFServer()
+        server.start()
+        if not server.listening.wait(support.SHORT_TIMEOUT):
+            raise RuntimeError("server took too long")
+
+        context = ssl.create_default_context(cafile=CERTFILE)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(support.SHORT_TIMEOUT)
+        sock.connect(server.address)
+        sslsock = context.wrap_socket(sock, server_hostname='localhost')
+        with sslsock:
+            sslsock.sendall(b'client\n')
+            # test the _ssl._SSLSocket object, not ssl.SSLSocket
+            sslobj = sslsock._sslobj
+
+            data = sslobj.read(1024)
+            self.assertEqual(data, b'server\n')
+
+            # The second read gets EOF error and sets got_eof_error to 1
+            with self.assertRaises(ssl.SSLEOFError):
+                sslobj.read(1024)
+
+            # Following read(), sendfile() and write() calls must raise
+            # SSLEOFError
+            with self.assertRaises(ssl.SSLEOFError):
+                # The _SSLSocket remembers the previous EOF error
+                # and raises again SSLEOFError
+                sslobj.read(1024)
+            with open(__file__, "rb") as fp:
+                fd = fp.fileno()
+                with self.assertRaises(ssl.SSLEOFError):
+                    sslobj.sendfile(fd, 0, 1)
+            with self.assertRaises(ssl.SSLEOFError):
+                sslobj.write(b'client2\n')
+
+        server.join()
 
 
 @unittest.skipUnless(has_tls_version('TLSv1_3') and ssl.HAS_PHA,

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5067,6 +5067,13 @@ class ThreadedTests(unittest.TestCase):
                         sslobj.sendfile(fd, 0, 1)
             with self.assertRaises(ssl.SSLEOFError):
                 sslobj.write(b'client2\n')
+            with self.assertRaises(ssl.SSLEOFError):
+                sslsock.do_handshake()
+
+            self.assertEqual(sslsock.pending(), 0)
+            with self.assertRaises(OSError) as cm:
+                sslsock.shutdown(socket.SHUT_WR)
+            self.assertEqual(cm.exception.errno, errno.ENOTCONN)
 
         server.join()
 

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5054,8 +5054,8 @@ class ThreadedTests(unittest.TestCase):
             with self.assertRaises(ssl.SSLEOFError):
                 sslobj.read(1024)
 
-            # Following read(), sendfile() and write() calls must raise
-            # SSLEOFError
+            # Following read(), sendfile(), write() and do_handshake() calls
+            # must raise SSLEOFError
             with self.assertRaises(ssl.SSLEOFError):
                 # The _SSLSocket remembers the previous EOF error
                 # and raises again SSLEOFError

--- a/Misc/NEWS.d/next/Library/2026-04-28-17-47-55.gh-issue-148292.oIq3ml.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-28-17-47-55.gh-issue-148292.oIq3ml.rst
@@ -1,7 +1,7 @@
-:mod:`ssl`: Update :class:`ssl.SSLSocket` for OpenSSL 4. The class now
-remembers if it gets a :exc:`ssl.SSLEOFError`. In this case, following
-:meth:`~ssl.SSLSocket.read`, :meth:`!sendfile`, :meth:`~ssl.SSLSocket.write`,
-and :meth:`~ssl.SSLSocket.do_handshake` calls raise :exc:`ssl.SSLEOFError`
-without calling the underlying OpenSSL function. Thanks to that,
-:class:`ssl.SSLSocket` behaves the same on all OpenSSL versions on EOF.  Patch
-by Victor Stinner.
+:mod:`ssl`: Update :class:`ssl.SSLSocket` and :class:`ssl.SSLObject` for
+OpenSSL 4. The class now remembers if it gets a :exc:`ssl.SSLEOFError`. In this
+case, following :meth:`~ssl.SSLSocket.read`, :meth:`!sendfile`,
+:meth:`~ssl.SSLSocket.write`, and :meth:`~ssl.SSLSocket.do_handshake` calls
+raise :exc:`ssl.SSLEOFError` without calling the underlying OpenSSL function.
+Thanks to that, :class:`ssl.SSLSocket` behaves the same on all OpenSSL versions
+on EOF.  Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Library/2026-04-28-17-47-55.gh-issue-148292.oIq3ml.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-28-17-47-55.gh-issue-148292.oIq3ml.rst
@@ -1,6 +1,7 @@
 :mod:`ssl`: Update :class:`ssl.SSLSocket` for OpenSSL 4. The class now
 remembers if it gets a :exc:`ssl.SSLEOFError`. In this case, following
-:meth:`~ssl.SSLSocket.read`, :meth:`!sendfile` and
-:meth:`~ssl.SSLSocket.write` calls raise :exc:`ssl.SSLEOFError` without calling
-the underlying OpenSSL function. Thanks to that, :class:`ssl.SSLSocket` behaves
-the same on all OpenSSL versions on EOF.  Patch by Victor Stinner.
+:meth:`~ssl.SSLSocket.read`, :meth:`!sendfile`, :meth:`~ssl.SSLSocket.write`,
+and :meth:`~ssl.SSLSocket.do_handshake` calls raise :exc:`ssl.SSLEOFError`
+without calling the underlying OpenSSL function. Thanks to that,
+:class:`ssl.SSLSocket` behaves the same on all OpenSSL versions on EOF.  Patch
+by Victor Stinner.

--- a/Misc/NEWS.d/next/Library/2026-04-28-17-47-55.gh-issue-148292.oIq3ml.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-28-17-47-55.gh-issue-148292.oIq3ml.rst
@@ -1,6 +1,6 @@
 :mod:`ssl`: Update :class:`ssl.SSLSocket` for OpenSSL 4. The class now
 remembers if it gets a :exc:`ssl.SSLEOFError`. In this case, following
-:meth:`~ssl.SSLSocket.read`, :meth:`~ssl.SSLSocket.sendfile` and
+:meth:`~ssl.SSLSocket.read`, :meth:`!sendfile` and
 :meth:`~ssl.SSLSocket.write` calls raise :exc:`ssl.SSLEOFError` without calling
 the underlying OpenSSL function. Thanks to that, :class:`ssl.SSLSocket` behaves
 the same on all OpenSSL versions on EOF.  Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Library/2026-04-28-17-47-55.gh-issue-148292.oIq3ml.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-28-17-47-55.gh-issue-148292.oIq3ml.rst
@@ -1,0 +1,6 @@
+:mod:`ssl`: Update :class:`ssl.SSLSocket` for OpenSSL 4. The class now
+remembers if it gets a :exc:`ssl.SSLEOFError`. In this case, following
+:meth:`~ssl.SSLSocket.read`, :meth:`~ssl.SSLSocket.sendfile` and
+:meth:`~ssl.SSLSocket.write` calls raise :exc:`ssl.SSLEOFError` without calling
+the underlying OpenSSL function. Thanks to that, :class:`ssl.SSLSocket` behaves
+the same on all OpenSSL versions on EOF.  Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Library/2026-04-28-17-47-55.gh-issue-148292.oIq3ml.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-28-17-47-55.gh-issue-148292.oIq3ml.rst
@@ -1,5 +1,5 @@
 :mod:`ssl`: Update :class:`ssl.SSLSocket` and :class:`ssl.SSLObject` for
-OpenSSL 4. The class now remembers if it gets a :exc:`ssl.SSLEOFError`. In this
+OpenSSL 4. The classes now remember if they get a :exc:`ssl.SSLEOFError`. In this
 case, following :meth:`~ssl.SSLSocket.read`, :meth:`!sendfile`,
 :meth:`~ssl.SSLSocket.write`, and :meth:`~ssl.SSLSocket.do_handshake` calls
 raise :exc:`ssl.SSLEOFError` without calling the underlying OpenSSL function.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -78,6 +78,7 @@
 #  error "OPENSSL_THREADS is not defined, Python requires thread-safe OpenSSL"
 #endif
 
+
 #ifdef BIO_get_ktls_send
 #  ifdef MS_WINDOWS
 typedef long long Py_off_t;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -377,9 +377,9 @@ typedef struct {
     enum py_ssl_server_or_client socket_type;
     PyObject *owner; /* weakref to Python level "owner" passed to servername callback */
     PyObject *server_hostname;
-    // gh-148292: If non-zero, read(), sendfile() and write() methods raise
-    // SSLEOFError without calling the underlying OpenSSL function. Set to 1
-    // on PY_SSL_ERROR_EOF error.
+    // gh-148292: If non-zero, read(), sendfile(), write() and do_handshake()
+    // methods raise SSLEOFError without calling the underlying OpenSSL
+    // function. Set to 1 on PY_SSL_ERROR_EOF error.
     //
     // On OpenSSL 4, if SSL_read_ex() fails with
     // SSL_R_UNEXPECTED_EOF_WHILE_READING, the following SSL_read_ex() call

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -78,7 +78,6 @@
 #  error "OPENSSL_THREADS is not defined, Python requires thread-safe OpenSSL"
 #endif
 
-
 #ifdef BIO_get_ktls_send
 #  ifdef MS_WINDOWS
 typedef long long Py_off_t;
@@ -377,6 +376,16 @@ typedef struct {
     enum py_ssl_server_or_client socket_type;
     PyObject *owner; /* weakref to Python level "owner" passed to servername callback */
     PyObject *server_hostname;
+    // gh-148292: If non-zero, read(), sendfile() and write() methods raise
+    // SSLEOFError without calling the underlying OpenSSL function. Set to 1
+    // on PY_SSL_ERROR_EOF error.
+    //
+    // On OpenSSL 4, if SSL_read_ex() fails with
+    // SSL_R_UNEXPECTED_EOF_WHILE_READING, the following SSL_read_ex() call
+    // fails with a generic protocol error (ERR_peek_last_error() returns 0).
+    // Use got_eof_error to have the same behavior on OpenSSL 4 and newer and
+    // on OpenSSL 3 and older.
+    int got_eof_error;
 } PySSLSocket;
 
 #define PySSLSocket_CAST(op)    ((PySSLSocket *)(op))
@@ -503,6 +512,10 @@ fill_and_set_sslerror(_sslmodulestate *state,
     PyObject *verify_obj = NULL, *verify_code_obj = NULL;
     PyObject *init_value, *msg, *key;
     PyUnicodeWriter *writer = NULL;
+
+    if (ssl_errno == PY_SSL_ERROR_EOF) {
+        sslsock->got_eof_error = 1;
+    }
 
     if (errcode != 0) {
         int lib, reason;
@@ -648,6 +661,18 @@ fail:
     Py_XDECREF(verify_obj);
     PyUnicodeWriter_Discard(writer);
 }
+
+
+static void
+set_eof_error(PySSLSocket *sslsock)
+{
+    _sslmodulestate *state = get_state_sock(sslsock);
+    fill_and_set_sslerror(state, sslsock, state->PySSLEOFErrorObject,
+                          PY_SSL_ERROR_EOF,
+                          "EOF occurred in violation of protocol",
+                          __LINE__, 0);
+}
+
 
 // Set the appropriate SSL error exception.
 // err - error information from SSL and libc
@@ -923,6 +948,7 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
     self->shutdown_seen_zero = 0;
     self->owner = NULL;
     self->server_hostname = NULL;
+    self->got_eof_error = 0;
 
     /* Make sure the SSL error state is initialized */
     ERR_clear_error();
@@ -2644,6 +2670,11 @@ _ssl__SSLSocket_sendfile_impl(PySSLSocket *self, int fd, Py_off_t offset,
         deadline = _PyDeadline_Init(timeout);
     }
 
+    if (self->got_eof_error) {
+        set_eof_error(self);
+        goto error;
+    }
+
     sockstate = PySSL_select(sock, 1, timeout);
     switch (sockstate) {
         case SOCKET_HAS_TIMED_OUT:
@@ -2769,6 +2800,11 @@ _ssl__SSLSocket_write_impl(PySSLSocket *self, Py_buffer *b)
     has_timeout = (timeout > 0);
     if (has_timeout) {
         deadline = _PyDeadline_Init(timeout);
+    }
+
+    if (self->got_eof_error) {
+        set_eof_error(self);
+        goto error;
     }
 
     sockstate = PySSL_select(sock, 1, timeout);
@@ -2903,6 +2939,11 @@ _ssl__SSLSocket_read_impl(PySSLSocket *self, Py_ssize_t len,
     PySocketSockObject *sock = NULL;
     if (get_socket(self, &sock, __FILE__, __LINE__) < 0) {
         return NULL;
+    }
+
+    if (self->got_eof_error) {
+        set_eof_error(self);
+        goto error;
     }
 
     if (!group_right_1) {

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -514,7 +514,7 @@ fill_and_set_sslerror(_sslmodulestate *state,
     PyObject *init_value, *msg, *key;
     PyUnicodeWriter *writer = NULL;
 
-    if (ssl_errno == PY_SSL_ERROR_EOF) {
+    if (ssl_errno == PY_SSL_ERROR_EOF && sslsock != NULL) {
         sslsock->got_eof_error = 1;
     }
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1079,6 +1079,11 @@ _ssl__SSLSocket_do_handshake_impl(PySSLSocket *self)
         return NULL;
     }
 
+    if (self->got_eof_error) {
+        set_eof_error(self);
+        goto error;
+    }
+
     timeout = GET_SOCKET_TIMEOUT(sock);
     has_timeout = (timeout > 0);
     if (has_timeout) {
@@ -2664,15 +2669,15 @@ _ssl__SSLSocket_sendfile_impl(PySSLSocket *self, int fd, Py_off_t offset,
         return NULL;
     }
 
+    if (self->got_eof_error) {
+        set_eof_error(self);
+        goto error;
+    }
+
     timeout = GET_SOCKET_TIMEOUT(sock);
     has_timeout = (timeout > 0);
     if (has_timeout) {
         deadline = _PyDeadline_Init(timeout);
-    }
-
-    if (self->got_eof_error) {
-        set_eof_error(self);
-        goto error;
     }
 
     sockstate = PySSL_select(sock, 1, timeout);
@@ -2796,15 +2801,15 @@ _ssl__SSLSocket_write_impl(PySSLSocket *self, Py_buffer *b)
         return NULL;
     }
 
+    if (self->got_eof_error) {
+        set_eof_error(self);
+        goto error;
+    }
+
     timeout = GET_SOCKET_TIMEOUT(sock);
     has_timeout = (timeout > 0);
     if (has_timeout) {
         deadline = _PyDeadline_Init(timeout);
-    }
-
-    if (self->got_eof_error) {
-        set_eof_error(self);
-        goto error;
     }
 
     sockstate = PySSL_select(sock, 1, timeout);


### PR DESCRIPTION
The _SSLSocket object now remembers if it gets an EOF error. In this case, read(), sendfile(), write() and do_handshake() method calls fail with SSLEOFError without calling the underlying OpenSSL function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148292 -->
* Issue: gh-148292
<!-- /gh-issue-number -->
