### PR TITLE
gh-149085: Add max_threads keyword to faulthandler.dump_traceback()

### DIFF
--- a/Doc/library/faulthandler.rst
+++ b/Doc/library/faulthandler.rst
@@ -189,11 +189,12 @@ Dumping the tracebacks after a timeout
 Dumping the traceback on a user signal
 --------------------------------------
 
-.. function:: register(signum, file=sys.stderr, all_threads=True, chain=False)
+.. function:: register(signum, file=sys.stderr, all_threads=True, chain=False, *, max_threads=100)
 
    Register a user signal: install a handler for the *signum* signal to dump
    the traceback of all threads, or of the current thread if *all_threads* is
    ``False``, into *file*. Call the previous handler if chain is ``True``.
+   *max_threads* caps the number of threads dumped.
 
    The *file* must be kept open until the signal is unregistered by
    :func:`unregister`: see :ref:`issue with file descriptors <faulthandler-fd>`.
@@ -202,6 +203,9 @@ Dumping the traceback on a user signal
 
    .. versionchanged:: 3.5
       Added support for passing file descriptor to this function.
+
+   .. versionchanged:: next
+      Added the *max_threads* keyword argument.
 
 .. function:: unregister(signum)
 

--- a/Doc/library/faulthandler.rst
+++ b/Doc/library/faulthandler.rst
@@ -31,8 +31,8 @@ tracebacks:
 * Each string is limited to 500 characters.
 * Only the filename, the function name and the line number are
   displayed. (no source code)
-* It is limited to 100 frames per thread, and by default to 100 threads
-  total in newest-first order (configurable via *max_threads*).
+* It is limited to 100 frames per thread, and 100 threads
+  (configurable via *max_threads*).
 * The order is reversed: the most recent call is shown first.
 
 By default, the Python traceback is written to :data:`sys.stderr`. To see
@@ -60,14 +60,14 @@ Dumping the traceback
 
    Dump the tracebacks of all threads into *file*. If *all_threads* is
    ``False``, dump only the current thread. *max_threads* caps the number
-   of threads dumped; a ``...`` marker is written if there are more.
+   of threads dumped.
 
    .. seealso:: :func:`traceback.print_tb`, which can be used to print a traceback object.
 
    .. versionchanged:: 3.5
       Added support for passing file descriptor to this function.
 
-   .. versionchanged:: 3.15
+   .. versionchanged:: next
       Added the *max_threads* keyword argument.
 
 
@@ -105,7 +105,7 @@ instead of the stack, even if the operating system supports dumping stacks.
 Fault handler state
 -------------------
 
-.. function:: enable(file=sys.stderr, all_threads=True, c_stack=True)
+.. function:: enable(file=sys.stderr, all_threads=True, c_stack=True, *, max_threads=100)
 
    Enable the fault handler: install handlers for the :const:`~signal.SIGSEGV`,
    :const:`~signal.SIGFPE`, :const:`~signal.SIGABRT`, :const:`~signal.SIGBUS`
@@ -120,6 +120,8 @@ Fault handler state
    If *c_stack* is ``True``, then the C stack trace is printed after the Python
    traceback, unless the system does not support it. See :func:`dump_c_stack` for
    more information on compatibility.
+
+   *max_threads* caps the number of threads dumped when a fatal signal fires.
 
    .. versionchanged:: 3.5
       Added support for passing file descriptor to this function.
@@ -137,6 +139,9 @@ Fault handler state
 
    .. versionchanged:: 3.14
       The dump now displays the C stack trace if *c_stack* is true.
+
+   .. versionchanged:: next
+      Added the *max_threads* keyword argument.
 
 .. function:: disable()
 
@@ -159,8 +164,7 @@ Dumping the tracebacks after a timeout
    :c:func:`!_exit` exits the process immediately, which means it doesn't do any
    cleanup like flushing file buffers.) If the function is called twice, the new
    call replaces previous parameters and resets the timeout. The timer has a
-   sub-second resolution. *max_threads* caps the number of threads dumped;
-   a ``...`` marker is written if there are more.
+   sub-second resolution. *max_threads* caps the number of threads dumped.
 
    The *file* must be kept open until the traceback is dumped or
    :func:`cancel_dump_traceback_later` is called: see :ref:`issue with file
@@ -174,7 +178,7 @@ Dumping the tracebacks after a timeout
    .. versionchanged:: 3.7
       This function is now always available.
 
-   .. versionchanged:: 3.15
+   .. versionchanged:: next
       Added the *max_threads* keyword argument.
 
 .. function:: cancel_dump_traceback_later()

--- a/Doc/library/faulthandler.rst
+++ b/Doc/library/faulthandler.rst
@@ -31,7 +31,8 @@ tracebacks:
 * Each string is limited to 500 characters.
 * Only the filename, the function name and the line number are
   displayed. (no source code)
-* It is limited to 100 frames and 100 threads.
+* It is limited to 100 frames per thread, and by default to 100 threads
+  total in newest-first order (configurable via *max_threads*).
 * The order is reversed: the most recent call is shown first.
 
 By default, the Python traceback is written to :data:`sys.stderr`. To see
@@ -55,15 +56,19 @@ at Python startup.
 Dumping the traceback
 ---------------------
 
-.. function:: dump_traceback(file=sys.stderr, all_threads=True)
+.. function:: dump_traceback(file=sys.stderr, all_threads=True, *, max_threads=100)
 
    Dump the tracebacks of all threads into *file*. If *all_threads* is
-   ``False``, dump only the current thread.
+   ``False``, dump only the current thread. *max_threads* caps the number
+   of threads dumped; a ``...`` marker is written if there are more.
 
    .. seealso:: :func:`traceback.print_tb`, which can be used to print a traceback object.
 
    .. versionchanged:: 3.5
       Added support for passing file descriptor to this function.
+
+   .. versionchanged:: 3.15
+      Added the *max_threads* keyword argument.
 
 
 Dumping the C stack
@@ -146,7 +151,7 @@ Fault handler state
 Dumping the tracebacks after a timeout
 --------------------------------------
 
-.. function:: dump_traceback_later(timeout, repeat=False, file=sys.stderr, exit=False)
+.. function:: dump_traceback_later(timeout, repeat=False, file=sys.stderr, exit=False, *, max_threads=100)
 
    Dump the tracebacks of all threads, after a timeout of *timeout* seconds, or
    every *timeout* seconds if *repeat* is ``True``.  If *exit* is ``True``, call
@@ -154,7 +159,8 @@ Dumping the tracebacks after a timeout
    :c:func:`!_exit` exits the process immediately, which means it doesn't do any
    cleanup like flushing file buffers.) If the function is called twice, the new
    call replaces previous parameters and resets the timeout. The timer has a
-   sub-second resolution.
+   sub-second resolution. *max_threads* caps the number of threads dumped;
+   a ``...`` marker is written if there are more.
 
    The *file* must be kept open until the traceback is dumped or
    :func:`cancel_dump_traceback_later` is called: see :ref:`issue with file
@@ -167,6 +173,9 @@ Dumping the tracebacks after a timeout
 
    .. versionchanged:: 3.7
       This function is now always available.
+
+   .. versionchanged:: 3.15
+      Added the *max_threads* keyword argument.
 
 .. function:: cancel_dump_traceback_later()
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -894,6 +894,14 @@ difflib
   (Contributed by Jiahao Li in :gh:`134580`.)
 
 
+faulthandler
+------------
+
+* Added the *max_threads* parameter in :func:`faulthandler.enable`,
+  :func:`faulthandler.dump_traceback`, and :func:`faulthandler.dump_traceback_later`.
+  (Contributed by Eric Froemling in :gh:`149085`.)
+
+
 functools
 ---------
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -898,7 +898,8 @@ faulthandler
 ------------
 
 * Added the *max_threads* parameter in :func:`faulthandler.enable`,
-  :func:`faulthandler.dump_traceback`, and :func:`faulthandler.dump_traceback_later`.
+  :func:`faulthandler.dump_traceback`, :func:`faulthandler.dump_traceback_later`,
+  and :func:`faulthandler.register`.
   (Contributed by Eric Froemling in :gh:`149085`.)
 
 

--- a/Include/internal/pycore_faulthandler.h
+++ b/Include/internal/pycore_faulthandler.h
@@ -42,6 +42,7 @@ struct faulthandler_user_signal {
     int chain;
     _Py_sighandler_t previous;
     PyInterpreterState *interp;
+    Py_ssize_t max_threads;
 };
 #endif /* FAULTHANDLER_USER */
 

--- a/Include/internal/pycore_faulthandler.h
+++ b/Include/internal/pycore_faulthandler.h
@@ -68,6 +68,8 @@ struct _faulthandler_runtime_state {
         int exit;
         char *header;
         size_t header_len;
+        /* Thread-count cap passed to _Py_DumpTracebackThreads. */
+        unsigned int max_nthreads;
         /* The main thread always holds this lock. It is only released when
            faulthandler_thread() is interrupted before this thread exits, or at
            Python exit. */

--- a/Include/internal/pycore_faulthandler.h
+++ b/Include/internal/pycore_faulthandler.h
@@ -57,6 +57,7 @@ struct _faulthandler_runtime_state {
         void *exc_handler;
 #endif
         int c_stack;
+        unsigned int max_threads;
     } fatal_error;
 
     struct {
@@ -68,8 +69,7 @@ struct _faulthandler_runtime_state {
         int exit;
         char *header;
         size_t header_len;
-        /* Thread-count cap passed to _Py_DumpTracebackThreads. */
-        unsigned int max_nthreads;
+        unsigned int max_threads;
         /* The main thread always holds this lock. It is only released when
            faulthandler_thread() is interrupted before this thread exits, or at
            Python exit. */

--- a/Include/internal/pycore_faulthandler.h
+++ b/Include/internal/pycore_faulthandler.h
@@ -57,7 +57,7 @@ struct _faulthandler_runtime_state {
         void *exc_handler;
 #endif
         int c_stack;
-        unsigned int max_threads;
+        Py_ssize_t max_threads;
     } fatal_error;
 
     struct {
@@ -69,7 +69,7 @@ struct _faulthandler_runtime_state {
         int exit;
         char *header;
         size_t header_len;
-        unsigned int max_threads;
+        Py_ssize_t max_threads;
         /* The main thread always holds this lock. It is only released when
            faulthandler_thread() is interrupted before this thread exits, or at
            Python exit. */

--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -1897,6 +1897,7 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(mask));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(match));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(max_length));
+    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(max_threads));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(maxdigits));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(maxevents));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(maxlen));

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -620,6 +620,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(mask)
         STRUCT_FOR_ID(match)
         STRUCT_FOR_ID(max_length)
+        STRUCT_FOR_ID(max_threads)
         STRUCT_FOR_ID(maxdigits)
         STRUCT_FOR_ID(maxevents)
         STRUCT_FOR_ID(maxlen)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -1895,6 +1895,7 @@ extern "C" {
     INIT_ID(mask), \
     INIT_ID(match), \
     INIT_ID(max_length), \
+    INIT_ID(max_threads), \
     INIT_ID(maxdigits), \
     INIT_ID(maxevents), \
     INIT_ID(maxlen), \

--- a/Include/internal/pycore_traceback.h
+++ b/Include/internal/pycore_traceback.h
@@ -58,10 +58,19 @@ extern void _Py_DumpTraceback(
 
    This function is signal safe. */
 
+/* The historical per-call cap on the number of threads dumped by
+   _Py_DumpTracebackThreads; surfaced as the public default for the
+   max_threads kwarg on faulthandler.dump_traceback{,_later}. */
+#define _Py_TRACEBACK_MAX_NTHREADS 100
+
+/* max_nthreads is the per-call cap. Pass _Py_TRACEBACK_MAX_NTHREADS
+   for the historical default; user-facing callers should use the
+   clinic-supplied default of the public Python API. */
 extern const char* _Py_DumpTracebackThreads(
     int fd,
     PyInterpreterState *interp,
-    PyThreadState *current_tstate);
+    PyThreadState *current_tstate,
+    unsigned int max_nthreads);
 
 /* Write a Unicode object into the file descriptor fd. Encode the string to
    ASCII using the backslashreplace error handler.

--- a/Include/internal/pycore_traceback.h
+++ b/Include/internal/pycore_traceback.h
@@ -62,7 +62,7 @@ extern const char* _Py_DumpTracebackThreads(
     int fd,
     PyInterpreterState *interp,
     PyThreadState *current_tstate,
-    unsigned int max_threads);
+    Py_ssize_t max_threads);
 
 /* Write a Unicode object into the file descriptor fd. Encode the string to
    ASCII using the backslashreplace error handler.

--- a/Include/internal/pycore_traceback.h
+++ b/Include/internal/pycore_traceback.h
@@ -58,19 +58,11 @@ extern void _Py_DumpTraceback(
 
    This function is signal safe. */
 
-/* The historical per-call cap on the number of threads dumped by
-   _Py_DumpTracebackThreads; surfaced as the public default for the
-   max_threads kwarg on faulthandler.dump_traceback{,_later}. */
-#define _Py_TRACEBACK_MAX_NTHREADS 100
-
-/* max_nthreads is the per-call cap. Pass _Py_TRACEBACK_MAX_NTHREADS
-   for the historical default; user-facing callers should use the
-   clinic-supplied default of the public Python API. */
 extern const char* _Py_DumpTracebackThreads(
     int fd,
     PyInterpreterState *interp,
     PyThreadState *current_tstate,
-    unsigned int max_nthreads);
+    unsigned int max_threads);
 
 /* Write a Unicode object into the file descriptor fd. Encode the string to
    ASCII using the backslashreplace error handler.

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -2260,6 +2260,10 @@ _PyUnicode_InitStaticStrings(PyInterpreterState *interp) {
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));
     assert(PyUnicode_GET_LENGTH(string) != 1);
+    string = &_Py_ID(max_threads);
+    _PyUnicode_InternStatic(interp, &string);
+    assert(_PyUnicode_CheckConsistency(string, 1));
+    assert(PyUnicode_GET_LENGTH(string) != 1);
     string = &_Py_ID(maxdigits);
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -895,6 +895,41 @@ class FaultHandlerTests(unittest.TestCase):
     def test_register_chain(self):
         self.check_register(chain=True)
 
+    @unittest.skipIf(not hasattr(faulthandler, "register"),
+                     "need faulthandler.register")
+    def test_register_max_threads(self):
+        # register(max_threads=N) caps the thread dump produced when
+        # the registered signal fires.
+        code = dedent("""
+            import faulthandler
+            import os
+            import signal
+            import threading
+
+            NTHREADS = 6
+            CAP = 3
+
+            ready = threading.Barrier(NTHREADS + 1)
+            stop = threading.Event()
+
+            def worker():
+                ready.wait()
+                stop.wait()
+
+            for _ in range(NTHREADS):
+                threading.Thread(target=worker, daemon=True).start()
+            ready.wait()
+            faulthandler.register(signal.SIGUSR1, all_threads=True,
+                                  max_threads=CAP)
+            os.kill(os.getpid(), signal.SIGUSR1)
+        """).strip()
+        proc = script_helper.assert_python_ok('-c', code)
+        output = proc.err
+        # Cap of 3 means the dump is truncated with "..." on its own line.
+        self.assertIn(b"\n...\n", output)
+        # Cap of 3 means exactly 3 thread headers in the dump.
+        self.assertEqual(output.count(b"Thread 0x"), 3)
+
     @contextmanager
     def check_stderr_none(self):
         stderr = sys.stderr

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -902,7 +902,6 @@ class FaultHandlerTests(unittest.TestCase):
         # the registered signal fires.
         code = dedent("""
             import faulthandler
-            import os
             import signal
             import threading
 
@@ -916,12 +915,18 @@ class FaultHandlerTests(unittest.TestCase):
                 ready.wait()
                 stop.wait()
 
-            for _ in range(NTHREADS):
-                threading.Thread(target=worker, daemon=True).start()
+            threads = [threading.Thread(target=worker) for _ in range(NTHREADS)]
+            for t in threads:
+                t.start()
             ready.wait()
-            faulthandler.register(signal.SIGUSR1, all_threads=True,
-                                  max_threads=CAP)
-            os.kill(os.getpid(), signal.SIGUSR1)
+            try:
+                faulthandler.register(signal.SIGUSR1, all_threads=True,
+                                      max_threads=CAP)
+                signal.raise_signal(signal.SIGUSR1)
+            finally:
+                stop.set()
+                for t in threads:
+                    t.join()
         """).strip()
         proc = script_helper.assert_python_ok('-c', code)
         output = proc.err

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -719,6 +719,62 @@ class FaultHandlerTests(unittest.TestCase):
     def test_dump_traceback_later_twice(self):
         self.check_dump_traceback_later(loops=2)
 
+    def test_dump_traceback_max_threads(self):
+        # max_threads caps the dump and writes "...\n" when truncated.
+        # Spawn N worker threads, dump with cap < N, and verify the
+        # marker is present and at most CAP thread headers are written.
+        code = dedent("""
+            import faulthandler
+            import sys
+            import threading
+
+            NTHREADS = 6
+            CAP = 3
+
+            ready = threading.Barrier(NTHREADS + 1)
+            stop = threading.Event()
+
+            def worker():
+                ready.wait()
+                stop.wait()
+
+            threads = [threading.Thread(target=worker) for _ in range(NTHREADS)]
+            for t in threads:
+                t.start()
+            ready.wait()
+            try:
+                faulthandler.dump_traceback(file=sys.stderr, max_threads=CAP)
+            finally:
+                stop.set()
+                for t in threads:
+                    t.join()
+        """).strip()
+        # spawn_python merges stderr into stdout by default.
+        with support.SuppressCrashReport():
+            process = script_helper.spawn_python('-c', code)
+            with process:
+                output, _ = process.communicate()
+                process.wait()
+        # Truncation marker is written when the cap is hit.
+        self.assertIn(b"...\n", output)
+        # Cap of 3 means at most 3 thread headers in the dump.
+        self.assertLessEqual(output.count(b"Thread 0x"), 3)
+
+    def test_dump_traceback_max_threads_default(self):
+        # The default max_threads of 100 preserves historical behavior:
+        # no truncation when the live thread count is below the cap.
+        code = dedent("""
+            import faulthandler
+            import sys
+            faulthandler.dump_traceback(file=sys.stderr)
+        """).strip()
+        with support.SuppressCrashReport():
+            process = script_helper.spawn_python('-c', code)
+            with process:
+                output, _ = process.communicate()
+                process.wait()
+        self.assertNotIn(b"...\n", output)
+
     @unittest.skipIf(not hasattr(faulthandler, "register"),
                      "need faulthandler.register")
     def check_register(self, filename=False, all_threads=False,

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -722,7 +722,7 @@ class FaultHandlerTests(unittest.TestCase):
     def test_dump_traceback_max_threads(self):
         # max_threads caps the dump and writes "...\n" when truncated.
         # Spawn N worker threads, dump with cap < N, and verify the
-        # marker is present and at most CAP thread headers are written.
+        # marker is present and exactly CAP thread headers are written.
         code = dedent("""
             import faulthandler
             import sys
@@ -749,31 +749,42 @@ class FaultHandlerTests(unittest.TestCase):
                 for t in threads:
                     t.join()
         """).strip()
-        # spawn_python merges stderr into stdout by default.
-        with support.SuppressCrashReport():
-            process = script_helper.spawn_python('-c', code)
-            with process:
-                output, _ = process.communicate()
-                process.wait()
-        # Truncation marker is written when the cap is hit.
-        self.assertIn(b"...\n", output)
-        # Cap of 3 means at most 3 thread headers in the dump.
-        self.assertLessEqual(output.count(b"Thread 0x"), 3)
+        proc = script_helper.assert_python_ok('-c', code)
+        output = proc.err
+        # Truncation marker is written on its own line when the cap is hit.
+        self.assertIn(b"\n...\n", output)
+        # Cap of 3 means exactly 3 thread headers in the dump.
+        self.assertEqual(output.count(b"Thread 0x"), 3)
 
-    def test_dump_traceback_max_threads_default(self):
-        # The default max_threads of 100 preserves historical behavior:
-        # no truncation when the live thread count is below the cap.
+    @skip_segfault_on_android
+    def test_enable_max_threads(self):
+        # enable(max_threads=N) caps the thread dump produced when a
+        # fatal signal fires.
         code = dedent("""
             import faulthandler
-            import sys
-            faulthandler.dump_traceback(file=sys.stderr)
+            import threading
+
+            NTHREADS = 6
+            CAP = 3
+
+            ready = threading.Barrier(NTHREADS + 1)
+            stop = threading.Event()
+
+            def worker():
+                ready.wait()
+                stop.wait()
+
+            for _ in range(NTHREADS):
+                threading.Thread(target=worker, daemon=True).start()
+            ready.wait()
+            faulthandler.enable(max_threads=CAP)
+            faulthandler._sigsegv()
         """).strip()
-        with support.SuppressCrashReport():
-            process = script_helper.spawn_python('-c', code)
-            with process:
-                output, _ = process.communicate()
-                process.wait()
-        self.assertNotIn(b"...\n", output)
+        output, exitcode = self.get_output(code)
+        output = '\n'.join(output)
+        # Cap of 3 means the dump is truncated with "..." on its own line.
+        self.assertIn("\n...\n", output)
+        self.assertNotEqual(exitcode, 0)
 
     @unittest.skipIf(not hasattr(faulthandler, "register"),
                      "need faulthandler.register")

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -757,6 +757,9 @@ class FaultHandlerTests(unittest.TestCase):
         self.assertEqual(output.count(b"Thread 0x"), 3)
 
     @skip_segfault_on_android
+    @unittest.skipIf(support.Py_GIL_DISABLED,
+                     "fatal-signal handler only dumps the current thread "
+                     "when the GIL is disabled")
     def test_enable_max_threads(self):
         # enable(max_threads=N) caps the thread dump produced when a
         # fatal signal fires.

--- a/Misc/NEWS.d/next/Library/2026-04-28-16-30-48.gh-issue-149085.5aNgBD.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-28-16-30-48.gh-issue-149085.5aNgBD.rst
@@ -1,2 +1,3 @@
 Add a *max_threads* keyword argument to :func:`faulthandler.dump_traceback`,
-:func:`faulthandler.dump_traceback_later`, and :func:`faulthandler.enable`.
+:func:`faulthandler.dump_traceback_later`, :func:`faulthandler.enable`, and
+:func:`faulthandler.register`.

--- a/Misc/NEWS.d/next/Library/2026-04-28-16-30-48.gh-issue-149085.5aNgBD.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-28-16-30-48.gh-issue-149085.5aNgBD.rst
@@ -1,7 +1,2 @@
-Add a *max_threads* keyword argument to :func:`faulthandler.dump_traceback`
-and :func:`faulthandler.dump_traceback_later`, raising the per-call cap on
-the number of threads dumped (previously a hard-coded ``MAX_NTHREADS = 100``
-in :file:`Python/traceback.c`). Useful for server processes with many
-worker or gRPC threads, where dump order (newest-thread-first) means the
-historical 100-thread cap silently elided the main thread. The default of
-``100`` preserves existing behavior.
+Add a *max_threads* keyword argument to :func:`faulthandler.dump_traceback`,
+:func:`faulthandler.dump_traceback_later`, and :func:`faulthandler.enable`.

--- a/Misc/NEWS.d/next/Library/2026-04-28-16-30-48.gh-issue-149085.5aNgBD.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-28-16-30-48.gh-issue-149085.5aNgBD.rst
@@ -1,0 +1,7 @@
+Add a *max_threads* keyword argument to :func:`faulthandler.dump_traceback`
+and :func:`faulthandler.dump_traceback_later`, raising the per-call cap on
+the number of threads dumped (previously a hard-coded ``MAX_NTHREADS = 100``
+in :file:`Python/traceback.c`). Useful for server processes with many
+worker or gRPC threads, where dump order (newest-thread-first) means the
+historical 100-thread cap silently elided the main thread. The default of
+``100`` preserves existing behavior.

--- a/Modules/clinic/faulthandler.c.h
+++ b/Modules/clinic/faulthandler.c.h
@@ -17,8 +17,7 @@ PyDoc_STRVAR(faulthandler_dump_traceback_py__doc__,
 "Dump the traceback of the current thread into file.\n"
 "\n"
 "Dump the traceback of all threads if all_threads is true. max_threads\n"
-"caps the number of threads dumped; a \"...\" marker is written if there\n"
-"are more.");
+"caps the number of threads dumped.");
 
 #define FAULTHANDLER_DUMP_TRACEBACK_PY_METHODDEF    \
     {"dump_traceback", _PyCFunction_CAST(faulthandler_dump_traceback_py), METH_FASTCALL|METH_KEYWORDS, faulthandler_dump_traceback_py__doc__},
@@ -166,7 +165,8 @@ exit:
 }
 
 PyDoc_STRVAR(faulthandler_py_enable__doc__,
-"enable($module, /, file=sys.stderr, all_threads=True, c_stack=True)\n"
+"enable($module, /, file=sys.stderr, all_threads=True, c_stack=True, *,\n"
+"       max_threads=100)\n"
 "--\n"
 "\n"
 "Enable the fault handler.");
@@ -176,7 +176,8 @@ PyDoc_STRVAR(faulthandler_py_enable__doc__,
 
 static PyObject *
 faulthandler_py_enable_impl(PyObject *module, PyObject *file,
-                            int all_threads, int c_stack);
+                            int all_threads, int c_stack,
+                            unsigned int max_threads);
 
 static PyObject *
 faulthandler_py_enable(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -184,7 +185,7 @@ faulthandler_py_enable(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
 
-    #define NUM_KEYWORDS 3
+    #define NUM_KEYWORDS 4
     static struct {
         PyGC_Head _this_is_not_used;
         PyObject_VAR_HEAD
@@ -193,7 +194,7 @@ faulthandler_py_enable(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     } _kwtuple = {
         .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
         .ob_hash = -1,
-        .ob_item = { &_Py_ID(file), &_Py_ID(all_threads), &_Py_ID(c_stack), },
+        .ob_item = { &_Py_ID(file), &_Py_ID(all_threads), &_Py_ID(c_stack), &_Py_ID(max_threads), },
     };
     #undef NUM_KEYWORDS
     #define KWTUPLE (&_kwtuple.ob_base.ob_base)
@@ -202,18 +203,19 @@ faulthandler_py_enable(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     #  define KWTUPLE NULL
     #endif  // !Py_BUILD_CORE
 
-    static const char * const _keywords[] = {"file", "all_threads", "c_stack", NULL};
+    static const char * const _keywords[] = {"file", "all_threads", "c_stack", "max_threads", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
         .fname = "enable",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
-    PyObject *argsbuf[3];
+    PyObject *argsbuf[4];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
     PyObject *file = NULL;
     int all_threads = 1;
     int c_stack = 1;
+    unsigned int max_threads = 100;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 0, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -238,12 +240,24 @@ faulthandler_py_enable(PyObject *module, PyObject *const *args, Py_ssize_t nargs
             goto skip_optional_pos;
         }
     }
-    c_stack = PyObject_IsTrue(args[2]);
-    if (c_stack < 0) {
-        goto exit;
+    if (args[2]) {
+        c_stack = PyObject_IsTrue(args[2]);
+        if (c_stack < 0) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_pos;
+        }
     }
 skip_optional_pos:
-    return_value = faulthandler_py_enable_impl(module, file, all_threads, c_stack);
+    if (!noptargs) {
+        goto skip_optional_kwonly;
+    }
+    if (!_PyLong_UnsignedInt_Converter(args[3], &max_threads)) {
+        goto exit;
+    }
+skip_optional_kwonly:
+    return_value = faulthandler_py_enable_impl(module, file, all_threads, c_stack, max_threads);
 
 exit:
     return return_value;
@@ -304,8 +318,7 @@ PyDoc_STRVAR(faulthandler_dump_traceback_later__doc__,
 "\n"
 "If repeat is true, the tracebacks of all threads are dumped every timeout\n"
 "seconds. If exit is true, call _exit(1) which is not safe. max_threads\n"
-"caps the number of threads dumped; a \"...\" marker is written if there\n"
-"are more.");
+"caps the number of threads dumped.");
 
 #define FAULTHANDLER_DUMP_TRACEBACK_LATER_METHODDEF    \
     {"dump_traceback_later", _PyCFunction_CAST(faulthandler_dump_traceback_later), METH_FASTCALL|METH_KEYWORDS, faulthandler_dump_traceback_later__doc__},
@@ -718,4 +731,4 @@ exit:
 #ifndef FAULTHANDLER__RAISE_EXCEPTION_METHODDEF
     #define FAULTHANDLER__RAISE_EXCEPTION_METHODDEF
 #endif /* !defined(FAULTHANDLER__RAISE_EXCEPTION_METHODDEF) */
-/*[clinic end generated code: output=b477248ff88dc172 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c11f71a7f495ba96 input=a9049054013a1b77]*/

--- a/Modules/clinic/faulthandler.c.h
+++ b/Modules/clinic/faulthandler.c.h
@@ -464,20 +464,22 @@ faulthandler_cancel_dump_traceback_later_py(PyObject *module, PyObject *Py_UNUSE
 
 PyDoc_STRVAR(faulthandler_register_py__doc__,
 "register($module, /, signum, file=sys.stderr, all_threads=True,\n"
-"         chain=False)\n"
+"         chain=False, *, max_threads=100)\n"
 "--\n"
 "\n"
 "Register a handler for the signal \'signum\'.\n"
 "\n"
 "Dump the traceback of the current thread, or of all threads if\n"
-"all_threads is True, into file.");
+"all_threads is True, into file. max_threads caps the number of threads\n"
+"dumped.");
 
 #define FAULTHANDLER_REGISTER_PY_METHODDEF    \
     {"register", _PyCFunction_CAST(faulthandler_register_py), METH_FASTCALL|METH_KEYWORDS, faulthandler_register_py__doc__},
 
 static PyObject *
 faulthandler_register_py_impl(PyObject *module, int signum, PyObject *file,
-                              int all_threads, int chain);
+                              int all_threads, int chain,
+                              Py_ssize_t max_threads);
 
 static PyObject *
 faulthandler_register_py(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -485,7 +487,7 @@ faulthandler_register_py(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
 
-    #define NUM_KEYWORDS 4
+    #define NUM_KEYWORDS 5
     static struct {
         PyGC_Head _this_is_not_used;
         PyObject_VAR_HEAD
@@ -494,7 +496,7 @@ faulthandler_register_py(PyObject *module, PyObject *const *args, Py_ssize_t nar
     } _kwtuple = {
         .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
         .ob_hash = -1,
-        .ob_item = { &_Py_ID(signum), &_Py_ID(file), &_Py_ID(all_threads), &_Py_ID(chain), },
+        .ob_item = { &_Py_ID(signum), &_Py_ID(file), &_Py_ID(all_threads), &_Py_ID(chain), &_Py_ID(max_threads), },
     };
     #undef NUM_KEYWORDS
     #define KWTUPLE (&_kwtuple.ob_base.ob_base)
@@ -503,19 +505,20 @@ faulthandler_register_py(PyObject *module, PyObject *const *args, Py_ssize_t nar
     #  define KWTUPLE NULL
     #endif  // !Py_BUILD_CORE
 
-    static const char * const _keywords[] = {"signum", "file", "all_threads", "chain", NULL};
+    static const char * const _keywords[] = {"signum", "file", "all_threads", "chain", "max_threads", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
         .fname = "register",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
-    PyObject *argsbuf[4];
+    PyObject *argsbuf[5];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     int signum;
     PyObject *file = NULL;
     int all_threads = 1;
     int chain = 0;
+    Py_ssize_t max_threads = 100;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 4, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -544,12 +547,33 @@ faulthandler_register_py(PyObject *module, PyObject *const *args, Py_ssize_t nar
             goto skip_optional_pos;
         }
     }
-    chain = PyObject_IsTrue(args[3]);
-    if (chain < 0) {
-        goto exit;
+    if (args[3]) {
+        chain = PyObject_IsTrue(args[3]);
+        if (chain < 0) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_pos;
+        }
     }
 skip_optional_pos:
-    return_value = faulthandler_register_py_impl(module, signum, file, all_threads, chain);
+    if (!noptargs) {
+        goto skip_optional_kwonly;
+    }
+    {
+        Py_ssize_t ival = -1;
+        PyObject *iobj = _PyNumber_Index(args[4]);
+        if (iobj != NULL) {
+            ival = PyLong_AsSsize_t(iobj);
+            Py_DECREF(iobj);
+        }
+        if (ival == -1 && PyErr_Occurred()) {
+            goto exit;
+        }
+        max_threads = ival;
+    }
+skip_optional_kwonly:
+    return_value = faulthandler_register_py_impl(module, signum, file, all_threads, chain, max_threads);
 
 exit:
     return return_value;
@@ -758,4 +782,4 @@ exit:
 #ifndef FAULTHANDLER__RAISE_EXCEPTION_METHODDEF
     #define FAULTHANDLER__RAISE_EXCEPTION_METHODDEF
 #endif /* !defined(FAULTHANDLER__RAISE_EXCEPTION_METHODDEF) */
-/*[clinic end generated code: output=ddd45864a02279e4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2452d767c85130a6 input=a9049054013a1b77]*/

--- a/Modules/clinic/faulthandler.c.h
+++ b/Modules/clinic/faulthandler.c.h
@@ -10,19 +10,23 @@ preserve
 #include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(faulthandler_dump_traceback_py__doc__,
-"dump_traceback($module, /, file=sys.stderr, all_threads=True)\n"
+"dump_traceback($module, /, file=sys.stderr, all_threads=True, *,\n"
+"               max_threads=100)\n"
 "--\n"
 "\n"
 "Dump the traceback of the current thread into file.\n"
 "\n"
-"Dump the traceback of all threads if all_threads is true.");
+"Dump the traceback of all threads if all_threads is true. max_threads\n"
+"caps the number of threads dumped; a \"...\" marker is written if there\n"
+"are more.");
 
 #define FAULTHANDLER_DUMP_TRACEBACK_PY_METHODDEF    \
     {"dump_traceback", _PyCFunction_CAST(faulthandler_dump_traceback_py), METH_FASTCALL|METH_KEYWORDS, faulthandler_dump_traceback_py__doc__},
 
 static PyObject *
 faulthandler_dump_traceback_py_impl(PyObject *module, PyObject *file,
-                                    int all_threads);
+                                    int all_threads,
+                                    unsigned int max_threads);
 
 static PyObject *
 faulthandler_dump_traceback_py(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -30,7 +34,7 @@ faulthandler_dump_traceback_py(PyObject *module, PyObject *const *args, Py_ssize
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
 
-    #define NUM_KEYWORDS 2
+    #define NUM_KEYWORDS 3
     static struct {
         PyGC_Head _this_is_not_used;
         PyObject_VAR_HEAD
@@ -39,7 +43,7 @@ faulthandler_dump_traceback_py(PyObject *module, PyObject *const *args, Py_ssize
     } _kwtuple = {
         .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
         .ob_hash = -1,
-        .ob_item = { &_Py_ID(file), &_Py_ID(all_threads), },
+        .ob_item = { &_Py_ID(file), &_Py_ID(all_threads), &_Py_ID(max_threads), },
     };
     #undef NUM_KEYWORDS
     #define KWTUPLE (&_kwtuple.ob_base.ob_base)
@@ -48,17 +52,18 @@ faulthandler_dump_traceback_py(PyObject *module, PyObject *const *args, Py_ssize
     #  define KWTUPLE NULL
     #endif  // !Py_BUILD_CORE
 
-    static const char * const _keywords[] = {"file", "all_threads", NULL};
+    static const char * const _keywords[] = {"file", "all_threads", "max_threads", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
         .fname = "dump_traceback",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
-    PyObject *argsbuf[2];
+    PyObject *argsbuf[3];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
     PyObject *file = NULL;
     int all_threads = 1;
+    unsigned int max_threads = 100;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 0, /*maxpos*/ 2, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -74,12 +79,24 @@ faulthandler_dump_traceback_py(PyObject *module, PyObject *const *args, Py_ssize
             goto skip_optional_pos;
         }
     }
-    all_threads = PyObject_IsTrue(args[1]);
-    if (all_threads < 0) {
-        goto exit;
+    if (args[1]) {
+        all_threads = PyObject_IsTrue(args[1]);
+        if (all_threads < 0) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_pos;
+        }
     }
 skip_optional_pos:
-    return_value = faulthandler_dump_traceback_py_impl(module, file, all_threads);
+    if (!noptargs) {
+        goto skip_optional_kwonly;
+    }
+    if (!_PyLong_UnsignedInt_Converter(args[2], &max_threads)) {
+        goto exit;
+    }
+skip_optional_kwonly:
+    return_value = faulthandler_dump_traceback_py_impl(module, file, all_threads, max_threads);
 
 exit:
     return return_value;
@@ -280,13 +297,15 @@ exit:
 
 PyDoc_STRVAR(faulthandler_dump_traceback_later__doc__,
 "dump_traceback_later($module, /, timeout, repeat=False,\n"
-"                     file=sys.stderr, exit=False)\n"
+"                     file=sys.stderr, exit=False, *, max_threads=100)\n"
 "--\n"
 "\n"
 "Dump the traceback of all threads in timeout seconds.\n"
 "\n"
 "If repeat is true, the tracebacks of all threads are dumped every timeout\n"
-"seconds. If exit is true, call _exit(1) which is not safe.");
+"seconds. If exit is true, call _exit(1) which is not safe. max_threads\n"
+"caps the number of threads dumped; a \"...\" marker is written if there\n"
+"are more.");
 
 #define FAULTHANDLER_DUMP_TRACEBACK_LATER_METHODDEF    \
     {"dump_traceback_later", _PyCFunction_CAST(faulthandler_dump_traceback_later), METH_FASTCALL|METH_KEYWORDS, faulthandler_dump_traceback_later__doc__},
@@ -294,7 +313,8 @@ PyDoc_STRVAR(faulthandler_dump_traceback_later__doc__,
 static PyObject *
 faulthandler_dump_traceback_later_impl(PyObject *module,
                                        PyObject *timeout_obj, int repeat,
-                                       PyObject *file, int exit);
+                                       PyObject *file, int exit,
+                                       unsigned int max_threads);
 
 static PyObject *
 faulthandler_dump_traceback_later(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -302,7 +322,7 @@ faulthandler_dump_traceback_later(PyObject *module, PyObject *const *args, Py_ss
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
 
-    #define NUM_KEYWORDS 4
+    #define NUM_KEYWORDS 5
     static struct {
         PyGC_Head _this_is_not_used;
         PyObject_VAR_HEAD
@@ -311,7 +331,7 @@ faulthandler_dump_traceback_later(PyObject *module, PyObject *const *args, Py_ss
     } _kwtuple = {
         .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
         .ob_hash = -1,
-        .ob_item = { &_Py_ID(timeout), &_Py_ID(repeat), &_Py_ID(file), &_Py_ID(exit), },
+        .ob_item = { &_Py_ID(timeout), &_Py_ID(repeat), &_Py_ID(file), &_Py_ID(exit), &_Py_ID(max_threads), },
     };
     #undef NUM_KEYWORDS
     #define KWTUPLE (&_kwtuple.ob_base.ob_base)
@@ -320,19 +340,20 @@ faulthandler_dump_traceback_later(PyObject *module, PyObject *const *args, Py_ss
     #  define KWTUPLE NULL
     #endif  // !Py_BUILD_CORE
 
-    static const char * const _keywords[] = {"timeout", "repeat", "file", "exit", NULL};
+    static const char * const _keywords[] = {"timeout", "repeat", "file", "exit", "max_threads", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
         .fname = "dump_traceback_later",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
-    PyObject *argsbuf[4];
+    PyObject *argsbuf[5];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *timeout_obj;
     int repeat = 0;
     PyObject *file = NULL;
     int exit = 0;
+    unsigned int max_threads = 100;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 4, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -358,12 +379,24 @@ faulthandler_dump_traceback_later(PyObject *module, PyObject *const *args, Py_ss
             goto skip_optional_pos;
         }
     }
-    exit = PyObject_IsTrue(args[3]);
-    if (exit < 0) {
-        goto exit;
+    if (args[3]) {
+        exit = PyObject_IsTrue(args[3]);
+        if (exit < 0) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_pos;
+        }
     }
 skip_optional_pos:
-    return_value = faulthandler_dump_traceback_later_impl(module, timeout_obj, repeat, file, exit);
+    if (!noptargs) {
+        goto skip_optional_kwonly;
+    }
+    if (!_PyLong_UnsignedInt_Converter(args[4], &max_threads)) {
+        goto exit;
+    }
+skip_optional_kwonly:
+    return_value = faulthandler_dump_traceback_later_impl(module, timeout_obj, repeat, file, exit, max_threads);
 
 exit:
     return return_value;
@@ -685,4 +718,4 @@ exit:
 #ifndef FAULTHANDLER__RAISE_EXCEPTION_METHODDEF
     #define FAULTHANDLER__RAISE_EXCEPTION_METHODDEF
 #endif /* !defined(FAULTHANDLER__RAISE_EXCEPTION_METHODDEF) */
-/*[clinic end generated code: output=31bf0149d0d02ccf input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b477248ff88dc172 input=a9049054013a1b77]*/

--- a/Modules/clinic/faulthandler.c.h
+++ b/Modules/clinic/faulthandler.c.h
@@ -6,6 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
+#include "pycore_abstract.h"      // _PyNumber_Index()
 #include "pycore_long.h"          // _PyLong_UnsignedInt_Converter()
 #include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
@@ -24,8 +25,7 @@ PyDoc_STRVAR(faulthandler_dump_traceback_py__doc__,
 
 static PyObject *
 faulthandler_dump_traceback_py_impl(PyObject *module, PyObject *file,
-                                    int all_threads,
-                                    unsigned int max_threads);
+                                    int all_threads, Py_ssize_t max_threads);
 
 static PyObject *
 faulthandler_dump_traceback_py(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -62,7 +62,7 @@ faulthandler_dump_traceback_py(PyObject *module, PyObject *const *args, Py_ssize
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
     PyObject *file = NULL;
     int all_threads = 1;
-    unsigned int max_threads = 100;
+    Py_ssize_t max_threads = 100;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 0, /*maxpos*/ 2, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -91,8 +91,17 @@ skip_optional_pos:
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    if (!_PyLong_UnsignedInt_Converter(args[2], &max_threads)) {
-        goto exit;
+    {
+        Py_ssize_t ival = -1;
+        PyObject *iobj = _PyNumber_Index(args[2]);
+        if (iobj != NULL) {
+            ival = PyLong_AsSsize_t(iobj);
+            Py_DECREF(iobj);
+        }
+        if (ival == -1 && PyErr_Occurred()) {
+            goto exit;
+        }
+        max_threads = ival;
     }
 skip_optional_kwonly:
     return_value = faulthandler_dump_traceback_py_impl(module, file, all_threads, max_threads);
@@ -177,7 +186,7 @@ PyDoc_STRVAR(faulthandler_py_enable__doc__,
 static PyObject *
 faulthandler_py_enable_impl(PyObject *module, PyObject *file,
                             int all_threads, int c_stack,
-                            unsigned int max_threads);
+                            Py_ssize_t max_threads);
 
 static PyObject *
 faulthandler_py_enable(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -215,7 +224,7 @@ faulthandler_py_enable(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *file = NULL;
     int all_threads = 1;
     int c_stack = 1;
-    unsigned int max_threads = 100;
+    Py_ssize_t max_threads = 100;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 0, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -253,8 +262,17 @@ skip_optional_pos:
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    if (!_PyLong_UnsignedInt_Converter(args[3], &max_threads)) {
-        goto exit;
+    {
+        Py_ssize_t ival = -1;
+        PyObject *iobj = _PyNumber_Index(args[3]);
+        if (iobj != NULL) {
+            ival = PyLong_AsSsize_t(iobj);
+            Py_DECREF(iobj);
+        }
+        if (ival == -1 && PyErr_Occurred()) {
+            goto exit;
+        }
+        max_threads = ival;
     }
 skip_optional_kwonly:
     return_value = faulthandler_py_enable_impl(module, file, all_threads, c_stack, max_threads);
@@ -327,7 +345,7 @@ static PyObject *
 faulthandler_dump_traceback_later_impl(PyObject *module,
                                        PyObject *timeout_obj, int repeat,
                                        PyObject *file, int exit,
-                                       unsigned int max_threads);
+                                       Py_ssize_t max_threads);
 
 static PyObject *
 faulthandler_dump_traceback_later(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -366,7 +384,7 @@ faulthandler_dump_traceback_later(PyObject *module, PyObject *const *args, Py_ss
     int repeat = 0;
     PyObject *file = NULL;
     int exit = 0;
-    unsigned int max_threads = 100;
+    Py_ssize_t max_threads = 100;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 4, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -405,8 +423,17 @@ skip_optional_pos:
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
-    if (!_PyLong_UnsignedInt_Converter(args[4], &max_threads)) {
-        goto exit;
+    {
+        Py_ssize_t ival = -1;
+        PyObject *iobj = _PyNumber_Index(args[4]);
+        if (iobj != NULL) {
+            ival = PyLong_AsSsize_t(iobj);
+            Py_DECREF(iobj);
+        }
+        if (ival == -1 && PyErr_Occurred()) {
+            goto exit;
+        }
+        max_threads = ival;
     }
 skip_optional_kwonly:
     return_value = faulthandler_dump_traceback_later_impl(module, timeout_obj, repeat, file, exit, max_threads);
@@ -731,4 +758,4 @@ exit:
 #ifndef FAULTHANDLER__RAISE_EXCEPTION_METHODDEF
     #define FAULTHANDLER__RAISE_EXCEPTION_METHODDEF
 #endif /* !defined(FAULTHANDLER__RAISE_EXCEPTION_METHODDEF) */
-/*[clinic end generated code: output=c11f71a7f495ba96 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ddd45864a02279e4 input=a9049054013a1b77]*/

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -185,7 +185,8 @@ get_thread_state(void)
 
 static void
 faulthandler_dump_traceback(int fd, int all_threads,
-                            PyInterpreterState *interp)
+                            PyInterpreterState *interp,
+                            unsigned int max_threads)
 {
     static volatile int reentrant = 0;
 
@@ -205,10 +206,7 @@ faulthandler_dump_traceback(int fd, int all_threads,
     PyThreadState *tstate = PyGILState_GetThisThreadState();
 
     if (all_threads == 1) {
-        /* Fatal-signal path has no caller-supplied cap; use the
-           historical default. */
-        (void)_Py_DumpTracebackThreads(fd, NULL, tstate,
-                                       _Py_TRACEBACK_MAX_NTHREADS);
+        (void)_Py_DumpTracebackThreads(fd, NULL, tstate, max_threads);
     }
     else {
         if (all_threads == FT_IGNORE_ALL_THREADS) {
@@ -252,15 +250,14 @@ faulthandler.dump_traceback as faulthandler_dump_traceback_py
 Dump the traceback of the current thread into file.
 
 Dump the traceback of all threads if all_threads is true. max_threads
-caps the number of threads dumped; a "..." marker is written if there
-are more.
+caps the number of threads dumped.
 [clinic start generated code]*/
 
 static PyObject *
 faulthandler_dump_traceback_py_impl(PyObject *module, PyObject *file,
                                     int all_threads,
                                     unsigned int max_threads)
-/*[clinic end generated code: output=e2b1d5c6bb275cb5 input=9c742d9382cc38b1]*/
+/*[clinic end generated code: output=e2b1d5c6bb275cb5 input=3f84b644d7b226a6]*/
 {
     PyThreadState *tstate;
     const char *errmsg;
@@ -417,7 +414,8 @@ faulthandler_fatal_error(int signum)
     }
 
     faulthandler_dump_traceback(fd, deduce_all_threads(),
-                                fatal_error.interp);
+                                fatal_error.interp,
+                                fatal_error.max_threads);
     faulthandler_dump_c_stack(fd);
 
     _Py_DumpExtensionModules(fd, fatal_error.interp);
@@ -493,7 +491,8 @@ faulthandler_exc_handler(struct _EXCEPTION_POINTERS *exc_info)
     }
 
     faulthandler_dump_traceback(fd, deduce_all_threads(),
-                                fatal_error.interp);
+                                fatal_error.interp,
+                                fatal_error.max_threads);
     faulthandler_dump_c_stack(fd);
 
     /* call the next exception handler */
@@ -598,14 +597,17 @@ faulthandler.enable as faulthandler_py_enable
     file: object(py_default="sys.stderr") = NULL
     all_threads: bool = True
     c_stack: bool = True
+    *
+    max_threads: unsigned_int(bitwise=False) = 100
 
 Enable the fault handler.
 [clinic start generated code]*/
 
 static PyObject *
 faulthandler_py_enable_impl(PyObject *module, PyObject *file,
-                            int all_threads, int c_stack)
-/*[clinic end generated code: output=580d89b5eb62f1cb input=77277746a88b25ca]*/
+                            int all_threads, int c_stack,
+                            unsigned int max_threads)
+/*[clinic end generated code: output=5050dceeeeda70a4 input=e2607dfbb2c7f4ac]*/
 {
     int fd;
     PyThreadState *tstate;
@@ -625,6 +627,7 @@ faulthandler_py_enable_impl(PyObject *module, PyObject *file,
     fatal_error.all_threads = all_threads;
     fatal_error.interp = PyThreadState_GetInterpreter(tstate);
     fatal_error.c_stack = c_stack;
+    fatal_error.max_threads = max_threads;
 
     if (faulthandler_enable() < 0) {
         return NULL;
@@ -712,7 +715,7 @@ faulthandler_thread(void *unused)
         (void)_Py_write_noraise(thread.fd, thread.header, (int)thread.header_len);
 
         errmsg = _Py_DumpTracebackThreads(thread.fd, thread.interp, NULL,
-                                          thread.max_nthreads);
+                                          thread.max_threads);
         ok = (errmsg == NULL);
 
         if (thread.exit)
@@ -793,8 +796,7 @@ Dump the traceback of all threads in timeout seconds.
 
 If repeat is true, the tracebacks of all threads are dumped every timeout
 seconds. If exit is true, call _exit(1) which is not safe. max_threads
-caps the number of threads dumped; a "..." marker is written if there
-are more.
+caps the number of threads dumped.
 [clinic start generated code]*/
 
 static PyObject *
@@ -802,7 +804,7 @@ faulthandler_dump_traceback_later_impl(PyObject *module,
                                        PyObject *timeout_obj, int repeat,
                                        PyObject *file, int exit,
                                        unsigned int max_threads)
-/*[clinic end generated code: output=a0a1551011fe9f5f input=f1c2477de74643bd]*/
+/*[clinic end generated code: output=a0a1551011fe9f5f input=9aabfe7079a05dd3]*/
 {
     PyTime_t timeout, timeout_us;
     int fd;
@@ -875,7 +877,7 @@ faulthandler_dump_traceback_later_impl(PyObject *module,
     thread.exit = exit;
     thread.header = header;
     thread.header_len = header_len;
-    thread.max_nthreads = max_threads;
+    thread.max_threads = max_threads;
 
     /* Arm these locks to serve as events when released */
     PyThread_acquire_lock(thread.running, 1);
@@ -960,7 +962,7 @@ faulthandler_user(int signum)
     if (!user->enabled)
         return;
 
-    faulthandler_dump_traceback(user->fd, user->all_threads, user->interp);
+    faulthandler_dump_traceback(user->fd, user->all_threads, user->interp, 0);
 
 #ifdef HAVE_SIGACTION
     if (user->chain) {

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -961,7 +961,8 @@ faulthandler_user(int signum)
     if (!user->enabled)
         return;
 
-    faulthandler_dump_traceback(user->fd, user->all_threads, user->interp, 0);
+    faulthandler_dump_traceback(user->fd, user->all_threads, user->interp,
+                                user->max_threads);
 
 #ifdef HAVE_SIGACTION
     if (user->chain) {
@@ -1011,17 +1012,21 @@ faulthandler.register as faulthandler_register_py
     file: object(py_default="sys.stderr") = NULL
     all_threads: bool = True
     chain: bool = False
+    *
+    max_threads: Py_ssize_t = 100
 
 Register a handler for the signal 'signum'.
 
 Dump the traceback of the current thread, or of all threads if
-all_threads is True, into file.
+all_threads is True, into file. max_threads caps the number of threads
+dumped.
 [clinic start generated code]*/
 
 static PyObject *
 faulthandler_register_py_impl(PyObject *module, int signum, PyObject *file,
-                              int all_threads, int chain)
-/*[clinic end generated code: output=1f770cee150a56cd input=ae9de829e850907b]*/
+                              int all_threads, int chain,
+                              Py_ssize_t max_threads)
+/*[clinic end generated code: output=d63a5b4f388dee5f input=c75096a20de502fe]*/
 {
     int fd;
     user_signal_t *user;
@@ -1072,6 +1077,7 @@ faulthandler_register_py_impl(PyObject *module, int signum, PyObject *file,
     user->all_threads = all_threads;
     user->chain = chain;
     user->interp = PyThreadState_GetInterpreter(tstate);
+    user->max_threads = max_threads;
     user->enabled = 1;
 
     Py_RETURN_NONE;

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -205,7 +205,10 @@ faulthandler_dump_traceback(int fd, int all_threads,
     PyThreadState *tstate = PyGILState_GetThisThreadState();
 
     if (all_threads == 1) {
-        (void)_Py_DumpTracebackThreads(fd, NULL, tstate);
+        /* Fatal-signal path has no caller-supplied cap; use the
+           historical default. */
+        (void)_Py_DumpTracebackThreads(fd, NULL, tstate,
+                                       _Py_TRACEBACK_MAX_NTHREADS);
     }
     else {
         if (all_threads == FT_IGNORE_ALL_THREADS) {
@@ -243,16 +246,21 @@ faulthandler.dump_traceback as faulthandler_dump_traceback_py
 
     file: object(py_default="sys.stderr") = NULL
     all_threads: bool = True
+    *
+    max_threads: unsigned_int(bitwise=False) = 100
 
 Dump the traceback of the current thread into file.
 
-Dump the traceback of all threads if all_threads is true.
+Dump the traceback of all threads if all_threads is true. max_threads
+caps the number of threads dumped; a "..." marker is written if there
+are more.
 [clinic start generated code]*/
 
 static PyObject *
 faulthandler_dump_traceback_py_impl(PyObject *module, PyObject *file,
-                                    int all_threads)
-/*[clinic end generated code: output=34efece0ca18314f input=b832ec55e27a7898]*/
+                                    int all_threads,
+                                    unsigned int max_threads)
+/*[clinic end generated code: output=e2b1d5c6bb275cb5 input=9c742d9382cc38b1]*/
 {
     PyThreadState *tstate;
     const char *errmsg;
@@ -273,7 +281,7 @@ faulthandler_dump_traceback_py_impl(PyObject *module, PyObject *file,
         /* gh-128400: Accessing other thread states while they're running
          * isn't safe if those threads are running. */
         _PyEval_StopTheWorld(interp);
-        errmsg = _Py_DumpTracebackThreads(fd, NULL, tstate);
+        errmsg = _Py_DumpTracebackThreads(fd, NULL, tstate, max_threads);
         _PyEval_StartTheWorld(interp);
         if (errmsg != NULL) {
             PyErr_SetString(PyExc_RuntimeError, errmsg);
@@ -703,7 +711,8 @@ faulthandler_thread(void *unused)
 
         (void)_Py_write_noraise(thread.fd, thread.header, (int)thread.header_len);
 
-        errmsg = _Py_DumpTracebackThreads(thread.fd, thread.interp, NULL);
+        errmsg = _Py_DumpTracebackThreads(thread.fd, thread.interp, NULL,
+                                          thread.max_nthreads);
         ok = (errmsg == NULL);
 
         if (thread.exit)
@@ -777,18 +786,23 @@ faulthandler.dump_traceback_later
     repeat: bool = False
     file: object(py_default="sys.stderr") = NULL
     exit: bool = False
+    *
+    max_threads: unsigned_int(bitwise=False) = 100
 
 Dump the traceback of all threads in timeout seconds.
 
 If repeat is true, the tracebacks of all threads are dumped every timeout
-seconds. If exit is true, call _exit(1) which is not safe.
+seconds. If exit is true, call _exit(1) which is not safe. max_threads
+caps the number of threads dumped; a "..." marker is written if there
+are more.
 [clinic start generated code]*/
 
 static PyObject *
 faulthandler_dump_traceback_later_impl(PyObject *module,
                                        PyObject *timeout_obj, int repeat,
-                                       PyObject *file, int exit)
-/*[clinic end generated code: output=a24d80d694d25ba2 input=fd005625ecc2ba9a]*/
+                                       PyObject *file, int exit,
+                                       unsigned int max_threads)
+/*[clinic end generated code: output=a0a1551011fe9f5f input=f1c2477de74643bd]*/
 {
     PyTime_t timeout, timeout_us;
     int fd;
@@ -861,6 +875,7 @@ faulthandler_dump_traceback_later_impl(PyObject *module,
     thread.exit = exit;
     thread.header = header;
     thread.header_len = header_len;
+    thread.max_nthreads = max_threads;
 
     /* Arm these locks to serve as events when released */
     PyThread_acquire_lock(thread.running, 1);

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -186,7 +186,7 @@ get_thread_state(void)
 static void
 faulthandler_dump_traceback(int fd, int all_threads,
                             PyInterpreterState *interp,
-                            unsigned int max_threads)
+                            Py_ssize_t max_threads)
 {
     static volatile int reentrant = 0;
 
@@ -245,7 +245,7 @@ faulthandler.dump_traceback as faulthandler_dump_traceback_py
     file: object(py_default="sys.stderr") = NULL
     all_threads: bool = True
     *
-    max_threads: unsigned_int(bitwise=False) = 100
+    max_threads: Py_ssize_t = 100
 
 Dump the traceback of the current thread into file.
 
@@ -255,9 +255,8 @@ caps the number of threads dumped.
 
 static PyObject *
 faulthandler_dump_traceback_py_impl(PyObject *module, PyObject *file,
-                                    int all_threads,
-                                    unsigned int max_threads)
-/*[clinic end generated code: output=e2b1d5c6bb275cb5 input=3f84b644d7b226a6]*/
+                                    int all_threads, Py_ssize_t max_threads)
+/*[clinic end generated code: output=ee1bbc2668e56e77 input=38630eb40e641de6]*/
 {
     PyThreadState *tstate;
     const char *errmsg;
@@ -598,7 +597,7 @@ faulthandler.enable as faulthandler_py_enable
     all_threads: bool = True
     c_stack: bool = True
     *
-    max_threads: unsigned_int(bitwise=False) = 100
+    max_threads: Py_ssize_t = 100
 
 Enable the fault handler.
 [clinic start generated code]*/
@@ -606,8 +605,8 @@ Enable the fault handler.
 static PyObject *
 faulthandler_py_enable_impl(PyObject *module, PyObject *file,
                             int all_threads, int c_stack,
-                            unsigned int max_threads)
-/*[clinic end generated code: output=5050dceeeeda70a4 input=e2607dfbb2c7f4ac]*/
+                            Py_ssize_t max_threads)
+/*[clinic end generated code: output=7ee655332317c47a input=e64759714f27b466]*/
 {
     int fd;
     PyThreadState *tstate;
@@ -790,7 +789,7 @@ faulthandler.dump_traceback_later
     file: object(py_default="sys.stderr") = NULL
     exit: bool = False
     *
-    max_threads: unsigned_int(bitwise=False) = 100
+    max_threads: Py_ssize_t = 100
 
 Dump the traceback of all threads in timeout seconds.
 
@@ -803,8 +802,8 @@ static PyObject *
 faulthandler_dump_traceback_later_impl(PyObject *module,
                                        PyObject *timeout_obj, int repeat,
                                        PyObject *file, int exit,
-                                       unsigned int max_threads)
-/*[clinic end generated code: output=a0a1551011fe9f5f input=9aabfe7079a05dd3]*/
+                                       Py_ssize_t max_threads)
+/*[clinic end generated code: output=543a0f3807113394 input=6836555ee157ddb4]*/
 {
     PyTime_t timeout, timeout_us;
     int fd;

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3342,7 +3342,9 @@ _Py_FatalError_DumpTracebacks(int fd, PyInterpreterState *interp,
 
     /* display the current Python stack */
 #ifndef Py_GIL_DISABLED
-    _Py_DumpTracebackThreads(fd, interp, tstate);
+    /* Fatal-error path has no caller-supplied cap; use the historical
+       default. */
+    _Py_DumpTracebackThreads(fd, interp, tstate, _Py_TRACEBACK_MAX_NTHREADS);
 #else
     _Py_DumpTraceback(fd, tstate);
 #endif

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3342,9 +3342,7 @@ _Py_FatalError_DumpTracebacks(int fd, PyInterpreterState *interp,
 
     /* display the current Python stack */
 #ifndef Py_GIL_DISABLED
-    /* Fatal-error path has no caller-supplied cap; use the historical
-       default. */
-    _Py_DumpTracebackThreads(fd, interp, tstate, _Py_TRACEBACK_MAX_NTHREADS);
+    _Py_DumpTracebackThreads(fd, interp, tstate, 0);
 #else
     _Py_DumpTraceback(fd, tstate);
 #endif

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -55,7 +55,9 @@
 
 #define MAX_STRING_LENGTH 500
 #define MAX_FRAME_DEPTH 100
-#define MAX_NTHREADS 100
+/* The historical default thread-dump cap is declared as
+   _Py_TRACEBACK_MAX_NTHREADS in pycore_traceback.h so callers of
+   _Py_DumpTracebackThreads can reference it directly. */
 
 /* Function from Parser/tokenizer/file_tokenizer.c */
 extern char* _PyTokenizer_FindEncodingFilename(int, PyObject *);
@@ -1265,7 +1267,8 @@ write_thread_id(int fd, PyThreadState *tstate, int is_current)
    handlers if signals were received. */
 const char* _Py_NO_SANITIZE_THREAD
 _Py_DumpTracebackThreads(int fd, PyInterpreterState *interp,
-                         PyThreadState *current_tstate)
+                         PyThreadState *current_tstate,
+                         unsigned int max_nthreads)
 {
     if (current_tstate == NULL) {
         /* _Py_DumpTracebackThreads() is called from signal handlers by
@@ -1316,7 +1319,7 @@ _Py_DumpTracebackThreads(int fd, PyInterpreterState *interp,
     {
         if (nthreads != 0)
             PUTS(fd, "\n");
-        if (nthreads >= MAX_NTHREADS) {
+        if (nthreads >= max_nthreads) {
             PUTS(fd, "...\n");
             break;
         }

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -1266,7 +1266,7 @@ write_thread_id(int fd, PyThreadState *tstate, int is_current)
 const char* _Py_NO_SANITIZE_THREAD
 _Py_DumpTracebackThreads(int fd, PyInterpreterState *interp,
                          PyThreadState *current_tstate,
-                         unsigned int max_threads)
+                         Py_ssize_t max_threads)
 {
     if (max_threads == 0) {
         max_threads = DEFAULT_MAX_NTHREADS;
@@ -1315,7 +1315,7 @@ _Py_DumpTracebackThreads(int fd, PyInterpreterState *interp,
         return "unable to get the thread head state";
 
     /* Dump the traceback of each thread */
-    unsigned int nthreads = 0;
+    Py_ssize_t nthreads = 0;
     _Py_BEGIN_SUPPRESS_IPH
     do
     {

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -55,9 +55,7 @@
 
 #define MAX_STRING_LENGTH 500
 #define MAX_FRAME_DEPTH 100
-/* The historical default thread-dump cap is declared as
-   _Py_TRACEBACK_MAX_NTHREADS in pycore_traceback.h so callers of
-   _Py_DumpTracebackThreads can reference it directly. */
+#define DEFAULT_MAX_NTHREADS 100
 
 /* Function from Parser/tokenizer/file_tokenizer.c */
 extern char* _PyTokenizer_FindEncodingFilename(int, PyObject *);
@@ -1268,8 +1266,12 @@ write_thread_id(int fd, PyThreadState *tstate, int is_current)
 const char* _Py_NO_SANITIZE_THREAD
 _Py_DumpTracebackThreads(int fd, PyInterpreterState *interp,
                          PyThreadState *current_tstate,
-                         unsigned int max_nthreads)
+                         unsigned int max_threads)
 {
+    if (max_threads == 0) {
+        max_threads = DEFAULT_MAX_NTHREADS;
+    }
+
     if (current_tstate == NULL) {
         /* _Py_DumpTracebackThreads() is called from signal handlers by
            faulthandler.
@@ -1319,7 +1321,7 @@ _Py_DumpTracebackThreads(int fd, PyInterpreterState *interp,
     {
         if (nthreads != 0)
             PUTS(fd, "\n");
-        if (nthreads >= max_nthreads) {
+        if (nthreads >= max_threads) {
             PUTS(fd, "...\n");
             break;
         }


### PR DESCRIPTION
Closes #149085.

Adds a keyword-only `max_threads` argument to `faulthandler.dump_traceback()` and `faulthandler.dump_traceback_later()`, raising the per-call cap on the number of threads dumped (previously a hardcoded `MAX_NTHREADS = 100` in `Python/traceback.c`). Default of 100 preserves existing behavior.

Motivation (covered in the issue): on server processes with many worker or gRPC threads, watchdog dumps silently lose the main thread because tstates are prepended to the interpreter's thread list and the cap chops the tail. This was the failure mode that prompted the issue.

Scope per @vstinner's confirmation in the issue: `max_threads` only; the frame/stack limits raised by @ZeroIntensity are left as-is for now.

The hardcoded 100 is moved to a new internal macro `_Py_TRACEBACK_MAX_NTHREADS` in `pycore_traceback.h` so the in-tree fatal-signal callers (`faulthandler.c`, `pylifecycle.c`) all share one source of truth.

<!-- gh-issue-number: gh-149085 -->
* Issue: gh-149085
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--149106.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->