### PR TITLE
gh-148829: bump number of static types

### DIFF
--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -531,7 +531,7 @@ struct _py_func_state {
 
 /* For now we hard-code this to a value for which we are confident
    all the static builtin types will fit (for all builds). */
-#define _Py_MAX_MANAGED_STATIC_BUILTIN_TYPES 202
+#define _Py_MAX_MANAGED_STATIC_BUILTIN_TYPES 203
 #define _Py_MAX_MANAGED_STATIC_EXT_TYPES 10
 #define _Py_MAX_MANAGED_STATIC_TYPES \
     (_Py_MAX_MANAGED_STATIC_BUILTIN_TYPES + _Py_MAX_MANAGED_STATIC_EXT_TYPES)


### PR DESCRIPTION
@diegorusso tells me the Windows JIT is broken because we added an additional static type, e.g. https://github.com/python/cpython/actions/runs/25081900933/job/73488687467?pr=146071 .

<!-- gh-issue-number: gh-148829 -->
* Issue: gh-148829
<!-- /gh-issue-number -->
