### PR TITLE
gh-149122: Fix segfault in compiler when certain builtin functions are passed a coroutine as arg

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -308,6 +308,27 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
 
         self.assertEqual(overridden_outputs, ['all', 'any', 'tuple', 'list', 'set'])
 
+    def test_builtin_call_async_genexpr_no_crash(self):
+        async def f_all():
+            return all(await 2 for _ in [])
+
+        async def f_any():
+            return any(await 2 for _ in [])
+
+        async def f_tuple():
+            return tuple(await 2 for _ in [])
+
+        async def f_list():
+            return list(await 2 for _ in [])
+
+        async def f_set():
+            return set(await 2 for _ in [])
+
+        for f in (f_all, f_any, f_tuple, f_list, f_set):
+            with self.subTest(func=f.__name__):
+                with self.assertRaises(TypeError):
+                    run_yielding_async_fn(f)
+
     def test_ascii(self):
         self.assertEqual(ascii(''), '\'\'')
         self.assertEqual(ascii(0), '0')

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-29-14-06-00.gh-issue-149122.P8k2Lm.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-29-14-06-00.gh-issue-149122.P8k2Lm.rst
@@ -1,0 +1,4 @@
+Fix a crash in optimized calls to :func:`all`, :func:`any`, :func:`tuple`,
+:func:`list`, and :func:`set` with an async generator expression argument
+(for example, ``tuple(await x for x in y)``). These calls now correctly raise
+``TypeError`` instead of crashing.

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -3959,6 +3959,12 @@ maybe_optimize_function_call(compiler *c, expr_ty e, jump_target_label end)
         return 0;
     }
 
+    expr_ty generator_exp = asdl_seq_GET(args, 0);
+    PySTEntryObject *generator_entry = _PySymtable_Lookup(SYMTABLE(c), (void *)generator_exp);
+    if (generator_entry->ste_coroutine) {
+        return 0;
+    }
+
     location loc = LOC(func);
 
     int optimized = 0;
@@ -3998,7 +4004,6 @@ maybe_optimize_function_call(compiler *c, expr_ty e, jump_target_label end)
         } else if (const_oparg == CONSTANT_BUILTIN_SET) {
             ADDOP_I(c, loc, BUILD_SET, 0);
         }
-        expr_ty generator_exp = asdl_seq_GET(args, 0);
         VISIT(c, expr, generator_exp);
 
         NEW_JUMP_TARGET_LABEL(c, loop);


### PR DESCRIPTION
Fixes #149122.

Disables the builtin-on-genexpr optimisation when the genexpr is a coroutine.

<!-- gh-issue-number: gh-149122 -->
* Issue: gh-149122
<!-- /gh-issue-number -->
