### PR TITLE
gh-149173: Fix inverted PYTHON_BASIC_REPL environment check in _pyrepl_available()

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -376,7 +376,7 @@ def get_default_backend():
 
 def _pyrepl_available():
     """return whether pdb should use _pyrepl for input"""
-    if not os.getenv("PYTHON_BASIC_REPL"):
+    if os.getenv("PYTHON_BASIC_REPL"):
         CAN_USE_PYREPL = False
     else:
         try:

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4753,6 +4753,16 @@ def bœr():
         stdout, stderr = self.run_pdb_script(script, commands)
         self.assertIn("The specified object 'C.foo' is not a function", stdout)
 
+    def test_pyrepl_available(self):
+        with patch.dict(os.environ, {"PYTHON_BASIC_REPL": "1"}):
+            self.assertFalse(pdb._pyrepl_available())
+
+        with patch.dict(os.environ, {}, clear=True):
+            mod = types.ModuleType("_pyrepl.main")
+            mod.CAN_USE_PYREPL = True
+            with patch.dict("sys.modules", {"_pyrepl.main": mod}):
+                self.assertTrue(pdb._pyrepl_available())
+
 
 class ChecklineTests(unittest.TestCase):
     def setUp(self):

--- a/Misc/NEWS.d/next/Library/2026-04-30-14-21-26.gh-issue-149173.KJqZm0.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-30-14-21-26.gh-issue-149173.KJqZm0.rst
@@ -1,2 +1,2 @@
 Fix inverted :envvar:`PYTHON_BASIC_REPL` environment check in
-:func:`pdb._pyrepl_available`.
+``pdb._pyrepl_available``.

--- a/Misc/NEWS.d/next/Library/2026-04-30-14-21-26.gh-issue-149173.KJqZm0.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-30-14-21-26.gh-issue-149173.KJqZm0.rst
@@ -1,2 +1,2 @@
 Fix inverted :envvar:`PYTHON_BASIC_REPL` environment check in
-:func:`pdb._pyrepl_available()`.
+:func:`pdb._pyrepl_available`.

--- a/Misc/NEWS.d/next/Library/2026-04-30-14-21-26.gh-issue-149173.KJqZm0.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-30-14-21-26.gh-issue-149173.KJqZm0.rst
@@ -1,0 +1,2 @@
+Fix inverted :envvar:`PYTHON_BASIC_REPL` environment check in
+:func:`pdb._pyrepl_available()`.


### PR DESCRIPTION


<!-- gh-issue-number: gh-149173 -->
* Issue: gh-149173
<!-- /gh-issue-number -->
