### PR TITLE
Revert pylock.toml change to make MSI builds pass

### DIFF
--- a/Doc/make.bat
+++ b/Doc/make.bat
@@ -13,7 +13,7 @@ if not defined SPHINXBUILD (
     %PYTHON% -c "import sphinx" > nul 2> nul
     if errorlevel 1 (
         echo Installing sphinx with %PYTHON%
-        %PYTHON% -m pip install -r pylock.toml
+        %PYTHON% -m pip install -r requirements.txt
         if errorlevel 1 exit /B
     )
     set SPHINXBUILD=%PYTHON% -c "import sphinx.cmd.build, sys; sys.exit(sphinx.cmd.build.main())"

--- a/Tools/msi/README.txt
+++ b/Tools/msi/README.txt
@@ -528,4 +528,3 @@ explicitly handled by the installer. Python packages installed later
 using a tool like pip will not be removed. Some components may be
 installed by other installers and these will not be removed if another
 product has a dependency on them.
-


### PR DESCRIPTION
gh-149058 made MSI installer tests fail. GHA didn't catch this because MSI-related files weren't changed.

The first commit here should demonstrate the issue.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
