### PR TITLE
gh-149028: Revert gh-92936 changes

### DIFF
--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -25,10 +25,8 @@ The character set, :data:`string.ascii_letters`, :data:`string.digits` and
 in a cookie name (as :attr:`~Morsel.key`).
 
 .. versionchanged:: 3.3
-   Allowed '``:``' as a valid cookie name character.
+   Allowed ':' as a valid cookie name character.
 
-.. versionchanged:: 3.15
-   Allowed '``"``' as a valid cookie value character.
 
 .. note::
 
@@ -313,10 +311,3 @@ The following example demonstrates how to use the :mod:`!http.cookies` module.
    >>> print(C)
    Set-Cookie: number=7
    Set-Cookie: string=seven
-   >>> import json
-   >>> C = cookies.SimpleCookie()
-   >>> C.load(f'cookies=7; mixins="{json.dumps({"chips": "dark chocolate"})}"; state=gooey')
-   >>> print(C)
-   Set-Cookie: cookies=7
-   Set-Cookie: mixins="{"chips": "dark chocolate"}"
-   Set-Cookie: state=gooey

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -938,13 +938,6 @@ http.client
   (Contributed by Alexander Enrique Urieles Nieto in :gh:`131724`.)
 
 
-http.cookies
-------------
-
-* Allow '``"``' double quotes in cookie values.
-  (Contributed by Nick Burns and Senthil Kumaran in :gh:`92936`.)
-
-
 http.server
 -----------
 

--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -462,7 +462,7 @@ _CookiePattern = re.compile(r"""
     (                              # Optional group: there may not be a value.
     \s*=\s*                          # Equal Sign
     (?P<val>                         # Start of group 'val'
-    "(?:\\"|.)*?"                    # Any double-quoted string
+    "(?:[^\\"]|\\.)*"                  # Any double-quoted string
     |                                  # or
     # Special case for "expires" attr
     (\w{3,6}day|\w{3}),\s              # Day of the week or abbreviated day

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -48,29 +48,6 @@ class CookieTests(unittest.TestCase):
                     'Set-Cookie: d=r',
                     'Set-Cookie: f=h'
                 ))
-            },
-
-            # gh-92936: allow double quote in cookie values
-            {
-                'data': 'cookie="{"key": "value"}"',
-                'dict': {'cookie': '{"key": "value"}'},
-                'repr': "<SimpleCookie: cookie='{\"key\": \"value\"}'>",
-                'output': 'Set-Cookie: cookie="{"key": "value"}"',
-            },
-            {
-                'data': 'key="some value; surrounded by quotes"',
-                'dict': {'key': 'some value; surrounded by quotes'},
-                'repr': "<SimpleCookie: key='some value; surrounded by quotes'>",
-                'output': 'Set-Cookie: key="some value; surrounded by quotes"',
-            },
-            {
-                'data': 'session="user123"; preferences="{"theme": "dark"}"',
-                'dict': {'session': 'user123', 'preferences': '{"theme": "dark"}'},
-                'repr': "<SimpleCookie: preferences='{\"theme\": \"dark\"}' session='user123'>",
-                'output': '\n'.join((
-                    'Set-Cookie: preferences="{"theme": "dark"}"',
-                    'Set-Cookie: session="user123"',
-                ))
             }
         ]
 


### PR DESCRIPTION
Revert "gh-92936: allow double quote in cookie values (#113663)"
This reverts commit d7dbde895884d58e3da7ed4107fd33171afad7cb.

Revert "gh-92936: update `http.cookies` docs post GH-113663 (#137566)"
This reverts commit d86c2257a69a8d6c650c0db470499463131a569f.


<!-- gh-issue-number: gh-149028 -->
* Issue: gh-149028
<!-- /gh-issue-number -->
