### PR TITLE
gh-149234:Add limit for 'IPv4address._init_' and 'IPV6address._init_'

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1948,7 +1948,6 @@ class IPv6Address(_BaseV6, _BaseAddress):
             self._scope_id = None
             return
 
-        
         if isinstance(address, bool):
             raise AddressValueError(f"This Value {address} isn't a vaild IPv6 address")
             return

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1283,6 +1283,9 @@ class IPv4Address(_BaseV4, _BaseAddress):
 
         """
         # Efficient constructor from integer.
+        if isinstance(address, bool):
+            raise AddressValueError( f"This Value {address} isn't a valid IPv4 address")
+            return
         if isinstance(address, int):
             self._check_int_address(address)
             self._ip = address
@@ -1943,6 +1946,11 @@ class IPv6Address(_BaseV6, _BaseAddress):
             self._check_packed_address(address, 16)
             self._ip = int.from_bytes(address, 'big')
             self._scope_id = None
+            return
+
+        
+        if isinstance(address, bool):
+            raise AddressValueError(f"This Value {address} isn't a vaild IPv6 address")
             return
 
         # Assume input argument to be string or any object representation

--- a/Misc/NEWS.d/next/图书馆/2026-05-01-15-04-43.gh-issue-149234.OU2urH.rst
+++ b/Misc/NEWS.d/next/图书馆/2026-05-01-15-04-43.gh-issue-149234.OU2urH.rst
@@ -1,0 +1,1 @@
+Fix boolean values silently accepted as IP addresses in :func:`IPv4Address.__init__` and :func:`IPv6Address.__init__`, using an explicit `isinstance(address, bool)` check to raise :exc:`AddressValueError` instead of interpreting `True`/`False` (since `bool` is a subclass of `int`).

--- a/Misc/NEWS.d/next/图书馆/2026-05-01-15-04-43.gh-issue-149234.OU2urH.rst
+++ b/Misc/NEWS.d/next/图书馆/2026-05-01-15-04-43.gh-issue-149234.OU2urH.rst
@@ -1,1 +1,1 @@
-Fix boolean values silently accepted as IP addresses in :func:`IPv4Address.__init__` and :func:`IPv6Address.__init__`, using an explicit `isinstance(address, bool)` check to raise :exc:`AddressValueError` instead of interpreting `True`/`False` (since `bool` is a subclass of `int`).
+Fix boolean values silently accepted as IP addresses in :func:`IPv4Address.__init__` and :func:`IPv6Address.__init__`, using an explicit`isinstance(address, bool)` check to raise :exc:`AddressValueError` instead of interpreting `True`/`False` (since `bool` is a subclass of `int`).


### PR DESCRIPTION
## Limit boolean input in IPv4Address.__init__ and IPv6Address.__init__

Added an explicit `isinstance(address, bool)` check at the beginning of both constructors. Since `bool` is a subclass of `int`, `True` and `False` were previously accepted and silently converted to `0.0.0.1` and `0.0.0.0` (or their IPv6 equivalents). Now an `AddressValueError` is raised immediately, preventing accidental misuse and making the intended type contract explicit.

<!-- gh-issue-number: gh-149234 -->
* Issue: gh-149234
<!-- /gh-issue-number -->
