### PR TITLE
gh-149495: Fix `input` assuming the last character being a '\n'

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -2813,7 +2813,8 @@ class PtyTests(unittest.TestCase):
     def check_input_tty(self, prompt, terminal_input, stdio_encoding=None, *,
                         expected=None,
                         stdin_errors='surrogateescape',
-                        stdout_errors='replace'):
+                        stdout_errors='replace',
+                        terminal_input_end=b'\r\n'):
         if not sys.stdin.isatty() or not sys.stdout.isatty():
             self.skipTest("stdin and stdout must be ttys")
         def child(wpipe):
@@ -2831,7 +2832,7 @@ class PtyTests(unittest.TestCase):
             except BaseException as e:
                 print(ascii(f'{e.__class__.__name__}: {e!s}'), file=wpipe)
         with self.detach_readline():
-            lines = self.run_child(child, terminal_input + b"\r\n")
+            lines = self.run_child(child, terminal_input + terminal_input_end)
         # Check we did exercise the GNU readline path
         self.assertIn(lines[0], {'tty = True', 'tty = False'})
         if lines[0] != 'tty = True':
@@ -2868,6 +2869,9 @@ class PtyTests(unittest.TestCase):
     def test_input_tty(self):
         # Test input() functionality when wired to a tty
         self.check_input_tty("prompt", b"quux")
+
+    def test_input_tty_eof_without_newline(self):
+        self.check_input_tty("prompt", b"quux", terminal_input_end=b"\x04")
 
     def test_input_tty_non_ascii(self):
         # Check stdin/stdout encoding is used when invoking PyOS_Readline()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-02-09-43-45.gh-issue-149237.-dY_PV.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-02-09-43-45.gh-issue-149237.-dY_PV.rst
@@ -1,0 +1,1 @@
+Fix `input` assuming the last character being a '\n' and removing it

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-02-09-43-45.gh-issue-149237.-dY_PV.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-02-09-43-45.gh-issue-149237.-dY_PV.rst
@@ -1,1 +1,1 @@
-Fix `input` assuming the last character being a '\n' and removing it
+Fix :func:`input` assuming the last character being a ``'\n'`` and removing it.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2586,7 +2586,8 @@ builtin_input_impl(PyObject *module, PyObject *prompt)
                 result = NULL;
             }
             else {
-                len--;   /* strip trailing '\n' */
+                if (s[len-1] == '\n')
+                    len--;   /* strip trailing '\n' */
                 if (len != 0 && s[len-1] == '\r')
                     len--;   /* strip trailing '\r' */
                 result = PyUnicode_Decode(s, len, stdin_encoding_str,

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2586,13 +2586,14 @@ builtin_input_impl(PyObject *module, PyObject *prompt)
                 result = NULL;
             }
             else {
-                if (s[len-1] == '\n')
                 /* strip trailing '\n' */
                 if (s[len-1] == '\n') {
                     len--;
                 }
-                if (len != 0 && s[len-1] == '\r')
-                    len--;   /* strip trailing '\r' */
+                /* strip trailing '\r' */
+                if (len != 0 && s[len-1] == '\r') {
+                    len--;
+                }
                 result = PyUnicode_Decode(s, len, stdin_encoding_str,
                                                   stdin_errors_str);
             }

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2587,7 +2587,10 @@ builtin_input_impl(PyObject *module, PyObject *prompt)
             }
             else {
                 if (s[len-1] == '\n')
-                    len--;   /* strip trailing '\n' */
+                /* strip trailing '\n' */
+                if (s[len-1] == '\n') {
+                    len--;
+                }
                 if (len != 0 && s[len-1] == '\r')
                     len--;   /* strip trailing '\r' */
                 result = PyUnicode_Decode(s, len, stdin_encoding_str,


### PR DESCRIPTION
# Fix `input` assuming the last character being a '\n'

When reading from the tty python's builtin `input` function assumes that the last character read is a newline and proceed to strip it out leading to missing input.

Current behaviour:
```
$ ./python -c 'print(repr(input()))'     # press ^D three times to send EOF without a newline
abc'ab'
```

Expected behaviour:
```
$ ./python -c 'print(repr(input()))'
abc'abc'
```

<!-- gh-issue-number: gh-149495 -->
* Issue: gh-149495
<!-- /gh-issue-number -->
