### PR TITLE
statistics: Fix geometric_mean() error message for negative inputs

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -248,7 +248,7 @@ def geometric_mean(data):
             elif x == 0.0:
                 found_zero = True
             else:
-                raise StatisticsError('No negative inputs allowed', x)
+                raise StatisticsError(f'No negative inputs allowed: {x!r}')
 
     total = fsum(map(log, count_positive(data)))
 


### PR DESCRIPTION
`geometric_mean()` raised `StatisticsError` with two positional arguments,
causing `str(e)` to display as a tuple:

    ('No negative inputs allowed', -2.0)

Every other `StatisticsError` in the module uses a single string message.
Replaced with an f-string so the message reads:

    No negative inputs allowed: -2.0