### PR TITLE
Build mpdecimal from source to workaround unreliable launchpad.net

### DIFF
--- a/.github/workflows/posix-deps-apt.sh
+++ b/.github/workflows/posix-deps-apt.sh
@@ -26,9 +26,16 @@ apt-get -yq --no-install-recommends install \
     xvfb \
     zlib1g-dev
 
-# Workaround missing libmpdec-dev on ubuntu 24.04:
-# https://launchpad.net/~ondrej/+archive/ubuntu/php
-# https://deb.sury.org/
-sudo add-apt-repository ppa:ondrej/php
-apt-get update
-apt-get -yq --no-install-recommends install libmpdec-dev
+# Workaround missing libmpdec-dev on ubuntu 24.04 by building mpdecimal
+# from source. ppa:ondrej/php (launchpad.net) are unreliable 
+# (https://status.canonical.com) so fetch the tarball directly
+# from the upstream host.
+# https://www.bytereef.org/mpdecimal/
+MPDECIMAL_VERSION=4.0.1
+curl -fsSL "https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-${MPDECIMAL_VERSION}.tar.gz" \
+    | tar -xz -C /tmp
+(cd "/tmp/mpdecimal-${MPDECIMAL_VERSION}" \
+    && ./configure --prefix=/usr/local \
+    && make -j"$(nproc)" \
+    && make install)
+ldconfig


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Canonical infra is unreliable right now:

* https://status.canonical.com/: "Canonical’s web infrastructure is under a sustained, cross-border attack and we are working to address it. We will provide more information in our official channels as soon as we are able to."
* https://www.theregister.com/2026/05/01/canonical_confirms_ubuntu_infrastructure_under/

This is causing the `libmpdec-dev` install to fail from ppa:ondrej/php and launchpad.net.

Instead, until things stabilise, we can temporarily build from source.
