### PR TITLE
gh-125231: register firefox channels as Mozilla controller

### DIFF
--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -152,13 +152,15 @@ for the controller classes, all defined in this module.
 +------------------------+-----------------------------------------+-------+
 | ``'firefox'``          | ``Mozilla('mozilla')``                  |       |
 +------------------------+-----------------------------------------+-------+
+| ``'firefox-*'``        | ``Mozilla('mozilla')``                  | \(1)  |
++------------------------+-----------------------------------------+-------+
 | ``'epiphany'``         | ``Epiphany('epiphany')``                |       |
 +------------------------+-----------------------------------------+-------+
-| ``'kfmclient'``        | ``Konqueror()``                         | \(1)  |
+| ``'kfmclient'``        | ``Konqueror()``                         | \(2)  |
 +------------------------+-----------------------------------------+-------+
-| ``'konqueror'``        | ``Konqueror()``                         | \(1)  |
+| ``'konqueror'``        | ``Konqueror()``                         | \(2)  |
 +------------------------+-----------------------------------------+-------+
-| ``'kfm'``              | ``Konqueror()``                         | \(1)  |
+| ``'kfm'``              | ``Konqueror()``                         | \(2)  |
 +------------------------+-----------------------------------------+-------+
 | ``'opera'``            | ``Opera()``                             |       |
 +------------------------+-----------------------------------------+-------+
@@ -170,11 +172,11 @@ for the controller classes, all defined in this module.
 +------------------------+-----------------------------------------+-------+
 | ``'w3m'``              | ``GenericBrowser('w3m')``               |       |
 +------------------------+-----------------------------------------+-------+
-| ``'windows-default'``  | ``WindowsDefault``                      | \(2)  |
+| ``'windows-default'``  | ``WindowsDefault``                      | \(3)  |
 +------------------------+-----------------------------------------+-------+
-| ``'macosx'``           | ``MacOSXOSAScript('default')``          | \(3)  |
+| ``'macosx'``           | ``MacOSXOSAScript('default')``          | \(4)  |
 +------------------------+-----------------------------------------+-------+
-| ``'safari'``           | ``MacOSXOSAScript('safari')``           | \(3)  |
+| ``'safari'``           | ``MacOSXOSAScript('safari')``           | \(4)  |
 +------------------------+-----------------------------------------+-------+
 | ``'google-chrome'``    | ``Chrome('google-chrome')``             |       |
 +------------------------+-----------------------------------------+-------+
@@ -184,25 +186,30 @@ for the controller classes, all defined in this module.
 +------------------------+-----------------------------------------+-------+
 | ``'chromium-browser'`` | ``Chromium('chromium-browser')``        |       |
 +------------------------+-----------------------------------------+-------+
-| ``'iosbrowser'``       | ``IOSBrowser``                          | \(4)  |
+| ``'iosbrowser'``       | ``IOSBrowser``                          | \(5)  |
 +------------------------+-----------------------------------------+-------+
+
 
 Notes:
 
 (1)
+   firefox-* are Firefox channels, such as firefox-dev, firefox-aurora,
+   firefox-beta, firefox-nightly, etc.
+
+(2)
    "Konqueror" is the file manager for the KDE desktop environment for Unix, and
    only makes sense to use if KDE is running.  Some way of reliably detecting KDE
    would be nice; the :envvar:`!KDEDIR` variable is not sufficient.  Note also that
    the name "kfm" is used even when using the :program:`konqueror` command with KDE
    2 --- the implementation selects the best strategy for running Konqueror.
 
-(2)
+(3)
    Only on Windows platforms.
 
-(3)
+(4)
    Only on macOS.
 
-(4)
+(5)
    Only on iOS.
 
 .. versionadded:: 3.2
@@ -220,6 +227,11 @@ Notes:
 
 .. versionchanged:: 3.13
    Support for iOS has been added.
+
+.. versionchanged:: 3.15
+   Support for firefox-* has been added, which includes Firefox
+   channels such as firefox-dev, firefox-aurora, firefox-beta,
+   firefox-nightly, etc.
 
 Here are some simple examples::
 

--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -526,6 +526,22 @@ class ImportTest(unittest.TestCase):
             webbrowser = import_helper.import_fresh_module('webbrowser')
             self.assertEqual(webbrowser.get().name, sys.executable)
 
+    @unittest.skipIf(
+        is_apple_mobile,
+        "Apple mobile doesn't allow modifying browser with environment"
+    )
+    def test_environment_firefox_channels_mocked_return_mozilla(self):
+        """Test with mocked shutil.which that firefox channels yield Mozilla controller."""
+        firefox_channels = ["firefox-aurora", "firefox-nightly", "firefox-beta"]
+        for channel in firefox_channels:
+            with self.subTest(channel=channel):
+                with mock.patch("shutil.which") as mock_which:
+                    mock_which.side_effect = lambda exe: exe == channel
+                    with os_helper.EnvironmentVarGuard() as env:
+                        env["BROWSER"] = channel
+                        webbrowser = import_helper.import_fresh_module('webbrowser')
+                        controller = webbrowser.get()
+                        self.assertIsInstance(controller, webbrowser.Mozilla)
 
 @force_not_colorized_test_class
 class CliTest(unittest.TestCase):

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -583,6 +583,10 @@ def register_standard_browsers():
                         _tryorder.insert(0, cmdline.lower())
                         continue
 
+            if cmdline.startswith("firefox-") and shutil.which(cmdline):
+                register(cmdline, None, Mozilla(cmdline), preferred=True)
+                continue
+
             if cmdline != '':
                 cmd = _synthesize(cmdline, preferred=True)
                 if cmd[1] is None:

--- a/Misc/NEWS.d/next/Library/2026-05-03-18-44-17.gh-issue-125231.Orj7KB.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-03-18-44-17.gh-issue-125231.Orj7KB.rst
@@ -1,0 +1,4 @@
+``register_standard_browsers`` in :mod:`webbrowser` registers firefox
+channels (e.g. firefox-dev, firefox-aurora, firefox-beta, firefox-nightly,
+etc.) as Mozilla controllers when BROWSER environment variable is set to
+``"firefox-*"``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
## Summary

Detect if BROWSER starts with `firefox-` and register it as the preferred Mozilla controller.


<!-- gh-issue-number: gh-125231 -->
* Issue: gh-125231
<!-- /gh-issue-number -->
