### PR TITLE
gh-149259: Fix median_grouped() exception chaining and error messages

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -453,9 +453,16 @@ def median_grouped(data, interval=1.0):
     # Coerce to floats, raising a TypeError if not possible
     try:
         interval = float(interval)
+    except ValueError as exc:
+        raise TypeError(
+            f'interval must be a real number, got {interval!r}'
+        ) from exc
+    try:
         x = float(x)
-    except ValueError:
-        raise TypeError(f'Value cannot be converted to a float')
+    except ValueError as exc:
+        raise TypeError(
+            f'data sequence must contain real numbers, found {x!r}'
+        ) from exc
 
     # Interpolate the median using the formula found at:
     # https://www.cuemath.com/data/median-of-grouped-data/

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -1799,6 +1799,25 @@ class TestMedianGrouped(TestMedian):
         interval = b""
         self.assertRaises(TypeError, self.func, data, interval)
 
+    def test_exception_chaining_and_messages(self):
+        # TypeError raised for bad interval should chain the original ValueError
+        # and identify the problematic parameter.
+        data = [1, 2, 3]
+        with self.assertRaises(TypeError) as cm:
+            self.func(data, interval="bad")
+        exc = cm.exception
+        self.assertIsInstance(exc.__cause__, ValueError)
+        self.assertIn("interval", str(exc))
+
+        # TypeError raised for non-numeric data should chain the original ValueError
+        # and identify that the data is the problem.
+        data = ["a", "b", "c"]
+        with self.assertRaises(TypeError) as cm:
+            self.func(data)
+        exc = cm.exception
+        self.assertIsInstance(exc.__cause__, ValueError)
+        self.assertIn("data", str(exc))
+
 
 class TestMode(NumericTestCase, AverageMixin, UnivariateTypeMixin):
     # Test cases for the discrete version of mode.

--- a/Misc/NEWS.d/next/Library/2026-05-02-11-32-35.gh-issue-149259.rJ6MXk.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-02-11-32-35.gh-issue-149259.rJ6MXk.rst
@@ -1,0 +1,3 @@
+Fix :func:`statistics.median_grouped` to chain the original :exc:`ValueError`
+when coercing *interval* or the median data value to ``float`` fails, and
+improve the error message to identify which parameter caused the failure.


### PR DESCRIPTION
Closes #149259.

`median_grouped()` placed both float conversions in a single `try` block
with no `from exc` chaining, so the original `ValueError` was silently
discarded and the message gave no clue which argument failed.

- Split into two `try` blocks so `interval` and data failures are
  reported separately.
- Add `from exc` so the original `ValueError` appears in tracebacks.
- Improve messages: `interval must be a real number, got 'bad'` vs
  `data sequence must contain real numbers, found 'b'`.

No behaviour change for callers (still `TypeError` in the same cases).
A new test `test_exception_chaining_and_messages` verifies the chain
and message content.

<!-- gh-issue-number: gh-149259 -->
* Issue: gh-149259
<!-- /gh-issue-number -->
