### PR TITLE
[3.14] gh-149254: Update macOS installer to use OpenSSL 3.0.20.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -246,9 +246,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 3.0.19",
-              url="https://github.com/openssl/openssl/releases/download/openssl-3.0.19/openssl-3.0.19.tar.gz",
-              checksum='fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072',
+              name="OpenSSL 3.0.20",
+              url="https://github.com/openssl/openssl/releases/download/openssl-3.0.20/openssl-3.0.20.tar.gz",
+              checksum='c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2026-05-01-19-38-16.gh-issue-149254.enO7uj.rst
+++ b/Misc/NEWS.d/next/macOS/2026-05-01-19-38-16.gh-issue-149254.enO7uj.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use OpenSSL 3.0.20.


### PR DESCRIPTION


<!-- gh-issue-number: gh-149254 -->
* Issue: gh-149254
<!-- /gh-issue-number -->
