### PR TITLE
gh-149267: Document ast.Constant.kind attribute

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -279,7 +279,7 @@ Literals
    and the constants :data:`None` and :data:`Ellipsis`.
 
    The ``kind`` attribute is an optional string. For string literals with a
-   ``u`` prefix (e.g. ``u'hello'``), ``kind`` is set to ``'u'``. For all other
+   ``u`` prefix, ``kind`` is set to ``'u'``. For all other
    constants, ``kind`` is ``None``.
 
    .. doctest::

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -271,18 +271,25 @@ Root nodes
 Literals
 ^^^^^^^^
 
-.. class:: Constant(value)
+.. class:: Constant(value, kind)
 
    A constant value. The ``value`` attribute of the ``Constant`` literal contains the
    Python object it represents. The values represented can be instances of :class:`str`,
    :class:`bytes`, :class:`int`, :class:`float`, :class:`complex`, and :class:`bool`,
    and the constants :data:`None` and :data:`Ellipsis`.
 
+   The ``kind`` attribute is an optional string. For string literals with a
+   ``u`` prefix (e.g. ``u'hello'``), ``kind`` is set to ``'u'``. For all other
+   constants, ``kind`` is ``None``.
+
    .. doctest::
 
         >>> print(ast.dump(ast.parse('123', mode='eval'), indent=4))
         Expression(
             body=Constant(value=123))
+        >>> print(ast.dump(ast.parse("u'hello'", mode='eval'), indent=4))
+        Expression(
+            body=Constant(value='hello', kind='u'))
 
 
 .. class:: FormattedValue(value, conversion, format_spec)


### PR DESCRIPTION
## Summary

- Add `kind` to the `Constant` class signature in `Doc/library/ast.rst`
- Document that `kind` is `'u'` for `u`-prefixed string literals and `None` for all other constants
- Add a doctest showing the `kind='u'` output

Fixes #149267

CC- @JelleZijlstra 

<!-- gh-issue-number: gh-149267 -->
* Issue: gh-149267
<!-- /gh-issue-number -->
