### PR TITLE
gh-149113: Add option to copy back data from Android testbed emulator to build machine

### DIFF
--- a/Misc/NEWS.d/next/Tests/2026-05-02-10-19-13.gh-issue-149113.wwDoqp.rst
+++ b/Misc/NEWS.d/next/Tests/2026-05-02-10-19-13.gh-issue-149113.wwDoqp.rst
@@ -1,0 +1,1 @@
+The Android testbed can now copy files back from the emulator to the build machine.

--- a/Platforms/Android/README.md
+++ b/Platforms/Android/README.md
@@ -161,6 +161,10 @@ configuring the execution of a third-party test suite:
   directory.
 * `--site-packages`: the directory to copy into the testbed app to use as site
   packages.
+* `--pull`: if specified, the testbed app will pull the file or folder from the device
+  back to the build machine after the test run. This is useful for retrieving coverage
+  data, for example. Can be used multiple times.
+* `--output-dir`: the directory on the build machine to which files will be pulled.
 
 Extra arguments on the `android.py test` command line will be passed through to
 Python – use `--` to separate them from `android.py`'s own options. You must include

--- a/Platforms/Android/README.md
+++ b/Platforms/Android/README.md
@@ -163,7 +163,8 @@ configuring the execution of a third-party test suite:
   packages.
 * `--pull`: if specified, the testbed app will pull the file or folder from the device
   back to the build machine after the test run. This is useful for retrieving coverage
-  data, for example. Can be used multiple times.
+  data, for example. Can be used multiple times. On managed devices this is supported
+  since Android API level 29, so only `--managed maxVersion` can be used.
 * `--output-dir`: the directory on the build machine to which files will be pulled.
 
 Extra arguments on the `android.py test` command line will be passed through to

--- a/Platforms/Android/__main__.py
+++ b/Platforms/Android/__main__.py
@@ -12,6 +12,7 @@ import signal
 import subprocess
 import sys
 import sysconfig
+import zipfile
 from asyncio import wait_for
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -629,6 +630,14 @@ def stop_app(serial):
     run([adb, "-s", serial, "shell", "am", "force-stop", APP_ID], log=False)
 
 
+def _extract_output_archives(output_dir):
+    """Extract all zip archives written by PythonSuite.kt and delete them."""
+    for zip_path in Path(output_dir).glob("*.zip"):
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(output_dir)
+        zip_path.unlink()
+
+
 async def gradle_task(context):
     env = os.environ.copy()
     if context.managed:
@@ -664,8 +673,16 @@ async def gradle_task(context):
             ("python.sitePackages", context.site_packages),
             ("python.cwd", context.cwd),
             (
+                "python.outputDir",
+                context.output_dir
+            ),
+            (
                 "android.testInstrumentationRunnerArguments.pythonArgs",
                 json.dumps(context.args),
+            ),
+            (
+                "android.testInstrumentationRunnerArguments.pythonPull",
+                json.dumps(context.pull) if context.pull else None,
             ),
         ]
         if value
@@ -689,6 +706,8 @@ async def gradle_task(context):
 
             status = await wait_for(process.wait(), timeout=1)
             if status == 0:
+                if context.pull and context.output_dir:
+                    _extract_output_archives(Path(context.output_dir))
                 exit(0)
             else:
                 raise CalledProcessError(status, args)
@@ -699,6 +718,9 @@ async def gradle_task(context):
 
 
 async def run_testbed(context):
+    if context.pull and not context.output_dir:
+        sys.exit("--output-dir is required when --pull is used.")
+
     setup_ci()
     setup_sdk()
     setup_testbed()
@@ -969,6 +991,15 @@ def parse_args():
     test.add_argument(
         "--cwd", metavar="DIR", type=abspath,
         help="Directory to copy as the app's working directory.")
+    test.add_argument(
+        "--pull", metavar="PATH", action="append", default=[],
+        help="File or directory to copy from the app's working directory back "
+        "to the host after the test run. Paths are relative to --cwd on the "
+        "device. May be given multiple times.")
+    test.add_argument(
+        "--output-dir", metavar="DIR", type=abspath,
+        help="Local directory to write files pulled via --pull. "
+        "Required when --pull is used.")
     test.add_argument(
         "args", nargs="*", help=f"Python command-line arguments. "
         f"Separate them from {SCRIPT_NAME}'s own arguments with `--`. "

--- a/Platforms/Android/testbed/app/build.gradle.kts
+++ b/Platforms/Android/testbed/app/build.gradle.kts
@@ -180,12 +180,18 @@ android {
                 }
             }
 
-            // If the previous test run succeeded and nothing has changed,
-            // Gradle thinks there's no need to run it again. Override that.
             afterEvaluate {
-                (localDevices.names + listOf("connected")).forEach {
-                    tasks.named("${it}DebugAndroidTest") {
+                (localDevices.names + listOf("connected")).forEach { deviceName ->
+                    val copyOutputTask = createCopyOutputTask(deviceName)
+                    tasks.named("${deviceName}DebugAndroidTest") {
+                        // If the previous test run succeeded and nothing has changed,
+                        // Gradle thinks there's no need to run it again. Override that.
                         outputs.upToDateWhen { false }
+
+                        // If python.outputDir is set, copy all files that are pulled
+                        // from the emulator to the host by the UTP to the given output
+                        // directory on the host.
+                        copyOutputTask?.let { finalizedBy(it) }
                     }
                 }
             }
@@ -330,6 +336,43 @@ abstract class CreateEmulatorTask : DefaultTask() {
         execOps.exec {
             commandLine(command)
         }
+    }
+}
+
+
+fun createCopyOutputTask(deviceName: String): TaskProvider<Copy>? {
+    val outputDir = findProperty("python.outputDir") as String?
+    if (outputDir.isNullOrEmpty()) return null
+
+    val additionalOutputPath = if (deviceName == "connected") {
+        "outputs/connected_android_test_additional_output"
+    } else {
+        "outputs/managed_device_android_test_additional_output"
+    }
+
+    // PythonSuite.kt packs all output files into a single zip archive,
+    // to avoid issues because the UTP copy skips dotfiles like ".coverage".
+    val archiveName = "org.python.testbed-output.zip"
+
+    return tasks.register<Copy>("${deviceName}CopyTestOutput") {
+        from(layout.buildDirectory.dir(additionalOutputPath))
+        // The subfolders of `connected_android_test_additional_output` contains
+        // names that are not equal to the serial of the device.
+        // The subfolders of `managed_device_android_test_additional_output` are
+        // also unpredictable, because e.g. the subfolder for the "maxVersion" emulator
+        // is named "minVersion".
+        // So we can't rely on the subfolder names and search for the archive in
+        // all subfolders. The archive should be in exactly one of the subfolders.
+        include("**/$archiveName")
+        into(outputDir)
+        // Flatten: drop any device-subfolder prefix, put the zip
+        // directly in outputDir.
+        eachFile { path = name }
+        includeEmptyDirs = false
+        // Each android.py invocation runs only one device at a time,
+        // so there should never be more than one archive. Fail loudly
+        // if that assumption is violated.
+        duplicatesStrategy = DuplicatesStrategy.FAIL
     }
 }
 

--- a/Platforms/Android/testbed/app/build.gradle.kts
+++ b/Platforms/Android/testbed/app/build.gradle.kts
@@ -179,22 +179,6 @@ android {
                     systemImageSource = "aosp_atd"
                 }
             }
-
-            afterEvaluate {
-                (localDevices.names + listOf("connected")).forEach { deviceName ->
-                    val copyOutputTask = createCopyOutputTask(deviceName)
-                    tasks.named("${deviceName}DebugAndroidTest") {
-                        // If the previous test run succeeded and nothing has changed,
-                        // Gradle thinks there's no need to run it again. Override that.
-                        outputs.upToDateWhen { false }
-
-                        // If python.outputDir is set, copy all files that are pulled
-                        // from the emulator to the host by the UTP to the given output
-                        // directory on the host.
-                        copyOutputTask?.let { finalizedBy(it) }
-                    }
-                }
-            }
         }
     }
 }
@@ -230,6 +214,20 @@ afterEvaluate {
         }
         tasks.named("${device.name}Setup") {
             dependsOn(createTask)
+        }
+    }
+
+    for (deviceName in android.testOptions.managedDevices.localDevices.names + listOf("connected")) {
+        val copyOutputTask = createCopyOutputTask(deviceName)
+        tasks.named("${deviceName}DebugAndroidTest") {
+            // If the previous test run succeeded and nothing has changed,
+            // Gradle thinks there's no need to run it again. Override that.
+            outputs.upToDateWhen { false }
+
+            // If python.outputDir is set, copy all files that are pulled
+            // from the emulator to the host by the UTP to the given output
+            // directory on the host.
+            copyOutputTask?.let { finalizedBy(it) }
         }
     }
 }

--- a/Platforms/Android/testbed/app/build.gradle.kts
+++ b/Platforms/Android/testbed/app/build.gradle.kts
@@ -349,7 +349,7 @@ fun createCopyOutputTask(deviceName: String): TaskProvider<Copy>? {
     }
 
     // PythonSuite.kt packs all output files into a single zip archive,
-    // to avoid issues because the UTP copy skips dotfiles like ".coverage".
+    // to avoid issues because the test runner skips dotfiles like ".coverage".
     val archiveName = "org.python.testbed-output.zip"
 
     return tasks.register<Copy>("${deviceName}CopyTestOutput") {

--- a/Platforms/Android/testbed/app/build.gradle.kts
+++ b/Platforms/Android/testbed/app/build.gradle.kts
@@ -346,10 +346,24 @@ fun createOutputTasks(deviceName: String): Pair<TaskProvider<Delete>, TaskProvid
     val outputDir = findProperty("python.outputDir") as String?
     if (outputDir.isNullOrEmpty()) return null
 
-    val additionalOutputPath = if (deviceName == "connected") {
-        "outputs/connected_android_test_additional_output"
+    val additionalOutputPaths = if (deviceName == "connected") {
+        // The output folder for connected devices is a folder like:
+        //    outputs/connected_android_test_additional_output/debugAndroidTest/connected/SM-S911B - 13/
+        listOf("outputs/connected_android_test_additional_output")
     } else {
-        "outputs/managed_device_android_test_additional_output"
+        // The output folder for the additional output of managed devices is unreliable.
+        // When using a `maxVersion` managed device, a subfolder named `minVersion` is
+        // created:
+        //    outputs/managed_device_android_test_additional_output/debug/minVersion
+        // And when changing the `minVersion` managed device to a API level >= 29 (or
+        // adding a new managed device), there is no subfolder created under `outputs`
+        // at all. Then the output is in `intermediates`:
+        //    intermediates/managed_device_android_test_additional_output/debugAndroidTest/minVersionDebugAndroidTest
+        // So to be reliable, we check both folders.
+        listOf(
+            "outputs/managed_device_android_test_additional_output",
+            "intermediates/managed_device_android_test_additional_output",
+        )
     }
 
     // PythonSuite.kt packs all output files into a single zip archive,
@@ -359,45 +373,48 @@ fun createOutputTasks(deviceName: String): Pair<TaskProvider<Delete>, TaskProvid
     // Delete any output from a previous run before the test starts, to avoid
     // picking up stale archives.
     val deleteTask = tasks.register<Delete>("${deviceName}DeleteTestOutput") {
-        delete(layout.buildDirectory.dir(additionalOutputPath))
+        for (path in additionalOutputPaths) {
+            delete(layout.buildDirectory.dir(path))
+        }        
         outputs.upToDateWhen { false }
     }
 
     val copyTask = tasks.register("${deviceName}CopyTestOutput") {
         outputs.upToDateWhen { false }
         doLast {
-            // The subfolders of `connected_android_test_additional_output` contains
-            // names that are not equal to the serial of the device.
-            // The subfolders of `managed_device_android_test_additional_output` are
-            // also unpredictable, because e.g. the subfolder for the "maxVersion" emulator
-            // is named "minVersion".
-            // So we can't rely on the subfolder names and search for the archive in
-            // all subfolders. The archive should be in exactly one of the subfolders.
-            project.copy {
-                from(layout.buildDirectory.dir(additionalOutputPath))
-                include("**/$archiveName")
-                into(outputDir)
-                // Flatten: drop any device-subfolder prefix, put the zip
-                // directly in outputDir.
-                eachFile { path = name }
-                includeEmptyDirs = false
-                // Each android.py invocation runs only one device at a time,
-                // so there should never be more than one archive. Fail loudly
-                // if that assumption is violated.
-                duplicatesStrategy = DuplicatesStrategy.FAIL
-            }
-            if (!file("$outputDir/$archiveName").exists()) {
-                val message = StringBuilder(
-                    "$archiveName was not found in " +
-                    layout.buildDirectory.dir(additionalOutputPath).get()
-                )
-                if (deviceName != "connected") {
-                    message.append(
-                        ". On managed devices, additionalTestOutput requires API level >= 29"
-                    )
+            for (path in additionalOutputPaths) {
+                project.copy {
+                    from(layout.buildDirectory.dir(path))
+                    // We dont know the exact path where the archive will be. So
+                    // we use a glob pattern to find it. This is safe because we
+                    // have cleaned up all old files before.
+                    include("**/$archiveName")
+                    into(outputDir)
+                    // Flatten: drop any device-subfolder prefix, put the zip
+                    // directly in outputDir.
+                    eachFile { this.path = name }
+                    includeEmptyDirs = false
+                    // Each android.py invocation runs only one device at a time,
+                    // so there should never be more than one archive. Fail loudly
+                    // if that assumption is violated.
+                    duplicatesStrategy = DuplicatesStrategy.FAIL
                 }
-                throw GradleException(message.toString())
+                if (file("$outputDir/$archiveName").exists()) {
+                    return@doLast
+                }
             }
+            val message = StringBuilder(
+                "$archiveName was not found in " +
+                additionalOutputPaths.joinToString(" or ") {
+                    layout.buildDirectory.dir(it).get().toString()
+                }
+            )
+            if (deviceName != "connected") {
+                message.append(
+                    ". On managed devices, additionalTestOutput requires API level >= 29"
+                )
+            }
+            throw GradleException(message.toString())
         }
     }
 

--- a/Platforms/Android/testbed/app/build.gradle.kts
+++ b/Platforms/Android/testbed/app/build.gradle.kts
@@ -218,16 +218,20 @@ afterEvaluate {
     }
 
     for (deviceName in android.testOptions.managedDevices.localDevices.names + listOf("connected")) {
-        val copyOutputTask = createCopyOutputTask(deviceName)
+        val outputTasks = createOutputTasks(deviceName)
         tasks.named("${deviceName}DebugAndroidTest") {
             // If the previous test run succeeded and nothing has changed,
             // Gradle thinks there's no need to run it again. Override that.
             outputs.upToDateWhen { false }
 
             // If python.outputDir is set, copy all files that are pulled
-            // from the emulator to the host by the UTP to the given output
-            // directory on the host.
-            copyOutputTask?.let { finalizedBy(it) }
+            // from the emulator to the host by the test runner to the given
+            // output directory on the host.
+            if (outputTasks != null) {
+                val (deleteTask, copyTask) = outputTasks
+                dependsOn(deleteTask)
+                finalizedBy(copyTask)
+            }
         }
     }
 }
@@ -338,7 +342,7 @@ abstract class CreateEmulatorTask : DefaultTask() {
 }
 
 
-fun createCopyOutputTask(deviceName: String): TaskProvider<Copy>? {
+fun createOutputTasks(deviceName: String): Pair<TaskProvider<Delete>, TaskProvider<Task>>? {
     val outputDir = findProperty("python.outputDir") as String?
     if (outputDir.isNullOrEmpty()) return null
 
@@ -352,26 +356,52 @@ fun createCopyOutputTask(deviceName: String): TaskProvider<Copy>? {
     // to avoid issues because the test runner skips dotfiles like ".coverage".
     val archiveName = "org.python.testbed-output.zip"
 
-    return tasks.register<Copy>("${deviceName}CopyTestOutput") {
-        from(layout.buildDirectory.dir(additionalOutputPath))
-        // The subfolders of `connected_android_test_additional_output` contains
-        // names that are not equal to the serial of the device.
-        // The subfolders of `managed_device_android_test_additional_output` are
-        // also unpredictable, because e.g. the subfolder for the "maxVersion" emulator
-        // is named "minVersion".
-        // So we can't rely on the subfolder names and search for the archive in
-        // all subfolders. The archive should be in exactly one of the subfolders.
-        include("**/$archiveName")
-        into(outputDir)
-        // Flatten: drop any device-subfolder prefix, put the zip
-        // directly in outputDir.
-        eachFile { path = name }
-        includeEmptyDirs = false
-        // Each android.py invocation runs only one device at a time,
-        // so there should never be more than one archive. Fail loudly
-        // if that assumption is violated.
-        duplicatesStrategy = DuplicatesStrategy.FAIL
+    // Delete any output from a previous run before the test starts, to avoid
+    // picking up stale archives.
+    val deleteTask = tasks.register<Delete>("${deviceName}DeleteTestOutput") {
+        delete(layout.buildDirectory.dir(additionalOutputPath))
+        outputs.upToDateWhen { false }
     }
+
+    val copyTask = tasks.register("${deviceName}CopyTestOutput") {
+        outputs.upToDateWhen { false }
+        doLast {
+            // The subfolders of `connected_android_test_additional_output` contains
+            // names that are not equal to the serial of the device.
+            // The subfolders of `managed_device_android_test_additional_output` are
+            // also unpredictable, because e.g. the subfolder for the "maxVersion" emulator
+            // is named "minVersion".
+            // So we can't rely on the subfolder names and search for the archive in
+            // all subfolders. The archive should be in exactly one of the subfolders.
+            project.copy {
+                from(layout.buildDirectory.dir(additionalOutputPath))
+                include("**/$archiveName")
+                into(outputDir)
+                // Flatten: drop any device-subfolder prefix, put the zip
+                // directly in outputDir.
+                eachFile { path = name }
+                includeEmptyDirs = false
+                // Each android.py invocation runs only one device at a time,
+                // so there should never be more than one archive. Fail loudly
+                // if that assumption is violated.
+                duplicatesStrategy = DuplicatesStrategy.FAIL
+            }
+            if (!file("$outputDir/$archiveName").exists()) {
+                val message = StringBuilder(
+                    "$archiveName was not found in " +
+                    layout.buildDirectory.dir(additionalOutputPath).get()
+                )
+                if (deviceName != "connected") {
+                    message.append(
+                        ". On managed devices, additionalTestOutput requires API level >= 29"
+                    )
+                }
+                throw GradleException(message.toString())
+            }
+        }
+    }
+
+    return Pair(deleteTask, copyTask)
 }
 
 

--- a/Platforms/Android/testbed/app/src/androidTest/java/org/python/testbed/PythonSuite.kt
+++ b/Platforms/Android/testbed/app/src/androidTest/java/org/python/testbed/PythonSuite.kt
@@ -1,13 +1,18 @@
 package org.python.testbed
 
+import android.content.Context
+import android.os.Bundle
 import androidx.test.annotation.UiThreadTest
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.json.JSONArray
 
 import org.junit.Test
 import org.junit.runner.RunWith
 
 import org.junit.Assert.*
+
+import java.io.File
 
 
 @RunWith(AndroidJUnit4::class)
@@ -15,21 +20,74 @@ class PythonSuite {
     @Test
     @UiThreadTest
     fun testPython() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val args = InstrumentationRegistry.getArguments()
         val start = System.currentTimeMillis()
         try {
-            val status = PythonTestRunner(
-                InstrumentationRegistry.getInstrumentation().targetContext
-            ).run(
-                InstrumentationRegistry.getArguments().getString("pythonArgs")!!,
+            val status = PythonTestRunner(instrumentation.targetContext).run(
+                args.getString("pythonArgs")!!,
             )
             assertEquals(0, status)
         } finally {
+            // Copy files requested via --pull to the directory that AGP/UTP
+            // injected as `additionalTestOutputDir`. AGP will pull everything
+            // written there back to the host before shutting down the emulator.
+            copyOutputFiles(instrumentation.targetContext, args)
+
             // Make sure the process lives long enough for the test script to
             // detect it (see `find_pid` in android.py).
             val delay = 2000 - (System.currentTimeMillis() - start)
             if (delay > 0) {
                 Thread.sleep(delay)
             }
+        }
+    }
+
+    private fun copyOutputFiles(context: Context, args: Bundle) {
+        // A list of file paths (relative to the Python working directory) that should be
+        // copied back to the host after the test finishes.
+        val pullPathsJson = args.getString("pythonPull") ?: return
+
+        // The output directory is created by AGP/UTP and points to a location inside
+        // the emulator's filesystem. AGP/UTP will pull everything from there back
+        // to the host after the test finishes.
+        val outputDir = args.getString("additionalTestOutputDir") ?: return
+
+        // Pack all files into a single zip archive to avoid issues because the UTP copy
+        // skips dotfiles like ".coverage".
+        val archiveFile = File(outputDir, "org.python.testbed-output.zip")
+        val srcBase = File(context.filesDir, "python/cwd")
+        val paths = JSONArray(pullPathsJson)
+        java.util.zip.ZipOutputStream(archiveFile.outputStream().buffered()).use { zip ->
+            for (i in 0 until paths.length()) {
+                val src = File(srcBase, paths.getString(i))
+                if (!src.exists()) {
+                    android.util.Log.w("python.stderr", "Pull path not found: $src\n")
+                    continue
+                }
+                try {
+                    addToZip(zip, src, src.name)
+                } catch (e: Exception) {
+                    android.util.Log.e("python.stderr", "Failed to zip $src: $e\n")
+                }
+            }
+        }
+        android.util.Log.i("python.stdout", "Created output archive: $archiveFile\n")
+    }
+
+    private fun addToZip(
+        zip: java.util.zip.ZipOutputStream,
+        file: File,
+        entryName: String,
+    ) {
+        if (file.isDirectory) {
+            for (child in file.listFiles() ?: emptyArray()) {
+                addToZip(zip, child, "$entryName/${child.name}")
+            }
+        } else {
+            zip.putNextEntry(java.util.zip.ZipEntry(entryName))
+            file.inputStream().use { it.copyTo(zip) }
+            zip.closeEntry()
         }
     }
 }

--- a/Platforms/Android/testbed/app/src/androidTest/java/org/python/testbed/PythonSuite.kt
+++ b/Platforms/Android/testbed/app/src/androidTest/java/org/python/testbed/PythonSuite.kt
@@ -29,7 +29,7 @@ class PythonSuite {
             )
             assertEquals(0, status)
         } finally {
-            // Copy files requested via --pull to the directory that AGP/UTP
+            // Copy files requested via --pull to the directory that AGP
             // injected as `additionalTestOutputDir`. AGP will pull everything
             // written there back to the host before shutting down the emulator.
             copyOutputFiles(instrumentation.targetContext, args)
@@ -48,13 +48,13 @@ class PythonSuite {
         // copied back to the host after the test finishes.
         val pullPathsJson = args.getString("pythonPull") ?: return
 
-        // The output directory is created by AGP/UTP and points to a location inside
-        // the emulator's filesystem. AGP/UTP will pull everything from there back
+        // The output directory is created by AGP and points to a location inside
+        // the emulator's filesystem. AGP will pull everything from there back
         // to the host after the test finishes.
         val outputDir = args.getString("additionalTestOutputDir") ?: return
 
-        // Pack all files into a single zip archive to avoid issues because the UTP copy
-        // skips dotfiles like ".coverage".
+        // Pack all files into a single zip archive to avoid issues because AGP
+        // skips dotfiles like ".coverage" when pulling files from the emulator.
         val archiveFile = File(outputDir, "org.python.testbed-output.zip")
         val srcBase = File(context.filesDir, "python/cwd")
         val paths = JSONArray(pullPathsJson)

--- a/Platforms/Android/testbed/app/src/main/java/org/python/testbed/MainActivity.kt
+++ b/Platforms/Android/testbed/app/src/main/java/org/python/testbed/MainActivity.kt
@@ -31,7 +31,7 @@ class PythonTestRunner(val context: Context) {
         // We leave argument 0 as an empty string, which is a placeholder for the
         // executable name in embedded mode.
         val argsJsonArray = JSONArray(args)
-        val argsStringArray = Array<String>(argsJsonArray.length() + 1) { it -> ""}
+        val argsStringArray = Array<String>(argsJsonArray.length() + 1) { _ -> ""}
         for (i in 0..<argsJsonArray.length()) {
             argsStringArray[i + 1] = argsJsonArray.getString(i)
         }


### PR DESCRIPTION
Fixes https://github.com/python/cpython/issues/149113

---

To test this I used

```
python3 Platforms/Android test --managed maxVersion --pull hello.txt --pull .coverage --output-dir output -v -- -c "open('hello.txt','w').write('Hello World'); open('.coverage','w').write('SOME COVERAGE DATA')"
```

Then the output folder should contain the files `hello.txt` and `.coverage`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149113 -->
* Issue: gh-149113
<!-- /gh-issue-number -->
