### PR TITLE
gh-117961: Fix matmul grammar in expression docs

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1567,7 +1567,7 @@ from the power operator, there are only two levels, one for multiplicative
 operators and one for additive operators:
 
 .. productionlist:: python-grammar
-   m_expr: `u_expr` | `m_expr` "*" `u_expr` | `m_expr` "@" `m_expr` |
+   m_expr: `u_expr` | `m_expr` "*" `u_expr` | `m_expr` "@" `u_expr` |
          : `m_expr` "//" `u_expr` | `m_expr` "/" `u_expr` |
          : `m_expr` "%" `u_expr`
    a_expr: `m_expr` | `a_expr` "+" `m_expr` | `a_expr` "-" `m_expr`

--- a/Lib/pydoc_data/topics.py
+++ b/Lib/pydoc_data/topics.py
@@ -1022,7 +1022,7 @@ numeric types.  Apart from the power operator, there are only two
 levels, one for multiplicative operators and one for additive
 operators:
 
-   m_expr: u_expr | m_expr "*" u_expr | m_expr "@" m_expr |
+   m_expr: u_expr | m_expr "*" u_expr | m_expr "@" u_expr |
            m_expr "//" u_expr | m_expr "/" u_expr |
            m_expr "%" u_expr
    a_expr: m_expr | a_expr "+" m_expr | a_expr "-" m_expr


### PR DESCRIPTION
Update the documented grammar for the `@` operator so that it matches the associativity specified in PEP 465.

The current documentation shows `m_expr "@" m_expr`, which makes the associativity unclear. Since `@` should parse like `*`, the right-hand side should be `u_expr`.

<!-- gh-issue-number: gh-117961 -->
* Issue: gh-117961
<!-- /gh-issue-number -->
