### PR TITLE
gh-149282: Fix `gc.c` compilation with `--enable-pystats`

### DIFF
--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1454,10 +1454,14 @@ gc_collect_main(PyThreadState *tstate, int generation, _PyGC_Reason reason)
     assert(generation >= 0 && generation < NUM_GENERATIONS);
 
 #ifdef Py_STATS
-    if (_Py_stats) {
-        _Py_stats->object_stats.object_visits = 0;
+    {
+        PyStats *s = _PyStats_GET();
+        if (s) {
+            s->object_stats.object_visits = 0;
+        }
     }
 #endif
+
     GC_STAT_ADD(generation, collections, 1);
 
     struct gc_generation_stats stats = { 0 };
@@ -1615,12 +1619,16 @@ gc_collect_main(PyThreadState *tstate, int generation, _PyGC_Reason reason)
 
     /* Update stats */
     add_stats(gcstate, generation, &stats);
-    GC_STAT_ADD(generation, objects_collected, m);
+    GC_STAT_ADD(generation, objects_collected, stats.collected);
+
 #ifdef Py_STATS
-    if (_Py_stats) {
-        GC_STAT_ADD(generation, object_visits,
-            _Py_stats->object_stats.object_visits);
-        _Py_stats->object_stats.object_visits = 0;
+    {
+        PyStats *s = _PyStats_GET();
+        if (s) {
+            GC_STAT_ADD(generation, object_visits,
+                s->object_stats.object_visits);
+            s->object_stats.object_visits = 0;
+        }
     }
 #endif
 


### PR DESCRIPTION
Skip news, since it was not released yet.

I might be wrong, but I think that there are no tests for this.

<!-- gh-issue-number: gh-149282 -->
* Issue: gh-149282
<!-- /gh-issue-number -->
