### PR TITLE
gh-149285: Increase recursion depth for `test_xml_etree` from 150k to 500k

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -3197,7 +3197,7 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
         # This should raise a RecursionError and not crash.
         # See https://github.com/python/cpython/issues/148801.
         root = cur = ET.Element('s')
-        for _ in range(150_000):
+        for _ in range(500_000):
             cur = ET.SubElement(cur, 'u')
         with support.infinite_recursion():
             with self.assertRaises(RecursionError):


### PR DESCRIPTION
<!-- gh-issue-number: gh-149285 -->
* Issue: gh-149285
<!-- /gh-issue-number -->

The same ideas as https://github.com/python/cpython/pull/142226