### PR TITLE
gh-143158: Hot cold code splitting for JIT compiler

### DIFF
--- a/Python/jit.c
+++ b/Python/jit.c
@@ -645,20 +645,23 @@ _PyJIT_Compile(_PyExecutorObject *executor, const _PyUOpInstruction trace[], siz
 {
     const StencilGroup *group;
     // Loop once to find the total compiled size:
-    size_t code_size = 0;
+    size_t hot_code_size = 0;
+    size_t cold_code_size = 0;
     size_t data_size = 0;
     jit_state state = {0};
     for (size_t i = 0; i < length; i++) {
         const _PyUOpInstruction *instruction = &trace[i];
         group = &stencil_groups[instruction->opcode];
-        state.instruction_starts[i] = code_size;
-        code_size += group->code_size;
+        state.instruction_starts[i] = hot_code_size;
+        hot_code_size += group->hot_code_size;
+        cold_code_size += group->cold_code_size;
         data_size += group->data_size;
         combine_symbol_mask(group->trampoline_mask, state.trampolines.mask);
         combine_symbol_mask(group->got_mask, state.got_symbols.mask);
     }
     group = &stencil_groups[_FATAL_ERROR_r00];
-    code_size += group->code_size;
+    hot_code_size += group->hot_code_size;
+    cold_code_size += group->cold_code_size;
     data_size += group->data_size;
     combine_symbol_mask(group->trampoline_mask, state.trampolines.mask);
     combine_symbol_mask(group->got_mask, state.got_symbols.mask);
@@ -672,6 +675,7 @@ _PyJIT_Compile(_PyExecutorObject *executor, const _PyUOpInstruction trace[], siz
     // Round up to the nearest page:
     size_t page_size = get_page_size();
     assert((page_size & (page_size - 1)) == 0);
+    size_t code_size = hot_code_size + cold_code_size;
     size_t code_padding = DATA_ALIGN - ((code_size + state.trampolines.size) & (DATA_ALIGN - 1));
     size_t padding = page_size - ((code_size + state.trampolines.size + code_padding + data_size + state.got_symbols.size) & (page_size - 1));
     size_t total_size = code_size + state.trampolines.size + code_padding + data_size + state.got_symbols.size + padding;
@@ -693,6 +697,7 @@ _PyJIT_Compile(_PyExecutorObject *executor, const _PyUOpInstruction trace[], siz
     }
     // Loop again to emit the code:
     unsigned char *code = memory;
+    unsigned char *cold = memory + hot_code_size;
     state.trampolines.mem = memory + code_size;
     unsigned char *data = memory + code_size + state.trampolines.size + code_padding;
     assert(trace[0].opcode == _START_EXECUTOR_r00 || trace[0].opcode == _COLD_EXIT_r00 || trace[0].opcode == _COLD_DYNAMIC_EXIT_r00);
@@ -700,16 +705,19 @@ _PyJIT_Compile(_PyExecutorObject *executor, const _PyUOpInstruction trace[], siz
     for (size_t i = 0; i < length; i++) {
         const _PyUOpInstruction *instruction = &trace[i];
         group = &stencil_groups[instruction->opcode];
-        group->emit(code, data, executor, instruction, &state);
-        code += group->code_size;
+        group->emit(code, cold, data, executor, instruction, &state);
+        code += group->hot_code_size;
+        cold += group->cold_code_size;
         data += group->data_size;
     }
     // Protect against accidental buffer overrun into data:
     group = &stencil_groups[_FATAL_ERROR_r00];
-    group->emit(code, data, executor, NULL, &state);
-    code += group->code_size;
+    group->emit(code, cold, data, executor, NULL, &state);
+    code += group->hot_code_size;
+    cold += group->cold_code_size;
     data += group->data_size;
-    assert(code == memory + code_size);
+    assert(code == memory + hot_code_size);
+    assert(cold == memory + code_size);
     assert(data == memory + code_size + state.trampolines.size + code_padding + data_size);
     if (mark_executable(memory, total_size)) {
         jit_free(memory, total_size);

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -384,18 +384,14 @@ class Optimizer:
         return label
 
     def _make_cross_section_target(self, block: _Block) -> str:
-        real_target = self._make_cold_target(block).removeprefix(
-            self.symbol_prefix
-        )
+        real_target = self._make_cold_target(block).removeprefix(self.symbol_prefix)
         return (
             f"{self.symbol_prefix}_JIT_CROSS_SECTION_"
             f"{real_target}_JIT_CROSS_SECTION"
         )
 
     def _relocation_marker(self, reloc: str, block: _Block) -> Instruction:
-        target = self._make_cross_section_target(block).removeprefix(
-            self.symbol_prefix
-        )
+        target = self._make_cross_section_target(block).removeprefix(self.symbol_prefix)
         label = f"{self.symbol_prefix}{reloc}_JIT_RELOCATION_{target}:"
         return Instruction(InstructionKind.OTHER, "", label, None, None)
 
@@ -716,10 +712,7 @@ class Optimizer:
             if (
                 block.link
                 and target is block.link.resolve()
-                and (
-                    self._same_layout_section(block, target)
-                    or target is continuation
-                )
+                and (self._same_layout_section(block, target) or target is continuation)
             ):
                 block.target = None
                 block.fallthrough = True

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -383,8 +383,17 @@ class Optimizer:
         block.noninstructions.insert(0, f"{label}:")
         return label
 
+    def _make_cross_section_target(self, block: _Block) -> str:
+        real_target = self._make_cold_target(block).removeprefix(
+            self.symbol_prefix
+        )
+        return (
+            f"{self.symbol_prefix}_JIT_CROSS_SECTION_"
+            f"{real_target}_JIT_CROSS_SECTION"
+        )
+
     def _relocation_marker(self, reloc: str, block: _Block) -> Instruction:
-        target = self._make_cold_target(block).removeprefix(
+        target = self._make_cross_section_target(block).removeprefix(
             self.symbol_prefix
         )
         label = f"{self.symbol_prefix}{reloc}_JIT_RELOCATION_{target}:"
@@ -555,15 +564,25 @@ class Optimizer:
         cold_blocks = [
             block for layout_hot, unit in units if not layout_hot for block in unit
         ]
-        self._relink_blocks(
-            [
-                *hot_blocks,
-                continuation,
-                cold_start,
-                *cold_blocks,
-                *self._metadata_blocks(),
-            ]
-        )
+        blocks = [
+            *hot_blocks,
+            continuation,
+            cold_start,
+            *cold_blocks,
+            *self._metadata_blocks(),
+        ]
+        if self._root in blocks and blocks[0] is not self._root:
+            assert self._root.label is None
+            assert not self._root.instructions
+            assert self._root.target is None
+            assert self._root.fallthrough
+            blocks.remove(self._root)
+            blocks.insert(0, self._root)
+        self._relink_blocks(blocks)
+        linked_blocks = list(self._blocks())
+        assert linked_blocks[0] is self._root
+        assert continuation in linked_blocks
+        assert cold_start in linked_blocks
 
     def _blocks(self) -> typing.Generator[_Block, None, None]:
         block: _Block | None = self._root
@@ -798,7 +817,7 @@ class Optimizer:
                 continue
             assert inst.kind is not InstructionKind.SHORT_BRANCH
             block.instructions[-1] = inst.update_target(
-                self._make_cold_target(target)
+                self._make_cross_section_target(target)
             )
 
     def _fixup_external_labels(self) -> None:

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -505,6 +505,11 @@ class Optimizer:
         self._insert_fallthrough_bridge(block, fallthrough)
 
     def _layout_units(self) -> list[tuple[bool, list[_Block]]]:
+        return self._layout_units_from(list(self._layout_blocks()))
+
+    def _layout_units_from(
+        self, blocks: list[_Block]
+    ) -> list[tuple[bool, list[_Block]]]:
         continuation = self._continuation()
         cold_start = self._cold_start_block()
         units: list[tuple[bool, list[_Block]]] = []
@@ -519,7 +524,7 @@ class Optimizer:
                 units.append((layout_hot, unit))
                 unit = []
 
-        for block in self._layout_blocks():
+        for block in blocks:
             if block is continuation or block is cold_start:
                 finish_unit()
                 continue
@@ -538,16 +543,23 @@ class Optimizer:
         if blocks:
             blocks[-1].link = None
 
-    def _partition_hot_cold_blocks(self) -> None:
-        # The entry point must remain in the hot layout, even when it can't
-        # reach _JIT_CONTINUE. The stencil parser expects _JIT_ENTRY at code
-        # offset 0.
-        entry_label = f"{self.symbol_prefix}_JIT_ENTRY"
-        for block in self._layout_blocks():
-            if block.label == entry_label:
-                block.layout_hot = True
+    def _split_at_entry(self) -> tuple[list[_Block], list[_Block]]:
+        entry = self._lookup_label(f"{self.symbol_prefix}_JIT_ENTRY")
+        layout_blocks = list(self._layout_blocks())
+        index = layout_blocks.index(entry)
+        return layout_blocks[:index], layout_blocks[index:]
 
-        for block in list(self._layout_blocks()):
+    def _partition_hot_cold_blocks(self) -> None:
+        # The entry point must remain first in the partitioned JIT body, even
+        # when it can't reach _JIT_CONTINUE. Blocks before _JIT_ENTRY are
+        # assembler prefix material; keep their original order before
+        # partitioning the JIT body.
+        prefix_blocks, body_blocks = self._split_at_entry()
+        for block in prefix_blocks:
+            block.layout_hot = True
+        body_blocks[0].layout_hot = True
+
+        for block in list(body_blocks):
             self._ensure_hot_fallthrough(block)
 
         continuation = self._continuation()
@@ -557,7 +569,10 @@ class Optimizer:
         cold_start.layout_hot = False
         cold_start.fallthrough = True
 
-        units = self._layout_units()
+        prefix_blocks, body_blocks = self._split_at_entry()
+        for block in prefix_blocks:
+            block.layout_hot = True
+        units = self._layout_units_from(body_blocks)
         hot_blocks = [
             block for layout_hot, unit in units if layout_hot for block in unit
         ]
@@ -565,19 +580,13 @@ class Optimizer:
             block for layout_hot, unit in units if not layout_hot for block in unit
         ]
         blocks = [
+            *prefix_blocks,
             *hot_blocks,
             continuation,
             cold_start,
             *cold_blocks,
             *self._metadata_blocks(),
         ]
-        if self._root in blocks and blocks[0] is not self._root:
-            assert self._root.label is None
-            assert not self._root.instructions
-            assert self._root.target is None
-            assert self._root.fallthrough
-            blocks.remove(self._root)
-            blocks.insert(0, self._root)
         self._relink_blocks(blocks)
         linked_blocks = list(self._blocks())
         assert linked_blocks[0] is self._root
@@ -762,25 +771,31 @@ class Optimizer:
     def _remove_unreachable(self) -> None:
         live = self._find_live_blocks()
         continuation = self._continuation()
+        entry = self._lookup_label(f"{self.symbol_prefix}_JIT_ENTRY")
         cont_or_cold_blocks = {continuation}
         if self._cold_start is not None:
             cont_or_cold_blocks.add(self._cold_start)
         # Keep only the original assembler tail. Cold code after _JIT_CONTINUE
         # is ordinary code and can be removed when unreachable.
         prev: _Block | None = None
-        block = self._root
+        block: _Block | None = self._root
+        seen_entry = False
         # We now walk the whole list, so keep explicit sentinel checks in place
         # of the old "stop at _JIT_CONTINUE" loop invariant.
         seen_continuation = False
         seen_cold_start = self._cold_start is None
         while block is not None:
+            preserve_prefix = not seen_entry
+            if block is entry:
+                seen_entry = True
             if block is continuation:
                 seen_continuation = True
             if block is self._cold_start:
                 seen_cold_start = True
             next = block.link
             if (
-                block not in live
+                not preserve_prefix
+                and block not in live
                 and block not in cont_or_cold_blocks
                 and not block.is_metadata
                 and prev is not None

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -65,7 +65,7 @@ _AARCH64_COND_CODES = {
 }
 # MyPy doesn't understand that a invariant variable can be initialized by a covariant value
 CUSTOM_AARCH64_BRANCH19: str | None = "CUSTOM_AARCH64_BRANCH19"
-CUSTOM_AARCH64_BRANCH26: str | None = "ARM64_RELOC_BRANCH26"
+ARM64_RELOC_BRANCH26: str | None = "ARM64_RELOC_BRANCH26"
 
 _AARCH64_SHORT_BRANCHES = {
     "tbz": "tbnz",
@@ -163,6 +163,13 @@ class _Block:
     def resolve(self) -> typing.Self:
         """Find the first non-empty block reachable from this one."""
         block = self
+        # Empty blocks are only transparent when control can fall through them:
+        #     .L1:
+        #     .L2:
+        #         mov x0, x1
+        # We set block.fallthrough to False for sentinels like _JIT_CONTINUE,
+        # which may be empty but still must not resolve through to
+        # _JIT_COLD_START.
         while block.link and not block.instructions and block.fallthrough:
             block = block.link
         return block
@@ -353,6 +360,7 @@ class Optimizer:
         return self._lookup_label(f"{self.label_prefix}_JIT_CONTINUE")
 
     def _cold_start_block(self) -> _Block:
+        """Create the marker block where the cold code section begins."""
         if self._cold_start is None:
             label = f"{self.symbol_prefix}_JIT_COLD_START"
             self._cold_start = self._lookup_label(label)
@@ -391,6 +399,7 @@ class Optimizer:
         )
 
     def _relocation_marker(self, reloc: str, block: _Block) -> Instruction:
+        """Create a marker symbol that _stencils.py converts to a relocation."""
         target = self._make_cross_section_target(block).removeprefix(self.symbol_prefix)
         label = f"{self.symbol_prefix}{reloc}_JIT_RELOCATION_{target}:"
         return Instruction(InstructionKind.OTHER, "", label, None, None)
@@ -414,6 +423,13 @@ class Optimizer:
         )
 
     def _effective_layout_hot(self, block: _Block) -> bool:
+        """Return the hot/cold section where a block should be emitted.
+
+        Empty label-only blocks inherit the layout of the block they resolve to.
+        Explicit layout_hot overrides are also respected, because a block can be
+        cold in the control-flow graph but still need to be emitted in the hot
+        section as a bridge.
+        """
         resolved = block.resolve()
         if resolved.layout_hot is not None:
             return resolved.layout_hot
@@ -506,6 +522,11 @@ class Optimizer:
     def _layout_units_from(
         self, blocks: list[_Block]
     ) -> list[tuple[bool, list[_Block]]]:
+        """Group adjacent blocks that must stay together during layout.
+
+        Label-only fallthrough blocks inherit the layout of the instruction
+        block they resolve to, so partitioning must move them as one unit.
+        """
         continuation = self._continuation()
         cold_start = self._cold_start_block()
         units: list[tuple[bool, list[_Block]]] = []
@@ -596,6 +617,7 @@ class Optimizer:
             block = block.link
 
     def _layout_blocks(self) -> typing.Generator[_Block, None, None]:
+        """Yield only blocks that participate in executable code layout."""
         for block in self._blocks():
             if not block.is_metadata:
                 yield block
@@ -802,7 +824,8 @@ class Optimizer:
         assert seen_continuation
         assert seen_cold_start
 
-    def _fixup_cross_section_branches(self) -> None:
+    def _insert_cross_section_branch_relocations(self) -> None:
+        """Insert relocation markers for branches crossing the hot/cold split."""
         layout_blocks = set(self._layout_blocks())
         for block in self._layout_blocks():
             target = block.target
@@ -876,7 +899,7 @@ class Optimizer:
             self._remove_redundant_jumps()
             self._remove_unreachable()
         self._fixup_external_labels()
-        self._fixup_cross_section_branches()
+        self._insert_cross_section_branch_relocations()
         self._fixup_constants()
         self._validate()
         self.path.write_text(self._body())
@@ -888,7 +911,7 @@ class OptimizerAArch64(Optimizer):  # pylint: disable = too-few-public-methods
     _branches = _AARCH64_BRANCHES
     _short_branches = _AARCH64_SHORT_BRANCHES
     _jump_name = "b"
-    _jump_reloc = CUSTOM_AARCH64_BRANCH26
+    _jump_reloc = ARM64_RELOC_BRANCH26
     # Mach-O does not support the 19 bit branch locations needed for branch reordering
     _supports_external_relocations = False
     _branch_patterns = [name.replace(".", r"\.") for name in _AARCH64_BRANCHES]

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -65,6 +65,7 @@ _AARCH64_COND_CODES = {
 }
 # MyPy doesn't understand that a invariant variable can be initialized by a covariant value
 CUSTOM_AARCH64_BRANCH19: str | None = "CUSTOM_AARCH64_BRANCH19"
+CUSTOM_AARCH64_BRANCH26: str | None = "ARM64_RELOC_BRANCH26"
 
 _AARCH64_SHORT_BRANCHES = {
     "tbz": "tbnz",
@@ -216,6 +217,7 @@ class Optimizer:
     label_index: int = 0
     _cold_start: _Block | None = dataclasses.field(init=False, default=None)
     _jump_name = "<Not supported>"
+    _jump_reloc: typing.ClassVar[str | None] = None
 
     def __post_init__(self) -> None:
         # Split the code into a linked list of basic blocks. A basic block is an
@@ -363,12 +365,30 @@ class Optimizer:
         self.label_index += 1
         return label
 
+    def _make_symbol_label(self, name: str) -> str:
+        label = f"{self.symbol_prefix}{name}_{self.label_index}"
+        self.label_index += 1
+        return label
+
     def _ensure_label(self, block: _Block) -> str:
         if block.label is None:
             block.label = self._make_label()
             self._labels[block.label] = block
             block.noninstructions.insert(0, f"{block.label}:")
         return block.label
+
+    def _make_cold_target(self, block: _Block) -> str:
+        label = self._make_symbol_label("_JIT_COLD")
+        self._labels[label] = block
+        block.noninstructions.insert(0, f"{label}:")
+        return label
+
+    def _relocation_marker(self, reloc: str, block: _Block) -> Instruction:
+        target = self._make_cold_target(block).removeprefix(
+            self.symbol_prefix
+        )
+        label = f"{self.symbol_prefix}{reloc}_JIT_RELOCATION_{target}:"
+        return Instruction(InstructionKind.OTHER, "", label, None, None)
 
     def _make_jump(self, target: _Block, *, hot: bool) -> _Block:
         label = self._ensure_label(target)
@@ -755,6 +775,32 @@ class Optimizer:
         assert seen_continuation
         assert seen_cold_start
 
+    def _fixup_cross_section_branches(self) -> None:
+        layout_blocks = set(self._layout_blocks())
+        for block in self._layout_blocks():
+            target = block.target
+            if target is None or target not in layout_blocks:
+                continue
+            if self._same_layout_section(block, target):
+                continue
+            inst = block.instructions[-1]
+            if inst.kind == InstructionKind.LONG_BRANCH:
+                reloc = self._branches[inst.name][1]
+                if reloc is not None:
+                    block.instructions[-1] = self._relocation_marker(reloc, target)
+                    block.instructions.append(inst.update_target("0"))
+                    continue
+            elif inst.kind == InstructionKind.JUMP and self._jump_reloc is not None:
+                block.instructions[-1] = self._relocation_marker(
+                    self._jump_reloc, target
+                )
+                block.instructions.append(inst.update_target("0"))
+                continue
+            assert inst.kind is not InstructionKind.SHORT_BRANCH
+            block.instructions[-1] = inst.update_target(
+                self._make_cold_target(target)
+            )
+
     def _fixup_external_labels(self) -> None:
         if self._supports_external_relocations:
             # Nothing to fix up
@@ -803,6 +849,7 @@ class Optimizer:
             self._remove_redundant_jumps()
             self._remove_unreachable()
         self._fixup_external_labels()
+        self._fixup_cross_section_branches()
         self._fixup_constants()
         self._validate()
         self.path.write_text(self._body())
@@ -814,6 +861,7 @@ class OptimizerAArch64(Optimizer):  # pylint: disable = too-few-public-methods
     _branches = _AARCH64_BRANCHES
     _short_branches = _AARCH64_SHORT_BRANCHES
     _jump_name = "b"
+    _jump_reloc = CUSTOM_AARCH64_BRANCH26
     # Mach-O does not support the 19 bit branch locations needed for branch reordering
     _supports_external_relocations = False
     _branch_patterns = [name.replace(".", r"\.") for name in _AARCH64_BRANCHES]

--- a/Tools/jit/_optimizers.py
+++ b/Tools/jit/_optimizers.py
@@ -152,11 +152,17 @@ class _Block:
     fallthrough: bool = True
     # Whether this block can eventually reach the next uop (_JIT_CONTINUE):
     hot: bool = False
+    # Whether this block should be emitted in the hot section. This is separate
+    # from "hot": some cold fallthrough bridges must stay in the hot layout.
+    layout_hot: bool | None = None
+    # Whether this original assembler metadata/tail block should be preserved
+    # even if it is unreachable.
+    is_metadata: bool = False
 
     def resolve(self) -> typing.Self:
         """Find the first non-empty block reachable from this one."""
         block = self
-        while block.link and not block.instructions:
+        while block.link and not block.instructions and block.fallthrough:
             block = block.link
         return block
 
@@ -208,6 +214,8 @@ class Optimizer:
     const_reloc = "<Not supported>"
     _frame_pointer_modify: typing.ClassVar[re.Pattern[str]] = _RE_NEVER_MATCH
     label_index: int = 0
+    _cold_start: _Block | None = dataclasses.field(init=False, default=None)
+    _jump_name = "<Not supported>"
 
     def __post_init__(self) -> None:
         # Split the code into a linked list of basic blocks. A basic block is an
@@ -339,18 +347,224 @@ class Optimizer:
     def _is_far_target(self, label: str) -> bool:
         return not label.startswith(self.label_prefix)
 
+    def _continuation(self) -> _Block:
+        return self._lookup_label(f"{self.label_prefix}_JIT_CONTINUE")
+
+    def _cold_start_block(self) -> _Block:
+        if self._cold_start is None:
+            label = f"{self.symbol_prefix}_JIT_COLD_START"
+            self._cold_start = self._lookup_label(label)
+            self._cold_start.noninstructions.append(f"{label}:")
+            self._cold_start.layout_hot = False
+        return self._cold_start
+
+    def _make_label(self) -> str:
+        label = f"{self.label_prefix}_JIT_LABEL_{self.label_index}"
+        self.label_index += 1
+        return label
+
+    def _ensure_label(self, block: _Block) -> str:
+        if block.label is None:
+            block.label = self._make_label()
+            self._labels[block.label] = block
+            block.noninstructions.insert(0, f"{block.label}:")
+        return block.label
+
+    def _make_jump(self, target: _Block, *, hot: bool) -> _Block:
+        label = self._ensure_label(target)
+        return _Block(
+            instructions=[
+                Instruction(
+                    InstructionKind.JUMP,
+                    self._jump_name,
+                    f"\t{self._jump_name} {label}",
+                    None,
+                    label,
+                )
+            ],
+            target=target,
+            fallthrough=False,
+            hot=hot,
+            layout_hot=True,
+        )
+
+    def _effective_layout_hot(self, block: _Block) -> bool:
+        resolved = block.resolve()
+        if resolved.layout_hot is not None:
+            return resolved.layout_hot
+        if block.layout_hot is not None:
+            return block.layout_hot
+        return resolved.hot
+
+    def _same_layout_section(self, left: _Block, right: _Block) -> bool:
+        return self._effective_layout_hot(left) == self._effective_layout_hot(right)
+
+    def _can_short_branch_to_layout(
+        self, inst: Instruction, source: _Block, target: _Block
+    ) -> bool:
+        if inst.kind != InstructionKind.SHORT_BRANCH:
+            return True
+        return self._same_layout_section(source, target)
+
+    def _insert_fallthrough_bridge(self, block: _Block, target: _Block) -> _Block:
+        bridge = self._make_jump(target, hot=target.hot)
+        bridge.link = block.link
+        block.link = bridge
+        return bridge
+
+    def _ensure_hot_fallthrough(self, block: _Block) -> None:
+        if block is self._continuation() or block is self._cold_start:
+            return
+        fallthrough = block.link
+        if (
+            fallthrough is None
+            or not self._effective_layout_hot(block)
+            or not block.fallthrough
+        ):
+            return
+
+        fallthrough_is_hot = self._effective_layout_hot(fallthrough)
+        target = block.target
+        inst = block.instructions[-1] if block.instructions else None
+
+        # Keep AArch64 short branches in the hot layout:
+        #     tbz x0, #0, .Lcold      ->      tbnz x0, #0, .Lhot
+        # .Lhot:                              b .Lcold
+        #                                 .Lhot:
+        if (
+            fallthrough_is_hot
+            and inst is not None
+            and inst.kind == InstructionKind.SHORT_BRANCH
+            and target is not None
+            and not self._effective_layout_hot(target)
+        ):
+            fallthrough_label = self._ensure_label(fallthrough)
+            inverted = self._invert_branch(inst, fallthrough_label)
+            assert inverted is not None
+            bridge = self._make_jump(target, hot=target.hot)
+            bridge.link = fallthrough
+            block.instructions[-1] = inverted
+            block.target = fallthrough
+            block.link = bridge
+            return
+
+        if fallthrough_is_hot:
+            return
+
+        # Make a hot-to-cold fallthrough explicit, preferably by inverting:
+        #     b.eq .Lhot              ->      b.ne .Lcold
+        # .Lcold:                         .Lhot:
+        if (
+            inst is not None
+            and inst.is_branch()
+            and target is not None
+            and self._effective_layout_hot(target)
+        ):
+            fallthrough_label = self._ensure_label(fallthrough)
+            inverted = None
+            if self._can_short_branch_to_layout(inst, block, fallthrough):
+                inverted = self._invert_branch(inst, fallthrough_label)
+            if inverted is not None:
+                bridge = self._make_jump(target, hot=True)
+                bridge.link = fallthrough
+                block.instructions[-1] = inverted
+                block.target = fallthrough
+                block.link = bridge
+                return
+        # If no inversion is possible, preserve the old fallthrough with:
+        #     b .Lcold
+        self._insert_fallthrough_bridge(block, fallthrough)
+
+    def _layout_units(self) -> list[tuple[bool, list[_Block]]]:
+        continuation = self._continuation()
+        cold_start = self._cold_start_block()
+        units: list[tuple[bool, list[_Block]]] = []
+        unit: list[_Block] = []
+
+        def finish_unit() -> None:
+            nonlocal unit
+            if unit:
+                layout_hot = self._effective_layout_hot(unit[0])
+                for unit_block in unit:
+                    unit_block.layout_hot = layout_hot
+                units.append((layout_hot, unit))
+                unit = []
+
+        for block in self._layout_blocks():
+            if block is continuation or block is cold_start:
+                finish_unit()
+                continue
+            unit.append(block)
+            if block.instructions or not block.fallthrough:
+                finish_unit()
+        finish_unit()
+        return units
+
+    def _metadata_blocks(self) -> list[_Block]:
+        return [block for block in self._blocks() if block.is_metadata]
+
+    def _relink_blocks(self, blocks: list[_Block]) -> None:
+        for current, next_block in zip(blocks, blocks[1:]):
+            current.link = next_block
+        if blocks:
+            blocks[-1].link = None
+
+    def _partition_hot_cold_blocks(self) -> None:
+        # The entry point must remain in the hot layout, even when it can't
+        # reach _JIT_CONTINUE. The stencil parser expects _JIT_ENTRY at code
+        # offset 0.
+        entry_label = f"{self.symbol_prefix}_JIT_ENTRY"
+        for block in self._layout_blocks():
+            if block.label == entry_label:
+                block.layout_hot = True
+
+        for block in list(self._layout_blocks()):
+            self._ensure_hot_fallthrough(block)
+
+        continuation = self._continuation()
+        continuation.layout_hot = True
+        continuation.fallthrough = False
+        cold_start = self._cold_start_block()
+        cold_start.layout_hot = False
+        cold_start.fallthrough = True
+
+        units = self._layout_units()
+        hot_blocks = [
+            block for layout_hot, unit in units if layout_hot for block in unit
+        ]
+        cold_blocks = [
+            block for layout_hot, unit in units if not layout_hot for block in unit
+        ]
+        self._relink_blocks(
+            [
+                *hot_blocks,
+                continuation,
+                cold_start,
+                *cold_blocks,
+                *self._metadata_blocks(),
+            ]
+        )
+
     def _blocks(self) -> typing.Generator[_Block, None, None]:
         block: _Block | None = self._root
         while block:
             yield block
             block = block.link
 
+    def _layout_blocks(self) -> typing.Generator[_Block, None, None]:
+        for block in self._blocks():
+            if not block.is_metadata:
+                yield block
+
     def _body(self) -> str:
         lines = ["#" + line for line in self.text.splitlines()]
-        hot = True
+        hot: bool | None = True
         for block in self._blocks():
-            if hot != block.hot:
-                hot = block.hot
+            layout_hot = block.layout_hot
+            if layout_hot is None:
+                layout_hot = block.hot
+            if hot != layout_hot:
+                hot = layout_hot
                 # Make it easy to tell at a glance where cold code is:
                 lines.append(f"# JIT: {'HOT' if hot else 'COLD'} ".ljust(80, "#"))
             lines.extend(block.noninstructions)
@@ -378,12 +592,17 @@ class Optimizer:
         continuation = self._lookup_label(f"{self.label_prefix}_JIT_CONTINUE")
         assert continuation.label
         continuation.noninstructions.append(f"{continuation.label}:")
+        continuation.layout_hot = True
+        tail = end.link
+        while tail:
+            tail.is_metadata = True
+            tail = tail.link
         end.link, continuation.link = continuation, end.link
 
     def _mark_hot_blocks(self) -> None:
-        # Start with the last block, and perform a DFS to find all blocks that
-        # can eventually reach it:
-        todo = list(self._blocks())[-1:]
+        # Start with the continuation block, and perform a DFS to find all
+        # blocks that can eventually reach it:
+        todo = [self._lookup_label(f"{self.label_prefix}_JIT_CONTINUE")]
         while todo:
             block = todo.pop()
             block.hot = True
@@ -413,11 +632,14 @@ class Optimizer:
                 and len(jump.instructions) == 1
                 and list(self._predecessors(jump)) == [branch]
             ):
+                jump.layout_hot = True
                 assert jump.target.label
                 assert branch.target.label
-                inverted = self._invert_branch(
-                    branch.instructions[-1], jump.target.label
-                )
+                inst = branch.instructions[-1]
+                if inst.kind == InstructionKind.SHORT_BRANCH:
+                    inverted = None
+                else:
+                    inverted = self._invert_branch(inst, jump.target.label)
                 # Check to see if the branch can even be inverted:
                 if inverted is None:
                     continue
@@ -427,10 +649,12 @@ class Optimizer:
                 )
                 branch.target, jump.target = jump.target, branch.target
                 jump.hot = True
+                jump.layout_hot = True
 
     def _remove_redundant_jumps(self) -> None:
         # Zero-length jumps can be introduced by _insert_continue_label and
         # _invert_hot_branches:
+        continuation = self._continuation()
         for block in self._blocks():
             target = block.target
             if target is None:
@@ -441,7 +665,14 @@ class Optimizer:
             #    FOO:
             # After:
             #    FOO:
-            if block.link and target is block.link.resolve():
+            if (
+                block.link
+                and target is block.link.resolve()
+                and (
+                    self._same_layout_section(block, target)
+                    or target is continuation
+                )
+            ):
                 block.target = None
                 block.fallthrough = True
                 block.instructions.pop()
@@ -459,11 +690,14 @@ class Optimizer:
             ):
                 assert target.target is not None
                 assert target.target.label is not None
+                inst = block.instructions[-1]
                 if block.instructions[
                     -1
                 ].kind == InstructionKind.SHORT_BRANCH and self._is_far_target(
                     target.target.label
                 ):
+                    continue
+                if not self._can_short_branch_to_layout(inst, block, target.target):
                     continue
                 block.target = target.target
                 block.instructions[-1] = block.instructions[-1].update_target(
@@ -488,20 +722,38 @@ class Optimizer:
 
     def _remove_unreachable(self) -> None:
         live = self._find_live_blocks()
-        continuation = self._lookup_label(f"{self.label_prefix}_JIT_CONTINUE")
-        # Keep blocks after continuation as they may contain data and
-        # metadata that the assembler needs
+        continuation = self._continuation()
+        cont_or_cold_blocks = {continuation}
+        if self._cold_start is not None:
+            cont_or_cold_blocks.add(self._cold_start)
+        # Keep only the original assembler tail. Cold code after _JIT_CONTINUE
+        # is ordinary code and can be removed when unreachable.
         prev: _Block | None = None
         block = self._root
-        while block is not continuation:
+        # We now walk the whole list, so keep explicit sentinel checks in place
+        # of the old "stop at _JIT_CONTINUE" loop invariant.
+        seen_continuation = False
+        seen_cold_start = self._cold_start is None
+        while block is not None:
+            if block is continuation:
+                seen_continuation = True
+            if block is self._cold_start:
+                seen_cold_start = True
             next = block.link
-            assert next is not None
-            if not block in live and prev:
+            if (
+                block not in live
+                and block not in cont_or_cold_blocks
+                and not block.is_metadata
+                and prev is not None
+            ):
                 prev.link = next
             else:
                 prev = block
             block = next
-            assert prev.link is block
+            if prev is not None:
+                assert prev.link is block
+        assert seen_continuation
+        assert seen_cold_start
 
     def _fixup_external_labels(self) -> None:
         if self._supports_external_relocations:
@@ -544,8 +796,10 @@ class Optimizer:
         self._mark_hot_blocks()
         # Removing branches can expose opportunities for more branch removal.
         # Repeat a few times. 2 would probably do, but it's fast enough with 4.
-        for _ in range(4):
+        for iter in range(4):
             self._invert_hot_branches()
+            if iter == 0:
+                self._partition_hot_cold_blocks()
             self._remove_redundant_jumps()
             self._remove_unreachable()
         self._fixup_external_labels()
@@ -559,6 +813,7 @@ class OptimizerAArch64(Optimizer):  # pylint: disable = too-few-public-methods
 
     _branches = _AARCH64_BRANCHES
     _short_branches = _AARCH64_SHORT_BRANCHES
+    _jump_name = "b"
     # Mach-O does not support the 19 bit branch locations needed for branch reordering
     _supports_external_relocations = False
     _branch_patterns = [name.replace(".", r"\.") for name in _AARCH64_BRANCHES]
@@ -776,6 +1031,7 @@ class OptimizerX86(Optimizer):  # pylint: disable = too-few-public-methods
 
     _branches = _X86_BRANCHES
     _short_branches = {}
+    _jump_name = "jmp"
     _re_branch = re.compile(
         rf"\s*(?P<instruction>{'|'.join(_X86_BRANCHES)})\s+(?P<target>[\w.]+)"
     )

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -17,6 +17,8 @@ class HoleValue(enum.Enum):
 
     # The base address of the machine code for the current uop (exposed as _JIT_ENTRY):
     CODE = enum.auto()
+    # The base address of the cold machine code for the current uop:
+    COLD_CODE = enum.auto()
     # The base address of the read-only data for this uop:
     DATA = enum.auto()
     # The base address of the "global" offset table located in the read-only data.
@@ -106,6 +108,7 @@ _PATCH_FUNCS = {
 # Translate HoleValues to C expressions:
 _HOLE_EXPRS = {
     HoleValue.CODE: "(uintptr_t)code",
+    HoleValue.COLD_CODE: "(uintptr_t)cold",
     HoleValue.DATA: "(uintptr_t)data",
     HoleValue.GOT: "",
     # These should all have been turned into DATA values by process_relocations:
@@ -144,7 +147,6 @@ _X86_GOT_RELOCATIONS = {
     "X86_64_RELOC_GOT_LOAD",
     "IMAGE_REL_AMD64_REL32",
 }
-
 
 @dataclasses.dataclass
 class Hole:
@@ -247,6 +249,7 @@ class StencilGroup:
     """
 
     code: Stencil = dataclasses.field(default_factory=Stencil, init=False)
+    cold_code: Stencil = dataclasses.field(default_factory=Stencil, init=False)
     data: Stencil = dataclasses.field(default_factory=Stencil, init=False)
     symbols: dict[int | str, tuple[HoleValue, int]] = dataclasses.field(
         default_factory=dict, init=False
@@ -257,6 +260,12 @@ class StencilGroup:
     _trampolines: set[int] = dataclasses.field(default_factory=set, init=False)
     _got_entries: set[int] = dataclasses.field(default_factory=set, init=False)
 
+    def _code_stencils(self) -> tuple[Stencil, Stencil]:
+        return self.code, self.cold_code
+
+    def _all_stencils(self) -> tuple[Stencil, Stencil, Stencil]:
+        return self.code, self.cold_code, self.data
+
     def convert_labels_to_relocations(self) -> None:
         holes_by_offset: dict[int, Hole] = {}
         first_in_pair: dict[str, Hole] = {}
@@ -265,10 +274,14 @@ class StencilGroup:
         for name, hole_plus in self.symbols.items():
             if isinstance(name, str) and "_JIT_RELOCATION_" in name:
                 _, offset = hole_plus
-                reloc, target, _ = name.split("_JIT_RELOCATION_")
+                reloc, target, *_ = name.split("_JIT_RELOCATION_")
                 value, symbol = symbol_to_value(target)
                 hole = Hole(
-                    int(offset), typing.cast(_schema.HoleKind, reloc), value, symbol, 0
+                    int(offset),
+                    typing.cast(_schema.HoleKind, reloc),
+                    value,
+                    symbol,
+                    0,
                 )
                 self.code.holes.append(hole)
             elif isinstance(name, str) and "_JIT_PAIR_" in name:
@@ -282,57 +295,89 @@ class StencilGroup:
                         first = first_in_pair[index]
                         hole.fold(first)
 
+        cold_start = self.symbols.get("_JIT_COLD_START")
+        if cold_start is None:
+            return
+        value, split = cold_start
+        assert value is HoleValue.CODE
+        assert 0 <= split <= len(self.code.body)
+
+        self.cold_code.body.extend(self.code.body[split:])
+        del self.code.body[split:]
+
+        hot_holes = []
+        cold_holes = []
+        for hole in self.code.holes:
+            if hole.offset2 >= 0:
+                assert (hole.offset < split) == (hole.offset2 < split)
+            if hole.offset < split:
+                hot_holes.append(hole)
+            else:
+                offset2 = hole.offset2
+                if offset2 >= 0:
+                    offset2 -= split
+                cold_holes.append(
+                    hole.replace(offset=hole.offset - split, offset2=offset2)
+                )
+        self.code.holes = hot_holes
+        self.cold_code.holes = cold_holes
+
+        for name, (symbol_value, offset) in self.symbols.copy().items():
+            if symbol_value is HoleValue.CODE and offset >= split:
+                self.symbols[name] = HoleValue.COLD_CODE, offset - split
+
     def process_relocations(self, known_symbols: dict[str, int]) -> None:
         """Fix up all GOT and internal relocations for this stencil group."""
-        for hole in self.code.holes.copy():
-            if (
-                hole.kind
-                in {"R_AARCH64_CALL26", "R_AARCH64_JUMP26", "ARM64_RELOC_BRANCH26"}
-                and hole.value is HoleValue.ZERO
-                and hole.symbol not in self.symbols
-            ):
-                hole.func = "patch_aarch64_trampoline"
-                hole.need_state = True
-                assert hole.symbol is not None
-                if hole.symbol in known_symbols:
-                    ordinal = known_symbols[hole.symbol]
-                else:
-                    ordinal = len(known_symbols)
-                    known_symbols[hole.symbol] = ordinal
-                self._trampolines.add(ordinal)
-                hole.addend = ordinal
-                hole.symbol = None
-            # x86_64 Darwin trampolines for external symbols
-            elif (
-                hole.kind == "X86_64_RELOC_BRANCH"
-                and hole.value is HoleValue.ZERO
-                and hole.symbol not in self.symbols
-            ):
-                hole.func = "patch_x86_64_trampoline"
-                hole.need_state = True
-                assert hole.symbol is not None
-                if hole.symbol in known_symbols:
-                    ordinal = known_symbols[hole.symbol]
-                else:
-                    ordinal = len(known_symbols)
-                    known_symbols[hole.symbol] = ordinal
-                self._trampolines.add(ordinal)
-                hole.addend = ordinal
-                hole.symbol = None
-            elif (
-                hole.kind in _AARCH64_GOT_RELOCATIONS | _X86_GOT_RELOCATIONS
-                and hole.symbol
-                and "_JIT_" not in hole.symbol
-                and hole.value is HoleValue.GOT
-            ):
-                if hole.symbol in known_symbols:
-                    ordinal = known_symbols[hole.symbol]
-                else:
-                    ordinal = len(known_symbols)
-                    known_symbols[hole.symbol] = ordinal
-                self._got_entries.add(ordinal)
+        for stencil in self._code_stencils():
+            for hole in stencil.holes.copy():
+                if (
+                    hole.kind
+                    in {"R_AARCH64_CALL26", "R_AARCH64_JUMP26", "ARM64_RELOC_BRANCH26"}
+                    and hole.value is HoleValue.ZERO
+                    and hole.symbol not in self.symbols
+                ):
+                    hole.func = "patch_aarch64_trampoline"
+                    hole.need_state = True
+                    assert hole.symbol is not None
+                    if hole.symbol in known_symbols:
+                        ordinal = known_symbols[hole.symbol]
+                    else:
+                        ordinal = len(known_symbols)
+                        known_symbols[hole.symbol] = ordinal
+                    self._trampolines.add(ordinal)
+                    hole.addend = ordinal
+                    hole.symbol = None
+                # x86_64 Darwin trampolines for external symbols
+                elif (
+                    hole.kind == "X86_64_RELOC_BRANCH"
+                    and hole.value is HoleValue.ZERO
+                    and hole.symbol not in self.symbols
+                ):
+                    hole.func = "patch_x86_64_trampoline"
+                    hole.need_state = True
+                    assert hole.symbol is not None
+                    if hole.symbol in known_symbols:
+                        ordinal = known_symbols[hole.symbol]
+                    else:
+                        ordinal = len(known_symbols)
+                        known_symbols[hole.symbol] = ordinal
+                    self._trampolines.add(ordinal)
+                    hole.addend = ordinal
+                    hole.symbol = None
+                elif (
+                    hole.kind in _AARCH64_GOT_RELOCATIONS | _X86_GOT_RELOCATIONS
+                    and hole.symbol
+                    and "_JIT_" not in hole.symbol
+                    and hole.value is HoleValue.GOT
+                ):
+                    if hole.symbol in known_symbols:
+                        ordinal = known_symbols[hole.symbol]
+                    else:
+                        ordinal = len(known_symbols)
+                        known_symbols[hole.symbol] = ordinal
+                    self._got_entries.add(ordinal)
         self.data.pad(8)
-        for stencil in [self.code, self.data]:
+        for stencil in self._all_stencils():
             for hole in stencil.holes:
                 if hole.value is HoleValue.GOT:
                     assert hole.symbol is not None
@@ -367,6 +412,7 @@ class StencilGroup:
         self._emit_jit_symbol_table()
         self._emit_global_offset_table()
         self.code.holes.sort(key=lambda hole: hole.offset)
+        self.cold_code.holes.sort(key=lambda hole: hole.offset)
         self.data.holes.sort(key=lambda hole: hole.offset)
 
     def _jit_symbol_table_lookup(self, symbol: str) -> int:
@@ -401,13 +447,14 @@ class StencilGroup:
             self.data.body.extend([0] * 8)
 
     def _emit_global_offset_table(self) -> None:
-        for hole in self.code.holes:
-            if hole.value is HoleValue.GOT:
-                _got_hole = Hole(0, "R_X86_64_64", hole.value, None, hole.addend)
-                _got_hole.func = "patch_got_symbol"
-                _got_hole.custom_location = "state"
-                if _got_hole not in self.data.holes:
-                    self.data.holes.append(_got_hole)
+        for stencil in self._code_stencils():
+            for hole in stencil.holes:
+                if hole.value is HoleValue.GOT:
+                    _got_hole = Hole(0, "R_X86_64_64", hole.value, None, hole.addend)
+                    _got_hole.func = "patch_got_symbol"
+                    _got_hole.custom_location = "state"
+                    if _got_hole not in self.data.holes:
+                        self.data.holes.append(_got_hole)
 
     def _get_symbol_mask(self, ordinals: set[int]) -> str:
         bitmask: int = 0
@@ -428,7 +475,7 @@ class StencilGroup:
 
     def as_c(self, opname: str) -> str:
         """Dump this hole as a StencilGroup initializer."""
-        return f"{{emit_{opname}, {len(self.code.body)}, {len(self.data.body)}, {self._get_trampoline_mask()}, {self._get_got_mask()}}}"
+        return f"{{emit_{opname}, {len(self.code.body)}, {len(self.cold_code.body)}, {len(self.data.body)}, {self._get_trampoline_mask()}, {self._get_got_mask()}}}"
 
 
 def symbol_to_value(symbol: str) -> tuple[HoleValue, str | None]:

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -152,6 +152,7 @@ _X86_GOT_RELOCATIONS = {
 _CROSS_SECTION_PREFIX = "_JIT_CROSS_SECTION_"
 _CROSS_SECTION_SUFFIX = "_JIT_CROSS_SECTION"
 
+
 @dataclasses.dataclass
 class Hole:
     """

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -1,5 +1,6 @@
 """Core data structures for compiled code templates."""
 
+import copy
 import dataclasses
 import enum
 import sys
@@ -148,6 +149,9 @@ _X86_GOT_RELOCATIONS = {
     "IMAGE_REL_AMD64_REL32",
 }
 
+_CROSS_SECTION_PREFIX = "_JIT_CROSS_SECTION_"
+_CROSS_SECTION_SUFFIX = "_JIT_CROSS_SECTION"
+
 @dataclasses.dataclass
 class Hole:
     """
@@ -170,8 +174,16 @@ class Hole:
     func: str = dataclasses.field(init=False)
     offset2: int = -1
     void: bool = False
-    # Convenience method:
-    replace = dataclasses.replace
+
+    def replace(self, **changes: typing.Any) -> typing.Self:
+        field_names = {field.name for field in dataclasses.fields(self)}
+        for name in changes:
+            if name not in field_names:
+                raise TypeError(f"unexpected field name: {name!r}")
+        result = copy.copy(self)
+        for name, value in changes.items():
+            setattr(result, name, value)
+        return result
 
     def __post_init__(self) -> None:
         self.func = _PATCH_FUNCS[self.kind]
@@ -295,6 +307,9 @@ class StencilGroup:
                         first = first_in_pair[index]
                         hole.fold(first)
 
+        self.split_code_at_cold_start()
+
+    def split_code_at_cold_start(self) -> None:
         cold_start = self.symbols.get("_JIT_COLD_START")
         if cold_start is None:
             return
@@ -330,6 +345,8 @@ class StencilGroup:
         """Fix up all GOT and internal relocations for this stencil group."""
         for stencil in self._code_stencils():
             for hole in stencil.holes.copy():
+                if self._resolve_cross_section_symbol(hole):
+                    continue
                 if (
                     hole.kind
                     in {"R_AARCH64_CALL26", "R_AARCH64_JUMP26", "ARM64_RELOC_BRANCH26"}
@@ -379,6 +396,8 @@ class StencilGroup:
         self.data.pad(8)
         for stencil in self._all_stencils():
             for hole in stencil.holes:
+                if self._resolve_cross_section_symbol(hole):
+                    continue
                 if hole.value is HoleValue.GOT:
                     assert hole.symbol is not None
                     if "_JIT_" in hole.symbol:
@@ -414,6 +433,29 @@ class StencilGroup:
         self.code.holes.sort(key=lambda hole: hole.offset)
         self.cold_code.holes.sort(key=lambda hole: hole.offset)
         self.data.holes.sort(key=lambda hole: hole.offset)
+
+    def _resolve_cross_section_symbol(self, hole: Hole) -> bool:
+        if hole.value is not HoleValue.ZERO or hole.symbol is None:
+            return False
+        symbol = hole.symbol
+        if not (
+            symbol.startswith(_CROSS_SECTION_PREFIX)
+            and symbol.endswith(_CROSS_SECTION_SUFFIX)
+        ):
+            return False
+        target = symbol.removeprefix(_CROSS_SECTION_PREFIX).removesuffix(
+            _CROSS_SECTION_SUFFIX
+        )
+        try:
+            value, addend = self.symbols[target]
+        except KeyError:
+            raise ValueError(
+                f"Missing cross-section relocation target {target}"
+            ) from None
+        hole.value = value
+        hole.addend += addend
+        hole.symbol = None
+        return True
 
     def _jit_symbol_table_lookup(self, symbol: str) -> int:
         return len(self.data.body) + self._jit_symbol_table.setdefault(

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -177,6 +177,7 @@ class Hole:
     void: bool = False
 
     def replace(self, **changes: typing.Any) -> typing.Self:
+        """Copy this hole without rerunning __post_init__ and resetting func."""
         field_names = {field.name for field in dataclasses.fields(self)}
         for name in changes:
             if name not in field_names:
@@ -346,6 +347,8 @@ class StencilGroup:
         """Fix up all GOT and internal relocations for this stencil group."""
         for stencil in self._code_stencils():
             for hole in stencil.holes.copy():
+                # Cross-section symbols are optimizer-generated internal
+                # targets; resolve them before external branch handling.
                 if self._resolve_cross_section_symbol(hole):
                     continue
                 if (
@@ -436,6 +439,7 @@ class StencilGroup:
         self.data.holes.sort(key=lambda hole: hole.offset)
 
     def _resolve_cross_section_symbol(self, hole: Hole) -> bool:
+        """Strip hot/cold target wrappers and rewrite holes to CODE/COLD_CODE."""
         if hole.value is not HoleValue.ZERO or hole.symbol is None:
             return False
         symbol = hole.symbol

--- a/Tools/jit/_writer.py
+++ b/Tools/jit/_writer.py
@@ -15,9 +15,11 @@ def _dump_footer(
     yield ""
     yield "typedef struct {"
     yield "    void (*emit)("
-    yield "        unsigned char *code, unsigned char *data, _PyExecutorObject *executor,"
+    yield "        unsigned char *code, unsigned char *cold, unsigned char *data,"
+    yield "        _PyExecutorObject *executor,"
     yield "        const _PyUOpInstruction *instruction, jit_state *state);"
-    yield "    size_t code_size;"
+    yield "    size_t hot_code_size;"
+    yield "    size_t cold_code_size;"
     yield "    size_t data_size;"
     yield "    symbol_mask trampoline_mask;"
     yield "    symbol_mask got_mask;"
@@ -40,10 +42,15 @@ def _dump_footer(
 def _dump_stencil(opname: str, group: _stencils.StencilGroup) -> typing.Iterator[str]:
     yield "void"
     yield f"emit_{opname}("
-    yield "    unsigned char *code, unsigned char *data, _PyExecutorObject *executor,"
+    yield "    unsigned char *code, unsigned char *cold, unsigned char *data,"
+    yield "    _PyExecutorObject *executor,"
     yield "    const _PyUOpInstruction *instruction, jit_state *state)"
     yield "{"
-    for part, stencil in [("code", group.code), ("data", group.data)]:
+    for part, stencil in [
+        ("code", group.code),
+        ("cold", group.cold_code),
+        ("data", group.data),
+    ]:
         for line in stencil.disassembly:
             yield f"    // {line}"
         stripped = stencil.body.rstrip(b"\x00")
@@ -54,7 +61,11 @@ def _dump_stencil(opname: str, group: _stencils.StencilGroup) -> typing.Iterator
                 yield f"        {row}"
             yield "    };"
     # Data is written first (so relaxations in the code work properly):
-    for part, stencil in [("data", group.data), ("code", group.code)]:
+    for part, stencil in [
+        ("data", group.data),
+        ("code", group.code),
+        ("cold", group.cold_code),
+    ]:
         if stencil.body.rstrip(b"\x00"):
             yield f"    memcpy({part}, {part}_body, sizeof({part}_body));"
         stencil.holes.sort(key=lambda hole: hole.offset)


### PR DESCRIPTION
<!-- gh-issue-number: gh-143158 -->
Issue: gh-143158
<!-- /gh-issue-number -->

This PR implements trace-level hot/cold code splitting for the JIT.

Previously, each uop stencil was emitted as one contiguous code block, so hot fast-path code and rarely executed cold/error-path code were interleaved
throughout the compiled trace:

`[uop0 hot+cold][uop1 hot+cold][uop2 hot+cold]...`

This change separates each stencil into hot and cold code and emits the trace as:

`[uop0 hot][uop1 hot][uop2 hot]...[uop0 cold][uop1 cold][uop2 cold]...`

Plan:
- [x] Move cold code after `_JIT_CONTINUE` and introduce `_JIT_COLD_START` for positioning.
- [x] Split cold / hot code when emitting stencils
