### PR TITLE
gh-145378: Generate consistent colors for pdb commands

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -402,6 +402,7 @@ class PdbPyReplInput:
                 completer_delims=frozenset(' \t\n`@#%^&*()=+[{]}\\|;:\'",<>?')
             )
         )
+        self.readline_wrapper.get_reader().gen_colors = self.gen_colors
 
     def readline(self):
 
@@ -462,6 +463,26 @@ class PdbPyReplInput:
             return self.completion_matches[state]
         except IndexError:
             return None
+
+    def gen_colors(self, buffer):
+        from _pyrepl.utils import ColorSpan, Span
+
+        if not buffer.strip():
+            return
+
+        leading_spaces = len(buffer) - len(buffer.lstrip())
+        leading_text = buffer.split()[0]
+        if hasattr(self.pdb_instance, 'do_' + leading_text):
+            yield ColorSpan(
+                Span(leading_spaces, leading_spaces + len(leading_text) - 1),
+                "soft_keyword"
+            )
+            redact_length = leading_spaces + len(leading_text)
+        else:
+            redact_length = 0
+
+        buffer = ' ' * redact_length + buffer[redact_length:]
+        yield from _pyrepl.utils.gen_colors(buffer)
 
 
 class Pdb(bdb.Bdb, cmd.Cmd):

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -477,11 +477,11 @@ class PdbPyReplInput:
                 Span(leading_spaces, leading_spaces + len(leading_text) - 1),
                 "soft_keyword"
             )
+            # Redact the command text with spaces so there will be no duplicated
+            # color span generated for it later.
             redact_length = leading_spaces + len(leading_text)
-        else:
-            redact_length = 0
+            buffer = ' ' * redact_length + buffer[redact_length:]
 
-        buffer = ' ' * redact_length + buffer[redact_length:]
         yield from _pyrepl.utils.gen_colors(buffer)
 
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4981,6 +4981,7 @@ class PdbTestColorize(unittest.TestCase):
         p.set_trace(commands=['w', 'c'])
         self.assertIn("\x1b", output.getvalue())
 
+    @unittest.skipIf(not pdb._pyrepl_available(), "pyrepl is not available")
     def test_gen_colors(self):
         p = pdb.Pdb()
         gen_colors = p.pyrepl_input.gen_colors
@@ -4998,7 +4999,6 @@ class PdbTestColorize(unittest.TestCase):
         ]
 
         for buffer, expected in test_cases:
-            print(list(gen_colors(buffer)))
             for color_span, ((start, end), tag) in zip(gen_colors(buffer), expected, strict=True):
                 self.assertEqual(color_span.span.start, start)
                 self.assertEqual(color_span.span.end, end)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4981,6 +4981,29 @@ class PdbTestColorize(unittest.TestCase):
         p.set_trace(commands=['w', 'c'])
         self.assertIn("\x1b", output.getvalue())
 
+    def test_gen_colors(self):
+        p = pdb.Pdb()
+        gen_colors = p.pyrepl_input.gen_colors
+
+        test_cases = [
+            ("longlist", [((0, 7), "soft_keyword")]),
+            ("!longlist", [((0, 0), "op")]),
+            ("list", [((0, 3), "soft_keyword")]),
+            ("list(", [((0, 3), "builtin"), ((4, 4), "op")]),
+            ("a = 1", [
+                ((0, 0), "soft_keyword"),
+                ((2, 2), "op"),
+                ((4, 4), "number"),
+            ])
+        ]
+
+        for buffer, expected in test_cases:
+            print(list(gen_colors(buffer)))
+            for color_span, ((start, end), tag) in zip(gen_colors(buffer), expected, strict=True):
+                self.assertEqual(color_span.span.start, start)
+                self.assertEqual(color_span.span.end, end)
+                self.assertEqual(color_span.tag, tag)
+
 
 @support.force_not_colorized_test_class
 @support.requires_subprocess()

--- a/Misc/NEWS.d/next/Library/2026-05-03-01-49-57.gh-issue-145378.rtyAWM.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-03-01-49-57.gh-issue-145378.rtyAWM.rst
@@ -1,0 +1,1 @@
+Generate consistent colors for :mod:`pdb` commands in :mod:`pdb` REPL.


### PR DESCRIPTION
We supported pyrepl for pdb input. We used the default pyrepl color scheme which works most of the time. However, for pdb commands, they are not recognized. There are also some pdb commands (list, continue) that would be recognized as different things in pyrepl.

We should recognize those commands and use a consistent color for it. It's actually pretty helpful because users will (probably) realize that `a = 1` won't work because `a` has a special color (`a` is a command for `arg`).

<!-- gh-issue-number: gh-145378 -->
* Issue: gh-145378
<!-- /gh-issue-number -->
