### PR TITLE
Ignore `/jit_unwind_info*.h` from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ Tools/unicode/data/
 /.ccache
 /cross-build*/
 /jit_stencils*.h
+/jit_unwind_info*.h
 /platform
 /profile-clean-stamp
 /profile-run-stamp


### PR DESCRIPTION
See https://github.com/python/cpython/pull/149310 for the context.