### PR TITLE
gh-149254: Update Windows builds to use OpenSSL 3.5.6

### DIFF
--- a/Misc/NEWS.d/next/Windows/2026-05-03-13-55-51.gh-issue-149254.ENtMYD.rst
+++ b/Misc/NEWS.d/next/Windows/2026-05-03-13-55-51.gh-issue-149254.ENtMYD.rst
@@ -1,0 +1,1 @@
+Updated bundled version of OpenSSL to 3.5.6.

--- a/Misc/externals.spdx.json
+++ b/Misc/externals.spdx.json
@@ -70,21 +70,21 @@
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "619b30acf7d9b13c9d0ba90d17349e8b524c380cd23d39334b143f74dc4e5ec9"
+          "checksumValue": "cf01946f3a61ba45a08c1e35b223d41d23963e3df5ac98cbad6c8fa5a81070ca"
         }
       ],
-      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/openssl-3.5.5.tar.gz",
+      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/openssl-3.5.6.tar.gz",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:openssl:openssl:3.5.5:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:openssl:openssl:3.5.6:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
       "licenseConcluded": "NOASSERTION",
       "name": "openssl",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "3.5.5"
+      "versionInfo": "3.5.6"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-sqlite",

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -54,7 +54,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.8
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.4.4
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-3.5.5
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-3.5.6
 set libraries=%libraries%                                       mpdecimal-4.0.0
 set libraries=%libraries%                                       sqlite-3.50.4.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.15.0
@@ -79,7 +79,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.4.4
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-3.5.5
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-3.5.6
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.15.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 if NOT "%IncludeLLVM%"=="false"    set binaries=%binaries% llvm-21.1.4.0

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -82,8 +82,8 @@
     <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
     <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
     <mpdecimalDir Condition="$(mpdecimalDir) == ''">$(ExternalsDir)\mpdecimal-4.0.0\</mpdecimalDir>
-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.5.5\</opensslDir>
-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.5.5\$(ArchName)\</opensslOutDir>
+    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.5.6\</opensslDir>
+    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.5.6\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.3.1\</zlibDir>


### PR DESCRIPTION


<!-- gh-issue-number: gh-149254 -->
* Issue: gh-149254
<!-- /gh-issue-number -->
