### PR TITLE
[3.13] gh-149254: Update CI to use latest OpenSSL versions (GH-149330)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,7 +291,7 @@ jobs:
         # Keep 1.1.1w in our list despite it being upstream EOL and otherwise
         # unsupported as it most resembles other 1.1.1-work-a-like ssl APIs
         # supported by important vendors such as AWS-LC.
-        openssl_ver: [1.1.1w, 3.0.19, 3.3.6, 3.4.4, 3.5.5, 3.6.1]
+        openssl_ver: [1.1.1w, 3.0.20, 3.3.7, 3.4.5, 3.5.6, 3.6.2]
         # See Tools/ssl/make_ssl_data.py for notes on adding a new version
     env:
       OPENSSL_VER: ${{ matrix.openssl_ver }}
@@ -366,7 +366,7 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-ubuntu == 'true'
     env:
-      OPENSSL_VER: 3.0.18
+      OPENSSL_VER: 3.0.20
       PYTHONSTRICTEXTENSIONBUILD: 1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -473,7 +473,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
     env:
-      OPENSSL_VER: 3.0.18
+      OPENSSL_VER: 3.0.20
       PYTHONSTRICTEXTENSIONBUILD: 1
       ASAN_OPTIONS: detect_leaks=0:allocator_may_return_null=1:handle_segv=0
     steps:

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
     env:
-      OPENSSL_VER: 3.0.18
+      OPENSSL_VER: 3.0.20
       PYTHONSTRICTEXTENSIONBUILD: 1
       TERM: linux
     steps:

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -49,11 +49,11 @@ OPENSSL_OLD_VERSIONS = [
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "3.0.19",
-    "3.3.6",
-    "3.4.4",
-    "3.5.5",
-    "3.6.1",
+    "3.0.20",
+    "3.3.7",
+    "3.4.5",
+    "3.5.6",
+    "3.6.2",
     # See make_ssl_data.py for notes on adding a new version.
 ]
 


### PR DESCRIPTION
(adapted from commit 68fe899feb8515113d09a4161f34ae45809b807a)

<!-- gh-issue-number: gh-149254 -->
* Issue: gh-149254
<!-- /gh-issue-number -->
