### PR TITLE
gh-61103: use PEP 3118 codes in the ctypes

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -879,6 +879,15 @@ contextlib
   (Contributed by Alex Grönholm & Gregory P. Smith in :gh:`125862`.)
 
 
+ctypes
+------
+
+* Change the ``format`` field of exported buffers from ``F``, ``D`` and ``G``
+  to ``Zf``, ``Zd`` and ``Zg``, respectively, for compatibility with
+  the :pep:`3118` and NumPy.
+  (Contributed by Sergey B Kirpichev in :gh:`149344`.)
+
+
 dataclasses
 -----------
 

--- a/Lib/test/test_ctypes/test_pep3118.py
+++ b/Lib/test/test_ctypes/test_pep3118.py
@@ -1,3 +1,4 @@
+import ctypes
 import re
 import sys
 import unittest
@@ -230,6 +231,14 @@ native_types = [
     (CFUNCTYPE(None),           "X{}",                  (),           CFUNCTYPE(None)),
 
     ]
+
+if hasattr(ctypes, 'c_float_complex'):
+    c_float_complex = ctypes.c_float_complex
+    c_double_complex = ctypes.c_double_complex
+    c_longdouble_complex = ctypes.c_longdouble_complex
+    native_types.extend([(c_float_complex * 4,      "<Zf", (4,), c_float_complex),
+                         (c_double_complex * 4,     "<Zd", (4,), c_double_complex),
+                         (c_longdouble_complex * 4, "<Zg", (4,), c_longdouble_complex)])
 
 
 class BEPoint(BigEndianStructure):

--- a/Misc/NEWS.d/next/Library/2026-05-04-05-08-17.gh-issue-61103.mONh4V.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-04-05-08-17.gh-issue-61103.mONh4V.rst
@@ -1,0 +1,2 @@
+Use :pep:`3118` type codes for the buffer protocol support of complex types
+in the :mod:`ctypes`.  Patch by Sergey B Kirpichev.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -305,13 +305,41 @@ _ctypes_alloc_format_string_for_type(char code, int big_endian)
 #else
 # error SIZEOF__BOOL has an unexpected value
 #endif /* SIZEOF__BOOL */
+#if defined(_Py_FFI_SUPPORT_C_COMPLEX)
+    /* complex types */
+    case 'F':
+    case 'D':
+    case 'G':
+    {
+        result = PyMem_Malloc(4);
+        if (result == NULL) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+
+        result[0] = big_endian ? '>' : '<';
+        result[1] = 'Z';
+        switch (code) {
+        case 'F':
+            result[2] = 'f';
+            break;
+        case 'D':
+            result[2] = 'd';
+            break;
+        default:
+            result[2] = 'g';
+        }
+        result[3] = '\0';
+        return result;
+    }
+#endif
     default:
         /* The standard-size code is the same as the ctypes one */
         pep_code = code;
         break;
     }
 
-    result = PyMem_Malloc(4);
+    result = PyMem_Malloc(3);
     if (result == NULL) {
         PyErr_NoMemory();
         return NULL;
@@ -320,7 +348,6 @@ _ctypes_alloc_format_string_for_type(char code, int big_endian)
     result[0] = big_endian ? '>' : '<';
     result[1] = pep_code;
     result[2] = '\0';
-    result[3] = '\0';
     return result;
 }
 
@@ -3121,27 +3148,7 @@ PyCData_NewGetBuffer(PyObject *myself, Py_buffer *view, int flags)
     view->len = self->b_size;
     view->readonly = 0;
     /* use default format character if not set */
-    if (!info->format) {
-        view->format = "B";
-    }
-    else {
-        view->format = info->format;
-        if (view->format[1] == 'F') {
-            view->format[1] = 'Z';
-            view->format[2] = 'f';
-            view->format[3] = '\0';
-        }
-        if (view->format[1] == 'D') {
-            view->format[1] = 'Z';
-            view->format[2] = 'd';
-            view->format[3] = '\0';
-        }
-        if (view->format[1] == 'G') {
-            view->format[1] = 'Z';
-            view->format[2] = 'g';
-            view->format[3] = '\0';
-        }
-    }
+    view->format = info->format ? info->format : "B";
     view->ndim = info->ndim;
     view->shape = info->shape;
     view->itemsize = item_info->size;

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -311,7 +311,7 @@ _ctypes_alloc_format_string_for_type(char code, int big_endian)
         break;
     }
 
-    result = PyMem_Malloc(3);
+    result = PyMem_Malloc(4);
     if (result == NULL) {
         PyErr_NoMemory();
         return NULL;
@@ -320,6 +320,7 @@ _ctypes_alloc_format_string_for_type(char code, int big_endian)
     result[0] = big_endian ? '>' : '<';
     result[1] = pep_code;
     result[2] = '\0';
+    result[3] = '\0';
     return result;
 }
 
@@ -3120,7 +3121,27 @@ PyCData_NewGetBuffer(PyObject *myself, Py_buffer *view, int flags)
     view->len = self->b_size;
     view->readonly = 0;
     /* use default format character if not set */
-    view->format = info->format ? info->format : "B";
+    if (!info->format) {
+        view->format = "B";
+    }
+    else {
+        view->format = info->format;
+        if (view->format[1] == 'F') {
+            view->format[1] = 'Z';
+            view->format[2] = 'f';
+            view->format[3] = '\0';
+        }
+        if (view->format[1] == 'D') {
+            view->format[1] = 'Z';
+            view->format[2] = 'd';
+            view->format[3] = '\0';
+        }
+        if (view->format[1] == 'G') {
+            view->format[1] = 'Z';
+            view->format[2] = 'g';
+            view->format[3] = '\0';
+        }
+    }
     view->ndim = info->ndim;
     view->shape = info->shape;
     view->itemsize = item_info->size;


### PR DESCRIPTION
This change only buffer protocol support for complex types, `_type_` properties aren't affected.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-61103 -->
* Issue: gh-61103
<!-- /gh-issue-number -->
