### PR TITLE
gh-149093: Resolved circular dependency between 'mapping' term and `collections.abc.Mapping`

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -996,8 +996,8 @@ Glossary
       Examples include :class:`dict`, :class:`collections.defaultdict`,
       :class:`collections.OrderedDict` and :class:`collections.Counter`.
 
-      See more details on implemented methods :ref:`there <collections-abstract-base-classes>`. 
-      
+      See more details on implemented methods :ref:`there <collections-abstract-base-classes>`.
+
    meta path finder
       A :term:`finder` returned by a search of :data:`sys.meta_path`.  Meta path
       finders are related to, but different from :term:`path entry finders

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -991,12 +991,12 @@ Glossary
 
    mapping
       A container object that supports arbitrary key lookups and implements the
-      methods specified in the :class:`collections.abc.Mapping` or
-      :class:`collections.abc.MutableMapping`
-      :ref:`abstract base classes <collections-abstract-base-classes>`.  Examples
-      include :class:`dict`, :class:`collections.defaultdict`,
+      methods of :class:`collections.abc.Mapping` or
+      :class:`collections.abc.MutableMapping` :term:`abstract base classes <abstract base class>`.
+      Examples include :class:`dict`, :class:`collections.defaultdict`,
       :class:`collections.OrderedDict` and :class:`collections.Counter`.
 
+      See more details on implemented methods :ref:`there <collections-abstract-base-classes>`. 
    meta path finder
       A :term:`finder` returned by a search of :data:`sys.meta_path`.  Meta path
       finders are related to, but different from :term:`path entry finders

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -997,6 +997,7 @@ Glossary
       :class:`collections.OrderedDict` and :class:`collections.Counter`.
 
       See more details on implemented methods :ref:`there <collections-abstract-base-classes>`. 
+      
    meta path finder
       A :term:`finder` returned by a search of :data:`sys.meta_path`.  Meta path
       finders are related to, but different from :term:`path entry finders

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -313,7 +313,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 .. class:: Mapping
            MutableMapping
 
-   ABCs for read-only and mutable :term:`mappings <mapping>`.
+   ABCs for read-only and mutable :ref:`mapping <typesmapping>`.
 
 .. class:: MappingView
            ItemsView


### PR DESCRIPTION
gh-149093: Resolved circular dependency between mapping term collections.abc.Mapping

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

After thinking for a bit I decided to redirect mapping link in [classes description](https://docs.python.org/3/library/collections.abc.html#collections.abc.Mapping) to [built-in types](https://docs.python.org/3/library/stdtypes.html), as it is implemented in sets. 

Also, in the glossary, I pointed out where to find a table with implemented methods, as was requested in the issue.