### PR TITLE
gh-149351:  Avoid possible broken macOS framework install names when DESTDIR is specified during builds

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1071,7 +1071,7 @@ $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK): \
 	$(INSTALL) -d -m $(DIRMODE) $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)
 	$(CC) -o $(LDLIBRARY) $(PY_CORE_LDFLAGS) -dynamiclib \
 		-all_load $(LIBRARY) \
-		-install_name $(DESTDIR)$(PYTHONFRAMEWORKINSTALLNAMEPREFIX)/$(PYTHONFRAMEWORK) \
+		-install_name $(PYTHONFRAMEWORKINSTALLNAMEPREFIX)/$(PYTHONFRAMEWORK) \
 		-compatibility_version $(VERSION) \
 		-current_version $(VERSION) \
 		-framework CoreFoundation $(LIBS);

--- a/Misc/NEWS.d/next/Build/2026-05-04-06-03-50.gh-issue-149351.hN4sF0.rst
+++ b/Misc/NEWS.d/next/Build/2026-05-04-06-03-50.gh-issue-149351.hN4sF0.rst
@@ -1,0 +1,2 @@
+Avoid possible broken macOS framework install names when DESTDIR is
+specified during builds.


### PR DESCRIPTION


<!-- gh-issue-number: gh-149351 -->
* Issue: gh-149351
<!-- /gh-issue-number -->
