### PR TITLE
gh-148292: Remove shutdown() test in test_ssl.test_got_eof()

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5074,14 +5074,6 @@ class ThreadedTests(unittest.TestCase):
                 sslsock.do_handshake()
 
             self.assertEqual(sslsock.pending(), 0)
-            try:
-                sslsock.shutdown(socket.SHUT_WR)
-            except OSError as exc:
-                self.assertEqual(exc.errno, errno.ENOTCONN)
-            else:
-                # On Windows and on OpenSSL 1.1.1, shutdown() doesn't
-                # raise an error
-                pass
 
 
 @unittest.skipUnless(has_tls_version('TLSv1_3') and ssl.HAS_PHA,


### PR DESCRIPTION
shutdown() behavior depends too much on the operating system and it's unrelated to the got_eof_error change.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148292 -->
* Issue: gh-148292
<!-- /gh-issue-number -->
