### PR TITLE
[3.13] GH-130750: Restore quoting of choices in argparse error messag…

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2601,7 +2601,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 choices = iter(choices)
             if value not in choices:
                 args = {'value': str(value),
-                        'choices': ', '.join(map(str, action.choices))}
+                        'choices': ', '.join(repr(str(choice)) for choice in action.choices)}
                 msg = _('invalid choice: %(value)r (choose from %(choices)s)')
                 raise ArgumentError(action, msg % args)
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1047,7 +1047,7 @@ class TestStrEnumChoices(TestCase):
         parser.add_argument('--color', choices=self.Color)
         self.assertRaisesRegex(
             argparse.ArgumentError,
-            r"invalid choice: 'yellow' \(choose from red, green, blue\)",
+            r"invalid choice: 'yellow' \(choose from 'red', 'green', 'blue'\)",
             parser.parse_args,
             ['--color', 'yellow'],
         )
@@ -2517,7 +2517,7 @@ class TestAddSubparsers(TestCase):
             parser.parse_args(('baz',))
         self.assertRegex(
             excinfo.exception.stderr,
-            r"error: argument {foo,bar}: invalid choice: 'baz' \(choose from foo, bar\)\n$"
+            r"error: argument {foo,bar}: invalid choice: 'baz' \(choose from 'foo', 'bar'\)\n$"
         )
 
     def test_optional_subparsers(self):

--- a/Misc/NEWS.d/next/Library/2026-02-19-04-40-57.gh-issue-130750.0hW52O.rst
+++ b/Misc/NEWS.d/next/Library/2026-02-19-04-40-57.gh-issue-130750.0hW52O.rst
@@ -1,0 +1,2 @@
+Restore quoting of choices in :mod:`argparse` error messages for improved clarity and consistency with documentation.
+


### PR DESCRIPTION
…es to match documentation and improve clarity (GH-144983)

(cherry picked from commit 53a7f76501923059188922be231db855265fe9a4)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130750 -->
* Issue: gh-130750
<!-- /gh-issue-number -->
