### PR TITLE
gh-149394: Document that `atexit` functions are not called when `os.exec*()` is called

### DIFF
--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -15,7 +15,8 @@ at interpreter termination time they will be run in the order ``C``, ``B``,
 
 **Note:** The functions registered via this module are not called when the
 program is killed by a signal not handled by Python, when a Python fatal
-internal error is detected, or when :func:`os._exit` is called.
+internal error is detected, or when :func:`os._exit` or :func:`os.exec\*
+<os.execl>` are called.
 
 **Note:** The effect of registering or unregistering functions from within
 a cleanup function is undefined.


### PR DESCRIPTION
Running the following test file

```python
#!/usr/bin/env python3
import atexit
import os
import sys

atexit.register(print, "atexit callback called")
# sys.exit()
os.execl("/usr/bin/true", "true")
```

does _not_ print a message to the console in Python 3.14, so add `os.exec*()` to the list of cases where `atexit` functions are not called.

Fixes #149394.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149394 -->
* Issue: gh-149394
<!-- /gh-issue-number -->
