### PR TITLE
Ignore `.jit-stamp` generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ Tools/unicode/data/
 /cross-build*/
 /jit_stencils*.h
 /jit_unwind_info*.h
+.jit-stamp
 /platform
 /profile-clean-stamp
 /profile-run-stamp


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/149269

It is only ever used in `Makefile`: `JIT_GENERATED_STAMP`, it is not needed in the repo.
No backports are needed, `3.14` does not have this logic in https://github.com/python/cpython/blob/3.14/Makefile.pre.in