### PR TITLE
gh-149425: Increase `test_write_without_source_date_epoch` assertion delta

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -1903,7 +1903,7 @@ class OtherTests(unittest.TestCase):
                 zip_info = zf.getinfo("test_no_source_date_epoch.txt")
                 current_time = time.localtime()[:6]
                 for z_time, c_time in zip(zip_info.date_time, current_time):
-                    self.assertAlmostEqual(z_time, c_time, delta=1)
+                    self.assertAlmostEqual(z_time, c_time, delta=2)
 
     def test_close(self):
         """Check that the zipfile is closed after the 'with' block."""

--- a/Misc/NEWS.d/next/Tests/2026-05-05-18-49-44.gh-issue-149425.QnQL8j.rst
+++ b/Misc/NEWS.d/next/Tests/2026-05-05-18-49-44.gh-issue-149425.QnQL8j.rst
@@ -1,0 +1,1 @@
+Increase time delta in test ``test_write_without_source_date_epoch``

--- a/Misc/NEWS.d/next/Tests/2026-05-05-18-49-44.gh-issue-149425.QnQL8j.rst
+++ b/Misc/NEWS.d/next/Tests/2026-05-05-18-49-44.gh-issue-149425.QnQL8j.rst
@@ -1,1 +1,1 @@
-Increase time delta in test ``test_write_without_source_date_epoch``
+Increase time delta in ``test.test_zipfile.test_core.OtherTests.test_write_without_source_date_epoch``


### PR DESCRIPTION
This pull request makes a minor adjustment to a test in `test_core.py` to allow for a slightly larger difference in timestamp values when comparing ZIP file metadata to the current time.

- Increased the allowable delta in the `assertAlmostEqual` check from 1 to 2 in the `test_write_without_source_date_epoch` test, to reduce test flakiness due to timing differences. (`Lib/test/test_zipfile/test_core.py`)

Fixes #149425 


<!-- gh-issue-number: gh-149425 -->
* Issue: gh-149425
<!-- /gh-issue-number -->
