### PR TITLE
gh-67071: Link devguide from configure build requirements

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -10,6 +10,12 @@ Configure Python
 Build Requirements
 ==================
 
+.. seealso::
+
+   For step-by-step instructions on installing dependencies and building
+   CPython, refer to the `Python Developer's Guide
+   <https://devguide.python.org/getting-started/setup-building/>`_.
+
 To build CPython, you will need:
 
 * A `C11 <https://en.cppreference.com/w/c/11>`_ compiler. `Optional C11

--- a/Misc/NEWS.d/next/Documentation/2026-05-05-21-30-00.gh-issue-67071.DevGuide.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-05-05-21-30-00.gh-issue-67071.DevGuide.rst
@@ -1,0 +1,3 @@
+Add a *See also* cross-reference from the *Build requirements* section of the
+*Configure Python* documentation to the Python Developer's Guide for setup
+and build instructions.


### PR DESCRIPTION
## Summary

Add a `.. seealso::` block at the top of the **Build requirements** section in `Doc/using/configure.rst`, pointing readers to the [Python Developer's Guide setup and building](https://devguide.python.org/getting-started/setup-building/) page.

This matches the direction on [gh-67071](https://github.com/python/cpython/issues/67071): cross-link from the official configure documentation rather than duplicating per-distro package lists in CPython (see discussion with @bitdancer and @StanFromIreland).

## News

`Misc/NEWS.d/next/Documentation/2026-05-05-21-30-00.gh-issue-67071.DevGuide.rst`

## Checklist

- [x] Documentation-only change; no code or tests.
