### PR TITLE
[3.14] gh-145736: Fix test_tkinter test_configure_values test case backport miss for Tk 9.

### DIFF
--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -576,7 +576,8 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         else:
             expected = (42, 3.14, '', 'any string')
         self.checkParam(widget, 'values', (42, 3.14, '', 'any string'),
-                        expected='42 3.14 {} {any string}')
+                        expected=expected)
+
         self.checkParam(widget, 'values', '')
 
     def test_configure_wrap(self):

--- a/Misc/NEWS.d/next/Tests/2026-05-05-17-08-36.gh-issue-145736.JYdLx4.rst
+++ b/Misc/NEWS.d/next/Tests/2026-05-05-17-08-36.gh-issue-145736.JYdLx4.rst
@@ -1,0 +1,1 @@
+Fix test_tkinter test_configure_values test case backport miss for Tk 9.


### PR DESCRIPTION


<!-- gh-issue-number: gh-145736 -->
* Issue: gh-145736
<!-- /gh-issue-number -->
