### PR TITLE
[3.14] gh-148615: Handle `--` separator in pdb argument parsing (GH-1…

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -3611,6 +3611,10 @@ def parse_args():
         opt_module = parser.parse_args(args[:2])
         opts.module = opt_module.module
         args = args[2:]
+    elif args[0] == '--':
+        args.pop(0)
+        if not args:
+            parser.error("missing script or module to run")
     elif args[0].startswith('-'):
         # Invalid argument before the script name.
         invalid_args = list(itertools.takewhile(lambda a: a.startswith('-'), args))

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4643,6 +4643,27 @@ def bœr():
             ]))
             self.assertIn('break in bar', stdout)
 
+    def test_end_of_options_separator(self):
+        # gh-148615: Test parsing when '--' separator is used
+        script = "import sys; print(f'ARGS: {sys.argv[1:]}')"
+        with open(os_helper.TESTFN, 'w', encoding='utf-8') as f:
+            f.write(script)
+        stdout, _ = self._run_pdb(['--', os_helper.TESTFN, '-foo'], 'c\nq')
+        self.assertIn("ARGS: ['-foo']", stdout)
+        stdout, _ = self._run_pdb(['-c', 'continue', '--', os_helper.TESTFN, '-c', 'foo'], 'q')
+        self.assertIn("ARGS: ['-c', 'foo']", stdout)
+        stdout, stderr = self._run_pdb(['--'], 'q', expected_returncode=2)
+        self.assertIn("missing script or module to run", stderr)
+        stdout, stderr = self._run_pdb(['-x', '--', os_helper.TESTFN], 'q', expected_returncode=2)
+        self.assertIn("unrecognized arguments: -x", stderr)
+        stdout, _ = self._run_pdb([os_helper.TESTFN, '--', 'arg'], 'c\nq')
+        self.assertIn("ARGS: ['--', 'arg']", stdout)
+        with os_helper.temp_cwd():
+            with open('mymod.py', 'w', encoding='utf-8') as f:
+                f.write(script)
+            stdout, _ = self._run_pdb(['-m', 'mymod', '--', 'arg'], 'c\nq')
+            self.assertIn("ARGS: ['--', 'arg']", stdout)
+
     def test_issue_59000(self):
         script = """
             def foo():

--- a/Misc/NEWS.d/next/Library/2026-04-15-16-08-12.gh-issue-148615.Uvx50R.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-15-16-08-12.gh-issue-148615.Uvx50R.rst
@@ -1,0 +1,1 @@
+Fix :mod:`pdb` to accept standard -- end of options separator. Reported by haampie. Patched by Shrey Naithani.


### PR DESCRIPTION
…48624)
(cherry picked from commit 970b0433f498fd0d048b1f50229a7f0fb4d9e07a)

Co-authored-by: Shrey Naithani <shrey.naithani@shelllite.tech>

<!-- gh-issue-number: gh-148615 -->
* Issue: gh-148615
<!-- /gh-issue-number -->
