### PR TITLE
gh-149324: Raise OSError for msvcrt getch() without console

### DIFF
--- a/Lib/test/test_msvcrt.py
+++ b/Lib/test/test_msvcrt.py
@@ -70,6 +70,22 @@ class TestConsoleIO(unittest.TestCase):
         subprocess.run(cmd, check=True, capture_output=True,
                        creationflags=subprocess.CREATE_NEW_CONSOLE)
 
+    @requires_resource('gui')
+    def assert_console_read_raises_after_freeconsole(self, funcname):
+        code = dedent(f'''
+            import ctypes
+            import msvcrt
+            import sys
+
+            ctypes.windll.kernel32.FreeConsole()
+            try:
+                msvcrt.{funcname}()
+            except OSError:
+                sys.exit(0)
+            sys.exit(1)
+        ''')
+        self.run_in_separated_process(code)
+
     def test_kbhit(self):
         code = dedent('''
             import msvcrt
@@ -80,6 +96,9 @@ class TestConsoleIO(unittest.TestCase):
     def test_getch(self):
         msvcrt.ungetch(b'c')
         self.assertEqual(msvcrt.getch(), b'c')
+
+    def test_getch_without_console(self):
+        self.assert_console_read_raises_after_freeconsole('getch')
 
     def check_getwch(self, funcname):
         code = dedent(f'''
@@ -94,12 +113,21 @@ class TestConsoleIO(unittest.TestCase):
     def test_getwch(self):
         self.check_getwch('getwch')
 
+    def test_getwch_without_console(self):
+        self.assert_console_read_raises_after_freeconsole('getwch')
+
     def test_getche(self):
         msvcrt.ungetch(b'c')
         self.assertEqual(msvcrt.getche(), b'c')
 
+    def test_getche_without_console(self):
+        self.assert_console_read_raises_after_freeconsole('getche')
+
     def test_getwche(self):
         self.check_getwch('getwche')
+
+    def test_getwche_without_console(self):
+        self.assert_console_read_raises_after_freeconsole('getwche')
 
     def test_putch(self):
         msvcrt.putch(b'c')

--- a/Misc/NEWS.d/next/Windows/2026-05-06-14-20-00.gh-issue-149324.EOFgetch.rst
+++ b/Misc/NEWS.d/next/Windows/2026-05-06-14-20-00.gh-issue-149324.EOFgetch.rst
@@ -1,0 +1,3 @@
+Fix :func:`msvcrt.getch`, :func:`msvcrt.getche`, :func:`msvcrt.getwch`, and
+:func:`msvcrt.getwche` to raise :exc:`OSError` instead of returning the CRT
+EOF sentinel when no console is attached.

--- a/PC/clinic/msvcrtmodule.c.h
+++ b/PC/clinic/msvcrtmodule.c.h
@@ -249,11 +249,17 @@ static PyObject *
 msvcrt_getch(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     PyObject *return_value = NULL;
+    int _return_value;
     char s[1];
 
-    s[0] = msvcrt_getch_impl(module);
+    _return_value = msvcrt_getch_impl(module);
+    if ((_return_value == EOF) && PyErr_Occurred()) {
+        goto exit;
+    }
+    s[0] = (char)_return_value;
     return_value = PyBytes_FromStringAndSize(s, 1);
 
+exit:
     return return_value;
 }
 
@@ -278,8 +284,12 @@ msvcrt_getwch(PyObject *module, PyObject *Py_UNUSED(ignored))
     wchar_t _return_value;
 
     _return_value = msvcrt_getwch_impl(module);
+    if ((_return_value == WEOF) && PyErr_Occurred()) {
+        goto exit;
+    }
     return_value = PyUnicode_FromOrdinal(_return_value);
 
+exit:
     return return_value;
 }
 
@@ -301,11 +311,17 @@ static PyObject *
 msvcrt_getche(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     PyObject *return_value = NULL;
+    int _return_value;
     char s[1];
 
-    s[0] = msvcrt_getche_impl(module);
+    _return_value = msvcrt_getche_impl(module);
+    if ((_return_value == EOF) && PyErr_Occurred()) {
+        goto exit;
+    }
+    s[0] = (char)_return_value;
     return_value = PyBytes_FromStringAndSize(s, 1);
 
+exit:
     return return_value;
 }
 
@@ -330,8 +346,12 @@ msvcrt_getwche(PyObject *module, PyObject *Py_UNUSED(ignored))
     wchar_t _return_value;
 
     _return_value = msvcrt_getwche_impl(module);
+    if ((_return_value == WEOF) && PyErr_Occurred()) {
+        goto exit;
+    }
     return_value = PyUnicode_FromOrdinal(_return_value);
 
+exit:
     return return_value;
 }
 
@@ -743,4 +763,4 @@ exit:
 #ifndef MSVCRT_GETERRORMODE_METHODDEF
     #define MSVCRT_GETERRORMODE_METHODDEF
 #endif /* !defined(MSVCRT_GETERRORMODE_METHODDEF) */
-/*[clinic end generated code: output=f67eaf745685429d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9daceaf7020298ef input=a9049054013a1b77]*/

--- a/PC/msvcrtmodule.c
+++ b/PC/msvcrtmodule.c
@@ -62,8 +62,11 @@ class byte_char_return_converter(CReturnConverter):
     type = 'int'
 
     def render(self, function, data):
+        self.declare(data)
+        self.err_occurred_if("_return_value == EOF", data)
         data.declarations.append('char s[1];')
-        data.return_value = 's[0]'
+        data.return_conversion.append(
+            's[0] = (char)_return_value;\n')
         data.return_conversion.append(
             'return_value = PyBytes_FromStringAndSize(s, 1);\n')
 
@@ -72,10 +75,11 @@ class wchar_t_return_converter(CReturnConverter):
 
     def render(self, function, data):
         self.declare(data)
+        self.err_occurred_if("_return_value == WEOF", data)
         data.return_conversion.append(
             'return_value = PyUnicode_FromOrdinal(_return_value);\n')
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=ff031be44ab3250d]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=4da08376e54a1a4d]*/
 
 /*[clinic input]
 module msvcrt
@@ -252,6 +256,9 @@ msvcrt_getch_impl(PyObject *module)
     Py_BEGIN_ALLOW_THREADS
     ch = _getch();
     Py_END_ALLOW_THREADS
+    if (ch == EOF) {
+        PyErr_SetFromWindowsErr(0);
+    }
     return ch;
 }
 
@@ -272,6 +279,9 @@ msvcrt_getwch_impl(PyObject *module)
     Py_BEGIN_ALLOW_THREADS
     ch = _getwch();
     Py_END_ALLOW_THREADS
+    if (ch == WEOF) {
+        PyErr_SetFromWindowsErr(0);
+    }
     return ch;
 }
 
@@ -292,6 +302,9 @@ msvcrt_getche_impl(PyObject *module)
     Py_BEGIN_ALLOW_THREADS
     ch = _getche();
     Py_END_ALLOW_THREADS
+    if (ch == EOF) {
+        PyErr_SetFromWindowsErr(0);
+    }
     return ch;
 }
 
@@ -312,6 +325,9 @@ msvcrt_getwche_impl(PyObject *module)
     Py_BEGIN_ALLOW_THREADS
     ch = _getwche();
     Py_END_ALLOW_THREADS
+    if (ch == WEOF) {
+        PyErr_SetFromWindowsErr(0);
+    }
     return ch;
 }
 


### PR DESCRIPTION
## Summary

Fix `msvcrt.getch()`, `getche()`, `getwch()`, and `getwche()` to raise `OSError` when no console is attached, instead of returning EOF/WEOF sentinel values as normal input.

## Issue

- gh-149324

## Testing

- Reviewed the source and generated changes locally
- Attempted `PCbuild\\amd64\\python_d.exe -m test -v -u gui test_msvcrt`
- Full local Windows test verification was blocked by unrelated stale/inconsistent extension build artifacts during rebuild
