### PR TITLE
gh-149277: Fix error position for invalid numeric literals

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -140,6 +140,26 @@ class TokenTests(unittest.TestCase):
         check("1e2_", "invalid decimal literal")
         check("1e+", "invalid decimal literal")
 
+    def test_end_of_numerical_literals_offset(self):
+        # gh-149277: verify the error caret points at the first invalid
+        # character, not the last valid digit.
+        cases = [
+            ("0xfg", 4),
+            ("0x9g", 4),
+            ("0b1z", 4),
+            ("0o7q", 4),
+            ("9spam", 2),
+            ("0xfspam", 4),
+            ("1.0x", 4),
+            ("1e3w", 4),
+            ("1jz", 3),
+        ]
+        for source, expected_offset in cases:
+            with self.subTest(source=source):
+                with self.assertRaises(SyntaxError) as cm:
+                    compile(source, "<test>", "eval")
+                self.assertEqual(cm.exception.offset, expected_offset)
+
     def test_end_of_numerical_literals(self):
         def check(test, error=False):
             with self.subTest(expr=test):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-06-18-16-33.gh-issue-149277.4uVfSK.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-06-18-16-33.gh-issue-149277.4uVfSK.rst
@@ -1,2 +1,2 @@
-Fix the :exec:`SyntaxError` caret position for invalid numeric literals to
+Fix the :exc:`SyntaxError` caret position for invalid numeric literals to
 point at the first invalid character instead of the last valid one.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-06-18-16-33.gh-issue-149277.4uVfSK.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-06-18-16-33.gh-issue-149277.4uVfSK.rst
@@ -1,0 +1,2 @@
+Fix the :exec:`SyntaxError` caret position for invalid numeric literals to
+point at the first invalid character instead of the last valid one.

--- a/Parser/lexer/lexer.c
+++ b/Parser/lexer/lexer.c
@@ -352,7 +352,6 @@ verify_end_of_number(struct tok_state *tok, int c, const char *kind) {
     }
     else /* In future releases, only error will remain. */
     if (c < 128 && is_potential_identifier_char(c)) {
-        tok_backup(tok, c);
         _PyTokenizer_syntaxerror(tok, "invalid %s literal", kind);
         return 0;
     }


### PR DESCRIPTION
## Summary

Fix the `SyntaxError` caret position for invalid numeric literals. Previously,
the caret pointed at the last valid digit instead of the first invalid character.

For example, `0x9g` now correctly shows:
0x9g
   ^
SyntaxError: invalid hexadecimal literal

Instead of the previous incorrect output:
0x9g
  ^
SyntaxError: invalid hexadecimal literal

The issue was a spurious `tok_backup(tok, c)` call in `verify_end_of_number()`
in the error branch. Since `_PyTokenizer_syntaxerror` computes the column offset
from `tok->cur`, backing up one character caused the caret to point at the
preceding (valid) character. Removing the backup keeps `tok->cur` at the correct
position.

Fixes #149277

<!-- gh-issue-number: gh-149277 -->
* Issue: gh-149277
<!-- /gh-issue-number -->
