### PR TITLE
gh-100239: specialize bytes binary operations

### DIFF
--- a/Include/internal/pycore_bytesobject.h
+++ b/Include/internal/pycore_bytesobject.h
@@ -19,6 +19,13 @@ extern PyObject* _PyBytes_FormatEx(
  * reference rather than modifying its first argument in place. */
 extern PyObject* _PyBytes_Concat(PyObject *a, PyObject *b);
 
+extern int _PyBytes_OffsetFromIndex(
+    PyObject *op,
+    Py_ssize_t index,
+    Py_ssize_t *offset);
+
+extern PyObject* _PyBytes_SubscriptIndex(PyObject *op, Py_ssize_t index);
+
 extern PyObject* _PyBytes_FromHex(
     PyObject *string,
     int use_bytearray);

--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -1439,6 +1439,21 @@ class TestSpecializer(TestBase):
         self.assert_specialized(binary_op_add_extend_sequences, "BINARY_OP_EXTEND")
         self.assert_no_opcode(binary_op_add_extend_sequences, "BINARY_OP")
 
+        def binary_op_extend_bytes():
+            b1 = b"foo"
+            b2 = b"bar"
+            for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+                bytes_sum = b1 + b2
+                self.assertEqual(bytes_sum, b"foobar")
+                bytes_repeat = b1 * 2
+                self.assertEqual(bytes_repeat, b"foofoo")
+                bytes_repeat = 2 * b1
+                self.assertEqual(bytes_repeat, b"foofoo")
+
+        binary_op_extend_bytes()
+        self.assert_specialized(binary_op_extend_bytes, "BINARY_OP_EXTEND")
+        self.assert_no_opcode(binary_op_extend_bytes, "BINARY_OP")
+
         def binary_op_zero_division():
             def compactlong_lhs(arg):
                 42 / arg
@@ -1952,6 +1967,29 @@ class TestSpecializer(TestBase):
         binary_subscr_str_int_non_compact()
         self.assert_specialized(binary_subscr_str_int_non_compact, "BINARY_OP_SUBSCR_USTR_INT")
         self.assert_no_opcode(binary_subscr_str_int_non_compact, "BINARY_OP_SUBSCR_STR_INT")
+
+        def binary_subscr_bytes_int():
+            a = b"foobar"
+            for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+                for idx, expected in enumerate(a):
+                    self.assertEqual(a[idx], expected)
+                self.assertEqual(a[-1], ord("r"))
+
+        binary_subscr_bytes_int()
+        self.assert_specialized(binary_subscr_bytes_int, "BINARY_OP_EXTEND")
+        self.assert_no_opcode(binary_subscr_bytes_int, "BINARY_OP")
+
+        def binary_subscr_bytes_slice():
+            a = b"foobar"
+            for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+                self.assertEqual(a[1:4], b"oob")
+                self.assertEqual(a[::-1], b"raboof")
+                self.assertEqual(a[:], a)
+                self.assertEqual(a[10:20], b"")
+
+        binary_subscr_bytes_slice()
+        self.assert_specialized(binary_subscr_bytes_slice, "BINARY_OP_EXTEND")
+        self.assert_no_opcode(binary_subscr_bytes_slice, "BINARY_OP")
 
         def binary_subscr_getitems():
             class C:

--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -1979,18 +1979,6 @@ class TestSpecializer(TestBase):
         self.assert_specialized(binary_subscr_bytes_int, "BINARY_OP_EXTEND")
         self.assert_no_opcode(binary_subscr_bytes_int, "BINARY_OP")
 
-        def binary_subscr_bytes_slice():
-            a = b"foobar"
-            for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
-                self.assertEqual(a[1:4], b"oob")
-                self.assertEqual(a[::-1], b"raboof")
-                self.assertEqual(a[:], a)
-                self.assertEqual(a[10:20], b"")
-
-        binary_subscr_bytes_slice()
-        self.assert_specialized(binary_subscr_bytes_slice, "BINARY_OP_EXTEND")
-        self.assert_no_opcode(binary_subscr_bytes_slice, "BINARY_OP")
-
         def binary_subscr_getitems():
             class C:
                 def __init__(self, val):

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1728,6 +1728,34 @@ bytes_hash(PyObject *self)
     return hash;
 }
 
+int
+_PyBytes_OffsetFromIndex(PyObject *op, Py_ssize_t index, Py_ssize_t *offset)
+{
+    PyBytesObject *self = _PyBytes_CAST(op);
+    Py_ssize_t size = PyBytes_GET_SIZE(self);
+    if (index < 0) {
+        index += size;
+    }
+    if (index < 0 || index >= size) {
+        return 0;
+    }
+    *offset = index;
+    return 1;
+}
+
+PyObject *
+_PyBytes_SubscriptIndex(PyObject *op, Py_ssize_t index)
+{
+    PyBytesObject *self = _PyBytes_CAST(op);
+    Py_ssize_t offset;
+    if (!_PyBytes_OffsetFromIndex(op, index, &offset)) {
+        PyErr_SetString(PyExc_IndexError,
+                        "index out of range");
+        return NULL;
+    }
+    return _PyLong_FromUnsignedChar((unsigned char)self->ob_sval[offset]);
+}
+
 static PyObject*
 bytes_subscript(PyObject *op, PyObject* item)
 {
@@ -1736,14 +1764,7 @@ bytes_subscript(PyObject *op, PyObject* item)
         Py_ssize_t i = PyNumber_AsSsize_t(item, PyExc_IndexError);
         if (i == -1 && PyErr_Occurred())
             return NULL;
-        if (i < 0)
-            i += PyBytes_GET_SIZE(self);
-        if (i < 0 || i >= PyBytes_GET_SIZE(self)) {
-            PyErr_SetString(PyExc_IndexError,
-                            "index out of range");
-            return NULL;
-        }
-        return _PyLong_FromUnsignedChar((unsigned char)self->ob_sval[i]);
+        return _PyBytes_SubscriptIndex(op, i);
     }
     else if (PySlice_Check(item)) {
         Py_ssize_t start, stop, step, slicelength, i;

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2,7 +2,7 @@
 
 #include "opcode.h"
 
-#include "pycore_bytesobject.h"   // _PyBytes_Concat
+#include "pycore_bytesobject.h"   // _PyBytes_Concat(), _PyBytes_SubscriptIndex()
 #include "pycore_code.h"
 #include "pycore_critical_section.h"
 #include "pycore_descrobject.h"   // _PyMethodWrapper_Type
@@ -2196,65 +2196,21 @@ BITWISE_LONGS_ACTION(compactlongs_xor, ^)
 /* bytes subscripting */
 
 static inline int
-bytes_compactlong_guard(PyObject *lhs, PyObject *rhs)
+bytes_compactlong_index_in_bounds_guard(PyObject *lhs, PyObject *rhs)
 {
     if (!PyBytes_CheckExact(lhs) || !is_compactlong(rhs)) {
         return 0;
     }
     Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)rhs);
-    Py_ssize_t size = PyBytes_GET_SIZE(lhs);
-    if (index < 0) {
-        index += size;
-    }
-    return 0 <= index && index < size;
+    Py_ssize_t offset;
+    return _PyBytes_OffsetFromIndex(lhs, index, &offset);
 }
 
 static PyObject *
 bytes_compactlong_subscr(PyObject *lhs, PyObject *rhs)
 {
     Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)rhs);
-    Py_ssize_t size = PyBytes_GET_SIZE(lhs);
-    if (index < 0) {
-        index += size;
-    }
-    unsigned char value = (unsigned char)PyBytes_AS_STRING(lhs)[index];
-    return _PyLong_FromUnsignedChar(value);
-}
-
-static PyObject *
-bytes_slice_subscr(PyObject *lhs, PyObject *rhs)
-{
-    assert(PyBytes_CheckExact(lhs));
-    assert(PySlice_Check(rhs));
-
-    Py_ssize_t start, stop, step;
-    if (PySlice_Unpack(rhs, &start, &stop, &step) < 0) {
-        return NULL;
-    }
-    Py_ssize_t size = PyBytes_GET_SIZE(lhs);
-    Py_ssize_t slicelength = PySlice_AdjustIndices(size, &start, &stop, step);
-    if (slicelength <= 0) {
-        return Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
-    }
-    if (start == 0 && step == 1 && slicelength == size) {
-        return Py_NewRef(lhs);
-    }
-    if (step == 1) {
-        return PyBytes_FromStringAndSize(
-            PyBytes_AS_STRING(lhs) + start,
-            slicelength);
-    }
-
-    const char *source_buf = PyBytes_AS_STRING(lhs);
-    PyObject *result = PyBytes_FromStringAndSize(NULL, slicelength);
-    if (result == NULL) {
-        return NULL;
-    }
-    char *result_buf = PyBytes_AS_STRING(result);
-    for (Py_ssize_t cur = start, i = 0; i < slicelength; cur += step, i++) {
-        result_buf[i] = source_buf[cur];
-    }
-    return result;
+    return _PyBytes_SubscriptIndex(lhs, index);
 }
 
 /* float-long */
@@ -2339,10 +2295,7 @@ static _PyBinaryOpSpecializationDescr binaryop_extend_descrs[] = {
 
     /* bytes[int]: guard includes bounds checks so the generic opcode still
        raises IndexError for out-of-range indexes. */
-    {NB_SUBSCR, bytes_compactlong_guard, bytes_compactlong_subscr, &PyLong_Type, 1, NULL, NULL},
-    /* bytes[slice]: may return the original bytes object or the empty bytes
-       singleton, so the result is not guaranteed to be unique. */
-    {NB_SUBSCR, NULL, bytes_slice_subscr, &PyBytes_Type, 0, &PyBytes_Type, &PySlice_Type},
+    {NB_SUBSCR, bytes_compactlong_index_in_bounds_guard, bytes_compactlong_subscr, &PyLong_Type, 1, NULL, NULL},
 
     /* float-long arithmetic: guards also check NaN and compactness. */
     {NB_ADD, float_compactlong_guard, float_compactlong_add, &PyFloat_Type, 1, NULL, NULL},

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2193,6 +2193,70 @@ BITWISE_LONGS_ACTION(compactlongs_and, &)
 BITWISE_LONGS_ACTION(compactlongs_xor, ^)
 #undef BITWISE_LONGS_ACTION
 
+/* bytes subscripting */
+
+static inline int
+bytes_compactlong_guard(PyObject *lhs, PyObject *rhs)
+{
+    if (!PyBytes_CheckExact(lhs) || !is_compactlong(rhs)) {
+        return 0;
+    }
+    Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)rhs);
+    Py_ssize_t size = PyBytes_GET_SIZE(lhs);
+    if (index < 0) {
+        index += size;
+    }
+    return 0 <= index && index < size;
+}
+
+static PyObject *
+bytes_compactlong_subscr(PyObject *lhs, PyObject *rhs)
+{
+    Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)rhs);
+    Py_ssize_t size = PyBytes_GET_SIZE(lhs);
+    if (index < 0) {
+        index += size;
+    }
+    unsigned char value = (unsigned char)PyBytes_AS_STRING(lhs)[index];
+    return _PyLong_FromUnsignedChar(value);
+}
+
+static PyObject *
+bytes_slice_subscr(PyObject *lhs, PyObject *rhs)
+{
+    assert(PyBytes_CheckExact(lhs));
+    assert(PySlice_Check(rhs));
+
+    Py_ssize_t start, stop, step;
+    if (PySlice_Unpack(rhs, &start, &stop, &step) < 0) {
+        return NULL;
+    }
+    Py_ssize_t size = PyBytes_GET_SIZE(lhs);
+    Py_ssize_t slicelength = PySlice_AdjustIndices(size, &start, &stop, step);
+    if (slicelength <= 0) {
+        return Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
+    }
+    if (start == 0 && step == 1 && slicelength == size) {
+        return Py_NewRef(lhs);
+    }
+    if (step == 1) {
+        return PyBytes_FromStringAndSize(
+            PyBytes_AS_STRING(lhs) + start,
+            slicelength);
+    }
+
+    const char *source_buf = PyBytes_AS_STRING(lhs);
+    PyObject *result = PyBytes_FromStringAndSize(NULL, slicelength);
+    if (result == NULL) {
+        return NULL;
+    }
+    char *result_buf = PyBytes_AS_STRING(result);
+    for (Py_ssize_t cur = start, i = 0; i < slicelength; cur += step, i++) {
+        result_buf[i] = source_buf[cur];
+    }
+    return result;
+}
+
 /* float-long */
 
 static inline int
@@ -2272,6 +2336,13 @@ static _PyBinaryOpSpecializationDescr binaryop_extend_descrs[] = {
     {NB_INPLACE_OR, compactlongs_guard, compactlongs_or, &PyLong_Type, 1, NULL, NULL},
     {NB_INPLACE_AND, compactlongs_guard, compactlongs_and, &PyLong_Type, 1, NULL, NULL},
     {NB_INPLACE_XOR, compactlongs_guard, compactlongs_xor, &PyLong_Type, 1, NULL, NULL},
+
+    /* bytes[int]: guard includes bounds checks so the generic opcode still
+       raises IndexError for out-of-range indexes. */
+    {NB_SUBSCR, bytes_compactlong_guard, bytes_compactlong_subscr, &PyLong_Type, 1, NULL, NULL},
+    /* bytes[slice]: may return the original bytes object or the empty bytes
+       singleton, so the result is not guaranteed to be unique. */
+    {NB_SUBSCR, NULL, bytes_slice_subscr, &PyBytes_Type, 0, &PyBytes_Type, &PySlice_Type},
 
     /* float-long arithmetic: guards also check NaN and compactness. */
     {NB_ADD, float_compactlong_guard, float_compactlong_add, &PyFloat_Type, 1, NULL, NULL},


### PR DESCRIPTION
The following was generated by Codex:

- `bytes[3]`: 20,000,000 iterations
- 7 repeats
- `PYTHON_UOPS_OPTIMIZE=0`
- compared normal specialization vs `PYTHON_SPECIALIZATION_OFF=1`

Results:

| Benchmark | Specialized median | Unspecialized median | Speedup |
|---|---:|---:|---:|
| `bytes[3]` | `0.513025s` | `0.701673s` | `~26.9%` faster |

<details>

```python
import statistics
import time

N = 20_000_000
REPEAT = 7


def bench_bytes_index():
    b = b"foobar"
    x = 0
    for _ in range(N):
        x = b[3]
    return x


# Warm up for specialization.
for _ in range(5):
    bench_bytes_index()

samples = []
for _ in range(REPEAT):
    t0 = time.perf_counter()
    result = bench_bytes_index()
    samples.append(time.perf_counter() - t0)

print("result", result)
print("samples", " ".join(f"{s:.6f}" for s in samples))
print("median", f"{statistics.median(samples):.6f}")
```

</details>

<!-- gh-issue-number: gh-100239 -->
* Issue: gh-100239
<!-- /gh-issue-number -->
