### PR TITLE
[3.14] gh-142295: Update macOS framework build Info.plist files. (#149479)

### DIFF
--- a/Mac/IDLE/IDLE.app/Contents/Info.plist
+++ b/Mac/IDLE/IDLE.app/Contents/Info.plist
@@ -1,9 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
+	<key>CFBundleName</key>
+	<string>IDLE</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.python.IDLE</string>
+	<key>CFBundleVersion</key>
+	<string>%version%</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleExecutable</key>
+	<string>IDLE</string>
+	<key>CFBundleIconFile</key>
+	<string>IDLE.icns</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
@@ -34,26 +48,16 @@
 			<string>Editor</string>
 		</dict>
 	</array>
-	<key>CFBundleExecutable</key>
-	<string>IDLE</string>
-	<key>CFBundleGetInfoString</key>
-	<string>%version%, © 2001-2024 Python Software Foundation</string>
-	<key>CFBundleIconFile</key>
-	<string>IDLE.icns</string>
-	<key>CFBundleIdentifier</key>
-	<string>org.python.IDLE</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>IDLE</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>%version%</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>%version%</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2001 Python Software Foundation. All rights reserved.</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>CFBundleAllowMixedLocalizations</key>

--- a/Mac/PythonLauncher/Info.plist.in
+++ b/Mac/PythonLauncher/Info.plist.in
@@ -2,8 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<key>CFBundleName</key>
+	<string>Python Launcher</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.python.PythonLauncher</string>
+	<key>CFBundleVersion</key>
+	<string>%VERSION%</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>PytL</string>
+	<key>CFBundleExecutable</key>
+	<string>Python Launcher</string>
+	<key>CFBundleIconFile</key>
+	<string>PythonLauncher.icns</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
@@ -37,28 +51,16 @@
 			<string>MyDocument</string>
 		</dict>
 	</array>
-	<key>CFBundleExecutable</key>
-	<string>Python Launcher</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2001 Python Software Foundation</string>
-	<key>CFBundleGetInfoString</key>
-	<string>%VERSION%, © 2001 Python Software Foundation</string>
-	<key>CFBundleIconFile</key>
-	<string>PythonLauncher.icns</string>
-	<key>CFBundleIdentifier</key>
-	<string>org.python.PythonLauncher</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>Python Launcher</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>%VERSION%</string>
-	<key>CFBundleSignature</key>
-	<string>PytL</string>
-	<key>CFBundleVersion</key>
-	<string>%VERSION%</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2001 Python Software Foundation. All rights reserved.</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/Mac/Resources/app/Info.plist.in
+++ b/Mac/Resources/app/Info.plist.in
@@ -1,9 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
+	<key>CFBundleName</key>
+	<string>Python</string>
+	<key>CFBundleIdentifier</key>
+	<string>%bundleid%</string>
+	<key>CFBundleVersion</key>
+	<string>%version%</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>PytX</string>
+	<key>CFBundleExecutable</key>
+	<string>Python</string>
+	<key>CFBundleIconFile</key>
+	<string>PythonInterpreter.icns</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
@@ -17,48 +31,33 @@
 			<string>Viewer</string>
 		</dict>
 	</array>
-	<key>CFBundleExecutable</key>
-	<string>Python</string>
-	<key>CFBundleGetInfoString</key>
-	<string>%version%, (c) 2001-2024 Python Software Foundation.</string>
-	<key>CFBundleHelpBookFolder</key>
-	<array>
-		<string>Documentation</string>
-		<string>PythonDocumentation</string>
-	</array>
-	<key>CFBundleHelpBookName</key>
-	<string>MacPython Help</string>
-	<key>CFBundleHelpTOCFile</key>
-	<string>index.html</string>
-	<key>CFBundleIconFile</key>
-	<string>PythonInterpreter.icns</string>
-	<key>CFBundleIdentifier</key>
-	<string>%bundleid%</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleLongVersionString</key>
-	<string>%version%, (c) 2001-2024 Python Software Foundation.</string>
-	<key>CFBundleName</key>
-	<string>Python</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>%version%</string>
-	<key>CFBundleSignature</key>
-	<string>PytX</string>
-	<key>CFBundleVersion</key>
-	<string>%version%</string>
-	<key>CSResourcesFileMapped</key>
-	<true/>
-	<key>LSRequiresCarbon</key>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2001 Python Software Foundation. All rights reserved.</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
-	<key>NSHumanReadableCopyright</key>
-	<string>(c) 2001-2024 Python Software Foundation.</string>
-	<key>NSHighResolutionCapable</key>
-	<true/>
 	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
+	<key>CFBundleHelpBookFolder</key>
+	<array>
+		<string>Documentation</string>
+	</array>
+	<key>CFBundleHelpBookName</key>
+	<string>Python Help</string>
+	<key>CFBundleHelpTOCFile</key>
+	<string>index.html</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>LSRequiresCarbon</key>
 	<true/>
 </dict>
 </plist>

--- a/Mac/Resources/framework/Info.plist.in
+++ b/Mac/Resources/framework/Info.plist.in
@@ -1,29 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
-<plist version="0.9">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
-	<key>CFBundleExecutable</key>
-	<string>Python</string>
-	<key>CFBundleGetInfoString</key>
-	<string>Python Runtime and Library</string>
-	<key>CFBundleIdentifier</key>
-	<string>@PYTHONFRAMEWORKIDENTIFIER@</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>Python</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>%VERSION%, (c) 2001-2024 Python Software Foundation.</string>
-	<key>CFBundleLongVersionString</key>
-	<string>%VERSION%, (c) 2001-2024 Python Software Foundation.</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
+	<key>CFBundleIdentifier</key>
+	<string>@PYTHONFRAMEWORKIDENTIFIER@</string>
 	<key>CFBundleVersion</key>
 	<string>%VERSION%</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleExecutable</key>
+	<string>Python</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%VERSION%</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2001 Python Software Foundation. All rights reserved.</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
 	<key>CFBundleAllowMixedLocalizations</key>
 	<true/>
 </dict>

--- a/Misc/NEWS.d/next/macOS/2026-05-06-18-23-36.gh-issue-142295.O9RmZH.rst
+++ b/Misc/NEWS.d/next/macOS/2026-05-06-18-23-36.gh-issue-142295.O9RmZH.rst
@@ -1,0 +1,3 @@
+For Python macOS framework builds, update Info.plist files to be more
+compliant with current Apple guidelines. Original patch contributed by
+Martinus Verburg.


### PR DESCRIPTION
For Python macOS framework builds, update all Info.plist files to be more compliant with current Apple guidelines. Original patch contributed by Martinus Verburg.

(cherry picked from commit 5fcab14c3506ecc7df14916a57bfbb1710b8c7ba)


<!-- gh-issue-number: gh-142295 -->
* Issue: gh-142295
<!-- /gh-issue-number -->
