### PR TITLE
gh-149202: Don't use -fno-omit-frame-pointer on ppc64le

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -792,6 +792,8 @@ also be used to improve performance.
    - ``-marm`` and/or ``-mno-thumb`` is added on 32-bit ARM when supported,
    - on s390x platforms, when supported, ``-mbackchain`` is added *instead*.
      of the above frame pointer flags.
+   - on ppc64le platforms, no compiler flags is needed since the power ABI
+     requires that compilers maintain a back chain by default.
 
    Frame pointers enable profilers, debuggers, and system tracing tools
    (``perf``, ``eBPF``, ``dtrace``, ``gdb``) to walk the C call stack

--- a/Lib/test/test_frame_pointer_unwind.py
+++ b/Lib/test/test_frame_pointer_unwind.py
@@ -56,6 +56,12 @@ def _frame_pointers_expected(machine):
             if sys.maxsize < 2**32:
                 return None
             return True
+        if machine == "ppc64le":
+            # The power ABI specification requires that compilers maintain a
+            # back chain by default, so unwinding already works without a
+            # dedicated frame pointer.
+            # https://openpowerfoundation.org/specifications/64bitelfabi/
+            return True
         if machine == "x86_64":
             final_opt = ""
             for opt in cflags.split():

--- a/configure
+++ b/configure
@@ -10437,6 +10437,14 @@ fi
      ;;
 esac
       case $host_cpu in #(
+  powerpc64le) :
+
+        frame_pointer_cflags=""
+       ;; #(
+  *) :
+     ;;
+esac
+      case $host_cpu in #(
   s390*) :
 
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -mbackchain" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -2557,6 +2557,9 @@ AS_VAR_IF([ac_cv_gcc_compat], [yes], [
           frame_pointer_cflags="$frame_pointer_cflags -mno-thumb"
         ], [], [-Werror])
       ])
+      AS_CASE([$host_cpu], [powerpc64le], [
+        frame_pointer_cflags=""
+      ])
       AS_CASE([$host_cpu], [s390*], [
         AX_CHECK_COMPILE_FLAG([-mbackchain], [
           dnl Do not use no-omit-frame-pointer; see gh-149362


### PR DESCRIPTION
The power ABI specification requires that compilers maintain a back chain by default, so unwinding already works without a dedicated frame pointer. Don't use -fno-omit-frame-pointer on ppc64le.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149202 -->
* Issue: gh-149202
<!-- /gh-issue-number -->
