### PR TITLE
Clarify docs for error case of PyDict_GetItemRef

### DIFF
--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -151,7 +151,7 @@ Dictionary objects
    * If the key is present, set *\*result* to a new :term:`strong reference`
      to the value and return ``1``.
    * If the key is missing, set *\*result* to ``NULL`` and return ``0``.
-   * On error, raise an exception, set *\*result* to ``NULL``, and return ``-1``.
+   * On error, raise an exception, set *\*result* to ``NULL`` and return ``-1``.
 
    The first argument can be a :class:`dict` or a :class:`frozendict`.
 

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -151,7 +151,7 @@ Dictionary objects
    * If the key is present, set *\*result* to a new :term:`strong reference`
      to the value and return ``1``.
    * If the key is missing, set *\*result* to ``NULL`` and return ``0``.
-   * On error, raise an exception and return ``-1``.
+   * On error, raise an exception, set *\*result* to ``NULL``, and return ``-1``.
 
    The first argument can be a :class:`dict` or a :class:`frozendict`.
 


### PR DESCRIPTION
I manually inspected and asked Claude to inspect the implementation, and I think all error paths set `*result` to NULL.

See https://github.com/numpy/numpy/pull/31256#discussion_r3203406973 for where this came up for me today.