### PR TITLE
gh-149388: Make PipeHandle.close idempotent

### DIFF
--- a/Lib/asyncio/windows_utils.py
+++ b/Lib/asyncio/windows_utils.py
@@ -111,8 +111,9 @@ class PipeHandle:
 
     def close(self, *, CloseHandle=_winapi.CloseHandle):
         if self._handle is not None:
-            CloseHandle(self._handle)
+            handle = self._handle
             self._handle = None
+            CloseHandle(handle)
 
     def __del__(self, _warn=warnings.warn):
         if self._handle is not None:

--- a/Lib/test/test_asyncio/test_windows_utils.py
+++ b/Lib/test/test_asyncio/test_windows_utils.py
@@ -77,6 +77,30 @@ class PipeTests(unittest.TestCase):
         else:
             raise RuntimeError('expected ERROR_INVALID_HANDLE')
 
+    def test_pipe_handle_close_after_external_close(self):
+        # gh-149388: PipeHandle.close() must clear ``_handle`` before calling
+        # CloseHandle so that if CloseHandle raises on a stale handle the
+        # PipeHandle is still marked closed and __del__ / subsequent close()
+        # calls are silent no-ops.
+        h1, h2 = windows_utils.pipe(overlapped=(False, False))
+        try:
+            p = windows_utils.PipeHandle(h1)
+            # Simulate an external close of the underlying handle (e.g.
+            # a finalizer race or a concurrent close on the same object).
+            _winapi.CloseHandle(p.handle)
+            # First close() still propagates the OSError from CloseHandle,
+            # but must clear ``_handle`` first.
+            with self.assertRaises(OSError):
+                p.close()
+            self.assertIsNone(p.handle)
+            # Second close() is a no-op.
+            p.close()
+            # __del__ through GC is also a silent no-op — no unraisable.
+            del p
+            support.gc_collect()
+        finally:
+            _winapi.CloseHandle(h2)
+
 
 class PopenTests(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2026-05-07-21-58-17.gh-issue-149388.DDBPeA.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-07-21-58-17.gh-issue-149388.DDBPeA.rst
@@ -1,0 +1,1 @@
+Make :class:`!asyncio.windows_utils.PipeHandle` closing idempotent.


### PR DESCRIPTION
Fixes #149388. Applies @kumaraditya303's suggestion from the issue thread: clear `_handle` before calling `CloseHandle`, so that when `CloseHandle` raises on an already-closed handle, `_handle` is already `None` and neither a second `close()` nor `__del__` re-raises.

The new regression test in `test_windows_utils.PipeTests` fails on `main`:

```
FAIL: test_pipe_handle_close_after_external_close
AssertionError: 792 is not None
```

and passes with the patch. Full `python -m test test_asyncio` is green on the patched build (2524 tests, 0 failures).

The end-to-end repro from the issue (`repro_v2.py`) goes from 6/20 → 0/60 trials firing `WinError 6`. Verified against a locally built CPython 3.16.0a0 (Windows x86_64) from this branch.


<!-- gh-issue-number: gh-149388 -->
* Issue: gh-149388
<!-- /gh-issue-number -->
