### PR TITLE
gh-139871: Fix 3.15 bytearray.take_bytes example

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -798,7 +798,7 @@ Other language changes
               n = buffer.find(b'\n')
               data = bytes(buffer[:n + 1])
               del buffer[:n + 1]
-              assert data == b'abc'
+              assert data == b'abc\n'
               assert buffer == bytearray(b'def')
 
         - .. code:: python


### PR DESCRIPTION
Currently:
```python
buffer = bytearray(b'abc\ndef')
n = buffer.find(b'\n')
data = bytes(buffer[:n + 1])
del buffer[:n + 1]
assert data == b'abc'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    assert data == b'abc'
           ^^^^^^^^^^^^^^
AssertionError
```

Adding in the newline both match:

```python
buffer = bytearray(b'abc\ndef')
n = buffer.find(b'\n')
data = bytes(buffer[:n + 1])
del buffer[:n + 1]
assert data == b'abc\n'
assert buffer == bytearray(b'def')

buffer = bytearray(b'abc\ndef')
n = buffer.find(b'\n')
data = buffer.take_bytes(n + 1)
assert data == b'abc\n'
assert buffer == bytearray(b'def')
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139871 -->
* Issue: gh-139871
<!-- /gh-issue-number -->
