### PR TITLE
gh-149528: Remove `annotationlib.ForwardRef._evaluate` for 3.16

### DIFF
--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -106,6 +106,14 @@ module_name
 Removed
 =======
 
+annotationlib
+-------------
+
+* The :meth:`!annotationlib.ForwardRef._evaluate` method
+  which has been deprecated since Python 3.14.
+  Use :meth:`annotationlib.ForwardRef.evaluate`
+  or :func:`typing.evaluate_forward_ref` instead.
+
 sysconfig
 ---------
 

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -226,29 +226,6 @@ class ForwardRef:
                 new_locals.transmogrify(self.__cell__)
                 return result
 
-    def _evaluate(self, globalns, localns, type_params=_sentinel, *, recursive_guard):
-        import typing
-        import warnings
-
-        if type_params is _sentinel:
-            typing._deprecation_warning_for_no_type_params_passed(
-                "typing.ForwardRef._evaluate"
-            )
-            type_params = ()
-        warnings._deprecated(
-            "ForwardRef._evaluate",
-            "{name} is a private API and is retained for compatibility, but will be removed"
-            " in Python 3.16. Use ForwardRef.evaluate() or typing.evaluate_forward_ref() instead.",
-            remove=(3, 16),
-        )
-        return typing.evaluate_forward_ref(
-            self,
-            globals=globalns,
-            locals=localns,
-            type_params=type_params,
-            _recursive_guard=recursive_guard,
-        )
-
     @property
     def __forward_arg__(self):
         if self.__arg__ is not None:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -434,19 +434,6 @@ def _rebuild_generic_alias(alias: GenericAlias, args: tuple[object, ...]) -> Gen
     return t
 
 
-def _deprecation_warning_for_no_type_params_passed(funcname: str) -> None:
-    import warnings
-
-    depr_message = (
-        f"Failing to pass a value to the 'type_params' parameter "
-        f"of {funcname!r} is deprecated, as it leads to incorrect behaviour "
-        f"when calling {funcname} on a stringified annotation "
-        f"that references a PEP 695 type parameter. "
-        f"It will be disallowed in Python 3.15."
-    )
-    warnings.warn(depr_message, category=DeprecationWarning, stacklevel=3)
-
-
 def _eval_type(t, globalns, localns, type_params, *, recursive_guard=frozenset(),
                format=None, owner=None, parent_fwdref=None, prefer_fwd_module=False):
     """Evaluate all forward references in the given type t.

--- a/Misc/NEWS.d/next/Library/2026-05-08-06-12-26.gh-issue-149528.AxdDxa.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-08-06-12-26.gh-issue-149528.AxdDxa.rst
@@ -1,0 +1,1 @@
+Remove ``annotationlib.ForwardRef._evaludate`` deprecated method.


### PR DESCRIPTION
My first 3.16 commit 🎉 

<!-- gh-issue-number: gh-149528 -->
* Issue: gh-149528
<!-- /gh-issue-number -->
