### PR TITLE
gh-149532: Remove `bool.__invert__` magic method

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -881,11 +881,6 @@ return a bool equivalent to the logical operations "and", "or", "xor". However,
 the logical operators ``and``, ``or`` and ``!=`` should be preferred
 over ``&``, ``|`` and ``^``.
 
-.. deprecated:: 3.12
-
-   The use of the bitwise inversion operator ``~`` is deprecated and will
-   raise an error in Python 3.16.
-
 :class:`bool` is a subclass of :class:`int` (see :ref:`typesnumeric`). In
 many numeric contexts, ``False`` and ``True`` behave like the integers 0 and 1, respectively.
 However, relying on this is discouraged; explicitly convert using :func:`int`

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -106,6 +106,16 @@ module_name
 Removed
 =======
 
+builtins
+--------
+
+* Bitwise inversion on boolean types, ``~True`` or ``~False``
+  has been deprecated since Python 3.12,
+  as it produces surprising and unintuitive results (``-2`` and ``-1``).
+  Use ``not x`` instead for the logical negation of a Boolean.
+  In the rare case that you need the bitwise inversion of
+  the underlying integer, convert to ``int`` explicitly (``~int(x)``).
+
 sysconfig
 ---------
 

--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -4,6 +4,8 @@ import unittest
 from test.support import os_helper
 
 import os
+import re
+
 
 class BoolTest(unittest.TestCase):
 
@@ -58,22 +60,6 @@ class BoolTest(unittest.TestCase):
         self.assertEqual(-True, -1)
         self.assertEqual(abs(True), 1)
         self.assertIsNot(abs(True), True)
-        with self.assertWarns(DeprecationWarning):
-            # We need to put the bool in a variable, because the constant
-            # ~False is evaluated at compile time due to constant folding;
-            # consequently the DeprecationWarning would be issued during
-            # module loading and not during test execution.
-            false = False
-            self.assertEqual(~false, -1)
-        with self.assertWarns(DeprecationWarning):
-            # also check that the warning is issued in case of constant
-            # folding at compile time
-            self.assertEqual(eval("~False"), -1)
-        with self.assertWarns(DeprecationWarning):
-            true = True
-            self.assertEqual(~true, -2)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(eval("~True"), -2)
 
         self.assertEqual(False+2, 2)
         self.assertEqual(True+2, 3)
@@ -168,6 +154,25 @@ class BoolTest(unittest.TestCase):
 
         self.assertIs(not True, False)
         self.assertIs(not False, True)
+
+    def test_invert(self):
+        # See gh-149532
+        msg = re.escape("bad operand type for unary ~: 'bool'")
+
+        # Check constants in case of a folding:
+        with self.assertRaisesRegex(TypeError, msg):
+            ~False
+        with self.assertRaisesRegex(TypeError, msg):
+            ~True
+
+        # Check variable:
+        for bool_val in [True, False]:
+            with self.subTest(bool_val), self.assertRaisesRegex(TypeError, msg):
+                ~bool_val
+
+        # Check `eval`:
+        with self.assertRaisesRegex(TypeError, msg):
+            eval("~False")
 
     def test_convert(self):
         self.assertRaises(TypeError, bool, 42, 42)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-08-07-43-01.gh-issue-149532.SSltRW.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-08-07-43-01.gh-issue-149532.SSltRW.rst
@@ -1,0 +1,2 @@
+Remove :meth:`!bool.__invert__` magic method, which was deprecated since
+3.12.

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -70,17 +70,9 @@ bool_vectorcall(PyObject *type, PyObject * const*args,
 static PyObject *
 bool_invert(PyObject *v)
 {
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                     "Bitwise inversion '~' on bool is deprecated and will be removed in "
-                     "Python 3.16. This returns the bitwise inversion of the underlying int "
-                     "object and is usually not what you expect from negating "
-                     "a bool. Use the 'not' operator for boolean negation or "
-                     "~int(x) if you really want the bitwise inversion of the "
-                     "underlying int.",
-                     1) < 0) {
-        return NULL;
-    }
-    return PyLong_Type.tp_as_number->nb_invert(v);
+    // This method is needed to shadow the `int` base method:
+    PyErr_SetString(PyExc_TypeError, "bad operand type for unary ~: 'bool'");
+    return NULL;
 }
 
 static PyObject *


### PR DESCRIPTION
Refs https://github.com/python/cpython/issues/82012

CC @hauntsaninja, @JelleZijlstra, @gvanrossum who reviewed https://github.com/python/cpython/pull/103487

<!-- gh-issue-number: gh-149532 -->
* Issue: gh-149532
<!-- /gh-issue-number -->
