### PR TITLE
gh-149083: Convert `_initial_missing` for pure py `reduce` to `sentinel`

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -232,7 +232,7 @@ except ImportError:
 ### reduce() sequence to a single item
 ################################################################################
 
-_initial_missing = object()
+_initial_missing = sentinel('_initial_missing')
 
 def reduce(function, sequence, initial=_initial_missing):
     """


### PR DESCRIPTION
This is not covered in https://github.com/python/cpython/pull/149084

Difference is not big, but noticable. Before:
<img width="788" height="533" alt="Снимок экрана 2026-05-08 в 08 09 31" src="https://github.com/user-attachments/assets/de3af5af-bcb2-4266-8ac2-6902ab51cb6c" />

Notice the default parameter repr, which is rather unpretty.

After:
<img width="788" height="533" alt="Снимок экрана 2026-05-08 в 08 10 17" src="https://github.com/user-attachments/assets/7ecd61b1-8bfe-45bc-a0e0-09bab7a1462d" />

`skip news`, because there should be no user facing changes.


<!-- gh-issue-number: gh-149083 -->
* Issue: gh-149083
<!-- /gh-issue-number -->
