### PR TITLE
gh-145176: Update CODEOWNERS for Emscripten migration to Platforms directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -176,8 +176,8 @@ Lib/test/test__osx_support.py @python/macos-team
 Tools/wasm/README.md          @brettcannon @freakboy3742 @emmatyping
 
 # WebAssembly (Emscripten)
-Tools/wasm/config.site-wasm32-emscripten  @freakboy3742 @emmatyping
-Tools/wasm/emscripten                     @freakboy3742 @emmatyping
+Platforms/emscripten          @freakboy3742 @emmatyping
+Tools/wasm/emscripten         @freakboy3742 @emmatyping
 
 # WebAssembly (WASI)
 Platforms/WASI                @brettcannon @emmatyping @savannahostrowski


### PR DESCRIPTION
I'll create a separate PR for Android and iOS, because they should only be backported as far as 3.15 (https://github.com/python/cpython/pull/149543).

<!-- gh-issue-number: gh-145176 -->
* Issue: gh-145176
<!-- /gh-issue-number -->
