### PR TITLE
[3.14] gh-145176: Update CODEOWNERS for Emscripten migration to Platforms directory (GH-149544)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -315,7 +315,7 @@ Lib/concurrent/futures/interpreter.py  @ericsnowcurrently
 **/*-ios*                     @freakboy3742
 
 # WebAssembly
-Tools/wasm/config.site-wasm32-emscripten  @freakboy3742
+/Platforms/emscripten         @freakboy3742
 /Tools/wasm/README.md         @brettcannon @freakboy3742
 /Tools/wasm/wasi-env          @brettcannon
 /Tools/wasm/wasi_build.py     @brettcannon


### PR DESCRIPTION
(cherry picked from commit 52a05e8da71abcc83df54e465d0a4df50785e910)


<!-- gh-issue-number: gh-145176 -->
* Issue: gh-145176
<!-- /gh-issue-number -->
