### PR TITLE
gh-112821: Fix rlcompleter failures on objects with descriptors

### DIFF
--- a/Lib/rlcompleter.py
+++ b/Lib/rlcompleter.py
@@ -179,14 +179,14 @@ class Completer:
                 if (word[:n] == attr and
                     not (noprefix and word[:n+1] == noprefix)):
                     match = "%s.%s" % (expr, word)
-                    if isinstance(getattr(type(thisobject), word, None),
-                                  property):
-                        # bpo-44752: thisobject.word is a method decorated by
-                        # `@property`. What follows applies a postfix if
-                        # thisobject.word is callable, but know we know that
-                        # this is not callable (because it is a property).
-                        # Also, getattr(thisobject, word) will evaluate the
-                        # property method, which is not desirable.
+
+                    class_attr = getattr(type(thisobject), word, None)
+                    if isinstance(
+                        class_attr,
+                        (property, types.GetSetDescriptorType, types.MemberDescriptorType)
+                    ) or (hasattr(class_attr, '__get__') and not callable(class_attr)):
+                        # Avoid evaluating descriptors, which could run
+                        # arbitrary code or raise exceptions.
                         matches.append(match)
                         continue
 

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 import builtins
+import types
 import rlcompleter
 from test.support import MISSING_C_DOCSTRINGS
 
@@ -135,6 +136,49 @@ class TestRlcompleter(unittest.TestCase):
         self.assertEqual(completer.complete('f.b', 0), 'f.bar')
         self.assertFalse(f.property_called)
 
+    def test_released_memoryview_completion_works(self):
+        mv = memoryview(b"abc")
+        mv.release()
+
+        self.assertIsInstance(type(mv).shape, types.GetSetDescriptorType)
+        self.assertIsInstance(type(mv).strides, types.GetSetDescriptorType)
+
+        completer = rlcompleter.Completer(dict(mv=mv))
+        matches = completer.attr_matches('mv.')
+
+        # These are getset descriptors on memoryview and should be completed
+        # without evaluating the released-memoryview getters.
+        self.assertIn('mv.shape', matches)
+        self.assertIn('mv.strides', matches)
+
+    def test_member_descriptor_not_evaluated(self):
+        class Foo:
+            __slots__ = ("boom",)
+
+            def __getattribute__(self, name):
+                if name == "boom":
+                    raise RuntimeError("boom access should be skipped")
+                return super().__getattribute__(name)
+
+        self.assertIsInstance(Foo.boom, types.MemberDescriptorType)
+
+        completer = rlcompleter.Completer(dict(f=Foo()))
+        matches = completer.attr_matches('f.')
+        self.assertIn('f.boom', matches)
+
+    def test_raising_descriptor_completion_works(self):
+        class ExplodingDescriptor:
+            def __get__(self, obj, owner):
+                if obj is None:
+                    return self
+                raise RuntimeError("descriptor getter exploded")
+
+        class Foo:
+            boom = ExplodingDescriptor()
+
+        completer = rlcompleter.Completer(dict(f=Foo()))
+        matches = completer.attr_matches('f.')
+        self.assertIn('f.boom', matches)
 
     def test_uncreated_attr(self):
         # Attributes like properties and slots should be completed even when

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -154,9 +154,11 @@ class TestRlcompleter(unittest.TestCase):
     def test_member_descriptor_not_evaluated(self):
         class Foo:
             __slots__ = ("boom",)
+            boom_accesses = 0
 
             def __getattribute__(self, name):
                 if name == "boom":
+                    type(self).boom_accesses += 1
                     raise RuntimeError("boom access should be skipped")
                 return super().__getattribute__(name)
 
@@ -165,12 +167,17 @@ class TestRlcompleter(unittest.TestCase):
         completer = rlcompleter.Completer(dict(f=Foo()))
         matches = completer.attr_matches('f.')
         self.assertIn('f.boom', matches)
+        self.assertEqual(Foo.boom_accesses, 0)
 
     def test_raising_descriptor_completion_works(self):
         class ExplodingDescriptor:
+            def __init__(self):
+                self.instance_get_calls = 0
+
             def __get__(self, obj, owner):
                 if obj is None:
                     return self
+                self.instance_get_calls += 1
                 raise RuntimeError("descriptor getter exploded")
 
         class Foo:
@@ -179,6 +186,7 @@ class TestRlcompleter(unittest.TestCase):
         completer = rlcompleter.Completer(dict(f=Foo()))
         matches = completer.attr_matches('f.')
         self.assertIn('f.boom', matches)
+        self.assertEqual(Foo.boom.instance_get_calls, 0)
 
     def test_uncreated_attr(self):
         # Attributes like properties and slots should be completed even when

--- a/Misc/NEWS.d/next/Library/2026-05-08-15-08-35.gh-issue-112821.t9T1YD.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-08-15-08-35.gh-issue-112821.t9T1YD.rst
@@ -1,0 +1,4 @@
+In the REPL, autocompletion might run arbitrary code in the getter of a
+descriptor. If that getter raised an exception, autocompletion would fail to
+present any options for the entire object.  Autocompletion now works as
+expected for these objects.


### PR DESCRIPTION
This issue came to light for me when it was discovered that autocompletion didn't work for a library I help maintain, written mainly in Cython.  Cython implements `@property`-annotated methods on its `cdef class`es as getset descriptors.  The `rlcompleter` logic doesn't exclude these (like it does regular Python properties) since `isinstance(member, property)` is False.  It then goes on to call the getter, which in some cases (in our library at least) raises an exception.  Any exception other than an `AttributeError` causes the rlcompleter to short circuit completely and not offer any options.

This is a more surgical (rlcompleter-only) solution than what was proposed in #112821.  If adding ABCs is preferred, I could do that.

> Restore the try/except removed in https://github.com/python/cpython/pull/27401
Create abstract classes for descriptors in _collections_abc (e.g. ImplementsGet, ImplementsSet, ImplementsDelete) and in rlcompleter, rather than checking for isinstance(obj, property), use isinstance(obj, ImplementsGet). 

#112821 also mentioned:

> This might cause false positives for method descriptors though.

I think this is handled here, but I also may not fully understand this specific issue.

<!-- gh-issue-number: gh-112821 -->
* Issue: gh-112821
<!-- /gh-issue-number -->
