### PR TITLE
gh-149496: Fix MacOSTest.test_default regression when BROWSER env var is set

### DIFF
--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -340,6 +340,10 @@ class MockPopenPipe:
 @requires_subprocess()
 class MacOSTest(unittest.TestCase):
 
+    def setUp(self):
+        env = self.enterContext(os_helper.EnvironmentVarGuard())
+        env.unset("BROWSER")
+
     def test_default(self):
         browser = webbrowser.get()
         self.assertIsInstance(browser, webbrowser.MacOS)


### PR DESCRIPTION
### Summary

- `MacOSTest.test_default` asserts that `webbrowser.get()` returns a
  `MacOS` instance on macOS. When `BROWSER=open` (or any other value)
  is set in the environment, `register_standard_browsers()` registers a
  `GenericBrowser` as the preferred browser instead, so the
  `assertIsInstance` check fails.
- This is a regression introduced in gh-137586, which added `MacOSTest`
  and moved `test_default` into it from `MacOSXOSAScriptTest`.
  `MacOSXOSAScriptTest` had an identical `setUp()` guard added in
  gh-131254 specifically to fix this same failure pattern. That guard
  was not carried over when the test was moved.
- Fix: add `setUp()` to `MacOSTest` to unset `BROWSER` for the duration
  of each test, matching the pattern already established in
  `MacOSXOSAScriptTest`.

### Test plan

- [ ] Run `python -m test test_webbrowser` with `BROWSER=open` set — should pass
- [ ] Run `python -m test test_webbrowser` with `BROWSER` unset — should pass

Fixes gh-149496