### PR TITLE
Fix typos in C API documentation

### DIFF
--- a/Doc/c-api/slots.rst
+++ b/Doc/c-api/slots.rst
@@ -7,10 +7,10 @@ Definition slots
 
 To define :ref:`module objects <moduleobjects>` and
 :ref:`classes <creating-heap-types>` using the C API, you may use
-an array of *slots* -- essentally, key-value pairs that describe features
+an array of *slots* -- essentially, key-value pairs that describe features
 of the object to create.
 This decouples the data from the structures used at runtime, allowing CPython
--- and other Python C API implementations -- to update the stuctures without
+-- and other Python C API implementations -- to update the structures without
 breaking backwards compatibility.
 
 This section documents slots in general.

--- a/Doc/c-api/synchronization.rst
+++ b/Doc/c-api/synchronization.rst
@@ -238,7 +238,7 @@ are not available.
 .. c:function:: void PyCriticalSection_BeginMutex(PyCriticalSection *c, PyMutex *m);
                 void PyCriticalSection2_BeginMutex(PyCriticalSection2 *c, PyMutex *m1, PyMutex *m2);
 
-   .. (These need to be in a separate section without a Stable ABI anotation.)
+   .. (These need to be in a separate section without a Stable ABI annotation.)
 
    To be used only as in the macro expansions
    listed :ref:`earlier in this section <critical-section-macros>`.


### PR DESCRIPTION
  This PR fixes three small typos in the C API documentation:

  - `Doc/c-api/slots.rst`:
    - "essentally" → "essentially" (line 10)
    - "stuctures" → "structures" (line 13)
  - `Doc/c-api/synchronization.rst`:
    - "anotation" → "annotation" (line 241, in a comment)

No behavioural change, no API change. Trivial documentation fixes only.