### PR TITLE
Correct Stable ABI documentation for METH_FASTCALL

### DIFF
--- a/Doc/data/stable_abi.dat
+++ b/Doc/data/stable_abi.dat
@@ -1,7 +1,7 @@
 role,name,added,ifdef_note,struct_abi_kind
 macro,METH_CLASS,3.2,,
 macro,METH_COEXIST,3.2,,
-macro,METH_FASTCALL,3.7,,
+macro,METH_FASTCALL,3.10,,
 macro,METH_METHOD,3.7,,
 macro,METH_NOARGS,3.2,,
 macro,METH_O,3.2,,

--- a/Misc/stable_abi.toml
+++ b/Misc/stable_abi.toml
@@ -1813,7 +1813,6 @@
 [const.METH_COEXIST]
     added = '3.2'
 # METH_STACKLESS is undocumented
-# METH_FASTCALL is not part of limited API.
 
 # The following are defined in private headers, but historically
 # they were exported as part of the stable ABI.
@@ -2149,8 +2148,6 @@
 
 # New method flags in 3.7 (PEP 590):
 
-[const.METH_FASTCALL]
-    added = '3.7'
 [const.METH_METHOD]
     added = '3.7'
 
@@ -2299,6 +2296,10 @@
     added = '3.11'
 [data.PyStructSequence_UnnamedField]
     added = '3.11'
+
+# Added in 3.7 but in the Stable ABI from 3.10
+[const.METH_FASTCALL]
+    added = '3.10'
 
 # Add stable Py_buffer API in Python 3.11 (https://bugs.python.org/issue45459)
 [struct.Py_buffer]


### PR DESCRIPTION
The current documentation says:

> 
> METH_FASTCALL
>    Part of the Stable ABI since version 3.7.
>
> [...]
>
>   Added in version 3.7.
>
>    Changed in version 3.10: METH_FASTCALL is now part of the stable ABI.

so is contradictory about when it was added to the Stable ABI.  Looking at the header it seems like 3.10 is right.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
