### PR TITLE
gh-149598: Remove `strm` argument support from `logging` handlers

### DIFF
--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -120,6 +120,13 @@ functools
 * Calling the Python implementation of :func:`functools.reduce` with *function*
   or *sequence* as keyword arguments has been deprecated since Python 3.14.
 
+logging
+-------
+
+* Support for custom logging handlers with the *strm* argument is deprecated
+  and scheduled for removal in Python 3.16. Define handlers with the *stream*
+  argument instead.
+
 symtable
 --------
 

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -865,28 +865,7 @@ class DictConfigurator(BaseConfigurator):
             else:
                 factory = klass
         kwargs = {k: config[k] for k in config if (k != '.' and valid_ident(k))}
-        # When deprecation ends for using the 'strm' parameter, remove the
-        # "except TypeError ..."
-        try:
-            result = factory(**kwargs)
-        except TypeError as te:
-            if "'stream'" not in str(te):
-                raise
-            #The argument name changed from strm to stream
-            #Retry with old name.
-            #This is so that code can be used with older Python versions
-            #(e.g. by Django)
-            kwargs['strm'] = kwargs.pop('stream')
-            result = factory(**kwargs)
-
-            import warnings
-            warnings.warn(
-                "Support for custom logging handlers with the 'strm' argument "
-                "is deprecated and scheduled for removal in Python 3.16. "
-                "Define handlers with the 'stream' argument instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        result = factory(**kwargs)
         if formatter:
             result.setFormatter(formatter)
         if level is not None:

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3297,12 +3297,11 @@ class ConfigDictTest(BaseTest):
         }
     }
 
-    # Remove when deprecation ends.
-    class DeprecatedStrmHandler(logging.StreamHandler):
+    class StrmHandler(logging.StreamHandler):
         def __init__(self, strm=None):
             super().__init__(stream=strm)
 
-    config_custom_handler_with_deprecated_strm_arg = {
+    config_custom_handler_with_removed_strm_arg = {
         "version": 1,
         "formatters": {
             "form1": {
@@ -3311,7 +3310,7 @@ class ConfigDictTest(BaseTest):
         },
         "handlers": {
             "hand1": {
-                "class": DeprecatedStrmHandler,
+                "class": StrmHandler,
                 "formatter": "form1",
                 "level": "NOTSET",
                 "stream": "ext://sys.stdout",
@@ -3417,14 +3416,9 @@ class ConfigDictTest(BaseTest):
         self.test_config1_ok(config=self.config5)
         self.check_handler('hand1', CustomHandler)
 
-    def test_deprecation_warning_custom_handler_with_strm_arg(self):
-        msg = (
-            "Support for custom logging handlers with the 'strm' argument "
-            "is deprecated and scheduled for removal in Python 3.16. "
-            "Define handlers with the 'stream' argument instead."
-        )
-        with self.assertWarnsRegex(DeprecationWarning, msg):
-            self.test_config1_ok(config=self.config_custom_handler_with_deprecated_strm_arg)
+    def test_removed_strm_arg(self):
+        with self.assertRaisesRegex(ValueError, 'hand1'):
+            self.apply_config(self.config_custom_handler_with_removed_strm_arg)
 
     def test_config6_failure(self):
         self.assertRaises(Exception, self.apply_config, self.config6)

--- a/Misc/NEWS.d/next/Library/2026-05-09-15-17-59.gh-issue-149598.aLrXRw.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-09-15-17-59.gh-issue-149598.aLrXRw.rst
@@ -1,0 +1,1 @@
+Remove support of deprecated *strm* argument for :mod:`logging` handlers.


### PR DESCRIPTION


<!-- gh-issue-number: gh-149598 -->
* Issue: gh-149598
<!-- /gh-issue-number -->
