### PR TITLE
gh-149574: Document that is_typeddict, is_protocol, is_dataclass, isclass return False for generic aliases

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -498,7 +498,7 @@ Module contents
 .. function:: is_dataclass(obj)
 
    Return ``True`` if its parameter is a dataclass (including subclasses of a
-   dataclass, but not including :ref:`generic specializations <types-generic-aliases>`)
+   dataclass, but not including :ref:`generic aliases <types-genericalias>`)
    or an instance of one, otherwise return ``False``.
 
    If you need to know if a class is an instance of a dataclass (and

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -498,7 +498,8 @@ Module contents
 .. function:: is_dataclass(obj)
 
    Return ``True`` if its parameter is a dataclass (including subclasses of a
-   dataclass) or an instance of one, otherwise return ``False``.
+   dataclass, but not including :ref:`generic specializations <types-generic-aliases>`)
+   or an instance of one, otherwise return ``False``.
 
    If you need to know if a class is an instance of a dataclass (and
    not a dataclass itself), then add a further check for ``not

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -416,7 +416,7 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
    Return ``True`` if the object is a class, whether built-in or created in Python
    code.
 
-   This function returns ``False`` for :ref:`generic specializations <types-generic-aliases>` of classes,
+   This function returns ``False`` for :ref:`generic aliases <types-genericalias>` of classes,
    such as ``list[int]``.
 
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -416,6 +416,9 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
    Return ``True`` if the object is a class, whether built-in or created in Python
    code.
 
+   This function returns ``False`` for :ref:`generic specializations <types-generic-aliases>` of classes,
+   such as ``list[int]``.
+
 
 .. function:: ismethod(object)
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5858,7 +5858,8 @@ type and the :class:`bytes` data type:
 
 ``GenericAlias`` objects are instances of the class
 :class:`types.GenericAlias`, which can also be used to create ``GenericAlias``
-objects directly.
+objects directly. Specializations of user-defined :ref:`generic classes <generic-classes>`
+may not be instances of :class:`types.GenericAlias`, but they provide similar functionality.
 
 .. describe:: T[X, Y, ...]
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3642,6 +3642,15 @@ Introspection helpers
       is_protocol(P)    # => True
       is_protocol(int)  # => False
 
+   This function only returns true for ``Protocol`` classes, not for
+   :ref:`generic specializations <types-generic-aliases>` of them::
+
+      class GenericP[T](Protocol):
+          def a(self) -> T: ...
+          b: int
+
+      assert not is_protocol(GenericP[int])
+
    .. versionadded:: 3.13
 
 .. function:: is_typeddict(tp)
@@ -3662,6 +3671,15 @@ Introspection helpers
       # TypedDict is a factory for creating typed dicts,
       # not a typed dict itself
       assert not is_typeddict(TypedDict)
+
+   This function only returns true for ``TypedDict`` classes, not for
+   :ref:`generic specializations <types-generic-aliases>` of them::
+
+      class GenericFilm[T](TypedDict):
+          title: str
+          year: T
+
+      assert not is_typeddict(GenericFilm[int])
 
    .. versionadded:: 3.10
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3633,17 +3633,21 @@ Introspection helpers
 
    Determine if a type is a :class:`Protocol`.
 
-   For example::
+   For example:
+
+   .. testcode::
 
       class P(Protocol):
           def a(self) -> str: ...
           b: int
 
-      is_protocol(P)    # => True
-      is_protocol(int)  # => False
+      assert is_protocol(P)
+      assert not is_protocol(int)
 
    This function only returns true for ``Protocol`` classes, not for
-   :ref:`generic specializations <types-generic-aliases>` of them::
+   :ref:`generic aliases <types-genericalias>` of them:
+
+   .. testcode::
 
       class GenericP[T](Protocol):
           def a(self) -> T: ...
@@ -3673,7 +3677,9 @@ Introspection helpers
       assert not is_typeddict(TypedDict)
 
    This function only returns true for ``TypedDict`` classes, not for
-   :ref:`generic specializations <types-generic-aliases>` of them::
+   :ref:`generic aliases <types-genericalias>` of them:
+
+   .. testcode::
 
       class GenericFilm[T](TypedDict):
           title: str


### PR DESCRIPTION


<!-- gh-issue-number: gh-149574 -->
* Issue: gh-149574
<!-- /gh-issue-number -->
