### PR TITLE
gh-149614: Restore deepcopiability of argparse.ArgumentParser instances

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -159,11 +159,20 @@ def _identity(value):
 # ===============
 
 class _ColorlessTheme:
+    color_fields = {
+        'usage', 'prog', 'prog_extra', 'heading', 'summary_long_option',
+        'summary_short_option', 'summary_label', 'summary_action',
+        'long_option', 'short_option', 'label', 'action', 'default',
+        'interpolated_value', 'reset', 'error', 'warning', 'message',
+    }
+
     # A 'fake' theme for no colors
     def __getattr__(self, name):
         # _colorize's no_color themes are just all empty strings
         # by directly using empty strings the import is avoided
-        return ""
+        if name in self.color_fields:
+            return ""
+        return super().__getattribute__(name)
 
 _colorless_theme = _ColorlessTheme()
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -159,20 +159,13 @@ def _identity(value):
 # ===============
 
 class _ColorlessTheme:
-    _COLOR_FIELDS = {
-        'usage', 'prog', 'prog_extra', 'heading', 'summary_long_option',
-        'summary_short_option', 'summary_label', 'summary_action',
-        'long_option', 'short_option', 'label', 'action', 'default',
-        'interpolated_value', 'reset', 'error', 'warning', 'message',
-    }
-
     # A 'fake' theme for no colors
     def __getattr__(self, name):
         # _colorize's no_color themes are just all empty strings
         # by directly using empty strings the import is avoided
-        if name in self._COLOR_FIELDS:
-            return ""
-        return super().__getattribute__(name)
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return ""
 
 _colorless_theme = _ColorlessTheme()
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -163,7 +163,7 @@ class _ColorlessTheme:
     def __getattr__(self, name):
         # _colorize's no_color themes are just all empty strings
         # by directly using empty strings the import is avoided
-        if name.startswith("__") and name.endswith("__"):
+        if name.startswith("_"):
             raise AttributeError(name)
         return ""
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -159,7 +159,7 @@ def _identity(value):
 # ===============
 
 class _ColorlessTheme:
-    color_fields = {
+    _COLOR_FIELDS = {
         'usage', 'prog', 'prog_extra', 'heading', 'summary_long_option',
         'summary_short_option', 'summary_label', 'summary_action',
         'long_option', 'short_option', 'label', 'action', 'default',
@@ -170,7 +170,7 @@ class _ColorlessTheme:
     def __getattr__(self, name):
         # _colorize's no_color themes are just all empty strings
         # by directly using empty strings the import is avoided
-        if name in self.color_fields:
+        if name in self._COLOR_FIELDS:
             return ""
         return super().__getattribute__(name)
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -7894,14 +7894,13 @@ class TestColorized(TestCase):
     def test_fake_color_theme_matches_real(self):
         from argparse import _colorless_theme
         _colorize_nocolor = _colorize.get_theme(force_no_color=True).argparse
-        self.assertEqual(
-            _colorless_theme._COLOR_FIELDS,
-            set(_colorize_nocolor.__dataclass_fields__)
-        )
         for k in _colorize_nocolor:
             self.assertEqual(
                 getattr(_colorless_theme, k), getattr(_colorize_nocolor, k)
             )
+
+        with self.assertRaises(AttributeError):
+            _colorless_theme.__deepcopy__
 
 
 class TestModule(unittest.TestCase):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -7893,14 +7893,24 @@ class TestColorized(TestCase):
 
     def test_fake_color_theme_matches_real(self):
         from argparse import _colorless_theme
+
+        # Check the attributes match those of the 'real' theme
         _colorize_nocolor = _colorize.get_theme(force_no_color=True).argparse
         for k in _colorize_nocolor:
             self.assertEqual(
                 getattr(_colorless_theme, k), getattr(_colorize_nocolor, k)
             )
 
+    def test_fake_color_theme_raises(self):
+        from argparse import _colorless_theme
+
+        # Make sure the _colorless_theme doesn't return empty strings
+        # for magic methods or private attributes
         with self.assertRaises(AttributeError):
             _colorless_theme.__unknown_dunder__
+
+        with self.assertRaises(AttributeError):
+            _colorless_theme._private_attribute
 
 
 class TestModule(unittest.TestCase):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -140,6 +140,36 @@ class TestLazyImports(unittest.TestCase):
         )
 
 
+class TestArgumentParserCopiable(unittest.TestCase):
+    def _get_parser(self):
+        parser = argparse.ArgumentParser(exit_on_error=False)
+        parser.add_argument('--foo', type=int, default=42)
+        parser.add_argument('bar', nargs='?', default='baz')
+        return parser
+
+    def test_copiable(self):
+        import copy
+        parser = self._get_parser()
+        parser2 = copy.copy(parser)
+        ns = parser2.parse_args(['--foo', '123', 'quux'])
+        self.assertEqual(ns.foo, 123)
+        self.assertEqual(ns.bar, 'quux')
+        ns2 = parser2.parse_args([])
+        self.assertEqual(ns2.foo, 42)
+        self.assertEqual(ns2.bar, 'baz')
+
+    def test_deepcopiable(self):
+        import copy
+        parser = self._get_parser()
+        parser2 = copy.deepcopy(parser)
+        ns = parser2.parse_args(['--foo', '123', 'quux'])
+        self.assertEqual(ns.foo, 123)
+        self.assertEqual(ns.bar, 'quux')
+        ns2 = parser2.parse_args([])
+        self.assertEqual(ns2.foo, 42)
+        self.assertEqual(ns2.bar, 'baz')
+
+
 class TestArgumentParserPickleable(unittest.TestCase):
 
     @force_not_colorized

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -7894,6 +7894,10 @@ class TestColorized(TestCase):
     def test_fake_color_theme_matches_real(self):
         from argparse import _colorless_theme
         _colorize_nocolor = _colorize.get_theme(force_no_color=True).argparse
+        self.assertEqual(
+            _colorless_theme._COLOR_FIELDS,
+            set(_colorize_nocolor.__dataclass_fields__)
+        )
         for k in _colorize_nocolor:
             self.assertEqual(
                 getattr(_colorless_theme, k), getattr(_colorize_nocolor, k)

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -7900,7 +7900,7 @@ class TestColorized(TestCase):
             )
 
         with self.assertRaises(AttributeError):
-            _colorless_theme.__deepcopy__
+            _colorless_theme.__unknown_dunder__
 
 
 class TestModule(unittest.TestCase):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -147,6 +147,7 @@ class TestArgumentParserCopiable(unittest.TestCase):
         parser.add_argument('bar', nargs='?', default='baz')
         return parser
 
+    @force_not_colorized
     def test_copiable(self):
         import copy
         parser = self._get_parser()
@@ -158,6 +159,12 @@ class TestArgumentParserCopiable(unittest.TestCase):
         self.assertEqual(ns2.foo, 42)
         self.assertEqual(ns2.bar, 'baz')
 
+        # Test shallow copy also gets new arguments
+        parser.add_argument("--extra")
+        ns3 = parser2.parse_args(["--extra", "bar"])
+        self.assertEqual(ns3.extra, "bar")
+
+    @force_not_colorized
     def test_deepcopiable(self):
         import copy
         parser = self._get_parser()
@@ -168,6 +175,11 @@ class TestArgumentParserCopiable(unittest.TestCase):
         ns2 = parser2.parse_args([])
         self.assertEqual(ns2.foo, 42)
         self.assertEqual(ns2.bar, 'baz')
+
+        # Test deep copy does not get new arguments
+        parser.add_argument("--extra")
+        with self.assertRaises(argparse.ArgumentError):
+            parser2.parse_args(["--extra", "bar"])
 
 
 class TestArgumentParserPickleable(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2026-05-09-21-02-08.gh-issue-149614.U4snj3.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-09-21-02-08.gh-issue-149614.U4snj3.rst
@@ -1,0 +1,1 @@
+Fix a regression that broke the ability to deepcopy ``argparse.ArgumentParser`` instances.

--- a/Misc/NEWS.d/next/Library/2026-05-09-21-02-08.gh-issue-149614.U4snj3.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-09-21-02-08.gh-issue-149614.U4snj3.rst
@@ -1,1 +1,1 @@
-Fix a regression that broke the ability to deepcopy ``argparse.ArgumentParser`` instances.
+Fix a regression that broke the ability to deepcopy :class:`argparse.ArgumentParser` instances.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

With the creation of the `_ColorlessTheme` to avoid importing `_colorize` early the new class unfortunately was returning empty strings for `__deepcopy__` along with other dunder methods which broke deepcopy.

I've added tests for `copy` and `deepcopy` based on the test for `pickle`.

Being more cautious, I've narrowed the class to only returning empty strings on attributes matching those taken from `_colorize`.

This does mean making sure the set remains in sync which could be more annoying to maintain, it would also be possible to just exclude anything starting with `_`. I've updated the test that checks this theme to directly check they are in sync.

<!-- gh-issue-number: gh-149614 -->
* Issue: gh-149614
<!-- /gh-issue-number -->
