### PR TITLE
Increase the size of the test document in test_deeply_nested_content_model

### DIFF
--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -735,7 +735,7 @@ class ElementDeclHandlerTest(unittest.TestCase):
     def test_deeply_nested_content_model(self):
         # This should raise a RecursionError and not crash.
         # See https://github.com/python/cpython/issues/145986.
-        N = 500_000
+        N = 800_000
         data = (
             b'<!DOCTYPE root [\n<!ELEMENT root '
             + b'(a, ' * N + b'a' + b')' * N


### PR DESCRIPTION
On Debian's `i386` builds of Python with system Expat, the parser was happily parsing the entire document without raising RecursionError or crashing. The test was meant to check that RecursionError was raised instead of crashing (#145986).

The increased limit is borrowed from the (later reverted) 255026d9eea81719214c8e807d23df55b5f39b54. Presumably that change ran into a similar issue.

https://bugs.debian.org/1135052