### PR TITLE
gh-149611: Explain return values for `Path.write_text()` and `Path.write_bytes()`

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1266,6 +1266,8 @@ Reading and writing files
       >>> p.read_text()
       'Text file contents'
 
+   Return the number of characters written.
+
    An existing file of the same name is overwritten. The optional parameters
    have the same meaning as in :func:`open`.
 
@@ -1285,6 +1287,8 @@ Reading and writing files
       20
       >>> p.read_bytes()
       b'Binary file contents'
+
+   Return the number of bytes written.
 
    An existing file of the same name is overwritten.
 

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -989,6 +989,7 @@ class Path(PurePath):
     def write_bytes(self, data):
         """
         Open the file in bytes mode, write to it, and close the file.
+        Return the number of bytes written.
         """
         # type-check for the buffer interface before truncating the file
         view = memoryview(data)
@@ -998,6 +999,7 @@ class Path(PurePath):
     def write_text(self, data, encoding=None, errors=None, newline=None):
         """
         Open the file in text mode, write to it, and close the file.
+        Return the number of characters written.
         """
         # Call io.text_encoding() here to ensure any warning is raised at an
         # appropriate stack level.

--- a/Lib/pathlib/types.py
+++ b/Lib/pathlib/types.py
@@ -431,6 +431,7 @@ class _WritablePath(_JoinablePath):
     def write_bytes(self, data):
         """
         Open the file in bytes mode, write to it, and close the file.
+        Return the number of bytes written.
         """
         # type-check for the buffer interface before truncating the file
         view = memoryview(data)
@@ -440,6 +441,7 @@ class _WritablePath(_JoinablePath):
     def write_text(self, data, encoding=None, errors=None, newline=None):
         """
         Open the file in text mode, write to it, and close the file.
+        Return the number of characters written.
         """
         # Call io.text_encoding() here to ensure any warning is raised at an
         # appropriate stack level.


### PR DESCRIPTION
`pathlib.Path.write_text` and `pathlib.Path.write_bytes` both return an integer from the underlying file object's `.write()` call (number of characters and number of bytes, respectively), but neither the Sphinx documentation nor the docstrings mention this.

Issue - #149611

<!-- gh-issue-number: gh-149611 -->
* Issue: gh-149611
<!-- /gh-issue-number -->
