### PR TITLE
gh-149634: Remove deprecated and unused `tarfile.Tarfile.tarfile` attr

### DIFF
--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -133,6 +133,12 @@ sysconfig
   which has been deprecated since Python 3.14.
   Use the ``vars`` argument of :func:`sysconfig.get_paths` instead.
 
+tarfile
+-------
+
+* The undocumented and unused :attr:`!tarfile.TarFile.tarfile` attribute
+  has been deprecated since Python 3.13.
+
 .. Add removals above alphabetically, not here at the end.
 
 

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -913,7 +913,6 @@ class TarInfo(object):
         pax_headers = ('A dictionary containing key-value pairs of an '
                        'associated pax extended header.'),
         sparse = 'Sparse member information.',
-        _tarfile = None,
         _sparse_structs = None,
         _link_target = None,
         )
@@ -941,24 +940,6 @@ class TarInfo(object):
 
         self.sparse = None      # sparse member information
         self.pax_headers = {}   # pax header information
-
-    @property
-    def tarfile(self):
-        import warnings
-        warnings.warn(
-            'The undocumented "tarfile" attribute of TarInfo objects '
-            + 'is deprecated and will be removed in Python 3.16',
-            DeprecationWarning, stacklevel=2)
-        return self._tarfile
-
-    @tarfile.setter
-    def tarfile(self, tarfile):
-        import warnings
-        warnings.warn(
-            'The undocumented "tarfile" attribute of TarInfo objects '
-            + 'is deprecated and will be removed in Python 3.16',
-            DeprecationWarning, stacklevel=2)
-        self._tarfile = tarfile
 
     @property
     def path(self):
@@ -2196,7 +2177,6 @@ class TarFile(object):
         # Now, fill the TarInfo object with
         # information specific for the file.
         tarinfo = self.tarinfo()
-        tarinfo._tarfile = self  # To be removed in 3.16.
 
         # Use os.stat or os.lstat, depending on if symlinks shall be resolved.
         if fileobj is None:

--- a/Misc/NEWS.d/next/Library/2026-05-10-14-10-00.gh-issue-149634.iT5cwC.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-10-14-10-00.gh-issue-149634.iT5cwC.rst
@@ -1,0 +1,1 @@
+Remove deprecated and unused :attr:`!tarfile.Tarfile.tarfile` attribute.


### PR DESCRIPTION


<!-- gh-issue-number: gh-149634 -->
* Issue: gh-149634
<!-- /gh-issue-number -->
