### PR TITLE
gh-149663: fix typo in unittest docs, hastattr -> hasattr

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1262,10 +1262,10 @@ Test cases
    | :meth:`assertNotEndsWith(a, b)        | ``not a.endswith(b)``          | 3.14         |
    | <TestCase.assertNotEndsWith>`         |                                |              |
    +---------------------------------------+--------------------------------+--------------+
-   | :meth:`assertHasAttr(a, b)            | ``hastattr(a, b)``             | 3.14         |
+   | :meth:`assertHasAttr(a, b)            | ``hasattr(a, b)``              | 3.14         |
    | <TestCase.assertHasAttr>`             |                                |              |
    +---------------------------------------+--------------------------------+--------------+
-   | :meth:`assertNotHasAttr(a, b)         | ``not hastattr(a, b)``         | 3.14         |
+   | :meth:`assertNotHasAttr(a, b)         | ``not hasattr(a, b)``          | 3.14         |
    | <TestCase.assertNotHasAttr>`          |                                |              |
    +---------------------------------------+--------------------------------+--------------+
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149663 -->
* Issue: gh-149663
<!-- /gh-issue-number -->
