### PR TITLE
gh-149634: Fix removed docs from `TarFile.tarfile` to `TarInfo.tarfile`

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.16.rst
+++ b/Doc/deprecations/pending-removal-in-3.16.rst
@@ -101,5 +101,5 @@ Pending removal in Python 3.16
 
 * :mod:`tarfile`:
 
-  * The undocumented and unused :attr:`!TarFile.tarfile` attribute
+  * The undocumented and unused :attr:`!TarInfo.tarfile` attribute
     has been deprecated since Python 3.13.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1965,7 +1965,7 @@ New Deprecations
 
 * :mod:`tarfile`:
 
-  * Deprecate the undocumented and unused :attr:`!TarFile.tarfile` attribute,
+  * Deprecate the undocumented and unused :attr:`!TarInfo.tarfile` attribute,
     to be removed in Python 3.16.
     (Contributed in :gh:`115256`.)
 

--- a/Misc/NEWS.d/next/Library/2026-05-10-14-10-00.gh-issue-149634.iT5cwC.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-10-14-10-00.gh-issue-149634.iT5cwC.rst
@@ -1,1 +1,1 @@
-Remove deprecated and unused :attr:`!tarfile.Tarfile.tarfile` attribute.
+Remove deprecated and unused :attr:`!tarfile.TarInfo.tarfile` attribute.


### PR DESCRIPTION
Sorry, I just copy pasted the error message from the existing docs. And there was a typo there :)

<!-- gh-issue-number: gh-149634 -->
* Issue: gh-149634
<!-- /gh-issue-number -->
