### PR TITLE
gh-131178: Add tests for mimetypes command-line interface

### DIFF
--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -6,8 +6,9 @@ import sys
 import unittest.mock
 from platform import win32_edition
 from test import support
-from test.support import cpython_only, force_not_colorized, os_helper
+from test.support import cpython_only, force_not_colorized, os_helper, requires_subprocess
 from test.support.import_helper import ensure_lazy_imports
+from test.support.script_helper import assert_python_ok, assert_python_failure
 
 try:
     import _winapi
@@ -506,6 +507,52 @@ class CommandLineTest(unittest.TestCase):
             with self.subTest(command=command):
                 result = "\n".join(mimetypes._main(shlex.split(command)))
                 self.assertEqual(result, expected)
+
+
+@requires_subprocess()
+class CommandLineSubprocessTest(unittest.TestCase):
+    def test_help(self):
+        rc, stdout, stderr = assert_python_ok('-m', 'mimetypes', '--help')
+        self.assertIn(b'mimetypes', stdout)
+        self.assertIn(b'--help', stdout)
+        self.assertIn(b'--extension', stdout)
+        self.assertIn(b'--lenient', stdout)
+
+    def test_type_lookup(self):
+        rc, stdout, stderr = assert_python_ok('-m', 'mimetypes', 'foo.pdf')
+        self.assertIn(b'application/pdf', stdout)
+
+    def test_type_lookup_unknown(self):
+        rc, stdout, stderr = assert_python_failure('-m', 'mimetypes', 'foo.unknownext12345')
+        self.assertIn(b'error:', stdout)
+
+    def test_extension_flag(self):
+        rc, stdout, stderr = assert_python_ok('-m', 'mimetypes', '-e', 'image/jpeg')
+        self.assertIn(b'.jpg', stdout)
+
+    def test_extension_flag_unknown(self):
+        rc, stdout, stderr = assert_python_failure('-m', 'mimetypes', '-e', 'image/unknowntype12345')
+        self.assertIn(b'error:', stdout)
+
+    def test_lenient_flag(self):
+        rc, stdout, stderr = assert_python_ok('-m', 'mimetypes', '--lenient', 'foo.webp')
+        self.assertIn(b'image/webp', stdout)
+
+    def test_multiple_inputs(self):
+        rc, stdout, stderr = assert_python_ok('-m', 'mimetypes', 'foo.pdf', 'foo.png')
+        self.assertIn(b'application/pdf', stdout)
+        self.assertIn(b'image/png', stdout)
+
+    def test_multiple_inputs_with_error(self):
+        rc, stdout, stderr = assert_python_failure(
+            '-m', 'mimetypes', 'foo.pdf', 'foo.unknownext12345'
+        )
+        self.assertIn(b'application/pdf', stdout)
+        self.assertIn(b'error:', stdout)
+
+    def test_unknown_flag(self):
+        rc, stdout, stderr = assert_python_failure('-m', 'mimetypes', '--unknown-flag')
+        self.assertNotEqual(rc, 0)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Tests/2026-05-11-23-26-02.gh-issue-131178.Y2o6Dt.rst
+++ b/Misc/NEWS.d/next/Tests/2026-05-11-23-26-02.gh-issue-131178.Y2o6Dt.rst
@@ -1,0 +1,1 @@
+Add tests for the :mod:`mimetypes` command-line interface.


### PR DESCRIPTION
Adds subprocess-based tests for the `mimetypes` command-line interface in a new `CommandLineSubprocessTest` class, covering:

- `--help` flag output
- Type lookup (success and unknown extension)
- Extension lookup via `-e` flag (success and unknown type)
- `--lenient` flag
- Multiple inputs including mixed success/error
- Exit code 1 on error, exit code 0 on success
- Unknown flag handling