### PR TITLE
gh-139310: Revert test skip for `test_aead_aes_gcm` (GH-139552)

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -324,16 +324,6 @@ def requires(resource, msg=None):
     if resource == 'gui' and not _is_gui_available():
         raise ResourceDenied(_is_gui_available.reason)
 
-def _get_kernel_version(sysname="Linux"):
-    import platform
-    if platform.system() != sysname:
-        return None
-    version_txt = platform.release().split('-', 1)[0]
-    try:
-        return tuple(map(int, version_txt.split('.')))
-    except ValueError:
-        return None
-
 def _requires_unix_version(sysname, min_version):
     """Decorator raising SkipTest if the OS is `sysname` and the version is less
     than `min_version`.

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -7172,7 +7172,7 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
             self.assertEqual(len(dec), msglen * multiplier)
             self.assertEqual(dec, msg * multiplier)
 
-    @support.requires_linux_version(4, 9)  # see issue29324
+    @support.requires_linux_version(4, 9)  # see gh-73510
     def test_aead_aes_gcm(self):
         key = bytes.fromhex('c939cc13397c1d37de6ae0e1cb7c423c')
         iv = bytes.fromhex('b3d8cc017cbb89b39e0f67e2')

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -7172,14 +7172,8 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
             self.assertEqual(len(dec), msglen * multiplier)
             self.assertEqual(dec, msg * multiplier)
 
-    @support.requires_linux_version(4, 9)  # see gh-73510
+    @support.requires_linux_version(4, 9)  # see issue29324
     def test_aead_aes_gcm(self):
-        kernel_version = support._get_kernel_version("Linux")
-        if kernel_version is not None:
-            if kernel_version >= (6, 16) and kernel_version < (6, 18):
-                # See https://github.com/python/cpython/issues/139310.
-                self.skipTest("upstream Linux kernel issue")
-
         key = bytes.fromhex('c939cc13397c1d37de6ae0e1cb7c423c')
         iv = bytes.fromhex('b3d8cc017cbb89b39e0f67e2')
         plain = bytes.fromhex('c3b3c41f113a31b73d9a5cd432103069')


### PR DESCRIPTION
This reverts commit 41712c4e095b2cc988febfe3887616c2779c6210.

Anyone running tests on a kernel with the bug will now see a test  failure.


<!-- gh-issue-number: gh-139310 -->
* Issue: gh-139310
<!-- /gh-issue-number -->
