### PR TITLE
[3.15] gh-149694: Fix missing docstring on asyncio.iscoroutinefunction

### DIFF
--- a/Lib/asyncio/coroutines.py
+++ b/Lib/asyncio/coroutines.py
@@ -18,8 +18,8 @@ _is_coroutine = object()
 
 
 def iscoroutinefunction(func):
-    import warnings
     """Return True if func is a decorated coroutine function."""
+    import warnings
     warnings._deprecated("asyncio.iscoroutinefunction",
                          f"{warnings._DEPRECATED_MSG}; "
                          "use inspect.iscoroutinefunction() instead",


### PR DESCRIPTION
gh-149694: Fix missing docstring on asyncio.iscoroutinefunction

The docstring in `asyncio.iscoroutinefunction` is currently dead code: it follows an `import warnings` statement, so Python does not treat it as docstring.

Before:
```python
  >>> import asyncio
  >>> asyncio.iscoroutinefunction.__doc__ is None
  True
```

After:
```python
  >>> asyncio.iscoroutinefunction.__doc__
  'Return True if func is a decorated coroutine function.'
```

The fix is a one-line reorder: move import warnings below the docstring.
