### PR TITLE
gh-149718: Aggregate same stack frames in Tachyon in some collectors

### DIFF
--- a/Lib/profiling/sampling/collector.py
+++ b/Lib/profiling/sampling/collector.py
@@ -143,6 +143,8 @@ def iter_async_frames(awaited_info_list):
 
 
 class Collector(ABC):
+    aggregating = False
+
     @abstractmethod
     def collect(self, stack_frames, timestamps_us=None):
         """Collect profiling data from stack frames.

--- a/Lib/profiling/sampling/gecko_collector.py
+++ b/Lib/profiling/sampling/gecko_collector.py
@@ -63,6 +63,8 @@ STACKWALK_DISABLED = 0
 
 
 class GeckoCollector(Collector):
+    aggregating = True
+
     def __init__(self, sample_interval_usec, *, skip_idle=False, opcodes=False):
         self.sample_interval_usec = sample_interval_usec
         self.skip_idle = skip_idle

--- a/Lib/profiling/sampling/heatmap_collector.py
+++ b/Lib/profiling/sampling/heatmap_collector.py
@@ -452,7 +452,8 @@ class HeatmapCollector(StackTraceCollector):
                 next_lineno = extract_lineno(next_frame[1])
                 self._record_call_relationship(
                     (filename, lineno, funcname),
-                    (next_frame[0], next_lineno, next_frame[2])
+                    (next_frame[0], next_lineno, next_frame[2]),
+                    weight=weight,
                 )
 
     def _is_valid_frame(self, filename, lineno):
@@ -561,7 +562,7 @@ class HeatmapCollector(StackTraceCollector):
         result.sort(key=lambda x: (-x['samples'], x['opcode']))
         return result
 
-    def _record_call_relationship(self, callee_frame, caller_frame):
+    def _record_call_relationship(self, callee_frame, caller_frame, weight=1):
         """Record caller/callee relationship between adjacent frames."""
         callee_filename, callee_lineno, callee_funcname = callee_frame
         caller_filename, caller_lineno, caller_funcname = caller_frame
@@ -587,7 +588,7 @@ class HeatmapCollector(StackTraceCollector):
 
         # Count this call edge for path analysis
         edge_key = (caller_key, callee_key)
-        self.edge_samples[edge_key] += 1
+        self.edge_samples[edge_key] += weight
 
     def export(self, output_path):
         """Export heatmap data as HTML files in a directory.

--- a/Lib/profiling/sampling/pstats_collector.py
+++ b/Lib/profiling/sampling/pstats_collector.py
@@ -8,6 +8,8 @@ from .constants import MICROSECONDS_PER_SECOND, PROFILING_MODE_CPU
 
 
 class PstatsCollector(Collector):
+    aggregating = True
+
     def __init__(self, sample_interval_usec, *, skip_idle=False):
         self.result = collections.defaultdict(
             lambda: dict(total_rec_calls=0, direct_calls=0, cumulative_calls=0)

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -109,7 +109,7 @@ class SampleProfiler:
         last_sample_time = start_time
         realtime_update_interval = 1.0  # Update every second
         last_realtime_update = start_time
-        aggregating = getattr(collector, 'aggregating', False)
+        aggregating = getattr(collector, 'aggregating', False) is True
         prev_stack = None
         pending_count = 0
         pending_timestamps = [] if aggregating else None
@@ -118,15 +118,10 @@ class SampleProfiler:
             nonlocal pending_count, pending_timestamps
             if pending_count == 0:
                 return
-            count = pending_count
             pending_count = 0
-            if aggregating:
-                ts = pending_timestamps
-                pending_timestamps = []
-                collector.collect(prev_stack, timestamps_us=ts)
-            else:
-                for _ in range(count):
-                    collector.collect(prev_stack)
+            ts = pending_timestamps
+            pending_timestamps = []
+            collector.collect(prev_stack, timestamps_us=ts)
 
         try:
             while duration_sec is None or running_time_sec < duration_sec:
@@ -145,12 +140,14 @@ class SampleProfiler:
                         stack_frames = self._get_stack_trace(
                             async_aware=async_aware
                         )
-                        if stack_frames != prev_stack:
-                            flush_pending()
-                            prev_stack = stack_frames
-                        pending_count += 1
                         if aggregating:
+                            if stack_frames != prev_stack:
+                                flush_pending()
+                                prev_stack = stack_frames
+                            pending_count += 1
                             pending_timestamps.append(current_time_us)
+                        else:
+                            collector.collect(stack_frames)
                     except ProcessLookupError as e:
                         running_time_sec = current_time - start_time
                         break

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -113,7 +113,6 @@ class SampleProfiler:
         prev_stack = None
         pending_count = 0
         pending_timestamps = [] if aggregating else None
-        consecutive_identical = 0
 
         def flush_pending():
             nonlocal pending_count, pending_timestamps
@@ -146,9 +145,7 @@ class SampleProfiler:
                         stack_frames = self._get_stack_trace(
                             async_aware=async_aware
                         )
-                        if stack_frames == prev_stack:
-                            consecutive_identical += 1
-                        else:
+                        if stack_frames != prev_stack:
                             flush_pending()
                             prev_stack = stack_frames
                         pending_count += 1
@@ -210,9 +207,7 @@ class SampleProfiler:
         if not is_live_mode:
             s = "" if num_samples == 1 else "s"
             print(f"Captured {num_samples:n} sample{s} in {fmt(running_time_sec, 2)} seconds")
-            comparable_samples = max(1, num_samples - errors - 1)
-            print(f"Sample rate: {fmt(sample_rate, 2)} samples/sec "
-                  f"(consecutive identical: {consecutive_identical:n}/{comparable_samples:n})")
+            print(f"Sample rate: {fmt(sample_rate, 2)} samples/sec")
             print(f"Error rate: {fmt(error_rate, 2)}")
 
             # Print unwinder stats if stats collection is enabled

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -109,6 +109,26 @@ class SampleProfiler:
         last_sample_time = start_time
         realtime_update_interval = 1.0  # Update every second
         last_realtime_update = start_time
+        aggregating = getattr(collector, 'aggregating', False)
+        prev_stack = None
+        pending_count = 0
+        pending_timestamps = [] if aggregating else None
+        consecutive_identical = 0
+
+        def flush_pending():
+            nonlocal pending_count, pending_timestamps
+            if pending_count == 0:
+                return
+            count = pending_count
+            pending_count = 0
+            if aggregating:
+                ts = pending_timestamps
+                pending_timestamps = []
+                collector.collect(prev_stack, timestamps_us=ts)
+            else:
+                for _ in range(count):
+                    collector.collect(prev_stack)
+
         try:
             while duration_sec is None or running_time_sec < duration_sec:
                 # Check if live collector wants to stop
@@ -116,6 +136,7 @@ class SampleProfiler:
                     break
 
                 current_time = time.perf_counter()
+                current_time_us = int(current_time * 1_000_000)
                 if next_time > current_time:
                     sleep_time = (next_time - current_time) * 0.9
                     if sleep_time > 0.0001:
@@ -125,13 +146,22 @@ class SampleProfiler:
                         stack_frames = self._get_stack_trace(
                             async_aware=async_aware
                         )
-                        collector.collect(stack_frames)
+                        if stack_frames == prev_stack:
+                            consecutive_identical += 1
+                        else:
+                            flush_pending()
+                            prev_stack = stack_frames
+                        pending_count += 1
+                        if aggregating:
+                            pending_timestamps.append(current_time_us)
                     except ProcessLookupError as e:
                         running_time_sec = current_time - start_time
                         break
                     except (RuntimeError, UnicodeDecodeError, MemoryError, OSError):
+                        flush_pending()
                         collector.collect_failed_sample()
                         errors += 1
+                        prev_stack = None
                     except Exception as e:
                         if not _is_process_running(self.pid):
                             break
@@ -163,6 +193,8 @@ class SampleProfiler:
             interrupted = True
             running_time_sec = time.perf_counter() - start_time
             print("Interrupted by user.")
+        finally:
+            flush_pending()
 
         # Clear real-time stats line if it was being displayed
         if self.realtime_stats and len(self.sample_intervals) > 0:
@@ -178,7 +210,9 @@ class SampleProfiler:
         if not is_live_mode:
             s = "" if num_samples == 1 else "s"
             print(f"Captured {num_samples:n} sample{s} in {fmt(running_time_sec, 2)} seconds")
-            print(f"Sample rate: {fmt(sample_rate, 2)} samples/sec")
+            comparable_samples = max(1, num_samples - errors - 1)
+            print(f"Sample rate: {fmt(sample_rate, 2)} samples/sec "
+                  f"(consecutive identical: {consecutive_identical:n}/{comparable_samples:n})")
             print(f"Error rate: {fmt(error_rate, 2)}")
 
             # Print unwinder stats if stats collection is enabled

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -47,6 +47,9 @@ _FREE_THREADED_BUILD = sysconfig.get_config_var("Py_GIL_DISABLED") is not None
 # If fewer samples are collected, we skip the TUI and just print a message
 MIN_SAMPLES_FOR_TUI = 200
 
+# Maximum number of consecutive identical samples to keep before flushing.
+MAX_PENDING_SAMPLES = 8192
+
 class SampleProfiler:
     def __init__(self, pid, sample_interval_usec, all_threads, *, mode=PROFILING_MODE_WALL, native=False, gc=True, opcodes=False, skip_non_matching_threads=True, collect_stats=False, blocking=False):
         self.pid = pid
@@ -146,6 +149,8 @@ class SampleProfiler:
                                 prev_stack = stack_frames
                             pending_count += 1
                             pending_timestamps.append(current_time_us)
+                            if pending_count >= MAX_PENDING_SAMPLES:
+                                flush_pending()
                         else:
                             collector.collect(stack_frames)
                     except ProcessLookupError as e:

--- a/Lib/profiling/sampling/stack_collector.py
+++ b/Lib/profiling/sampling/stack_collector.py
@@ -16,6 +16,8 @@ from .module_utils import extract_module_name, get_python_path_info
 
 
 class StackTraceCollector(Collector):
+    aggregating = True
+
     def __init__(self, sample_interval_usec, *, skip_idle=False):
         self.sample_interval_usec = sample_interval_usec
         self.skip_idle = skip_idle

--- a/Lib/test/test_profiling/test_heatmap.py
+++ b/Lib/test/test_profiling/test_heatmap.py
@@ -345,6 +345,21 @@ class TestHeatmapCollectorProcessFrames(unittest.TestCase):
         # Check that edge count is tracked
         self.assertGreater(len(collector.edge_samples), 0)
 
+    def test_process_frames_weight_applies_to_identical_samples(self):
+        collector = HeatmapCollector(sample_interval_usec=100)
+
+        frames = [
+            ('callee.py', (5, 5, -1, -1), 'callee', None),
+            ('caller.py', (10, 10, -1, -1), 'caller', None),
+        ]
+
+        collector.process_frames(frames, thread_id=1, weight=5)
+
+        edge_key = (('caller.py', 10), ('callee.py', 5))
+        self.assertEqual(collector.edge_samples[edge_key], 5)
+        self.assertEqual(collector.line_samples[('callee.py', 5)], 5)
+        self.assertEqual(collector.line_samples[('caller.py', 10)], 5)
+
     def test_process_frames_handles_empty_frames(self):
         """Test that process_frames handles empty frame list."""
         collector = HeatmapCollector(sample_interval_usec=100)

--- a/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
@@ -205,6 +205,77 @@ class TestSampleProfiler(unittest.TestCase):
             self.assertGreaterEqual(total_weight, 5)
             self.assertLessEqual(total_weight, 11)
 
+    def test_sample_profiler_does_not_buffer_non_aggregating_collectors(self):
+        """Test that non-aggregating collectors get each sample immediately."""
+
+        stack_frames = [mock.sentinel.stack_frames]
+        mock_collector = mock.MagicMock()
+        mock_collector.aggregating = False
+
+        with self._patched_unwinder() as u:
+            u.instance.get_stack_trace.return_value = stack_frames
+
+            manager = mock.Mock()
+            manager.attach_mock(u.instance.get_stack_trace, "unwind")
+            manager.attach_mock(mock_collector.collect, "collect")
+
+            profiler = SampleProfiler(
+                pid=12345, sample_interval_usec=10000, all_threads=False
+            )
+
+            times = [0.0, 0.01, 0.011, 0.02, 0.03]
+            with mock.patch("time.perf_counter", side_effect=times):
+                with io.StringIO() as output:
+                    with mock.patch("sys.stdout", output):
+                        profiler.sample(mock_collector, duration_sec=0.025)
+
+        self.assertEqual(
+            manager.mock_calls,
+            [
+                mock.call.unwind(),
+                mock.call.collect(stack_frames),
+                mock.call.unwind(),
+                mock.call.collect(stack_frames),
+            ],
+        )
+
+    def test_sample_profiler_flushes_aggregated_batches_at_limit(self):
+        """Test that aggregating collectors flush after MAX_PENDING_SAMPLES samples."""
+
+        stack_frames = [mock.sentinel.stack_frames]
+        mock_collector = mock.MagicMock()
+        mock_collector.aggregating = True
+
+        with self._patched_unwinder() as u:
+            u.instance.get_stack_trace.return_value = stack_frames
+
+            profiler = SampleProfiler(
+                pid=12345, sample_interval_usec=10000, all_threads=False
+            )
+
+            times = [
+                0.0,
+                0.01, 0.011,
+                0.02, 0.021,
+                0.03, 0.031,
+                0.04, 0.041,
+                0.05, 0.051,
+            ]
+            with mock.patch("profiling.sampling.sample.MAX_PENDING_SAMPLES", 2):
+                with mock.patch("time.perf_counter", side_effect=times):
+                    with io.StringIO() as output:
+                        with mock.patch("sys.stdout", output):
+                            profiler.sample(mock_collector, duration_sec=0.045)
+
+        batches = [
+            (c.args[0], len(c.kwargs["timestamps_us"]))
+            for c in mock_collector.collect.call_args_list
+        ]
+        self.assertEqual(
+            batches,
+            [(stack_frames, 2), (stack_frames, 2), (stack_frames, 1)],
+        )
+
     def test_sample_profiler_error_handling(self):
         """Test that the sample method handles errors gracefully."""
 

--- a/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
@@ -198,8 +198,12 @@ class TestSampleProfiler(unittest.TestCase):
             self.assertIn("samples", result)
 
             # Verify collector was called multiple times
-            self.assertGreaterEqual(mock_collector.collect.call_count, 5)
-            self.assertLessEqual(mock_collector.collect.call_count, 11)
+            total_weight = sum(
+                len(c.kwargs.get("timestamps_us") or [None])
+                for c in mock_collector.collect.call_args_list
+            )
+            self.assertGreaterEqual(total_weight, 5)
+            self.assertLessEqual(total_weight, 11)
 
     def test_sample_profiler_error_handling(self):
         """Test that the sample method handles errors gracefully."""

--- a/Misc/NEWS.d/next/Library/2026-05-12-13-03-45.gh-issue-149718.SaM1NJ.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-12-13-03-45.gh-issue-149718.SaM1NJ.rst
@@ -1,0 +1,4 @@
+Coalesce consecutive identical stack frames in Tachyon, so aggregating
+collectors (pstats, collapsed, flamegraph, gecko) receive one collect.
+Improves sample rate 3x, error rate and missed rate drop by 70%. Patch by
+Maurycy Pawłowski-Wieroński.


### PR DESCRIPTION
Please see gh-149718 for more details.

On [a MacBook M4](https://gist.github.com/maurycy/d20d3a37431b95c0725353b71bc9d95a), using `test_asyncio` since it has longer stacks (without `--async-aware`):

## Sample rate (samples/sec)

| Format | main (`c6fd7de`) | remote-debugger-batching (`2864c275847`) |
|--------------|----------------:|-------------------------:|
| `--pstats` | 31,161.59 | 103,657.01 |
| `--collapsed` | 57,302.45 | 102,350.22 |
| `--flamegraph` | 33,490.73 | 100,641.14 |
| `--gecko` | 31,346.37 | 98,031.88 |
| `--heatmap` | 14,960.64 | 97,607.28 |
| `--jsonl` | 24,554.56 | 98,018.93 |

## Error rate (%)

| Format | main (`c6fd7de`) | remote-debugger-batching (`2864c275847`) |
|--------------|-----:|-------------------------:|
| `--pstats` | 1.94 | 0.54 |
| `--collapsed` | 1.47 | 0.78 |
| `--flamegraph` | 1.77 | 0.57 |
| `--gecko` | 1.92 | 0.57 |
| `--heatmap` | 2.33 | 0.44 |
| `--jsonl` | 2.06 | 0.54 |

## Missed samples (%)

| Format | main (`c6fd7de`) | remote-debugger-batching (`2864c275847`) |
|--------------|------:|-------------------------:|
| `--pstats` | 90.65 | 68.90 |
| `--collapsed` | 82.81 | 69.29 |
| `--flamegraph` | 89.95 | 69.81 |
| `--gecko` | 90.60 | 70.59 |
| `--heatmap` | 95.51 | 70.72 |
| `--jsonl` | 92.63 | 70.59 |

## Bench

```sh
mkdir -p /tmp/bench_results

git checkout c6fd7de
sudo -n ./python.exe -m profiling.sampling run -r 300khz --pstats     -o /dev/null            -m test test_asyncio 2>&1 | tee /tmp/bench_results/main_pstats.txt
sudo -n ./python.exe -m profiling.sampling run -r 300khz --collapsed  -o /dev/null            -m test test_asyncio 2>&1 | tee /tmp/bench_results/main_collapsed.txt
sudo -n ./python.exe -m profiling.sampling run -r 300khz --flamegraph -o /dev/null            -m test test_asyncio 2>&1 | tee /tmp/bench_results/main_flamegraph.txt
sudo -n ./python.exe -m profiling.sampling run -r 300khz --gecko      -o /dev/null            -m test test_asyncio 2>&1 | tee /tmp/bench_results/main_gecko.txt
sudo -n ./python.exe -m profiling.sampling run -r 300khz --heatmap    -o /tmp/heatmap_main    -m test test_asyncio 2>&1 | tee /tmp/bench_results/main_heatmap.txt
sudo -n ./python.exe -m profiling.sampling run -r 300khz --jsonl      -o /dev/null            -m test test_asyncio 2>&1 | tee /tmp/bench_results/main_jsonl.txt

git checkout remote-debugger-batching
sudo -n ./python.exe -m profiling.sampling run -r 300khz --pstats     -o /dev/null              -m test test_asyncio 2>&1 | tee /tmp/bench_results/batching_pstats.txt
sudo -n ./python.exe -m profiling.sampling run -r 300khz --collapsed  -o /dev/null              -m test test_asyncio 2>&1 | tee /tmp/bench_results/batching_collapsed.txt
sudo -n ./python.exe -m profiling.sampling run -r 300khz --flamegraph -o /dev/null              -m test test_asyncio 2>&1 | tee /tmp/bench_results/batching_flamegraph.txt
sudo -n ./python.exe -m profiling.sampling run -r 300khz --gecko      -o /dev/null              -m test test_asyncio 2>&1 | tee /tmp/bench_results/batching_gecko.txt
sudo -n ./python.exe -m profiling.sampling run -r 300khz --heatmap    -o /tmp/heatmap_batching  -m test test_asyncio 2>&1 | tee /tmp/bench_results/batching_heatmap.txt
sudo -n ./python.exe -m profiling.sampling run -r 300khz --jsonl      -o /dev/null              -m test test_asyncio 2>&1 | tee /tmp/bench_results/batching_jsonl.txt
```