### PR TITLE
gh-149720: Remove support for undotted `ext` in `mimetypes.MimeType.add_type`

### DIFF
--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -129,9 +129,17 @@ behavior of the module.
    Add a mapping from the MIME type *type* to the extension *ext*. When the
    extension is already known, the new type will replace the old one. When the type
    is already known the extension will be added to the list of known extensions.
+   Valid extensions are empty or start with a ``'.'``.
 
    When *strict* is ``True`` (the default), the mapping will be added to the
    official MIME types, otherwise to the non-standard ones.
+
+   .. versinchanged:: 3.14
+      *ext* values that do not start with ``'.'`` are deprecated.
+
+   .. versionchanged:: next
+      *ext* now must start with ``'.'``. Otherwise :exc:`ValueError` is raised.
+
 
 
 .. data:: inited

--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -134,7 +134,7 @@ behavior of the module.
    When *strict* is ``True`` (the default), the mapping will be added to the
    official MIME types, otherwise to the non-standard ones.
 
-   .. versionchanged:: 3.14
+   .. deprecated:: 3.14
       *ext* values that do not start with ``'.'`` are deprecated.
 
    .. versionchanged:: next

--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -134,7 +134,7 @@ behavior of the module.
    When *strict* is ``True`` (the default), the mapping will be added to the
    official MIME types, otherwise to the non-standard ones.
 
-   .. versinchanged:: 3.14
+   .. versionchanged:: 3.14
       *ext* values that do not start with ``'.'`` are deprecated.
 
    .. versionchanged:: next

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -127,6 +127,13 @@ logging
   and scheduled for removal in Python 3.16. Define handlers with the *stream*
   argument instead.
 
+mimetypes
+---------
+
+* Valid extensions start with a '.' or are empty for
+  :meth:`mimetypes.MimeTypes.add_type`.
+  Undotted extensions now raise a :exc:`ValueError`.
+
 symtable
 --------
 

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -93,13 +93,9 @@ class MimeTypes:
         Valid extensions are empty or start with a '.'.
         """
         if ext and not ext.startswith('.'):
-            from warnings import _deprecated
-
-            _deprecated(
-                "Undotted extensions",
-                "Using undotted extensions is deprecated and "
-                "will raise a ValueError in Python {remove}",
-                remove=(3, 16),
+            raise ValueError(
+                "Adding an extension without a leading dot "
+                f"{ext!r} is not supported"
             )
 
         if not type:

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -93,10 +93,7 @@ class MimeTypes:
         Valid extensions are empty or start with a '.'.
         """
         if ext and not ext.startswith('.'):
-            raise ValueError(
-                "Adding an extension without a leading dot "
-                f"{ext!r} is not supported"
-            )
+            raise ValueError(f"Extension {ext!r} must start with '.'")
 
         if not type:
             return

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -389,9 +389,21 @@ class MimeTypesTestCase(unittest.TestCase):
         mime_type, _ = mimetypes.guess_type('test.myext')
         self.assertEqual(mime_type, 'testing/type')
 
-    def test_add_type_with_undotted_extension_deprecated(self):
-        with self.assertWarns(DeprecationWarning):
+    def test_add_type_with_undotted_extension_not_supported(self):
+        msg = (
+            "Adding an extension without a leading dot "
+            "'undotted' is not supported"
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            msg,
+        ):
             mimetypes.add_type("testing/type", "undotted")
+        with self.assertRaisesRegex(
+            ValueError,
+            msg,
+        ):
+            mimetypes.add_type("", "undotted")
 
 
 @unittest.skipUnless(sys.platform.startswith("win"), "Windows only")

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -390,19 +390,10 @@ class MimeTypesTestCase(unittest.TestCase):
         self.assertEqual(mime_type, 'testing/type')
 
     def test_add_type_with_undotted_extension_not_supported(self):
-        msg = (
-            "Adding an extension without a leading dot "
-            "'undotted' is not supported"
-        )
-        with self.assertRaisesRegex(
-            ValueError,
-            msg,
-        ):
+        msg = "Extension 'undotted' must start with '.'"
+        with self.assertRaisesRegex(ValueError, msg):
             mimetypes.add_type("testing/type", "undotted")
-        with self.assertRaisesRegex(
-            ValueError,
-            msg,
-        ):
+        with self.assertRaisesRegex(ValueError, msg):
             mimetypes.add_type("", "undotted")
 
 

--- a/Misc/NEWS.d/next/Library/2026-05-12-14-44-39.gh-issue-149720.ccsoW-.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-12-14-44-39.gh-issue-149720.ccsoW-.rst
@@ -1,0 +1,1 @@
+Remove support for undotted *ext* in :meth:`mimetypes.MimeTypes.add_type`.


### PR DESCRIPTION
CC @clin1234 who commits regularly to `mimetypes.py` :)

<!-- gh-issue-number: gh-149720 -->
* Issue: gh-149720
<!-- /gh-issue-number -->
