### PR TITLE
gh-149509: Fix posix_spawn heap corruption when environ is mutated during the call

### DIFF
--- a/Lib/test/test_os/test_posix.py
+++ b/Lib/test/test_os/test_posix.py
@@ -2271,6 +2271,52 @@ class _PosixSpawnMixin:
         with open(dupfile, encoding="utf-8") as f:
             self.assertEqual(f.read(), 'hello')
 
+    @support.requires_subprocess()
+    def test_env_none_with_environ_mutated_during_call(self):
+        # Regression test for gh-149509: when env is None the C-level
+        # ``environ`` array is borrowed, not copied. If anything mutates
+        # ``environ`` between argument parsing and the cleanup block
+        # (this is what an LD_PRELOAD interposer such as gprofng does),
+        # the previous identity check ``envlist != environ`` could
+        # mis-classify the borrowed pointer as owned and try to free it
+        # using an uninitialised count.
+        #
+        # The subprocess uses an audit hook to swap the global ``environ``
+        # pointer to a fresh array just before the spawn call. With the
+        # bug present this triggers a crash in the cleanup path; with the
+        # fix the borrowed pointer is left alone.
+        try:
+            import ctypes  # noqa: F401
+        except ImportError:
+            self.skipTest("ctypes required")
+        spawn_name = self.spawn_func.__name__
+        code = textwrap.dedent(f"""
+            import ctypes
+            import os
+            import sys
+
+            libc = ctypes.CDLL(None)
+            environ_var = ctypes.c_void_p.in_dll(libc, 'environ')
+            saved = environ_var.value
+
+            # A fresh, empty environ array we substitute in.
+            replacement = (ctypes.c_char_p * 1)(None)
+            replacement_addr = ctypes.cast(replacement, ctypes.c_void_p).value
+
+            def hook(event, args):
+                if event == 'os.posix_spawn':
+                    environ_var.value = replacement_addr
+
+            sys.addaudithook(hook)
+            try:
+                pid = os.{spawn_name}(sys.executable,
+                                      [sys.executable, '-c', 'pass'], None)
+                os.waitpid(pid, 0)
+            finally:
+                environ_var.value = saved
+            """)
+        assert_python_ok('-c', code)
+
 
 @unittest.skipUnless(hasattr(os, 'posix_spawn'), "test needs os.posix_spawn")
 @support.requires_subprocess()

--- a/Misc/NEWS.d/next/Library/2026-05-12-07-01-29.gh-issue-149509.WwKxjE.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-12-07-01-29.gh-issue-149509.WwKxjE.rst
@@ -1,0 +1,5 @@
+Fix a crash in :func:`os.posix_spawn` and :func:`os.posix_spawnp` when
+``env`` is ``None`` and the global ``environ`` array is mutated during
+the call (for example, by an ``LD_PRELOAD`` interposer such as
+``gprofng``). The cleanup path no longer attempts to free the borrowed
+``environ`` pointer.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7903,11 +7903,12 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
     const char *func_name = use_posix_spawnp ? "posix_spawnp" : "posix_spawn";
     EXECV_CHAR **argvlist = NULL;
     EXECV_CHAR **envlist = NULL;
+    int envlist_owned = 0;
     posix_spawn_file_actions_t file_actions_buf;
     posix_spawn_file_actions_t *file_actionsp = NULL;
     posix_spawnattr_t attr;
     posix_spawnattr_t *attrp = NULL;
-    Py_ssize_t argc, envc;
+    Py_ssize_t argc, envc = 0;
     PyObject *result = NULL;
     PyObject *temp_buffer = NULL;
     pid_t pid;
@@ -7966,6 +7967,7 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
         if (envlist == NULL) {
             goto exit;
         }
+        envlist_owned = 1;
     }
 
     if (file_actions != NULL && file_actions != Py_None) {
@@ -8028,7 +8030,11 @@ exit:
     if (attrp) {
         (void)posix_spawnattr_destroy(attrp);
     }
-    if (envlist && envlist != environ) {
+    /* Only free envlist if we own it. Code that wraps posix_spawn (e.g.
+       gprofng) can mutate the global environ during the spawn call, which
+       would make `envlist != environ` true even for the borrowed case and
+       cause a free of process-owned memory with an uninitialized count. */
+    if (envlist_owned) {
         free_string_array(envlist, envc);
     }
     if (argvlist) {


### PR DESCRIPTION
Closes #149509.

When `os.posix_spawn(..., env=None)` is called and the global C `environ` is replaced between the argv parsing and the cleanup branch, the `if (envlist != environ)` cleanup test misfires. The original `environ` pointer was captured by `parse_envlist`, the new `environ` does not match, so the cleanup treats the borrowed `envlist` as an owned heap allocation. `_Py_FREELIST_FREE` then walks past `envc` (which the borrow path leaves uninitialised), corrupting the heap and crashing the interpreter.

The fix tracks ownership explicitly. An `envlist_owned` flag is set only on the path that calls `parse_envlist` (which mallocs). The cleanup runs only when that flag is set, and the matching `envc` initialisation is moved up so the cleanup loop always has a defined upper bound.

## Tests

`Lib/test/test_os/test_posix.py::_PosixSpawnMixin::test_env_none_with_environ_mutated_during_call` reproduces the bug in an `assert_python_ok` subprocess so the environ swap stays isolated. The subprocess installs a `sys.addaudithook` that, when `os.posix_spawn` fires, uses `ctypes.c_void_p.in_dll(libc, 'environ')` to point `environ` at an empty replacement array, then calls the spawn, then restores. Because `_PosixSpawnMixin` is inherited by both `PosixSpawnTests` and `PosixSpawnPTests`, the test covers `posix_spawn` and `posix_spawnp`.

The test aborts the interpreter on `main` with `Debug memory block ... pad bytes are not all FORBIDDENBYTE` (exit 139). With this PR it passes.

## NEWS

`Misc/NEWS.d/next/Library/2026-05-12-07-01-29.gh-issue-149509.WwKxjE.rst`.

<!-- gh-issue-number: gh-149509 -->
* Issue: gh-149509
<!-- /gh-issue-number -->
