### PR TITLE
Run mypy with four worker processes and uv

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -77,4 +77,4 @@ jobs:
           cache-dependency-path: Tools/requirements-dev.txt
       - run: pip install -r Tools/requirements-dev.txt
       - run: python3 Misc/mypy/make_symlinks.py --symlink
-      - run: mypy --config-file ${{ matrix.target }}/mypy.ini
+      - run: mypy --num-workers 4 --config-file ${{ matrix.target }}/mypy.ini

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -69,12 +69,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.15"
-          allow-prereleases: true
-          cache: pip
-          cache-dependency-path: Tools/requirements-dev.txt
-      - run: pip install -r Tools/requirements-dev.txt
+          activate-environment: true
+          cache-dependency-glob: Tools/requirements-dev.txt
+      - run: uv pip install -r Tools/requirements-dev.txt
       - run: python3 Misc/mypy/make_symlinks.py --symlink
       - run: mypy --num-workers 4 --config-file ${{ matrix.target }}/mypy.ini


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Follow on from https://github.com/python/cpython/pull/149709, mypy 2.0.0 introduced `--num-workers`.

Along with uv, makes the workflow about twice as fast.

Before: 4m 34s https://github.com/hugovk/cpython/actions/runs/25497945357/usage
After: 2m 25s https://github.com/hugovk/cpython/actions/runs/25742656577/usage

Over the last 30 days, this workflow had 662 runs taking 5,953 minutes.

cc @hauntsaninja 