### PR TITLE
gh-149728: Fix free-threaded race in importlib lazy-submodule fast path

### DIFF
--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -918,6 +918,7 @@ def _load_unlocked(spec):
                 del sys.modules[spec.name]
             except KeyError:
                 pass
+            spec._initializing = False
             raise
         # Move the module to the end of sys.modules.
         # We don't ensure that the import-related module attributes get
@@ -926,8 +927,10 @@ def _load_unlocked(spec):
         module = sys.modules.pop(spec.name)
         sys.modules[spec.name] = module
         _verbose_message('import {!r} # {!r}', spec.name, spec.loader)
-    finally:
+    except:
+        # Any other exception bubbles up; clear the flag too.
         spec._initializing = False
+        raise
 
     return module
 
@@ -942,7 +945,10 @@ def _load(spec):
 
     """
     with _ModuleLockManager(spec.name):
-        return _load_unlocked(spec)
+        try:
+            return _load_unlocked(spec)
+        finally:
+            spec._initializing = False
 
 
 # Loaders #####################################################################
@@ -1306,20 +1312,24 @@ def _find_and_load_unlocked(name, import_):
         finally:
             if parent_spec:
                 parent_spec._uninitialized_submodules.pop()
-    if parent:
-        # Set the module as an attribute on its parent.
-        parent_module = sys.modules[parent]
-        try:
-            setattr(parent_module, child, module)
-        except AttributeError:
-            msg = f"Cannot set an attribute on {parent!r} for child module {child!r}"
-            _warnings.warn(msg, ImportWarning)
-    # Set attributes to lazy submodules on the module.
     try:
-        _imp._set_lazy_attributes(module, name)
-    except Exception as e:
-        msg = f"Cannot set lazy attributes on {name!r}: {e!r}"
-        _warnings.warn(msg, ImportWarning)
+        if parent:
+            # Set the module as an attribute on its parent.
+            parent_module = sys.modules[parent]
+            try:
+                setattr(parent_module, child, module)
+            except AttributeError:
+                msg = (f"Cannot set an attribute on {parent!r} for child "
+                       f"module {child!r}")
+                _warnings.warn(msg, ImportWarning)
+        # Set attributes to lazy submodules on the module.
+        try:
+            _imp._set_lazy_attributes(module, name)
+        except Exception as e:
+            msg = f"Cannot set lazy attributes on {name!r}: {e!r}"
+            _warnings.warn(msg, ImportWarning)
+    finally:
+        spec._initializing = False
     return module
 
 
@@ -1486,7 +1496,10 @@ def _builtin_from_name(name):
     spec = BuiltinImporter.find_spec(name)
     if spec is None:
         raise ImportError('no built-in module named ' + name)
-    return _load_unlocked(spec)
+    try:
+        return _load_unlocked(spec)
+    finally:
+        spec._initializing = False
 
 
 def _setup(sys_module, _imp_module):

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -890,8 +890,14 @@ def _exec(spec, module):
             sys.modules[spec.name] = module
     return module
 
-def _load_unlocked(spec):
+def _load_unlocked(spec, finish_load=None):
     # A helper for direct use by the import system.
+    #
+    # If given, finish_load() is called with the loaded module just before
+    # spec._initializing is cleared.  Other threads may use a module whose
+    # spec is no longer initializing without taking the import lock, so
+    # anything that has to be in place by then (such as binding the module
+    # on its parent package) belongs in finish_load().
     module = module_from_spec(spec)
 
     # This must be done before putting the module in sys.modules
@@ -920,6 +926,8 @@ def _load_unlocked(spec):
         module = sys.modules.pop(spec.name)
         sys.modules[spec.name] = module
         _verbose_message('import {!r} # {!r}', spec.name, spec.loader)
+        if finish_load is not None:
+            finish_load(module)
     finally:
         spec._initializing = False
 
@@ -1295,29 +1303,35 @@ def _find_and_load_unlocked(name, import_, *, lazy_submodule=False):
             return None
         raise ModuleNotFoundError(f'{_ERR_MSG_PREFIX}{name!r}', name=name)
     else:
+        def finish_load(module):
+            # Called by _load_unlocked() while spec._initializing is still
+            # true, so that no thread can see the module as fully imported
+            # before it is reachable as an attribute of its parent.
+            if parent:
+                # Set the module as an attribute on its parent.
+                parent_module = sys.modules[parent]
+                try:
+                    setattr(parent_module, child, module)
+                except AttributeError:
+                    msg = (f"Cannot set an attribute on {parent!r} "
+                           f"for child module {child!r}")
+                    _warnings.warn(msg, ImportWarning)
+            # Set attributes to lazy submodules on the module.
+            try:
+                _imp._set_lazy_attributes(module, name)
+            except Exception as e:
+                msg = f"Cannot set lazy attributes on {name!r}: {e!r}"
+                _warnings.warn(msg, ImportWarning)
+
         if parent_spec:
             # Temporarily add child we are currently importing to parent's
             # _uninitialized_submodules for circular import tracking.
             parent_spec._uninitialized_submodules.append(child)
         try:
-            module = _load_unlocked(spec)
+            module = _load_unlocked(spec, finish_load)
         finally:
             if parent_spec:
                 parent_spec._uninitialized_submodules.pop()
-    if parent:
-        # Set the module as an attribute on its parent.
-        parent_module = sys.modules[parent]
-        try:
-            setattr(parent_module, child, module)
-        except AttributeError:
-            msg = f"Cannot set an attribute on {parent!r} for child module {child!r}"
-            _warnings.warn(msg, ImportWarning)
-    # Set attributes to lazy submodules on the module.
-    try:
-        _imp._set_lazy_attributes(module, name)
-    except Exception as e:
-        msg = f"Cannot set lazy attributes on {name!r}: {e!r}"
-        _warnings.warn(msg, ImportWarning)
     return module
 
 

--- a/Lib/test/test_importlib/test_threaded_import.py
+++ b/Lib/test/test_importlib/test_threaded_import.py
@@ -461,6 +461,93 @@ raise RuntimeError("Intentional import failure")
                 errors, [],
                 f"Import(s) failed on iteration {i}: {errors}")
 
+    def test_lazy_submodule_getattr_no_recursion(self):
+        # Regression test: a package that uses a lazy `__getattr__` doing
+        # `import pkg.sub as sub` must not recurse to RecursionError when
+        # another thread first-touches the same submodule during the
+        # window between `_load_unlocked` clearing `spec._initializing`
+        # and `_find_and_load_unlocked` running `setattr(parent, child,
+        # module)`. The race is widened deterministically with a
+        # threading.Event so the test does not depend on luck.
+        import importlib._bootstrap as _b
+
+        os.makedirs(os.path.join(TESTFN, "lazypkg", "sub"))
+        self.addCleanup(shutil.rmtree, TESTFN)
+        with open(os.path.join(TESTFN, "lazypkg", "__init__.py"), "w") as f:
+            f.write(
+                "def __getattr__(attr):\n"
+                "    if attr == 'sub':\n"
+                "        import lazypkg.sub as sub\n"
+                "        return sub\n"
+                "    raise AttributeError(attr)\n"
+            )
+        with open(os.path.join(TESTFN, "lazypkg", "sub", "__init__.py"), "w") as f:
+            f.write("X = 42\n")
+
+        sys.path.insert(0, TESTFN)
+        self.addCleanup(sys.path.remove, TESTFN)
+        for mod in ("lazypkg", "lazypkg.sub"):
+            self.addCleanup(forget, mod)
+        importlib.invalidate_caches()
+
+        gate = threading.Event()
+        done = threading.Event()
+        orig_find_and_load_unlocked = _b._find_and_load_unlocked
+
+        def widen(name, import_):
+            if name != "lazypkg.sub":
+                return orig_find_and_load_unlocked(name, import_)
+            parent_module = sys.modules["lazypkg"]
+            spec = _b._find_spec(name, parent_module.__path__)
+            parent_module.__spec__._uninitialized_submodules.append("sub")
+            try:
+                module = _b._load_unlocked(spec)
+            finally:
+                parent_module.__spec__._uninitialized_submodules.pop()
+            # Pause inside the unsafe window so the observer thread
+            # can probe the half-initialized state. Without the fix
+            # in _bootstrap, that probe drives `__getattr__` into
+            # infinite recursion.
+            gate.set()
+            done.wait(timeout=5.0)
+            setattr(parent_module, "sub", module)
+            return module
+
+        _b._find_and_load_unlocked = widen
+        self.addCleanup(setattr, _b, "_find_and_load_unlocked",
+                        orig_find_and_load_unlocked)
+
+        result = {}
+
+        def loader():
+            __import__("lazypkg").sub
+
+        def observer():
+            gate.wait(timeout=5.0)
+            try:
+                result["value"] = __import__("lazypkg").sub
+            except BaseException as exc:
+                result["error"] = exc
+            done.set()
+
+        t_loader = threading.Thread(target=loader)
+        t_observer = threading.Thread(target=observer)
+        t_observer.start()
+        t_loader.start()
+        t_loader.join(timeout=10)
+        t_observer.join(timeout=10)
+
+        self.assertFalse(t_loader.is_alive(), "loader thread deadlocked")
+        self.assertFalse(t_observer.is_alive(), "observer thread deadlocked")
+        self.assertNotIn(
+            "error", result,
+            f"observer thread raised {type(result.get('error')).__name__}: "
+            f"{result.get('error')!r}",
+        )
+        self.assertIs(
+            result["value"], sys.modules["lazypkg.sub"],
+            "observer thread did not get the loaded submodule")
+
 
 def setUpModule():
     thread_info = threading_helper.threading_setup()

--- a/Lib/test/test_importlib/test_threaded_import.py
+++ b/Lib/test/test_importlib/test_threaded_import.py
@@ -461,6 +461,120 @@ raise RuntimeError("Intentional import failure")
                 errors, [],
                 f"Import(s) failed on iteration {i}: {errors}")
 
+    def test_lazy_submodule_not_visible_before_parent_setattr(self):
+        # gh-149728: a submodule must not be advertised as fully imported
+        # before it is bound as an attribute of its parent package.  A
+        # thread seeing that window in a package that resolves its
+        # submodules from a module-level __getattr__ would re-enter
+        # __getattr__ for the same submodule over and over, until
+        # RecursionError.
+        os.makedirs(os.path.join(TESTFN, "lazypkg"))
+        self.addCleanup(shutil.rmtree, TESTFN)
+        with open(os.path.join(TESTFN, "lazypkg", "__init__.py"), "w") as f:
+            f.write("""if 1:
+                import sys
+                import threading
+                from types import ModuleType
+
+                # Set when the import system is about to bind 'sub' on this
+                # package, i.e. at the start of the window under test.
+                setattr_reached = threading.Event()
+                # Set by the probing thread once it is out of that window.
+                probe_finished = threading.Event()
+                # __spec__._initializing of 'lazypkg.sub', as seen from
+                # inside the window.
+                observed_initializing = []
+                # Whether the probing thread was still blocked when the
+                # window closed.
+                probe_blocked = []
+
+                _importing = threading.local()
+
+                class _Package(ModuleType):
+                    def __setattr__(self, name, value):
+                        if name == "sub":
+                            observed_initializing.append(
+                                value.__spec__._initializing)
+                            setattr_reached.set()
+                            # Hold the window open long enough to see what
+                            # the other thread does with it.  This is a cap,
+                            # not a synchronisation point: a thread wrongly
+                            # handed the module returns at once and sets
+                            # probe_finished, while a thread correctly made
+                            # to block cannot set it at all, since it waits
+                            # on the module lock held right here.
+                            probe_blocked.append(
+                                not probe_finished.wait(0.1))
+                        super().__setattr__(name, value)
+
+                def __getattr__(name):
+                    if name != "sub":
+                        raise AttributeError(name)
+                    if getattr(_importing, "sub", False):
+                        raise AssertionError(
+                            "lazypkg.__getattr__ re-entered for 'sub': the "
+                            "submodule was handed out as fully imported "
+                            "before being bound on its parent package")
+                    _importing.sub = True
+                    try:
+                        import lazypkg.sub as sub
+                    finally:
+                        _importing.sub = False
+                    return sub
+
+                sys.modules[__name__].__class__ = _Package
+                """)
+        with open(os.path.join(TESTFN, "lazypkg", "sub.py"), "w") as f:
+            f.write("X = 42\n")
+
+        sys.path.insert(0, TESTFN)
+        self.addCleanup(sys.path.remove, TESTFN)
+        for mod in ("lazypkg", "lazypkg.sub"):
+            self.addCleanup(forget, mod)
+        importlib.invalidate_caches()
+
+        pkg = importlib.import_module("lazypkg")
+        results = {}
+
+        def importer():
+            try:
+                results["importer"] = pkg.sub
+            except BaseException as exc:
+                results["importer_error"] = exc
+
+        def prober():
+            pkg.setattr_reached.wait(support.SHORT_TIMEOUT)
+            try:
+                results["prober"] = pkg.sub
+            except BaseException as exc:
+                results["prober_error"] = exc
+            finally:
+                pkg.probe_finished.set()
+
+        threads = [threading.Thread(target=prober),
+                   threading.Thread(target=importer)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=support.SHORT_TIMEOUT)
+        for thread in threads:
+            self.assertFalse(thread.is_alive(), "thread deadlocked")
+
+        for key in ("importer_error", "prober_error"):
+            if key in results:
+                raise results[key]
+        sub = sys.modules["lazypkg.sub"]
+        self.assertIs(results["importer"], sub)
+        self.assertIs(results["prober"], sub)
+        # The submodule is bound on its parent while its spec still says it
+        # is initializing, so no thread can take the lock-free fast path
+        # for it before it is reachable through the parent package.
+        self.assertEqual(pkg.observed_initializing, [True])
+        # And the other thread really was held off for as long as that
+        # window was open, rather than let through to a package that does
+        # not have 'sub' yet.
+        self.assertEqual(pkg.probe_blocked, [True])
+
 
 def setUpModule():
     thread_info = threading_helper.threading_setup()

--- a/Misc/NEWS.d/next/Library/2026-05-12-22-00-00.gh-issue-149728.LzyImp.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-12-22-00-00.gh-issue-149728.LzyImp.rst
@@ -1,7 +1,1 @@
-Fix a race in :mod:`importlib._bootstrap` where the fast path in
-``_find_and_load`` could return a module whose ``parent.child`` attribute had
-not yet been set. Under free-threaded CPython this caused packages using the
-lazy-submodule ``__getattr__`` pattern (e.g. NumPy) to recurse to
-:exc:`RecursionError` when multiple threads first-touched the same lazy
-submodule concurrently. ``spec._initializing`` is now kept ``True`` until
-after ``_find_and_load_unlocked`` has attached the module to its parent.
+fix race in importlib when importing module which defined getattr

--- a/Misc/NEWS.d/next/Library/2026-05-12-22-00-00.gh-issue-149728.LzyImp.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-12-22-00-00.gh-issue-149728.LzyImp.rst
@@ -1,0 +1,7 @@
+Fix a race in :mod:`importlib._bootstrap` where the fast path in
+``_find_and_load`` could return a module whose ``parent.child`` attribute had
+not yet been set. Under free-threaded CPython this caused packages using the
+lazy-submodule ``__getattr__`` pattern (e.g. NumPy) to recurse to
+:exc:`RecursionError` when multiple threads first-touched the same lazy
+submodule concurrently. ``spec._initializing`` is now kept ``True`` until
+after ``_find_and_load_unlocked`` has attached the module to its parent.

--- a/Misc/NEWS.d/next/Library/2026-09-07-16-40-00.gh-issue-149728.LzyImp.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-07-16-40-00.gh-issue-149728.LzyImp.rst
@@ -1,0 +1,5 @@
+Fix a race in the import system where a submodule was briefly visible as
+fully imported before being set as an attribute of its parent package.  A
+package importing its submodules from a module-level ``__getattr__`` could
+raise :exc:`RecursionError` when several threads first used the same
+submodule.


### PR DESCRIPTION
Fixes #149728.

## Cause

`_load_unlocked` clears `spec._initializing` at the end of its body, before `_find_and_load_unlocked` runs `setattr(parent_module, child, module)`. Between those two events, `sys.modules[name]` is set and `_initializing == False`, but `parent.__dict__[child]` is still missing. The fast path in `_find_and_load` returns the module without taking the import lock once it sees `_initializing == False`, so under free-threaded CPython a second thread can observe this window. `IMPORT_FROM 'child'` on that thread does `getattr(parent, 'child')`, falls into a lazy `__getattr__`, runs the same `import parent.child as child` line, fast-paths again, and recurses to `RecursionError`. See the linked issue for the full walkthrough and reproducer.

## Change

Keep `spec._initializing == True` until after the parent setattr in `_find_and_load_unlocked`:

* `_load_unlocked` no longer clears `_initializing` on the success path. Failure paths still clear it.
* `_find_and_load_unlocked` clears `_initializing` in a `finally` block after `setattr(parent_module, child, module)` and `_imp._set_lazy_attributes`.
* The two other callers of `_load_unlocked` (`_load` and `_builtin_from_name`) have no parent setattr, so they clear `_initializing` in a local `finally`.

This preserves the invariant the fast path needs: `_initializing == False` implies the module is reachable via `getattr(parent_module, child)`.

## Test

`Lib/test/test_importlib/test_threaded_import.py::ThreadedImportTests::test_lazy_submodule_getattr_no_recursion` widens the natural microsecond race window with one `threading.Event` and verifies that an observer thread does not recurse on the lazy `__getattr__`. Fails on the unpatched interpreter, passes on this branch. Full `test_importlib` suite remains green (1220/1220).

## Notes

* Tested on macOS arm64 with both the free-threaded build (3.16.0a0 from this branch) and the system GIL build (3.14.3). The bug reproduces on both builds under the deterministic shim, confirming the code path itself is build-independent; free-threading just makes the window naturally observable.


<!-- gh-issue-number: gh-149728 -->
* Issue: gh-149728
<!-- /gh-issue-number -->
