### PR TITLE
gh-149707: Fix compiler warning in _ctypes_test on strchr()

### DIFF
--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -446,7 +446,7 @@ EXPORT(char *)my_strtok(char *token, const char *delim)
     return strtok(token, delim);
 }
 
-EXPORT(char *)my_strchr(const char *s, int c)
+EXPORT(const char *) my_strchr(const char *s, int c)
 {
     return strchr(s, c);
 }


### PR DESCRIPTION
Change my_strchr() return type to "const char*" (add "const").

Fix the compiler warning:

```
Modules/_ctypes/_ctypes_test.c: In function 'my_strchr': Modules/_ctypes/_ctypes_test.c:451:12: warning: return discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  451 |     return strchr(s, c);
      |            ^~~~~~
```

When using C23, strchr(text, ch) return type is "const char*" if text type is "const char*".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149707 -->
* Issue: gh-149707
<!-- /gh-issue-number -->
