### PR TITLE
gh-148200: Update Modules/_hacl/ for Cygwin

### DIFF
--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -608,11 +608,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0a0b7f3714167ad45ddf5a6a48d76f525a119c9c"
+          "checksumValue": "67a029736da5efe96f1b2d41b92f00934b955253"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "135d4afb4812468885c963c9c87a55ba5fae9181df4431af5fbad08588dda229"
+          "checksumValue": "0d80c2e3f5ff3b31ef0d435fc3196660df89ccf95bdcbb6545dc2f9df07bec9f"
         }
       ],
       "fileName": "Modules/_hacl/Lib_Memzero0.c"
@@ -916,11 +916,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "63e47cc290c4ec887dca708000876ac37ee75ba0"
+          "checksumValue": "8d6a23f4e932cace0c67896bdda46cb24bf5e0ea"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "d09a6196d65c2645974100eb922002bd387d3ae13f2653780f82ed97a79af635"
+          "checksumValue": "25decbcadf1fef51f473daa4975a3754480fc903b03068bf95f149fb5349456e"
         }
       ],
       "fileName": "Modules/_hacl/libintvector.h"
@@ -1027,11 +1027,11 @@
           "checksumValue": "61e48893f37cb2280d106cefacf6fb5afe84edf625fec39572d0ee94e1018f26"
         }
       ],
-      "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/8ba599b2f6c9701b3dc961db895b0856a2210f76.zip",
+      "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/504c2987452f87fe44bce9b9f12e19d6e051761f.zip",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:hacl-star:hacl-star:8ba599b2f6c9701b3dc961db895b0856a2210f76:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:hacl-star:hacl-star:504c2987452f87fe44bce9b9f12e19d6e051761f:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
@@ -1039,7 +1039,7 @@
       "name": "hacl-star",
       "originator": "Organization: HACL* Developers",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "8ba599b2f6c9701b3dc961db895b0856a2210f76"
+      "versionInfo": "504c2987452f87fe44bce9b9f12e19d6e051761f"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-macholib",

--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -1024,7 +1024,7 @@
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "61e48893f37cb2280d106cefacf6fb5afe84edf625fec39572d0ee94e1018f26"
+          "checksumValue": "d6db56a5d061dcc0890eabdbb5f58a9fa6c606d9f2fbbe9d626925b870ffadfb"
         }
       ],
       "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/504c2987452f87fe44bce9b9f12e19d6e051761f.zip",

--- a/Modules/_hacl/Lib_Memzero0.c
+++ b/Modules/_hacl/Lib_Memzero0.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #endif
 
-#if defined(__FreeBSD__) || defined(__NetBSD__)
+#if defined(__CYGWIN__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #include <strings.h>
 #endif
 
@@ -57,7 +57,7 @@ void Lib_Memzero0_memzero0(void *dst, uint64_t len) {
     SecureZeroMemory(dst, len_);
   #elif defined(__APPLE__) && defined(__MACH__) && defined(APPLE_HAS_MEMSET_S)
     memset_s(dst, len_, 0, len_);
-  #elif (defined(__linux__) && !defined(LINUX_NO_EXPLICIT_BZERO)) || defined(__FreeBSD__) || defined(__OpenBSD__)
+  #elif (defined(__linux__) && !defined(LINUX_NO_EXPLICIT_BZERO)) || defined(__CYGWIN__) || defined(__FreeBSD__) || defined(__OpenBSD__)
     explicit_bzero(dst, len_);
   #elif defined(__NetBSD__)
     explicit_memset(dst, 0, len_);

--- a/Modules/_hacl/libintvector.h
+++ b/Modules/_hacl/libintvector.h
@@ -802,6 +802,18 @@ vector128 Lib_IntVector_Intrinsics_vec128_xor(vector128 x0, vector128 x1) {
 #if defined(HACL_CAN_COMPILE_VEC128)
 
 #include <altivec.h>
+
+/* GCC's AltiVec extension hijacks 'bool' as '__vector __bool int'.
+   Restore C99/C11 scalar bool for HACL* code. */
+#if defined(__GNUC__) && !defined(__clang__)
+#undef bool
+#define bool _Bool
+#undef true
+#define true 1
+#undef false
+#define false 0
+#endif
+
 #include <string.h> // for memcpy
 #include <stdint.h>
 

--- a/Modules/_hacl/refresh.sh
+++ b/Modules/_hacl/refresh.sh
@@ -22,7 +22,7 @@ fi
 
 # Update this when updating to a new version after verifying that the changes
 # the update brings in are good.
-expected_hacl_star_rev=8ba599b2f6c9701b3dc961db895b0856a2210f76
+expected_hacl_star_rev=504c2987452f87fe44bce9b9f12e19d6e051761f
 
 hacl_dir="$(realpath "$1")"
 cd "$(dirname "$0")"


### PR DESCRIPTION
This pulls an updated version of HACL* that fixes Lib_Memzero0.c on Cygwin, via an upstream fix.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148200 -->
* Issue: gh-148200
<!-- /gh-issue-number -->
