### PR TITLE
Link to existing rules in compound_stmts.rst

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -618,8 +618,8 @@ The match statement is used for pattern matching.  Syntax:
 
 .. productionlist:: python-grammar
    match_stmt: 'match' `subject_expr` ":" NEWLINE INDENT `case_block`+ DEDENT
-   subject_expr: `!star_named_expression` "," `!star_named_expressions`?
-               : | `!named_expression`
+   subject_expr: `flexible_expression` "," [`flexible_expression_list` [',']]
+               : | `assignment_expression`
    case_block: 'case' `patterns` [`guard`] ":" `!block`
 
 .. note::
@@ -709,7 +709,7 @@ Guards
 .. index:: ! guard
 
 .. productionlist:: python-grammar
-   guard: "if" `!named_expression`
+   guard: "if" `assignment_expression`
 
 A ``guard`` (which is part of the ``case``) must succeed for code inside
 the ``case`` block to execute.  It takes the form: :keyword:`if` followed by an


### PR DESCRIPTION
In gh-138418, `!` was added to links to rules that don't exist in the docs, in order to silence broken link warnings. However, productionlist doesn't parse the `!`, which ends up in the rendered documentation. (It's possible that gh-127835 broke the `!` support.)

Replace the names with ones that appear in docs:

- `star_named_expression` in the grammar corresponds to `flexible_expression` in the docs
- `star_named_expressions` in the grammar corresponds to `flexible_expression_list` in the docs
- `named_expression` in the grammar corresponds to `assignment_expression` in the docs

Having two sets of names isn't great of course. Consolidating them is tracked in (subissues of) gh-127833.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
