### PR TITLE
gh-149816: Fix a RC in `_random.Random.__init__` method

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-05-14-15-55-28.gh-issue-149816.ZaXQ0q.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-14-15-55-28.gh-issue-149816.ZaXQ0q.rst
@@ -1,0 +1,2 @@
+Fix a race condition in ``_random.Random.__init__`` method in free-threading
+mode.

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -123,9 +123,9 @@ typedef struct {
 
 /*[clinic input]
 module _random
-class _random.Random "RandomObject *" "_randomstate_type(type)->Random_Type"
+class _random.Random "RandomObject *" "(PyTypeObject *)_randomstate_type(Py_TYPE(self))->Random_Type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=70a2c99619474983]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=f04bcbfba61a322e]*/
 
 /* Random methods */
 
@@ -549,26 +549,19 @@ _random_Random_getrandbits_impl(RandomObject *self, uint64_t k)
     return result;
 }
 
+/*[clinic input]
+@critical_section
+@text_signature "($self, /, *args, **kwargs)"
+_random.Random.__init__ as random_init
+
+    arg: object = NULL
+    /
+[clinic start generated code]*/
+
 static int
-random_init(PyObject *self, PyObject *args, PyObject *kwds)
+random_init_impl(RandomObject *self, PyObject *arg)
+/*[clinic end generated code: output=823329df8669c8a7 input=3772473c67871d42]*/
 {
-    PyObject *arg = NULL;
-    _randomstate *state = _randomstate_type(Py_TYPE(self));
-
-    if ((Py_IS_TYPE(self, (PyTypeObject *)state->Random_Type) ||
-         Py_TYPE(self)->tp_init == ((PyTypeObject*)state->Random_Type)->tp_init) &&
-        !_PyArg_NoKeywords("Random", kwds)) {
-        return -1;
-    }
-
-    if (PyTuple_GET_SIZE(args) > 1) {
-        PyErr_SetString(PyExc_TypeError, "Random() requires 0 or 1 argument");
-        return -1;
-    }
-
-    if (PyTuple_GET_SIZE(args) == 1)
-        arg = PyTuple_GET_ITEM(args, 0);
-
     return random_seed(RandomObject_CAST(self), arg);
 }
 

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -551,18 +551,18 @@ _random_Random_getrandbits_impl(RandomObject *self, uint64_t k)
 
 /*[clinic input]
 @critical_section
-@text_signature "($self, /, *args, **kwargs)"
+@text_signature "($self, [seed])"
 _random.Random.__init__ as random_init
 
-    arg: object = NULL
+    seed: object = NULL
     /
 [clinic start generated code]*/
 
 static int
-random_init_impl(RandomObject *self, PyObject *arg)
-/*[clinic end generated code: output=823329df8669c8a7 input=3772473c67871d42]*/
+random_init_impl(RandomObject *self, PyObject *seed)
+/*[clinic end generated code: output=260734a3739c394f input=e516bf32e8a05e28]*/
 {
-    return random_seed(RandomObject_CAST(self), arg);
+    return random_seed(self, seed);
 }
 
 

--- a/Modules/clinic/_randommodule.c.h
+++ b/Modules/clinic/_randommodule.c.h
@@ -145,14 +145,14 @@ exit:
 }
 
 static int
-random_init_impl(RandomObject *self, PyObject *arg);
+random_init_impl(RandomObject *self, PyObject *seed);
 
 static int
 random_init(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     int return_value = -1;
     PyTypeObject *base_tp = (PyTypeObject *)_randomstate_type(Py_TYPE(self))->Random_Type;
-    PyObject *arg = NULL;
+    PyObject *seed = NULL;
 
     if ((Py_IS_TYPE(self, base_tp) ||
          Py_TYPE(self)->tp_new == base_tp->tp_new) &&
@@ -165,13 +165,13 @@ random_init(PyObject *self, PyObject *args, PyObject *kwargs)
     if (PyTuple_GET_SIZE(args) < 1) {
         goto skip_optional;
     }
-    arg = PyTuple_GET_ITEM(args, 0);
+    seed = PyTuple_GET_ITEM(args, 0);
 skip_optional:
     Py_BEGIN_CRITICAL_SECTION(self);
-    return_value = random_init_impl((RandomObject *)self, arg);
+    return_value = random_init_impl((RandomObject *)self, seed);
     Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5d4c7afe866d5104 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ec95f7df0c3f3c19 input=a9049054013a1b77]*/

--- a/Modules/clinic/_randommodule.c.h
+++ b/Modules/clinic/_randommodule.c.h
@@ -143,4 +143,35 @@ _random_Random_getrandbits(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7ce97b2194eecaf7 input=a9049054013a1b77]*/
+
+static int
+random_init_impl(RandomObject *self, PyObject *arg);
+
+static int
+random_init(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    int return_value = -1;
+    PyTypeObject *base_tp = (PyTypeObject *)_randomstate_type(Py_TYPE(self))->Random_Type;
+    PyObject *arg = NULL;
+
+    if ((Py_IS_TYPE(self, base_tp) ||
+         Py_TYPE(self)->tp_new == base_tp->tp_new) &&
+        !_PyArg_NoKeywords("Random", kwargs)) {
+        goto exit;
+    }
+    if (!_PyArg_CheckPositional("Random", PyTuple_GET_SIZE(args), 0, 1)) {
+        goto exit;
+    }
+    if (PyTuple_GET_SIZE(args) < 1) {
+        goto skip_optional;
+    }
+    arg = PyTuple_GET_ITEM(args, 0);
+skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = random_init_impl((RandomObject *)self, arg);
+    Py_END_CRITICAL_SECTION();
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=5d4c7afe866d5104 input=a9049054013a1b77]*/


### PR DESCRIPTION
I am not sure that it would be easy to repro / test in a real env, but it can be a potential problem.

Original description from `17.md`:

---

## Vulnerability #17

**Title:** Unlocked __init__ races with PRNG state access

**Category:** Concurrency and Race Conditions

**Tags:** race,read,dos

**CWEs:** CWE-125, CWE-367

**CVSS:** CVSS:4.0/AV:L/AC:L/AT:P/PR:N/UI:N/VC:L/VI:N/VA:L/SC:N/SI:N/SA:N

**Severity:** Low (2.1)

**Location:** `cpython/Modules/_randommodule.c:572:572` in function `random_init`


### Description

`random_init` reseeds internal MT state by calling `random_seed` without acquiring the object critical section at `cpython/Modules/_randommodule.c:572`, while normal methods use `Py_BEGIN_CRITICAL_SECTION(self)` (e.g. `cpython/Modules/clinic/_randommodule.c.h:26`, `cpython/Modules/clinic/_randommodule.c.h:139`). During reseed, `init_genrand` writes `self->index = N` at `cpython/Modules/_randommodule.c:212`. A concurrent reader in `genrand_uint32` can pass the bounds check `self->index >= N` at `cpython/Modules/_randommodule.c:143` and then use a raced value at `cpython/Modules/_randommodule.c:160`, causing `mt[624]` access.


### Trigger Conditions

Pre-conditions:
- CPython is built in free-threaded mode (`Py_GIL_DISABLED`); with the GIL enabled, the race is serialized.
- The same `_random.Random` instance is shared across threads.
- The attacker can cause concurrent calls to `__init__` and `random()`/`getrandbits()` on that same object (directly or through an exposed application API).

Data flow:
1. Create `r = _random.Random(0)`, then advance to a near-boundary index (e.g., call `r.getrandbits(32)` 623 times so index becomes 623).
2. Thread A calls `r.getrandbits(32)` and enters `genrand_uint32`; it evaluates `self->index >= N` as false at `cpython/Modules/_randommodule.c:143`.
3. Thread B concurrently calls `_random.Random.__init__(r, 1)` (or `r.__init__(1)`), reaching unlocked `random_init` at `cpython/Modules/_randommodule.c:572` and then `init_genrand` setting `self->index = 624` at `cpython/Modules/_randommodule.c:212`.
4. Thread A resumes and executes `y = mt[self->index++]` at `cpython/Modules/_randommodule.c:160`, reading out-of-bounds element `state[624]`.


### Impact

In the free-threaded runtime, this race introduces undefined behavior and a concrete out-of-bounds read on PRNG object state. Most severe outcomes are process crash (availability impact) or unintended memory disclosure via corrupted/random output, depending on allocator/layout and timing. Exploitability requires precise concurrency and access to concurrent method invocation on the same object, which lowers reliability but does not remove the bug.


### Remediation
1. In `random_init()` (`cpython/Modules/_randommodule.c`), wrap the `random_seed(...)` call in the same object critical section used by other mutating/accessor methods, so `__init__` cannot race with `random()`, `getrandbits()`, `getstate()`, `setstate()`, or `seed()` on the same instance.
2. Ensure the lock/unlock structure in `random_init()` is exception-safe on all return paths (including failures), matching existing critical-section patterns used in generated wrappers.
3. Keep locking semantics consistent for inherited `tp_init` use as well (the fix should apply regardless of whether `Random` is used directly or via subclasses reusing this `tp_init`).
4. Add a free-threaded regression test in `Lib/test` (random module tests) that repeatedly races `r.__init__(...)` against `r.random()` / `r.getrandbits(...)` on the same object and asserts no crash/UB under stress.


### Reproduction
1. Build a **free-threaded** CPython (`Py_GIL_DISABLED`) with a sanitizer-enabled/debug configuration (ASAN or UBSAN strongly recommended) so races and out-of-bounds reads are visible instead of silently ignored.
2. In one process, create a single shared `random.Random` instance and drive it close to the MT boundary state (consume enough outputs so `index` is near `623`), then keep using that same object from multiple threads.
3. Run two concurrent activities against that *same* object:
   - one thread repeatedly calling `random()` or `getrandbits(32)`,
   - another thread repeatedly calling `obj.__init__(seed_value)` (re-initializing the existing object, not creating a new one).
4. Keep both operations running at high iteration counts; if nothing appears immediately, increase contention (more CPU load, more iterations, pinning threads, repeated retries).
5. Confirm the issue by observing at least one of:
   - sanitizer report indicating a race or out-of-bounds access in `_randommodule.c` (notably around `genrand_uint32` / seed-init paths),
   - intermittent crash/abort in free-threaded builds during this concurrent `__init__` + `random/getrandbits` workload.


### Code Context

```
    return random_seed(RandomObject_CAST(self), arg);
```

---


<!-- gh-issue-number: gh-149816 -->
* Issue: gh-149816
<!-- /gh-issue-number -->
