### PR TITLE
gh-149828: make Protocol compatible with Enum instantiation

### DIFF
--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2478,6 +2478,26 @@ class TestSpecial(unittest.TestCase):
         globals()['T'] = T
         test_pickle_dump_load(self.assertIs, SomeEnum.first)
 
+    def test_protocol_mixin_as_enum_member_value(self):
+        class Example(typing.Protocol):
+            def method(self) -> None: ...
+
+        class Impl(Example):
+            def method(self) -> None: ...
+
+        class CompatEnumType(type(typing.Protocol), EnumType): ...
+
+        class ProtoEnum(Example, Enum, metaclass=CompatEnumType):
+            __qualname__ = 'ProtoEnum'  # needed for pickle protocol 4
+            impl = Impl()
+
+        self.assertIsInstance(ProtoEnum.impl.value, Impl)
+        globals()['Example'] = Example
+        globals()['Impl'] = Impl
+        globals()['ProtoEnum'] = ProtoEnum
+        ProtoEnum.__reduce_ex__ = enum.pickle_by_enum_name
+        test_pickle_dump_load(self.assertIs, ProtoEnum.impl)
+
     def test_duplicate_values_give_unique_enum_items(self):
         class AutoNumber(Enum):
             first = ()

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1882,7 +1882,11 @@ def _get_protocol_attrs(cls):
 def _no_init_or_replace_init(self, *args, **kwargs):
     cls = type(self)
 
-    if cls._is_protocol:
+    # Determine if this is a protocol or a concrete subclass.
+    # Note: not using cls._is_protocol here,
+    #  since this may be called before __init_subclass__ is resolved.
+    #  for example when subclassing enum.Enum.
+    if any(b is Protocol for b in cls.__bases__):
         raise TypeError('Protocols cannot be instantiated')
 
     # Already using a custom `__init__`. No need to calculate correct

--- a/Misc/NEWS.d/next/Library/2026-05-14-15-44-25.gh-issue-149828.ADCPIl.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-14-15-44-25.gh-issue-149828.ADCPIl.rst
@@ -1,0 +1,1 @@
+Fixed an issue that prevented creation of an :class:`enum.Enum` that inherits from a subclass :class:`typing.Protocol`.


### PR DESCRIPTION
Fixes #149828

This was surprisingly easy, the issue is that with enums, `__init_subclass__` is only called after `EnumType.__new__` is finished.

However, when subclassing from `typing.Protocol`, `_is_protocol` is only set during `__init_subclass__`. The fix is to replace the lookup of `_is_protocol` inside `_no_init_or_replace_init` with the actual check.

A more robust solution would probably be for `_is_protocol` to be a lazy class property, but that would be a larger change and class-properties are not natively supported...


cc @sobolevn 


<!-- gh-issue-number: gh-149828 -->
* Issue: gh-149828
<!-- /gh-issue-number -->
