### PR TITLE
gh-149831: Fix ctypes wrong DLL library name for CYGWIN.

### DIFF
--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -549,10 +549,10 @@ pydll = LibraryLoader(PyDLL)
 
 if _os.name == "nt":
     pythonapi = PyDLL("python dll", None, _sys.dllhandle)
-elif _sys.platform in ["android"]:
+elif _sys.platform == "android":
     # These are Unix-like platforms which use a dynamically-linked libpython.
     pythonapi = PyDLL(_sysconfig.get_config_var("LDLIBRARY"))
-elif _sys.platform in ["cygwin"]:
+elif _sys.platform == "cygwin":
     # These platforms must load the DLL file from DLLLIBRARY
     # and not the import library provided by LDLIBRARY.
     pythonapi = PyDLL(_sysconfig.get_config_var("DLLLIBRARY"))

--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -549,9 +549,13 @@ pydll = LibraryLoader(PyDLL)
 
 if _os.name == "nt":
     pythonapi = PyDLL("python dll", None, _sys.dllhandle)
-elif _sys.platform in ["android", "cygwin"]:
+elif _sys.platform in ["android"]:
     # These are Unix-like platforms which use a dynamically-linked libpython.
     pythonapi = PyDLL(_sysconfig.get_config_var("LDLIBRARY"))
+elif _sys.platform in ["cygwin"]:
+    # These platforms must load the DLL file from DLLLIBRARY
+    # and not the import library provided by LDLIBRARY.
+    pythonapi = PyDLL(_sysconfig.get_config_var("DLLLIBRARY"))
 else:
     pythonapi = PyDLL(None)
 

--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -553,8 +553,6 @@ elif _sys.platform == "android":
     # These are Unix-like platforms which use a dynamically-linked libpython.
     pythonapi = PyDLL(_sysconfig.get_config_var("LDLIBRARY"))
 elif _sys.platform == "cygwin":
-    # These platforms must load the DLL file from DLLLIBRARY
-    # and not the import library provided by LDLIBRARY.
     pythonapi = PyDLL(_sysconfig.get_config_var("DLLLIBRARY"))
 else:
     pythonapi = PyDLL(None)


### PR DESCRIPTION
This patch fixes issue #149831.

<!-- gh-issue-number: gh-149831 -->
* Issue: gh-149831
<!-- /gh-issue-number -->
