### PR TITLE
gh-149835: Resolve symlinks in shutil._destinsrc

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -940,8 +940,8 @@ def move(src, dst, copy_function=copy2):
     return real_dst
 
 def _destinsrc(src, dst):
-    src = os.path.abspath(src)
-    dst = os.path.abspath(dst)
+    src = os.path.realpath(src)
+    dst = os.path.realpath(dst)
     if not src.endswith(os.path.sep):
         src += os.path.sep
     if not dst.endswith(os.path.sep):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2915,6 +2915,25 @@ class TestMove(BaseTest, unittest.TestCase):
             os_helper.rmtree(TESTFN)
 
     @os_helper.skip_unless_symlink
+    def test_destinsrc_symlink_bypass(self):
+        # gh-149835: a symlink component in dst must not allow dst to
+        # appear outside src in string space while being physically inside.
+        tmp = self.mkdtemp()
+        src = os.path.join(tmp, 'src')
+        os.makedirs(src)
+        # tmp/link -> tmp (one level up)
+        link = os.path.join(tmp, 'link')
+        os.symlink(tmp, link)
+        # raw path: tmp/link/src/sub - no src prefix in string space
+        # real path: tmp/src/sub     - physically inside src
+        dst = os.path.join(link, 'src', 'sub')
+        self.assertTrue(
+            shutil._destinsrc(src, dst),
+            msg='_destinsrc failed to detect dst inside src via symlink '
+                '(dst=%s, src=%s)' % (dst, src),
+        )
+
+    @os_helper.skip_unless_symlink
     @mock_rename
     def test_move_file_symlink(self):
         dst = os.path.join(self.src_dir, 'bar')

--- a/Misc/NEWS.d/next/Library/2026-05-14-17-00-00.gh-issue-149835.kQ8mZ7.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-14-17-00-00.gh-issue-149835.kQ8mZ7.rst
@@ -1,0 +1,4 @@
+Fix :func:`shutil.move` so that the guard against moving a directory into
+itself is not bypassed when the destination contains a symlink component.
+:func:`!shutil._destinsrc` now resolves symlinks with :func:`os.path.realpath`
+instead of using :func:`os.path.abspath`.


### PR DESCRIPTION
Fixes #149835.

`shutil.move`, in the cross-device fallback path, uses `_destinsrc(src, dst)` to refuse moving a directory into itself (which would make `copytree` recurse infinitely). The guard normalises the two paths with `os.path.abspath` and then does a string-prefix check. `abspath` only collapses `.` / `..` components — it does not resolve symlinks — so a symlink component anywhere in `dst` can make a destination that is physically inside `src` look like it is outside in string space, and the guard silently passes.

This change uses `os.path.realpath` for both `src` and `dst` so the comparison is done on the resolved, canonical paths.

A regression test (`TestMove.test_destinsrc_symlink_bypass`) is added that constructs the symlink layout described in the issue and asserts that `_destinsrc` correctly reports containment.

**Author:** @ding-alex


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.staging.augmentcode.com/session?agentId=01KRMB9GVGVXZ8QY7Y4VP0R6MN&panel=chat)

<!-- gh-issue-number: gh-149835 -->
* Issue: gh-149835
<!-- /gh-issue-number -->
