### PR TITLE
gh-141968: Use `take_bytes` to simplify and remove copy from pyrepl `BaseEventQueue`

### DIFF
--- a/Lib/_pyrepl/base_eventqueue.py
+++ b/Lib/_pyrepl/base_eventqueue.py
@@ -79,7 +79,7 @@ class BaseEventQueue:
             if isinstance(k, dict):
                 self.keymap = k
             else:
-                self.insert(Event('key', k, self.buf.take_bytes()))
+                self.insert(Event('key', k, self.buf.take_bytes()))  # type: ignore[attr-defined]
                 self.keymap = self.compiled_keymap
 
         elif self.buf and self.buf[0] == 27:  # escape
@@ -89,7 +89,7 @@ class BaseEventQueue:
             trace('unrecognized escape sequence, propagating...')
             self.keymap = self.compiled_keymap
             self.insert(Event('key', '\033', b'\033'))
-            for _c in self.buf.take_bytes()[1:]:
+            for _c in self.buf.take_bytes()[1:]:  # type: ignore[attr-defined]
                 self.push(_c)
 
         else:
@@ -98,5 +98,5 @@ class BaseEventQueue:
             except UnicodeError:
                 return
             else:
-                self.insert(Event('key', decoded, self.buf.take_bytes()))
+                self.insert(Event('key', decoded, self.buf.take_bytes()))  # type: ignore[attr-defined]
             self.keymap = self.compiled_keymap

--- a/Lib/_pyrepl/base_eventqueue.py
+++ b/Lib/_pyrepl/base_eventqueue.py
@@ -54,13 +54,11 @@ class BaseEventQueue:
         """
         return not self.events
 
-    def flush_buf(self) -> bytearray:
+    def flush_buf(self) -> bytes:
         """
         Flushes the buffer and returns its contents.
         """
-        old = self.buf
-        self.buf = bytearray()
-        return old
+        return self.buf.take_bytes()
 
     def insert(self, event: Event) -> None:
         """
@@ -87,7 +85,7 @@ class BaseEventQueue:
             if isinstance(k, dict):
                 self.keymap = k
             else:
-                self.insert(Event('key', k, bytes(self.flush_buf())))
+                self.insert(Event('key', k, self.flush_buf()))
                 self.keymap = self.compiled_keymap
 
         elif self.buf and self.buf[0] == 27:  # escape
@@ -102,9 +100,9 @@ class BaseEventQueue:
 
         else:
             try:
-                decoded = bytes(self.buf).decode(self.encoding)
+                decoded = self.buf.decode(self.encoding)
             except UnicodeError:
                 return
             else:
-                self.insert(Event('key', decoded, bytes(self.flush_buf())))
+                self.insert(Event('key', decoded, self.flush_buf()))
             self.keymap = self.compiled_keymap

--- a/Lib/_pyrepl/base_eventqueue.py
+++ b/Lib/_pyrepl/base_eventqueue.py
@@ -58,7 +58,7 @@ class BaseEventQueue:
         """
         Flushes the buffer and returns its contents.
         """
-        return self.buf.take_bytes()
+        return self.buf.take_bytes()  # type: ignore[attr-defined, no-any-return]
 
     def insert(self, event: Event) -> None:
         """

--- a/Lib/_pyrepl/base_eventqueue.py
+++ b/Lib/_pyrepl/base_eventqueue.py
@@ -54,12 +54,6 @@ class BaseEventQueue:
         """
         return not self.events
 
-    def flush_buf(self) -> bytes:
-        """
-        Flushes the buffer and returns its contents.
-        """
-        return self.buf.take_bytes()  # type: ignore[attr-defined, no-any-return]
-
     def insert(self, event: Event) -> None:
         """
         Inserts an event into the queue.
@@ -85,7 +79,7 @@ class BaseEventQueue:
             if isinstance(k, dict):
                 self.keymap = k
             else:
-                self.insert(Event('key', k, self.flush_buf()))
+                self.insert(Event('key', k, self.buf.take_bytes()))
                 self.keymap = self.compiled_keymap
 
         elif self.buf and self.buf[0] == 27:  # escape
@@ -95,7 +89,7 @@ class BaseEventQueue:
             trace('unrecognized escape sequence, propagating...')
             self.keymap = self.compiled_keymap
             self.insert(Event('key', '\033', b'\033'))
-            for _c in self.flush_buf()[1:]:
+            for _c in self.buf.take_bytes()[1:]:
                 self.push(_c)
 
         else:
@@ -104,5 +98,5 @@ class BaseEventQueue:
             except UnicodeError:
                 return
             else:
-                self.insert(Event('key', decoded, self.flush_buf()))
+                self.insert(Event('key', decoded, self.buf.take_bytes()))
             self.keymap = self.compiled_keymap

--- a/Lib/test/test_pyrepl/test_eventqueue.py
+++ b/Lib/test/test_pyrepl/test_eventqueue.py
@@ -87,7 +87,7 @@ class EventQueueTestBase:
         eq.push(b"a")
         mock_keymap.compile_keymap.assert_called()
         self.assertTrue(eq.empty())
-        del eq.buf[:]
+        eq.buf.resize(0)
         eq.push(b"\033")
         self.assertEqual(eq.events[0].evt, "key")
         self.assertEqual(eq.events[0].data, "\033")

--- a/Lib/test/test_pyrepl/test_eventqueue.py
+++ b/Lib/test/test_pyrepl/test_eventqueue.py
@@ -38,12 +38,6 @@ class EventQueueTestBase:
         eq.insert(Event("key", "a", b"a"))
         self.assertFalse(eq.empty())
 
-    def test_flush_buf(self):
-        eq = self.make_eventqueue()
-        eq.buf.extend(b"test")
-        self.assertEqual(eq.flush_buf(), b"test")
-        self.assertEqual(eq.buf, bytearray())
-
     def test_insert(self):
         eq = self.make_eventqueue()
         event = Event("key", "a", b"a")
@@ -93,7 +87,7 @@ class EventQueueTestBase:
         eq.push(b"a")
         mock_keymap.compile_keymap.assert_called()
         self.assertTrue(eq.empty())
-        eq.flush_buf()
+        del eq.buf[:]
         eq.push(b"\033")
         self.assertEqual(eq.events[0].evt, "key")
         self.assertEqual(eq.events[0].data, "\033")


### PR DESCRIPTION
This PR uses `bytearray.take_bytes` to simplify pyrepl's `BaseEventQueue.flush_buf` and remove copies from `BaseEventQueue.push`

```python
import timeit
from statistics import mean, stdev

times = timeit.repeat(
    "[q.push(b) for b in data]",
    setup=(
        "from _pyrepl.base_eventqueue import BaseEventQueue\n"
        "q = BaseEventQueue('utf-8', {})\n"
        "data = b'hello world' * 8\n"
    ),
    number=50_000,
    repeat=5,
)
print(f"{mean(times) * 1e3:.2f} ± {stdev(times) * 1e3:.2f} ms")
```
```
main:    1845.39 ± 10.02 ms
this PR: 1371.56 ± 3.85 ms
```

<!-- gh-issue-number: gh-141968 -->
* Issue: gh-141968
<!-- /gh-issue-number -->
