### PR TITLE
gh-149816: Fix race condition in `memoryview` with free-threading

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-15-11-31-57.gh-issue-149816.ugN2rx.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-15-11-31-57.gh-issue-149816.ugN2rx.rst
@@ -1,0 +1,1 @@
+Fix a race condition in :class:`memoryview` with free-threading.

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -67,6 +67,25 @@ class memoryview "PyMemoryViewObject *" "&PyMemoryView_Type"
      releasebufferprocs must NOT decrement view.obj.
 */
 
+static inline void
+exports_increment(PyMemoryViewObject *self)
+{
+    #ifdef Py_GIL_DISABLED
+        _Py_atomic_add_ssize(&self->exports, 1);
+    #else
+        self->exports++;
+    #endif
+}
+
+static inline void
+exports_decrement(PyMemoryViewObject *self)
+{
+    #ifdef Py_GIL_DISABLED
+        _Py_atomic_add_ssize(&self->exports, -1);
+    #else
+        self->exports--;
+    #endif
+}
 
 static inline _PyManagedBufferObject *
 mbuf_alloc(void)
@@ -1629,11 +1648,7 @@ memory_getbuf(PyObject *_self, Py_buffer *view, int flags)
 
 
     view->obj = Py_NewRef(self);
-#ifdef Py_GIL_DISABLED
-    _Py_atomic_add_ssize(&self->exports, 1);
-#else
-    self->exports++;
-#endif
+    exports_increment(self);
 
     return 0;
 }
@@ -1642,11 +1657,7 @@ static void
 memory_releasebuf(PyObject *_self, Py_buffer *view)
 {
     PyMemoryViewObject *self = (PyMemoryViewObject *)_self;
-#ifdef Py_GIL_DISABLED
-    _Py_atomic_add_ssize(&self->exports, -1);
-#else
-    self->exports--;
-#endif
+    exports_decrement(self);
     return;
     /* PyBuffer_Release() decrements view->obj after this function returns. */
 }
@@ -2434,9 +2445,9 @@ memoryview_hex_impl(PyMemoryViewObject *self, PyObject *sep,
         // Prevent 'self' from being freed if computing len(sep) mutates 'self'
         // in _Py_strhex_with_sep().
         // See: https://github.com/python/cpython/issues/143195.
-        self->exports++;
+        exports_increment(self);
         PyObject *ret = _Py_strhex_with_sep(src->buf, src->len, sep, bytes_per_sep);
-        self->exports--;
+        exports_decrement(self);
         return ret;
     }
 
@@ -3363,9 +3374,9 @@ memory_hash(PyObject *_self)
         if (view->obj != NULL) {
             // Prevent 'self' from being freed when computing the item's hash.
             // See https://github.com/python/cpython/issues/142664.
-            self->exports++;
+            exports_increment(self);
             Py_hash_t h = PyObject_Hash(view->obj);
-            self->exports--;
+            exports_decrement(self);
             if (h == -1) {
                 /* Keep the original error message */
                 return -1;

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -67,25 +67,6 @@ class memoryview "PyMemoryViewObject *" "&PyMemoryView_Type"
      releasebufferprocs must NOT decrement view.obj.
 */
 
-static inline void
-exports_increment(PyMemoryViewObject *self)
-{
-    #ifdef Py_GIL_DISABLED
-        _Py_atomic_add_ssize(&self->exports, 1);
-    #else
-        self->exports++;
-    #endif
-}
-
-static inline void
-exports_decrement(PyMemoryViewObject *self)
-{
-    #ifdef Py_GIL_DISABLED
-        _Py_atomic_add_ssize(&self->exports, -1);
-    #else
-        self->exports--;
-    #endif
-}
 
 static inline _PyManagedBufferObject *
 mbuf_alloc(void)
@@ -1648,7 +1629,7 @@ memory_getbuf(PyObject *_self, Py_buffer *view, int flags)
 
 
     view->obj = Py_NewRef(self);
-    exports_increment(self);
+    FT_ATOMIC_ADD_SSIZE(self->exports, 1);
 
     return 0;
 }
@@ -1657,7 +1638,7 @@ static void
 memory_releasebuf(PyObject *_self, Py_buffer *view)
 {
     PyMemoryViewObject *self = (PyMemoryViewObject *)_self;
-    exports_decrement(self);
+    FT_ATOMIC_ADD_SSIZE(self->exports, -1);
     return;
     /* PyBuffer_Release() decrements view->obj after this function returns. */
 }
@@ -2445,9 +2426,9 @@ memoryview_hex_impl(PyMemoryViewObject *self, PyObject *sep,
         // Prevent 'self' from being freed if computing len(sep) mutates 'self'
         // in _Py_strhex_with_sep().
         // See: https://github.com/python/cpython/issues/143195.
-        exports_increment(self);
+        FT_ATOMIC_ADD_SSIZE(self->exports, 1);
         PyObject *ret = _Py_strhex_with_sep(src->buf, src->len, sep, bytes_per_sep);
-        exports_decrement(self);
+        FT_ATOMIC_ADD_SSIZE(self->exports, -1);
         return ret;
     }
 
@@ -3374,9 +3355,9 @@ memory_hash(PyObject *_self)
         if (view->obj != NULL) {
             // Prevent 'self' from being freed when computing the item's hash.
             // See https://github.com/python/cpython/issues/142664.
-            exports_increment(self);
+            FT_ATOMIC_ADD_SSIZE(self->exports, 1);
             Py_hash_t h = PyObject_Hash(view->obj);
-            exports_decrement(self);
+            FT_ATOMIC_ADD_SSIZE(self->exports, -1);
             if (h == -1) {
                 /* Keep the original error message */
                 return -1;


### PR DESCRIPTION
Before:

```
» ./python.exe /Users/sobolev/Desktop/cpython-ft/repros/132.py         
finding: 132 memoryview.hex() export/release race
expected signal: memoryview.release() unexpectedly succeeds inside sep.__len__, or native crash/sanitizer report
parameters: seconds=30; GIL=disabled (free-threaded build); size=1048576; hexers=6; exporters=12; len_yields=1
------------------------------------------------------------------------
Exception in thread hex-1:
Fatal Python error: Segmentation fault

<Cannot show all threads while the GIL is disabled>
Stack (most recent call first):
  File "/Users/sobolev/Desktop/cpython-ft/repros/132.py", line 152 in hex_worker
  File "/Users/sobolev/Desktop/cpython/Lib/threading.py", line 1160 in run
  File "/Users/sobolev/Desktop/cpython/Lib/threading.py", line 1218 in _bootstrap_inner
  File "/Users/sobolev/Desktop/cpython/Lib/threading.py", line 1180 in _bootstrap

Current thread's C stack trace (most recent call first):
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _Py_DumpStack+0x44 [0x105012b3c]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at faulthandler_fatal_error+0x240 [0x105034d74]
  Binary file "/usr/lib/system/libsystem_platform.dylib", at _sigtramp+0x38 [0x19ce6d6a4]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _Py_strhex_impl+0x170 [0x105017858]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at memoryview_hex+0x1d8 [0x104e19fa8]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _PyCallMethodDescriptorFastWithKeywords_StackRef+0xcc [0x104f26100]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _PyEval_EvalFrameDefault+0x82a4 [0x104f2eda8]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _PyEval_Vector+0x340 [0x104f2511c]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _PyObject_VectorcallTstate+0x6c [0x104d9d318]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _PyObject_VectorcallPrepend+0xec [0x104d9f3b0]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at context_run+0xa4 [0x104f697d0]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _PyObject_VectorcallTstate+0x6c [0x104d9d318]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _Py_VectorCallInstrumentation_StackRefSteal+0x11c [0x104f25830]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _PyEval_EvalFrameDefault+0x4020 [0x104f2ab24]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _PyEval_Vector+0x340 [0x104f2511c]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _PyObject_VectorcallTstate+0x6c [0x104d9d318]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at _PyObject_VectorcallPrepend+0xec [0x104d9f3b0]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at thread_run+0x84 [0x1050ace48]
  Binary file "/Users/sobolev/Desktop/cpython/python.exe", at pythread_wrapper+0x1c [0x10500f810]
  Binary file "/usr/lib/system/libsystem_pthread.dylib", at _pthread_start+0x88 [0x19ce33c0c]
  Binary file "/usr/lib/system/libsystem_pthread.dylib", at thread_start+0x8 [0x19ce2eb80]
[1]    88946 segmentation fault  ./python.exe /Users/sobolev/Desktop/cpython-ft/repros/132.py
```

After: code snippet passes.
I am not really sure that there's an easy and predictable way to trigger this error without going really deep into implementation details and making a test too fragile.


[132.py](https://github.com/user-attachments/files/27793757/132.py)
[132.md](https://github.com/user-attachments/files/27793767/132.md)


<!-- gh-issue-number: gh-149816 -->
* Issue: gh-149816
<!-- /gh-issue-number -->
