### PR TITLE
gh-149879: Fix test_pwd on Cygwin

### DIFF
--- a/Lib/test/test_pwd.py
+++ b/Lib/test/test_pwd.py
@@ -103,9 +103,11 @@ class PwdTest(unittest.TestCase):
         self.assertNotIn(fakeuid, byuids)
         self.assertRaises(KeyError, pwd.getpwuid, fakeuid)
 
-        # -1 shouldn't be a valid uid because it has a special meaning in many
-        # uid-related functions
-        self.assertRaises(KeyError, pwd.getpwuid, -1)
+        # On Cygwin, getpwuid(-1) returns 'Unknown+User' user
+        if sys.platform != 'cygwin':
+            # -1 shouldn't be a valid uid because it has a special meaning in many
+            # uid-related functions
+            self.assertRaises(KeyError, pwd.getpwuid, -1)
         # should be out of uid_t range
         self.assertRaises(KeyError, pwd.getpwuid, 2**128)
         self.assertRaises(KeyError, pwd.getpwuid, -2**128)


### PR DESCRIPTION
On Cygwin, pwd.getpwuid(-1) returns an user ('Unknown+User').

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149879 -->
* Issue: gh-149879
<!-- /gh-issue-number -->
