### PR TITLE
gh-149819: Fix .pth files not loaded in Python subprocesses

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -490,13 +490,16 @@ def addsitedir(sitedir, known_paths=None, *, defer_processing_start_files=False)
         reset = False
     sitedir, sitedircase = makepath(sitedir)
 
-    # If the normcase'd new sitedir isn't already known, append it to
-    # sys.path, keep a record of it, and process all .pth and .start files
-    # found in that directory.  If the new sitedir is known, be sure not
-    # to process all of those more than once!  gh-75723
+    # If the normcase'd new sitedir isn't already known, record it to
+    # prevent re-processing, append it to sys.path (only if not already
+    # present), and process all .pth and .start files found in that
+    # directory.  Use a direct sys.path membership check for the append
+    # guard so that callers (like main()) can pass a fresh known_paths
+    # set while avoiding duplicate sys.path entries (gh-149819).
     if sitedircase not in known_paths:
-        sys.path.append(sitedir)
         known_paths.add(sitedircase)
+        if sitedir not in sys.path:
+            sys.path.append(sitedir)
 
         try:
             names = os.listdir(sitedir)
@@ -1000,7 +1003,8 @@ def main():
     global ENABLE_USER_SITE
 
     orig_path = sys.path[:]
-    known_paths = removeduppaths()
+    removeduppaths()
+    known_paths = set()
     if orig_path != sys.path:
         # removeduppaths() might make sys.path absolute.
         # Fix __file__ of already imported modules too.

--- a/Misc/NEWS.d/next/Library/2026-05-15-16-28-00.gh-issue-149819.fixpth.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-15-16-28-00.gh-issue-149819.fixpth.rst
@@ -1,0 +1,4 @@
+Fix regression in :func:`site.addsitedir` where ``.pth`` files were no
+longer processed in Python subprocesses. This happened because
+:func:`site.main` seeded ``known_paths`` with entries inherited from
+the parent process, causing ``addsitedir`` to skip ``.pth`` processing.


### PR DESCRIPTION
After PR gh-149583 (Fix double evaluation of .pth and .site files in venvs), .pth files are no longer loaded in subprocesses started with subprocess.run([sys.executable, ...]).

**Root cause**: `main()` seeds `known_paths` from `removeduppaths()` with all sys.path entries inherited from the parent process. `addsitedir()` then skips .pth processing for every directory already in known_paths.

**Fix** (2 changes in Lib/site.py, +10/−6 lines):
1. `main()`: call `removeduppaths()` for dedup but start `known_paths` as a fresh empty set
2. `addsitedir()`: guard `sys.path.append` with `sitedir not in sys.path` to avoid duplicates when called with fresh known_paths

**Verification**:
- `./python -m test test_site`: 90/90 tests pass (0 failures, 6 skipped)
- Functional test: .pth files correctly processed in subprocess scenario with empty known_paths
- Functional test (unpatched): .pth files skipped when known_paths is pre-seeded — bug confirmed

Closes gh-149819