### PR TITLE
gh-149879: Fix test_signal on Cygwin

### DIFF
--- a/Lib/signal.py
+++ b/Lib/signal.py
@@ -15,7 +15,7 @@ _IntEnum._convert_(
         'Handlers', __name__,
         lambda name: name in ('SIG_DFL', 'SIG_IGN'))
 
-if 'pthread_sigmask' in _globals:
+if 'SIG_BLOCK' in _globals:
     _IntEnum._convert_(
             'Sigmasks', __name__,
             lambda name: name in ('SIG_BLOCK', 'SIG_UNBLOCK', 'SIG_SETMASK'))

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -833,6 +833,8 @@ class ItimerTest(unittest.TestCase):
     # Issue 3864, unknown if this affects earlier versions of freebsd also
     @unittest.skipIf(sys.platform in ('netbsd5',) or is_apple_mobile,
         'itimer not reliable (does not mix well with threading) on some BSDs.')
+    @unittest.skipIf(sys.platform == 'cygwin',
+                     "Cygwin doesn't support ITIMER_VIRTUAL")
     def test_itimer_virtual(self):
         self.itimer = signal.ITIMER_VIRTUAL
         signal.signal(signal.SIGVTALRM, self.sig_vtalrm)
@@ -850,6 +852,8 @@ class ItimerTest(unittest.TestCase):
         # and the handler should have been called
         self.assertEqual(self.hndl_called, True)
 
+    @unittest.skipIf(sys.platform == 'cygwin',
+                     "Cygwin doesn't support ITIMER_PROF")
     def test_itimer_prof(self):
         self.itimer = signal.ITIMER_PROF
         signal.signal(signal.SIGPROF, self.sig_prof)


### PR DESCRIPTION
* Check for SIG_BLOCK instead of pthread_sigmask() to decide if SIG_BLOCK, SIG_UNBLOCK and SIG_SETMASK constants should be converted to enums.
* Skip ITIMER_VIRTUAL and ITIMER_PROF tests on Cygwin: setitimer() fails with ItimerError(EINVAL).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149879 -->
* Issue: gh-149879
<!-- /gh-issue-number -->
