### PR TITLE
Remote Debugging: silence some unused function warnings

### DIFF
--- a/Modules/_remote_debugging/subprocess.c
+++ b/Modules/_remote_debugging/subprocess.c
@@ -96,7 +96,7 @@ pid_array_contains(pid_array_t *arr, pid_t pid)
 /* Find child PIDs using BFS traversal of the pid->ppid mapping.
  * all_pids and ppids must have the same count (parallel arrays).
  * Returns 0 on success, -1 on error. */
-static int
+UNUSED static int
 find_children_bfs(pid_t target_pid, int recursive,
                   pid_t *all_pids, pid_t *ppids, size_t pid_count,
                   pid_array_t *result)

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -161,7 +161,7 @@ _Py_RemoteDebug_ReadRemoteMemory(proc_handle_t *handle, uintptr_t remote_address
 typedef int (*section_validator_t)(proc_handle_t *handle, uintptr_t address);
 
 // Validate that a candidate address starts with _Py_Debug_Cookie.
-static int
+UNUSED static int
 _Py_RemoteDebug_ValidatePyRuntimeCookie(proc_handle_t *handle, uintptr_t address)
 {
     if (address == 0) {


### PR DESCRIPTION
Seen in the logs of the iOS buildbot, for example, [this run](https://buildbot.python.org/#/builders/1380/builds/6651):
```
../../Modules/_remote_debugging/../../Python/remote_debug.h:165:1: warning: unused function '_Py_RemoteDebug_ValidatePyRuntimeCookie' [-Wunused-function]
../../Modules/_remote_debugging/subprocess.c:100:1: warning: unused function 'find_children_bfs' [-Wunused-function]
```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
