### PR TITLE
gh-149879: Don't import msvcrt in _pyio on Cygwin

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -10,7 +10,7 @@ import stat
 import sys
 # Import _thread instead of threading to reduce startup cost
 from _thread import allocate_lock as Lock
-if sys.platform in {'win32', 'cygwin'}:
+if sys.platform == 'win32':
     from msvcrt import setmode as _setmode
 else:
     _setmode = None


### PR DESCRIPTION
The msvcrt extension module cannot be built on Cygwin.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149879 -->
* Issue: gh-149879
<!-- /gh-issue-number -->
