### PR TITLE
gh-149887: Install python3t.lib for GIL-enabled Windows install

### DIFF
--- a/Tools/msi/dev/dev_files.wxs
+++ b/Tools/msi/dev/dev_files.wxs
@@ -13,6 +13,9 @@
             <Component Id="libs_python3.lib" Directory="libs" Guid="*">
                 <File Id="libs_python_stable.lib" Name="python$(var.MajorVersionNumber).lib" KeyPath="yes" />
             </Component>
+            <Component Id="libs_python3t.lib" Directory="libs" Guid="*">
+                <File Id="libs_python_abi3tcompat.lib" Name="python$(var.MajorVersionNumber)t.lib" KeyPath="yes" />
+            </Component>
             <Component Id="libs_python.lib" Directory="libs" Guid="*">
                 <File Id="libs_python.lib" Name="python$(var.MajorVersionNumber)$(var.MinorVersionNumber).lib" KeyPath="yes" />
             </Component>
@@ -23,6 +26,9 @@
         <ComponentGroup Id="dev_libs_d">
             <Component Id="libs_python3_d.lib" Directory="libs" Guid="*">
                 <File Id="libs_python_stable_d.lib" Name="python$(var.MajorVersionNumber)_d.lib" />
+            </Component>
+            <Component Id="libs_python3t_d.lib" Directory="libs" Guid="*">
+                <File Id="libs_python_abi3tcompat_d.lib" Name="python$(var.MajorVersionNumber)t_d.lib" />
             </Component>
             <Component Id="libs_python_d.lib" Directory="libs" Guid="*">
                 <File Id="libs_python_d.lib" Name="python$(var.MajorVersionNumber)$(var.MinorVersionNumber)_d.lib" />


### PR DESCRIPTION


<!-- gh-issue-number: gh-149887 -->
* Issue: gh-149887
<!-- /gh-issue-number -->
