### PR TITLE
gh-149879: Fix test_resource on Cygwin

### DIFF
--- a/Lib/test/test_resource.py
+++ b/Lib/test/test_resource.py
@@ -45,8 +45,8 @@ class ResourceTest(unittest.TestCase):
         resource.setrlimit(resource.RLIMIT_FSIZE, (max, max))
         resource.setrlimit(resource.RLIMIT_FSIZE, (cur, max))
 
-    @unittest.skipIf(sys.platform == "vxworks",
-                     "setting RLIMIT_FSIZE is not supported on VxWorks")
+    @unittest.skipIf(sys.platform in ("vxworks", "cygwin"),
+                     f"setting RLIMIT_FSIZE is not supported on {sys.platform}")
     @unittest.skipUnless(hasattr(resource, 'RLIMIT_FSIZE'), 'requires resource.RLIMIT_FSIZE')
     def test_fsize_enforced(self):
         self.addCleanup(os_helper.unlink, os_helper.TESTFN)
@@ -84,8 +84,8 @@ class ResourceTest(unittest.TestCase):
         except (OverflowError, ValueError):
             pass
 
-    @unittest.skipIf(sys.platform == "vxworks",
-                     "setting RLIMIT_FSIZE is not supported on VxWorks")
+    @unittest.skipIf(sys.platform in ("vxworks", "cygwin"),
+                     f"setting RLIMIT_FSIZE is not supported on {sys.platform}")
     @unittest.skipUnless(hasattr(resource, 'RLIMIT_FSIZE'), 'requires resource.RLIMIT_FSIZE')
     def test_fsize_not_too_big(self):
         (cur, max) = resource.getrlimit(resource.RLIMIT_FSIZE)
@@ -163,8 +163,8 @@ class ResourceTest(unittest.TestCase):
             pass
 
     # Issue 6083: Reference counting bug
-    @unittest.skipIf(sys.platform == "vxworks",
-                     "setting RLIMIT_CPU is not supported on VxWorks")
+    @unittest.skipIf(sys.platform in ("vxworks", "cygwin"),
+                     f"setting RLIMIT_CPU is not supported on {sys.platform}")
     @unittest.skipUnless(hasattr(resource, 'RLIMIT_CPU'), 'requires resource.RLIMIT_CPU')
     def test_setrusage_refcount(self):
         limits = resource.getrlimit(resource.RLIMIT_CPU)


### PR DESCRIPTION
Setting RLIMIT_FSIZE or RLIMIT_CPU fails with EINVAL on Cygwin.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149879 -->
* Issue: gh-149879
<!-- /gh-issue-number -->
