### PR TITLE
gh-149906: Update README with details on CPython internals

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2026-05-16-02-31-05.gh-issue-149906.8T5RhO.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-05-16-02-31-05.gh-issue-149906.8T5RhO.rst
@@ -1,0 +1,9 @@
+Technical Documentation: Extended Python/README and convert to Markdown
+* Updated the Python/ directory README to provide more context on the compiler and runtime execution logic.
+* Converted the file to README.md to support hyperlinking to the Python DevGuide and internal documentation.
+* Added relative links to the InternalDocs directory.
+
+
+<!-- gh-issue-number: gh-149906 -->
+* Issue: gh-149906
+<!-- /gh-issue-number -->

--- a/Misc/NEWS.d/next/Documentation/2026-05-16-02-31-05.gh-issue-149906.8T5RhO.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-05-16-02-31-05.gh-issue-149906.8T5RhO.rst
@@ -1,9 +1,1 @@
-Technical Documentation: Extended Python/README and convert to Markdown
-* Updated the Python/ directory README to provide more context on the compiler and runtime execution logic.
-* Converted the file to README.md to support hyperlinking to the Python DevGuide and internal documentation.
-* Added relative links to the InternalDocs directory.
 
-
-<!-- gh-issue-number: gh-149906 -->
-* Issue: gh-149906
-<!-- /gh-issue-number -->

--- a/Misc/NEWS.d/next/Documentation/2026-05-16-02-31-05.gh-issue-149906.8T5RhO.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-05-16-02-31-05.gh-issue-149906.8T5RhO.rst
@@ -1,1 +1,7 @@
-
+Technical Documentation: Extended Python/README and convert to Markdown
+* Updated the Python/ directory README to provide more context on the compiler and runtime execution logic.
+* Converted the file to README.md to support hyperlinking to the Python DevGuide and internal documentation.
+* Added relative links to the InternalDocs directory.
+<!-- gh-issue-number: gh-149906 -->
+* Issue: gh-149906
+<!-- /gh-issue-number -->

--- a/Misc/NEWS.d/next/Documentation/2026-05-16-02-31-05.gh-issue-149906.8T5RhO.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-05-16-02-31-05.gh-issue-149906.8T5RhO.rst
@@ -1,7 +1,0 @@
-Technical Documentation: Extended Python/README and convert to Markdown
-* Updated the Python/ directory README to provide more context on the compiler and runtime execution logic.
-* Converted the file to README.md to support hyperlinking to the Python DevGuide and internal documentation.
-* Added relative links to the InternalDocs directory.
-<!-- gh-issue-number: gh-149906 -->
-* Issue: gh-149906
-<!-- /gh-issue-number -->

--- a/Python/README
+++ b/Python/README
@@ -1,1 +1,0 @@
-Miscellaneous source files for the main Python shared library

--- a/Python/README.md
+++ b/Python/README.md
@@ -1,0 +1,3 @@
+Miscellaneous source files for the compiler and runtime execution logic of the CPython interpreter. 
+* For high-level architecture, see the Python Developer's Guide on [CPython's internals](https://devguide.python.org/internals/).
+* For technical deep-dives, see the `InternalDocs` directory and read the [InternalDocs/interpreter.md](../InternalDocs/interpreter.md) file.

--- a/Python/README.md
+++ b/Python/README.md
@@ -1,3 +1,3 @@
 Miscellaneous source files for the compiler and runtime execution logic of the CPython interpreter.
-* For high-level architecture, see the Python Developer's Guide on [CPython's internals](https://devguide.python.org/internals/).
-* For technical deep-dives, see the `InternalDocs` directory and read the [InternalDocs/interpreter.md](../InternalDocs/interpreter.md) file.
+* For high-level compiler architecture, see the compiler design at [InternalDocs/compiler.md](../InternalDocs/compiler.md).
+* For technical details on the interpreter, see the bytecode interpreter at [InternalDocs/interpreter.md](../InternalDocs/interpreter.md).

--- a/Python/README.md
+++ b/Python/README.md
@@ -1,3 +1,3 @@
-Miscellaneous source files for the compiler and runtime execution logic of the CPython interpreter. 
+Miscellaneous source files for the compiler and runtime execution logic of the CPython interpreter.
 * For high-level architecture, see the Python Developer's Guide on [CPython's internals](https://devguide.python.org/internals/).
 * For technical deep-dives, see the `InternalDocs` directory and read the [InternalDocs/interpreter.md](../InternalDocs/interpreter.md) file.


### PR DESCRIPTION
Technical Documentation: Extended Python/README and convert to Markdown
* Updated the Python/ directory README to provide more context on the compiler and runtime execution logic.
* Converted the file to README.md to support hyperlinking to the internal documentation.
* Added relative links to the InternalDocs directory.

<!-- gh-issue-number: gh-149906 -->
* Issue: gh-149906
<!-- /gh-issue-number -->
