### PR TITLE
gh-67512: Document IMAP4.append() flags argument

### DIFF
--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -199,6 +199,11 @@ An :class:`IMAP4` instance has the following methods:
 
    Append *message* to named mailbox.
 
+   *flags* may be ``None`` or a string of IMAP flag tokens.  Multiple
+   flags are separated by spaces, for example ``r'\Seen \Answered'``.
+   If *flags* is not already enclosed in parentheses, parentheses are
+   added automatically.
+
 
 .. method:: IMAP4.authenticate(mechanism, authobject)
 


### PR DESCRIPTION
Clarify the type and format expected for the `flags` argument to `imaplib.IMAP4.append()`.

The current documentation names the argument but does not explain that it should be an IMAP flag string. This can lead readers to pass a Python tuple or list of flags, which does not match the API. The updated text documents that `flags` may be `None` or a string of IMAP flag tokens, shows a multi-flag example, and notes that parentheses are added automatically when omitted.

Docs-only change.

Testing:
- `make -C Doc check`
- `./Doc/venv/bin/pre-commit run sphinx-lint --files Doc/library/imaplib.rst`

<!-- gh-issue-number: gh-67512 -->
* Issue: gh-67512
<!-- /gh-issue-number -->
