### PR TITLE
gh-149816: Fix a race condition in `_PyBytes_FromList` with free-threading

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-16-11-03-54.gh-issue-149816.X_gqMT.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-16-11-03-54.gh-issue-149816.X_gqMT.rst
@@ -1,0 +1,1 @@
+Fix a race condition in ``_PyBytes_FromList`` in free-threading mode.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -11,6 +11,7 @@
 #include "pycore_global_objects.h"// _Py_GET_GLOBAL_OBJECT()
 #include "pycore_initconfig.h"    // _PyStatus_OK()
 #include "pycore_long.h"          // _PyLong_DigitValue
+#include "pycore_list.h"          // _PyList_GetItemRef
 #include "pycore_object.h"        // _PyObject_GC_TRACK
 #include "pycore_pymem.h"         // PYMEM_CLEANBYTE
 #include "pycore_strhex.h"        // _Py_strhex_with_sep()
@@ -2991,8 +2992,10 @@ _PyBytes_FromList(PyObject *x)
     size = _PyBytesWriter_GetAllocated(writer);
 
     for (Py_ssize_t i = 0; i < PyList_GET_SIZE(x); i++) {
-        PyObject *item = PyList_GET_ITEM(x, i);
-        Py_INCREF(item);
+        PyObject *item = _PyList_GetItemRef((PyListObject *)x, i);
+        if (item == NULL) {
+            goto error;
+        }
         Py_ssize_t value = PyNumber_AsSsize_t(item, NULL);
         Py_DECREF(item);
         if (value == -1 && PyErr_Occurred())


### PR DESCRIPTION
`_PyBytes_FromList` is called from `PyBytes_FromObject` which does not own the passed object, so it is a borrowed reference.

Using `_PyList_GetItemRef` seems like the correct solution here.
However, I was not successful in actually triggering the failure without C-API direct usage.

<!-- gh-issue-number: gh-149816 -->
* Issue: gh-149816
<!-- /gh-issue-number -->
