### PR TITLE
gh-149816: fix `dict.clear()` race on split-table dict with non-embedded values

### DIFF
--- a/Lib/test/test_free_threading/test_dict.py
+++ b/Lib/test/test_free_threading/test_dict.py
@@ -268,6 +268,34 @@ class TestDict(TestCase):
         finally:
             _testcapi.clear_dict_watcher(wid)
 
+    def test_racing_split_dict_clear_and_lookup(self):
+        class C:
+            pass
+
+        keys = [f"a{i}" for i in range(16)]
+
+        def make_split_nonembedded():
+            inst = C()
+            for key in keys:
+                setattr(inst, key, keys.index(key))
+            # dict.copy() of a split instance dict yields a split table
+            # with non-embedded values
+            return inst.__dict__.copy()
+
+        d = make_split_nonembedded()
+
+        def clearer():
+            for _ in range(1000):
+                d.clear()
+                d.update(make_split_nonembedded())
+
+        def reader():
+            for _ in range(1000):
+                for k in keys:
+                    d.get(k)
+
+        threading_helper.run_concurrently([clearer, reader, reader])
+
     def test_racing_dict_update_and_method_lookup(self):
         # gh-144295: test race between dict modifications and method lookups.
         # Uses BytesIO because the race requires a type without Py_TPFLAGS_INLINE_VALUES

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3083,10 +3083,12 @@ clear_lock_held(PyObject *op)
         set_keys(mp, Py_EMPTY_KEYS);
         n = oldkeys->dk_nentries;
         for (i = 0; i < n; i++) {
-            Py_CLEAR(oldvalues->values[i]);
+            PyObject *tmp = oldvalues->values[i];
+            FT_ATOMIC_STORE_PTR_RELEASE(oldvalues->values[i], NULL);
+            Py_XDECREF(tmp);
         }
         free_values(oldvalues, IS_DICT_SHARED(mp));
-        dictkeys_decref(oldkeys, false);
+        dictkeys_decref(oldkeys, IS_DICT_SHARED(mp));
     }
     ASSERT_CONSISTENT(mp);
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149816 -->
* Issue: gh-149816
<!-- /gh-issue-number -->
