### PR TITLE
doc: 'import tkinter as tk' in examples

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -1007,9 +1007,9 @@ Tk allows you to register and unregister a callback function which will be
 called from the Tk mainloop when I/O is possible on a file descriptor.
 Only one handler may be registered per file descriptor. Example code::
 
-   import tkinter
-   widget = tkinter.Tk()
-   mask = tkinter.READABLE | tkinter.WRITABLE
+   import tkinter as tk
+   widget = tk.Tk()
+   mask = tk.READABLE | tk.WRITABLE
    widget.tk.createfilehandler(file, mask, callback)
    ...
    widget.tk.deletefilehandler(file)

--- a/Doc/library/tkinter.ttk.rst
+++ b/Doc/library/tkinter.ttk.rst
@@ -1290,9 +1290,9 @@ option. If you don't know the class name of a widget, use the method
       some padding and a different background color::
 
          from tkinter import ttk
-         import tkinter
+         import tkinter as tk
 
-         root = tkinter.Tk()
+         root = tk.Tk()
 
          ttk.Style().configure("TButton", padding=6, relief="flat",
             background="#ccc")


### PR DESCRIPTION
I have replaced all `import tkinter` with `import tkinter as tk` in examples.