### PR TITLE
gh-146406: add clear() cross-language hint for immutable types

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4637,6 +4637,9 @@ class SuggestionFormattingTestBase(SuggestionFormattingTestMixin):
             (frozenset, 'remove', "Did you mean to use a 'set' object?"),
             (frozenset, 'update', "Did you mean to use a 'set' object?"),
             (frozendict, 'update', "Did you mean to use a 'dict' object?"),
+            (tuple, 'clear', "Did you mean to use a 'list' object?"),
+            (frozenset, 'clear', "Did you mean to use a 'set' object?"),
+            (frozendict, 'clear', "Did you mean to use a 'dict' object?"),
         ]
         for test_type, attr, expected in cases:
             with self.subTest(type=test_type.__name__, attr=attr):

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1775,6 +1775,10 @@ _CROSS_LANGUAGE_HINTS = frozendict({
     # frozendict -- mutable method on immutable type (user expected a dict)
     "update": ((frozenset, "Did you mean to use a 'set' object?", True),
                (frozendict, "Did you mean to use a 'dict' object?", True)),
+    # clear() -- shared across immutable container types (user expected the mutable counterpart)
+    "clear": ((tuple, "Did you mean to use a 'list' object?", True),
+              (frozenset, "Did you mean to use a 'set' object?", True),
+              (frozendict, "Did you mean to use a 'dict' object?", True)),
     # float -- bitwise operators belong to int
     "__or__": ((float, "Did you mean to use an 'int' object? Bitwise operators are not supported by 'float'.", True),),
     "__and__": ((float, "Did you mean to use an 'int' object? Bitwise operators are not supported by 'float'.", True),),

--- a/Misc/NEWS.d/next/Library/2026-05-16-22-00-00.gh-issue-146406.10e0da.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-16-22-00-00.gh-issue-146406.10e0da.rst
@@ -1,0 +1,3 @@
+Add cross-language hints for ``.clear()`` on :class:`tuple`,
+:class:`frozenset`, and :class:`frozendict`, suggesting the mutable
+counterpart. Follow-up to :gh:`146406`.


### PR DESCRIPTION
Follow-up to #146407. Calling `.clear()` on a `tuple`, `frozenset`, or `frozendict` now suggests the mutable counterpart, mirroring the existing `append`/`extend`/`insert`/`remove`/`discard`/`update` entries for the same immutable types.

Requested by @vstinner after @henryiii flagged that `.clear()` was the first method they tried on these types in the new hint table from #146407 and got no useful suggestion.

```
>>> (1, 2, 3).clear()
AttributeError: 'tuple' object has no attribute 'clear'. Did you mean to use a 'list' object?
>>> frozenset({1, 2, 3}).clear()
AttributeError: 'frozenset' object has no attribute 'clear'. Did you mean to use a 'set' object?
```

Verified locally: `./python.exe -m test test_traceback` 434/434 passing.

<!-- gh-issue-number: gh-146406 -->
* Issue: gh-146406
<!-- /gh-issue-number -->
