### PR TITLE
Add "rv" short form to pdb's retval docstring

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2251,7 +2251,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     do_a = do_args
 
     def do_retval(self, arg):
-        """retval
+        """rv | retval
 
         Print the return value for the last return of a function.
         """


### PR DESCRIPTION
Similar to other cases e.g. "ll | longlist"