### PR TITLE
Doc: Clarify class creation behavior for dataclass(slots=True)

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -60,8 +60,9 @@ Module contents
    The ``@dataclass`` decorator will add various "dunder" methods to
    the class, described below.  If any of the added methods already
    exist in the class, the behavior depends on the parameter, as documented
-   below. The decorator returns the same class that it is called on; no new
-   class is created.
+   below. By default the decorator returns the same class that it is called on
+   without creating a new class. However, if the ``slots=True`` parameter is used,
+   a new class is generated and returned instead.
 
    If ``@dataclass`` is used just as a simple decorator with no parameters,
    it acts as if it has the default values documented in this

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -60,9 +60,8 @@ Module contents
    The ``@dataclass`` decorator will add various "dunder" methods to
    the class, described below.  If any of the added methods already
    exist in the class, the behavior depends on the parameter, as documented
-   below. By default the decorator returns the same class that it is called on
-   without creating a new class. However, if the ``slots=True`` parameter is used,
-   a new class is generated and returned instead.
+   below. Except when ``slots=True``, the decorator returns the same class
+   that it is called on without creating a new class.
 
    If ``@dataclass`` is used just as a simple decorator with no parameters,
    it acts as if it has the default values documented in this


### PR DESCRIPTION
### Summary
This PR resolves a contradiction in the `dataclasses` documentation regarding class creation.

The introductory section currently states unconditionally that the `@dataclass` decorator returns the same class it is called on. However, the documentation for the `slots=True` parameter later clarifies that a new class is actually generated and returned instead.

This PR updates the module introduction to immediately acknowledge the `slots=True` exception, preventing reader confusion.

*(Note: As this is a minor documentation clarification, I have not opened a separate GitHub issue for it.)*