### PR TITLE
gh-149951 Use def instead of lambda assignments in asyncio.subprocess

### DIFF
--- a/Lib/asyncio/subprocess.py
+++ b/Lib/asyncio/subprocess.py
@@ -206,8 +206,8 @@ class Process:
 async def create_subprocess_shell(cmd, stdin=None, stdout=None, stderr=None,
                                   limit=streams._DEFAULT_LIMIT, **kwds):
     loop = events.get_running_loop()
-    protocol_factory = lambda: SubprocessStreamProtocol(limit=limit,
-                                                        loop=loop)
+    def protocol_factory():
+        return SubprocessStreamProtocol(limit=limit, loop=loop)
     transport, protocol = await loop.subprocess_shell(
         protocol_factory,
         cmd, stdin=stdin, stdout=stdout,
@@ -219,8 +219,8 @@ async def create_subprocess_exec(program, *args, stdin=None, stdout=None,
                                  stderr=None, limit=streams._DEFAULT_LIMIT,
                                  **kwds):
     loop = events.get_running_loop()
-    protocol_factory = lambda: SubprocessStreamProtocol(limit=limit,
-                                                        loop=loop)
+    def protocol_factory():
+        return SubprocessStreamProtocol(limit=limit, loop=loop)
     transport, protocol = await loop.subprocess_exec(
         protocol_factory,
         program, *args,


### PR DESCRIPTION
Replace the two `protocol_factory = lambda: ...` assignments in
  `asyncio.subprocess` with proper `def` statements, as recommended by
  [PEP 8 (E731)](https://peps.python.org/pep-0008/#programming-recommendations:~:text=Always%20use%20a%20def%20statement%20instead%20of%20an%20assignment%20statement%20that%20binds%20a%20lambda%20expression%20directly%20to%20an%20identifier%3A):

Affected functions: `create_subprocess_shell` and `create_subprocess_exec`.

Before:

```python
protocol_factory = lambda: SubprocessStreamProtocol(limit=limit, loop=loop)
```

After:

```python
def protocol_factory():
    return SubprocessStreamProtocol(limit=limit, loop=loop)
```

This change also gives the factories a meaningful `__name__`  and `__qualname__`.

<details>
  <summary>Reproducer </summary>

  ```python
import traceback


def make_with_lambda():
    limit = 1024
    loop = "fake_loop"
    protocol_factory = lambda: SubprocessStreamProtocol(limit=limit, loop=loop)
    return protocol_factory


def make_with_def():
    limit = 1024
    loop = "fake_loop"

    def protocol_factory():
        return SubprocessStreamProtocol(limit=limit, loop=loop)

    return protocol_factory


class SubprocessStreamProtocol:
    def __init__(self, limit, loop):
        raise RuntimeError("simulated init failure")


def show(label, factory):
    print(f"=== {label} ===")
    print(f"  __name__     = {factory.__name__!r}")
    print(f"  __qualname__ = {factory.__qualname__!r}")
    print(f"  repr         = {factory!r}")
    print()
    print("  Traceback when factory raises:")
    try:
        factory()
    except RuntimeError:
        tb = traceback.format_exc()
        for line in tb.splitlines():
            print(f"    {line}")
    print()


show("lambda-traceback", make_with_lambda())
show("def-traceback", make_with_def())

  ```
  </details>

Output:

```
=== lambda-traceback ===
  __name__     = '<lambda>'
  __qualname__ = 'make_with_lambda.<locals>.<lambda>'
  repr         = <function make_with_lambda.<locals>.<lambda> at 0x1010156d0>

File "/Users/timofeiivankov/Desktop/untitled folder/cpython/lws.py", line 7, in <lambda>
     protocol_factory = lambda: SubprocessStreamProtocol(limit=limit, loop=loop)
                              ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
```

```
=== def-traceback ===
  __name__     = 'protocol_factory'
  __qualname__ = 'make_with_def.<locals>.protocol_factory'
  repr         = <function make_with_def.<locals>.protocol_factory at 0x100e413d0>

 File "/Users/timofeiivankov/Desktop/untitled folder/cpython/lws.py", line 16, in protocol_factory
       return SubprocessStreamProtocol(limit=limit, loop=loop)
```

Cleanup only, no behavior change.


<!-- gh-issue-number: gh-149951 -->
* Issue: gh-149951
<!-- /gh-issue-number -->
