### PR TITLE
gh-145411: Add runtime (now: `unix` only) control to Tachyon

### DIFF
--- a/Lib/profiling/sampling/_control.py
+++ b/Lib/profiling/sampling/_control.py
@@ -1,0 +1,244 @@
+"""Control runtime for the sampling profiler."""
+
+import os
+import selectors
+import socket
+import warnings
+
+from .errors import ControlError, ControlURIError
+
+
+class ProfilerControl:
+    def __init__(self):
+        self.enabled = True
+        self.running = True
+        self.sample_interval_usec = 0
+
+
+def parse_control_uri(uri, *, allowed_schemes=("unix",)):
+    if ":" not in uri:
+        raise ControlURIError("control URI must include a scheme")
+
+    scheme, path = uri.split(":", 1)
+    if scheme not in allowed_schemes:
+        expected = ", ".join(allowed_schemes)
+        raise ControlURIError(
+            f"unsupported control URI scheme {scheme!r}; "
+            f"expected one of: {expected}"
+        )
+    if not path:
+        raise ControlURIError("control URI path must not be empty")
+    return scheme, path
+
+
+_MAX_OUTBUF_BYTES = 64 * 1024
+_MAX_INBUF_BYTES = 4 * 1024
+_MAX_CONNECTIONS = 8
+_SOCKET_PERMISSIONS = 0o600
+
+
+class _Connection:
+    def __init__(self, sock):
+        self.sock = sock
+        self.inbuf = bytearray()
+        self.outbuf = bytearray()
+        self.close_after_write = False
+
+
+class ControlServer:
+    def __init__(self, uri):
+        self.uri = uri
+        self.control = ProfilerControl()
+        _, self._path = parse_control_uri(uri)
+        self.selector = selectors.DefaultSelector()
+        self._connections = set()
+        self._listener = None
+        self._created_stat = None
+
+    def start(self):
+        self._listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            self._listener.bind(self._path)
+            os.chmod(self._path, _SOCKET_PERMISSIONS)
+            self._created_stat = os.lstat(self._path)
+            self._listener.listen(socket.SOMAXCONN)
+            self._listener.setblocking(False)
+            self.selector.register(self._listener, selectors.EVENT_READ, None)
+        except OSError as exc:
+            self._close_listener()
+            raise ControlError(
+                f"failed to start control socket {self._path!r}: {exc}"
+            ) from exc
+
+    def stop(self):
+        for conn in list(self._connections):
+            self._close_connection(conn)
+        self.selector.close()
+        self._close_listener()
+
+    def _close_listener(self):
+        listener, self._listener = self._listener, None
+        if listener is not None:
+            listener.close()
+
+        created_stat, self._created_stat = self._created_stat, None
+        if created_stat is None:
+            return
+        try:
+            current_stat = os.lstat(self._path)
+            if (current_stat.st_ino, current_stat.st_dev) == (
+                created_stat.st_ino,
+                created_stat.st_dev,
+            ):
+                os.unlink(self._path)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+
+    def poll(self, timeout):
+        try:
+            ready = self.selector.select(timeout)
+        except OSError as exc:
+            warnings.warn(
+                f"control selector.select() failed: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return
+
+        for key, events in ready:
+            if key.fileobj is self._listener:
+                self._accept_connection()
+            else:
+                self._handle_connection(key.data, events)
+
+    def _accept_connection(self):
+        try:
+            sock, _addr = self._listener.accept()
+        except BlockingIOError:
+            return
+        except OSError as exc:
+            warnings.warn(
+                f"control accept failed: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return
+
+        if len(self._connections) >= _MAX_CONNECTIONS:
+            sock.close()
+            return
+
+        try:
+            sock.setblocking(False)
+            conn = _Connection(sock)
+            self.selector.register(sock, selectors.EVENT_READ, conn)
+        except OSError:
+            sock.close()
+            return
+
+        self._connections.add(conn)
+
+    def _handle_connection(self, conn, events):
+        if events & selectors.EVENT_READ:
+            self._read_connection(conn)
+        if conn in self._connections and events & selectors.EVENT_WRITE:
+            self._flush_connection(conn)
+
+    def _read_connection(self, conn):
+        try:
+            chunk = conn.sock.recv(_MAX_INBUF_BYTES)
+        except (BlockingIOError, InterruptedError):
+            return
+        except OSError:
+            self._close_connection(conn)
+            return
+
+        if not chunk:
+            self._close_connection(conn)
+            return
+
+        conn.inbuf.extend(chunk)
+        if len(conn.inbuf) > _MAX_INBUF_BYTES:
+            self._close_connection(conn)
+            return
+
+        while True:
+            newline = conn.inbuf.find(b"\n")
+            if newline == -1:
+                break
+            raw = conn.inbuf.take_bytes(newline + 1)
+            line = raw[:-1].decode("utf-8", "replace").strip()
+            self._dispatch(conn, line)
+            if conn not in self._connections or conn.close_after_write:
+                break
+
+        if conn in self._connections:
+            self._flush_connection(conn)
+
+    def _dispatch(self, conn, command):
+        match command:
+            case "enable":
+                self.control.enabled = True
+                reply = "ok\n"
+            case "disable":
+                self.control.enabled = False
+                reply = "ok\n"
+            case "ping":
+                reply = "ok\n"
+            case "status":
+                reply = (
+                    f"ok enabled={self.control.enabled} "
+                    f"rate_usec={self.control.sample_interval_usec}\n"
+                )
+            case "quit":
+                self.control.running = False
+                conn.close_after_write = True
+                reply = "ok\n"
+            case _:
+                reply = "err unknown_command\n"
+
+        conn.outbuf.extend(reply.encode("ascii"))
+        if len(conn.outbuf) > _MAX_OUTBUF_BYTES:
+            self._close_connection(conn)
+
+    def _flush_connection(self, conn):
+        while conn.outbuf:
+            try:
+                sent = conn.sock.send(conn.outbuf)
+            except (BlockingIOError, InterruptedError):
+                break
+            except OSError:
+                self._close_connection(conn)
+                return
+
+            if sent == 0:
+                self._close_connection(conn)
+                return
+
+            del conn.outbuf[:sent]
+
+        if not conn.outbuf and conn.close_after_write:
+            self._close_connection(conn)
+            return
+
+        events = selectors.EVENT_READ
+        if conn.outbuf:
+            events |= selectors.EVENT_WRITE
+        try:
+            self.selector.modify(conn.sock, events, conn)
+        except (KeyError, OSError):
+            self._close_connection(conn)
+
+    def _close_connection(self, conn):
+        if conn not in self._connections:
+            return
+        self._connections.discard(conn)
+
+        try:
+            self.selector.unregister(conn.sock)
+        except (KeyError, OSError):
+            pass
+
+        conn.sock.close()

--- a/Lib/profiling/sampling/_control.py
+++ b/Lib/profiling/sampling/_control.py
@@ -12,7 +12,6 @@ class ProfilerControl:
     def __init__(self):
         self.enabled = True
         self.running = True
-        self.sample_interval_usec = 0
 
 
 def parse_control_uri(uri, *, allowed_schemes=("unix",)):
@@ -188,10 +187,7 @@ class ControlServer:
             case "ping":
                 reply = "ok\n"
             case "status":
-                reply = (
-                    f"ok enabled={self.control.enabled} "
-                    f"rate_usec={self.control.sample_interval_usec}\n"
-                )
+                reply = f"ok enabled={self.control.enabled}\n"
             case "quit":
                 self.control.running = False
                 conn.close_after_write = True

--- a/Lib/profiling/sampling/_control.py
+++ b/Lib/profiling/sampling/_control.py
@@ -90,8 +90,6 @@ class ControlServer:
                 created_stat.st_dev,
             ):
                 os.unlink(self._path)
-        except FileNotFoundError:
-            pass
         except OSError:
             pass
 

--- a/Lib/profiling/sampling/cli.py
+++ b/Lib/profiling/sampling/cli.py
@@ -1,7 +1,6 @@
 """Command-line interface for the sampling profiler."""
 
 import argparse
-import contextlib
 import importlib.util
 import locale
 import os
@@ -12,7 +11,7 @@ import subprocess
 import sys
 import time
 import webbrowser
-from contextlib import nullcontext
+from contextlib import ExitStack, nullcontext
 
 from .errors import (
     SamplingUnknownProcessError,
@@ -1202,7 +1201,7 @@ def _handle_attach(args):
     )
 
     server = None
-    with contextlib.ExitStack() as stack:
+    with ExitStack() as stack:
         if args.control:
             server = ControlServer(args.control)
             try:
@@ -1319,7 +1318,7 @@ def _handle_run(args):
     )
 
     server = None
-    with contextlib.ExitStack() as stack:
+    with ExitStack() as stack:
         stack.enter_context(_get_child_monitor_context(args, process.pid))
 
         def _terminate_main_subprocess():
@@ -1380,7 +1379,7 @@ def _handle_live_attach(args, pid):
 
     # Sample in live mode
     server = None
-    with contextlib.ExitStack() as stack:
+    with ExitStack() as stack:
         if args.control:
             server = ControlServer(args.control)
             try:
@@ -1438,7 +1437,7 @@ def _handle_live_run(args):
     # Profile the subprocess in live mode
     server = None
     try:
-        with contextlib.ExitStack() as stack:
+        with ExitStack() as stack:
             if args.control:
                 server = ControlServer(args.control)
                 try:

--- a/Lib/profiling/sampling/cli.py
+++ b/Lib/profiling/sampling/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface for the sampling profiler."""
 
 import argparse
+import contextlib
 import importlib.util
 import locale
 import os
@@ -13,7 +14,13 @@ import time
 import webbrowser
 from contextlib import nullcontext
 
-from .errors import SamplingUnknownProcessError, SamplingModuleNotFoundError, SamplingScriptNotFoundError
+from .errors import (
+    SamplingUnknownProcessError,
+    SamplingModuleNotFoundError,
+    SamplingScriptNotFoundError,
+    ControlError,
+    ControlURIError,
+)
 from .sample import sample, sample_live, dump_stack, _is_process_running
 from .dump import print_stack_dump
 from .pstats_collector import PstatsCollector
@@ -23,6 +30,10 @@ from .gecko_collector import GeckoCollector
 from .jsonl_collector import JsonlCollector
 from .binary_collector import BinaryCollector
 from .binary_reader import BinaryReader
+from ._control import (
+    ControlServer,
+    parse_control_uri,
+)
 from .constants import (
     MICROSECONDS_PER_SECOND,
     PROFILING_MODE_ALL,
@@ -424,6 +435,16 @@ def _add_sampling_options(parser):
         help="Stop all threads in target process before sampling to get consistent snapshots. "
         "Uses thread_suspend on macOS and ptrace on Linux. Adds overhead but ensures memory "
         "reads are from a frozen state.",
+    )
+
+
+def _add_control_options(parser):
+    control_group = parser.add_argument_group("Control socket")
+    control_group.add_argument(
+        "--control",
+        default=None,
+        metavar="URI",
+        help="control socket URI (unix:<path>)",
     )
 
 
@@ -859,6 +880,16 @@ def _validate_args(args, parser):
     if command == "replay":
         return
 
+    if getattr(args, 'control', None) is not None:
+        if args.subprocesses:
+            parser.error("--control is incompatible with --subprocesses.")
+        if os.name == "nt":
+            parser.error("--control is not supported on Windows.")
+        try:
+            parse_control_uri(args.control)
+        except ControlURIError as exc:
+            parser.error(str(exc))
+
     # Check if live mode is available
     if hasattr(args, 'live') and args.live and LiveStatsCollector is None:
         parser.error(
@@ -1035,6 +1066,7 @@ Examples:
         help="Interactive TUI profiler (top-like interface, press 'q' to quit, 's' to cycle sort)",
     )
     _add_sampling_options(run_parser)
+    _add_control_options(run_parser)
     _add_mode_options(run_parser)
     _add_format_options(run_parser)
     _add_pstats_options(run_parser)
@@ -1064,6 +1096,7 @@ Examples:
         help="Interactive TUI profiler (top-like interface, press 'q' to quit, 's' to cycle sort)",
     )
     _add_sampling_options(attach_parser)
+    _add_control_options(attach_parser)
     _add_mode_options(attach_parser)
     _add_format_options(attach_parser)
     _add_pstats_options(attach_parser)
@@ -1168,7 +1201,16 @@ def _handle_attach(args):
         diff_baseline=args.diff_baseline
     )
 
-    with _get_child_monitor_context(args, args.pid):
+    server = None
+    with contextlib.ExitStack() as stack:
+        if args.control:
+            server = ControlServer(args.control)
+            try:
+                server.start()
+            except ControlError as exc:
+                sys.exit(f"Error: {exc}")
+            stack.callback(server.stop)
+        stack.enter_context(_get_child_monitor_context(args, args.pid))
         collector = sample(
             args.pid,
             collector,
@@ -1181,6 +1223,7 @@ def _handle_attach(args):
             gc=args.gc,
             opcodes=args.opcodes,
             blocking=args.blocking,
+            control_server=server,
         )
         _handle_output(collector, args, args.pid, mode)
 
@@ -1275,23 +1318,11 @@ def _handle_run(args):
         diff_baseline=args.diff_baseline
     )
 
-    with _get_child_monitor_context(args, process.pid):
-        try:
-            collector = sample(
-                process.pid,
-                collector,
-                duration_sec=args.duration,
-                all_threads=args.all_threads,
-                realtime_stats=args.realtime_stats,
-                mode=mode,
-                async_aware=args.async_mode if args.async_aware else None,
-                native=args.native,
-                gc=args.gc,
-                opcodes=args.opcodes,
-                blocking=args.blocking,
-            )
-            _handle_output(collector, args, process.pid, mode)
-        finally:
+    server = None
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(_get_child_monitor_context(args, process.pid))
+
+        def _terminate_main_subprocess():
             # Terminate the main subprocess - child profilers finish when their
             # target processes exit
             if process.poll() is None:
@@ -1301,6 +1332,31 @@ def _handle_run(args):
                 except subprocess.TimeoutExpired:
                     process.kill()
                     process.wait()
+        stack.callback(_terminate_main_subprocess)
+
+        if args.control:
+            server = ControlServer(args.control)
+            try:
+                server.start()
+            except ControlError as exc:
+                sys.exit(f"Error: {exc}")
+            stack.callback(server.stop)
+
+        collector = sample(
+            process.pid,
+            collector,
+            duration_sec=args.duration,
+            all_threads=args.all_threads,
+            realtime_stats=args.realtime_stats,
+            mode=mode,
+            async_aware=args.async_mode if args.async_aware else None,
+            native=args.native,
+            gc=args.gc,
+            opcodes=args.opcodes,
+            blocking=args.blocking,
+            control_server=server,
+        )
+        _handle_output(collector, args, process.pid, mode)
 
 
 def _handle_live_attach(args, pid):
@@ -1323,19 +1379,29 @@ def _handle_live_attach(args, pid):
     )
 
     # Sample in live mode
-    sample_live(
-        pid,
-        collector,
-        duration_sec=args.duration,
-        all_threads=args.all_threads,
-        realtime_stats=args.realtime_stats,
-        mode=mode,
-        async_aware=args.async_mode if args.async_aware else None,
-        native=args.native,
-        gc=args.gc,
-        opcodes=args.opcodes,
-        blocking=args.blocking,
-    )
+    server = None
+    with contextlib.ExitStack() as stack:
+        if args.control:
+            server = ControlServer(args.control)
+            try:
+                server.start()
+            except ControlError as exc:
+                sys.exit(f"Error: {exc}")
+            stack.callback(server.stop)
+        sample_live(
+            pid,
+            collector,
+            duration_sec=args.duration,
+            all_threads=args.all_threads,
+            realtime_stats=args.realtime_stats,
+            mode=mode,
+            async_aware=args.async_mode if args.async_aware else None,
+            native=args.native,
+            gc=args.gc,
+            opcodes=args.opcodes,
+            blocking=args.blocking,
+            control_server=server,
+        )
 
 
 def _handle_live_run(args):
@@ -1370,20 +1436,30 @@ def _handle_live_run(args):
     )
 
     # Profile the subprocess in live mode
+    server = None
     try:
-        sample_live(
-            process.pid,
-            collector,
-            duration_sec=args.duration,
-            all_threads=args.all_threads,
-            realtime_stats=args.realtime_stats,
-            mode=mode,
-            async_aware=args.async_mode if args.async_aware else None,
-            native=args.native,
-            gc=args.gc,
-            opcodes=args.opcodes,
-            blocking=args.blocking,
-        )
+        with contextlib.ExitStack() as stack:
+            if args.control:
+                server = ControlServer(args.control)
+                try:
+                    server.start()
+                except ControlError as exc:
+                    sys.exit(f"Error: {exc}")
+                stack.callback(server.stop)
+            sample_live(
+                process.pid,
+                collector,
+                duration_sec=args.duration,
+                all_threads=args.all_threads,
+                realtime_stats=args.realtime_stats,
+                mode=mode,
+                async_aware=args.async_mode if args.async_aware else None,
+                native=args.native,
+                gc=args.gc,
+                opcodes=args.opcodes,
+                blocking=args.blocking,
+                control_server=server,
+            )
     finally:
         # Clean up the subprocess and get any error output
         returncode = process.poll()

--- a/Lib/profiling/sampling/errors.py
+++ b/Lib/profiling/sampling/errors.py
@@ -17,3 +17,9 @@ class SamplingModuleNotFoundError(SamplingProfilerError):
     def __init__(self, module_name):
         self.module_name = module_name
         super().__init__(f"Module '{module_name}' not found.")
+
+class ControlError(SamplingProfilerError):
+    """Base exception for profiler control channel errors."""
+
+class ControlURIError(ControlError):
+    """Raised when a control URI is malformed or has an unsupported scheme."""

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -149,6 +149,7 @@ class SampleProfiler:
                 if control_server is not None and current_time >= next_control_poll:
                     control_server.poll(timeout=0)
                     next_control_poll = current_time + 0.001
+                # Check if live collector or runtime control wants to stop
                 if not getattr(control, 'running', True) or not getattr(collector, 'running', True):
                     break
                 enabled = getattr(control, 'enabled', True)

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -125,8 +125,6 @@ class SampleProfiler:
         pending_timestamps = [] if aggregating else None
 
         control = control_server.control if control_server is not None else None
-        if control is not None:
-            control.sample_interval_usec = self.sample_interval_usec
 
         def flush_pending():
             nonlocal pending_count, pending_timestamps

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -135,14 +135,6 @@ class SampleProfiler:
             pending_timestamps = []
             collector.collect(prev_stack, timestamps_us=ts)
 
-        def wait(timeout):
-            if not timeout:
-                return
-            if control_server is not None:
-                control_server.poll(timeout=timeout)
-                return
-            time.sleep(timeout)
-
         try:
             while duration_sec is None or running_time_sec < duration_sec:
                 current_time = time.perf_counter()
@@ -158,7 +150,7 @@ class SampleProfiler:
                     if enabled_since is not None:
                         enabled_time_sec += current_time - enabled_since
                         enabled_since = None
-                    wait(sample_interval_sec)
+                    time.sleep(sample_interval_sec)
                     running_time_sec = time.perf_counter() - start_time
                     continue
 
@@ -172,7 +164,7 @@ class SampleProfiler:
                 if next_time > current_time:
                     sleep_time = (next_time - current_time) * 0.9
                     if sleep_time > 0.0001:
-                        wait(sleep_time)
+                        time.sleep(sleep_time)
                 elif next_time < current_time:
                     try:
                         stack_frames = self._get_stack_trace(

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -225,9 +225,10 @@ class SampleProfiler:
                 running_time_sec = time.perf_counter() - start_time
         except KeyboardInterrupt:
             interrupted = True
-            running_time_sec = time.perf_counter() - start_time
+            now = time.perf_counter()
+            running_time_sec = now - start_time
             if enabled_since is not None:
-                enabled_time_sec += time.perf_counter() - enabled_since
+                enabled_time_sec += now - enabled_since
             print("Interrupted by user.")
         finally:
             flush_pending()

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -102,20 +102,31 @@ class SampleProfiler:
         """Return a single stack snapshot from the target process."""
         return self._get_stack_trace(async_aware=async_aware)
 
-    def sample(self, collector, duration_sec=None, *, async_aware=False):
+    def sample(
+        self,
+        collector,
+        duration_sec=None,
+        *,
+        async_aware=False,
+        control_server=None,
+    ):
         sample_interval_sec = self.sample_interval_usec / 1_000_000
         num_samples = 0
         errors = 0
         interrupted = False
         running_time_sec = 0
-        start_time = next_time = time.perf_counter()
-        last_sample_time = start_time
+        enabled_time_sec = 0
         realtime_update_interval = 1.0  # Update every second
-        last_realtime_update = start_time
+        start_time = next_time = time.perf_counter()
+        enabled_since = last_sample_time = last_realtime_update = next_control_poll = start_time
         aggregating = getattr(collector, 'aggregating', False) is True
         prev_stack = None
         pending_count = 0
         pending_timestamps = [] if aggregating else None
+
+        control = control_server.control if control_server is not None else None
+        if control is not None:
+            control.sample_interval_usec = self.sample_interval_usec
 
         def flush_pending():
             nonlocal pending_count, pending_timestamps
@@ -126,18 +137,43 @@ class SampleProfiler:
             pending_timestamps = []
             collector.collect(prev_stack, timestamps_us=ts)
 
+        def wait(timeout):
+            if not timeout:
+                return
+            if control_server is not None:
+                control_server.poll(timeout=timeout)
+                return
+            time.sleep(timeout)
+
         try:
             while duration_sec is None or running_time_sec < duration_sec:
-                # Check if live collector wants to stop
-                if hasattr(collector, 'running') and not collector.running:
-                    break
-
                 current_time = time.perf_counter()
+                if control_server is not None and current_time >= next_control_poll:
+                    control_server.poll(timeout=0)
+                    next_control_poll = current_time + 0.001
+                if not getattr(control, 'running', True) or not getattr(collector, 'running', True):
+                    break
+                enabled = getattr(control, 'enabled', True)
+
+                if not enabled:
+                    if enabled_since is not None:
+                        enabled_time_sec += current_time - enabled_since
+                        enabled_since = None
+                    wait(sample_interval_sec)
+                    running_time_sec = time.perf_counter() - start_time
+                    continue
+
+                if enabled_since is None:
+                    enabled_since = current_time
+                    next_time = current_time + sample_interval_sec
+                    last_sample_time = current_time
+                    last_realtime_update = current_time
+
                 current_time_us = int(current_time * 1_000_000)
                 if next_time > current_time:
                     sleep_time = (next_time - current_time) * 0.9
                     if sleep_time > 0.0001:
-                        time.sleep(sleep_time)
+                        wait(sleep_time)
                 elif next_time < current_time:
                     try:
                         stack_frames = self._get_stack_trace(
@@ -191,17 +227,25 @@ class SampleProfiler:
         except KeyboardInterrupt:
             interrupted = True
             running_time_sec = time.perf_counter() - start_time
+            if enabled_since is not None:
+                enabled_time_sec += time.perf_counter() - enabled_since
             print("Interrupted by user.")
         finally:
             flush_pending()
+
+        if not interrupted:
+            final_time = time.perf_counter()
+            if enabled_since is not None:
+                enabled_time_sec += final_time - enabled_since
+            running_time_sec = final_time - start_time
 
         # Clear real-time stats line if it was being displayed
         if self.realtime_stats and len(self.sample_intervals) > 0:
             print()  # Add newline after real-time stats
 
-        sample_rate = num_samples / running_time_sec if running_time_sec > 0 else 0
+        sample_rate = num_samples / enabled_time_sec if enabled_time_sec > 0 else 0
         error_rate = (errors / num_samples) * 100 if num_samples > 0 else 0
-        expected_samples = int(running_time_sec / sample_interval_sec)
+        expected_samples = int(enabled_time_sec / sample_interval_sec)
         missed_samples = (expected_samples - num_samples) / expected_samples * 100 if expected_samples > 0 else 0
 
         # Don't print stats for live mode (curses is handling display)
@@ -427,6 +471,7 @@ def sample(
     gc=True,
     opcodes=False,
     blocking=False,
+    control_server=None,
 ):
     """Sample a process using the provided collector.
 
@@ -474,7 +519,12 @@ def sample(
     profiler.realtime_stats = realtime_stats
 
     # Run the sampling
-    profiler.sample(collector, duration_sec, async_aware=async_aware)
+    profiler.sample(
+        collector,
+        duration_sec,
+        async_aware=async_aware,
+        control_server=control_server,
+    )
 
     return collector
 
@@ -523,6 +573,7 @@ def sample_live(
     gc=True,
     opcodes=False,
     blocking=False,
+    control_server=None,
 ):
     """Sample a process in live/interactive mode with curses TUI.
 
@@ -544,6 +595,8 @@ def sample_live(
         The collector with collected samples
     """
     import curses
+
+    control = control_server.control if control_server is not None else None
 
     # Check if process is alive before doing any heavy initialization
     if not _is_process_running(pid):
@@ -576,7 +629,12 @@ def sample_live(
     def curses_wrapper_func(stdscr):
         collector.init_curses(stdscr)
         try:
-            profiler.sample(collector, duration_sec, async_aware=async_aware)
+            profiler.sample(
+                collector,
+                duration_sec,
+                async_aware=async_aware,
+                control_server=control_server,
+            )
             # If too few samples were collected, exit cleanly without showing TUI
             if collector.successful_samples < MIN_SAMPLES_FOR_TUI:
                 # Clear screen before exiting to avoid visual artifacts
@@ -586,7 +644,7 @@ def sample_live(
             # Mark as finished and keep the TUI running until user presses 'q'
             collector.mark_finished()
             # Keep processing input until user quits
-            while collector.running:
+            while collector.running and (control is None or control.running):
                 collector._handle_input()
                 time.sleep(0.05)  # Small sleep to avoid busy waiting
         finally:

--- a/Lib/test/test_profiling/test_sampling_profiler/test_control.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_control.py
@@ -110,13 +110,12 @@ class ControlServerTests(unittest.TestCase):
                     self.assertEqual(server.control.enabled, expected_enabled)
 
     def test_dispatch_status_format(self):
-        """status reply exposes enabled and rate_usec."""
+        """status reply exposes the enabled flag."""
         server = self.start_server()
-        server.control.sample_interval_usec = 1000
         client = self.connect()
         self.assertEqual(
             self.request(server, client, b"status\n"),
-            b"ok enabled=True rate_usec=1000\n",
+            b"ok enabled=True\n",
         )
 
     def test_dispatch_quit_sets_running_and_closes(self):
@@ -163,8 +162,11 @@ class ControlServerTests(unittest.TestCase):
     def test_cli_rejects_control_with_subprocesses(self):
         """--control and --subprocesses are mutually exclusive."""
         argv = [
-            "profiling.sampling.cli", "attach",
-            "--subprocesses", "--control", "unix:/tmp/x.sock",
+            "profiling.sampling.cli",
+            "attach",
+            "--subprocesses",
+            "--control",
+            "unix:/tmp/x.sock",
             "123",
         ]
         with (
@@ -181,8 +183,11 @@ class ControlServerTests(unittest.TestCase):
     def test_cli_rejects_bad_uri(self):
         """An unsupported control URI scheme is rejected during validation."""
         argv = [
-            "profiling.sampling.cli", "attach",
-            "--control", "fifo:/tmp/x", "123",
+            "profiling.sampling.cli",
+            "attach",
+            "--control",
+            "fifo:/tmp/x",
+            "123",
         ]
         with (
             mock.patch("sys.argv", argv),

--- a/Lib/test/test_profiling/test_sampling_profiler/test_control.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_control.py
@@ -1,0 +1,223 @@
+"""Tests for the sampling profiler control socket."""
+
+import io
+import os
+import shutil
+import socket
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+try:
+    from profiling.sampling._control import (
+        ControlServer,
+        _MAX_INBUF_BYTES,
+        parse_control_uri,
+    )
+    from profiling.sampling.cli import main
+    from profiling.sampling.errors import ControlError, ControlURIError
+except ImportError:
+    raise unittest.SkipTest(
+        "Test only runs when profiling.sampling is available"
+    )
+
+
+class ControlServerTests(unittest.TestCase):
+    """Tests for ControlServer protocol, lifecycle and CLI integration."""
+
+    def setUp(self):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+        self.path = os.path.join(tmpdir, "control.sock")
+
+    def start_server(self):
+        server = ControlServer(f"unix:{self.path}")
+        server.start()
+        self.addCleanup(server.stop)
+        return server
+
+    def connect(self):
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.connect(self.path)
+        client.setblocking(False)
+        self.addCleanup(client.close)
+        return client
+
+    def request(self, server, client, command):
+        client.sendall(command)
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            server.poll(timeout=0.05)
+            try:
+                return client.recv(4096)
+            except BlockingIOError:
+                pass
+        self.fail("timed out waiting for control reply")
+
+    def test_parse_control_uri_valid_unix(self):
+        """parse_control_uri returns (scheme, path) for unix: URIs."""
+        self.assertEqual(
+            parse_control_uri("unix:/tmp/tachyon.sock"),
+            ("unix", "/tmp/tachyon.sock"),
+        )
+
+    def test_parse_control_uri_rejects_invalids(self):
+        """parse_control_uri raises ControlURIError on malformed URIs."""
+        cases = [
+            ("/tmp/x", "must include a scheme"),
+            ("unix:", "path must not be empty"),
+            ("fifo:/tmp/x", "unsupported control URI scheme"),
+            ("", "must include a scheme"),
+        ]
+        for uri, expected in cases:
+            with self.subTest(uri=uri):
+                with self.assertRaisesRegex(ControlURIError, expected):
+                    parse_control_uri(uri)
+
+    def test_start_creates_and_stop_unlinks_socket(self):
+        """start() binds the socket on disk; stop() removes it."""
+        server = ControlServer(f"unix:{self.path}")
+        server.start()
+        try:
+            self.assertTrue(os.path.exists(self.path))
+        finally:
+            server.stop()
+        self.assertFalse(os.path.exists(self.path))
+
+    def test_start_fails_on_occupied_path(self):
+        """start() raises ControlError when the path is already bound."""
+        squatter = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        squatter.bind(self.path)
+        self.addCleanup(squatter.close)
+        with self.assertRaisesRegex(ControlError, "failed to start"):
+            ControlServer(f"unix:{self.path}").start()
+
+    def test_dispatch_basic_commands(self):
+        """enable/disable/ping/unknown produce the documented replies."""
+        server = self.start_server()
+        client = self.connect()
+        cases = [
+            (b"enable\n", b"ok\n", True),
+            (b"disable\n", b"ok\n", False),
+            (b"ping\n", b"ok\n", False),
+            (b"pingu nut nut\n", b"err unknown_command\n", False),
+        ]
+        for command, reply, expected_enabled in cases:
+            with self.subTest(command=command):
+                self.assertEqual(self.request(server, client, command), reply)
+                if command in (b"enable\n", b"disable\n"):
+                    self.assertEqual(server.control.enabled, expected_enabled)
+
+    def test_dispatch_status_format(self):
+        """status reply exposes enabled and rate_usec."""
+        server = self.start_server()
+        server.control.sample_interval_usec = 1000
+        client = self.connect()
+        self.assertEqual(
+            self.request(server, client, b"status\n"),
+            b"ok enabled=True rate_usec=1000\n",
+        )
+
+    def test_dispatch_quit_sets_running_and_closes(self):
+        """quit replies ok, sets running=False, and closes the connection."""
+        server = self.start_server()
+        client = self.connect()
+        self.assertEqual(self.request(server, client, b"quit\n"), b"ok\n")
+        self.assertFalse(server.control.running)
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            server.poll(timeout=0.05)
+            try:
+                chunk = client.recv(4096)
+            except BlockingIOError:
+                continue
+            self.assertEqual(chunk, b"")
+            return
+        self.fail("server did not close the connection after quit")
+
+    def test_inbuf_overflow_drops_connection(self):
+        """A client filling the input buffer without a newline is dropped."""
+        server = self.start_server()
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.connect(self.path)
+        self.addCleanup(client.close)
+        client.sendall(b"x" * (_MAX_INBUF_BYTES + 1))
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            server.poll(timeout=0.05)
+            if not server._connections:
+                return
+        self.fail("server did not drop client over the inbuf cap")
+
+    def test_close_listener_preserves_replaced_path(self):
+        """stop() refuses to unlink a different file at the same path."""
+        server = self.start_server()
+        os.unlink(self.path)
+        replacement = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        replacement.bind(self.path)
+        self.addCleanup(replacement.close)
+        server.stop()
+        self.assertTrue(os.path.exists(self.path))
+
+    def test_cli_rejects_control_with_subprocesses(self):
+        """--control and --subprocesses are mutually exclusive."""
+        argv = [
+            "profiling.sampling.cli", "attach",
+            "--subprocesses", "--control", "unix:/tmp/x.sock",
+            "123",
+        ]
+        with (
+            mock.patch("sys.argv", argv),
+            mock.patch("sys.stderr", io.StringIO()) as stderr,
+            self.assertRaises(SystemExit) as cm,
+        ):
+            main()
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn(
+            "--control is incompatible with --subprocesses", stderr.getvalue()
+        )
+
+    def test_cli_rejects_bad_uri(self):
+        """An unsupported control URI scheme is rejected during validation."""
+        argv = [
+            "profiling.sampling.cli", "attach",
+            "--control", "fifo:/tmp/x", "123",
+        ]
+        with (
+            mock.patch("sys.argv", argv),
+            mock.patch("sys.stderr", io.StringIO()) as stderr,
+            self.assertRaises(SystemExit) as cm,
+        ):
+            main()
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("unsupported control URI scheme", stderr.getvalue())
+
+    def test_cli_accepts_control_with_live(self):
+        """--control and --live coexist after the mutex was dropped."""
+        argv = [
+            "profiling.sampling.cli",
+            "attach",
+            "--live",
+            "--control",
+            "unix:/tmp/ignored.sock",
+            "123",
+        ]
+        with (
+            mock.patch("sys.argv", argv),
+            mock.patch("sys.stderr", io.StringIO()) as stderr,
+            mock.patch(
+                "profiling.sampling.cli._is_process_running", return_value=True
+            ),
+            mock.patch("profiling.sampling.cli._handle_live_attach") as live,
+        ):
+            main()
+        self.assertNotIn("incompatible with --live", stderr.getvalue())
+        live.assert_called_once()
+        (forwarded_args, forwarded_pid), _ = live.call_args
+        self.assertEqual(forwarded_args.control, "unix:/tmp/ignored.sock")
+        self.assertTrue(forwarded_args.live)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_profiling/test_sampling_profiler/test_control.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_control.py
@@ -2,12 +2,12 @@
 
 import io
 import os
-import shutil
 import socket
-import tempfile
 import time
 import unittest
 from unittest import mock
+
+from test.support import SHORT_TIMEOUT, os_helper, socket_helper
 
 try:
     from profiling.sampling._control import (
@@ -15,7 +15,7 @@ try:
         _MAX_INBUF_BYTES,
         parse_control_uri,
     )
-    from profiling.sampling.cli import main
+    from profiling.sampling.cli import LiveStatsCollector, main
     from profiling.sampling.errors import ControlError, ControlURIError
 except ImportError:
     raise unittest.SkipTest(
@@ -23,13 +23,13 @@ except ImportError:
     )
 
 
+@socket_helper.skip_unless_bind_unix_socket
 class ControlServerTests(unittest.TestCase):
     """Tests for ControlServer protocol, lifecycle and CLI integration."""
 
     def setUp(self):
-        tmpdir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
-        self.path = os.path.join(tmpdir, "control.sock")
+        self.path = socket_helper.create_unix_domain_name()
+        self.addCleanup(os_helper.unlink, self.path)
 
     def start_server(self):
         server = ControlServer(f"unix:{self.path}")
@@ -46,7 +46,7 @@ class ControlServerTests(unittest.TestCase):
 
     def request(self, server, client, command):
         client.sendall(command)
-        deadline = time.monotonic() + 1.0
+        deadline = time.monotonic() + SHORT_TIMEOUT
         while time.monotonic() < deadline:
             server.poll(timeout=0.05)
             try:
@@ -88,7 +88,7 @@ class ControlServerTests(unittest.TestCase):
     def test_start_fails_on_occupied_path(self):
         """start() raises ControlError when the path is already bound."""
         squatter = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        squatter.bind(self.path)
+        socket_helper.bind_unix_socket(squatter, self.path)
         self.addCleanup(squatter.close)
         with self.assertRaisesRegex(ControlError, "failed to start"):
             ControlServer(f"unix:{self.path}").start()
@@ -124,7 +124,7 @@ class ControlServerTests(unittest.TestCase):
         client = self.connect()
         self.assertEqual(self.request(server, client, b"quit\n"), b"ok\n")
         self.assertFalse(server.control.running)
-        deadline = time.monotonic() + 1.0
+        deadline = time.monotonic() + SHORT_TIMEOUT
         while time.monotonic() < deadline:
             server.poll(timeout=0.05)
             try:
@@ -142,7 +142,7 @@ class ControlServerTests(unittest.TestCase):
         client.connect(self.path)
         self.addCleanup(client.close)
         client.sendall(b"x" * (_MAX_INBUF_BYTES + 1))
-        deadline = time.monotonic() + 1.0
+        deadline = time.monotonic() + SHORT_TIMEOUT
         while time.monotonic() < deadline:
             server.poll(timeout=0.05)
             if not server._connections:
@@ -154,7 +154,7 @@ class ControlServerTests(unittest.TestCase):
         server = self.start_server()
         os.unlink(self.path)
         replacement = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        replacement.bind(self.path)
+        socket_helper.bind_unix_socket(replacement, self.path)
         self.addCleanup(replacement.close)
         server.stop()
         self.assertTrue(os.path.exists(self.path))
@@ -198,6 +198,8 @@ class ControlServerTests(unittest.TestCase):
         self.assertEqual(cm.exception.code, 2)
         self.assertIn("unsupported control URI scheme", stderr.getvalue())
 
+    @unittest.skipUnless(LiveStatsCollector is not None,
+                         "requires curses for --live")
     def test_cli_accepts_control_with_live(self):
         """--control and --live coexist after the mutex was dropped."""
         argv = [

--- a/Lib/test/test_profiling/test_sampling_profiler/test_integration.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_integration.py
@@ -5,9 +5,11 @@ import io
 import marshal
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from unittest import mock
 
@@ -32,6 +34,7 @@ from test.support import (
 from .helpers import (
     test_subprocess,
     close_and_unlink,
+    _cleanup_process,
 )
 from .mocks import MockFrameInfo, MockThreadInfo, MockInterpreterInfo
 
@@ -953,3 +956,63 @@ class TestDeepGeneratorFrameCache(unittest.TestCase):
             f"missing the entry point function 'run_forever'. This indicates "
             f"incomplete stacks are being returned, likely due to frame cache "
             f"storing partial stack traces.")
+
+
+@requires_remote_subprocess_debugging()
+@unittest.skipIf(
+    sys.platform == "darwin" and os.geteuid() != 0,
+    "macOS profiling requires elevated permissions",
+)
+class TestControlSocketIntegration(unittest.TestCase):
+    """End-to-end tests for the --control socket via a real profiler subprocess."""
+
+    def _send_recv(self, client, request, expected_reply):
+        client.sendall(request)
+        self.assertEqual(client.recv(4096), expected_reply)
+
+    def test_control_socket_disable_enable_quit_cycle(self):
+        """Drive disable/enable/quit through a real ControlServer subprocess."""
+        script = '''
+import time
+_test_sock.sendall(b"working")
+for _ in range(200):
+    sum(i * i for i in range(50_000))
+    time.sleep(0.05)
+'''
+        with test_subprocess(script, wait_for_working=True) as target:
+            tmpdir = tempfile.mkdtemp()
+            self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+            socket_path = os.path.join(tmpdir, "tachyon.sock")
+
+            profiler = subprocess.Popen(
+                [sys.executable, "-m", "profiling.sampling", "attach",
+                 "--control", f"unix:{socket_path}",
+                 "-d", "30",
+                 str(target.process.pid)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            self.addCleanup(_cleanup_process, profiler)
+
+            deadline = time.monotonic() + SHORT_TIMEOUT
+            while time.monotonic() < deadline:
+                if os.path.exists(socket_path):
+                    break
+                time.sleep(0.05)
+            else:
+                self.fail("profiler did not create the control socket")
+
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                client.settimeout(SHORT_TIMEOUT)
+                client.connect(socket_path)
+                self._send_recv(client, b"disable\n", b"ok\n")
+                time.sleep(0.2)
+                self._send_recv(client, b"enable\n", b"ok\n")
+                self._send_recv(client, b"quit\n", b"ok\n")
+
+            stdout, stderr = profiler.communicate(timeout=SHORT_TIMEOUT)
+            self.assertEqual(
+                profiler.returncode, 0,
+                msg=f"stdout={stdout!r} stderr={stderr!r}",
+            )
+            self.assertFalse(os.path.exists(socket_path))

--- a/Lib/test/test_profiling/test_sampling_profiler/test_integration.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_integration.py
@@ -9,6 +9,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
 from unittest import mock
@@ -17,6 +18,7 @@ try:
     import _remote_debugging
     import profiling.sampling
     import profiling.sampling.sample
+    from profiling.sampling._control import ControlServer
     from profiling.sampling.pstats_collector import PstatsCollector
     from profiling.sampling.stack_collector import CollapsedStackCollector
     from profiling.sampling.sample import SampleProfiler, _is_process_running
@@ -29,12 +31,13 @@ except ImportError:
 from test.support import (
     requires_remote_subprocess_debugging,
     SHORT_TIMEOUT,
+    os_helper,
+    socket_helper,
 )
 
 from .helpers import (
     test_subprocess,
     close_and_unlink,
-    _cleanup_process,
 )
 from .mocks import MockFrameInfo, MockThreadInfo, MockInterpreterInfo
 
@@ -959,19 +962,20 @@ class TestDeepGeneratorFrameCache(unittest.TestCase):
 
 
 @requires_remote_subprocess_debugging()
+@socket_helper.skip_unless_bind_unix_socket
 @unittest.skipIf(
     sys.platform == "darwin" and os.geteuid() != 0,
     "macOS profiling requires elevated permissions",
 )
 class TestControlSocketIntegration(unittest.TestCase):
-    """End-to-end tests for the --control socket via a real profiler subprocess."""
+    """End-to-end tests for the --control socket via in-process sample()."""
 
     def _send_recv(self, client, request, expected_reply):
         client.sendall(request)
         self.assertEqual(client.recv(4096), expected_reply)
 
     def test_control_socket_disable_enable_quit_cycle(self):
-        """Drive disable/enable/quit through a real ControlServer subprocess."""
+        """Drive disable/enable/quit through a real ControlServer."""
         script = '''
 import time
 _test_sock.sendall(b"working")
@@ -980,27 +984,31 @@ for _ in range(200):
     time.sleep(0.05)
 '''
         with test_subprocess(script, wait_for_working=True) as target:
-            tmpdir = tempfile.mkdtemp()
-            self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
-            socket_path = os.path.join(tmpdir, "tachyon.sock")
+            socket_path = socket_helper.create_unix_domain_name()
+            self.addCleanup(os_helper.unlink, socket_path)
 
-            profiler = subprocess.Popen(
-                [sys.executable, "-m", "profiling.sampling", "attach",
-                 "--control", f"unix:{socket_path}",
-                 "-d", "30",
-                 str(target.process.pid)],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            self.addCleanup(_cleanup_process, profiler)
+            server = ControlServer(f"unix:{socket_path}")
+            server.start()
+            self.addCleanup(server.stop)
 
-            deadline = time.monotonic() + SHORT_TIMEOUT
-            while time.monotonic() < deadline:
-                if os.path.exists(socket_path):
-                    break
-                time.sleep(0.05)
-            else:
-                self.fail("profiler did not create the control socket")
+            exception = [None]
+
+            collector = PstatsCollector(sample_interval_usec=1000, skip_idle=False)
+
+            def sample_worker():
+                try:
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        profiling.sampling.sample.sample(
+                            target.process.pid,
+                            collector,
+                            duration_sec=SHORT_TIMEOUT,
+                            control_server=server,
+                        )
+                except Exception as exc:
+                    exception[0] = exc
+
+            thread = threading.Thread(target=sample_worker, daemon=True)
+            thread.start()
 
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
                 client.settimeout(SHORT_TIMEOUT)
@@ -1010,9 +1018,7 @@ for _ in range(200):
                 self._send_recv(client, b"enable\n", b"ok\n")
                 self._send_recv(client, b"quit\n", b"ok\n")
 
-            stdout, stderr = profiler.communicate(timeout=SHORT_TIMEOUT)
-            self.assertEqual(
-                profiler.returncode, 0,
-                msg=f"stdout={stdout!r} stderr={stderr!r}",
-            )
-            self.assertFalse(os.path.exists(socket_path))
+            thread.join(timeout=SHORT_TIMEOUT)
+            self.assertFalse(thread.is_alive(), "sample() did not exit on quit")
+            if exception[0] is not None:
+                raise exception[0]

--- a/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
@@ -436,29 +436,10 @@ class TestSampleProfiler(unittest.TestCase):
     @staticmethod
     def _fake_control_server(*, enabled=True, running=True):
         """Build a minimal control_server stub for sample() integration."""
-        control = types.SimpleNamespace(
-            enabled=enabled, running=running, sample_interval_usec=0,
-        )
+        control = types.SimpleNamespace(enabled=enabled, running=running)
         server = mock.MagicMock()
         server.control = control
         return server
-
-    def test_sample_passes_interval_to_control_server(self):
-        """Test that sample() copies its interval into control.sample_interval_usec."""
-        control_server = self._fake_control_server(running=False)
-        with self._patched_unwinder() as u:
-            u.instance.get_stack_trace.return_value = []
-            profiler = SampleProfiler(
-                pid=12345, sample_interval_usec=4242, all_threads=False
-            )
-            with io.StringIO() as output:
-                with mock.patch("sys.stdout", output):
-                    profiler.sample(
-                        mock.MagicMock(),
-                        duration_sec=10,
-                        control_server=control_server,
-                    )
-        self.assertEqual(control_server.control.sample_interval_usec, 4242)
 
     def test_sample_polls_control_server_periodically(self):
         """Test that sample() drives control_server.poll() during the loop."""
@@ -523,9 +504,7 @@ class TestSampleProfiler(unittest.TestCase):
 
     def test_sample_resumes_after_re_enable(self):
         """Test that sampling resumes when control flips from disabled to enabled."""
-        control = types.SimpleNamespace(
-            enabled=False, running=True, sample_interval_usec=0,
-        )
+        control = types.SimpleNamespace(enabled=False, running=True)
         control_server = mock.MagicMock()
         control_server.control = control
 
@@ -556,9 +535,7 @@ class TestSampleProfiler(unittest.TestCase):
 
     def test_sample_rate_reflects_enabled_time(self):
         """Test that Sample rate divides by enabled time, not wall time."""
-        control = types.SimpleNamespace(
-            enabled=False, running=True, sample_interval_usec=0,
-        )
+        control = types.SimpleNamespace(enabled=False, running=True)
         control_server = mock.MagicMock()
         control_server.control = control
 

--- a/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
@@ -210,7 +210,6 @@ class TestSampleProfiler(unittest.TestCase):
 
         stack_frames = [mock.sentinel.stack_frames]
         mock_collector = mock.MagicMock()
-        mock_collector.aggregating = False
 
         with self._patched_unwinder() as u:
             u.instance.get_stack_trace.return_value = stack_frames
@@ -445,7 +444,6 @@ class TestSampleProfiler(unittest.TestCase):
         """Test that sample() drives control_server.poll() during the loop."""
         control_server = self._fake_control_server()
         mock_collector = mock.MagicMock()
-        mock_collector.aggregating = False
         times = [1000.0 + i * 0.01 for i in range(60)]
         with self._patched_unwinder() as u:
             u.instance.get_stack_trace.return_value = []
@@ -466,7 +464,6 @@ class TestSampleProfiler(unittest.TestCase):
         """Test that sample() exits immediately when control.running is False."""
         control_server = self._fake_control_server(running=False)
         mock_collector = mock.MagicMock()
-        mock_collector.aggregating = False
         with self._patched_unwinder() as u:
             u.instance.get_stack_trace.return_value = []
             profiler = SampleProfiler(
@@ -485,7 +482,6 @@ class TestSampleProfiler(unittest.TestCase):
         """Test that disabled state stops sample collection."""
         control_server = self._fake_control_server(enabled=False)
         mock_collector = mock.MagicMock()
-        mock_collector.aggregating = False
         times = [1000.0 + i * 0.01 for i in range(60)]
         with self._patched_unwinder() as u:
             u.instance.get_stack_trace.return_value = []
@@ -514,7 +510,6 @@ class TestSampleProfiler(unittest.TestCase):
         control_server.poll.side_effect = poll_side_effect
 
         mock_collector = mock.MagicMock()
-        mock_collector.aggregating = False
         times = [1000.0 + i * 0.01 for i in range(80)]
         with self._patched_unwinder() as u:
             u.instance.get_stack_trace.return_value = [
@@ -545,7 +540,6 @@ class TestSampleProfiler(unittest.TestCase):
         control_server.poll.side_effect = poll_side_effect
 
         mock_collector = mock.MagicMock()
-        mock_collector.aggregating = False
         times = [1000.0 + i * 0.01 for i in range(120)]
         with self._patched_unwinder() as u:
             u.instance.get_stack_trace.return_value = [

--- a/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
@@ -223,7 +223,7 @@ class TestSampleProfiler(unittest.TestCase):
                 pid=12345, sample_interval_usec=10000, all_threads=False
             )
 
-            times = [0.0, 0.01, 0.011, 0.02, 0.03]
+            times = [0.0, 0.01, 0.011, 0.02, 0.03, 0.04, 0.05]
             with mock.patch("time.perf_counter", side_effect=times):
                 with io.StringIO() as output:
                     with mock.patch("sys.stdout", output):
@@ -260,6 +260,7 @@ class TestSampleProfiler(unittest.TestCase):
                 0.03, 0.031,
                 0.04, 0.041,
                 0.05, 0.051,
+                0.06, 0.061,
             ]
             with mock.patch("profiling.sampling.sample.MAX_PENDING_SAMPLES", 2):
                 with mock.patch("time.perf_counter", side_effect=times):
@@ -322,7 +323,7 @@ class TestSampleProfiler(unittest.TestCase):
             mock_collector = mock.MagicMock()
 
             # Control timing to run exactly 5 samples
-            times = [0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06]
+            times = [0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08]
 
             with mock.patch("time.perf_counter", side_effect=times):
                 with io.StringIO() as output:
@@ -376,6 +377,9 @@ class TestSampleProfiler(unittest.TestCase):
                 0.5,
                 0.6,
                 0.7,
+                0.8,
+                0.9,
+                1.0,
             ]  # Extra time points to avoid StopIteration
 
             with mock.patch("time.perf_counter", side_effect=times):
@@ -413,7 +417,7 @@ class TestSampleProfiler(unittest.TestCase):
                 pid=12345, sample_interval_usec=10000, all_threads=False
             )
             mock_collector = mock.MagicMock()
-            times = [0.0, 0.01, 0.02, 0.03, 0.04]
+            times = [0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06]
             with mock.patch("time.perf_counter", side_effect=times):
                 with io.StringIO() as output:
                     with mock.patch("sys.stdout", output):
@@ -428,6 +432,164 @@ class TestSampleProfiler(unittest.TestCase):
             self.assertIn("Captured", result)
             self.assertIn("samples", result)
             self.assertNotIn("Warning: missed", result)
+
+    @staticmethod
+    def _fake_control_server(*, enabled=True, running=True):
+        """Build a minimal control_server stub for sample() integration."""
+        control = types.SimpleNamespace(
+            enabled=enabled, running=running, sample_interval_usec=0,
+        )
+        server = mock.MagicMock()
+        server.control = control
+        return server
+
+    def test_sample_passes_interval_to_control_server(self):
+        """Test that sample() copies its interval into control.sample_interval_usec."""
+        control_server = self._fake_control_server(running=False)
+        with self._patched_unwinder() as u:
+            u.instance.get_stack_trace.return_value = []
+            profiler = SampleProfiler(
+                pid=12345, sample_interval_usec=4242, all_threads=False
+            )
+            with io.StringIO() as output:
+                with mock.patch("sys.stdout", output):
+                    profiler.sample(
+                        mock.MagicMock(),
+                        duration_sec=10,
+                        control_server=control_server,
+                    )
+        self.assertEqual(control_server.control.sample_interval_usec, 4242)
+
+    def test_sample_polls_control_server_periodically(self):
+        """Test that sample() drives control_server.poll() during the loop."""
+        control_server = self._fake_control_server()
+        mock_collector = mock.MagicMock()
+        mock_collector.aggregating = False
+        times = [1000.0 + i * 0.01 for i in range(60)]
+        with self._patched_unwinder() as u:
+            u.instance.get_stack_trace.return_value = []
+            profiler = SampleProfiler(
+                pid=12345, sample_interval_usec=10000, all_threads=False
+            )
+            with mock.patch("time.perf_counter", side_effect=times):
+                with io.StringIO() as output:
+                    with mock.patch("sys.stdout", output):
+                        profiler.sample(
+                            mock_collector,
+                            duration_sec=0.2,
+                            control_server=control_server,
+                        )
+        self.assertTrue(control_server.poll.called)
+
+    def test_sample_breaks_when_control_running_false(self):
+        """Test that sample() exits immediately when control.running is False."""
+        control_server = self._fake_control_server(running=False)
+        mock_collector = mock.MagicMock()
+        mock_collector.aggregating = False
+        with self._patched_unwinder() as u:
+            u.instance.get_stack_trace.return_value = []
+            profiler = SampleProfiler(
+                pid=12345, sample_interval_usec=10000, all_threads=False
+            )
+            with io.StringIO() as output:
+                with mock.patch("sys.stdout", output):
+                    profiler.sample(
+                        mock_collector,
+                        duration_sec=60,
+                        control_server=control_server,
+                    )
+        mock_collector.collect.assert_not_called()
+
+    def test_sample_pauses_when_control_disabled(self):
+        """Test that disabled state stops sample collection."""
+        control_server = self._fake_control_server(enabled=False)
+        mock_collector = mock.MagicMock()
+        mock_collector.aggregating = False
+        times = [1000.0 + i * 0.01 for i in range(60)]
+        with self._patched_unwinder() as u:
+            u.instance.get_stack_trace.return_value = []
+            profiler = SampleProfiler(
+                pid=12345, sample_interval_usec=10000, all_threads=False
+            )
+            with mock.patch("time.perf_counter", side_effect=times):
+                with io.StringIO() as output:
+                    with mock.patch("sys.stdout", output):
+                        profiler.sample(
+                            mock_collector,
+                            duration_sec=0.2,
+                            control_server=control_server,
+                        )
+        mock_collector.collect.assert_not_called()
+
+    def test_sample_resumes_after_re_enable(self):
+        """Test that sampling resumes when control flips from disabled to enabled."""
+        control = types.SimpleNamespace(
+            enabled=False, running=True, sample_interval_usec=0,
+        )
+        control_server = mock.MagicMock()
+        control_server.control = control
+
+        def poll_side_effect(timeout=0):
+            if control_server.poll.call_count >= 3:
+                control.enabled = True
+        control_server.poll.side_effect = poll_side_effect
+
+        mock_collector = mock.MagicMock()
+        mock_collector.aggregating = False
+        times = [1000.0 + i * 0.01 for i in range(80)]
+        with self._patched_unwinder() as u:
+            u.instance.get_stack_trace.return_value = [
+                (1, [mock.MagicMock(filename="t.py", lineno=1, funcname="f")])
+            ]
+            profiler = SampleProfiler(
+                pid=12345, sample_interval_usec=10000, all_threads=False
+            )
+            with mock.patch("time.perf_counter", side_effect=times):
+                with io.StringIO() as output:
+                    with mock.patch("sys.stdout", output):
+                        profiler.sample(
+                            mock_collector,
+                            duration_sec=0.3,
+                            control_server=control_server,
+                        )
+        self.assertGreater(mock_collector.collect.call_count, 0)
+
+    def test_sample_rate_reflects_enabled_time(self):
+        """Test that Sample rate divides by enabled time, not wall time."""
+        control = types.SimpleNamespace(
+            enabled=False, running=True, sample_interval_usec=0,
+        )
+        control_server = mock.MagicMock()
+        control_server.control = control
+
+        def poll_side_effect(timeout=0):
+            if control_server.poll.call_count >= 10:
+                control.enabled = True
+        control_server.poll.side_effect = poll_side_effect
+
+        mock_collector = mock.MagicMock()
+        mock_collector.aggregating = False
+        times = [1000.0 + i * 0.01 for i in range(120)]
+        with self._patched_unwinder() as u:
+            u.instance.get_stack_trace.return_value = [
+                (1, [mock.MagicMock(filename="t.py", lineno=1, funcname="f")])
+            ]
+            profiler = SampleProfiler(
+                pid=12345, sample_interval_usec=10000, all_threads=False
+            )
+            with mock.patch("time.perf_counter", side_effect=times):
+                with io.StringIO() as output:
+                    with mock.patch("sys.stdout", output):
+                        profiler.sample(
+                            mock_collector,
+                            duration_sec=0.5,
+                            control_server=control_server,
+                        )
+        mock_collector.set_stats.assert_called_once()
+        args = mock_collector.set_stats.call_args.args
+        running_time_sec, sample_rate = args[1], args[2]
+        samples = mock_collector.collect.call_count
+        self.assertGreater(sample_rate, samples / running_time_sec)
 
 
 @force_not_colorized_test_class

--- a/Misc/NEWS.d/next/Library/2026-05-17-21-48-02.gh-issue-149958.6rG3lT.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-17-21-48-02.gh-issue-149958.6rG3lT.rst
@@ -1,0 +1,3 @@
+The Tachyon module now supports runtime control over a unix socket, via
+``--control unix:<path>``. Supported commands are ``enable``, ``disable``,
+``ping``, ``status`` and ``quit``. Patch by Maurycy Pawłowski-Wieroński.


### PR DESCRIPTION
Only `unix:` for starters:

```
Control socket:
  --control URI         control socket URI (unix:<path>) (default: None)
```

Supported commands are `enable`, `disable`, `ping`, `status` and `quit`.  Each command is confirmed with either `ok` or `err`.

Example session:

```
[1] 2026-05-17T21:18:38.400172000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (tachyon-runtime-socket ed77e71) % sudo -E ./python.exe -m profiling.sampling run --control unix:/tmp/tachyon.sock -r 666khz -m test test_asyncio &>/dev/null &
[1] 84494
2026-05-17T21:18:41.130015000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (tachyon-runtime-socket ed77e71) % echo -e 'ping' | sudo nc -U /tmp/tachyon.sock
ok
2026-05-17T21:18:42.759758000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (tachyon-runtime-socket ed77e71) % echo -e 'status' | sudo nc -U /tmp/tachyon.sock
ok enabled=True 
2026-05-17T21:18:44.875693000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (tachyon-runtime-socket ed77e71) % echo -e 'enable' | sudo nc -U /tmp/tachyon.sock
ok
2026-05-17T21:18:46.871140000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (tachyon-runtime-socket ed77e71) % echo -e 'disable' | sudo nc -U /tmp/tachyon.sock
ok
2026-05-17T21:18:48.756932000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (tachyon-runtime-socket ed77e71) % echo -e 'enable' | sudo nc -U /tmp/tachyon.sock
ok
2026-05-17T21:18:49.083766000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (tachyon-runtime-socket ed77e71) % echo -e 'zażółć gęślą jaźn' | sudo nc -U /tmp/tachyon.sock
err unknown_command
2026-05-17T21:18:50.670507000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (tachyon-runtime-socket ed77e71) % echo -e 'quit' | sudo nc -U /tmp/tachyon.sock
ok
[1]  + done       sudo -E ./python.exe -m profiling.sampling run --control  -r 666khz -m test 
```

Closes #149958


<!-- gh-issue-number: gh-145411 -->
* Issue: gh-145411
<!-- /gh-issue-number -->
