### PR TITLE
gh-138325: steal list items in INTRINSIC_LIST_TO_TUPLE

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-17-12-00-00.gh-issue-138325.h2XSfe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-17-12-00-00.gh-issue-138325.h2XSfe.rst
@@ -1,0 +1,3 @@
+Speed up converting a list to a tuple in the ``tuple(genexpr)`` fast path
+and in starred tuple displays (e.g. ``(*a, *b)``) by stealing the list's
+items into the tuple instead of copying them.

--- a/Python/intrinsics.c
+++ b/Python/intrinsics.c
@@ -7,6 +7,8 @@
 #include "pycore_genobject.h"     // _PyAsyncGenValueWrapperNew
 #include "pycore_interpframe.h"   // _PyFrame_GetLocals()
 #include "pycore_intrinsics.h"    // INTRINSIC_PRINT
+#include "pycore_list.h"          // _PyList_AsTupleAndClear()
+#include "pycore_object.h"        // _PyObject_IsUniquelyReferenced()
 #include "pycore_pyerrors.h"      // _PyErr_SetString()
 #include "pycore_runtime.h"       // _Py_ID()
 #include "pycore_typevarobject.h" // _Py_make_typevar()
@@ -190,8 +192,12 @@ unary_pos(PyThreadState* unused, PyObject *value)
 static PyObject *
 list_to_tuple(PyThreadState* unused, PyObject *v)
 {
-    assert(PyList_Check(v));
-    return PyTuple_FromArray(((PyListObject *)v)->ob_item, Py_SIZE(v));
+    /* INTRINSIC_LIST_TO_TUPLE is only emitted by the compiler for a
+       freshly-built, uniquely-referenced temporary list, so steal its items
+       into the tuple instead of copying them. */
+    assert(PyList_CheckExact(v));
+    assert(_PyObject_IsUniquelyReferenced(v));
+    return _PyList_AsTupleAndClear((PyListObject *)v);
 }
 
 static PyObject *


### PR DESCRIPTION
`INTRINSIC_LIST_TO_TUPLE` is only emitted by the compiler for a freshly-built, uniquely-referenced temporary list. We can steal its items into the tuple via `_PyList_AsTupleAndClear` instead of copying them with `PyTuple_FromArray`.

Benchmark results:

| Benchmark         | main    | PR                       |
|-------------------|---------|--------------------------|
| tuple(genexpr)    | 23.6 us | 22.2 us: 1.07x faster    |
| (*genexpr,)       | 26.1 us | 24.8 us: 1.05x faster    |
| (*[listcomp],)    | 19.1 us | 17.7 us: 1.08x faster    |
| tuple([listcomp]) | 17.5 us | 17.5 us: not significant |
| Geometric mean    | (ref)   | 1.05x faster    

`tuple([listcomp])` (a plain `tuple()` call, no intrinsic) is a control benchmark

<details>
<summary>Benchmark script</summary>

```python
import pyperf

CASES = {
    "tuple(genexpr)":    "tuple(2*x for x in range(1000))",
    "tuple([listcomp])": "tuple([2*x for x in range(1000)])",
    "(*genexpr,)":       "(*(2*x for x in range(1000)),)",
    "(*[listcomp],)":    "(*[2*x for x in range(1000)],)",
}

runner = pyperf.Runner()
for name, stmt in CASES.items():
    runner.timeit(name=name, stmt=stmt)
```

Run: `python bench.py -o OUT.json`, then
`python -m pyperf compare_to main.json branch.json --table`.
</details>



<!-- gh-issue-number: gh-138325 -->
* Issue: gh-138325
<!-- /gh-issue-number -->
