### PR TITLE
gh-149835: `_destinsrc` to use realpath instead of abspath

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -940,8 +940,8 @@ def move(src, dst, copy_function=copy2):
     return real_dst
 
 def _destinsrc(src, dst):
-    src = os.path.abspath(src)
-    dst = os.path.abspath(dst)
+    src = os.path.realpath(src)
+    dst = os.path.realpath(dst)
     if not src.endswith(os.path.sep):
         src += os.path.sep
     if not dst.endswith(os.path.sep):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2915,6 +2915,23 @@ class TestMove(BaseTest, unittest.TestCase):
             os_helper.rmtree(TESTFN)
 
     @os_helper.skip_unless_symlink
+    def test_destinsrc_symlink_bypass(self):
+        tmp = self.mkdtemp()
+        src = os.path.join(tmp, 'src')
+        os.makedirs(src)
+        # tmp/link -> tmp (one level up)
+        link = os.path.join(tmp, 'link')
+        os.symlink(tmp, link)
+        # raw path: tmp/link/src/sub - no src prefix in string space
+        # real path: tmp/src/sub     - physically inside src
+        dst = os.path.join(link, 'src', 'sub')
+        self.assertTrue(
+            shutil._destinsrc(src, dst),
+            msg='_destinsrc failed to detect dst inside src via symlink '
+                '(dst=%s, src=%s)' % (dst, src),
+        )
+
+    @os_helper.skip_unless_symlink
     @mock_rename
     def test_move_file_symlink(self):
         dst = os.path.join(self.src_dir, 'bar')

--- a/Misc/NEWS.d/next/Security/2026-05-18-17-46-00.gh-issue-149835.EebFlk.rst
+++ b/Misc/NEWS.d/next/Security/2026-05-18-17-46-00.gh-issue-149835.EebFlk.rst
@@ -1,0 +1,3 @@
+:func:`shutil.move` now resolves symlinks via :func:`os.path.realpath`
+when checking whether the destination is inside the source directory,
+preventing a symlink-based bypass of that guard.


### PR DESCRIPTION
Fixes #149835.

<!-- gh-issue-number: gh-149835 -->
* Issue: gh-149835
<!-- /gh-issue-number -->
