### PR TITLE
gh-148260: Use at least 1 MiB stack size on musl

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-05-18-16-00-41.gh-issue-148260.UwFiIX.rst
+++ b/Misc/NEWS.d/next/Build/2026-05-18-16-00-41.gh-issue-148260.UwFiIX.rst
@@ -1,0 +1,3 @@
+On Linux when Python is linked to the musl C library, use a thread stack
+size of at least 1 MiB instead of musl default which is 128 kiB. Patch by
+Victor Stinner.

--- a/configure
+++ b/configure
@@ -9861,6 +9861,58 @@ fi
      ;;
 esac
 
+if test "$ac_sys_system" = "Linux" -a "$cross_compiling" = no; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for thread stack size" >&5
+printf %s "checking for thread stack size... " >&6; }
+if test ${ac_cv_thread_stack_size+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+    cat > conftest.c <<EOF
+#include <pthread.h>
+
+int main()
+{
+    pthread_attr_t attrs;
+    size_t size;
+
+    int rc = pthread_attr_init(&attrs);
+    if (rc != 0) {
+        return 2;
+    }
+
+    rc = pthread_attr_getstacksize(&attrs, &size);
+    if (rc != 0) {
+        return 2;
+    }
+
+    if (size < 1024 * 1024) {
+        return 1;
+    }
+    return 0;
+}
+EOF
+
+    ac_cv_thread_stack_size="default"
+    if $CC -pthread $CFLAGS conftest.c -o conftest &>/dev/null; then
+      ./conftest &>/dev/null
+      if test $? -eq 1; then
+          ac_cv_thread_stack_size=1048576
+      fi
+    fi
+    rm -f conftest.c conftest
+     ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_thread_stack_size" >&5
+printf "%s\n" "$ac_cv_thread_stack_size" >&6; }
+
+    if test "$ac_cv_thread_stack_size" != "default"; then
+        LDFLAGS="$LDFLAGS -Wl,-z,stack-size=$ac_cv_thread_stack_size"
+    fi
+fi
+
 case $enable_wasm_dynamic_linking in #(
   yes) :
     ac_cv_func_dlopen=yes ;; #(

--- a/configure
+++ b/configure
@@ -9894,12 +9894,15 @@ int main()
 }
 EOF
 
-    ac_cv_thread_stack_size="default"
+    ac_cv_thread_stack_size=unknown
     if $CC -pthread $CFLAGS conftest.c -o conftest &>/dev/null; then
-      ./conftest &>/dev/null
-      if test $? -eq 1; then
-          ac_cv_thread_stack_size=1048576
-      fi
+        ./conftest &>/dev/null
+        exitcode=$?
+        if test $exitcode -eq 1; then
+            ac_cv_thread_stack_size=1048576
+        elif test $exitcode -eq 0; then
+            ac_cv_thread_stack_size="default"
+        fi
     fi
     rm -f conftest.c conftest
      ;;
@@ -9908,7 +9911,7 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_thread_stack_size" >&5
 printf "%s\n" "$ac_cv_thread_stack_size" >&6; }
 
-    if test "$ac_cv_thread_stack_size" != "default"; then
+    if test "$ac_cv_thread_stack_size" != "default" -a "$ac_cv_thread_stack_size" != "unknown"; then
         LDFLAGS="$LDFLAGS -Wl,-z,stack-size=$ac_cv_thread_stack_size"
     fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -2464,7 +2464,7 @@ AS_CASE([$ac_sys_system],
 
 dnl On Linux, check the thread stack size. musl (ex: Alpine Linux) uses
 dnl a default thread stack size of 128 kB, whereas the glibc uses 8 MiB.
-dnl Python uses at least 1 MiB.
+dnl Python needs at least 1 MiB.
 if test "$ac_sys_system" = "Linux" -a "$cross_compiling" = no; then
     AC_CACHE_CHECK([for thread stack size], [ac_cv_thread_stack_size], [
     cat > conftest.c <<EOF
@@ -2492,17 +2492,20 @@ int main()
 }
 EOF
 
-    ac_cv_thread_stack_size="default"
+    ac_cv_thread_stack_size=unknown
     if $CC -pthread $CFLAGS conftest.c -o conftest &>/dev/null; then
-      ./conftest &>/dev/null
-      if test $? -eq 1; then
-          ac_cv_thread_stack_size=1048576
-      fi
+        ./conftest &>/dev/null
+        exitcode=$?
+        if test $exitcode -eq 1; then
+            ac_cv_thread_stack_size=1048576
+        elif test $exitcode -eq 0; then
+            ac_cv_thread_stack_size="default"
+        fi
     fi
     rm -f conftest.c conftest
     ])
 
-    if test "$ac_cv_thread_stack_size" != "default"; then
+    if test "$ac_cv_thread_stack_size" != "default" -a "$ac_cv_thread_stack_size" != "unknown"; then
         LDFLAGS="$LDFLAGS -Wl,-z,stack-size=$ac_cv_thread_stack_size"
     fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -2462,6 +2462,51 @@ AS_CASE([$ac_sys_system],
   ]
 )
 
+dnl On Linux, check the thread stack size. musl (ex: Alpine Linux) uses
+dnl a default thread stack size of 128 kB, whereas the glibc uses 8 MiB.
+dnl Python uses at least 1 MiB.
+if test "$ac_sys_system" = "Linux" -a "$cross_compiling" = no; then
+    AC_CACHE_CHECK([for thread stack size], [ac_cv_thread_stack_size], [
+    cat > conftest.c <<EOF
+#include <pthread.h>
+
+int main()
+{
+    pthread_attr_t attrs;
+    size_t size;
+
+    int rc = pthread_attr_init(&attrs);
+    if (rc != 0) {
+        return 2;
+    }
+
+    rc = pthread_attr_getstacksize(&attrs, &size);
+    if (rc != 0) {
+        return 2;
+    }
+
+    if (size < 1024 * 1024) {
+        return 1;
+    }
+    return 0;
+}
+EOF
+
+    ac_cv_thread_stack_size="default"
+    if $CC -pthread $CFLAGS conftest.c -o conftest &>/dev/null; then
+      ./conftest &>/dev/null
+      if test $? -eq 1; then
+          ac_cv_thread_stack_size=1048576
+      fi
+    fi
+    rm -f conftest.c conftest
+    ])
+
+    if test "$ac_cv_thread_stack_size" != "default"; then
+        LDFLAGS="$LDFLAGS -Wl,-z,stack-size=$ac_cv_thread_stack_size"
+    fi
+fi
+
 AS_CASE([$enable_wasm_dynamic_linking],
   [yes], [ac_cv_func_dlopen=yes],
   [no], [ac_cv_func_dlopen=no],


### PR DESCRIPTION
On Linux when Python is linked to the musl C library, use a thread stack size of at least 1 MiB instead of musl default which is 128 kiB.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148260 -->
* Issue: gh-148260
<!-- /gh-issue-number -->
