### PR TITLE
gh-149619: Fix `_remote_debugging` permissions error on Linux

### DIFF
--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -169,7 +169,9 @@ _Py_RemoteDebug_ValidatePyRuntimeCookie(proc_handle_t *handle, uintptr_t address
     }
     char buf[sizeof(_Py_Debug_Cookie) - 1];
     if (_Py_RemoteDebug_ReadRemoteMemory(handle, address, sizeof(buf), buf) != 0) {
-        PyErr_Clear();
+        if (!PyErr_ExceptionMatches(PyExc_PermissionError)) {
+            PyErr_Clear();
+        }
         return 0;
     }
     return memcmp(buf, _Py_Debug_Cookie, sizeof(buf)) == 0;
@@ -781,6 +783,10 @@ search_linux_map_for_section(proc_handle_t *handle, const char* secname, const c
         }
 
         if (strstr(filename, substr)) {
+            if (PyErr_ExceptionMatches(PyExc_PermissionError)) {
+                retval = 0;
+                break;
+            }
             PyErr_Clear();
             retval = search_elf_file_for_section(handle, secname, start, path);
             if (retval
@@ -956,12 +962,14 @@ _Py_RemoteDebug_GetPyRuntimeAddress(proc_handle_t* handle)
     address = search_linux_map_for_section(handle, "PyRuntime", "python",
                                            _Py_RemoteDebug_ValidatePyRuntimeCookie);
     if (address == 0) {
-        // Error out: 'python' substring covers both executable and DLL
-        PyObject *exc = PyErr_GetRaisedException();
-        PyErr_Format(PyExc_RuntimeError,
-            "Failed to find the PyRuntime section in process %d on Linux platform",
-            handle->pid);
-        _PyErr_ChainExceptions1(exc);
+        if (!PyErr_ExceptionMatches(PyExc_PermissionError)) {
+            // Error out: 'python' substring covers both executable and DLL
+            PyObject *exc = PyErr_GetRaisedException();
+            PyErr_Format(PyExc_RuntimeError,
+                "Failed to find the PyRuntime section in process %d on Linux platform",
+                handle->pid);
+            _PyErr_ChainExceptions1(exc);
+        }
     }
 #elif defined(__APPLE__) && defined(TARGET_OS_OSX) && TARGET_OS_OSX
     // On macOS, try libpython first, then fall back to python


### PR DESCRIPTION
When running profiling on Linux without sudo, attempts to read process memory would fail with the misleading error '_Failed to find the PyRuntime section in process <pid> on Linux platform_'.

The actual issue is a permissions error because profiling was not run with sudo. We were clearing the exception on Linux when trying to read memory, instead, we should bubble up the permissions error and show it properly.

<!-- gh-issue-number: gh-149619 -->
* Issue: gh-149619
<!-- /gh-issue-number -->