### PR TITLE
gh-149980: Strip all trailing slashes from GNU long directory names i…

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1425,7 +1425,7 @@ class TarInfo(object):
         # Remove redundant slashes from directories. This is to be consistent
         # with frombuf().
         if next.isdir():
-            next.name = next.name.removesuffix("/")
+            next.name = next.name.rstrip("/")
 
         return next
 

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1313,6 +1313,27 @@ class GNUReadTest(LongnameTest, ReadTest, unittest.TestCase):
         else:
             return False
 
+    def test_gnulong_dirname_strips_all_trailing_slashes(self):
+        # gh-149980: _proc_gnulong must normalize trailing slashes the same
+        # way _frombuf and _proc_builtin do (rstrip, not removesuffix), so
+        # a GNU long-name directory entry agrees with a short-name one.
+        long_name = "a" * 120 + "///"   # > 100 bytes => GNUTYPE_LONGNAME
+        short_name = "b" * 20 + "///"
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w",
+                          format=tarfile.GNU_FORMAT) as tar:
+            for name in (short_name, long_name):
+                info = tarfile.TarInfo(name=name)
+                info.type = tarfile.DIRTYPE
+                tar.addfile(info)
+
+        buf.seek(0)
+        with tarfile.open(fileobj=buf, mode="r") as tar:
+            names = [m.name for m in tar.getmembers()]
+
+        self.assertEqual(names, ["b" * 20, "a" * 120])
+
 
 class PaxReadTest(LongnameTest, ReadTest, unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2026-05-19-12-00-00.gh-issue-149980.Kx7p2A.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-19-12-00-00.gh-issue-149980.Kx7p2A.rst
@@ -1,0 +1,3 @@
+Fix :mod:`tarfile` so that GNU long-name directory entries have all
+trailing slashes stripped from their names, matching the behavior for
+short-name entries.  Previously, only a single trailing slash was removed.


### PR DESCRIPTION
Title:
  gh-149980: Strip all trailing slashes from GNU long directory names in tarfile

  Body:
  In `tarfile._proc_gnulong`, GNU long-name directory entries had only a single
  trailing slash removed (`removesuffix("/")`), while short-name directories and
  PAX entries have *all* trailing slashes stripped (`rstrip("/")` in `_frombuf` /
  `_proc_builtin`). This made a `foo///` directory show up as `foo` via the
  short path and `foo//` via the GNU long-name path.

  This PR aligns `_proc_gnulong` with the other paths by using `rstrip("/")`, and
  adds a regression test that writes a GNU-format archive containing both a short
  and a long directory name ending in `///` and asserts the parsed names match.

  <!-- gh-issue-number: gh-149980 -->
  * Issue: gh-149980
  <!-- /gh-issue-number -->