### PR TITLE
gh-69619: Clarify whitespace definition in str.strip docs

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2747,6 +2747,8 @@ expression support in the :mod:`re` module).
    The *chars* argument is not a prefix or suffix; rather, all combinations of its
    values are stripped.
 
+   Whitespace characters are those defined by Unicode as spaces, tabs, and newline characters.
+
    For example:
 
    .. doctest::

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2747,8 +2747,8 @@ expression support in the :mod:`re` module).
    The *chars* argument is not a prefix or suffix; rather, all combinations of its
    values are stripped.
 
-   Whitespace characters are those defined by Unicode as spaces, tabs, and newline characters.
-
+   Whitespace characters are defined by :meth:`str.isspace`.
+   
    For example:
 
    .. doctest::

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2748,7 +2748,7 @@ expression support in the :mod:`re` module).
    values are stripped.
 
    Whitespace characters are defined by :meth:`str.isspace`.
-   
+
    For example:
 
    .. doctest::


### PR DESCRIPTION
Clarify that whitespace characters in str.strip are defined by Unicode,
including spaces, tabs, and newline characters.

<!-- gh-issue-number: gh-69619 -->
* Issue: gh-69619
<!-- /gh-issue-number -->
