### PR TITLE
gh-149590: Remove faulthandler_traverse

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-18-13-47-17.gh-issue-149590.IPBeQx.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-18-13-47-17.gh-issue-149590.IPBeQx.rst
@@ -1,1 +1,1 @@
-Removed faulthandler traversal function to resolve double deref of singleton
+Fix crash when faulthandler is imported more than once.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-18-13-47-17.gh-issue-149590.IPBeQx.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-18-13-47-17.gh-issue-149590.IPBeQx.rst
@@ -1,0 +1,1 @@
+Removed faulthandler traversal function to resolve double deref of singleton

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1349,21 +1349,6 @@ faulthandler__stack_overflow_impl(PyObject *module)
 #endif   /* defined(FAULTHANDLER_USE_ALT_STACK) && defined(HAVE_SIGACTION) */
 
 
-static int
-faulthandler_traverse(PyObject *module, visitproc visit, void *arg)
-{
-    Py_VISIT(thread.file);
-#ifdef FAULTHANDLER_USER
-    if (user_signals != NULL) {
-        for (size_t signum=0; signum < Py_NSIG; signum++)
-            Py_VISIT(user_signals[signum].file);
-    }
-#endif
-    Py_VISIT(fatal_error.file);
-    return 0;
-}
-
-
 #ifdef MS_WINDOWS
 /*[clinic input]
 faulthandler._raise_exception
@@ -1459,7 +1444,6 @@ static struct PyModuleDef module_def = {
     .m_name = "faulthandler",
     .m_doc = module_doc,
     .m_methods = module_methods,
-    .m_traverse = faulthandler_traverse,
     .m_slots = faulthandler_slots
 };
 


### PR DESCRIPTION
tldr; `faulthandler_traverse` visits Python objects owned by `_PyRuntime`, not by the module instance. With multi-phase init allowing multiple module instances, each instance's GC traversal decrements `gc_refs` on the same runtime-owned objects, driving it negative when two instances are collected simultaneously. Cleanup is already handled well, traversal is redundant, and harmless with a single instantiation.

## Expanded Explanation:

> Author's note: This is my first foray into the CPython codebase. Would appreciate all the scrutiny :D

### RCA:
BG: `faulthandler` uses multi-phase init, so deleting it from `sys.modules` and re-importing produces a second, independent module object. Both module objects are tracked by the garbage collector and both have `md_state_traverse = faulthandler_traverse` stored. 

1. `subtract_refs` iterates every object in the GC generation list.
2.  For each object it calls `Py_TYPE(op)->tp_traverse` — for module objects that's `module_traverse` in `Objects/moduleobject.c`
3. `module_traverse` calls `md_state_traverse` (i.e. `faulthandler_traverse`) then visits `md_dict`
4. `faulthandler_traverse` calls `Py_VISIT(fatal_error.file)`(expands to `visit_decref(_PyRuntime.faulthandler.fatal_error.file)`)
5. With two module instances this runs twice; `gc_refs` on `fatal_error.file` (stderr, by default) is decremented twice
6. But `fatal_error.file`'s real refcount only has one reference from `_PyRuntime`; `gc_refs` goes negative → debug assertion fires, silent UAF in release

### Safety

`m_traverse` exists to tell the GC about Python objects owned by per-module C state (`md_state`, allocated when `m_size > 0`). `faulthandler` has `m_size = 0`, so there is no per-module C state. `fatal_error.file`, `thread.file`, and `user_signals[signum].file` are all owned by `_PyRuntime`, not by any module instance. `_PyRuntime` is not a Python object and is never in `containers`, so its references are never passed to `visit_decref`, they contribute to `ob_refcnt` but are never subtracted, meaning `gc_refs >= 1` after `subtract_refs`. GC will never mark these objects as unreachable regardless of whether the module traverse visits them. Cleanup is already handled correctly: `faulthandler_disable()` calls `Py_CLEAR(fatal_error.file)` (and equivalents), and `_PyFaulthandler_Fini()` calls `faulthandler_disable()` at shutdown. No GC involvement is needed.

### Functionality

From main:
<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/a7beee56-a118-4880-8199-a8c5011f043a" />

After removal:
<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/44010e3d-bae1-4601-858c-f4dff8cde80e" />

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149590 -->
* Issue: gh-149590
<!-- /gh-issue-number -->
