### PR TITLE
gh-146452: Improve locking granularity in pickle's batch_dict_exact

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-05-18-15-30-34.gh-issue-146452.RM0EVJ.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-18-15-30-34.gh-issue-146452.RM0EVJ.rst
@@ -1,0 +1,2 @@
+Fix race condition when pickling dictionaries in free threaded builds. Also
+reduce critical section cover.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3450,9 +3450,12 @@ batch_dict(PickleState *state, PicklerObject *self, PyObject *iter, PyObject *or
  * Returns 0 on success, -1 on error.
  *
  * Note that this currently doesn't work for protocol 0.
+
+ * gh-146452: Wrap the dict iteration in a critical sections to prevent
+ * concurrent mutation from invalidating PyDict_Next() iteration state.
  */
 static int
-batch_dict_exact_impl(PickleState *state, PicklerObject *self, PyObject *obj)
+batch_dict_exact(PickleState *state, PicklerObject *self, PyObject *obj)
 {
     PyObject *key = NULL, *value = NULL;
     int i;
@@ -3466,15 +3469,24 @@ batch_dict_exact_impl(PickleState *state, PicklerObject *self, PyObject *obj)
     assert(self->proto > 0);
 
     dict_size = PyDict_GET_SIZE(obj);
-    assert(dict_size);
 
     /* Write in batches of BATCHSIZE. */
     Py_ssize_t total = 0;
     do {
         if (dict_size - total == 1) {
-            PyDict_Next(obj, &ppos, &key, &value);
-            Py_INCREF(key);
-            Py_INCREF(value);
+            int next;
+            Py_BEGIN_CRITICAL_SECTION(obj);
+            next = PyDict_Next(obj, &ppos, &key, &value);
+            if (next) {
+                Py_INCREF(key);
+                Py_INCREF(value);
+            }
+            Py_END_CRITICAL_SECTION();
+            if (!next) {
+                PyErr_SetString(PyExc_RuntimeError,
+                                "dictionary changed size during iteration");
+                goto error;
+            }
             if (save(state, self, key, 0) < 0) {
                 goto error;
             }
@@ -3492,9 +3504,18 @@ batch_dict_exact_impl(PickleState *state, PicklerObject *self, PyObject *obj)
         i = 0;
         if (_Pickler_Write(self, &mark_op, 1) < 0)
             return -1;
-        while (PyDict_Next(obj, &ppos, &key, &value)) {
-            Py_INCREF(key);
-            Py_INCREF(value);
+        int next;
+        while (1) {
+            Py_BEGIN_CRITICAL_SECTION(obj);
+            next = PyDict_Next(obj, &ppos, &key, &value);
+            if (next) {
+                Py_INCREF(key);
+                Py_INCREF(value);
+            }
+            Py_END_CRITICAL_SECTION();
+            if (!next) {
+                break;
+            }
             if (save(state, self, key, 0) < 0) {
                 goto error;
             }
@@ -3523,18 +3544,6 @@ error:
     Py_XDECREF(key);
     Py_XDECREF(value);
     return -1;
-}
-
-/* gh-146452: Wrap the dict iteration in a critical section to prevent
-   concurrent mutation from invalidating PyDict_Next() iteration state. */
-static int
-batch_dict_exact(PickleState *state, PicklerObject *self, PyObject *obj)
-{
-    int ret;
-    Py_BEGIN_CRITICAL_SECTION(obj);
-    ret = batch_dict_exact_impl(state, self, obj);
-    Py_END_CRITICAL_SECTION();
-    return ret;
 }
 
 static int


### PR DESCRIPTION
Improve critical section locking in `batch_dict_exact`. This originally held a lock for the entirey of `batch_dict_exact_impl`, which is not necessary. We can instead have localised locks for sections which require it. It wrapped possibly expensive calls to `save()` etc

Remove `batch_dict_exact_impl` which existed to allow the wrapping with critical sections. Called by `batch_dict_exact`.

Additionally handle the case where `PyDict_Next` returns 0 in the size 1 special case (modified during pickling).

Note: this spun out of looking into https://github.com/python/cpython/issues/149816 89, it was fixed in https://github.com/python/cpython/issues/146452.

Test was added in https://github.com/python/cpython/pull/146470/changes

<!-- gh-issue-number: gh-146452 -->
* Issue: gh-146452
<!-- /gh-issue-number -->
