### PR TITLE
gh-79413: Add `qualname` parameter to `dataclass.make_dataclass`.

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -435,8 +435,7 @@ Module contents
    By default, it is set to the module name of the caller.
 
    If *qualname* is defined, the :attr:`!__qualname__` attribute of the dataclass
-   is set to that value.
-   By default, it is set to the value passed to *cls_name*.
+   is set to that value. By default, it is set to the value passed to *cls_name*.
 
    The *decorator* parameter is a callable that will be used to create the dataclass.
    It should take the class object as a first argument and the same keyword arguments
@@ -468,6 +467,8 @@ Module contents
 
    .. versionadded:: 3.14
       Added the *decorator* parameter.
+   .. versionadded:: next
+      Added the *qualname* parameter.
 
 .. function:: replace(obj, /, **changes)
 

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -434,7 +434,7 @@ Module contents
    of the dataclass is set to that value.
    By default, it is set to the module name of the caller.
 
-   If *qualname* is defined, the :attr:`!__qualname__` attribute of the dataclass
+   If *qualname* is defined, the :attr:`~type.__qualname__` attribute of the dataclass
    is set to that value. By default, it is set to the value passed to *cls_name*.
 
    The *decorator* parameter is a callable that will be used to create the dataclass.

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -418,7 +418,7 @@ Module contents
    :func:`!astuple` raises :exc:`TypeError` if *obj* is not a dataclass
    instance.
 
-.. function:: make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False, match_args=True, kw_only=False, slots=False, weakref_slot=False, module=None, decorator=dataclass)
+.. function:: make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False, match_args=True, kw_only=False, slots=False, weakref_slot=False, module=None, qualname=None, decorator=dataclass)
 
    Creates a new dataclass with name *cls_name*, fields as defined
    in *fields*, base classes as given in *bases*, and initialized
@@ -433,6 +433,10 @@ Module contents
    If *module* is defined, the :attr:`!__module__` attribute
    of the dataclass is set to that value.
    By default, it is set to the module name of the caller.
+
+   If *qualname* is defined, the :attr:`!__qualname__` attribute of the dataclass
+   is set to that value.
+   By default, it is set to the value passed to *cls_name*.
 
    The *decorator* parameter is a callable that will be used to create the dataclass.
    It should take the class object as a first argument and the same keyword arguments

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1644,7 +1644,7 @@ def _astuple_inner(obj, tuple_factory):
 def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
                    repr=True, eq=True, order=False, unsafe_hash=False,
                    frozen=False, match_args=True, kw_only=False, slots=False,
-                   weakref_slot=False, module=None, decorator=dataclass):
+                   weakref_slot=False, module=None, qualname=None, decorator=dataclass):
     """Return a new dynamically created dataclass.
 
     The dataclass name will be 'cls_name'.  'fields' is an iterable
@@ -1669,6 +1669,9 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
 
     If module parameter is defined, the '__module__' attribute of the dataclass is
     set to that value.
+
+    If qualname parameter is defined, the '__qualname__' attribute of the dataclass is set
+    to that value.
     """
 
     if namespace is None:
@@ -1757,6 +1760,9 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
                 pass
     if module is not None:
         cls.__module__ = module
+
+    if qualname:
+        cls.__qualname__ = qualname
 
     # Apply the normal provided decorator.
     cls = decorator(cls, init=init, repr=repr, eq=eq, order=order,

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -5293,9 +5293,11 @@ class TestKeywordArgs(unittest.TestCase):
         A = make_dataclass("A", ['a'], qualname='ClassA')
         self.assertEqual(A.__qualname__, 'ClassA')
 
-        B = make_dataclass("B", ['b'], qualname='ClassB')
-        self.assertEqual(B.__qualname__, 'ClassB')
+        B = make_dataclass("B", ['b'], qualname='module1.ClassB')
+        self.assertEqual(B.__qualname__, 'module1.ClassB')
 
+        C = make_dataclass("C", ['c'])
+        self.assertEqual(C.__qualname__, 'C')
 
 class TestZeroArgumentSuperWithSlots(unittest.TestCase):
     def test_zero_argument_super(self):

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -5289,6 +5289,13 @@ class TestKeywordArgs(unittest.TestCase):
         self.assertEqual(len(fs), 1)
         self.assertEqual(fs[0].name, 'x')
 
+    def test_makedataclass_with_qualname(self):
+        A = make_dataclass("A", ['a'], qualname='ClassA')
+        self.assertEqual(A.__qualname__, 'ClassA')
+
+        B = make_dataclass("B", ['b'], qualname='ClassB')
+        self.assertEqual(B.__qualname__, 'ClassB')
+
 
 class TestZeroArgumentSuperWithSlots(unittest.TestCase):
     def test_zero_argument_super(self):

--- a/Misc/NEWS.d/next/Library/2026-05-18-13-43-06.gh-issue-79413.OpTXbV.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-18-13-43-06.gh-issue-79413.OpTXbV.rst
@@ -1,0 +1,3 @@
+Update :func:`dataclasses.make_dataclass` to add a *qualname* parameter. The
+*qualname* parameter will be used to set the :attr:`!__qualname__` of the
+created ``dataclass``.


### PR DESCRIPTION
Resolves #79413 

Added `qualname` parameter to `dataclasses.make_dataclass` in order to allow user to set `__qualname__` for the generated class.

The `pickle` issue mentioned in GH-79413 was resolved by #102104 which added the `module` argument however that PR did not include allowing the user to set `__qualname__` for the generated class. This PR resolves that remaining part of this issue.

There should be no backwards compatibility issues - current code that calls `make_dataclass` without the `qualname` parameter will continue to create classes that use the `cls_name` parameter as the `__qualname__` with no changes. 