### PR TITLE
gh-149902: Remove dead packaging docs link and add a new section for external resources

### DIFF
--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -53,7 +53,7 @@
   <div class="contentstable">
     <ul>
       <li class="biglink"><a class="biglink" href="{{ pathto("whatsnew/" + version) }}">{% trans %}What's new in Python {{ version }}?{% endtrans %}</a><br>
-         <span class="linkdescr"> {% trans whatsnew_index=pathto("whatsnew/index") %}Or <a href="{{ whatsnew_index }}">all "What's new" documents since Python 2.0</a>{% endtrans %}</span></li>
+         <span class="linkdescr"> {% trans whatsnew_index=pathto("whatsnew/index") %}<a href="{{ whatsnew_index }}">All "What's new" documents since Python 2.0</a>{% endtrans %}</span></li>
       <li class="biglink"><a class="biglink" href="{{ pathto("tutorial/index") }}">{% trans %}Tutorial{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Start here: a tour of Python's syntax and features{% endtrans %}</span></li>
       <li class="biglink"><a class="biglink" href="{{ pathto("library/index") }}">{% trans %}Library reference{% endtrans %}</a><br>
@@ -83,7 +83,7 @@
   <div class="contentstable">
     <ul>
       <li class="biglink"><a class="biglink" href="https://packaging.python.org">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}A collection of resources relating to Python packaging{% endtrans %}</span></li>
+         <span class="linkdescr">{% trans %}Resources relating to Python packaging{% endtrans %}</span></li>
     </ul>
     <ul>
       <li class="biglink"><a class="biglink" href="https://typing.python.org">{% trans %}Static Typing with Python{% endtrans %}</a><br>
@@ -105,7 +105,7 @@
       <li class="biglink"><a class="biglink" href="{{ pathto("search") }}">{% trans %}Search page{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Search this documentation{% endtrans %}</span></li>
       <li class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{% trans %}Complete table of contents{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Lists all sections and subsections{% endtrans %}</span></li>
+         <span class="linkdescr">{% trans %}All sections and subsections{% endtrans %}</span></li>
     </ul>
   </div>
 

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -53,7 +53,7 @@
   <div class="contentstable">
     <ul>
       <li class="biglink"><a class="biglink" href="{{ pathto("whatsnew/" + version) }}">{% trans %}What's new in Python {{ version }}?{% endtrans %}</a><br>
-         <span class="linkdescr"> {% trans whatsnew_index=pathto("whatsnew/index") %}<a href="{{ whatsnew_index }}">All "What's new" documents since Python 2.0</a>{% endtrans %}</span></li>
+         <span class="linkdescr"> {% trans whatsnew_index=pathto("whatsnew/index") %}Or <a href="{{ whatsnew_index }}">all "What's new" documents since Python 2.0</a>{% endtrans %}</span></li>
       <li class="biglink"><a class="biglink" href="{{ pathto("tutorial/index") }}">{% trans %}Tutorial{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Start here: a tour of Python's syntax and features{% endtrans %}</span></li>
       <li class="biglink"><a class="biglink" href="{{ pathto("library/index") }}">{% trans %}Library reference{% endtrans %}</a><br>

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -52,11 +52,11 @@
   <p><strong>{% trans %}Other resources:{% endtrans %}</strong></p>
    <table class="contentstable" align="center"><tr>
       <td widht="50%">
-         <p class="biglink"><a class="biglink" href="https://packaging.python.org/en/latest">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
+         <p class="biglink"><a class="biglink" href="https://packaging.python.org">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
             <span class="linkdescr">{% trans %}A collection of resources relating to Python packaging{% endtrans %}</span></p>
       </td>
       <td widht="50%">
-         <p class="biglink"><a class="biglink" href="https://typing.python.org/en/latest">{% trans %}Static Typing with Python{% endtrans %}</a><br>
+         <p class="biglink"><a class="biglink" href="https://typing.python.org">{% trans %}Static Typing with Python{% endtrans %}</a><br>
             <span class="linkdescr">{% trans %}Information and guides about Python type safety{% endtrans %}</span></p>
       </td></tr>
    </table>

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -49,6 +49,19 @@
     </td></tr>
   </table>
 
+  <p><strong>{% trans %}Other resources:{% endtrans %}</strong></p>
+   <table class="contentstable" align="center"><tr>
+      <td widht="50%">
+         <p class="biglink"><a class="biglink" href="https://packaging.python.org/en/latest">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
+            <span class="linkdescr">{% trans %}A collection of resources relating to Python packaging{% endtrans %}</span></p>
+      </td>
+      <td widht="50%">
+         <p class="biglink"><a class="biglink" href="https://typing.python.org/en/latest">{% trans %}Static Typing with Python{% endtrans %}</a><br>
+            <span class="linkdescr">{% trans %}Information and guides about Python type safety{% endtrans %}</span></p>
+      </td></tr>
+   </table>
+
+
   <p><strong>{% trans %}Indices, glossary, and search:{% endtrans %}</strong></p>
   <table class="contentstable" align="center"><tr>
     <td width="50%">

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -38,8 +38,6 @@
     </td><td width="50%">
       <p class="biglink"><a class="biglink" href="{{ pathto("installing/index") }}">{% trans %}Installing Python modules{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Third-party modules and PyPI.org{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("distributing/index") }}">{% trans %}Distributing Python modules{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Publishing modules for use by other people{% endtrans %}</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("extending/index") }}">{% trans %}Extending and embedding{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}For C/C++ programmers{% endtrans %}</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("c-api/index") }}">{% trans %}Python's C API{% endtrans %}</a><br>

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -51,7 +51,7 @@
 
   <p><strong>{% trans %}Other resources:{% endtrans %}</strong></p>
    <table class="contentstable" align="center"><tr>
-      <td widht="50%">
+      <td width="50%">
          <p class="biglink"><a class="biglink" href="https://packaging.python.org">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
             <span class="linkdescr">{% trans %}A collection of resources relating to Python packaging{% endtrans %}</span></p>
       </td>

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -55,7 +55,7 @@
          <p class="biglink"><a class="biglink" href="https://packaging.python.org">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
             <span class="linkdescr">{% trans %}A collection of resources relating to Python packaging{% endtrans %}</span></p>
       </td>
-      <td widht="50%">
+      <td width="50%">
          <p class="biglink"><a class="biglink" href="https://typing.python.org">{% trans %}Static Typing with Python{% endtrans %}</a><br>
             <span class="linkdescr">{% trans %}Information and guides about Python type safety{% endtrans %}</span></p>
       </td></tr>

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -61,7 +61,6 @@
       </td></tr>
    </table>
 
-
   <p><strong>{% trans %}Indices, glossary, and search:{% endtrans %}</strong></p>
   <table class="contentstable" align="center"><tr>
     <td width="50%">

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -14,6 +14,35 @@
     <meta property="og:image:width" content="200">
     <meta property="og:image:height" content="200">
     <meta name="theme-color" content="#3776ab">
+    <style>
+      .contentstable {
+        display: grid;
+        gap: 0 2em;
+        grid-template-columns: 1fr 1fr;
+        margin: 0 auto;
+        max-width: 90%;
+      }
+      .contentstable ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      .contentstable a {
+        text-decoration: none;
+      }
+      .contentstable a:hover {
+        text-decoration: underline;
+      }
+      .contentstable li.biglink {
+        line-height: 150%;
+        margin-bottom: 1em;
+      }
+      @media (max-width: 600px) {
+        .contentstable {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
 {%- endblock -%}
 {% block body %}
   <h1>{{ docstitle|e }}</h1>
@@ -21,73 +50,76 @@
   {% trans %}Welcome! This is the official documentation for Python {{ release }}.{% endtrans %}
   </p>
   <p><strong>{% trans %}Documentation sections:{% endtrans %}</strong></p>
-  <table class="contentstable" align="center"><tr>
-    <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("whatsnew/" + version) }}">{% trans %}What's new in Python {{ version }}?{% endtrans %}</a><br>
-         <span class="linkdescr"> {% trans whatsnew_index=pathto("whatsnew/index") %}Or <a href="{{ whatsnew_index }}">all "What's new" documents since Python 2.0</a>{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("tutorial/index") }}">{% trans %}Tutorial{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Start here: a tour of Python's syntax and features{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("library/index") }}">{% trans %}Library reference{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Standard library and builtins{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("reference/index") }}">{% trans %}Language reference{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Syntax and language elements{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("using/index") }}">{% trans %}Python setup and usage{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}How to install, configure, and use Python{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("howto/index") }}">{% trans %}Python HOWTOs{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}In-depth topic manuals{% endtrans %}</span></p>
-    </td><td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("installing/index") }}">{% trans %}Installing Python modules{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Third-party modules and PyPI.org{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("extending/index") }}">{% trans %}Extending and embedding{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}For C/C++ programmers{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("c-api/index") }}">{% trans %}Python's C API{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}C API reference{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("faq/index") }}">{% trans %}FAQs{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Frequently asked questions (with answers!){% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("deprecations/index") }}">{% trans %}Deprecations{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Deprecated functionality{% endtrans %}</span></p>
-    </td></tr>
-  </table>
+  <div class="contentstable">
+    <ul>
+      <li class="biglink"><a class="biglink" href="{{ pathto("whatsnew/" + version) }}">{% trans %}What's new in Python {{ version }}?{% endtrans %}</a><br>
+         <span class="linkdescr"> {% trans whatsnew_index=pathto("whatsnew/index") %}Or <a href="{{ whatsnew_index }}">all "What's new" documents since Python 2.0</a>{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("tutorial/index") }}">{% trans %}Tutorial{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Start here: a tour of Python's syntax and features{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("library/index") }}">{% trans %}Library reference{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Standard library and builtins{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("reference/index") }}">{% trans %}Language reference{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Syntax and language elements{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("using/index") }}">{% trans %}Python setup and usage{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}How to install, configure, and use Python{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("howto/index") }}">{% trans %}Python HOWTOs{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}In-depth topic manuals{% endtrans %}</span></li>
+    </ul>
+    <ul>
+      <li class="biglink"><a class="biglink" href="{{ pathto("installing/index") }}">{% trans %}Installing Python modules{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Third-party modules and PyPI.org{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("extending/index") }}">{% trans %}Extending and embedding{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}For C/C++ programmers{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("c-api/index") }}">{% trans %}Python's C API{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}C API reference{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("faq/index") }}">{% trans %}FAQs{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Frequently asked questions (with answers!){% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("deprecations/index") }}">{% trans %}Deprecations{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Deprecated functionality{% endtrans %}</span></li>
+    </ul>
+  </div>
 
   <p><strong>{% trans %}Other resources:{% endtrans %}</strong></p>
-   <table class="contentstable" align="center"><tr>
-      <td width="50%">
-         <p class="biglink"><a class="biglink" href="https://packaging.python.org">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
-            <span class="linkdescr">{% trans %}A collection of resources relating to Python packaging{% endtrans %}</span></p>
-      </td>
-      <td width="50%">
-         <p class="biglink"><a class="biglink" href="https://typing.python.org">{% trans %}Static Typing with Python{% endtrans %}</a><br>
-            <span class="linkdescr">{% trans %}Information and guides about Python type safety{% endtrans %}</span></p>
-      </td></tr>
-   </table>
+  <div class="contentstable">
+    <ul>
+      <li class="biglink"><a class="biglink" href="https://packaging.python.org">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}A collection of resources relating to Python packaging{% endtrans %}</span></li>
+    </ul>
+    <ul>
+      <li class="biglink"><a class="biglink" href="https://typing.python.org">{% trans %}Static Typing with Python{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Information and guides about Python type safety{% endtrans %}</span></li>
+    </ul>
+  </div>
 
   <p><strong>{% trans %}Indices, glossary, and search:{% endtrans %}</strong></p>
-  <table class="contentstable" align="center"><tr>
-    <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("py-modindex") }}">{% trans %}Global module index{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}All modules and libraries{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("genindex") }}">{% trans %}General index{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}All functions, classes, and terms{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("glossary") }}">{% trans %}Glossary{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Terms explained{% endtrans %}</span></p>
-    </td><td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("search") }}">{% trans %}Search page{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Search this documentation{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{% trans %}Complete table of contents{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Lists all sections and subsections{% endtrans %}</span></p>
-    </td></tr>
-  </table>
+  <div class="contentstable">
+    <ul>
+      <li class="biglink"><a class="biglink" href="{{ pathto("py-modindex") }}">{% trans %}Global module index{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}All modules and libraries{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("genindex") }}">{% trans %}General index{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}All functions, classes, and terms{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("glossary") }}">{% trans %}Glossary{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Terms explained{% endtrans %}</span></li>
+    </ul>
+    <ul>
+      <li class="biglink"><a class="biglink" href="{{ pathto("search") }}">{% trans %}Search page{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Search this documentation{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{% trans %}Complete table of contents{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Lists all sections and subsections{% endtrans %}</span></li>
+    </ul>
+  </div>
 
   <p><strong>{% trans %}Project information:{% endtrans %}</strong></p>
-  <table class="contentstable" align="center"><tr>
-    <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("bugs") }}">{% trans %}Reporting issues{% endtrans %}</a></p>
-      <p class="biglink"><a class="biglink" href="https://devguide.python.org/documentation/help-documenting/">{% trans %}Contributing to docs{% endtrans %}</a></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("download") }}">{% trans %}Download the documentation{% endtrans %}</a></p>
-    </td><td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("license") }}">{% trans %}History and license of Python{% endtrans %}</a></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("copyright") }}">{% trans %}Copyright{% endtrans %}</a></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("about") }}">{% trans %}About the documentation{% endtrans %}</a></p>
-    </td></tr>
-  </table>
+  <div class="contentstable">
+    <ul>
+      <li class="biglink"><a class="biglink" href="{{ pathto("bugs") }}">{% trans %}Reporting issues{% endtrans %}</a></li>
+      <li class="biglink"><a class="biglink" href="https://devguide.python.org/documentation/help-documenting/">{% trans %}Contributing to docs{% endtrans %}</a></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("download") }}">{% trans %}Download the documentation{% endtrans %}</a></li>
+    </ul>
+    <ul>
+      <li class="biglink"><a class="biglink" href="{{ pathto("license") }}">{% trans %}History and license of Python{% endtrans %}</a></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("copyright") }}">{% trans %}Copyright{% endtrans %}</a></li>
+      <li class="biglink"><a class="biglink" href="{{ pathto("about") }}">{% trans %}About the documentation{% endtrans %}</a></li>
+    </ul>
+  </div>
 {% endblock %}


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Hi folks,

This PR removes a link to "Distributing Python Modules" from the front page of the docs. Said page was empty save for a message telling users to go to packaging.python.org. It was already marked as an orphan, so I removed the link and made a new section for "Other resources", linking packaging.python.org and (at the suggestion of Petr) typing.python.org.

I understand this is a fairly visible change and will probably require some discussion (and possibly modification) before it's ready to merge. I'm here to answer any questions or fix issues.

Before:
<img width="778" height="662" alt="image" src="https://github.com/user-attachments/assets/499c87f2-1efe-49b2-a870-4ed491e76dcd" />


After:
<img width="778" height="662" alt="image" src="https://github.com/user-attachments/assets/d11f08a0-000e-48f5-933e-b6e171a5e1d7" />


cc @encukou (helped me plan this approach) and @nedbat (docs team)

Closes #149902

Thank you!

<!-- gh-issue-number: gh-149902 -->
* Issue: gh-149902
<!-- /gh-issue-number -->
