### PR TITLE
gh-149879: Fix multiprocessing tests on Cygwin

### DIFF
--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -50,7 +50,7 @@ _MAX_PIPE_ATTEMPTS = 100
 default_family = 'AF_INET'
 families = ['AF_INET']
 
-if hasattr(socket, 'AF_UNIX'):
+if hasattr(socket, 'AF_UNIX') and sys.platform != 'cygwin':
     default_family = 'AF_UNIX'
     families += ['AF_UNIX']
 

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -326,8 +326,10 @@ if sys.platform != 'win32':
     _concrete_contexts = {
         'fork': ForkContext(),
         'spawn': SpawnContext(),
-        'forkserver': ForkServerContext(),
     }
+    if reduction.HAVE_SEND_HANDLE:
+        _concrete_contexts['forkserver'] = ForkServerContext()
+
     # bpo-33725: running arbitrary code after fork() is no longer reliable
     # on macOS since macOS 10.14 (Mojave). Use spawn by default instead.
     # gh-84559: We changed everyones default to a thread safeish one in 3.14.

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6143,7 +6143,10 @@ class TestStartMethod(unittest.TestCase):
     @only_run_in_spawn_testsuite("avoids redundant testing.")
     def test_mixed_startmethod(self):
         # Fork-based locks cannot be used with spawned process
-        for process_method in ["spawn", "forkserver"]:
+        test_methods = ["spawn"]
+        if "forkserver" in multiprocessing.get_all_start_methods():
+            test_methods.append("forkserver")
+        for process_method in test_methods:
             queue = multiprocessing.get_context("fork").Queue()
             process_ctx = multiprocessing.get_context(process_method)
             p = process_ctx.Process(target=close_queue, args=(queue,))
@@ -6152,7 +6155,7 @@ class TestStartMethod(unittest.TestCase):
                 p.start()
 
         # non-fork-based locks can be used with all other start methods
-        for queue_method in ["spawn", "forkserver"]:
+        for queue_method in test_methods:
             for process_method in multiprocessing.get_all_start_methods():
                 queue = multiprocessing.get_context(queue_method).Queue()
                 process_ctx = multiprocessing.get_context(process_method)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4065,11 +4065,7 @@ class ConfigDictTest(BaseTest):
         # and thus cannot be used as a queue-like object (gh-124653)
 
         import multiprocessing
-
-        if support.MS_WINDOWS:
-            start_methods = ['spawn']
-        else:
-            start_methods = ['spawn', 'fork', 'forkserver']
+        start_methods = multiprocessing.get_all_start_methods()
 
         for start_method in start_methods:
             with self.subTest(start_method=start_method):
@@ -4085,10 +4081,8 @@ class ConfigDictTest(BaseTest):
                                            " assertions in multiprocessing")
     def test_config_queue_handler_multiprocessing_context(self):
         # regression test for gh-121723
-        if support.MS_WINDOWS:
-            start_methods = ['spawn']
-        else:
-            start_methods = ['spawn', 'fork', 'forkserver']
+        import multiprocessing
+        start_methods = multiprocessing.get_all_start_methods()
         for start_method in start_methods:
             with self.subTest(start_method=start_method):
                 ctx = multiprocessing.get_context(start_method)

--- a/Lib/test/test_multiprocessing_forkserver/__init__.py
+++ b/Lib/test/test_multiprocessing_forkserver/__init__.py
@@ -6,7 +6,7 @@ from test import support
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-if sys.platform == "win32":
+if sys.platform in ("win32", "cygwin"):
     raise unittest.SkipTest("forkserver is not available on Windows")
 
 if not support.has_fork_support:


### PR DESCRIPTION
* Disable AF_UNIX connection family on Cygwin.
* forkserver start method is not available on Cygwin: update tests for that.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149879 -->
* Issue: gh-149879
<!-- /gh-issue-number -->
