### PR TITLE
gh-149716: Document PySlot_DATA for Py_mod_gil and Py_mod_multiple_interpreters

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -247,6 +247,14 @@ Feature slots
    If ``Py_mod_multiple_interpreters`` is not specified, the import
    machinery defaults to ``Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED``.
 
+   A suitable slot value can be defined using the :c:macro:`PySlot_DATA` macro,
+   as in:
+
+   .. code-block:: c
+
+      PySlot_DATA(Py_mod_multiple_interpreters,
+                  Py_MOD_PER_INTERPRETER_GIL_SUPPORTED)
+
    .. versionadded:: 3.12
 
 .. c:macro:: Py_mod_gil
@@ -271,6 +279,13 @@ Feature slots
 
    If ``Py_mod_gil`` is not specified, the import machinery defaults to
    ``Py_MOD_GIL_USED``.
+
+   A suitable slot value can be defined using the :c:macro:`PySlot_DATA` macro,
+   as in:
+
+   .. code-block:: c
+
+      PySlot_DATA(Py_mod_gil, Py_MOD_GIL_NOT_USED)
 
    .. versionadded:: 3.13
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -247,8 +247,9 @@ Feature slots
    If ``Py_mod_multiple_interpreters`` is not specified, the import
    machinery defaults to ``Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED``.
 
-   A suitable slot value can be defined using the :c:macro:`PySlot_DATA` macro,
-   as in:
+   For historical reasons, the values are declared as pointers (``void *``).
+   When using :c:type:`PySlot` arrays, use :c:macro:`PySlot_DATA` for
+   :c:macro:`!Py_mod_multiple_interpreters`:
 
    .. code-block:: c
 
@@ -280,8 +281,9 @@ Feature slots
    If ``Py_mod_gil`` is not specified, the import machinery defaults to
    ``Py_MOD_GIL_USED``.
 
-   A suitable slot value can be defined using the :c:macro:`PySlot_DATA` macro,
-   as in:
+   For historical reasons, the values are declared as pointers (``void *``).
+   When using :c:type:`PySlot` arrays, use :c:macro:`PySlot_DATA` for
+   :c:macro:`!Py_mod_gil`:
 
    .. code-block:: c
 


### PR DESCRIPTION
Fixes #149716.

## Summary

Adds short code examples to the documentation of two module slot IDs
(`Py_mod_gil` since 3.13, `Py_mod_multiple_interpreters` since 3.12).
The examples mirror the existing one under `Py_mod_abi` and make it
explicit that `PySlot_DATA` (not `PySlot_INT64` / `PySlot_UINT64`)
is the correct slot-definition macro for these two slots, because
their values (`Py_MOD_GIL_*`, `Py_MOD_MULTIPLE_INTERPRETERS_*`,
`Py_MOD_PER_INTERPRETER_GIL_SUPPORTED`) are defined as `(void *)N`
in `Include/moduleobject.h`, and `PySlot_DATA` casts to `void *`
(`Include/slots.h`).

## Changes

- `Doc/c-api/module.rst`: add a `PySlot_DATA(...)` code-block to each
  of the two slot sections, in the same 4-part style (intro sentence +
  `.. code-block:: c` + 6-space code + `.. versionadded::`) as the
  existing `Py_mod_abi` example.

The `Py_mod_multiple_interpreters` example shows
`Py_MOD_PER_INTERPRETER_GIL_SUPPORTED` (rather than the default
`_SUPPORTED`) since that is the value extension authors most often need
to set explicitly. Likewise the `Py_mod_gil` example shows
`Py_MOD_GIL_NOT_USED` (rather than the default `_USED`).

## Notes

- Docs-only change; no `Misc/NEWS.d` entry per the
  [devguide](https://devguide.python.org/getting-started/pull-request-lifecycle/#what-s-new-and-news-entries).
- RST format mirrors `Py_mod_abi` byte-for-byte (3-space body
  indentation, 6-space code indentation, identical directive order).


<!-- gh-issue-number: gh-149716 -->
* Issue: gh-149716
<!-- /gh-issue-number -->
