### PR TITLE
gh-59999:` zipfile:` restore Unix permissions after extraction

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -1715,6 +1715,25 @@ class ExtractTests(unittest.TestCase):
         with temp_dir() as extdir:
             self._test_extract_all_with_target(FakePath(extdir))
 
+    @unittest.skipUnless(hasattr(os, 'chmod'), 'requires os.chmod')
+    @unittest.skipIf(sys.platform == 'win32', 'Unix permissions only')
+    def test_extract_preserves_unix_permissions(self):
+        """_extract_member must apply Unix mode stored in external_attr."""
+        info = zipfile.ZipInfo('secret.txt')
+        info.external_attr = (stat.S_IFREG | 0o600) << 16
+        with zipfile.ZipFile(TESTFN2, 'w') as zf:
+            zf.writestr(info, b'data')
+
+        with temp_dir() as extdir:
+            with zipfile.ZipFile(TESTFN2, 'r') as zf:
+                zf.extract('secret.txt', path=extdir)
+
+            extracted = os.path.join(extdir, 'secret.txt')
+            actual = stat.S_IMODE(os.stat(extracted).st_mode)
+            self.assertEqual(actual, 0o600, f'expected 0o600, got 0o{actual:03o}')
+
+        unlink(TESTFN2)
+
     def check_file(self, filename, content):
         self.assertTrue(os.path.isfile(filename))
         with open(filename, 'rb') as f:

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1933,11 +1933,19 @@ class ZipFile:
                 except FileExistsError:
                     if not os.path.isdir(targetpath):
                         raise
+            unix_mode = member.external_attr >> 16
+            if unix_mode:
+                os.chmod(targetpath, unix_mode)
             return targetpath
 
         with self.open(member, pwd=pwd) as source, \
              open(targetpath, "wb") as target:
             shutil.copyfileobj(source, target)
+
+        # Restore Unix permissions stored in the upper 16 bits of external_attr.
+        unix_mode = member.external_attr >> 16
+        if unix_mode:
+            os.chmod(targetpath, unix_mode)
 
         return targetpath
 


### PR DESCRIPTION
fixes #149839 

- When extracting a `zip file`, stored Unix permissions were ignored and files always got default permissions instead.
-   Fixed by applying the stored permissions with `os.chmod` after extraction.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149839 -->
* Issue: gh-149839
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-59999 -->
* Issue: gh-59999
<!-- /gh-issue-number -->
