### PR TITLE
gh-149879: Fix test_tempfile on Cygwin

### DIFF
--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -511,6 +511,8 @@ class TestMkstempInner(TestBadTempdir, BaseTestCase):
         self.assertFalse(retval > 0, "child process reports failure %d"%retval)
 
     @unittest.skipUnless(has_textmode, "text mode not available")
+    @unittest.skipIf(sys.platform == "cygwin",
+                     "truncate text mode is not supported on Cygwin")
     def test_textmode(self):
         # _mkstemp_inner can create files in text mode
 


### PR DESCRIPTION
On Cygwin, text files are not truncated at the first Ctrl+Z byte.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149879 -->
* Issue: gh-149879
<!-- /gh-issue-number -->
