### PR TITLE
gh-149879: Fix test_c_stack_unwind on Cygwin

### DIFF
--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -240,10 +240,17 @@ classify_address(uintptr_t addr, int jit_enabled, PyInterpreterState *interp)
         if (strncmp(base, "python", 6) == 0) {
             return "python";
         }
+#ifdef __CYGWIN__
+        // Match Cygwin "cygpython3.16.dll"
+        if (strncmp(base, "cygpython", 9) == 0) {
+            return "python";
+        }
+#else
         // Match "libpython3.15.so.1.0"
         if (strncmp(base, "libpython", 9) == 0) {
             return "python";
         }
+#endif
         return "other";
     }
 #ifdef _Py_JIT


### PR DESCRIPTION
On Cygwin, the Python library is called "cygpython3.16.dll".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149879 -->
* Issue: gh-149879
<!-- /gh-issue-number -->
