### PR TITLE
gh-72798: Add example to str.translate documentation

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2851,6 +2851,14 @@ expression support in the :mod:`re` module).
       >>> 'abc123'.translate({ord('a'): 'X', ord('b'): 'Y', ord('c'): None})
       'XY123'
 
+   For example, removing vowels using :meth:`str.maketrans`:
+
+   .. doctest::
+
+      >>> table = str.maketrans('', '', 'aeiou')
+      >>> 'hello world'.translate(table)
+      'hll wrld'
+
    See also the :mod:`codecs` module for a more flexible approach to custom
    character mappings.
 


### PR DESCRIPTION
Adds an example showing how to remove vowels using `str.maketrans` and `str.translate`.

<!-- gh-issue-number: gh-72798 -->
* Issue: gh-72798
<!-- /gh-issue-number -->
