### PR TITLE
[3.14] gh-149590: Remove faulthandler_traverse (GH-150023)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-18-13-47-17.gh-issue-149590.IPBeQx.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-18-13-47-17.gh-issue-149590.IPBeQx.rst
@@ -1,0 +1,1 @@
+Fix crash when faulthandler is imported more than once.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1248,20 +1248,6 @@ faulthandler_stack_overflow(PyObject *self, PyObject *Py_UNUSED(ignored))
 #endif   /* defined(FAULTHANDLER_USE_ALT_STACK) && defined(HAVE_SIGACTION) */
 
 
-static int
-faulthandler_traverse(PyObject *module, visitproc visit, void *arg)
-{
-    Py_VISIT(thread.file);
-#ifdef FAULTHANDLER_USER
-    if (user_signals != NULL) {
-        for (size_t signum=0; signum < Py_NSIG; signum++)
-            Py_VISIT(user_signals[signum].file);
-    }
-#endif
-    Py_VISIT(fatal_error.file);
-    return 0;
-}
-
 #ifdef MS_WINDOWS
 static PyObject *
 faulthandler_raise_exception(PyObject *self, PyObject *args)
@@ -1394,7 +1380,6 @@ static struct PyModuleDef module_def = {
     .m_name = "faulthandler",
     .m_doc = module_doc,
     .m_methods = module_methods,
-    .m_traverse = faulthandler_traverse,
     .m_slots = faulthandler_slots
 };
 


### PR DESCRIPTION
`faulthandler_traverse` visits Python objects owned by `_PyRuntime`, not by the module instance. With multi-phase init allowing multiple module instances, each instance's GC traversal decrements `gc_refs` on the same runtime-owned objects, driving it negative when two instances are collected simultaneously.
(cherry picked from commit 56737483c2ffdaadfec648fd38d409c6b10941c0)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149590 -->
* Issue: gh-149590
<!-- /gh-issue-number -->
