### PR TITLE
gh-150046: Fix `test_add_python_opts` to ignore `PYTHON*` vars

### DIFF
--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -2277,7 +2277,7 @@ class ArgsTestCase(BaseTestCase):
 
         # Use directly subprocess to control the exact command line
         cmd = [sys.executable,
-               "-m", "test", option,
+               "-E", "-m", "test", option,
                f'--testdir={self.tmptestdir}',
                testname]
         proc = subprocess.run(cmd,

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -2277,13 +2277,14 @@ class ArgsTestCase(BaseTestCase):
 
         # Use directly subprocess to control the exact command line
         cmd = [sys.executable,
-               "-E", "-m", "test", option,
+               "-m", "test", option,
                f'--testdir={self.tmptestdir}',
                testname]
         proc = subprocess.run(cmd,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT,
-                              text=True)
+                              text=True,
+                              env=support.make_clean_env())
         self.assertEqual(proc.returncode, 0, proc)
 
     def test_add_python_opts(self):

--- a/Misc/NEWS.d/next/Tests/2026-05-19-08-10-20.gh-issue-150046.MndDD8.rst
+++ b/Misc/NEWS.d/next/Tests/2026-05-19-08-10-20.gh-issue-150046.MndDD8.rst
@@ -1,1 +1,0 @@
-Avoid ``PYTHON*`` environment variables affecting regrtest's own tests.

--- a/Misc/NEWS.d/next/Tests/2026-05-19-08-10-20.gh-issue-150046.MndDD8.rst
+++ b/Misc/NEWS.d/next/Tests/2026-05-19-08-10-20.gh-issue-150046.MndDD8.rst
@@ -1,0 +1,1 @@
+Avoid ``PYTHON*`` environment variables affecting regrtest's own tests.


### PR DESCRIPTION
Avoid the runtime environment from affecting the tests' behaviours, which checks the warning filters. The filters can be affected by various `PYTHON*` environment variables.



<!-- gh-issue-number: gh-150046 -->
* Issue: gh-150046
<!-- /gh-issue-number -->
