### PR TITLE
gh-124111: Keep tests passing for Tcl prior to 9.0

### DIFF
--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -22,8 +22,6 @@ permissions:
 
 env:
   FORCE_COLOR: 1
-  IncludeUwp: >-
-    true
 
 jobs:
   build:

--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -55,7 +55,7 @@ class TclTest(unittest.TestCase):
     def test_eval_surrogates_in_result(self):
         tcl = self.interp
         result = tcl.eval(r'set a "<\ud83d\udcbb>"')
-        if sys.platform == 'win32':
+        if sys.platform == 'win32' and tcl_version >= (9, 0):
             self.assertEqual('<\ud83d\udcbb>', result)
         else:
             self.assertEqual('<\U0001f4bb>', result)
@@ -294,7 +294,7 @@ class TclTest(unittest.TestCase):
             """)
         tcl.evalfile(filename)
         result = tcl.eval('set b')
-        if sys.platform == 'win32':
+        if sys.platform == 'win32' and tcl_version >= (9, 0):
             self.assertEqual('<\ud83d\udcbb>', result)
         else:
             self.assertEqual('<\U0001f4bb>', result)


### PR DESCRIPTION


<!-- gh-issue-number: gh-124111 -->
* Issue: gh-124111
<!-- /gh-issue-number -->
