### PR TITLE
gh-150101: Expose OpenSSL's error queue through SSLError.error_queue

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -268,7 +268,9 @@ Exceptions
       item of the list is the top of the queue. If :attr:`reason` is not enough
       to diagnose a problem, OpenSSL may report more detail through this queue.
       The format of the strings follows that of OpenSSL's
-      `ERR_error_string <https://docs.openssl.org/master/man3/ERR_error_string/>`_.
+      `ERR_error_string <https://docs.openssl.org/master/man3/ERR_error_string/>`_,
+      and may change between OpenSSL versions (i.e. do not rely on the exact
+      wording of these messages).
 
       .. versionadded:: 3.16
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -262,7 +262,15 @@ Exceptions
       example ``CERTIFICATE_VERIFY_FAILED``.  The range of possible
       values depends on the OpenSSL version.
 
-      .. versionadded:: 3.3
+   .. attribute:: error_queue
+
+      The full OpenSSL error queue, as a list of strings, where the last
+      item of the list is the top of the queue. If :attr:`reason` is not enough
+      to diagnose a problem, OpenSSL may report more detail through this queue.
+      The format of the strings follows that of OpenSSL's
+      `ERR_error_string <https://docs.openssl.org/master/man3/ERR_error_string/>`_.
+
+      .. versionadded:: 3.16
 
 .. exception:: SSLZeroReturnError
 

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1909,6 +1909,7 @@ class SSLErrorTests(unittest.TestCase):
         self.assertEqual(cm.exception.library, 'PEM')
         regex = "(NO_START_LINE|UNSUPPORTED_PUBLIC_KEY_TYPE)"
         self.assertRegex(cm.exception.reason, regex)
+        self.assertTrue(len(cm.exception.error_queue >= 1))
         s = str(cm.exception)
         self.assertIn("NO_START_LINE", s)
 
@@ -4688,6 +4689,7 @@ class ThreadedTests(unittest.TestCase):
                                        chatty=False,
                                        sni_name='supermessage')
         self.assertEqual(cm.exception.reason, 'TLSV1_ALERT_ACCESS_DENIED')
+        self.assertTrue(len(cm.exception.error_queue >= 1))
 
     def test_sni_callback_raising(self):
         # Raising fails the connection with a TLS handshake failure alert.
@@ -4708,6 +4710,7 @@ class ThreadedTests(unittest.TestCase):
                      "|SSLV3_ALERT_HANDSHAKE_FAILURE"
                      "|NO_PRIVATE_VALUE)")
             self.assertRegex(cm.exception.reason, regex)
+            self.assertTrue(len(cm.exception.error_queue >= 1))
             self.assertEqual(catch.unraisable.exc_type, ZeroDivisionError)
 
     def test_sni_callback_wrong_return_type(self):
@@ -4727,6 +4730,7 @@ class ThreadedTests(unittest.TestCase):
 
 
             self.assertEqual(cm.exception.reason, 'TLSV1_ALERT_INTERNAL_ERROR')
+            self.assertTrue(len(cm.exception.error_queue >= 1))
             self.assertEqual(catch.unraisable.exc_type, TypeError)
 
     def test_shared_ciphers(self):

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1909,7 +1909,7 @@ class SSLErrorTests(unittest.TestCase):
         self.assertEqual(cm.exception.library, 'PEM')
         regex = "(NO_START_LINE|UNSUPPORTED_PUBLIC_KEY_TYPE)"
         self.assertRegex(cm.exception.reason, regex)
-        self.assertTrue(len(cm.exception.error_queue >= 1))
+        self.assertTrue(len(cm.exception.error_queue) >= 1)
         s = str(cm.exception)
         self.assertIn("NO_START_LINE", s)
 
@@ -4689,7 +4689,7 @@ class ThreadedTests(unittest.TestCase):
                                        chatty=False,
                                        sni_name='supermessage')
         self.assertEqual(cm.exception.reason, 'TLSV1_ALERT_ACCESS_DENIED')
-        self.assertTrue(len(cm.exception.error_queue >= 1))
+        self.assertTrue(len(cm.exception.error_queue) >= 1)
 
     def test_sni_callback_raising(self):
         # Raising fails the connection with a TLS handshake failure alert.
@@ -4710,7 +4710,7 @@ class ThreadedTests(unittest.TestCase):
                      "|SSLV3_ALERT_HANDSHAKE_FAILURE"
                      "|NO_PRIVATE_VALUE)")
             self.assertRegex(cm.exception.reason, regex)
-            self.assertTrue(len(cm.exception.error_queue >= 1))
+            self.assertTrue(len(cm.exception.error_queue) >= 1)
             self.assertEqual(catch.unraisable.exc_type, ZeroDivisionError)
 
     def test_sni_callback_wrong_return_type(self):
@@ -4730,7 +4730,7 @@ class ThreadedTests(unittest.TestCase):
 
 
             self.assertEqual(cm.exception.reason, 'TLSV1_ALERT_INTERNAL_ERROR')
-            self.assertTrue(len(cm.exception.error_queue >= 1))
+            self.assertTrue(len(cm.exception.error_queue) >= 1)
             self.assertEqual(catch.unraisable.exc_type, TypeError)
 
     def test_shared_ciphers(self):

--- a/Misc/NEWS.d/next/Library/2026-05-19-19-07-32.gh-issue-150101.x62Rm6.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-19-19-07-32.gh-issue-150101.x62Rm6.rst
@@ -1,0 +1,1 @@
+Expose OpenSSL's error queue through SSLError.error_queue

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -513,6 +513,8 @@ fill_and_set_sslerror(_sslmodulestate *state,
     PyObject *verify_obj = NULL, *verify_code_obj = NULL;
     PyObject *init_value, *msg, *key;
     PyUnicodeWriter *writer = NULL;
+    PyObject *error_queue = PyList_New(0);
+    if (!error_queue) goto fail;
 
     if (ssl_errno == PY_SSL_ERROR_EOF && sslsock != NULL) {
         sslsock->got_eof_error = 1;
@@ -541,6 +543,45 @@ fill_and_set_sslerror(_sslmodulestate *state,
         }
         if (errstr == NULL) {
             errstr = ERR_reason_error_string(errcode);
+        }
+
+        /* populate error_list from OpenSSL's error queue */
+        unsigned int q_pos = 0;  /* Error queue position */
+        const char *eq_filename, *eq_func, *eq_data;
+        char eq_msg[256];
+        int eq_lineno;
+        int flags;  /* Flags (discarded) */
+        unsigned long openssl_errorcode;
+
+        /* Presumably, we no longer need the OpenSSL error queue after this, so
+           we can call ERR_get_error (destructive) instead of ERR_peek_error */
+        while ((openssl_errorcode = ERR_get_error_all(&eq_filename, &eq_lineno, &eq_func,
+                                                      &eq_data, &flags))) {
+            if (q_pos == 0) {
+                /* errcode should have come from a caller, and should have been
+                   returned from ERR_peek_last_error() */
+                assert(openssl_errorcode == errcode);
+            }
+
+            ERR_error_string_n(openssl_errorcode, eq_msg, 256);
+
+            // Follows [lib reason] error_string extra_data (OpenSSL file:func:line)
+            PyObject *current_eq_msg = NULL;
+            if (eq_data != NULL) {
+                current_eq_msg = PyUnicode_FromFormat(
+                    "%s %s (%s:%s:%d)",
+                    eq_msg, eq_data, eq_filename, eq_func, eq_lineno
+                );
+            } else {
+                current_eq_msg = PyUnicode_FromFormat(
+                    "%s (%s:%s:%d)",
+                    eq_msg, eq_filename, eq_func, eq_lineno
+                );
+            }
+            if (PyList_Append(error_queue, current_eq_msg) != 0) {
+                goto fail;
+            }
+            q_pos++;
         }
     }
 
@@ -654,6 +695,12 @@ fill_and_set_sslerror(_sslmodulestate *state,
         if (PyObject_SetAttr(err_value, state->str_verify_message, verify_obj))
             goto fail;
     }
+
+    /* Add the full OpenSSL error queue to exception */
+    if (PyObject_SetAttr(err_value, state->str_error_queue, error_queue) != 0) {
+        goto fail;
+    }
+    Py_DECREF(error_queue);
 
     PyErr_SetObject(type, err_value);
 fail:
@@ -7357,6 +7404,10 @@ sslmodule_init_strings(PyObject *module)
     }
     state->str_verify_code = PyUnicode_InternFromString("verify_code");
     if (state->str_verify_code == NULL) {
+        return -1;
+    }
+    state->str_error_queue = PyUnicode_InternFromString("error_queue");
+    if (state->str_error_queue == NULL) {
         return -1;
     }
     return 0;

--- a/Modules/_ssl.h
+++ b/Modules/_ssl.h
@@ -33,6 +33,7 @@ typedef struct {
     PyObject *str_reason;
     PyObject *str_verify_code;
     PyObject *str_verify_message;
+    PyObject *str_error_queue;
     /* keylog lock */
     PyThread_type_lock keylog_lock;
 } _sslmodulestate;


### PR DESCRIPTION
See gh-150101 for background

In the associated PR, we drain the OpenSSL error queue and expose it via the error_queue attribute on the SSLError exception. With this modification to Python's SSL module, we can see what's in that queue:

With script:

    #!/usr/bin/env python3
    """Test TLS 1.2 connection to a site using only stdlib."""

    import pprint
    import ssl
    import socket

    def main():
        hostname = "www.example.com"

        # Create SSL context with TLS 1.2 maximum
        context = ssl.create_default_context()
        context.maximum_version = ssl.TLSVersion.TLSv1_2

        # Connect with TLS 1.2
        try:
            with socket.create_connection((hostname, 443)) as sock:
                with context.wrap_socket(sock, server_hostname=hostname) as ssock:
                    print(f"Connected to {hostname}")
                    print(f"TLS version: {ssock.version()}")
                    print(f"Cipher: {ssock.cipher()}")

                    # Send a simple HTTP request
                    request = f"GET / HTTP/1.1\r\nHost: {hostname}\r\nConnection: close\r\n\r\n".encode('ascii')
                    ssock.sendall(request)

                    response = ssock.recv(4096)
                    status_line = response.split(b'\r\n')[0].decode('utf-8', errors='replace')
                    print(f"\nResponse status: {status_line}")
        except ssl.SSLError as e:
            if hasattr(e, 'error_queue'):
                print("\nSSL error queue:")
                pprint.pprint(e.error_queue)
            raise

    if __name__ == "__main__":
        main()

We get that OpenSSL error queue that's helpful in debugging these kinds of problems:

    $ python3.13 test_tls1.2.py

    SSL error queue:
    ['error:1C8000E9:Provider routines::reason(233)  '
    '(providers/implementations/kdfs/tls1_prf.c:(unknown function):208)',
    'error:0A0C0103:SSL routines::internal error  (ssl/t1_enc.c:tls1_PRF:79)']
    Traceback (most recent call last):
      File "/opt/bigcorp/test_tls1.2.py", line 37, in <module>
        main()
        ~~~~^^
      File "/opt/bigcorp/test_tls1.2.py", line 18, in main
        with context.wrap_socket(sock, server_hostname=hostname) as ssock:
            ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/bigcorp/lib/python3.13/ssl.py", line 460, in wrap_socket
        return self.sslsocket_class._create(
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
            sock=sock,
            ^^^^^^^^^^
        ...<5 lines>...
            session=session
            ^^^^^^^^^^^^^^^
        )
        ^
      File "/opt/bigcorp/lib/python3.13/ssl.py", line 1084, in _create
        self.do_handshake()
        ~~~~~~~~~~~~~~~~~^^
      File "/opt/bigcorp/lib/python3.13/ssl.py", line 1380, in do_handshake
        self._sslobj.do_handshake()
        ~~~~~~~~~~~~~~~~~~~~~~~~~^^
    ssl.SSLError: [SSL] internal error (_ssl.c:1102)

It's worth noting, that on a stock Linux distribution (e.g. Ubuntu 24.04), the above script doesn't fail. Trying to attempt to raise SSLError in the limited ways I know how, e.g.

    context = ssl.create_default_context()
    context.check_hostname = True
    context.verify_mode = ssl.CERT_REQUIRED

    # Connect to a site but verify against a completely different hostname
    # that doesn't match any SAN in the certificate

    try:
        with socket.create_connection(("www.python.org", 443)) as sock:
            # Try to verify as "totally-fake-hostname.example.com"
            with context.wrap_socket(
                sock, server_hostname="totally-fake-hostname.example.com"
            ) as ssock:
                print(f"Connected: {ssock.version()}")
    except ssl.SSLError as e:
        print(f"SSLError from hostname mismatch: {e}, {e.error_queue=}")
        raise

results in only 1 item in the OpenSSL error queue (see first line, you may need to scroll sideways):

    SSLError from hostname mismatch: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'totally-fake-hostname.example.com'. (_ssl.c:1088), e.error_queue=['error:0A000086:SSL routines::certificate verify failed  (../ssl/statem/statem_clnt.c:tls_post_process_server_certificate:1889)']
    Traceback (most recent call last):
      File "/home/xjjk/src/git/cpython/test_ssl_error.py", line 279, in <module>
        test_ssl_error_with_hostname_verification()
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
      File "/home/xjjk/src/git/cpython/test_ssl_error.py", line 31, in test_ssl_error_with_hostname_verification
        with context.wrap_socket(
            ~~~~~~~~~~~~~~~~~~~^
            sock, server_hostname="totally-fake-hostname.example.com"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        ) as ssock:
        ^
      File "/home/xjjk/src/git/cpython/install/lib/python3.13t/ssl.py", line 455, in wrap_socket
        return self.sslsocket_class._create(
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
            sock=sock,
            ^^^^^^^^^^
        ...<5 lines>...
            session=session
            ^^^^^^^^^^^^^^^
        )
        ^
      File "/home/xjjk/src/git/cpython/install/lib/python3.13t/ssl.py", line 1076, in _create
        self.do_handshake()
        ~~~~~~~~~~~~~~~~~^^
      File "/home/xjjk/src/git/cpython/install/lib/python3.13t/ssl.py", line 1372, in do_handshake
        self._sslobj.do_handshake()
        ~~~~~~~~~~~~~~~~~~~~~~~~~^^
    ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'totally-fake-hostname.example.com'. (_ssl.c:1088)

i.e.
```
e.error_queue=['error:0A000086:SSL routines::certificate verify failed  (../ssl/statem/statem_clnt.c:tls_post_process_server_certificate:1889)']
```
is new.

I can't think up of a way to raise an SSLError that results in a longer OpenSSL error queue that's significantly different than what was already in the original exception. As such, the unit tests are sort of superficial (and difficult to reliably improve, as the messages in the queue may change depending on the version of OpenSSL used). Even without a better test case, outputing what OpenSSL provides directly (e.g. we add the OpenSSL filenames and functions here) may help folks because those errors may be more Google-able.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
