### PR TITLE
gh-150114: Reduce memory usage of test_free_threading.test_iteration

### DIFF
--- a/Lib/test/test_free_threading/test_iteration.py
+++ b/Lib/test/test_free_threading/test_iteration.py
@@ -12,7 +12,7 @@ if support.check_sanitizer(thread=True):
     NUMITEMS = 1000
     NUMTHREADS = 2
 else:
-    NUMITEMS = 100000
+    NUMITEMS = 5000
     NUMTHREADS = 5
 NUMMUTATORS = 2
 


### PR DESCRIPTION
Reduce NUMITEMS from 100000 to 5000. Peak RSS for the full test_free_threading suite drops from ~850 MB to ~175 MB.


<!-- gh-issue-number: gh-150114 -->
* Issue: gh-150114
<!-- /gh-issue-number -->
