### PR TITLE
gh-150116 Remove dead try/except in asyncio.Lock._wake_up_first

### DIFF
--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -145,10 +145,7 @@ class Lock(_ContextManagerMixin, mixins._LoopBoundMixin):
         """Ensure that the first waiter will wake up."""
         if not self._waiters:
             return
-        try:
-            fut = next(iter(self._waiters))
-        except StopIteration:
-            return
+        fut = next(iter(self._waiters))
 
         # .done() means that the waiter is already set to wake up.
         if not fut.done():


### PR DESCRIPTION
`asyncio.Lock._wake_up_first` had a `try/except StopIteration` block guarding `next(iter(self._waiters))`:

```python
  def _wake_up_first(self):
      if not self._waiters:
          return
      try:
          fut = next(iter(self._waiters))
      except StopIteration:
          return
      ...
```

The except branch is unreachable. The preceding early return ensures `self._waiters` is a non-empty `collections.deque`

After:

```python
  def _wake_up_first(self):
      if not self._waiters:
          return
      fut = next(iter(self._waiters))
      if not fut.done():
          fut.set_result(True)
```

No behavior change.


<!-- gh-issue-number: gh-150116 -->
* Issue: gh-150116
<!-- /gh-issue-number -->
