### PR TITLE
Remove 'expat' dependency for Linux in `Misc/Brewfile`

### DIFF
--- a/Misc/Brewfile
+++ b/Misc/Brewfile
@@ -7,7 +7,6 @@ brew "xz"
 brew "zstd"
 
 brew "bzip2" if OS.linux?
-brew "expat" if OS.linux?
 brew "libedit" if OS.linux?
 brew "libffi" if OS.linux?
 brew "ncurses" if OS.linux?


### PR DESCRIPTION
Expat is vendored.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
