### PR TITLE
[3.13] gh-150146: Fix NULL dereference in `_Py_subs_parameters` (GH-150147)

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -56,9 +56,8 @@ from unittest.case import _AssertRaisesContext
 from queue import Queue, SimpleQueue
 from weakref import WeakSet, ReferenceType, ref
 import typing
-from typing import Unpack
+from typing import TypeVar, Unpack
 
-from typing import TypeVar
 T = TypeVar('T')
 K = TypeVar('K')
 V = TypeVar('V')
@@ -537,6 +536,13 @@ class BaseTest(unittest.TestCase):
         iter_x = iter(t)
         del iter_x
 
+    def test_gh150146(self):
+        # It used to crash:
+        for container in [memoryview, list, tuple]:
+            with self.subTest(container=container):
+                x = container[TypeVar("")]
+                with self.assertRaises(TypeError):
+                    x[*typing.Mapping[..., ...]]
 
 class TypeIterationTests(unittest.TestCase):
     _UNITERABLE_TYPES = (list, tuple)

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -538,7 +538,7 @@ class BaseTest(unittest.TestCase):
 
     def test_gh150146(self):
         # It used to crash:
-        for container in [memoryview, list, tuple]:
+        for container in [list, tuple]:
             with self.subTest(container=container):
                 x = container[TypeVar("")]
                 with self.assertRaises(TypeError):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-20-13-06-17.gh-issue-150146.i5m_SL.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-20-13-06-17.gh-issue-150146.i5m_SL.rst
@@ -1,0 +1,5 @@
+Fix a crash on a complex type variable substitution.
+
+``from typing import TypeVar; memoryview[TypeVar("")][*typing.Mapping[...,
+...]]`` used to fail due to missing ``NULL`` check on ``_unpack_args`` C
+function call.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -443,6 +443,9 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
                             self);
     }
     item = _unpack_args(item);
+    if (item == NULL) {
+        return NULL;
+    }
     for (Py_ssize_t i = 0; i < nparams; i++) {
         PyObject *param = PyTuple_GET_ITEM(parameters, i);
         PyObject *prepare, *tmp;


### PR DESCRIPTION
(cherry picked from commit f621ba16b72510e1abc9646a844a632df4ac275c)


<!-- gh-issue-number: gh-150146 -->
* Issue: gh-150146
<!-- /gh-issue-number -->
