### PR TITLE
gh-137855: Improve import time of textwrap by lazy importing re modules

### DIFF
--- a/Lib/test/test_textwrap.py
+++ b/Lib/test/test_textwrap.py
@@ -10,6 +10,9 @@
 
 import unittest
 
+from test.support import cpython_only
+from test.support.import_helper import ensure_lazy_imports
+
 from textwrap import TextWrapper, wrap, fill, dedent, indent, shorten
 
 
@@ -1131,6 +1134,13 @@ class ShortenTestCase(BaseTestCase):
 
     def test_first_word_too_long_but_placeholder_fits(self):
         self.check_shorten("Helloo", 5, "[...]")
+
+
+class LazyImportTest(unittest.TestCase):
+
+    @cpython_only
+    def test_lazy_import(self):
+        ensure_lazy_imports("textwrap", {"re"})
 
 
 if __name__ == '__main__':

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2002 Python Software Foundation.
 # Written by Greg Ward <gward@python.net>
 
-import re
+lazy import re
 
 __all__ = ['TextWrapper', 'wrap', 'fill', 'dedent', 'indent', 'shorten']
 
@@ -65,49 +65,56 @@ class TextWrapper:
 
     unicode_whitespace_trans = dict.fromkeys(map(ord, _whitespace), ord(' '))
 
-    # This funky little regex is just the trick for splitting
-    # text up into word-wrappable chunks.  E.g.
-    #   "Hello there -- you goof-ball, use the -b option!"
-    # splits into
-    #   Hello/ /there/ /--/ /you/ /goof-/ball,/ /use/ /the/ /-b/ /option!
-    # (after stripping out empty strings).
-    word_punct = r'[\w!"\'&.,?]'
-    letter = r'[^\d\W]'
-    whitespace = r'[%s]' % re.escape(_whitespace)
-    nowhitespace = '[^' + whitespace[1:]
-    wordsep_re = re.compile(r'''
-        ( # any whitespace
-          %(ws)s+
-        | # em-dash between words
-          (?<=%(wp)s) -{2,} (?=\w)
-        | # word, possibly hyphenated
-          %(nws)s+? (?:
-            # hyphenated word
-              -(?: (?<=%(lt)s{2}-) | (?<=%(lt)s-%(lt)s-))
-              (?= %(lt)s -? %(lt)s)
-            | # end of word
-              (?=%(ws)s|\z)
-            | # em-dash
-              (?<=%(wp)s) (?=-{2,}\w)
-            )
-        )''' % {'wp': word_punct, 'lt': letter,
-                'ws': whitespace, 'nws': nowhitespace},
-        re.VERBOSE)
-    del word_punct, letter, nowhitespace
+    wordsep_re = None
+    wordsep_simple_re = None
+    sentence_end_re = None
 
-    # This less funky little regex just split on recognized spaces. E.g.
-    #   "Hello there -- you goof-ball, use the -b option!"
-    # splits into
-    #   Hello/ /there/ /--/ /you/ /goof-ball,/ /use/ /the/ /-b/ /option!/
-    wordsep_simple_re = re.compile(r'(%s+)' % whitespace)
-    del whitespace
+    @classmethod
+    def _compile_wordseps(cls):
+        """Compile word-separator regexes on first use."""
+        if cls.wordsep_re is not None:
+            return
+        # This funky little regex is just the trick for splitting
+        # text up into word-wrappable chunks.  E.g.
+        #   "Hello there -- you goof-ball, use the -b option!"
+        # splits into
+        #   Hello/ /there/ /--/ /you/ /goof-/ball,/ /use/ /the/ /-b/ /option!
+        # (after stripping out empty strings).
+        word_punct = r'[\w!"\'&.,?]'
+        letter = r'[^\d\W]'
+        whitespace = r'[%s]' % re.escape(_whitespace)
+        nowhitespace = '[^' + whitespace[1:]
+        cls.wordsep_re = re.compile(r'''
+            ( # any whitespace
+              %(ws)s+
+            | # em-dash between words
+              (?<=%(wp)s) -{2,} (?=\w)
+            | # word, possibly hyphenated
+              %(nws)s+? (?:
+                # hyphenated word
+                  -(?: (?<=%(lt)s{2}-) | (?<=%(lt)s-%(lt)s-))
+                  (?= %(lt)s -? %(lt)s)
+                | # end of word
+                  (?=%(ws)s|\z)
+                | # em-dash
+                  (?<=%(wp)s) (?=-{2,}\w)
+                )
+            )''' % {'wp': word_punct, 'lt': letter,
+                    'ws': whitespace, 'nws': nowhitespace},
+            re.VERBOSE)
 
-    # XXX this is not locale- or charset-aware -- string.lowercase
-    # is US-ASCII only (and therefore English-only)
-    sentence_end_re = re.compile(r'[a-z]'             # lowercase letter
-                                 r'[\.\!\?]'          # sentence-ending punct.
-                                 r'[\"\']?'           # optional end-of-quote
-                                 r'\z')               # end of chunk
+        # This less funky little regex just split on recognized spaces. E.g.
+        #   "Hello there -- you goof-ball, use the -b option!"
+        # splits into
+        #   Hello/ /there/ /--/ /you/ /goof-ball,/ /use/ /the/ /-b/ /option!/
+        cls.wordsep_simple_re = re.compile(r'(%s+)' % whitespace)
+
+        # XXX this is not locale- or charset-aware -- string.lowercase
+        # is US-ASCII only (and therefore English-only)
+        cls.sentence_end_re = re.compile(r'[a-z]'             # lowercase letter
+                                         r'[\.\!\?]'          # sentence-ending punct.
+                                         r'[\"\']?'           # optional end-of-quote
+                                         r'\z')               # end of chunk
 
     def __init__(self,
                  width=70,
@@ -135,6 +142,7 @@ class TextWrapper:
         self.tabsize = tabsize
         self.max_lines = max_lines
         self.placeholder = placeholder
+        self._compile_wordseps()
 
 
     # -- Private methods -----------------------------------------------


### PR DESCRIPTION
## Summary
- Improve `textwrap` import time by lazy-importing `re` (PEP 810) instead of loading it at module import.
- Defer compilation of `TextWrapper` word-separator regexes from class body to `_compile_wordseps()`, called on first `TextWrapper()` instantiation. Compiled patterns remain class attributes, shared across instances (same semantics as before).
- Add `LazyImportTest.test_lazy_import` using `ensure_lazy_imports()` to guard against regressions.
Part of the ongoing stdlib import-time work tracked in gh-137855.
## Motivation
`textwrap` is imported eagerly by many modules (e.g. tests, `traceback`, `optparse` paths) often only for `dedent()` / `indent()`, which do not need `re`. Previously, `import re` at module level and `re.compile()` in the `TextWrapper` class body caused `re` to load on every `import textwrap`.
## Before
<img width="1280" height="871" alt="db7456bb-64c0-4ff9-92c7-528726129fdb" src="https://github.com/user-attachments/assets/e01f054c-4107-4e02-8585-15d3aab057db" />

## After
<img width="1295" height="648" alt="c4648acf-c2dc-4307-ad57-cddaa0feee9c" src="https://github.com/user-attachments/assets/39a97178-2bdf-48a7-84da-e03722d7f57d" />
