### PR TITLE
gh-142317: Do not set a stack size for cpython on MacOS

### DIFF
--- a/Lib/test/test_resource.py
+++ b/Lib/test/test_resource.py
@@ -229,6 +229,18 @@ class ResourceTest(unittest.TestCase):
         self.assertEqual(resource.prlimit(0, resource.RLIMIT_AS, BadSeq()),
                          limits)
 
+    # Issue 142317: Setting RLIMIT_STACK not working on Darwin
+    @unittest.skipIf(sys.platform == "vxworks",
+                     "setting RLIMIT_STACK is not supported on VxWorks")
+    @unittest.skipUnless(hasattr(resource, 'RLIMIT_FSIZE'), 'requires resource.RLIMIT_FSIZE')
+    @unittest.skipIf(
+        sys.platform == "darwin" and support.check_sanitizer(ub=True),
+        "UBSan on MacOS explicitly compiles with a large stack size which breaks this test"
+    )
+    def test_rlimit_stack(self):
+        resource.setrlimit(
+            resource.RLIMIT_STACK, resource.getrlimit(resource.RLIMIT_STACK)
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/macOS/2026-05-20-18-23-16.gh-issue-142317.BDTpn9.rst
+++ b/Misc/NEWS.d/next/macOS/2026-05-20-18-23-16.gh-issue-142317.BDTpn9.rst
@@ -1,0 +1,3 @@
+Avoid failures to set RLIMIT_STACK with the resource module by no longer
+setting a default stack size for the cpython executable in the standard
+build configuration.

--- a/configure
+++ b/configure
@@ -14251,18 +14251,25 @@ then
 	Darwin/*|iOS/*)
 		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
 
-		# Issue #18075: the default maximum stack size (8MBytes) is too
-		# small for the default recursion limit. Increase the stack size
-		# to ensure that tests don't crash
-		stack_size="1000000"  # 16 MB
+		# Use the default stack size (0) unless otherwise requested to
+		# ensure that modifying RLIMIT_STACK works.
+		stack_size="0"
 		if test "$with_ubsan" = "yes"
 		then
 			# Undefined behavior sanitizer requires an even deeper stack
 			stack_size="4000000"  # 64 MB
 		fi
 
+		thread_stack_size="$stack_size"
+		# 0 does not map to a default thread stack size value, so we
+		# explicitly set the platform default (8MB) here if necessary.
+		if test "$stack_size" = "0"
+		then
+			thread_stack_size="800000"
+		fi
 
-printf "%s\n" "#define THREAD_STACK_SIZE 0x$stack_size" >>confdefs.h
+
+printf "%s\n" "#define THREAD_STACK_SIZE 0x$thread_stack_size" >>confdefs.h
 
 
 		if test $ac_sys_system = "Darwin"; then

--- a/configure.ac
+++ b/configure.ac
@@ -3719,18 +3719,25 @@ then
 	Darwin/*|iOS/*)
 		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
 
-		# Issue #18075: the default maximum stack size (8MBytes) is too
-		# small for the default recursion limit. Increase the stack size
-		# to ensure that tests don't crash
-		stack_size="1000000"  # 16 MB
+		# Use the default stack size (0) unless otherwise requested to
+		# ensure that modifying RLIMIT_STACK works.
+		stack_size="0"
 		if test "$with_ubsan" = "yes"
 		then
 			# Undefined behavior sanitizer requires an even deeper stack
 			stack_size="4000000"  # 64 MB
 		fi
 
+		thread_stack_size="$stack_size"
+		# 0 does not map to a default thread stack size value, so we
+		# explicitly set the platform default (8MB) here if necessary.
+		if test "$stack_size" = "0"
+		then
+			thread_stack_size="800000"
+		fi
+
 		AC_DEFINE_UNQUOTED([THREAD_STACK_SIZE],
-				[0x$stack_size],
+				[0x$thread_stack_size],
 				[Custom thread stack size depending on chosen sanitizer runtimes.])
 
 		if test $ac_sys_system = "Darwin"; then


### PR DESCRIPTION
We were originally setting a stack size beyond the default limit to allow the interpreter to hit the default recursion limit after some MacOS changes made it no longer possible to actually use RLIMIT_STACK to adjust the default stack size. 5bbbc733e6cc0804f19b071944af8d4719e26ae6 was the commit implenting that.

However, we no longer need extra stack space to hit the default recursion limit after b4903afd4debbbd71dc49a2c8fefa74a3b6c6832.

Given that setting the default stack size prevents setting RLIMIT_STACK in other circumstances where it would be useful (e.g., inside of LLVM's integrated tester where we want to emulate ulimit), and that it is no longer necessary to achieve the stated goal, do not set the stack size and set the thread stack size limit to the platform default to match what we were doing before.

I've added a simple regression test that ensures we can call `setrlimit` with `resource.RLIMIT_STACK` at all.

Fixes #142317.

<!-- gh-issue-number: gh-142317 -->
* Issue: gh-142317
<!-- /gh-issue-number -->
