### PR TITLE
gh-140950: Reset shlex state in push_source() so post-EOF pushes are read

### DIFF
--- a/Lib/shlex.py
+++ b/Lib/shlex.py
@@ -81,6 +81,9 @@ class shlex:
         self.infile = newfile
         self.instream = newstream
         self.lineno = 1
+        # Reset state so that a source pushed after EOF (when state is None)
+        # is still read.  Mirrors pop_source().
+        self.state = ' '
         if self.debug:
             if newfile is not None:
                 print('shlex: pushing to file %s' % (self.infile,))

--- a/Lib/test/test_shlex.py
+++ b/Lib/test/test_shlex.py
@@ -368,6 +368,18 @@ class ShlexTest(unittest.TestCase):
         with self.assertRaises(AttributeError):
             shlex_instance.punctuation_chars = False
 
+    def testPushSourceAfterEOF(self):
+        # gh-140950: a source pushed after the current input has reached
+        # EOF must still be read.  Previously get_token() set state to None
+        # at EOF, and push_source() did not reset it, so the new source
+        # was silently ignored.
+        lexer = shlex.shlex('a')
+        self.assertEqual(lexer.get_token(), 'a')
+        self.assertEqual(lexer.get_token(), lexer.eof)
+        lexer.push_source('b')
+        self.assertEqual(lexer.get_token(), 'b')
+        self.assertEqual(lexer.get_token(), lexer.eof)
+
     @cpython_only
     def test_lazy_imports(self):
         import_helper.ensure_lazy_imports('shlex', {'collections', 're', 'os'})

--- a/Misc/NEWS.d/next/Library/2026-05-20-16-02-48.gh-issue-140950.3zwzaKTA.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-20-16-02-48.gh-issue-140950.3zwzaKTA.rst
@@ -1,0 +1,4 @@
+Fix :class:`shlex.shlex` ignoring a source pushed via
+:meth:`~shlex.shlex.push_source` after the current input had reached EOF.
+:meth:`!push_source` now resets the internal lexer state, mirroring
+:meth:`~shlex.shlex.pop_source`.


### PR DESCRIPTION
Fixes gh-140950.

After `shlex.shlex.get_token()` reaches end of input it sets `self.state` to `None`. A subsequent `push_source()` did not reset that state, so the next `get_token()` call returned EOF immediately and the newly pushed source was silently ignored.

`pop_source()` already resets `state` to `' '` for the same reason. This change does the same in `push_source()`, which is the minimal symmetric fix.

Reproducer from the issue:

    >>> from shlex import shlex
    >>> lexer = shlex('a')
    >>> lexer.get_token()
    'a'
    >>> lexer.get_token()      # EOF, state becomes None
    ''
    >>> lexer.push_source('b')
    >>> lexer.get_token()      # before: '' (EOF); after: 'b'
    'b'

Push during an active stream is unaffected because `state` is already `' '` in that case. A regression test is added in `Lib/test/test_shlex.py` and a Library news entry is added under `Misc/NEWS.d/next/Library/`.