### PR TITLE
gh-150175: Fix ThreadingMock call_count race condition

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -3113,6 +3113,10 @@ class ThreadingMixin(Base):
 
         return ret_value
 
+    def _increment_mock_call(self, /, *args, **kwargs):
+        with self._mock_calls_events_lock:
+            super()._increment_mock_call(*args, **kwargs)
+
     def wait_until_called(self, *, timeout=_timeout_unset):
         """Wait until the mock object is called.
 

--- a/Misc/NEWS.d/next/Library/2026-05-21-11-25-58.gh-issue-150175.8H4Caz.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-21-11-25-58.gh-issue-150175.8H4Caz.rst
@@ -1,0 +1,3 @@
+Fix race condition in :class:`unittest.mock.ThreadingMock` where
+concurrent calls could lose increments to ``call_count`` and other
+attributes due to a missing lock in ``_increment_mock_call``.


### PR DESCRIPTION
## Problem
ThreadingMock._increment_mock_call() is not thread-safe. 
Multiple threads calling the mock simultaneously lose increments 
due to race conditions on call_count and other attributes.

This causes intermittent test failures like:
    AssertionError: 983 != 1000

Reported in Yocto Project bug:
https://bugzilla.yoctoproject.org/show_bug.cgi?id=16213

Fixes gh-150175

## Root Cause
In the base Mock class, _increment_mock_call does:
    self.called = True
    self.call_count += 1   # not atomic!
    self.call_args = _call
    self.call_args_list.append(_call)

These are not protected by any lock in ThreadingMock.

## Fix
Override _increment_mock_call in ThreadingMixin and wrap it 
with the existing _mock_calls_events_lock:

    def _increment_mock_call(self, /, *args, **kwargs):
        with self._mock_calls_events_lock:
            super()._increment_mock_call(*args, **kwargs)

## Testing
Verified on both x86 and ARM64 (qemuarm64):
- Before fix: 23/30 failures with 50 threads x 10000 calls
- After fix:  0/30 failures with 50 threads x 10000 calls