### PR TITLE
gh-150178: Fix refcount leaks in hamt allocation failure paths

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-21-15-32-07.gh-issue-150178.2UKr8i.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-21-15-32-07.gh-issue-150178.2UKr8i.rst
@@ -1,0 +1,4 @@
+Fix two reference count leaks in :mod:`!hamt` on memory allocation failure
+paths inside ``hamt_node_bitmap_assoc`` and ``hamt_node_bitmap_without``.
+These leaks could occur if ``hamt_node_bitmap_clone`` failed after a
+recursive ``assoc``/``without`` call had already produced a new sub-node.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-21-15-32-07.gh-issue-150178.2UKr8i.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-21-15-32-07.gh-issue-150178.2UKr8i.rst
@@ -1,4 +1,0 @@
-Fix two reference count leaks in :mod:`!hamt` on memory allocation failure
-paths inside ``hamt_node_bitmap_assoc`` and ``hamt_node_bitmap_without``.
-These leaks could occur if ``hamt_node_bitmap_clone`` failed after a
-recursive ``assoc``/``without`` call had already produced a new sub-node.

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -702,6 +702,7 @@ hamt_node_bitmap_assoc(PyHamtNode_Bitmap *self,
 
             PyHamtNode_Bitmap *ret = hamt_node_bitmap_clone(self);
             if (ret == NULL) {
+                Py_DECREF(sub_node);
                 return NULL;
             }
             Py_SETREF(ret->b_array[val_idx], (PyObject*)sub_node);
@@ -994,6 +995,7 @@ hamt_node_bitmap_without(PyHamtNode_Bitmap *self,
 
                 PyHamtNode_Bitmap *clone = hamt_node_bitmap_clone(self);
                 if (clone == NULL) {
+                    Py_DECREF(sub_node);
                     return W_ERROR;
                 }
 


### PR DESCRIPTION
fix:https://github.com/python/cpython/issues/150178

<!-- gh-issue-number: gh-150178 -->
* Issue: gh-150178
<!-- /gh-issue-number -->
