### PR TITLE
[3.15] gh-149981: Test lazy import corner cases with module-level `__getattr__` (GH-149982)

### DIFF
--- a/Lib/test/test_lazy_import/__init__.py
+++ b/Lib/test/test_lazy_import/__init__.py
@@ -98,6 +98,59 @@ class LazyImportTests(unittest.TestCase):
         assert_python_ok("-c", code)
 
     @support.requires_subprocess()
+    def test_from_import_with_module_getattr_raising(self):
+        """Lazy from import should respect module-level __getattr__."""
+        code = textwrap.dedent("""
+            lazy from test.test_lazy_import.data.module_with_getattr import raising_attr
+
+            try:
+                raising_attr
+            except ValueError as exc:
+                assert str(exc) == 'from_getattr', exc
+            else:
+                assert False, f'ValueError is not raised: {raising_attr}'
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_from_import_with_module_getattr_missing(self):
+        """Lazy from import should respect module-level __getattr__."""
+        for attr in ("missing_attr", "import_error_attr"):
+            with self.subTest(attr=attr):
+                code = textwrap.dedent(f"""
+                    lazy from test.test_lazy_import.data.module_with_getattr import {attr}
+
+                    try:
+                        {attr}
+                    except ImportError as exc:
+                        assert '{attr}' in str(exc), exc
+                        assert exc.__cause__ is not None
+                    else:
+                        assert False, ('ImportError is not raised', {attr})
+                """)
+                assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_from_import_with_module_getattr_warning(self):
+        """Lazy from import should respect module-level __getattr__."""
+        code = textwrap.dedent("""
+            import warnings
+
+            with warnings.catch_warnings(record=True) as log:
+                lazy from test.test_lazy_import.data.module_with_getattr import warning_attr
+
+            assert log == []
+
+            with warnings.catch_warnings(record=True) as log:
+                warning_attr
+            assert warning_attr == 'from_warning_attr', warning_attr
+            assert len(log) == 1, log
+            assert isinstance(log[0].message, UserWarning), log
+            assert str(log[0].message) == 'from_getattr', log
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
     def test_from_import_with_imported_module_getattr(self):
         """Lazy from import should not shadow an imported module's __getattr__."""
         code = textwrap.dedent("""
@@ -479,6 +532,59 @@ class PackageTests(unittest.TestCase):
             assert "nonexistent_attr" not in json.__dict__, (
                 "lazy from import should not publish attributes on the parent module"
             )
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_package_from_import_with_module_getattr_raising(self):
+        """Lazy from import should respect a package's __getattr__."""
+        code = textwrap.dedent("""
+            lazy from test.test_lazy_import.data.pkg import raising_attr
+
+            try:
+                raising_attr
+            except ValueError as exc:
+                assert str(exc) == 'from_getattr', exc
+            else:
+                assert False, f'ValueError is not raised: {raising_attr}'
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_package_from_import_with_module_getattr_missing(self):
+        """Lazy from import should respect package's __getattr__."""
+        for attr in ("missing_attr", "import_error_attr"):
+            with self.subTest(attr=attr):
+                code = textwrap.dedent(f"""
+                    lazy from test.test_lazy_import.data.pkg import {attr}
+
+                    try:
+                        {attr}
+                    except ImportError as exc:
+                        assert '{attr}' in str(exc), exc
+                        assert exc.__cause__ is not None
+                    else:
+                        assert False, ('ImportError is not raised', {attr})
+                """)
+                assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_from_import_with_module_getattr_warning(self):
+        """Lazy from import should respect package's __getattr__."""
+        code = textwrap.dedent("""
+            import warnings
+
+            with warnings.catch_warnings(record=True) as log:
+                lazy from test.test_lazy_import.data.pkg import warning_attr
+
+            assert log == []
+
+            with warnings.catch_warnings(record=True) as log:
+                warning_attr
+            assert warning_attr == 'from_warning_attr', warning_attr
+            assert len(log) == 1, log
+            assert isinstance(log[0].message, UserWarning), log
+            assert str(log[0].message) == 'from_getattr', log
         """)
         assert_python_ok("-c", code)
 

--- a/Lib/test/test_lazy_import/data/module_with_getattr.py
+++ b/Lib/test/test_lazy_import/data/module_with_getattr.py
@@ -1,4 +1,12 @@
 def __getattr__(name):
     if name == "dynamic_attr":
         return "from_getattr"
+    elif name == "raising_attr":
+        raise ValueError("from_getattr")
+    elif name == "import_error_attr":
+        raise ImportError(name)
+    elif name == "warning_attr":
+        import warnings
+        warnings.warn("from_getattr", category=UserWarning)
+        return "from_warning_attr"
     raise AttributeError(name)

--- a/Lib/test/test_lazy_import/data/pkg/__init__.py
+++ b/Lib/test/test_lazy_import/data/pkg/__init__.py
@@ -3,4 +3,12 @@ x = 42
 def __getattr__(name):
     if name == "dynamic_attr":
         return "from_getattr"
+    elif name == "raising_attr":
+        raise ValueError("from_getattr")
+    elif name == "import_error_attr":
+        raise ImportError(name)
+    elif name == "warning_attr":
+        import warnings
+        warnings.warn("from_getattr", category=UserWarning)
+        return "from_warning_attr"
     raise AttributeError(name)


### PR DESCRIPTION
(cherry picked from commit 6dbf4ba403cd38d0219d3c7514f61c2ac8f6a74f)


<!-- gh-issue-number: gh-149981 -->
* Issue: gh-149981
<!-- /gh-issue-number -->
