### PR TITLE
gh-150204: Optimize literal null unpack idiom

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -1535,9 +1535,6 @@ class ASTHelpers_Test(unittest.TestCase):
             ('[*()]', ast.List, []),
             ('{*()}', ast.Set, []),
             ('(*(),)', ast.Tuple, []),
-            ('[1, *(), 2]', ast.List, [1, 2]),
-            ('{1, *(), 2}', ast.Set, [1, 2]),
-            ('(1, *(), 2)', ast.Tuple, [1, 2]),
         ]
 
         for source, node_type, expected_values in tests:
@@ -1548,6 +1545,22 @@ class ASTHelpers_Test(unittest.TestCase):
                     [elt.value for elt in node.elts],
                     expected_values,
                 )
+
+    def test_parse_preserves_multiple_null_container_unpacks(self):
+        tests = [
+            ('[1, *(), 2]', ast.List),
+            ('{1, *(), 2}', ast.Set),
+            ('(1, *(), 2)', ast.Tuple),
+            ('[*(), *()]', ast.List),
+            ('{*(), *()}', ast.Set),
+            ('(*(), *())', ast.Tuple),
+        ]
+
+        for source, node_type in tests:
+            with self.subTest(source=source):
+                node = ast.parse(source, mode='eval').body
+                self.assertIsInstance(node, node_type)
+                self.assertTrue(any(isinstance(elt, ast.Starred) for elt in node.elts))
 
     def test_parse_in_error(self):
         try:

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -1549,6 +1549,26 @@ class ASTHelpers_Test(unittest.TestCase):
                     expected_values,
                 )
 
+    def test_parse_elides_null_container_unpacks_in_assignment(self):
+        tests = [
+            ('x = [*()]', ast.List, []),
+            ('x = {*()}', ast.Set, []),
+            ('x = *(),', ast.Tuple, []),
+            ('x = [*(), 2]', ast.List, [2]),
+            ('x = {*(), 2}', ast.Set, [2]),
+            ('x = *(), 2', ast.Tuple, [2]),
+        ]
+
+        for source, node_type, expected_values in tests:
+            with self.subTest(source=source):
+                node = ast.parse(source).body[0]
+                self.assertIsInstance(node, ast.Assign)
+                self.assertIsInstance(node.value, node_type)
+                self.assertEqual(
+                    [elt.value for elt in node.value.elts],
+                    expected_values,
+                )
+
     def test_parse_preserves_multiple_null_container_unpacks(self):
         tests = [
             ('[1, *(), 2]', ast.List),
@@ -1564,6 +1584,25 @@ class ASTHelpers_Test(unittest.TestCase):
                 node = ast.parse(source, mode='eval').body
                 self.assertIsInstance(node, node_type)
                 self.assertTrue(any(isinstance(elt, ast.Starred) for elt in node.elts))
+
+    def test_parse_preserves_multiple_null_container_unpacks_in_assignment(self):
+        tests = [
+            ('x = [1, *(), 2]', ast.List),
+            ('x = {1, *(), 2}', ast.Set),
+            ('x = 1, *(), 2', ast.Tuple),
+            ('x = [*(), *()]', ast.List),
+            ('x = {*(), *()}', ast.Set),
+            ('x = *(), *()', ast.Tuple),
+        ]
+
+        for source, node_type in tests:
+            with self.subTest(source=source):
+                node = ast.parse(source).body[0]
+                self.assertIsInstance(node, ast.Assign)
+                self.assertIsInstance(node.value, node_type)
+                self.assertTrue(
+                    any(isinstance(elt, ast.Starred) for elt in node.value.elts)
+                )
 
     def test_parse_in_error(self):
         try:

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -1535,9 +1535,6 @@ class ASTHelpers_Test(unittest.TestCase):
             ('[*()]', ast.List, []),
             ('{*()}', ast.Set, []),
             ('(*(),)', ast.Tuple, []),
-            ('[*(), 2]', ast.List, [2]),
-            ('{*(), 2}', ast.Set, [2]),
-            ('(*(), 2)', ast.Tuple, [2]),
         ]
 
         for source, node_type, expected_values in tests:
@@ -1554,9 +1551,6 @@ class ASTHelpers_Test(unittest.TestCase):
             ('x = [*()]', ast.List, []),
             ('x = {*()}', ast.Set, []),
             ('x = *(),', ast.Tuple, []),
-            ('x = [*(), 2]', ast.List, [2]),
-            ('x = {*(), 2}', ast.Set, [2]),
-            ('x = *(), 2', ast.Tuple, [2]),
         ]
 
         for source, node_type, expected_values in tests:
@@ -1571,6 +1565,9 @@ class ASTHelpers_Test(unittest.TestCase):
 
     def test_parse_preserves_multiple_null_container_unpacks(self):
         tests = [
+            ('[*(), 2]', ast.List),
+            ('{*(), 2}', ast.Set),
+            ('(*(), 2)', ast.Tuple),
             ('[1, *(), 2]', ast.List),
             ('{1, *(), 2}', ast.Set),
             ('(1, *(), 2)', ast.Tuple),
@@ -1587,6 +1584,9 @@ class ASTHelpers_Test(unittest.TestCase):
 
     def test_parse_preserves_multiple_null_container_unpacks_in_assignment(self):
         tests = [
+            ('x = [*(), 2]', ast.List),
+            ('x = {*(), 2}', ast.Set),
+            ('x = *(), 2', ast.Tuple),
             ('x = [1, *(), 2]', ast.List),
             ('x = {1, *(), 2}', ast.Set),
             ('x = 1, *(), 2', ast.Tuple),

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -160,6 +160,83 @@ class AST_Tests(unittest.TestCase):
             self.assertRaises(TypeError, ast.parse, ast.Constant(42),
                               optimize=optval)
 
+    def test_parse_removes_single_null_container_unpack(self):
+        tests = [
+            ('[*()]', ast.List, []),
+            ('{*()}', ast.Set, []),
+            ('(*(),)', ast.Tuple, []),
+        ]
+
+        for source, node_type, expected_values in tests:
+            with self.subTest(source=source):
+                node = ast.parse(source, mode='eval').body
+                self.assertIsInstance(node, node_type)
+                self.assertEqual(
+                    [elt.value for elt in node.elts],
+                    expected_values,
+                )
+
+    def test_parse_removes_single_null_container_unpack_in_assignment(self):
+        tests = [
+            ('x = [*()]', ast.List, []),
+            ('x = {*()}', ast.Set, []),
+            ('x = *(),', ast.Tuple, []),
+            ('x = (*(),)', ast.Tuple, []),
+        ]
+
+        for source, node_type, expected_values in tests:
+            with self.subTest(source=source):
+                node = ast.parse(source).body[0]
+                self.assertIsInstance(node, ast.Assign)
+                self.assertIsInstance(node.value, node_type)
+                self.assertEqual(
+                    [elt.value for elt in node.value.elts],
+                    expected_values,
+                )
+
+    def test_parse_keeps_null_container_unpack_in_larger_literal(self):
+        tests = [
+            ('[*(), 2]', ast.List, 2),
+            ('{*(), 2}', ast.Set, 2),
+            ('(*(), 2)', ast.Tuple, 2),
+            ('[1, *(), 2]', ast.List, 3),
+            ('{1, *(), 2}', ast.Set, 3),
+            ('(1, *(), 2)', ast.Tuple, 3),
+            ('[*(), *()]', ast.List, 2),
+            ('{*(), *()}', ast.Set, 2),
+            ('(*(), *())', ast.Tuple, 2),
+        ]
+
+        for source, node_type, expected_len in tests:
+            with self.subTest(source=source):
+                node = ast.parse(source, mode='eval').body
+                self.assertIsInstance(node, node_type)
+                self.assertEqual(len(node.elts), expected_len)
+                self.assertTrue(any(isinstance(elt, ast.Starred) for elt in node.elts))
+
+    def test_parse_keeps_null_container_unpack_in_larger_assignment_value(self):
+        tests = [
+            ('x = [*(), 2]', ast.List, 2),
+            ('x = {*(), 2}', ast.Set, 2),
+            ('x = *(), 2', ast.Tuple, 2),
+            ('x = [1, *(), 2]', ast.List, 3),
+            ('x = {1, *(), 2}', ast.Set, 3),
+            ('x = 1, *(), 2', ast.Tuple, 3),
+            ('x = [*(), *()]', ast.List, 2),
+            ('x = {*(), *()}', ast.Set, 2),
+            ('x = *(), *()', ast.Tuple, 2),
+        ]
+
+        for source, node_type, expected_len in tests:
+            with self.subTest(source=source):
+                node = ast.parse(source).body[0]
+                self.assertIsInstance(node, ast.Assign)
+                self.assertIsInstance(node.value, node_type)
+                self.assertEqual(len(node.value.elts), expected_len)
+                self.assertTrue(
+                    any(isinstance(elt, ast.Starred) for elt in node.value.elts)
+                )
+
     def test_optimization_levels__debug__(self):
         cases = [(-1, '__debug__'), (0, '__debug__'), (1, False), (2, False)]
         for (optval, expected) in cases:
@@ -1529,80 +1606,6 @@ class ASTHelpers_Test(unittest.TestCase):
         a = ast.parse('foo(1 + 1)')
         b = compile('foo(1 + 1)', '<unknown>', 'exec', ast.PyCF_ONLY_AST)
         self.assertEqual(ast.dump(a), ast.dump(b))
-
-    def test_parse_elides_null_container_unpacks(self):
-        tests = [
-            ('[*()]', ast.List, []),
-            ('{*()}', ast.Set, []),
-            ('(*(),)', ast.Tuple, []),
-        ]
-
-        for source, node_type, expected_values in tests:
-            with self.subTest(source=source):
-                node = ast.parse(source, mode='eval').body
-                self.assertIsInstance(node, node_type)
-                self.assertEqual(
-                    [elt.value for elt in node.elts],
-                    expected_values,
-                )
-
-    def test_parse_elides_null_container_unpacks_in_assignment(self):
-        tests = [
-            ('x = [*()]', ast.List, []),
-            ('x = {*()}', ast.Set, []),
-            ('x = *(),', ast.Tuple, []),
-        ]
-
-        for source, node_type, expected_values in tests:
-            with self.subTest(source=source):
-                node = ast.parse(source).body[0]
-                self.assertIsInstance(node, ast.Assign)
-                self.assertIsInstance(node.value, node_type)
-                self.assertEqual(
-                    [elt.value for elt in node.value.elts],
-                    expected_values,
-                )
-
-    def test_parse_preserves_multiple_null_container_unpacks(self):
-        tests = [
-            ('[*(), 2]', ast.List),
-            ('{*(), 2}', ast.Set),
-            ('(*(), 2)', ast.Tuple),
-            ('[1, *(), 2]', ast.List),
-            ('{1, *(), 2}', ast.Set),
-            ('(1, *(), 2)', ast.Tuple),
-            ('[*(), *()]', ast.List),
-            ('{*(), *()}', ast.Set),
-            ('(*(), *())', ast.Tuple),
-        ]
-
-        for source, node_type in tests:
-            with self.subTest(source=source):
-                node = ast.parse(source, mode='eval').body
-                self.assertIsInstance(node, node_type)
-                self.assertTrue(any(isinstance(elt, ast.Starred) for elt in node.elts))
-
-    def test_parse_preserves_multiple_null_container_unpacks_in_assignment(self):
-        tests = [
-            ('x = [*(), 2]', ast.List),
-            ('x = {*(), 2}', ast.Set),
-            ('x = *(), 2', ast.Tuple),
-            ('x = [1, *(), 2]', ast.List),
-            ('x = {1, *(), 2}', ast.Set),
-            ('x = 1, *(), 2', ast.Tuple),
-            ('x = [*(), *()]', ast.List),
-            ('x = {*(), *()}', ast.Set),
-            ('x = *(), *()', ast.Tuple),
-        ]
-
-        for source, node_type in tests:
-            with self.subTest(source=source):
-                node = ast.parse(source).body[0]
-                self.assertIsInstance(node, ast.Assign)
-                self.assertIsInstance(node.value, node_type)
-                self.assertTrue(
-                    any(isinstance(elt, ast.Starred) for elt in node.value.elts)
-                )
 
     def test_parse_in_error(self):
         try:

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -1530,6 +1530,25 @@ class ASTHelpers_Test(unittest.TestCase):
         b = compile('foo(1 + 1)', '<unknown>', 'exec', ast.PyCF_ONLY_AST)
         self.assertEqual(ast.dump(a), ast.dump(b))
 
+    def test_parse_elides_null_container_unpacks(self):
+        tests = [
+            ('[*()]', ast.List, []),
+            ('{*()}', ast.Set, []),
+            ('(*(),)', ast.Tuple, []),
+            ('[1, *(), 2]', ast.List, [1, 2]),
+            ('{1, *(), 2}', ast.Set, [1, 2]),
+            ('(1, *(), 2)', ast.Tuple, [1, 2]),
+        ]
+
+        for source, node_type, expected_values in tests:
+            with self.subTest(source=source):
+                node = ast.parse(source, mode='eval').body
+                self.assertIsInstance(node, node_type)
+                self.assertEqual(
+                    [elt.value for elt in node.elts],
+                    expected_values,
+                )
+
     def test_parse_in_error(self):
         try:
             1/0

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -1535,6 +1535,9 @@ class ASTHelpers_Test(unittest.TestCase):
             ('[*()]', ast.List, []),
             ('{*()}', ast.Set, []),
             ('(*(),)', ast.Tuple, []),
+            ('[*(), 2]', ast.List, [2]),
+            ('{*(), 2}', ast.Set, [2]),
+            ('(*(), 2)', ast.Tuple, [2]),
         ]
 
         for source, node_type, expected_values in tests:

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -392,9 +392,14 @@ class UnparseTestCase(ASTTestCase):
         self.check_ast_roundtrip("{'a', 'b', 'c'}")
 
     def test_empty_set(self):
+        empty_set = ast.Set(elts=[])
         self.assertASTEqual(
-            ast.parse(ast.unparse(ast.Set(elts=[]))),
+            ast.parse(ast.unparse(empty_set)),
             ast.parse('{*()}')
+        )
+        self.assertASTEqual(
+            empty_set,
+            ast.parse('{*(),}', mode='eval').body
         )
 
     def test_set_comprehension(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-21-17-39-59.gh-issue-150204.fgbNA9.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-21-17-39-59.gh-issue-150204.fgbNA9.rst
@@ -1,0 +1,3 @@
+ast.parse() now canonicalizes lone empty-tuple unpacks in container
+literals, improving AST round-tripping for cases such as the empty-set idiom
+``{*()}`` produced by ast.unparse().

--- a/Python/ast_preprocess.c
+++ b/Python/ast_preprocess.c
@@ -180,13 +180,17 @@ is_null_container_unpack(expr_ty elt)
 static void
 remove_null_container_unpacks(asdl_expr_seq *elts)
 {
-    if (elts == NULL || asdl_seq_LEN(elts) != 1) {
+    if (elts == NULL || asdl_seq_LEN(elts) == 0) {
         return;
     }
     if (!is_null_container_unpack(asdl_seq_GET(elts, 0))) {
         return;
     }
-    elts->size = 0;
+    Py_ssize_t n = asdl_seq_LEN(elts);
+    for (Py_ssize_t i = 0; i < n - 1; i++) {
+        asdl_seq_SET(elts, i, asdl_seq_GET(elts, i + 1));
+    }
+    elts->size = n - 1;
 }
 
 static expr_ty

--- a/Python/ast_preprocess.c
+++ b/Python/ast_preprocess.c
@@ -167,6 +167,33 @@ has_starred(asdl_expr_seq *elts)
     return 0;
 }
 
+static int
+is_null_container_unpack(expr_ty elt)
+{
+    if (elt->kind != Starred_kind) {
+        return 0;
+    }
+    expr_ty value = elt->v.Starred.value;
+    return value->kind == Tuple_kind && asdl_seq_LEN(value->v.Tuple.elts) == 0;
+}
+
+static void
+remove_null_container_unpacks(asdl_expr_seq *elts)
+{
+    if (elts == NULL) {
+        return;
+    }
+    Py_ssize_t write = 0;
+    Py_ssize_t n = asdl_seq_LEN(elts);
+    for (Py_ssize_t read = 0; read < n; read++) {
+        expr_ty elt = asdl_seq_GET(elts, read);
+        if (!is_null_container_unpack(elt)) {
+            asdl_seq_SET(elts, write++, elt);
+        }
+    }
+    elts->size = write;
+}
+
 static expr_ty
 parse_literal(PyObject *fmt, Py_ssize_t *ppos, PyArena *arena)
 {
@@ -546,6 +573,7 @@ astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTPreprocessState *state)
         break;
     case Set_kind:
         CALL_SEQ(astfold_expr, expr, node_->v.Set.elts);
+        remove_null_container_unpacks(node_->v.Set.elts);
         break;
     case ListComp_kind:
         CALL(astfold_expr, expr_ty, node_->v.ListComp.elt);
@@ -615,9 +643,11 @@ astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTPreprocessState *state)
         break;
     case List_kind:
         CALL_SEQ(astfold_expr, expr, node_->v.List.elts);
+        remove_null_container_unpacks(node_->v.List.elts);
         break;
     case Tuple_kind:
         CALL_SEQ(astfold_expr, expr, node_->v.Tuple.elts);
+        remove_null_container_unpacks(node_->v.Tuple.elts);
         break;
     case Name_kind:
         if (state->syntax_check_only) {

--- a/Python/ast_preprocess.c
+++ b/Python/ast_preprocess.c
@@ -180,17 +180,13 @@ is_null_container_unpack(expr_ty elt)
 static void
 remove_null_container_unpacks(asdl_expr_seq *elts)
 {
-    if (elts == NULL || asdl_seq_LEN(elts) == 0) {
+    if (elts == NULL || asdl_seq_LEN(elts) != 1) {
         return;
     }
     if (!is_null_container_unpack(asdl_seq_GET(elts, 0))) {
         return;
     }
-    Py_ssize_t n = asdl_seq_LEN(elts);
-    for (Py_ssize_t i = 0; i < n - 1; i++) {
-        asdl_seq_SET(elts, i, asdl_seq_GET(elts, i + 1));
-    }
-    elts->size = n - 1;
+    elts->size = 0;
 }
 
 static expr_ty

--- a/Python/ast_preprocess.c
+++ b/Python/ast_preprocess.c
@@ -180,18 +180,13 @@ is_null_container_unpack(expr_ty elt)
 static void
 remove_null_container_unpacks(asdl_expr_seq *elts)
 {
-    if (elts == NULL) {
+    if (elts == NULL || asdl_seq_LEN(elts) != 1) {
         return;
     }
-    Py_ssize_t write = 0;
-    Py_ssize_t n = asdl_seq_LEN(elts);
-    for (Py_ssize_t read = 0; read < n; read++) {
-        expr_ty elt = asdl_seq_GET(elts, read);
-        if (!is_null_container_unpack(elt)) {
-            asdl_seq_SET(elts, write++, elt);
-        }
+    if (!is_null_container_unpack(asdl_seq_GET(elts, 0))) {
+        return;
     }
-    elts->size = write;
+    elts->size = 0;
 }
 
 static expr_ty


### PR DESCRIPTION
## Proposal

When parsing a set container literal whose only element is a direct `*()`, simplify that element out of the AST during preprocessing.

Proposed examples:

```python
ast.parse('{*()}', mode='eval').body     # Set(elts=[])
```

Motivation is full `ast.unparse()` symmetry for the empty-set idiom.

Today, `ast.unparse(ast.Set(elts=[]))` renders as `{*()}`, because Python has no dedicated empty-set literal. Without AST canonicalization on parse, reparsing that output produces a `Set` containing `Starred(Tuple([]))` instead of an empty `Set`, so the AST does not round-trip cleanly.

With this change:

```python
empty_set = ast.Set(elts=[])
ast.parse(ast.unparse(empty_set), mode='eval').body
```

would produce the same `ast.Set(elts=[])` structure again.

## Scope

This proposal is intentionally narrow for performance reasons.

Only simplify the direct lone `{*()}` case:

- `{*()}`
- assignment forms such as `x = {*(),}`

Do not simplify larger literals such as:

- `{*(), 2}`
- `{1, *(), 2}`

That keeps the rule cheap and focused on empty-set idiom rather than introducing a broader AST rewrite.

## Compatibility and behavior

Runtime semantics do not change.

The visible AST change is that tools would no longer see `Starred(Tuple([]))` for the lone forms above; they would instead see empty `Set` node.

That is an externally visible AST change, but it is narrow and maps a degenerate form to the canonical empty set node.

Notable consequences:

- `ast.literal_eval('{*()}')` can evaluate to `set()` once the parsed AST is canonicalized


<!-- gh-issue-number: gh-150204 -->
* Issue: gh-150204
<!-- /gh-issue-number -->
