### PR TITLE
gh-150220: List valid member values in Enum's default lookup ValueError

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1218,6 +1218,15 @@ class Enum(metaclass=EnumType):
             else:
                 ve_exc = ValueError("%r is not a valid %s" % (value, cls.__qualname__))
                 if result is None and exc is None:
+                    # If `_missing_` has not been overridden, augment the
+                    # default error message with the list of valid values to
+                    # save users from having to inspect ``cls.__members__``.
+                    if cls._missing_.__func__ is Enum._missing_.__func__:
+                        valid_values = ", ".join(repr(m._value_) for m in cls)
+                        if valid_values:
+                            ve_exc = ValueError(
+                                "%r is not a valid %s. Valid values: %s"
+                                % (value, cls.__qualname__, valid_values))
                     raise ve_exc
                 elif exc is None:
                     exc = TypeError(


### PR DESCRIPTION
- Problem

```pycon
>>> from enum import Enum
>>> class Currency(Enum):
...     USD = "USD"; EUR = "EUR"; JPY = "JPY"
>>> Currency("USO")
ValueError: 'USO' is not a valid Currency
```

The user has to inspect `cls.__members__` to discover the legal set.
Pydantic and similar validators already include the list (`"Input should be 'USD', 'EUR' or 'JPY'"`).

- Proposal

```diff
-ValueError: 'USO' is not a valid Currency
+ValueError: 'USO' is not a valid Currency. Valid values: 'USD', 'EUR', 'JPY'
```

…but only when `_missing_` has not been overridden. Subclasses that
override `_missing_` (case-insensitive matching, aliases,
`Flag`/`IntFlag`'s bitwise composition, ...) own their own error
messages.

- Behaviour matrix

| Case                                                 | Listing?                   |
| ---------------------------------------------------- | -------------------------- |
| `Enum` / `IntEnum` / `StrEnum` (default `_missing_`) | yes                        |
| `Flag` / `IntFlag` (override for bitwise)            | no                         |
| Subclass `_missing_` returning `None`                | no (subclass owns msg)     |
| Subclass `_missing_` raising `ValueError`            | no (own message preserved) |

Existing `test_enum.py` suite passes unchanged.

- Backward compatibility

Additive. `ValueError` type and prefix unchanged; only a `Valid values: ...` suffix.
Code asserting on the exact bare message would need a minor change.

<!-- gh-issue-number: gh-150220 -->
* Issue: gh-150220
<!-- /gh-issue-number -->
