### PR TITLE
gh-150226: Speed up uuid.UUID string parsing

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -213,8 +213,12 @@ class UUID:
         if int is not None:
             pass
         elif hex is not None:
-            hex = hex.replace('urn:', '').replace('uuid:', '')
+            original_hex = hex
+            hex = hex.removeprefix('urn:uuid:')
             hex = hex.strip('{}').replace('-', '')
+            if len(hex) != 32:
+                hex = original_hex.replace('urn:', '').replace('uuid:', '')
+                hex = hex.strip('{}').replace('-', '')
             if len(hex) != 32:
                 raise ValueError('badly formed hexadecimal UUID string')
             int = int_(hex, 16)

--- a/Misc/NEWS.d/next/Library/2026-05-22-12-10-00.gh-issue-150226.uuid-perf.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-22-12-10-00.gh-issue-150226.uuid-perf.rst
@@ -1,0 +1,1 @@
+Speed up construction of :class:`uuid.UUID` from documented string formats.


### PR DESCRIPTION
gh-150226

## Summary

This speeds up `uuid.UUID` construction from the documented string forms by handling the documented `urn:uuid:` prefix directly with `str.removeprefix()` before stripping braces and hyphens.

The previous broader normalization path is still used as a fallback whenever the direct normalization does not produce 32 hex characters, preserving legacy accepted inputs such as `urn:<hex>`.

## Benchmark

Same-process benchmark on a local Windows CPython debug build, comparing `origin/main:Lib/uuid.py` with this patch while blocking `_uuid` to isolate the pure-Python constructor path:

```text
plain_hex:  11584.5 ns -> 11366.8 ns (1.9%)
canonical:  12424.6 ns -> 12253.1 ns (1.4%)
braced:     13293.5 ns -> 12981.1 ns (2.3%)
urn:        13800.0 ns -> 12912.8 ns (6.4%)
```

Absolute timings are from a debug build; the benchmark compares old and new code in the same process.

## Tests

- `PCbuild\build.bat -d -p x64`
- `PCbuild\amd64\python_d.exe -m test test_uuid -v`

I also attempted a local Windows Release build, but MSVC failed with an internal compiler error while compiling/linking `externals\zlib-ng-2.2.4\arch\x86\chunkset_avx2.c`, unrelated to this `uuid` change.