### PR TITLE
gh-132372: Speed up logging.config existing logger handling

### DIFF
--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -36,6 +36,7 @@ import struct
 import threading
 import traceback
 
+from bisect import bisect_left
 from socketserver import ThreadingTCPServer, StreamRequestHandler
 
 
@@ -197,6 +198,21 @@ def _handle_existing_loggers(existing, child_loggers, disable_existing):
         else:
             logger.disabled = disable_existing
 
+def _discard_existing_logger(name, existing, existing_set, child_loggers):
+    """Discard a configured logger and record its existing children."""
+    if name in existing_set:
+        prefixed = name + "."
+        i = bisect_left(existing, prefixed)
+        num_existing = len(existing)
+        while i < num_existing:
+            child = existing[i]
+            if not child.startswith(prefixed):
+                break
+            if child in existing_set:
+                child_loggers.add(child)
+            i += 1
+        existing_set.remove(name)
+
 def _install_loggers(cp, handlers, disable_existing):
     """Create and install loggers"""
 
@@ -235,25 +251,17 @@ def _install_loggers(cp, handlers, disable_existing):
     #named loggers. With a sorted list it is easier
     #to find the child loggers.
     existing.sort()
+    existing_set = set(existing)
     #We'll keep the list of existing loggers
     #which are children of named loggers here...
-    child_loggers = []
+    child_loggers = set()
     #now set up the new ones...
     for log in llist:
         section = cp["logger_%s" % log]
         qn = section["qualname"]
         propagate = section.getint("propagate", fallback=1)
         logger = logging.getLogger(qn)
-        if qn in existing:
-            i = existing.index(qn) + 1 # start with the entry after qn
-            prefixed = qn + "."
-            pflen = len(prefixed)
-            num_existing = len(existing)
-            while i < num_existing:
-                if existing[i][:pflen] == prefixed:
-                    child_loggers.append(existing[i])
-                i += 1
-            existing.remove(qn)
+        _discard_existing_logger(qn, existing, existing_set, child_loggers)
         if "level" in section:
             level = section["level"]
             logger.setLevel(level)
@@ -281,6 +289,7 @@ def _install_loggers(cp, handlers, disable_existing):
     #        logger.propagate = 1
     #    elif disable_existing_loggers:
     #        logger.disabled = 1
+    existing = [name for name in existing if name in existing_set]
     _handle_existing_loggers(existing, child_loggers, disable_existing)
 
 
@@ -638,22 +647,15 @@ class DictConfigurator(BaseConfigurator):
                 #named loggers. With a sorted list it is easier
                 #to find the child loggers.
                 existing.sort()
+                existing_set = set(existing)
                 #We'll keep the list of existing loggers
                 #which are children of named loggers here...
-                child_loggers = []
+                child_loggers = set()
                 #now set up the new ones...
                 loggers = config.get('loggers', EMPTY_DICT)
                 for name in loggers:
-                    if name in existing:
-                        i = existing.index(name) + 1 # look after name
-                        prefixed = name + "."
-                        pflen = len(prefixed)
-                        num_existing = len(existing)
-                        while i < num_existing:
-                            if existing[i][:pflen] == prefixed:
-                                child_loggers.append(existing[i])
-                            i += 1
-                        existing.remove(name)
+                    _discard_existing_logger(name, existing, existing_set,
+                                             child_loggers)
                     try:
                         self.configure_logger(name, loggers[name])
                     except Exception as e:
@@ -673,6 +675,7 @@ class DictConfigurator(BaseConfigurator):
                 #        logger.propagate = True
                 #    elif disable_existing:
                 #        logger.disabled = True
+                existing = [name for name in existing if name in existing_set]
                 _handle_existing_loggers(existing, child_loggers,
                                          disable_existing)
 

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -187,24 +187,18 @@ def _handle_existing_loggers(existing, child_loggers, disable_existing):
     what was intended by the user. Also, allow existing loggers to NOT be
     disabled if disable_existing is false.
     """
-    root = logging.root
-    cache_clear_needed = False
     for log in existing:
-        logger = root.manager.loggerDict[log]
+        logger = logging.root.manager.loggerDict[log]
         if log in child_loggers:
             if not isinstance(logger, logging.PlaceHolder):
-                # Equivalent to setLevel(NOTSET), but clear the cache once.
-                logger.level = logging.NOTSET
+                logger.setLevel(logging.NOTSET)
                 logger.handlers = []
                 logger.propagate = True
-                cache_clear_needed = True
         else:
             logger.disabled = disable_existing
-    if cache_clear_needed:
-        root.manager._clear_cache()
 
-def _discard_existing_logger(name, existing, existing_set, child_loggers):
-    """Discard a configured logger and record its existing children."""
+def _forget_existing_logger(name, existing, existing_set, child_loggers):
+    """Forget a configured logger and record its existing children."""
     prefixed = name + "."
     i = bisect_left(existing, prefixed)
     num_existing = len(existing)
@@ -266,7 +260,7 @@ def _install_loggers(cp, handlers, disable_existing):
         propagate = section.getint("propagate", fallback=1)
         logger = logging.getLogger(qn)
         if qn in existing_set:
-            _discard_existing_logger(qn, existing, existing_set, child_loggers)
+            _forget_existing_logger(qn, existing, existing_set, child_loggers)
         if "level" in section:
             level = section["level"]
             logger.setLevel(level)
@@ -660,8 +654,8 @@ class DictConfigurator(BaseConfigurator):
                 loggers = config.get('loggers', EMPTY_DICT)
                 for name in loggers:
                     if name in existing_set:
-                        _discard_existing_logger(name, existing, existing_set,
-                                                 child_loggers)
+                        _forget_existing_logger(name, existing, existing_set,
+                                                child_loggers)
                     try:
                         self.configure_logger(name, loggers[name])
                     except Exception as e:

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -205,18 +205,17 @@ def _handle_existing_loggers(existing, child_loggers, disable_existing):
 
 def _discard_existing_logger(name, existing, existing_set, child_loggers):
     """Discard a configured logger and record its existing children."""
-    if name in existing_set:
-        prefixed = name + "."
-        i = bisect_left(existing, prefixed)
-        num_existing = len(existing)
-        while i < num_existing:
-            child = existing[i]
-            if not child.startswith(prefixed):
-                break
-            if child in existing_set:
-                child_loggers.add(child)
-            i += 1
-        existing_set.remove(name)
+    prefixed = name + "."
+    i = bisect_left(existing, prefixed)
+    num_existing = len(existing)
+    while i < num_existing:
+        child = existing[i]
+        if not child.startswith(prefixed):
+            break
+        if child in existing_set:
+            child_loggers[child] = None
+        i += 1
+    existing_set.remove(name)
 
 def _install_loggers(cp, handlers, disable_existing):
     """Create and install loggers"""
@@ -259,14 +258,15 @@ def _install_loggers(cp, handlers, disable_existing):
     existing_set = set(existing)
     #We'll keep the list of existing loggers
     #which are children of named loggers here...
-    child_loggers = set()
+    child_loggers = {}
     #now set up the new ones...
     for log in llist:
         section = cp["logger_%s" % log]
         qn = section["qualname"]
         propagate = section.getint("propagate", fallback=1)
         logger = logging.getLogger(qn)
-        _discard_existing_logger(qn, existing, existing_set, child_loggers)
+        if qn in existing_set:
+            _discard_existing_logger(qn, existing, existing_set, child_loggers)
         if "level" in section:
             level = section["level"]
             logger.setLevel(level)
@@ -655,12 +655,13 @@ class DictConfigurator(BaseConfigurator):
                 existing_set = set(existing)
                 #We'll keep the list of existing loggers
                 #which are children of named loggers here...
-                child_loggers = set()
+                child_loggers = {}
                 #now set up the new ones...
                 loggers = config.get('loggers', EMPTY_DICT)
                 for name in loggers:
-                    _discard_existing_logger(name, existing, existing_set,
-                                             child_loggers)
+                    if name in existing_set:
+                        _discard_existing_logger(name, existing, existing_set,
+                                                 child_loggers)
                     try:
                         self.configure_logger(name, loggers[name])
                     except Exception as e:

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -188,15 +188,20 @@ def _handle_existing_loggers(existing, child_loggers, disable_existing):
     disabled if disable_existing is false.
     """
     root = logging.root
+    cache_clear_needed = False
     for log in existing:
         logger = root.manager.loggerDict[log]
         if log in child_loggers:
             if not isinstance(logger, logging.PlaceHolder):
-                logger.setLevel(logging.NOTSET)
+                # Equivalent to setLevel(NOTSET), but clear the cache once.
+                logger.level = logging.NOTSET
                 logger.handlers = []
                 logger.propagate = True
+                cache_clear_needed = True
         else:
             logger.disabled = disable_existing
+    if cache_clear_needed:
+        root.manager._clear_cache()
 
 def _discard_existing_logger(name, existing, existing_set, child_loggers):
     """Discard a configured logger and record its existing children."""

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4176,6 +4176,8 @@ class ConfigDictTest(BaseTest):
     def test_disable_existing_loggers_preserves_children(self):
         parent = logging.getLogger('many')
         child = logging.getLogger('many.child')
+        child.setLevel(logging.CRITICAL)
+        self.assertFalse(child.isEnabledFor(logging.INFO))
         cousin = logging.getLogger('many-child')
         for i in range(20):
             logging.getLogger(f'many-sibling-{i}')
@@ -4191,6 +4193,8 @@ class ConfigDictTest(BaseTest):
 
         self.assertFalse(parent.disabled)
         self.assertFalse(child.disabled)
+        self.assertEqual(child.level, logging.NOTSET)
+        self.assertTrue(child.isEnabledFor(logging.INFO))
         self.assertTrue(cousin.disabled)
 
     def test_111615(self):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4173,6 +4173,26 @@ class ConfigDictTest(BaseTest):
         # Logger should be enabled, since explicitly mentioned
         self.assertFalse(logger.disabled)
 
+    def test_disable_existing_loggers_preserves_children(self):
+        parent = logging.getLogger('many')
+        child = logging.getLogger('many.child')
+        cousin = logging.getLogger('many-child')
+        for i in range(20):
+            logging.getLogger(f'many-sibling-{i}')
+
+        self.apply_config({
+            'version': 1,
+            'loggers': {
+                'many': {
+                    'level': 'INFO',
+                },
+            },
+        })
+
+        self.assertFalse(parent.disabled)
+        self.assertFalse(child.disabled)
+        self.assertTrue(cousin.disabled)
+
     def test_111615(self):
         # See gh-111615
         import_helper.import_module('_multiprocessing')  # see gh-113692

--- a/Misc/NEWS.d/next/Library/2026-05-22-15-30-00.gh-issue-132372.YP4a6x.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-22-15-30-00.gh-issue-132372.YP4a6x.rst
@@ -1,0 +1,2 @@
+Speed up :func:`logging.config.fileConfig` and
+:func:`logging.config.dictConfig` when handling many existing loggers.


### PR DESCRIPTION
gh-132372

This speeds up `logging.config.fileConfig()` and `logging.config.dictConfig()` when they need to handle existing loggers while `disable_existing_loggers` is active.

The old code kept the existing logger names in a sorted list, but still used repeated list membership, `index()`, tail scans, and `remove()` calls for every configured logger. This keeps the sorted list for child logger ordering, uses a set for membership/removal tracking, and uses `bisect_left()` to jump directly to the dotted child logger range.

Validation:

- `PCbuild\amd64\python_d.exe -m test test_logging -j0`
- `PCbuild\amd64\python_d.exe Tools\patchcheck\patchcheck.py`
- `git diff --check upstream/main...HEAD`

Benchmark:

Loaded `upstream/main:Lib/logging/config.py` and the patched `Lib/logging/config.py` into the same CPython `main` release build, then timed only the `dictConfig()` call while resetting identical existing logger state outside the timer. Each `n` creates `n` configured loggers plus one dotted child and one non-child similarly-prefixed logger per configured logger.

Interpreter details:

```text
3.16.0a0 [MSC v.1930 64 bit (AMD64)]
executable: PCbuild\amd64\python.exe
Py_DEBUG: 0
has gettotalrefcount: False
```

Small `n` remains effectively neutral. The mean speedup crosses `1.1x` at about `n=12`; `n=10` is just below that at `1.09x`.

```text
 n    old_mean_us old_med_us  new_mean_us new_med_us  mean_speed median_speed
 1        31.80      29.10        32.86      29.80        0.97x         0.98x
 2        51.15      44.70        51.83      45.40        0.99x         0.98x
 3        67.61      61.60        66.51      61.40        1.02x         1.00x
 5       110.90     102.50       107.52      99.30        1.03x         1.03x
 8       192.42     179.55       179.64     168.20        1.07x         1.07x
10       257.54     242.70       235.29     222.10        1.09x         1.09x
12       378.77     319.60       328.01     289.00        1.15x         1.11x
15       470.00     439.85       413.28     388.80        1.14x         1.13x
20       756.52     694.95       648.66     599.90        1.17x         1.16x
30      1692.62    1540.90      1400.42    1285.80        1.21x         1.20x
50      3488.47    3356.40      2823.61    2730.80        1.24x         1.23x
100    13144.77   12569.75     10381.35    9855.15        1.27x         1.28x
```
