### PR TITLE
gh-150232: Change Thread group parameter doc from 'should be' to 'must be'

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -515,7 +515,7 @@ since it is impossible to detect the termination of alien threads.
    This constructor should always be called with keyword arguments.  Arguments
    are:
 
-   *group* should be ``None``; reserved for future extension when a
+   *group* **must** be ``None``; reserved for future extension when a
    :class:`!ThreadGroup` class is implemented.
 
    *target* is the callable object to be invoked by the :meth:`run` method.


### PR DESCRIPTION
This PR updates the documentation for threading.Thread to accurately reflect the implementation.
The implementation uses assert group is None, which makes the parameter mandatory. The documentation is updated from "should be None" to "must be None".

Fixes #150232

<!-- gh-issue-number: gh-150232 -->
* Issue: gh-150232
<!-- /gh-issue-number -->
