### PR TITLE
gh-149879: Fix test__locale on Cygwin

### DIFF
--- a/Lib/test/test__locale.py
+++ b/Lib/test/test__locale.py
@@ -89,6 +89,9 @@ known_alt_digits = {
     'ar_AE': (100, {0: '\u0660', 10: '\u0661\u0660', 99: '\u0669\u0669'}),
     'bn_IN': (100, {0: '\u09e6', 10: '\u09e7\u09e6', 99: '\u09ef\u09ef'}),
 }
+if sys.platform == 'cygwin':
+    count, samples = known_alt_digits['ja_JP']
+    known_alt_digits['ja_JP'] = (101, samples)
 
 known_era = {
     'C': (0, ''),


### PR DESCRIPTION
On Cygwin with the LC_TIME locale "ja_JP", nl_langinfo(ALT_DIGITS) returns 101 items instead of 100.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149879 -->
* Issue: gh-149879
<!-- /gh-issue-number -->
