### PR TITLE
gh-150372: add missing null check on `completer_word_break_characters` in `readline.c`

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-05-25-07-22-05.gh-issue-150372.9hLqhe.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-25-07-22-05.gh-issue-150372.9hLqhe.rst
@@ -1,2 +1,2 @@
-:mod:`readline`: Fix missing null check on the result of :func:`!strdup`
-in module initialization, preventing a potential null pointer
+:mod:`readline`: Fix a potential crash during tab completion caused by an
+out-of-memory error during module initialization.

--- a/Misc/NEWS.d/next/Library/2026-05-25-07-22-05.gh-issue-150372.9hLqhe.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-25-07-22-05.gh-issue-150372.9hLqhe.rst
@@ -1,4 +1,2 @@
-Fix missing null check on the result of :func:`!strdup` in
-:mod:`readline` module initialization, preventing a potential null pointer
 :mod:`readline`: Fix missing null check on the result of :func:`!strdup`
 in module initialization, preventing a potential null pointer

--- a/Misc/NEWS.d/next/Library/2026-05-25-07-22-05.gh-issue-150372.9hLqhe.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-25-07-22-05.gh-issue-150372.9hLqhe.rst
@@ -1,3 +1,4 @@
 Fix missing null check on the result of :func:`!strdup` in
 :mod:`readline` module initialization, preventing a potential null pointer
-dereference on memory allocation failure.
+:mod:`readline`: Fix missing null check on the result of :func:`!strdup`
+in module initialization, preventing a potential null pointer

--- a/Misc/NEWS.d/next/Library/2026-05-25-07-22-05.gh-issue-150372.9hLqhe.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-25-07-22-05.gh-issue-150372.9hLqhe.rst
@@ -1,0 +1,3 @@
+Fix missing null check on the result of :func:`!strdup` in
+:mod:`readline` module initialization, preventing a potential null pointer
+dereference on memory allocation failure.

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1406,6 +1406,7 @@ setup_readline(readlinestate *mod_state)
         /* All nonalphanums except '.' */
 
     if (!completer_word_break_characters) {
+        RESTORE_LOCALE(saved_locale)
         return -1;
     }
 #ifdef WITH_EDITLINE

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1404,6 +1404,10 @@ setup_readline(readlinestate *mod_state)
     completer_word_break_characters =
         strdup(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?");
         /* All nonalphanums except '.' */
+
+    if (!completer_word_break_characters) {
+        return -1;
+    }
 #ifdef WITH_EDITLINE
     // libedit uses rl_basic_word_break_characters instead of
     // rl_completer_word_break_characters as complete delimiter

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1406,8 +1406,7 @@ setup_readline(readlinestate *mod_state)
         /* All nonalphanums except '.' */
 
     if (!completer_word_break_characters) {
-        RESTORE_LOCALE(saved_locale)
-        return -1;
+        goto error;
     }
 #ifdef WITH_EDITLINE
     // libedit uses rl_basic_word_break_characters instead of
@@ -1452,6 +1451,10 @@ setup_readline(readlinestate *mod_state)
 
     RESTORE_LOCALE(saved_locale)
     return 0;
+
+error:
+    RESTORE_LOCALE(saved_locale)
+    return -1;
 }
 
 /* Wrapper around GNU readline that handles signals differently. */


### PR DESCRIPTION
## What is this PR?

This adds a missing null pointer check on the result of an `strdup` call used to populate `completer_word_break_characters`. This matches what the remainder of the files does (so I assume this wasn't on purpose / being optimistic about `strdup`). 


<!-- gh-issue-number: gh-150372 -->
* Issue: gh-150372
<!-- /gh-issue-number -->
