### PR TITLE
gh-150195: Bump recursion limit to 300,000

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2808,7 +2808,7 @@ def adjust_int_max_str_digits(max_digits):
 
 def exceeds_recursion_limit():
     """For recursion tests, easily exceeds default recursion limit."""
-    return 150_000
+    return 300_000
 
 
 # Windows doesn't have os.uname() but it doesn't support s390x.

--- a/Misc/NEWS.d/next/Library/2026-05-22-15-54-44.gh-issue-150195.BxC_8y.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-22-15-54-44.gh-issue-150195.BxC_8y.rst
@@ -1,0 +1,1 @@
+Bump recursion limit to 300,000


### PR DESCRIPTION
Silences `AssertionError: RecursionError not raised` when compiling on macOS 26 with Clang 22 with `-fstack-protection-strong`

<!-- gh-issue-number: gh-150195 -->
* Issue: gh-150195
<!-- /gh-issue-number -->
