### PR TITLE
gh-150257: Skip test_free_threading.test_pickle

### DIFF
--- a/Lib/test/test_free_threading/test_pickle.py
+++ b/Lib/test/test_free_threading/test_pickle.py
@@ -8,6 +8,8 @@ from test.support import threading_helper
 @threading_helper.requires_working_threading()
 class TestPickleFreeThreading(unittest.TestCase):
 
+    @unittest.skip("gh-150257: pickle.dumps(dict) has a race condition "
+                   "causing an unfinite loop")
     def test_pickle_dumps_with_concurrent_dict_mutation(self):
         # gh-146452: Pickling a dict while another thread mutates it
         # used to segfault. batch_dict_exact() iterated dict items via


### PR DESCRIPTION
Skip test_pickle_dumps_with_concurrent_dict_mutation() of test_free_threading.test_pickle for now, since pickle.dumps(dict) has a race condition causing an unfinite loop.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-150257 -->
* Issue: gh-150257
<!-- /gh-issue-number -->
