### PR TITLE
[3.14] Revert "[3.14] gh-146452: Improve locking granularity in pickle's batch_dict_… (#150062)"

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-05-18-15-30-34.gh-issue-146452.RM0EVJ.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-18-15-30-34.gh-issue-146452.RM0EVJ.rst
@@ -1,2 +1,0 @@
-Fix race condition when pickling dictionaries in free threaded builds. Also
-reduce critical section cover.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3351,12 +3351,9 @@ batch_dict(PickleState *state, PicklerObject *self, PyObject *iter, PyObject *or
  * Returns 0 on success, -1 on error.
  *
  * Note that this currently doesn't work for protocol 0.
-
- * gh-146452: Wrap the dict iteration in a critical sections to prevent
- * concurrent mutation from invalidating PyDict_Next() iteration state.
  */
 static int
-batch_dict_exact(PickleState *state, PicklerObject *self, PyObject *obj)
+batch_dict_exact_impl(PickleState *state, PicklerObject *self, PyObject *obj)
 {
     PyObject *key = NULL, *value = NULL;
     int i;
@@ -3373,19 +3370,9 @@ batch_dict_exact(PickleState *state, PicklerObject *self, PyObject *obj)
 
     /* Special-case len(d) == 1 to save space. */
     if (dict_size == 1) {
-        int next;
-        Py_BEGIN_CRITICAL_SECTION(obj);
-        next = PyDict_Next(obj, &ppos, &key, &value);
-        if (next) {
-            Py_INCREF(key);
-            Py_INCREF(value);
-        }
-        Py_END_CRITICAL_SECTION();
-        if (!next) {
-            PyErr_SetString(PyExc_RuntimeError,
-                            "dictionary changed size during iteration");
-            goto error;
-        }
+        PyDict_Next(obj, &ppos, &key, &value);
+        Py_INCREF(key);
+        Py_INCREF(value);
         if (save(state, self, key, 0) < 0) {
             goto error;
         }
@@ -3405,18 +3392,9 @@ batch_dict_exact(PickleState *state, PicklerObject *self, PyObject *obj)
         i = 0;
         if (_Pickler_Write(self, &mark_op, 1) < 0)
             return -1;
-        int next;
-        while (1) {
-            Py_BEGIN_CRITICAL_SECTION(obj);
-            next = PyDict_Next(obj, &ppos, &key, &value);
-            if (next) {
-                Py_INCREF(key);
-                Py_INCREF(value);
-            }
-            Py_END_CRITICAL_SECTION();
-            if (!next) {
-                break;
-            }
+        while (PyDict_Next(obj, &ppos, &key, &value)) {
+            Py_INCREF(key);
+            Py_INCREF(value);
             if (save(state, self, key, 0) < 0) {
                 goto error;
             }
@@ -3444,6 +3422,18 @@ error:
     Py_XDECREF(key);
     Py_XDECREF(value);
     return -1;
+}
+
+/* gh-146452: Wrap the dict iteration in a critical section to prevent
+   concurrent mutation from invalidating PyDict_Next() iteration state. */
+static int
+batch_dict_exact(PickleState *state, PicklerObject *self, PyObject *obj)
+{
+    int ret;
+    Py_BEGIN_CRITICAL_SECTION(obj);
+    ret = batch_dict_exact_impl(state, self, obj);
+    Py_END_CRITICAL_SECTION();
+    return ret;
 }
 
 static int


### PR DESCRIPTION
This reverts commit 1243cd677d7f62b90c50546c5ff27e26ef24ca4f.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146452 -->
* Issue: gh-146452
<!-- /gh-issue-number -->
