### PR TITLE
gh-150204: Optimize bytecode for leading null unpack idioms in collection literals

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1119,6 +1119,65 @@ class TestSpecifics(unittest.TestCase):
                 self.assertIn('LOAD_', opcodes[-2].opname)
                 self.assertEqual('RETURN_VALUE', opcodes[-1].opname)
 
+    def test_empty_set_unpack_literal_bytecode_optimization(self):
+        code = compile('{*()}', '<test>', 'eval')
+        instructions = [
+            (instruction.opname, instruction.argval)
+            for instruction in dis.get_instructions(code)
+        ]
+
+        self.assertEqual(
+            instructions,
+            [
+                ('RESUME', 0),
+                ('BUILD_SET', 0),
+                ('RETURN_VALUE', None),
+            ],
+        )
+
+    def test_empty_leading_tuple_unpack_list_and_tuple_bytecode_optimization(self):
+        cases = {
+            '[*()]': [
+                ('RESUME', 0),
+                ('BUILD_LIST', 0),
+                ('RETURN_VALUE', None),
+            ],
+            '[*(), 1]': [
+                ('RESUME', 0),
+                ('BUILD_LIST', 0),
+                ('LOAD_SMALL_INT', 1),
+                ('LIST_APPEND', 1),
+                ('RETURN_VALUE', None),
+            ],
+            '[1, *()]': [
+                ('RESUME', 0),
+                ('LOAD_SMALL_INT', 1),
+                ('BUILD_LIST', 1),
+                ('LOAD_COMMON_CONSTANT', ()),
+                ('LIST_EXTEND', 1),
+                ('RETURN_VALUE', None),
+            ],
+            '(*(),)': [
+                ('RESUME', 0),
+                ('LOAD_COMMON_CONSTANT', ()),
+                ('RETURN_VALUE', None),
+            ],
+            '(*(), 1)': [
+                ('RESUME', 0),
+                ('LOAD_CONST', (1,)),
+                ('RETURN_VALUE', None),
+            ],
+        }
+
+        for source, expected in cases.items():
+            with self.subTest(source=source):
+                code = compile(source, '<test>', 'eval')
+                instructions = [
+                    (instruction.opname, instruction.argval)
+                    for instruction in dis.get_instructions(code)
+                ]
+                self.assertEqual(instructions, expected)
+
     def test_imported_load_method(self):
         sources = [
             """\

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1735,6 +1735,44 @@ class DirectCfgOptimizerTests(CfgOptimizationTestCase):
         ]
         self.cfg_optimization_test(same, expected, consts=[None], expected_consts=[None])
 
+    def test_optimize_empty_set_unpack_idiom(self):
+        before = [
+            ('RESUME', 0, 0),
+            ('BUILD_SET', 0, 0),
+            ('BUILD_TUPLE', 0, 0),
+            ('SET_UPDATE', 1, 0),
+            ('POP_TOP', None, 0),
+            ('LOAD_CONST', 0, 0),
+            ('RETURN_VALUE', None, 0),
+        ]
+        after = [
+            ('RESUME', 0, 0),
+            ('BUILD_SET', 0, 0),
+            ('POP_TOP', None, 0),
+            ('LOAD_COMMON_CONSTANT', 7, 0),
+            ('RETURN_VALUE', None, 0),
+        ]
+        self.cfg_optimization_test(before, after, consts=[None], expected_consts=[None])
+
+    def test_optimize_empty_list_unpack_idiom(self):
+        before = [
+            ('RESUME', 0, 0),
+            ('BUILD_LIST', 0, 0),
+            ('BUILD_TUPLE', 0, 0),
+            ('LIST_EXTEND', 1, 0),
+            ('POP_TOP', None, 0),
+            ('LOAD_CONST', 0, 0),
+            ('RETURN_VALUE', None, 0),
+        ]
+        after = [
+            ('RESUME', 0, 0),
+            ('BUILD_LIST', 0, 0),
+            ('POP_TOP', None, 0),
+            ('LOAD_COMMON_CONSTANT', 7, 0),
+            ('RETURN_VALUE', None, 0),
+        ]
+        self.cfg_optimization_test(before, after, consts=[None], expected_consts=[None])
+
     def test_optimize_unary_not(self):
         # test folding
         before = [

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-22-13-04-50.gh-issue-150204.Fs3Ukl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-22-13-04-50.gh-issue-150204.Fs3Ukl.rst
@@ -1,0 +1,3 @@
+Optimize bytecode for leading null unpack idioms in set, tuple, and list
+literals. Removing redundant empty tuple unpack bytecode for cases such as
+the ``ast.unparse`` empty set representation ``{*()}``.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1742,6 +1742,43 @@ optimize_lists_and_sets(basicblock *bb, int i, int nextop,
     return SUCCESS;
 }
 
+/*
+Optimize lists and sets for:
+    1. Empty unpack idiom as first element `*()`:
+           Replace BUILD_SET 0, BUILD_TUPLE 0, SET_UPDATE 1 with BUILD_SET 0,
+           or BUILD_LIST 0, BUILD_TUPLE 0, LIST_EXTEND 1 with
+           BUILD_LIST 0.
+*/
+static int
+optimize_empty_first_unpack(basicblock *bb, int i, int build_opcode,
+                            int update_opcode)
+{
+    if (i < 0 || i + 2 >= bb->b_iused)
+    {
+        return SUCCESS;
+    }
+
+    cfg_instr *build = &bb->b_instr[i];
+    cfg_instr *empty = &bb->b_instr[i + 1];
+    cfg_instr *update = &bb->b_instr[i + 2];
+
+    if (build->i_opcode != build_opcode || build->i_oparg != 0) {
+        return SUCCESS;
+    }
+    if (empty->i_opcode != BUILD_TUPLE || empty->i_oparg != 0) {
+        return SUCCESS;
+    }
+    if (update->i_opcode != update_opcode || update->i_oparg != 1) {
+        return SUCCESS;
+    }
+
+    INSTR_SET_OP0(empty, NOP);
+    INSTR_SET_LOC(empty, NO_LOCATION);
+    INSTR_SET_OP0(update, NOP);
+    INSTR_SET_LOC(update, NO_LOCATION);
+    return SUCCESS;
+}
+
 /* Check whether the total number of items in the (possibly nested) collection obj exceeds
  * limit. Return a negative number if it does, and a non-negative number otherwise.
  * Used to avoid creating constants which are slow to hash.
@@ -2438,8 +2475,12 @@ optimize_basic_block(PyObject *const_cache, basicblock *bb, PyObject *consts,
                 RETURN_IF_ERROR(fold_tuple_of_constants(bb, i, consts, const_cache, consts_index));
                 break;
             case BUILD_LIST:
+                RETURN_IF_ERROR(optimize_lists_and_sets(bb, i, nextop, consts, const_cache, consts_index));
+                RETURN_IF_ERROR(optimize_empty_first_unpack(bb, i, BUILD_LIST, LIST_EXTEND));
+                break;
             case BUILD_SET:
                 RETURN_IF_ERROR(optimize_lists_and_sets(bb, i, nextop, consts, const_cache, consts_index));
+                RETURN_IF_ERROR(optimize_empty_first_unpack(bb, i, BUILD_SET, SET_UPDATE));
                 break;
             case POP_JUMP_IF_NOT_NONE:
             case POP_JUMP_IF_NONE:


### PR DESCRIPTION
This pull request introduces an optimization to Python's bytecode generation for set, list, and tuple literals that start with an empty unpack (e.g., `{*()}`, `[*()]`, `(*(),)`). The changes remove redundant bytecode instructions generated for these patterns, resulting in more efficient execution and cleaner disassembly output. Comprehensive tests are included to ensure correctness and visibility of this optimization.

**Note:** If needed, this PR can easily be reduced to only alter the set literal idiom case `{*()}`.

<!-- gh-issue-number: gh-150204 -->
* Issue: gh-150204
<!-- /gh-issue-number -->


# Benchmark

Results summarized below are comparison of results for non-debug windows build on `main` vs this branch.

[leading_empty_unpack_benchmark.py](https://github.com/user-attachments/files/28327031/empty_unpack_benchmark.py)

The change is a clear runtime win for the targeted idioms and modestly improves compile-time for those same forms without introducing a broader compile-time cost.

## Compile-time

Compile-time results are favorable for the targeted forms and effectively flat elsewhere.

| Benchmark | Before mean (ms) | After mean (ms) | Change |
| --- | ---: | ---: | ---: |
| `compile_list_empty_unpack` | 1.378 | 1.326 | -3.8% |
| `compile_set_empty_unpack` | 1.459 | 1.414 | -3.1% |
| `compile_tuple_empty_unpack` | 1.804 | 1.752 | -2.8% |
| `compile_tuple_assign_empty_unpack` | 1.083 | 1.036 | -4.4% |

The relevant near-miss and control cases also stay close to flat. All of the nearby non-target compile workloads move by less than 1%, which is consistent with noise rather than a systematic cost from the new optimization.

The important point is that the compiler is not paying an obvious global penalty for recognizing this pattern. The targeted forms are consistently faster to compile in this sample, while non-target controls drift in both directions inside a very narrow band.

The unpack spellings are still slower to compile than simpler constructor or literal forms, but that was already true on `main`. This change does not add to that pre-existing syntax cost, and may slightly reduce it for the exact optimized shapes. Unlike the runtime results, the compile-time `set()` versus `{*()}` relationship is essentially unchanged before and after.


## Runtime

The optimized empty-unpack forms all improve substantially:

| Benchmark | Before mean (ns) | After mean (ns) | Change |
| --- | ---: | ---: | ---: |
| `[*()]` | 36.93 | 25.69 | -30.4% |
| `{*()}` | 57.33 | 38.15 | -33.5% |
| `(*(),)` | 42.98 | 15.32 | -64.3% |
| `x = *(),` | 43.72 | 18.56 | -57.6% |
| `[*(), 1]` | 48.68 | 37.04 | -23.9% |
| `{*(), 1}` | 67.61 | 48.64 | -28.1% |

These gains match the bytecode simplification in the benchmark output:

- `[*()]` drops from 5 instructions to 3 by removing `LOAD_COMMON_CONSTANT ()` and `LIST_EXTEND`.
- `{*()}` drops from 5 instructions to 3 by removing `LOAD_COMMON_CONSTANT ()` and `SET_UPDATE`.
- `(*(),)` drops from 6 instructions to 3, eliminating the temporary list build and `INTRINSIC_LIST_TO_TUPLE` conversion.
- `x = *(),` drops from 8 instructions to 5 for the same reason, and now has the same shape as `x = ()`.
- `[*(), 1]` and `{*(), 1}` keep the seeded-container behavior but lose the now-useless empty extend/update step.

The `set()` versus `{*()}` comparison is especially useful because it changes qualitatively across the two branches:

| Case | `set()` mean (ns) | `{*()}` mean (ns) | `{*()}` vs `set()` |
| --- | ---: | ---: | ---: |
| Before | 53.15 | 57.33 | +7.9% slower |
| After | 53.96 | 38.15 | -29.3% faster |

Before this change, `{*()}` was paying for a redundant empty update and ended up slower than the constructor call. After the change, `{*()}` compiles down to a direct `BUILD_SET 0; RETURN_VALUE` path, while `set()` still has to load the global and perform a zero-argument call.
