### PR TITLE
gh-148932: Docs / `profiling.sampling` Windows limitations

### DIFF
--- a/Doc/library/profiling.sampling.rst
+++ b/Doc/library/profiling.sampling.rst
@@ -387,8 +387,11 @@ This requires one of:
 On Windows, the profiler requires administrative privileges or the
 ``SeDebugPrivilege`` privilege to read another process's memory.
 
-*Note*: Running ``profiling.sampling`` from a virtual environment on the Windows platform is not supported. It should be run from the global Python installation.
-
+*Note*: On Windows, ``python -m profiling.sampling`` fails inside a virtual
+environment because the venv's ``python.exe`` is just a launcher shim that
+re-executes the base interpreter as a child process. The shim itself isn't
+a Python process and has no ``PyRuntime`` section to attach to. Instead,
+run it from the global Python installation.
 
 Version compatibility
 ---------------------

--- a/Doc/library/profiling.sampling.rst
+++ b/Doc/library/profiling.sampling.rst
@@ -387,7 +387,7 @@ This requires one of:
 On Windows, the profiler requires administrative privileges or the
 ``SeDebugPrivilege`` privilege to read another process's memory.
 
-*Note*: Running `profiling.sampling` from a virtual environmnent on Windows platform is not supported. It should be run from the global Python installation.
+*Note*: Running ``profiling.sampling`` from a virtual environment on the Windows platform is not supported. It should be run from the global Python installation.
 
 
 Version compatibility

--- a/Doc/library/profiling.sampling.rst
+++ b/Doc/library/profiling.sampling.rst
@@ -387,6 +387,8 @@ This requires one of:
 On Windows, the profiler requires administrative privileges or the
 ``SeDebugPrivilege`` privilege to read another process's memory.
 
+*Note*: Running `profiling.sampling` from a virtual environmnent on Windows platform is not supported. It should be run from the global Python installation.
+
 
 Version compatibility
 ---------------------


### PR DESCRIPTION
Updates the docs for `profiling.sampling` to note the limitation when running in a virtual environment on Windows platform.

See #149560

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148932 -->
* Issue: gh-148932
<!-- /gh-issue-number -->
