### PR TITLE
gh-150207: Raise MemoryError on tokenizer allocation failure instead of crashing

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-22-21-52-38.gh-issue-150207.l2BUtI.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-22-21-52-38.gh-issue-150207.l2BUtI.rst
@@ -1,0 +1,1 @@
+fails in the tokenizer's ``_PyTokenizer_translate_newlines`` helper, so the out-of-memory condition is propagated as a proper Python exception instead of only being recorded in ``tok->done``.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-22-21-52-38.gh-issue-150207.l2BUtI.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-22-21-52-38.gh-issue-150207.l2BUtI.rst
@@ -1,1 +1,1 @@
-fails in the tokenizer's ``_PyTokenizer_translate_newlines`` helper, so the out-of-memory condition is propagated as a proper Python exception instead of only being recorded in ``tok->done``.
+Fix a crash when a memory allocation fails during tokenizer initialization. A proper :exc:`MemoryError` is now raised instead.

--- a/Parser/lexer/state.c
+++ b/Parser/lexer/state.c
@@ -15,8 +15,11 @@ _PyTokenizer_tok_new(void)
     struct tok_state *tok = (struct tok_state *)PyMem_Calloc(
                                             1,
                                             sizeof(struct tok_state));
-    if (tok == NULL)
+    if (tok == NULL) {
+        PyErr_NoMemory();
         return NULL;
+    }
+
     tok->buf = tok->cur = tok->inp = NULL;
     tok->fp_interactive = 0;
     tok->interactive_src_start = NULL;

--- a/Parser/tokenizer/file_tokenizer.c
+++ b/Parser/tokenizer/file_tokenizer.c
@@ -378,7 +378,7 @@ _PyTokenizer_FromFile(FILE *fp, const char* enc,
         return NULL;
     if ((tok->buf = (char *)PyMem_Malloc(BUFSIZ)) == NULL) {
         _PyTokenizer_Free(tok);
-	PyErr_NoMemory();
+        PyErr_NoMemory();
         return NULL;
     }
     tok->cur = tok->inp = tok->buf;

--- a/Parser/tokenizer/file_tokenizer.c
+++ b/Parser/tokenizer/file_tokenizer.c
@@ -378,6 +378,7 @@ _PyTokenizer_FromFile(FILE *fp, const char* enc,
         return NULL;
     if ((tok->buf = (char *)PyMem_Malloc(BUFSIZ)) == NULL) {
         _PyTokenizer_Free(tok);
+	PyErr_NoMemory();
         return NULL;
     }
     tok->cur = tok->inp = tok->buf;

--- a/Parser/tokenizer/helpers.c
+++ b/Parser/tokenizer/helpers.c
@@ -193,6 +193,7 @@ _PyTokenizer_new_string(const char *s, Py_ssize_t len, struct tok_state *tok)
     char* result = (char *)PyMem_Malloc(len + 1);
     if (!result) {
         tok->done = E_NOMEM;
+        PyErr_NoMemory();
         return NULL;
     }
     memcpy(result, s, len);
@@ -221,6 +222,7 @@ _PyTokenizer_translate_newlines(const char *s, int exec_input, int preserve_crlf
     buf = PyMem_Malloc(needed_length);
     if (buf == NULL) {
         tok->done = E_NOMEM;
+        PyErr_NoMemory();
         return NULL;
     }
     for (current = buf; *s; s++, current++) {

--- a/Parser/tokenizer/readline_tokenizer.c
+++ b/Parser/tokenizer/readline_tokenizer.c
@@ -114,6 +114,7 @@ _PyTokenizer_FromReadline(PyObject* readline, const char* enc,
         return NULL;
     if ((tok->buf = (char *)PyMem_Malloc(BUFSIZ)) == NULL) {
         _PyTokenizer_Free(tok);
+        PyErr_NoMemory();
         return NULL;
     }
     tok->cur = tok->inp = tok->buf;


### PR DESCRIPTION
Original report was around this snippet of code:
```import resource 
MB_512 = 512 * 1024 * 1024
resource.setrlimit(resource.RLIMIT_AS, (MB_512, MB_512)) 
eval("A"* 420000000)
```

Throwing a system error. Based off the write up made in https://github.com/python/cpython/issues/150207 I felt like there was a fair case to actually show the user a Mem error instead of a system crash.
```>>> import resource
... MB_512 = 512 * 1024 * 1024
... resource.setrlimit(resource.RLIMIT_AS, (MB_512, MB_512))
... eval("A"* 420000000)
...
Traceback (most recent call last):
  File "<python-input-0>", line 4, in <module>
    eval("A"* 420000000)
    ~~~~^^^^^^^^^^^^^^^^
MemoryError
>>>
```

I think this does provide a bit nicer of an experience but I think I need an actual adult to verify this for me. I also dont know the larger ramifications but it felt worth to throw something up 


<!-- gh-issue-number: gh-150207 -->
* Issue: gh-150207
<!-- /gh-issue-number -->

