### PR TITLE
gh-150075: tar.addfile() doesn't set member offsets

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2381,11 +2381,14 @@ class TarFile(object):
             raise ValueError("fileobj not provided for non zero-size regular file")
 
         tarinfo = copy.copy(tarinfo)
-
+        # get current offset
+        tarinfo.offset = self.offset
         buf = tarinfo.tobuf(self.format, self.encoding, self.errors)
         self.fileobj.write(buf)
         self.offset += len(buf)
+        # add original offset to block size
         bufsize=self.copybufsize
+        tarinfo.offset_data = self.offset
         # If there's data to follow, append it.
         if fileobj is not None:
             copyfileobj(fileobj, self.fileobj, tarinfo.size, bufsize=bufsize)

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1485,6 +1485,29 @@ class WriteTest(WriteTestBase, unittest.TestCase):
 
     prefix = "w:"
 
+    def test_addfile_sets_offsets(self):
+        # gh-150075: addfile() must set offset and offset_data on the
+        # TarInfo stored in the archive so they match a subsequent read.
+        data = b"data"
+
+        with tarfile.open(tmpname, self.mode) as tar:
+            t1 = tarfile.TarInfo("test1.txt")
+            t1.size = len(data)
+            tar.addfile(t1, io.BytesIO(data))
+
+            t2 = tarfile.TarInfo("test2.txt")
+            t2.size = len(data)
+            tar.addfile(t2, io.BytesIO(data))
+
+            write_members = tar.getmembers()
+
+        with tarfile.open(tmpname) as tar:
+            read_members = tar.getmembers()
+
+        for w, r in zip(write_members, read_members):
+            self.assertEqual(w.offset, r.offset)
+            self.assertEqual(w.offset_data, r.offset_data)
+
     def test_100_char_name(self):
         # The name field in a tar header stores strings of at most 100 chars.
         # If a string is shorter than 100 chars it has to be padded with '\0',

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-21-14-21-06.gh-issue-150075.dLI21Z.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-21-14-21-06.gh-issue-150075.dLI21Z.rst
@@ -1,0 +1,1 @@
+tar.addfile() doesn't set member offsets in 3.15. From reviewing the file it seemed like the copy was not adding the proper offsets to the tarinfo object. The way I fixed this is that I added the classes current offset of when.addFile is called and then added the block size after .tobuf function was called.


### PR DESCRIPTION
Original bug report:

# Bug report

### Bug description:

It appears that `tarfile.TarFile.addfile()` sets neither `offset` nor `offset_data` attributes in the `TarInfo` added to `self.members`, when it's done adding the file. Members in a reopened TAR have correct values.

**Reproducer**
```python
from io import BytesIO
from tarfile import TarFile, TarInfo

with TarFile("test.tar", "w") as tar:
    data = b"data"

    tarinfo = TarInfo("test1.txt")
    tarinfo.size = len(data)
    tar.addfile(tarinfo, BytesIO(data))

    tarinfo = TarInfo("test2.txt")
    tarinfo.size = len(data)
    tar.addfile(tarinfo, BytesIO(data))

    for member in tar.getmembers():
        print(member.name, member.offset, member.offset_data)

with TarFile("test.tar", "r") as tar:
    for member in tar.getmembers():
        print(member.name, member.offset, member.offset_data)
```

**Expected output**
```
test1.txt 0 512
test2.txt 1024 1536
test1.txt 0 512
test2.txt 1024 1536
```

**Actual output**
```
test1.txt 0 0
test2.txt 0 0
test1.txt 0 512
test2.txt 1024 1536
```

### CPython versions tested on:

3.15

### Operating systems tested on:

Linux

-----------------------------
**Fix**
I added the offset info for a given file based on the current offset of the file and then after the block size is calculated. I also included a test to validate the behavior



<!-- gh-issue-number: gh-150075 -->
* Issue: gh-150075
<!-- /gh-issue-number -->

