### PR TITLE
gh-150167: Make shutil compression probes eager

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -10,34 +10,29 @@ import stat
 import fnmatch
 import collections
 import errno
+import importlib
 
-try:
-    import zlib
-    del zlib
-    _ZLIB_SUPPORTED = True
-except ImportError:
-    _ZLIB_SUPPORTED = False
+def _compression_module_supported(module_name):
+    set_lazy_imports = getattr(sys, "set_lazy_imports", None)
+    try:
+        if set_lazy_imports is None:
+            importlib.import_module(module_name)
+            return True
 
-try:
-    import bz2
-    del bz2
-    _BZ2_SUPPORTED = True
-except ImportError:
-    _BZ2_SUPPORTED = False
+        lazy_imports_mode = sys.get_lazy_imports()
+        set_lazy_imports("normal")
+        importlib.import_module(module_name)
+    except ImportError:
+        return False
+    finally:
+        if set_lazy_imports is not None:
+            set_lazy_imports(lazy_imports_mode)
+    return True
 
-try:
-    import lzma
-    del lzma
-    _LZMA_SUPPORTED = True
-except ImportError:
-    _LZMA_SUPPORTED = False
-
-try:
-    from compression import zstd
-    del zstd
-    _ZSTD_SUPPORTED = True
-except ImportError:
-    _ZSTD_SUPPORTED = False
+_ZLIB_SUPPORTED = _compression_module_supported("zlib")
+_BZ2_SUPPORTED = _compression_module_supported("bz2")
+_LZMA_SUPPORTED = _compression_module_supported("lzma")
+_ZSTD_SUPPORTED = _compression_module_supported("compression.zstd")
 
 _WINDOWS = os.name == 'nt'
 posix = nt = None

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -31,6 +31,7 @@ except ImportError:
 from test import support
 from test.support import os_helper
 from test.support.os_helper import TESTFN, FakePath
+from test.support.script_helper import assert_python_ok
 
 TESTFN2 = TESTFN + "2"
 TESTFN_SRC = TESTFN + "_SRC"
@@ -2176,6 +2177,27 @@ class TestArchives(BaseTest, unittest.TestCase):
     @support.requires_bz2()
     def test_unpack_archive_bztar(self):
         self.check_unpack_tarball('bztar')
+
+    @support.requires_subprocess()
+    def test_bz2_support_probe_is_eager_under_lazy_imports(self):
+        module_dir = self.mkdtemp()
+        create_file(
+            (module_dir, 'bz2.py'),
+            'import _bz2\n'
+            'SENTINEL = True\n',
+        )
+        create_file(
+            (module_dir, '_bz2.py'),
+            'raise ImportError("missing _bz2 backend")\n',
+        )
+        code = f"""
+import sys
+sys.path.insert(0, {module_dir!r})
+import shutil
+print(shutil._BZ2_SUPPORTED)
+"""
+        proc = assert_python_ok('-X', 'lazy_imports=all', '-S', '-c', code)
+        self.assertEqual(proc.out.strip(), b'False')
 
     @support.requires_zstd()
     def test_unpack_archive_zstdtar(self):

--- a/Misc/NEWS.d/next/Library/2026-05-22-18-40-00.gh-issue-150167.5L9x2h.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-22-18-40-00.gh-issue-150167.5L9x2h.rst
@@ -1,0 +1,4 @@
+Make :mod:`shutil` probe compression-module support eagerly even when Python is
+started with ``-X lazy_imports=all``. This fixes cases where
+``shutil._BZ2_SUPPORTED`` could be reported as ``True`` even though the
+underlying ``_bz2`` extension is unavailable.


### PR DESCRIPTION
gh-150167

Make `shutil` detect compression-module support eagerly even when Python starts with `-X lazy_imports=all`.

This keeps `_BZ2_SUPPORTED` accurate when `bz2` imports successfully but its `_bz2` backend would fail once reified. The support probe now temporarily disables lazy imports while importing the compression module, and the regression test exercises that failure mode in a subprocess.

## Testing
- `./python.exe -m test test_shutil`
- `./python.exe -m test test_lazy_import`
- `./python.exe -X lazy_imports=all -S -c "import sys; sys.path.insert(0, TMPDIR); import shutil; print(shutil._BZ2_SUPPORTED)"` (with a fake `bz2` module whose `_bz2` backend raises `ImportError`)
