### PR TITLE
gh-150244: Fix `test_create_subprocess_env_shell` to handle PATH with spaces

### DIFF
--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import signal
 import sys
 import textwrap
@@ -770,9 +771,7 @@ class SubprocessMixin:
 
     def test_create_subprocess_env_shell(self) -> None:
         async def main() -> None:
-            executable = sys.executable
-            if sys.platform == "win32":
-                executable = f'"{executable}"'
+            executable = f'"{sys.executable}"' if sys.platform == "win32" else shlex.quote(sys.executable)
             cmd = f'''{executable} -c "import os, sys; sys.stdout.write(os.getenv('FOO'))"'''
             env = os.environ.copy()
             env["FOO"] = "bar"

--- a/Misc/NEWS.d/next/Tests/2026-05-23-02-42-45.gh-issue-150244.J9yP1-.rst
+++ b/Misc/NEWS.d/next/Tests/2026-05-23-02-42-45.gh-issue-150244.J9yP1-.rst
@@ -1,0 +1,1 @@
+Fix ``test_create_subprocess_env_shell`` to properly quote the executable path on both Win32 and UNIX-like systems to properly handle spaces in the path.

--- a/Misc/NEWS.d/next/Tests/2026-05-23-02-42-45.gh-issue-150244.J9yP1-.rst
+++ b/Misc/NEWS.d/next/Tests/2026-05-23-02-42-45.gh-issue-150244.J9yP1-.rst
@@ -1,1 +1,0 @@
-Fix ``test_create_subprocess_env_shell`` to properly quote the executable path on both Win32 and UNIX-like systems to properly handle spaces in the path.


### PR DESCRIPTION
Fix ``test_create_subprocess_env_shell`` to properly quote the executable path on both Win32 and UNIX-like systems to properly handle spaces in the path. 

<!-- gh-issue-number: gh-150244 -->
* Issue: gh-150244
<!-- /gh-issue-number -->
