### PR TITLE
gh-150285: Fix too long docstrings in the zstd module

### DIFF
--- a/Lib/compression/zstd/__init__.py
+++ b/Lib/compression/zstd/__init__.py
@@ -61,8 +61,9 @@ class FrameInfo:
 def get_frame_info(frame_buffer):
     """Get Zstandard frame information from a frame header.
 
-    *frame_buffer* is a bytes-like object. It should start from the beginning
-    of a frame, and needs to include at least the frame header (6 to 18 bytes).
+    *frame_buffer* is a bytes-like object. It should start from the
+    beginning of a frame, and needs to include at least the frame header
+    (6 to 18 bytes).
 
     The returned FrameInfo object has two attributes.
     'decompressed_size' is the size in bytes of the data in the frame when
@@ -103,16 +104,17 @@ def finalize_dict(zstd_dict, /, samples, dict_size, level):
     finalize *zstd_dict* by adding headers and statistics according to the
     Zstandard dictionary format.
 
-    You may compose an effective dictionary content by hand, which is used as
-    basis dictionary, and use some samples to finalize a dictionary. The basis
-    dictionary may be a "raw content" dictionary. See *is_raw* in ZstdDict.
+    You may compose an effective dictionary content by hand, which is used
+    as basis dictionary, and use some samples to finalize a dictionary.  The
+    basis dictionary may be a "raw content" dictionary.  See *is_raw* in
+    ZstdDict.
 
-    *samples* is an iterable of samples, where a sample is a bytes-like object
-    representing a file.
+    *samples* is an iterable of samples, where a sample is a bytes-like
+    object representing a file.
     *dict_size* is the dictionary's maximum size, in bytes.
     *level* is the expected compression level. The statistics for each
-    compression level differ, so tuning the dictionary to the compression level
-    can provide improvements.
+    compression level differ, so tuning the dictionary to the compression
+    level can provide improvements.
     """
 
     if not isinstance(zstd_dict, ZstdDict):
@@ -140,8 +142,8 @@ def compress(data, level=None, options=None, zstd_dict=None):
     COMPRESSION_LEVEL_DEFAULT ('3').
     *options* is a dict object that contains advanced compression
     parameters. See CompressionParameter for more on options.
-    *zstd_dict* is a ZstdDict object, a pre-trained Zstandard dictionary. See
-    the function train_dict for how to train a ZstdDict on sample data.
+    *zstd_dict* is a ZstdDict object, a pre-trained Zstandard dictionary.
+    See the function train_dict for how to train a ZstdDict on sample data.
 
     For incremental compression, use a ZstdCompressor instead.
     """
@@ -152,8 +154,8 @@ def compress(data, level=None, options=None, zstd_dict=None):
 def decompress(data, zstd_dict=None, options=None):
     """Decompress one or more frames of Zstandard compressed *data*.
 
-    *zstd_dict* is a ZstdDict object, a pre-trained Zstandard dictionary. See
-    the function train_dict for how to train a ZstdDict on sample data.
+    *zstd_dict* is a ZstdDict object, a pre-trained Zstandard dictionary.
+    See the function train_dict for how to train a ZstdDict on sample data.
     *options* is a dict object that contains advanced compression
     parameters. See DecompressionParameter for more on options.
 

--- a/Lib/compression/zstd/_zstdfile.py
+++ b/Lib/compression/zstd/_zstdfile.py
@@ -36,9 +36,9 @@ class ZstdFile(_streams.BaseStream):
 
         *file* can be either an file-like object, or a file name to open.
 
-        *mode* can be 'r' for reading (default), 'w' for (over)writing, 'x' for
-        creating exclusively, or 'a' for appending. These can equivalently be
-        given as 'rb', 'wb', 'xb' and 'ab' respectively.
+        *mode* can be 'r' for reading (default), 'w' for (over)writing, 'x'
+        for creating exclusively, or 'a' for appending.  These can
+        equivalently be given as 'rb', 'wb', 'xb' and 'ab' respectively.
 
         *level* is an optional int specifying the compression level to use,
         or COMPRESSION_LEVEL_DEFAULT if not given.
@@ -296,26 +296,27 @@ def open(file, /, mode='rb', *, level=None, options=None, zstd_dict=None,
          encoding=None, errors=None, newline=None):
     """Open a Zstandard compressed file in binary or text mode.
 
-    file can be either a file name (given as a str, bytes, or PathLike object),
-    in which case the named file is opened, or it can be an existing file object
-    to read from or write to.
+    file can be either a file name (given as a str, bytes, or PathLike
+    object), in which case the named file is opened, or it can be
+    an existing file object to read from or write to.
 
-    The mode parameter can be 'r', 'rb' (default), 'w', 'wb', 'x', 'xb', 'a',
-    'ab' for binary mode, or 'rt', 'wt', 'xt', 'at' for text mode.
+    The mode parameter can be 'r', 'rb' (default), 'w', 'wb', 'x', 'xb',
+    'a', 'ab' for binary mode, or 'rt', 'wt', 'xt', 'at' for text mode.
 
-    The level, options, and zstd_dict parameters specify the settings the same
-    as ZstdFile.
+    The level, options, and zstd_dict parameters specify the settings the
+    same as ZstdFile.
 
     When using read mode (decompression), the options parameter is a dict
-    representing advanced decompression options. The level parameter is not
-    supported in this case. When using write mode (compression), only one of
-    level, an int representing the compression level, or options, a dict
-    representing advanced compression options, may be passed. In both modes,
-    zstd_dict is a ZstdDict instance containing a trained Zstandard dictionary.
+    representing advanced decompression options.  The level parameter is not
+    supported in this case.  When using write mode (compression), only one
+    of level, an int representing the compression level, or options, a dict
+    representing advanced compression options, may be passed.  In both
+    modes, zstd_dict is a ZstdDict instance containing a trained Zstandard
+    dictionary.
 
-    For binary mode, this function is equivalent to the ZstdFile constructor:
-    ZstdFile(filename, mode, ...). In this case, the encoding, errors and
-    newline parameters must not be provided.
+    For binary mode, this function is equivalent to the ZstdFile
+    constructor: ZstdFile(filename, mode, ...).  In this case, the encoding,
+    errors and newline parameters must not be provided.
 
     For text mode, an ZstdFile object is created, and wrapped in an
     io.TextIOWrapper instance with the specified encoding, error handling

--- a/Modules/_zstd/clinic/compressor.c.h
+++ b/Modules/_zstd/clinic/compressor.c.h
@@ -21,8 +21,8 @@ PyDoc_STRVAR(_zstd_ZstdCompressor_new__doc__,
 "  zstd_dict\n"
 "    A ZstdDict object, a pre-trained Zstandard dictionary.\n"
 "\n"
-"Thread-safe at method level. For one-shot compression, use the compress()\n"
-"function instead.");
+"Thread-safe at method level.  For one-shot compression, use the\n"
+"compress() function instead.");
 
 static PyObject *
 _zstd_ZstdCompressor_new_impl(PyTypeObject *type, PyObject *level,
@@ -105,9 +105,9 @@ PyDoc_STRVAR(_zstd_ZstdCompressor_compress__doc__,
 "    Can be these 3 values ZstdCompressor.CONTINUE,\n"
 "    ZstdCompressor.FLUSH_BLOCK, ZstdCompressor.FLUSH_FRAME\n"
 "\n"
-"Return a chunk of compressed data if possible, or b\'\' otherwise. When you have\n"
-"finished providing data to the compressor, call the flush() method to finish\n"
-"the compression process.");
+"Return a chunk of compressed data if possible, or b\'\' otherwise.\n"
+"When you have finished providing data to the compressor, call the\n"
+"flush() method to finish the compression process.");
 
 #define _ZSTD_ZSTDCOMPRESSOR_COMPRESS_METHODDEF    \
     {"compress", _PyCFunction_CAST(_zstd_ZstdCompressor_compress), METH_FASTCALL|METH_KEYWORDS, _zstd_ZstdCompressor_compress__doc__},
@@ -189,9 +189,9 @@ PyDoc_STRVAR(_zstd_ZstdCompressor_flush__doc__,
 "    Can be these 2 values ZstdCompressor.FLUSH_FRAME,\n"
 "    ZstdCompressor.FLUSH_BLOCK\n"
 "\n"
-"Flush any remaining data left in internal buffers. Since Zstandard data\n"
-"consists of one or more independent frames, the compressor object can still\n"
-"be used after this method is called.");
+"Flush any remaining data left in internal buffers.  Since Zstandard\n"
+"data consists of one or more independent frames, the compressor\n"
+"object can still be used after this method is called.");
 
 #define _ZSTD_ZSTDCOMPRESSOR_FLUSH_METHODDEF    \
     {"flush", _PyCFunction_CAST(_zstd_ZstdCompressor_flush), METH_FASTCALL|METH_KEYWORDS, _zstd_ZstdCompressor_flush__doc__},
@@ -262,13 +262,14 @@ PyDoc_STRVAR(_zstd_ZstdCompressor_set_pledged_input_size__doc__,
 "  size\n"
 "    The size of the uncompressed data to be provided to the compressor.\n"
 "\n"
-"This method can be used to ensure the header of the frame about to be written\n"
-"includes the size of the data, unless the CompressionParameter.content_size_flag\n"
-"is set to False. If last_mode != FLUSH_FRAME, then a RuntimeError is raised.\n"
+"This method can be used to ensure the header of the frame about to\n"
+"be written includes the size of the data, unless the\n"
+"CompressionParameter.content_size_flag is set to False.\n"
+"If last_mode != FLUSH_FRAME, then a RuntimeError is raised.\n"
 "\n"
-"It is important to ensure that the pledged data size matches the actual data\n"
-"size. If they do not match the compressed output data may be corrupted and the\n"
-"final chunk written may be lost.");
+"It is important to ensure that the pledged data size matches the\n"
+"actual data size.  If they do not match the compressed output data\n"
+"may be corrupted and the final chunk written may be lost.");
 
 #define _ZSTD_ZSTDCOMPRESSOR_SET_PLEDGED_INPUT_SIZE_METHODDEF    \
     {"set_pledged_input_size", (PyCFunction)_zstd_ZstdCompressor_set_pledged_input_size, METH_O, _zstd_ZstdCompressor_set_pledged_input_size__doc__},
@@ -291,4 +292,4 @@ _zstd_ZstdCompressor_set_pledged_input_size(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c1d5c2cf06a8becd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1a5e21476885866c input=a9049054013a1b77]*/

--- a/Modules/_zstd/clinic/decompressor.c.h
+++ b/Modules/_zstd/clinic/decompressor.c.h
@@ -20,8 +20,8 @@ PyDoc_STRVAR(_zstd_ZstdDecompressor_new__doc__,
 "  options\n"
 "    A dict object that contains advanced decompression parameters.\n"
 "\n"
-"Thread-safe at method level. For one-shot decompression, use the decompress()\n"
-"function instead.");
+"Thread-safe at method level.  For one-shot decompression, use the\n"
+"decompress() function instead.");
 
 static PyObject *
 _zstd_ZstdDecompressor_new_impl(PyTypeObject *type, PyObject *zstd_dict,
@@ -91,7 +91,8 @@ PyDoc_STRVAR(_zstd_ZstdDecompressor_unused_data__doc__,
 "A bytes object of un-consumed input data.\n"
 "\n"
 "When ZstdDecompressor object stops after a frame is\n"
-"decompressed, unused input data after the frame. Otherwise this will be b\'\'.");
+"decompressed, unused input data after the frame.  Otherwise this\n"
+"will be b\'\'.");
 #if defined(_zstd_ZstdDecompressor_unused_data_DOCSTR)
 #   undef _zstd_ZstdDecompressor_unused_data_DOCSTR
 #endif
@@ -129,18 +130,19 @@ PyDoc_STRVAR(_zstd_ZstdDecompressor_decompress__doc__,
 "    output buffer is unlimited. When it is nonnegative, returns at\n"
 "    most max_length bytes of decompressed data.\n"
 "\n"
-"If *max_length* is nonnegative, returns at most *max_length* bytes of\n"
-"decompressed data. If this limit is reached and further output can be\n"
-"produced, *self.needs_input* will be set to ``False``. In this case, the next\n"
-"call to *decompress()* may provide *data* as b\'\' to obtain more of the output.\n"
+"If *max_length* is nonnegative, returns at most *max_length* bytes\n"
+"of decompressed data.  If this limit is reached and further output\n"
+"can be produced, *self.needs_input* will be set to ``False``.  In\n"
+"this case, the next call to *decompress()* may provide *data* as b\'\'\n"
+"to obtain more of the output.\n"
 "\n"
-"If all of the input data was decompressed and returned (either because this\n"
-"was less than *max_length* bytes, or because *max_length* was negative),\n"
-"*self.needs_input* will be set to True.\n"
+"If all of the input data was decompressed and returned (either\n"
+"because this was less than *max_length* bytes, or because\n"
+"*max_length* was negative), *self.needs_input* will be set to True.\n"
 "\n"
-"Attempting to decompress data after the end of a frame is reached raises an\n"
-"EOFError. Any data found after the end of the frame is ignored and saved in\n"
-"the self.unused_data attribute.");
+"Attempting to decompress data after the end of a frame is reached\n"
+"raises an EOFError.  Any data found after the end of the frame is\n"
+"ignored and saved in the self.unused_data attribute.");
 
 #define _ZSTD_ZSTDDECOMPRESSOR_DECOMPRESS_METHODDEF    \
     {"decompress", _PyCFunction_CAST(_zstd_ZstdDecompressor_decompress), METH_FASTCALL|METH_KEYWORDS, _zstd_ZstdDecompressor_decompress__doc__},
@@ -220,4 +222,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=30c12ef047027ede input=a9049054013a1b77]*/
+/*[clinic end generated code: output=70bc308e86463751 input=a9049054013a1b77]*/

--- a/Modules/_zstd/clinic/zstddict.c.h
+++ b/Modules/_zstd/clinic/zstddict.c.h
@@ -21,8 +21,8 @@ PyDoc_STRVAR(_zstd_ZstdDict_new__doc__,
 "    advanced cases. Otherwise, check that the content represents\n"
 "    a Zstandard dictionary created by the zstd library or CLI.\n"
 "\n"
-"The dictionary can be used for compression or decompression, and can be shared\n"
-"by multiple ZstdCompressor or ZstdDecompressor objects.");
+"The dictionary can be used for compression or decompression, and can be\n"
+"shared by multiple ZstdCompressor or ZstdDecompressor objects.");
 
 static PyObject *
 _zstd_ZstdDict_new_impl(PyTypeObject *type, Py_buffer *dict_content,
@@ -125,11 +125,11 @@ PyDoc_STRVAR(_zstd_ZstdDict_as_digested_dict__doc__,
 "Pass this attribute as zstd_dict argument:\n"
 "compress(dat, zstd_dict=zd.as_digested_dict)\n"
 "\n"
-"1. Some advanced compression parameters of compressor may be overridden\n"
-"   by parameters of digested dictionary.\n"
-"2. ZstdDict has a digested dictionaries cache for each compression level.\n"
-"   It\'s faster when loading again a digested dictionary with the same\n"
-"   compression level.\n"
+"1. Some advanced compression parameters of compressor may be\n"
+"   overridden by parameters of digested dictionary.\n"
+"2. ZstdDict has a digested dictionaries cache for each compression\n"
+"   level.  It\'s faster when loading again a digested dictionary with\n"
+"   the same compression level.\n"
 "3. No need to use this for decompression.");
 #if defined(_zstd_ZstdDict_as_digested_dict_DOCSTR)
 #   undef _zstd_ZstdDict_as_digested_dict_DOCSTR
@@ -161,9 +161,10 @@ PyDoc_STRVAR(_zstd_ZstdDict_as_undigested_dict__doc__,
 "Pass this attribute as zstd_dict argument:\n"
 "compress(dat, zstd_dict=zd.as_undigested_dict)\n"
 "\n"
-"1. The advanced compression parameters of compressor will not be overridden.\n"
-"2. Loading an undigested dictionary is costly. If load an undigested dictionary\n"
-"   multiple times, consider reusing a compressor object.\n"
+"1. The advanced compression parameters of compressor will not be\n"
+"   overridden.\n"
+"2. Loading an undigested dictionary is costly. If load an undigested\n"
+"   dictionary multiple times, consider reusing a compressor object.\n"
 "3. No need to use this for decompression.");
 #if defined(_zstd_ZstdDict_as_undigested_dict_DOCSTR)
 #   undef _zstd_ZstdDict_as_undigested_dict_DOCSTR
@@ -195,9 +196,10 @@ PyDoc_STRVAR(_zstd_ZstdDict_as_prefix__doc__,
 "Pass this attribute as zstd_dict argument:\n"
 "compress(dat, zstd_dict=zd.as_prefix)\n"
 "\n"
-"1. Prefix is compatible with long distance matching, while dictionary is not.\n"
-"2. It only works for the first frame, then the compressor/decompressor will\n"
-"   return to no prefix state.\n"
+"1. Prefix is compatible with long distance matching, while\n"
+"   dictionary is not.\n"
+"2. It only works for the first frame, then the\n"
+"   compressor/decompressor will return to no prefix state.\n"
 "3. When decompressing, must use the same prefix as when compressing.");
 #if defined(_zstd_ZstdDict_as_prefix_DOCSTR)
 #   undef _zstd_ZstdDict_as_prefix_DOCSTR
@@ -222,4 +224,4 @@ _zstd_ZstdDict_as_prefix_get(PyObject *self, void *Py_UNUSED(context))
 {
     return _zstd_ZstdDict_as_prefix_get_impl((ZstdDict *)self);
 }
-/*[clinic end generated code: output=f41d9e2e2cc2928f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=49b66061b4fcdb5f input=a9049054013a1b77]*/

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -332,14 +332,14 @@ _zstd.ZstdCompressor.__new__ as _zstd_ZstdCompressor_new
 
 Create a compressor object for compressing data incrementally.
 
-Thread-safe at method level. For one-shot compression, use the compress()
-function instead.
+Thread-safe at method level.  For one-shot compression, use the
+compress() function instead.
 [clinic start generated code]*/
 
 static PyObject *
 _zstd_ZstdCompressor_new_impl(PyTypeObject *type, PyObject *level,
                               PyObject *options, PyObject *zstd_dict)
-/*[clinic end generated code: output=cdef61eafecac3d7 input=92de0211ae20ffdc]*/
+/*[clinic end generated code: output=cdef61eafecac3d7 input=bbfeeaa06fd3bd4d]*/
 {
     ZstdCompressor* self = PyObject_GC_New(ZstdCompressor, type);
     if (self == NULL) {
@@ -583,7 +583,6 @@ error:
 }
 
 /*[clinic input]
-@permit_long_docstring_body
 _zstd.ZstdCompressor.compress
 
     data: Py_buffer
@@ -593,15 +592,15 @@ _zstd.ZstdCompressor.compress
 
 Provide data to the compressor object.
 
-Return a chunk of compressed data if possible, or b'' otherwise. When you have
-finished providing data to the compressor, call the flush() method to finish
-the compression process.
+Return a chunk of compressed data if possible, or b'' otherwise.
+When you have finished providing data to the compressor, call the
+flush() method to finish the compression process.
 [clinic start generated code]*/
 
 static PyObject *
 _zstd_ZstdCompressor_compress_impl(ZstdCompressor *self, Py_buffer *data,
                                    int mode)
-/*[clinic end generated code: output=ed7982d1cf7b4f98 input=6018ed6cc729cea6]*/
+/*[clinic end generated code: output=ed7982d1cf7b4f98 input=11726dff64d7b2f9]*/
 {
     PyObject *ret;
 
@@ -643,7 +642,6 @@ _zstd_ZstdCompressor_compress_impl(ZstdCompressor *self, Py_buffer *data,
 }
 
 /*[clinic input]
-@permit_long_docstring_body
 _zstd.ZstdCompressor.flush
 
     mode: int(c_default="ZSTD_e_end") = ZstdCompressor.FLUSH_FRAME
@@ -652,14 +650,14 @@ _zstd.ZstdCompressor.flush
 
 Finish the compression process.
 
-Flush any remaining data left in internal buffers. Since Zstandard data
-consists of one or more independent frames, the compressor object can still
-be used after this method is called.
+Flush any remaining data left in internal buffers.  Since Zstandard
+data consists of one or more independent frames, the compressor
+object can still be used after this method is called.
 [clinic start generated code]*/
 
 static PyObject *
 _zstd_ZstdCompressor_flush_impl(ZstdCompressor *self, int mode)
-/*[clinic end generated code: output=b7cf2c8d64dcf2e3 input=a9871ec742d79003]*/
+/*[clinic end generated code: output=b7cf2c8d64dcf2e3 input=130e0b1eddf0f498]*/
 {
     PyObject *ret;
 
@@ -693,7 +691,7 @@ _zstd_ZstdCompressor_flush_impl(ZstdCompressor *self, int mode)
 
 
 /*[clinic input]
-@permit_long_docstring_body
+@permit_long_summary
 _zstd.ZstdCompressor.set_pledged_input_size
 
     size: zstd_contentsize
@@ -702,19 +700,20 @@ _zstd.ZstdCompressor.set_pledged_input_size
 
 Set the uncompressed content size to be written into the frame header.
 
-This method can be used to ensure the header of the frame about to be written
-includes the size of the data, unless the CompressionParameter.content_size_flag
-is set to False. If last_mode != FLUSH_FRAME, then a RuntimeError is raised.
+This method can be used to ensure the header of the frame about to
+be written includes the size of the data, unless the
+CompressionParameter.content_size_flag is set to False.
+If last_mode != FLUSH_FRAME, then a RuntimeError is raised.
 
-It is important to ensure that the pledged data size matches the actual data
-size. If they do not match the compressed output data may be corrupted and the
-final chunk written may be lost.
+It is important to ensure that the pledged data size matches the
+actual data size.  If they do not match the compressed output data
+may be corrupted and the final chunk written may be lost.
 [clinic start generated code]*/
 
 static PyObject *
 _zstd_ZstdCompressor_set_pledged_input_size_impl(ZstdCompressor *self,
                                                  unsigned long long size)
-/*[clinic end generated code: output=3a09e55cc0e3b4f9 input=b4c87bcbd5ce6111]*/
+/*[clinic end generated code: output=3a09e55cc0e3b4f9 input=714cd7a9aa10e2a8]*/
 {
     // Error occurred while converting argument, should be unreachable
     assert(size != ZSTD_CONTENTSIZE_ERROR);

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -469,7 +469,6 @@ error:
 
 
 /*[clinic input]
-@permit_long_docstring_body
 @classmethod
 _zstd.ZstdDecompressor.__new__ as _zstd_ZstdDecompressor_new
     zstd_dict: object = None
@@ -479,14 +478,14 @@ _zstd.ZstdDecompressor.__new__ as _zstd_ZstdDecompressor_new
 
 Create a decompressor object for decompressing data incrementally.
 
-Thread-safe at method level. For one-shot decompression, use the decompress()
-function instead.
+Thread-safe at method level.  For one-shot decompression, use the
+decompress() function instead.
 [clinic start generated code]*/
 
 static PyObject *
 _zstd_ZstdDecompressor_new_impl(PyTypeObject *type, PyObject *zstd_dict,
                                 PyObject *options)
-/*[clinic end generated code: output=590ca65c1102ff4a input=ed8891edfd14cdaa]*/
+/*[clinic end generated code: output=590ca65c1102ff4a input=73879de69bf89f59]*/
 {
     ZstdDecompressor* self = PyObject_GC_New(ZstdDecompressor, type);
     if (self == NULL) {
@@ -571,19 +570,19 @@ ZstdDecompressor_dealloc(PyObject *ob)
 }
 
 /*[clinic input]
-@permit_long_docstring_body
 @getter
 _zstd.ZstdDecompressor.unused_data
 
 A bytes object of un-consumed input data.
 
 When ZstdDecompressor object stops after a frame is
-decompressed, unused input data after the frame. Otherwise this will be b''.
+decompressed, unused input data after the frame.  Otherwise this
+will be b''.
 [clinic start generated code]*/
 
 static PyObject *
 _zstd_ZstdDecompressor_unused_data_get_impl(ZstdDecompressor *self)
-/*[clinic end generated code: output=f3a20940f11b6b09 input=37c2c531ab56f914]*/
+/*[clinic end generated code: output=f3a20940f11b6b09 input=0462065c5e60ba01]*/
 {
     PyObject *ret;
 
@@ -613,7 +612,6 @@ _zstd_ZstdDecompressor_unused_data_get_impl(ZstdDecompressor *self)
 
 /*[clinic input]
 @permit_long_summary
-@permit_long_docstring_body
 _zstd.ZstdDecompressor.decompress
 
     data: Py_buffer
@@ -625,25 +623,26 @@ _zstd.ZstdDecompressor.decompress
 
 Decompress *data*, returning uncompressed bytes if possible, or b'' otherwise.
 
-If *max_length* is nonnegative, returns at most *max_length* bytes of
-decompressed data. If this limit is reached and further output can be
-produced, *self.needs_input* will be set to ``False``. In this case, the next
-call to *decompress()* may provide *data* as b'' to obtain more of the output.
+If *max_length* is nonnegative, returns at most *max_length* bytes
+of decompressed data.  If this limit is reached and further output
+can be produced, *self.needs_input* will be set to ``False``.  In
+this case, the next call to *decompress()* may provide *data* as b''
+to obtain more of the output.
 
-If all of the input data was decompressed and returned (either because this
-was less than *max_length* bytes, or because *max_length* was negative),
-*self.needs_input* will be set to True.
+If all of the input data was decompressed and returned (either
+because this was less than *max_length* bytes, or because
+*max_length* was negative), *self.needs_input* will be set to True.
 
-Attempting to decompress data after the end of a frame is reached raises an
-EOFError. Any data found after the end of the frame is ignored and saved in
-the self.unused_data attribute.
+Attempting to decompress data after the end of a frame is reached
+raises an EOFError.  Any data found after the end of the frame is
+ignored and saved in the self.unused_data attribute.
 [clinic start generated code]*/
 
 static PyObject *
 _zstd_ZstdDecompressor_decompress_impl(ZstdDecompressor *self,
                                        Py_buffer *data,
                                        Py_ssize_t max_length)
-/*[clinic end generated code: output=a4302b3c940dbec6 input=e5c905a774df1553]*/
+/*[clinic end generated code: output=a4302b3c940dbec6 input=4ddda5a0bdd00673]*/
 {
     PyObject *ret;
     /* Thread-safe code */

--- a/Modules/_zstd/zstddict.c
+++ b/Modules/_zstd/zstddict.c
@@ -23,7 +23,6 @@ class _zstd.ZstdDict "ZstdDict *" "&zstd_dict_type_spec"
 #define ZstdDict_CAST(op) ((ZstdDict *)op)
 
 /*[clinic input]
-@permit_long_docstring_body
 @classmethod
 _zstd.ZstdDict.__new__ as _zstd_ZstdDict_new
     dict_content: Py_buffer
@@ -37,14 +36,14 @@ _zstd.ZstdDict.__new__ as _zstd_ZstdDict_new
 
 Represents a Zstandard dictionary.
 
-The dictionary can be used for compression or decompression, and can be shared
-by multiple ZstdCompressor or ZstdDecompressor objects.
+The dictionary can be used for compression or decompression, and can be
+shared by multiple ZstdCompressor or ZstdDecompressor objects.
 [clinic start generated code]*/
 
 static PyObject *
 _zstd_ZstdDict_new_impl(PyTypeObject *type, Py_buffer *dict_content,
                         int is_raw)
-/*[clinic end generated code: output=685b7406a48b0949 input=b132ee40b784c293]*/
+/*[clinic end generated code: output=685b7406a48b0949 input=3bb66063c0240433]*/
 {
     /* All dictionaries must be at least 8 bytes */
     if (dict_content->len < 8) {
@@ -154,7 +153,6 @@ _zstd_ZstdDict_dict_content_get_impl(ZstdDict *self)
 }
 
 /*[clinic input]
-@permit_long_docstring_body
 @getter
 _zstd.ZstdDict.as_digested_dict
 
@@ -163,23 +161,22 @@ Load as a digested dictionary to compressor.
 Pass this attribute as zstd_dict argument:
 compress(dat, zstd_dict=zd.as_digested_dict)
 
-1. Some advanced compression parameters of compressor may be overridden
-   by parameters of digested dictionary.
-2. ZstdDict has a digested dictionaries cache for each compression level.
-   It's faster when loading again a digested dictionary with the same
-   compression level.
+1. Some advanced compression parameters of compressor may be
+   overridden by parameters of digested dictionary.
+2. ZstdDict has a digested dictionaries cache for each compression
+   level.  It's faster when loading again a digested dictionary with
+   the same compression level.
 3. No need to use this for decompression.
 [clinic start generated code]*/
 
 static PyObject *
 _zstd_ZstdDict_as_digested_dict_get_impl(ZstdDict *self)
-/*[clinic end generated code: output=09b086e7a7320dbb input=8d01ff0b8b043f2e]*/
+/*[clinic end generated code: output=09b086e7a7320dbb input=a9417d40f1d7fedd]*/
 {
     return Py_BuildValue("Oi", self, DICT_TYPE_DIGESTED);
 }
 
 /*[clinic input]
-@permit_long_docstring_body
 @getter
 _zstd.ZstdDict.as_undigested_dict
 
@@ -188,21 +185,21 @@ Load as an undigested dictionary to compressor.
 Pass this attribute as zstd_dict argument:
 compress(dat, zstd_dict=zd.as_undigested_dict)
 
-1. The advanced compression parameters of compressor will not be overridden.
-2. Loading an undigested dictionary is costly. If load an undigested dictionary
-   multiple times, consider reusing a compressor object.
+1. The advanced compression parameters of compressor will not be
+   overridden.
+2. Loading an undigested dictionary is costly. If load an undigested
+   dictionary multiple times, consider reusing a compressor object.
 3. No need to use this for decompression.
 [clinic start generated code]*/
 
 static PyObject *
 _zstd_ZstdDict_as_undigested_dict_get_impl(ZstdDict *self)
-/*[clinic end generated code: output=43c7a989e6d4253a input=b1bdb306c3798ad4]*/
+/*[clinic end generated code: output=43c7a989e6d4253a input=56443c9c4e589cd5]*/
 {
     return Py_BuildValue("Oi", self, DICT_TYPE_UNDIGESTED);
 }
 
 /*[clinic input]
-@permit_long_docstring_body
 @getter
 _zstd.ZstdDict.as_prefix
 
@@ -211,15 +208,16 @@ Load as a prefix to compressor/decompressor.
 Pass this attribute as zstd_dict argument:
 compress(dat, zstd_dict=zd.as_prefix)
 
-1. Prefix is compatible with long distance matching, while dictionary is not.
-2. It only works for the first frame, then the compressor/decompressor will
-   return to no prefix state.
+1. Prefix is compatible with long distance matching, while
+   dictionary is not.
+2. It only works for the first frame, then the
+   compressor/decompressor will return to no prefix state.
 3. When decompressing, must use the same prefix as when compressing.
 [clinic start generated code]*/
 
 static PyObject *
 _zstd_ZstdDict_as_prefix_get_impl(ZstdDict *self)
-/*[clinic end generated code: output=6f7130c356595a16 input=77966c012d15e6ab]*/
+/*[clinic end generated code: output=6f7130c356595a16 input=192681a899c6fad0]*/
 {
     return Py_BuildValue("Oi", self, DICT_TYPE_PREFIX);
 }


### PR DESCRIPTION
This is a new module, docstrings in which were wrapped using incorrect line widths in Argument Clinic.

<!-- gh-issue-number: gh-150285 -->
* Issue: gh-150285
<!-- /gh-issue-number -->
