### PR TITLE
[3.14] gh-148450: abc.register needs to update type_version when tp_flags is changed (GH-148623)

### DIFF
--- a/Lib/test/test_type_cache.py
+++ b/Lib/test/test_type_cache.py
@@ -1,4 +1,5 @@
 """ Tests for the internal type cache in CPython. """
+import collections.abc
 import dis
 import unittest
 import warnings
@@ -113,6 +114,25 @@ class TypeCacheTests(unittest.TestCase):
         for _ in range(1050):
             Holder.set_value()
             HolderSub.value
+
+    def test_abc_register_invalidates_subclass_versions(self):
+        class Parent:
+            pass
+
+        class Child(Parent):
+            pass
+
+        type_assign_version(Parent)
+        type_assign_version(Child)
+        parent_version = type_get_version(Parent)
+        child_version = type_get_version(Child)
+        if parent_version == 0 or child_version == 0:
+            self.skipTest("Could not assign valid type versions")
+
+        collections.abc.Mapping.register(Parent)
+
+        self.assertEqual(type_get_version(Parent), 0)
+        self.assertEqual(type_get_version(Child), 0)
 
 @support.cpython_only
 class TypeCacheWithSpecializationTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-15-15-48-04.gh-issue-148450.2MEVqH.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-15-15-48-04.gh-issue-148450.2MEVqH.rst
@@ -1,0 +1,1 @@
+Fix ``abc.register()`` so it invalidates type version tags for registered classes.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6066,14 +6066,16 @@ void
 _PyType_SetFlagsRecursive(PyTypeObject *self, unsigned long mask, unsigned long flags)
 {
     BEGIN_TYPE_LOCK();
-    /* Invalidate the old version first so
-        readers cannot assign a fresh tag from stale flags. */
+    /* Ideally, changing flags and invalidating the old version tag would happen
+       in one step. In 3.14, invalidate first while holding TYPE_LOCK so readers
+       cannot assign a fresh tag from stale flags. Immutable types are skipped by
+       set_flags_recursive(). */
     if (!PyType_HasFeature(self, Py_TPFLAGS_IMMUTABLETYPE) &&
         (self->tp_flags & mask) != flags)
     {
         type_modified_unlocked(self);
-        set_flags_recursive(self, mask, flags);
     }
+    set_flags_recursive(self, mask, flags);
     END_TYPE_LOCK();
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6080,7 +6080,11 @@ _PyType_SetFlagsRecursive(PyTypeObject *self, unsigned long mask, unsigned long 
        can reassign a version tag before the flag update. */
     type_lock_prevent_release();
     types_stop_world();
+    /* Make TYPE_LOCK visible while mutating tp_flags. */
+    type_lock_allow_release();
     set_flags_recursive(self, mask, flags);
+    /* Hide TYPE_LOCK again before restarting the world. */
+    type_lock_prevent_release();
     types_start_world();
     type_lock_allow_release();
     END_TYPE_LOCK();

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6066,27 +6066,14 @@ void
 _PyType_SetFlagsRecursive(PyTypeObject *self, unsigned long mask, unsigned long flags)
 {
     BEGIN_TYPE_LOCK();
-    /* Ideally, changing flags and invalidating the old version tag would
-       happen in one step. But type_modified_unlocked() is re-entrant and
-       cannot run with the world stopped, so we must invalidate first.
-       Immutable/static-builtin types are skipped because
-       set_flags_recursive() does not modify them. */
+    /* Invalidate the old version first so
+        readers cannot assign a fresh tag from stale flags. */
     if (!PyType_HasFeature(self, Py_TPFLAGS_IMMUTABLETYPE) &&
         (self->tp_flags & mask) != flags)
     {
         type_modified_unlocked(self);
+        set_flags_recursive(self, mask, flags);
     }
-    /* Keep TYPE_LOCK held while waiting for stop-the-world so no thread
-       can reassign a version tag before the flag update. */
-    type_lock_prevent_release();
-    types_stop_world();
-    /* Make TYPE_LOCK visible while mutating tp_flags. */
-    type_lock_allow_release();
-    set_flags_recursive(self, mask, flags);
-    /* Hide TYPE_LOCK again before restarting the world. */
-    type_lock_prevent_release();
-    types_start_world();
-    type_lock_allow_release();
     END_TYPE_LOCK();
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6066,7 +6066,23 @@ void
 _PyType_SetFlagsRecursive(PyTypeObject *self, unsigned long mask, unsigned long flags)
 {
     BEGIN_TYPE_LOCK();
+    /* Ideally, changing flags and invalidating the old version tag would
+       happen in one step. But type_modified_unlocked() is re-entrant and
+       cannot run with the world stopped, so we must invalidate first.
+       Immutable/static-builtin types are skipped because
+       set_flags_recursive() does not modify them. */
+    if (!PyType_HasFeature(self, Py_TPFLAGS_IMMUTABLETYPE) &&
+        (self->tp_flags & mask) != flags)
+    {
+        type_modified_unlocked(self);
+    }
+    /* Keep TYPE_LOCK held while waiting for stop-the-world so no thread
+       can reassign a version tag before the flag update. */
+    type_lock_prevent_release();
+    types_stop_world();
     set_flags_recursive(self, mask, flags);
+    types_start_world();
+    type_lock_allow_release();
     END_TYPE_LOCK();
 }
 


### PR DESCRIPTION
refer: https://github.com/python/cpython/pull/148623

<!-- gh-issue-number: gh-148450 -->
* Issue: gh-148450
<!-- /gh-issue-number -->
