### PR TITLE
gh-150313: Add tests for computed flow control write limits

### DIFF
--- a/Lib/test/test_asyncio/test_transports.py
+++ b/Lib/test/test_asyncio/test_transports.py
@@ -98,6 +98,34 @@ class TransportTests(unittest.TestCase):
         self.assertTrue(transport._protocol_paused)
         self.assertEqual(transport.get_write_buffer_limits(), (128, 256))
 
+    def test_flowcontrol_mixin_compute_write_limits(self):
+
+        class MyTransport(transports._FlowControlMixin,
+                          transports.Transport):
+
+            def get_write_buffer_size(self):
+                return 0
+
+        loop = mock.Mock()
+        transport = MyTransport(loop=loop)
+
+        self.assertEqual(
+            transport.get_write_buffer_limits(),
+            (16 * 1024, 64 * 1024)
+        )
+
+        transport.set_write_buffer_limits(low=100)
+        self.assertEqual(
+            transport.get_write_buffer_limits(),
+            (100, 400)
+        )
+
+        transport.set_write_buffer_limits(high=200)
+        self.assertEqual(
+            transport.get_write_buffer_limits(),
+            (50, 200)
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds test coverage for computed write buffer limit behavior in
asyncio._FlowControlMixin.

The new tests verify:

* default computed limits: (16 * 1024, 64 * 1024)
* `high` computed from `low`
* `low` computed from `high`

These behaviors are implemented in `_set_write_buffer_limits()`
but were not explicitly covered by tests.

Tests help protect against future regressions in flow control
buffer calculations.

Closes gh-150313.
