### PR TITLE
gh-138700: Add :sorted: option to automatically sort glossary

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -7,6 +7,7 @@ Glossary
 .. if you add new entries, keep the alphabetical sorting!
 
 .. glossary::
+   :sorted:
 
    ``>>>``
       The default Python prompt of the :term:`interactive` shell.  Often


### PR DESCRIPTION
# Pull Request title

gh-138700: Add :sorted: option to automatically sort glossary

# Description

This PR adds the `:sorted:` option to the `.. glossary::` directive block inside `Doc/glossary.rst`.

### Rationale
Currently, the Python documentation glossary is only organized in hardcoded alphabetical order for English. When the documentation is built for localized translations, the terms remain out of native alphabetical order for those target languages. Utilizing Sphinx's built-in `:sorted:` flag ensures that all language translations automatically compile their localized glossaries in clean, native alphabetical ordering during the build process.

### Verification
- Ran a local clean documentation build (`make clean && make html`) using a custom virtual environment.
- Confirmed that the internal cross-reference anchor label (`.. _glossary:`) resolves perfectly and the build completes without errors.