### PR TITLE
gh-150311: Fix minor issues in configure.ac for the CYGWIN port

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-05-24-12-30-00.gh-issue-150311.Xk9m3P.rst
+++ b/Misc/NEWS.d/next/Build/2026-05-24-12-30-00.gh-issue-150311.Xk9m3P.rst
@@ -1,4 +1,0 @@
-Fix three minor issues in ``configure.ac`` for the Cygwin port: use
-consistent uppercase ``CYGWIN`` for ``ac_sys_system``, correct the static
-library extension from ``.dll.a`` to ``.a`` when shared is disabled, and use
-``$(CC)``/``$(CXX)`` instead of hardcoded ``gcc``/``g++``.

--- a/Misc/NEWS.d/next/Build/2026-05-24-12-30-00.gh-issue-150311.Xk9m3P.rst
+++ b/Misc/NEWS.d/next/Build/2026-05-24-12-30-00.gh-issue-150311.Xk9m3P.rst
@@ -1,0 +1,4 @@
+Fix three minor issues in ``configure.ac`` for the Cygwin port: use
+consistent uppercase ``CYGWIN`` for ``ac_sys_system``, correct the static
+library extension from ``.dll.a`` to ``.a`` when shared is disabled, and use
+``$(CC)``/``$(CXX)`` instead of hardcoded ``gcc``/``g++``.

--- a/configure
+++ b/configure
@@ -14226,8 +14226,8 @@ then :
 
 fi;;
 	CYGWIN*)
-		LDSHARED="$(CC) -shared -Wl,--enable-auto-image-base"
-		LDCXXSHARED="$(CXX) -shared -Wl,--enable-auto-image-base";;
+		LDSHARED='$(CC) -shared -Wl,--enable-auto-image-base'
+		LDCXXSHARED='$(CXX) -shared -Wl,--enable-auto-image-base';;
 	*)	LDSHARED="ld";;
 	esac
 fi

--- a/configure
+++ b/configure
@@ -4151,7 +4151,7 @@ then
 		ac_sys_system=Linux
 		;;
 	*-*-cygwin*)
-		ac_sys_system=Cygwin
+		ac_sys_system=CYGWIN
 		;;
 	*-apple-ios*)
 		ac_sys_system=iOS
@@ -7842,7 +7842,7 @@ else # shared is disabled
   case $ac_sys_system in
     CYGWIN*)
       BLDLIBRARY='$(LIBRARY)'
-      LDLIBRARY='libpython$(LDVERSION).dll.a'
+      LDLIBRARY='libpython$(LDVERSION).a'
       ;;
   esac
 fi
@@ -14226,8 +14226,8 @@ then :
 
 fi;;
 	CYGWIN*)
-		LDSHARED="gcc -shared -Wl,--enable-auto-image-base"
-		LDCXXSHARED="g++ -shared -Wl,--enable-auto-image-base";;
+		LDSHARED="$(CC) -shared -Wl,--enable-auto-image-base"
+		LDCXXSHARED="$(CXX) -shared -Wl,--enable-auto-image-base";;
 	*)	LDSHARED="ld";;
 	esac
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -3694,8 +3694,8 @@ then
 			dnl not implemented yet
 		]);;
 	CYGWIN*)
-		LDSHARED="$(CC) -shared -Wl,--enable-auto-image-base"
-		LDCXXSHARED="$(CXX) -shared -Wl,--enable-auto-image-base";;
+		LDSHARED='$(CC) -shared -Wl,--enable-auto-image-base'
+		LDCXXSHARED='$(CXX) -shared -Wl,--enable-auto-image-base';;
 	*)	LDSHARED="ld";;
 	esac
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -334,7 +334,7 @@ then
 		ac_sys_system=Linux
 		;;
 	*-*-cygwin*)
-		ac_sys_system=Cygwin
+		ac_sys_system=CYGWIN
 		;;
 	*-apple-ios*)
 		ac_sys_system=iOS
@@ -1650,7 +1650,7 @@ else # shared is disabled
   case $ac_sys_system in
     CYGWIN*)
       BLDLIBRARY='$(LIBRARY)'
-      LDLIBRARY='libpython$(LDVERSION).dll.a'
+      LDLIBRARY='libpython$(LDVERSION).a'
       ;;
   esac
 fi
@@ -3694,8 +3694,8 @@ then
 			dnl not implemented yet
 		]);;
 	CYGWIN*)
-		LDSHARED="gcc -shared -Wl,--enable-auto-image-base"
-		LDCXXSHARED="g++ -shared -Wl,--enable-auto-image-base";;
+		LDSHARED="$(CC) -shared -Wl,--enable-auto-image-base"
+		LDCXXSHARED="$(CXX) -shared -Wl,--enable-auto-image-base";;
 	*)	LDSHARED="ld";;
 	esac
 fi


### PR DESCRIPTION
Fix three configure.ac issues for the Cygwin port.

  •	ac_sys_system was set to Cygwin but all case patterns in configure.ac match against CYGWIN*. Changed to CYGWIN for consistency.
	•	When shared libraries are disabled, LDLIBRARY was incorrectly set to libpython$(LDVERSION).dll.a. The .dll.a extension is a DLL import library; changed to libpython$(LDVERSION).a for static builds.
	•	LDSHARED and LDCXXSHARED in the CYGWIN* case were hardcoded to gcc and g++. Replaced with $(CC) and $(CXX) to respect the configured compiler, consistent with other platforms such as UnixWare and SCO_SV.

gh-150311