### PR TITLE
gh-149156: Fix perf trampoline crash after fork

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-24-14-45-00.gh-issue-149156.NP73rB.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-24-14-45-00.gh-issue-149156.NP73rB.rst
@@ -1,0 +1,3 @@
+Fix an intermittent crash after :func:`os.fork` when perf trampoline
+profiling is enabled and the child returns through trampoline frames
+inherited from the parent process.

--- a/Python/perf_trampoline.c
+++ b/Python/perf_trampoline.c
@@ -210,14 +210,20 @@ enum perf_trampoline_type {
 static void free_code_arenas(void);
 
 static void
-perf_trampoline_reset_state(void)
+perf_trampoline_clear_code_watcher(void)
 {
-    free_code_arenas();
     if (code_watcher_id >= 0) {
         PyCode_ClearWatcher(code_watcher_id);
         code_watcher_id = -1;
     }
     extra_code_index = -1;
+}
+
+static void
+perf_trampoline_reset_state(void)
+{
+    free_code_arenas();
+    perf_trampoline_clear_code_watcher();
 }
 
 static int
@@ -621,9 +627,10 @@ _PyPerfTrampoline_AfterFork_Child(void)
             // After fork, Fini may leave the old code watcher registered
             // if trampolined code objects from the parent still exist
             // (trampoline_refcount > 0). Clear it unconditionally before
-            // Init registers a new one, to prevent two watchers sharing
-            // the same globals and double-decrementing trampoline_refcount.
-            perf_trampoline_reset_state();
+            // Init registers a new one, but keep the old arenas mapped: the
+            // child may still need to return through trampoline frames that
+            // were on the C stack at fork().
+            perf_trampoline_clear_code_watcher();
             _PyPerfTrampoline_Init(1);
         }
     }


### PR DESCRIPTION
Keep inherited perf trampoline arenas mapped in fork children.


<!-- gh-issue-number: gh-149156 -->
* Issue: gh-149156
<!-- /gh-issue-number -->
