### PR TITLE
gh-150355: Allow creating tasks in cancelled TaskGroup with cooperative cancellation

### DIFF
--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -30,6 +30,7 @@ class TaskGroup:
         self._entered = False
         self._exiting = False
         self._aborting = False
+        self._explicitly_cancelled = False
         self._loop = None
         self._parent_task = None
         self._parent_cancel_requested = False
@@ -196,7 +197,7 @@ class TaskGroup:
         if self._exiting and not self._tasks:
             coro.close()
             raise RuntimeError(f"TaskGroup {self!r} is finished")
-        if self._aborting:
+        if self._aborting and not self._explicitly_cancelled:
             coro.close()
             raise RuntimeError(f"TaskGroup {self!r} is shutting down")
         task = self._loop.create_task(coro, **kwargs)
@@ -209,6 +210,12 @@ class TaskGroup:
         # the current task too early. gh-128550, gh-128588
         self._tasks.add(task)
         task.add_done_callback(self._on_task_done)
+        if self._aborting and self._explicitly_cancelled:
+            def _cancel_later(task=task):
+                if not task.done():
+                    task.cancel()
+            self._loop.call_soon(_cancel_later)
+
         try:
             return task
         finally:
@@ -307,6 +314,7 @@ class TaskGroup:
         if self._exiting and not self._tasks:
             return
         if not self._aborting:
+            self._explicitly_cancelled = True
             self._abort()
             if self._parent_task and not self._parent_cancel_requested:
                 self._parent_cancel_requested = True

--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -1149,10 +1149,9 @@ class BaseTestTaskGroup:
     async def test_taskgroup_cancel_before_create_task(self):
         async with asyncio.TaskGroup() as tg:
             tg.cancel()
-            # TODO: This behavior is not ideal.  We'd rather have no exception
-            #   raised, and the child task run until the first await.
-            with self.assertRaises(RuntimeError):
-                tg.create_task(asyncio.sleep(1))
+            t = tg.create_task(asyncio.sleep(1))
+            await asyncio.sleep(0)
+            self.assertTrue(t.cancelled())
 
     async def test_taskgroup_cancel_before_exception(self):
         async def raise_exc(parent_tg: asyncio.TaskGroup):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

gh-150355: Allow create_task after tg.cancel() – cooperative cancellation

**Problem:**  
After `tg.cancel()`, `create_task()` raises `RuntimeError: TaskGroup is shutting down`. The test TODO says this is not ideal – the task should run until the first await and then be cancelled.

**Solution:**  
Add `_explicitly_cancelled` flag. On explicit `cancel()` the flag is set. In `create_task()`, if `_aborting` and `_explicitly_cancelled` is true, the task is created normally and then scheduled for cancellation with `call_soon`. This allows the synchronous code up to the first `await` to run. Failure‑induced abort still raises `RuntimeError`.

**Testing:**  
All 118 tests in `test_asyncio.test_taskgroups` pass.