### PR TITLE
gh-150358 Remove unused _complete_fut attribute from asyncio.StreamWriter

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -321,8 +321,6 @@ class StreamWriter:
         assert reader is None or isinstance(reader, StreamReader)
         self._reader = reader
         self._loop = loop
-        self._complete_fut = self._loop.create_future()
-        self._complete_fut.set_result(None)
 
     def __repr__(self):
         info = [self.__class__.__name__, f'transport={self._transport!r}']


### PR DESCRIPTION
`asyncio.StreamWriter.__init__` allocates and resolves a `Future` and stores it as `self._complete_fut`, but the attribute is never read anywhere in CPython.

Before:

```python
def __init__(self, transport, protocol, reader, loop):
    self._transport = transport
    self._protocol = protocol
    assert reader is None or isinstance(reader, StreamReader)
    self._reader = reader
    self._loop = loop
    self._complete_fut = self._loop.create_future()
    self._complete_fut.set_result(None)
```

  After:

```python
def __init__(self, transport, protocol, reader, loop):
    self._transport = transport
    self._protocol = protocol
    assert reader is None or isinstance(reader, StreamReader)
    self._reader = reader
    self._loop = loop
```

The `StreamWriter` class is used by functions such as: `asyncio.open_connection`, `asyncio.start_server`, `asyncio.open_unix_connection`, `asyncio.start_unix_server`. So the allocation of an unused future happens on every asyncio network connection

No behavior change.

<!-- gh-issue-number: gh-150358 -->
* Issue: gh-150358
<!-- /gh-issue-number -->
