### PR TITLE
gh-85668: Add `typing.evaluate_type()` function

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3727,6 +3727,24 @@ Introspection helpers
 
    .. versionadded:: 3.14
 
+.. function:: evaluate_type(type_hint, *, owner=None, globals=None, locals=None, type_params=None, format=annotationlib.Format.VALUE)
+
+   Evaluate a :term:`type hint`, by resolving any forward references nested
+   within the type hint.
+
+   This is similar to calling :func:`evaluate_forward_ref`, but unlike that
+   method, :func:`evaluate_type` also supports arbitrary type hints.
+
+   See the documentation for :meth:`annotationlib.ForwardRef.evaluate` for
+   the meaning of the *owner*, *globals*, *locals*, *type_params*, and *format* parameters.
+
+   .. caution::
+
+      This function may execute arbitrary code contained the type hint.
+      See :ref:`annotationlib-security` for more information.
+
+   .. versionadded:: next
+
 .. data:: NoDefault
 
    A sentinel object used to indicate that a type parameter has no default

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -129,6 +129,7 @@ __all__ = [
     'dataclass_transform',
     'disjoint_base',
     'evaluate_forward_ref',
+    'evaluate_type',
     'final',
     'get_args',
     'get_origin',
@@ -1049,6 +1050,24 @@ def evaluate_forward_ref(
         owner=owner,
         parent_fwdref=forward_ref,
     )
+
+
+def evaluate_type(
+    type_hint,
+    *,
+    owner=None,
+    globalns=None,
+    localns=None,
+    type_params=None,
+    format=None,
+):
+    """Evaluate a type hint, by resolving any forward references.
+
+    This is similar to the evaluate_forward_ref() method, but unlike that method,
+    evaluate_type() also supports arbitrary type hints.
+    """
+
+    return _eval_type(type_hint, owner=owner, globalns=globalns, localns=localns, type_params=type_params, format=format)
 
 
 def _is_unpacked_typevartuple(x: Any) -> bool:

--- a/Misc/NEWS.d/next/Library/2026-05-24-21-20-19.gh-issue-85668.KwCVdi.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-24-21-20-19.gh-issue-85668.KwCVdi.rst
@@ -1,0 +1,1 @@
+Add :func:`typing.evaluate_type` function.


### PR DESCRIPTION
As per the discussion in https://discuss.python.org/t/100698.

With the new stuff since 3.14, we end up in a bit of an unfortunate situation, where we already have [`typing.evaluate_forward_ref()`](https://docs.python.org/3/library/typing.html#typing.evaluate_forward_ref) as a public function that can do pretty much anything, expect it requires a forward ref instance. So with this PR we end up with the chain `evaluate_type()` which is like `evaluate_forward_ref()` but allows arbitrary type hints, and `evaluate_forward_ref()` being like `annotationlib.ForwardRef.evaluate()` but also recursively evaluates nested forward references; this may be a bit confusing for users.

Once we agree on the expected behavior and signature for this new function, I'll add tests (wondering if I should keep the scope narrow, `_eval_type()` is already extensively tested by `get_type_hints()`) and flesh out the code docstring of the function.

This should also fix https://github.com/python/cpython/issues/87629.

<!-- gh-issue-number: gh-85668 -->
* Issue: gh-85668
<!-- /gh-issue-number -->
