### PR TITLE
gh-149800: Fix macOS universal2 build of perf trampoline (GH-149894 follow-up)

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -3120,8 +3120,18 @@ Python/asm_trampoline_aarch64.o: $(srcdir)/Python/asm_trampoline_aarch64.S
 Python/asm_trampoline_riscv64.o: $(srcdir)/Python/asm_trampoline_riscv64.S
 	$(CC) -c $(PY_CORE_CFLAGS) -o $@ $<
 
-Python/asm_trampoline_universal2.o: Python/asm_trampoline_aarch64.o Python/asm_trampoline_x86_64.o
-	lipo -create -output $@ Python/asm_trampoline_aarch64.o Python/asm_trampoline_x86_64.o
+# On macOS universal2 builds, $(PY_CORE_CFLAGS) contains "-arch arm64 -arch x86_64",
+# which would produce fat .o files containing both architectures for each .S input.
+# lipo -create then refuses to combine them because they share architectures.
+# Build each per-arch object with a single -arch flag before merging with lipo.
+Python/asm_trampoline_universal2.o: $(srcdir)/Python/asm_trampoline_aarch64.S $(srcdir)/Python/asm_trampoline_x86_64.S
+	$(CC) -c $(filter-out -arch arm64 x86_64,$(PY_CORE_CFLAGS)) -arch arm64 \
+		-o Python/asm_trampoline_arm64-apple-darwin.o $(srcdir)/Python/asm_trampoline_aarch64.S
+	$(CC) -c $(filter-out -arch arm64 x86_64,$(PY_CORE_CFLAGS)) -arch x86_64 \
+		-o Python/asm_trampoline_x86_64-apple-darwin.o $(srcdir)/Python/asm_trampoline_x86_64.S
+	lipo -create -output $@ \
+		Python/asm_trampoline_arm64-apple-darwin.o \
+		Python/asm_trampoline_x86_64-apple-darwin.o
 
 Python/emscripten_trampoline_inner.wasm: $(srcdir)/Python/emscripten_trampoline_inner.c
 	# emcc has a path that ends with emsdk/upstream/emscripten/emcc, we're looking for emsdk/upstream/bin/clang.

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -3132,8 +3132,8 @@ Python/asm_trampoline_universal2.o: $(srcdir)/Python/asm_trampoline_aarch64.S $(
 	lipo -create -output $@ \
 		Python/asm_trampoline_arm64-apple-darwin.o \
 		Python/asm_trampoline_x86_64-apple-darwin.o
-		rm -f Python/asm_trampoline_arm64-apple-darwin.o \
-                  Python/asm_trampoline_x86_64-apple-darwin.o
+	rm -f Python/asm_trampoline_arm64-apple-darwin.o \
+	  Python/asm_trampoline_x86_64-apple-darwin.o
 
 Python/emscripten_trampoline_inner.wasm: $(srcdir)/Python/emscripten_trampoline_inner.c
 	# emcc has a path that ends with emsdk/upstream/emscripten/emcc, we're looking for emsdk/upstream/bin/clang.

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -3132,6 +3132,8 @@ Python/asm_trampoline_universal2.o: $(srcdir)/Python/asm_trampoline_aarch64.S $(
 	lipo -create -output $@ \
 		Python/asm_trampoline_arm64-apple-darwin.o \
 		Python/asm_trampoline_x86_64-apple-darwin.o
+		rm -f Python/asm_trampoline_arm64-apple-darwin.o \
+                  Python/asm_trampoline_x86_64-apple-darwin.o
 
 Python/emscripten_trampoline_inner.wasm: $(srcdir)/Python/emscripten_trampoline_inner.c
 	# emcc has a path that ends with emsdk/upstream/emscripten/emcc, we're looking for emsdk/upstream/bin/clang.


### PR DESCRIPTION
…

After the perf trampoline assembly was split into per-architecture files, the macOS universal2 build failed at the lipo step:

    fatal error: lipo: Python/asm_trampoline_aarch64.o and
    Python/asm_trampoline_x86_64.o have the same architectures (x86_64)
    and can't be in the same fat output file

PY_CORE_CFLAGS on universal2 contains "-arch arm64 -arch x86_64", so each .S file was assembled into a fat .o containing both slices (with one slice empty because of the #ifdef guards). lipo then refused to merge two fat objects that share architectures.

Compile each per-arch object with a single -arch flag before merging.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149800 -->
* Issue: gh-149800
<!-- /gh-issue-number -->
