### PR TITLE
gh-149800: Fix macOS universal2 build of perf trampoline

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -3120,8 +3120,13 @@ Python/asm_trampoline_aarch64.o: $(srcdir)/Python/asm_trampoline_aarch64.S
 Python/asm_trampoline_riscv64.o: $(srcdir)/Python/asm_trampoline_riscv64.S
 	$(CC) -c $(PY_CORE_CFLAGS) -o $@ $<
 
+# Extract the matching slice from each fat per-arch object before lipo -create,
+# which rejects two fat inputs that share architectures.
 Python/asm_trampoline_universal2.o: Python/asm_trampoline_aarch64.o Python/asm_trampoline_x86_64.o
-	lipo -create -output $@ Python/asm_trampoline_aarch64.o Python/asm_trampoline_x86_64.o
+	lipo -thin arm64  Python/asm_trampoline_aarch64.o -output $@.arm64
+	lipo -thin x86_64 Python/asm_trampoline_x86_64.o  -output $@.x86_64
+	lipo -create -output $@ $@.arm64 $@.x86_64
+	rm -f $@.arm64 $@.x86_64
 
 Python/emscripten_trampoline_inner.wasm: $(srcdir)/Python/emscripten_trampoline_inner.c
 	# emcc has a path that ends with emsdk/upstream/emscripten/emcc, we're looking for emsdk/upstream/bin/clang.

--- a/Misc/NEWS.d/next/Build/2026-05-24-19-24-28.gh-issue-149800.Mq994d.rst
+++ b/Misc/NEWS.d/next/Build/2026-05-24-19-24-28.gh-issue-149800.Mq994d.rst
@@ -1,0 +1,3 @@
+Fix macOS universal2 build of the perf trampoline.  After the per-architecture
+split in :gh:`149800`, the ``arm64`` and ``x86_64`` trampoline objects were
+each compiled as fat Mach-O files, and ``lipo -create`` refused to merge them.


### PR DESCRIPTION
Address failing JIT CI, see https://github.com/python/cpython/actions/runs/26343871355/job/77550446716?pr=150324


Claude analysis:

After splitting the perf trampoline into per-architecture .S files in #149894, PY_CORE_CFLAGS still carries `-arch arm64 -arch x86_64` on universal2 builds, so each per-arch object becomes a fat Mach-O whose wrong-arch slice is empty (thanks to the `#ifdef` guards in the sources). `lipo -create` then refused to merge two fat inputs sharing both architectures:

    fatal error: lipo: Python/asm_trampoline_aarch64.o and
    Python/asm_trampoline_x86_64.o have the same architectures (x86_64)
    and can't be in the same fat output file

Extract the matching slice from each per-arch object with `lipo -thin` before recombining into `asm_trampoline_universal2.o`.

The PR #149894 passed because it did not trigger jit builds.

Marking as DO-NOT-MERGE until someone can verify the above is correct.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149800 -->
* Issue: gh-149800
<!-- /gh-issue-number -->
