### PR TITLE
gh-150379:Fix PyLong ref leak in C API monitoring events

### DIFF
--- a/Misc/NEWS.d/next/C_API/2026-05-25-17-53-16.gh-issue-150379.1y54ks.rst
+++ b/Misc/NEWS.d/next/C_API/2026-05-25-17-53-16.gh-issue-150379.1y54ks.rst
@@ -1,1 +1,0 @@
-Fix a reference leak of the offset argument in C API monitoring event calls.

--- a/Misc/NEWS.d/next/C_API/2026-05-25-17-53-16.gh-issue-150379.1y54ks.rst
+++ b/Misc/NEWS.d/next/C_API/2026-05-25-17-53-16.gh-issue-150379.1y54ks.rst
@@ -1,0 +1,1 @@
+Fix a reference leak of the offset argument in C API monitoring event calls.

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -2630,8 +2630,9 @@ capi_call_instrumentation(PyMonitoringState *state, PyObject *codelike, int32_t 
         PyErr_SetString(PyExc_ValueError, "offset must be non-negative");
         return -1;
     }
+    PyObject *offset_obj = NULL;
     if (event != PY_MONITORING_EVENT_LINE) {
-        PyObject *offset_obj = PyLong_FromLong(offset);
+        offset_obj = PyLong_FromLong(offset);
         if (offset_obj == NULL) {
             return -1;
         }
@@ -2672,6 +2673,7 @@ capi_call_instrumentation(PyMonitoringState *state, PyObject *codelike, int32_t 
             }
         }
     }
+    Py_XDECREF(offset_obj);
     return err;
 }
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-150379 -->
* Issue: gh-150379
<!-- /gh-issue-number -->
