### PR TITLE
gh-84352: Raise `PermissionError` when importing inaccessible packages

### DIFF
--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -156,7 +156,9 @@ def _path_is_mode_type(path, mode):
     """Test whether the path is the specified mode type."""
     try:
         stat_info = _path_stat(path)
-    except OSError:
+    except OSError as exc:
+        if isinstance(exc, PermissionError):
+            raise
         return False
     return (stat_info.st_mode & 0o170000) == mode
 

--- a/Lib/test/test_importlib/import_/test_path.py
+++ b/Lib/test/test_importlib/import_/test_path.py
@@ -1,4 +1,5 @@
-from test.support import os_helper
+from test import support
+from test.support import os_helper, import_helper
 from test.test_importlib import util
 
 importlib = util.import_importlib('importlib')
@@ -179,6 +180,21 @@ class FinderTests:
 
             # Do not want PermissionError raised.
             self.assertIsNone(self.machinery.PathFinder.find_spec('whatever'))
+
+    @os_helper.skip_unless_working_chmod
+    @unittest.skipIf(os.getuid() == 0, "root skips permission error checks")
+    def test_permission_error_raised_on_import_inaccessible_package(self):
+        # Issue #84352
+        with (os_helper.temp_dir() as new_dir,
+            os_helper.save_mode(new_dir)):
+            pkg_dir = os.path.join(new_dir, 'pkg')
+            os.mkdir(pkg_dir)
+            with open(os.path.join(pkg_dir, '__init__.py'), 'w') as f:
+                f.write("x = 1")
+            with import_helper.DirsOnSysPath(new_dir):
+                with os_helper.save_mode(pkg_dir):
+                    os.chmod(pkg_dir, 0o000)
+                    self.assertRaises(PermissionError, self.importlib.import_module, 'pkg')
 
     def test_invalidate_caches_finders(self):
         # Finders with an invalidate_caches() method have it called.

--- a/Lib/test/test_importlib/import_/test_path.py
+++ b/Lib/test/test_importlib/import_/test_path.py
@@ -1,4 +1,3 @@
-from test import support
 from test.support import os_helper, import_helper
 from test.test_importlib import util
 

--- a/Misc/NEWS.d/next/Library/2026-05-25-19-30-06.gh-issue-84352.E9JWLk.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-25-19-30-06.gh-issue-84352.E9JWLk.rst
@@ -1,0 +1,3 @@
+Fixed an issue where :mod:`importlib` would raise :exc:`AttributeError`
+instead of :exc:`PermissionError` when accessing a package directory with
+insufficient permissions.


### PR DESCRIPTION
Raise `PermissionError` when importing inaccessible packages due to insufficient permission,
instead of importing an empty package and raising `AttributeError`.

<!-- gh-issue-number: gh-84352 -->
* Issue: gh-84352
<!-- /gh-issue-number -->
