### PR TITLE
Fix docs for PyThreadState_GetDict() in threads.rst

### DIFF
--- a/Doc/c-api/threads.rst
+++ b/Doc/c-api/threads.rst
@@ -736,10 +736,10 @@ Low-level APIs
 .. c:function:: PyObject* PyThreadState_GetDict()
 
    Return a dictionary in which extensions can store thread-specific state
-   information.  Each extension should use a unique key to use to store state in
+   information.  Each extension should use a unique key to use and store a state in
    the dictionary.  It is okay to call this function when no :term:`thread state`
    is :term:`attached <attached thread state>`. If this function returns
-   ``NULL``, no exception has been raised and the caller should assume no
+   ``NULL`` and no exception has been raised, then the caller should assume no
    thread state is attached.
 
 

--- a/Doc/c-api/threads.rst
+++ b/Doc/c-api/threads.rst
@@ -736,7 +736,7 @@ Low-level APIs
 .. c:function:: PyObject* PyThreadState_GetDict()
 
    Return a dictionary in which extensions can store thread-specific state
-   information.  Each extension should use a unique key to use and store a state in
+   information.  Each extension should use a unique key to store a state in
    the dictionary.  It is okay to call this function when no :term:`thread state`
    is :term:`attached <attached thread state>`. If this function returns
    ``NULL`` and no exception has been raised, then the caller should assume no


### PR DESCRIPTION
The following PR focusses on fixing 2 sentences for better clarity and readability for the documentation of ```PyThreadState_GetDict()``` in threads.rst
The sentences are:
```python
Each extension should use a unique key to use to store state in
the dictionary.
```
```python
If this function returns
``NULL``, no exception has been raised and the caller should assume no
thread state is attached.
```