### PR TITLE
gh-150387: Fix hang in test_run_failed_script_live on slow buildbots

### DIFF
--- a/Lib/test/test_profiling/test_sampling_profiler/test_live_collector_ui.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_live_collector_ui.py
@@ -835,8 +835,7 @@ class TestLiveModeErrors(unittest.TestCase):
         # still failing
         for _ in range(n_times):
             mock_self.display.simulate_input(-1)
-        if n_times >= 500:
-            mock_self.display.simulate_input(ord('q'))
+        mock_self.display.simulate_input(ord('q'))
 
     def test_run_failed_module_live(self):
         """Test that running a existing module that fails exits with clean error."""

--- a/Misc/NEWS.d/next/Tests/2026-05-25-15-39-53.gh-issue-150387.yzZ7jq.rst
+++ b/Misc/NEWS.d/next/Tests/2026-05-25-15-39-53.gh-issue-150387.yzZ7jq.rst
@@ -1,0 +1,5 @@
+Fix hang in
+``test.test_profiling.test_sampling_profiler.test_live_collector_ui.TestLiveModeErrors.test_run_failed_script_live``
+on slow buildbots. The test now always queues a final ``q`` keystroke so the
+live TUI loop exits even when the profiler collects enough samples to enter
+the post-finished input loop.


### PR DESCRIPTION
The test relied on the failing script (``1/0``) crashing fast enough that fewer than ``MIN_SAMPLES_FOR_TUI`` (200) samples were collected, which would trigger the early-return path in ``sample.sample_live`` and bypass the TUI input loop. On slow buildbots (ASan, TraceRefs, NoGIL) the interpreter takes long enough to bootstrap and reach the ``1/0`` that the profiler easily collects >=200 samples, pushing execution into the ``while collector.running:`` loop. Because the mock only queued a final ``q`` keystroke when ``n_times >= 500`` (and the failed-script test used ``n_times=200``), nothing ever set ``running`` to ``False`` and the test hung until the regrtest timeout.

Always queue the final ``q`` so the live TUI loop exits regardless of how many samples were collected.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-150387 -->
* Issue: gh-150387
<!-- /gh-issue-number -->
