### PR TITLE
Make the crash warning in `ctypes`  more prominent

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -16,8 +16,10 @@ used to wrap these libraries in pure Python.
 
 .. warning::
 
-   :mod:`!ctypes` can call arbitrary functions in native libraries.
-   Incorrect use can crash Python or otherwise compromise the running process.
+   :mod:`!ctypes` provides low-level access to native libraries and the
+   process's memory. Incorrect use can bypass Python's memory safety, corrupt
+   memory, crash Python, execute arbitrary native code,
+   or otherwise compromise the running process.
    The :mod:`faulthandler` module can help debug crashes,
    such as segmentation faults produced by erroneous C library calls.
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -17,11 +17,10 @@ used to wrap these libraries in pure Python.
 .. warning::
 
    :mod:`!ctypes` provides low-level access to native libraries and the
-   process's memory. Incorrect use can bypass Python's memory safety, corrupt
-   memory, crash Python, execute arbitrary native code,
-   or otherwise compromise the running process.
-   The :mod:`faulthandler` module can help debug crashes,
-   such as segmentation faults produced by erroneous C library calls.
+   process's memory, bypassing Python's safety mechanisms and allowing
+   execution of arbitrary native code.
+   Incorrect use can corrupt data and objects, reveal sensitive information,
+   cause crashes, or otherwise compromise the running process.
 
 
 .. _ctypes-ctypes-tutorial:
@@ -206,6 +205,9 @@ argument values::
      File "<stdin>", line 1, in <module>
    OSError: exception: access violation reading 0x00000020
    >>>
+
+The :mod:`faulthandler` module can help debug crashes,
+such as segmentation faults produced by erroneous C library calls.
 
 ``None``, integers, bytes objects and (unicode) strings are the only native
 Python objects that can directly be used as parameters in these function calls.

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -14,6 +14,13 @@ used to wrap these libraries in pure Python.
 
 .. include:: ../includes/optional-module.rst
 
+.. warning::
+
+   :mod:`!ctypes` can call arbitrary functions in native libraries.
+   Incorrect use can crash Python or otherwise compromise the running process.
+   The :mod:`faulthandler` module can help debug crashes,
+   such as segmentation faults produced by erroneous C library calls.
+
 
 .. _ctypes-ctypes-tutorial:
 
@@ -197,11 +204,6 @@ argument values::
      File "<stdin>", line 1, in <module>
    OSError: exception: access violation reading 0x00000020
    >>>
-
-There are, however, enough ways to crash Python with :mod:`!ctypes`, so you
-should be careful anyway.  The :mod:`faulthandler` module can be helpful in
-debugging crashes (e.g. from segmentation faults produced by erroneous C library
-calls).
 
 ``None``, integers, bytes objects and (unicode) strings are the only native
 Python objects that can directly be used as parameters in these function calls.


### PR DESCRIPTION
(I was in a warning-y mood today ;-)

I agree with Jelle:

> The note you cite in the ctypes docs is buried in a section about a more specific topic (calling functions). I think it's worth adding a more prominent warning like the one on https://docs.python.org/3/library/pickle.html . However, once we do that I don't think we need to do anything in the devguide: the note in the CPython docs should be enough. 

 _Originally posted by @JelleZijlstra in [#211](https://github.com/python/devguide/issues/211#issuecomment-4531040203)_

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
