### PR TITLE
gh-150411: fix `gc_generation.count` race

### DIFF
--- a/Lib/test/test_free_threading/test_gc.py
+++ b/Lib/test/test_free_threading/test_gc.py
@@ -124,6 +124,35 @@ class TestGC(TestCase):
         finally:
             gc.set_threshold(*current_threshold)
 
+    def test_get_count(self):
+        class CyclicReference:
+            def __init__(self):
+                self.ref = self
+
+        NUM_ALLOCATORS = 7
+        NUM_READERS = 1
+        NUM_THREADS = NUM_ALLOCATORS + NUM_READERS
+        NUM_ITERS = 200_000
+
+        barrier = threading.Barrier(NUM_THREADS)
+
+        def allocator():
+            barrier.wait()
+            for _ in range(NUM_ITERS):
+                CyclicReference()
+
+
+        def reader():
+            barrier.wait()
+            for _ in range(NUM_ITERS):
+                gc.get_count()
+
+        threads = [Thread(target=allocator) for _ in range(NUM_ALLOCATORS)]
+        threads.extend(Thread(target=reader) for _ in range(NUM_READERS))
+
+        with threading_helper.start_threads(threads):
+            pass
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_free_threading/test_gc.py
+++ b/Lib/test/test_free_threading/test_gc.py
@@ -132,7 +132,7 @@ class TestGC(TestCase):
         NUM_ALLOCATORS = 7
         NUM_READERS = 1
         NUM_THREADS = NUM_ALLOCATORS + NUM_READERS
-        NUM_ITERS = 200_000
+        NUM_ITERS = 1000
 
         barrier = threading.Barrier(NUM_THREADS)
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-26-00-06-30.gh-issue-150411.u-d-_5.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-26-00-06-30.gh-issue-150411.u-d-_5.rst
@@ -1,0 +1,2 @@
+Fix a data race in the free-threaded build when :func:`gc.get_count` reads
+the young generation allocation count while another thread updates it.

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -234,8 +234,8 @@ gc_get_count_impl(PyObject *module)
 #else
     return Py_BuildValue("(iii)",
                          _Py_atomic_load_int_relaxed(&gcstate->young.count),
-                         _Py_atomic_load_int_relaxed(&gcstate->old[0].count),
-                         _Py_atomic_load_int_relaxed(&gcstate->old[1].count));
+                         gcstate->old[0].count,
+                         gcstate->old[1].count);
 #endif
 }
 

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -233,9 +233,9 @@ gc_get_count_impl(PyObject *module)
                          gcstate->generations[2].count);
 #else
     return Py_BuildValue("(iii)",
-                         gcstate->young.count,
-                         gcstate->old[0].count,
-                         gcstate->old[1].count);
+                         _Py_atomic_load_int_relaxed(&gcstate->young.count),
+                         _Py_atomic_load_int_relaxed(&gcstate->old[0].count),
+                         _Py_atomic_load_int_relaxed(&gcstate->old[1].count));
 #endif
 }
 


### PR DESCRIPTION
# Issue

gh-150411

# Root Cause

Refer the analytics in issue gh-150411, it should be a `gc_generation.count` update during the cyclic object allocation triggered the local allocation count migrated to young generation. Meantime we try to read the `gc_generation.count` without sync caused the race.

https://github.com/python/cpython/blob/c714b5679817099ac574890392f408129e6c67cb/Python/gc_free_threading.c#L2017-L2037

I find this problem during proposing gh-150356. So they have similar reproduce way.

# Proposed Changes

I added an atomic relax load guard for the `gc_generation.count`.
It was protected in other places expect current one.
