### PR TITLE
gh-131372: Fix a typo

### DIFF
--- a/configure
+++ b/configure
@@ -31747,7 +31747,7 @@ then :
   withval=$with_build_details_suffix;
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --with-build-details-suffix" >&5
 printf %s "checking for --with-build-details-suffix... " >&6; }
-    if test "x$with_build_detials_suffix" = xno
+    if test "x$with_build_details_suffix" = xno
 then :
   as_fn_error $? "invalid --with-build-details-suffix option: expected custom suffix or \"yes\", not \"no\"" "$LINENO" 5
 

--- a/configure.ac
+++ b/configure.ac
@@ -7850,7 +7850,7 @@ AC_ARG_WITH([build-details-suffix],
   [
     AC_MSG_CHECKING([for --with-build-details-suffix])
     AS_VAR_IF(
-      [with_build_detials_suffix], [no],
+      [with_build_details_suffix], [no],
       [AC_MSG_ERROR([invalid --with-build-details-suffix option: expected custom suffix or "yes", not "no"])]
     )
     AS_VAR_IF(


### PR DESCRIPTION
Fix a typo in an error-handling path.

Introduced in #150098

<!-- gh-issue-number: gh-131372 -->
* Issue: gh-131372
<!-- /gh-issue-number -->
