### PR TITLE
gh-149879: Fix test_concurrent_futures on Cygwin

### DIFF
--- a/Lib/test/test_concurrent_futures/test_init.py
+++ b/Lib/test/test_concurrent_futures/test_init.py
@@ -147,6 +147,8 @@ class FailingInitializerResourcesTest(unittest.TestCase):
         self._test(ProcessPoolSpawnFailingInitializerTest)
 
     @support.skip_if_sanitizer("TSAN doesn't support threads after fork", thread=True)
+    @unittest.skipIf(sys.platform == "cygwin",
+                     "Forkserver is not available on Cygwin")
     def test_forkserver(self):
         self._test(ProcessPoolForkserverFailingInitializerTest)
 

--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -115,11 +115,12 @@ class ProcessPoolExecutorTest(ExecutorTest):
             with self.assertRaises(BrokenProcessPool) as bpe:
                 future.result()
 
-        cause = bpe.exception.__cause__
-        self.assertIsInstance(cause, futures.process._RemoteTraceback)
-        self.assertIn(
-            f"terminated abruptly with exit code {exit_code}", cause.tb
-        )
+        if sys.platform != 'cygwin':
+            cause = bpe.exception.__cause__
+            self.assertIsInstance(cause, futures.process._RemoteTraceback)
+            self.assertIn(
+                f"terminated abruptly with exit code {exit_code}", cause.tb
+            )
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     @hashlib_helper.requires_hashdigest('md5')

--- a/Lib/test/test_concurrent_futures/util.py
+++ b/Lib/test/test_concurrent_futures/util.py
@@ -135,7 +135,7 @@ class ProcessPoolForkserverMixin(ExecutorMixin):
             _check_system_limits()
         except NotImplementedError:
             self.skipTest("ProcessPoolExecutor unavailable on this system")
-        if sys.platform == "win32":
+        if sys.platform in ("win32", "cygwin"):
             self.skipTest("require unix system")
         if support.check_sanitizer(thread=True):
             self.skipTest("TSAN doesn't support threads after fork")


### PR DESCRIPTION
On Cygwin, skip tests using "forkserver" start method.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149879 -->
* Issue: gh-149879
<!-- /gh-issue-number -->
