### PR TITLE
gh-149879: Skip test_venv on Cygwin

### DIFF
--- a/Lib/test/support/venv.py
+++ b/Lib/test/support/venv.py
@@ -6,6 +6,7 @@ import shlex
 import sys
 import sysconfig
 import tempfile
+import unittest
 import venv
 
 
@@ -72,6 +73,9 @@ class VirtualEnvironment:
 
 class VirtualEnvironmentMixin:
     def venv(self, name=None, **venv_create_args):
+        if sys.platform == 'cygwin':
+            raise unittest.SkipTest('FIXME: venv is broken on Cygwin')
+
         venv_name = self.id()
         if name:
             venv_name += f'-{name}'

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -34,6 +34,9 @@ try:
 except ImportError:
     ctypes = None
 
+if sys.platform == 'cygwin':
+    raise unittest.SkipTest('FIXME: venv is broken on Cygwin')
+
 # Platforms that set sys._base_executable can create venvs from within
 # another venv, so no need to skip tests that require venv.create().
 requireVenvCreate = unittest.skipUnless(


### PR DESCRIPTION
Skip test_venv tests for now since the feature is broken on Cygwin.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149879 -->
* Issue: gh-149879
<!-- /gh-issue-number -->
