### PR TITLE
gh-150427: Remove unused `__linecnt` attribute from `_sitebuiltins`

### DIFF
--- a/Lib/_sitebuiltins.py
+++ b/Lib/_sitebuiltins.py
@@ -55,7 +55,6 @@ class _Printer(object):
         if not data:
             data = self.__data
         self.__lines = data.split('\n')
-        self.__linecnt = len(self.__lines)
 
     def __repr__(self):
         self.__setup()


### PR DESCRIPTION
`_sitebuiltins._Printer.__setup` creates an instance attribute, `__linecnt`, which is unused:
```
cpython % git grep __linecnt
Lib/_sitebuiltins.py:        self.__linecnt = len(self.__lines)
```

This _could_ be used by `_sitebuiltins._Printer.__repr__` in lieu of `len(self.__lines)`:
```
        self.__setup()
        if len(self.__lines) <= self.MAXLINES:
            return "\n".join(self.__lines)
```

But because `len(self.__lines)` is only referenced as such, we can remove `__linecnt` instead.

This was introduced in d1252395bd697b2f2b2f461c1078fda22ab739b1 but also unused then.

There is no behavior change, and all tests pass.

<!-- gh-issue-number: gh-150427 -->
* Issue: gh-150427
<!-- /gh-issue-number -->
