### PR TITLE
gh-149879: Fix test_ftplib on Cygwin

### DIFF
--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -8,6 +8,7 @@ import socket
 import io
 import errno
 import os
+import sys
 import threading
 import time
 import unittest
@@ -590,6 +591,8 @@ class TestFTPClass(TestCase):
         # Ensure the connection gets closed; sock attribute should be None
         self.assertEqual(self.client.sock, None)
 
+    @unittest.skipIf(sys.platform == 'cygwin',
+                     "MSG_OOB doesn't work properly on Cygwin")
     def test_abort(self):
         self.client.abort()
 


### PR DESCRIPTION
Skip test_abort() since MSG_OOB doesn't work properly on Cygwin. The server gets b'\n' and then b'ABOR\r', instead of getting b'ABOR\r\n'.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149879 -->
* Issue: gh-149879
<!-- /gh-issue-number -->
