### PR TITLE
gh-79459 tempfile: Raise a ``ValueError`` if the ``prefix`` or ``suffix`` contains a directory component.

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -117,11 +117,15 @@ def _sanitize_params(prefix, suffix, dir):
     output_type = _infer_return_type(prefix, suffix, dir)
     if suffix is None:
         suffix = output_type()
+    if _os.path.dirname(suffix):
+        raise ValueError("'prefix' or 'suffix' can't contain a directory component")
     if prefix is None:
         if output_type is str:
             prefix = template
         else:
             prefix = _os.fsencode(template)
+    if _os.path.dirname(prefix):
+        raise ValueError("'prefix' or 'suffix' can't contain a directory component")
     if dir is None:
         if output_type is str:
             dir = gettempdir()

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -118,14 +118,14 @@ def _sanitize_params(prefix, suffix, dir):
     if suffix is None:
         suffix = output_type()
     if _os.path.dirname(suffix):
-        raise ValueError("'prefix' or 'suffix' can't contain a directory component")
+        raise ValueError("'suffix' can't contain a directory component")
     if prefix is None:
         if output_type is str:
             prefix = template
         else:
             prefix = _os.fsencode(template)
     if _os.path.dirname(prefix):
-        raise ValueError("'prefix' or 'suffix' can't contain a directory component")
+        raise ValueError("'prefix' can't contain a directory component")
     if dir is None:
         if output_type is str:
             dir = gettempdir()

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -2056,28 +2056,47 @@ class TestTemporaryDirectory(BaseTestCase):
 
 
 class TestPrefixAndSuffix(BaseTestCase):
-    def test_value_error_if_prefix_or_suffix_contains_directory(self):
-        MESSAGE = "'prefix' or 'suffix' can't contain a directory component"
+    DATA = (
+        f"dir{os.sep}name",
+        f"{os.sep}abs_name",
+        os.fsencode(f"dir{os.sep}name"),
+        os.fsencode(f"{os.sep}abs_name"),
+    )
+    if os.altsep is not None:
+        DATA += (
+            f"dir{os.altsep}name",
+            f"{os.altsep}abs_name",
+            os.fsencode(f"dir{os.altsep}name"),
+            os.fsencode(f"{os.altsep}abs_name"),
+        )
 
-        if os.altsep is None:
-            data = (
-                ((os.sep), None),
-                (os.fsencode(os.sep), tempfile.gettempdirb()),
-                )
-        else:
-            data = (
-                ((os.altsep), None),
-                (os.fsencode(os.altsep), tempfile.gettempdirb()),
-                )
+    def test_prefix_error(self):
+        MESSAGE = "'prefix' can't contain a directory component"
 
-        for value, directory in data:
-            with self.subTest((value, directory)):
+        for value in self.DATA:
+            with self.subTest((value)):
                 with self.assertRaisesRegex(ValueError, MESSAGE):
-                    tempfile.mkstemp(dir=directory, prefix=value)
+                    tempfile.mkstemp(prefix=value)
                 with self.assertRaisesRegex(ValueError, MESSAGE):
-                    os.rmdir(tempfile.mkdtemp(dir=directory, prefix=value))
+                    os.rmdir(tempfile.mkdtemp(prefix=value))
                 with self.assertRaisesRegex(ValueError, MESSAGE):
-                    tempfile.NamedTemporaryFile(dir=directory, prefix=value, delete=True)
+                    tempfile.TemporaryFile(prefix=value)
+                with self.assertRaisesRegex(ValueError, MESSAGE):
+                    tempfile.NamedTemporaryFile(prefix=value)
+
+    def test_suffix_error(self):
+        MESSAGE = "'suffix' can't contain a directory component"
+
+        for value in self.DATA:
+            with self.subTest((value)):
+                with self.assertRaisesRegex(ValueError, MESSAGE):
+                    tempfile.mkstemp(suffix=value)
+                with self.assertRaisesRegex(ValueError, MESSAGE):
+                    os.rmdir(tempfile.mkdtemp(suffix=value))
+                with self.assertRaisesRegex(ValueError, MESSAGE):
+                    tempfile.TemporaryFile(suffix=value)
+                with self.assertRaisesRegex(ValueError, MESSAGE):
+                    tempfile.NamedTemporaryFile(suffix=value)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -2054,5 +2054,30 @@ class TestTemporaryDirectory(BaseTestCase):
         self.assertTrue(os.path.exists(working_dir))
         shutil.rmtree(working_dir)
 
+
+class TestPrefixAndSuffix(BaseTestCase):
+    def test_value_error_if_prefix_or_suffix_contains_directory(self):
+        MESSAGE = "'prefix' or 'suffix' can't contain a directory component"
+
+        if os.altsep is None:
+            data = (
+                ((os.sep), None),
+                (os.fsencode(os.sep), tempfile.gettempdirb()),
+                )
+        else:
+            data = (
+                ((os.altsep), None),
+                (os.fsencode(os.altsep), tempfile.gettempdirb()),
+                )
+
+        for value, directory in data:
+            with self.subTest((value, directory)):
+                with self.assertRaisesRegex(ValueError, MESSAGE):
+                    tempfile.mkstemp(dir=directory, prefix=value)
+                with self.assertRaisesRegex(ValueError, MESSAGE):
+                    os.rmdir(tempfile.mkdtemp(dir=directory, prefix=value))
+                with self.assertRaisesRegex(ValueError, MESSAGE):
+                    tempfile.NamedTemporaryFile(dir=directory, prefix=value, delete=True)
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -2055,48 +2055,45 @@ class TestTemporaryDirectory(BaseTestCase):
         shutil.rmtree(working_dir)
 
 
-class TestPrefixAndSuffix(BaseTestCase):
-    DATA = (
-        f"dir{os.sep}name",
-        f"{os.sep}abs_name",
-        os.fsencode(f"dir{os.sep}name"),
-        os.fsencode(f"{os.sep}abs_name"),
-    )
-    if os.altsep is not None:
-        DATA += (
-            f"dir{os.altsep}name",
-            f"{os.altsep}abs_name",
-            os.fsencode(f"dir{os.altsep}name"),
-            os.fsencode(f"{os.altsep}abs_name"),
-        )
+class TestMisc(BaseTestCase):
+    def test_prefix_suffix_error(self):
+        tests = [
+            f"dir{os.sep}name",
+            f"{os.sep}abs_name",
+        ]
+        if os.altsep is not None:
+            tests.extend((
+                f"dir{os.altsep}name",
+                f"{os.altsep}abs_name",
+            ))
+        if support.MS_WINDOWS:
+            tests.append('C:name')
+        tests.extend(tuple(os.fsencode(path) for path in tests))
 
-    def test_prefix_error(self):
-        MESSAGE = "'prefix' can't contain a directory component"
-
-        for value in self.DATA:
-            with self.subTest((value)):
-                with self.assertRaisesRegex(ValueError, MESSAGE):
+        PREFIX_ERR = "'prefix' can't contain a directory component"
+        SUFFIX_ERR = "'suffix' can't contain a directory component"
+        for value in tests:
+            with self.subTest(value):
+                # test prefix
+                with self.assertRaisesRegex(ValueError, PREFIX_ERR):
                     tempfile.mkstemp(prefix=value)
-                with self.assertRaisesRegex(ValueError, MESSAGE):
-                    os.rmdir(tempfile.mkdtemp(prefix=value))
-                with self.assertRaisesRegex(ValueError, MESSAGE):
+                with self.assertRaisesRegex(ValueError, PREFIX_ERR):
+                    tempfile.mkdtemp(prefix=value)
+                with self.assertRaisesRegex(ValueError, PREFIX_ERR):
                     tempfile.TemporaryFile(prefix=value)
-                with self.assertRaisesRegex(ValueError, MESSAGE):
+                with self.assertRaisesRegex(ValueError, PREFIX_ERR):
                     tempfile.NamedTemporaryFile(prefix=value)
 
-    def test_suffix_error(self):
-        MESSAGE = "'suffix' can't contain a directory component"
-
-        for value in self.DATA:
-            with self.subTest((value)):
-                with self.assertRaisesRegex(ValueError, MESSAGE):
+                # test suffix
+                with self.assertRaisesRegex(ValueError, SUFFIX_ERR):
                     tempfile.mkstemp(suffix=value)
-                with self.assertRaisesRegex(ValueError, MESSAGE):
-                    os.rmdir(tempfile.mkdtemp(suffix=value))
-                with self.assertRaisesRegex(ValueError, MESSAGE):
+                with self.assertRaisesRegex(ValueError, SUFFIX_ERR):
+                    tempfile.mkdtemp(suffix=value)
+                with self.assertRaisesRegex(ValueError, SUFFIX_ERR):
                     tempfile.TemporaryFile(suffix=value)
-                with self.assertRaisesRegex(ValueError, MESSAGE):
+                with self.assertRaisesRegex(ValueError, SUFFIX_ERR):
                     tempfile.NamedTemporaryFile(suffix=value)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
tempfile: Raise a ``ValueError`` if the ``prefix`` or ``suffix`` contains a directory component.

gh-79459

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
