### PR TITLE
gh-150486: Remove dead _buffer_factory attribute from _SelectorDatagramTransport

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -1233,7 +1233,6 @@ class _SelectorSocketTransport(_SelectorTransport):
 
 class _SelectorDatagramTransport(_SelectorTransport, transports.DatagramTransport):
 
-    _buffer_factory = collections.deque
     _header_size = 8
 
     def __init__(self, loop, sock, protocol, address=None,


### PR DESCRIPTION
`_SelectorDatagramTransport` defines a class-level attribute `_buffer_factory = collections.deque` that is not  used anywhere in CPython.

Before:

```python
class _SelectorDatagramTransport(_SelectorTransport, transports.DatagramTransport):
    _buffer_factory = collections.deque
    _header_size = 8
```

After:

```python
class _SelectorDatagramTransport(_SelectorTransport, transports.DatagramTransport):
    _header_size = 8
```

No behavior change.

<!-- gh-issue-number: gh-150486 -->
* Issue: gh-150486
<!-- /gh-issue-number -->
