### PR TITLE
gh-150499: http.server: enforce RFC 7230 framing rules for keep-alive connections

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -393,6 +393,23 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
             )
             return False
 
+        # RFC 7230 section 3.3.3 rule 3: this handler does not implement
+        # a chunked decoder, so any Transfer-Encoding is rejected.
+        if self.headers.get('Transfer-Encoding'):
+            self.send_error(
+                HTTPStatus.BAD_REQUEST,
+                "Transfer-Encoding not supported")
+            return False
+
+        # RFC 7230 section 3.3.3 rule 4: reject duplicate Content-Length
+        # values that disagree.
+        cl_values = self.headers.get_all('Content-Length') or []
+        if len({v.strip() for v in cl_values}) > 1:
+            self.send_error(
+                HTTPStatus.BAD_REQUEST,
+                "Conflicting Content-Length values")
+            return False
+
         conntype = self.headers.get('Connection', "")
         if conntype.lower() == 'close':
             self.close_connection = True

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -364,6 +364,110 @@ class BaseHTTPServerTestCase(BaseTestCase):
             self.assertEqual(b'', data)
 
 
+class RFC7230FramingTestCase(BaseTestCase):
+    """Exercise the framing checks added for RFC 7230 section 3.3.3."""
+
+    class request_handler(NoLogRequestHandler, BaseHTTPRequestHandler):
+        protocol_version = 'HTTP/1.1'
+        default_request_version = 'HTTP/1.1'
+
+        def do_POST(self):
+            cl = self.headers.get('Content-Length')
+            n = int(cl) if cl and cl.isdigit() else 0
+            body = self.rfile.read(n) if n else b''
+            out = b'POST body=' + body + b'\n'
+            self.send_response(HTTPStatus.OK)
+            self.send_header('Content-Type', 'text/plain')
+            self.send_header('Content-Length', str(len(out)))
+            self.end_headers()
+            self.wfile.write(out)
+
+    def _send_raw(self, payload, timeout=2):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        sock.connect((self.HOST, self.PORT))
+        try:
+            sock.sendall(payload)
+            data = b''
+            try:
+                while True:
+                    chunk = sock.recv(4096)
+                    if not chunk:
+                        break
+                    data += chunk
+            except TimeoutError:
+                pass
+        finally:
+            sock.close()
+        return data
+
+    def test_transfer_encoding_rejected(self):
+        # RFC 7230 section 3.3.3 rule 3 plus no chunked decoder.
+        data = self._send_raw(
+            b'POST / HTTP/1.1\r\n'
+            b'Host: 127.0.0.1\r\n'
+            b'Transfer-Encoding: chunked\r\n'
+            b'Content-Length: 5\r\n'
+            b'\r\n'
+            b'0\r\n\r\nGET /pwn HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n'
+        )
+        self.assertTrue(
+            data.startswith(b'HTTP/1.0 400') or data.startswith(b'HTTP/1.1 400'),
+            data[:80])
+        self.assertIn(b'Connection: close', data)
+        self.assertNotIn(b'/pwn', data)
+
+    def test_duplicate_content_length_rejected(self):
+        # RFC 7230 section 3.3.3 rule 4.
+        data = self._send_raw(
+            b'POST / HTTP/1.1\r\n'
+            b'Host: 127.0.0.1\r\n'
+            b'Content-Length: 4\r\n'
+            b'Content-Length: 0\r\n'
+            b'\r\n'
+            b'ABCD'
+        )
+        self.assertTrue(
+            data.startswith(b'HTTP/1.0 400') or data.startswith(b'HTTP/1.1 400'),
+            data[:80])
+        self.assertIn(b'Connection: close', data)
+
+    def test_duplicate_content_length_same_value_accepted(self):
+        # Two Content-Length headers with the same value are not a conflict
+        # per RFC 7230 section 3.3.3 rule 4.
+        data = self._send_raw(
+            b'POST / HTTP/1.1\r\n'
+            b'Host: 127.0.0.1\r\n'
+            b'Content-Length: 4\r\n'
+            b'Content-Length: 4\r\n'
+            b'\r\n'
+            b'ABCD'
+        )
+        self.assertTrue(
+            data.startswith(b'HTTP/1.0 200') or data.startswith(b'HTTP/1.1 200'),
+            data[:80])
+        self.assertIn(b"POST body=ABCD", data)
+
+    def test_keep_alive_post_pipeline(self):
+        # Regression: two pipelined POSTs with correct Content-Length
+        # both succeed on a single keep-alive connection.
+        data = self._send_raw(
+            b'POST / HTTP/1.1\r\n'
+            b'Host: 127.0.0.1\r\n'
+            b'Content-Length: 4\r\n'
+            b'\r\n'
+            b'ABCD'
+            b'POST / HTTP/1.1\r\n'
+            b'Host: 127.0.0.1\r\n'
+            b'Content-Length: 3\r\n'
+            b'\r\n'
+            b'XYZ'
+        )
+        self.assertEqual(data.count(b'HTTP/1.1 200'), 2)
+        self.assertIn(b'POST body=ABCD', data)
+        self.assertIn(b'POST body=XYZ', data)
+
+
 class HTTP09ServerTestCase(BaseTestCase):
 
     class request_handler(NoLogRequestHandler, BaseHTTPRequestHandler):

--- a/Misc/NEWS.d/next/Library/2026-05-27-00-43-54.gh-issue-150499.ykruLi.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-27-00-43-54.gh-issue-150499.ykruLi.rst
@@ -1,0 +1,4 @@
+:mod:`http.server` now rejects requests that send any ``Transfer-Encoding``
+header or that pair conflicting ``Content-Length`` values, since the module
+does not implement a chunked decoder. Both rejections return
+``400 Bad Request`` with ``Connection: close``, per :rfc:`7230#section-3.3.3`.


### PR DESCRIPTION
Refs gh-150499 (paired with a follow-up PR for the §6.3 body-drain piece).

## Summary

`BaseHTTPRequestHandler` in `Lib/http/server.py` does not enforce two
RFC 7230 §3.3.3 framing-validation rules, so a non-conforming request can
desynchronise the keep-alive loop. This PR fixes both in a single
class:

1. **RFC 7230 §3.3.3 rule 3** — any `Transfer-Encoding` header is now
   rejected with `400 Bad Request` and `Connection: close`, because
   `http.server` does not implement a chunked decoder. Once a decoder
   is added this check can be narrowed to anything other than
   `identity`.
2. **RFC 7230 §3.3.3 rule 4** — duplicate `Content-Length` headers
   with disagreeing values are now rejected with `400 Bad Request` and
   `Connection: close`. Identical values are still accepted.

The §6.3 keep-alive body-drain piece is split into a separate
follow-up PR against the same issue.

## Backwards compatibility

The module's class docstring already warns that `http.server` is not
intended for production use. The two checks tighten conformance to
RFC 7230 and only change behaviour for non-conforming clients:

- Duplicate-equal `Content-Length` still works.
- `Transfer-Encoding` was previously accepted and silently ignored,
  which is a request-smuggling primitive; clients sending TE must now
  either dechunk themselves or stop sending it.

## Tests

`Lib/test/test_httpservers.py` adds `RFC7230FramingTestCase` with:

- `test_transfer_encoding_rejected` — rule 3, plus assertion that the
  smuggled trailing request is not dispatched.
- `test_duplicate_content_length_rejected` — rule 4.
- `test_duplicate_content_length_same_value_accepted` — confirms the
  same-value case is unchanged.
- `test_keep_alive_post_pipeline` — regression test for two pipelined
  POSTs with correct `Content-Length` on the same keep-alive
  connection.

All four tests pass against `main` with the patched module. Full
`test_httpservers` (106 tests) and `test_wsgiref` (38 tests) suites
also pass with no regression.

## News entry

`Misc/NEWS.d/next/Library/2026-05-27-00-43-54.gh-issue-150499.ykruLi.rst`.

## Backport

This PR targets `main` only; per CPython practice the backport policy
is left to the core dev review.


<!-- gh-issue-number: gh-150499 -->
* Issue: gh-150499
<!-- /gh-issue-number -->
