### PR TITLE
gh-141984: Remove accidental merge markers

### DIFF
--- a/Doc/tools/removed-ids.txt
+++ b/Doc/tools/removed-ids.txt
@@ -12,7 +12,7 @@ using/configure.html: cmdoption-with-system-libmpdec
 # Removed APIs
 library/symtable.html: symtable.Class.get_methods
 library/sys.html: sys._enablelegacywindowsfsencoding
-<<<<<<<< HEAD
+c-api/import.html: c.PyImport_LazyImportsMode.PyImport_LAZY_NONE
 
 ## Old names for grammar tokens
 reference/expressions.html: grammar-token-python-grammar-comp_for
@@ -26,7 +26,3 @@ reference/expressions.html: grammar-token-python-grammar-enclosure
 reference/expressions.html: grammar-token-python-grammar-list_display
 reference/expressions.html: grammar-token-python-grammar-parenth_form
 reference/expressions.html: grammar-token-python-grammar-set_display
-|||||||| 50476a7e879
-========
-c-api/import.html: c.PyImport_LazyImportsMode.PyImport_LAZY_NONE
->>>>>>>> origin/main


### PR DESCRIPTION
Sorry for the noise! I had a bit of trouble rebasing this branch, and forgot these markers in the final iteration.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-141984 -->
* Issue: gh-141984
<!-- /gh-issue-number -->
