### PR TITLE
gh-150524: Remove outdated note in `binascii.a2b_hex` documentation

### DIFF
--- a/Doc/library/binascii.rst
+++ b/Doc/library/binascii.rst
@@ -367,7 +367,7 @@ The :mod:`!binascii` module defines the following functions:
    *ignorechars* should be a :term:`bytes-like object` containing characters
    to ignore from the input.
 
-   Similar functionality (more liberal towards whitespace) is also accessible
+   Similar functionality (but more liberal towards whitespace) is also accessible
    using the :meth:`bytes.fromhex` class method.
 
    .. versionchanged:: 3.15

--- a/Doc/library/binascii.rst
+++ b/Doc/library/binascii.rst
@@ -367,9 +367,8 @@ The :mod:`!binascii` module defines the following functions:
    *ignorechars* should be a :term:`bytes-like object` containing characters
    to ignore from the input.
 
-   Similar functionality (accepting only text string arguments, but more
-   liberal towards whitespace) is also accessible using the
-   :meth:`bytes.fromhex` class method.
+   Similar functionality (more liberal towards whitespace) is also accessible
+   using the :meth:`bytes.fromhex` class method.
 
    .. versionchanged:: 3.15
       Added the *ignorechars* parameter.


### PR DESCRIPTION
`bytes.fromhex` accepts ASCII bytes and bytes-like objects as input since 3.14

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-150524 -->
* Issue: gh-150524
<!-- /gh-issue-number -->
