### PR TITLE
[3.13] gh-150285: Fix too long docstrings in _wmi.exec_query (GH-150373) (GH-150520)

### DIFF
--- a/PC/_wmimodule.cpp
+++ b/PC/_wmimodule.cpp
@@ -230,13 +230,13 @@ _wmi.exec_query
 
 Runs a WMI query against the local machine.
 
-This returns a single string with 'name=value' pairs in a flat array separated
-by null characters.
+This returns a single string with 'name=value' pairs in a flat array
+separated by null characters.
 [clinic start generated code]*/
 
 static PyObject *
 _wmi_exec_query_impl(PyObject *module, PyObject *query)
-/*[clinic end generated code: output=a62303d5bb5e003f input=48d2d0a1e1a7e3c2]*/
+/*[clinic end generated code: output=a62303d5bb5e003f input=a8d5710acdfbf515]*/
 
 /*[clinic end generated code]*/
 {

--- a/PC/clinic/_wmimodule.cpp.h
+++ b/PC/clinic/_wmimodule.cpp.h
@@ -14,8 +14,8 @@ PyDoc_STRVAR(_wmi_exec_query__doc__,
 "\n"
 "Runs a WMI query against the local machine.\n"
 "\n"
-"This returns a single string with \'name=value\' pairs in a flat array separated\n"
-"by null characters.");
+"This returns a single string with \'name=value\' pairs in a flat array\n"
+"separated by null characters.");
 
 #define _WMI_EXEC_QUERY_METHODDEF    \
     {"exec_query", _PyCFunction_CAST(_wmi_exec_query), METH_FASTCALL|METH_KEYWORDS, _wmi_exec_query__doc__},
@@ -69,4 +69,4 @@ _wmi_exec_query(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObj
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ba04920d127f3ceb input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fefbbab59fa1584b input=a9049054013a1b77]*/


### PR DESCRIPTION

(cherry picked from commit 40c80434a68613403ecf278ae0744ffd0867490c)


(cherry picked from commit fbeafc062e55a52ba7369c36be0b3eb34eabb560)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-150285 -->
* Issue: gh-150285
<!-- /gh-issue-number -->
