### PR TITLE
fix unittest.mock: make mock_open.__exit__ accept variable args (gh-150484)

### DIFF
--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -2108,6 +2108,16 @@ class MockTest(unittest.TestCase):
         self.assertEqual([], h.readlines())
         self.assertEqual([], h.readlines())
 
+    def test_mock_open_exit_stack_issue_150484(self):
+        # Regression test for gh#150484
+        # mock_open().__exit__ must accept 4 args (ExitStack passes
+        # exc_info tuple) while previously it only accepted 3.
+        from contextlib import ExitStack
+        with mock.patch('builtins.open', mock.mock_open()):
+            with mock.mock_open() as m:
+                with ExitStack() as exit_stack:
+                    exit_stack.enter_context(open('/tmp/test.txt', 'w'))
+
     def test_mock_parents(self):
         for Klass in Mock, MagicMock:
             m = Klass()

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -3002,7 +3002,7 @@ def mock_open(mock=None, read_data=''):
             return handle.readline.return_value
         return next(_state[0])
 
-    def _exit_side_effect(exctype, excinst, exctb):
+    def _exit_side_effect(*exc_details):
         handle.close()
 
     global file_spec

--- a/Misc/NEWS.d/next/Library/2026-05-28-14-35-00.gh-issue-150484.mock_open.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-28-14-35-00.gh-issue-150484.mock_open.rst
@@ -1,0 +1,3 @@
+Fix :meth:`unittest.mock.mock_open.__exit__` to accept variable arguments
+(``*exc_details``) to support Python 3.13+ where ``ExitStack.__exit__``
+passes the full exc_info tuple.


### PR DESCRIPTION
## Fix: mock_open.__exit__ must accept variable args

Fixes gh#150484.

### Problem
In Python 3.13+, using `mock.mock_open()` with `contextlib.ExitStack` raises:

```
TypeError: mock_open.<locals>._exit_side_effect() takes 3 positional
arguments but 4 were given
```

`ExitStack.__exit__` passes the full exc_info tuple (4 args) but
`_exit_side_effect` only accepted 3.

### Fix
Changed `_exit_side_effect(exctype, excinst, exctb)` to
`_exit_side_effect(*exc_details)` — accepts variable args to handle all
Python versions.

### Test
Added `test_mock_open_exit_stack_issue_150484` regression test.