### PR TITLE
gh-150557: Fix os.path.ismount() for UNC paths with no share on Windows

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -287,7 +287,20 @@ def ismount(path):
     path = abspath(path)
     drive, root, rest = splitroot(path)
     if drive and drive[0] in seps:
-        return not rest
+        if rest:
+            return False
+        # A UNC mount point must name both a server and a share; a bare
+        # server (e.g. \\server or \\?\UNC\server) is not one.
+        if isinstance(drive, bytes):
+            sep, altsep, unc_prefix = b'\\', b'/', b'\\\\?\\UNC\\'
+        else:
+            sep, altsep, unc_prefix = '\\', '/', '\\\\?\\UNC\\'
+        normd = drive.replace(altsep, sep)
+        if normd[:len(unc_prefix)].upper() == unc_prefix:
+            start = len(unc_prefix)
+        else:
+            start = 2
+        return start < normd.find(sep, start) < len(normd) - 1
     if root and not rest:
         return True
 

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -1407,6 +1407,17 @@ class TestNtpath(NtpathTestCase):
             self.assertTrue(ntpath.ismount(b"\\\\localhost\\c$"))
             self.assertTrue(ntpath.ismount(b"\\\\localhost\\c$\\"))
 
+            # gh-150557: a UNC path that names a server but no share is not
+            # a mount point.
+            self.assertFalse(ntpath.ismount("\\\\server"))
+            self.assertFalse(ntpath.ismount("\\\\server\\"))
+            self.assertFalse(ntpath.ismount("\\\\?\\UNC\\server"))
+            self.assertFalse(ntpath.ismount("\\\\?\\UNC\\server\\"))
+            self.assertFalse(ntpath.ismount(b"\\\\server"))
+            self.assertFalse(ntpath.ismount(b"\\\\?\\UNC\\server"))
+            self.assertTrue(ntpath.ismount("\\\\?\\UNC\\server\\share"))
+            self.assertTrue(ntpath.ismount(b"\\\\?\\UNC\\server\\share"))
+
     def test_ismount_invalid_paths(self):
         ismount = ntpath.ismount
         self.assertFalse(ismount("c:\\\udfff"))

--- a/Misc/NEWS.d/next/Library/2026-05-29-10-30-00.gh-issue-150557.K9mA2q.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-29-10-30-00.gh-issue-150557.K9mA2q.rst
@@ -1,0 +1,3 @@
+Fix :func:`os.path.ismount` on Windows incorrectly returning ``True`` for a UNC
+path that names a server but no share, such as ``\\server`` or
+``\\?\UNC\server``. Patch by Amrutha Modela.


### PR DESCRIPTION
### Bug

On Windows, `os.path.ismount()` (`ntpath.ismount()`) reports a UNC path that names a **server but no share** as a mount point. A UNC mount point requires both a server *and* a share (`\\server\share`); a bare server name is not one.

```python
>>> import os.path
>>> os.path.ismount(r"\\server")        # server, no share
True                                     # should be False
>>> os.path.ismount(r"\\?\UNC\server")  # extended UNC, no share
True                                     # should be False
```

Genuine share roots are correct and stay unchanged:

```python
>>> os.path.ismount(r"\\server\share")
True
>>> os.path.ismount(r"\\?\UNC\server\share")
True
```

### Regression

This is partly a regression from 3.11, where `os.path.ismount(r"\\?\UNC\server")` returned `False`. The `splitroot()`-based rewrite of `ismount()` (gh-101000) changed it to `True`. (That same rewrite *correctly* fixed `\\?\UNC\server\share`, which was wrongly `False` on 3.11.)

### Root cause

`ismount()` treats the UNC/device branch as a mount point whenever the path equals its drive with no trailing component:

```python
drive, root, rest = splitroot(path)
if drive and drive[0] in seps:
    return not rest
```

But `splitroot()` packs an incomplete, one-component UNC entirely into `drive`:

```python
>>> ntpath.splitroot(r"\\server")
('\\server', '', '')
>>> ntpath.splitroot(r"\\?\UNC\server")
('\\?\UNC\server', '', '')
```

So `rest` is empty and the check passes despite there being no share.

### Fix

Require a UNC `drive` to name **both** a server and a share - i.e. a separator with non-empty text on both sides must appear after the leading `\\` (or after the `\\?\UNC\` prefix for extended UNC):

```python
if drive and drive[0] in seps:
    if rest:
        return False
    # A UNC mount point must name both a server and a share; a bare
    # server (e.g. \\server or \\?\UNC\server) is not one.
    if isinstance(drive, bytes):
        sep, altsep, unc_prefix = b'\\', b'/', b'\\\\?\\UNC\\'
    else:
        sep, altsep, unc_prefix = '\\', '/', '\\\\?\\UNC\\'
    normd = drive.replace(altsep, sep)
    if normd[:len(unc_prefix)].upper() == unc_prefix:
        start = len(unc_prefix)
    else:
        start = 2
    return start < normd.find(sep, start) < len(normd) - 1
```

Device paths (`\\.\dev`, `\\?\dev`), extended drive-letter paths (`\\?\c:`), volume GUID paths, and drive-letter roots all keep their current behavior.

### Scope & safety

`ismount()` is a leaf function: nothing in `ntpath` calls it, and `join()` / `normpath()` / `split()` / `splitdrive()` are all driven by `splitroot()`, not `ismount()`. Its only stdlib consumer is `pathlib.Path.is_mount()`. `splitroot()` is **not** modified, so no other path operation changes. This also aligns with the existing docs, which already state that "a drive letter root and a share UNC are always mount points" - a bare server is not a share UNC.

### Tests

News entry added via `blurb`. Regression tests added to `test_ntpath.test_ismount`:

- `\\server` -> `False`
- `\\server\` (trailing separator) -> `False`
- `\\?\UNC\server` and `\\?\UNC\server\` -> `False`
- bytes variants `b"\\server"` and `b"\\?\UNC\server"` -> `False`
- `\\server\share` and `\\?\UNC\server\share` (str and bytes) -> still `True`

The existing assertions for `\\localhost\c$` (with/without trailing slash, str and bytes) continue to pass. Verified locally on Windows after rebuild: `test_ntpath` passes, and the full test suite passes with no new failures.

### Backport

The bug exists on every branch since 3.12 (where the `splitroot()` rewrite landed), so this looks like a backport candidate for the active maintenance branches - deferring to maintainers on exactly which.

Split off from #139916 per discussion in #150557.


<!-- gh-issue-number: gh-150557 -->
* Issue: gh-150557
<!-- /gh-issue-number -->
