### PR TITLE
gh-144774: Add critical section in `BaseException.__setstate__`

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1954,25 +1954,6 @@ class ExceptionTests(unittest.TestCase):
         self.assertGreater(len(output), 0)  # At minimum, should not hang
         self.assertIn(b"MemoryError", output)
 
-    def test_data_race(self):
-        from threading import Thread
-        import copy
-
-        E = Exception()
-
-        def func():
-            for i in range(100):
-                setattr(E, 'x', i)
-                copy.copy(E)
-
-        threads = [Thread(target=func) for _ in range(4)]
-
-        for t in threads:
-            t.start()
-
-        for t in threads:
-            t.join()
-
 class NameErrorTests(unittest.TestCase):
     def test_name_error_has_name(self):
         try:

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1954,6 +1954,7 @@ class ExceptionTests(unittest.TestCase):
         self.assertGreater(len(output), 0)  # At minimum, should not hang
         self.assertIn(b"MemoryError", output)
 
+
 class NameErrorTests(unittest.TestCase):
     def test_name_error_has_name(self):
         try:

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1954,6 +1954,24 @@ class ExceptionTests(unittest.TestCase):
         self.assertGreater(len(output), 0)  # At minimum, should not hang
         self.assertIn(b"MemoryError", output)
 
+    def test_data_race(self):
+        from threading import Thread
+        import copy
+
+        E = Exception()
+
+        def func():
+            for i in range(100):
+                setattr(E, 'x', i)
+                copy.copy(E)
+
+        threads = [Thread(target=func) for _ in range(4)]
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
 
 class NameErrorTests(unittest.TestCase):
     def test_name_error_has_name(self):

--- a/Lib/test/test_free_threading/test_exceptions.py
+++ b/Lib/test/test_free_threading/test_exceptions.py
@@ -1,0 +1,16 @@
+import unittest
+import copy
+
+from test.support import threading_helper
+
+threading_helper.requires_working_threading(module=True)
+class ExceptionTests(unittest.TestCase):
+    def test_setstate_data_race(self):
+        E = Exception()
+
+        def func():
+            for i in range(100):
+                setattr(E, 'x', i)
+                copy.copy(E)
+
+        threading_helper.run_concurrently(func, nthreads=4)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-29-17-51-11.gh-issue-144774.jPcixe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-29-17-51-11.gh-issue-144774.jPcixe.rst
@@ -1,0 +1,1 @@
+Fix potential data race in `meth:: BaseException.__setstate__`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-29-17-51-11.gh-issue-144774.jPcixe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-29-17-51-11.gh-issue-144774.jPcixe.rst
@@ -1,1 +1,1 @@
-Fix data race in :meth:`BaseException.__setstate__` when an exception is copied while being mutated.
+Fix data race in :class:`BaseException` when an exception is copied while being mutated.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-29-17-51-11.gh-issue-144774.jPcixe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-29-17-51-11.gh-issue-144774.jPcixe.rst
@@ -1,1 +1,1 @@
-Fix potential data race in `meth:: BaseException.__setstate__`.
+Fix data race in :meth:`BaseException.__setstate__` when an exception is copied while being mutated.

--- a/Objects/clinic/exceptions.c.h
+++ b/Objects/clinic/exceptions.c.h
@@ -44,9 +44,9 @@ BaseException___setstate__(PyObject *self, PyObject *state)
 {
     PyObject *return_value = NULL;
 
-    Py_BEGIN_CRITICAL_SECTION(self);
+    Py_BEGIN_CRITICAL_SECTION2(self, state);
     return_value = BaseException___setstate___impl((PyBaseExceptionObject *)self, state);
-    Py_END_CRITICAL_SECTION();
+    Py_END_CRITICAL_SECTION2();
 
     return return_value;
 }
@@ -380,4 +380,4 @@ BaseExceptionGroup_subgroup(PyObject *self, PyObject *matcher_value)
 
     return return_value;
 }
-/*[clinic end generated code: output=fcf70b3b71f3d14a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8dfe83ced9f55506 input=a9049054013a1b77]*/

--- a/Objects/clinic/exceptions.c.h
+++ b/Objects/clinic/exceptions.c.h
@@ -44,9 +44,9 @@ BaseException___setstate__(PyObject *self, PyObject *state)
 {
     PyObject *return_value = NULL;
 
-    Py_BEGIN_CRITICAL_SECTION2(self, state);
+    Py_BEGIN_CRITICAL_SECTION(state);
     return_value = BaseException___setstate___impl((PyBaseExceptionObject *)self, state);
-    Py_END_CRITICAL_SECTION2();
+    Py_END_CRITICAL_SECTION();
 
     return return_value;
 }
@@ -380,4 +380,4 @@ BaseExceptionGroup_subgroup(PyObject *self, PyObject *matcher_value)
 
     return return_value;
 }
-/*[clinic end generated code: output=8dfe83ced9f55506 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e63b88d0443b4f92 input=a9049054013a1b77]*/

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -233,7 +233,7 @@ BaseException.__setstate__
 
 static PyObject *
 BaseException___setstate___impl(PyBaseExceptionObject *self, PyObject *state)
-/*[clinic end generated code: output=f3834889950453ab input=2ddc941f42fc5bf6]*/
+/*[clinic end generated code: output=f3834889950453ab input=f9b1aea70382cdb6]*/
 {
     PyObject *d_key, *d_value;
     Py_ssize_t i = 0;

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -225,7 +225,7 @@ BaseException___reduce___impl(PyBaseExceptionObject *self)
  */
 
 /*[clinic input]
-@critical_section
+@critical_section self state
 BaseException.__setstate__
     state: object
     /
@@ -233,7 +233,7 @@ BaseException.__setstate__
 
 static PyObject *
 BaseException___setstate___impl(PyBaseExceptionObject *self, PyObject *state)
-/*[clinic end generated code: output=f3834889950453ab input=5524b61cfe9b9856]*/
+/*[clinic end generated code: output=f3834889950453ab input=2ddc941f42fc5bf6]*/
 {
     PyObject *d_key, *d_value;
     Py_ssize_t i = 0;
@@ -243,8 +243,6 @@ BaseException___setstate___impl(PyBaseExceptionObject *self, PyObject *state)
             PyErr_SetString(PyExc_TypeError, "state is not a dictionary");
             return NULL;
         }
-        int error = 0;
-        Py_BEGIN_CRITICAL_SECTION(state);
         while (PyDict_Next(state, &i, &d_key, &d_value)) {
             Py_INCREF(d_key);
             Py_INCREF(d_value);
@@ -252,13 +250,8 @@ BaseException___setstate___impl(PyBaseExceptionObject *self, PyObject *state)
             Py_DECREF(d_value);
             Py_DECREF(d_key);
             if (res < 0) {
-                error = 1;
-                break;
+                return NULL;
             }
-        }
-        Py_END_CRITICAL_SECTION();
-        if (error) {
-            return NULL;
         }
     }
     Py_RETURN_NONE;

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -243,6 +243,8 @@ BaseException___setstate___impl(PyBaseExceptionObject *self, PyObject *state)
             PyErr_SetString(PyExc_TypeError, "state is not a dictionary");
             return NULL;
         }
+        int error = 0;
+        Py_BEGIN_CRITICAL_SECTION(state);
         while (PyDict_Next(state, &i, &d_key, &d_value)) {
             Py_INCREF(d_key);
             Py_INCREF(d_value);
@@ -250,8 +252,13 @@ BaseException___setstate___impl(PyBaseExceptionObject *self, PyObject *state)
             Py_DECREF(d_value);
             Py_DECREF(d_key);
             if (res < 0) {
-                return NULL;
+                error = 1;
+                break;
             }
+        }
+        Py_END_CRITICAL_SECTION();
+        if (error) {
+            return NULL;
         }
     }
     Py_RETURN_NONE;

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -225,7 +225,7 @@ BaseException___reduce___impl(PyBaseExceptionObject *self)
  */
 
 /*[clinic input]
-@critical_section self state
+@critical_section state
 BaseException.__setstate__
     state: object
     /


### PR DESCRIPTION
Adds a critical section to prevent a data race in `exceptions.c`.
Unsure if the test is in the right location.
I don't think that a news entry is necessary.

<!-- gh-issue-number: gh-144774 -->
* Issue: gh-144774
<!-- /gh-issue-number -->
