### PR TITLE
gh-94937: Allow len() to return large Python lengths

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1158,8 +1158,9 @@ are always available.  They are listed here in alphabetical order.
 
    .. impl-detail::
 
-      ``len`` raises :exc:`OverflowError` on lengths larger than
-      :data:`sys.maxsize`, such as :class:`range(2 ** 100) <range>`.
+      CPython's C length protocol is limited to :data:`sys.maxsize`.
+      When that limit is reached, ``len`` may still return a larger Python
+      integer if the object's :meth:`~object.__len__` method can provide one.
 
 
 .. _func-list:

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1533,8 +1533,9 @@ loops.
    indices.
 
    Ranges containing absolute values larger than :data:`sys.maxsize` are
-   permitted but some features (such as :func:`len`) may raise
-   :exc:`OverflowError`.
+   permitted, though some operations that use the C length protocol may still
+   raise :exc:`OverflowError` for ranges with lengths larger than
+   :data:`!sys.maxsize`.
 
    Range examples::
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -3226,11 +3226,10 @@ through the object's keys; for sequences, it should iterate through the values.
 
    .. impl-detail::
 
-      In CPython, the length is required to be at most :data:`sys.maxsize`.
-      If the length is larger than :data:`!sys.maxsize` some features (such as
-      :func:`len`) may raise :exc:`OverflowError`.  To prevent raising
-      :exc:`!OverflowError` by truth value testing, an object must define a
-      :meth:`~object.__bool__` method.
+      In CPython, the C length protocol is limited to :data:`sys.maxsize`.
+      Some features that use that protocol may raise :exc:`OverflowError`
+      for larger lengths.  To prevent raising :exc:`!OverflowError` by truth
+      value testing, an object must define a :meth:`~object.__bool__` method.
 
 
 .. method:: object.__length_hint__(self)

--- a/Include/internal/pycore_abstract.h
+++ b/Include/internal/pycore_abstract.h
@@ -21,6 +21,7 @@ PyAPI_FUNC(PyObject *) _PyNumber_PowerNoMod(PyObject *lhs, PyObject *rhs);
 PyAPI_FUNC(PyObject *) _PyNumber_InPlacePowerNoMod(PyObject *lhs, PyObject *rhs);
 
 PyAPI_FUNC(int) _PyObject_HasLen(PyObject *o);
+PyAPI_FUNC(PyObject *) _PyObject_LengthAsPyLong(PyObject *o);
 
 /* === Sequence protocol ================================================ */
 

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1364,7 +1364,10 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         class HugeLen:
             def __len__(self):
                 return sys.maxsize + 1
-        self.assertRaises(OverflowError, len, HugeLen())
+        self.assertEqual(len(HugeLen()), sys.maxsize + 1)
+        huge_len = HugeLen()
+        huge_len.__len__ = lambda: 0
+        self.assertEqual(len(huge_len), sys.maxsize + 1)
         class HugeNegativeLen:
             def __len__(self):
                 return -sys.maxsize-10

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -5,6 +5,7 @@ import os
 import time
 import pickle
 import shlex
+import sys
 import warnings
 import test.support
 
@@ -122,6 +123,7 @@ class TestBasicOps:
             choice([])
         self.assertEqual(choice([50]), 50)
         self.assertIn(choice([25, 75]), [25, 75])
+        self.assertIn(choice(range(sys.maxsize * 2)), range(sys.maxsize * 2))
 
     def test_choice_with_numpy(self):
         # Accommodation for NumPy arrays which have disabled __bool__().
@@ -177,6 +179,11 @@ class TestBasicOps:
         self.gen.sample(range(20), 2)
         self.gen.sample(str('abcdefghijklmnopqrst'), 2)
         self.gen.sample(tuple('abcdefghijklmnopqrst'), 2)
+        population = range(sys.maxsize * 2)
+        sample = self.gen.sample(population, 10)
+        self.assertEqual(len(sample), 10)
+        self.assertEqual(len(set(sample)), 10)
+        self.assertTrue(all(element in population for element in sample))
 
     def test_sample_on_dicts(self):
         self.assertRaises(TypeError, self.gen.sample, dict.fromkeys('abcdef'), 2)

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -162,24 +162,14 @@ class RangeTest(unittest.TestCase):
 
     def test_large_range(self):
         # Check long ranges (len > sys.maxsize)
-        # len() is expected to fail due to limitations of the __len__ protocol
-        def _range_len(x):
-            try:
-                length = len(x)
-            except OverflowError:
-                step = x[1] - x[0]
-                length = 1 + ((x[-1] - x[0]) // step)
-            return length
-
         a = -sys.maxsize
         b = sys.maxsize
         expected_len = b - a
         x = range(a, b)
         self.assertIn(a, x)
         self.assertNotIn(b, x)
-        self.assertRaises(OverflowError, len, x)
+        self.assertEqual(len(x), expected_len)
         self.assertTrue(x)
-        self.assertEqual(_range_len(x), expected_len)
         self.assertEqual(x[0], a)
         idx = sys.maxsize+1
         self.assertEqual(x[idx], a+idx)
@@ -195,9 +185,8 @@ class RangeTest(unittest.TestCase):
         x = range(a, b)
         self.assertIn(a, x)
         self.assertNotIn(b, x)
-        self.assertRaises(OverflowError, len, x)
+        self.assertEqual(len(x), expected_len)
         self.assertTrue(x)
-        self.assertEqual(_range_len(x), expected_len)
         self.assertEqual(x[0], a)
         idx = sys.maxsize+1
         self.assertEqual(x[idx], a+idx)
@@ -214,9 +203,8 @@ class RangeTest(unittest.TestCase):
         x = range(a, b, c)
         self.assertIn(a, x)
         self.assertNotIn(b, x)
-        self.assertRaises(OverflowError, len, x)
+        self.assertEqual(len(x), expected_len)
         self.assertTrue(x)
-        self.assertEqual(_range_len(x), expected_len)
         self.assertEqual(x[0], a)
         idx = sys.maxsize+1
         self.assertEqual(x[idx], a+(idx*c))
@@ -233,9 +221,8 @@ class RangeTest(unittest.TestCase):
         x = range(a, b, c)
         self.assertIn(a, x)
         self.assertNotIn(b, x)
-        self.assertRaises(OverflowError, len, x)
+        self.assertEqual(len(x), expected_len)
         self.assertTrue(x)
-        self.assertEqual(_range_len(x), expected_len)
         self.assertEqual(x[0], a)
         idx = sys.maxsize+1
         self.assertEqual(x[idx], a+(idx*c))

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-29-12-25-00.gh-issue-94937.len-overflow-fallback.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-29-12-25-00.gh-issue-94937.len-overflow-fallback.rst
@@ -1,0 +1,3 @@
+Allow :func:`len` to return values larger than :data:`sys.maxsize` when
+``__len__`` can provide a Python integer fallback, including for large
+:class:`range` objects.

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -3710,13 +3710,8 @@
                 STAT_INC(CALL, hit);
                 PyObject *arg_o = PyStackRef_AsPyObjectBorrow(arg);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_ssize_t len_i = PyObject_Length(arg_o);
+                PyObject *res_o = _PyObject_LengthAsPyLong(arg_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
-                if (len_i < 0) {
-                    JUMP_TO_LABEL(error);
-                }
-                PyObject *res_o = PyLong_FromSsize_t(len_i);
-                assert((res_o != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
                 if (res_o == NULL) {
                     JUMP_TO_LABEL(error);
                 }
@@ -6688,12 +6683,8 @@
             _PyStackRef len;
             obj = stack_pointer[-1];
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            Py_ssize_t len_i = PyObject_Length(PyStackRef_AsPyObjectBorrow(obj));
+            PyObject *len_o = _PyObject_LengthAsPyLong(PyStackRef_AsPyObjectBorrow(obj));
             stack_pointer = _PyFrame_GetStackPointer(frame);
-            if (len_i < 0) {
-                JUMP_TO_LABEL(error);
-            }
-            PyObject *len_o = PyLong_FromSsize_t(len_i);
             if (len_o == NULL) {
                 JUMP_TO_LABEL(error);
             }

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -79,6 +79,48 @@ PyObject_Length(PyObject *o)
 }
 #define PyObject_Length PyObject_Size
 
+PyObject *
+_PyObject_LengthAsPyLong(PyObject *o)
+{
+    Py_ssize_t res = PyObject_Size(o);
+    if (res >= 0) {
+        return PyLong_FromSsize_t(res);
+    }
+    assert(PyErr_Occurred());
+    if (!PyErr_ExceptionMatches(PyExc_OverflowError)) {
+        return NULL;
+    }
+
+    PyErr_Clear();
+    PyObject *meth = _PyObject_LookupSpecial(o, &_Py_ID(__len__));
+    if (meth == NULL) {
+        if (!PyErr_Occurred()) {
+            type_error("object of type '%.200s' has no len()", o);
+        }
+        return NULL;
+    }
+
+    PyObject *len = _PyObject_CallNoArgs(meth);
+    Py_DECREF(meth);
+    if (len == NULL) {
+        return NULL;
+    }
+
+    Py_SETREF(len, PyNumber_Index(len));
+    if (len == NULL) {
+        return NULL;
+    }
+
+    assert(PyLong_Check(len));
+    if (_PyLong_IsNegative((PyLongObject *)len)) {
+        Py_DECREF(len);
+        PyErr_SetString(PyExc_ValueError,
+                        "__len__() should return >= 0");
+        return NULL;
+    }
+    return len;
+}
+
 int
 _PyObject_HasLen(PyObject *o) {
     return (Py_TYPE(o)->tp_as_sequence && Py_TYPE(o)->tp_as_sequence->sq_length) ||

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -330,6 +330,13 @@ range_length(PyObject *op)
 }
 
 static PyObject *
+range_len(PyObject *op, PyObject *Py_UNUSED(ignored))
+{
+    rangeobject *r = (rangeobject*)op;
+    return Py_NewRef(r->length);
+}
+
+static PyObject *
 compute_item(rangeobject *r, PyObject *i)
 {
     PyObject *incr, *result;
@@ -779,6 +786,7 @@ PyDoc_STRVAR(index_doc,
 "Raise ValueError if the value is not present.");
 
 static PyMethodDef range_methods[] = {
+    {"__len__",         range_len,                  METH_NOARGS | METH_COEXIST, NULL},
     {"__reversed__",    range_reverse,              METH_NOARGS, reverse_doc},
     {"__reduce__",      range_reduce,               METH_NOARGS},
     {"count",           range_count,                METH_O,      count_doc},

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1,6 +1,7 @@
 /* Built-in functions */
 
 #include "Python.h"
+#include "pycore_abstract.h"      // _PyObject_LengthAsPyLong()
 #include "pycore_ast.h"           // _PyAST_Validate()
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_cell.h"          // PyCell_GetRef()
@@ -1992,14 +1993,7 @@ static PyObject *
 builtin_len(PyObject *module, PyObject *obj)
 /*[clinic end generated code: output=fa7a270d314dfb6c input=bc55598da9e9c9b5]*/
 {
-    Py_ssize_t res;
-
-    res = PyObject_Size(obj);
-    if (res < 0) {
-        assert(PyErr_Occurred());
-        return NULL;
-    }
-    return PyLong_FromSsize_t(res);
+    return _PyObject_LengthAsPyLong(obj);
 }
 
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -7,7 +7,7 @@
 // See Tools/cases_generator/README.md for more information.
 
 #include "Python.h"
-#include "pycore_abstract.h"      // _PyIndex_Check()
+#include "pycore_abstract.h"      // _PyIndex_Check(), _PyObject_LengthAsPyLong()
 #include "pycore_audit.h"         // _PySys_Audit()
 #include "pycore_backoff.h"
 #include "pycore_cell.h"          // PyCell_GetRef()
@@ -3698,9 +3698,7 @@ dummy_func(
 
         inst(GET_LEN, (obj -- obj, len)) {
             // PUSH(len(TOS))
-            Py_ssize_t len_i = PyObject_Length(PyStackRef_AsPyObjectBorrow(obj));
-            ERROR_IF(len_i < 0);
-            PyObject *len_o = PyLong_FromSsize_t(len_i);
+            PyObject *len_o = _PyObject_LengthAsPyLong(PyStackRef_AsPyObjectBorrow(obj));
             ERROR_IF(len_o == NULL);
             len = PyStackRef_FromPyObjectSteal(len_o);
         }
@@ -5037,12 +5035,7 @@ dummy_func(
             /* len(o) */
             STAT_INC(CALL, hit);
             PyObject *arg_o = PyStackRef_AsPyObjectBorrow(arg);
-            Py_ssize_t len_i = PyObject_Length(arg_o);
-            if (len_i < 0) {
-                ERROR_NO_POP();
-            }
-            PyObject *res_o = PyLong_FromSsize_t(len_i);
-            assert((res_o != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
+            PyObject *res_o = _PyObject_LengthAsPyLong(arg_o);
             if (res_o == NULL) {
                 ERROR_NO_POP();
             }

--- a/Python/ceval.h
+++ b/Python/ceval.h
@@ -1,7 +1,7 @@
 #define _PY_INTERPRETER
 
 #include "Python.h"
-#include "pycore_abstract.h"      // _PyIndex_Check()
+#include "pycore_abstract.h"      // _PyIndex_Check(), _PyObject_LengthAsPyLong()
 #include "pycore_audit.h"         // _PySys_Audit()
 #include "pycore_backoff.h"
 #include "pycore_call.h"          // _PyObject_CallNoArgs()

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -14036,13 +14036,8 @@
             stack_pointer += 1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            Py_ssize_t len_i = PyObject_Length(PyStackRef_AsPyObjectBorrow(obj));
+            PyObject *len_o = _PyObject_LengthAsPyLong(PyStackRef_AsPyObjectBorrow(obj));
             stack_pointer = _PyFrame_GetStackPointer(frame);
-            if (len_i < 0) {
-                SET_CURRENT_CACHED_VALUES(0);
-                JUMP_TO_ERROR();
-            }
-            PyObject *len_o = PyLong_FromSsize_t(len_i);
             if (len_o == NULL) {
                 SET_CURRENT_CACHED_VALUES(0);
                 JUMP_TO_ERROR();
@@ -18584,14 +18579,8 @@
             stack_pointer += 3;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            Py_ssize_t len_i = PyObject_Length(arg_o);
+            PyObject *res_o = _PyObject_LengthAsPyLong(arg_o);
             stack_pointer = _PyFrame_GetStackPointer(frame);
-            if (len_i < 0) {
-                SET_CURRENT_CACHED_VALUES(0);
-                JUMP_TO_ERROR();
-            }
-            PyObject *res_o = PyLong_FromSsize_t(len_i);
-            assert((res_o != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
             if (res_o == NULL) {
                 SET_CURRENT_CACHED_VALUES(0);
                 JUMP_TO_ERROR();

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3710,13 +3710,8 @@
                 STAT_INC(CALL, hit);
                 PyObject *arg_o = PyStackRef_AsPyObjectBorrow(arg);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_ssize_t len_i = PyObject_Length(arg_o);
+                PyObject *res_o = _PyObject_LengthAsPyLong(arg_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
-                if (len_i < 0) {
-                    JUMP_TO_LABEL(error);
-                }
-                PyObject *res_o = PyLong_FromSsize_t(len_i);
-                assert((res_o != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
                 if (res_o == NULL) {
                     JUMP_TO_LABEL(error);
                 }
@@ -6688,12 +6683,8 @@
             _PyStackRef len;
             obj = stack_pointer[-1];
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            Py_ssize_t len_i = PyObject_Length(PyStackRef_AsPyObjectBorrow(obj));
+            PyObject *len_o = _PyObject_LengthAsPyLong(PyStackRef_AsPyObjectBorrow(obj));
             stack_pointer = _PyFrame_GetStackPointer(frame);
-            if (len_i < 0) {
-                JUMP_TO_LABEL(error);
-            }
-            PyObject *len_o = PyLong_FromSsize_t(len_i);
             if (len_o == NULL) {
                 JUMP_TO_LABEL(error);
             }

--- a/Tools/jit/template.c
+++ b/Tools/jit/template.c
@@ -1,5 +1,6 @@
 #include "Python.h"
 
+#include "pycore_abstract.h"
 #include "pycore_backoff.h"
 #include "pycore_call.h"
 #include "pycore_cell.h"


### PR DESCRIPTION
This implements the `len()` fallback discussed in gh-94937 while keeping the existing `Py_ssize_t` fast path.

The change adds an internal object-returning length helper. It first uses `PyObject_Size()` for the normal C protocol path, then falls back on `OverflowError` to the type-level `__len__` special method and validates the result with `PyNumber_Index()` plus the existing non-negative check.

`range` now exposes a `METH_COEXIST` `__len__` method that returns its stored Python integer length, so large ranges can participate in the fallback without changing `PyObject_Size()` or the C length protocol.

The optimized `len()` bytecode paths now use the same helper as the builtin, so callers such as `random.choice()` and `random.sample()` see the same behavior.

Tests and docs are updated for:

- pure Python `__len__` values larger than `sys.maxsize`
- special-method lookup ignoring instance-level `__len__`
- large `range` lengths
- `random.choice()` and `random.sample()` over ranges larger than `sys.maxsize`

Tested with:

- `PYTHONPATH=./Lib:./Modules ./python.exe -m unittest -v test.test_builtin.BuiltinTest.test_len test.test_range.RangeTest.test_large_range test.test_random.MersenneTwister_TestBasicOps.test_choice test.test_random.MersenneTwister_TestBasicOps.test_sample_inputs`
- `PYTHONPATH=./Lib:./Modules ./python.exe -m test test_builtin test_range test_random`
