### PR TITLE
gh-150579: use lazy imports for concurrent.futures

### DIFF
--- a/Lib/concurrent/futures/__init__.py
+++ b/Lib/concurrent/futures/__init__.py
@@ -17,6 +17,9 @@ from concurrent.futures._base import (FIRST_COMPLETED,
                                       wait,
                                       as_completed)
 
+lazy from .process import ProcessPoolExecutor
+lazy from .thread import ThreadPoolExecutor
+
 __all__ = [
     'FIRST_COMPLETED',
     'FIRST_EXCEPTION',
@@ -40,26 +43,10 @@ except ImportError:
     _interpreters = None
 
 if _interpreters:
+    lazy from .interpreter import InterpreterPoolExecutor
     __all__.append('InterpreterPoolExecutor')
 
 
 def __dir__():
     return __all__ + ['__author__', '__doc__']
 
-
-def __getattr__(name):
-    global ProcessPoolExecutor, ThreadPoolExecutor, InterpreterPoolExecutor
-
-    if name == 'ProcessPoolExecutor':
-        from .process import ProcessPoolExecutor
-        return ProcessPoolExecutor
-
-    if name == 'ThreadPoolExecutor':
-        from .thread import ThreadPoolExecutor
-        return ThreadPoolExecutor
-
-    if _interpreters and name == 'InterpreterPoolExecutor':
-        from .interpreter import InterpreterPoolExecutor
-        return InterpreterPoolExecutor
-
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/concurrent/futures/__init__.py
+++ b/Lib/concurrent/futures/__init__.py
@@ -43,10 +43,9 @@ except ImportError:
     _interpreters = None
 
 if _interpreters:
-    lazy from .interpreter import InterpreterPoolExecutor
+    lazy from .interpreter import InterpreterPoolExecutor  # noqa: F401
     __all__.append('InterpreterPoolExecutor')
 
 
 def __dir__():
     return __all__ + ['__author__', '__doc__']
-

--- a/Misc/NEWS.d/next/Library/2026-07-03-17-29-34.gh-issue-150579.0tLpQukIU.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-03-17-29-34.gh-issue-150579.0tLpQukIU.rst
@@ -1,0 +1,2 @@
+:mod:`concurrent.futures` now uses lazy imports for its executor submodules
+instead of a module ``__getattr__`` hook.


### PR DESCRIPTION
This module has a manual lazy import hack using `__getattr__`. Now that lazy imports exist and cannot be disabled, this could use lazy imports instead.

Key differences: this will now show up in `sys.lazy_modules` when accessed. Error messages should be a bit better without the wrapper `__getattr__` involved.  That's the only differences I can think of.

Closes #150579 (though that can be closed without this, the bug was already fixed in #144957).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-150579 -->
* Issue: gh-150579
<!-- /gh-issue-number -->
