### PR TITLE
gh-150583: Fix zstd compression with digested ZstdDict

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-03-19-35-32.gh-issue-150583.dedI24.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-03-19-35-32.gh-issue-150583.dedI24.rst
@@ -1,0 +1,2 @@
+Fix compression level in :mod:`compression.zstd` when passing a digested
+dictionary during compression.

--- a/Misc/NEWS.d/next/Library/2026-06-03-19-35-32.gh-issue-150583.dedI24.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-03-19-35-32.gh-issue-150583.dedI24.rst
@@ -1,2 +1,2 @@
-Fix compression level in :mod:`compression.zstd` when passing a digested
+Correctly set the default compression level in :mod:`compression.zstd` when passing a digested
 dictionary during compression.

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -347,6 +347,7 @@ _zstd_ZstdCompressor_new_impl(PyTypeObject *type, PyObject *level,
     }
 
     self->use_multithread = 0;
+    self->compression_level = ZSTD_CLEVEL_DEFAULT;
     self->dict = NULL;
     self->lock = (PyMutex){0};
 


### PR DESCRIPTION
### Changes

Force setting a `compression_level` of `ZSTD_CLEVEL_DEFAULT` when creating the `ZstdCompressor` object.

Question for reviewers: should I use `_zstd_set_c_level(ZSTD_CLEVEL_DEFAULT)` instead?

See reproducer in #150583.

### Analysis

When creating a `ZstdCompressor` object (`_zstd_ZstdCompressor_new_impl`), the `compression_level` field is unset, and as a result keeps its value from whatever was in memory (not deterministic), assuming no level is passed in the constructor.

Then, when set, the C dict is loaded into the compression context with `_zstd_load_c_dict`, which in turn calls `_zstd_load_impl`.

In the case of a digested dictionary, `_get_CDict(zd, self->compression_level)` is now called, which in turns calls `ZSTD_createCDict(..., compressionLevel)`.

So an arbitrary compression level is passed to that call to `libzstd`.

### Bug impact

Prerequisites:
 - Compress data with `compression.zstd`
 - Do not specify a compression level (neither with `level` nor through `options`)
 - Pass a **digested** dictionary with `zstd_dict` (e.g. with `ZstdDict(...).as_digested_dict`)

Consequence: the compression level used is arbitrary, and may change from one run to another.

### Misc

Backport suggestion: to 3.15 and 3.14.

AI disclosure: analysis was performed with help of an LLM.

@emmatyping :wave: 

<!-- gh-issue-number: gh-150583 -->
* Issue: gh-150583
<!-- /gh-issue-number -->
