### PR TITLE
gh-150587: Harden BINARY_OP_SUBSCR_LIST_INT/STORE_SUBSCR_LIST_INT against non-compact int subscripts

### DIFF
--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -2041,6 +2041,36 @@ class TestSpecializer(TestBase):
 
     @cpython_only
     @requires_specialization
+    def test_binary_subscr_list_int_wide_int(self):
+        def load(lst, idx):
+            return lst[idx]
+
+        lst = [1, 2, 3]
+        for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+            load(lst, 0)
+        self.assert_specialized(load, "BINARY_OP_SUBSCR_LIST_INT")
+        # 2**30+2 is non-compact; ob_digit[0]=2 so _PyLong_CompactValue
+        # would silently return 2 and read lst[2] instead of raising IndexError.
+        with self.assertRaises(IndexError):
+            load(lst, 2**30 + 2)
+
+    @cpython_only
+    @requires_specialization
+    def test_store_subscr_list_int_wide_int(self):
+        def store(lst, idx):
+            lst[idx] = 99
+
+        lst = [1, 2, 3]
+        for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+            store(lst, 0)
+        self.assert_specialized(store, "STORE_SUBSCR_LIST_INT")
+        # 2**30+2 is non-compact; ob_digit[0]=2 so _PyLong_CompactValue
+        # would silently write to lst[2] instead of raising IndexError.
+        with self.assertRaises(IndexError):
+            store(lst, 2**30 + 2)
+
+    @cpython_only
+    @requires_specialization
     def test_compare_op(self):
         def compare_op_int():
             for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-29-00-00-00.gh-issue-150587.xK3mPq.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-29-00-00-00.gh-issue-150587.xK3mPq.rst
@@ -1,0 +1,4 @@
+``BINARY_OP_SUBSCR_LIST_INT`` and ``STORE_SUBSCR_LIST_INT`` now verify that
+the subscript is a compact non-negative int before calling the compact-only
+internal helper, rather than relying solely on the shared ``_GUARD_TOS_INT``
+guard to enforce that invariant.

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -832,6 +832,11 @@
                 PyObject *list = PyStackRef_AsPyObjectBorrow(list_st);
                 assert(PyLong_CheckExact(sub));
                 assert(PyList_CheckExact(list));
+                if (!_PyLong_IsNonNegativeCompact((PyLongObject *)sub)) {
+                    UPDATE_MISS_STATS(BINARY_OP);
+                    assert(_PyOpcode_Deopt[opcode] == (BINARY_OP));
+                    JUMP_TO_PREDICTED(BINARY_OP);
+                }
                 Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)sub);
                 if (index < 0) {
                     index += PyList_GET_SIZE(list);
@@ -12215,6 +12220,11 @@
                 PyObject *list = PyStackRef_AsPyObjectBorrow(list_st);
                 assert(PyLong_CheckExact(sub));
                 assert(PyList_CheckExact(list));
+                if (!_PyLong_IsNonNegativeCompact((PyLongObject *)sub)) {
+                    UPDATE_MISS_STATS(STORE_SUBSCR);
+                    assert(_PyOpcode_Deopt[opcode] == (STORE_SUBSCR));
+                    JUMP_TO_PREDICTED(STORE_SUBSCR);
+                }
                 Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)sub);
                 if (!LOCK_OBJECT(list)) {
                     UPDATE_MISS_STATS(STORE_SUBSCR);

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1141,6 +1141,7 @@ dummy_func(
 
             assert(PyLong_CheckExact(sub));
             assert(PyList_CheckExact(list));
+            EXIT_IF(!_PyLong_IsNonNegativeCompact((PyLongObject *)sub));
 
             Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)sub);
             if (index < 0) {
@@ -1419,6 +1420,7 @@ dummy_func(
 
             assert(PyLong_CheckExact(sub));
             assert(PyList_CheckExact(list));
+            DEOPT_IF(!_PyLong_IsNonNegativeCompact((PyLongObject *)sub));
 
             Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)sub);
             DEOPT_IF(!LOCK_OBJECT(list));

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -6867,6 +6867,13 @@
             PyObject *list = PyStackRef_AsPyObjectBorrow(list_st);
             assert(PyLong_CheckExact(sub));
             assert(PyList_CheckExact(list));
+            if (!_PyLong_IsNonNegativeCompact((PyLongObject *)sub)) {
+                UOP_STAT_INC(uopcode, miss);
+                _tos_cache1 = sub_st;
+                _tos_cache0 = list_st;
+                SET_CURRENT_CACHED_VALUES(2);
+                JUMP_TO_JUMP_TARGET();
+            }
             Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)sub);
             if (index < 0) {
                 index += PyList_GET_SIZE(list);
@@ -8300,6 +8307,14 @@
             PyObject *list = PyStackRef_AsPyObjectBorrow(list_st);
             assert(PyLong_CheckExact(sub));
             assert(PyList_CheckExact(list));
+            if (!_PyLong_IsNonNegativeCompact((PyLongObject *)sub)) {
+                UOP_STAT_INC(uopcode, miss);
+                _tos_cache2 = sub_st;
+                _tos_cache1 = list_st;
+                _tos_cache0 = value;
+                SET_CURRENT_CACHED_VALUES(3);
+                JUMP_TO_JUMP_TARGET();
+            }
             Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)sub);
             if (!LOCK_OBJECT(list)) {
                 UOP_STAT_INC(uopcode, miss);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -832,6 +832,11 @@
                 PyObject *list = PyStackRef_AsPyObjectBorrow(list_st);
                 assert(PyLong_CheckExact(sub));
                 assert(PyList_CheckExact(list));
+                if (!_PyLong_IsNonNegativeCompact((PyLongObject *)sub)) {
+                    UPDATE_MISS_STATS(BINARY_OP);
+                    assert(_PyOpcode_Deopt[opcode] == (BINARY_OP));
+                    JUMP_TO_PREDICTED(BINARY_OP);
+                }
                 Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)sub);
                 if (index < 0) {
                     index += PyList_GET_SIZE(list);
@@ -12212,6 +12217,11 @@
                 PyObject *list = PyStackRef_AsPyObjectBorrow(list_st);
                 assert(PyLong_CheckExact(sub));
                 assert(PyList_CheckExact(list));
+                if (!_PyLong_IsNonNegativeCompact((PyLongObject *)sub)) {
+                    UPDATE_MISS_STATS(STORE_SUBSCR);
+                    assert(_PyOpcode_Deopt[opcode] == (STORE_SUBSCR));
+                    JUMP_TO_PREDICTED(STORE_SUBSCR);
+                }
                 Py_ssize_t index = _PyLong_CompactValue((PyLongObject *)sub);
                 if (!LOCK_OBJECT(list)) {
                     UPDATE_MISS_STATS(STORE_SUBSCR);


### PR DESCRIPTION
Add `EXIT_IF(!_PyLong_IsNonNegativeCompact(...))` to `_BINARY_OP_SUBSCR_LIST_INT` and `DEOPT_IF(!_PyLong_IsNonNegativeCompact(...))` to `_STORE_SUBSCR_LIST_INT` before the `_PyLong_CompactValue` call.

Both opcodes currently rely on `_GUARD_TOS_INT` having already rejected non-compact ints, but do not enforce this themselves. If `_GUARD_TOS_INT` were relaxed, `_PyLong_CompactValue` would be called on a wide int, silently reading `ob_digit[0]` as the index instead of the full value.

Fixes gh-150587.