### PR TITLE
gh-150633: properly handle imports with null bytes in names

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -364,6 +364,15 @@ class ImportTests(unittest.TestCase):
         with self.assertRaises(ModuleNotFoundError):
             import something_that_should_not_exist_anywhere
 
+    def test_import_null_byte_in_name_raises_ModuleNotFoundError(self):
+        # gh-150633: module names containing null bytes should not
+        # lead to duplicates in sys.modules
+        before = set(sys.modules.keys())
+        with self.assertRaises(ModuleNotFoundError):
+            __import__('codecs\x00junk')
+
+        self.assertEqual(set(sys.modules.keys()), before)
+
     def test_from_import_missing_module_raises_ModuleNotFoundError(self):
         with self.assertRaises(ModuleNotFoundError):
             from something_that_should_not_exist_anywhere import blah

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -369,7 +369,7 @@ class ImportTests(unittest.TestCase):
         # lead to duplicates in sys.modules
         before = set(sys.modules.keys())
         with self.assertRaises(ModuleNotFoundError):
-            __import__('codecs\x00junk')
+            __import__('zipimport\x00junk')
 
         self.assertEqual(set(sys.modules.keys()), before)
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-30-20-19-35.gh-issue-150633.XkNul0.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-30-20-19-35.gh-issue-150633.XkNul0.rst
@@ -1,3 +1,3 @@
-Fix :func:`__import__` accepting module names with embedded null bytes, which
-caused the frozen importer to bypass the :data:`sys.modules` cache and create
-duplicate module objects.
+Fix the frozen importer accepting module names with embedded null bytes, which
+caused it to bypass the :data:`sys.modules` cache and create duplicate module
+objects.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-30-20-19-35.gh-issue-150633.XkNul0.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-30-20-19-35.gh-issue-150633.XkNul0.rst
@@ -1,0 +1,3 @@
+Fix :func:`__import__` accepting module names with embedded null bytes, which
+caused the frozen importer to bypass the :data:`sys.modules` cache and create
+duplicate module objects.

--- a/Python/import.c
+++ b/Python/import.c
@@ -3174,7 +3174,7 @@ find_frozen(PyObject *nameobj, struct frozen_info *info)
     if (nameobj == NULL || nameobj == Py_None) {
         return FROZEN_BAD_NAME;
     }
-    const char *name = PyUnicode_AsUTF8(nameobj);
+    const char *name = _PyUnicode_AsUTF8NoNUL(nameobj);
     if (name == NULL) {
         // Note that this function previously used
         // _PyUnicode_EqualToASCIIString().  We clear the error here


### PR DESCRIPTION
## What is this PR?

Fixes #150633.



<!-- gh-issue-number: gh-150633 -->
* Issue: gh-150633
<!-- /gh-issue-number -->
