### PR TITLE
gh-150636: Clarify difference between copy.copy() and the copy() methods

### DIFF
--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -72,9 +72,13 @@ file, socket, window, or any similar types.  It does "copy" functions and
 classes (shallow and deeply), by returning the original object unchanged; this
 is compatible with the way these are treated by the :mod:`pickle` module.
 
-Shallow copies of dictionaries can be made using :meth:`dict.copy`, and
-of lists by assigning a slice of the entire list, for example,
-``copied_list = original_list[:]``.
+Shallow copies of many collections can be made using the corresponding
+:meth:`!copy` method (such as :meth:`list.copy`, :meth:`dict.copy`,
+:meth:`set.copy`), and of sequences (lists, bytearrays, etc) by making a slice
+of the entire sequence, for example, ``alist[:]``.
+But such methods can create an instance of the base type when copying
+an instance of a subclass, whereas :func:`copy.copy` normally returns
+an instance of the same type.
 
 .. index:: pair: module; pickle
 

--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -74,11 +74,11 @@ is compatible with the way these are treated by the :mod:`pickle` module.
 
 Shallow copies of many collections can be made using the corresponding
 :meth:`!copy` method (such as :meth:`list.copy`, :meth:`dict.copy` or
-:meth:`set.copy`), and of sequences (lists, bytearrays, etc.) by making a slice
-of the entire sequence, for example, ``alist[:]``.
-But such methods can create an instance of the base type when copying
-an instance of a subclass, whereas :func:`copy.copy` normally returns
-an instance of the same type.
+:meth:`set.copy`), and of sequences (such as lists or bytearrays) by making
+a slice of the entire sequence (``sequence[:]``).
+However, these methods and slicing can create an instance of the base type
+when copying an instance of a subclass, whereas :func:`copy.copy` normally
+returns an instance of the same type.
 
 .. index:: pair: module; pickle
 

--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -73,8 +73,8 @@ classes (shallow and deeply), by returning the original object unchanged; this
 is compatible with the way these are treated by the :mod:`pickle` module.
 
 Shallow copies of many collections can be made using the corresponding
-:meth:`!copy` method (such as :meth:`list.copy`, :meth:`dict.copy`,
-:meth:`set.copy`), and of sequences (lists, bytearrays, etc) by making a slice
+:meth:`!copy` method (such as :meth:`list.copy`, :meth:`dict.copy` or
+:meth:`set.copy`), and of sequences (lists, bytearrays, etc.) by making a slice
 of the entire sequence, for example, ``alist[:]``.
 But such methods can create an instance of the base type when copying
 an instance of a subclass, whereas :func:`copy.copy` normally returns


### PR DESCRIPTION


<!-- gh-issue-number: gh-150636 -->
* Issue: gh-150636
<!-- /gh-issue-number -->
