### PR TITLE
gh-150644: Tag Apple system log messages as public.

### DIFF
--- a/Misc/NEWS.d/next/macOS/2026-05-31-10-40-00.gh-issue-150644.zLWyjj.rst
+++ b/Misc/NEWS.d/next/macOS/2026-05-31-10-40-00.gh-issue-150644.zLWyjj.rst
@@ -1,0 +1,3 @@
+When system logging is enabled (with ``config.use_system_logger``, messages
+are now tagged as public. This allows the macOS 26 system logger to view
+messages without special configuration.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3327,7 +3327,9 @@ apple_log_write_impl(PyObject *self, PyObject *args)
 
     // Pass the user-provided text through explicit %s formatting
     // to avoid % literals being interpreted as a formatting directive.
-    os_log_with_type(OS_LOG_DEFAULT, logtype, "%s", text);
+    // Using {public} ensures "dynamic" string messages are visible
+    // in the log without special configuration.
+    os_log_with_type(OS_LOG_DEFAULT, logtype, "%{public}s", text);
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
macOS 26 has changed the default visibility of "dynamic" system messages. This changes the logging strategy to tag all messages as "public" so they are visible in the system log without special configuration.


<!-- gh-issue-number: gh-150644 -->
* Issue: gh-150644
<!-- /gh-issue-number -->
