### PR TITLE
gh-150641: Fix evaluating forward references in STRING format can 'leak' internal names in `typing`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7565,18 +7565,13 @@ class EvaluateForwardRefTests(BaseTestCase):
         # Test evaluating forward references in STRING format
         # does not 'leak' internal names
         # See https://github.com/python/cpython/issues/150641
-        from annotationlib import Format, get_annotations
 
         def f(arg: unknown | str | int | list[str] | tuple[int, ...]): ...
 
-        ref = get_annotations(f, format=Format.FORWARDREF)['arg']
+        ref = annotationlib.get_annotations(f, format=annotationlib.Format.FORWARDREF)['arg']
         self.assertEqual(
-            typing.evaluate_forward_ref(ref, format=Format.STRING),
+            typing.evaluate_forward_ref(ref, format=annotationlib.Format.STRING),
             "unknown | str | int | list[str] | tuple[int, ...]",
-        )
-        self.assertEqual(
-            typing.evaluate_forward_ref(ref, format=Format.STRING),
-            ref.__resolved_str__
         )
 
 class CollectionsAbcTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7561,6 +7561,23 @@ class EvaluateForwardRefTests(BaseTestCase):
         typing.evaluate_forward_ref(
             fwdref_module.fw,)
 
+    def test_evaluate_forward_ref_string_format(self):
+        # Test evaluating forward references in STRING format
+        # does not 'leak' internal names
+        # See https://github.com/python/cpython/issues/150641
+        from annotationlib import Format, get_annotations
+
+        def f(arg: unknown | str | int | list[str] | tuple[int, ...]): ...
+
+        ref = get_annotations(f, format=Format.FORWARDREF)['arg']
+        self.assertEqual(
+            typing.evaluate_forward_ref(ref, format=Format.STRING),
+            "unknown | str | int | list[str] | tuple[int, ...]",
+        )
+        self.assertEqual(
+            typing.evaluate_forward_ref(ref, format=Format.STRING),
+            ref.__resolved_str__
+        )
 
 class CollectionsAbcTests(BaseTestCase):
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1019,8 +1019,8 @@ def evaluate_forward_ref(
 
     """
     if format == annotationlib.Format.STRING:
-        return forward_ref.__forward_arg__
-    if forward_ref.__forward_arg__ in _recursive_guard:
+        return forward_ref.__resolved_str__
+    if forward_ref.__resolved_str__ in _recursive_guard:
         return forward_ref
 
     if format is None:
@@ -1044,7 +1044,7 @@ def evaluate_forward_ref(
         globals,
         locals,
         type_params,
-        recursive_guard=_recursive_guard | {forward_ref.__forward_arg__},
+        recursive_guard=_recursive_guard | {forward_ref.__resolved_str__},
         format=format,
         owner=owner,
         parent_fwdref=forward_ref,

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1020,7 +1020,7 @@ def evaluate_forward_ref(
     """
     if format == annotationlib.Format.STRING:
         return forward_ref.__resolved_str__
-    if forward_ref.__resolved_str__ in _recursive_guard:
+    if forward_ref.__forward_arg__ in _recursive_guard:
         return forward_ref
 
     if format is None:
@@ -1044,7 +1044,7 @@ def evaluate_forward_ref(
         globals,
         locals,
         type_params,
-        recursive_guard=_recursive_guard | {forward_ref.__resolved_str__},
+        recursive_guard=_recursive_guard | {forward_ref.__forward_arg__},
         format=format,
         owner=owner,
         parent_fwdref=forward_ref,

--- a/Misc/NEWS.d/next/Library/2026-05-31-14-39-25.gh-issue-150641.LLIhd1.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-31-14-39-25.gh-issue-150641.LLIhd1.rst
@@ -1,2 +1,2 @@
-Fix evaluating forward references in STRING format can 'leak' internal names
-in ``typing``.
+Fix bug where :func:`typing.evaluate_forward_ref` with the ``STRING`` format
+could leak internal names used by the annotation machinery.

--- a/Misc/NEWS.d/next/Library/2026-05-31-14-39-25.gh-issue-150641.LLIhd1.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-31-14-39-25.gh-issue-150641.LLIhd1.rst
@@ -1,0 +1,2 @@
+Fix evaluating forward references in STRING format can 'leak' internal names
+in ``typing``.


### PR DESCRIPTION


<!-- gh-issue-number: gh-150641 -->
* Issue: gh-150641
<!-- /gh-issue-number -->
