### PR TITLE
Two typos in 'Exception Handling' C-API documentation

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -303,7 +303,7 @@ For convenience, some of these functions will always return a
 
    Set file, line, and offset information for the current exception.  If the
    current exception is not a :exc:`SyntaxError`, then it sets additional
-   attributes, which make the exception printing subsystem to think that the exception
+   attributes, which make the exception printing subsystem think the exception
    is a :exc:`SyntaxError`.
 
    .. versionadded:: 3.4

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -1385,14 +1385,14 @@ Tracebacks
    interpreter using thread-specific storage. If it cannot, it will return an
    error.
 
-   If *current_tstate* is not ``NULL`` then it will be used to identify what the
+   If *current_tstate* is not ``NULL`` then it will be used to identify which 
    current thread is in the written output. If it is ``NULL`` then this function
    will identify the current thread using thread-specific storage. It is not an
    error if the function is unable to get the current Python thread state.
 
    This function will return ``NULL`` on success, or an error message on error.
 
-   This function is meant to debug debug situations such as segfaults, fatal
+   This function is meant to debug situations such as segfaults, fatal
    errors, and similar. It calls :c:func:`PyUnstable_DumpTraceback` for each
    thread. It only writes the tracebacks of the first *max_threads* threads,
    further output is truncated with the line ``...``. If *max_threads* is 0, the

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -1385,7 +1385,7 @@ Tracebacks
    interpreter using thread-specific storage. If it cannot, it will return an
    error.
 
-   If *current_tstate* is not ``NULL`` then it will be used to identify which 
+   If *current_tstate* is not ``NULL`` then it will be used to identify which
    current thread is in the written output. If it is ``NULL`` then this function
    will identify the current thread using thread-specific storage. It is not an
    error if the function is unable to get the current Python thread state.

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -1385,7 +1385,7 @@ Tracebacks
    interpreter using thread-specific storage. If it cannot, it will return an
    error.
 
-   If *current_tstate* is not ``NULL`` then it will be used to identify which
+   If *current_tstate* is not ``NULL`` then it will be used to identify what the
    current thread is in the written output. If it is ``NULL`` then this function
    will identify the current thread using thread-specific storage. It is not an
    error if the function is unable to get the current Python thread state.

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -303,7 +303,7 @@ For convenience, some of these functions will always return a
 
    Set file, line, and offset information for the current exception.  If the
    current exception is not a :exc:`SyntaxError`, then it sets additional
-   attributes, which make the exception printing subsystem think the exception
+   attributes, which make the exception printing subsystem to think that the exception
    is a :exc:`SyntaxError`.
 
    .. versionadded:: 3.4
@@ -412,7 +412,7 @@ an error value).
 
 .. c:function:: int PyErr_WarnFormat(PyObject *category, Py_ssize_t stack_level, const char *format, ...)
 
-   Function similar to :c:func:`PyErr_WarnEx`, but use
+   Function similar to :c:func:`PyErr_WarnEx`, but uses
    :c:func:`PyUnicode_FromFormat` to format the warning message.  *format* is
    an ASCII-encoded string.
 


### PR DESCRIPTION
This PR addresses minor typos in  ```Doc/c-api/exceptions.rst``` by fixing the 2 following statements for better clarity and readability.
```
If *current_tstate* is not ``NULL`` then it will be used to identify what the
current thread is in the written output
```

and
```
This function is meant to debug debug situations such as segfaults, fatal
errors, and similar.
```