### PR TITLE
gh-142732: Prevent reentrancy in `itertools.zip_longest`

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -2489,6 +2489,25 @@ class RegressionTests(unittest.TestCase):
         for j in range(2):
             next(g, None)  # shouldn't crash
 
+    def test_zip_longest_reentrancy(self):
+        class Reenter:
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                z = self.zip_longest
+                if z is None:
+                    raise StopIteration
+                self.zip_longest = None
+                next(z, None)
+                raise StopIteration
+
+        driver = Reenter()
+        driver.zip_longest = itertools.zip_longest(itertools.chain(driver), itertools.repeat(None))
+
+        with self.assertRaises(ValueError):
+            next(driver.zip_longest)
+
 
 class SubclassWithKwargsTest(unittest.TestCase):
     def test_keywords_in_subclass(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-31-16-58-14.gh-issue-142732.6Q80QA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-31-16-58-14.gh-issue-142732.6Q80QA.rst
@@ -1,1 +1,1 @@
-Now :func:`itertools.zip_longest` raises an :exc:`ValueError` when a reentrancy is detected.
+Now :func:`itertools.zip_longest` raises a :exc:`ValueError` when a reentrancy is detected.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-31-16-58-14.gh-issue-142732.6Q80QA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-31-16-58-14.gh-issue-142732.6Q80QA.rst
@@ -1,1 +1,1 @@
-Now :func:`functools.zip_longest` raises an :exc:`ValueError` when a reentrancy is detected.
+Now :func:`itertools.zip_longest` raises an :exc:`ValueError` when a reentrancy is detected.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-31-16-58-14.gh-issue-142732.6Q80QA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-31-16-58-14.gh-issue-142732.6Q80QA.rst
@@ -1,0 +1,1 @@
+Now :func:`functools.zip_longest` raises an :exc:`ValueError` when a reentrancy is detected.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3785,6 +3785,7 @@ typedef struct {
     PyObject *ittuple;                  /* tuple of iterators */
     PyObject *result;
     PyObject *fillvalue;
+    int running;
 } ziplongestobject;
 
 #define ziplongestobject_CAST(op)   ((ziplongestobject *)(op))
@@ -3854,6 +3855,7 @@ zip_longest_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     lz->numactive = tuplesize;
     lz->result = result;
     lz->fillvalue = Py_NewRef(fillvalue);
+    lz->running = 0;
     return (PyObject *)lz;
 }
 
@@ -3891,6 +3893,12 @@ zip_longest_next_lock_held(PyObject *op)
     PyObject *it;
     PyObject *item;
     PyObject *olditem;
+
+    if (lz->running == 1) {
+        PyErr_SetString(PyExc_ValueError, "zip_logest already executing");
+        return NULL;
+    }
+    lz->running = 1;
 
     if (tuplesize == 0)
         return NULL;
@@ -3950,6 +3958,7 @@ zip_longest_next_lock_held(PyObject *op)
             PyTuple_SET_ITEM(result, i, item);
         }
     }
+    lz->running = 0;
     return result;
 }
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3896,7 +3896,7 @@ zip_longest_next_lock_held(PyObject *op)
 
     if (lz->running == 1) {
         PyErr_SetString(PyExc_ValueError,
-                        "zip_logest() iterator already executing");
+                        "zip_longest() iterator already executing");
         return NULL;
     }
     lz->running = 1;

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3785,7 +3785,7 @@ typedef struct {
     PyObject *ittuple;                  /* tuple of iterators */
     PyObject *result;
     PyObject *fillvalue;
-    int running;
+    uint8_t running;
 } ziplongestobject;
 
 #define ziplongestobject_CAST(op)   ((ziplongestobject *)(op))
@@ -3895,15 +3895,20 @@ zip_longest_next_lock_held(PyObject *op)
     PyObject *olditem;
 
     if (lz->running == 1) {
-        PyErr_SetString(PyExc_ValueError, "zip_logest already executing");
+        PyErr_SetString(PyExc_ValueError,
+                        "zip_logest() iterator already executing");
         return NULL;
     }
     lz->running = 1;
 
-    if (tuplesize == 0)
-        return NULL;
-    if (lz->numactive == 0)
-        return NULL;
+    if (tuplesize == 0) {
+        result = NULL;
+        goto done;
+    }
+    if (lz->numactive == 0) {
+        result = NULL;
+        goto done;
+    }
     if (_PyObject_IsUniquelyReferenced(result)) {
         Py_INCREF(result);
         for (i=0 ; i < tuplesize ; i++) {
@@ -3917,7 +3922,8 @@ zip_longest_next_lock_held(PyObject *op)
                     if (lz->numactive == 0 || PyErr_Occurred()) {
                         lz->numactive = 0;
                         Py_DECREF(result);
-                        return NULL;
+                        result = NULL;
+                        goto done;
                     } else {
                         item = Py_NewRef(lz->fillvalue);
                         PyTuple_SET_ITEM(lz->ittuple, i, NULL);
@@ -3934,8 +3940,10 @@ zip_longest_next_lock_held(PyObject *op)
         _PyTuple_Recycle(result);
     } else {
         result = PyTuple_New(tuplesize);
-        if (result == NULL)
-            return NULL;
+        if (result == NULL) {
+            result = NULL;
+            goto done;
+        }
         for (i=0 ; i < tuplesize ; i++) {
             it = PyTuple_GET_ITEM(lz->ittuple, i);
             if (it == NULL) {
@@ -3947,7 +3955,8 @@ zip_longest_next_lock_held(PyObject *op)
                     if (lz->numactive == 0 || PyErr_Occurred()) {
                         lz->numactive = 0;
                         Py_DECREF(result);
-                        return NULL;
+                        result = NULL;
+                        goto done;
                     } else {
                         item = Py_NewRef(lz->fillvalue);
                         PyTuple_SET_ITEM(lz->ittuple, i, NULL);
@@ -3958,6 +3967,7 @@ zip_longest_next_lock_held(PyObject *op)
             PyTuple_SET_ITEM(result, i, item);
         }
     }
+done:
     lz->running = 0;
     return result;
 }


### PR DESCRIPTION
Adds a check in `itertools.zip_longest` that raises a `ValueError` when a reentrancy is detected.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142732 -->
* Issue: gh-142732
<!-- /gh-issue-number -->
