### PR TITLE
gh-89554: Document typing.ParamSpecArgs and ParamSpecKwargs as classes

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2292,8 +2292,8 @@ without the dedicated syntax, as documented below.
       * :data:`Concatenate`
       * :ref:`annotating-callables`
 
-.. data:: ParamSpecArgs
-          ParamSpecKwargs
+.. class:: ParamSpecArgs
+           ParamSpecKwargs
 
    Arguments and keyword arguments attributes of a :class:`ParamSpec`. The
    ``P.args`` attribute of a ``ParamSpec`` is an instance of ``ParamSpecArgs``,


### PR DESCRIPTION
`typing.ParamSpecArgs` and `typing.ParamSpecKwargs` are classes (the runtime types of the `args` and `kwargs` attributes of a `ParamSpec`), but the documentation marks them with the `.. data::` directive. The existing `:class:` cross-references to them in `Doc/library/typing.rst` and `Doc/whatsnew/3.10.rst` therefore resolve against a missing py:class target.

Switch the stacked entry to `.. class::` so the references resolve. Both names share a single entry, so both are covered.

Refs: gh-89554. Documentation-only change, so no `Misc/NEWS` entry (skip news).
