### PR TITLE
gh-89554: Document weakref type objects as classes

### DIFF
--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -324,17 +324,17 @@ same issues as the :meth:`WeakKeyDictionary.keyrefs` method.
    .. versionadded:: 3.4
 
 
-.. data:: ReferenceType
+.. class:: ReferenceType
 
    The type object for weak references objects.
 
 
-.. data:: ProxyType
+.. class:: ProxyType
 
    The type object for proxies of objects which are not callable.
 
 
-.. data:: CallableProxyType
+.. class:: CallableProxyType
 
    The type object for proxies of callable objects.
 


### PR DESCRIPTION
`weakref.ReferenceType`, `weakref.ProxyType`, and `weakref.CallableProxyType` are classes (the type objects for weak references and proxies), but the documentation marks them with the `.. data::` directive, so `:class:` cross-references to them cannot resolve against a py:class target.

Switch these three entries to `.. class::`. `weakref.ProxyTypes` is left as `.. data::` since it is a sequence of the proxy type objects, not a type itself.

Refs: gh-89554. Documentation-only change, so no `Misc/NEWS` entry (skip news).
