### PR TITLE
gh-89554: Document socket, thread and expat type objects as classes

### DIFF
--- a/Doc/library/_thread.rst
+++ b/Doc/library/_thread.rst
@@ -36,7 +36,7 @@ This module defines the following constants and functions:
       This is now a synonym of the built-in :exc:`RuntimeError`.
 
 
-.. data:: LockType
+.. class:: LockType
 
    This is the type of lock objects.
 

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -49,7 +49,7 @@ This module provides one exception and one type object:
    Alias for :exc:`ExpatError`.
 
 
-.. data:: XMLParserType
+.. class:: XMLParserType
 
    The type of the return values from the :func:`ParserCreate` function.
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1025,7 +1025,7 @@ The following functions all create :ref:`socket objects <socket-objects>`.
    .. versionadded:: 3.3
 
 
-.. data:: SocketType
+.. class:: SocketType
 
    This is a Python type object that represents the socket object type. It is the
    same as ``type(socket(...))``.


### PR DESCRIPTION
`socket.SocketType`, `_thread.LockType`, and `xml.parsers.expat.XMLParserType` are classes (the type objects for socket, lock, and expat parser objects), but the documentation marks them with the `.. data::` directive, so `:class:` cross-references to them cannot resolve against a py:class target.

Switch these three entries to `.. class::`.

Refs: gh-89554. Documentation-only change, so no `Misc/NEWS` entry (skip news).

These files are not covered by CODEOWNERS, so cc @vstinner (socket and _thread) and @picnixz (pyexpat), who review most changes to these modules.
