### PR TITLE
gh-89554: Document NoneType, NotImplementedType and EllipsisType as classes

### DIFF
--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -22,7 +22,7 @@ A small number of constants live in the built-in namespace.  They are:
    An object frequently used to represent the absence of a value, as when
    default arguments are not passed to a function. Assignments to ``None``
    are illegal and raise a :exc:`SyntaxError`.
-   ``None`` is the sole instance of the :data:`~types.NoneType` type.
+   ``None`` is the sole instance of the :class:`~types.NoneType` type.
 
 
 .. data:: NotImplemented
@@ -33,7 +33,7 @@ A small number of constants live in the built-in namespace.  They are:
    the other type; may be returned by the in-place binary special methods
    (e.g. :meth:`~object.__imul__`, :meth:`~object.__iand__`, etc.) for the same purpose.
    It should not be evaluated in a boolean context.
-   :data:`!NotImplemented` is the sole instance of the :data:`types.NotImplementedType` type.
+   :data:`!NotImplemented` is the sole instance of the :class:`types.NotImplementedType` type.
 
    .. note::
 
@@ -68,7 +68,7 @@ A small number of constants live in the built-in namespace.  They are:
    The same as the ellipsis literal "``...``", an object frequently used to
    indicate that something is omitted. Assignment to ``Ellipsis`` is possible, but
    assignment to  ``...`` raises a :exc:`SyntaxError`.
-   ``Ellipsis`` is the sole instance of the :data:`types.EllipsisType` type.
+   ``Ellipsis`` is the sole instance of the :class:`types.EllipsisType` type.
 
 
 .. data:: __debug__

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -143,7 +143,7 @@ If you instantiate any of these types, note that signatures may vary between Pyt
 
 Standard names are defined for the following types:
 
-.. data:: NoneType
+.. class:: NoneType
 
    The type of :data:`None`.
 
@@ -233,7 +233,7 @@ Standard names are defined for the following types:
    .. versionadded:: 3.7
 
 
-.. data:: NotImplementedType
+.. class:: NotImplementedType
 
    The type of :data:`NotImplemented`.
 
@@ -273,7 +273,7 @@ Standard names are defined for the following types:
          creating :class:`!ModuleType` instances which ensures the various
          attributes are set appropriately.
 
-.. data:: EllipsisType
+.. class:: EllipsisType
 
    The type of :data:`Ellipsis`.
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1446,8 +1446,8 @@ as a positional-only argument.
 types
 -----
 
-Reintroduce the :data:`types.EllipsisType`, :data:`types.NoneType`
-and :data:`types.NotImplementedType` classes, providing a new set
+Reintroduce the :class:`types.EllipsisType`, :class:`types.NoneType`
+and :class:`types.NotImplementedType` classes, providing a new set
 of types readily interpretable by type checkers.
 (Contributed by Bas van Beek in :issue:`41810`.)
 


### PR DESCRIPTION
`types.NoneType`, `types.NotImplementedType`, and `types.EllipsisType` are classes, but the documentation marks them with the `.. data::` directive. This part of gh-89554 is worth a separate look: unlike the descriptor and function type objects, these three are sometimes referenced as `:data:`, as the type of a singleton value such as `None`.

This proposes switching them to `.. class::`, matching the other type objects in `types.rst` and the *What's New in 3.10* entry that introduced them, which already describes them as "classes". It also updates the `:data:` references in `Doc/library/constants.rst` and `Doc/whatsnew/3.10.rst` to `:class:`.

I am happy to drop this if you would rather keep `.. data::` for the singleton-value types. It is split out from the uncontroversial cases in #150676 so the decision can be made on its own.

Refs: gh-89554. Documentation-only change, so no `Misc/NEWS` entry (skip news).

cc @AA-Turner as the `Lib/types.py` maintainer.
