### PR TITLE
RTD Previews: Get correct base branch for backports

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,19 +11,21 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3"
+  apt_packages:
+    - jq
 
   jobs:
-    post_checkout:
+    post_system_dependencies:
       # https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html#skip-builds-based-on-conditions
       #
-      # Cancel building pull requests when there aren't changes in the Doc
+      # Cancel building pull requests when there are no changes in the Doc
       # directory or RTD configuration, or if we can't cleanly merge the base
       # branch.
       - |
         set -eEux;
         if [ "$READTHEDOCS_VERSION_TYPE" = "external" ];
         then
-          base_branch=main;
+          base_branch=$(wget -qO- "https://api.github.com/repos/python/cpython/pulls/$READTHEDOCS_VERSION" | jq -er ".base.ref");
           git fetch --depth=50 origin $base_branch:origin-$base_branch;
           for attempt in $(seq 10);
           do


### PR DESCRIPTION
It is currently hard-coded to `main`, so 3.15 backports don't get previews as the merge will always fail.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
