### PR TITLE
gh-115075: Fix info about initialization of mimetypes.MimeTypes attributes

### DIFF
--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -223,30 +223,32 @@ than one MIME-type database; it provides an interface similar to the one of the
       Dictionary mapping suffixes to suffixes.  This is used to allow recognition of
       encoded files for which the encoding and the type are indicated by the same
       extension.  For example, the :file:`.tgz` extension is mapped to :file:`.tar.gz`
-      to allow the encoding and type to be recognized separately.  This is initially a
-      copy of the global :data:`suffix_map` defined in the module.
+      to allow the encoding and type to be recognized separately.
+      This is initialized with some predefined values.
 
 
    .. attribute:: MimeTypes.encodings_map
 
-      Dictionary mapping filename extensions to encoding types.  This is initially a
-      copy of the global :data:`encodings_map` defined in the module.
+      Dictionary mapping filename extensions to encoding types.
+      This is initialized with some predefined values.
 
 
    .. attribute:: MimeTypes.types_map
 
       Tuple containing two dictionaries, mapping filename extensions to MIME types:
       the first dictionary is for the non-standards types and the second one is for
-      the standard types. They are initialized by :data:`common_types` and
-      :data:`types_map`.
+      the standard types.
+      They are initialized with some predefined values and MIME type
+      information loaded from files specified by the *filenames* argument.
 
 
    .. attribute:: MimeTypes.types_map_inv
 
       Tuple containing two dictionaries, mapping MIME types to a list of filename
       extensions: the first dictionary is for the non-standards types and the
-      second one is for the standard types. They are initialized by
-      :data:`common_types` and :data:`types_map`.
+      second one is for the standard types.
+      They are initialized with some predefined values and MIME type
+      information loaded from files specified by the *filenames* argument.
 
 
    .. method:: MimeTypes.guess_extension(type, strict=True)

--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -209,7 +209,8 @@ than one MIME-type database; it provides an interface similar to the one of the
 
    This class represents a MIME-types database.  By default, it provides access to
    the same database as the rest of this module. The initial database is a copy of
-   that provided by the module, and may be extended by loading additional
+the same database as the rest of this module. The initial database is created from
+Python's built-in MIME type tables. It may be extended by loading additional
    :file:`mime.types`\ -style files into the database using the :meth:`read` or
    :meth:`readfp` methods.  The mapping dictionaries may also be cleared before
    loading additional data if the default data is not desired.

--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -208,9 +208,8 @@ than one MIME-type database; it provides an interface similar to the one of the
 .. class:: MimeTypes(filenames=(), strict=True)
 
    This class represents a MIME-types database.  By default, it provides access to
-   the same database as the rest of this module. The initial database is a copy of
-the same database as the rest of this module. The initial database is created from
-Python's built-in MIME type tables. It may be extended by loading additional
+   the same database as the rest of this module. The initial database is created from
+   Python's built-in MIME type tables. It may be extended by loading additional
    :file:`mime.types`\ -style files into the database using the :meth:`read` or
    :meth:`readfp` methods.  The mapping dictionaries may also be cleared before
    loading additional data if the default data is not desired.


### PR DESCRIPTION
They are no longer depended on the current value of global variables since Python 3.9 (see gh-49213).


<!-- gh-issue-number: gh-115075 -->
* Issue: gh-115075
<!-- /gh-issue-number -->
