### PR TITLE
gh-150693: Combine docs sections for external resources

### DIFF
--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -84,10 +84,16 @@
     <ul>
       <li class="biglink"><a class="biglink" href="https://packaging.python.org">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Resources relating to Python packaging{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="https://devguide.python.org">{% trans %}Python developer's guide{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Information on contributing to Python{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="https://peps.python.org/">{% trans %}Python Enhancement Proposals{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Index of proposed improvements to Python{% endtrans %}</span></li>
     </ul>
     <ul>
       <li class="biglink"><a class="biglink" href="https://typing.python.org">{% trans %}Static Typing with Python{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Information and guides about Python type safety{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="https://www.python.org/doc/av/">{% trans %}Audio/visual talks{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Podcasts, talks, and video presentations from the community{% endtrans %}</span></li>
     </ul>
   </div>
 

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -82,18 +82,18 @@
   <p><strong>{% trans %}Other resources:{% endtrans %}</strong></p>
   <div class="contentstable">
     <ul>
-      <li class="biglink"><a class="biglink" href="https://packaging.python.org">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Resources relating to Python packaging{% endtrans %}</span></li>
       <li class="biglink"><a class="biglink" href="https://devguide.python.org">{% trans %}Python developer's guide{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Information on contributing to Python{% endtrans %}</span></li>
-      <li class="biglink"><a class="biglink" href="https://peps.python.org/">{% trans %}Python Enhancement Proposals{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Index of proposed improvements to Python{% endtrans %}</span></li>
-    </ul>
-    <ul>
-      <li class="biglink"><a class="biglink" href="https://typing.python.org">{% trans %}Static Typing with Python{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Information and guides about Python type safety{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="https://packaging.python.org">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Resources relating to Python packaging{% endtrans %}</span></li>
       <li class="biglink"><a class="biglink" href="https://www.python.org/doc/av/">{% trans %}Audio/visual talks{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Podcasts, talks, and video presentations from the community{% endtrans %}</span></li>
+    </ul>
+    <ul>
+      <li class="biglink"><a class="biglink" href="https://peps.python.org/">{% trans %}Python Enhancement Proposals{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Index of proposed improvements to Python{% endtrans %}</span></li>
+      <li class="biglink"><a class="biglink" href="https://typing.python.org">{% trans %}Static Typing with Python{% endtrans %}</a><br>
+         <span class="linkdescr">{% trans %}Information and guides about Python type safety{% endtrans %}</span></li>
     </ul>
   </div>
 

--- a/Doc/tools/templates/indexsidebar.html
+++ b/Doc/tools/templates/indexsidebar.html
@@ -6,12 +6,3 @@
   {% include "_docs_by_version.html" without context %}
   <li><a href="https://www.python.org/doc/versions/">{% trans %}All versions{% endtrans %}</a></li>
 </ul>
-<h3>{% trans %}Other resources{% endtrans %}</h3>
-<ul>
-  {# XXX: many of these should probably be merged in the main docs #}
-  <li><a href="https://peps.python.org/">{% trans %}PEP index{% endtrans %}</a></li>
-  <li><a href="https://wiki.python.org/moin/BeginnersGuide">{% trans %}Beginner's guide{% endtrans %}</a></li>
-  <li><a href="https://wiki.python.org/moin/PythonBooks">{% trans %}Book list{% endtrans %}</a></li>
-  <li><a href="https://www.python.org/doc/av/">{% trans %}Audio/visual talks{% endtrans %}</a></li>
-  <li><a href="https://devguide.python.org/">{% trans %}Python developer’s guide{% endtrans %}</a></li>
-</ul>


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
This PR removes "Other resources" from the docs sidebar and puts all active links in the front-page section made by #150030. Note that 2 of the links from the sidebar go to the deprecated Python wiki, so I've dropped those entirely.

<!-- gh-issue-number: gh-150693 -->
* Issue: gh-150693
<!-- /gh-issue-number -->
