### PR TITLE
gh-135812: Respect ignore_cleanup_errors in TemporaryDirectory permission reset

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -922,9 +922,14 @@ class TemporaryDirectory:
                     raise
 
                 try:
-                    if path != name:
-                        _resetperms(_os.path.dirname(path))
-                    _resetperms(path)
+                    try:
+                        if path != name:
+                            _resetperms(_os.path.dirname(path))
+                        _resetperms(path)
+                    except PermissionError:
+                        if ignore_errors:
+                            return
+                        raise
 
                     try:
                         _os.unlink(path)

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1705,6 +1705,37 @@ class TestTemporaryDirectory(BaseTestCase):
                 temp_path.exists(),
                 f"TemporaryDirectory {temp_path!s} exists after cleanup")
 
+    def test_explicit_cleanup_ignore_errors_resetperms(self):
+        with tempfile.TemporaryDirectory() as working_dir:
+            temp_dir = self.do_create(
+                dir=working_dir, ignore_cleanup_errors=True)
+
+            def fake_rmtree(path, onexc):
+                onexc(os.open, path, PermissionError())
+
+            def fake_resetperms(path):
+                raise PermissionError(path)
+
+            with support.swap_attr(tempfile._shutil, "rmtree", fake_rmtree), \
+                 support.swap_attr(tempfile, "_resetperms", fake_resetperms):
+                temp_dir.cleanup()
+
+    def test_explicit_cleanup_resetperms_error(self):
+        with tempfile.TemporaryDirectory() as working_dir:
+            temp_dir = self.do_create(dir=working_dir)
+            self.addCleanup(temp_dir.cleanup)
+
+            def fake_rmtree(path, onexc):
+                onexc(os.open, path, PermissionError())
+
+            def fake_resetperms(path):
+                raise PermissionError(path)
+
+            with support.swap_attr(tempfile._shutil, "rmtree", fake_rmtree), \
+                 support.swap_attr(tempfile, "_resetperms", fake_resetperms):
+                with self.assertRaises(PermissionError):
+                    temp_dir.cleanup()
+
     @unittest.skipUnless(os.name == "nt", "Only on Windows.")
     def test_explicit_cleanup_correct_error(self):
         with tempfile.TemporaryDirectory() as working_dir:

--- a/Misc/NEWS.d/next/Library/2026-06-01-16-05-00.gh-issue-135812.TemporaryDirectory.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-01-16-05-00.gh-issue-135812.TemporaryDirectory.rst
@@ -1,0 +1,3 @@
+Fix :class:`tempfile.TemporaryDirectory` so that
+``ignore_cleanup_errors=True`` also ignores cleanup errors raised while
+resetting permissions.


### PR DESCRIPTION
Fix `tempfile.TemporaryDirectory` so that `ignore_cleanup_errors=True` also suppresses `PermissionError` raised while resetting permissions during cleanup.

Add regression tests for both ignored and non-ignored cleanup behavior.

<!-- gh-issue-number: gh-135812 -->
* Issue: gh-135812
<!-- /gh-issue-number -->
