### PR TITLE
gh-150717: Avoid mark-array allocation for groupless regex patterns

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-01-08-12-34.gh-issue-150717.LVRJXH.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-01-08-12-34.gh-issue-150717.LVRJXH.rst
@@ -1,0 +1,2 @@
+Avoid an unnecessary per-call memory allocation when matching :mod:`re`
+patterns that have no capturing groups. Patch by Bernát Gábor.

--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -548,10 +548,16 @@ state_init(SRE_STATE* state, PatternObject* pattern, PyObject* string,
 
     memset(state, 0, sizeof(SRE_STATE));
 
-    state->mark = PyMem_New(const void *, pattern->groups * 2);
-    if (!state->mark) {
-        PyErr_NoMemory();
-        goto err;
+    /* Patterns with no capturing groups never emit MARK opcodes and never
+       read state->mark (group 0's span comes from state->start/ptr), so skip
+       the allocation entirely -- state->mark stays NULL, which both the err
+       path and state_fini already free safely. */
+    if (pattern->groups) {
+        state->mark = PyMem_New(const void *, pattern->groups * 2);
+        if (!state->mark) {
+            PyErr_NoMemory();
+            goto err;
+        }
     }
     state->lastmark = -1;
     state->lastindex = -1;


### PR DESCRIPTION
Every `match`, `search`, or `fullmatch` on a pattern with no capturing groups allocates capture-group bookkeeping, then frees it without ever reading it. Group-less patterns are common in validation and scanning code.

This skips the allocation for patterns with no capturing groups. Patterns that capture stay untouched, and results are identical.

It helps validation and scanning in tight loops: checking record formats during an import with `re.match(r"\d{4}-\d{2}-\d{2}", value)`, scanning log lines with `re.search(r"ERROR|WARN", line)`, or testing many small patterns per request.

A `pyperf` comparison of base versus patched builds (script and full table in a comment below) uses the most widely used group-less patterns mined from the top-1000 PyPI packages. They run 1.03 to 1.17x faster, geometric mean 1.09x, with the short `match`/`search` cases gaining most; a capturing-group control is unchanged.

Resolves #150717.