### PR TITLE
gh-150726: validate wsgiref Headers control characters under -O

### DIFF
--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -510,15 +510,28 @@ class HeaderTests(TestCase):
                 headers = Headers()
                 self.assertRaises(ValueError, headers.__setitem__, f"key{c0}", "val")
                 self.assertRaises(ValueError, headers.add_header, f"key{c0}", "val", param="param")
+                self.assertRaises(ValueError, Headers, [(f"key{c0}", "val")])
                 # HTAB (\x09) is allowed in values, not names.
                 if c0 == "\t":
                     headers["key"] = f"val{c0}"
                     headers.add_header("key", f"val{c0}")
                     headers.setdefault(f"key", f"val{c0}")
+                    Headers([("key", f"val{c0}")])
                 else:
                     self.assertRaises(ValueError, headers.__setitem__, "key", f"val{c0}")
                     self.assertRaises(ValueError, headers.add_header, "key", f"val{c0}", param="param")
                     self.assertRaises(ValueError, headers.add_header, "key", "val", param=f"param{c0}")
+                    self.assertRaises(ValueError, Headers, [("key", f"val{c0}")])
+
+    def testConstructorValidatesWithoutDebug(self):
+        # The constructor must reject control characters even under -O, where
+        # __debug__-guarded code is skipped; the headers it is given are stored
+        # and written to the response unchanged.
+        from test.support.script_helper import assert_python_failure
+        code = ("from wsgiref.headers import Headers\n"
+                "Headers([('Foo', 'bar\\r\\nSet-Cookie: evil')])\n")
+        rc, out, err = assert_python_failure('-O', '-c', code)
+        self.assertIn(b'ValueError', err)
 
 class ErrorHandler(BaseCGIHandler):
     """Simple handler subclass for testing BaseHandler"""

--- a/Lib/wsgiref/headers.py
+++ b/Lib/wsgiref/headers.py
@@ -38,10 +38,9 @@ class Headers:
         if type(headers) is not list:
             raise TypeError("Headers must be a list of name/value tuples")
         self._headers = headers
-        if __debug__:
-            for k, v in headers:
-                self._convert_string_type(k, name=True)
-                self._convert_string_type(v, name=False)
+        for k, v in headers:
+            self._convert_string_type(k, name=True)
+            self._convert_string_type(v, name=False)
 
     def _convert_string_type(self, value, *, name):
         """Convert/check value type."""

--- a/Misc/NEWS.d/next/Security/2026-06-01-12-30-00.gh-issue-150726.Wk4Tn7.rst
+++ b/Misc/NEWS.d/next/Security/2026-06-01-12-30-00.gh-issue-150726.Wk4Tn7.rst
@@ -1,0 +1,3 @@
+:class:`wsgiref.headers.Headers` now rejects control characters in header
+names and values passed to its constructor even when Python is run with
+:option:`-O`, where the check was previously skipped.


### PR DESCRIPTION
`Headers.__init__` rejects control characters in header names and values only inside an `if __debug__:` block, so the check is dropped under `-O`/`-OO`. `BaseHandler.start_response` builds its headers through this constructor, so a CR/LF value reflected from a request passes straight to the response there, splitting it. The other mutators (`__setitem__`, `add_header`, `setdefault`) already validate unconditionally; this makes `__init__` match.

Closes #150726

<!-- gh-issue-number: gh-150726 -->
* Issue: gh-150726
<!-- /gh-issue-number -->
