### PR TITLE
gh-150720: Remove '-d 1' in test_script_error_treatment

### DIFF
--- a/Lib/test/test_profiling/test_sampling_profiler/test_integration.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_integration.py
@@ -686,8 +686,6 @@ class TestSampleProfilerErrorHandling(unittest.TestCase):
                 "-m",
                 "profiling.sampling.cli",
                 "run",
-                "-d",
-                "1",
                 script_file.name,
             ],
             capture_output=True,


### PR DESCRIPTION
Fix race condition in test_script_error_treatment in test_sampling_profiler. An overloaded system can end up running the subprocess under the test so slowly that it never reaches the point of emitting the error message when the one second duration in the profiler expires. We can just drop the `-d 1` argument to let the profiler wait until the target process finishes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-150720 -->
* Issue: gh-150720
<!-- /gh-issue-number -->
