### PR TITLE
gh-150753: check frame owner before clearing locals

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-01-18-10-00.gh-issue-150753.hZhndY.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-01-18-10-00.gh-issue-150753.hZhndY.rst
@@ -1,0 +1,1 @@
+Fix a bug where garbage collection could corrupt a live generator by clearing its locals.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1985,6 +1985,10 @@ frame_tp_clear(PyObject *op)
     Py_CLEAR(f->f_locals_cache);
     Py_CLEAR(f->f_overwritten_fast_locals);
 
+    if (f->f_frame->owner != FRAME_OWNED_BY_FRAME_OBJECT) {
+        return 0;
+    }
+
     /* locals and stack */
     _PyStackRef *locals = _PyFrame_GetLocalsArray(f->f_frame);
     _PyStackRef *sp = f->f_frame->stackpointer;


### PR DESCRIPTION
Fixes #150753.

<!-- gh-issue-number: gh-150753 -->
* Issue: gh-150753
<!-- /gh-issue-number -->
