### PR TITLE
[3.13] gh-149738: Fix segmentation fault bug in sqllite3 (#149754)

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1436,6 +1436,9 @@ Connection objects
 
       See :ref:`sqlite3-howto-row-factory` for more details.
 
+      .. versionchanged:: next
+         Deleting the ``row_factory`` attribute is no longer allowed.
+
    .. attribute:: text_factory
 
       A :term:`callable` that accepts a :class:`bytes` parameter
@@ -1444,6 +1447,9 @@ Connection objects
       By default, this attribute is set to :class:`str`.
 
       See :ref:`sqlite3-howto-encoding` for more details.
+
+      .. versionchanged:: next
+         Deleting the ``text_factory`` attribute is no longer allowed.
 
    .. attribute:: total_changes
 
@@ -1727,6 +1733,9 @@ Cursor objects
       :attr:`Connection.row_factory` of the parent connection.
 
       See :ref:`sqlite3-howto-row-factory` for more details.
+
+      .. versionchanged:: next
+         Deleting the ``row_factory`` attribute is no longer allowed.
 
 
 .. The sqlite3.Row example used to be a how-to. It has now been incorporated

--- a/Lib/test/test_sqlite3/test_factory.py
+++ b/Lib/test/test_sqlite3/test_factory.py
@@ -155,6 +155,16 @@ class RowFactoryTests(MemoryDatabaseMixin, unittest.TestCase):
         with self.assertRaises(IndexError):
             row[complex()]  # index must be int or string
 
+    def test_delete_connection_row_factory(self):
+        # gh-149738: deleting row_factory should raise an exception
+        with self.assertRaises(AttributeError):
+            del self.con.row_factory
+
+    def test_delete_connection_text_factory(self):
+        # gh-149738: deleting text_factory should raise an exception
+        with self.assertRaises(AttributeError):
+            del self.con.text_factory
+
     def test_sqlite_row_index_unicode(self):
         row = self.con.execute("select 1 as \xff").fetchone()
         self.assertEqual(row["\xff"], 1)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-05-13-06-54-41.gh-issue-149738.4BLFoH.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-05-13-06-54-41.gh-issue-149738.4BLFoH.rst
@@ -1,0 +1,2 @@
+:mod:`sqlite3`: Disallow removing ``row_factory`` and ``text_factory`` attributes
+of a connection to prevent a crash on a query.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -570,6 +570,47 @@ pysqlite_connection_cursor_impl(pysqlite_Connection *self, PyObject *factory)
     return cursor;
 }
 
+static PyObject *
+connection_get_row_factory(PyObject *op, void *closure)
+{
+    pysqlite_Connection *self = (pysqlite_Connection *)op;
+    return Py_NewRef(self->row_factory);
+}
+
+static int
+connection_set_row_factory(PyObject *op, PyObject *value, void *closure)
+{
+    pysqlite_Connection *self = (pysqlite_Connection *)op;
+    if (value == NULL) {
+        PyErr_SetString(PyExc_AttributeError,
+                        "cannot delete row_factory attribute");
+        return -1;
+    }
+    Py_XSETREF(self->row_factory, Py_NewRef(value));
+    return 0;
+}
+
+static PyObject *
+connection_get_text_factory(PyObject *op, void *closure)
+{
+    pysqlite_Connection *self = (pysqlite_Connection *)op;
+    return Py_NewRef(self->text_factory);
+}
+
+static int
+connection_set_text_factory(PyObject *op, PyObject *value, void *closure)
+{
+    pysqlite_Connection *self = (pysqlite_Connection *)op;
+    if (value == NULL) {
+        PyErr_SetString(PyExc_AttributeError,
+                        "cannot delete text_factory attribute");
+        return -1;
+    }
+    Py_XSETREF(self->text_factory, Py_NewRef(value));
+    return 0;
+}
+
+
 /*[clinic input]
 _sqlite3.Connection.blobopen as blobopen
 
@@ -2631,6 +2672,10 @@ static PyGetSetDef connection_getset[] = {
     {"in_transaction",  (getter)pysqlite_connection_get_in_transaction, (setter)0},
     {"autocommit",  (getter)get_autocommit, (setter)set_autocommit},
     {"__text_signature__", get_sig, (setter)0},
+    {"row_factory", connection_get_row_factory,
+                    connection_set_row_factory},
+    {"text_factory", connection_get_text_factory,
+                     connection_set_text_factory},
     {NULL}
 };
 
@@ -2678,8 +2723,6 @@ static struct PyMemberDef connection_members[] =
     {"InternalError", _Py_T_OBJECT, offsetof(pysqlite_Connection, InternalError), Py_READONLY},
     {"ProgrammingError", _Py_T_OBJECT, offsetof(pysqlite_Connection, ProgrammingError), Py_READONLY},
     {"NotSupportedError", _Py_T_OBJECT, offsetof(pysqlite_Connection, NotSupportedError), Py_READONLY},
-    {"row_factory", _Py_T_OBJECT, offsetof(pysqlite_Connection, row_factory)},
-    {"text_factory", _Py_T_OBJECT, offsetof(pysqlite_Connection, text_factory)},
     {NULL}
 };
 


### PR DESCRIPTION
Deleting the `row_factory` or `text_factory` attribute is no longer allowed.

For the 3.13 backport, I fixed a conflict on connection_getset array.

(cherry picked from commit 60fdb3192b897168ec0418fb0ea6c8d2d49ea513)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149738 -->
* Issue: gh-149738
<!-- /gh-issue-number -->
