### PR TITLE
Silence experimental coroutine deprecation warnings

### DIFF
--- a/PC/python_uwp.cpp
+++ b/PC/python_uwp.cpp
@@ -13,6 +13,7 @@
 #if defined(__clang__)
 #define _SILENCE_CLANG_COROUTINE_MESSAGE
 #endif
+#define _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS
 
 #include <appmodel.h>
 #include <winrt\Windows.ApplicationModel.h>


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The Windows release build fails for today's 3.15 beta 2:

```
C:\...\MSVC\14.51.36231\include\experimental\coroutine(37,1): error C2338:
static assertion failed: 'error STL1011: The /await compiler option,
<experimental/coroutine>, <experimental/generator>, and <experimental/resumable>
are deprecated by Microsoft and will be REMOVED SOON. ... You can define
_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS to suppress this error for now.'
```

https://dev.azure.com/Python/cpython/_build/results?buildId=170819&view=logs&j=0108ec1a-385a-59f8-f3cd-2c3a968973ca&t=e19eaefe-6260-5118-3fc8-77764c035640

Here's Claude's summary, and it affects more than free-threaded debug AMD64. This PR does fix number 1.

---

**Build:** Azure Pipelines build 170819 (Python 3.15.0b2, free-threaded debug AMD64), 2026-06-02.

## Symptom

`python_uwp.vcxproj` fails at the very end of the build:

```
C:\...\MSVC\14.51.36231\include\experimental\coroutine(37,1): error C2338:
static assertion failed: 'error STL1011: The /await compiler option,
<experimental/coroutine>, <experimental/generator>, and <experimental/resumable>
are deprecated by Microsoft and will be REMOVED SOON. ... You can define
_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS to suppress this error for now.'
```

## Root cause

Toolchain bump on the agent image — **not** a code regression.

| Build | Date | Toolchain | Result |
|---|---|---|---|
| Previous | 2026-05-10 | VS 2022 / MSVC **14.44.35207** | ✅ passes (deprecation = warning) |
| Failing | 2026-06-02 | VS 18 / MSVC **14.51.36231** | ❌ fails (deprecation = `static_assert`) |

`PC/python_uwp.cpp` transitively pulls in `<experimental/coroutine>` via its `<winrt/...>` includes under
 `/std:c++17`. The file already silences the clang-equivalent warning but has **no MSVC silencer**.

## Why the toolchain changed

`windows-release/azure-pipelines.yml:174` (added in release-tools **PR https://github.com/python/release-tools/pull/346**, *Support optionally
building AMD64 with tailcalling*) routes tail-calling builds to the `windows-2025-vs2026` agent image,
which ships VS 18:

```yaml
vmImage: ${{ iif(eq(parameters.DoTailCalling, 'true'),
                  'windows-2025-vs2026',
                  parameters.vmImage) }}
```

Non-tailcall builds still go to the default `windows-2025` (VS 2022) image and are unaffected.

## Fix options (upstream CPython, not release-tools)

1. **Quick** — add `_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` to `PC/python_uwp.cpp`
(matching the existing clang silencer) or to the preprocessor defines in `PCbuild/python_uwp.vcxproj` and
 `PCbuild/pythonw_uwp.vcxproj`.
2. **Proper** — bump those two vcxprojs from `/std:c++17` to `/std:c++20`; modern C++/WinRT uses the
standard `<coroutine>` header in C++20 mode. `PCbuild/_wmi.vcxproj` is already on C++20.

## Workaround to ship now

Queue the release build **without** `DoTailCalling=true` so it lands on the VS 2022 agent.