### PR TITLE
gh-141510 Document and test frozendict class matching behaviour

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1172,6 +1172,7 @@ subject value:
    * :class:`bytes`
    * :class:`dict`
    * :class:`float`
+   * :class:`frozendict`
    * :class:`frozenset`
    * :class:`int`
    * :class:`list`

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -2852,7 +2852,7 @@ class TestPatma(unittest.TestCase):
         self.assertEqual(x, 0)
         self.assertEqual(y, 1)
 
-    def test_patma_267(self):
+    def test_patma_frozendict_class_self(self):
         x = frozendict()
         match x:
             case frozendict(z):

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -2852,6 +2852,15 @@ class TestPatma(unittest.TestCase):
         self.assertEqual(x, 0)
         self.assertEqual(y, 1)
 
+    def test_patma_267(self):
+        x = frozendict()
+        match x:
+            case frozendict(z):
+                y = 0
+        self.assertEqual(x, frozendict())
+        self.assertEqual(y, 0)
+        self.assertIs(z, x)
+
     def test_patma_runtime_checkable_protocol(self):
         # Runtime-checkable protocol
         from typing import Protocol, runtime_checkable


### PR DESCRIPTION
Frozendict has `_Py_TPFLAGS_MATCH_SELF` set so works correctly with the single-arg class matching. However it isn't documented in the list of classes this works with and it isn't tested.

The test is some way below the other similar tests but anything else would need a large renumbering

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-58370 -->
* Issue: gh-58370
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-141510 -->
* Issue: gh-141510
<!-- /gh-issue-number -->
