### PR TITLE
Add link to new security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,17 +1,24 @@
 # Security Policy
 
-## Supported Versions
+Python [provides a security policy and threat model](https://devguide.python.org/security/policy/)
+in the Python Development Guide documenting what bugs are vulnerabilities,
+how to structure reports, and what versions of Python accept reports.
 
-The Python team applies security fixes according to the table
-in [the devguide](
-https://devguide.python.org/versions/#supported-versions
-).
+Python Security Response Team (PSRT) members
+balance security work against many other responsibilities. Please be thoughtful
+about the time and attention your report requires. Repeated failure to respect
+the security policy will result in future reports being rejected, or the
+reporter being banned from the ``python`` GitHub organization, regardless of
+technical merit.
 
 ## Reporting a Vulnerability
 
-Please read the guidelines on reporting security issues [on the
-official website](https://www.python.org/dev/security/) for
-instructions on how to report a security-related problem to
-the Python team responsibly.
+The [Python security policy](https://devguide.python.org/security/policy/)
+documents [how to submit a vulnerability report](https://devguide.python.org/security/policy/#how-to-submit-a-vulnerability-report)
+using GitHub Security Advisories. Please read the security policy
+prior to filing a vulnerability report, especially the section on [what information to
+include and exclude](https://devguide.python.org/security/policy/#what-to-include-and-how-to-structure-a-vulnerability-report)
+in vulnerability reports. Following the security policy means the PSRT can
+quickly and efficiently triage your report, not following the security policy
+will only delay triaging your report.
 
-To reach the response team, email `security at python dot org`.


### PR DESCRIPTION
Adds a link to the new security policy available in the Developers Guide. cc @python/psrt