### PR TITLE
gh-150737: Optimize bytecode for empty unpack cases such as ``{*()}``.

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1119,6 +1119,139 @@ class TestSpecifics(unittest.TestCase):
                 self.assertIn('LOAD_', opcodes[-2].opname)
                 self.assertEqual('RETURN_VALUE', opcodes[-1].opname)
 
+    def test_empty_set_unpack_literal_bytecode_optimization(self):
+        cases = {
+            # optimized cases
+            '{*()}': [
+                ('RESUME', 0),
+                ('BUILD_SET', 0),
+                ('RETURN_VALUE', None),
+            ],
+            '{*(), 1}': [
+                ('RESUME', 0),
+                ('LOAD_SMALL_INT', 1),
+                ('BUILD_SET', 1),
+                ('RETURN_VALUE', None),
+            ],
+            '{*(), 1, 2, 3}': [
+                ('RESUME', 0),
+                ('BUILD_SET', 0),
+                ('LOAD_CONST', frozenset({1, 2, 3})),
+                ('SET_UPDATE', 1),
+                ('RETURN_VALUE', None),
+            ],
+            # unoptimized cases
+            '{*(1,)}': [
+                ('RESUME', 0),
+                ('BUILD_SET', 0),
+                ('LOAD_CONST', (1,)),
+                ('SET_UPDATE', 1),
+                ('RETURN_VALUE', None),
+            ],
+            '{*(x,)}': [
+                ('RESUME', 0),
+                ('BUILD_SET', 0),
+                ('LOAD_NAME', 'x'),
+                ('BUILD_TUPLE', 1),
+                ('SET_UPDATE', 1),
+                ('RETURN_VALUE', None),
+            ],
+            '{1, *()}': [
+                ('RESUME', 0),
+                ('LOAD_SMALL_INT', 1),
+                ('BUILD_SET', 1),
+                ('LOAD_COMMON_CONSTANT', ()),
+                ('SET_UPDATE', 1),
+                ('RETURN_VALUE', None),
+            ],
+            '{1, 2, 3, *()}': [
+                ('RESUME', 0),
+                ('BUILD_SET', 0),
+                ('LOAD_CONST', frozenset({1, 2, 3})),
+                ('SET_UPDATE', 1),
+                ('LOAD_COMMON_CONSTANT', ()),
+                ('SET_UPDATE', 1),
+                ('RETURN_VALUE', None),
+            ],
+        }
+
+        for source, expected in cases.items():
+            with self.subTest(source=source):
+                code = compile(source, '<test>', 'eval')
+                instructions = [
+                    (instruction.opname, instruction.argval)
+                    for instruction in dis.get_instructions(code)
+                ]
+                self.assertEqual(instructions, expected)
+
+    def test_empty_leading_tuple_unpack_list_and_tuple_bytecode_optimization(self):
+        cases = {
+            # optimized cases
+            '[*()]': [
+                ('RESUME', 0),
+                ('BUILD_LIST', 0),
+                ('RETURN_VALUE', None),
+            ],
+            '[*(), 1]': [
+                ('RESUME', 0),
+                ('LOAD_SMALL_INT', 1),
+                ('BUILD_LIST', 1),
+                ('RETURN_VALUE', None),
+            ],
+            '(*(),)': [
+                ('RESUME', 0),
+                ('LOAD_COMMON_CONSTANT', ()),
+                ('RETURN_VALUE', None),
+            ],
+            '(*(), 1)': [
+                ('RESUME', 0),
+                ('LOAD_CONST', (1,)),
+                ('RETURN_VALUE', None),
+            ],
+            # unoptimized cases
+            '[*(1,)]': [
+                ('RESUME', 0),
+                ('BUILD_LIST', 0),
+                ('LOAD_CONST', (1,)),
+                ('LIST_EXTEND', 1),
+                ('RETURN_VALUE', None),
+            ],
+            '[*(x,)]': [
+                ('RESUME', 0),
+                ('BUILD_LIST', 0),
+                ('LOAD_NAME', 'x'),
+                ('BUILD_TUPLE', 1),
+                ('LIST_EXTEND', 1),
+                ('RETURN_VALUE', None),
+            ],
+            '[1, *()]': [
+                ('RESUME', 0),
+                ('LOAD_SMALL_INT', 1),
+                ('BUILD_LIST', 1),
+                ('LOAD_COMMON_CONSTANT', ()),
+                ('LIST_EXTEND', 1),
+                ('RETURN_VALUE', None),
+            ],
+            '[1, 2, 3, *()]': [
+                ('RESUME', 0),
+                ('BUILD_LIST', 0),
+                ('LOAD_CONST', (1, 2, 3)),
+                ('LIST_EXTEND', 1),
+                ('LOAD_COMMON_CONSTANT', ()),
+                ('LIST_EXTEND', 1),
+                ('RETURN_VALUE', None),
+            ],
+        }
+
+        for source, expected in cases.items():
+            with self.subTest(source=source):
+                code = compile(source, '<test>', 'eval')
+                instructions = [
+                    (instruction.opname, instruction.argval)
+                    for instruction in dis.get_instructions(code)
+                ]
+                self.assertEqual(instructions, expected)
+
     def test_imported_load_method(self):
         sources = [
             """\

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-02-16-21-02.gh-issue-150737.LoYUFY.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-02-16-21-02.gh-issue-150737.LoYUFY.rst
@@ -1,0 +1,2 @@
+Optimize bytecode for leading null unpack cases such as the ``ast.unparse``
+empty set representation.

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -3414,13 +3414,15 @@ codegen_boolop(compiler *c, expr_ty e)
 
 static int
 starunpack_helper_impl(compiler *c, location loc,
-                       asdl_expr_seq *elts, PyObject *injected_arg, int pushed,
+                       asdl_expr_seq *elts, Py_ssize_t start,
+                       PyObject *injected_arg, int pushed,
                        int build, int add, int extend, int tuple)
 {
-    Py_ssize_t n = asdl_seq_LEN(elts);
+    Py_ssize_t end = asdl_seq_LEN(elts);
+    Py_ssize_t n = end - start;
     int big = n + pushed + (injected_arg ? 1 : 0) > _PY_STACK_USE_GUIDELINE;
     int seen_star = 0;
-    for (Py_ssize_t i = 0; i < n; i++) {
+    for (Py_ssize_t i = start; i < end; i++) {
         expr_ty elt = asdl_seq_GET(elts, i);
         if (elt->kind == Starred_kind) {
             seen_star = 1;
@@ -3428,7 +3430,7 @@ starunpack_helper_impl(compiler *c, location loc,
         }
     }
     if (!seen_star && !big) {
-        for (Py_ssize_t i = 0; i < n; i++) {
+        for (Py_ssize_t i = start; i < end; i++) {
             expr_ty elt = asdl_seq_GET(elts, i);
             VISIT(c, expr, elt);
         }
@@ -3448,7 +3450,7 @@ starunpack_helper_impl(compiler *c, location loc,
         ADDOP_I(c, loc, build, pushed);
         sequence_built = 1;
     }
-    for (Py_ssize_t i = 0; i < n; i++) {
+    for (Py_ssize_t i = start; i < end; i++) {
         expr_ty elt = asdl_seq_GET(elts, i);
         if (elt->kind == Starred_kind) {
             if (sequence_built == 0) {
@@ -3476,12 +3478,25 @@ starunpack_helper_impl(compiler *c, location loc,
     return SUCCESS;
 }
 
+static bool
+is_empty_starred_tuple(expr_ty elt)
+{
+    if (elt->kind != Starred_kind) {
+        return false;
+    }
+    expr_ty value = elt->v.Starred.value;
+    return value->kind == Tuple_kind &&
+           value->v.Tuple.ctx == Load &&
+           asdl_seq_LEN(value->v.Tuple.elts) == 0;
+}
+
 static int
 starunpack_helper(compiler *c, location loc,
                   asdl_expr_seq *elts, int pushed,
                   int build, int add, int extend, int tuple)
 {
-    return starunpack_helper_impl(c, loc, elts, NULL, pushed,
+    Py_ssize_t start = asdl_seq_LEN(elts) && is_empty_starred_tuple(asdl_seq_GET(elts, 0));
+    return starunpack_helper_impl(c, loc, elts, start, NULL, pushed,
                                   build, add, extend, tuple);
 }
 
@@ -4446,7 +4461,7 @@ ex_call:
         VISIT(c, expr, ((expr_ty)asdl_seq_GET(args, 0))->v.Starred.value);
     }
     else {
-        RETURN_IF_ERROR(starunpack_helper_impl(c, loc, args, injected_arg, n,
+        RETURN_IF_ERROR(starunpack_helper_impl(c, loc, args, 0, injected_arg, n,
                                                BUILD_LIST, LIST_APPEND, LIST_EXTEND, 1));
     }
     /* Then keyword arguments */


### PR DESCRIPTION
This is preferred implementation of the proposal in issue.

This change strives to be as self contained as possible but requires adding `starunpack_helper_impl(..., start, ...)` argument to support `elts` slice to ignore leading AST starred node.

Less intrusive alternate implementation can be viewed here (suboptimal since it operates without AST, slight behavioral differences shown in the tests): https://github.com/python/cpython/commit/f857d88ef3aac90deadf438625211040e73df832#diff-3cbf15668c31488528b7ab0f903c674a0ecf550f4f53c1be6cf8cd965246c2a0


<!-- gh-issue-number: gh-150737 -->
* Issue: gh-150737
<!-- /gh-issue-number -->
