### PR TITLE
gh-150815: Speed up copy.deepcopy() of containers with atomic elements

### DIFF
--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -118,13 +118,18 @@ def deepcopy(x, memo=None):
     if cls in _atomic_types:
         return x
 
-    d = id(x)
     if memo is None:
         memo = {}
-    else:
-        y = memo.get(d, None)
-        if y is not None:
-            return y
+    return _deepcopy_fallback(x, memo, cls)
+
+
+def _deepcopy_fallback(x, memo, cls):
+    # Deep-copy a value already known to be non-atomic, with its type already
+    # computed by the caller, so type(x) is evaluated exactly once per element.
+    d = id(x)
+    y = memo.get(d, None)
+    if y is not None:
+        return y
 
     copier = _deepcopy_dispatch.get(cls)
     if copier is not None:
@@ -173,16 +178,18 @@ def _deepcopy_list(x, memo, deepcopy=deepcopy):
     y = []
     memo[id(x)] = y
     append = y.append
+    fallback = _deepcopy_fallback
+    atomic = _atomic_types
     for a in x:
-        # Inline the atomic-type check so atomic elements (int, str, None, ...)
-        # skip the deepcopy() call overhead entirely; deepcopy() would just
-        # return them unchanged after the same check.
-        append(a if type(a) in _atomic_types else deepcopy(a, memo))
+        cls = type(a)
+        append(a if cls in atomic else fallback(a, memo, cls))
     return y
 d[list] = _deepcopy_list
 
 def _deepcopy_tuple(x, memo, deepcopy=deepcopy):
-    y = [a if type(a) in _atomic_types else deepcopy(a, memo) for a in x]
+    atomic = _atomic_types
+    fallback = _deepcopy_fallback
+    y = [a if (cls := type(a)) in atomic else fallback(a, memo, cls) for a in x]
     # We're not going to put the tuple in the memo, but it's still important we
     # check for it, in case the tuple contains recursive mutable structures.
     try:
@@ -201,19 +208,25 @@ d[tuple] = _deepcopy_tuple
 def _deepcopy_dict(x, memo, deepcopy=deepcopy):
     y = {}
     memo[id(x)] = y
+    atomic = _atomic_types
+    fallback = _deepcopy_fallback
     for key, value in x.items():
-        # Inline the atomic-type check for keys and values: atomic objects
-        # (str keys, int/str/None values, ...) are returned as-is by
-        # deepcopy(), so skip the per-item call in that common case.
-        y[key if type(key) in _atomic_types else deepcopy(key, memo)] = (
-            value if type(value) in _atomic_types else deepcopy(value, memo))
+        kc = type(key)
+        vc = type(value)
+        y[key if kc in atomic else fallback(key, memo, kc)] = (
+            value if vc in atomic else fallback(value, memo, vc))
     return y
 d[dict] = _deepcopy_dict
 
 def _deepcopy_frozendict(x, memo, deepcopy=deepcopy):
     y = {}
+    atomic = _atomic_types
+    fallback = _deepcopy_fallback
     for key, value in x.items():
-        y[deepcopy(key, memo)] = deepcopy(value, memo)
+        kc = type(key)
+        vc = type(value)
+        y[key if kc in atomic else fallback(key, memo, kc)] = (
+            value if vc in atomic else fallback(value, memo, vc))
 
     # We're not going to put the frozendict in the memo, but it's still
     # important we check for it, in case the frozendict contains recursive

--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -169,17 +169,20 @@ _atomic_types = frozenset({types.NoneType, types.EllipsisType, types.NotImplemen
 _deepcopy_dispatch = d = {}
 
 
-def _deepcopy_list(x, memo, deepcopy=deepcopy):
+def _deepcopy_list(x, memo, deepcopy=deepcopy, _atomic=_atomic_types):
     y = []
     memo[id(x)] = y
     append = y.append
     for a in x:
-        append(deepcopy(a, memo))
+        # Inline the atomic-type check so atomic elements (int, str, None, ...)
+        # skip the deepcopy() call overhead entirely; deepcopy() would just
+        # return them unchanged after the same check.
+        append(a if type(a) in _atomic else deepcopy(a, memo))
     return y
 d[list] = _deepcopy_list
 
-def _deepcopy_tuple(x, memo, deepcopy=deepcopy):
-    y = [deepcopy(a, memo) for a in x]
+def _deepcopy_tuple(x, memo, deepcopy=deepcopy, _atomic=_atomic_types):
+    y = [a if type(a) in _atomic else deepcopy(a, memo) for a in x]
     # We're not going to put the tuple in the memo, but it's still important we
     # check for it, in case the tuple contains recursive mutable structures.
     try:
@@ -195,11 +198,15 @@ def _deepcopy_tuple(x, memo, deepcopy=deepcopy):
     return y
 d[tuple] = _deepcopy_tuple
 
-def _deepcopy_dict(x, memo, deepcopy=deepcopy):
+def _deepcopy_dict(x, memo, deepcopy=deepcopy, _atomic=_atomic_types):
     y = {}
     memo[id(x)] = y
     for key, value in x.items():
-        y[deepcopy(key, memo)] = deepcopy(value, memo)
+        # Inline the atomic-type check for keys and values: atomic objects
+        # (str keys, int/str/None values, ...) are returned as-is by
+        # deepcopy(), so skip the per-item call in that common case.
+        y[key if type(key) in _atomic else deepcopy(key, memo)] = (
+            value if type(value) in _atomic else deepcopy(value, memo))
     return y
 d[dict] = _deepcopy_dict
 

--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -169,7 +169,7 @@ _atomic_types = frozenset({types.NoneType, types.EllipsisType, types.NotImplemen
 _deepcopy_dispatch = d = {}
 
 
-def _deepcopy_list(x, memo, deepcopy=deepcopy, _atomic=_atomic_types):
+def _deepcopy_list(x, memo, deepcopy=deepcopy):
     y = []
     memo[id(x)] = y
     append = y.append
@@ -177,12 +177,12 @@ def _deepcopy_list(x, memo, deepcopy=deepcopy, _atomic=_atomic_types):
         # Inline the atomic-type check so atomic elements (int, str, None, ...)
         # skip the deepcopy() call overhead entirely; deepcopy() would just
         # return them unchanged after the same check.
-        append(a if type(a) in _atomic else deepcopy(a, memo))
+        append(a if type(a) in _atomic_types else deepcopy(a, memo))
     return y
 d[list] = _deepcopy_list
 
-def _deepcopy_tuple(x, memo, deepcopy=deepcopy, _atomic=_atomic_types):
-    y = [a if type(a) in _atomic else deepcopy(a, memo) for a in x]
+def _deepcopy_tuple(x, memo, deepcopy=deepcopy):
+    y = [a if type(a) in _atomic_types else deepcopy(a, memo) for a in x]
     # We're not going to put the tuple in the memo, but it's still important we
     # check for it, in case the tuple contains recursive mutable structures.
     try:
@@ -198,15 +198,15 @@ def _deepcopy_tuple(x, memo, deepcopy=deepcopy, _atomic=_atomic_types):
     return y
 d[tuple] = _deepcopy_tuple
 
-def _deepcopy_dict(x, memo, deepcopy=deepcopy, _atomic=_atomic_types):
+def _deepcopy_dict(x, memo, deepcopy=deepcopy):
     y = {}
     memo[id(x)] = y
     for key, value in x.items():
         # Inline the atomic-type check for keys and values: atomic objects
         # (str keys, int/str/None values, ...) are returned as-is by
         # deepcopy(), so skip the per-item call in that common case.
-        y[key if type(key) in _atomic else deepcopy(key, memo)] = (
-            value if type(value) in _atomic else deepcopy(value, memo))
+        y[key if type(key) in _atomic_types else deepcopy(key, memo)] = (
+            value if type(value) in _atomic_types else deepcopy(value, memo))
     return y
 d[dict] = _deepcopy_dict
 

--- a/Misc/NEWS.d/next/Library/2026-06-02-15-44-55.gh-issue-150815.LLaYtD.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-02-15-44-55.gh-issue-150815.LLaYtD.rst
@@ -1,0 +1,4 @@
+Speed up :func:`copy.deepcopy` of :class:`dict`, :class:`list` and
+:class:`tuple` containers whose elements are atomic immutable objects, by
+skipping the per-element recursive call for those elements. Patch by Bernát
+Gábor.


### PR DESCRIPTION
`copy.deepcopy()` copies a structure by sending every element back through `deepcopy()`. For elements that need no copying at all — strings, ints, `None`, booleans, floats and the other immutable atomic types — that round trip costs a full function call each, even though the value handed back is the same object. Real data is dominated by these atomic leaves: a parsed JSON document, a settings dict cloned before mutation, a record copied inside a framework. The keys are strings and most values are strings and numbers, so copying spends most of its time calling `deepcopy()` only to get the same object straight back.

This folds the atomic-type check that already gates the top of `deepcopy()` into the `dict`, `list` and `tuple` copiers, so an atomic element is returned as-is without the per-item call. The check is the same one `deepcopy()` runs, and atomic objects are not memoized either way, so the result is identical for shared references, recursive structures and `int`/`tuple` subclasses.

Deep-copying 105 JSON documents drawn from the top-1000 PyPI projects improves from 1.21 ms to 990 µs, 22% faster. This follows the atomic fast path added in gh-114264, extending it from the entry point to the per-element loop.

| Benchmark | base | patched |
|---|---|---|
| deepcopy 105 real corpus JSON objects | 1.21 ms | 990 µs: **22% faster** |

<details><summary>Benchmark (pyperf)</summary>

Run base vs patched by swapping `Lib/copy.py` on the same interpreter. The figure above is from 105 JSON documents in the top-1000 PyPI corpus; the self-contained script below builds an equivalent atomic-heavy structure and shows a comparable percentage gain.

```python
import copy, pyperf

# Representative of parsed-JSON / config data: string keys, scalar leaves.
doc = {
    "name": "example-package", "version": "1.2.3", "private": False,
    "scripts": {"build": "tsc", "test": "pytest", "lint": "ruff check ."},
    "keywords": ["cli", "async", "http", "json"],
    "dependencies": {f"dep{i}": f"^{i}.0.0" for i in range(20)},
    "authors": [{"name": f"Person {i}", "email": f"p{i}@example.com", "active": True} for i in range(10)],
    "config": {"timeout": 30, "retries": 3, "verbose": False, "level": None},
}
objs = [doc] * 50

runner = pyperf.Runner()
runner.bench_func("deepcopy atomic-heavy structures", lambda: [copy.deepcopy(o) for o in objs])
```
</details>

Resolves #150815.


<!-- gh-issue-number: gh-150815 -->
* Issue: gh-150815
<!-- /gh-issue-number -->
