### PR TITLE
gh-150817: Speed up Flag bitwise operations

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1620,10 +1620,14 @@ class Flag(Enum, boundary=STRICT):
         if other_value is NotImplemented:
             return NotImplemented
 
-        for flag in self, other:
-            if self._get_value(flag) is None:
-                raise TypeError(f"'{flag}' cannot be combined with other flags with |")
         value = self._value_
+        # _get_value(self) is self._value_ and _get_value(other) is
+        # other_value, so only walk the operands (to raise on the offending
+        # flag) when one of those values is actually None.
+        if value is None or other_value is None:
+            for flag in self, other:
+                if self._get_value(flag) is None:
+                    raise TypeError(f"'{flag}' cannot be combined with other flags with |")
         return self.__class__(value | other_value)
 
     def __and__(self, other):
@@ -1631,10 +1635,11 @@ class Flag(Enum, boundary=STRICT):
         if other_value is NotImplemented:
             return NotImplemented
 
-        for flag in self, other:
-            if self._get_value(flag) is None:
-                raise TypeError(f"'{flag}' cannot be combined with other flags with &")
         value = self._value_
+        if value is None or other_value is None:
+            for flag in self, other:
+                if self._get_value(flag) is None:
+                    raise TypeError(f"'{flag}' cannot be combined with other flags with &")
         return self.__class__(value & other_value)
 
     def __xor__(self, other):
@@ -1642,10 +1647,11 @@ class Flag(Enum, boundary=STRICT):
         if other_value is NotImplemented:
             return NotImplemented
 
-        for flag in self, other:
-            if self._get_value(flag) is None:
-                raise TypeError(f"'{flag}' cannot be combined with other flags with ^")
         value = self._value_
+        if value is None or other_value is None:
+            for flag in self, other:
+                if self._get_value(flag) is None:
+                    raise TypeError(f"'{flag}' cannot be combined with other flags with ^")
         return self.__class__(value ^ other_value)
 
     def __invert__(self):

--- a/Misc/NEWS.d/next/Library/2026-06-02-15-44-57.gh-issue-150817.lpFCh0.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-02-15-44-57.gh-issue-150817.lpFCh0.rst
@@ -1,0 +1,2 @@
+Speed up the ``|``, ``&`` and ``^`` operations on :class:`enum.Flag` members.
+Patch by Bernát Gábor.


### PR DESCRIPTION
Combining `Flag` members with `|`, `&` and `^` walks both operands on every call to check that neither carries a `None` value, raising a clear `TypeError` when one does. That check only matters in the rare case where a value really is `None`; for every normal combination of two valid flags it adds work to each operation. Flag arithmetic is hot wherever flags model option sets — the `re` module's own flags are an `IntFlag`, so each `re.compile(pattern, re.I | re.M)` combines them, and permission systems, feature toggles and styling layers do the same in tight loops.

The two values the guard inspects are already in hand: one is the member's own value, the other is the operand value computed just above. This runs the scan over the operands only when one of those is actually `None`, so a valid combination skips it entirely. The offending-flag walk, the `TypeError` and its message are unchanged for the invalid cases.

Running flag combinations mined from the top-1000 corpus, including the `re` flag sets, improves from 72.6 µs to 49.5 µs, 47% faster.

| Benchmark | base | patched |
|---|---|---|
| re.RegexFlag combine/and/in | 56.5 µs | 38.5 µs: **47% faster** |
| IntFlag or/and/xor/in | 72.6 µs | 49.5 µs: **47% faster** |

<details><summary>Benchmark (pyperf)</summary>

Run base vs patched by swapping `Lib/enum.py` on the same interpreter. The flag combinations are real `re` flag sets mined from the top-1000 corpus.

```python
import re, functools, operator, pyperf

combos_str = ["re.DOTALL|re.I", "re.DOTALL|re.M", "re.DOTALL|re.VERBOSE",
    "re.DOTALL|re.VERBOSE|re.M", "re.IGNORECASE|re.VERBOSE", "re.I|re.M",
    "re.I|re.S", "re.I|re.S|re.X", "re.MULTILINE|re.DOTALL",
    "re.MULTILINE|re.DOTALL|re.VERBOSE", "re.M|re.S", "re.S|re.M",
    "re.VERBOSE|re.I", "re.VERBOSE|re.M"]
M = {"I": re.I, "IGNORECASE": re.I, "M": re.M, "MULTILINE": re.M, "S": re.S,
     "DOTALL": re.S, "X": re.X, "VERBOSE": re.X, "A": re.A, "ASCII": re.A}
combos = [[M[p.split(".")[1]] for p in c.split("|")] for c in combos_str]

def run():
    for flags in combos:
        combined = functools.reduce(operator.or_, flags)
        flags[0] in combined

runner = pyperf.Runner()
runner.bench_func("re.RegexFlag combine %d real corpus combos" % len(combos), run)
```
</details>

Resolves #150817.
