### PR TITLE
gh-150818: Speed up logging.getLogger() for existing loggers (GH-150825)

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1373,9 +1373,17 @@ class Manager(object):
         logger and fix up the parent/child references which pointed to the
         placeholder to now point to the logger.
         """
-        rv = None
         if not isinstance(name, str):
             raise TypeError('A logger name must be a string')
+        # Fast path: an already-registered, non-placeholder logger can be
+        # returned without taking the lock. dict.get() is atomic under both
+        # the GIL and free threading, and a Logger is fully initialised before
+        # being inserted into loggerDict under the lock, so this never sees a
+        # partially-constructed object.
+        rv = self.loggerDict.get(name)
+        if rv is not None and not isinstance(rv, PlaceHolder):
+            return rv
+        rv = None
         with _lock:
             if name in self.loggerDict:
                 rv = self.loggerDict[name]

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1383,7 +1383,6 @@ class Manager(object):
         rv = self.loggerDict.get(name)
         if rv is not None and not isinstance(rv, PlaceHolder):
             return rv
-        rv = None
         with _lock:
             if name in self.loggerDict:
                 rv = self.loggerDict[name]

--- a/Misc/NEWS.d/next/Library/2026-06-02-15-44-58.gh-issue-150818.Orcefu.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-02-15-44-58.gh-issue-150818.Orcefu.rst
@@ -1,0 +1,3 @@
+Speed up :func:`logging.getLogger` with a lock-free fast path that returns an
+already-registered logger without acquiring the logging lock. Patch by Bernát
+Gábor.


### PR DESCRIPTION
`logging.getLogger(name)` returns the singleton logger for a name, creating it on first use. Every call takes the logging lock, even the overwhelmingly common case where the logger already exists and is returned unchanged. Libraries fetch their logger by name throughout their code, at module import and again inside functions, so the same handful of names are looked up over and over for the life of a process. Those repeat lookups are pure overhead: the logger is already there.

This returns an existing, fully-initialised logger through a lock-free fast path before falling back to the locked section. The fast path reads `loggerDict` with a single `dict.get()`, which is atomic under both the GIL and free threading, and a `Logger` is inserted into that dict only after it is fully constructed under the lock, so the fast path never observes a half-built object or a placeholder. First-time creation, placeholder resolution and the parent/child wiring still run under the lock exactly as before.

Resolving logger names collected from the top-1000 corpus improves from 6.68 µs to 5.02 µs, 33% faster.

| Benchmark | base | patched |
|---|---|---|
| getLogger, existing loggers | 6.68 µs | 5.02 µs: **33% faster** |

<details><summary>Benchmark (pyperf)</summary>

Run base vs patched by swapping `Lib/logging/__init__.py` on the same interpreter. The names are real `getLogger()` string arguments mined from the top-1000 corpus.

```python
import logging, pyperf

names = ["elastic_transport.transport", "peewee.pool", "LiteLLM", "httpx",
    "uvicorn.error", "uvicorn.access", "fsspec", "boto3", "posthog", "amqp",
    "nox", "tldextract.cache", "dulwich.lfs", "urllib3.connectionpool",
    "asyncio", "sqlalchemy.engine", "werkzeug", "django.request", "celery.worker",
    "kafka.conn", "redis.client", "paramiko.transport", "matplotlib.font_manager"]
for n in names:
    logging.getLogger(n)   # pre-create, as modules do at import

runner = pyperf.Runner()
runner.bench_func("getLogger %d existing loggers" % len(names),
                  lambda: [logging.getLogger(n) for n in names])
```
</details>

Resolves #150818.


<!-- gh-issue-number: gh-150818 -->
* Issue: gh-150818
<!-- /gh-issue-number -->
