### PR TITLE
gh-150819: Cache ConfigParser converter names per class

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -1373,14 +1373,25 @@ class ConverterMapping(MutableMapping):
 
     GETTERCRE = re.compile(r"^get(?P<name>.+)$")
 
+    # The set of ``get<name>`` converter methods is fixed per parser class, so
+    # cache the discovered names per class instead of running dir() + a regex
+    # over every attribute on each ConfigParser construction.
+    _getter_names_cache = {}
+
     def __init__(self, parser):
         self._parser = parser
-        self._data = {}
-        for getter in dir(self._parser):
-            m = self.GETTERCRE.match(getter)
-            if not m or not callable(getattr(self._parser, getter)):
-                continue
-            self._data[m.group('name')] = None   # See class docstring.
+        cls = type(parser)
+        try:
+            names = ConverterMapping._getter_names_cache[cls]
+        except KeyError:
+            getter_re = self.GETTERCRE
+            names = tuple(
+                m['name']
+                for getter in dir(parser)
+                if (m := getter_re.match(getter)) and callable(getattr(parser, getter))
+            )
+            ConverterMapping._getter_names_cache[cls] = names
+        self._data = dict.fromkeys(names)   # See class docstring (values None).
 
     def __getitem__(self, key):
         return self._data[key]

--- a/Misc/NEWS.d/next/Library/2026-06-02-15-44-59.gh-issue-150819.D3JQey.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-02-15-44-59.gh-issue-150819.D3JQey.rst
@@ -1,0 +1,3 @@
+Speed up :class:`configparser.ConfigParser` construction by caching the
+discovered ``get*`` converter method names per parser class. Patch by Bernát
+Gábor.


### PR DESCRIPTION
Constructing a `ConfigParser` scans every attribute on the parser with `dir()` and matches each name against a regular expression to discover its `get<type>` converter methods. That discovery produces the same answer for every instance of a given parser class, yet it runs in full on each construction. Tools that read several config files, or build a fresh parser per file, pay this cost repeatedly — build backends, linters and test runners commonly create many parsers over a run.

This caches the discovered converter names per parser class and reuses them on later constructions, keyed on the exact type so a subclass that adds converters is handled correctly. The discovered set is identical to what the scan produces today.

Constructing a parser improves from 390 µs to 78.9 µs, 394% faster; constructing and reading a real `setup.cfg` end to end improves by 19%.

| Benchmark | base | patched |
|---|---|---|
| ConfigParser() construct | 390 µs | 78.9 µs: **394% faster** |
| ConfigParser + read real setup.cfg | 2.19 ms | 1.84 ms: **19% faster** |

<details><summary>Benchmark (pyperf)</summary>

Run base vs patched by swapping `Lib/configparser.py` on the same interpreter. The config text is a real `setup.cfg` from the top-1000 corpus (`msal`).

```python
import configparser, pyperf

cfg = """\
[metadata]
name = msal
version = attr: msal.__version__
license = MIT
classifiers =
    Development Status :: 5 - Production/Stable
    Programming Language :: Python :: 3
[options]
python_requires = >=3.9
install_requires =
    requests>=2.0.0,<3
    PyJWT[crypto]>=1.0.0,<3
    cryptography>=2.5,<51
[options.extras_require]
broker =
    pymsalruntime>=0.20,<0.21; platform_system=='Windows'
"""

runner = pyperf.Runner()
runner.bench_func("ConfigParser() construct",
                  lambda: [configparser.ConfigParser() for _ in range(20)])

def parse_real():
    for _ in range(20):
        cp = configparser.ConfigParser()
        cp.read_string(cfg)
runner.bench_func("ConfigParser + read real setup.cfg", parse_real)
```
</details>

Resolves #150819.
