### PR TITLE
gh-150820: Speed up json.dumps() for small documents

### DIFF
--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -355,10 +355,16 @@ class JSONDecoder(object):
         containing a JSON document).
 
         """
-        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
-        end = _w(s, end).end()
+        # Skip the WHITESPACE.match() call (and its match-object allocation)
+        # for the common case where there is no leading whitespace.
+        idx = _w(s, 0).end() if s and s[0] in ' \t\n\r' else 0
+        obj, end = self.raw_decode(s, idx=idx)
+        # Likewise avoid the trailing-whitespace match when the parse already
+        # consumed the whole string.
         if end != len(s):
-            raise JSONDecodeError("Extra data", s, end)
+            end = _w(s, end).end()
+            if end != len(s):
+                raise JSONDecodeError("Extra data", s, end)
         return obj
 
     def raw_decode(self, s, idx=0):

--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -355,16 +355,10 @@ class JSONDecoder(object):
         containing a JSON document).
 
         """
-        # Skip the WHITESPACE.match() call (and its match-object allocation)
-        # for the common case where there is no leading whitespace.
-        idx = _w(s, 0).end() if s and s[0] in ' \t\n\r' else 0
-        obj, end = self.raw_decode(s, idx=idx)
-        # Likewise avoid the trailing-whitespace match when the parse already
-        # consumed the whole string.
+        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+        end = _w(s, end).end()
         if end != len(s):
-            end = _w(s, end).end()
-            if end != len(s):
-                raise JSONDecodeError("Extra data", s, end)
+            raise JSONDecodeError("Extra data", s, end)
         return obj
 
     def raw_decode(self, s, idx=0):

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -223,29 +223,6 @@ class JSONEncoder(object):
         else:
             _encoder = encode_basestring
 
-        def floatstr(o, allow_nan=self.allow_nan,
-                _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
-            # Check for specials.  Note that this type of test is processor
-            # and/or platform-specific, so do tests which don't depend on the
-            # internals.
-
-            if o != o:
-                text = 'NaN'
-            elif o == _inf:
-                text = 'Infinity'
-            elif o == _neginf:
-                text = '-Infinity'
-            else:
-                return _repr(o)
-
-            if not allow_nan:
-                raise ValueError(
-                    "Out of range float values are not JSON compliant: " +
-                    repr(o))
-
-            return text
-
-
         if self.indent is None or isinstance(self.indent, str):
             indent = self.indent
         else:
@@ -256,6 +233,31 @@ class JSONEncoder(object):
                 self.key_separator, self.item_separator, self.sort_keys,
                 self.skipkeys, self.allow_nan)
         else:
+            # floatstr is only needed by the pure-Python encoder; defining it
+            # lazily avoids building this closure on every encode that takes
+            # the C fast path above.
+            def floatstr(o, allow_nan=self.allow_nan,
+                    _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
+                # Check for specials.  Note that this type of test is processor
+                # and/or platform-specific, so do tests which don't depend on
+                # the internals.
+
+                if o != o:
+                    text = 'NaN'
+                elif o == _inf:
+                    text = 'Infinity'
+                elif o == _neginf:
+                    text = '-Infinity'
+                else:
+                    return _repr(o)
+
+                if not allow_nan:
+                    raise ValueError(
+                        "Out of range float values are not JSON compliant: " +
+                        repr(o))
+
+                return text
+
             _iterencode = _make_iterencode(
                 markers, self.default, _encoder, indent, floatstr,
                 self.key_separator, self.item_separator, self.sort_keys,

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -233,9 +233,6 @@ class JSONEncoder(object):
                 self.key_separator, self.item_separator, self.sort_keys,
                 self.skipkeys, self.allow_nan)
         else:
-            # floatstr is only needed by the pure-Python encoder; defining it
-            # lazily avoids building this closure on every encode that takes
-            # the C fast path above.
             def floatstr(o, allow_nan=self.allow_nan,
                     _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
                 # Check for specials.  Note that this type of test is processor

--- a/Misc/NEWS.d/next/Library/2026-06-02-15-45-00.gh-issue-150820.W7tpO7.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-02-15-45-00.gh-issue-150820.W7tpO7.rst
@@ -1,0 +1,3 @@
+Speed up :func:`json.loads` and :func:`json.dumps` for small documents by
+avoiding a redundant whitespace scan on decode and by building the float
+helper only on the Python encoding path. Patch by Bernát Gábor.

--- a/Misc/NEWS.d/next/Library/2026-06-02-15-45-00.gh-issue-150820.W7tpO7.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-02-15-45-00.gh-issue-150820.W7tpO7.rst
@@ -1,3 +1,1 @@
-Speed up :func:`json.dumps` for small documents by building the float
-formatting helper only on the slower Python encoding path instead of on every
-call. Patch by Bernát Gábor.
+Speed up :func:`json.dumps` for small documents. Patch by Bernát Gábor.

--- a/Misc/NEWS.d/next/Library/2026-06-02-15-45-00.gh-issue-150820.W7tpO7.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-02-15-45-00.gh-issue-150820.W7tpO7.rst
@@ -1,3 +1,3 @@
-Speed up :func:`json.loads` and :func:`json.dumps` for small documents by
-avoiding a redundant whitespace scan on decode and by building the float
-helper only on the Python encoding path. Patch by Bernát Gábor.
+Speed up :func:`json.dumps` for small documents by building the float
+formatting helper only on the slower Python encoding path instead of on every
+call. Patch by Bernát Gábor.


### PR DESCRIPTION
`json.dumps()` runs through the pure-Python `iterencode()` wrapper on every call before the C encoder does the heavy lifting, and that wrapper builds a float-formatting helper closure each time — even though the common C fast path never uses it. For the small documents that dominate real traffic (an API response, a single record, a config fragment), that per-call closure construction is a measurable slice of the total work.

This builds the float helper only inside the branch that runs the pure-Python encoder, so the C fast path no longer allocates a closure it never calls. The wrapper stays in Python, so the win lands on the default build; output is byte-identical.

Over 20 small documents, `json.dumps()` is about 8% faster, consistently across float-heavy, mixed, and no-float payloads:

| Benchmark | base | patched |
|---|---|---|
| dumps 20 mixed small docs | 22.1 µs | 20.6 µs: **8% faster** |
| dumps 20 float-heavy docs | 32.7 µs | 31.1 µs: **5% faster** |
| dumps 20 no-float docs | 16.5 µs | 14.9 µs: **11% faster** |

<details><summary>Benchmark (pyperf)</summary>

Run base vs patched by swapping `Lib/json/encoder.py` on the same interpreter. The script is self-contained.

```python
import json, pyperf
small  = [{"id": i, "name": f"item{i}", "ok": i % 2 == 0, "tags": ["a","b"], "v": i*1.5} for i in range(20)]
floaty = [{"lat": 51.5074+i, "lon": -0.1278-i, "alt": i*3.3, "err": i/7.0} for i in range(20)]
plain  = [{"id": i, "name": f"n{i}", "ok": True} for i in range(20)]
runner = pyperf.Runner()
runner.bench_func("dumps 20 mixed small docs", lambda: [json.dumps(o) for o in small])
runner.bench_func("dumps 20 float-heavy docs", lambda: [json.dumps(o) for o in floaty])
runner.bench_func("dumps 20 no-float docs", lambda: [json.dumps(o) for o in plain])
```
</details>

The decoder whitespace-skip change that originally accompanied this has moved to a separate PR, since it is more contentious (it depends on the outcome of gh-117397 and shows mixed results on large documents); this PR is now the encoder change alone.

Resolves #150820.


<!-- gh-issue-number: gh-150820 -->
* Issue: gh-150820
<!-- /gh-issue-number -->
