### PR TITLE
gh-150821: Skip URL parsing in mimetypes.guess_type() for file paths

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -126,10 +126,11 @@ class MimeTypes:
 
         # TODO: Deprecate accepting file paths (in particular path-like objects).
         url = os.fspath(url)
-        # A URL scheme requires a ':'; a plain file path (the common case) has
-        # none, so skip the relatively expensive urlparse() for it.
+        # Without a ':' the argument cannot carry a URL scheme, so it cannot
+        # be a URL; skip the relatively expensive urlparse() in that case.
         if isinstance(url, str) and ':' not in url:
             return self.guess_file_type(url, strict=strict)
+
         import urllib.parse
         p = urllib.parse.urlparse(url)
         if p.scheme and len(p.scheme) > 1:

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -123,10 +123,14 @@ class MimeTypes:
         """
         # Lazy import to improve module import time
         import os
-        import urllib.parse
 
         # TODO: Deprecate accepting file paths (in particular path-like objects).
         url = os.fspath(url)
+        # A URL scheme requires a ':'; a plain file path (the common case) has
+        # none, so skip the relatively expensive urlparse() for it.
+        if isinstance(url, str) and ':' not in url:
+            return self.guess_file_type(url, strict=strict)
+        import urllib.parse
         p = urllib.parse.urlparse(url)
         if p.scheme and len(p.scheme) > 1:
             scheme = p.scheme

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -23,6 +23,10 @@ init([files]) -- parse a list of files, default knownfiles (on Windows, the
 read_mime_types(file) -- parse one file, return a dictionary or None
 """
 
+lazy import os
+lazy import posixpath
+lazy import urllib.parse
+
 try:
     from _winapi import _mimetypes_read_windows_registry
 except ImportError:
@@ -32,8 +36,6 @@ try:
     import winreg as _winreg
 except ImportError:
     _winreg = None
-
-lazy import urllib.parse
 
 __all__ = [
     "knownfiles", "inited", "MimeTypes",
@@ -123,9 +125,6 @@ class MimeTypes:
         Optional 'strict' argument when False adds a bunch of commonly found,
         but non-standard types.
         """
-        # Lazy import to improve module import time
-        import os
-
         # TODO: Deprecate accepting file paths (in particular path-like objects).
         url = os.fspath(url)
         # Without a ':' the argument cannot carry a URL scheme, so it cannot
@@ -159,9 +158,6 @@ class MimeTypes:
                 type = 'text/plain'
             return type, None           # never compressed, so encoding is None
 
-        # Lazy import to improve module import time
-        import posixpath
-
         return self._guess_file_type(url, strict, posixpath.splitext)
 
     def guess_file_type(self, path, *, strict=True):
@@ -169,9 +165,6 @@ class MimeTypes:
 
         Similar to guess_type(), but takes file path instead of URL.
         """
-        # Lazy import to improve module import time
-        import os
-
         path = os.fsdecode(path)
         path = os.path.splitdrive(path)[1]
         return self._guess_file_type(path, strict, os.path.splitext)
@@ -417,9 +410,6 @@ def init(files=None):
             files = knownfiles + list(files)
     else:
         db = _db
-
-    # Lazy import to improve module import time
-    import os
 
     for file in files:
         if os.path.isfile(file):

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -33,6 +33,8 @@ try:
 except ImportError:
     _winreg = None
 
+lazy import urllib.parse
+
 __all__ = [
     "knownfiles", "inited", "MimeTypes",
     "guess_type", "guess_file_type", "guess_all_extensions", "guess_extension",
@@ -131,7 +133,6 @@ class MimeTypes:
         if isinstance(url, str) and ':' not in url:
             return self.guess_file_type(url, strict=strict)
 
-        import urllib.parse
         p = urllib.parse.urlparse(url)
         if p.scheme and len(p.scheme) > 1:
             scheme = p.scheme

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -375,6 +375,15 @@ class MimeTypesClassTestCase(unittest.TestCase):
         result = self.db.guess_type('http://example.com/host.html?q=x.tar')
         self.assertSequenceEqual(result, ('text/html', None))
 
+    def test_path_with_colon_but_no_url_scheme(self):
+        # A ':' that does not introduce a real URL scheme -- a single-letter
+        # Windows drive, or a colon elsewhere in the name -- is treated as a
+        # file path rather than a URL.
+        eq = self.assertSequenceEqual
+        eq(self.db.guess_type("c:fake.html"), ("text/html", None))
+        eq(self.db.guess_type(r"c:\dir\fake.html"), ("text/html", None))
+        eq(self.db.guess_type("note 12:30.txt"), ("text/plain", None))
+
     def test_guess_all_types(self):
         # First try strict.  Use a set here for testing the results because if
         # test_urllib2 is run before test_mimetypes, global state is modified

--- a/Misc/NEWS.d/next/Library/2026-06-02-15-45-02.gh-issue-150821.yKimWm.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-02-15-45-02.gh-issue-150821.yKimWm.rst
@@ -1,0 +1,2 @@
+Speed up :func:`mimetypes.guess_type` for plain file paths by skipping URL
+parsing when the argument has no scheme. Patch by Bernát Gábor.


### PR DESCRIPTION
`mimetypes.guess_type()` accepts either a URL or a filesystem path, so it parses its argument as a URL with `urllib.parse.urlparse()` before looking at the extension. The common argument is a plain file path, which has no URL scheme to find, so the parse — and the `urllib.parse` import it triggers — is spent on nothing. Guessing content types from file names is everywhere: static-file servers, upload handlers, archive and build tools deciding how to treat each file as they walk a tree of thousands.

A URL scheme requires a `:`, so a path without one cannot be a URL. This detects that case and goes straight to extension lookup, skipping `urlparse()` and its lazy import. Real URLs, and the rare path that contains a `:`, still take the full parsing path, and results are unchanged for both.

Guessing types for 15 real file names sampled from the top-1000 corpus improves from 23.4 µs to 11.0 µs, 112% faster.

| Benchmark | base | patched |
|---|---|---|
| guess_type x15 file paths | 23.4 µs | 11.0 µs: **112% faster** |

<details><summary>Benchmark (pyperf)</summary>

Run base vs patched by swapping `Lib/mimetypes.py` on the same interpreter. The names are real file names sampled from the top-1000 corpus.

```python
import mimetypes, pyperf
mimetypes.init()

names = ["webhook_list.py", "tox.ini", "api_management_delete_policy.py",
    ".env.sample.entra-id", "alerts_get_by_id.py", "ai_prompt_workflow.md",
    "functions.py", "sample_connections.py", "certificate_delete.py",
    "_ai_agents_instrumentor.py", ".flake8", "agent_trace_configurator.py",
    "test_ws_invoke.py", "README.md", "setup.cfg"]

runner = pyperf.Runner()
runner.bench_func("guess_type x15 file paths",
                  lambda: [mimetypes.guess_type(n) for n in names])
```
</details>

Resolves #150821.


<!-- gh-issue-number: gh-150821 -->
* Issue: gh-150821
<!-- /gh-issue-number -->
