### PR TITLE
Add warning to Thread.run() docstring so that users are aware Thread.start() is the correct way to start a thread

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -578,7 +578,7 @@ since it is impossible to detect the termination of alien threads.
 
    .. method:: run()
 
-      Method representing the thread's activity.
+      Method representing the thread's activity. Use Thread.start() to start a thread's execution
 
       You may override this method in a subclass.  The standard :meth:`run`
       method invokes the callable object passed to the object's constructor as

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1147,7 +1147,7 @@ class Thread:
         self._started.wait()  # Will set ident and native_id
 
     def run(self):
-        """Method representing the thread's activity.
+        """Method representing the thread's activity. Use Thread.start() to start a thread's execution
 
         You may override this method in a subclass. The standard run() method
         invokes the callable object passed to the object's constructor as the


### PR DESCRIPTION
add a warning to Thread.run() docstring so that users are aware that Thread.start() is the correct way to start a thread's execution

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
