### PR TITLE
gh-150834: Build the address-list mailbox list in linear time

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -310,13 +310,15 @@ class AddressList(TokenList):
 
     @property
     def mailboxes(self):
-        return sum((x.mailboxes
-                    for x in self if x.token_type=='address'), [])
+        return [mailbox
+                for x in self if x.token_type == 'address'
+                for mailbox in x.mailboxes]
 
     @property
     def all_mailboxes(self):
-        return sum((x.all_mailboxes
-                    for x in self if x.token_type=='address'), [])
+        return [mailbox
+                for x in self if x.token_type == 'address'
+                for mailbox in x.all_mailboxes]
 
 
 class Address(TokenList):

--- a/Misc/NEWS.d/next/Library/2026-06-02-21-46-29.gh-issue-150834.xvMJes.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-02-21-46-29.gh-issue-150834.xvMJes.rst
@@ -1,0 +1,4 @@
+Building the combined mailbox list of a parsed :mod:`email` address header
+(the ``mailboxes`` and ``all_mailboxes`` properties of its address-list parse
+tree) is now linear rather than quadratic in the number of addresses. Patch by
+Bernát Gábor.


### PR DESCRIPTION
A parsed email address header can return every mailbox it contains through the `mailboxes` and `all_mailboxes` properties of its address-list parse tree. That combined list is built by adding each address's mailboxes onto a running list one address at a time, which recreates the growing list on every step, so the cost grows with the square of the number of addresses. A handful of recipients never notice, but a large `To` or `Cc` line, a mailing-list expansion, or a bulk-mail run can hold hundreds, and asking such a header for its mailboxes then spends almost all of its time copying the partial list over and over.

This gathers the mailboxes in a single linear pass with a flattening comprehension instead of the running-sum accumulation. The per-recipient cost stays flat instead of climbing, and the resulting list is identical in contents and order.

The improvement grows with the number of addresses, since the work goes from quadratic to linear:

| Recipients | base | patched |
|---|---|---|
| 10 | 1.49 µs | 999 ns: **49% faster** |
| 50 | 7.41 µs | 4.65 µs: **59% faster** |
| 200 | 49.4 µs | 18.7 µs: **164% faster** |
| 500 | 204 µs | 48.3 µs: **323% faster** |

<details><summary>Benchmark (pyperf)</summary>

Run base vs patched by swapping `Lib/email/_header_value_parser.py` on the same interpreter. The script is self-contained.

```python
import pyperf
from email._header_value_parser import get_address_list

def header(n):
    return ", ".join(f"User {i} <user{i}@example.com>" for i in range(n))

parsed = {n: get_address_list(header(n))[0] for n in (10, 50, 200, 500)}

runner = pyperf.Runner()
for n, al in parsed.items():
    runner.bench_func(f"AddressList.mailboxes, {n} recipients", lambda al=al: al.mailboxes)
```
</details>

Resolves #150834.


<!-- gh-issue-number: gh-150834 -->
* Issue: gh-150834
<!-- /gh-issue-number -->
