### PR TITLE
Docs: Replace hardcoded `SOURCE_URI` with `patchlevel` check

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -15,8 +15,7 @@ from importlib.util import find_spec
 sys.path.append(os.path.abspath('tools/extensions'))
 sys.path.append(os.path.abspath('includes'))
 
-# Python specific content from Doc/Tools/extensions/pyspecific.py
-from pyspecific import SOURCE_URI
+from patchlevel import get_header_version_info
 
 # General configuration
 # ---------------------
@@ -555,8 +554,12 @@ linkcheck_ignore = [
     r'https://unix.org/version2/whatsnew/lp64_wp.html',
 ]
 
+
 # Options for sphinx.ext.extlinks
 # -------------------------------
+
+v = get_header_version_info()
+branch = "main" if v.releaselevel == "alpha" else f"{v.major}.{v.minor}"
 
 # This config is a dictionary of external sites,
 # mapping unique short aliases to a base URL and a prefix.
@@ -564,7 +567,7 @@ linkcheck_ignore = [
 extlinks = {
     "oss-fuzz": ("https://issues.oss-fuzz.com/issues/%s", "#%s"),
     "pypi": ("https://pypi.org/project/%s/", "%s"),
-    "source": (SOURCE_URI, "%s"),
+    "source": (f"https://github.com/python/cpython/tree/{branch}/%s", "%s"),
 }
 extlinks_detect_hardcoded_links = True
 

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -8,14 +8,13 @@
 
 import os
 import sys
-from importlib import import_module
 from importlib.util import find_spec
 
 # Make our custom extensions available to Sphinx
 sys.path.append(os.path.abspath('tools/extensions'))
 sys.path.append(os.path.abspath('includes'))
 
-from patchlevel import get_header_version_info
+from patchlevel import get_header_version_info, get_version_info
 
 # General configuration
 # ---------------------
@@ -77,7 +76,7 @@ _doc_authors = 'Python documentation authors'
 # We look for the Include/patchlevel.h file in the current Python source tree
 # and replace the values accordingly.
 # See Doc/tools/extensions/patchlevel.py
-version, release = import_module('patchlevel').get_version_info()
+version, release = get_version_info()
 
 rst_epilog = f"""
 .. |python_version_literal| replace:: ``Python {version}``

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -10,19 +10,10 @@
 """
 
 import re
-import io
-from os import getenv, path
 
-from docutils import nodes
-from docutils.parsers.rst import directives
-from docutils.utils import unescape
 from sphinx import addnodes
-from sphinx.domains.python import PyFunction, PyMethod, PyModule
-from sphinx.locale import _ as sphinx_gettext
-from sphinx.util.docutils import SphinxDirective
+from sphinx.domains.python import PyFunction, PyMethod
 
-# Used in conf.py and updated here by python/release-tools/run_release.py
-SOURCE_URI = 'https://github.com/python/cpython/tree/main/%s'
 
 class PyAwaitableMixin(object):
     def handle_signature(self, sig, signode):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

During yesterday's 3.15.0b2 release, the reminder to update `SOURCE_URI` triggered. 

`SOURCE_URI` is used for linking stdlib pages such as:
* https://docs.python.org/3/library/random.html -> https://github.com/python/cpython/tree/3.14/Lib/random.py
* https://docs.python.org/3.15/library/random.html -> https://github.com/python/cpython/blob/3.15/Lib/random.py

But this reminder was meant to happen during b1, when the `3.15` branch is created. It happened during b1 for 3.14.

See https://github.com/python/cpython/pull/150783#issuecomment-4602198566.

The cause of this was this fix: https://github.com/python/release-tools/pull/379.

But rather than updating release-tools to trigger the reminder during b1 (and it's a disruptive reminder), let's remove the hardcoding in `SOURCE_URI` altogether, and replace it with a check for the release level:

* For alpha (and that includes `main` as it is now, pre-a1): link to `main`.
* Otherwise: link to the relevant `3.x`.

And we do this directly where it's used in `conf.py` instead of in `pyspecfic.py` and importing from there.

Also remove a bunch of unused imports `pyspecfic.py`.
