### PR TITLE
gh-150860: Skip the whitespace scan in json.loads() when there is none

### DIFF
--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -355,10 +355,16 @@ class JSONDecoder(object):
         containing a JSON document).
 
         """
-        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
-        end = _w(s, end).end()
+        # Skip the WHITESPACE.match() call (and its match-object allocation)
+        # for the common case where there is no leading whitespace.
+        idx = _w(s, 0).end() if s and s[0] in ' \t\n\r' else 0
+        obj, end = self.raw_decode(s, idx=idx)
+        # Likewise avoid the trailing-whitespace match when the parse already
+        # consumed the whole string.
         if end != len(s):
-            raise JSONDecodeError("Extra data", s, end)
+            end = _w(s, end).end()
+            if end != len(s):
+                raise JSONDecodeError("Extra data", s, end)
         return obj
 
     def raw_decode(self, s, idx=0):

--- a/Misc/NEWS.d/next/Library/2026-06-03-07-31-11.gh-issue-150860.8VbmHU.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-03-07-31-11.gh-issue-150860.8VbmHU.rst
@@ -1,0 +1,3 @@
+Speed up :func:`json.loads` for documents without leading or trailing
+whitespace by skipping the whitespace scan in that common case. Patch by Bernát
+Gábor.


### PR DESCRIPTION
Decoding with `json.loads()` runs a whitespace-skipping regular expression at both ends of the document through the pure-Python `decode()` wrapper, on every call, before and after the C scanner does the real work. Almost all documents have no surrounding whitespace, so both matches scan nothing yet still pay for the call and a match-object allocation. For the small documents that dominate real traffic, that fixed overhead is a meaningful slice of the decode time.

This skips the leading match when the document does not start with whitespace, and the trailing match when the parse already consumed the whole string. Documents that do have surrounding whitespace keep the original behavior, output is unchanged, and the wrapper stays in Python so the win applies to the default C-accelerated build.

The effect is concentrated on small, whitespace-free documents (the common case). It costs a little on the rare document padded with both leading and trailing whitespace (one extra branch), and is neutral on large documents:

| Benchmark | base | patched |
|---|---|---|
| loads tiny, no whitespace | 469 ns | 297 ns: **1.58x faster** |
| loads tiny, leading whitespace | 473 ns | 392 ns: **1.21x faster** |
| loads tiny, trailing whitespace | 463 ns | 400 ns: **1.16x faster** |
| loads tiny, both leading + trailing | 473 ns | 518 ns: **1.09x slower** |
| loads 4 KB / 32 KB / 100 KB, no whitespace | — | within noise (±2–3%) |

The large-document deltas sit inside run-to-run noise: the change only adds or removes work at the document boundaries, so it cannot scale with document size. A constant-overhead change measuring as a size-proportional regression is the signature of measurement noise on a contended machine, not a real cost.

This overlaps with the broader rewrite in gh-117397 and is filed separately so the small, self-contained version can be judged on its own. It was split out of #150827, which now carries only the encoder change.

<details><summary>Benchmark (pyperf)</summary>

Run base vs patched by swapping `Lib/json/decoder.py` on the same interpreter.

```python
import json, pyperf
def sized(target):
    n = target // 12
    while True:
        s = json.dumps({str(i): i for i in range(n)})
        if len(s) >= target: return s
        n += target // 24
PAYLOADS = {
    "no_ws_tiny": '{"a":1}', "leading_ws": '  {"a":1}', "trailing_ws": '{"a":1}  ',
    "both_ws": '  {"a":1}  ', "no_ws_4kb": sized(4*1024),
    "no_ws_32kb": sized(32*1024), "no_ws_100kb": sized(100*1024),
}
runner = pyperf.Runner()
for name, payload in PAYLOADS.items():
    runner.timeit(name=f"json_loads/{name}", stmt="loads(s)",
                  setup=f"from json import loads; s = {payload!r}")
```
</details>

Resolves #150860.


<!-- gh-issue-number: gh-150860 -->
* Issue: gh-150860
<!-- /gh-issue-number -->
