### PR TITLE
make get_nowait() consistant with put_nowait() description

### DIFF
--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -173,7 +173,7 @@ provide the public methods described below.
 
 .. method:: Queue.get_nowait()
 
-   Equivalent to ``get(False)``.
+   Equivalent to ``get(block=False)``.
 
 Two methods are offered to support tracking whether enqueued tasks have been
 fully processed by daemon consumer threads.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This is a very simple PR which adds `block` as a `kwarg` to `get_nowait()` in the same way that `put_nowait()` does. I know that block can be passed as an `*arg` but I think this just clears up any confusion in case the read sees it as `get_nowait(timeout=False)` or something! 