### PR TITLE
gh-150866: Fix asyncio.shutdown_asyncgens to report BaseException

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -590,7 +590,7 @@ class BaseEventLoop(events.AbstractEventLoop):
             return_exceptions=True)
 
         for result, agen in zip(results, closing_agens):
-            if isinstance(result, Exception):
+            if isinstance(result, (Exception, exceptions.CancelledError)):
                 self.call_exception_handler({
                     'message': f'an error occurred during closing of '
                                f'asynchronous generator {agen!r}',

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -590,7 +590,7 @@ class BaseEventLoop(events.AbstractEventLoop):
             return_exceptions=True)
 
         for result, agen in zip(results, closing_agens):
-            if isinstance(result, (Exception, exceptions.CancelledError)):
+            if isinstance(result, BaseException):
                 self.call_exception_handler({
                     'message': f'an error occurred during closing of '
                                f'asynchronous generator {agen!r}',

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1041,6 +1041,45 @@ class BaseEventLoopTests(test_utils.TestCase):
 
         asyncio.create_task(iter_one())
         return status
+        
+    def test_shutdown_asyncgens_reports_cancelled_error(self):
+        # gh-150866: shutdown_asyncgens silently swallowed
+        # CancelledError raised during aclose() because the check was
+        # isinstance(result, Exception), but CancelledError inherits
+        # from BaseException.
+        self.loop._process_events = mock.Mock()
+        self.loop._write_to_self = mock.Mock()
+        
+        async def agen_cancel():
+            try:
+                yield 1
+            finally:
+                raise asyncio.CancelledError("agen got cancelled during cleanup")
+
+        async def agen_value_error():
+            try:
+                yield 1
+            finally:
+                raise ValueError("agen failed during cleanup")
+
+        caught = []
+
+        def handler(loop, context):
+            caught.append(context['message'])
+
+        async def main():
+            loop = asyncio.get_running_loop()
+            loop.set_exception_handler(handler)
+
+            g1 = agen_cancel()
+            g2 = agen_value_error()
+            await g1.__anext__()
+            await g2.__anext__()
+
+            await loop.shutdown_asyncgens()
+
+        self.loop.run_until_complete(main())
+        self.assertEqual(len(caught), 2)
 
     def test_asyncgen_finalization_by_gc(self):
         # Async generators should be finalized when garbage collected.

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1041,7 +1041,7 @@ class BaseEventLoopTests(test_utils.TestCase):
 
         asyncio.create_task(iter_one())
         return status
-        
+
     def test_shutdown_asyncgens_reports_cancelled_error(self):
         # gh-150866: shutdown_asyncgens silently swallowed
         # CancelledError raised during aclose() because the check was
@@ -1049,7 +1049,7 @@ class BaseEventLoopTests(test_utils.TestCase):
         # from BaseException.
         self.loop._process_events = mock.Mock()
         self.loop._write_to_self = mock.Mock()
-        
+
         async def agen_cancel():
             try:
                 yield 1

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1042,19 +1042,28 @@ class BaseEventLoopTests(test_utils.TestCase):
         asyncio.create_task(iter_one())
         return status
 
-    def test_shutdown_asyncgens_reports_cancelled_error(self):
-        # gh-150866: shutdown_asyncgens silently swallowed
-        # CancelledError raised during aclose() because the check was
-        # isinstance(result, Exception), but CancelledError inherits
+    def test_shutdown_asyncgens_reports_base_exceptions(self):
+        # gh-150866: shutdown_asyncgens silently swallowed exceptions that
+        # don't inherit from Exception raised during aclose() because the
+        # check was isinstance(result, Exception), but CancelledError inherits
         # from BaseException.
         self.loop._process_events = mock.Mock()
         self.loop._write_to_self = mock.Mock()
+
+        class MyBaseException(BaseException):
+            pass
 
         async def agen_cancel():
             try:
                 yield 1
             finally:
                 raise asyncio.CancelledError("agen got cancelled during cleanup")
+
+        async def agen_base():
+            try:
+                yield 1
+            finally:
+                raise MyBaseException("base exc during cleanup")
 
         async def agen_value_error():
             try:
@@ -1065,21 +1074,27 @@ class BaseEventLoopTests(test_utils.TestCase):
         caught = []
 
         def handler(loop, context):
-            caught.append(context['message'])
+            caught.append(context['exception'])
 
         async def main():
             loop = asyncio.get_running_loop()
             loop.set_exception_handler(handler)
 
             g1 = agen_cancel()
-            g2 = agen_value_error()
+            g2 = agen_base()
+            g3 = agen_value_error()
             await g1.__anext__()
             await g2.__anext__()
+            await g3.__anext__()
 
             await loop.shutdown_asyncgens()
 
         self.loop.run_until_complete(main())
-        self.assertEqual(len(caught), 2)
+        self.assertEqual(len(caught), 3)
+        self.assertEqual(
+            {type(exc) for exc in caught},
+            {asyncio.CancelledError, MyBaseException, ValueError},
+        )
 
     def test_asyncgen_finalization_by_gc(self):
         # Async generators should be finalized when garbage collected.

--- a/Misc/NEWS.d/next/Library/2026-06-03-18-41-42.gh-issue-150866.gXGyX-.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-03-18-41-42.gh-issue-150866.gXGyX-.rst
@@ -1,0 +1,2 @@
+Fix :meth:`asyncio.loop.shutdown_asyncgens` to report
+:exc:`asyncio.CancelledError` raised during asynchronous generator cleanup.

--- a/Misc/NEWS.d/next/Library/2026-06-03-18-41-42.gh-issue-150866.gXGyX-.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-03-18-41-42.gh-issue-150866.gXGyX-.rst
@@ -1,2 +1,2 @@
-Fix :meth:`asyncio.loop.shutdown_asyncgens` to report
-:exc:`asyncio.CancelledError` raised during asynchronous generator cleanup.
+Fix :meth:`asyncio.loop.shutdown_asyncgens` to report any
+:exc:`BaseException` raised during asynchronous generator cleanup.


### PR DESCRIPTION
`asyncio.BaseEventLoop.shutdown_asyncgens` silently swallowed `BaseException` raised during asynchronous generator cleanup because the check was `isinstance(result, Exception)`. 

This PR adds `BaseException` to the `isinstance` check.

See gh-150866 for details and reproducer.
