### PR TITLE
gh-150868: Fix incorrect specialized deallocation of float subclasses in sum()

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -3046,7 +3046,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
                     return NULL;
                 }
             }
-            if (PyFloat_Check(item)) {
+            if (PyFloat_CheckExact(item)) {
                 double value = PyFloat_AS_DOUBLE(item);
                 re_sum = cs_add(re_sum, value);
                 _Py_DECREF_SPECIALIZED(item, _PyFloat_ExactDealloc);


### PR DESCRIPTION
In the complex-number fast path of `builtin_sum_impl` (`Python/bltinmodule.c`),
items are tested with `PyFloat_Check()` but then released with
`_Py_DECREF_SPECIALIZED(item, _PyFloat_ExactDealloc)`. `PyFloat_Check()` also
matches `float` subclasses, whereas `_PyFloat_ExactDealloc` is only valid for
exact `float` objects. As a result, when summing instances of a `float`
subclass into a complex start value, the subclass instances are deallocated as
exact floats, bypassing their real `tp_dealloc` (instance `__dict__`, weakref,
and GC cleanup). This can leak memory and leave the GC in an inconsistent state.

The adjacent float fast path already guards the same specialized dealloc with
`PyFloat_CheckExact()`; this change brings the complex path in line by using
`PyFloat_CheckExact()` as well. Subclass instances then fall through to the
generic `PyNumber_Add` path with a normal `Py_DECREF`, preserving numeric
behavior while fixing the deallocation.

## Reproducer

```python
class F(float):
    pass

sum([F(1.0), F(2.0)], 0j)  # subclass instances were freed as exact floats
```

**Change:** in the complex branch of `builtin_sum_impl`, replace
`PyFloat_Check(item)` with `PyFloat_CheckExact(item)` (one line).

<!-- gh-issue-number: gh-150868 -->
* Issue: gh-150868
<!-- /gh-issue-number -->
