### PR TITLE
gh-150871: Speed up JSON string decoding for long ASCII strings

### DIFF
--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -155,6 +155,25 @@ class TestDecode:
             with self.assertRaises(ValueError):
                 self.loads('1' * (maxdigits + 1))
 
+    def test_long_string_scan_paths(self):
+        # Exercise the string scan over long runs that cross the 8-byte scan
+        # windows: a terminator, a backslash escape and a \uXXXX escape at every
+        # offset, in 1-byte and wider (BMP, astral) strings.
+        loads = self.loads
+        for n in range(40):
+            run = "a" * n
+            self.assertEqual(loads('"' + run + '"'), run)
+            self.assertEqual(loads('"' + run + '\\nz"'), run + "\nz")
+            self.assertEqual(loads('"' + run + '\\u00e9z"'), run + "\xe9z")
+            self.assertEqual(loads('"' + "中" * n + '\\n"'), "中" * n + "\n")
+            self.assertEqual(loads('"' + "\U0001f600" * n + '"'), "\U0001f600" * n)
+        # Strict control-character detection at the window boundaries, and the
+        # non-strict path that keeps them.
+        for n in (7, 8, 15, 16, 17, 23, 24):
+            self.assertRaises(self.JSONDecodeError, loads, '"' + "a" * n + '\x01"')
+            self.assertEqual(loads('"' + "a" * n + '\x01"', strict=False),
+                             "a" * n + "\x01")
+
 
 class TestPyDecode(TestDecode, PyTest): pass
 class TestCDecode(TestDecode, CTest): pass

--- a/Misc/NEWS.d/next/Library/2026-06-03-09-23-45.gh-issue-150871.aEM9sM.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-03-09-23-45.gh-issue-150871.aEM9sM.rst
@@ -1,0 +1,4 @@
+Speed up :func:`json.loads` decoding of strings that contain long runs of
+ordinary characters by scanning eight bytes at a time for the closing quote, a
+backslash, or a control character. Strings containing non-Latin-1 characters
+and short strings are unaffected. Patch by Bernát Gábor.

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -501,7 +501,35 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
         {
             // Use tight scope variable to help register allocation.
             Py_UCS4 d = 0;
-            for (next = end; next < len; next++) {
+            next = end;
+            /* SWAR PROTOTYPE: for the 1-byte representation, skip 8 bytes at a
+               time while none is '"', '\\', or (strict) a control char < 0x20.
+               Masks use the exact haszero trick (no false negatives); the
+               scalar loop below pins the exact first special char. */
+            if (kind == PyUnicode_1BYTE_KIND) {
+                const Py_UCS1 *p = (const Py_UCS1 *)buf;
+                const uint64_t ones = 0x0101010101010101ULL;
+                const uint64_t high = 0x8080808080808080ULL;
+                const uint64_t bq = 0x22ULL * ones;   /* '"'  */
+                const uint64_t bs = 0x5cULL * ones;    /* '\\' */
+                const uint64_t bc = 0xE0ULL * ones;    /* (b & 0xE0)==0 iff b<0x20 */
+                while (next + 8 <= len) {
+                    uint64_t w;
+                    memcpy(&w, p + next, 8);
+                    uint64_t mq = w ^ bq; mq = (mq - ones) & ~mq & high;
+                    uint64_t ms = w ^ bs; ms = (ms - ones) & ~ms & high;
+                    uint64_t mc = 0;
+                    if (strict) {
+                        uint64_t v = w & bc;
+                        mc = (v - ones) & ~v & high;
+                    }
+                    if (mq | ms | mc) {
+                        break;
+                    }
+                    next += 8;
+                }
+            }
+            for (; next < len; next++) {
                 d = PyUnicode_READ(kind, buf, next);
                 if (d == '"' || d == '\\') {
                     break;

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -502,10 +502,10 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             // Use tight scope variable to help register allocation.
             Py_UCS4 d = 0;
             next = end;
-            /* SWAR PROTOTYPE: for the 1-byte representation, skip 8 bytes at a
-               time while none is '"', '\\', or (strict) a control char < 0x20.
-               Masks use the exact haszero trick (no false negatives); the
-               scalar loop below pins the exact first special char. */
+            /* For the 1-byte representation, skip 8 bytes at a time while none
+               is '"', '\\', or (strict) a control char < 0x20.  The masks are
+               exact (no false negatives); the scalar loop below pins the exact
+               first special char and does the work. */
             if (kind == PyUnicode_1BYTE_KIND) {
                 const Py_UCS1 *p = (const Py_UCS1 *)buf;
                 const uint64_t ones = 0x0101010101010101ULL;


### PR DESCRIPTION
JSON documents whose payload is long text (log lines, description and content fields, base64 or embedded-document values) spend most of their decode time finding the end of each string. This speeds that up by scanning eight bytes at a time instead of one, with no SIMD intrinsics and no CPU detection, and it is byte-identical to the current decoder.

## What we do now (scalar, one code point at a time)

The current `scanstring_unicode` inner loop:

```c
for (next = end; next < len; next++) {
    d = PyUnicode_READ(kind, buf, next);   // read ONE character
    if (d == '"' || d == '\\') break;      // is it a terminator/escape?
    if (d <= 0x1f && strict) { error }     // is it an illegal control char?
}
```

For a 64-character string with no escapes that is 64 iterations, each doing one read, up to three comparisons, and a loop branch: about 64 × 4 operations just to find the closing `"`. The CPU walks the string one byte at a time while its 64-bit registers sit mostly idle.

## What SWAR does (8 bytes at a time, in one register)

SWAR is "SIMD within a register": load 8 bytes into a single `uint64_t` and test all 8 lanes at once with ordinary integer ops.

```c
while (next + 8 <= len) {
    memcpy(&w, p + next, 8);                          // load 8 bytes as one 64-bit word
    mq = haszero(w ^ (0x22 * 0x0101010101010101));   // any lane == '"' ?
    ms = haszero(w ^ (0x5c * 0x0101010101010101));   // any lane == '\\' ?
    mc = strict ? haszero(w & 0xE0E0E0E0E0E0E0E0) : 0;// any lane < 0x20 ?
    if (mq | ms | mc) break;                          // something special in these 8 -> stop
    next += 8;                                        // nothing special -> skip all 8 at once
}
// then the scalar loop above runs to pin the exact byte and do the real work
```

Two tricks make this work:

* **Broadcast**: `0x22 * 0x0101010101010101` puts `"` (0x22) into all 8 byte lanes. XOR-ing the word with it turns "this lane equals `"`" into "this lane is zero".
* **`haszero(v)`** `= (v - 0x0101…) & ~v & 0x8080…`: a zero lane borrows and lights its high bit, and the masks isolate exactly the zero lanes, with no false positives or negatives. For control characters it uses `w & 0xE0`, since a byte is `< 0x20` exactly when its top three bits are zero, again detected by `haszero`.

One loop iteration answers "do any of these 8 bytes need attention?" in about 6 integer ops. If not, it advances 8 bytes, so the 64-character string takes 8 iterations instead of 64.

## The key design point: SWAR only skips, it never decides

When the mask is nonzero, meaning a `"`, `\\`, or control char sits somewhere in the 8-byte window, the loop breaks and the original scalar loop re-scans those 8 bytes to find the exact position and do the actual work: terminate the string, handle the escape, or raise the error at the right index. Every decode decision stays on the proven scalar path. SWAR is purely a fast-forward over the runs of ordinary characters that make up the bulk of most strings.

### Worked example

Chunk `hello wo` (8 ordinary ASCII bytes):
* Now: 8 iterations, 8 reads, about 24 comparisons.
* SWAR: 1 `memcpy`, 3 `haszero` tests, all zero, `next += 8`. One iteration.

Chunk `lo","wor` (a `"` at offset 2):
* SWAR: `mq` is nonzero, so it breaks. The scalar loop walks `l`, `o`, hits `"` at offset 2: identical to today, reached after skipping the prior runs.

### Why it is a win, and its limits

| | Now (scalar) | SWAR |
|---|---|---|
| Chars per iteration | 1 | 8 |
| Ops per 8 ordinary chars | ~32 | ~6 |
| Finds exact special char | itself | hands off to scalar |
| Representation handled | all (UCS-1/2/4) | UCS-1 only; UCS-2/4 fall back to scalar |

* It helps in proportion to string length: large for long text and blob values, modest for medium strings, neutral for short keys where the loop barely runs.
* It engages only for the 1-byte (ASCII/Latin-1) representation. The moment a string contains an emoji or CJK character it is UCS-2/UCS-4 and uses the unchanged scalar loop, which is why multi-kind input measures neutral, not regressed.
* It uses the same masks CPython already applies for ASCII detection ([`ASCII_CHAR_MASK = 0x8080…`, `VECTOR_0101 = 0x0101…`](https://github.com/python/cpython/blob/7a468a101268d2b13105f94ae027df8b502d0c87/Objects/unicodeobject.c#L4887) in `unicodeobject.c`, and [`UCS1_ASCII_CHAR_MASK`](https://github.com/python/cpython/blob/7a468a101268d2b13105f94ae027df8b502d0c87/Objects/stringlib/find_max_char.h#L11) in `find_max_char.h`), so it is not exotic for this codebase.

Mental model: today we ask "is this byte special?" once per byte; SWAR asks "is any of these eight bytes special?" once per eight, and drops to per-byte only when the answer is yes.

## When and how this changes performance

`json.loads`, current decoder versus this change:

| Document shape | Effect |
|---|---|
| One long text field (~11 KB string) | 6.3x faster |
| Many 200-character ASCII string values | 4.5x faster |
| Realistic mixed records (short and medium strings) | 1.17x faster |
| Short keys, numbers, the pyperformance document | no change |
| Strings with emoji or other non-Latin-1 text | no change (scalar path) |

The standard `pyperformance bm_json_loads` document is short-string and dict dominated and shows no change. The benefit lands on documents whose strings are long.

## Correctness

Output is byte-identical to the current decoder, error positions included. Verified three ways: the full `test_json` suite; a 347-input differential corpus (real-world JSON, plus a quote, backslash, raw control character, escape, and `\uXXXX` placed at every offset across the eight-byte window in all three string representations, plus surrogate pairs, lone surrogates, embedded nulls, and truncated escapes); and all 340 files of [`nst/JSONTestSuite`](https://github.com/nst/JSONTestSuite) (318 parsing and 22 transform, including the must-reject and implementation-defined cases). Every value and every raised error position matched the current implementation.

<details><summary>Benchmark</summary>

```python
import json, pyperf
long_ascii = json.dumps([("x"*200) for _ in range(200)])
text_blob  = json.dumps({"body": "lorem ipsum dolor sit amet " * 400})
short_keys = json.dumps({f"k{i}": i for i in range(2000)})
mixed_real = json.dumps([{"id":i,"name":f"user_{i}","email":f"u{i}@example.com","bio":"hello "*10} for i in range(300)])
multikind  = json.dumps(["emoji 😀 中文 текст "*20 for _ in range(200)])
docs = {"long_ascii_values": long_ascii, "huge_text_blob": text_blob,
        "short_keys": short_keys, "mixed_real": mixed_real, "multikind_emoji": multikind}
runner = pyperf.Runner()
for name, s in docs.items():
    runner.bench_func(f"loads/{name}", lambda s=s: json.loads(s))
```

References for the bit tricks: Sean Anderson, Bit Twiddling Hacks ([zero byte](https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord), [byte equal to n](https://graphics.stanford.edu/~seander/bithacks.html#ValueInWord), [byte less than n](https://graphics.stanford.edu/~seander/bithacks.html#HasLessInWord)); Henry S. Warren Jr., Hacker's Delight, 2nd ed., chapter 6.
</details>

It is not the SIMD parsing backend from #142915: it adds no intrinsics, no CPU detection, and no build configuration, and it does not depend on #125022.

Resolves #150871.


<!-- gh-issue-number: gh-150871 -->
* Issue: gh-150871
<!-- /gh-issue-number -->

