### PR TITLE
gh-150875: Speed up JSON string encoding for long ASCII strings

### DIFF
--- a/Lib/test/test_json/test_dump.py
+++ b/Lib/test/test_json/test_dump.py
@@ -130,6 +130,25 @@ class TestDump:
         self.assertEqual(self.dumps({'key': obj}),
                          '{"key": "nonascii:\\u00e9"}')
 
+    def test_ascii_encode_long_string_paths(self):
+        # Exercise the ensure_ascii encoder's escape scan over long runs that
+        # cross the 8-byte scan windows and the short-string guard: a character
+        # needing escaping at every offset, in 1-byte and wider strings.
+        dumps, loads = self.dumps, self.loads
+        for n in range(40):
+            run = "a" * n
+            for tail in ('"', "\\", "\n", "\x01", "\x7f", "\xe9", "中",
+                         "\U0001f600"):
+                s = run + tail + "tail"
+                self.assertEqual(loads(dumps(s)), s)
+        # No-escape pure-ASCII fast path returns the string verbatim.
+        self.assertEqual(dumps("x" * 20), '"' + "x" * 20 + '"')
+        # Non-ASCII is escaped under the default ensure_ascii=True.
+        self.assertEqual(dumps("a" * 20 + "\xe9"), '"' + "a" * 20 + '\\u00e9"')
+        self.assertEqual(dumps("a" * 20 + "中"), '"' + "a" * 20 + '\\u4e2d"')
+        self.assertEqual(dumps("a" * 20 + "\x7f"), '"' + "a" * 20 + '\\u007f"')
+        self.assertEqual(dumps("a" * 20 + '"'), '"' + "a" * 20 + '\\""')
+
 
 class TestPyDump(TestDump, PyTest): pass
 

--- a/Misc/NEWS.d/next/Library/2026-06-03-11-10-06.gh-issue-150875.WK9OTj.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-03-11-10-06.gh-issue-150875.WK9OTj.rst
@@ -1,0 +1,4 @@
+Speed up :func:`json.dumps` encoding of strings made up of long runs of
+characters that need no escaping, by scanning eight bytes at a time. Short
+strings, strings that need escaping, and strings containing non-Latin-1
+characters are unaffected. Patch by Bernát Gábor.

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -164,6 +164,43 @@ ascii_escape_size(const void *input, int kind, Py_ssize_t input_chars)
     Py_ssize_t i;
     Py_ssize_t output_size;
 
+    /* SWAR no-escape fast path (1-byte): when no byte needs escaping the
+       output is just the input plus the two surrounding quotes.  needs-escape
+       is c < 0x20 || c > 0x7e || c == '"' || c == '\\'; skip 8 bytes at a time
+       and fall through to the per-character loop at the first such byte.  The
+       length guard keeps short strings (the common dict key) on the original
+       loop, where the fast path's setup would not pay off. */
+    if (kind == PyUnicode_1BYTE_KIND && input_chars >= 16
+            && input_chars < PY_SSIZE_T_MAX - 2) {
+        const Py_UCS1 *p = (const Py_UCS1 *)input;
+        const uint64_t ones = 0x0101010101010101ULL;
+        const uint64_t high = 0x8080808080808080ULL;
+        const uint64_t bq = 0x22ULL * ones, bs = 0x5cULL * ones;
+        const uint64_t b7f = 0x7fULL * ones, bc = 0xE0ULL * ones;
+        Py_ssize_t j = 0;
+        int needs_escape = 0;
+        for (; j + 8 <= input_chars; j += 8) {
+            uint64_t w;
+            memcpy(&w, p + j, 8);
+            uint64_t mq = w ^ bq; mq = (mq - ones) & ~mq & high;          /* == '"'  */
+            uint64_t ms = w ^ bs; ms = (ms - ones) & ~ms & high;          /* == '\\' */
+            uint64_t vc = w & bc; uint64_t mlo = (vc - ones) & ~vc & high;/* < 0x20  */
+            uint64_t m7 = w ^ b7f; m7 = (m7 - ones) & ~m7 & high;         /* == 0x7f */
+            if (mq | ms | mlo | (w & high) | m7) {  /* (w & high): >= 0x80 */
+                needs_escape = 1;
+                break;
+            }
+        }
+        if (!needs_escape) {
+            for (; j < input_chars; j++) {
+                if (!S_CHAR(p[j])) { needs_escape = 1; break; }
+            }
+        }
+        if (!needs_escape) {
+            return input_chars + 2;
+        }
+    }
+
     /* Compute the output size */
     for (i = 0, output_size = 2; i < input_chars; i++) {
         Py_UCS4 c = PyUnicode_READ(kind, input, i);


### PR DESCRIPTION
`json.dumps` escapes each string by first scanning it one character at a time to size the escaped output (`ascii_escape_size`), after which `write_escaped_ascii` copies the string verbatim when nothing needs escaping. For a long string with no characters that need escaping, which is the common case for text values, log messages, and other long content, that per-character sizing scan is pure overhead before the verbatim copy.

This detects the no-escape case on the one-byte (ASCII/Latin-1) representation eight bytes at a time, so it returns the verbatim size after about one eighth of the work. It is the encode-side counterpart to #150872; the two touch different code paths and are separate changes.

## What we do now (scalar, one code point at a time)

```c
for (i = 0, output_size = 2; i < input_chars; i++) {
    Py_UCS4 c = PyUnicode_READ(kind, input, i);
    if (S_CHAR(c)) { output_size += 1; }   // ordinary char, needs no escaping
    else { /* compute the escaped width */ }
}
```

`S_CHAR` is printable ASCII except `"` and `\`, so a byte needs escaping when `c < 0x20 || c > 0x7e || c == '"' || c == '\\'`. For a long escape-free string this reads and tests every byte just to learn that the output equals the input plus two quotes.

## What SWAR does (8 bytes at a time, in one register)

SWAR is "SIMD within a register": load 8 bytes into a single `uint64_t` and test all 8 lanes at once with ordinary integer ops.

```c
for (; j + 8 <= input_chars; j += 8) {
    memcpy(&w, p + j, 8);
    mq  = haszero(w ^ (0x22 * 0x0101010101010101));   // any lane == '"' ?
    ms  = haszero(w ^ (0x5c * 0x0101010101010101));   // any lane == '\\' ?
    mlo = haszero(w & 0xE0E0E0E0E0E0E0E0);            // any lane < 0x20 ?
    mhi = (w & 0x8080808080808080)                    // any lane >= 0x80 ?
        | haszero(w ^ (0x7f * 0x0101010101010101));   // any lane == 0x7f ?
    if (mq | ms | mlo | mhi) { needs_escape = 1; break; }  // escape needed -> scalar
}
// no escape found anywhere -> output is the input plus two quotes
if (!needs_escape) return input_chars + 2;
```

`haszero(v) = (v - 0x0101…) & ~v & 0x8080…` lights the high bit of exactly the zero lanes, with no false positives or negatives. Broadcasting a byte (`b * 0x0101…`) and XOR-ing turns "equals b" into "is zero". The range checks `< 0x20` and `> 0x7e` reuse the same idea. When all 8 lanes are ordinary, the loop advances 8 bytes; at the first lane that needs escaping it breaks and the existing per-character loop computes the exact size and does the work. A length guard keeps short strings (the common dict key) on the original loop, where the fast path's setup would not pay off.

These are the same `0x0101…` / `0x8080…` masks that [`Objects/unicodeobject.c`](https://github.com/python/cpython/blob/7a468a101268d2b13105f94ae027df8b502d0c87/Objects/unicodeobject.c#L4887) and [`Objects/stringlib/find_max_char.h`](https://github.com/python/cpython/blob/7a468a101268d2b13105f94ae027df8b502d0c87/Objects/stringlib/find_max_char.h#L11) already use for ASCII scanning.

## When and how this changes performance

`json.dumps`, current encoder versus this change:

| Document shape | Effect |
|---|---|
| One long text field (~11 KB string) | 5.3x faster |
| Many 200-character ASCII string values | 3.1x faster |
| Realistic mixed records (short and medium strings) | 1.3x faster |
| Short keys, strings that need escaping, the pyperformance document | no change |
| Strings with emoji or other non-Latin-1 text | no change (scalar path) |

The gain scales with string length. The short-string guard keeps key-heavy documents unaffected; an earlier guardless version measured about 1.18x slower on a 2000-short-key document, which the guard removes.

## Correctness

Output is byte-identical to the current encoder. Verified against the full `test_json` suite and a 199-case differential corpus that places each escape-relevant character (`"`, `\\`, control chars, `0x7f`, and non-Latin-1 characters) at every offset across the eight-byte window, in both `ensure_ascii=True` and `ensure_ascii=False` modes. Every output matched.

<details><summary>Benchmark</summary>

```python
import json, pyperf
long_ascii = [("x"*200) for _ in range(200)]
text_blob  = {"body": "lorem ipsum dolor sit amet " * 400}
escaped    = [('a"b\\c\n'*30) for _ in range(200)]
short_keys = {f"k{i}": i for i in range(2000)}
mixed_real = [{"id":i,"name":f"user_{i}","email":f"u{i}@x.com","bio":"hello world "*10} for i in range(300)]
nonascii   = ["café 😀 中文 "*20 for _ in range(200)]
objs = {"long_ascii": long_ascii, "text_blob": text_blob, "escaped": escaped,
        "short_keys": short_keys, "mixed_real": mixed_real, "nonascii": nonascii}
runner = pyperf.Runner()
for n, o in objs.items():
    runner.bench_func(f"dumps/{n}", lambda o=o: json.dumps(o))
```

References for the bit tricks: Sean Anderson, Bit Twiddling Hacks ([zero byte](https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord), [byte equal to n](https://graphics.stanford.edu/~seander/bithacks.html#ValueInWord), [byte less than n](https://graphics.stanford.edu/~seander/bithacks.html#HasLessInWord)); Henry S. Warren Jr., Hacker's Delight, 2nd ed., chapter 6.
</details>

It is not the SIMD parsing backend from #142915: it adds no intrinsics, no CPU detection, and no build configuration, and it does not depend on #125022.

Resolves #150875.


<!-- gh-issue-number: gh-150875 -->
* Issue: gh-150875
<!-- /gh-issue-number -->
