### PR TITLE
gh-150885: Remove unused shutil._ensure_directory

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1307,12 +1307,6 @@ def unregister_unpack_format(name):
     """Removes the pack format from the registry."""
     del _UNPACK_FORMATS[name]
 
-def _ensure_directory(path):
-    """Ensure that the parent directory of `path` exists"""
-    dirname = os.path.dirname(path)
-    if not os.path.isdir(dirname):
-        os.makedirs(dirname)
-
 def _unpack_zipfile(filename, extract_dir):
     """Unpack zip `filename` to `extract_dir`
     """


### PR DESCRIPTION
`shutil._ensure_directory()` arrived in #8295 with `shutil.unpack_archive()`, where it created the parent directory of each extracted member. The ZIP path-traversal fix in gh-146581 (GH-146591) reworked `_unpack_zipfile()` to create directories inline and removed the last call to it, so the private helper now has no caller.

Nothing in the repository references the name outside its own definition, found by a word-boundary search across `Lib`, `Modules`, `Python`, `Objects`, and `Include`, and a GitHub code search turns up no downstream importer.

`_ensure_directory` is private and undocumented, so this has no user-facing effect and needs no `Misc/NEWS.d` entry. The `skip news` label applies.
