### PR TITLE
gh-150886: Remove unused importlib._bootstrap._object_name

### DIFF
--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -20,12 +20,6 @@ work. One should use importlib as the public-facing version of this module.
 # reference any injected objects! This includes not only global code but also
 # anything specified at the class level.
 
-def _object_name(obj):
-    try:
-        return obj.__qualname__
-    except AttributeError:
-        return type(obj).__qualname__
-
 # Bootstrap-related code ######################################################
 
 # Modules injected manually by _setup()

--- a/Misc/NEWS.d/next/Library/2026-06-03-21-59-11.gh-issue-150886.r2c25g.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-03-21-59-11.gh-issue-150886.r2c25g.rst
@@ -1,0 +1,4 @@
+Remove the private, undocumented function
+``importlib._bootstrap._object_name()``. It had no caller after
+``load_module()`` and its deprecation warnings were removed from
+:mod:`importlib`.


### PR DESCRIPTION
`importlib._bootstrap._object_name()` arrived in GH-23469 (bpo-26131) to render an object's qualified name inside the `load_module()` deprecation warnings. gh-142205 (GH-97850) removed `load_module()` and those warnings, deleting the last call site, so the private helper now has no caller.

Nothing in the repository references the name outside its own definition, and a GitHub code search turns up no downstream importer. Removing it from `Lib/importlib/_bootstrap.py` and regenerating the frozen module drops it from the runtime.

`_object_name` is private and undocumented, so this has no user-facing effect and needs no `Misc/NEWS.d` entry. The `skip news` label applies.


<!-- gh-issue-number: gh-150886 -->
* Issue: gh-150886
<!-- /gh-issue-number -->
