### PR TITLE
gh-150836: Build Tcl/Tk with noembed on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2026-06-04-18-53-18.gh-issue-150836.Wci7bZ.rst
+++ b/Misc/NEWS.d/next/Windows/2026-06-04-18-53-18.gh-issue-150836.Wci7bZ.rst
@@ -1,1 +1,1 @@
-On Windows Tcl/Tk 9.0.3 is built without embedded Tcl/Tk library scripts.
+Make released and installed tkinter work after import on Windows.

--- a/Misc/NEWS.d/next/Windows/2026-06-04-18-53-18.gh-issue-150836.Wci7bZ.rst
+++ b/Misc/NEWS.d/next/Windows/2026-06-04-18-53-18.gh-issue-150836.Wci7bZ.rst
@@ -1,0 +1,1 @@
+On Windows Tcl/Tk 9.0.3 is built without embedded Tcl/Tk library scripts.

--- a/PCbuild/tcl.vcxproj
+++ b/PCbuild/tcl.vcxproj
@@ -55,8 +55,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   
   <PropertyGroup>
-    <TclOpts>msvcrt</TclOpts>
-    <TclOpts Condition="$(Configuration) == 'Debug'">symbols,msvcrt</TclOpts>
+    <TclOpts>noembed,msvcrt</TclOpts>
+    <TclOpts Condition="$(Configuration) == 'Debug'">symbols,noembed,msvcrt</TclOpts>
     <TclDirs>BUILDDIRTOP="$(BuildDirTop)" INSTALLDIR="$(OutDir.TrimEnd(`\`))" INSTALL_DIR="$(OutDir.TrimEnd(`\`))"</TclDirs>
     <DebugFlags Condition="'$(Configuration)' == 'Debug'">DEBUGFLAGS="-wd4456 -wd4457 -wd4458 -wd4459 -wd4996"</DebugFlags>
     <WarningsFlags>WARNINGS="-W3 -wd4311 -wd4312"</WarningsFlags>

--- a/PCbuild/tcl.vcxproj
+++ b/PCbuild/tcl.vcxproj
@@ -63,7 +63,7 @@
     <NMakeBuildCommandLine>setlocal
 set VCINSTALLDIR=$(VCInstallDir)
 cd /D "$(tclDir)win"
-nmake -f makefile.vc MACHINE=$(TclMachine) OPTS=$(TclOpts) $(TclDirs) $(DebugFlags) $(WarningsFlags) $(TclshNativeFlag) core shell dlls
+nmake -f makefile.vc MACHINE=$(TclMachine) OPTS=$(TclOpts) $(TclDirs) $(DebugFlags) $(WarningsFlags) $(TclshNativeFlag) core shell dlls libtclzip
 nmake -f makefile.vc MACHINE=$(TclMachine) OPTS=$(TclOpts) $(TclDirs) $(DebugFlags) $(WarningsFlags) $(TclshNativeFlag) install-binaries install-libraries
 copy /Y ..\license.terms "$(OutDir)\tcllicense.terms"
 </NMakeBuildCommandLine>

--- a/PCbuild/tk.vcxproj
+++ b/PCbuild/tk.vcxproj
@@ -56,8 +56,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   
   <PropertyGroup>
-    <TkOpts>msvcrt</TkOpts>
-    <TkOpts Condition="$(Configuration) == 'Debug'">symbols,msvcrt</TkOpts>
+    <TkOpts>noembed,msvcrt</TkOpts>
+    <TkOpts Condition="$(Configuration) == 'Debug'">symbols,noembed,msvcrt</TkOpts>
     <TkDirs>BUILDDIRTOP="$(BuildDirTop)" TCLDIR="$(tclDir.TrimEnd(`\`))" INSTALLDIR="$(OutDir.TrimEnd(`\`))"</TkDirs>
     <DebugFlags Condition="'$(Configuration)' == 'Debug'">DEBUGFLAGS="-wd4456 -wd4457 -wd4458 -wd4459 -wd4996"</DebugFlags>
     <WarningsFlags>WARNINGS="-W3 -wd4244 -wd4267 -wd4311 -wd4312 -wd4334"</WarningsFlags>


### PR DESCRIPTION
Build Tcl/Tk with the noembed option on Windows. With this option the Tcl and Tk script libraries are not embedded in the DLLs but rather copied into directories in the install prefix.

<!-- gh-issue-number: gh-150836 -->
* Issue: gh-150836
<!-- /gh-issue-number -->
