### PR TITLE
Docs: avoid repetitions of class references in functions.rst

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -484,7 +484,7 @@ are always available.  They are listed here in alphabetical order.
            dict(iterable, /, **kwargs)
    :noindex:
 
-   Create a new dictionary.  The :class:`dict` object is the dictionary class.
+   Create a new dictionary.  The :class:`!dict` object is the dictionary class.
    See :class:`dict` and :ref:`typesmapping` for documentation about this class.
 
    For other containers see the built-in :class:`frozendict`, :class:`list`,
@@ -872,7 +872,7 @@ are always available.  They are listed here in alphabetical order.
            frozendict(iterable, /, **kwargs)
    :noindex:
 
-   Create a new frozen dictionary.  The :class:`frozendict` object is a built-in class.
+   Create a new frozen dictionary.  The :class:`!frozendict` object is a built-in class.
    See :class:`frozendict` and :ref:`typesmapping` for documentation about this class.
 
    For other containers see the built-in :class:`dict`, :class:`list`, :class:`set`,
@@ -885,8 +885,8 @@ are always available.  They are listed here in alphabetical order.
 .. class:: frozenset(iterable=(), /)
    :noindex:
 
-   Return a new :class:`frozenset` object, optionally with elements taken from
-   *iterable*.  ``frozenset`` is a built-in class.  See :class:`frozenset` and
+   Return a new :class:`!frozenset` object, optionally with elements taken from
+   *iterable*.  :class:`!frozenset` is a built-in class.  See :class:`frozenset` and
    :ref:`types-set` for documentation about this class.
 
    For other containers see the built-in :class:`set`, :class:`list`,
@@ -1813,8 +1813,8 @@ are always available.  They are listed here in alphabetical order.
 .. class:: set(iterable=(), /)
    :noindex:
 
-   Return a new :class:`set` object, optionally with elements taken from
-   *iterable*.  ``set`` is a built-in class.  See :class:`set` and
+   Return a new :class:`!set` object, optionally with elements taken from
+   *iterable*.  :class:`!set` is a built-in class.  See :class:`set` and
    :ref:`types-set` for documentation about this class.
 
    For other containers see the built-in :class:`frozenset`, :class:`list`,

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -484,8 +484,8 @@ are always available.  They are listed here in alphabetical order.
            dict(iterable, /, **kwargs)
    :noindex:
 
-   Create a new dictionary.  The :class:`!dict` object is the dictionary class.
-   See :class:`dict` and :ref:`typesmapping` for documentation about this class.
+   Create a new dictionary.  The :class:`dict` object is the dictionary class.
+   See also :ref:`typesmapping` for documentation about this class.
 
    For other containers see the built-in :class:`frozendict`, :class:`list`,
    :class:`set`, and :class:`tuple` classes, as well as the :mod:`collections` module.
@@ -872,8 +872,8 @@ are always available.  They are listed here in alphabetical order.
            frozendict(iterable, /, **kwargs)
    :noindex:
 
-   Create a new frozen dictionary.  The :class:`!frozendict` object is a built-in class.
-   See :class:`frozendict` and :ref:`typesmapping` for documentation about this class.
+   Create a new frozen dictionary.  The :class:`frozendict` object is a built-in class.
+   See also :ref:`typesmapping` for documentation about this class.
 
    For other containers see the built-in :class:`dict`, :class:`list`, :class:`set`,
    and :class:`tuple` classes, as well as the :mod:`collections` module.
@@ -885,8 +885,8 @@ are always available.  They are listed here in alphabetical order.
 .. class:: frozenset(iterable=(), /)
    :noindex:
 
-   Return a new :class:`!frozenset` object, optionally with elements taken from
-   *iterable*.  :class:`!frozenset` is a built-in class.  See :class:`frozenset` and
+   Return a new :class:`frozenset` object, optionally with elements taken from
+   *iterable*.  :class:`frozenset` is a built-in class.  See also
    :ref:`types-set` for documentation about this class.
 
    For other containers see the built-in :class:`set`, :class:`list`,
@@ -1813,8 +1813,8 @@ are always available.  They are listed here in alphabetical order.
 .. class:: set(iterable=(), /)
    :noindex:
 
-   Return a new :class:`!set` object, optionally with elements taken from
-   *iterable*.  :class:`!set` is a built-in class.  See :class:`set` and
+   Return a new :class:`set` object, optionally with elements taken from
+   *iterable*.  :class:`set` is a built-in class.  See also
    :ref:`types-set` for documentation about this class.
 
    For other containers see the built-in :class:`frozenset`, :class:`list`,


### PR DESCRIPTION
With Linklint we link only first reference in a paragraph. In effect references intended to link aren't links.

Simplify descriptions to avoid repetitions and this issue. In dict, frozendict, frozenset and set reference docs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Before:

<img width="600" alt="Zrzut ekranu 2026-06-3 o 23 49 34" src="https://github.com/user-attachments/assets/222c56a7-125f-4eeb-a361-c0a11afab9e6" />
<img width="600" alt="Zrzut ekranu 2026-06-3 o 23 57 08" src="https://github.com/user-attachments/assets/a82f42f7-c5d0-4200-9ccc-43bb665f65ea" />
<img width="600" alt="Zrzut ekranu 2026-06-3 o 23 57 31" src="https://github.com/user-attachments/assets/c3d89181-4fa0-4381-b7ac-02e0ac0e723c" />
<img width="600" alt="Zrzut ekranu 2026-06-3 o 23 57 58" src="https://github.com/user-attachments/assets/1e14c213-f502-4718-b4d9-f4e4af1f95c0" />

After:

<img width=400 alt=Screenshot_20260604-153809_Firefox.png src=https://github.com/user-attachments/assets/f271652f-014d-48de-9865-c4f9ed495312 />

<img width=400 alt=Screenshot_20260604-153853_Firefox.png src=https://github.com/user-attachments/assets/1c498a5a-d9c9-4cd2-a00b-c59b36d261ac />

<img width=400 alt=Screenshot_20260604-153913_Firefox.png src=https://github.com/user-attachments/assets/806ed686-fe7c-4faf-85b6-9f0b7b2d21c6 />

<img width=400 alt=Screenshot_20260604-153938_Firefox.png src=https://github.com/user-attachments/assets/fd873ca3-5c76-4bd3-afec-15392c3575fc />

Changelog:
* first iteration was mechanically changing which references are links
* second iteration does editorial change to avoid repetitions