### PR TITLE
Fix 2 broken links in documentation

### DIFF
--- a/Doc/c-api/complex.rst
+++ b/Doc/c-api/complex.rst
@@ -130,7 +130,7 @@ rather than dereferencing them through pointers.
 
 Please note, that these functions are :term:`soft deprecated` since Python
 3.15.  Avoid using this API in a new code to do complex arithmetic: either use
-the `Number Protocol <number>`_ API or use native complex types, like
+the :ref:`Number Protocol <number>` API or use native complex types, like
 :c:expr:`double complex`.
 
 

--- a/Doc/extending/first-extension-module.rst
+++ b/Doc/extending/first-extension-module.rst
@@ -164,7 +164,7 @@ Then, create ``meson.build`` containing the following:
 
 .. note::
 
-   See `meson-python documentation`_ for details on
+   See the :ref:`meson-python documentation <meson-python>` for details on
    configuration.
 
 Now, build install the *project in the current directory* (``.``) via ``pip``:
@@ -183,7 +183,6 @@ the compiler, which is often useful during development.
    (Or, if you prefer another tool that can build and install
    ``pyproject.toml``-based projects, use that.)
 
-.. _meson-python documentation: meson-python_
 .. _meson-python: https://mesonbuild.com/meson-python/
 .. _virtual environment: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#create-and-use-virtual-environments
 

--- a/Doc/extending/first-extension-module.rst
+++ b/Doc/extending/first-extension-module.rst
@@ -164,7 +164,7 @@ Then, create ``meson.build`` containing the following:
 
 .. note::
 
-   See `meson-python documentation <meson-python>`_ for details on
+   See `meson-python documentation`_ for details on
    configuration.
 
 Now, build install the *project in the current directory* (``.``) via ``pip``:
@@ -183,6 +183,7 @@ the compiler, which is often useful during development.
    (Or, if you prefer another tool that can build and install
    ``pyproject.toml``-based projects, use that.)
 
+.. _meson-python documentation: meson-python_
 .. _meson-python: https://mesonbuild.com/meson-python/
 .. _virtual environment: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#create-and-use-virtual-environments
 

--- a/Doc/extending/first-extension-module.rst
+++ b/Doc/extending/first-extension-module.rst
@@ -164,7 +164,7 @@ Then, create ``meson.build`` containing the following:
 
 .. note::
 
-   See the :ref:`meson-python documentation <meson-python>` for details on
+   See the `meson-python documentation <meson-python_>`_ for details on
    configuration.
 
 Now, build install the *project in the current directory* (``.``) via ``pip``:


### PR DESCRIPTION
Discovered in Fedora's RPM build with linkchecker:

    URL        `meson-python'
    Name       `meson-python documentation'
    Parent URL file:///builddir/build/BUILD/python3-docs-3.15.0_b2-build/Python-3.15.0b2/Doc/build/html/extending/first-extension-module.html, line 347, col 8
    Real URL   file:///builddir/build/BUILD/python3-docs-3.15.0_b2-build/Python-3.15.0b2/Doc/build/html/extending/meson-python
    Check time 0.000 seconds
    Result     Error: URLError: <urlopen error [Errno 2] No such file or directory: '/builddir/build/BUILD/python3-docs-3.15.0_b2-build/Python-3.15.0b2/Doc/build/html/extending/meson-python'>

    URL        `number'
    Name       `Number Protocol'
    Parent URL file:///builddir/build/BUILD/python3-docs-3.15.0_b2-build/Python-3.15.0b2/Doc/build/html/c-api/complex.html, line 336, col 5
    Real URL   file:///builddir/build/BUILD/python3-docs-3.15.0_b2-build/Python-3.15.0b2/Doc/build/html/c-api/number
    Check time 0.001 seconds
    Result     Error: URLError: <urlopen error [Errno 2] No such file or directory: '/builddir/build/BUILD/python3-docs-3.15.0_b2-build/Python-3.15.0b2/Doc/build/html/c-api/number'>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
