### PR TITLE
gh-150899: Do not reset custom `-Xlazy_imports` mode in `test_lazy_imports`

### DIFF
--- a/Lib/test/test_lazy_import/__init__.py
+++ b/Lib/test/test_lazy_import/__init__.py
@@ -21,8 +21,10 @@ except ImportError:
     _testcapi = None
 
 
-class LazyImportTests(unittest.TestCase):
-    """Tests for basic lazy import functionality."""
+class LazyImportTestCase(unittest.TestCase):
+    def setUp(self):
+        self.lazy_imports_filter = sys.get_lazy_imports_filter()
+        self.lazy_imports = sys.get_lazy_imports()
 
     def tearDown(self):
         """Clean up any test modules from sys.modules."""
@@ -30,9 +32,13 @@ class LazyImportTests(unittest.TestCase):
             if key.startswith('test.test_lazy_import.data'):
                 del sys.modules[key]
 
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
+        sys.set_lazy_imports_filter(self.lazy_imports_filter)
+        sys.set_lazy_imports(self.lazy_imports)
         sys.lazy_modules.clear()
+
+
+class LazyImportTests(LazyImportTestCase):
+    """Tests for basic lazy import functionality."""
 
     def test_basic_unused(self):
         """Lazy imported module should not be loaded if never accessed."""
@@ -162,16 +168,8 @@ class LazyImportTests(unittest.TestCase):
         assert_python_ok("-c", code)
 
 
-class GlobalLazyImportModeTests(unittest.TestCase):
+class GlobalLazyImportModeTests(LazyImportTestCase):
     """Tests for sys.set_lazy_imports() global mode control."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_global_off_rejected(self):
         """Mode 'none' is not supported."""
@@ -204,16 +202,8 @@ class GlobalLazyImportModeTests(unittest.TestCase):
         self.assertNotIn("test.test_lazy_import.data.basic2", sys.modules)
 
 
-class CompatibilityModeTests(unittest.TestCase):
+class CompatibilityModeTests(LazyImportTestCase):
     """Tests for __lazy_modules__ compatibility mode."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_compatibility_mode(self):
         """__lazy_modules__ should enable lazy imports for listed modules."""
@@ -241,16 +231,8 @@ class CompatibilityModeTests(unittest.TestCase):
         self.assertNotIn("test.test_lazy_import.data.basic2", sys.modules)
 
 
-class ModuleIntrospectionTests(unittest.TestCase):
+class ModuleIntrospectionTests(LazyImportTestCase):
     """Tests for module dict and getattr behavior with lazy imports."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_modules_dict(self):
         """Accessing module.__dict__ should not trigger reification."""
@@ -268,16 +250,8 @@ class ModuleIntrospectionTests(unittest.TestCase):
         self.assertNotIn("test.test_lazy_import.data.basic2", sys.modules)
 
 
-class LazyImportTypeTests(unittest.TestCase):
+class LazyImportTypeTests(LazyImportTestCase):
     """Tests for the LazyImportType and its resolve() method."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_lazy_value_resolve(self):
         """resolve() method should force the lazy import to load."""
@@ -304,16 +278,8 @@ class LazyImportTypeTests(unittest.TestCase):
         self.assertIn(b"<built-in method resolve of lazy_import object at", proc.out)
 
 
-class SyntaxRestrictionTests(unittest.TestCase):
+class SyntaxRestrictionTests(LazyImportTestCase):
     """Tests for syntax restrictions on lazy imports."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_lazy_try_except(self):
         """lazy import inside try/except should raise SyntaxError."""
@@ -383,16 +349,8 @@ class SyntaxRestrictionTests(unittest.TestCase):
         self.assertIn("OK", result.stdout)
 
 
-class EagerImportInLazyModeTests(unittest.TestCase):
+class EagerImportInLazyModeTests(LazyImportTestCase):
     """Tests for imports that should remain eager even in lazy mode."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_try_except_eager(self):
         """Imports in try/except should be eager even with mode='all'."""
@@ -459,16 +417,8 @@ class EagerImportInLazyModeTests(unittest.TestCase):
             del globals()["__lazy_modules__"]
 
 
-class WithStatementTests(unittest.TestCase):
+class WithStatementTests(LazyImportTestCase):
     """Tests for lazy imports in with statement context."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_lazy_with(self):
         """lazy import with 'with' statement should work."""
@@ -481,16 +431,8 @@ class WithStatementTests(unittest.TestCase):
         self.assertNotIn("test.test_lazy_import.data.basic2", sys.modules)
 
 
-class PackageTests(unittest.TestCase):
+class PackageTests(LazyImportTestCase):
     """Tests for lazy imports with packages."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_lazy_import_pkg(self):
         """lazy import of package submodule should load the package."""
@@ -600,16 +542,8 @@ class PackageTests(unittest.TestCase):
         assert_python_ok("-c", code)
 
 
-class DunderLazyImportTests(unittest.TestCase):
+class DunderLazyImportTests(LazyImportTestCase):
     """Tests for __lazy_import__ builtin function."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_dunder_lazy_import(self):
         """__lazy_import__ should create lazy import proxy."""
@@ -645,16 +579,8 @@ class DunderLazyImportTests(unittest.TestCase):
         self.assertEqual(dunder_lazy_import_builtins.basic.basic2, 42)
 
 
-class SysLazyImportsAPITests(unittest.TestCase):
+class SysLazyImportsAPITests(LazyImportTestCase):
     """Tests for sys lazy imports API functions."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_set_lazy_imports_requires_string(self):
         """set_lazy_imports should reject non-string arguments."""
@@ -720,20 +646,12 @@ class SysLazyImportsAPITests(unittest.TestCase):
 
 
 @support.requires_subprocess()
-class ErrorHandlingTests(unittest.TestCase):
+class ErrorHandlingTests(LazyImportTestCase):
     """Tests for error handling during lazy import reification.
 
     PEP 810: Errors during reification should show exception chaining with
     both the lazy import definition location and the access location.
     """
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_import_error_shows_chained_traceback(self):
         """Accessing a nonexistent lazy submodule via parent attr raises AttributeError."""
@@ -867,21 +785,13 @@ class ErrorHandlingTests(unittest.TestCase):
 
 
 @support.requires_subprocess()
-class GlobalsAndDictTests(unittest.TestCase):
+class GlobalsAndDictTests(LazyImportTestCase):
     """Tests for globals() and __dict__ behavior with lazy imports.
 
     PEP 810: "Calling globals() or accessing a module's __dict__ does not trigger
     reification – they return the module's dictionary, and accessing lazy objects
     through that dictionary still returns lazy proxy objects."
     """
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_globals_returns_lazy_proxy_when_accessed_from_function(self):
         """globals() accessed from a function should return lazy proxy without reification.
@@ -1037,7 +947,7 @@ class GlobalsAndDictTests(unittest.TestCase):
 
 
 @support.requires_subprocess()
-class MultipleNameFromImportTests(unittest.TestCase):
+class MultipleNameFromImportTests(LazyImportTestCase):
     """Tests for lazy from ... import with multiple names.
 
     PEP 810: "When using lazy from ... import, each imported name is bound to a
@@ -1045,14 +955,6 @@ class MultipleNameFromImportTests(unittest.TestCase):
     of the entire module and reifies only that specific name to its actual value.
     Other names remain as lazy proxies until they are accessed."
     """
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_accessing_one_name_leaves_others_as_proxies(self):
         """Accessing one name from multi-name import should leave others lazy."""
@@ -1118,19 +1020,11 @@ class MultipleNameFromImportTests(unittest.TestCase):
 
 
 @support.requires_subprocess()
-class SysLazyModulesTrackingTests(unittest.TestCase):
+class SysLazyModulesTrackingTests(LazyImportTestCase):
     """Tests for sys.lazy_modules tracking behavior.
 
     PEP 810: "When the module is reified, it's removed from sys.lazy_modules"
     """
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_module_added_to_lazy_modules_on_lazy_import(self):
         """Module should be added to sys.lazy_modules when lazily imported."""
@@ -1328,19 +1222,11 @@ class CommandLineAndEnvVarTests(unittest.TestCase):
 
 
 @support.requires_subprocess()
-class FilterFunctionSignatureTests(unittest.TestCase):
+class FilterFunctionSignatureTests(LazyImportTestCase):
     """Tests for the filter function signature per PEP 810.
 
     PEP 810: func(importer: str, name: str, fromlist: tuple[str, ...] | None) -> bool
     """
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def _run_subprocess_with_modules(self, code, files):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1611,16 +1497,8 @@ class FilterFunctionSignatureTests(unittest.TestCase):
         self.assertIn("OK", result.stdout)
 
 
-class AdditionalSyntaxRestrictionTests(unittest.TestCase):
+class AdditionalSyntaxRestrictionTests(LazyImportTestCase):
     """Additional syntax restriction tests per PEP 810."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_lazy_import_inside_class_raises_syntax_error(self):
         """lazy import inside class body should raise SyntaxError."""
@@ -1631,21 +1509,13 @@ class AdditionalSyntaxRestrictionTests(unittest.TestCase):
 
 
 @support.requires_subprocess()
-class MixedLazyEagerImportTests(unittest.TestCase):
+class MixedLazyEagerImportTests(LazyImportTestCase):
     """Tests for mixing lazy and eager imports of the same module.
 
     PEP 810: "If module foo is imported both lazily and eagerly in the same
     program, the eager import takes precedence and both bindings resolve to
     the same module object."
     """
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_eager_import_before_lazy_resolves_to_same_module(self):
         """Eager import before lazy should make lazy resolve to same module."""
@@ -1692,16 +1562,8 @@ class MixedLazyEagerImportTests(unittest.TestCase):
         self.assertIn("OK", result.stdout)
 
 
-class RelativeImportTests(unittest.TestCase):
+class RelativeImportTests(LazyImportTestCase):
     """Tests for relative imports with lazy keyword."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_relative_lazy_import(self):
         """lazy from . import submodule should work."""
@@ -1727,20 +1589,12 @@ class RelativeImportTests(unittest.TestCase):
         self.assertIn("test.test_lazy_import.data.basic2", sys.modules)
 
 
-class LazyModulesCompatibilityFromImportTests(unittest.TestCase):
+class LazyModulesCompatibilityFromImportTests(LazyImportTestCase):
     """Tests for __lazy_modules__ with from imports.
 
     PEP 810: "When a module is made lazy this way, from-imports using that
     module are also lazy"
     """
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_lazy_modules_makes_from_imports_lazy(self):
         """__lazy_modules__ should make from imports of listed modules lazy."""
@@ -1756,7 +1610,7 @@ class LazyModulesCompatibilityFromImportTests(unittest.TestCase):
 
 
 @support.requires_subprocess()
-class ImportStateAtReificationTests(unittest.TestCase):
+class ImportStateAtReificationTests(LazyImportTestCase):
     """Tests for import system state at reification time.
 
     PEP 810: "Reification still calls __import__ to resolve the import, which uses
@@ -1764,14 +1618,6 @@ class ImportStateAtReificationTests(unittest.TestCase):
     and __import__) at reification time, not the state when the lazy import
     statement was evaluated."
     """
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_sys_path_at_reification_time_is_used(self):
         """sys.path changes after lazy import should affect reification."""
@@ -1815,16 +1661,8 @@ class ImportStateAtReificationTests(unittest.TestCase):
 
 
 @support.requires_subprocess()
-class ThreadSafetyTests(unittest.TestCase):
+class ThreadSafetyTests(LazyImportTestCase):
     """Tests for thread-safety of lazy imports."""
-
-    def tearDown(self):
-        for key in list(sys.modules.keys()):
-            if key.startswith('test.test_lazy_import.data'):
-                del sys.modules[key]
-
-        sys.set_lazy_imports_filter(None)
-        sys.set_lazy_imports("normal")
 
     def test_concurrent_lazy_import_reification(self):
         """Multiple threads racing to reify the same lazy import should succeed."""
@@ -2087,11 +1925,7 @@ class LazyImportDisTests(unittest.TestCase):
 
 
 @unittest.skipIf(_testcapi is None, 'need the _testcapi module')
-class LazyCApiTests(unittest.TestCase):
-    def tearDown(self):
-        sys.set_lazy_imports("normal")
-        sys.set_lazy_imports_filter(None)
-
+class LazyCApiTests(LazyImportTestCase):
     def test_set_matches_sys(self):
         self.assertEqual(_testcapi.PyImport_GetLazyImportsMode(), sys.get_lazy_imports())
         for mode in ("normal", "all"):


### PR DESCRIPTION
Both `./python.exe -Xlazy_imports=all -m test test_lazy_import` and `./python.exe -Xlazy_imports=normal -m test test_lazy_import` pass locally.

<!-- gh-issue-number: gh-150899 -->
* Issue: gh-150899
<!-- /gh-issue-number -->
