### PR TITLE
gh-146495: Improve `SyntaxError` message for `&&` and `||` operators

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -1642,7 +1642,15 @@ invalid_type_params:
             "Type parameter list cannot be empty")}
 
 invalid_bitwise_and:
-    | a=bitwise_and b='&' c='&' { RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'?") }
+    | a=bitwise_and b='&' c='&' {
+        _PyPegen_tokens_are_adjacent(b, c)
+        ? RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'?")
+        : NULL
+    }
 
 invalid_bitwise_or:
-    | a=bitwise_or b='|' c='|' { RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'?") }
+    | a=bitwise_or b='|' c='|' {
+        _PyPegen_tokens_are_adjacent(b, c)
+        ? RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'?")
+        : NULL
+    }

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -1642,7 +1642,7 @@ invalid_type_params:
             "Type parameter list cannot be empty")}
 
 invalid_bitwise_and:
-    | a=bitwise_and b='&' c='&' { RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'") }
+    | a=bitwise_and b='&' c='&' { RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'?") }
 
 invalid_bitwise_or:
-    | a=bitwise_or b='|' c='|' { RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'") }
+    | a=bitwise_or b='|' c='|' { RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'?") }

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -819,6 +819,7 @@ is_bitwise_or[CmpopExprPair*]: 'is' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, I
 
 bitwise_or[expr_ty]:
     | a=bitwise_or '|' b=bitwise_xor { _PyAST_BinOp(a, BitOr, b, EXTRA) }
+    | invalid_bitwise_or
     | bitwise_xor
 
 bitwise_xor[expr_ty]:
@@ -827,6 +828,7 @@ bitwise_xor[expr_ty]:
 
 bitwise_and[expr_ty]:
     | a=bitwise_and '&' b=shift_expr { _PyAST_BinOp(a, BitAnd, b, EXTRA) }
+    | invalid_bitwise_and
     | shift_expr
 
 shift_expr[expr_ty]:
@@ -1638,3 +1640,9 @@ invalid_type_params:
         RAISE_SYNTAX_ERROR_STARTING_FROM(
             token,
             "Type parameter list cannot be empty")}
+
+invalid_bitwise_and:
+    | a=bitwise_and b='&' c='&' { RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'") }
+
+invalid_bitwise_or:
+    | a=bitwise_or b='|' c='|' { RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'") }

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -3508,7 +3508,7 @@ while 1:
     def test_double_ampersand(self):
         self._check_error(
             "a && b",
-            "Maybe you meant 'and' or '&' instead of '&&'",
+            "Maybe you meant 'and' or '&' instead of '&&'?",
             lineno=1,
             end_lineno=1,
             offset=3,

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -3514,6 +3514,14 @@ while 1:
             offset=3,
             end_offset=5,
         )
+        self._check_error(
+            "a & & b",
+            "invalid syntax",
+            lineno=1,
+            end_lineno=1,
+            offset=5,
+            end_offset=6,
+        )
 
     def test_double_pipe(self):
         self._check_error(
@@ -3524,18 +3532,6 @@ while 1:
             offset=3,
             end_offset=5,
         )
-
-    def test_ampersand_with_space(self):
-        self._check_error(
-            "a & & b",
-            "invalid syntax",
-            lineno=1,
-            end_lineno=1,
-            offset=5,
-            end_offset=6,
-        )
-
-    def test_pipe_with_space(self):
         self._check_error(
             "a | | b",
             "invalid syntax",

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -3518,7 +3518,7 @@ while 1:
     def test_double_pipe(self):
         self._check_error(
             "a || b",
-            "Maybe you meant 'or' or '|' instead of '||'",
+            "Maybe you meant 'or' or '|' instead of '||'?",
             lineno=1,
             end_lineno=1,
             offset=3,

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -3508,7 +3508,7 @@ while 1:
     def test_double_ampersand(self):
         self._check_error(
             "a && b",
-            "Maybe you meant 'and' or '&' instead of '&&'?",
+            r"Maybe you meant 'and' or '&' instead of '&&'\?",
             lineno=1,
             end_lineno=1,
             offset=3,
@@ -3522,11 +3522,19 @@ while 1:
             offset=5,
             end_offset=6,
         )
+        self._check_error(
+            "(a &\n    & b)",
+            "invalid syntax",
+            lineno=2,
+            end_lineno=2,
+            offset=5,
+            end_offset=6,
+        )
 
     def test_double_pipe(self):
         self._check_error(
             "a || b",
-            "Maybe you meant 'or' or '|' instead of '||'?",
+            r"Maybe you meant 'or' or '|' instead of '||'\?",
             lineno=1,
             end_lineno=1,
             offset=3,

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -3525,6 +3525,26 @@ while 1:
             end_offset=5,
         )
 
+    def test_ampersand_with_space(self):
+        self._check_error(
+            "a & & b",
+            "invalid syntax",
+            lineno=1,
+            end_lineno=1,
+            offset=5,
+            end_offset=6,
+        )
+
+    def test_pipe_with_space(self):
+        self._check_error(
+            "a | | b",
+            "invalid syntax",
+            lineno=1,
+            end_lineno=1,
+            offset=5,
+            end_offset=6,
+        )
+
 
 class LazyImportRestrictionTestCase(SyntaxErrorTestCase):
     """Test syntax restrictions for lazy imports."""

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -3505,6 +3505,18 @@ while 1:
         ]:
             self._check_error(f"x = {lhs_stmt} if 1 else {rhs_stmt}", msg)
 
+    def test_double_ampersand(self):
+        self._check_error(
+            "a && b",
+            "Maybe you meant 'and' or '&' instead of '&&'",
+        )
+
+    def test_double_pipe(self):
+        self._check_error(
+            "a || b",
+            "Maybe you meant 'or' or '|' instead of '||'",
+        )
+
 
 class LazyImportRestrictionTestCase(SyntaxErrorTestCase):
     """Test syntax restrictions for lazy imports."""

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -3509,12 +3509,20 @@ while 1:
         self._check_error(
             "a && b",
             "Maybe you meant 'and' or '&' instead of '&&'",
+            lineno=1,
+            end_lineno=1,
+            offset=3,
+            end_offset=5,
         )
 
     def test_double_pipe(self):
         self._check_error(
             "a || b",
             "Maybe you meant 'or' or '|' instead of '||'",
+            lineno=1,
+            end_lineno=1,
+            offset=3,
+            end_offset=5,
         )
 
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-04-15-02-35.gh-issue-146495.wWRRvx.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-04-15-02-35.gh-issue-146495.wWRRvx.rst
@@ -1,1 +1,1 @@
-Improve SyntaxError message for ``&&`` and ``||`` operators, suggesting ``and``/``&`` and ``or``/``|`` respectively.
+Improve :exc:`SyntaxError` message for ``&&`` and ``||`` operators, suggesting ``and``/``&`` and ``or``/``|`` respectively.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-04-15-02-35.gh-issue-146495.wWRRvx.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-04-15-02-35.gh-issue-146495.wWRRvx.rst
@@ -1,0 +1,1 @@
+Improve SyntaxError message for ``&&`` and ``||`` operators, suggesting ``and``/``&`` and ``or``/``|`` respectively.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -28508,7 +28508,7 @@ invalid_bitwise_and_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ invalid_bitwise_and[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_and '&' '&'"));
-            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( b , c , "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'" );
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( b , c , "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'?" );
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;
@@ -28558,7 +28558,7 @@ invalid_bitwise_or_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ invalid_bitwise_or[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_or '|' '|'"));
-            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( b , c , "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'" );
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( b , c , "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'?" );
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -28508,7 +28508,7 @@ invalid_bitwise_and_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ invalid_bitwise_and[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_and '&' '&'"));
-            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( b , c , "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'?" );
+            _res = _PyPegen_tokens_are_adjacent ( b , c ) ? RAISE_SYNTAX_ERROR_KNOWN_RANGE ( b , c , "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'?" ) : NULL;
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;
@@ -28558,7 +28558,7 @@ invalid_bitwise_or_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ invalid_bitwise_or[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_or '|' '|'"));
-            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( b , c , "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'?" );
+            _res = _PyPegen_tokens_are_adjacent ( b , c ) ? RAISE_SYNTAX_ERROR_KNOWN_RANGE ( b , c , "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'?" ) : NULL;
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -362,186 +362,188 @@ static char *soft_keywords[] = {
 #define invalid_arithmetic_type 1273
 #define invalid_factor_type 1274
 #define invalid_type_params_type 1275
-#define _loop0_1_type 1276
-#define _loop1_2_type 1277
-#define _loop0_3_type 1278
-#define _gather_4_type 1279
-#define _tmp_5_type 1280
-#define _tmp_6_type 1281
-#define _tmp_7_type 1282
-#define _tmp_8_type 1283
-#define _tmp_9_type 1284
-#define _tmp_10_type 1285
-#define _tmp_11_type 1286
-#define _loop1_12_type 1287
-#define _loop0_13_type 1288
-#define _gather_14_type 1289
-#define _tmp_15_type 1290
-#define _tmp_16_type 1291
-#define _loop0_17_type 1292
-#define _loop1_18_type 1293
-#define _loop0_19_type 1294
-#define _gather_20_type 1295
-#define _tmp_21_type 1296
-#define _loop0_22_type 1297
-#define _gather_23_type 1298
-#define _loop1_24_type 1299
-#define _tmp_25_type 1300
-#define _tmp_26_type 1301
-#define _loop0_27_type 1302
-#define _loop0_28_type 1303
-#define _loop1_29_type 1304
-#define _loop1_30_type 1305
-#define _loop0_31_type 1306
-#define _loop1_32_type 1307
-#define _loop0_33_type 1308
-#define _gather_34_type 1309
-#define _tmp_35_type 1310
-#define _loop1_36_type 1311
-#define _loop1_37_type 1312
-#define _loop1_38_type 1313
-#define _loop0_39_type 1314
-#define _gather_40_type 1315
-#define _tmp_41_type 1316
-#define _tmp_42_type 1317
-#define _tmp_43_type 1318
-#define _loop0_44_type 1319
-#define _gather_45_type 1320
-#define _loop0_46_type 1321
-#define _gather_47_type 1322
-#define _tmp_48_type 1323
-#define _loop0_49_type 1324
-#define _gather_50_type 1325
-#define _loop0_51_type 1326
-#define _gather_52_type 1327
-#define _loop0_53_type 1328
-#define _gather_54_type 1329
-#define _loop1_55_type 1330
-#define _loop1_56_type 1331
-#define _loop0_57_type 1332
-#define _gather_58_type 1333
-#define _loop0_59_type 1334
-#define _gather_60_type 1335
-#define _loop1_61_type 1336
-#define _loop1_62_type 1337
-#define _loop1_63_type 1338
-#define _tmp_64_type 1339
-#define _loop0_65_type 1340
-#define _gather_66_type 1341
-#define _tmp_67_type 1342
-#define _tmp_68_type 1343
-#define _tmp_69_type 1344
-#define _tmp_70_type 1345
-#define _tmp_71_type 1346
-#define _loop0_72_type 1347
-#define _loop0_73_type 1348
-#define _loop1_74_type 1349
-#define _loop1_75_type 1350
-#define _loop0_76_type 1351
-#define _loop1_77_type 1352
-#define _loop0_78_type 1353
-#define _loop0_79_type 1354
-#define _loop0_80_type 1355
-#define _loop0_81_type 1356
-#define _loop1_82_type 1357
-#define _loop1_83_type 1358
-#define _tmp_84_type 1359
-#define _loop0_85_type 1360
-#define _gather_86_type 1361
-#define _loop1_87_type 1362
-#define _loop0_88_type 1363
-#define _tmp_89_type 1364
-#define _loop0_90_type 1365
-#define _gather_91_type 1366
-#define _tmp_92_type 1367
-#define _loop0_93_type 1368
-#define _gather_94_type 1369
-#define _loop0_95_type 1370
-#define _gather_96_type 1371
-#define _loop0_97_type 1372
-#define _loop0_98_type 1373
-#define _gather_99_type 1374
-#define _loop1_100_type 1375
-#define _tmp_101_type 1376
-#define _loop0_102_type 1377
-#define _gather_103_type 1378
-#define _loop0_104_type 1379
-#define _gather_105_type 1380
-#define _tmp_106_type 1381
-#define _tmp_107_type 1382
-#define _loop0_108_type 1383
-#define _gather_109_type 1384
-#define _tmp_110_type 1385
-#define _tmp_111_type 1386
-#define _tmp_112_type 1387
-#define _tmp_113_type 1388
-#define _tmp_114_type 1389
-#define _loop1_115_type 1390
-#define _tmp_116_type 1391
-#define _tmp_117_type 1392
-#define _tmp_118_type 1393
-#define _tmp_119_type 1394
-#define _tmp_120_type 1395
-#define _loop0_121_type 1396
-#define _loop0_122_type 1397
-#define _tmp_123_type 1398
-#define _tmp_124_type 1399
-#define _tmp_125_type 1400
-#define _tmp_126_type 1401
-#define _tmp_127_type 1402
-#define _tmp_128_type 1403
-#define _tmp_129_type 1404
-#define _tmp_130_type 1405
-#define _loop0_131_type 1406
-#define _gather_132_type 1407
-#define _tmp_133_type 1408
-#define _tmp_134_type 1409
-#define _tmp_135_type 1410
-#define _tmp_136_type 1411
-#define _loop0_137_type 1412
-#define _gather_138_type 1413
-#define _tmp_139_type 1414
-#define _loop0_140_type 1415
-#define _gather_141_type 1416
-#define _loop0_142_type 1417
-#define _gather_143_type 1418
-#define _tmp_144_type 1419
-#define _loop0_145_type 1420
-#define _tmp_146_type 1421
-#define _tmp_147_type 1422
-#define _tmp_148_type 1423
-#define _tmp_149_type 1424
-#define _tmp_150_type 1425
-#define _tmp_151_type 1426
-#define _tmp_152_type 1427
-#define _tmp_153_type 1428
-#define _tmp_154_type 1429
-#define _tmp_155_type 1430
-#define _tmp_156_type 1431
-#define _tmp_157_type 1432
-#define _tmp_158_type 1433
-#define _tmp_159_type 1434
-#define _tmp_160_type 1435
-#define _tmp_161_type 1436
-#define _tmp_162_type 1437
-#define _tmp_163_type 1438
-#define _tmp_164_type 1439
-#define _tmp_165_type 1440
-#define _tmp_166_type 1441
-#define _tmp_167_type 1442
-#define _tmp_168_type 1443
-#define _tmp_169_type 1444
-#define _tmp_170_type 1445
-#define _tmp_171_type 1446
-#define _tmp_172_type 1447
-#define _tmp_173_type 1448
-#define _loop0_174_type 1449
-#define _tmp_175_type 1450
-#define _tmp_176_type 1451
-#define _tmp_177_type 1452
-#define _tmp_178_type 1453
-#define _tmp_179_type 1454
-#define _tmp_180_type 1455
+#define invalid_bitwise_and_type 1276  // Left-recursive
+#define invalid_bitwise_or_type 1277  // Left-recursive
+#define _loop0_1_type 1278
+#define _loop1_2_type 1279
+#define _loop0_3_type 1280
+#define _gather_4_type 1281
+#define _tmp_5_type 1282
+#define _tmp_6_type 1283
+#define _tmp_7_type 1284
+#define _tmp_8_type 1285
+#define _tmp_9_type 1286
+#define _tmp_10_type 1287
+#define _tmp_11_type 1288
+#define _loop1_12_type 1289
+#define _loop0_13_type 1290
+#define _gather_14_type 1291
+#define _tmp_15_type 1292
+#define _tmp_16_type 1293
+#define _loop0_17_type 1294
+#define _loop1_18_type 1295
+#define _loop0_19_type 1296
+#define _gather_20_type 1297
+#define _tmp_21_type 1298
+#define _loop0_22_type 1299
+#define _gather_23_type 1300
+#define _loop1_24_type 1301
+#define _tmp_25_type 1302
+#define _tmp_26_type 1303
+#define _loop0_27_type 1304
+#define _loop0_28_type 1305
+#define _loop1_29_type 1306
+#define _loop1_30_type 1307
+#define _loop0_31_type 1308
+#define _loop1_32_type 1309
+#define _loop0_33_type 1310
+#define _gather_34_type 1311
+#define _tmp_35_type 1312
+#define _loop1_36_type 1313
+#define _loop1_37_type 1314
+#define _loop1_38_type 1315
+#define _loop0_39_type 1316
+#define _gather_40_type 1317
+#define _tmp_41_type 1318
+#define _tmp_42_type 1319
+#define _tmp_43_type 1320
+#define _loop0_44_type 1321
+#define _gather_45_type 1322
+#define _loop0_46_type 1323
+#define _gather_47_type 1324
+#define _tmp_48_type 1325
+#define _loop0_49_type 1326
+#define _gather_50_type 1327
+#define _loop0_51_type 1328
+#define _gather_52_type 1329
+#define _loop0_53_type 1330
+#define _gather_54_type 1331
+#define _loop1_55_type 1332
+#define _loop1_56_type 1333
+#define _loop0_57_type 1334
+#define _gather_58_type 1335
+#define _loop0_59_type 1336
+#define _gather_60_type 1337
+#define _loop1_61_type 1338
+#define _loop1_62_type 1339
+#define _loop1_63_type 1340
+#define _tmp_64_type 1341
+#define _loop0_65_type 1342
+#define _gather_66_type 1343
+#define _tmp_67_type 1344
+#define _tmp_68_type 1345
+#define _tmp_69_type 1346
+#define _tmp_70_type 1347
+#define _tmp_71_type 1348
+#define _loop0_72_type 1349
+#define _loop0_73_type 1350
+#define _loop1_74_type 1351
+#define _loop1_75_type 1352
+#define _loop0_76_type 1353
+#define _loop1_77_type 1354
+#define _loop0_78_type 1355
+#define _loop0_79_type 1356
+#define _loop0_80_type 1357
+#define _loop0_81_type 1358
+#define _loop1_82_type 1359
+#define _loop1_83_type 1360
+#define _tmp_84_type 1361
+#define _loop0_85_type 1362
+#define _gather_86_type 1363
+#define _loop1_87_type 1364
+#define _loop0_88_type 1365
+#define _tmp_89_type 1366
+#define _loop0_90_type 1367
+#define _gather_91_type 1368
+#define _tmp_92_type 1369
+#define _loop0_93_type 1370
+#define _gather_94_type 1371
+#define _loop0_95_type 1372
+#define _gather_96_type 1373
+#define _loop0_97_type 1374
+#define _loop0_98_type 1375
+#define _gather_99_type 1376
+#define _loop1_100_type 1377
+#define _tmp_101_type 1378
+#define _loop0_102_type 1379
+#define _gather_103_type 1380
+#define _loop0_104_type 1381
+#define _gather_105_type 1382
+#define _tmp_106_type 1383
+#define _tmp_107_type 1384
+#define _loop0_108_type 1385
+#define _gather_109_type 1386
+#define _tmp_110_type 1387
+#define _tmp_111_type 1388
+#define _tmp_112_type 1389
+#define _tmp_113_type 1390
+#define _tmp_114_type 1391
+#define _loop1_115_type 1392
+#define _tmp_116_type 1393
+#define _tmp_117_type 1394
+#define _tmp_118_type 1395
+#define _tmp_119_type 1396
+#define _tmp_120_type 1397
+#define _loop0_121_type 1398
+#define _loop0_122_type 1399
+#define _tmp_123_type 1400
+#define _tmp_124_type 1401
+#define _tmp_125_type 1402
+#define _tmp_126_type 1403
+#define _tmp_127_type 1404
+#define _tmp_128_type 1405
+#define _tmp_129_type 1406
+#define _tmp_130_type 1407
+#define _loop0_131_type 1408
+#define _gather_132_type 1409
+#define _tmp_133_type 1410
+#define _tmp_134_type 1411
+#define _tmp_135_type 1412
+#define _tmp_136_type 1413
+#define _loop0_137_type 1414
+#define _gather_138_type 1415
+#define _tmp_139_type 1416
+#define _loop0_140_type 1417
+#define _gather_141_type 1418
+#define _loop0_142_type 1419
+#define _gather_143_type 1420
+#define _tmp_144_type 1421
+#define _loop0_145_type 1422
+#define _tmp_146_type 1423
+#define _tmp_147_type 1424
+#define _tmp_148_type 1425
+#define _tmp_149_type 1426
+#define _tmp_150_type 1427
+#define _tmp_151_type 1428
+#define _tmp_152_type 1429
+#define _tmp_153_type 1430
+#define _tmp_154_type 1431
+#define _tmp_155_type 1432
+#define _tmp_156_type 1433
+#define _tmp_157_type 1434
+#define _tmp_158_type 1435
+#define _tmp_159_type 1436
+#define _tmp_160_type 1437
+#define _tmp_161_type 1438
+#define _tmp_162_type 1439
+#define _tmp_163_type 1440
+#define _tmp_164_type 1441
+#define _tmp_165_type 1442
+#define _tmp_166_type 1443
+#define _tmp_167_type 1444
+#define _tmp_168_type 1445
+#define _tmp_169_type 1446
+#define _tmp_170_type 1447
+#define _tmp_171_type 1448
+#define _tmp_172_type 1449
+#define _tmp_173_type 1450
+#define _loop0_174_type 1451
+#define _tmp_175_type 1452
+#define _tmp_176_type 1453
+#define _tmp_177_type 1454
+#define _tmp_178_type 1455
+#define _tmp_179_type 1456
+#define _tmp_180_type 1457
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -819,6 +821,8 @@ static void *invalid_string_tstring_concat_rule(Parser *p);
 static void *invalid_arithmetic_rule(Parser *p);
 static void *invalid_factor_rule(Parser *p);
 static void *invalid_type_params_rule(Parser *p);
+static void *invalid_bitwise_and_rule(Parser *p);
+static void *invalid_bitwise_or_rule(Parser *p);
 static asdl_seq *_loop0_1_rule(Parser *p);
 static asdl_seq *_loop1_2_rule(Parser *p);
 static asdl_seq *_loop0_3_rule(Parser *p);
@@ -13503,7 +13507,7 @@ is_bitwise_or_rule(Parser *p)
 }
 
 // Left-recursive
-// bitwise_or: bitwise_or '|' bitwise_xor | bitwise_xor
+// bitwise_or: bitwise_or '|' bitwise_xor | invalid_bitwise_or | bitwise_xor
 static expr_ty bitwise_or_raw(Parser *);
 static expr_ty
 bitwise_or_rule(Parser *p)
@@ -13598,6 +13602,25 @@ bitwise_or_raw(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s bitwise_or[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "bitwise_or '|' bitwise_xor"));
+    }
+    if (p->call_invalid_rules) { // invalid_bitwise_or
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_bitwise_or"));
+        void *invalid_bitwise_or_var;
+        if (
+            (invalid_bitwise_or_var = invalid_bitwise_or_rule(p))  // invalid_bitwise_or
+        )
+        {
+            D(fprintf(stderr, "%*c+ bitwise_or[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "invalid_bitwise_or"));
+            _res = invalid_bitwise_or_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s bitwise_or[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_bitwise_or"));
     }
     { // bitwise_xor
         if (p->error_indicator) {
@@ -13747,7 +13770,7 @@ bitwise_xor_raw(Parser *p)
 }
 
 // Left-recursive
-// bitwise_and: bitwise_and '&' shift_expr | shift_expr
+// bitwise_and: bitwise_and '&' shift_expr | invalid_bitwise_and | shift_expr
 static expr_ty bitwise_and_raw(Parser *);
 static expr_ty
 bitwise_and_rule(Parser *p)
@@ -13842,6 +13865,25 @@ bitwise_and_raw(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s bitwise_and[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "bitwise_and '&' shift_expr"));
+    }
+    if (p->call_invalid_rules) { // invalid_bitwise_and
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> bitwise_and[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_bitwise_and"));
+        void *invalid_bitwise_and_var;
+        if (
+            (invalid_bitwise_and_var = invalid_bitwise_and_rule(p))  // invalid_bitwise_and
+        )
+        {
+            D(fprintf(stderr, "%*c+ bitwise_and[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "invalid_bitwise_and"));
+            _res = invalid_bitwise_and_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s bitwise_and[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_bitwise_and"));
     }
     { // shift_expr
         if (p->error_indicator) {
@@ -28427,6 +28469,106 @@ invalid_type_params_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s invalid_type_params[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'[' ']'"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
+// Left-recursive
+// invalid_bitwise_and: bitwise_and '&' '&'
+static void *
+invalid_bitwise_and_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // bitwise_and '&' '&'
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_bitwise_and[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_and '&' '&'"));
+        expr_ty a;
+        Token * b;
+        Token * c;
+        if (
+            (a = bitwise_and_rule(p))  // bitwise_and
+            &&
+            (b = _PyPegen_expect_token(p, 19))  // token='&'
+            &&
+            (c = _PyPegen_expect_token(p, 19))  // token='&'
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_bitwise_and[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_and '&' '&'"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( b , c , "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'" );
+            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_bitwise_and[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "bitwise_and '&' '&'"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
+// Left-recursive
+// invalid_bitwise_or: bitwise_or '|' '|'
+static void *
+invalid_bitwise_or_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // bitwise_or '|' '|'
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_or '|' '|'"));
+        expr_ty a;
+        Token * b;
+        Token * c;
+        if (
+            (a = bitwise_or_rule(p))  // bitwise_or
+            &&
+            (b = _PyPegen_expect_token(p, 18))  // token='|'
+            &&
+            (c = _PyPegen_expect_token(p, 18))  // token='|'
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_bitwise_or[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_or '|' '|'"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( b , c , "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'" );
+            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_bitwise_or[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "bitwise_or '|' '|'"));
     }
     _res = NULL;
   done:

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -209,6 +209,12 @@ RAISE_ERROR_KNOWN_LOCATION(Parser *p, PyObject *errtype,
     RAISE_ERROR_KNOWN_LOCATION(p, PyExc_SyntaxError, (a)->lineno, (a)->col_offset, CURRENT_POS, CURRENT_POS, msg, ##__VA_ARGS__)
 #define RAISE_SYNTAX_ERROR_INVALID_TARGET(type, e) _RAISE_SYNTAX_ERROR_INVALID_TARGET(p, type, e)
 
+Py_LOCAL_INLINE(int)
+_PyPegen_tokens_are_adjacent(Token *a, Token *b)
+{
+    return (a->end_lineno == b->lineno) && (a->end_col_offset == b->col_offset);
+}
+
 Py_LOCAL_INLINE(void *)
 CHECK_CALL(Parser *p, void *result)
 {

--- a/Parser/pegen_errors.c
+++ b/Parser/pegen_errors.c
@@ -442,6 +442,16 @@ _Pypegen_set_syntax_error(Parser* p, Token* last_token) {
         RAISE_INDENTATION_ERROR(last_token->type == INDENT ? "unexpected indent" : "unexpected unindent");
         return;
     }
+    if (last_token->type == AMPER && p->tokens[p->fill - 2]->type == AMPER) {
+        RAISE_SYNTAX_ERROR_KNOWN_RANGE(p->tokens[p->fill - 2], last_token,
+                                       "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'");
+        return;
+    }
+    if (last_token->type == VBAR && p->tokens[p->fill - 2]->type == VBAR) {
+        RAISE_SYNTAX_ERROR_KNOWN_RANGE(p->tokens[p->fill - 2], last_token,
+                                       "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'");
+        return;
+    }
     // Unknown error (generic case)
 
     // Use the last token we found on the first pass to avoid reporting

--- a/Parser/pegen_errors.c
+++ b/Parser/pegen_errors.c
@@ -442,16 +442,6 @@ _Pypegen_set_syntax_error(Parser* p, Token* last_token) {
         RAISE_INDENTATION_ERROR(last_token->type == INDENT ? "unexpected indent" : "unexpected unindent");
         return;
     }
-    if (last_token->type == AMPER && p->tokens[p->fill - 2]->type == AMPER) {
-        RAISE_SYNTAX_ERROR_KNOWN_RANGE(p->tokens[p->fill - 2], last_token,
-                                       "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'");
-        return;
-    }
-    if (last_token->type == VBAR && p->tokens[p->fill - 2]->type == VBAR) {
-        RAISE_SYNTAX_ERROR_KNOWN_RANGE(p->tokens[p->fill - 2], last_token,
-                                       "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'");
-        return;
-    }
     // Unknown error (generic case)
 
     // Use the last token we found on the first pass to avoid reporting


### PR DESCRIPTION
fixes #146495 

> [@Aniketsy](https://github.com/Aniketsy) I would prefer that a parser expert takes care of that. This is likely a non-trivial change so to make it easier to review, it would be better if a core dev or someone familiar with the parser takes care of this.

As there was not any pr for this for long time, so i thought to give a try for this as @skirpichev have shared the patch towards fix. Hoping it does not create much pain to review for members. Thank you !
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146495 -->
* Issue: gh-146495
<!-- /gh-issue-number -->
