### PR TITLE
gh-150907: Fix dynamic_annotations.h when built with C++ and Valgrind

### DIFF
--- a/Include/dynamic_annotations.h
+++ b/Include/dynamic_annotations.h
@@ -461,6 +461,7 @@ int RunningOnValgrind(void);
 
 #if DYNAMIC_ANNOTATIONS_ENABLED != 0 && defined(__cplusplus)
 
+extern "C++" {
   /* _Py_ANNOTATE_UNPROTECTED_READ is the preferred way to annotate racey reads.
 
      Instead of doing
@@ -476,6 +477,8 @@ int RunningOnValgrind(void);
     _Py_ANNOTATE_IGNORE_READS_END();
     return res;
   }
+}
+
   /* Apply _Py_ANNOTATE_BENIGN_RACE_SIZED to a static variable. */
 #define _Py_ANNOTATE_BENIGN_RACE_STATIC(static_var, description)        \
     namespace {                                                       \

--- a/Misc/NEWS.d/next/C_API/2026-06-04-14-26-17.gh-issue-150907.CA91_B.rst
+++ b/Misc/NEWS.d/next/C_API/2026-06-04-14-26-17.gh-issue-150907.CA91_B.rst
@@ -1,0 +1,2 @@
+Fix ``dynamic_annotations.h`` header file when built with C++ and Valgrind:
+add ``extern "C++" scope`` for the C++ template. Patch by Victor Stinner.


### PR DESCRIPTION
Add extern "C++" scope for the C++ template.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-150907 -->
* Issue: gh-150907
<!-- /gh-issue-number -->
