### PR TITLE
gh-150913: Fix sqlite3.Blob validation for empty slice assignment

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1400,6 +1400,18 @@ class BlobTests(unittest.TestCase):
         self.blob[0:0] = b""
         self.assertEqual(self.blob[:], self.data)
 
+    def test_blob_set_empty_slice_wrong_type(self):
+        with self.assertRaises(TypeError):
+            self.blob[5:5] = None
+
+    def test_blob_set_empty_slice_wrong_size(self):
+        with self.assertRaisesRegex(IndexError, "wrong size"):
+            self.blob[5:5] = b"123"
+
+    def test_blob_set_empty_slice_correct(self):
+        self.blob[5:5] = b""
+        self.assertEqual(self.blob[:], self.data)
+
     def test_blob_set_slice_with_skip(self):
         self.blob[0:10:2] = b"12345"
         actual = self.cx.execute("select b from test").fetchone()[0]

--- a/Misc/NEWS.d/next/Library/2026-06-04-21-49-18.gh-issue-150913.EmptyBl.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-04-21-49-18.gh-issue-150913.EmptyBl.rst
@@ -1,0 +1,3 @@
+Fix :class:`sqlite3.Blob` slice assignment to raise
+:exc:`TypeError` and :exc:`IndexError` for type and size mismatches
+respectively, even when the target slice is empty.

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -531,21 +531,25 @@ ass_subscript_slice(pysqlite_Blob *self, PyObject *item, PyObject *value)
         return -1;
     }
 
-    if (len == 0) {
-        return 0;
-    }
-
     Py_buffer vbuf;
     if (PyObject_GetBuffer(value, &vbuf, PyBUF_SIMPLE) < 0) {
         return -1;
     }
 
-    int rc = -1;
     if (vbuf.len != len) {
         PyErr_SetString(PyExc_IndexError,
                         "Blob slice assignment is wrong size");
+        PyBuffer_Release(&vbuf);
+        return -1;
     }
-    else if (step == 1) {
+
+    if (len == 0) {
+        PyBuffer_Release(&vbuf);
+        return 0;
+    }
+
+    int rc = -1;
+    if (step == 1) {
         rc = inner_write(self, vbuf.buf, len, start);
     }
     else {


### PR DESCRIPTION
ass_subscript_slice() returned early when the computed slice length was zero, bypassing validation performed for non-empty slices.

Move validation before the empty-slice fast path so that invalid assignments raise the appropriate exception regardless of slice length.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-150913 -->
* Issue: gh-150913
<!-- /gh-issue-number -->
