### PR TITLE
GH-148960: Ensure that asserts are ignored if `NDEBUG` is set

### DIFF
--- a/Tools/jit/template.c
+++ b/Tools/jit/template.c
@@ -1,8 +1,10 @@
 
 #include "Python.h"
 
+#ifndef NDEBUG
 #undef assert
 #define assert(TEST) ((TEST) ? 0 : _Py_jit_assertion_failure(__LINE__))
+#endif
 
 #include "pycore_backoff.h"
 #include "pycore_call.h"
@@ -40,8 +42,10 @@
 
 #include "jit.h"
 
+#ifndef NDEBUG
 #undef assert
 #define assert(TEST) ((TEST) ? 0 : _Py_jit_assertion_failure(__LINE__))
+#endif
 
 #undef CURRENT_OPERAND0_64
 #define CURRENT_OPERAND0_64() (_operand0_64)


### PR DESCRIPTION
In https://github.com/python/cpython/pull/150551 the assertion tests were accidentally left in the stencils for the non debug build.
This PR fixes that.

<!-- gh-issue-number: gh-148960 -->
* Issue: gh-148960
<!-- /gh-issue-number -->
