### PR TITLE
gh-145177: Bump emscripten version to 4.0.19

### DIFF
--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -534,7 +534,7 @@ class PlatformTest(unittest.TestCase):
 
     def test_libc_ver(self):
         if support.is_emscripten:
-            assert platform.libc_ver() == ("emscripten", "4.0.12")
+            assert platform.libc_ver() == ("emscripten", "4.0.18")
             return
         # check that libc_ver(executable) doesn't raise an exception
         if os.path.isdir(sys.executable) and \

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -534,7 +534,7 @@ class PlatformTest(unittest.TestCase):
 
     def test_libc_ver(self):
         if support.is_emscripten:
-            assert platform.libc_ver() == ("emscripten", "4.0.18")
+            assert platform.libc_ver() == ("emscripten", "4.0.19")
             return
         # check that libc_ver(executable) doesn't raise an exception
         if os.path.isdir(sys.executable) and \

--- a/Platforms/emscripten/config.toml
+++ b/Platforms/emscripten/config.toml
@@ -1,7 +1,7 @@
 # Any data that can vary between Python versions is to be kept in this file.
 # This allows for blanket copying of the Emscripten build code between supported
 # Python versions.
-emscripten-version = "4.0.12"
+emscripten-version = "4.0.18"
 node-version = "24"
 test-args = [
     "-m", "test",

--- a/Platforms/emscripten/config.toml
+++ b/Platforms/emscripten/config.toml
@@ -1,7 +1,7 @@
 # Any data that can vary between Python versions is to be kept in this file.
 # This allows for blanket copying of the Emscripten build code between supported
 # Python versions.
-emscripten-version = "4.0.18"
+emscripten-version = "4.0.19"
 node-version = "24"
 test-args = [
     "-m", "test",

--- a/Platforms/emscripten/streams.mjs
+++ b/Platforms/emscripten/streams.mjs
@@ -112,7 +112,7 @@ const prepareBuffer = (buffer, offset, length) =>
 
 const TTY_OPS = {
   ioctl_tiocgwinsz(tty) {
-    return tty.devops.ioctl_tiocgwinsz?.();
+    return tty.devops.ioctl_tiocgwinsz?.() ?? [24, 80];
   },
 };
 
@@ -187,6 +187,10 @@ class NodeReader {
 
   fsync() {
     nodeFsync(this.nodeStream.fd);
+  }
+
+  ioctl_tiocgwinsz() {
+    return [this.nodeStream.rows ?? 24, this.nodeStream.columns ?? 80];
   }
 }
 


### PR DESCRIPTION
In this one ctypes works. 4.0.20 is bad, 4.0.19 is good
<!-- gh-issue-number: gh-145177 -->
* Issue: gh-145177
<!-- /gh-issue-number -->
