### PR TITLE
gh-62825: Fix encoding aliases "KS_C_5601-1987", "KS X 1001", etc

### DIFF
--- a/Lib/encodings/aliases.py
+++ b/Lib/encodings/aliases.py
@@ -226,6 +226,12 @@ aliases = {
 
     # cp949 codec
     '949'                : 'cp949',
+    'korean'             : 'cp949',
+    'ksc5601'            : 'cp949',
+    'ks_c_5601'          : 'cp949',
+    'ks_c_5601_1987'     : 'cp949',
+    'ksx1001'            : 'cp949',
+    'ks_x_1001'          : 'cp949',
     'ms949'              : 'cp949',
     'uhc'                : 'cp949',
 
@@ -248,12 +254,6 @@ aliases = {
 
     # euc_kr codec
     'euckr'              : 'euc_kr',
-    'korean'             : 'euc_kr',
-    'ksc5601'            : 'euc_kr',
-    'ks_c_5601'          : 'euc_kr',
-    'ks_c_5601_1987'     : 'euc_kr',
-    'ksx1001'            : 'euc_kr',
-    'ks_x_1001'          : 'euc_kr',
     'cseuckr'            : 'euc_kr',
 
     # gb18030 codec

--- a/Misc/NEWS.d/next/Library/2026-06-04-23-10-31.gh-issue-62825.BtG_yQ.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-04-23-10-31.gh-issue-62825.BtG_yQ.rst
@@ -1,0 +1,2 @@
+Encodings "KS_C_5601-1987", "KS X 1001", etc are now aliases of "CP949"
+instead of "EUC-KR".


### PR DESCRIPTION
They are now aliases of CP949 instead of EUC-KR.


<!-- gh-issue-number: gh-62825 -->
* Issue: gh-62825
<!-- /gh-issue-number -->
