### PR TITLE
gh-150818: Wire logger parent before publishing it in getLogger() (GH-150941)

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1377,9 +1377,10 @@ class Manager(object):
             raise TypeError('A logger name must be a string')
         # Fast path: an already-registered, non-placeholder logger can be
         # returned without taking the lock. dict.get() is atomic under both
-        # the GIL and free threading, and a Logger is fully initialised before
-        # being inserted into loggerDict under the lock, so this never sees a
-        # partially-constructed object.
+        # the GIL and free threading. A Logger is inserted into loggerDict only
+        # after it is fully wired up (parent/child references fixed) under the
+        # lock, so the fast path never observes a logger whose parent is not yet
+        # set.
         rv = self.loggerDict.get(name)
         if rv is not None and not isinstance(rv, PlaceHolder):
             return rv
@@ -1390,14 +1391,18 @@ class Manager(object):
                     ph = rv
                     rv = (self.loggerClass or _loggerClass)(name)
                     rv.manager = self
-                    self.loggerDict[name] = rv
                     self._fixupChildren(ph, rv)
                     self._fixupParents(rv)
+                    # Publish only after rv is fully wired: the fast path reads
+                    # loggerDict without the lock.
+                    self.loggerDict[name] = rv
             else:
                 rv = (self.loggerClass or _loggerClass)(name)
                 rv.manager = self
-                self.loggerDict[name] = rv
                 self._fixupParents(rv)
+                # Publish only after rv is fully wired: the fast path reads
+                # loggerDict without the lock.
+                self.loggerDict[name] = rv
         return rv
 
     def setLoggerClass(self, klass):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4269,6 +4269,42 @@ class ManagerTest(BaseTest):
         man.setLogRecordFactory(expected)
         self.assertEqual(man.logRecordFactory, expected)
 
+    def test_getLogger_fast_path_never_returns_unwired_logger(self):
+        # getLogger()'s lock-free fast path returns a logger straight out of
+        # loggerDict, so a logger must be published there only after
+        # _fixupParents() has set its parent; otherwise a concurrent caller
+        # observes it detached from the hierarchy (gh-150818 follow-up).
+        manager = logging.Manager(logging.RootLogger(logging.WARNING))
+        name = 'a.b.c'
+
+        paused = threading.Event()
+        seen = []
+        real_fixup = manager._fixupParents
+
+        # Pause the creating thread between publishing rv and wiring its
+        # parent, then read loggerDict the way the fast path does and snapshot
+        # the parent at that instant (rv is wired in place soon after).
+        def fixup(alogger):
+            paused.set()
+            reader.join()
+            real_fixup(alogger)
+
+        def read():
+            paused.wait()
+            rv = manager.loggerDict.get(name)
+            if rv is not None and not isinstance(rv, logging.PlaceHolder):
+                seen.append(rv.parent)
+
+        reader = threading.Thread(target=read)
+        manager._fixupParents = fixup
+        try:
+            reader.start()
+            manager.getLogger(name)
+        finally:
+            manager._fixupParents = real_fixup
+
+        self.assertNotIn(None, seen)
+
 class ChildLoggerTest(BaseTest):
     def test_child_loggers(self):
         r = logging.getLogger()

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4269,6 +4269,7 @@ class ManagerTest(BaseTest):
         man.setLogRecordFactory(expected)
         self.assertEqual(man.logRecordFactory, expected)
 
+    @threading_helper.requires_working_threading()
     def test_getLogger_fast_path_never_returns_unwired_logger(self):
         # getLogger()'s lock-free fast path returns a logger straight out of
         # loggerDict, so a logger must be published there only after


### PR DESCRIPTION
The lock-free fast path added in GH-150825 reads `loggerDict` without the lock and returns any non-placeholder logger it finds. The slow path, however, inserted a freshly created logger into `loggerDict` *before* calling `_fixupParents()`, which assigns its `parent`. A caller hitting the fast path during that window receives a logger whose `parent` is still `None`: `getEffectiveLevel()` returns `NOTSET` and records do not propagate to ancestors until the creating thread finishes.

Both slow-path branches now publish the logger to `loggerDict` only after `_fixupParents()` (and `_fixupChildren()` for the placeholder case) have wired it. Neither helper reads `loggerDict[name]`, so the move is safe, and the fast path is unchanged.

The added regression test forces the publish/wire interleaving deterministically and fails without this change.

The reorder is confined to the locked creation path, so the fast path is unaffected. Median of 5 runs against GH-150825 as merged (PGO build, same interpreter, swapping `Lib/logging/__init__.py`):

| Benchmark | base (GH-150825) | patched |
|---|---|---|
| getLogger, 23 existing loggers | 2.68 us | 2.65 us: 1.01x faster |

The difference is within the run-to-run noise floor (base 2.66-2.76 us, patched 2.64-2.65 us); `pyperf compare_to` reports it as not significant.

<details><summary>Benchmark (pyperf)</summary>

```python
import logging, pyperf

names = ["elastic_transport.transport", "peewee.pool", "LiteLLM", "httpx",
    "uvicorn.error", "uvicorn.access", "fsspec", "boto3", "posthog", "amqp",
    "nox", "tldextract.cache", "dulwich.lfs", "urllib3.connectionpool",
    "asyncio", "sqlalchemy.engine", "werkzeug", "django.request", "celery.worker",
    "kafka.conn", "redis.client", "paramiko.transport", "matplotlib.font_manager"]
for n in names:
    logging.getLogger(n)

runner = pyperf.Runner()
runner.bench_func("getLogger %d existing loggers" % len(names),
                  lambda: [logging.getLogger(n) for n in names])
```

Base is `Lib/logging/__init__.py` at GH-150825; patched swaps in this PR's version on the same interpreter. Run base vs patched with `pyperf compare_to base.json patched.json`.
</details>

Thanks to @methane for catching this in review of GH-150825.

<!-- gh-issue-number: gh-150818 -->
* Issue: gh-150818
<!-- /gh-issue-number -->
