### PR TITLE
gh-150942: Speed up json.loads array and object decoding

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-05-31-10-00-00.gh-issue-150942.Tk9aRef.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-31-10-00-00.gh-issue-150942.Tk9aRef.rst
@@ -1,0 +1,3 @@
+Speed up :func:`json.loads` decoding of arrays and objects by storing
+parsed values into the result list/dict without an extra reference-count
+round-trip (using the internal reference-stealing append/insert helpers).

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -11,6 +11,8 @@
 #include "Python.h"
 #include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
 #include "pycore_critical_section.h" // Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST()
+#include "pycore_dict.h"          // _PyDict_SetItem_Take2()
+#include "pycore_list.h"          // _PyList_AppendTakeRef()
 #include "pycore_global_strings.h" // _Py_ID()
 #include "pycore_pyerrors.h"      // _PyErr_FormatNote
 #include "pycore_runtime.h"       // _PyRuntime
@@ -752,7 +754,6 @@ _parse_object_unicode(PyScannerObject *s, PyObject *memo, PyObject *pystr, Py_ss
     const void *str;
     int kind;
     Py_ssize_t end_idx;
-    PyObject *val = NULL;
     PyObject *rval = NULL;
     PyObject *key = NULL;
     int has_pairs_hook = (s->object_pairs_hook != Py_None);
@@ -802,13 +803,16 @@ _parse_object_unicode(PyScannerObject *s, PyObject *memo, PyObject *pystr, Py_ss
             while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
 
             /* read any JSON term */
-            val = scan_once_unicode(s, memo, pystr, idx, &next_idx);
+            PyObject *val = scan_once_unicode(s, memo, pystr, idx, &next_idx);
             if (val == NULL)
                 goto bail;
 
+            /* The steal below takes our references to both key and val
+               (releasing them on failure).  Only key is reset for the bail
+               path; val is never live there, so it needs no cleanup. */
             if (has_pairs_hook) {
                 PyObject *item = _PyTuple_FromPairSteal(key, val);
-                key = val = NULL;
+                key = NULL;
                 if (item == NULL)
                     goto bail;
                 if (PyList_Append(rval, item) == -1) {
@@ -818,10 +822,10 @@ _parse_object_unicode(PyScannerObject *s, PyObject *memo, PyObject *pystr, Py_ss
                 Py_DECREF(item);
             }
             else {
-                if (PyDict_SetItem(rval, key, val) < 0)
+                int err = _PyDict_SetItem_Take2((PyDictObject *)rval, key, val);
+                key = NULL;
+                if (err < 0)
                     goto bail;
-                Py_CLEAR(key);
-                Py_CLEAR(val);
             }
             idx = next_idx;
 
@@ -851,21 +855,20 @@ _parse_object_unicode(PyScannerObject *s, PyObject *memo, PyObject *pystr, Py_ss
     *next_idx_ptr = idx + 1;
 
     if (has_pairs_hook) {
-        val = PyObject_CallOneArg(s->object_pairs_hook, rval);
+        PyObject *res = PyObject_CallOneArg(s->object_pairs_hook, rval);
         Py_DECREF(rval);
-        return val;
+        return res;
     }
 
     /* if object_hook is not None: rval = object_hook(rval) */
     if (s->object_hook != Py_None) {
-        val = PyObject_CallOneArg(s->object_hook, rval);
+        PyObject *res = PyObject_CallOneArg(s->object_hook, rval);
         Py_DECREF(rval);
-        return val;
+        return res;
     }
     return rval;
 bail:
     Py_XDECREF(key);
-    Py_XDECREF(val);
     Py_XDECREF(rval);
     return NULL;
 }
@@ -882,7 +885,6 @@ _parse_array_unicode(PyScannerObject *s, PyObject *memo, PyObject *pystr, Py_ssi
     const void *str;
     int kind;
     Py_ssize_t end_idx;
-    PyObject *val = NULL;
     PyObject *rval;
     Py_ssize_t next_idx;
     Py_ssize_t comma_idx;
@@ -903,14 +905,12 @@ _parse_array_unicode(PyScannerObject *s, PyObject *memo, PyObject *pystr, Py_ssi
         while (1) {
 
             /* read any JSON term  */
-            val = scan_once_unicode(s, memo, pystr, idx, &next_idx);
+            PyObject *val = scan_once_unicode(s, memo, pystr, idx, &next_idx);
             if (val == NULL)
                 goto bail;
 
-            if (PyList_Append(rval, val) == -1)
+            if (_PyList_AppendTakeRef((PyListObject *)rval, val) < 0)
                 goto bail;
-
-            Py_CLEAR(val);
             idx = next_idx;
 
             /* skip whitespace between term and , */
@@ -944,13 +944,12 @@ _parse_array_unicode(PyScannerObject *s, PyObject *memo, PyObject *pystr, Py_ssi
     *next_idx_ptr = idx + 1;
     /* if array_hook is not None: return array_hook(rval) */
     if (!Py_IsNone(s->array_hook)) {
-        val = PyObject_CallOneArg(s->array_hook, rval);
+        PyObject *res = PyObject_CallOneArg(s->array_hook, rval);
         Py_DECREF(rval);
-        return val;
+        return res;
     }
     return rval;
 bail:
-    Py_XDECREF(val);
     Py_DECREF(rval);
     return NULL;
 }


### PR DESCRIPTION
Benchmarks on FT build:

| Benchmark | speedup vs main |
| --- | :---: |
| `array_strings` | 1.16× |
| `array_ints` | 1.08× |
| `config` | 1.07× |
| `bm_json_loads` | 1.03× |
| **geomean** | **1.08×** |

The relative performance gain is larger with https://github.com/python/cpython/pull/150639 included (geomean 1.12x)

<details>
<summary>Benchmark script</summary>

```python
"""Compare json.loads across four shapes: bm_json_loads, config, int array, string array."""
import json
import random
import sys
import pyperf

# --- bm_json_loads (pyperformance) documents ---
DICT = {'ads_flags': 0, 'age': 18, 'bulletin_count': 0, 'comment_count': 0,
        'country': 'BR', 'encrypted_id': 'G9urXXAJwjE', 'favorite_count': 9,
        'first_name': '', 'flags': 412317970704, 'friend_count': 0, 'gender': 'm',
        'gender_for_display': 'Male', 'id': 302935349, 'is_custom_profile_icon': 0,
        'last_name': '', 'locale_preference': 'pt_BR', 'member': 0,
        'tags': ['a', 'b', 'c', 'd', 'e', 'f', 'g'], 'profile_foo_id': 827119638,
        'secure_encrypted_id': 'Z_xxx2dYx3t4YAdnmfgyKw', 'session_number': 2,
        'signup_id': '201-19225-223', 'status': 'A', 'theme': 1,
        'time_created': 1225237014, 'time_updated': 1233134493,
        'unread_message_count': 0, 'user_group': '0', 'username': 'collinwinter',
        'play_count': 9, 'view_count': 7, 'zip': ''}
TUPLE = ([265867233, 265868503, 265252341, 265243910, 265879514, 266219766,
          266021701, 265843726, 265592821, 265246784, 265853180, 45526486,
          265463699, 265848143, 265863062, 265392591, 265877490, 265823665,
          265828884, 265753032], 60)


def _mutate(o, r):
    d = dict(o)
    for k, v in d.items():
        rv = r.random() * sys.maxsize
        if isinstance(k, (int, bytes, str)):
            d[k] = type(k)(rv)
    return d


_r = random.Random(5)
DICT_GROUP = [_mutate(DICT, _r) for _ in range(3)]
BM_OBJS = (json.dumps(DICT), json.dumps(TUPLE), json.dumps(DICT_GROUP))


def bm_json_loads(objs):
    for obj in objs:
        for _ in range(20):
            json.loads(obj)


# --- config.json shape (objects + small int arrays) ---
CONFIG = json.dumps({f"section_{i}": {"enabled": True, "values": list(range(50)),
                     "meta": {"name": f"s{i}", "desc": "x" * 40}} for i in range(3000)})
# --- array of ints ---
INTS = json.dumps([i for i in range(100000)])
# --- array of small strings ---
STRS = json.dumps([f"item_{i}" for i in range(100000)])

if __name__ == "__main__":
    runner = pyperf.Runner()
    runner.bench_func("bm_json_loads", bm_json_loads, BM_OBJS, inner_loops=20)
    runner.bench_func("config", json.loads, CONFIG)
    runner.bench_func("array_ints", json.loads, INTS)
    runner.bench_func("array_strings", json.loads, STRS)
```

</details>


<!-- gh-issue-number: gh-150942 -->
* Issue: gh-150942
<!-- /gh-issue-number -->
