### PR TITLE
[3.13] gh-150157: add critical section for `PyDict_Next` in `_pickle.c`

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-05-21-20-47-45.gh-issue-150157.ZvmO-bQZ.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-21-20-47-45.gh-issue-150157.ZvmO-bQZ.rst
@@ -1,0 +1,3 @@
+Fix a crash in free-threaded builds that occurs when pickling by name
+objects without a ``__module__`` attribute while :data:`sys.modules`
+is concurrently being modified.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1966,16 +1966,28 @@ whichmodule(PyObject *global, PyObject *dotted_path)
         return NULL;
     }
     if (PyDict_CheckExact(modules)) {
+        PyObject *found_name = NULL;
+        int error = 0;
         i = 0;
+        Py_BEGIN_CRITICAL_SECTION(modules);
         while (PyDict_Next(modules, &i, &module_name, &module)) {
             if (_checkmodule(module_name, module, global, dotted_path) == 0) {
-                Py_DECREF(modules);
-                return Py_NewRef(module_name);
+                found_name = Py_NewRef(module_name);
+                break;
             }
             if (PyErr_Occurred()) {
-                Py_DECREF(modules);
-                return NULL;
+                error = 1;
+                break;
             }
+        }
+        Py_END_CRITICAL_SECTION();
+        if (error) {
+            Py_DECREF(modules);
+            return NULL;
+        }
+        if (found_name != NULL) {
+            Py_DECREF(modules);
+            return found_name;
         }
     }
     else {


### PR DESCRIPTION
Backport of #150158 to 3.13 

Fixes #150157.

<!-- gh-issue-number: gh-150157 -->
* Issue: gh-150157
<!-- /gh-issue-number -->
