### PR TITLE
gh-146527: Fix memory leak in _PyGC_Fini()

### DIFF
--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1876,7 +1876,7 @@ _PyGC_Fini(PyInterpreterState *interp)
     GCState *gcstate = &interp->gc;
     Py_CLEAR(gcstate->garbage);
     Py_CLEAR(gcstate->callbacks);
-    PyMem_Free(gcstate->generation_stats);
+    PyMem_RawFree(gcstate->generation_stats);
     gcstate->generation_stats = NULL;
 
     /* Prevent a subtle bug that affects sub-interpreters that use basic

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1876,6 +1876,8 @@ _PyGC_Fini(PyInterpreterState *interp)
     GCState *gcstate = &interp->gc;
     Py_CLEAR(gcstate->garbage);
     Py_CLEAR(gcstate->callbacks);
+    PyMem_Free(gcstate->generation_stats);
+    gcstate->generation_stats = NULL;
 
     /* Prevent a subtle bug that affects sub-interpreters that use basic
      * single-phase init extensions (m_size == -1).  Those extensions cause objects


### PR DESCRIPTION
Free generation_stats allocated by _PyGC_Init().

Fix Python/gc.c: Python/gc_free_threading.c was already fixed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146527 -->
* Issue: gh-146527
<!-- /gh-issue-number -->
