### PR TITLE
Fix inconsistent spacing in pairwise docstring

### DIFF
--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -111,7 +111,7 @@ PyDoc_STRVAR(pairwise_new__doc__,
 "\n"
 "Return an iterator of overlapping pairs taken from the input iterator.\n"
 "\n"
-"    s -> (s0,s1), (s1,s2), (s2, s3), ...");
+"    s -> (s0,s1), (s1,s2), (s2,s3), ...");
 
 static PyObject *
 pairwise_new_impl(PyTypeObject *type, PyObject *iterable);
@@ -980,4 +980,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=a34a31f60100e0ff input=a9049054013a1b77]*/
+/*[clinic end generated code: output=95a5ca43da64212e input=a9049054013a1b77]*/

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -289,7 +289,7 @@ itertools.pairwise.__new__ as pairwise_new
     /
 Return an iterator of overlapping pairs taken from the input iterator.
 
-    s -> (s0,s1), (s1,s2), (s2, s3), ...
+    s -> (s0,s1), (s1,s2), (s2,s3), ...
 
 [clinic start generated code]*/
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -295,7 +295,7 @@ Return an iterator of overlapping pairs taken from the input iterator.
 
 static PyObject *
 pairwise_new_impl(PyTypeObject *type, PyObject *iterable)
-/*[clinic end generated code: output=9f0267062d384456 input=6e7c3cddb431a8d6]*/
+/*[clinic end generated code: output=9f0267062d384456 input=9a46953818e0801a]*/
 {
     PyObject *it;
     pairwiseobject *po;


### PR DESCRIPTION
This is a minor fix to the docstring of the itertools.pairwise method. The docstring shows 3 sets of tuples where the last tuple contains a space that the first two don't. For consistency I removed the extra space.