### PR TITLE
gh-145239: Colorize `case +` in the REPL

### DIFF
--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -274,7 +274,7 @@ def is_soft_keyword_used(*tokens: TI | None) -> bool:
             None | TI(T.NEWLINE) | TI(T.INDENT) | TI(T.DEDENT) | TI(string=":"),
             TI(string="case"),
             TI(T.NUMBER | T.STRING | T.FSTRING_START | T.TSTRING_START)
-            | TI(T.OP, string="(" | "*" | "-" | "[" | "{")
+            | TI(T.OP, string="(" | "*" | "-" | "+" | "[" | "{")
         ):
             return True
         case (

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -132,13 +132,6 @@ class TestUtils(TestCase):
                     ("+", "op"),
                 ],
             ),
-            (
-                "case -1",
-                [
-                    ("case", "soft_keyword"),
-                    ("-", "op"),
-                ],
-            ),
         ]
         for code, expected_highlights in cases:
             with self.subTest(code=code):

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -125,6 +125,15 @@ class TestUtils(TestCase):
                     ("import", "keyword"),
                 ],
             ),
+            # `case` soft keyword with unary +/- operators (gh-145239)
+            (
+                "case +1",
+                [("case", "soft_keyword"), ("+", "op")],
+            ),
+            (
+                "case -1",
+                [("case", "soft_keyword"), ("-", "op")],
+            ),
         ]
         for code, expected_highlights in cases:
             with self.subTest(code=code):

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -125,14 +125,19 @@ class TestUtils(TestCase):
                     ("import", "keyword"),
                 ],
             ),
-            # `case` soft keyword with unary +/- operators (gh-145239)
             (
                 "case +1",
-                [("case", "soft_keyword"), ("+", "op")],
+                [
+                    ("case", "soft_keyword"),
+                    ("+", "op"),
+                ],
             ),
             (
                 "case -1",
-                [("case", "soft_keyword"), ("-", "op")],
+                [
+                    ("case", "soft_keyword"),
+                    ("-", "op"),
+                ],
             ),
         ]
         for code, expected_highlights in cases:

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -130,6 +130,7 @@ class TestUtils(TestCase):
                 [
                     ("case", "soft_keyword"),
                     ("+", "op"),
+                    ("1", "number"),
                 ],
             ),
         ]


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


| Before | After |
| - | - |
| <img width="257" height="253" alt="Screenshot 2026-06-05 at 19 21 35" src="https://github.com/user-attachments/assets/406842d6-5da8-4aaf-91cf-bb58370cc9c4" /> | <img width="249" height="247" alt="Screenshot 2026-06-05 at 19 22 39" src="https://github.com/user-attachments/assets/459dd00c-6073-49f6-99ed-2e980d004120" /> |

cc @Eclips4 

<!-- gh-issue-number: gh-145239 -->
* Issue: gh-145239
<!-- /gh-issue-number -->
