### PR TITLE
gh-150932: Add a partial-line-marker on Apple system logger and optimize the iOS testbed runner

### DIFF
--- a/Lib/_apple_support.py
+++ b/Lib/_apple_support.py
@@ -37,6 +37,13 @@ class SystemLog(io.TextIOWrapper):
 
 
 class LogStream(io.RawIOBase):
+    # Marker appended to any log message that does not end with a newline,
+    # so a cooperating log reader can re-join it with the following message
+    # instead of rendering it as a spurious standalone line. Placing the
+    # marker after the data also prevents the system log from stripping any
+    # trailing whitespace. Uses ASCII Unit Separator (0x1f).
+    PARTIAL_LINE_MARKER = b"\x1f"
+
     def __init__(self, log_write, level):
         self.log_write = log_write
         self.level = level
@@ -59,8 +66,14 @@ class LogStream(io.RawIOBase):
         # Writing an empty string to the stream should have no effect.
         if b:
             # Encode null bytes using "modified UTF-8" to avoid truncating the
-            # message. This should not affect the return value, as the caller
-            # may be expecting it to match the length of the input.
-            self.log_write(self.level, b.replace(b"\x00", b"\xc0\x80"))
+            # message.
+            data = b.replace(b"\x00", b"\xc0\x80")
 
+            # Append a marker to partial lines (see PARTIAL_LINE_MARKER).
+            if not b.endswith(b"\n"):
+                data += self.PARTIAL_LINE_MARKER
+            self.log_write(self.level, data)
+
+        # Modifications of the changed data should not affect the return value, as
+        # the caller may be expecting it to match the length of the input.
         return len(b)

--- a/Lib/test/test_apple.py
+++ b/Lib/test/test_apple.py
@@ -1,11 +1,12 @@
 import unittest
-from _apple_support import SystemLog
+from _apple_support import LogStream, SystemLog
 from test.support import is_apple
 from unittest.mock import Mock, call
 
 if not is_apple:
     raise unittest.SkipTest("Apple-specific")
 
+MARKER = LogStream.PARTIAL_LINE_MARKER
 
 # Test redirection of stdout and stderr to the Apple system log.
 class TestAppleSystemLogOutput(unittest.TestCase):
@@ -52,6 +53,21 @@ class TestAppleSystemLogOutput(unittest.TestCase):
 
         self.assert_writes([b"hello world\n"])
 
+    def test_partial_line_marker(self):
+        self.log.write("complete\n")
+        self.assert_writes([b"complete\n"])
+
+        self.log.write("partial")
+        self.log.flush()
+        self.assert_writes([b"partial" + MARKER])
+
+        self.log.write("trailing whitespace ")
+        self.log.flush()
+        self.assert_writes([b"trailing whitespace " + MARKER])
+
+        self.log.write("done\n")
+        self.assert_writes([b"done\n"])
+
     def test_buffered_str(self):
         self.log.write("h")
         self.log.write("ello")
@@ -60,7 +76,7 @@ class TestAppleSystemLogOutput(unittest.TestCase):
         self.log.write("goodbye.")
         self.log.flush()
 
-        self.assert_writes([b"hello world\n", b"goodbye."])
+        self.assert_writes([b"hello world\n", b"goodbye." + MARKER])
 
     def test_manual_flush(self):
         self.log.write("Hello")
@@ -74,7 +90,7 @@ class TestAppleSystemLogOutput(unittest.TestCase):
         self.assert_writes([b"Goodbye world\n"])
 
         self.log.flush()
-        self.assert_writes([b"Hello again"])
+        self.assert_writes([b"Hello again" + MARKER])
 
     def test_non_ascii(self):
         # Spanish
@@ -142,7 +158,7 @@ class TestAppleSystemLogOutput(unittest.TestCase):
         self.log.buffer.write(b"goodbye")
         self.log.flush()
 
-        self.assert_writes([b"hello", b"goodbye"])
+        self.assert_writes([b"hello" + MARKER, b"goodbye" + MARKER])
 
     def test_non_byteslike_in_buffer(self):
         for obj in ["hello", None, 42]:

--- a/Misc/NEWS.d/next/Tests/2026-06-05-20-03-04.gh-issue-150932.UUHd4C.rst
+++ b/Misc/NEWS.d/next/Tests/2026-06-05-20-03-04.gh-issue-150932.UUHd4C.rst
@@ -1,0 +1,1 @@
+On iOS and macOS, when ``PyConfig.use_system_logger`` is enabled, partial-line writes to ``sys.stdout`` or ``sys.stderr`` are now tagged with a marker so that a cooperating log reader can re-join them instead of rendering each flush as a separate line.

--- a/Platforms/Apple/testbed/__main__.py
+++ b/Platforms/Apple/testbed/__main__.py
@@ -24,6 +24,23 @@ LOG_PREFIX_REGEX = re.compile(
     r"\s+iOSTestbed\[\d+:\w+\] "  # Process/thread ID
 )
 
+# The system log escapes non-printable bytes using caret notation (e.g. ESC
+# becomes "\^["). This regex matches those sequences so they can be restored.
+LOG_CTRL_CHAR_REGEX = re.compile(r"\\\^(.)")
+
+# Matches the partial-line marker (ASCII Unit Separator, 0x1f) appended by
+# Lib/_apple_support.py to log messages that did not end with a newline,
+# followed by the log-appended newline. Removing both causes the next write
+# to continue on the same line rather than starting a new one.
+LOG_PARTIAL_LINE_REGEX = re.compile(r"\x1f\n$")
+
+
+def _decode_log_ctrl_char(match):
+    char = match.group(1)
+    # Caret notation: "^?" is DEL (0x7f); otherwise XOR the character with
+    # 0x40 (e.g. "^[" -> ESC 0x1b).
+    return "\x7f" if char == "?" else chr(ord(char) ^ 0x40)
+
 
 # Select a simulator device to use.
 def select_simulator_device(platform):
@@ -99,6 +116,16 @@ def xcode_test(location: Path, platform: str, simulator: str, verbose: bool):
     while line := (process.stdout.readline()).decode(*DECODE_ARGS):
         # Strip the timestamp/process prefix from each log line
         line = LOG_PREFIX_REGEX.sub("", line)
+
+        # Restore control characters (e.g. ANSI color escapes) escaped by the
+        # system log.
+        line = LOG_CTRL_CHAR_REGEX.sub(_decode_log_ctrl_char, line)
+
+        # A marker immediately before the message's trailing newline means the
+        # writer did not emit a newline: it is a partial line that should be
+        # joined with the following message rather than shown on its own line.
+        line = LOG_PARTIAL_LINE_REGEX.sub("", line)
+
         sys.stdout.write(line)
         sys.stdout.flush()
 


### PR DESCRIPTION
This adds a marker for partial lines on the Apple system logger, so that a cooperating log reader (like the iOS testbed runner) can re-join them instead of rendering each flush as a separate line in the Apple system log.

Additionally, this optimizes the iOS testbed runner by:
 - Joining partial lines marked by the system log, so that they are rendered as a single line in the testbed output.
 - Restoring control characters (e.g. ANSI color escapes) escaped by the system log.

Fixes #150932

---

To test this, I used this test script and ran it in an iOS testbed:

```python
# Test colors ###################################
colors = {
    "red":     "\033[31m",
    "green":   "\033[32m",
    "yellow":  "\033[33m",
    "blue":    "\033[34m",
    "magenta": "\033[35m",
    "cyan":    "\033[36m",
    "white":   "\033[37m",
}
reset = "\033[0m"

for name, code in colors.items():
    print(f"{code}Hello in {name}!{reset}")

# Test newline handling #########################
print("This should be ", end="", flush=True)
print("in one line.")

print("This should al", end="", flush=True)
print("so be in one", end="", flush=True)
print(" line.")

print("This are \n two lines.")

# Test live output ##############################
import time
for i in range(10):
    print(".", end="")
    time.sleep(1)
```


<!-- gh-issue-number: gh-150932 -->
* Issue: gh-150932
<!-- /gh-issue-number -->
