### PR TITLE
GH-59633: Clarify dest collisions in argparse docs

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1371,8 +1371,8 @@ behavior::
 
 Multiple arguments may share the same ``dest``.  By default the value from the
 last such argument given on the command line wins; use ``action='append'`` to
-collect values from all of them into a list instead.  (For conflicting *option
-strings* rather than ``dest`` names, see conflict_handler_.)
+collect values from all of them into a list instead.  For conflicting *option
+strings* rather than ``dest`` names, see conflict_handler_.
 
 .. versionchanged:: 3.15
    Single-dash long option now takes precedence over short options.

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1783,8 +1783,9 @@ Subcommands
    ``baz`` attributes are present.
 
    If a subparser defines an argument with the same ``dest`` as the parent
-   parser, the subparser's value overwrites the parent's, so users should give
-   them distinct ``dest`` values to keep both.
+   parser, the two share a single namespace attribute, so the parent's value
+   won't be retained. Users should give them  distinct ``dest`` values to
+   keep both.
 
    Similarly, when a help message is requested from a subparser, only the help
    for that particular parser will be printed.  The help message will not

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1371,7 +1371,8 @@ behavior::
 
 Multiple arguments may share the same ``dest``.  By default the value from the
 last such argument given on the command line wins; use ``action='append'`` to
-collect values from all of them into a list instead.
+collect values from all of them into a list instead.  (For conflicting *option
+strings* rather than ``dest`` names, see conflict_handler_.)
 
 .. versionchanged:: 3.15
    Single-dash long option now takes precedence over short options.
@@ -1780,6 +1781,10 @@ Subcommands
    the ``a`` command is specified, only the ``foo`` and ``bar`` attributes are
    present, and when the ``b`` command is specified, only the ``foo`` and
    ``baz`` attributes are present.
+
+   If a subparser defines an argument with the same ``dest`` as the parent
+   parser, the subparser's value overwrites the parent's, so users should give
+   them distinct ``dest`` values to keep both.
 
    Similarly, when a help message is requested from a subparser, only the help
    for that particular parser will be printed.  The help message will not

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1369,6 +1369,10 @@ behavior::
    >>> parser.parse_args('--foo XXX'.split())
    Namespace(bar='XXX')
 
+Multiple arguments may share the same ``dest``.  By default the value from the
+last such argument given on the command line wins; use ``action='append'`` to
+collect values from all of them into a list instead.
+
 .. versionchanged:: 3.15
    Single-dash long option now takes precedence over short options.
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1369,8 +1369,8 @@ behavior::
    >>> parser.parse_args('--foo XXX'.split())
    Namespace(bar='XXX')
 
-Multiple arguments may share the same ``dest``.  By default the value from the
-last such argument given on the command line wins; use ``action='append'`` to
+Multiple arguments may share the same ``dest``.  By default, the value from the
+last such argument given on the command line wins.  Use ``action='append'`` to
 collect values from all of them into a list instead.  For conflicting *option
 strings* rather than ``dest`` names, see conflict_handler_.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-59633 -->
* Issue: gh-59633
<!-- /gh-issue-number -->
