### PR TITLE
gh-150988: Fix refleak in `OSError` when attrs are set before `super().__init__`

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1718,24 +1718,24 @@ class ExceptionTests(unittest.TestCase):
         msg = "some error message"
         filename = "some filename"
         filename2 = "some filename 2"
-    
+
         class LeakingOSError(OSError):
             def __init__(self, code, message, filename, filename2):
                 self.strerror = message
                 self.filename = filename
                 self.filename2 = filename2
                 super().__init__(code, message, filename, None, filename2)
-    
+
         refcount_msg = sys.getrefcount(msg)
         refcount_filename = sys.getrefcount(filename)
         refcount_filename2 = sys.getrefcount(filename2)
-    
+
         for _ in range(5):
             try:
                 raise LeakingOSError(1, msg, filename, filename2)
             except OSError:
                 pass
-    
+
         gc_collect()
         self.assertEqual(sys.getrefcount(msg), refcount_msg)
         self.assertEqual(sys.getrefcount(filename), refcount_filename)

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1723,7 +1723,8 @@ class ExceptionTests(unittest.TestCase):
                 self.filename2 = filename2
                 super().__init__(code, message, filename, None, filename2)
 
-        LeakingOSError(1, "some message", "filename.py", "filename2.py")
+        exc = LeakingOSError(1, "some message", "filename.py", "filename2.py")
+        exc.__init__(2, "another message", "filename3.py", "filename4.py")
 
     def test_errno_ENOTDIR(self):
         # Issue #12802: "not a directory" errors are ENOTDIR even on Windows

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1715,7 +1715,7 @@ class ExceptionTests(unittest.TestCase):
         self.assertEqual(wr(), None)
 
     def test_oserror_reinit_leak(self):
-        # gh-150988: Check for memory leak when re-initializing OSError
+        # gh-150988: Check for memory leak when re-initializing OSError.
         # Previously, setting OSError attributes in a subclass
         # before calling super().__init__() leaked memory.
         class LeakingOSError(OSError):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1716,6 +1716,8 @@ class ExceptionTests(unittest.TestCase):
 
     def test_oserror_reinit_leak(self):
         # gh-150988: Check for memory leak when re-initializing OSError
+        # Previously, setting OSError attributes in a subclass
+        # before calling super().__init__() leaked memory.
         class LeakingOSError(OSError):
             def __init__(self, code, message, filename, filename2):
                 self.strerror = message

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1714,6 +1714,33 @@ class ExceptionTests(unittest.TestCase):
         gc_collect()  # For PyPy or other GCs.
         self.assertEqual(wr(), None)
 
+    def test_oserror_reinit_leak(self):
+        msg = "some error message"
+        filename = "some filename"
+        filename2 = "some filename 2"
+    
+        class LeakingOSError(OSError):
+            def __init__(self, code, message, filename, filename2):
+                self.strerror = message
+                self.filename = filename
+                self.filename2 = filename2
+                super().__init__(code, message, filename, None, filename2)
+    
+        refcount_msg = sys.getrefcount(msg)
+        refcount_filename = sys.getrefcount(filename)
+        refcount_filename2 = sys.getrefcount(filename2)
+    
+        for _ in range(5):
+            try:
+                raise LeakingOSError(1, msg, filename, filename2)
+            except OSError:
+                pass
+    
+        gc_collect()
+        self.assertEqual(sys.getrefcount(msg), refcount_msg)
+        self.assertEqual(sys.getrefcount(filename), refcount_filename)
+        self.assertEqual(sys.getrefcount(filename2), refcount_filename2)
+
     def test_errno_ENOTDIR(self):
         # Issue #12802: "not a directory" errors are ENOTDIR even on Windows
         with self.assertRaises(OSError) as cm:

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1715,10 +1715,7 @@ class ExceptionTests(unittest.TestCase):
         self.assertEqual(wr(), None)
 
     def test_oserror_reinit_leak(self):
-        msg = "some error message"
-        filename = "some filename"
-        filename2 = "some filename 2"
-
+        # gh-150988: Check for memory leak when re-initializing OSError
         class LeakingOSError(OSError):
             def __init__(self, code, message, filename, filename2):
                 self.strerror = message
@@ -1726,20 +1723,7 @@ class ExceptionTests(unittest.TestCase):
                 self.filename2 = filename2
                 super().__init__(code, message, filename, None, filename2)
 
-        refcount_msg = sys.getrefcount(msg)
-        refcount_filename = sys.getrefcount(filename)
-        refcount_filename2 = sys.getrefcount(filename2)
-
-        for _ in range(5):
-            try:
-                raise LeakingOSError(1, msg, filename, filename2)
-            except OSError:
-                pass
-
-        gc_collect()
-        self.assertEqual(sys.getrefcount(msg), refcount_msg)
-        self.assertEqual(sys.getrefcount(filename), refcount_filename)
-        self.assertEqual(sys.getrefcount(filename2), refcount_filename2)
+        LeakingOSError(1, "some message", "filename.py", "filename2.py")
 
     def test_errno_ENOTDIR(self):
         # Issue #12802: "not a directory" errors are ENOTDIR even on Windows

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-05-22-52-41.gh-issue-150988.fDKfMJ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-05-22-52-41.gh-issue-150988.fDKfMJ.rst
@@ -1,2 +1,2 @@
 Fix a reference leak in :exc:`OSError` when attributes are set before
-``super().__init__``.
+``super().__init__()``.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-05-22-52-41.gh-issue-150988.fDKfMJ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-05-22-52-41.gh-issue-150988.fDKfMJ.rst
@@ -1,0 +1,2 @@
+Fix a reference leak in :exc:`OSError` when attributes are set before
+``super().__init__``.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2140,10 +2140,10 @@ oserror_init(PyOSErrorObject *self, PyObject **p_args,
                 return -1;
         }
         else {
-            self->filename = Py_NewRef(filename);
+            Py_XSETREF(self->filename, Py_NewRef(filename));
 
             if (filename2 && filename2 != Py_None) {
-                self->filename2 = Py_NewRef(filename2);
+                Py_XSETREF(self->filename2, Py_NewRef(filename2));
             }
 
             if (nargs >= 2 && nargs <= 5) {
@@ -2158,10 +2158,10 @@ oserror_init(PyOSErrorObject *self, PyObject **p_args,
             }
         }
     }
-    self->myerrno = Py_XNewRef(myerrno);
-    self->strerror = Py_XNewRef(strerror);
+    Py_XSETREF(self->myerrno, Py_XNewRef(myerrno));
+    Py_XSETREF(self->strerror, Py_XNewRef(strerror));
 #ifdef MS_WINDOWS
-    self->winerror = Py_XNewRef(winerror);
+    Py_XSETREF(self->winerror, Py_XNewRef(winerror));
 #endif
 
     /* Steals the reference to args */


### PR DESCRIPTION
This PR uses `Py_XSETREF` instead of raw assignments inside `oserror_init` to prevent reference leaks when assigning attributed before `oserror_init` is called.

<!-- gh-issue-number: gh-150988 -->
* Issue: gh-150988
<!-- /gh-issue-number -->
