### PR TITLE
gh-150942: Speed up frame local item collection

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-06-08-20-00.gh-issue-150942.Jk9pQr.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-06-08-20-00.gh-issue-150942.Jk9pQr.rst
@@ -1,3 +1,3 @@
 Speed up frame local variable item collection by appending result pairs to the
 output list without an extra reference-count round-trip (using the internal
-reference-stealing list append helper).
+reference-stealing list append helper). Patch by Omkar Kabde.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-06-08-20-00.gh-issue-150942.Jk9pQr.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-06-08-20-00.gh-issue-150942.Jk9pQr.rst
@@ -1,0 +1,3 @@
+Speed up frame local variable item collection by appending result pairs to the
+output list without an extra reference-count round-trip (using the internal
+reference-stealing list append helper).

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -9,6 +9,7 @@
 #include "pycore_function.h"      // _PyFunction_FromConstructor()
 #include "pycore_genobject.h"     // _PyGen_GetGeneratorFromFrame()
 #include "pycore_interpframe.h"   // _PyFrame_GetLocalsArray()
+#include "pycore_list.h"          // _PyList_AppendTakeRef()
 #include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 #include "pycore_object.h"        // _PyObject_GC_UNTRACK()
 #include "pycore_opcode_metadata.h" // _PyOpcode_Caches
@@ -636,9 +637,7 @@ framelocalsproxy_items(PyObject *self, PyObject *Py_UNUSED(ignored))
                 goto error;
             }
 
-            int rc = PyList_Append(items, pair);
-            Py_DECREF(pair);
-            if (rc < 0) {
+            if (_PyList_AppendTakeRef((PyListObject *)items, pair) < 0) {
                 goto error;
             }
         }
@@ -655,9 +654,7 @@ framelocalsproxy_items(PyObject *self, PyObject *Py_UNUSED(ignored))
                 goto error;
             }
 
-            int rc = PyList_Append(items, pair);
-            Py_DECREF(pair);
-            if (rc < 0) {
+            if (_PyList_AppendTakeRef((PyListObject *)items, pair) < 0) {
                 goto error;
             }
         }


### PR DESCRIPTION
Use `_PyList_AppendTakeRef` while collecting frame-local `(name, value)` pairs
instead of `PyList_Append` followed by `Py_DECREF`, removing an incref/decref
pair per returned item pair.

## benchmarks

| Benchmark | main | this PR | speedup |
| --- | ---: | ---: | :---: |
| `frame_locals_items_100locals` | 9.09 ms | 8.61 ms | 1.06x |
| `frame_locals_items_1000locals` | 17.19 ms | 16.59 ms | 1.04x |
| `frame_locals_items_5000locals` | 29.92 ms | 28.94 ms | 1.03x |
| **geomean** | | | **1.04x** |

<details>
<summary>Benchmark script</summary>

```python
"""Micro-benchmark for frame.f_locals.items() result-list building."""

from __future__ import annotations

import argparse
import json
import statistics
import sys
import time
from pathlib import Path


def make_frame(local_count: int):
    assignments = "\n".join(f"    v{i} = {i}" for i in range(local_count))
    src = (
        "def make_frame():\n"
        f"{assignments}\n"
        "    return sys._getframe()\n"
    )
    ns = {"sys": sys}
    exec(src, ns)
    return ns["make_frame"]()


def time_items(frame, loops: int) -> float:
    t0 = time.perf_counter_ns()
    for _ in range(loops):
        frame.f_locals.items()
    return (time.perf_counter_ns() - t0) / 1e9


def main() -> int:
    ap = argparse.ArgumentParser()
    ap.add_argument("--locals", type=int, default=1_000)
    ap.add_argument("--loops", type=int, default=2_000)
    ap.add_argument("--trials", type=int, default=15)
    ap.add_argument("--warmup", type=int, default=3)
    ap.add_argument("--label", default="run")
    ap.add_argument("--outdir", default="results/frame-locals-items")
    args = ap.parse_args()

    frame = make_frame(args.locals)
    item_count = len(frame.f_locals.items())

    for _ in range(args.warmup):
        time_items(frame, args.loops)

    trials = [time_items(frame, args.loops) for _ in range(args.trials)]

    outdir = Path(args.outdir)
    outdir.mkdir(parents=True, exist_ok=True)
    summary = {
        "label": args.label,
        "python": sys.executable,
        "locals": args.locals,
        "item_count": item_count,
        "loops": args.loops,
        "trials": args.trials,
        "warmup": args.warmup,
        "items_built": item_count * args.loops,
        "seconds": {
            "min": min(trials),
            "median": statistics.median(trials),
            "mean": statistics.fmean(trials),
            "stdev": statistics.pstdev(trials),
            "all": trials,
        },
        "items_per_sec_at_min": (item_count * args.loops) / min(trials),
    }
    out = outdir / f"bench_{args.label}.json"
    out.write_text(json.dumps(summary, indent=2))

    s = summary["seconds"]
    print(
        f"{args.label}: min={s['min']*1000:.2f}ms median={s['median']*1000:.2f}ms "
        f"mean={s['mean']*1000:.2f}ms stdev={s['stdev']*1000:.2f}ms "
        f"items/s@min={summary['items_per_sec_at_min']:.2e}"
    )
    print(f"wrote {out}")
    return 0


if __name__ == "__main__":
    raise SystemExit(main())
```

</details>


<!-- gh-issue-number: gh-150942 -->
* Issue: gh-150942
<!-- /gh-issue-number -->
