### PR TITLE
gh-139669: Make `__name__` and `__file__` as a proxy for `_LazyModule.__spec__`

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1371,6 +1371,18 @@ an :term:`importer`.
       compatibility warning for :class:`importlib.machinery.BuiltinImporter` and
       :class:`importlib.machinery.ExtensionFileLoader`.
 
+   .. versionchanged:: 3.16
+      Reading a lazily-loaded module's :attr:`~module.__name__` and
+      :attr:`~module.__file__` attributes no longer triggers the load.  Until
+      the module is loaded they act as aliases for the
+      :attr:`~importlib.machinery.ModuleSpec.name` and
+      :attr:`~importlib.machinery.ModuleSpec.origin` of its
+      :attr:`~module.__spec__`, and assigning to them updates the spec
+      instead.  This keeps introspection tools such as
+      :func:`inspect.getmodule` -- used indirectly by, for example,
+      :func:`inspect.getframeinfo` -- from forcing every lazily-loaded module
+      in :data:`sys.modules` to be imported (:gh:`139669`).
+
    .. classmethod:: factory(loader)
 
       A class method which returns a callable that creates a lazy loader. This
@@ -1481,6 +1493,11 @@ The example below shows how to implement lazy imports::
     >>> #but it is not loaded in memory yet.
     >>> lazy_typing.TYPE_CHECKING
     False
+
+Reading the module's :attr:`~module.__name__` or :attr:`~module.__file__`
+does not trigger the load; until then they mirror the module's
+:attr:`~module.__spec__`.  Accessing any other attribute (such as
+``TYPE_CHECKING`` above) loads the module.
 
 
 Setting up an importer

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1373,15 +1373,13 @@ an :term:`importer`.
 
    .. versionchanged:: 3.16
       Reading a lazily-loaded module's :attr:`~module.__name__` and
-      :attr:`~module.__file__` attributes no longer triggers the load.  Until
+      :attr:`~module.__file__` attributes no longer triggers the load. Until
       the module is loaded they act as aliases for the
       :attr:`~importlib.machinery.ModuleSpec.name` and
       :attr:`~importlib.machinery.ModuleSpec.origin` of its
       :attr:`~module.__spec__`, and assigning to them updates the spec
-      instead.  This keeps introspection tools such as
-      :func:`inspect.getmodule` -- used indirectly by, for example,
-      :func:`inspect.getframeinfo` -- from forcing every lazily-loaded module
-      in :data:`sys.modules` to be imported (:gh:`139669`).
+      instead. This avoids the unintentional loading caused by
+      introspection tools like :func:`inspect.getframeinfo` (:gh:`139669`).
 
    .. classmethod:: factory(loader)
 

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -171,6 +171,13 @@ class _LazyModule(types.ModuleType):
     def __getattribute__(self, attr):
         """Trigger the load of the module and return the attribute."""
         __spec__ = object.__getattribute__(self, '__spec__')
+
+        # gh-139669: avoid triggering lazy loading from these 2 attrs
+        if attr == "__name__":
+            return __spec__.name
+        if attr == "__file__":
+            return __spec__.origin
+
         loader_state = __spec__.loader_state
         with loader_state['lock']:
             # Only the first thread to get the lock should trigger the load
@@ -223,11 +230,23 @@ class _LazyModule(types.ModuleType):
 
         return getattr(self, attr)
 
+    def __setattr__(self, attr, value):
+        """Keep __name__/__file__ in sync with __spec__ without loading."""
+        __spec__ = object.__getattribute__(self, '__spec__')
+        if attr == "__name__":
+            __spec__.name = value
+        elif attr == "__file__":
+            __spec__.origin = value
+        else:
+            object.__setattr__(self, attr, value)
+
     def __delattr__(self, attr):
         """Trigger the load and then perform the deletion."""
-        # To trigger the load and raise an exception if the attribute
-        # doesn't exist.
-        self.__getattribute__(attr)
+        # Reading __name__/__file__ aliases the spec and no longer triggers
+        # the load, so access __spec__ to force it.  This also resets
+        # __class__ to the real module type, avoiding infinite recursion in
+        # the delattr() below.
+        self.__getattribute__('__spec__')
         delattr(self, attr)
 
 

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -242,11 +242,8 @@ class _LazyModule(types.ModuleType):
 
     def __delattr__(self, attr):
         """Trigger the load and then perform the deletion."""
-        # Reading __name__/__file__ aliases the spec and no longer triggers
-        # the load, so access __spec__ to force it.  This also resets
-        # __class__ to the real module type, avoiding infinite recursion in
-        # the delattr() below.
         self.__getattribute__('__spec__')
+        # Goes into ModuleType.__delattr__
         delattr(self, attr)
 
 

--- a/Lib/test/test_importlib/test_lazy.py
+++ b/Lib/test/test_importlib/test_lazy.py
@@ -1,6 +1,7 @@
 import importlib
 from importlib import abc
 from importlib import util
+import inspect
 import sys
 import time
 import threading
@@ -99,6 +100,9 @@ class LazyLoaderTests(unittest.TestCase):
         # An attribute only mutated as a side-effect of import should not be
         # changed needlessly.
         module = self.new_module()
+        # __name__ itself doesn't trigger the lazy loading,
+        # trigger via another attr
+        module.__package__
         self.assertEqual(TestingImporter.mutated_name, module.__name__)
 
     def test_new_attr(self):
@@ -138,14 +142,14 @@ class LazyLoaderTests(unittest.TestCase):
             sys.modules[TestingImporter.module_name] = fresh_module
             module = self.new_module()
             with self.assertRaisesRegex(ValueError, "substituted"):
-                module.__name__
+                module.__package__
 
     def test_module_already_in_sys(self):
         with test_util.uncache(TestingImporter.module_name):
             module = self.new_module()
             sys.modules[TestingImporter.module_name] = module
             # Force the load; just care that no exception is raised.
-            module.__name__
+            module.__package__
 
     @threading_helper.requires_working_threading()
     def test_module_load_race(self):
@@ -223,6 +227,43 @@ sys.modules[__name__].__class__ = ImmutableModule
             module.CONSTANT = 2.71
         with self.assertRaises(AttributeError):
             del module.CONSTANT
+
+    def test_name_file_alias_spec(self):
+        # gh-139669: __name__/__file__ are aliases for __spec__.name and
+        # __spec__.origin.  Reading them returns the spec values and does not
+        # trigger the load; writing them flows through to the spec.
+        loader = TestingImporter()
+        module = self.new_module(loader=loader)
+        spec = object.__getattribute__(module, '__spec__')
+        spec.origin = '/some/where.py'
+        self.assertEqual(module.__name__, spec.name)
+        self.assertEqual(module.__file__, '/some/where.py')
+        # Neither read triggered the load.
+        self.assertIsNone(loader.loaded)
+        self.assertEqual(0, loader.load_count)
+        # Writes flow through to the spec, still without loading.
+        module.__name__ = 'renamed'
+        module.__file__ = '/other.py'
+        self.assertEqual(spec.name, 'renamed')
+        self.assertEqual(spec.origin, '/other.py')
+        self.assertEqual(module.__name__, 'renamed')
+        self.assertEqual(module.__file__, '/other.py')
+        self.assertIsNone(loader.loaded)
+        self.assertIsInstance(module, util._LazyModule)
+
+    def test_inspect_does_not_trigger_lazy_load(self):
+        # gh-139669: introspecting an unrelated frame iterates over
+        # sys.modules and must not force lazy modules to be loaded.
+        loader = TestingImporter()
+        module = self.new_module(loader=loader)
+        with test_util.uncache(TestingImporter.module_name):
+            sys.modules[TestingImporter.module_name] = module
+            self.assertIsInstance(module, util._LazyModule)
+
+            inspect.getframeinfo(inspect.currentframe())
+            self.assertIsNone(loader.loaded)
+            self.assertEqual(0, loader.load_count)
+            self.assertIsInstance(module, util._LazyModule)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_importlib/test_lazy.py
+++ b/Lib/test/test_importlib/test_lazy.py
@@ -228,29 +228,6 @@ sys.modules[__name__].__class__ = ImmutableModule
         with self.assertRaises(AttributeError):
             del module.CONSTANT
 
-    def test_name_file_alias_spec(self):
-        # gh-139669: __name__/__file__ are aliases for __spec__.name and
-        # __spec__.origin.  Reading them returns the spec values and does not
-        # trigger the load; writing them flows through to the spec.
-        loader = TestingImporter()
-        module = self.new_module(loader=loader)
-        spec = object.__getattribute__(module, '__spec__')
-        spec.origin = '/some/where.py'
-        self.assertEqual(module.__name__, spec.name)
-        self.assertEqual(module.__file__, '/some/where.py')
-        # Neither read triggered the load.
-        self.assertIsNone(loader.loaded)
-        self.assertEqual(0, loader.load_count)
-        # Writes flow through to the spec, still without loading.
-        module.__name__ = 'renamed'
-        module.__file__ = '/other.py'
-        self.assertEqual(spec.name, 'renamed')
-        self.assertEqual(spec.origin, '/other.py')
-        self.assertEqual(module.__name__, 'renamed')
-        self.assertEqual(module.__file__, '/other.py')
-        self.assertIsNone(loader.loaded)
-        self.assertIsInstance(module, util._LazyModule)
-
     def test_inspect_does_not_trigger_lazy_load(self):
         # gh-139669: introspecting an unrelated frame iterates over
         # sys.modules and must not force lazy modules to be loaded.

--- a/Misc/NEWS.d/next/Library/2026-06-06-12-00-00.gh-issue-139669.La9Zk1.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-06-12-00-00.gh-issue-139669.La9Zk1.rst
@@ -1,0 +1,7 @@
+Reading the :attr:`~module.__name__` and :attr:`~module.__file__` attributes
+of a module created by :class:`importlib.util.LazyLoader` no longer triggers
+the load.  While the module remains unloaded these attributes are aliases for
+its :attr:`~module.__spec__`, and assigning to them updates the spec.  This
+prevents introspection tools such as :func:`inspect.getframeinfo`, via
+:func:`inspect.getmodule`, from forcing every lazily-loaded module in
+:data:`sys.modules` to be imported.


### PR DESCRIPTION
This PR makes `__name__` and `__file__`, as a proxy for `_LazyModule.__spec__`. That says, reading & writing both will be directly forwarded to `_LazyModule.__spec__`, which will **NOT** trigger the lazy loading.

<!-- gh-issue-number: gh-139669 -->
* Issue: gh-139669
<!-- /gh-issue-number -->
