### PR TITLE
gh-151021: Fix mmap empty searches past the end

### DIFF
--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -354,6 +354,8 @@ class MmapTests(unittest.TestCase):
         self.assertEqual(m.find(b'one', 1, -1), 8)
         self.assertEqual(m.find(b'one', 1, -2), -1)
         self.assertEqual(m.find(bytearray(b'one')), 0)
+        self.assertEqual(m.find(b'', n + 1), -1)
+        self.assertEqual(m.rfind(b'', n + 1), -1)
 
         for i in range(-n-1, n+1):
             for j in range(-n-1, n+1):

--- a/Misc/NEWS.d/next/Library/2026-06-06-15-20-54.gh-issue-151021.J4qk2A.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-06-15-20-54.gh-issue-151021.J4qk2A.rst
@@ -1,0 +1,3 @@
+Fix :meth:`mmap.mmap.find` and :meth:`~mmap.mmap.rfind` to return ``-1``
+when searching for an empty subsequence with a start position past the end
+of the mapping.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -620,8 +620,6 @@ mmap_gfind_lock_held(mmap_object *self, Py_buffer *view, PyObject *start_obj,
         start += self->size;
     if (start < 0)
         start = 0;
-    else if (start > self->size)
-        start = self->size;
 
     if (end < 0)
         end += self->size;


### PR DESCRIPTION
Problem:
`mmap.find()` and `mmap.rfind()` return the mapping length when an empty subsequence is searched with `start > len(mapping)`.

Root cause:
`mmap_gfind_lock_held()` clamps an oversized positive start to the mapping size, turning an out-of-range search into a valid empty match.

Fix:
Preserve positive start values beyond the mapping length. The existing `end < start` check then returns `-1` before any buffer access.

Tests:
- `PCbuild\amd64\python_d.exe -m unittest -v test.test_mmap.MmapTests.test_find_end`
- `PCbuild\amd64\python_d.exe -m test test_mmap -j0`
- `PCbuild\amd64\python_d.exe -m test test_mmap -R 3:3`
- Windows debug build and patchcheck

Compatibility/risk:
This aligns mmap with `bytes`, `bytearray`, and `str`. Non-empty searches and valid start positions are unchanged.

Docs/NEWS:
Adds a Library NEWS entry.

* Issue: gh-151021