### PR TITLE
gh-151042: venv: Pass VIRTUAL_ENV through cygpath inside fish on Windows

### DIFF
--- a/Lib/venv/scripts/common/activate.fish
+++ b/Lib/venv/scripts/common/activate.fish
@@ -34,6 +34,9 @@ end
 deactivate nondestructive
 
 set -gx VIRTUAL_ENV __VENV_DIR__
+if string match -qr 'CYGWIN|MSYS|MINGW' (uname)
+    set -gx VIRTUAL_ENV (cygpath -u $VIRTUAL_ENV)
+end
 
 set -gx _OLD_VIRTUAL_PATH $PATH
 set -gx PATH "$VIRTUAL_ENV/"__VENV_BIN_NAME__ $PATH

--- a/Misc/NEWS.d/next/Library/2026-06-07-13-47-05.gh-issue-151042.NMdzF2.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-07-13-47-05.gh-issue-151042.NMdzF2.rst
@@ -1,0 +1,1 @@
+Fixed venv exporting mixed path styles to PATH on Windows inside fish (via Cygwin, MinGW or MSYS2)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
gh-151042: Fixed venv exporting mixed path styles to PATH on Windows inside fish (via Cygwin, MinGW or MSYS2)

This PR mirrors the changes from gh-103325, gh-125399 and gh-112508 to the fish activation script.