### PR TITLE
Fix missing colon in bisect example function

### DIFF
--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -200,7 +200,7 @@ example uses :py:func:`~bisect.bisect` to look up a letter grade for an exam sco
 based on a set of ordered numeric breakpoints: 90 and up is an 'A', 80 to 89 is
 a 'B', and so on::
 
-   >>> def grade(score)
+   >>> def grade(score):
    ...     i = bisect([60, 70, 80, 90], score)
    ...     return "FDCBA"[i]
    ...


### PR DESCRIPTION
Fixes a syntax error in `Doc/library/bisect.rst` by adding amissing colon at the end of the `grade()` function declaration.

Note: This PR #148839 exists, but it was closed by the author.


