### PR TITLE
gh-150626: Fix format string syntax grammar

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -219,8 +219,9 @@ The grammar for a replacement field is as follows:
 .. productionlist:: format-string
    replacement_field: "{" [`field_name`] ["!" `conversion`] [":" `format_spec`] "}"
    field_name: `arg_name` ("." `attribute_name` | "[" `element_index` "]")*
-   arg_name: [`~python-grammar:identifier` | `~python-grammar:digit`+]
-   attribute_name: `~python-grammar:identifier`
+   arg_name: [`name_string` | `~python-grammar:digit`+]
+   attribute_name: `name_string`
+   name_string: <any source character except "!", ".", ":", "[", "{", "}"> +
    element_index: `~python-grammar:digit`+ | `index_string`
    index_string: <any source character except "]"> +
    conversion: "r" | "s" | "a"


### PR DESCRIPTION
When it comes to names for fields or attributes, format strings are much more permissive than the documentation implies.

Fixes: gh-150626
