### PR TITLE
gh-150902: Optimize `PyCriticalSection2` to skip locking the same locks as the ones held by the current CS2

### DIFF
--- a/Include/internal/pycore_critical_section.h
+++ b/Include/internal/pycore_critical_section.h
@@ -196,10 +196,9 @@ _PyCriticalSection2_Begin(PyThreadState *tstate, PyCriticalSection2 *c, PyObject
 static inline void
 _PyCriticalSection2_End(PyThreadState *tstate, PyCriticalSection2 *c)
 {
-    // if mutex1 is NULL, we used the fast path in
-    // _PyCriticalSection_BeginSlow for mutexes that are already held,
-    // which should only happen when mutex1 and mutex2 were the same mutex,
-    // and mutex2 should also be NULL.
+    // if mutex1 is NULL, we used the fast path in either
+    // _PyCriticalSection_BeginSlow or _PyCriticalSection2_BeginSlow for mutexes
+    // that are already held, and mutex2 should also be NULL.
     if (c->_cs_base._cs_mutex == NULL) {
         assert(c->_cs_mutex2 == NULL);
         return;

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-08-13-14-42.gh-issue-150902.-CWZ66.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-08-13-14-42.gh-issue-150902.-CWZ66.rst
@@ -1,0 +1,1 @@
+Apply an existing optimization of PyCriticalSection (single mutex) to PyCriticalSection2: avoid acquiring the same locks that the current CS has already acquired.

--- a/Python/critical_section.c
+++ b/Python/critical_section.c
@@ -78,8 +78,9 @@ _PyCriticalSection2_BeginSlow(PyThreadState *tstate, PyCriticalSection2 *c, PyMu
         tstate->critical_section & _Py_CRITICAL_SECTION_TWO_MUTEXES) {
         PyCriticalSection2 *prev2 = (PyCriticalSection2 *)
             untag_critical_section(tstate->critical_section);
-        assert(m1 < m2);
-        assert(prev2->_cs_base._cs_mutex < prev2->_cs_mutex2);
+        assert((uintptr_t)m1 < (uintptr_t)m2);
+        assert((uintptr_t)prev2->_cs_base._cs_mutex <
+            (uintptr_t)prev2->_cs_mutex2);
         if (prev2->_cs_base._cs_mutex == m1 && prev2->_cs_mutex2 == m2) {
             c->_cs_base._cs_mutex = NULL;
             c->_cs_mutex2 = NULL;

--- a/Python/critical_section.c
+++ b/Python/critical_section.c
@@ -72,6 +72,21 @@ _PyCriticalSection2_BeginSlow(PyThreadState *tstate, PyCriticalSection2 *c, PyMu
         c->_cs_base._cs_prev = 0;
         return;
     }
+    // Same optimization as in _PyCriticalSection_BeginSlow: skip locking when
+    // recursively acquiring the same locks.
+    if (tstate->critical_section &&
+        tstate->critical_section & _Py_CRITICAL_SECTION_TWO_MUTEXES) {
+        PyCriticalSection2 *prev2 = (PyCriticalSection2 *)
+            untag_critical_section(tstate->critical_section);
+        assert(m1 < m2);
+        assert(prev2->_cs_base._cs_mutex < prev2->_cs_mutex2);
+        if (prev2->_cs_base._cs_mutex == m1 && prev2->_cs_mutex2 == m2) {
+            c->_cs_base._cs_mutex = NULL;
+            c->_cs_mutex2 = NULL;
+            c->_cs_base._cs_prev = 0;
+            return;
+        }
+    }
     c->_cs_base._cs_mutex = NULL;
     c->_cs_mutex2 = NULL;
     c->_cs_base._cs_prev = tstate->critical_section;


### PR DESCRIPTION
This mimics an optimization already present for the single-mutex critical section.

<!-- gh-issue-number: gh-150902 -->
* Issue: gh-150902
<!-- /gh-issue-number -->
