### PR TITLE
Drop historical `:author:`s from HOWTOs

### DIFF
--- a/Doc/howto/annotations.rst
+++ b/Doc/howto/annotations.rst
@@ -4,8 +4,6 @@
 Annotations Best Practices
 **************************
 
-:author: Larry Hastings
-
 .. topic:: Abstract
 
   This document is designed to encapsulate the best practices

--- a/Doc/howto/argparse.rst
+++ b/Doc/howto/argparse.rst
@@ -4,8 +4,6 @@
 Argparse Tutorial
 *****************
 
-:author: Tshepang Mbambo
-
 .. currentmodule:: argparse
 
 This tutorial is intended to be a gentle introduction to :mod:`argparse`, the

--- a/Doc/howto/curses.rst
+++ b/Doc/howto/curses.rst
@@ -6,9 +6,6 @@
 
 .. currentmodule:: curses
 
-:Author: A.M. Kuchling, Eric S. Raymond
-:Release: 2.04
-
 
 .. topic:: Abstract
 

--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -4,9 +4,6 @@
 Descriptor Guide
 ================
 
-:Author: Raymond Hettinger
-:Contact: <python at rcn dot com>
-
 .. Contents::
 
 

--- a/Doc/howto/functional.rst
+++ b/Doc/howto/functional.rst
@@ -4,9 +4,6 @@
   Functional Programming HOWTO
 ********************************
 
-:Author: \A. M. Kuchling
-:Release: 0.32
-
 In this document, we'll take a tour of Python's features suitable for
 implementing programs in a functional style.  After an introduction to the
 concepts of functional programming, we'll look at language features such as
@@ -1185,7 +1182,8 @@ about whether this lambda-free style is better.
 Revision History and Acknowledgements
 =====================================
 
-The author would like to thank the following people for offering suggestions,
+This HOWTO was originally written by A. M. Kuchling. The author would like to
+thank the following people for offering suggestions,
 corrections and assistance with various drafts of this article: Ian Bicking,
 Nick Coghlan, Nick Efford, Raymond Hettinger, Jim Jewett, Mike Krell, Leandro
 Lameiro, Jussi Salmela, Collin Winter, Blake Winton.
@@ -1239,9 +1237,9 @@ Text Processing".
 
 Mertz also wrote a 3-part series of articles on functional programming
 for IBM's DeveloperWorks site; see
-`part 1 <https://developer.ibm.com/articles/l-prog/>`__,
-`part 2 <https://developer.ibm.com/tutorials/l-prog2/>`__, and
-`part 3 <https://developer.ibm.com/tutorials/l-prog3/>`__,
+`part 1 <https://web.archive.org/web/20211006103639/https://developer.ibm.com/articles/l-prog/>`__,
+`part 2 <https://web.archive.org/web/20211205224606/https://developer.ibm.com/tutorials/l-prog2/>`__, and
+`part 3 <https://web.archive.org/web/20211127083846/https://developer.ibm.com/tutorials/l-prog3/>`__.
 
 
 Python documentation

--- a/Doc/howto/instrumentation.rst
+++ b/Doc/howto/instrumentation.rst
@@ -6,9 +6,6 @@
 Instrumenting CPython with DTrace and SystemTap
 ===============================================
 
-:author: David Malcolm
-:author: Łukasz Langa
-
 DTrace and SystemTap are monitoring tools, each providing a way to inspect
 what the processes on a computer system are doing.  They both use
 domain-specific languages allowing a user to write scripts which:

--- a/Doc/howto/ipaddress.rst
+++ b/Doc/howto/ipaddress.rst
@@ -8,9 +8,6 @@
 An introduction to the ipaddress module
 ***************************************
 
-:author: Peter Moody
-:author: Nick Coghlan
-
 .. topic:: Overview
 
    This document aims to provide a gentle introduction to the

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -4,8 +4,6 @@
 Logging Cookbook
 ================
 
-:Author: Vinay Sajip <vinay_sajip at red-dove dot com>
-
 This page contains a number of recipes related to logging, which have been found
 useful in the past. For links to tutorial and reference information, please see
 :ref:`cookbook-ref-links`.

--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -4,8 +4,6 @@
 Logging HOWTO
 =============
 
-:Author: Vinay Sajip <vinay_sajip at red-dove dot com>
-
 .. _logging-basic-tutorial:
 
 .. currentmodule:: logging

--- a/Doc/howto/perf_profiling.rst
+++ b/Doc/howto/perf_profiling.rst
@@ -6,8 +6,6 @@
 Python support for the ``perf map`` compatible profilers
 ========================================================
 
-:author: Pablo Galindo
-
 `The Linux perf profiler <https://perf.wiki.kernel.org>`_ and
 `samply <https://github.com/mstange/samply>`_ are powerful tools that allow you to
 profile and obtain information about the performance of your application.

--- a/Doc/howto/pyporting.rst
+++ b/Doc/howto/pyporting.rst
@@ -6,8 +6,6 @@
 How to port Python 2 Code to Python 3
 *************************************
 
-:author: Brett Cannon
-
 Python 2 reached its official end-of-life at the start of 2020. This means
 that no new bug reports, fixes, or changes will be made to Python 2 - it's
 no longer supported: see :pep:`373` and

--- a/Doc/howto/regex.rst
+++ b/Doc/howto/regex.rst
@@ -4,8 +4,6 @@
   Regular expression HOWTO
 ****************************
 
-:Author: A.M. Kuchling <amk@amk.ca>
-
 .. TODO:
    Document lookbehind assertions
    Better way of displaying a RE, a string, and what it matches

--- a/Doc/howto/sockets.rst
+++ b/Doc/howto/sockets.rst
@@ -4,9 +4,6 @@
   Socket Programming HOWTO
 ****************************
 
-:Author: Gordon McMillan
-
-
 .. topic:: Abstract
 
    Sockets are used nearly everywhere, but are one of the most severely

--- a/Doc/howto/sorting.rst
+++ b/Doc/howto/sorting.rst
@@ -3,9 +3,6 @@
 Sorting Techniques
 ******************
 
-:Author: Andrew Dalke and Raymond Hettinger
-
-
 Python lists have a built-in :meth:`list.sort` method that modifies the list
 in-place.  There is also a :func:`sorted` built-in function that builds a new
 sorted list from an iterable.

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -4,8 +4,6 @@
   Unicode HOWTO
 *****************
 
-:Release: 1.12
-
 This HOWTO discusses Python's support for the Unicode specification
 for representing textual data, and explains various problems that
 people commonly encounter when trying to work with Unicode.

--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -4,9 +4,6 @@
   HOWTO Fetch Internet Resources Using The urllib Package
 ***********************************************************
 
-:Author: `Michael Foord <https://agileabstractions.com/>`_
-
-
 Introduction
 ============
 


### PR DESCRIPTION
Continuing https://github.com/python/cpython/pull/145002, as noted in https://github.com/python/docs-community/issues/180#issuecomment-3929783843. See https://github.com/python/docs-community/issues/180 for discussion and motivation.

I opted to leave the `:editor:`s of What's News, as that is still an [active practice](https://github.com/python/release-tools/blob/a0a84ff93031874539e8add1016f8cd0014187d6/run_release.py#L53) and can be useful for clarity.