### PR TITLE
gh-151099: Better repr output for template strings.

### DIFF
--- a/Doc/library/string.templatelib.rst
+++ b/Doc/library/string.templatelib.rst
@@ -33,10 +33,7 @@ To write a t-string, use a ``'t'`` prefix instead of an ``'f'``, like so:
 
    >>> pi = 3.14
    >>> t't-strings are new in Python {pi!s}!'
-   Template(
-      strings=('t-strings are new in Python ', '!'),
-      interpolations=(Interpolation(3.14, 'pi', 's', ''),)
-   )
+   <Template t't-strings are new in Python {pi!s=3.14}!' at 0x...>
 
 Types
 -----
@@ -118,7 +115,7 @@ Types
       >>> cheese = 'Camembert'
       >>> template = t'Ah! We do have {cheese}.'
       >>> template.interpolations
-      (Interpolation('Camembert', 'cheese', None, ''),)
+      (Interpolation('Camembert', 'cheese'),)
 
       The ``interpolations`` tuple may be empty and always contains one fewer
       values than the ``strings`` tuple:
@@ -153,7 +150,7 @@ Types
       ...     'Ah! We do have ', Interpolation(cheese, 'cheese'), '.'
       ... )
       >>> list(template)
-      ['Ah! We do have ', Interpolation('Camembert', 'cheese', None, ''), '.']
+      ['Ah! We do have ', Interpolation('Camembert', 'cheese'), '.']
 
       If multiple strings are passed consecutively, they will be concatenated
       into a single value in the :attr:`~Template.strings` attribute. For example,
@@ -184,7 +181,7 @@ Types
 
       >>> cheese = 'Camembert'
       >>> list(t'Ah! We do have {cheese}.')
-      ['Ah! We do have ', Interpolation('Camembert', 'cheese', None, ''), '.']
+      ['Ah! We do have ', Interpolation('Camembert', 'cheese'), '.']
 
       .. caution::
 
@@ -194,8 +191,8 @@ Types
          >>> cheese = 'Camembert'
          >>> list(t'Ah! {response}{cheese}.')  # doctest: +NORMALIZE_WHITESPACE
          ['Ah! ',
-          Interpolation('We do have ', 'response', None, ''),
-          Interpolation('Camembert', 'cheese', None, ''),
+          Interpolation('We do have ', 'response'),
+          Interpolation('Camembert', 'cheese'),
           '.']
 
    .. describe:: template + other
@@ -206,7 +203,7 @@ Types
 
       >>> cheese = 'Camembert'
       >>> list(t'Ah! ' + t'We do have {cheese}.')
-      ['Ah! We do have ', Interpolation('Camembert', 'cheese', None, ''), '.']
+      ['Ah! We do have ', Interpolation('Camembert', 'cheese'), '.']
 
       Concatenating a :class:`!Template` and a ``str`` is **not** supported.
       This is because it is unclear whether the string should be treated as
@@ -224,7 +221,7 @@ Types
       >>> cheese = 'Camembert'
       >>> template += Template(Interpolation(cheese, 'cheese'))
       >>> list(template)
-      ['Ah! We do have ', Interpolation('Camembert', 'cheese', None, '')]
+      ['Ah! We do have ', Interpolation('Camembert', 'cheese')]
 
 
 .. class:: Interpolation

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -318,7 +318,7 @@ Also, template string literals may only be combined with other template
 string literals::
 
    >>> t"Hello" t"{name}!"
-   Template(strings=('Hello', '!'), interpolations=(...))
+   <Template t'Hello{name='Blaise'}!' at 0x...>
 
 Formally:
 

--- a/Include/internal/pycore_interpolation.h
+++ b/Include/internal/pycore_interpolation.h
@@ -18,6 +18,8 @@ PyAPI_FUNC(PyObject *) _PyInterpolation_Build(PyObject *value, PyObject *str,
 
 extern PyStatus _PyInterpolation_InitTypes(PyInterpreterState *interp);
 extern PyObject *_PyInterpolation_GetValueRef(PyObject *interpolation);
+extern int _PyInterpolation_WriteSource(PyUnicodeWriter *writer,
+                                        PyObject *interpolation);
 
 #ifdef __cplusplus
 }

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -753,13 +753,15 @@ class PrettyPrinter:
         cls_name = object.__class__.__name__
         if self._expand:
             indent += self._indent_per_level
+            stream.write(self._format_block_start(cls_name + "(", indent))
             items = (
                 ("value", object.value),
                 ("expression", object.expression),
-                ("conversion", object.conversion),
-                ("format_spec", object.format_spec),
             )
-            stream.write(self._format_block_start(cls_name + "(", indent))
+            if object.conversion is not None or object.format_spec:
+                items += (("conversion", object.conversion),)
+                if object.format_spec:
+                    items += (("format_spec", object.format_spec),)
             self._format_namespace_items(
                 items, stream, indent, allowance, context, level
             )
@@ -768,13 +770,15 @@ class PrettyPrinter:
             )
         else:
             indent += len(cls_name)
+            stream.write(cls_name + "(")
             items = (
                 object.value,
                 object.expression,
-                object.conversion,
-                object.format_spec,
             )
-            stream.write(cls_name + "(")
+            if object.conversion is not None or object.format_spec:
+                items += (object.conversion,)
+                if object.format_spec:
+                    items += (object.format_spec,)
             self._format_items(
                 items, stream, indent, allowance, context, level
             )

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -737,18 +737,13 @@ class PrettyPrinter:
 
     def _pprint_template(self, object, stream, indent, allowance, context, level):
         cls_name = object.__class__.__name__
-        if self._expand:
-            indent += self._indent_per_level
-        else:
-            indent += len(cls_name) + 1
 
-        items = (
-            ("strings", object.strings),
-            ("interpolations", object.interpolations),
-        )
+        if not self._expand:
+            indent += len(cls_name)
+
         stream.write(self._format_block_start(cls_name + "(", indent))
-        self._format_namespace_items(
-            items, stream, indent, allowance, context, level
+        self._format_items(
+            object, stream, indent, allowance, context, level
         )
         stream.write(
             self._format_block_end(")", indent - self._indent_per_level)

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -785,8 +785,11 @@ class PrettyPrinter:
             stream.write(")")
 
     t = t"{0}"
-    _dispatch[type(t).__repr__] = _pprint_template
-    _dispatch[type(t.interpolations[0]).__repr__] = _pprint_interpolation
+    _template = type(t)
+    _dispatch[_template.__repr__] = _pprint_template
+
+    _interpolation = type(t.interpolations[0])
+    _dispatch[_interpolation.__repr__] = _pprint_interpolation
     del t
 
     def _safe_repr(self, object, context, maxlevels, level):
@@ -914,6 +917,42 @@ class PrettyPrinter:
                     recursive = True
             del context[objid]
             return typ.__name__ + '([%s])' % ", ".join(components), readable, recursive
+
+        if (issubclass(typ, self._template) and r is self._template.__repr__) or \
+           (issubclass(typ, self._interpolation) and r is self._interpolation.__repr__):
+            # Don't use the repr of templates and interpolations, since the repr
+            # of a template resembles its source code (and includes the id of
+            # the template). Use constructor syntax instead, which is what
+            # _pprint_template and _pprint_interpolation produce as well.
+            objid = id(object)
+            if maxlevels and level >= maxlevels:
+                return f"{typ.__name__}(...)", False, objid in context
+            if objid in context:
+                return _recursion(object), False, True
+            if typ is self._template:
+                items = object
+            else:
+                items = (object.value, object.expression)
+                if object.conversion is not None or object.format_spec:
+                    items += (object.conversion,)
+                    if object.format_spec:
+                        items += (object.format_spec,)
+            context[objid] = 1
+            readable = True
+            recursive = False
+            components = []
+            append = components.append
+            level += 1
+            for item in items:
+                irepr, ireadable, irecur = self.format(
+                    item, context, maxlevels, level)
+                append(irepr)
+                readable = readable and ireadable
+                if irecur:
+                    recursive = True
+            del context[objid]
+            rep = "%s(%s)" % (typ.__name__, ", ".join(components))
+            return rep, readable, recursive
 
         rep = repr(object)
         return rep, (rep and not rep.startswith('<')), False

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -1517,41 +1517,36 @@ ValuesView({'a': 6,
 
     def test_template(self):
         d = t""
-        self.assertEqual(pprint.pformat(d),
-                         "Template(strings=('',), interpolations=())")
+        self.assertEqual(pprint.pformat(d), "Template()")
         self.assertEqual(pprint.pformat(d), repr(d))
-        self.assertEqual(pprint.pformat(d, width=1),
-"""\
-Template(strings=('',),
-         interpolations=())""")
+        self.assertEqual(pprint.pformat(d, width=1), "Template()")
         name = "World"
         d = t"Hello {name}"
         self.assertEqual(pprint.pformat(d),
 """\
-Template(strings=('Hello ', ''),
-         interpolations=(Interpolation('World', 'name', None, ''),))""")
+Template('Hello ', Interpolation('World', 'name', None, ''))""")
         ver = {3.13: False, 3.14: True}
         d = t"Hello { {"name": "Python", "version": ver}!s:z}!"
         self.assertEqual(pprint.pformat(d, width=1),
 """\
-Template(strings=('Hello ',
-                  '!'),
-         interpolations=(Interpolation({'name': 'Python',
-                                        'version': {3.13: False,
-                                                    3.14: True}},
-                                       ' '
-                                       '{"name": '
-                                       '"Python", '
-                                       '"version": '
-                                       'ver}',
-                                       's',
-                                       'z'),))""")
+Template('Hello ',
+         Interpolation({'name': 'Python',
+                        'version': {3.13: False,
+                                    3.14: True}},
+                       ' '
+                       '{"name": '
+                       '"Python", '
+                       '"version": '
+                       'ver}',
+                       's',
+                       'z'),
+         '!')""")
 
     def test_expand_template(self):
         d = t""
         self.assertEqual(
             pprint.pformat(d, expand=True),
-            "Template(strings=('',), interpolations=())",
+            "Template()",
         )
         name = "World"
         d = t"Hello {name}"
@@ -1559,14 +1554,12 @@ Template(strings=('Hello ',
             pprint.pformat(d, width=40, indent=4, expand=True),
             """\
 Template(
-    strings=('Hello ', ''),
-    interpolations=(
-        Interpolation(
-            value='World',
-            expression='name',
-            conversion=None,
-            format_spec='',
-        ),
+    'Hello ',
+    Interpolation(
+        value='World',
+        expression='name',
+        conversion=None,
+        format_spec='',
     ),
 )""",
         )
@@ -1576,22 +1569,18 @@ Template(
             pprint.pformat(d, width=40, indent=4, expand=True),
             """\
 Template(
-    strings=('Hello ', '!'),
-    interpolations=(
-        Interpolation(
-            value={
-                'name': 'Python',
-                'version': {
-                    3.13: False,
-                    3.14: True,
-                },
-            },
-            expression=' {"name": "Python", '
-            '"version": ver}',
-            conversion='s',
-            format_spec='z',
-        ),
+    'Hello ',
+    Interpolation(
+        value={
+            'name': 'Python',
+            'version': {3.13: False, 3.14: True},
+        },
+        expression=' {"name": "Python", '
+        '"version": ver}',
+        conversion='s',
+        format_spec='z',
     ),
+    '!',
 )""",
         )
 

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -1524,7 +1524,48 @@ ValuesView({'a': 6,
         d = t"Hello {name}"
         self.assertEqual(pprint.pformat(d),
 """\
-Template('Hello ', Interpolation('World', 'name', None, ''))""")
+Template('Hello ', Interpolation('World', 'name'))""")
+        d = t"Hello {name!r}"
+        self.assertEqual(pprint.pformat(d),
+"""\
+Template('Hello ', Interpolation('World', 'name', 'r'))""")
+        d = t"Hello {name:0}"
+        self.assertEqual(pprint.pformat(d),
+"""\
+Template('Hello ', Interpolation('World', 'name', None, '0'))""")
+        d = t"Hello {name!r:0}"
+        self.assertEqual(pprint.pformat(d),
+"""\
+Template('Hello ', Interpolation('World', 'name', 'r', '0'))""")
+        d = t"Hello {name}"
+        self.assertEqual(pprint.pformat(d, width=10),
+"""\
+Template('Hello ',
+         Interpolation('World',
+                       'name'))""")
+        d = t"Hello {name!r}"
+        self.assertEqual(pprint.pformat(d, width=10),
+"""\
+Template('Hello ',
+         Interpolation('World',
+                       'name',
+                       'r'))""")
+        d = t"Hello {name:0}"
+        self.assertEqual(pprint.pformat(d, width=10),
+"""\
+Template('Hello ',
+         Interpolation('World',
+                       'name',
+                       None,
+                       '0'))""")
+        d = t"Hello {name!r:0}"
+        self.assertEqual(pprint.pformat(d, width=10),
+"""\
+Template('Hello ',
+         Interpolation('World',
+                       'name',
+                       'r',
+                       '0'))""")
         ver = {3.13: False, 3.14: True}
         d = t"Hello { {"name": "Python", "version": ver}!s:z}!"
         self.assertEqual(pprint.pformat(d, width=1),
@@ -1551,7 +1592,32 @@ Template('Hello ',
         name = "World"
         d = t"Hello {name}"
         self.assertEqual(
-            pprint.pformat(d, width=40, indent=4, expand=True),
+            pprint.pformat(d, width=30, indent=4, expand=True),
+            """\
+Template(
+    'Hello ',
+    Interpolation(
+        value='World',
+        expression='name',
+    ),
+)""",
+        )
+        d = t"Hello {name!r}"
+        self.assertEqual(
+            pprint.pformat(d, width=30, indent=4, expand=True),
+            """\
+Template(
+    'Hello ',
+    Interpolation(
+        value='World',
+        expression='name',
+        conversion='r',
+    ),
+)""",
+        )
+        d = t"Hello {name:0}"
+        self.assertEqual(
+            pprint.pformat(d, width=30, indent=4, expand=True),
             """\
 Template(
     'Hello ',
@@ -1559,7 +1625,21 @@ Template(
         value='World',
         expression='name',
         conversion=None,
-        format_spec='',
+        format_spec='0',
+    ),
+)""",
+        )
+        d = t"Hello {name!r:0}"
+        self.assertEqual(
+            pprint.pformat(d, width=30, indent=4, expand=True),
+            """\
+Template(
+    'Hello ',
+    Interpolation(
+        value='World',
+        expression='name',
+        conversion='r',
+        format_spec='0',
     ),
 )""",
         )

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -1517,14 +1517,27 @@ ValuesView({'a': 6,
 
     def test_template(self):
         d = t""
+        # Templates are always printed using constructor syntax, i.e. the
+        # "<Template ...>" format of repr() is never used
         self.assertEqual(pprint.pformat(d), "Template()")
-        self.assertEqual(pprint.pformat(d), repr(d))
+        self.assertNotEqual(pprint.pformat(d), repr(d))
         self.assertEqual(pprint.pformat(d, width=1), "Template()")
         name = "World"
         d = t"Hello {name}"
         self.assertEqual(pprint.pformat(d),
 """\
 Template('Hello ', Interpolation('World', 'name'))""")
+        # This is also true for templates nested inside other objects and for
+        # saferepr()
+        self.assertEqual(pprint.pformat({'greeting': d}),
+"""\
+{'greeting': Template('Hello ', Interpolation('World', 'name'))}""")
+        self.assertEqual(pprint.saferepr(d),
+"""\
+Template('Hello ', Interpolation('World', 'name'))""")
+        self.assertEqual(pprint.saferepr(d.interpolations[0]),
+"""\
+Interpolation('World', 'name')""")
         d = t"Hello {name!r}"
         self.assertEqual(pprint.pformat(d),
 """\

--- a/Lib/test/test_string/test_templatelib.py
+++ b/Lib/test/test_string/test_templatelib.py
@@ -104,10 +104,18 @@ world"""
     def test_repr(self):
         self.assertEqual(repr(t''), 'Template()')
         self.assertEqual(repr(t'foo'), "Template('foo')")
+
+        # Test various combination for present/absent conversion and format_spec
         x = 42
         self.assertEqual(
             repr(t'{x}'),
-            "Template(Interpolation(42, 'x', None, ''))")
+            "Template(Interpolation(42, 'x'))")
+        self.assertEqual(
+            repr(t'{x!r}'),
+            "Template(Interpolation(42, 'x', 'r'))")
+        self.assertEqual(
+            repr(t'{x:02}'),
+            "Template(Interpolation(42, 'x', None, '02'))")
         self.assertEqual(
             repr(t'a{x!r:02}b'),
             "Template('a', Interpolation(42, 'x', 'r', '02'), 'b')")
@@ -118,7 +126,7 @@ world"""
         x.append(t)
         self.assertEqual(
             repr(t),
-            "Template('a', Interpolation([Template(...)], 'x', None, ''), 'b')")
+            "Template('a', Interpolation([Template(...)], 'x'), 'b')")
 
     def test_pickle_template(self):
         user = 'test'

--- a/Lib/test/test_string/test_templatelib.py
+++ b/Lib/test/test_string/test_templatelib.py
@@ -101,6 +101,25 @@ world"""
         t = t'Hello, {name}, {age} from {country}'
         self.assertEqual(t.values, ("Lys", 0, "GR"))
 
+    def test_repr(self):
+        self.assertEqual(repr(t''), 'Template()')
+        self.assertEqual(repr(t'foo'), "Template('foo')")
+        x = 42
+        self.assertEqual(
+            repr(t'{x}'),
+            "Template(Interpolation(42, 'x', None, ''))")
+        self.assertEqual(
+            repr(t'a{x!r:02}b'),
+            "Template('a', Interpolation(42, 'x', 'r', '02'), 'b')")
+
+        # Test a "recursive" template
+        x = []
+        t = t'a{x}b'
+        x.append(t)
+        self.assertEqual(
+            repr(t),
+            "Template('a', Interpolation([Template(...)], 'x', None, ''), 'b')")
+
     def test_pickle_template(self):
         user = 'test'
         for template in (

--- a/Lib/test/test_string/test_templatelib.py
+++ b/Lib/test/test_string/test_templatelib.py
@@ -1,4 +1,5 @@
 import pickle
+import re
 import unittest
 from collections.abc import Iterator, Iterable
 from string.templatelib import Template, Interpolation, convert
@@ -101,32 +102,45 @@ world"""
         t = t'Hello, {name}, {age} from {country}'
         self.assertEqual(t.values, ("Lys", 0, "GR"))
 
+    def check_repr(self, template, source):
+        """
+        Check that the repr of 'template' consists of the class name, 'source'
+        (the source-like part of the repr, including the 't' prefix and the
+        quotes) and the id of the template.
+        """
+        self.assertRegex(
+            repr(template),
+            rf'^<Template {re.escape(source)} at 0x[0-9A-Fa-f]+>$')
+
     def test_repr(self):
-        self.assertEqual(repr(t''), 'Template()')
-        self.assertEqual(repr(t'foo'), "Template('foo')")
+        self.check_repr(t'', """t''""")
+        self.check_repr(t'foo', """t'foo'""")
 
         # Test various combination for present/absent conversion and format_spec
         x = 42
-        self.assertEqual(
-            repr(t'{x}'),
-            "Template(Interpolation(42, 'x'))")
-        self.assertEqual(
-            repr(t'{x!r}'),
-            "Template(Interpolation(42, 'x', 'r'))")
-        self.assertEqual(
-            repr(t'{x:02}'),
-            "Template(Interpolation(42, 'x', None, '02'))")
-        self.assertEqual(
-            repr(t'a{x!r:02}b'),
-            "Template('a', Interpolation(42, 'x', 'r', '02'), 'b')")
+        self.check_repr(t'{x}', """t'{x=42}'""")
+        self.check_repr(t'{x!r}', """t'{x!r=42}'""")
+        self.check_repr(t'{x:02}', """t'{x:02=42}'""")
+        self.check_repr(t'a{x!r:02}b', """t'a{x!r:02=42}b'""")
+
+        # Braces in the literal parts have to be doubled
+        self.check_repr(t'{{a}}{x}', """t'{{a}}{x=42}'""")
+
+        # The literal parts are escaped like in a string repr, and the quote
+        # is chosen the same way
+        self.check_repr(t'a\n{x}', """t'a\\n{x=42}'""")
+        self.check_repr(t'"a"{x}', """t'"a"{x=42}'""")
+        self.check_repr(t"'a'{x}", '''t"'a'{x=42}"''')
+        self.check_repr(t'\'a\'"b"{x}', """t'\\'a\\'"b"{x=42}'""")
 
         # Test a "recursive" template
         x = []
         t = t'a{x}b'
         x.append(t)
-        self.assertEqual(
+        self.assertRegex(
             repr(t),
-            "Template('a', Interpolation([Template(...)], 'x'), 'b')")
+            r"^<Template t'a\{x=\[<Template \.\.\. at 0x[0-9A-Fa-f]+>\]\}b' "
+            r"at 0x[0-9A-Fa-f]+>$")
 
     def test_pickle_template(self):
         user = 'test'

--- a/Lib/test/test_tstring.py
+++ b/Lib/test/test_tstring.py
@@ -7,13 +7,12 @@ class TestTString(unittest.TestCase, TStringBaseCase):
     def test_string_representation(self):
         # Test __repr__
         t = t"Hello"
-        self.assertEqual(repr(t), "Template(strings=('Hello',), interpolations=())")
+        self.assertRegex(repr(t), r"^<Template t'Hello' at 0x[0-9A-Fa-f]+>$")
 
         name = "Python"
         t = t"Hello, {name}"
-        self.assertEqual(repr(t),
-            "Template(strings=('Hello, ', ''), "
-            "interpolations=(Interpolation('Python', 'name', None, ''),))"
+        self.assertRegex(repr(t),
+            r"^<Template t'Hello, \{name='Python'\}' at 0x[0-9A-Fa-f]+>$"
         )
 
     def test_interpolation_basics(self):

--- a/Misc/NEWS.d/next/Library/2026-06-08-20-38-28.gh-issue-151099.6Opls1.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-08-20-38-28.gh-issue-151099.6Opls1.rst
@@ -1,0 +1,2 @@
+Change :func:`repr` output of :class:`string.templatelib.Template` objects
+to list the parts of the template in their original source order.

--- a/Misc/NEWS.d/next/Library/2026-06-08-20-38-28.gh-issue-151099.6Opls1.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-08-20-38-28.gh-issue-151099.6Opls1.rst
@@ -1,2 +1,3 @@
-Change :func:`repr` output of :class:`string.templatelib.Template` objects
-to list the parts of the template in their original source order.
+Change :func:`repr` output of :class:`string.templatelib.Template` objects to
+resemble the source code the template was created from, additionally including
+the value of each interpolation.

--- a/Objects/interpolationobject.c
+++ b/Objects/interpolationobject.c
@@ -112,9 +112,31 @@ static PyObject *
 interpolation_repr(PyObject *op)
 {
     interpolationobject *self = interpolationobject_CAST(op);
-    return PyUnicode_FromFormat("%s(%R, %R, %R, %R)",
-                                _PyType_Name(Py_TYPE(self)), self->value, self->expression,
-                                self->conversion, self->format_spec);
+
+    /* Only emit trailing arguments that differ from their default values
+       (conversion=None and format_spec=""). We never use keyword arguments, so
+       if 'format_spec' is non-default, 'conversion' has to be emitted too even
+       when it still has its default value. */
+    int show_format_spec = PyUnicode_GET_LENGTH(self->format_spec) > 0;
+    int show_conversion = show_format_spec || self->conversion != Py_None;
+
+    if (show_format_spec) {
+        return PyUnicode_FromFormat("%s(%R, %R, %R, %R)",
+                                    _PyType_Name(Py_TYPE(self)),
+                                    self->value, self->expression,
+                                    self->conversion, self->format_spec);
+    }
+    else if (show_conversion) {
+        return PyUnicode_FromFormat("%s(%R, %R, %R)",
+                                    _PyType_Name(Py_TYPE(self)),
+                                    self->value, self->expression,
+                                    self->conversion);
+    }
+    else {
+        return PyUnicode_FromFormat("%s(%R, %R)",
+                                    _PyType_Name(Py_TYPE(self)),
+                                    self->value, self->expression);
+    }
 }
 
 static PyMemberDef interpolation_members[] = {

--- a/Objects/interpolationobject.c
+++ b/Objects/interpolationobject.c
@@ -139,6 +139,46 @@ interpolation_repr(PyObject *op)
     }
 }
 
+/* Write a representation of the interpolation that resembles the source code
+   it was created from, i.e. the expression, the conversion and the format spec
+   (if they are non-default), followed by "=" and the repr of the value, all
+   enclosed in braces. This is used by the repr of Template. */
+int
+_PyInterpolation_WriteSource(PyUnicodeWriter *writer, PyObject *op)
+{
+    interpolationobject *self = interpolationobject_CAST(op);
+
+    if (PyUnicodeWriter_WriteChar(writer, '{') < 0) {
+        return -1;
+    }
+    if (PyUnicodeWriter_WriteStr(writer, self->expression) < 0) {
+        return -1;
+    }
+    if (self->conversion != Py_None) {
+        if (PyUnicodeWriter_WriteChar(writer, '!') < 0) {
+            return -1;
+        }
+        if (PyUnicodeWriter_WriteStr(writer, self->conversion) < 0) {
+            return -1;
+        }
+    }
+    if (PyUnicode_GET_LENGTH(self->format_spec) > 0) {
+        if (PyUnicodeWriter_WriteChar(writer, ':') < 0) {
+            return -1;
+        }
+        if (PyUnicodeWriter_WriteStr(writer, self->format_spec) < 0) {
+            return -1;
+        }
+    }
+    if (PyUnicodeWriter_WriteChar(writer, '=') < 0) {
+        return -1;
+    }
+    if (PyUnicodeWriter_WriteRepr(writer, self->value) < 0) {
+        return -1;
+    }
+    return PyUnicodeWriter_WriteChar(writer, '}');
+}
+
 static PyMemberDef interpolation_members[] = {
     {"value", Py_T_OBJECT_EX, offsetof(interpolationobject, value), Py_READONLY, "Value"},
     {"expression", Py_T_OBJECT_EX, offsetof(interpolationobject, expression), Py_READONLY, "Expression"},

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -212,10 +212,70 @@ static PyObject *
 template_repr(PyObject *op)
 {
     templateobject *self = templateobject_CAST(op);
-    return PyUnicode_FromFormat("%s(strings=%R, interpolations=%R)",
-                                _PyType_Name(Py_TYPE(self)),
-                                self->strings,
-                                self->interpolations);
+
+    int res = Py_ReprEnter(self);
+    if (res != 0) {
+        return (res > 0 ? PyUnicode_FromString("Template(...)") : NULL);
+    }
+
+    Py_ssize_t stringslen = PyTuple_GET_SIZE(self->strings);
+    Py_ssize_t interpolationslen = PyTuple_GET_SIZE(self->interpolations);
+
+    PyUnicodeWriter *writer = PyUnicodeWriter_Create(10);
+    if (writer == NULL) {
+        return NULL;
+    }
+
+    if (PyUnicodeWriter_WriteUTF8(writer, _PyType_Name(Py_TYPE(self)), -1) < 0) {
+        goto error;
+    }
+    if (PyUnicodeWriter_WriteChar(writer, '(') < 0) {
+        goto error;
+    }
+
+    /* Render the strings and interpolations in the order they appeared in the
+       constructor call, i.e. interleaved and skipping empty strings. This
+       matches the order produced by templateiter_next. */
+    int first = 1;
+    for (Py_ssize_t i = 0; i < stringslen; i++) {
+        PyObject *string = PyTuple_GET_ITEM(self->strings, i);
+        if (PyUnicode_GET_LENGTH(string) > 0) {
+            if (!first) {
+                if (PyUnicodeWriter_WriteASCII(writer, ", ", 2) < 0) {
+                    goto error;
+                }
+            }
+            if (PyUnicodeWriter_WriteRepr(writer, string) < 0) {
+                goto error;
+            }
+            first = 0;
+        }
+        if (i < interpolationslen) {
+            PyObject *interpolation = PyTuple_GET_ITEM(self->interpolations, i);
+            if (!first) {
+                if (PyUnicodeWriter_WriteASCII(writer, ", ", 2) < 0) {
+                    goto error;
+                }
+            }
+            if (PyUnicodeWriter_WriteRepr(writer, interpolation) < 0) {
+                goto error;
+            }
+            first = 0;
+        }
+    }
+
+    if (PyUnicodeWriter_WriteChar(writer, ')') < 0) {
+        goto error;
+    }
+
+    Py_ReprLeave(self);
+
+    return PyUnicodeWriter_Finish(writer);
+
+error:
+    Py_ReprLeave(self);
+    PyUnicodeWriter_Discard(writer);
+    return NULL;
 }
 
 static PyObject *

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -213,9 +213,12 @@ template_repr(PyObject *op)
 {
     templateobject *self = templateobject_CAST(op);
 
-    int res = Py_ReprEnter(self);
+    int res = Py_ReprEnter(op);
     if (res != 0) {
-        return (res > 0 ? PyUnicode_FromString("Template(...)") : NULL);
+        if (res < 0)
+            return NULL;
+        else
+            return PyUnicode_FromFormat("%s(...)", _PyType_Name(Py_TYPE(self)));
     }
 
     Py_ssize_t stringslen = PyTuple_GET_SIZE(self->strings);
@@ -268,12 +271,12 @@ template_repr(PyObject *op)
         goto error;
     }
 
-    Py_ReprLeave(self);
+    Py_ReprLeave(op);
 
     return PyUnicodeWriter_Finish(writer);
 
 error:
-    Py_ReprLeave(self);
+    Py_ReprLeave(op);
     PyUnicodeWriter_Discard(writer);
     return NULL;
 }

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -208,6 +208,100 @@ template_traverse(PyObject *op, visitproc visit, void *arg)
     return 0;
 }
 
+/* Return the quote character to use for the t-string in the repr: a single
+   quote, unless that would have to be escaped in one of the literal parts and
+   a double quote wouldn't. This mirrors what the repr of a string does. */
+static Py_UCS4
+template_quote(PyObject *strings)
+{
+    int single_quote_found = 0;
+
+    for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(strings); i++) {
+        PyObject *string = PyTuple_GET_ITEM(strings, i);
+        Py_ssize_t len = PyUnicode_GET_LENGTH(string);
+        if (PyUnicode_FindChar(string, '"', 0, len, 1) >= 0) {
+            return '\'';
+        }
+        if (PyUnicode_FindChar(string, '\'', 0, len, 1) >= 0) {
+            single_quote_found = 1;
+        }
+    }
+    return single_quote_found ? '"' : '\'';
+}
+
+/* Write a literal part of the template to 'writer' the way it would appear in
+   the source code of a t-string delimited by 'quote': backslashes, the quote
+   character itself and unprintable characters are escaped, and braces are
+   doubled (since a single brace would start or end an interpolation). */
+static int
+template_write_string(PyUnicodeWriter *writer, PyObject *string, Py_UCS4 quote)
+{
+    Py_ssize_t len = PyUnicode_GET_LENGTH(string);
+    int kind = PyUnicode_KIND(string);
+    const void *data = PyUnicode_DATA(string);
+
+    for (Py_ssize_t i = 0; i < len; i++) {
+        Py_UCS4 ch = PyUnicode_READ(kind, data, i);
+        const char *escape = NULL;
+        switch (ch) {
+            case '\\':
+                escape = "\\\\";
+                break;
+            case '\t':
+                escape = "\\t";
+                break;
+            case '\n':
+                escape = "\\n";
+                break;
+            case '\r':
+                escape = "\\r";
+                break;
+        }
+        if (escape != NULL) {
+            if (PyUnicodeWriter_WriteASCII(writer, escape, 2) < 0) {
+                return -1;
+            }
+        }
+        else if (ch == quote) {
+            if (PyUnicodeWriter_WriteChar(writer, '\\') < 0) {
+                return -1;
+            }
+            if (PyUnicodeWriter_WriteChar(writer, ch) < 0) {
+                return -1;
+            }
+        }
+        else if (ch == '{' || ch == '}') {
+            if (PyUnicodeWriter_WriteChar(writer, ch) < 0) {
+                return -1;
+            }
+            if (PyUnicodeWriter_WriteChar(writer, ch) < 0) {
+                return -1;
+            }
+        }
+        else if (Py_UNICODE_ISPRINTABLE(ch)) {
+            if (PyUnicodeWriter_WriteChar(writer, ch) < 0) {
+                return -1;
+            }
+        }
+        else {
+            const char *format;
+            if (ch <= 0xff) {
+                format = "\\x%02x";
+            }
+            else if (ch <= 0xffff) {
+                format = "\\u%04x";
+            }
+            else {
+                format = "\\U%08x";
+            }
+            if (PyUnicodeWriter_Format(writer, format, ch) < 0) {
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
 static PyObject *
 template_repr(PyObject *op)
 {
@@ -218,56 +312,48 @@ template_repr(PyObject *op)
         if (res < 0)
             return NULL;
         else
-            return PyUnicode_FromFormat("%s(...)", _PyType_Name(Py_TYPE(self)));
+            return PyUnicode_FromFormat("<%s ... at %p>",
+                                        _PyType_Name(Py_TYPE(self)), self);
     }
 
     Py_ssize_t stringslen = PyTuple_GET_SIZE(self->strings);
     Py_ssize_t interpolationslen = PyTuple_GET_SIZE(self->interpolations);
+    Py_UCS4 quote = template_quote(self->strings);
 
     PyUnicodeWriter *writer = PyUnicodeWriter_Create(10);
     if (writer == NULL) {
+        Py_ReprLeave(op);
         return NULL;
     }
 
-    if (PyUnicodeWriter_WriteUTF8(writer, _PyType_Name(Py_TYPE(self)), -1) < 0) {
+    if (PyUnicodeWriter_Format(writer, "<%s t",
+                               _PyType_Name(Py_TYPE(self))) < 0) {
         goto error;
     }
-    if (PyUnicodeWriter_WriteChar(writer, '(') < 0) {
+    if (PyUnicodeWriter_WriteChar(writer, quote) < 0) {
         goto error;
     }
 
-    /* Render the strings and interpolations in the order they appeared in the
-       constructor call, i.e. interleaved and skipping empty strings. This
-       matches the order produced by templateiter_next. */
-    int first = 1;
+    /* Render the strings and interpolations interleaved, so that the result
+       resembles the source code the template was created from, but with the
+       value of each interpolation included. */
     for (Py_ssize_t i = 0; i < stringslen; i++) {
         PyObject *string = PyTuple_GET_ITEM(self->strings, i);
-        if (PyUnicode_GET_LENGTH(string) > 0) {
-            if (!first) {
-                if (PyUnicodeWriter_WriteASCII(writer, ", ", 2) < 0) {
-                    goto error;
-                }
-            }
-            if (PyUnicodeWriter_WriteRepr(writer, string) < 0) {
-                goto error;
-            }
-            first = 0;
+        if (template_write_string(writer, string, quote) < 0) {
+            goto error;
         }
         if (i < interpolationslen) {
             PyObject *interpolation = PyTuple_GET_ITEM(self->interpolations, i);
-            if (!first) {
-                if (PyUnicodeWriter_WriteASCII(writer, ", ", 2) < 0) {
-                    goto error;
-                }
-            }
-            if (PyUnicodeWriter_WriteRepr(writer, interpolation) < 0) {
+            if (_PyInterpolation_WriteSource(writer, interpolation) < 0) {
                 goto error;
             }
-            first = 0;
         }
     }
 
-    if (PyUnicodeWriter_WriteChar(writer, ')') < 0) {
+    if (PyUnicodeWriter_WriteChar(writer, quote) < 0) {
+        goto error;
+    }
+    if (PyUnicodeWriter_Format(writer, " at %p>", self) < 0) {
         goto error;
     }
 


### PR DESCRIPTION
This changes the `repr` ouput for template strings to list the template parts in their original order (which is the same order in which those parts can be passed to the `Template` constructor to recreate the `Template` object).

This has been discussed here: https://discuss.python.org/t/repr-output-of-t-strings/107653/8

The issue is here: https://github.com/python/cpython/issues/151099

<!-- gh-issue-number: gh-151099 -->
* Issue: gh-151099
<!-- /gh-issue-number -->
