### PR TITLE
gh-98894: Fix DTrace test_check_probes for shared builds

### DIFF
--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -378,11 +378,14 @@ class CheckDtraceProbes(unittest.TestCase):
     def get_readelf_version():
         try:
             cmd = ["readelf", "--version"]
+            # Force the C locale to disable localization.
+            env = dict(os.environ, LC_ALL="C")
             proc = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 universal_newlines=True,
+                env=env,
             )
             with proc:
                 version, stderr = proc.communicate()
@@ -427,11 +430,14 @@ class CheckDtraceProbes(unittest.TestCase):
                         break
 
         command = ["readelf", "-n", binary]
+        # Force the C locale to disable localization.
+        env = dict(os.environ, LC_ALL="C")
         stdout, _ = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
+            env=env,
         ).communicate()
         return stdout
 

--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -405,7 +405,28 @@ class CheckDtraceProbes(unittest.TestCase):
         return int(match.group(1)), int(match.group(2))
 
     def get_readelf_output(self):
-        command = ["readelf", "-n", sys.executable]
+        binary = sys.executable
+        if sysconfig.get_config_var("Py_ENABLE_SHARED"):
+            lib_dir = sysconfig.get_config_var("LIBDIR")
+            if not lib_dir or sysconfig.is_python_build():
+                lib_dir = os.path.abspath(os.path.dirname(sys.executable))
+
+            lib_names = []
+            for name in (
+                sysconfig.get_config_var("INSTSONAME"),
+                sysconfig.get_config_var("LDLIBRARY"),
+            ):
+                if name and name not in lib_names:
+                    lib_names.append(name)
+
+            if lib_dir:
+                for name in lib_names:
+                    libpython_path = os.path.join(lib_dir, name)
+                    if os.path.exists(libpython_path):
+                        binary = libpython_path
+                        break
+
+        command = ["readelf", "-n", binary]
         stdout, _ = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
When building with --enable-shared, the SystemTap/DTrace notes live in libpython. Add detection logic to be used by readelf.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98894 -->
* Issue: gh-98894
<!-- /gh-issue-number -->
