### PR TITLE
gh-151126: Fix missing `PyErr_NoMemory()` in `remove_unused_consts`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
@@ -1,1 +1,3 @@
-Add missing :c:func:`PyErr_NoMemory` call to ``Python/flowgraph.c`` module.
+Fix a crash, when there's no memory left on a device,
+which happened in code compilation.
+Now it raises a proper :exc:`MemoryError`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
@@ -1,0 +1,1 @@
+Add missing :c:func:`PyErr_NoMemory` call to ``Python/flowgraph.c`` module.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -3279,6 +3279,7 @@ remove_unused_consts(basicblock *entryblock, PyObject *consts)
 
     index_map = PyMem_Malloc(nconsts * sizeof(Py_ssize_t));
     if (index_map == NULL) {
+        PyErr_NoMemory();
         goto end;
     }
     for (Py_ssize_t i = 1; i < nconsts; i++) {

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -3332,6 +3332,7 @@ remove_unused_consts(basicblock *entryblock, PyObject *consts)
     /* adjust const indices in the bytecode */
     reverse_index_map = PyMem_Malloc(nconsts * sizeof(Py_ssize_t));
     if (reverse_index_map == NULL) {
+        PyErr_NoMemory();
         goto end;
     }
     for (Py_ssize_t i = 0; i < nconsts; i++) {


### PR DESCRIPTION
All supported versions down to 3.13 have this problem.

<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
