### PR TITLE
gh-80384: Check that callback is callable at weak reference creation

### DIFF
--- a/Doc/c-api/weakref.rst
+++ b/Doc/c-api/weakref.rst
@@ -43,7 +43,11 @@ as much as it can.
    should accept a single parameter, which will be the weak reference object
    itself. *callback* may also be ``None`` or ``NULL``.  If *ob* is not a
    weakly referenceable object, or if *callback* is not callable, ``None``, or
-   ``NULL``, this will return ``NULL`` and raise :exc:`TypeError`.
+   ``NULL``, this will raise :exc:`TypeError` and return ``NULL``.
+
+   .. versionchanged:: next
+      Raise :exc:`!TypeError` if *callback* is not callable, ``None``, or
+      ``NULL``.
 
    .. seealso::
       :c:func:`PyType_SUPPORTS_WEAKREFS` for checking if *ob* is weakly
@@ -59,7 +63,11 @@ as much as it can.
    collected; it should accept a single parameter, which will be the weak
    reference object itself. *callback* may also be ``None`` or ``NULL``.  If *ob*
    is not a weakly referenceable object, or if *callback* is not callable,
-   ``None``, or ``NULL``, this will return ``NULL`` and raise :exc:`TypeError`.
+   ``NULL``, this will raise :exc:`TypeError` and return ``NULL``.
+
+   .. versionchanged:: next
+      Raise :exc:`!TypeError` if *callback* is not callable, ``None``, or
+      ``NULL``.
 
    .. seealso::
       :c:func:`PyType_SUPPORTS_WEAKREFS` for checking if *ob* is weakly

--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -132,6 +132,9 @@ See :ref:`__slots__ documentation <slots>` for details.
    .. versionchanged:: 3.4
       Added the :attr:`__callback__` attribute.
 
+   .. versionchanged:: next
+      Raise :exc:`!TypeError` if *callback* is not callable or ``None``.
+
 
 .. function:: proxy(object[, callback])
 
@@ -150,6 +153,9 @@ See :ref:`__slots__ documentation <slots>` for details.
    .. versionchanged:: 3.8
       Extended the operator support on proxy objects to include the matrix
       multiplication operators ``@`` and ``@=``.
+
+   .. versionchanged:: next
+      Raise :exc:`!TypeError` if *callback* is not callable or ``None``.
 
 
 .. function:: getweakrefcount(object)

--- a/Lib/test/test_capi/test_weakref.py
+++ b/Lib/test/test_capi/test_weakref.py
@@ -97,6 +97,7 @@ class CAPIWeakrefTest(unittest.TestCase):
         # PyWeakref_NewRef() handles None callback as NULL callback
         wr = newref(obj, None)
         self.assertIs(type(wr), weakref.ReferenceType)
+        self.assertRaises(TypeError, newref, obj, 42)
         log = []
         wr = newref(obj, log.append)
         self.assertIs(type(wr), weakref.ReferenceType)
@@ -116,6 +117,7 @@ class CAPIWeakrefTest(unittest.TestCase):
         # PyWeakref_NewProxy() handles None callback as NULL callback
         wp = newproxy(obj, None)
         self.assertIs(type(wp), weakref.ProxyType)
+        self.assertRaises(TypeError, newproxy, obj, 42)
         log = []
         wp = newproxy(obj, log.append)
         self.assertIs(type(wp), weakref.ProxyType)

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -206,7 +206,7 @@ class TracebackCases(unittest.TestCase):
                 sys.setrecursionlimit(15)
 
                 def f():
-                    ref(lambda: 0, [])
+                    ref(lambda: 0, ord)
                     f()
 
                 try:

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -167,6 +167,11 @@ class ReferencesTestCase(TestBase):
         self.check_basic_callback(create_function)
         self.check_basic_callback(create_bound_method)
 
+    def test_non_callable_callback(self):
+        c = C()
+        self.assertRaises(TypeError, weakref.ref, c, 42)
+        self.assertRaises(TypeError, weakref.proxy, c, 42)
+
     @support.cpython_only
     def test_cfunction(self):
         _testcapi = import_helper.import_module("_testcapi")

--- a/Misc/NEWS.d/next/C_API/2026-06-09-14-50-35.gh-issue-80384.UEGyvB.rst
+++ b/Misc/NEWS.d/next/C_API/2026-06-09-14-50-35.gh-issue-80384.UEGyvB.rst
@@ -1,0 +1,3 @@
+:c:func:`PyWeakref_NewRef` and :c:func:`PyWeakref_NewProxy` now raise
+:exc:`TypeError` if the *callback* argument is not callable, ``None``, or
+``NULL``.

--- a/Misc/NEWS.d/next/Library/2026-06-09-14-49-17.gh-issue-80384.ttRAja.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-09-14-49-17.gh-issue-80384.ttRAja.rst
@@ -1,0 +1,2 @@
+:func:`weakref.ref` and :func:`weakref.proxy` now raise :exc:`TypeError` if
+the *callback* argument is not callable or ``None``.

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -416,8 +416,15 @@ get_or_create_weakref(PyTypeObject *type, PyObject *obj, PyObject *callback)
                      Py_TYPE(obj)->tp_name);
         return NULL;
     }
-    if (callback == Py_None)
+    if (callback == Py_None) {
         callback = NULL;
+    }
+    if (callback != NULL && !PyCallable_Check(callback)) {
+        PyErr_Format(PyExc_TypeError,
+                     "callback must be callable or None, not '%T'",
+                     callback);
+        return NULL;
+    }
 
     PyWeakReference **list = GET_WEAKREFS_LISTPTR(obj);
     if ((type == &_PyWeakref_RefType) ||


### PR DESCRIPTION
* Python functions weakref.ref() and weakref.proxy() now raise TypeError if the callback argument is not callable or None.
* C functions PyWeakref_NewRef() and PyWeakref_NewProxy() now raise TypeError if the callback argument is not callable, None, or NULL.


<!-- gh-issue-number: gh-80384 -->
* Issue: gh-80384
<!-- /gh-issue-number -->
