### PR TITLE
gh-90949: Fix copy-paste typo in pyexpat capsule API initialization

### DIFF
--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -2549,8 +2549,8 @@ pyexpat_exec(PyObject *mod)
     capi->SetBillionLaughsAttackProtectionActivationThreshold = XML_SetBillionLaughsAttackProtectionActivationThreshold;
     capi->SetBillionLaughsAttackProtectionMaximumAmplification = XML_SetBillionLaughsAttackProtectionMaximumAmplification;
 #else
-    capi->SetAllocTrackerActivationThreshold = NULL;
-    capi->SetAllocTrackerMaximumAmplification = NULL;
+    capi->SetBillionLaughsAttackProtectionActivationThreshold = NULL;
+    capi->SetBillionLaughsAttackProtectionMaximumAmplification = NULL;
 #endif
 
     /* export using capsule */


### PR DESCRIPTION
Noticed in https://github.com/python/cpython/pull/150496/changes#r3380342256.

<!-- gh-issue-number: gh-90949 -->
* Issue: gh-90949
<!-- /gh-issue-number -->
