### PR TITLE
Docs: Only add `profiling-sampling-visualization.{css,js}` to files when necessary

### DIFF
--- a/Doc/tools/extensions/profiling_trace.py
+++ b/Doc/tools/extensions/profiling_trace.py
@@ -154,10 +154,15 @@ def inject_trace(app, exception):
         )
 
 
+def add_assets(app, pagename, templatename, context, doctree):
+    if pagename == 'library/profiling.sampling':
+        app.add_js_file('profiling-sampling-visualization.js')
+        app.add_css_file('profiling-sampling-visualization.css')
+
+
 def setup(app):
     app.connect('build-finished', inject_trace)
-    app.add_js_file('profiling-sampling-visualization.js')
-    app.add_css_file('profiling-sampling-visualization.css')
+    app.connect('html-page-context', add_assets)
 
     return {
         'version': '1.0',


### PR DESCRIPTION
Now, I know Tachyon is cool and all, but I don't think we need to advertise it on every page ;-)
We are currently including the JS and CSS on every page of the docs, e.g. the about page:

```html
    <title>About this documentation &#8212; Python 3.16.0a0 documentation</title><meta name="viewport" content="width=device-width, initial-scale=1.0">
[...]
    <link rel="stylesheet" type="text/css" href="_static/profiling-sampling-visualization.css?v=0c2600ae" />
[...]
    <script src="_static/profiling-sampling-visualization.js?v=9811ed04"></script>
```

CC @lkollar

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
