### PR TITLE
gh-145497: Fix _Py_MAX_MANAGED_STATIC_BUILTIN_TYPES

### DIFF
--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -529,14 +529,49 @@ struct _py_func_state {
 
 /****** type state *********/
 
+/* One TYPE(name) per textual _PyStaticType_InitBuiltin /
+   _PyStructSequence_InitBuiltin{,WithFlags} call site outside the static_types
+   and static_exceptions arrays.  Count-only -- the calls themselves stay at
+   their existing locations.  Forgetting an entry trips the
+   `index < _Py_MAX_MANAGED_STATIC_BUILTIN_TYPES` assertion in
+   Objects/typeobject.c on interpreter start. */
+#define _Py_FOREACH_STATIC_EXTRA_TYPE(TYPE) \
+    /* Python/crossinterp_exceptions.h */ \
+    TYPE(_PyExc_InterpreterError) \
+    TYPE(_PyExc_InterpreterNotFoundError) \
+    /* Objects/unicodeobject.c */ \
+    TYPE(EncodingMapType) \
+    TYPE(PyFieldNameIter_Type) \
+    TYPE(PyFormatterIter_Type) \
+    /* Python/thread.c */ \
+    TYPE(ThreadInfoType) \
+    /* Python/sysmodule.c */ \
+    TYPE(Hash_InfoType) \
+    TYPE(AsyncGenHooksType) \
+    TYPE(VersionInfoType) \
+    TYPE(FlagsType) \
+    TYPE(WindowsVersionType) \
+    /* Python/errors.c */ \
+    TYPE(UnraisableHookArgsType) \
+    /* Objects/longobject.c */ \
+    TYPE(Int_InfoType) \
+    /* Objects/floatobject.c */ \
+    TYPE(FloatInfoType)
+
+#define _PY_COUNT_STATIC_TYPE_(name) + 1
+#define _Py_NUM_MANAGED_STATIC_EXTRA_TYPES \
+    (0 _Py_FOREACH_STATIC_EXTRA_TYPE(_PY_COUNT_STATIC_TYPE_))
+
 /* For now we hard-code this to a value for which we are confident
    all the static builtin types will fit (for all builds).
    If you add a new static type to the standard library, you may have to
    update one of these numbers.
    */
 #define _Py_NUM_MANAGED_PREINITIALIZED_TYPES 120
+#define _Py_NUM_STATIC_EXCEPTIONS 69
 #define _Py_MAX_MANAGED_STATIC_BUILTIN_TYPES \
-    (_Py_NUM_MANAGED_PREINITIALIZED_TYPES + 83)
+    (_Py_NUM_MANAGED_PREINITIALIZED_TYPES + _Py_NUM_STATIC_EXCEPTIONS \
+     + _Py_NUM_MANAGED_STATIC_EXTRA_TYPES)
 #define _Py_MAX_MANAGED_STATIC_EXT_TYPES 10
 #define _Py_MAX_MANAGED_STATIC_TYPES \
     (_Py_MAX_MANAGED_STATIC_BUILTIN_TYPES + _Py_MAX_MANAGED_STATIC_EXT_TYPES)

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -4392,7 +4392,7 @@ struct static_exception {
     const char *name;
 };
 
-static struct static_exception static_exceptions[] = {
+static struct static_exception static_exceptions[_Py_NUM_STATIC_EXCEPTIONS] = {
 #define ITEM(NAME) {&_PyExc_##NAME, #NAME}
     // Level 1
     ITEM(BaseException),


### PR DESCRIPTION
The _Py_MAX_MANAGED_STATIC_BUILTIN_TYPES macro is no longer a hardcoded number to reduce the maintenance burden.

* Add _Py_NUM_STATIC_EXCEPTIONS: size of the static_exceptions array.
* Add _Py_FOREACH_STATIC_EXTRA_TYPE() to count the number of extra types.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145497 -->
* Issue: gh-145497
<!-- /gh-issue-number -->
