### PR TITLE
gh-151112: Move an `assert` that may fail in `cfg_builder_check`

### DIFF
--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -404,7 +404,6 @@ cfg_builder_maybe_start_new_block(cfg_builder *g)
 static bool
 cfg_builder_check(cfg_builder *g)
 {
-    assert(g->g_entryblock->b_iused > 0);
     for (basicblock *block = g->g_block_list; block != NULL; block = block->b_list) {
         assert(!_PyMem_IsPtrFreed(block));
         if (block->b_instr != NULL) {
@@ -3762,6 +3761,7 @@ _PyCfg_OptimizeCodeUnit(cfg_builder *g, PyObject *consts, PyObject *const_cache,
                         int nlocals, int nparams, int firstlineno)
 {
     assert(cfg_builder_check(g));
+    assert(g->g_entryblock->b_iused > 0);
     /** Preprocessing **/
     /* Map labels to targets and mark exception handlers */
     RETURN_IF_ERROR(translate_jump_labels_to_targets(g->g_entryblock));


### PR DESCRIPTION
Also found with the same reproducer, just setting nomemory at a different time. In `_PyCfg_FromInstructionSequence` if `_PyCfgBuilder_Addop` fails on the first instruction, it jumps to `error` and calls `_PyCfgBuilder_Free(g)`. The entry block is still empty, but `cfg_builder_check` asserts `g_entryblock->b_iused > 0`.

If you want to reproduce, you'll have to play around a little with the start/stop for nomemory, but for me it's:
```
./python -c 'import _testcapi

compile("pass", "<warmup>", "single")
_testcapi.set_nomemory(40, 41)
try:
    compile("pass", "<trigger>", "single")
except MemoryError:
    pass
first = bytes(128)
second = bytes(128)'
python: Python/flowgraph.c:407: cfg_builder_check: Assertion `g->g_entryblock->b_iused > 0' failed.
Aborted                    (core dumped) ./python -c 'import _testcapi
```

Debug only so skipping news.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151112 -->
* Issue: gh-151112
<!-- /gh-issue-number -->
