### PR TITLE
gh-151126: Add missing `PyErr_NoMemory` in `_winapi` module

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
@@ -1,3 +1,7 @@
 Fix a crash, when there's no memory left on a device,
-which happened in code compilation.
-Now it raises a proper :exc:`MemoryError`.
+which happened in:
+
+- code compilation
+- :func:`!_winapi.CreateProcess`
+
+Now these places raise proper :exc:`MemoryError` errors.

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1194,8 +1194,10 @@ gethandlelist(PyObject *mapping, const char *name, Py_ssize_t *size)
     }
 
     ret = PyMem_Malloc(*size);
-    if (ret == NULL)
+    if (ret == NULL) {
+        PyErr_NoMemory();
         goto cleanup;
+    }
 
     for (i = 0; i < PySequence_Fast_GET_SIZE(value_fast); i++) {
         ret[i] = PYNUM_TO_HANDLE(PySequence_Fast_GET_ITEM(value_fast, i));
@@ -1278,6 +1280,7 @@ getattributelist(PyObject *obj, const char *name, AttributeList *attribute_list)
     attribute_list->attribute_list = PyMem_Malloc(attribute_list_size);
     if (attribute_list->attribute_list == NULL) {
         ret = -1;
+        PyErr_NoMemory();
         goto cleanup;
     }
 


### PR DESCRIPTION
This place misses it:

https://github.com/python/cpython/blob/9fdbade99e6bcc607d9f12416bfca5bbf94022b9/Modules/_winapi.c#L1196-L1198

It is used as:

```c
attribute_list->handle_list = gethandlelist(value, "handle_list", &handle_list_size);
if (attribute_list->handle_list == NULL && PyErr_Occurred()) {
    ret = -1;
    goto cleanup;
}
```

It would be rather strange to swallow `MemoryError` here.
Before that we allow `KeyError` to pass silently and return early if this code path should not be taken: 

```c
value = PyMapping_GetItemString(mapping, name);
if (!value) {
    PyErr_Clear();
    return NULL;
}
```

---

All other error paths in the same function set exceptions, except this `if`:

https://github.com/python/cpython/blob/9fdbade99e6bcc607d9f12416bfca5bbf94022b9/Modules/_winapi.c#L1278-L1282

Later this `NULL` is returned from `_winapi.CreateProcess` without an exception set.


<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
