### PR TITLE
gh-151162: Increase test coverage for string formatting

### DIFF
--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -1557,7 +1557,8 @@ class StrTest(string_tests.StringLikeTest,
         self.assertEqual('%F' % NAN, 'NAN')
         self.assertEqual('%f' % INF, 'inf')
         self.assertEqual('%F' % INF, 'INF')
-
+        self.assertEqual('%f' % -INF, '-inf')
+        self.assertEqual('%F' % -INF, '-INF')
         # PEP 393
         self.assertEqual('%.1s' % "a\xe9\u20ac", 'a')
         self.assertEqual('%.2s' % "a\xe9\u20ac", 'a\xe9')


### PR DESCRIPTION
In ```Lib/test/test_str.py```, string formatting is tested for nan and inf but not for -inf. -inf could be the most important among them (since we have to check if '-' formats correctly). The following PR adds 2 test cases for -inf with %f and %F.

Existing:
```python
self.assertEqual('%f' % NAN, 'nan')
self.assertEqual('%F' % NAN, 'NAN')
self.assertEqual('%f' % INF, 'inf')
self.assertEqual('%F' % INF, 'INF')
```

Added:
```python
self.assertEqual('%f' % -INF, '-inf')
self.assertEqual('%F' % -INF, '-INF')
 ```

<!-- gh-issue-number: gh-151162 -->
* Issue: gh-151162
<!-- /gh-issue-number -->
