### PR TITLE
[3.13] gh-151159: Update macOS installer to use OpenSSL 3.0.21.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -246,9 +246,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 3.0.20",
-              url="https://github.com/openssl/openssl/releases/download/openssl-3.0.20/openssl-3.0.20.tar.gz",
-              checksum='c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f',
+              name="OpenSSL 3.0.21",
+              url="https://github.com/openssl/openssl/releases/download/openssl-3.0.21/openssl-3.0.21.tar.gz",
+              checksum="617e29af8e421f46649484a4937e48c685e47f46488167c982f88bc4ec1d522f",
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/Windows/2026-06-09-11-40-17.gh-issue-151159.9si8Fo.rst
+++ b/Misc/NEWS.d/next/Windows/2026-06-09-11-40-17.gh-issue-151159.9si8Fo.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use OpenSSL 3.0.21.

--- a/Misc/NEWS.d/next/macOS/2026-05-01-19-38-16.gh-issue-149254.enO7uj.rst
+++ b/Misc/NEWS.d/next/macOS/2026-05-01-19-38-16.gh-issue-149254.enO7uj.rst
@@ -1,1 +1,0 @@
-Update macOS installer to use OpenSSL 3.0.20.


### PR DESCRIPTION


<!-- gh-issue-number: gh-151159 -->
* Issue: gh-151159
<!-- /gh-issue-number -->
