### PR TITLE
[3.14] gh-151159: Bump OpenSSL versions for iOS and Android (GH-151164)

### DIFF
--- a/Android/android.py
+++ b/Android/android.py
@@ -216,7 +216,7 @@ def unpack_deps(host, prefix_dir, cache_dir):
     for name_ver in [
         "bzip2-1.0.8-3",
         "libffi-3.4.4-3",
-        "openssl-3.5.6-0",
+        "openssl-3.5.7-0",
         "sqlite-3.50.4-0",
         "xz-5.4.6-1",
         "zstd-1.5.7-2"

--- a/Apple/__main__.py
+++ b/Apple/__main__.py
@@ -319,7 +319,7 @@ def unpack_deps(
     for name_ver in [
         "BZip2-1.0.8-2",
         "libFFI-3.4.7-2",
-        "OpenSSL-3.5.6-1",
+        "OpenSSL-3.5.7-1",
         "XZ-5.6.4-2",
         "mpdecimal-4.0.0-2",
         "zstd-1.5.7-1",

--- a/Misc/NEWS.d/next/Build/2026-05-04-08-39-19.gh-issue-149329.mcu6PU.rst
+++ b/Misc/NEWS.d/next/Build/2026-05-04-08-39-19.gh-issue-149329.mcu6PU.rst
@@ -1,1 +1,0 @@
-Updated bundled version of OpenSSL on iOS and Android to 3.5.6.

--- a/Misc/NEWS.d/next/Security/2026-06-09-10-23-57.gh-issue-151159.91GpWQ.rst
+++ b/Misc/NEWS.d/next/Security/2026-06-09-10-23-57.gh-issue-151159.91GpWQ.rst
@@ -1,0 +1,1 @@
+Update Android and iOS installers to use OpenSSL 3.5.7.


### PR DESCRIPTION
(cherry picked from commit 627dd14346b4c4c13d9203430c32556467b7fbd3)


<!-- gh-issue-number: gh-151159 -->
* Issue: gh-151159
<!-- /gh-issue-number -->
