### PR TITLE
[3.13] gh-151159: Bump OpenSSL version for Android

### DIFF
--- a/Android/android.py
+++ b/Android/android.py
@@ -216,7 +216,7 @@ def unpack_deps(host, prefix_dir, cache_dir):
     for name_ver in [
         "bzip2-1.0.8-3",
         "libffi-3.4.4-3",
-        "openssl-3.0.20-0",
+        "openssl-3.0.21-0",
         "sqlite-3.50.4-0",
         "xz-5.4.6-1"
     ]:

--- a/Misc/NEWS.d/next/Security/2026-05-02-16-27-17.gh-issue-149254.ng1cPU.rst
+++ b/Misc/NEWS.d/next/Security/2026-05-02-16-27-17.gh-issue-149254.ng1cPU.rst
@@ -1,1 +1,0 @@
-Bumps the OpenSSL version to 3.0.20 on Android.

--- a/Misc/NEWS.d/next/Security/2026-06-09-12-27-17.gh-issue-151159.ng1cPU.rst
+++ b/Misc/NEWS.d/next/Security/2026-06-09-12-27-17.gh-issue-151159.ng1cPU.rst
@@ -1,0 +1,1 @@
+Bumps the OpenSSL version to 3.0.21 on Android.


### PR DESCRIPTION


<!-- gh-issue-number: gh-151159 -->
* Issue: gh-151159
<!-- /gh-issue-number -->
