### PR TITLE
[3.14] gh-151159: Update CI to use latest SSL library versions (GH-151176)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -305,11 +305,10 @@ jobs:
           # unsupported as it most resembles other 1.1.1-work-a-like ssl APIs
           # supported by important vendors such as AWS-LC.
           - { name: openssl, version: 1.1.1w }
-          - { name: openssl, version: 3.0.20 }
-          - { name: openssl, version: 3.3.7 }
-          - { name: openssl, version: 3.4.5 }
-          - { name: openssl, version: 3.5.6 }
-          - { name: openssl, version: 3.6.2 }
+          - { name: openssl, version: 3.0.21 }
+          - { name: openssl, version: 3.4.6 }
+          - { name: openssl, version: 3.5.7 }
+          - { name: openssl, version: 3.6.3 }
     env:
       SSLLIB_VER: ${{ matrix.ssllib.version }}
       MULTISSL_DIR: ${{ github.workspace }}/multissl
@@ -423,7 +422,7 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-ubuntu == 'true'
     env:
-      OPENSSL_VER: 3.5.6
+      OPENSSL_VER: 3.5.7
       PYTHONSTRICTEXTENSIONBUILD: 1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -531,7 +530,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
     env:
-      OPENSSL_VER: 3.5.6
+      OPENSSL_VER: 3.5.7
       PYTHONSTRICTEXTENSIONBUILD: 1
       ASAN_OPTIONS: detect_leaks=0:allocator_may_return_null=1:handle_segv=0
     steps:

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     timeout-minutes: 60
     env:
-      OPENSSL_VER: 3.5.6
+      OPENSSL_VER: 3.5.7
       PYTHONSTRICTEXTENSIONBUILD: 1
       TERM: linux
     steps:

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -46,14 +46,14 @@ OPENSSL_OLD_VERSIONS = [
     "1.1.1w",
     "3.1.8",
     "3.2.6",
+    "3.3.7",
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "3.0.20",
-    "3.3.7",
-    "3.4.5",
-    "3.5.6",
-    "3.6.2",
+    "3.0.21",
+    "3.4.6",
+    "3.5.7",
+    "3.6.3",
     # See make_ssl_data.py for notes on adding a new version.
 ]
 


### PR DESCRIPTION
(cherry picked from commit 7053bbd7fd4967b8782bf0c8f6ad00248f0b0c5b)




<!-- gh-issue-number: gh-151159 -->
* Issue: gh-151159
<!-- /gh-issue-number -->
