### PR TITLE
gh-150942: Speed up ElementTree attribute parsing

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-09-23-04-44.gh-issue-150942.Iu583J.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-09-23-04-44.gh-issue-150942.Iu583J.rst
@@ -1,0 +1,2 @@
+Speed up :mod:`xml.etree.ElementTree` parsing of element attributes by using
+reference-stealing dict insertion.

--- a/Misc/NEWS.d/next/Library/2026-06-09-23-04-44.gh-issue-150942.Iu583J.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-09-23-04-44.gh-issue-150942.Iu583J.rst
@@ -1,2 +1,0 @@
-Speed up :mod:`xml.etree.ElementTree` parsing of element attributes by using
-reference-stealing dict insertion.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3343,9 +3343,7 @@ expat_start_handler(void *op, const XML_Char *tag_in,
                 Py_DECREF(tag);
                 return;
             }
-            ok = PyDict_SetItem(attrib, key, value);
-            Py_DECREF(value);
-            Py_DECREF(key);
+            ok = _PyDict_SetItem_Take2((PyDictObject *)attrib, key, value);
             if (ok < 0) {
                 Py_DECREF(attrib);
                 Py_DECREF(tag);


### PR DESCRIPTION
`expat_start_handler()` in `Modules/_elementtree.c` calls a `PyDict_SetItem()` and two `Py_DECREF()` while building `attrib` dictionary. Replaced it with reference-stealing `_PyDict_SetItem_Take2()`, dropped the pair of `Py_DECREF()`.

Benchmark:

```python
import pyperf
import xml.etree.ElementTree as ET


def make_doc(n_elements, n_attrs):
    attrs = " ".join(f'a{i}="v{i}"' for i in range(n_attrs))
    body = "".join(f"<item {attrs}/>" for _ in range(n_elements))
    return f"<root>{body}</root>"


DOCS = {
    "many-attrs-per-elem": make_doc(n_elements=2000, n_attrs=16),
    "few-attrs-many-elems": make_doc(n_elements=20000, n_attrs=2),
    "wide-attrs": make_doc(n_elements=200, n_attrs=64),
}


if __name__ == "__main__":
    runner = pyperf.Runner()
    for name, xml in DOCS.items():
        runner.bench_func(f"ET.fromstring {name}", ET.fromstring, xml)
```

Results:

```
+------------------------------------+---------+-----------------------+
| Benchmark                          | base    | opt                   |
+====================================+=========+=======================+
| ET.fromstring many-attrs-per-elem  | 9.07 ms | 8.51 ms: 1.07x faster |
+------------------------------------+---------+-----------------------+
| ET.fromstring few-attrs-many-elems | 20.3 ms | 19.6 ms: 1.03x faster |
+------------------------------------+---------+-----------------------+
| ET.fromstring wide-attrs           | 3.29 ms | 3.08 ms: 1.07x faster |
+------------------------------------+---------+-----------------------+
| Geometric mean                     | (ref)   | 1.06x faster          |
+------------------------------------+---------+-----------------------+
```


<!-- gh-issue-number: gh-150942 -->
* Issue: gh-150942
<!-- /gh-issue-number -->
