### PR TITLE
gh-131697: Test reproducible gzip output metadata

### DIFF
--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -8,6 +8,7 @@ import io
 import os
 import struct
 import sys
+import tarfile
 import unittest
 from subprocess import PIPE, Popen
 from unittest import mock
@@ -789,6 +790,51 @@ class TestGzip(BaseTest):
         with gzip.GzipFile(fileobj=io.BytesIO(datac3), mode="rb") as f:
             f.read(1) # to set mtime attribute
             self.assertGreater(f.mtime, 1)
+
+    def assertReproducibleGzipMetadata(self, datac, data_size):
+        self.assertEqual(datac[:4], b"\x1f\x8b\x08\x00")
+        self.assertEqual(struct.unpack("<I", datac[4:8])[0], 0)
+        self.assertEqual(datac[9], 255)
+        self.assertEqual(struct.unpack("<I", datac[-4:])[0], data_size)
+
+    def test_reproducible_output_metadata(self):
+        data = b"Hello world"
+
+        def gzip_file():
+            buf = io.BytesIO()
+            with gzip.GzipFile(fileobj=buf, mode="wb", mtime=0) as f:
+                f.write(data)
+            return buf.getvalue()
+
+        def gzip_open():
+            buf = io.BytesIO()
+            with gzip.open(buf, mode="wb", mtime=0) as f:
+                f.write(data)
+            return buf.getvalue()
+
+        def gzipped_tarfile():
+            buf = io.BytesIO()
+            tarinfo = tarfile.TarInfo("data")
+            tarinfo.size = len(data)
+            tarinfo.mtime = 0
+            with tarfile.open(fileobj=buf, mode="w:gz", mtime=0) as tar:
+                tar.addfile(tarinfo, io.BytesIO(data))
+            return buf.getvalue()
+
+        cases = [
+            ("compress default mtime", lambda: gzip.compress(data), len(data)),
+            ("compress explicit mtime", lambda: gzip.compress(data, mtime=0), len(data)),
+            ("GzipFile", gzip_file, len(data)),
+            ("gzip.open", gzip_open, len(data)),
+            ("gzipped tarfile", gzipped_tarfile, None),
+        ]
+        for name, make_gzip, data_size in cases:
+            with self.subTest(name):
+                datac = make_gzip()
+                self.assertEqual(datac, make_gzip())
+                if data_size is None:
+                    data_size = len(gzip.decompress(datac))
+                self.assertReproducibleGzipMetadata(datac, data_size)
 
     def test_compress_correct_level(self):
         for mtime in (0, 42):

--- a/Misc/NEWS.d/next/Tests/2026-06-10-00-00-03.gh-issue-131697.Cx1316.rst
+++ b/Misc/NEWS.d/next/Tests/2026-06-10-00-00-03.gh-issue-131697.Cx1316.rst
@@ -1,0 +1,1 @@
+Add tests for reproducible gzip output metadata.


### PR DESCRIPTION
Adds regression tests for gzip's reproducible output metadata. gh-131697 asked for a fragile reproducibility test so the gh-112346 regression (3.10→3.11) can't recur silently.

The test asserts the gzip header/footer metadata is fixed and deterministic across the main code paths — `gzip.compress` (default and explicit `mtime=0`), `GzipFile`, `gzip.open`, and a `w:gz` tarfile — checking the output is byte-identical across two runs and that the header records mtime 0, the "unknown" OS byte (255), and the correct ISIZE. Tests-only; includes a Tests NEWS entry.

Disclosure: AI-assisted; I've reviewed the tests.

<!-- gh-issue-number: gh-131697 -->
* Issue: gh-131697
<!-- /gh-issue-number -->
