### PR TITLE
gh-117807: Handle invalid UTF-8 in mimetypes map files

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -237,7 +237,7 @@ class MimeTypes:
         list of standard types, else to the list of non-standard
         types.
         """
-        with open(filename, encoding='utf-8') as fp:
+        with open(filename, encoding='utf-8', errors='replace') as fp:
             self.readfp(fp, strict)
 
     def readfp(self, fp, strict=True):
@@ -428,7 +428,7 @@ def init(files=None):
 
 def read_mime_types(file):
     try:
-        f = open(file, encoding='utf-8')
+        f = open(file, encoding='utf-8', errors='replace')
     except OSError:
         return None
     with f:

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -237,7 +237,7 @@ class MimeTypes:
         list of standard types, else to the list of non-standard
         types.
         """
-        with open(filename, encoding='utf-8') as fp:
+        with open(filename, encoding='utf-8', errors='surrogateescape') as fp:
             self.readfp(fp, strict)
 
     def readfp(self, fp, strict=True):
@@ -428,7 +428,7 @@ def init(files=None):
 
 def read_mime_types(file):
     try:
-        f = open(file, encoding='utf-8')
+        f = open(file, encoding='utf-8', errors='surrogateescape')
     except OSError:
         return None
     with f:

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -67,8 +67,32 @@ class MimeTypesModuleTestCase(unittest.TestCase):
         with unittest.mock.patch.object(mimetypes, 'open',
                                         return_value=fp) as mock_open:
             mime_dict = mimetypes.read_mime_types(filename)
-            mock_open.assert_called_with(filename, encoding='utf-8')
+            mock_open.assert_called_with(filename, encoding='utf-8',
+                                         errors='replace')
         eq(mime_dict[".Français"], "application/no-mans-land")
+
+    def test_read_mime_types_invalid_utf8_comment(self):
+        with os_helper.temp_dir() as directory:
+            data = (b"# non-UTF-8 comment: \x83\n"
+                    b"x-application/x-unittest pyunit\n")
+            file = os.path.join(directory, "sample.mimetype")
+            with open(file, "wb") as f:
+                f.write(data)
+
+            mime_dict = mimetypes.read_mime_types(file)
+            self.assertEqual(
+                mime_dict[".pyunit"], "x-application/x-unittest")
+
+            db = mimetypes.MimeTypes()
+            db.read(file)
+            self.assertEqual(
+                db.guess_file_type("sample.pyunit")[0],
+                "x-application/x-unittest")
+
+            mimetypes.init(files=[file])
+            self.assertEqual(
+                mimetypes.guess_file_type("sample.pyunit")[0],
+                "x-application/x-unittest")
 
     def test_init_reinitializes(self):
         # Issue 4936: make sure an init starts clean

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -67,8 +67,49 @@ class MimeTypesModuleTestCase(unittest.TestCase):
         with unittest.mock.patch.object(mimetypes, 'open',
                                         return_value=fp) as mock_open:
             mime_dict = mimetypes.read_mime_types(filename)
-            mock_open.assert_called_with(filename, encoding='utf-8')
+            mock_open.assert_called_with(filename, encoding='utf-8',
+                                         errors='surrogateescape')
         eq(mime_dict[".Français"], "application/no-mans-land")
+
+    def test_read_mime_types_invalid_utf8_comment(self):
+        with os_helper.temp_dir() as directory:
+            data = (b"# non-UTF-8 comment: \x83\n"
+                    b"x-application/x-unittest pyunit\n")
+            file = os.path.join(directory, "sample.mimetype")
+            with open(file, "wb") as f:
+                f.write(data)
+
+            mime_dict = mimetypes.read_mime_types(file)
+            self.assertEqual(
+                mime_dict[".pyunit"], "x-application/x-unittest")
+
+            db = mimetypes.MimeTypes()
+            db.read(file)
+            self.assertEqual(
+                db.guess_file_type("sample.pyunit")[0],
+                "x-application/x-unittest")
+
+            mimetypes.init(files=[file])
+            self.assertEqual(
+                mimetypes.guess_file_type("sample.pyunit")[0],
+                "x-application/x-unittest")
+
+    def test_read_mime_types_invalid_utf8_type(self):
+        # A non-UTF-8 byte in a type or extension (not only in a comment) is
+        # preserved via surrogateescape, so the mapping is not corrupted.
+        with os_helper.temp_dir() as directory:
+            data = (b"x-application/x-unittest pyunit\n"
+                    b"application/bad\x83 badext\x83\n")
+            file = os.path.join(directory, "sample.mimetype")
+            with open(file, "wb") as f:
+                f.write(data)
+
+            bad_type = b"application/bad\x83".decode("utf-8", "surrogateescape")
+            bad_ext = b".badext\x83".decode("utf-8", "surrogateescape")
+
+            mime_dict = mimetypes.read_mime_types(file)
+            self.assertEqual(mime_dict[".pyunit"], "x-application/x-unittest")
+            self.assertEqual(mime_dict[bad_ext], bad_type)
 
     def test_init_reinitializes(self):
         # Issue 4936: make sure an init starts clean

--- a/Misc/NEWS.d/next/Library/2026-06-10-00-00-01.gh-issue-117807.Cx1178.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-10-00-00-01.gh-issue-117807.Cx1178.rst
@@ -1,0 +1,2 @@
+Fix :mod:`mimetypes` initialization from MIME map files containing invalid
+UTF-8 bytes in comments.

--- a/Misc/NEWS.d/next/Library/2026-06-10-00-00-01.gh-issue-117807.Cx1178.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-10-00-00-01.gh-issue-117807.Cx1178.rst
@@ -1,0 +1,2 @@
+Fix :mod:`mimetypes` initialization from MIME map files containing invalid
+UTF-8 bytes.


### PR DESCRIPTION
Reading a MIME map file that contains invalid UTF-8 bytes in a comment raised `UnicodeDecodeError`, because `mimetypes` opens these files with `encoding='utf-8'` and strict error handling. A stray non-UTF-8 byte in a comment line shouldn't make the whole file unreadable.

Fix: open MIME map files with `errors='replace'` in both `MimeTypes.read()` and `read_mime_types()`, so invalid bytes are tolerated and the valid type mappings still load.

Added a regression test that reads a file with a non-UTF-8 byte in a comment and checks the following mapping parses correctly. Includes a NEWS entry.

Disclosure: AI-assisted; I've reviewed the change.

<!-- gh-issue-number: gh-117807 -->
* Issue: gh-117807
<!-- /gh-issue-number -->
