### PR TITLE
gh-151221: Fix plistlib loading of partial ISO 8601 dates

### DIFF
--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -81,6 +81,11 @@ This module defines the following functions:
    .. versionchanged:: 3.13
       The keyword-only parameter *aware_datetime* has been added.
 
+   .. versionchanged:: next
+      ``<date>`` values that omit smaller units (for example ``2024-06Z``)
+      are now accepted, with the omitted components defaulting to the start
+      of the period.  Previously such values raised :exc:`TypeError`.
+
 
 .. function:: loads(data, *, fmt=None, dict_type=dict, aware_datetime=False)
 

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -139,13 +139,11 @@ _dateParser = re.compile(r"(?P<year>\d\d\d\d)(?:-(?P<month>\d\d)(?:-(?P<day>\d\d
 
 def _date_from_string(s, aware_datetime):
     order = ('year', 'month', 'day', 'hour', 'minute', 'second')
+    # Smaller units may be omitted; default them to the start of the period.
+    defaults = (1, 1, 1, 0, 0, 0)
     gd = _dateParser.match(s).groupdict()
-    lst = []
-    for key in order:
-        val = gd[key]
-        if val is None:
-            break
-        lst.append(int(val))
+    lst = [int(val) if (val := gd[key]) is not None else default
+           for key, default in zip(order, defaults)]
     if aware_datetime:
         return datetime.datetime(*lst, tzinfo=datetime.UTC)
     return datetime.datetime(*lst)

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -938,6 +938,24 @@ class TestPlistlib(unittest.TestCase):
                             aware_datetime=True)
         self.assertEqual(dt.tzinfo, datetime.UTC)
 
+    def test_load_partial_datetime(self):
+        # Smaller units may be omitted; missing components default to the
+        # start of the period.
+        for data, expected in [
+            (b"<plist><date>2024Z</date></plist>",
+             datetime.datetime(2024, 1, 1)),
+            (b"<plist><date>2024-06Z</date></plist>",
+             datetime.datetime(2024, 6, 1)),
+            (b"<plist><date>2024-06-07Z</date></plist>",
+             datetime.datetime(2024, 6, 7)),
+            (b"<plist><date>2024-06-07T08Z</date></plist>",
+             datetime.datetime(2024, 6, 7, 8)),
+            (b"<plist><date>2024-06-07T08:09Z</date></plist>",
+             datetime.datetime(2024, 6, 7, 8, 9)),
+        ]:
+            with self.subTest(data=data):
+                self.assertEqual(plistlib.loads(data), expected)
+
     @unittest.skipUnless("America/Los_Angeles" in zoneinfo.available_timezones(),
                          "Can't find timezone datebase")
     def test_dump_aware_datetime(self):

--- a/Misc/NEWS.d/next/Library/2026-06-10-06-36-35.gh-issue-151221.DPeEZr.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-10-06-36-35.gh-issue-151221.DPeEZr.rst
@@ -1,0 +1,3 @@
+Fix :mod:`plistlib` raising a confusing :exc:`TypeError` when loading a
+``<date>`` that omits smaller units (for example ``2024-06Z`` or ``2024Z``).
+The omitted components now default to the start of the period.


### PR DESCRIPTION
Summary:

- Fix `plistlib._date_from_string` raising a confusing `TypeError` when a `<date>` omits smaller units (e.g. `2024-06Z` or `2024Z`). The date regex makes month/day/time optional, but the argument list for `datetime.datetime()` was truncated at the first missing component. Missing components now default to the start of the period.

- Add coverage for loading partial dates (year only, year-month, etc.).

Tests:

- ./python -m test test_plistlib

<!-- gh-issue-number: gh-151221 -->
* Issue: gh-151221
<!-- /gh-issue-number -->
