### PR TITLE
gh-150988: Fix OSError reference leak in oserror_init()

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1714,6 +1714,48 @@ class ExceptionTests(unittest.TestCase):
         gc_collect()  # For PyPy or other GCs.
         self.assertEqual(wr(), None)
 
+    @cpython_only
+    def test_oserror_refleak_attributes_before_init(self):
+        # gh-150988: no leak when a subclass sets OSError fields before
+        # super().__init__(), or when __init__ is called more than once.
+        class LeakingOSError(OSError):
+            def __init__(self, code, message, filename, filename2):
+                self.strerror = message
+                self.filename = filename
+                self.filename2 = filename2
+                super().__init__(code, message, filename, None, filename2)
+
+        msg = "some error message"
+        filename = "some filename"
+        filename2 = "some filename 2"
+        refcount_msg = sys.getrefcount(msg)
+        refcount_filename = sys.getrefcount(filename)
+        refcount_filename2 = sys.getrefcount(filename2)
+
+        for _ in range(5):
+            try:
+                raise LeakingOSError(1, msg, filename, filename2)
+            except OSError:
+                pass
+
+        gc_collect()
+        self.assertEqual(sys.getrefcount(msg), refcount_msg)
+        self.assertEqual(sys.getrefcount(filename), refcount_filename)
+        self.assertEqual(sys.getrefcount(filename2), refcount_filename2)
+
+        exc = LeakingOSError(1, msg, filename, filename2)
+        exc.__init__(2, msg, filename, filename2)
+        self.assertEqual(exc.errno, 2)
+        self.assertEqual(exc.strerror, msg)
+        self.assertEqual(exc.filename, filename)
+        self.assertEqual(exc.filename2, filename2)
+        del exc
+
+        gc_collect()
+        self.assertEqual(sys.getrefcount(msg), refcount_msg)
+        self.assertEqual(sys.getrefcount(filename), refcount_filename)
+        self.assertEqual(sys.getrefcount(filename2), refcount_filename2)
+
     def test_errno_ENOTDIR(self):
         # Issue #12802: "not a directory" errors are ENOTDIR even on Windows
         with self.assertRaises(OSError) as cm:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-10-12-00-00.gh-issue-150988.bH7kQ2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-10-12-00-00.gh-issue-150988.bH7kQ2.rst
@@ -1,0 +1,2 @@
+Fix a reference leak in :exc:`OSError` when attributes are set before
+``super().__init__()`` or when :meth:`~object.__init__` runs more than once.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2140,10 +2140,10 @@ oserror_init(PyOSErrorObject *self, PyObject **p_args,
                 return -1;
         }
         else {
-            self->filename = Py_NewRef(filename);
+            Py_XSETREF(self->filename, Py_NewRef(filename));
 
             if (filename2 && filename2 != Py_None) {
-                self->filename2 = Py_NewRef(filename2);
+                Py_XSETREF(self->filename2, Py_NewRef(filename2));
             }
 
             if (nargs >= 2 && nargs <= 5) {
@@ -2158,10 +2158,10 @@ oserror_init(PyOSErrorObject *self, PyObject **p_args,
             }
         }
     }
-    self->myerrno = Py_XNewRef(myerrno);
-    self->strerror = Py_XNewRef(strerror);
+    Py_XSETREF(self->myerrno, Py_XNewRef(myerrno));
+    Py_XSETREF(self->strerror, Py_XNewRef(strerror));
 #ifdef MS_WINDOWS
-    self->winerror = Py_XNewRef(winerror);
+    Py_XSETREF(self->winerror, Py_XNewRef(winerror));
 #endif
 
     /* Steals the reference to args */


### PR DESCRIPTION
Fixes #150988

Assigning OSError fields in a subclass before super().__init__() stored
references in the C struct that oserror_init() later overwrote without
decref'ing, leaking one reference per field per exception.

Use Py_XSETREF when updating errno, strerror, filename, filename2, and
winerror. Add a refcount regression test in test_exceptions.py.

<!-- gh-issue-number: gh-150988 -->
* Issue: gh-150988
<!-- /gh-issue-number -->
