### PR TITLE
gh-151112: Fix crash in `compiler_mod()` when entering the current compilation unit fails

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -893,6 +893,7 @@ compiler_mod(compiler *c, mod_ty mod)
 {
     PyCodeObject *co = NULL;
     int addNone = mod->kind != Expression_kind;
+    assert(c->u == NULL);
     if (compiler_codegen(c, mod) < 0) {
         goto finally;
     }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -898,7 +898,9 @@ compiler_mod(compiler *c, mod_ty mod)
     }
     co = _PyCompile_OptimizeAndAssemble(c, addNone);
 finally:
-    _PyCompile_ExitScope(c);
+    if (c->u != NULL) {
+        _PyCompile_ExitScope(c);
+    }
     return co;
 }
 


### PR DESCRIPTION
`_PyCodegen_EnterAnonymousScope` can fail to enter the module's compilation unit (e.g. when OOM, like the in repro), so `c->u` is left NULL. `compiler_mod`'s cleanup then calls `_PyCompile_ExitScope`, which derefs that NULL unit in `compiler_unit_free` and segfaults.

The reproducers start/stop for nomemory will probably have to be adjusted, but for me I can reproduce with:
```
import _testcapi

compile("pass", "<warmup>", "single")
_testcapi.set_nomemory(31, 32)
try:
    compile("pass", "<trigger>", "single")
except MemoryError:
    pass
first = bytes(128)
second = bytes(128)
```

Skipping news, the other PR has one which I think can cover this too, these are both quite rare.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151112 -->
* Issue: gh-151112
<!-- /gh-issue-number -->
