### PR TITLE
gh-151126: Fix missing memory errors in `_interpchannelsmodule.c`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
@@ -1,7 +1,5 @@
-Fix a crash, when there's no memory left on a device, which happened in:
-
-- code compilation
-- :mod:`!_interpchannels` module
-- :func:`!_winapi.CreateProcess` function
+Fix a crash, when there's no memory left on a device,
+which happened in: code compilation, :mod:`!_interpchannels` module,
+:func:`!_winapi.CreateProcess` function.
 
 Now these places raise proper :exc:`MemoryError` errors.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
@@ -1,8 +1,7 @@
-Fix a crash, when there's no memory left on a device,
-which happened in:
+Fix a crash, when there's no memory left on a device, which happened in:
 
 - code compilation
-- :func:`!_winapi.CreateProcess`
 - :mod:`!_interpchannels` module
+- :func:`!_winapi.CreateProcess` function
 
 Now these places raise proper :exc:`MemoryError` errors.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
@@ -3,5 +3,6 @@ which happened in:
 
 - code compilation
 - :func:`!_winapi.CreateProcess`
+- :mod:`!_interpchannels` module
 
 Now these places raise proper :exc:`MemoryError` errors.

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -921,7 +921,8 @@ static _channelends *
 _channelends_new(void)
 {
     _channelends *ends = GLOBAL_MALLOC(_channelends);
-    if (ends== NULL) {
+    if (ends == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     ends->numsendopen = 0;
@@ -1115,6 +1116,7 @@ _channel_new(PyThread_type_lock mutex, struct _channeldefaults defaults)
     assert(check_unbound(defaults.unboundop));
     _channel_state *chan = GLOBAL_MALLOC(_channel_state);
     if (chan == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     chan->mutex = mutex;
@@ -1313,6 +1315,7 @@ _channelref_new(int64_t cid, _channel_state *chan)
 {
     _channelref *ref = GLOBAL_MALLOC(_channelref);
     if (ref == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     ref->cid = cid;
@@ -1698,6 +1701,7 @@ _channel_set_closing(_channelref *ref, PyThread_type_lock mutex) {
     }
     chan->closing = GLOBAL_MALLOC(struct _channel_closing);
     if (chan->closing == NULL) {
+        PyErr_NoMemory();
         goto done;
     }
     chan->closing->ref = ref;


### PR DESCRIPTION


<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
