### PR TITLE
gh-151238: Check for `_get_resized_exprs` failure in `_PyPegen_{joined,template}_str`

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -593,6 +593,17 @@ x = (
                              r"""b'' f''""",
                              ])
 
+    def test_concat_decode_failure_does_not_crash(self):
+        script = r'''
+import builtins
+builtins.__import__ = builtins  # Breaks warning machinery so _get_resized_exprs returns NULL
+try:
+    compile('"x"f"\]"b""', '<test>', 'exec')
+except Exception:
+    pass
+'''
+        assert_python_ok('-c', script)
+
     def test_literal(self):
         self.assertEqual(f'', '')
         self.assertEqual(f'a', 'a')

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-10-15-19-58.gh-issue-151238.C9Wu4x.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-10-15-19-58.gh-issue-151238.C9Wu4x.rst
@@ -1,0 +1,2 @@
+Fix a crash when compiling a concatenated f-string or t-string if an error
+occurs when processing one of it's parts.

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -1416,6 +1416,9 @@ expr_ty
 _PyPegen_template_str(Parser *p, Token *a, asdl_expr_seq *raw_expressions, Token *b) {
 
     asdl_expr_seq *resized_exprs = _get_resized_exprs(p, a, raw_expressions, b, TSTRING);
+    if (resized_exprs == NULL) {
+        return NULL;
+    }
     return _PyAST_TemplateStr(resized_exprs, a->lineno, a->col_offset,
                               b->end_lineno, b->end_col_offset,
                               p->arena);
@@ -1425,6 +1428,9 @@ expr_ty
 _PyPegen_joined_str(Parser *p, Token* a, asdl_expr_seq* raw_expressions, Token*b) {
 
     asdl_expr_seq *resized_exprs = _get_resized_exprs(p, a, raw_expressions, b, FSTRING);
+    if (resized_exprs == NULL) {
+        return NULL;
+    }
     return _PyAST_JoinedStr(resized_exprs, a->lineno, a->col_offset,
                             b->end_lineno, b->end_col_offset,
                             p->arena);


### PR DESCRIPTION
There are several cases where `_get_resized_exprs` can fail and return NULL (all of which are quite rare, however):

https://github.com/python/cpython/blob/e2bd50d2e1cfe474f3b1f88a3d2b7e26cfda1295/Parser/action_helpers.c#L1341-L1344

https://github.com/python/cpython/blob/e2bd50d2e1cfe474f3b1f88a3d2b7e26cfda1295/Parser/action_helpers.c#L1362-L1368

https://github.com/python/cpython/blob/e2bd50d2e1cfe474f3b1f88a3d2b7e26cfda1295/Parser/action_helpers.c#L1347-L1351

https://github.com/python/cpython/blob/e2bd50d2e1cfe474f3b1f88a3d2b7e26cfda1295/Parser/action_helpers.c#L1401-L1404

And the one triggered by the reproducer in the issue (which I test):

https://github.com/python/cpython/blob/e2bd50d2e1cfe474f3b1f88a3d2b7e26cfda1295/Parser/action_helpers.c#L1383-L1386

`_PyPegen_decode_fstring_part` returns NULL because it calls `_PyPegen_decode_string` which in turn calls `warn_invalid_escape_sequence` which triggers the failure as it tries to import modules to issue a warning, but gets a `TypeError`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151238 -->
* Issue: gh-151238
<!-- /gh-issue-number -->
