### PR TITLE
GHA: Display output when a sanitizer test fails

### DIFF
--- a/.github/workflows/reusable-san.yml
+++ b/.github/workflows/reusable-san.yml
@@ -89,12 +89,12 @@ jobs:
         ./python -m test
         ${{ inputs.sanitizer == 'TSan' && '--tsan' || '' }}
         ${{ inputs.sanitizer == 'UBSan' && '-x test_capi -x test_faulthandler' || '' }}
-        -j4
+        -j4 -W
     - name: Parallel tests
       if: >-
         inputs.sanitizer == 'TSan'
         && fromJSON(inputs.free-threading)
-      run: ./python -m test --tsan-parallel --parallel-threads=4 -j4
+      run: ./python -m test --tsan-parallel --parallel-threads=4 -j4 -W
     - name: Display logs
       if: always()
       run: find "${GITHUB_WORKSPACE}" -name 'san_log.*' | xargs head -n 1000


### PR DESCRIPTION
Modify GitHub Action "Reusable Sanitizer" to display output when a test fails: pass -W option.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
