### PR TITLE
gh-151278: Fix test_faulthandler on UBSan

### DIFF
--- a/.github/workflows/reusable-san.yml
+++ b/.github/workflows/reusable-san.yml
@@ -82,13 +82,13 @@ jobs:
       run: make -j4
     - name: Display build info
       run: make pythoninfo
-    # test_{capi,faulthandler} are skipped under UBSan because
+    # test_capi is skipped under UBSan because
     # they raise signals that UBSan with halt_on_error=1 intercepts.
     - name: Tests
       run: >-
         ./python -m test
         ${{ inputs.sanitizer == 'TSan' && '--tsan' || '' }}
-        ${{ inputs.sanitizer == 'UBSan' && '-x test_capi -x test_faulthandler' || '' }}
+        ${{ inputs.sanitizer == 'UBSan' && '-x test_capi' || '' }}
         -j4 -W
     - name: Parallel tests
       if: >-

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -33,6 +33,11 @@ CURRENT_THREAD_ID = fr'Current thread 0x[0-9a-f]+{THREAD_NAME}'
 CURRENT_THREAD_HEADER = fr'{CURRENT_THREAD_ID} \(most recent call first\):'
 
 
+def skip_if_sanitizer_signal(signame):
+    return support.skip_if_sanitizer(f"TSAN/UBSan itercepts {signame}",
+                                     thread=True, ub=True)
+
+
 def expected_traceback(lineno1, lineno2, header, min_count=1):
     regex = header
     regex += '  File "<string>", line %s in func\n' % lineno1
@@ -224,7 +229,7 @@ class FaultHandlerTests(unittest.TestCase):
             func='faulthandler_fatal_error_thread',
             py_fatal_error=True)
 
-    @support.skip_if_sanitizer("TSAN itercepts SIGABRT", thread=True)
+    @skip_if_sanitizer_signal("SIGABRT")
     def test_sigabrt(self):
         self.check_fatal_error("""
             import faulthandler
@@ -236,7 +241,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == 'win32',
                      "SIGFPE cannot be caught on Windows")
-    @support.skip_if_sanitizer("TSAN itercepts SIGFPE", thread=True)
+    @skip_if_sanitizer_signal("SIGFPE")
     def test_sigfpe(self):
         self.check_fatal_error("""
             import faulthandler
@@ -248,7 +253,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(_testcapi is None, 'need _testcapi')
     @unittest.skipUnless(hasattr(signal, 'SIGBUS'), 'need signal.SIGBUS')
-    @support.skip_if_sanitizer("TSAN itercepts SIGBUS", thread=True)
+    @skip_if_sanitizer_signal("SIGBUS")
     @skip_segfault_on_android
     def test_sigbus(self):
         self.check_fatal_error("""
@@ -263,7 +268,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(_testcapi is None, 'need _testcapi')
     @unittest.skipUnless(hasattr(signal, 'SIGILL'), 'need signal.SIGILL')
-    @support.skip_if_sanitizer("TSAN itercepts SIGILL", thread=True)
+    @skip_if_sanitizer_signal("SIGILL")
     @skip_segfault_on_android
     def test_sigill(self):
         self.check_fatal_error("""

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3731,7 +3731,9 @@ fatal_error(int fd, int header, const char *prefix, const char *msg,
        This function already did its best to display a traceback.
        Disable faulthandler to prevent writing a second traceback
        on abort(). */
-    _PyFaulthandler_Fini();
+    if (has_tstate_and_gil) {
+        _PyFaulthandler_Fini();
+    }
 
     /* Check if the current Python thread hold the GIL */
     if (has_tstate_and_gil) {


### PR DESCRIPTION
* Py_FatalError() no longer calls _PyFaulthandler_Fini() if it doesn't hold the GIL.
* Skip test_faulthandler tests raising signals if run with UBSan.
* Enable test_faulthandler in GitHub Action "Reusable Sanitizer".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151278 -->
* Issue: gh-151278
<!-- /gh-issue-number -->
