### PR TITLE
[3.13][3.14] GHA: Display output when a sanitizer test fails (#151268) (#151273)

### DIFF
--- a/.github/workflows/reusable-san.yml
+++ b/.github/workflows/reusable-san.yml
@@ -86,7 +86,7 @@ jobs:
       run: >-
         ./python -m test
         ${{ inputs.sanitizer == 'TSan' && '--tsan' || '' }}
-        -j4
+        -j4 -W
     - name: Display logs
       if: always()
       run: find "${GITHUB_WORKSPACE}" -name 'san_log.*' | xargs head -n 1000


### PR DESCRIPTION
GHA: Display output when a sanitizer test fails (#151268)

Modify GitHub Action "Reusable Sanitizer" to display output when a test fails: pass -W option.

(cherry picked from commit 3a8bebd86f36be05442fa2f3adcc83c2a4b00ef2) (cherry picked from commit bc75e47ffaffbfd33bb2a57c98e25055a1337308)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
