### PR TITLE
plistlib: fix TypeError when parsing partial ISO 8601 dates (gh-151221)

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -143,9 +143,17 @@ def _date_from_string(s, aware_datetime):
     lst = []
     for key in order:
         val = gd[key]
-        if val is None:
-            break
-        lst.append(int(val))
+        if val is not None:
+            lst.append(int(val))
+        else:
+            # Fill missing components with defaults: month/day -> 1, hour/minute/second -> 0
+            if key in ('month', 'day'):
+                lst.append(1)
+            elif key in ('hour', 'minute', 'second'):
+                lst.append(0)
+            else:
+                # Year should never be missing due to regex
+                raise ValueError("Missing year in date string")
     if aware_datetime:
         return datetime.datetime(*lst, tzinfo=datetime.UTC)
     return datetime.datetime(*lst)

--- a/Misc/NEWS.d/next/Library/2026-06-10-20-33-34.gh-issue-151221.gV-PqB.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-10-20-33-34.gh-issue-151221.gV-PqB.rst
@@ -1,0 +1,1 @@
+plistlib._date_from_string() was raising a confusing TypeError for partial ISO 8601 dates (e.g., '2024-06Z') because it broke early on missing components. The fix fills missing components with sensible defaults: month/day → 1, hour/minute/second → 0.


### PR DESCRIPTION
Fixes issue #151221: plistlib._date_from_string() was raising a confusing TypeError for partial ISO 8601 dates (e.g., '2024-06Z') because it broke early on missing components. The fix fills missing components with sensible defaults: month/day → 1, hour/minute/second → 0.

<!-- gh-issue-number: gh-151221 -->
* Issue: gh-151221
<!-- /gh-issue-number -->
