### PR TITLE
gh-151096: Fix test_embed with split exec prefix

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1458,7 +1458,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         if prefix is None:
             prefix = config['config']['prefix']
         if exec_prefix is None:
-            exec_prefix = config['config']['prefix']
+            exec_prefix = config['config']['exec_prefix']
         if MS_WINDOWS:
             return config['config']['module_search_paths']
         else:
@@ -1614,8 +1614,10 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             expected_paths[1 if MS_WINDOWS else 2] = os.path.normpath(
                 os.path.join(exedir, f'{f.read()}\n$'.splitlines()[0]))
         if not MS_WINDOWS:
-            # PREFIX (default) is set when running in build directory
-            prefix = exec_prefix = sys.prefix
+            # PREFIX and EXEC_PREFIX (defaults) are set when running in the
+            # build directory and may differ with --exec-prefix (gh-151096).
+            prefix = sys.prefix
+            exec_prefix = sys.exec_prefix
             # stdlib calculation (/Lib) is not yet supported
             expected_paths[0] = self.module_search_paths(prefix=prefix)[0]
             config.update(prefix=prefix, base_prefix=prefix,

--- a/Misc/NEWS.d/next/Tests/2026-06-16-05-11-38.gh-issue-151096.Kq3Lp9.rst
+++ b/Misc/NEWS.d/next/Tests/2026-06-16-05-11-38.gh-issue-151096.Kq3Lp9.rst
@@ -1,0 +1,2 @@
+Fix ``test_embed`` failing when CPython is configured with a split exec prefix
+(``--exec-prefix`` differing from ``--prefix``).


### PR DESCRIPTION
Fix `test_init_is_python_build_with_home` for builds configured with different `--prefix` and `--exec-prefix`.

When running from the build directory on POSIX, getpath uses `PREFIX` for `prefix`/`base_prefix` and `EXEC_PREFIX` for `exec_prefix`/`base_exec_prefix`. The test assumed both match `sys.prefix`, which fails on a split-prefix build. This also fixes the `module_search_paths()` helper so its default `exec_prefix` comes from the expected config's `exec_prefix` rather than `prefix`.

Verified with a local split-prefix build (`--prefix=… --exec-prefix=…/exec`): the targeted test failed before and passes after, and full `test_embed` passes. Tests-only change.

Disclosure: AI-assisted; I've reviewed it.

<!-- gh-issue-number: gh-151096 -->
* Issue: gh-151096
<!-- /gh-issue-number -->
