### PR TITLE
gh-151177: Fix race condition in `_testembed`

### DIFF
--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -2715,8 +2715,8 @@ do_tstate_ensure(void *arg)
     PyThreadState_Release(tokens[2]);
     PyThreadState_Release(tokens[1]);
     PyThreadState_Release(tokens[0]);
-    PyInterpreterGuard_Close(guard);
     _Py_atomic_store_int(&data->done, 1);
+    PyInterpreterGuard_Close(guard);
 }
 
 static int


### PR DESCRIPTION
The interpreter guard needs to be released after the flag has been set, not before. Otherwise, the main thread will be unblocked and can potentially read the `done` flag before the thread has a chance to set it.

<!-- gh-issue-number: gh-151177 -->
* Issue: gh-151177
<!-- /gh-issue-number -->
