### PR TITLE
gh-151295: Fix use-after-free in bytes.join()/bytearray.join() via re-entrant __buffer__

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -650,8 +650,7 @@ class BaseBytesTest:
         # to that item by mutating the joined sequence.
         # See: https://github.com/python/cpython/issues/151295
         def make_seq(mutate):
-            # The mutating item is only referenced from the list slot, so
-            # mutate() drops its last reference mid-join.
+            # Item is only referenced from the list slot, so mutate() frees it.
             class Item:
                 def __buffer__(self, flags):
                     mutate(seq)
@@ -665,15 +664,12 @@ class BaseBytesTest:
 
         for sep in (self.type2test(b''), self.type2test(b'::')):
             with self.subTest(sep=sep):
-                # Clearing the list changes its length, which is reported as a
-                # RuntimeError.
+                # Changing the list length is reported as a RuntimeError.
                 seq = make_seq(lambda seq: seq.clear())
                 self.assertRaises(RuntimeError, sep.join, seq)
 
-                # Replacing the item in place keeps the list length unchanged,
-                # so the size-change recheck cannot fire; only keeping the item
-                # alive across __buffer__() prevents the use-after-free, and
-                # the join uses the buffer returned by __buffer__().
+                # The list length is unchanged, so the size-change recheck
+                # cannot fire: only keeping the item alive avoids the crash.
                 def replace(seq):
                     seq[1] = b'z'
                 seq = make_seq(replace)

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -645,9 +645,9 @@ class BaseBytesTest:
         with self.assertRaises(TypeError):
             dot_join([memoryview(b"ab"), "cd", b"ef"])
 
-    def test_join_reentrant_buffer_mutation(self):
-        # An item's __buffer__() may run Python that drops the last reference
-        # to that item by mutating the joined sequence.
+    def test_join_concurrent_buffer_mutation(self):
+        # __buffer__() can release the GIL, letting another thread concurrently
+        # mutate the joined sequence (simulated here by mutating in __buffer__).
         # See: https://github.com/python/cpython/issues/151295
         def make_seq(mutate):
             # Item is only referenced from the list slot, so mutate() frees it.
@@ -657,10 +657,6 @@ class BaseBytesTest:
                     return memoryview(b'x')
             seq = [b'a', Item(), b'c']
             return seq
-
-        class Benign:
-            def __buffer__(self, flags):
-                return memoryview(b'x')
 
         for sep in (self.type2test(b''), self.type2test(b'::')):
             with self.subTest(sep=sep):
@@ -674,10 +670,6 @@ class BaseBytesTest:
                     seq[1] = b'z'
                 seq = make_seq(replace)
                 self.assertEqual(sep.join(seq), sep.join([b'a', b'x', b'c']))
-
-                # A benign __buffer__() that does not mutate joins normally.
-                self.assertEqual(sep.join([Benign(), b'Y', Benign()]),
-                                 sep.join([b'x', b'Y', b'x']))
 
     def test_count(self):
         b = self.type2test(b'mississippi')

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -645,6 +645,44 @@ class BaseBytesTest:
         with self.assertRaises(TypeError):
             dot_join([memoryview(b"ab"), "cd", b"ef"])
 
+    def test_join_reentrant_buffer_mutation(self):
+        # An item's __buffer__() may run Python that drops the last reference
+        # to that item by mutating the joined sequence.
+        # See: https://github.com/python/cpython/issues/151295
+        def make_seq(mutate):
+            # The mutating item is only referenced from the list slot, so
+            # mutate() drops its last reference mid-join.
+            class Item:
+                def __buffer__(self, flags):
+                    mutate(seq)
+                    return memoryview(b'x')
+            seq = [b'a', Item(), b'c']
+            return seq
+
+        class Benign:
+            def __buffer__(self, flags):
+                return memoryview(b'x')
+
+        for sep in (self.type2test(b''), self.type2test(b'::')):
+            with self.subTest(sep=sep):
+                # Clearing the list changes its length, which is reported as a
+                # RuntimeError.
+                seq = make_seq(lambda seq: seq.clear())
+                self.assertRaises(RuntimeError, sep.join, seq)
+
+                # Replacing the item in place keeps the list length unchanged,
+                # so the size-change recheck cannot fire; only keeping the item
+                # alive across __buffer__() prevents the use-after-free, and
+                # the join uses the buffer returned by __buffer__().
+                def replace(seq):
+                    seq[1] = b'z'
+                seq = make_seq(replace)
+                self.assertEqual(sep.join(seq), sep.join([b'a', b'x', b'c']))
+
+                # A benign __buffer__() that does not mutate joins normally.
+                self.assertEqual(sep.join([Benign(), b'Y', Benign()]),
+                                 sep.join([b'x', b'Y', b'x']))
+
     def test_count(self):
         b = self.type2test(b'mississippi')
         i = 105

--- a/Misc/NEWS.d/next/Library/2026-06-11-00-00-00.gh-issue-151295.NQYUzW.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-11-00-00-00.gh-issue-151295.NQYUzW.rst
@@ -1,0 +1,4 @@
+Fixed a crash (use-after-free) in :meth:`bytes.join` and
+:meth:`bytearray.join` that could occur if an item's
+:meth:`~object.__buffer__` concurrently mutates the sequence being joined.
+The mutation is now reported as a :exc:`RuntimeError` instead.

--- a/Objects/stringlib/join.h
+++ b/Objects/stringlib/join.h
@@ -68,13 +68,21 @@ STRINGLIB(bytes_join)(PyObject *sep, PyObject *iterable)
             buffers[i].len = PyBytes_GET_SIZE(item);
         }
         else {
+            /* Keep item alive across PyObject_GetBuffer(): item is only
+               borrowed from the sequence, and its __buffer__() may run
+               Python that drops that last reference (e.g. by mutating the
+               sequence being joined), freeing item while the buffer
+               machinery is still using it. */
+            Py_INCREF(item);
             if (PyObject_GetBuffer(item, &buffers[i], PyBUF_SIMPLE) != 0) {
+                Py_DECREF(item);
                 PyErr_Format(PyExc_TypeError,
                              "sequence item %zd: expected a bytes-like object, "
                              "%.80s found",
                              i, Py_TYPE(item)->tp_name);
                 goto error;
             }
+            Py_DECREF(item);
             /* If the backing objects are mutable, then dropping the GIL
              * opens up race conditions where another thread tries to modify
              * the object which we hold a buffer on it. Such code has data

--- a/Objects/stringlib/join.h
+++ b/Objects/stringlib/join.h
@@ -68,11 +68,8 @@ STRINGLIB(bytes_join)(PyObject *sep, PyObject *iterable)
             buffers[i].len = PyBytes_GET_SIZE(item);
         }
         else {
-            /* Keep item alive across PyObject_GetBuffer(): item is only
-               borrowed from the sequence, and its __buffer__() may run
-               Python that drops that last reference (e.g. by mutating the
-               sequence being joined), freeing item while the buffer
-               machinery is still using it. */
+            /* item is only borrowed; its __buffer__() may run Python that
+               drops the sequence's last reference to it. */
             Py_INCREF(item);
             if (PyObject_GetBuffer(item, &buffers[i], PyBUF_SIMPLE) != 0) {
                 Py_DECREF(item);


### PR DESCRIPTION
<!-- gh-issue-number: gh-151295 -->
* Issue: gh-151295
<!-- /gh-issue-number -->

## What

`bytes.join()` and `bytearray.join()` could crash with a use-after-free when a
non-`bytes` item's `__buffer__()` dropped the last reference to that item by
mutating the sequence being joined.

`STRINGLIB(bytes_join)` (`Objects/stringlib/join.h`) borrows each item from the
`PySequence_Fast` view. The exact-`bytes` fast path keeps the item alive with
`Py_NewRef(item)`, but the general buffer path called
`PyObject_GetBuffer(item, ...)` on the borrowed item without owning a
reference. `PyObject_GetBuffer()` runs `item.__buffer__()` (PEP 688), which can
execute arbitrary Python; if that callback drops the item's last reference
(e.g. `L.clear()`), the item is freed while the buffer machinery is still
dereferencing it.

## Why

This is the same class of re-entrant `__buffer__` mutation bug as gh-143988
(`sendmsg`/`recvmsg_into`). The end-of-loop "sequence changed size" recheck
does not catch it because the use-after-free happens inside the current
iteration's `PyObject_GetBuffer()` call.

Unlike the `sendmsg` fix, this does not snapshot the whole sequence up front.
`bytes_join` already has a "sequence changed size during iteration" recheck
after each item, so the minimal fix is just to keep the current `item` alive
across its own `PyObject_GetBuffer()` call (`Py_INCREF`/`Py_DECREF`); the
existing recheck then reports the mutation as a `RuntimeError`. Snapshotting
the whole sequence would be a larger change and would alter that error
behaviour, so the targeted reference fix is preferred.

This is a crash-robustness fix, not a security vulnerability: the caller has to
pass an object with a malicious `__buffer__` into its own `join()` call, so it
crashes the caller's own process with no trust boundary crossed.

## Fix

Hold a reference to `item` across `PyObject_GetBuffer()` in the buffer path
(`Py_INCREF` before the call, `Py_DECREF` on both the success and the failure
path), mirroring the `Py_NewRef(item)` already used by the exact-`bytes` fast
path.

## Testing

`BaseBytesTest.test_join_reentrant_buffer_mutation` (runs for both `bytes` and
`bytearray`) exercises a `__buffer__` that mutates the joined list, for empty
and non-empty separators. One case clears the list (changing its length) and
asserts a `RuntimeError` is raised instead of crashing. A second case replaces
the item in place with an object: the list length is unchanged, so the
"sequence changed size" recheck cannot fire and only keeping the item alive
across `__buffer__()` avoids the use-after-free; it asserts the join still
returns the expected result. A benign `__buffer__` negative control (also run
for both types and separators) verifies normal joins still produce the correct
result.

Verified locally on macOS arm64 against a fresh build (both `--with-pydebug`
and a release build): without the patch the new test fatally crashes the
interpreter (on a debug build the fault is in `bufferwrapper_releasebuf`,
confirming a use-after-free); with the patch `python -m test test_bytes`
passes (312 tests) with no reference leaks under `-R 3:3`.

This affects 3.12+, since PEP 688 made `__buffer__` overridable in pure
Python, so the fix should be backported to the maintained 3.13 and 3.14
branches.

## AI usage disclosure

I used Claude to help draft this change (the C fix, the regression test, and
this description). I reviewed every line, ran the reproducer and the full
`test_bytes` suite locally (debug and release builds), and confirmed the fix
and the test behave as described.
