### PR TITLE
[3.14] gh-130796: Undeprecate locale.getdefaultlocale() (GH-143069)

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.15.rst
+++ b/Doc/deprecations/pending-removal-in-3.15.rst
@@ -33,16 +33,6 @@ Pending removal in Python 3.15
 
   * ``load_module()`` method: use ``exec_module()`` instead.
 
-* :class:`locale`:
-
-  * The :func:`~locale.getdefaultlocale` function
-    has been deprecated since Python 3.11.
-    Its removal was originally planned for Python 3.13 (:gh:`90817`),
-    but has been postponed to Python 3.15.
-    Use :func:`~locale.getlocale`, :func:`~locale.setlocale`,
-    and :func:`~locale.getencoding` instead.
-    (Contributed by Hugo van Kemenade in :gh:`111187`.)
-
 * :mod:`pathlib`:
 
   * :meth:`.PurePath.is_reserved`

--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -367,8 +367,6 @@ The :mod:`!locale` module defines the following exception and functions:
    determined.
    The "C" locale is represented as ``(None, None)``.
 
-   .. deprecated-removed:: 3.11 3.15
-
 
 .. function:: getlocale(category=LC_CTYPE)
 

--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -545,12 +545,6 @@ def getdefaultlocale(envvars=('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE')):
 
     """
 
-    import warnings
-    warnings._deprecated(
-        "locale.getdefaultlocale",
-        "{name!r} is deprecated and slated for removal in Python {remove}. "
-        "Use setlocale(), getencoding() and getlocale() instead.",
-        remove=(3, 15))
     return _getdefaultlocale(envvars)
 
 

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -1,6 +1,5 @@
 from decimal import Decimal
 from test.support import cpython_only, verbose, is_android, linked_to_musl, os_helper
-from test.support.warnings_helper import check_warnings
 from test.support.import_helper import ensure_lazy_imports, import_fresh_module
 from unittest import mock
 import unittest
@@ -554,8 +553,7 @@ class TestMiscellaneous(unittest.TestCase):
                 env.unset('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE')
                 env.set('LC_CTYPE', 'UTF-8')
 
-                with check_warnings(('', DeprecationWarning)):
-                    self.assertEqual(locale.getdefaultlocale(), (None, 'UTF-8'))
+                self.assertEqual(locale.getdefaultlocale(), (None, 'UTF-8'))
         finally:
             if orig_getlocale is not None:
                 _locale._getdefaultlocale = orig_getlocale

--- a/Misc/NEWS.d/next/Library/2025-12-23-11-43-05.gh-issue-130796.TkzUGx.rst
+++ b/Misc/NEWS.d/next/Library/2025-12-23-11-43-05.gh-issue-130796.TkzUGx.rst
@@ -1,0 +1,2 @@
+Undeprecate the :func:`locale.getdefaultlocale` function.
+Patch by Victor Stinner.


### PR DESCRIPTION
(cherry picked from commit 6536fab19410ce701575b553d381cf805d3ef323)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Conflict was `Doc/whatsnew/3.15.rst`:

```rst
* Undeprecate the :func:`locale.getdefaultlocale` function.
  (Contributed by Victor Stinner in :gh:`130796`.)
```

https://github.com/python/cpython/pull/143069/changes#diff-bd7a9c5b54eeb2b40e6db5e48e8d79d309d8738e776a40918773c6840189edf9

Do we want that in `Doc/whatsnew/3.14.rst`?


<!-- gh-issue-number: gh-130796 -->
* Issue: gh-130796
<!-- /gh-issue-number -->
