### PR TITLE
gh-151228: fix data race on clearing embedded values

### DIFF
--- a/Lib/test/test_free_threading/test_dict.py
+++ b/Lib/test/test_free_threading/test_dict.py
@@ -296,6 +296,24 @@ class TestDict(TestCase):
 
         threading_helper.run_concurrently([clearer, reader, reader])
 
+    def test_racing_embedded_values_clear_and_lookup(self):
+        class C:
+            pass
+
+        obj = C()
+        def writer():
+            for _ in range(1000):
+                obj.x = 1
+                obj.y = 2
+                obj.z = 3
+                obj.__dict__.clear()
+
+        def reader():
+            for _ in range(1000):
+                obj.__dict__.get('x')
+
+        threading_helper.run_concurrently([writer, reader, reader])
+
     def test_racing_dict_update_and_method_lookup(self):
         # gh-144295: test race between dict modifications and method lookups.
         # Uses BytesIO because the race requires a type without Py_TPFLAGS_INLINE_VALUES

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3039,7 +3039,7 @@ clear_embedded_values(PyDictValues *values, Py_ssize_t nentries)
     assert(nentries <= SHARED_KEYS_MAX_SIZE);
     for (Py_ssize_t i = 0; i < nentries; i++) {
         refs[i] = values->values[i];
-        values->values[i] = NULL;
+        FT_ATOMIC_STORE_PTR_RELEASE(values->values[i], NULL);
     }
     values->size = 0;
     for (Py_ssize_t i = 0; i < nentries; i++) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151228 -->
* Issue: gh-151228
<!-- /gh-issue-number -->
