### PR TITLE
gh-151335: Add test for string with digits and whitespaces in test_isdigit()

### DIFF
--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -1127,7 +1127,7 @@ class BaseTest:
         self.checkequal(True, '0', 'isdigit')
         self.checkequal(True, '0123456789', 'isdigit')
         self.checkequal(False, '0123456789a', 'isdigit')
-
+        self.checkequal(False, '123 ', 'isdigit')
         self.checkraises(TypeError, 'abc', 'isdigit', 42)
 
     def test_title(self):


### PR DESCRIPTION
The following PR adds a test case for test_isdigit() in ```Lib/test/string_tests.py``` to test strings with only digits and whitespaces. 

```python
self.checkequal(False, '123 ', 'isdigit')
```

<!-- gh-issue-number: gh-151335 -->
* Issue: gh-151335
<!-- /gh-issue-number -->
