### PR TITLE
[3.14] gh-151126: Fix missing memory errors in `_interpchannelsmodule.c` (GH-151239)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-09-10-28-30.gh-issue-151126.DKa6Sl.rst
@@ -1,0 +1,4 @@
+Fix a crash, when there's no memory left on a device,
+which happened in :mod:`!_interpchannels` module.
+
+Now it raises proper :exc:`MemoryError` errors.

--- a/Misc/NEWS.d/next/Library/2026-06-11-16-07-00.gh-issue-151126.cWw5pb.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-11-16-07-00.gh-issue-151126.cWw5pb.rst
@@ -1,0 +1,4 @@
+Fix a crash, when there's no memory left on a device, which happened in
+:mod:`!_interpchannels` module.
+
+Now it raises proper :exc:`MemoryError` errors.

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -921,7 +921,8 @@ static _channelends *
 _channelends_new(void)
 {
     _channelends *ends = GLOBAL_MALLOC(_channelends);
-    if (ends== NULL) {
+    if (ends == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     ends->numsendopen = 0;
@@ -1115,6 +1116,7 @@ _channel_new(PyThread_type_lock mutex, struct _channeldefaults defaults)
     assert(check_unbound(defaults.unboundop));
     _channel_state *chan = GLOBAL_MALLOC(_channel_state);
     if (chan == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     chan->mutex = mutex;
@@ -1313,6 +1315,7 @@ _channelref_new(int64_t cid, _channel_state *chan)
 {
     _channelref *ref = GLOBAL_MALLOC(_channelref);
     if (ref == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     ref->cid = cid;
@@ -1698,6 +1701,7 @@ _channel_set_closing(_channelref *ref, PyThread_type_lock mutex) {
     }
     chan->closing = GLOBAL_MALLOC(struct _channel_closing);
     if (chan->closing == NULL) {
+        PyErr_NoMemory();
         goto done;
     }
     chan->closing->ref = ref;


### PR DESCRIPTION
Python 3.14.6 was released in the meantime, so I addapted the NEWS entry.

(cherry picked from commit 9fd1a125bc0ebdc26eae684da6e48ef24ee23b34)


<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
