### PR TITLE
gh-151126: Fix missing memory error in `os._path_splitroot`

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-11-16-25-38.gh-issue-151126.bh_Usy.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-11-16-25-38.gh-issue-151126.bh_Usy.rst
@@ -1,1 +1,2 @@
-Fix :exc:`MemoryError` in :func:`!os._path_splitroot`.
+Fix a crash when :exc:`MemoryError` in :func:`!os._path_splitroot`
+was not set properly.

--- a/Misc/NEWS.d/next/Library/2026-06-11-16-25-38.gh-issue-151126.bh_Usy.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-11-16-25-38.gh-issue-151126.bh_Usy.rst
@@ -1,0 +1,1 @@
+Fix :exc:`MemoryError` in :func:`!os._path_splitroot`.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5699,7 +5699,7 @@ os__path_splitroot_impl(PyObject *module, path_t *path)
 
     buffer = (wchar_t*)PyMem_Malloc(sizeof(wchar_t) * (wcslen(path->wide) + 1));
     if (!buffer) {
-        return NULL;
+        return PyErr_NoMemory();
     }
     wcscpy(buffer, path->wide);
     for (wchar_t *p = wcschr(buffer, L'/'); p; p = wcschr(p, L'/')) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
