### PR TITLE
gh-139588: Docs: serialize latex prerequisites before running build

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -88,9 +88,9 @@ htmlhelp: build
 	      "build/htmlhelp/pydoc.hhp project file."
 
 .PHONY: latex
-latex: _ensure-sphinxcontrib-svg2pdfconverter
 latex: BUILDER = latex
-latex: build
+latex: _ensure-sphinxcontrib-svg2pdfconverter
+	$(MAKE) build BUILDER=$(BUILDER)
 	@echo "Build finished; the LaTeX files are in build/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
 	      "run these through (pdf)latex."


### PR DESCRIPTION
Adding `_ensure-sphinxcontrib-svg2pdfconverter` as a sibling prerequisite of build makes `make -jN latex` nondeterministic, because GNU Make may run both prerequisites in parallel. In that mode, build can start before the converter package (and even the venv it depends on) is installed, so the LaTeX doc build can fail intermittently with missing tooling even though the target is supposed to prepare it first.

This fixes a bug introduced in https://github.com/python/cpython/pull/145480.

[Example faulty run](https://github.com/python/python-docs-pl/actions/runs/27067980946/job/79892549863?pr=144). In this job build is invoked first, and then the installation of the required package. In effect in generated artifact there are no PDF images converted from SVGs. 

Could it be please marked for a backport to 3.15?

This is already fixed for 3.14: https://github.com/python/cpython/pull/145741.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139588 -->
* Issue: gh-139588
<!-- /gh-issue-number -->
