### PR TITLE
gh-146102: Fix type slot_bf_getbuffer() error handling

### DIFF
--- a/Objects/stringlib/join.h
+++ b/Objects/stringlib/join.h
@@ -72,11 +72,11 @@ STRINGLIB(bytes_join)(PyObject *sep, PyObject *iterable)
                drops the sequence's last reference to it. */
             Py_INCREF(item);
             if (PyObject_GetBuffer(item, &buffers[i], PyBUF_SIMPLE) != 0) {
-                Py_DECREF(item);
                 PyErr_Format(PyExc_TypeError,
                              "sequence item %zd: expected a bytes-like object, "
                              "%.80s found",
                              i, Py_TYPE(item)->tp_name);
+                Py_DECREF(item);
                 goto error;
             }
             Py_DECREF(item);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -11327,6 +11327,7 @@ slot_bf_getbuffer(PyObject *self, Py_buffer *buffer, int flags)
 
     wrapper = PyObject_GC_New(PyBufferWrapper, &_PyBufferWrapper_Type);
     if (wrapper == NULL) {
+        PyBuffer_Release(buffer);
         goto fail;
     }
     wrapper->mv = ret;


### PR DESCRIPTION
Call PyBuffer_Release() if PyObject_GC_New() fails.

Fix also bytes_join(): only call Py_DECREF(item) after formatting the error message which uses item.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146102 -->
* Issue: gh-146102
<!-- /gh-issue-number -->
