### PR TITLE
gh-146102: Don't clear exception on success in odictobject.c

### DIFF
--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -2206,13 +2206,14 @@ update       __setitem__
 static int
 mutablemapping_add_pairs(PyObject *self, PyObject *pairs)
 {
+    assert(!PyErr_Occurred());
+
     PyObject *pair, *iterator, *unexpected;
     int res = 0;
 
     iterator = PyObject_GetIter(pairs);
     if (iterator == NULL)
         return -1;
-    PyErr_Clear();
 
     while ((pair = PyIter_Next(iterator)) != NULL) {
         /* could be more efficient (see UNPACK_SEQUENCE in ceval.c) */


### PR DESCRIPTION
Calling PyErr_Clear() on success can mask a pending exception. Replace it with an assertion checking that no exception is set.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146102 -->
* Issue: gh-146102
<!-- /gh-issue-number -->
