### PR TITLE
gh-150285: Fix too long docstrings in GenericAlias and __class_getitem__

### DIFF
--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -572,7 +572,8 @@ PyDoc_STRVAR(genericalias__doc__,
 "--\n\n"
 "Represent a PEP 585 generic type\n"
 "\n"
-"E.g. for t = list[int], t.__origin__ is list and t.__args__ is (int,).");
+"For example, for t = list[int], t.__origin__ is list and t.__args__\n"
+"is (int,).");
 
 static PyObject *
 ga_getitem(PyObject *self, PyObject *item)

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -957,8 +957,10 @@ tuple___getnewargs___impl(PyTupleObject *self)
 
 PyDoc_STRVAR(tuple_class_getitem_doc,
 "Tuples are generic over the types of their contents.\n\n\
-For example, use ``tuple[int, str]`` for a pair whose first element is an int and second element is a string.\n\n\
-Tuples also support the form ``tuple[T, ...]`` to indicate an arbitrary length tuple of elements of type T.");
+For example, use ``tuple[int, str]`` for a pair whose first element\n\
+is an int and second element is a string.\n\n\
+Tuples also support the form ``tuple[T, ...]`` to indicate\n\
+an arbitrary length tuple of elements of type T.");
 
 static PyMethodDef tuple_methods[] = {
     TUPLE___GETNEWARGS___METHODDEF

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -2311,8 +2311,9 @@ PyDoc_STRVAR(generic_class_getitem_doc,
 "Parameterizes a generic class.\n\
 \n\
 At least, parameterizing a generic class is the *main* thing this\n\
-method does. For example, for some generic class `Foo`, this is called\n\
-when we do `Foo[int]` - there, with `cls=Foo` and `params=int`.\n\
+method does.  For example, for some generic class `Foo`, this is\n\
+called when we do `Foo[int]` - there, with `cls=Foo` and\n\
+`params=int`.\n\
 \n\
 However, note that this method is also called when defining generic\n\
 classes in the first place with `class Foo[T]: ...`.\n\


### PR DESCRIPTION


<!-- gh-issue-number: gh-150285 -->
* Issue: gh-150285
<!-- /gh-issue-number -->
