### PR TITLE
gh-151126: Fix crash on unset memory error in `ctypes.get_errno`

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-12-00-04-34.gh-issue-151126.aHaBYq.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-12-00-04-34.gh-issue-151126.aHaBYq.rst
@@ -1,0 +1,2 @@
+Fix crash on unset :exc:`MemoryError` on allocation failure in
+:func:`ctypes.get_errno`.

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -168,8 +168,9 @@ _ctypes_get_errobj(ctypes_state *st, int **pspace)
     }
     else {
         void *space = PyMem_Calloc(2, sizeof(int));
-        if (space == NULL)
-            return NULL;
+        if (space == NULL) {
+            return PyErr_NoMemory();
+        }
         errobj = PyCapsule_New(space, CTYPES_CAPSULE_NAME_PYMEM, pymem_destructor);
         if (errobj == NULL) {
             PyMem_Free(space);


### PR DESCRIPTION


<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
