### PR TITLE
gh-151390: Colorize `match +` and `match -` in the REPL

### DIFF
--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -259,7 +259,7 @@ def is_soft_keyword_used(*tokens: TI | None) -> bool:
             None | TI(T.NEWLINE) | TI(T.INDENT) | TI(string=":"),
             TI(string="match"),
             TI(T.NUMBER | T.STRING | T.FSTRING_START | T.TSTRING_START)
-            | TI(T.OP, string="(" | "*" | "[" | "{" | "~" | "...")
+            | TI(T.OP, string="(" | "*" | "-" | "+" | "[" | "{" | "~" | "...")
         ):
             return True
         case (

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -133,6 +133,22 @@ class TestUtils(TestCase):
                     ("1", "number"),
                 ],
             ),
+            (
+                "match +1",
+                [
+                    ("match", "soft_keyword"),
+                    ("+", "op"),
+                    ("1", "number"),
+                ],
+            ),
+            (
+                "match -1",
+                [
+                    ("match", "soft_keyword"),
+                    ("-", "op"),
+                    ("1", "number"),
+                ],
+            ),
         ]
         for code, expected_highlights in cases:
             with self.subTest(code=code):

--- a/Misc/NEWS.d/next/Library/2026-06-12-07-20-08.gh-issue-151390.CmYN9EeJ.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-12-07-20-08.gh-issue-151390.CmYN9EeJ.rst
@@ -1,2 +1,1 @@
-Fix the :term:`REPL` not colorizing ``match`` as a soft keyword when followed
-by a unary ``+`` or ``-`` operator. Patch by Bartosz Sławecki.
+Colorize ``match`` in the :term:`REPL` when followed by a unary ``+`` or ``-`` operator. Patch by Bartosz Sławecki.

--- a/Misc/NEWS.d/next/Library/2026-06-12-07-20-08.gh-issue-151390.CmYN9EeJ.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-12-07-20-08.gh-issue-151390.CmYN9EeJ.rst
@@ -1,0 +1,2 @@
+Fix the :term:`REPL` not colorizing ``match`` as a soft keyword when followed
+by a unary ``+`` or ``-`` operator. Patch by Bartosz Sławecki.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151390 -->
* Issue: gh-151390
<!-- /gh-issue-number -->
