### PR TITLE
gh-151403: Fix use-after-free when an argv item's __fspath__ mutates args

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-12-22-46-31.gh-issue-151403.DalZWh.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-12-22-46-31.gh-issue-151403.DalZWh.rst
@@ -1,3 +1,3 @@
 Fixed a crash in :class:`subprocess.Popen` (and ``_posixsubprocess.fork_exec``)
-when an ``argv`` item's :meth:`~object.__fspath__` concurrently mutates the
+when an ``argv`` item's :meth:`~os.PathLike.__fspath__` concurrently mutates the
 ``args`` sequence being converted.

--- a/Misc/NEWS.d/next/Library/2026-06-12-22-46-31.gh-issue-151403.DalZWh.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-12-22-46-31.gh-issue-151403.DalZWh.rst
@@ -1,0 +1,3 @@
+Fixed a crash in :class:`subprocess.Popen` (and ``_posixsubprocess.fork_exec``)
+when an ``argv`` item's :meth:`~object.__fspath__` concurrently mutates the
+``args`` sequence being converted.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -1090,8 +1090,14 @@ subprocess_fork_exec_impl(PyObject *module, PyObject *process_args,
                 goto cleanup;
             }
             borrowed_arg = PySequence_Fast_GET_ITEM(fast_args, arg_num);
-            if (PyUnicode_FSConverter(borrowed_arg, &converted_arg) == 0)
+            /* borrowed_arg is only borrowed; its __fspath__() may run Python
+               that drops fast_args' last reference to it. */
+            Py_INCREF(borrowed_arg);
+            if (PyUnicode_FSConverter(borrowed_arg, &converted_arg) == 0) {
+                Py_DECREF(borrowed_arg);
                 goto cleanup;
+            }
+            Py_DECREF(borrowed_arg);
             PyTuple_SET_ITEM(converted_args, arg_num, converted_arg);
         }
 


### PR DESCRIPTION
`_posixsubprocess.fork_exec()` converts each `args` item with
`PyUnicode_FSConverter()`, which runs the item's `__fspath__()`. The item is only
borrowed from the (incref'd) `args` sequence. If `__fspath__()` drops the
sequence's last reference to the item and then returns a non-`str`/`bytes`
object, the error path in `PyOS_FSPath()` reads `Py_TYPE()` of the now-freed item
— a use-after-free.

It is reachable from `subprocess.Popen` when a later `argv` item is a `PathLike`
whose `__fspath__()` mutates the `args` list, e.g.
`subprocess.Popen(["/bin/true", Evil()])`.

The between-iteration length recheck only catches a shrink *between* iterations;
the free here happens *inside* the current iteration's `PyUnicode_FSConverter()`
call. The fix keeps the borrowed item alive with an `Py_INCREF` across the
conversion.

Same family as gh-151295 (`bytes.join`, GH-151296) and gh-151370
(`marshal.dumps`, GH-151371). Triggering requires a custom `__fspath__`, so this
is a robustness / crash-hardening fix with no security impact; the NEWS entry is
under `Library/`.


<!-- gh-issue-number: gh-151403 -->
* Issue: gh-151403
<!-- /gh-issue-number -->
