### PR TITLE
gh-151408: Fix bug with lazy importing a previously imported and removed module

### DIFF
--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -39,6 +39,9 @@ extern PyObject * _PyImport_GetAbsName(
 // Symbol is exported for the JIT on Windows builds.
 PyAPI_FUNC(PyObject *) _PyImport_LoadLazyImportTstate(
     PyThreadState *tstate, PyObject *lazy_import);
+extern PyObject * _PyImport_ResolveLazyImportFromAttr(
+    PyThreadState *tstate, PyObject *package_name,
+    PyObject *name, PyObject *attr);
 extern PyObject * _PyImport_TryLoadLazySubmodule(
     PyObject *mod_name, PyObject *attr_name);
 extern PyObject * _PyImport_LazyImportModuleLevelObject(

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -29,6 +29,7 @@ import unittest
 from unittest import mock
 import _imp
 
+from test import support
 from test.support import os_helper
 from test.support import (
     STDLIB_DIR,
@@ -416,22 +417,26 @@ class ImportTests(unittest.TestCase):
         self.assertIn(cm.exception.name, {'posixpath', 'ntpath'})
         self.assertIsNotNone(cm.exception)
 
+    @support.requires_subprocess()
     def test_from_import_module_attr_from_non_package(self):
-        module_name = 'test_from_import_module_attr_from_non_package'
-        child_name = f'{module_name}.child'
-        module = types.ModuleType(module_name)
-        child = types.ModuleType(child_name)
-        module.child = child
-        self.addCleanup(unload, module_name)
-        self.addCleanup(unload, child_name)
-        sys.modules[module_name] = module
+        code = textwrap.dedent("""
+            import sys
+            import types
 
-        # A plain module can expose a module-valued attribute without being a
-        # package, so from-import must return the attribute as-is.
-        ns = {}
-        exec(f'from {module_name} import child as imported', ns)
-        self.assertIs(ns['imported'], child)
-        self.assertNotIn(child_name, sys.modules)
+            module_name = 'test_from_import_module_attr_from_non_package'
+            child_name = f'{module_name}.child'
+            module = types.ModuleType(module_name)
+            child = types.ModuleType(child_name)
+            module.child = child
+            sys.modules[module_name] = module
+
+            # A plain module can expose a module-valued attribute without
+            # being a package, so from-import must return the attribute as-is.
+            from test_from_import_module_attr_from_non_package import child as imported
+            assert imported is child
+            assert child_name not in sys.modules, child_name
+        """)
+        script_helper.assert_python_ok("-c", code)
 
     def test_from_import_star_invalid_type(self):
         with ready_to_import() as (name, path):

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -416,6 +416,23 @@ class ImportTests(unittest.TestCase):
         self.assertIn(cm.exception.name, {'posixpath', 'ntpath'})
         self.assertIsNotNone(cm.exception)
 
+    def test_from_import_module_attr_from_non_package(self):
+        module_name = 'test_from_import_module_attr_from_non_package'
+        child_name = f'{module_name}.child'
+        module = types.ModuleType(module_name)
+        child = types.ModuleType(child_name)
+        module.child = child
+        self.addCleanup(unload, module_name)
+        self.addCleanup(unload, child_name)
+        sys.modules[module_name] = module
+
+        # A plain module can expose a module-valued attribute without being a
+        # package, so from-import must return the attribute as-is.
+        ns = {}
+        exec(f'from {module_name} import child as imported', ns)
+        self.assertIs(ns['imported'], child)
+        self.assertNotIn(child_name, sys.modules)
+
     def test_from_import_star_invalid_type(self):
         with ready_to_import() as (name, path):
             with open(path, 'w', encoding='utf-8') as f:

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -29,7 +29,6 @@ import unittest
 from unittest import mock
 import _imp
 
-from test import support
 from test.support import os_helper
 from test.support import (
     STDLIB_DIR,
@@ -416,27 +415,6 @@ class ImportTests(unittest.TestCase):
             from os.path import i_dont_exist
         self.assertIn(cm.exception.name, {'posixpath', 'ntpath'})
         self.assertIsNotNone(cm.exception)
-
-    @support.requires_subprocess()
-    def test_from_import_module_attr_from_non_package(self):
-        code = textwrap.dedent("""
-            import sys
-            import types
-
-            module_name = 'test_from_import_module_attr_from_non_package'
-            child_name = f'{module_name}.child'
-            module = types.ModuleType(module_name)
-            child = types.ModuleType(child_name)
-            module.child = child
-            sys.modules[module_name] = module
-
-            # A plain module can expose a module-valued attribute without
-            # being a package, so from-import must return the attribute as-is.
-            from test_from_import_module_attr_from_non_package import child as imported
-            assert imported is child
-            assert child_name not in sys.modules, child_name
-        """)
-        script_helper.assert_python_ok("-c", code)
 
     def test_from_import_star_invalid_type(self):
         with ready_to_import() as (name, path):

--- a/Lib/test/test_lazy_import/__init__.py
+++ b/Lib/test/test_lazy_import/__init__.py
@@ -545,6 +545,36 @@ class PackageTests(LazyImportTestCase):
         """)
         assert_python_ok("-c", code)
 
+    @support.requires_subprocess()
+    def test_lazy_import_reimports_submodule_evicted_from_sys_modules(self):
+        """A submodule evicted from sys.modules but still cached on its parent
+        must be re-imported, like eager 'import a.b.c as t' is."""
+        code = textwrap.dedent("""
+            import sys
+            modname = "test.test_lazy_import.data.pkg.bar"
+            import test.test_lazy_import.data.pkg.bar
+            del sys.modules[modname]
+            lazy import test.test_lazy_import.data.pkg.bar as t
+            t.f()
+            assert modname in sys.modules, modname
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_lazy_from_import_reimports_submodule_evicted_from_sys_modules(self):
+        """Same as above for 'from a.b import c': the stale parent attribute
+        must not shadow a re-import after sys.modules eviction."""
+        code = textwrap.dedent("""
+            import sys
+            modname = "test.test_lazy_import.data.pkg.bar"
+            import test.test_lazy_import.data.pkg.bar
+            del sys.modules[modname]
+            lazy from test.test_lazy_import.data.pkg import bar
+            bar.f()
+            assert modname in sys.modules, modname
+        """)
+        assert_python_ok("-c", code)
+
 
 class DunderLazyImportTests(LazyImportTestCase):
     """Tests for __lazy_import__ builtin function."""

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-12-11-45-00.gh-issue-151408.4s9KpL.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-12-11-45-00.gh-issue-151408.4s9KpL.rst
@@ -1,0 +1,2 @@
+Fix lazy submodule imports so package submodules removed from
+:data:`sys.modules` are properly re-imported.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3123,6 +3123,60 @@ error:
     return res;
 }
 
+static PyObject *
+import_from_resolve_module_attr(PyThreadState *tstate, PyObject *package_name,
+                                PyObject *name, PyObject *attr)
+{
+    if (!PyModule_Check(attr) || package_name == NULL
+        || !PyUnicode_Check(package_name)) {
+        return Py_NewRef(attr);
+    }
+
+    PyObject *fullmodname = PyUnicode_FromFormat("%U.%U", package_name, name);
+    if (fullmodname == NULL) {
+        return NULL;
+    }
+
+    PyObject *attr_name;
+    if (PyObject_GetOptionalAttr(attr, &_Py_ID(__name__), &attr_name) < 0) {
+        Py_DECREF(fullmodname);
+        return NULL;
+    }
+
+    int matches = (attr_name != NULL && PyUnicode_Check(attr_name))
+        ? PyObject_RichCompareBool(attr_name, fullmodname, Py_EQ)
+        : 0;
+    Py_XDECREF(attr_name);
+    if (matches <= 0) {
+        /* Not the canonical submodule (matches == 0), or compare failed
+           (matches < 0, exception set). */
+        Py_DECREF(fullmodname);
+        return matches < 0 ? NULL : Py_NewRef(attr);
+    }
+
+    /* If the package still caches a submodule object after its entry was
+       removed from sys.modules, import the canonical submodule again. */
+    PyObject *submod = PyImport_GetModule(fullmodname);
+    if (submod == NULL && !_PyErr_Occurred(tstate)) {
+        PyObject *imported = PyImport_ImportModuleLevelObject(
+            fullmodname, NULL, NULL, NULL, 0);
+        if (imported == NULL) {
+            Py_DECREF(fullmodname);
+            return NULL;
+        }
+        Py_DECREF(imported);
+        submod = PyImport_GetModule(fullmodname);
+    }
+    Py_DECREF(fullmodname);
+    if (submod != NULL) {
+        return submod;
+    }
+    if (_PyErr_Occurred(tstate)) {
+        return NULL;
+    }
+    return Py_NewRef(attr);
+}
+
 PyObject *
 _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
 {
@@ -3130,6 +3184,17 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
     PyObject *fullmodname, *mod_name, *origin, *mod_name_or_unknown, *errmsg, *spec;
 
     if (PyObject_GetOptionalAttr(v, name, &x) != 0) {
+        if (x != NULL && PyModule_Check(x)) {
+            PyObject *resolved;
+            if (PyObject_GetOptionalAttr(v, &_Py_ID(__name__), &mod_name) < 0) {
+                Py_DECREF(x);
+                return NULL;
+            }
+            resolved = import_from_resolve_module_attr(tstate, mod_name, name, x);
+            Py_XDECREF(mod_name);
+            Py_DECREF(x);
+            return resolved;
+        }
         return x;
     }
     /* Issue #17636: in case this failed because of a circular relative
@@ -3311,8 +3376,11 @@ _PyEval_LazyImportFrom(PyThreadState *tstate, _PyInterpreterFrame *frame, PyObje
                     return NULL;
                 }
                 if (ret != NULL) {
+                    PyObject *resolved = import_from_resolve_module_attr(
+                        tstate, d->lz_from, name, ret);
+                    Py_DECREF(ret);
                     Py_DECREF(mod);
-                    return ret;
+                    return resolved;
                 }
             }
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3132,6 +3132,25 @@ import_from_resolve_module_attr(PyThreadState *tstate, PyObject *package_name,
         return Py_NewRef(attr);
     }
 
+    /* Only packages can legitimately republish importable submodules here.
+       Plain modules may expose arbitrary module-valued attributes. */
+    PyObject *package = PyImport_GetModule(package_name);
+    if (package == NULL) {
+        if (_PyErr_Occurred(tstate)) {
+            return NULL;
+        }
+        return Py_NewRef(attr);
+    }
+
+    int is_package = PyObject_HasAttrWithError(package, &_Py_ID(__path__));
+    Py_DECREF(package);
+    if (is_package <= 0) {
+        if (is_package < 0) {
+            return NULL;
+        }
+        return Py_NewRef(attr);
+    }
+
     PyObject *fullmodname = PyUnicode_FromFormat("%U.%U", package_name, name);
     if (fullmodname == NULL) {
         return NULL;
@@ -3190,6 +3209,8 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
                 Py_DECREF(x);
                 return NULL;
             }
+            /* If this is a cached submodule, resolve it through sys.modules
+               so from-import repairs stale package entries. */
             resolved = import_from_resolve_module_attr(tstate, mod_name, name, x);
             Py_XDECREF(mod_name);
             Py_DECREF(x);
@@ -3366,8 +3387,8 @@ _PyEval_LazyImportFrom(PyThreadState *tstate, _PyInterpreterFrame *frame, PyObje
     PyLazyImportObject *d = (PyLazyImportObject *)v;
     PyObject *mod = PyImport_GetModule(d->lz_from);
     if (mod != NULL) {
-        // Check if the module already has the attribute, if so, resolve it
-        // eagerly.
+        /* If the parent is already imported, resolve any module-valued
+           attribute through the same stale-submodule check. */
         if (PyModule_Check(mod)) {
             PyObject *mod_dict = PyModule_GetDict(mod);
             if (mod_dict != NULL) {

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3123,79 +3123,6 @@ error:
     return res;
 }
 
-static PyObject *
-import_from_resolve_module_attr(PyThreadState *tstate, PyObject *package_name,
-                                PyObject *name, PyObject *attr)
-{
-    if (!PyModule_Check(attr) || package_name == NULL
-        || !PyUnicode_Check(package_name)) {
-        return Py_NewRef(attr);
-    }
-
-    /* Only packages can legitimately republish importable submodules here.
-       Plain modules may expose arbitrary module-valued attributes. */
-    PyObject *package = PyImport_GetModule(package_name);
-    if (package == NULL) {
-        if (_PyErr_Occurred(tstate)) {
-            return NULL;
-        }
-        return Py_NewRef(attr);
-    }
-
-    int is_package = PyObject_HasAttrWithError(package, &_Py_ID(__path__));
-    Py_DECREF(package);
-    if (is_package <= 0) {
-        if (is_package < 0) {
-            return NULL;
-        }
-        return Py_NewRef(attr);
-    }
-
-    PyObject *fullmodname = PyUnicode_FromFormat("%U.%U", package_name, name);
-    if (fullmodname == NULL) {
-        return NULL;
-    }
-
-    PyObject *attr_name;
-    if (PyObject_GetOptionalAttr(attr, &_Py_ID(__name__), &attr_name) < 0) {
-        Py_DECREF(fullmodname);
-        return NULL;
-    }
-
-    int matches = (attr_name != NULL && PyUnicode_Check(attr_name))
-        ? PyObject_RichCompareBool(attr_name, fullmodname, Py_EQ)
-        : 0;
-    Py_XDECREF(attr_name);
-    if (matches <= 0) {
-        /* Not the canonical submodule (matches == 0), or compare failed
-           (matches < 0, exception set). */
-        Py_DECREF(fullmodname);
-        return matches < 0 ? NULL : Py_NewRef(attr);
-    }
-
-    /* If the package still caches a submodule object after its entry was
-       removed from sys.modules, import the canonical submodule again. */
-    PyObject *submod = PyImport_GetModule(fullmodname);
-    if (submod == NULL && !_PyErr_Occurred(tstate)) {
-        PyObject *imported = PyImport_ImportModuleLevelObject(
-            fullmodname, NULL, NULL, NULL, 0);
-        if (imported == NULL) {
-            Py_DECREF(fullmodname);
-            return NULL;
-        }
-        Py_DECREF(imported);
-        submod = PyImport_GetModule(fullmodname);
-    }
-    Py_DECREF(fullmodname);
-    if (submod != NULL) {
-        return submod;
-    }
-    if (_PyErr_Occurred(tstate)) {
-        return NULL;
-    }
-    return Py_NewRef(attr);
-}
-
 PyObject *
 _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
 {
@@ -3203,19 +3130,6 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
     PyObject *fullmodname, *mod_name, *origin, *mod_name_or_unknown, *errmsg, *spec;
 
     if (PyObject_GetOptionalAttr(v, name, &x) != 0) {
-        if (x != NULL && PyModule_Check(x)) {
-            PyObject *resolved;
-            if (PyObject_GetOptionalAttr(v, &_Py_ID(__name__), &mod_name) < 0) {
-                Py_DECREF(x);
-                return NULL;
-            }
-            /* If this is a cached submodule, resolve it through sys.modules
-               so from-import repairs stale package entries. */
-            resolved = import_from_resolve_module_attr(tstate, mod_name, name, x);
-            Py_XDECREF(mod_name);
-            Py_DECREF(x);
-            return resolved;
-        }
         return x;
     }
     /* Issue #17636: in case this failed because of a circular relative
@@ -3397,7 +3311,7 @@ _PyEval_LazyImportFrom(PyThreadState *tstate, _PyInterpreterFrame *frame, PyObje
                     return NULL;
                 }
                 if (ret != NULL) {
-                    PyObject *resolved = import_from_resolve_module_attr(
+                    PyObject *resolved = _PyImport_ResolveLazyImportFromAttr(
                         tstate, d->lz_from, name, ret);
                     Py_DECREF(ret);
                     Py_DECREF(mod);

--- a/Python/import.c
+++ b/Python/import.c
@@ -3886,6 +3886,76 @@ _PyImport_ResolveName(PyThreadState *tstate, PyObject *name,
 }
 
 PyObject *
+_PyImport_ResolveLazyImportFromAttr(PyThreadState *tstate,
+                                    PyObject *package_name,
+                                    PyObject *name, PyObject *attr)
+{
+    /* Lazy from-imports repair evicted package submodules without
+       changing eager from-import behavior. */
+    if (!PyModule_Check(attr) || package_name == NULL
+        || !PyUnicode_Check(package_name)) {
+        return Py_NewRef(attr);
+    }
+
+    PyObject *package = PyImport_GetModule(package_name);
+    if (package == NULL) {
+        if (_PyErr_Occurred(tstate)) {
+            return NULL;
+        }
+        return Py_NewRef(attr);
+    }
+
+    int is_package = PyObject_HasAttrWithError(package, &_Py_ID(__path__));
+    Py_DECREF(package);
+    if (is_package <= 0) {
+        if (is_package < 0) {
+            return NULL;
+        }
+        return Py_NewRef(attr);
+    }
+
+    PyObject *fullmodname = PyUnicode_FromFormat("%U.%U", package_name, name);
+    if (fullmodname == NULL) {
+        return NULL;
+    }
+
+    PyObject *attr_name;
+    if (PyObject_GetOptionalAttr(attr, &_Py_ID(__name__), &attr_name) < 0) {
+        Py_DECREF(fullmodname);
+        return NULL;
+    }
+
+    int matches = (attr_name != NULL && PyUnicode_Check(attr_name))
+        ? PyObject_RichCompareBool(attr_name, fullmodname, Py_EQ)
+        : 0;
+    Py_XDECREF(attr_name);
+    if (matches <= 0) {
+        Py_DECREF(fullmodname);
+        return matches < 0 ? NULL : Py_NewRef(attr);
+    }
+
+    PyObject *submod = import_get_module(tstate, fullmodname);
+    if (submod == NULL && !_PyErr_Occurred(tstate)) {
+        PyObject *imported = PyImport_ImportModuleLevelObject(
+            fullmodname, NULL, NULL, NULL, 0);
+        if (imported == NULL) {
+            Py_DECREF(fullmodname);
+            return NULL;
+        }
+        Py_DECREF(imported);
+        submod = import_get_module(tstate, fullmodname);
+    }
+    Py_DECREF(fullmodname);
+    if (submod != NULL) {
+        return submod;
+    }
+    if (_PyErr_Occurred(tstate)) {
+        return NULL;
+    }
+    return Py_NewRef(attr);
+}
+
+PyObject *
 _PyImport_LoadLazyImportTstate(PyThreadState *tstate, PyObject *lazy_import)
 {
     PyObject *obj = NULL;
@@ -4004,7 +4074,20 @@ _PyImport_LoadLazyImportTstate(PyThreadState *tstate, PyObject *lazy_import)
 
     if (lz->lz_attr != NULL && PyUnicode_Check(lz->lz_attr)) {
         PyObject *from = obj;
-        obj = _PyEval_ImportFrom(tstate, from, lz->lz_attr);
+        obj = NULL;
+        PyObject *attr;
+        if (PyObject_GetOptionalAttr(from, lz->lz_attr, &attr) < 0) {
+            Py_DECREF(from);
+            goto error;
+        }
+        if (attr != NULL) {
+            obj = _PyImport_ResolveLazyImportFromAttr(
+                tstate, lz->lz_from, lz->lz_attr, attr);
+            Py_DECREF(attr);
+        }
+        else {
+            obj = _PyEval_ImportFrom(tstate, from, lz->lz_attr);
+        }
         Py_DECREF(from);
         if (obj == NULL) {
             goto error;


### PR DESCRIPTION
**Fix**
This PR ensures that a submodule is fully re-imported instead of relying on pre-existing cached submodule objects. 

**Testing**
This PR adds several tests for TDD that fail prior to the `ceval.c` changes.
Also, after this PR lands-- `test_trace` no longer fails with `lazy_imports=all` as documented in the attached issue. 

https://github.com/python/cpython/issues/151408

<!-- gh-issue-number: gh-151408 -->
* Issue: gh-151408
<!-- /gh-issue-number -->
