### PR TITLE
gh-146353: Document PyBytesWriter_GetData pointer validity

### DIFF
--- a/Doc/c-api/bytes.rst
+++ b/Doc/c-api/bytes.rst
@@ -384,14 +384,18 @@ Getters
 
    Get the writer size.
 
+   The function does not invalidate pointers returned by
+   :c:func:`PyBytesWriter_GetData`.
+
    The function cannot fail.
 
 .. c:function:: void* PyBytesWriter_GetData(PyBytesWriter *writer)
 
    Get the writer data: start of the internal buffer.
 
-   The pointer is valid until :c:func:`PyBytesWriter_Finish` or
-   :c:func:`PyBytesWriter_Discard` is called on *writer*.
+   The pointer remains valid until a :c:type:`PyBytesWriter` function other
+   than :c:func:`PyBytesWriter_GetData` or :c:func:`PyBytesWriter_GetSize` is
+   called on *writer*.
 
    The function cannot fail.
 


### PR DESCRIPTION
Clarifies the pointer-lifetime guarantees in the `PyBytesWriter` C-API docs:

- `PyBytesWriter_GetData()`: the returned pointer stays valid until a `PyBytesWriter` function *other than* `GetData`/`GetSize` is called on the writer. The old wording named only `Finish`/`Discard`, which wrongly implied resizing operations were safe.
- `PyBytesWriter_GetSize()`: now notes that it does not invalidate a pointer previously returned by `GetData()`.

Docs-only.

Disclosure: AI-assisted wording; reviewed by me.

<!-- gh-issue-number: gh-146353 -->
* Issue: gh-146353
<!-- /gh-issue-number -->
