### PR TITLE
gh-124113: Clarify venv target directory reuse

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -77,9 +77,9 @@ containing a copy or symlink of the Python executable
 It also creates a :file:`lib/pythonX.Y/site-packages` subdirectory
 (on Windows, this is :file:`Lib\\site-packages`).
 If an existing directory is specified, it will be re-used.
-This does not leave the directory unchanged: ``venv`` creates or replaces
-environment files in the target directory. Use a dedicated directory for the
-virtual environment, and avoid placing project files in it.
+Reusing an existing directory does not leave it unchanged: ``venv`` may create,
+update, or replace files in the target directory. Use a dedicated directory for
+the virtual environment, and avoid placing project files directly inside it.
 
 .. versionchanged:: 3.5
    The use of ``venv`` is now recommended for creating virtual environments.

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -130,6 +130,7 @@ The command, if run with ``-h``, will show the available options::
 .. option:: --clear
 
    Delete all contents of the environment directory if it already exists,
+   including files that were not created by ``venv``,
    before environment creation.
 
 .. option:: --upgrade

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -77,6 +77,9 @@ containing a copy or symlink of the Python executable
 It also creates a :file:`lib/pythonX.Y/site-packages` subdirectory
 (on Windows, this is :file:`Lib\\site-packages`).
 If an existing directory is specified, it will be re-used.
+This does not leave the directory unchanged: ``venv`` creates or replaces
+environment files in the target directory. Use a dedicated directory for the
+virtual environment, and avoid placing project files in it.
 
 .. versionchanged:: 3.5
    The use of ``venv`` is now recommended for creating virtual environments.
@@ -126,7 +129,8 @@ The command, if run with ``-h``, will show the available options::
 
 .. option:: --clear
 
-   Delete the contents of the environment directory if it already exists, before environment creation.
+   Delete all contents of the environment directory if it already exists,
+   before environment creation.
 
 .. option:: --upgrade
 


### PR DESCRIPTION
Clarifies the `venv` docs for the case where the target directory already exists:

- an existing directory is reused, not rejected;
- reuse doesn't leave the directory untouched — `venv` may create, update, or replace files in it, so a dedicated directory is best;
- `--clear` deletes *all* contents of the target directory (including files venv didn't create) before creating the environment.

Docs-only, no behavior change. Per the maintainer direction in gh-135604, the intended fix here is this clarification rather than a behavior change.

Disclosure: AI-assisted wording; I've reviewed it.

<!-- gh-issue-number: gh-124113 -->
* Issue: gh-124113
<!-- /gh-issue-number -->
