### PR TITLE
gh-145177: Bump emscripten to 5.0.4

### DIFF
--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -534,7 +534,20 @@ class PlatformTest(unittest.TestCase):
 
     def test_libc_ver(self):
         if support.is_emscripten:
-            assert platform.libc_ver() == ("emscripten", "4.0.19")
+            import tomllib
+            from pathlib import Path
+
+            # Get expected emscripten version from emscripten config
+            config_path = (
+                Path(__file__).parents[2] / "Platforms/emscripten/config.toml"
+            )
+            with open(config_path, "rb") as fp:
+                emscripten_version = tomllib.load(fp)["emscripten-version"]
+
+            self.assertEqual(
+                platform.libc_ver(), ("emscripten", emscripten_version)
+            )
+
             return
         # check that libc_ver(executable) doesn't raise an exception
         if os.path.isdir(sys.executable) and \

--- a/Platforms/emscripten/config.toml
+++ b/Platforms/emscripten/config.toml
@@ -1,7 +1,7 @@
 # Any data that can vary between Python versions is to be kept in this file.
 # This allows for blanket copying of the Emscripten build code between supported
 # Python versions.
-emscripten-version = "4.0.19"
+emscripten-version = "5.0.4"
 node-version = "24"
 test-args = [
     "-m", "test",


### PR DESCRIPTION
Before Emscripten 4.0.19, there was a bug in the dynamic loader that caused any
dynamic library that links libffi to fail to load. _ctypes_test.so unnecessarily
links libffi so it would fail to load and tests that needed it were skipped.

There are two test failures behind that: one involving stack overflows which
we have to skip as usual, and one that assumes that the abi for a function
that takes a single struct with two doubles is the same as the abi for a
function that takes two double arguments. This is not true in webassembly so we
skip the test.

There is another regression in Emscripten 5.0.5 which breaks a couple tests in
test_secrets and test_random, so I'm leaving updating past that to a followup.

Ideally #151423 should merge before this.

<!-- gh-issue-number: gh-145177 -->
* Issue: gh-145177
<!-- /gh-issue-number -->
