### PR TITLE
gh-151422: Don't link libffi into _ctypes_test.so

### DIFF
--- a/Lib/test/test_ctypes/test_as_parameter.py
+++ b/Lib/test/test_ctypes/test_as_parameter.py
@@ -5,7 +5,7 @@ from ctypes import (Structure, CDLL, CFUNCTYPE,
                     c_short, c_int, c_long, c_longlong,
                     c_byte, c_wchar, c_float, c_double,
                     ArgumentError)
-from test.support import import_helper, skip_if_sanitizer
+from test.support import import_helper, skip_if_sanitizer, skip_emscripten_stack_overflow
 _ctypes_test = import_helper.import_module("_ctypes_test")
 
 
@@ -193,6 +193,7 @@ class BasicWrapTestCase(unittest.TestCase):
                              (9*2, 8*3, 7*4, 6*5, 5*6, 4*7, 3*8, 2*9))
 
     @skip_if_sanitizer('requires deep stack', thread=True)
+    @skip_emscripten_stack_overflow()
     def test_recursive_as_param(self):
         class A:
             pass

--- a/Lib/test/test_ctypes/test_structures.py
+++ b/Lib/test/test_ctypes/test_structures.py
@@ -299,17 +299,15 @@ class StructureTestCase(unittest.TestCase, StructCheckMixin):
         self.assertEqual(s.first, got.first)
         self.assertEqual(s.second, got.second)
 
+    @unittest.skipIf(support.is_wasm32, "wasm ABI is incompatible with test expectations")
     def _test_issue18060(self, Vector):
         # Regression tests for gh-62260
 
-        # This test passes a struct of two doubles by value to the atan2(),
-        # whose actual C signature is atan2(double, double), so it only works on
-        # platforms where the abi of a function that takes a struct with two
-        # doubles matches the abi of a function that takes two doubles. The
-        # wasm32 ABI does not satisfy this condition and the test breaks.
-        if support.is_wasm32:
-            self.skipTest(
-                "wasm ABI is incompatible with test expectations")
+        # This test passes a struct of two doubles by value to atan2(), whose C
+        # signature is atan2(double, double), so it only works on platforms
+        # where the abi of a function that takes a struct with two doubles
+        # matches the abi of a function that takes two doubles. The wasm32 ABI
+        # does not satisfy this condition and the test breaks.
 
         # The call to atan2() should succeed if the
         # class fields were correctly cloned in the

--- a/Lib/test/test_ctypes/test_structures.py
+++ b/Lib/test/test_ctypes/test_structures.py
@@ -302,6 +302,15 @@ class StructureTestCase(unittest.TestCase, StructCheckMixin):
     def _test_issue18060(self, Vector):
         # Regression tests for gh-62260
 
+        # This test passes a struct of two doubles by value to the atan2(),
+        # whose actual C signature is atan2(double, double), so it only works on
+        # platforms where the abi of a function that takes a struct with two
+        # doubles matches the abi of a function that takes two doubles. The
+        # wasm32 ABI does not satisfy this condition and the test breaks.
+        if support.is_wasm32:
+            self.skipTest(
+                "wasm ABI is incompatible with test expectations")
+
         # The call to atan2() should succeed if the
         # class fields were correctly cloned in the
         # subclasses. Otherwise, it will segfault.

--- a/configure
+++ b/configure
@@ -35116,8 +35116,8 @@ fi
   if test "x$py_cv_module__ctypes_test" = xyes
 then :
 
-    as_fn_append MODULE_BLOCK "MODULE__CTYPES_TEST_CFLAGS=$LIBFFI_CFLAGS$as_nl"
-    as_fn_append MODULE_BLOCK "MODULE__CTYPES_TEST_LDFLAGS=$LIBFFI_LIBS $LIBM$as_nl"
+
+    as_fn_append MODULE_BLOCK "MODULE__CTYPES_TEST_LDFLAGS=$LIBM$as_nl"
 
 fi
    if test "$py_cv_module__ctypes_test" = yes; then

--- a/configure.ac
+++ b/configure.ac
@@ -8447,9 +8447,11 @@ PY_STDLIB_MOD([_testmultiphase], [test "$TEST_MODULES" = yes], [test "$ac_cv_fun
 PY_STDLIB_MOD([_testsinglephase], [test "$TEST_MODULES" = yes], [test "$ac_cv_func_dlopen" = yes])
 PY_STDLIB_MOD([xxsubtype], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([_xxtestfuzz], [test "$TEST_MODULES" = yes])
+dnl Check have_libffi so _ctypes_test is only built if _ctypes is built.
+dnl _ctypes_test doesn't use libffi directly.
 PY_STDLIB_MOD([_ctypes_test],
   [test "$TEST_MODULES" = yes], [test "$have_libffi" = yes -a "$ac_cv_func_dlopen" = yes],
-  [$LIBFFI_CFLAGS], [$LIBFFI_LIBS $LIBM])
+  [], [$LIBM])
 
 dnl Limited API template modules.
 dnl Emscripten does not support shared libraries yet.


### PR DESCRIPTION
Minor build fix. This makes the ctypes tests run on Emscripten. 

There is a bug in the Emscripten dynamic loader that caused any dynamic library that links libffi to fail to load. _ctypes_test.so unnecessarily links libffi so it would fail to load and tests that needed it were skipped.

There are two test failures behind that: one involving stack overflows which we have to skip as usual, and one that assumes that the abi for a function that takes a single struct with two doubles is the same as the abi for a function that takes two double arguments. This is not true in webassembly so we skip the test.

<!-- gh-issue-number: gh-151422 -->
* Issue: gh-151422
<!-- /gh-issue-number -->
