### PR TITLE
gh-137528: Document the co_linetable code object attribute

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1489,6 +1489,7 @@ indirectly) to mutable objects.
    single: co_consts (code object attribute)
    single: co_filename (code object attribute)
    single: co_firstlineno (code object attribute)
+   single: co_linetable (code object attribute)
    single: co_flags (code object attribute)
    single: co_name (code object attribute)
    single: co_names (code object attribute)
@@ -1561,6 +1562,16 @@ Special read-only attributes
 
    * - .. attribute:: codeobject.co_firstlineno
      - The line number of the first line of the function
+
+   * - .. attribute:: codeobject.co_linetable
+     - A :class:`bytes` object containing encoded source location information.
+       The exact format is an implementation detail and may change between
+       Python versions. It is made available to support the creation of new
+       code objects; use :meth:`~codeobject.co_lines` and
+       :meth:`~codeobject.co_positions` for supported access to line and
+       position information.
+
+       .. versionadded:: 3.10
 
    * - .. attribute:: codeobject.co_stacksize
      - The required stack size of the code object


### PR DESCRIPTION
Documents the previously undocumented `codeobject.co_linetable` attribute in the data model reference. The entry states that it is a `bytes` object containing encoded source-location information, notes that the exact format is an implementation detail that may change between versions, points readers to `co_lines()` and `co_positions()` for supported access, and recommends `codeobject.replace()` for creating a modified copy. It also records that the attribute was added in Python 3.10.

Docs-only.

Disclosure: AI-assisted wording; reviewed by me.

<!-- gh-issue-number: gh-137528 -->
* Issue: gh-137528
<!-- /gh-issue-number -->
