### PR TITLE
gh-151424: Fix impossible stack traces in `RemoteUnwinder(..., cache_frames=True)` by copying chunks on cache miss

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-13-04-11-00.gh-issue-151426.f2V67e.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-13-04-11-00.gh-issue-151426.f2V67e.rst
@@ -1,4 +1,4 @@
 Fix impossible stack traces (callers and callees cross called, orphans and
-incorrect lines) in the Tachyon profiler, by snapshotting the stack chunks
-before walking the frame chain on a cache miss. Patch by Maurycy
-Pawłowski-Wieroński.
+incorrect lines) in the Tachyon profiler when caching frames, by snapshotting
+the stack chunks before walking the frame chain on a cache miss. Patch by
+Maurycy Pawłowski-Wieroński.

--- a/Misc/NEWS.d/next/Library/2026-06-13-04-11-00.gh-issue-151426.f2V67e.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-13-04-11-00.gh-issue-151426.f2V67e.rst
@@ -1,0 +1,4 @@
+Fix impossible stack traces (callers and callees cross called, orphans and
+incorrect lines) in the Tachyon profiler, by snapshotting the stack chunks
+before walking the frame chain on a cache miss. Patch by Maurycy
+Pawłowski-Wieroński.

--- a/Modules/_remote_debugging/frames.c
+++ b/Modules/_remote_debugging/frames.c
@@ -580,6 +580,14 @@ collect_frames_with_cache(
         return full_hit < 0 ? -1 : 0;
     }
 
+    assert(ctx->chunks != NULL);
+
+    if (ctx->chunks->count == 0) {
+        if (copy_stack_chunks(unwinder, ctx->thread_state_addr, ctx->chunks) < 0) {
+            PyErr_Clear();
+        }
+    }
+
     Py_ssize_t frames_before = PyList_GET_SIZE(ctx->frame_info);
 
     if (process_frame_chain(unwinder, ctx) < 0) {


### PR DESCRIPTION
The issue is caused by memory walks with `cache_frames=True` when there's a cache miss.

If I understand the whole machniery correctly.

Basically, we don't copy chunks in cache mode:

https://github.com/python/cpython/blob/f4f102027a9b0edc72a048f17b696aa92d2e6893/Modules/_remote_debugging/threads.c#L506-L512

So there are never any chunks in the cache mode, not a problem with full cache hits:

https://github.com/python/cpython/blob/f4f102027a9b0edc72a048f17b696aa92d2e6893/Modules/_remote_debugging/frames.c#L328-L351

But when there's no cache hit:

https://github.com/python/cpython/blob/f4f102027a9b0edc72a048f17b696aa92d2e6893/Modules/_remote_debugging/frames.c#L578-L585

it falls back to many memory reads:

https://github.com/python/cpython/blob/f4f102027a9b0edc72a048f17b696aa92d2e6893/Modules/_remote_debugging/frames.c#L315

https://github.com/python/cpython/blob/f4f102027a9b0edc72a048f17b696aa92d2e6893/Modules/_remote_debugging/frames.c#L236-L242

which isn't very atomic... the target mutates between reads and we're lost.

That's definitely the cause. Is there a cleaner fix ?

One side-note - let's not tighten the validation yet?

Generally, it's a statistical profiler so we should have some statistical tests for correctness, too.

# Proof

Reusing 

```python
def leaf_a(): return sum(range(50))
def leaf_b(): return sum(range(50))
def hot_a(): return leaf_a()
def hot_b(): return leaf_b()
while True:
    hot_a(); hot_b();
```

from #151424 we get

```bash
2026-06-13T03:14:37.706845000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (gh-151424 141f623*?) % sudo ./python.exe -m profiling.sampling run --collapsed -o /tmp/stacks.txt -d 10 repro.py
Captured 10,000 samples in 10.00 seconds
Sample rate: 999.99 samples/sec
Error rate: 14.91
Collapsed stack output written to /tmp/stacks.txt
2026-06-13T03:14:51.568490000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (gh-151424 141f623*?) % cat /tmp/stacks.txt 
tid:13199240;<frozen runpy>:_run_module_as_main:201;<frozen runpy>:_run_code:87;repro.py:<module>:6;repro.py:hot_a:3;repro.py:leaf_a:1 3324
tid:13199240;<frozen runpy>:_run_module_as_main:201;<frozen runpy>:_run_code:87;repro.py:<module>:6;repro.py:hot_b:4;repro.py:leaf_b:2 3269
tid:13199240;<frozen runpy>:_run_module_as_main:201;<frozen runpy>:_run_code:87;repro.py:<module>:6 1234
tid:13199240;<frozen runpy>:_run_module_as_main:201;<frozen runpy>:_run_code:87;repro.py:<module>:6;repro.py:hot_a:3 341
tid:13199240;<frozen runpy>:_run_module_as_main:201;<frozen runpy>:_run_code:87;repro.py:<module>:6;repro.py:hot_b:4 324
tid:13199240;<frozen runpy>:_run_module_as_main:201;<frozen runpy>:_run_code:87;repro.py:<module>:6;repro.py:hot_b:4;repro.py:leaf_b:-1 8
tid:13199240;<frozen runpy>:_run_module_as_main:201;<frozen runpy>:_run_code:87;repro.py:<module>:6;repro.py:hot_a:3;repro.py:leaf_a:-1 6
tid:13199240;<frozen runpy>:_run_module_as_main:201;<frozen runpy>:_run_code:87;repro.py:<module>:6;repro.py:hot_a:3;repro.py:leaf_b:2 1
tid:13199240;<frozen runpy>:_run_module_as_main:201;<frozen runpy>:_run_code:87;repro.py:<module>:6;repro.py:leaf_a:1 1
tid:13199240;<frozen runpy>:_run_module_as_main:201;<frozen runpy>:_run_code:87;repro.py:<module>:6;repro.py:leaf_b:2 1
2026-06-13T03:15:14.324823000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (gh-151424 141f623*?) % 
```

The impossible rate went to just 0,20%.

<!-- gh-issue-number: gh-151424 -->
* Issue: gh-151424
<!-- /gh-issue-number -->
