### PR TITLE
gh-151443: Fix documented default of read_data in unittest.mock.mock_open

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2539,7 +2539,7 @@ Alternatively you can just use ``vars(my_mock)`` (instance members) and
 mock_open
 ~~~~~~~~~
 
-.. function:: mock_open(mock=None, read_data=None)
+.. function:: mock_open(mock=None, read_data='')
 
    A helper function to create a mock to replace the use of :func:`open`. It works
    for :func:`open` called directly or used as a context manager.


### PR DESCRIPTION
The documented signature of `unittest.mock.mock_open` shows `read_data=None`, but the real default is the empty string `''`:

- `Lib/unittest/mock.py`: `def mock_open(mock=None, read_data=''):`
- the function's own docstring ("This is an empty string by default")
- `inspect.signature(mock_open)` -> `(mock=None, read_data='')`

The default was changed from `None` to `''` in 2012 (`0dccf657b51`); the documentation was never updated. This corrects the signature in the docs.

Documentation-only change, so no `Misc/NEWS.d` entry is included.

<!-- gh-issue-number: gh-151443 -->
* Issue: gh-151443
<!-- /gh-issue-number -->
