### PR TITLE
gh-132312: Significantly reduce thread state lookups in the interpreter

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -388,6 +388,45 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
     } while (0)
 #endif
 
+#ifdef _Py_TYPEOF
+#define _Py_SETREF(tstate, dst, src) \
+    do { \
+        _Py_TYPEOF(dst)* _tmp_dst_ptr = &(dst); \
+        _Py_TYPEOF(dst) _tmp_old_dst = (*_tmp_dst_ptr); \
+        *_tmp_dst_ptr = (src); \
+        _Py_DECREF(tstate, _tmp_old_dst); \
+    } while (0)
+#else
+#define _Py_SETREF(tstate, dst, src) \
+    do { \
+        PyObject **_tmp_dst_ptr = _Py_CAST(PyObject**, &(dst)); \
+        PyObject *_tmp_old_dst = (*_tmp_dst_ptr); \
+        PyObject *_tmp_src = _PyObject_CAST(src); \
+        memcpy(_tmp_dst_ptr, &_tmp_src, sizeof(PyObject*)); \
+        _Py_DECREF(tstate, _tmp_old_dst); \
+    } while (0)
+#endif
+
+
+#ifdef _Py_TYPEOF
+#define _Py_XSETREF(tstate, dst, src) \
+    do { \
+        _Py_TYPEOF(dst)* _tmp_dst_ptr = &(dst); \
+        _Py_TYPEOF(dst) _tmp_old_dst = (*_tmp_dst_ptr); \
+        *_tmp_dst_ptr = (src); \
+        _Py_XDECREF(tstate, _tmp_old_dst); \
+    } while (0)
+#else
+#define _Py_XSETREF(tstate, dst, src) \
+    do { \
+        PyObject **_tmp_dst_ptr = _Py_CAST(PyObject**, &(dst)); \
+        PyObject *_tmp_old_dst = (*_tmp_dst_ptr); \
+        PyObject *_tmp_src = _PyObject_CAST(src); \
+        memcpy(_tmp_dst_ptr, &_tmp_src, sizeof(PyObject*)); \
+        _Py_XDECREF(tstate, _tmp_old_dst); \
+    } while (0)
+#endif
+
 
 /* Define a pair of assertion macros:
    _PyObject_ASSERT_FROM(), _PyObject_ASSERT_WITH_MSG() and _PyObject_ASSERT().

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -317,9 +317,9 @@ PyAPI_FUNC(void) PyUnstable_Object_ClearWeakRefsNoCallbacks(PyObject *);
 /* Same as PyObject_Generic{Get,Set}Attr, but passing the attributes
    dict as the last parameter. */
 PyAPI_FUNC(PyObject *)
-_PyObject_GenericGetAttrWithDict(PyObject *, PyObject *, PyObject *, int);
+_PyObject_GenericGetAttrWithDict(PyThreadState *, PyObject *, PyObject *, PyObject *, int);
 PyAPI_FUNC(int)
-_PyObject_GenericSetAttrWithDict(PyObject *, PyObject *,
+_PyObject_GenericSetAttrWithDict(PyThreadState *, PyObject *, PyObject *,
                                  PyObject *, PyObject *);
 
 PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);

--- a/Include/internal/pycore_call.h
+++ b/Include/internal/pycore_call.h
@@ -179,10 +179,6 @@ PyAPI_FUNC(void) _PyStack_UnpackDict_FreeNoDecRef(
 PyAPI_FUNC(PyObject *)
 _PyObject_CallOneArgTstate(PyThreadState *tstate, PyObject *func, PyObject *arg);
 
-PyAPI_FUNC(PyObject *)
-_PyObject_Call(PyThreadState *tstate, PyObject *callable,
-               PyObject *args, PyObject *kwargs);
-
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_call.h
+++ b/Include/internal/pycore_call.h
@@ -176,6 +176,13 @@ PyAPI_FUNC(void) _PyStack_UnpackDict_FreeNoDecRef(
     PyObject *const *stack,
     PyObject *kwnames);
 
+PyAPI_FUNC(PyObject *)
+_PyObject_CallOneArgTstate(PyThreadState *tstate, PyObject *func, PyObject *arg);
+
+PyAPI_FUNC(PyObject *)
+_PyObject_Call(PyThreadState *tstate, PyObject *callable,
+               PyObject *args, PyObject *kwargs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_call.h
+++ b/Include/internal/pycore_call.h
@@ -46,7 +46,7 @@ extern PyObject* _PyObject_VectorcallDictTstate(
     size_t nargsf,
     PyObject *kwargs);
 
-extern PyObject* _PyObject_Call(
+PyAPI_FUNC(PyObject*) _PyObject_Call(
     PyThreadState *tstate,
     PyObject *callable,
     PyObject *args,

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -411,6 +411,7 @@ PyAPI_DATA(const _Py_CODEUNIT *) _Py_INTERPRETER_TRAMPOLINE_INSTRUCTIONS_PTR;
 
 PyAPI_FUNC(PyObject *)
 _Py_VectorCall_StackRefSteal(
+    PyThreadState *tstate,
     _PyStackRef callable,
     _PyStackRef *arguments,
     int total_args,

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -328,7 +328,7 @@ PyAPI_FUNC(PyObject *) _PyEval_GetAwaitable(PyObject *iterable, int oparg);
 PyAPI_FUNC(PyObject *) _PyEval_LoadName(PyThreadState *tstate, _PyInterpreterFrame *frame, PyObject *name);
 PyAPI_FUNC(int)
 _Py_Check_ArgsIterable(PyThreadState *tstate, PyObject *func, PyObject *args);
-PyAPI_FUNC(_PyStackRef) _PyEval_GetIter(_PyStackRef iterable, _PyStackRef *null_or_index, int yield_from);
+PyAPI_FUNC(_PyStackRef) _PyEval_GetIter(PyThreadState *tstate, _PyStackRef iterable, _PyStackRef *null_or_index, int yield_from);
 
 /*
  * Indicate whether a special method of given 'oparg' can use the (improved)

--- a/Include/internal/pycore_moduleobject.h
+++ b/Include/internal/pycore_moduleobject.h
@@ -77,7 +77,7 @@ extern Py_ssize_t _PyModule_GetFilenameUTF8(
         char *buffer,
         Py_ssize_t maxlen);
 
-PyObject* _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress);
+PyObject* _Py_module_getattro_impl(PyThreadState *tstate, PyModuleObject *m, PyObject *name, int suppress);
 PyObject* _Py_module_getattro(PyObject *m, PyObject *name);
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -854,7 +854,7 @@ _PyType_PreHeaderSize(PyTypeObject *tp)
     );
 }
 
-void _PyObject_GC_Link(PyObject *op);
+void _PyObject_GC_Link(PyThreadState *tstate, PyObject *op);
 
 // Usage: assert(_Py_CheckSlotResult(obj, "__getitem__", result != NULL));
 extern int _Py_CheckSlotResult(
@@ -874,7 +874,7 @@ extern PyTypeObject* _PyType_CalculateMetaclass(PyTypeObject *, PyObject *);
 extern PyObject* _PyType_GetDocFromInternalDoc(const char *, const char *);
 extern PyObject* _PyType_GetTextSignatureFromInternalDoc(const char *, const char *, int);
 // Exported for external JIT support
-PyAPI_FUNC(int) _PyObject_SetAttributeErrorContext(PyObject *v, PyObject* name);
+PyAPI_FUNC(int) _PyObject_SetAttributeErrorContext(PyThreadState *tstate, PyObject *v, PyObject* name);
 
 void _PyObject_InitInlineValues(PyObject *obj, PyTypeObject *tp);
 extern int _PyObject_StoreInstanceAttribute(PyObject *obj,
@@ -896,7 +896,7 @@ extern int _PyObject_GetMethodStackRef(PyThreadState *ts, _PyStackRef *self,
 
 // Like PyObject_GetAttr but returns a _PyStackRef. For types, this can
 // return a deferred reference to reduce reference count contention.
-PyAPI_FUNC(_PyStackRef) _PyObject_GetAttrStackRef(PyObject *obj, PyObject *name);
+PyAPI_FUNC(_PyStackRef) _PyObject_GetAttrStackRef(PyThreadState *tstate, PyObject *obj, PyObject *name);
 
 // Cache the provided init method in the specialization cache of type if the
 // provided type version matches the current version of the type.
@@ -965,7 +965,7 @@ _PyObject_MaybeCallSpecialOneArg(PyObject *self, PyObject *attr, PyObject *arg);
 
 extern int _PyObject_IsAbstract(PyObject *);
 
-PyAPI_FUNC(int) _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method);
+PyAPI_FUNC(int) _PyObject_GetMethod(PyThreadState *tstate, PyObject *obj, PyObject *name, PyObject **method);
 extern PyObject* _PyObject_NextNotImplemented(PyObject *);
 
 // Pickle support.
@@ -1032,6 +1032,10 @@ static inline Py_ALWAYS_INLINE void _Py_INCREF_MORTAL(PyObject *op)
 /* Utility for the tp_traverse slot of mutable heap types that have no other
  * references. */
 PyAPI_FUNC(int) _PyObject_VisitType(PyObject *op, visitproc visit, void *arg);
+
+PyAPI_FUNC(PyObject *) _PyObject_RichCompare(PyThreadState *, PyObject *, PyObject *, int);
+PyAPI_FUNC(int) _PyObject_RichCompareBool(PyThreadState *, PyObject *, PyObject *, int);
+PyAPI_FUNC(PyObject *) _PyObject_GetAttr(PyThreadState *, PyObject *, PyObject *);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -420,6 +420,7 @@ static inline void Py_DECREF_MORTAL(const char *filename, int lineno, PyObject *
     }
 }
 #define Py_DECREF_MORTAL(op) Py_DECREF_MORTAL(__FILE__, __LINE__, _PyObject_CAST(op))
+#define _Py_DECREF_MORTAL(tstate, op) Py_DECREF_MORTAL(op)
 
 static inline void _Py_DECREF_MORTAL_SPECIALIZED(const char *filename, int lineno, PyObject *op, destructor destruct)
 {
@@ -442,6 +443,16 @@ static inline void _Py_DECREF_MORTAL_SPECIALIZED(const char *filename, int linen
 #define Py_DECREF_MORTAL_SPECIALIZED(op, destruct) _Py_DECREF_MORTAL_SPECIALIZED(__FILE__, __LINE__, op, destruct)
 
 #else
+
+static inline void _Py_DECREF_MORTAL(PyThreadState *tstate, PyObject *op)
+{
+    assert(!_Py_IsStaticImmortal(op));
+    _Py_DECREF_STAT_INC();
+    if (--op->ob_refcnt == 0) {
+        _Py_DeallocTstate(tstate, op);
+    }
+}
+#define _Py_DECREF_MORTAL(tstate, op) _Py_DECREF_MORTAL(tstate, _PyObject_CAST(op))
 
 static inline void Py_DECREF_MORTAL(PyObject *op)
 {
@@ -466,6 +477,7 @@ static inline void Py_DECREF_MORTAL_SPECIALIZED(PyObject *op, destructor destruc
 
 #endif
 #else  // Py_GIL_DISABLED
+# define _Py_DECREF_MORTAL(tstate, op) _Py_DECREF(tstate, op)
 # define Py_DECREF_MORTAL(op) Py_DECREF(op)
 # define Py_DECREF_MORTAL_SPECIALIZED(op, destruct) Py_DECREF(op)
 #endif

--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -211,6 +211,12 @@ extern int _PyUnicodeError_GetParams(
     Py_ssize_t *slen,
     int as_bytes);
 
+PyAPI_FUNC(void)
+_PyErr_FormatUnraisable(PyThreadState *tstate, const char *format, ...);
+
+PyAPI_FUNC(void)
+_PyErr_WriteUnraisable(PyThreadState *tstate, PyObject *obj);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -112,9 +112,16 @@ PyAPI_FUNC(PyThreadState *) _PyThreadState_GetCurrent(void);
    The caller must hold the GIL.
 
    See also PyThreadState_Get() and PyThreadState_GetUnchecked(). */
+
+#ifdef Py_DEBUG
+// Forcing this to be non-inlined is nice for finding where this is called often.
+static Py_NO_INLINE PyThreadState*
+#else
 static inline PyThreadState*
+#endif
 _PyThreadState_GET(void)
 {
+
 #if !defined(Py_BUILD_CORE_MODULE)
     return _Py_tss_tstate;
 #else
@@ -204,7 +211,13 @@ _Py_EnsureFuncTstateNotNULL(const char *func, PyThreadState *tstate)
 
    See also PyInterpreterState_Get()
    and _PyGILState_GetInterpreterStateUnsafe(). */
-static inline PyInterpreterState* _PyInterpreterState_GET(void) {
+#ifdef Py_DEBUG
+// Forcing this to be non-inlined is nice for finding where this is called often.
+static Py_NO_INLINE PyInterpreterState*
+#else
+static inline PyInterpreterState*
+#endif
+_PyInterpreterState_GET(void) {
 #ifdef Py_DEBUG
     PyThreadState *tstate = _PyThreadState_GET();
     _Py_EnsureTstateNotNULL(tstate);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -113,11 +113,12 @@ PyAPI_FUNC(PyThreadState *) _PyThreadState_GetCurrent(void);
 
    See also PyThreadState_Get() and PyThreadState_GetUnchecked(). */
 
-#ifdef Py_DEBUG
+static PyThreadState*
 // Forcing this to be non-inlined is nice for finding where this is called often.
-static Py_NO_INLINE PyThreadState*
+#ifdef Py_DEBUG
+_Py_MAYBE_UNUSED Py_NO_INLINE
 #else
-static inline PyThreadState*
+inline
 #endif
 _PyThreadState_GET(void)
 {
@@ -211,11 +212,11 @@ _Py_EnsureFuncTstateNotNULL(const char *func, PyThreadState *tstate)
 
    See also PyInterpreterState_Get()
    and _PyGILState_GetInterpreterStateUnsafe(). */
+static _Py_MAYBE_UNUSED PyInterpreterState*
 #ifdef Py_DEBUG
-// Forcing this to be non-inlined is nice for finding where this is called often.
-static Py_NO_INLINE PyInterpreterState*
+Py_NO_INLINE
 #else
-static inline PyInterpreterState*
+inline
 #endif
 _PyInterpreterState_GET(void) {
 #ifdef Py_DEBUG

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -112,17 +112,9 @@ PyAPI_FUNC(PyThreadState *) _PyThreadState_GetCurrent(void);
    The caller must hold the GIL.
 
    See also PyThreadState_Get() and PyThreadState_GetUnchecked(). */
-
-static PyThreadState*
-// Forcing this to be non-inlined is nice for finding where this is called often.
-#ifdef Py_DEBUG
-_Py_MAYBE_UNUSED Py_NO_INLINE
-#else
-inline
-#endif
+static inline PyThreadState*
 _PyThreadState_GET(void)
 {
-
 #if !defined(Py_BUILD_CORE_MODULE)
     return _Py_tss_tstate;
 #else
@@ -212,13 +204,7 @@ _Py_EnsureFuncTstateNotNULL(const char *func, PyThreadState *tstate)
 
    See also PyInterpreterState_Get()
    and _PyGILState_GetInterpreterStateUnsafe(). */
-static _Py_MAYBE_UNUSED PyInterpreterState*
-#ifdef Py_DEBUG
-Py_NO_INLINE
-#else
-inline
-#endif
-_PyInterpreterState_GET(void) {
+static inline PyInterpreterState* _PyInterpreterState_GET(void) {
 #ifdef Py_DEBUG
     PyThreadState *tstate = _PyThreadState_GET();
     _Py_EnsureTstateNotNULL(tstate);

--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -213,7 +213,7 @@ _PyStackRef_FromPyObjectBorrow(PyObject *obj, const char *filename, int linenumb
 #define PyStackRef_FromPyObjectBorrow(obj) _PyStackRef_FromPyObjectBorrow(_PyObject_CAST(obj), __FILE__, __LINE__)
 
 static inline void
-_PyStackRef_CLOSE(_PyStackRef ref, const char *filename, int linenumber)
+_PyStackRef_CloseWithFile(_PyStackRef ref, const char *filename, int linenumber)
 {
     assert(!PyStackRef_IsError(ref));
     assert(!PyStackRef_IsNull(ref));
@@ -226,10 +226,10 @@ _PyStackRef_CLOSE(_PyStackRef ref, const char *filename, int linenumber)
         Py_DECREF(obj);
     }
 }
-#define PyStackRef_CLOSE(REF) _PyStackRef_CLOSE((REF), __FILE__, __LINE__)
+#define PyStackRef_CLOSE(REF) _PyStackRef_CloseWithFile((REF), __FILE__, __LINE__)
 
 static inline void
-_PyStackRef_XCLOSE(_PyStackRef ref, const char *filename, int linenumber)
+_PyStackRef_XCloseWithFile(_PyStackRef ref, const char *filename, int linenumber)
 {
     assert(!PyStackRef_IsError(ref));
     if (PyStackRef_IsNull(ref)) {
@@ -237,7 +237,7 @@ _PyStackRef_XCLOSE(_PyStackRef ref, const char *filename, int linenumber)
     }
     _PyStackRef_CLOSE(ref, filename, linenumber);
 }
-#define PyStackRef_XCLOSE(REF) _PyStackRef_XCLOSE((REF), __FILE__, __LINE__)
+#define PyStackRef_XCLOSE(REF) _PyStackRef_XCloseWithFile((REF), __FILE__, __LINE__)
 
 static inline _PyStackRef
 _PyStackRef_DUP(_PyStackRef ref, const char *filename, int linenumber)
@@ -694,7 +694,21 @@ do { \
     _PyStackRef _temp = (REF); \
     if (PyStackRef_RefcountOnObject(_temp)) Py_DECREF_MORTAL(BITS_TO_PTR(_temp)); \
 } while (0)
+#define _PyStackRef_CLOSE(tstate, REF) \
+do { \
+    _PyStackRef _temp = (REF); \
+    if (PyStackRef_RefcountOnObject(_temp)) _Py_DECREF_MORTAL(tstate, BITS_TO_PTR(_temp)); \
+} while (0)
 #else
+static inline void
+_PyStackRef_CLOSE(PyThreadState *tstate, _PyStackRef ref)
+{
+    assert(!PyStackRef_IsNull(ref));
+    if (PyStackRef_RefcountOnObject(ref)) {
+        _Py_DECREF_MORTAL(tstate, BITS_TO_PTR(ref));
+    }
+}
+
 static inline void
 PyStackRef_CLOSE(_PyStackRef ref)
 {
@@ -716,7 +730,18 @@ PyStackRef_CLOSE_SPECIALIZED(_PyStackRef ref, destructor destruct)
 
 #ifdef _WIN32
 #define PyStackRef_XCLOSE PyStackRef_CLOSE
+#define _PyStackRef_XCLOSE _PyStackRef_CLOSE
 #else
+static inline void
+_PyStackRef_XCLOSE(PyThreadState *tstate, _PyStackRef ref)
+{
+    assert(ref.bits != 0);
+    if (PyStackRef_RefcountOnObject(ref)) {
+        assert(!PyStackRef_IsNull(ref));
+        _Py_DECREF_MORTAL(tstate, BITS_TO_PTR(ref));
+    }
+}
+
 static inline void
 PyStackRef_XCLOSE(_PyStackRef ref)
 {
@@ -736,6 +761,13 @@ PyStackRef_XCLOSE(_PyStackRef ref)
         PyStackRef_XCLOSE(_tmp_old_op); \
     } while (0)
 
+#define _PyStackRef_CLEAR(tstate, REF) \
+    do { \
+        _PyStackRef *_tmp_op_ptr = &(REF); \
+        _PyStackRef _tmp_old_op = (*_tmp_op_ptr); \
+        *_tmp_op_ptr = PyStackRef_NULL; \
+        _PyStackRef_XCLOSE(tstate, _tmp_old_op); \
+    } while (0)
 
 // Note: this is a macro because MSVC (Windows) has trouble inlining it.
 
@@ -808,7 +840,7 @@ _PyThreadState_PopCStackRef(PyThreadState *tstate, _PyCStackRef *ref)
     assert(tstate_impl->c_stack_refs == ref);
     tstate_impl->c_stack_refs = ref->next;
 #endif
-    PyStackRef_XCLOSE(ref->ref);
+    _PyStackRef_XCLOSE(tstate, ref->ref);
 }
 
 static inline _PyStackRef
@@ -856,6 +888,13 @@ _Py_TryXGetStackRef(PyObject **src, _PyStackRef *out)
         _PyStackRef _tmp_dst_ref = (dst); \
         (dst) = (src); \
         PyStackRef_XCLOSE(_tmp_dst_ref); \
+    } while(0)
+
+#define _PyStackRef_XSETREF(tstate, dst, src) \
+    do { \
+        _PyStackRef _tmp_dst_ref = (dst); \
+        (dst) = (src); \
+        _PyStackRef_XCLOSE(tstate, _tmp_dst_ref); \
     } while(0)
 
 // Like Py_VISIT but for _PyStackRef fields

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -111,10 +111,10 @@ _PyType_IsReady(PyTypeObject *type)
     return _PyType_GetDict(type) != NULL;
 }
 
-extern PyObject* _Py_type_getattro_impl(PyTypeObject *type, PyObject *name,
+extern PyObject* _Py_type_getattro_impl(PyThreadState *tstate, PyTypeObject *type, PyObject *name,
                                         int *suppress_missing_attribute);
 extern PyObject* _Py_type_getattro(PyObject *type, PyObject *name);
-extern _PyStackRef _Py_type_getattro_stackref(PyTypeObject *type, PyObject *name,
+extern _PyStackRef _Py_type_getattro_stackref(PyThreadState *tstate, PyTypeObject *type, PyObject *name,
                                               int *suppress_missing_attribute);
 
 extern PyObject* _Py_BaseObject_RichCompare(PyObject* self, PyObject* other, int op);

--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -122,8 +122,6 @@ PyAPI_FUNC(PyObject *) PyCMethod_New(PyMethodDef *, PyObject *,
 #  define METH_STACKLESS 0x0000
 #endif
 
-#define _METH_TSTATE 0x0100
-
 /* METH_METHOD means the function stores an
  * additional reference to the class that defines it;
  * both self and class are passed to it.

--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -117,10 +117,12 @@ PyAPI_FUNC(PyObject *) PyCMethod_New(PyMethodDef *, PyObject *,
 
 /* This bit is preserved for Stackless Python */
 #ifdef STACKLESS
-#  define METH_STACKLESS 0x0100
+#  define METH_STACKLESS 0x0000
 #else
 #  define METH_STACKLESS 0x0000
 #endif
+
+#define _METH_TSTATE 0x0100
 
 /* METH_METHOD means the function stores an
  * additional reference to the class that defines it;

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -667,13 +667,5 @@ extern "C" {
 #  define _Py_STACK_GROWS_DOWN 1
 #endif
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
-// C23 standard attribute
-#  define _Py_MAYBE_UNUSED [[maybe_unused]]
-#elif _Py__has_attribute(__unused__)
-#  define _Py_MAYBE_UNUSED __attribute__((__unused__))
-#else
-#  define _Py_MAYBE_UNUSED
-#endif
 
 #endif /* Py_PYPORT_H */

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -667,5 +667,13 @@ extern "C" {
 #  define _Py_STACK_GROWS_DOWN 1
 #endif
 
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+// C23 standard attribute
+#  define _Py_MAYBE_UNUSED [[maybe_unused]]
+#elif _Py__has_attribute(__unused__)
+#  define _Py_MAYBE_UNUSED __attribute__((__unused__))
+#else
+#  define _Py_MAYBE_UNUSED
+#endif
 
 #endif /* Py_PYPORT_H */

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -314,14 +314,17 @@ static inline Py_ALWAYS_INLINE void Py_INCREF(PyObject *op)
 #if !defined(Py_LIMITED_API)
 #if defined(Py_GIL_DISABLED)
 // Implements Py_DECREF on objects not owned by the current thread.
-PyAPI_FUNC(void) _Py_DecRefShared(PyThreadState *, PyObject *);
-PyAPI_FUNC(void) _Py_DecRefSharedDebug(PyThreadState *, PyObject *, const char *, int);
+PyAPI_FUNC(void) _Py_DecRefShared(PyObject *);
+PyAPI_FUNC(void) _Py_DecRefSharedDebug(PyObject *, const char *, int);
+PyAPI_FUNC(void) _Py_DecRefSharedTstate(PyThreadState *, PyObject *);
+PyAPI_FUNC(void) _Py_DecRefSharedDebugTstate(PyThreadState *, PyObject *, const char *, int);
 
 // Called from Py_DECREF by the owning thread when the local refcount reaches
 // zero. The call will deallocate the object if the shared refcount is also
 // zero. Otherwise, the thread gives up ownership and merges the reference
 // count fields.
-PyAPI_FUNC(void) _Py_MergeZeroLocalRefcount(PyThreadState *, PyObject *);
+PyAPI_FUNC(void) _Py_MergeZeroLocalRefcount(PyObject *);
+PyAPI_FUNC(void) _Py_MergeZeroLocalRefcountTstate(PyThreadState *, PyObject *);
 #endif  // Py_GIL_DISABLED
 #endif  // Py_LIMITED_API
 
@@ -385,7 +388,7 @@ static inline void Py_DECREF(PyObject *op)
         }
     }
     else {
-        _Py_DecRefShared(_PyThreadState_GET(), op);
+        _Py_DecRefShared(op);
     }
 }
 #define Py_DECREF(op) Py_DECREF(_PyObject_CAST(op))
@@ -402,11 +405,11 @@ static inline void _Py_DECREF(PyThreadState *tstate, PyObject *op)
         local--;
         _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
         if (local == 0) {
-            _Py_MergeZeroLocalRefcount(tstate, op);
+            _Py_MergeZeroLocalRefcountTstate(tstate, op);
         }
     }
     else {
-        _Py_DecRefShared(tstate, op);
+        _Py_DecRefSharedTstate(tstate, op);
     }
 }
 

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -413,7 +413,7 @@ static inline void _Py_DECREF(PyThreadState *tstate, PyObject *op)
     }
 }
 
-#define _Py_DECREF(op) _Py_DECREF(_PyObject_CAST(op))
+#define _Py_DECREF(tstate, op) _Py_DECREF(tstate, _PyObject_CAST(op))
 
 #elif defined(Py_REF_DEBUG)
 

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -237,9 +237,7 @@ PyAPI_FUNC(void) _Py_INCREF_IncRefTotal(void);
 PyAPI_FUNC(void) _Py_DECREF_DecRefTotal(void);
 #endif  // Py_REF_DEBUG && !Py_LIMITED_API
 
-#if !defined(Py_LIMITED_API)
 PyAPI_FUNC(void) _Py_DeallocTstate(PyThreadState *, PyObject *);
-#endif
 PyAPI_FUNC(void) _Py_Dealloc(PyObject *);
 
 
@@ -341,6 +339,7 @@ static inline void Py_DECREF(PyObject *op) {
 #  endif
 }
 #define Py_DECREF(op) Py_DECREF(_PyObject_CAST(op))
+#define _Py_DECREF(tstate, op) Py_DECREF(op)
 
 #elif defined(Py_GIL_DISABLED) && defined(Py_REF_DEBUG)
 static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
@@ -386,7 +385,7 @@ static inline void Py_DECREF(PyObject *op)
         }
     }
     else {
-        _Py_DecRefShared(op);
+        _Py_DecRefShared(_PyThreadState_GET(), op);
     }
 }
 #define Py_DECREF(op) Py_DECREF(_PyObject_CAST(op))
@@ -410,6 +409,8 @@ static inline void _Py_DECREF(PyThreadState *tstate, PyObject *op)
         _Py_DecRefShared(tstate, op);
     }
 }
+
+#define _Py_DECREF(op) _Py_DECREF(_PyObject_CAST(op))
 
 #elif defined(Py_REF_DEBUG)
 
@@ -452,6 +453,7 @@ static inline Py_ALWAYS_INLINE void _Py_DECREF(PyThreadState *tstate, PyObject *
         _Py_DeallocTstate(tstate, op);
     }
 }
+#define _Py_DECREF(tstate, op) _Py_DECREF(tstate, _PyObject_CAST(op))
 
 // We copy the implementation instead of doing _Py_DECREF(_PyThreadState_GET(), op)
 // because we don't necessarily need a thread state for every Py_DECREF() call, so
@@ -464,7 +466,7 @@ static inline Py_ALWAYS_INLINE void Py_DECREF(PyObject *op)
     }
     _Py_DECREF_STAT_INC();
     if (--op->ob_refcnt == 0) {
-        _Py_DeallocTstate(_PyThreadState_GET(), op);
+        _Py_Dealloc(op);
     }
 }
 #define Py_DECREF(op) Py_DECREF(_PyObject_CAST(op))
@@ -585,6 +587,14 @@ static inline void Py_XDECREF(PyObject *op)
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #  define Py_XDECREF(op) Py_XDECREF(_PyObject_CAST(op))
 #endif
+
+static inline void _Py_XDECREF(PyThreadState *tstate, PyObject *op)
+{
+    if (op != _Py_NULL) {
+        _Py_DECREF(tstate, op);
+    }
+}
+#  define _Py_XDECREF(tstate, op) _Py_XDECREF(tstate, _PyObject_CAST(op))
 
 // Create a new strong reference to an object:
 // increment the reference count of the object and return the object.

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -237,6 +237,9 @@ PyAPI_FUNC(void) _Py_INCREF_IncRefTotal(void);
 PyAPI_FUNC(void) _Py_DECREF_DecRefTotal(void);
 #endif  // Py_REF_DEBUG && !Py_LIMITED_API
 
+#if !defined(Py_LIMITED_API)
+PyAPI_FUNC(void) _Py_DeallocTstate(PyThreadState *, PyObject *);
+#endif
 PyAPI_FUNC(void) _Py_Dealloc(PyObject *);
 
 
@@ -313,14 +316,14 @@ static inline Py_ALWAYS_INLINE void Py_INCREF(PyObject *op)
 #if !defined(Py_LIMITED_API)
 #if defined(Py_GIL_DISABLED)
 // Implements Py_DECREF on objects not owned by the current thread.
-PyAPI_FUNC(void) _Py_DecRefShared(PyObject *);
-PyAPI_FUNC(void) _Py_DecRefSharedDebug(PyObject *, const char *, int);
+PyAPI_FUNC(void) _Py_DecRefShared(PyThreadState *, PyObject *);
+PyAPI_FUNC(void) _Py_DecRefSharedDebug(PyThreadState *, PyObject *, const char *, int);
 
 // Called from Py_DECREF by the owning thread when the local refcount reaches
 // zero. The call will deallocate the object if the shared refcount is also
 // zero. Otherwise, the thread gives up ownership and merges the reference
 // count fields.
-PyAPI_FUNC(void) _Py_MergeZeroLocalRefcount(PyObject *);
+PyAPI_FUNC(void) _Py_MergeZeroLocalRefcount(PyThreadState *, PyObject *);
 #endif  // Py_GIL_DISABLED
 #endif  // Py_LIMITED_API
 
@@ -364,6 +367,7 @@ static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
     }
 }
 #define Py_DECREF(op) Py_DECREF(__FILE__, __LINE__, _PyObject_CAST(op))
+#define _Py_DECREF(tstate, op) Py_DECREF(op)
 
 #elif defined(Py_GIL_DISABLED)
 static inline void Py_DECREF(PyObject *op)
@@ -386,6 +390,26 @@ static inline void Py_DECREF(PyObject *op)
     }
 }
 #define Py_DECREF(op) Py_DECREF(_PyObject_CAST(op))
+
+static inline void _Py_DECREF(PyThreadState *tstate, PyObject *op)
+{
+    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
+    if (local == _Py_IMMORTAL_REFCNT_LOCAL) {
+        _Py_DECREF_IMMORTAL_STAT_INC();
+        return;
+    }
+    _Py_DECREF_STAT_INC();
+    if (_Py_IsOwnedByCurrentThread(op)) {
+        local--;
+        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
+        if (local == 0) {
+            _Py_MergeZeroLocalRefcount(tstate, op);
+        }
+    }
+    else {
+        _Py_DecRefShared(tstate, op);
+    }
+}
 
 #elif defined(Py_REF_DEBUG)
 
@@ -411,10 +435,11 @@ static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
     }
 }
 #define Py_DECREF(op) Py_DECREF(__FILE__, __LINE__, _PyObject_CAST(op))
+#define _Py_DECREF(tstate, op) Py_DECREF(op)
 
 #else
 
-static inline Py_ALWAYS_INLINE void Py_DECREF(PyObject *op)
+static inline Py_ALWAYS_INLINE void _Py_DECREF(PyThreadState *tstate, PyObject *op)
 {
     // Non-limited C API and limited C API for Python 3.9 and older access
     // directly PyObject.ob_refcnt.
@@ -424,7 +449,22 @@ static inline Py_ALWAYS_INLINE void Py_DECREF(PyObject *op)
     }
     _Py_DECREF_STAT_INC();
     if (--op->ob_refcnt == 0) {
-        _Py_Dealloc(op);
+        _Py_DeallocTstate(tstate, op);
+    }
+}
+
+// We copy the implementation instead of doing _Py_DECREF(_PyThreadState_GET(), op)
+// because we don't necessarily need a thread state for every Py_DECREF() call, so
+// we get it lazily.
+static inline Py_ALWAYS_INLINE void Py_DECREF(PyObject *op)
+{
+    if (_Py_IsImmortal(op)) {
+        _Py_DECREF_IMMORTAL_STAT_INC();
+        return;
+    }
+    _Py_DECREF_STAT_INC();
+    if (--op->ob_refcnt == 0) {
+        _Py_DeallocTstate(_PyThreadState_GET(), op);
     }
 }
 #define Py_DECREF(op) Py_DECREF(_PyObject_CAST(op))
@@ -480,6 +520,29 @@ static inline Py_ALWAYS_INLINE void Py_DECREF(PyObject *op)
  * Py_CLEAR().
  */
 #ifdef _Py_TYPEOF
+#define _Py_CLEAR(tstate, op) \
+    do { \
+        _Py_TYPEOF(op)* _tmp_op_ptr = &(op); \
+        _Py_TYPEOF(op) _tmp_old_op = (*_tmp_op_ptr); \
+        if (_tmp_old_op != NULL) { \
+            *_tmp_op_ptr = _Py_NULL; \
+            _Py_DECREF(tstate, _tmp_old_op); \
+        } \
+    } while (0)
+#else
+#define _Py_CLEAR(tstate, op) \
+    do { \
+        PyObject **_tmp_op_ptr = _Py_CAST(PyObject**, &(op)); \
+        PyObject *_tmp_old_op = (*_tmp_op_ptr); \
+        if (_tmp_old_op != NULL) { \
+            PyObject *_null_ptr = _Py_NULL; \
+            memcpy(_tmp_op_ptr, &_null_ptr, sizeof(PyObject*)); \
+            _Py_DECREF(tstate, _tmp_old_op); \
+        } \
+    } while (0)
+#endif
+
+#ifdef _Py_TYPEOF
 #define Py_CLEAR(op) \
     do { \
         _Py_TYPEOF(op)* _tmp_op_ptr = &(op); \
@@ -501,7 +564,6 @@ static inline Py_ALWAYS_INLINE void Py_DECREF(PyObject *op)
         } \
     } while (0)
 #endif
-
 
 /* Function to use in case the object pointer can be NULL: */
 static inline void Py_XINCREF(PyObject *op)

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -2721,7 +2721,7 @@
                 assert(kwargs == NULL || PyDict_CheckExact(kwargs));
                 stack_pointer[-2] = callargs_st;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyObject *result_o = PyObject_Call(func, callargs, kwargs);
+                PyObject *result_o = _PyObject_Call(tstate, func, callargs, kwargs);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -2970,7 +2970,7 @@
                         JUMP_TO_LABEL(error);
                     }
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    result_o = PyObject_Call(func, callargs, kwargs);
+                    result_o = _PyObject_Call(tstate, func, callargs, kwargs);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (!PyFunction_Check(func) && !PyMethod_Check(func)) {
                         if (result_o == NULL) {
@@ -3027,7 +3027,7 @@
                     assert(kwargs == NULL || PyDict_CheckExact(kwargs));
                     stack_pointer[-2] = callargs_st;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    result_o = PyObject_Call(func, callargs, kwargs);
+                    result_o = _PyObject_Call(tstate, func, callargs, kwargs);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
                 stack_pointer += -1;
@@ -3526,6 +3526,7 @@
                 }
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyObject *res_o = _Py_VectorCall_StackRefSteal(
+                    tstate,
                     callable,
                     arguments,
                     total_args,
@@ -4360,6 +4361,7 @@
                 }
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyObject *res_o = _Py_VectorCall_StackRefSteal(
+                    tstate,
                     callable,
                     arguments,
                     total_args,
@@ -6996,7 +6998,7 @@
                         JUMP_TO_LABEL(error);
                     }
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    result_o = PyObject_Call(func, callargs, kwargs);
+                    result_o = _PyObject_Call(tstate, func, callargs, kwargs);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (!PyFunction_Check(func) && !PyMethod_Check(func)) {
                         if (result_o == NULL) {
@@ -7053,7 +7055,7 @@
                     assert(kwargs == NULL || PyDict_CheckExact(kwargs));
                     stack_pointer[-2] = callargs_st;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    result_o = PyObject_Call(func, callargs, kwargs);
+                    result_o = _PyObject_Call(tstate, func, callargs, kwargs);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
                 stack_pointer += -1;
@@ -7533,7 +7535,7 @@
                 {
                     PyObject *stack[] = {class, self};
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    super = PyObject_Vectorcall(global_super, stack, oparg & 2, NULL);
+                    super = _PyObject_VectorcallTstate(tstate, global_super, stack, oparg & 2, NULL);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
                 if (opcode == INSTRUMENTED_LOAD_SUPER_ATTR) {
@@ -10013,7 +10015,7 @@
                 {
                     PyObject *stack[] = {class, self};
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    super = PyObject_Vectorcall(global_super, stack, oparg & 2, NULL);
+                    super = _PyObject_VectorcallTstate(tstate, global_super, stack, oparg & 2, NULL);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
                 if (opcode == INSTRUMENTED_LOAD_SUPER_ATTR) {
@@ -12979,7 +12981,7 @@
                 PyObject *stack[5] = {NULL, PyStackRef_AsPyObjectBorrow(exit_self), exc, val_o, tb};
                 int has_self = !PyStackRef_IsNull(exit_self);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                res_o = PyObject_Vectorcall(exit_func_o, stack + 2 - has_self,
+                res_o = _PyObject_VectorcallTstate(tstate, exit_func_o, stack + 2 - has_self,
                     (3 + has_self) | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -8310,7 +8310,7 @@
                 }
                 else {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    attr = _PyObject_GetAttrStackRef(PyStackRef_AsPyObjectBorrow(owner), name);
+                    attr = _PyObject_GetAttrStackRef(tstate, PyStackRef_AsPyObjectBorrow(owner), name);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     stack_pointer[-1] = attr;
                     stack_pointer += (oparg&1);

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -3310,7 +3310,7 @@
                     stack_pointer += -3 - oparg;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(kwnames);
+                    _PyStackRef_CLOSE(tstate, kwnames);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (new_frame == NULL) {
                         JUMP_TO_LABEL(error);
@@ -3412,7 +3412,7 @@
                 stack_pointer[-3 - oparg] = callable;
                 stack_pointer[-2 - oparg] = self_or_null;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(callable_s);
+                _PyStackRef_CLOSE(tstate, callable_s);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // flush
@@ -3441,7 +3441,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(kwnames);
+                _PyStackRef_CLOSE(tstate, kwnames);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -3630,7 +3630,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(kwnames);
+                _PyStackRef_CLOSE(tstate, kwnames);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -6594,7 +6594,7 @@
             // _GET_ITER
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                _PyStackRef result = _PyEval_GetIter(iterable, &index_or_null, oparg);
+                _PyStackRef result = _PyEval_GetIter(tstate, iterable, &index_or_null, oparg);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (PyStackRef_IsError(result)) {
                     JUMP_TO_LABEL(pop_1_error);
@@ -7183,7 +7183,7 @@
                     stack_pointer += -3 - oparg;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(kwnames);
+                    _PyStackRef_CLOSE(tstate, kwnames);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (new_frame == NULL) {
                         JUMP_TO_LABEL(error);
@@ -9556,7 +9556,7 @@
                     if (PyLazyImport_CheckExact(v_o)) {
                         _PyFrame_SetStackPointer(frame, stack_pointer);
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
-                        Py_SETREF(v_o, l_v);
+                        _Py_SETREF(tstate, v_o, l_v);
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         if (v_o == NULL) {
                             JUMP_TO_LABEL(error);
@@ -9589,7 +9589,7 @@
                     if (PyLazyImport_CheckExact(v_o)) {
                         _PyFrame_SetStackPointer(frame, stack_pointer);
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
-                        Py_SETREF(v_o, l_v);
+                        _Py_SETREF(tstate, v_o, l_v);
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         if (v_o == NULL) {
                             JUMP_TO_LABEL(error);
@@ -9868,7 +9868,7 @@
                     JUMP_TO_LABEL(error);
                 }
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_SETREF(v_o, l_v);
+                _Py_SETREF(tstate, v_o, l_v);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             v = PyStackRef_FromPyObjectSteal(v_o);
@@ -12599,7 +12599,7 @@
             PyObject *prev_code = PyStackRef_AsPyObjectBorrow(frame->f_executable);
             if (tracer->prev_state.instr_code != (PyCodeObject *)prev_code) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_SETREF(tracer->prev_state.instr_code, (PyCodeObject*)Py_NewRef((prev_code)));
+                _Py_SETREF(tstate, tracer->prev_state.instr_code, (PyCodeObject*)Py_NewRef((prev_code)));
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             tracer->prev_state.instr_frame = frame;

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -77,7 +77,7 @@
                 stack_pointer[-2] = res;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -86,7 +86,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -382,7 +382,7 @@
                 stack_pointer[-2] = res;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -391,7 +391,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -685,7 +685,7 @@
                 stack_pointer[-2] = res;
                 stack_pointer[-1] = ds;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -694,7 +694,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -873,7 +873,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -944,7 +944,7 @@
                 stack_pointer[-2] = res;
                 stack_pointer[-1] = ls;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -953,7 +953,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -1134,7 +1134,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -1427,7 +1427,7 @@
                     else {
                         _PyFrame_SetStackPointer(frame, stack_pointer);
                         res_o = PyObject_GetItem(container_o, slice);
-                        Py_DECREF(slice);
+                        _Py_DECREF(tstate, slice);
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                     }
                 }
@@ -1435,15 +1435,15 @@
                 _PyStackRef tmp = stop;
                 stop = PyStackRef_NULL;
                 stack_pointer[-1] = stop;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = start;
                 start = PyStackRef_NULL;
                 stack_pointer[-2] = start;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = container;
                 container = PyStackRef_NULL;
                 stack_pointer[-3] = container;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -1490,7 +1490,7 @@
                 stack_pointer += -(oparg & 1);
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(format[0]);
+                _PyStackRef_CLOSE(tstate, format[0]);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             else {
@@ -1499,12 +1499,12 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(str);
+            _PyStackRef_CLOSE(tstate, str);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (interpolation_o == NULL) {
                 JUMP_TO_LABEL(error);
@@ -1586,7 +1586,7 @@
                 for (int _i = oparg; --_i >= 0;) {
                     tmp = values[_i];
                     values[_i] = PyStackRef_NULL;
-                    PyStackRef_CLOSE(tmp);
+                    _PyStackRef_CLOSE(tstate, tmp);
                 }
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -oparg;
@@ -1604,7 +1604,7 @@
                 }
                 else {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(value);
+                    _PyStackRef_CLOSE(tstate, value);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -1612,7 +1612,7 @@
                 stack_pointer += -oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_DECREF(set_o);
+                _Py_DECREF(tstate, set_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 JUMP_TO_LABEL(error);
             }
@@ -1643,7 +1643,7 @@
             for (int _i = oparg; --_i >= 0;) {
                 tmp = args[_i];
                 args[_i] = PyStackRef_NULL;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
             }
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -oparg;
@@ -1705,12 +1705,12 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(interpolations);
+            _PyStackRef_CLOSE(tstate, interpolations);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(strings);
+            _PyStackRef_CLOSE(tstate, strings);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (template_o == NULL) {
                 JUMP_TO_LABEL(error);
@@ -1804,7 +1804,7 @@
                     stack_pointer[-2 - oparg] = callable;
                     stack_pointer[-1 - oparg] = self_or_null;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -1963,7 +1963,7 @@
                 stack_pointer[-2 - oparg] = callable;
                 stack_pointer[-1 - oparg] = self_or_null;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CREATE_INIT_FRAME
@@ -2064,7 +2064,7 @@
                 stack_pointer[-2 - oparg] = callable;
                 stack_pointer[-1 - oparg] = self_or_null;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // flush
@@ -2222,7 +2222,7 @@
                 stack_pointer[-2 - oparg] = callable;
                 stack_pointer[-1 - oparg] = self_or_null;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // flush
@@ -2342,7 +2342,7 @@
                 callable = PyStackRef_FromPyObjectSteal(res_o);
                 stack_pointer[-2 - oparg] = callable;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_OPARG
@@ -2358,7 +2358,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -2430,7 +2430,7 @@
                 callable = PyStackRef_FromPyObjectSteal(res_o);
                 stack_pointer[-2 - oparg] = callable;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_OPARG
@@ -2446,7 +2446,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -2514,7 +2514,7 @@
                 callable = PyStackRef_FromPyObjectSteal(res_o);
                 stack_pointer[-2 - oparg] = callable;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_OPARG
@@ -2530,7 +2530,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -2628,7 +2628,7 @@
                 stack_pointer += -oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -2637,7 +2637,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -2703,7 +2703,7 @@
                     callargs = PyStackRef_FromPyObjectSteal(tuple_o);
                     stack_pointer[-2] = callargs;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -2726,17 +2726,17 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(kwargs_st);
+                _PyStackRef_XCLOSE(tstate, kwargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(callargs_st);
+                _PyStackRef_CLOSE(tstate, callargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(func_st);
+                _PyStackRef_CLOSE(tstate, func_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (result_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -2807,7 +2807,7 @@
                     callargs = PyStackRef_FromPyObjectSteal(tuple_o);
                     stack_pointer[-2] = callargs;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -2938,7 +2938,7 @@
                     callargs = PyStackRef_FromPyObjectSteal(tuple_o);
                     stack_pointer[-2] = callargs;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -2988,7 +2988,7 @@
                             stack_pointer = _PyFrame_GetStackPointer(frame);
                             if (err < 0) {
                                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                                Py_CLEAR(result_o);
+                                _Py_CLEAR(tstate, result_o);
                                 stack_pointer = _PyFrame_GetStackPointer(frame);
                             }
                         }
@@ -3033,17 +3033,17 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(kwargs_st);
+                _PyStackRef_XCLOSE(tstate, kwargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(callargs_st);
+                _PyStackRef_CLOSE(tstate, callargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(func_st);
+                _PyStackRef_CLOSE(tstate, func_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (result_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -3094,7 +3094,7 @@
                 value = v;
                 stack_pointer[-1] = res;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -3137,7 +3137,7 @@
                 stack_pointer[-2] = res;
                 stack_pointer[-1] = vs1;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -3146,7 +3146,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -3207,17 +3207,17 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(cls);
+                _PyStackRef_CLOSE(tstate, cls);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(instance);
+                _PyStackRef_CLOSE(tstate, instance);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(callable);
+                _PyStackRef_CLOSE(tstate, callable);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 res = retval ? PyStackRef_True : PyStackRef_False;
                 assert((!PyStackRef_IsNull(res)) ^ (_PyErr_Occurred(tstate) != NULL));
@@ -3276,7 +3276,7 @@
                     stack_pointer[-3 - oparg] = callable;
                     stack_pointer[-2 - oparg] = self_or_null;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -3733,7 +3733,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -3742,7 +3742,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -3827,7 +3827,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -3836,7 +3836,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -3923,7 +3923,7 @@
                 callable = PyStackRef_FromPyObjectSteal(res_o);
                 stack_pointer[-2 - oparg] = callable;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_OPARG
@@ -3938,7 +3938,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4035,7 +4035,7 @@
                 callable = PyStackRef_FromPyObjectSteal(res_o);
                 stack_pointer[-2 - oparg] = callable;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_OPARG
@@ -4050,7 +4050,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4159,7 +4159,7 @@
                 stack_pointer += -oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -4168,7 +4168,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4280,7 +4280,7 @@
                 stack_pointer += 1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -4289,7 +4289,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -4298,7 +4298,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4664,7 +4664,7 @@
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4739,7 +4739,7 @@
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4808,7 +4808,7 @@
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -4838,11 +4838,11 @@
                 _PyStackRef tmp = match_type_st;
                 match_type_st = PyStackRef_NULL;
                 stack_pointer[-1] = match_type_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = exc_value_st;
                 exc_value_st = PyStackRef_NULL;
                 stack_pointer[-2] = exc_value_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -4856,11 +4856,11 @@
             _PyStackRef tmp = match_type_st;
             match_type_st = PyStackRef_NULL;
             stack_pointer[-1] = match_type_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = exc_value_st;
             exc_value_st = PyStackRef_NULL;
             stack_pointer[-2] = exc_value_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -4913,7 +4913,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(right);
+            _PyStackRef_CLOSE(tstate, right);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             b = res ? PyStackRef_True : PyStackRef_False;
             stack_pointer[0] = b;
@@ -4957,19 +4957,19 @@
                 _PyStackRef tmp = sub_iter;
                 sub_iter = value;
                 stack_pointer[-4] = sub_iter;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = exc_value_st;
                 exc_value_st = PyStackRef_NULL;
                 stack_pointer[-1] = exc_value_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = last_sent_val;
                 last_sent_val = PyStackRef_NULL;
                 stack_pointer[-2] = last_sent_val;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = null_in;
                 null_in = PyStackRef_NULL;
                 stack_pointer[-3] = null_in;
-                PyStackRef_XCLOSE(tmp);
+                _PyStackRef_XCLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -4;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -5032,11 +5032,11 @@
                 _PyStackRef tmp = right;
                 right = PyStackRef_NULL;
                 stack_pointer[-1] = right;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = left;
                 left = PyStackRef_NULL;
                 stack_pointer[-2] = left;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -5046,7 +5046,7 @@
                 if (oparg & 16) {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
                     int res_bool = PyObject_IsTrue(res_o);
-                    Py_DECREF(res_o);
+                    _Py_DECREF(tstate, res_o);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (res_bool < 0) {
                         JUMP_TO_LABEL(error);
@@ -5333,7 +5333,7 @@
                 stack_pointer[-2] = b;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -5342,7 +5342,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -5401,7 +5401,7 @@
                 stack_pointer[-2] = b;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -5410,7 +5410,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -5469,7 +5469,7 @@
                 stack_pointer[-2] = b;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -5478,7 +5478,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -5504,7 +5504,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (result_o == NULL) {
                 JUMP_TO_LABEL(error);
@@ -5572,7 +5572,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(owner);
+            _PyStackRef_CLOSE(tstate, owner);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {
                 JUMP_TO_LABEL(error);
@@ -5597,7 +5597,7 @@
                 JUMP_TO_LABEL(error);
             }
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            Py_DECREF(oldobj);
+            _Py_DECREF(tstate, oldobj);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -5623,7 +5623,7 @@
             _PyStackRef tmp = GETLOCAL(oparg);
             GETLOCAL(oparg) = PyStackRef_NULL;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -5703,11 +5703,11 @@
             _PyStackRef tmp = sub;
             sub = PyStackRef_NULL;
             stack_pointer[-1] = sub;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = container;
             container = PyStackRef_NULL;
             stack_pointer[-2] = container;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -5757,7 +5757,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -5796,7 +5796,7 @@
                             _PyErr_Format(tstate, PyExc_TypeError,
                                       "'%T' object is not a mapping",
                                       update_o);
-                            Py_DECREF(exc);
+                            _Py_DECREF(tstate, exc);
                             stack_pointer = _PyFrame_GetStackPointer(frame);
                         }
                         else {
@@ -5815,7 +5815,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -5847,11 +5847,11 @@
                 _PyStackRef tmp = exc_st;
                 exc_st = PyStackRef_NULL;
                 stack_pointer[-1] = exc_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = awaitable_st;
                 awaitable_st = PyStackRef_NULL;
                 stack_pointer[-2] = awaitable_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -5878,7 +5878,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -5904,7 +5904,7 @@
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(receiver);
+            _PyStackRef_CLOSE(tstate, receiver);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -6017,7 +6017,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (res_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -6052,11 +6052,11 @@
             _PyStackRef tmp = fmt_spec;
             fmt_spec = PyStackRef_NULL;
             stack_pointer[-1] = fmt_spec;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = value;
             value = PyStackRef_NULL;
             stack_pointer[-2] = value;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -6474,7 +6474,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(obj);
+                _PyStackRef_CLOSE(tstate, obj);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 JUMP_TO_LABEL(error);
             }
@@ -6484,7 +6484,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(obj);
+            _PyStackRef_CLOSE(tstate, obj);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (iter_o == NULL) {
                 JUMP_TO_LABEL(error);
@@ -6496,7 +6496,7 @@
                               "'async for' received an object from __aiter__ "
                               "that does not implement __anext__: %.100s",
                               Py_TYPE(iter_o)->tp_name);
-                Py_DECREF(iter_o);
+                _Py_DECREF(tstate, iter_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 JUMP_TO_LABEL(error);
             }
@@ -6548,7 +6548,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(iterable);
+            _PyStackRef_CLOSE(tstate, iterable);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (iter_o == NULL) {
                 JUMP_TO_LABEL(error);
@@ -6777,11 +6777,11 @@
             _PyStackRef tmp = fromlist;
             fromlist = PyStackRef_NULL;
             stack_pointer[-1] = fromlist;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = level;
             level = PyStackRef_NULL;
             stack_pointer[-2] = level;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -6827,7 +6827,7 @@
                     stack_pointer[-2 - oparg] = callable;
                     stack_pointer[-1 - oparg] = self_or_null;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -6966,7 +6966,7 @@
                     callargs = PyStackRef_FromPyObjectSteal(tuple_o);
                     stack_pointer[-2] = callargs;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -7016,7 +7016,7 @@
                             stack_pointer = _PyFrame_GetStackPointer(frame);
                             if (err < 0) {
                                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                                Py_CLEAR(result_o);
+                                _Py_CLEAR(tstate, result_o);
                                 stack_pointer = _PyFrame_GetStackPointer(frame);
                             }
                         }
@@ -7061,17 +7061,17 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(kwargs_st);
+                _PyStackRef_XCLOSE(tstate, kwargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(callargs_st);
+                _PyStackRef_CLOSE(tstate, callargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(func_st);
+                _PyStackRef_CLOSE(tstate, func_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (result_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -7125,7 +7125,7 @@
                     stack_pointer[-3 - oparg] = callable;
                     stack_pointer[-2 - oparg] = self_or_null;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -7249,11 +7249,11 @@
                     _PyStackRef tmp = exc_st;
                     exc_st = PyStackRef_NULL;
                     stack_pointer[-1] = exc_st;
-                    PyStackRef_CLOSE(tmp);
+                    _PyStackRef_CLOSE(tstate, tmp);
                     tmp = awaitable_st;
                     awaitable_st = PyStackRef_NULL;
                     stack_pointer[-2] = awaitable_st;
-                    PyStackRef_CLOSE(tmp);
+                    _PyStackRef_CLOSE(tstate, tmp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     stack_pointer += -2;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -7293,7 +7293,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -7330,7 +7330,7 @@
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(receiver);
+            _PyStackRef_CLOSE(tstate, receiver);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -7516,15 +7516,15 @@
                         _PyStackRef tmp = self_st;
                         self_st = PyStackRef_NULL;
                         stack_pointer[-1] = self_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         tmp = class_st;
                         class_st = PyStackRef_NULL;
                         stack_pointer[-2] = class_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         tmp = global_super_st;
                         global_super_st = PyStackRef_NULL;
                         stack_pointer[-3] = global_super_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         stack_pointer += -3;
                         ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -7555,7 +7555,7 @@
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         if (err < 0) {
                             _PyFrame_SetStackPointer(frame, stack_pointer);
-                            Py_CLEAR(super);
+                            _Py_CLEAR(tstate, super);
                             stack_pointer = _PyFrame_GetStackPointer(frame);
                         }
                     }
@@ -7564,15 +7564,15 @@
                 _PyStackRef tmp = self_st;
                 self_st = PyStackRef_NULL;
                 stack_pointer[-1] = self_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = class_st;
                 class_st = PyStackRef_NULL;
                 stack_pointer[-2] = class_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = global_super_st;
                 global_super_st = PyStackRef_NULL;
                 stack_pointer[-3] = global_super_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -7582,7 +7582,7 @@
                 PyObject *name = GETITEM(FRAME_CO_NAMES, oparg >> 2);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyObject *attr_o = PyObject_GetAttr(super, name);
-                Py_DECREF(super);
+                _Py_DECREF(tstate, super);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (attr_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -7638,7 +7638,7 @@
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(iter);
+            _PyStackRef_CLOSE(tstate, iter);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -7689,7 +7689,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += 1;
             }
@@ -7717,7 +7717,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 INSTRUMENTED_JUMP(this_instr, next_instr + oparg, PY_MONITORING_EVENT_BRANCH_RIGHT);
             }
@@ -7991,7 +7991,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(executor);
+                _PyStackRef_CLOSE(tstate, executor);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += 1;
             }
@@ -8029,7 +8029,7 @@
                 stack_pointer[-2] = b;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -8038,7 +8038,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -8259,7 +8259,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -8318,7 +8318,7 @@
                     stack_pointer += (oparg&1);
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(owner);
+                    _PyStackRef_CLOSE(tstate, owner);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (PyStackRef_IsNull(attr)) {
                         JUMP_TO_LABEL(error);
@@ -8375,7 +8375,7 @@
                 _PyStackRef tmp = owner;
                 owner = attr;
                 stack_pointer[-1] = owner;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _PUSH_NULL_CONDITIONAL
@@ -8443,7 +8443,7 @@
                 _PyStackRef tmp = owner;
                 owner = attr;
                 stack_pointer[-1] = owner;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _PUSH_NULL_CONDITIONAL
@@ -8619,7 +8619,7 @@
                 value = o;
                 stack_pointer[-1] = attr;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             /* Skip 5 cache entries */
@@ -8858,7 +8858,7 @@
                 value = o;
                 stack_pointer[-1] = attr;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             /* Skip 5 cache entries */
@@ -8911,7 +8911,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(owner);
+                _PyStackRef_CLOSE(tstate, owner);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 attr = PyStackRef_FromPyObjectNew(descr);
             }
@@ -8968,7 +8968,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(owner);
+                _PyStackRef_CLOSE(tstate, owner);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 attr = PyStackRef_FromPyObjectNew(descr);
             }
@@ -9121,7 +9121,7 @@
                 value = o;
                 stack_pointer[-1] = attr;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             /* Skip 5 cache entries */
@@ -9238,7 +9238,7 @@
                 value = o;
                 stack_pointer[-1] = attr;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             /* Skip 5 cache entries */
@@ -9502,7 +9502,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(class_dict_st);
+            _PyStackRef_CLOSE(tstate, class_dict_st);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             value = PyStackRef_FromPyObjectSteal(value_o);
             stack_pointer[0] = value;
@@ -9530,7 +9530,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(mod_or_class_dict);
+            _PyStackRef_CLOSE(tstate, mod_or_class_dict);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err < 0) {
                 JUMP_TO_LABEL(error);
@@ -9853,7 +9853,7 @@
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (l_v == NULL) {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    Py_DECREF(v_o);
+                    _Py_DECREF(tstate, v_o);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     JUMP_TO_LABEL(error);
                 }
@@ -9862,8 +9862,8 @@
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err < 0) {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    Py_DECREF(v_o);
-                    Py_DECREF(l_v);
+                    _Py_DECREF(tstate, v_o);
+                    _Py_DECREF(tstate, l_v);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     JUMP_TO_LABEL(error);
                 }
@@ -9996,15 +9996,15 @@
                         _PyStackRef tmp = self_st;
                         self_st = PyStackRef_NULL;
                         stack_pointer[-1] = self_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         tmp = class_st;
                         class_st = PyStackRef_NULL;
                         stack_pointer[-2] = class_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         tmp = global_super_st;
                         global_super_st = PyStackRef_NULL;
                         stack_pointer[-3] = global_super_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         stack_pointer += -3;
                         ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -10035,7 +10035,7 @@
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         if (err < 0) {
                             _PyFrame_SetStackPointer(frame, stack_pointer);
-                            Py_CLEAR(super);
+                            _Py_CLEAR(tstate, super);
                             stack_pointer = _PyFrame_GetStackPointer(frame);
                         }
                     }
@@ -10044,15 +10044,15 @@
                 _PyStackRef tmp = self_st;
                 self_st = PyStackRef_NULL;
                 stack_pointer[-1] = self_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = class_st;
                 class_st = PyStackRef_NULL;
                 stack_pointer[-2] = class_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = global_super_st;
                 global_super_st = PyStackRef_NULL;
                 stack_pointer[-3] = global_super_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -10062,7 +10062,7 @@
                 PyObject *name = GETITEM(FRAME_CO_NAMES, oparg >> 2);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyObject *attr_o = PyObject_GetAttr(super, name);
-                Py_DECREF(super);
+                _Py_DECREF(tstate, super);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (attr_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -10122,15 +10122,15 @@
             _PyStackRef tmp = self_st;
             self_st = PyStackRef_NULL;
             stack_pointer[-1] = self_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = class_st;
             class_st = PyStackRef_NULL;
             stack_pointer[-2] = class_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = global_super_st;
             global_super_st = PyStackRef_NULL;
             stack_pointer[-3] = global_super_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -3;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -10205,7 +10205,7 @@
                     stack_pointer += -1;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(self_st);
+                    _PyStackRef_CLOSE(tstate, self_st);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     self_or_null = PyStackRef_NULL;
                     stack_pointer += 1;
@@ -10216,11 +10216,11 @@
                 _PyStackRef tmp = global_super_st;
                 global_super_st = self_or_null;
                 stack_pointer[-2] = global_super_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = class_st;
                 class_st = PyStackRef_NULL;
                 stack_pointer[-1] = class_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -10249,7 +10249,7 @@
             _PyStackRef tmp = GETLOCAL(oparg);
             GETLOCAL(oparg) = PyStackRef_FromPyObjectSteal(cell);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -10287,7 +10287,7 @@
                 value = co;
                 stack_pointer[-1] = func;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -10373,7 +10373,7 @@
                 stack_pointer[-2] = s;
                 stack_pointer[-1] = tp;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -10382,7 +10382,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -10391,7 +10391,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -10521,7 +10521,7 @@
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(iter);
+            _PyStackRef_CLOSE(tstate, iter);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -10574,7 +10574,7 @@
                     _PyStackRef tmp = value;
                     value = b;
                     stack_pointer[-1] = value;
-                    PyStackRef_CLOSE(tmp);
+                    _PyStackRef_CLOSE(tstate, tmp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -10617,7 +10617,7 @@
                     _PyStackRef tmp = value;
                     value = b;
                     stack_pointer[-1] = value;
-                    PyStackRef_CLOSE(tmp);
+                    _PyStackRef_CLOSE(tstate, tmp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -10669,7 +10669,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(value);
+            _PyStackRef_XCLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -11135,7 +11135,7 @@
                     stack_pointer += -1;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(v);
+                    _PyStackRef_CLOSE(tstate, v);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     retval = PyStackRef_FromPyObjectSteal(res.object);
                     if (res.kind == PYGEN_RETURN) {
@@ -11194,7 +11194,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(v);
+                _PyStackRef_CLOSE(tstate, v);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 asend = iter;
                 null_out = null_in;
@@ -11376,7 +11376,7 @@
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 err = PyObject_SetItem(LOCALS(), &_Py_ID(__annotations__),
                                        ann_dict);
-                Py_DECREF(ann_dict);
+                _Py_DECREF(tstate, ann_dict);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err) {
                     JUMP_TO_LABEL(error);
@@ -11384,7 +11384,7 @@
             }
             else {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_DECREF(ann_dict);
+                _Py_DECREF(tstate, ann_dict);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11473,7 +11473,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11521,11 +11521,11 @@
                 _PyStackRef tmp = owner;
                 owner = PyStackRef_NULL;
                 stack_pointer[-1] = owner;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = v;
                 v = PyStackRef_NULL;
                 stack_pointer[-2] = v;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -11621,7 +11621,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11683,7 +11683,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11782,7 +11782,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11830,7 +11830,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11854,7 +11854,7 @@
             value2 = PyStackRef_DUP(GETLOCAL(oparg2));
             stack_pointer[-1] = value2;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -11878,14 +11878,14 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             tmp = GETLOCAL(oparg2);
             GETLOCAL(oparg2) = value2;
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -11907,7 +11907,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(v);
+            _PyStackRef_CLOSE(tstate, v);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {
                 JUMP_TO_LABEL(error);
@@ -11936,7 +11936,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(v);
+                _PyStackRef_CLOSE(tstate, v);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 JUMP_TO_LABEL(error);
             }
@@ -11953,7 +11953,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(v);
+            _PyStackRef_CLOSE(tstate, v);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {
                 JUMP_TO_LABEL(error);
@@ -11999,7 +11999,7 @@
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
                     err = PyObject_SetItem(PyStackRef_AsPyObjectBorrow(container), slice, PyStackRef_AsPyObjectBorrow(v));
-                    Py_DECREF(slice);
+                    _Py_DECREF(tstate, slice);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     stack_pointer += 2;
                 }
@@ -12007,11 +12007,11 @@
                 _PyStackRef tmp = container;
                 container = PyStackRef_NULL;
                 stack_pointer[-3] = container;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = v;
                 v = PyStackRef_NULL;
                 stack_pointer[-4] = v;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -4;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -12062,15 +12062,15 @@
                 _PyStackRef tmp = sub;
                 sub = PyStackRef_NULL;
                 stack_pointer[-1] = sub;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = container;
                 container = PyStackRef_NULL;
                 stack_pointer[-2] = container;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = v;
                 v = PyStackRef_NULL;
                 stack_pointer[-3] = v;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -12130,7 +12130,7 @@
                     stack_pointer += -3;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(dict_st);
+                    _PyStackRef_CLOSE(tstate, dict_st);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     JUMP_TO_LABEL(error);
                 }
@@ -12142,7 +12142,7 @@
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12226,7 +12226,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_DECREF(old_value);
+                _Py_DECREF(tstate, old_value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_INT
@@ -12241,7 +12241,7 @@
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12306,7 +12306,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err < 0) {
                     JUMP_TO_LABEL(error);
@@ -12358,7 +12358,7 @@
                 value = v;
                 stack_pointer[-1] = res;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12472,7 +12472,7 @@
                 value = v;
                 stack_pointer[-1] = res;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12591,7 +12591,7 @@
             }
             for (int i = 0; i < tracer->prev_state.recorded_count; i++) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_CLEAR(tracer->prev_state.recorded_values[i]);
+                _Py_CLEAR(tstate, tracer->prev_state.recorded_values[i]);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             tracer->prev_state.recorded_count = 0;
@@ -12652,7 +12652,7 @@
                 value = v;
                 stack_pointer[-1] = res;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12686,7 +12686,7 @@
                 value = v;
                 stack_pointer[-1] = res;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12727,7 +12727,7 @@
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             int res = _PyEval_UnpackIterableStackRef(tstate, seq_o, oparg & 0xFF, oparg >> 8, top);
-            Py_DECREF(seq_o);
+            _Py_DECREF(tstate, seq_o);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (res == 0) {
                 JUMP_TO_LABEL(error);
@@ -12777,7 +12777,7 @@
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 int res = _PyEval_UnpackIterableStackRef(tstate, seq_o, oparg, -1, top);
-                Py_DECREF(seq_o);
+                _Py_DECREF(tstate, seq_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (res == 0) {
                     JUMP_TO_LABEL(error);
@@ -12841,7 +12841,7 @@
                 stack_pointer += -1 + oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(seq);
+                _PyStackRef_CLOSE(tstate, seq);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12891,7 +12891,7 @@
                 stack_pointer += -1 + oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(seq);
+                _PyStackRef_CLOSE(tstate, seq);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12942,7 +12942,7 @@
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(seq);
+                _PyStackRef_CLOSE(tstate, seq);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -13137,7 +13137,7 @@ JUMP_TO_LABEL(error);
                 _PyStackRef *stackbase = _PyFrame_Stackbase(frame);
                 while (frame->stackpointer > stackbase) {
                     _PyStackRef ref = _PyFrame_StackPop(frame);
-                    PyStackRef_XCLOSE(ref);
+                    _PyStackRef_XCLOSE(tstate, ref);
                 }
                 monitor_unwind(tstate, frame, next_instr-1);
                 JUMP_TO_LABEL(exit_unwind);
@@ -13147,7 +13147,7 @@ JUMP_TO_LABEL(error);
             assert(frame->stackpointer >= new_top);
             while (frame->stackpointer > new_top) {
                 _PyStackRef ref = _PyFrame_StackPop(frame);
-                PyStackRef_XCLOSE(ref);
+                _PyStackRef_XCLOSE(tstate, ref);
             }
             if (lasti) {
                 int frame_lasti = _PyInterpreterFrame_LASTI(frame);
@@ -13199,7 +13199,7 @@ JUMP_TO_LABEL(error);
                 assert(tstate->current_executor == NULL);
                 if (!PyStackRef_IsNull(executor)) {
                     tstate->current_executor = PyStackRef_AsPyObjectBorrow(executor);
-                    PyStackRef_CLOSE(executor);
+                    _PyStackRef_CLOSE(tstate, executor);
                 }
                 #endif
                 return NULL;

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1752,18 +1752,20 @@ local_setattro(PyObject *op, PyObject *name, PyObject *v)
         goto err;
     }
 
-    int r = PyObject_RichCompareBool(name, &_Py_ID(__dict__), Py_EQ);
+    PyThreadState *tstate = _PyThreadState_GET();
+
+    int r = _PyObject_RichCompareBool(tstate, name, &_Py_ID(__dict__), Py_EQ);
     if (r == -1) {
         goto err;
     }
     if (r == 1) {
-        PyErr_Format(PyExc_AttributeError,
+        _PyErr_Format(tstate, PyExc_AttributeError,
                      "'%.100s' object attribute %R is read-only",
                      Py_TYPE(self)->tp_name, name);
         goto err;
     }
 
-    int st = _PyObject_GenericSetAttrWithDict(op, name, v, ldict);
+    int st = _PyObject_GenericSetAttrWithDict(tstate, op, name, v, ldict);
     Py_DECREF(ldict);
     return st;
 
@@ -1806,6 +1808,7 @@ local_getattro(PyObject *op, PyObject *name)
     PyObject *module = PyType_GetModuleByDef(Py_TYPE(self), &thread_module);
     assert(module != NULL);
     thread_module_state *state = get_thread_state(module);
+    PyThreadState *tstate = _PyThreadState_GET();
 
     PyObject *ldict = _ldict(self, state);
     if (ldict == NULL)
@@ -1822,7 +1825,7 @@ local_getattro(PyObject *op, PyObject *name)
 
     if (!Py_IS_TYPE(self, state->local_type)) {
         /* use generic lookup for subtypes */
-        PyObject *res = _PyObject_GenericGetAttrWithDict(op, name, ldict, 0);
+        PyObject *res = _PyObject_GenericGetAttrWithDict(tstate, op, name, ldict, 0);
         Py_DECREF(ldict);
         return res;
     }
@@ -1836,7 +1839,7 @@ local_getattro(PyObject *op, PyObject *name)
     }
 
     /* Fall back on generic to get __class__ and __dict__ */
-    PyObject *res = _PyObject_GenericGetAttrWithDict(op, name, ldict, 0);
+    PyObject *res = _PyObject_GenericGetAttrWithDict(tstate, op, name, ldict, 0);
     Py_DECREF(ldict);
     return res;
 }

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -383,16 +383,21 @@ PyCFunction_Call(PyObject *callable, PyObject *args, PyObject *kwargs)
 
 
 PyObject *
-PyObject_CallOneArg(PyObject *func, PyObject *arg)
+_PyObject_CallOneArgTstate(PyThreadState *tstate, PyObject *func, PyObject *arg)
 {
     EVAL_CALL_STAT_INC_IF_FUNCTION(EVAL_CALL_API, func);
     assert(arg != NULL);
     PyObject *_args[2];
     PyObject **args = _args + 1;  // For PY_VECTORCALL_ARGUMENTS_OFFSET
     args[0] = arg;
-    PyThreadState *tstate = _PyThreadState_GET();
     size_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
     return _PyObject_VectorcallTstate(tstate, func, args, nargsf, NULL);
+}
+
+PyObject *
+PyObject_CallOneArg(PyObject *func, PyObject *arg)
+{
+    return _PyObject_CallOneArgTstate(_PyThreadState_GET(), func, arg);
 }
 
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -7374,10 +7374,11 @@ store_instance_attr_lock_held(PyObject *obj, PyDictValues *values,
 
     PyObject *old_value = values->values[ix];
     if (old_value == NULL && value == NULL) {
-        PyErr_Format(PyExc_AttributeError,
+        PyThreadState *tstate = _PyThreadState_GET();
+        _PyErr_Format(tstate, PyExc_AttributeError,
                         "'%.100s' object has no attribute '%U'",
                         Py_TYPE(obj)->tp_name, name);
-        (void)_PyObject_SetAttributeErrorContext(obj, name);
+        (void)_PyObject_SetAttributeErrorContext(tstate, obj, name);
         return -1;
     }
 

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -285,11 +285,12 @@ framelocalsproxy_setitem(PyObject *self, PyObject *key, PyObject *value)
             PyCell_SetTakeRef((PyCellObject *)cell, value);
         } else if (value != PyStackRef_AsPyObjectBorrow(oldvalue)) {
             PyObject *old_obj = PyStackRef_AsPyObjectBorrow(fast[i]);
+            PyThreadState *tstate = _PyThreadState_GET();
             if (old_obj != NULL && !_Py_IsImmortal(old_obj)) {
                 if (add_overwritten_fast_local(frame, old_obj) < 0) {
                     return -1;
                 }
-                PyStackRef_CLOSE(fast[i]);
+                _PyStackRef_CLOSE(tstate, fast[i]);
             }
             fast[i] = PyStackRef_FromPyObjectNew(value);
         }

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1925,6 +1925,8 @@ static PyGetSetDef frame_getsetlist[] = {
 static void
 frame_dealloc(PyObject *op)
 {
+    PyThreadState *tstate = _PyThreadState_GET();
+
     /* It is the responsibility of the owning generator/coroutine
      * to have cleared the generator pointer */
     PyFrameObject *f = PyFrameObject_CAST(op);
@@ -1940,21 +1942,21 @@ frame_dealloc(PyObject *op)
 
     /* Kill all local variables including specials, if we own them */
     if (f->f_frame == frame && frame->owner == FRAME_OWNED_BY_FRAME_OBJECT) {
-        PyStackRef_CLEAR(frame->f_executable);
-        PyStackRef_CLEAR(frame->f_funcobj);
-        Py_CLEAR(frame->f_locals);
+        _PyStackRef_CLEAR(tstate, frame->f_executable);
+        _PyStackRef_CLEAR(tstate, frame->f_funcobj);
+        _Py_CLEAR(tstate, frame->f_locals);
         _PyStackRef *locals = _PyFrame_GetLocalsArray(frame);
         _PyStackRef *sp = frame->stackpointer;
         while (sp > locals) {
             sp--;
-            PyStackRef_CLEAR(*sp);
+            _PyStackRef_CLEAR(tstate, *sp);
         }
     }
-    Py_CLEAR(f->f_back);
-    Py_CLEAR(f->f_trace);
-    Py_CLEAR(f->f_extra_locals);
-    Py_CLEAR(f->f_locals_cache);
-    Py_CLEAR(f->f_overwritten_fast_locals);
+    _Py_CLEAR(tstate, f->f_back);
+    _Py_CLEAR(tstate, f->f_trace);
+    _Py_CLEAR(tstate, f->f_extra_locals);
+    _Py_CLEAR(tstate, f->f_locals_cache);
+    _Py_CLEAR(tstate, f->f_overwritten_fast_locals);
     PyObject_GC_Del(f);
 }
 
@@ -1977,11 +1979,12 @@ frame_traverse(PyObject *op, visitproc visit, void *arg)
 static int
 frame_tp_clear(PyObject *op)
 {
+    PyThreadState *tstate = _PyThreadState_GET();
     PyFrameObject *f = PyFrameObject_CAST(op);
-    Py_CLEAR(f->f_trace);
-    Py_CLEAR(f->f_extra_locals);
-    Py_CLEAR(f->f_locals_cache);
-    Py_CLEAR(f->f_overwritten_fast_locals);
+    _Py_CLEAR(tstate, f->f_trace);
+    _Py_CLEAR(tstate, f->f_extra_locals);
+    _Py_CLEAR(tstate, f->f_locals_cache);
+    _Py_CLEAR(tstate, f->f_overwritten_fast_locals);
 
     /* locals and stack */
     _PyStackRef *locals = _PyFrame_GetLocalsArray(f->f_frame);
@@ -1989,10 +1992,10 @@ frame_tp_clear(PyObject *op)
     assert(sp >= locals);
     while (sp > locals) {
         sp--;
-        PyStackRef_CLEAR(*sp);
+        _PyStackRef_CLEAR(tstate, *sp);
     }
     f->f_frame->stackpointer = locals;
-    Py_CLEAR(f->f_frame->f_locals);
+    _Py_CLEAR(tstate, f->f_frame->f_locals);
     return 0;
 }
 

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -1327,11 +1327,11 @@ try_load_lazy_submodule(PyModuleObject *m, PyObject *name)
 }
 
 PyObject*
-_Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
+_Py_module_getattro_impl(PyThreadState *tstate, PyModuleObject *m, PyObject *name, int suppress)
 {
     // When suppress=1, this function suppresses AttributeError.
     PyObject *attr, *mod_name, *getattr;
-    attr = _PyObject_GenericGetAttrWithDict((PyObject *)m, name, NULL, suppress);
+    attr = _PyObject_GenericGetAttrWithDict(tstate, (PyObject *)m, name, NULL, suppress);
     if (attr) {
         if (PyLazyImport_CheckExact(attr)) {
             // gh-144957: Module __getattr__ should get a chance to provide
@@ -1351,10 +1351,10 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
                     Py_DECREF(attr);
                     return NULL;
                 }
-                PyErr_Clear();
+                _PyErr_Clear(tstate);
             }
             PyObject *new_value = _PyImport_LoadLazyImportTstate(
-                PyThreadState_GET(), attr);
+                tstate, attr);
             if (new_value == NULL) {
                 if (suppress &&
                     PyErr_ExceptionMatches(PyExc_ImportCycleError)) {
@@ -1362,7 +1362,7 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
                     // to import itself. In this case, the error should not
                     // propagate to the caller and instead treated as if the
                     // attribute doesn't exist.
-                    PyErr_Clear();
+                    _PyErr_Clear(tstate);
                 }
                 Py_DECREF(attr);
                 return NULL;
@@ -1377,24 +1377,24 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
         return attr;
     }
     if (suppress == 1) {
-        if (PyErr_Occurred()) {
+        if (_PyErr_Occurred(tstate)) {
             // pass up non-AttributeError exception
             return NULL;
         }
     }
     else {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        if (!_PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
             // pass up non-AttributeError exception
             return NULL;
         }
-        PyErr_Clear();
+        _PyErr_Clear(tstate);
     }
     assert(m->md_dict != NULL);
     attr = try_load_lazy_submodule(m, name);
     if (attr != NULL) {
         return attr;
     }
-    if (PyErr_Occurred()) {
+    if (_PyErr_Occurred(tstate)) {
         return NULL;
     }
     if (PyDict_GetItemRef(m->md_dict, &_Py_ID(__getattr__), &getattr) < 0) {
@@ -1402,9 +1402,9 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
     }
     if (getattr) {
         PyObject *result = PyObject_CallOneArg(getattr, name);
-        if (result == NULL && suppress == 1 && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        if (result == NULL && suppress == 1 && _PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
             // suppress AttributeError
-            PyErr_Clear();
+            _PyErr_Clear(tstate);
         }
         Py_DECREF(getattr);
         return result;
@@ -1420,8 +1420,8 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
     }
     if (!mod_name || !PyUnicode_Check(mod_name)) {
         Py_XDECREF(mod_name);
-        PyErr_Format(PyExc_AttributeError,
-                    "module has no attribute '%U'", name);
+        _PyErr_Format(tstate, PyExc_AttributeError,
+                      "module has no attribute '%U'", name);
         return NULL;
     }
     PyObject *spec;
@@ -1430,9 +1430,9 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
         return NULL;
     }
     if (spec == NULL) {
-        PyErr_Format(PyExc_AttributeError,
-                     "module '%U' has no attribute '%U'",
-                     mod_name, name);
+        _PyErr_Format(tstate, PyExc_AttributeError,
+                      "module '%U' has no attribute '%U'",
+                      mod_name, name);
         Py_DECREF(mod_name);
         return NULL;
     }
@@ -1464,12 +1464,12 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
 
     if (is_possibly_shadowing_stdlib) {
         assert(origin);
-        PyErr_Format(PyExc_AttributeError,
-                    "module '%U' has no attribute '%U' "
-                    "(consider renaming '%U' since it has the same "
-                    "name as the standard library module named '%U' "
-                    "and prevents importing that standard library module)",
-                    mod_name, name, origin, mod_name);
+        _PyErr_Format(tstate, PyExc_AttributeError,
+                     "module '%U' has no attribute '%U' "
+                     "(consider renaming '%U' since it has the same "
+                     "name as the standard library module named '%U' "
+                     "and prevents importing that standard library module)",
+                     mod_name, name, origin, mod_name);
     }
     else {
         int rc = _PyModuleSpec_IsInitializing(spec);
@@ -1481,40 +1481,40 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
                 assert(origin);
                 // For non-stdlib modules, only mention the possibility of
                 // shadowing if the module is being initialized.
-                PyErr_Format(PyExc_AttributeError,
-                            "module '%U' has no attribute '%U' "
-                            "(consider renaming '%U' if it has the same name "
-                            "as a library you intended to import)",
-                            mod_name, name, origin);
+                _PyErr_Format(tstate, PyExc_AttributeError,
+                              "module '%U' has no attribute '%U' "
+                              "(consider renaming '%U' if it has the same name "
+                              "as a library you intended to import)",
+                              mod_name, name, origin);
             }
             else if (origin) {
-                PyErr_Format(PyExc_AttributeError,
-                            "partially initialized "
-                            "module '%U' from '%U' has no attribute '%U' "
-                            "(most likely due to a circular import)",
-                            mod_name, origin, name);
+                _PyErr_Format(tstate, PyExc_AttributeError,
+                              "partially initialized "
+                              "module '%U' from '%U' has no attribute '%U' "
+                              "(most likely due to a circular import)",
+                              mod_name, origin, name);
             }
             else {
-                PyErr_Format(PyExc_AttributeError,
-                            "partially initialized "
-                            "module '%U' has no attribute '%U' "
-                            "(most likely due to a circular import)",
-                            mod_name, name);
+                _PyErr_Format(tstate, PyExc_AttributeError,
+                              "partially initialized "
+                              "module '%U' has no attribute '%U' "
+                              "(most likely due to a circular import)",
+                              mod_name, name);
             }
         }
         else {
             assert(rc == 0);
             rc = _PyModuleSpec_IsUninitializedSubmodule(spec, name);
             if (rc > 0) {
-                PyErr_Format(PyExc_AttributeError,
-                            "cannot access submodule '%U' of module '%U' "
-                            "(most likely due to a circular import)",
-                            name, mod_name);
+                _PyErr_Format(tstate, PyExc_AttributeError,
+                              "cannot access submodule '%U' of module '%U' "
+                              "(most likely due to a circular import)",
+                              name, mod_name);
             }
             else if (rc == 0) {
-                PyErr_Format(PyExc_AttributeError,
-                            "module '%U' has no attribute '%U'",
-                            mod_name, name);
+                _PyErr_Format(tstate, PyExc_AttributeError,
+                              "module '%U' has no attribute '%U'",
+                              mod_name, name);
             }
         }
     }
@@ -1531,7 +1531,7 @@ PyObject*
 _Py_module_getattro(PyObject *self, PyObject *name)
 {
     PyModuleObject *m = _PyModule_CAST(self);
-    return _Py_module_getattro_impl(m, name, 0);
+    return _Py_module_getattro_impl(_PyThreadState_GET(), m, name, 0);
 }
 
 static int

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -420,21 +420,33 @@ _Py_DecRefSharedIsDead(PyObject *o, const char *filename, int lineno)
 }
 
 void
-_Py_DecRefSharedDebug(PyThreadState *tstate, PyObject *o, const char *filename, int lineno)
+_Py_DecRefSharedDebugTstate(PyThreadState *tstate, PyObject *o, const char *filename, int lineno)
 {
     if (_Py_DecRefSharedIsDead(o, filename, lineno)) {
-        _Py_Dealloc(tstate, o);
+        _Py_DeallocTstate(tstate, o);
     }
 }
 
 void
-_Py_DecRefShared(PyThreadState *tstate, PyObject *o)
+_Py_DecRefSharedDebug(PyObject *o, const char *filename, int lineno)
 {
-    _Py_DecRefSharedDebug(tstate, o, NULL, 0);
+    _Py_DecRefSharedDebugTstate(_PyThreadState_GET(), o, filename, lineno);
 }
 
 void
-_Py_MergeZeroLocalRefcount(PyThreadState *tstate, PyObject *op)
+_Py_DecRefSharedTstate(PyThreadState *tstate, PyObject *o)
+{
+    _Py_DecRefSharedDebugTstate(tstate, o, NULL, 0);
+}
+
+void
+_Py_DecRefShared(PyObject *o)
+{
+    _Py_DecRefSharedTstate(_PyThreadState_GET(), o);
+}
+
+void
+_Py_MergeZeroLocalRefcountTstate(PyThreadState *tstate, PyObject *op)
 {
     assert(op->ob_ref_local == 0);
 
@@ -462,6 +474,12 @@ _Py_MergeZeroLocalRefcount(PyThreadState *tstate, PyObject *op)
         // deallocate the object.
         _Py_DeallocTstate(tstate, op);
     }
+}
+
+void
+_Py_MergeZeroLocalRefcount(PyObject *op)
+{
+    _Py_MergeZeroLocalRefcountTstate(_PyThreadState_GET(), op);
 }
 
 Py_ssize_t

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1799,14 +1799,14 @@ _PyObject_GetMethodStackRef(PyThreadState *ts, _PyStackRef *self,
     PyTypeObject *tp = Py_TYPE(obj);
     if (!_PyType_IsReady(tp)) {
         if (PyType_Ready(tp) < 0) {
-            PyStackRef_CLEAR(*self);
+            _PyStackRef_CLEAR(ts, *self);
             return -1;
         }
     }
 
     if (tp->tp_getattro != PyObject_GenericGetAttr || !PyUnicode_CheckExact(name)) {
         PyObject *res = _PyObject_GetAttr(ts, obj, name);
-        PyStackRef_CLEAR(*self);
+        _PyStackRef_CLEAR(ts, *self);
         if (res != NULL) {
             *method = PyStackRef_FromPyObjectSteal(res);
             return 0;
@@ -1825,8 +1825,8 @@ _PyObject_GetMethodStackRef(PyThreadState *ts, _PyStackRef *self,
             f = Py_TYPE(descr)->tp_descr_get;
             if (f != NULL && PyDescr_IsData(descr)) {
                 PyObject *value = f(descr, obj, (PyObject *)Py_TYPE(obj));
-                PyStackRef_CLEAR(*method);
-                PyStackRef_CLEAR(*self);
+                _PyStackRef_CLEAR(ts, *method);
+                _PyStackRef_CLEAR(ts, *self);
                 if (value != NULL) {
                     *method = PyStackRef_FromPyObjectSteal(value);
                     return 0;
@@ -1840,7 +1840,7 @@ _PyObject_GetMethodStackRef(PyThreadState *ts, _PyStackRef *self,
          _PyObject_TryGetInstanceAttribute(obj, name, &attr)) {
         if (attr != NULL) {
             PyStackRef_XSETREF(*method, PyStackRef_FromPyObjectSteal(attr));
-            PyStackRef_CLEAR(*self);
+            _PyStackRef_CLEAR(ts, *self);
             return 0;
         }
         dict = NULL;
@@ -1862,11 +1862,11 @@ _PyObject_GetMethodStackRef(PyThreadState *ts, _PyStackRef *self,
         int found = _PyDict_GetMethodStackRef((PyDictObject *)dict, name, method);
         if (found < 0) {
             assert(PyStackRef_IsNull(*method));
-            PyStackRef_CLEAR(*self);
+            _PyStackRef_CLEAR(ts, *self);
             return -1;
         }
         else if (found) {
-            PyStackRef_CLEAR(*self);
+            _PyStackRef_CLEAR(ts, *self);
             return 0;
         }
     }
@@ -1886,12 +1886,12 @@ _PyObject_GetMethodStackRef(PyThreadState *ts, _PyStackRef *self,
         else if (Py_IS_TYPE(descr, &PyStaticMethod_Type)) {
             PyObject *callable = _PyStaticMethod_GetFunc(descr);
             PyStackRef_XSETREF(*method, PyStackRef_FromPyObjectNew(callable));
-            PyStackRef_CLEAR(*self);
+            _PyStackRef_CLEAR(ts, *self);
             return 0;
         }
         PyObject *value = f(descr, obj, (PyObject *)tp);
-        PyStackRef_CLEAR(*method);
-        PyStackRef_CLEAR(*self);
+        _PyStackRef_CLEAR(ts, *method);
+        _PyStackRef_CLEAR(ts, *self);
         if (value) {
             *method = PyStackRef_FromPyObjectSteal(value);
             return 0;
@@ -1901,7 +1901,7 @@ _PyObject_GetMethodStackRef(PyThreadState *ts, _PyStackRef *self,
 
     if (descr != NULL) {
         assert(!PyStackRef_IsNull(*method));
-        PyStackRef_CLEAR(*self);
+        _PyStackRef_CLEAR(ts, *self);
         return 0;
     }
 
@@ -1911,7 +1911,7 @@ _PyObject_GetMethodStackRef(PyThreadState *ts, _PyStackRef *self,
 
     _PyObject_SetAttributeErrorContext(ts, obj, name);
     assert(PyStackRef_IsNull(*method));
-    PyStackRef_CLEAR(*self);
+    _PyStackRef_CLEAR(ts, *self);
     return -1;
 }
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1096,9 +1096,8 @@ do_richcompare(PyThreadState *tstate, PyObject *v, PyObject *w, int op)
    with a check for NULL arguments and a recursion check. */
 
 PyObject *
-PyObject_RichCompare(PyObject *v, PyObject *w, int op)
+_PyObject_RichCompare(PyThreadState *tstate, PyObject *v, PyObject *w, int op)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
 
     assert(Py_LT <= op && op <= Py_GE);
     if (v == NULL || w == NULL) {
@@ -1115,10 +1114,16 @@ PyObject_RichCompare(PyObject *v, PyObject *w, int op)
     return res;
 }
 
+PyObject *
+PyObject_RichCompare(PyObject *v, PyObject *w, int op)
+{
+    return _PyObject_RichCompare(_PyThreadState_GET(), v, w, op);
+}
+
 /* Perform a rich comparison with integer result.  This wraps
    PyObject_RichCompare(), returning -1 for error, 0 for false, 1 for true. */
 int
-PyObject_RichCompareBool(PyObject *v, PyObject *w, int op)
+_PyObject_RichCompareBool(PyThreadState *tstate, PyObject *v, PyObject *w, int op)
 {
     PyObject *res;
     int ok;
@@ -1132,7 +1137,7 @@ PyObject_RichCompareBool(PyObject *v, PyObject *w, int op)
             return 0;
     }
 
-    res = PyObject_RichCompare(v, w, op);
+    res = _PyObject_RichCompare(tstate, v, w, op);
     if (res == NULL)
         return -1;
     if (PyBool_Check(res)) {
@@ -1144,6 +1149,12 @@ PyObject_RichCompareBool(PyObject *v, PyObject *w, int op)
         Py_DECREF(res);
     }
     return ok;
+}
+
+int
+PyObject_RichCompareBool(PyObject *v, PyObject *w, int op)
+{
+    return _PyObject_RichCompareBool(_PyThreadState_GET(), v, w, op);
 }
 
 Py_hash_t
@@ -1279,14 +1290,14 @@ _Py_COMP_DIAG_POP
 }
 
 int
-_PyObject_SetAttributeErrorContext(PyObject* v, PyObject* name)
+_PyObject_SetAttributeErrorContext(PyThreadState *tstate, PyObject* v, PyObject* name)
 {
-    assert(PyErr_Occurred());
-    if (!PyErr_ExceptionMatches(PyExc_AttributeError)){
+    assert(_PyErr_Occurred(tstate));
+    if (!_PyErr_ExceptionMatches(tstate, PyExc_AttributeError)){
         return 0;
     }
     // Intercept AttributeError exceptions and augment them to offer suggestions later.
-    PyObject *exc = PyErr_GetRaisedException();
+    PyObject *exc = _PyErr_GetRaisedException(tstate);
     if (!PyErr_GivenExceptionMatches(exc, PyExc_AttributeError)) {
         goto restore;
     }
@@ -1302,18 +1313,18 @@ _PyObject_SetAttributeErrorContext(PyObject* v, PyObject* name)
         return 1;
     }
 restore:
-    PyErr_SetRaisedException(exc);
+    _PyErr_SetRaisedException(tstate, exc);
     return 0;
 }
 
 PyObject *
-PyObject_GetAttr(PyObject *v, PyObject *name)
+_PyObject_GetAttr(PyThreadState *tstate, PyObject *v, PyObject *name)
 {
     PyTypeObject *tp = Py_TYPE(v);
     if (!PyUnicode_Check(name)) {
-        PyErr_Format(PyExc_TypeError,
-                     "attribute name must be string, not '%.200s'",
-                     Py_TYPE(name)->tp_name);
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "attribute name must be string, not '%.200s'",
+                      Py_TYPE(name)->tp_name);
         return NULL;
     }
 
@@ -1335,30 +1346,36 @@ PyObject_GetAttr(PyObject *v, PyObject *name)
     }
 
     if (result == NULL) {
-        _PyObject_SetAttributeErrorContext(v, name);
+        _PyObject_SetAttributeErrorContext(tstate, v, name);
     }
     return result;
+}
+
+PyObject *
+PyObject_GetAttr(PyObject *v, PyObject *name)
+{
+    return _PyObject_GetAttr(_PyThreadState_GET(), v, name);
 }
 
 /* Like PyObject_GetAttr but returns a _PyStackRef.
    For types (tp_getattro == _Py_type_getattro), this can return
    a deferred reference to reduce reference count contention. */
 _PyStackRef
-_PyObject_GetAttrStackRef(PyObject *v, PyObject *name)
+_PyObject_GetAttrStackRef(PyThreadState *tstate, PyObject *v, PyObject *name)
 {
     PyTypeObject *tp = Py_TYPE(v);
     if (!PyUnicode_Check(name)) {
-        PyErr_Format(PyExc_TypeError,
-                     "attribute name must be string, not '%.200s'",
-                     Py_TYPE(name)->tp_name);
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "attribute name must be string, not '%.200s'",
+                      Py_TYPE(name)->tp_name);
         return PyStackRef_NULL;
     }
 
     /* Fast path for types - can return deferred references */
     if (tp->tp_getattro == _Py_type_getattro) {
-        _PyStackRef result = _Py_type_getattro_stackref((PyTypeObject *)v, name, NULL);
+        _PyStackRef result = _Py_type_getattro_stackref(tstate, (PyTypeObject *)v, name, NULL);
         if (PyStackRef_IsNull(result)) {
-            _PyObject_SetAttributeErrorContext(v, name);
+            _PyObject_SetAttributeErrorContext(tstate, v, name);
         }
         return result;
     }
@@ -1376,44 +1393,45 @@ _PyObject_GetAttrStackRef(PyObject *v, PyObject *name)
         result = (*tp->tp_getattr)(v, (char *)name_str);
     }
     else {
-        PyErr_Format(PyExc_AttributeError,
-                    "'%.100s' object has no attribute '%U'",
-                    tp->tp_name, name);
+        _PyErr_Format(tstate, PyExc_AttributeError,
+                      "'%.100s' object has no attribute '%U'",
+                      tp->tp_name, name);
     }
 
     if (result == NULL) {
-        _PyObject_SetAttributeErrorContext(v, name);
+        _PyObject_SetAttributeErrorContext(tstate, v, name);
         return PyStackRef_NULL;
     }
     return PyStackRef_FromPyObjectSteal(result);
 }
 
 int
-PyObject_GetOptionalAttr(PyObject *v, PyObject *name, PyObject **result)
+_PyObject_GetOptionalAttr(PyThreadState *tstate,
+                          PyObject *v, PyObject *name, PyObject **result)
 {
     PyTypeObject *tp = Py_TYPE(v);
 
     if (!PyUnicode_Check(name)) {
-        PyErr_Format(PyExc_TypeError,
-                     "attribute name must be string, not '%.200s'",
-                     Py_TYPE(name)->tp_name);
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "attribute name must be string, not '%.200s'",
+                      Py_TYPE(name)->tp_name);
         *result = NULL;
         return -1;
     }
 
     if (tp->tp_getattro == PyObject_GenericGetAttr) {
-        *result = _PyObject_GenericGetAttrWithDict(v, name, NULL, 1);
+        *result = _PyObject_GenericGetAttrWithDict(tstate, v, name, NULL, 1);
         if (*result != NULL) {
             return 1;
         }
-        if (PyErr_Occurred()) {
+        if (_PyErr_Occurred(tstate)) {
             return -1;
         }
         return 0;
     }
     if (tp->tp_getattro == _Py_type_getattro) {
         int suppress_missing_attribute_exception = 0;
-        *result = _Py_type_getattro_impl((PyTypeObject*)v, name, &suppress_missing_attribute_exception);
+        *result = _Py_type_getattro_impl(tstate, (PyTypeObject*)v, name, &suppress_missing_attribute_exception);
         if (suppress_missing_attribute_exception) {
             // return 0 without having to clear the exception
             return 0;
@@ -1421,7 +1439,7 @@ PyObject_GetOptionalAttr(PyObject *v, PyObject *name, PyObject **result)
     }
     else if (tp->tp_getattro == (getattrofunc)_Py_module_getattro) {
         // optimization: suppress attribute error from module getattro method
-        *result = _Py_module_getattro_impl((PyModuleObject*)v, name, 1);
+        *result = _Py_module_getattro_impl(tstate, (PyModuleObject*)v, name, 1);
         if (*result != NULL) {
             return 1;
         }
@@ -1454,6 +1472,12 @@ PyObject_GetOptionalAttr(PyObject *v, PyObject *name, PyObject **result)
     }
     PyErr_Clear();
     return 0;
+}
+
+int
+PyObject_GetOptionalAttr(PyObject *v, PyObject *name, PyObject **result)
+{
+    return _PyObject_GetOptionalAttr(_PyThreadState_GET(), v, name, result);
 }
 
 int
@@ -1505,9 +1529,8 @@ PyObject_HasAttr(PyObject *obj, PyObject *name)
 }
 
 int
-PyObject_SetAttr(PyObject *v, PyObject *name, PyObject *value)
+_PyObject_SetAttr(PyThreadState *tstate, PyObject *v, PyObject *name, PyObject *value)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
     if (value == NULL && _PyErr_Occurred(tstate)) {
         PyObject *exc = _PyErr_GetRaisedException(tstate);
         _PyErr_SetString(tstate, PyExc_SystemError,
@@ -1521,9 +1544,9 @@ PyObject_SetAttr(PyObject *v, PyObject *name, PyObject *value)
     int err;
 
     if (!PyUnicode_Check(name)) {
-        PyErr_Format(PyExc_TypeError,
-                     "attribute name must be string, not '%.200s'",
-                     Py_TYPE(name)->tp_name);
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "attribute name must be string, not '%.200s'",
+                      Py_TYPE(name)->tp_name);
         return -1;
     }
     Py_INCREF(name);
@@ -1547,26 +1570,38 @@ PyObject_SetAttr(PyObject *v, PyObject *name, PyObject *value)
     Py_DECREF(name);
     _PyObject_ASSERT(name, Py_REFCNT(name) >= 1);
     if (tp->tp_getattr == NULL && tp->tp_getattro == NULL)
-        PyErr_Format(PyExc_TypeError,
-                     "'%.100s' object has no attributes "
-                     "(%s .%U)",
-                     tp->tp_name,
-                     value==NULL ? "del" : "assign to",
-                     name);
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "'%.100s' object has no attributes "
+                      "(%s .%U)",
+                      tp->tp_name,
+                      value==NULL ? "del" : "assign to",
+                      name);
     else
-        PyErr_Format(PyExc_TypeError,
-                     "'%.100s' object has only read-only attributes "
-                     "(%s .%U)",
-                     tp->tp_name,
-                     value==NULL ? "del" : "assign to",
-                     name);
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "'%.100s' object has only read-only attributes "
+                      "(%s .%U)",
+                      tp->tp_name,
+                      value==NULL ? "del" : "assign to",
+                      name);
     return -1;
+}
+
+int
+PyObject_SetAttr(PyObject *v, PyObject *name, PyObject *value)
+{
+    return _PyObject_SetAttr(_PyThreadState_GET(), v, name, value);
+}
+
+int
+_PyObject_DelAttr(PyThreadState *tstate, PyObject *v, PyObject *name)
+{
+    return _PyObject_SetAttr(tstate, v, name, NULL);
 }
 
 int
 PyObject_DelAttr(PyObject *v, PyObject *name)
 {
-    return PyObject_SetAttr(v, name, NULL);
+    return _PyObject_DelAttr(_PyThreadState_GET(), v, name);
 }
 
 PyObject **
@@ -1653,7 +1688,7 @@ _PyObject_NextNotImplemented(PyObject *self)
    latter case, an error will be set.
 */
 int
-_PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
+_PyObject_GetMethod(PyThreadState *tstate, PyObject *obj, PyObject *name, PyObject **method)
 {
     int meth_found = 0;
 
@@ -1667,7 +1702,7 @@ _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
     }
 
     if (tp->tp_getattro != PyObject_GenericGetAttr || !PyUnicode_CheckExact(name)) {
-        *method = PyObject_GetAttr(obj, name);
+        *method = _PyObject_GetAttr(tstate, obj, name);
         return 0;
     }
 
@@ -1740,7 +1775,7 @@ _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
                  "'%.100s' object has no attribute '%U'",
                  tp->tp_name, name);
 
-    _PyObject_SetAttributeErrorContext(obj, name);
+    _PyObject_SetAttributeErrorContext(tstate, obj, name);
     return 0;
 }
 
@@ -1770,7 +1805,7 @@ _PyObject_GetMethodStackRef(PyThreadState *ts, _PyStackRef *self,
     }
 
     if (tp->tp_getattro != PyObject_GenericGetAttr || !PyUnicode_CheckExact(name)) {
-        PyObject *res = PyObject_GetAttr(obj, name);
+        PyObject *res = _PyObject_GetAttr(ts, obj, name);
         PyStackRef_CLEAR(*self);
         if (res != NULL) {
             *method = PyStackRef_FromPyObjectSteal(res);
@@ -1870,11 +1905,11 @@ _PyObject_GetMethodStackRef(PyThreadState *ts, _PyStackRef *self,
         return 0;
     }
 
-    PyErr_Format(PyExc_AttributeError,
-                 "'%.100s' object has no attribute '%U'",
-                 tp->tp_name, name);
+    _PyErr_Format(ts, PyExc_AttributeError,
+                  "'%.100s' object has no attribute '%U'",
+                  tp->tp_name, name);
 
-    _PyObject_SetAttributeErrorContext(obj, name);
+    _PyObject_SetAttributeErrorContext(ts, obj, name);
     assert(PyStackRef_IsNull(*method));
     PyStackRef_CLEAR(*self);
     return -1;
@@ -1884,7 +1919,7 @@ _PyObject_GetMethodStackRef(PyThreadState *ts, _PyStackRef *self,
 /* Generic GetAttr functions - put these in your tp_[gs]etattro slot. */
 
 PyObject *
-_PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
+_PyObject_GenericGetAttrWithDict(PyThreadState *tstate, PyObject *obj, PyObject *name,
                                  PyObject *dict, int suppress)
 {
     /* Make sure the logic of _PyObject_GetMethod is in sync with
@@ -1899,9 +1934,9 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
     descrgetfunc f;
 
     if (!PyUnicode_Check(name)){
-        PyErr_Format(PyExc_TypeError,
-                     "attribute name must be string, not '%.200s'",
-                     Py_TYPE(name)->tp_name);
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "attribute name must be string, not '%.200s'",
+                      Py_TYPE(name)->tp_name);
         return NULL;
     }
 
@@ -1912,7 +1947,6 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
 
     Py_INCREF(name);
 
-    PyThreadState *tstate = _PyThreadState_GET();
     _PyCStackRef cref;
     _PyThreadState_PushCStackRef(tstate, &cref);
 
@@ -1925,8 +1959,8 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
         if (f != NULL && PyDescr_IsData(descr)) {
             res = f(descr, obj, (PyObject *)Py_TYPE(obj));
             if (res == NULL && suppress &&
-                    PyErr_ExceptionMatches(PyExc_AttributeError)) {
-                PyErr_Clear();
+                    _PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
+                _PyErr_Clear(tstate);
             }
             goto done;
         }
@@ -1969,8 +2003,8 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
             goto done;
         }
         else if (rc < 0) {
-            if (suppress && PyErr_ExceptionMatches(PyExc_AttributeError)) {
-                PyErr_Clear();
+            if (suppress && _PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
+                _PyErr_Clear(tstate);
             }
             else {
                 goto done;
@@ -1981,8 +2015,8 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
     if (f != NULL) {
         res = f(descr, obj, (PyObject *)Py_TYPE(obj));
         if (res == NULL && suppress &&
-                PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
+                _PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
+            _PyErr_Clear(tstate);
         }
         goto done;
     }
@@ -1994,11 +2028,11 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
     }
 
     if (!suppress) {
-        PyErr_Format(PyExc_AttributeError,
-                     "'%.100s' object has no attribute '%U'",
-                     tp->tp_name, name);
+        _PyErr_Format(tstate, PyExc_AttributeError,
+                      "'%.100s' object has no attribute '%U'",
+                      tp->tp_name, name);
 
-        _PyObject_SetAttributeErrorContext(obj, name);
+        _PyObject_SetAttributeErrorContext(tstate, obj, name);
     }
   done:
     _PyThreadState_PopCStackRef(tstate, &cref);
@@ -2009,11 +2043,11 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
 PyObject *
 PyObject_GenericGetAttr(PyObject *obj, PyObject *name)
 {
-    return _PyObject_GenericGetAttrWithDict(obj, name, NULL, 0);
+    return _PyObject_GenericGetAttrWithDict(_PyThreadState_GET(), obj, name, NULL, 0);
 }
 
 int
-_PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
+_PyObject_GenericSetAttrWithDict(PyThreadState *tstate, PyObject *obj, PyObject *name,
                                  PyObject *value, PyObject *dict)
 {
     PyTypeObject *tp = Py_TYPE(obj);
@@ -2023,9 +2057,9 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
 
     assert(!PyType_IsSubtype(tp, &PyType_Type));
     if (!PyUnicode_Check(name)){
-        PyErr_Format(PyExc_TypeError,
-                     "attribute name must be string, not '%.200s'",
-                     Py_TYPE(name)->tp_name);
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "attribute name must be string, not '%.200s'",
+                      Py_TYPE(name)->tp_name);
         return -1;
     }
 
@@ -2036,7 +2070,6 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
     Py_INCREF(name);
     _Py_INCREF_TYPE(tp);
 
-    PyThreadState *tstate = _PyThreadState_GET();
     _PyCStackRef cref;
     _PyThreadState_PushCStackRef(tstate, &cref);
 
@@ -2069,22 +2102,22 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
         if (dictptr == NULL) {
             if (descr == NULL) {
                 if (tp->tp_setattro == PyObject_GenericSetAttr) {
-                    PyErr_Format(PyExc_AttributeError,
-                                "'%.100s' object has no attribute '%U' and no "
-                                "__dict__ for setting new attributes",
-                                tp->tp_name, name);
+                    _PyErr_Format(tstate, PyExc_AttributeError,
+                                  "'%.100s' object has no attribute '%U' and no "
+                                  "__dict__ for setting new attributes",
+                                  tp->tp_name, name);
                 }
                 else {
-                    PyErr_Format(PyExc_AttributeError,
-                                "'%.100s' object has no attribute '%U'",
-                                tp->tp_name, name);
+                    _PyErr_Format(tstate, PyExc_AttributeError,
+                                  "'%.100s' object has no attribute '%U'",
+                                  tp->tp_name, name);
                 }
-                _PyObject_SetAttributeErrorContext(obj, name);
+                _PyObject_SetAttributeErrorContext(tstate, obj, name);
             }
             else {
-                PyErr_Format(PyExc_AttributeError,
-                            "'%.100s' object attribute '%U' is read-only",
-                            tp->tp_name, name);
+                _PyErr_Format(tstate, PyExc_AttributeError,
+                              "'%.100s' object attribute '%U' is read-only",
+                              tp->tp_name, name);
             }
             goto done;
         }
@@ -2102,10 +2135,10 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
     }
   error_check:
     if (res < 0 && PyErr_ExceptionMatches(PyExc_KeyError)) {
-        PyErr_Format(PyExc_AttributeError,
+        _PyErr_Format(tstate, PyExc_AttributeError,
                         "'%.100s' object has no attribute '%U'",
                         tp->tp_name, name);
-        _PyObject_SetAttributeErrorContext(obj, name);
+        _PyObject_SetAttributeErrorContext(tstate, obj, name);
     }
   done:
     _PyThreadState_PopCStackRef(tstate, &cref);
@@ -2117,7 +2150,7 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
 int
 PyObject_GenericSetAttr(PyObject *obj, PyObject *name, PyObject *value)
 {
-    return _PyObject_GenericSetAttrWithDict(obj, name, value, NULL);
+    return _PyObject_GenericSetAttrWithDict(_PyThreadState_GET(), obj, name, value, NULL);
 }
 
 int

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -420,28 +420,28 @@ _Py_DecRefSharedIsDead(PyObject *o, const char *filename, int lineno)
 }
 
 void
-_Py_DecRefSharedDebug(PyObject *o, const char *filename, int lineno)
+_Py_DecRefSharedDebug(PyThreadState *tstate, PyObject *o, const char *filename, int lineno)
 {
     if (_Py_DecRefSharedIsDead(o, filename, lineno)) {
-        _Py_Dealloc(o);
+        _Py_Dealloc(tstate, o);
     }
 }
 
 void
-_Py_DecRefShared(PyObject *o)
+_Py_DecRefShared(PyThreadState *tstate, PyObject *o)
 {
-    _Py_DecRefSharedDebug(o, NULL, 0);
+    _Py_DecRefSharedDebug(tstate, o, NULL, 0);
 }
 
 void
-_Py_MergeZeroLocalRefcount(PyObject *op)
+_Py_MergeZeroLocalRefcount(PyThreadState *tstate, PyObject *op)
 {
     assert(op->ob_ref_local == 0);
 
     Py_ssize_t shared = _Py_atomic_load_ssize_acquire(&op->ob_ref_shared);
     if (shared == 0) {
         // Fast-path: shared refcount is zero (including flags)
-        _Py_Dealloc(op);
+        _Py_DeallocTstate(tstate, op);
         return;
     }
 
@@ -460,7 +460,7 @@ _Py_MergeZeroLocalRefcount(PyObject *op)
     if (new_shared == _Py_REF_MERGED) {
         // i.e., the shared refcount is zero (only the flags are set) so we
         // deallocate the object.
-        _Py_Dealloc(op);
+        _Py_DeallocTstate(tstate, op);
     }
 }
 
@@ -3320,12 +3320,11 @@ To avoid that, if the C stack is nearing its limit, instead of calling
 dealloc on the object, it is added to a queue to be freed later when the
 stack is shallower */
 void
-_Py_Dealloc(PyObject *op)
+_Py_DeallocTstate(PyThreadState *tstate, PyObject *op)
 {
     PyTypeObject *type = Py_TYPE(op);
     unsigned long gc_flag = type->tp_flags & Py_TPFLAGS_HAVE_GC;
     destructor dealloc = type->tp_dealloc;
-    PyThreadState *tstate = _PyThreadState_GET();
     intptr_t margin = _Py_RecursionLimit_GetMargin(tstate);
     if (margin < 2 && gc_flag) {
         _PyTrash_thread_deposit_object(tstate, (PyObject *)op);
@@ -3378,6 +3377,11 @@ _Py_Dealloc(PyObject *op)
     }
 }
 
+void
+_Py_Dealloc(PyObject *op)
+{
+    _Py_DeallocTstate(_PyThreadState_GET(), op);
+}
 
 PyObject **
 PyObject_GET_WEAKREFS_LISTPTR(PyObject *op)

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -326,7 +326,7 @@ _PyObject_MiCalloc(void *ctx, size_t nelem, size_t elsize)
 void *
 _PyObject_MiRealloc(void *ctx, void *ptr, size_t nbytes)
 {
-#ifdef Py_GIL_DIABLED
+#ifdef Py_GIL_DISABLED
     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
     // Implement our own realloc logic so that we can copy PyObject header
     // in a thread-safe way.

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -326,7 +326,7 @@ _PyObject_MiCalloc(void *ctx, size_t nelem, size_t elsize)
 void *
 _PyObject_MiRealloc(void *ctx, void *ptr, size_t nbytes)
 {
-#ifdef Py_GIL_DISABLED
+#ifdef Py_GIL_DIABLED
     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
     // Implement our own realloc logic so that we can copy PyObject header
     // in a thread-safe way.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1779,7 +1779,7 @@ type_get_mro(PyObject *tp, void *Py_UNUSED(closure))
 static PyTypeObject *find_best_base(PyObject *);
 static int mro_internal(PyTypeObject *, int, PyObject **);
 static int type_is_subtype_base_chain(PyTypeObject *, PyTypeObject *);
-static int compatible_for_assignment(PyTypeObject *, PyTypeObject *, const char *, int);
+static int compatible_for_assignment(PyThreadState *, PyTypeObject *, PyTypeObject *, const char *, int);
 static int add_subclass(PyTypeObject*, PyTypeObject*);
 static int add_all_subclasses(PyTypeObject *type, PyObject *bases);
 static void remove_subclass(PyTypeObject *, PyTypeObject *);
@@ -1863,7 +1863,7 @@ mro_hierarchy_for_complete_type(PyTypeObject *type, PyObject *temp)
 }
 
 static int
-type_check_new_bases(PyTypeObject *type, PyObject *new_bases, PyTypeObject **best_base)
+type_check_new_bases(PyThreadState *tstate, PyTypeObject *type, PyObject *new_bases, PyTypeObject **best_base)
 {
     // Check arguments, this is re-entrant due to the PySys_Audit() call
     if (!check_set_special_type_attr(type, new_bases, "__bases__")) {
@@ -1872,13 +1872,13 @@ type_check_new_bases(PyTypeObject *type, PyObject *new_bases, PyTypeObject **bes
     assert(new_bases != NULL);
 
     if (!PyTuple_Check(new_bases)) {
-        PyErr_Format(PyExc_TypeError,
+        _PyErr_Format(tstate, PyExc_TypeError,
              "can only assign tuple to %s.__bases__, not %s",
                  type->tp_name, Py_TYPE(new_bases)->tp_name);
         return -1;
     }
     if (PyTuple_GET_SIZE(new_bases) == 0) {
-        PyErr_Format(PyExc_TypeError,
+        _PyErr_Format(tstate, PyExc_TypeError,
              "can only assign non-empty tuple to %s.__bases__, not ()",
                  type->tp_name);
         return -1;
@@ -1887,9 +1887,9 @@ type_check_new_bases(PyTypeObject *type, PyObject *new_bases, PyTypeObject **bes
     for (Py_ssize_t i = 0; i < n; i++) {
         PyObject *ob = PyTuple_GET_ITEM(new_bases, i);
         if (!PyType_Check(ob)) {
-            PyErr_Format(PyExc_TypeError,
-                         "%s.__bases__ must be tuple of classes, not '%s'",
-                         type->tp_name, Py_TYPE(ob)->tp_name);
+            _PyErr_Format(tstate, PyExc_TypeError,
+                          "%s.__bases__ must be tuple of classes, not '%s'",
+                          type->tp_name, Py_TYPE(ob)->tp_name);
             return -1;
         }
         PyTypeObject *base = (PyTypeObject*)ob;
@@ -1907,7 +1907,7 @@ type_check_new_bases(PyTypeObject *type, PyObject *new_bases, PyTypeObject **bes
             (lookup_tp_mro(base) != NULL
              && type_is_subtype_base_chain(base, type)))
         {
-            PyErr_SetString(PyExc_TypeError,
+            _PyErr_SetString(tstate, PyExc_TypeError,
                             "a __bases__ item causes an inheritance cycle");
             return -1;
         }
@@ -1918,7 +1918,7 @@ type_check_new_bases(PyTypeObject *type, PyObject *new_bases, PyTypeObject **bes
     if (*best_base == NULL)
         return -1;
 
-    if (!compatible_for_assignment(type, *best_base, "__bases__", 0)) {
+    if (!compatible_for_assignment(tstate, type, *best_base, "__bases__", 0)) {
         return -1;
     }
 
@@ -2027,7 +2027,7 @@ type_set_bases(PyObject *tp, PyObject *new_bases, void *Py_UNUSED(closure))
     PyTypeObject *best_base;
     int res;
     BEGIN_TYPE_LOCK();
-    res = type_check_new_bases(type, new_bases, &best_base);
+    res = type_check_new_bases(_PyThreadState_GET(), type, new_bases, &best_base);
     if (res == 0) {
         res = type_set_bases_unlocked(type, new_bases, best_base);
     }
@@ -2511,6 +2511,9 @@ _PyType_NewManagedObject(PyTypeObject *type)
 PyObject *
 _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems)
 {
+    PyThreadState *tstate = _PyThreadState_GET();
+    assert(tstate != NULL);
+
     PyObject *obj;
     /* The +1 on nitems is needed for most types but not all. We could save a
      * bit of space by allocating one less item in certain cases, depending on
@@ -2527,7 +2530,7 @@ _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems)
     }
     char *alloc = _PyObject_MallocWithType(type, size + presize);
     if (alloc  == NULL) {
-        return PyErr_NoMemory();
+        return _PyErr_NoMemory(tstate);
     }
     obj = (PyObject *)(alloc + presize);
     if (presize) {
@@ -2535,7 +2538,7 @@ _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems)
         ((PyObject **)alloc)[1] = NULL;
     }
     if (PyType_IS_GC(type)) {
-        _PyObject_GC_Link(obj);
+        _PyObject_GC_Link(tstate, obj);
     }
     // Zero out the object after the PyObject header. The header fields are
     // initialized by _PyObject_Init[Var]().
@@ -6529,9 +6532,10 @@ _PyType_SetFlagsRecursive(PyTypeObject *self, unsigned long mask, unsigned long 
 
    */
 PyObject *
-_Py_type_getattro_impl(PyTypeObject *type, PyObject *name, int *suppress_missing_attribute)
+_Py_type_getattro_impl(PyThreadState *tstate,
+                       PyTypeObject *type, PyObject *name, int *suppress_missing_attribute)
 {
-    _PyStackRef ref = _Py_type_getattro_stackref(type, name, suppress_missing_attribute);
+    _PyStackRef ref = _Py_type_getattro_stackref(tstate, type, name, suppress_missing_attribute);
     if (PyStackRef_IsNull(ref)) {
         return NULL;
     }
@@ -6544,7 +6548,7 @@ PyObject *
 _Py_type_getattro(PyObject *tp, PyObject *name)
 {
     PyTypeObject *type = PyTypeObject_CAST(tp);
-    return _Py_type_getattro_impl(type, name, NULL);
+    return _Py_type_getattro_impl(_PyThreadState_GET(), type, name, NULL);
 }
 
 /* Like _Py_type_getattro but returns a _PyStackRef.
@@ -6558,7 +6562,7 @@ _Py_type_getattro(PyObject *tp, PyObject *name)
      having suppressed the exception (other exceptions are not suppressed)
 */
 _PyStackRef
-_Py_type_getattro_stackref(PyTypeObject *type, PyObject *name,
+_Py_type_getattro_stackref(PyThreadState *tstate, PyTypeObject *type, PyObject *name,
                            int *suppress_missing_attribute)
 {
     PyTypeObject *metatype = Py_TYPE(type);
@@ -6579,7 +6583,6 @@ _Py_type_getattro_stackref(PyTypeObject *type, PyObject *name,
 
     /* Set up GC-visible stack refs */
     _PyCStackRef result_ref, meta_attribute_ref, attribute_ref;
-    PyThreadState *tstate = _PyThreadState_GET();
     _PyThreadState_PushCStackRef(tstate, &result_ref);
     _PyThreadState_PushCStackRef(tstate, &meta_attribute_ref);
     _PyThreadState_PushCStackRef(tstate, &attribute_ref);
@@ -6681,7 +6684,7 @@ done:
 // Called by type_setattro().  Updates both the type dict and
 // the type versions.
 static int
-type_update_dict(PyTypeObject *type, PyDictObject *dict, PyObject *name,
+type_update_dict(PyThreadState *tstate, PyTypeObject *type, PyDictObject *dict, PyObject *name,
                  PyObject *value, PyObject **old_value)
 {
     // We don't want any re-entrancy between when we update the dict
@@ -6702,10 +6705,10 @@ type_update_dict(PyTypeObject *type, PyDictObject *dict, PyObject *name,
     type_modified_unlocked(type);
 
     if (_PyDict_SetItem_LockHeld(dict, name, value) < 0) {
-        PyErr_Format(PyExc_AttributeError,
-                     "type object '%.50s' has no attribute '%U'",
-                     ((PyTypeObject*)type)->tp_name, name);
-        _PyObject_SetAttributeErrorContext((PyObject *)type, name);
+        _PyErr_Format(tstate, PyExc_AttributeError,
+                      "type object '%.50s' has no attribute '%U'",
+                      ((PyTypeObject*)type)->tp_name, name);
+        _PyObject_SetAttributeErrorContext(tstate, (PyObject *)type, name);
         return -1;
     }
 
@@ -6740,18 +6743,20 @@ static int
 type_setattro(PyObject *self, PyObject *name, PyObject *value)
 {
     PyTypeObject *type = PyTypeObject_CAST(self);
+    PyThreadState *tstate = _PyThreadState_GET();
     int res;
     if (type->tp_flags & Py_TPFLAGS_IMMUTABLETYPE) {
-        PyErr_Format(
+        _PyErr_Format(
+            tstate,
             PyExc_TypeError,
             "cannot set %R attribute of immutable type '%s'",
             name, type->tp_name);
         return -1;
     }
     if (!PyUnicode_Check(name)) {
-        PyErr_Format(PyExc_TypeError,
-                     "attribute name must be string, not '%.200s'",
-                     Py_TYPE(name)->tp_name);
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "attribute name must be string, not '%.200s'",
+                      Py_TYPE(name)->tp_name);
         return -1;
     }
 
@@ -6764,11 +6769,10 @@ type_setattro(PyObject *self, PyObject *name, PyObject *value)
             return -1;
     }
     if (!PyUnicode_CHECK_INTERNED(name)) {
-        PyInterpreterState *interp = _PyInterpreterState_GET();
-        _PyUnicode_InternMortal(interp, &name);
+        _PyUnicode_InternMortal(tstate->interp, &name);
         if (!PyUnicode_CHECK_INTERNED(name)) {
-            PyErr_SetString(PyExc_MemoryError,
-                            "Out of memory interning an attribute name");
+            _PyErr_SetString(tstate, PyExc_MemoryError,
+                             "Out of memory interning an attribute name");
             Py_DECREF(name);
             return -1;
         }
@@ -6817,7 +6821,7 @@ type_setattro(PyObject *self, PyObject *name, PyObject *value)
     }
 
     BEGIN_TYPE_DICT_LOCK(dict);
-    res = type_update_dict(type, (PyDictObject *)dict, name, value, &old_value);
+    res = type_update_dict(tstate, type, (PyDictObject *)dict, name, value, &old_value);
     assert(_PyType_CheckConsistency(type));
     if (res == 0) {
         if (is_dunder_name(name) && has_slotdef(name)) {
@@ -7575,7 +7579,7 @@ compatible_with_tp_base(PyTypeObject *child)
 }
 
 static int
-same_slots_added(PyTypeObject *a, PyTypeObject *b)
+same_slots_added(PyThreadState *tstate, PyTypeObject *a, PyTypeObject *b)
 {
     PyTypeObject *base = a->tp_base;
     Py_ssize_t size;
@@ -7596,7 +7600,7 @@ same_slots_added(PyTypeObject *a, PyTypeObject *b)
     slots_a = ((PyHeapTypeObject *)a)->ht_slots;
     slots_b = ((PyHeapTypeObject *)b)->ht_slots;
     if (slots_a && slots_b) {
-        if (PyObject_RichCompareBool(slots_a, slots_b, Py_EQ) != 1)
+        if (_PyObject_RichCompareBool(tstate, slots_a, slots_b, Py_EQ) != 1)
             return 0;
         size += sizeof(PyObject *) * PyTuple_GET_SIZE(slots_a);
     }
@@ -7615,19 +7619,19 @@ compatible_flags(int setclass, PyTypeObject *origto, PyTypeObject *newto, unsign
 }
 
 static int
-compatible_for_assignment(PyTypeObject *origto, PyTypeObject *newto,
+compatible_for_assignment(PyThreadState *tstate, PyTypeObject *origto, PyTypeObject *newto,
                           const char *attr, int setclass)
 {
     PyTypeObject *newbase, *oldbase;
     PyTypeObject *oldto = setclass ? origto : origto->tp_base;
 
     if (setclass && newto->tp_free != oldto->tp_free) {
-        PyErr_Format(PyExc_TypeError,
-                     "%s assignment: "
-                     "'%s' deallocator differs from '%s'",
-                     attr,
-                     newto->tp_name,
-                     oldto->tp_name);
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "%s assignment: "
+                      "'%s' deallocator differs from '%s'",
+                      attr,
+                      newto->tp_name,
+                      oldto->tp_name);
         return 0;
     }
     if (!compatible_flags(setclass, origto, newto,
@@ -7670,12 +7674,12 @@ compatible_for_assignment(PyTypeObject *origto, PyTypeObject *newto,
         oldbase = oldbase->tp_base;
     if (newbase != oldbase &&
         (newbase->tp_base != oldbase->tp_base ||
-         !same_slots_added(newbase, oldbase))) {
+         !same_slots_added(tstate, newbase, oldbase))) {
         goto differs;
     }
     return 1;
 differs:
-    PyErr_Format(PyExc_TypeError,
+    _PyErr_Format(tstate, PyExc_TypeError,
                     "%s assignment: "
                     "'%s' object layout differs from '%s'",
                     attr,
@@ -7687,7 +7691,7 @@ differs:
 
 
 static int
-object_set_class_world_stopped(PyObject *self, PyTypeObject *newto)
+object_set_class_world_stopped(PyThreadState *tstate, PyObject *self, PyTypeObject *newto)
 {
     PyTypeObject *oldto = Py_TYPE(self);
 
@@ -7744,13 +7748,13 @@ object_set_class_world_stopped(PyObject *self, PyTypeObject *newto)
           PyType_IsSubtype(oldto, &PyModule_Type)) &&
         (_PyType_HasFeature(newto, Py_TPFLAGS_IMMUTABLETYPE) ||
          _PyType_HasFeature(oldto, Py_TPFLAGS_IMMUTABLETYPE))) {
-        PyErr_Format(PyExc_TypeError,
-                     "__class__ assignment only supported for mutable types "
-                     "or ModuleType subclasses");
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "__class__ assignment only supported for mutable types "
+                      "or ModuleType subclasses");
         return -1;
     }
 
-    if (compatible_for_assignment(oldto, newto, "__class__", 1)) {
+    if (compatible_for_assignment(tstate, oldto, newto, "__class__", 1)) {
         /* Changing the class will change the implicit dict keys,
          * so we must materialize the dictionary first. */
         if (oldto->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
@@ -7789,14 +7793,14 @@ object_set_class_world_stopped(PyObject *self, PyTypeObject *newto)
 static int
 object_set_class(PyObject *self, PyObject *value, void *closure)
 {
-
+    PyThreadState *tstate = _PyThreadState_GET();
     if (value == NULL) {
-        PyErr_SetString(PyExc_TypeError,
-                        "can't delete __class__ attribute");
+        _PyErr_SetString(tstate, PyExc_TypeError,
+                         "can't delete __class__ attribute");
         return -1;
     }
     if (!PyType_Check(value)) {
-        PyErr_Format(PyExc_TypeError,
+        _PyErr_Format(tstate, PyExc_TypeError,
           "__class__ must be set to a class, not '%s' object",
           Py_TYPE(value)->tp_name);
         return -1;
@@ -7813,7 +7817,7 @@ object_set_class(PyObject *self, PyObject *value, void *closure)
         types_stop_world();
     }
     PyTypeObject *oldto = Py_TYPE(self);
-    int res = object_set_class_world_stopped(self, newto);
+    int res = object_set_class_world_stopped(tstate, self, newto);
     if (!unique) {
         types_start_world();
     }
@@ -10997,6 +11001,7 @@ _Py_slot_tp_getattr_hook(PyObject *self, PyObject *name)
 #endif
         return _Py_slot_tp_getattro(self, name);
     }
+    PyThreadState *tstate = _PyThreadState_GET();
     /* speed hack: we could use lookup_maybe, but that would resolve the
        method fully for each attribute lookup for classes with
        __getattr__, even when self has the default __getattribute__
@@ -11008,18 +11013,18 @@ _Py_slot_tp_getattr_hook(PyObject *self, PyObject *name)
          ((PyWrapperDescrObject *)getattribute)->d_wrapped ==
              (void *)PyObject_GenericGetAttr)) {
         Py_XDECREF(getattribute);
-        res = _PyObject_GenericGetAttrWithDict(self, name, NULL, 1);
+        res = _PyObject_GenericGetAttrWithDict(tstate, self, name, NULL, 1);
         /* if res == NULL with no exception set, then it must be an
            AttributeError suppressed by us. */
-        if (res == NULL && !PyErr_Occurred()) {
+        if (res == NULL && !_PyErr_Occurred(tstate)) {
             res = call_attribute(self, getattr, name);
         }
     }
     else {
         res = call_attribute(self, getattribute, name);
         Py_DECREF(getattribute);
-        if (res == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
+        if (res == NULL && _PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
+            _PyErr_Clear(tstate);
             res = call_attribute(self, getattr, name);
         }
     }
@@ -11191,7 +11196,7 @@ slot_tp_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     _PyCStackRef func_ref;
     _PyThreadState_PushCStackRef(tstate, &func_ref);
-    func_ref.ref = _PyObject_GetAttrStackRef((PyObject *)type, &_Py_ID(__new__));
+    func_ref.ref = _PyObject_GetAttrStackRef(tstate, (PyObject *)type, &_Py_ID(__new__));
     if (PyStackRef_IsNull(func_ref.ref)) {
         _PyThreadState_PopCStackRef(tstate, &func_ref);
         return NULL;

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2743,7 +2743,7 @@ dummy_func(
             {
                 // scope to tell MSVC that stack is not escaping
                 PyObject *stack[] = {class, self};
-                super = PyObject_Vectorcall(global_super, stack, oparg & 2, NULL);
+                super = _PyObject_VectorcallTstate(tstate, global_super, stack, oparg & 2, NULL);
             }
             if (opcode == INSTRUMENTED_LOAD_SUPER_ATTR) {
                 PyObject *arg = oparg & 2 ? class : &_PyInstrumentation_MISSING;
@@ -4211,7 +4211,7 @@ dummy_func(
                 // scope to tell MSVC that stack is not escaping
                 PyObject *stack[5] = {NULL, PyStackRef_AsPyObjectBorrow(exit_self), exc, val_o, tb};
                 int has_self = !PyStackRef_IsNull(exit_self);
-                res_o = PyObject_Vectorcall(exit_func_o, stack + 2 - has_self,
+                res_o = _PyObject_VectorcallTstate(tstate, exit_func_o, stack + 2 - has_self,
                         (3 + has_self) | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
             }
             Py_XDECREF(original_tb);
@@ -4581,6 +4581,7 @@ dummy_func(
                 total_args++;
             }
             PyObject *res_o = _Py_VectorCall_StackRefSteal(
+                tstate,
                 callable,
                 arguments,
                 total_args,
@@ -5616,6 +5617,7 @@ dummy_func(
                 total_args++;
             }
             PyObject *res_o = _Py_VectorCall_StackRefSteal(
+                tstate,
                 callable,
                 arguments,
                 total_args,
@@ -5679,7 +5681,7 @@ dummy_func(
                 if (err) {
                     ERROR_NO_POP();
                 }
-                result_o = PyObject_Call(func, callargs, kwargs);
+                result_o = _PyObject_Call(tstate, func, callargs, kwargs);
 
                 if (!PyFunction_Check(func) && !PyMethod_Check(func)) {
                     if (result_o == NULL) {
@@ -5726,7 +5728,7 @@ dummy_func(
                 assert(PyTuple_CheckExact(callargs));
                 PyObject *kwargs = PyStackRef_AsPyObjectBorrow(kwargs_st);
                 assert(kwargs == NULL || PyDict_CheckExact(kwargs));
-                result_o = PyObject_Call(func, callargs, kwargs);
+                result_o = _PyObject_Call(tstate, func, callargs, kwargs);
             }
             PyStackRef_XCLOSE(kwargs_st);
             PyStackRef_CLOSE(callargs_st);
@@ -5805,7 +5807,7 @@ dummy_func(
             assert(PyTuple_CheckExact(callargs));
             PyObject *kwargs = PyStackRef_AsPyObjectBorrow(kwargs_st);
             assert(kwargs == NULL || PyDict_CheckExact(kwargs));
-            PyObject *result_o = PyObject_Call(func, callargs, kwargs);
+            PyObject *result_o = _PyObject_Call(tstate, func, callargs, kwargs);
             PyStackRef_XCLOSE(kwargs_st);
             PyStackRef_CLOSE(callargs_st);
             DEAD(null);

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2881,7 +2881,7 @@ dummy_func(
             }
             else {
                 /* Classic, pushes one value. */
-                attr = _PyObject_GetAttrStackRef(PyStackRef_AsPyObjectBorrow(owner), name);
+                attr = _PyObject_GetAttrStackRef(tstate, PyStackRef_AsPyObjectBorrow(owner), name);
                 PyStackRef_CLOSE(owner);
                 ERROR_IF(PyStackRef_IsNull(attr));
             }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -3767,7 +3767,7 @@ dummy_func(
         }
 
         op(_GET_ITER, (iterable -- iter, index_or_null)) {
-            _PyStackRef result = _PyEval_GetIter(iterable, &index_or_null, oparg);
+            _PyStackRef result = _PyEval_GetIter(tstate, iterable, &index_or_null, oparg);
             DEAD(iterable);
             ERROR_IF(PyStackRef_IsError(result));
             iter = result;
@@ -5466,7 +5466,7 @@ dummy_func(
                 DEAD(args);
                 DEAD(self_or_null);
                 DEAD(callable);
-                PyStackRef_CLOSE(kwnames);
+                _PyStackRef_CLOSE(tstate, kwnames);
                 // Sync stack explicitly since we leave using DISPATCH_INLINED().
                 SYNC_SP();
                 // The frame has stolen all the arguments from the stack,
@@ -5514,7 +5514,7 @@ dummy_func(
                 tstate, callable, locals,
                 arguments, positional_args, kwnames_o, frame
             );
-            PyStackRef_CLOSE(kwnames);
+            _PyStackRef_CLOSE(tstate, kwnames);
             // The frame has stolen all the arguments from the stack,
             // so there is no need to clean them up.
             DEAD(args);
@@ -5560,7 +5560,7 @@ dummy_func(
             self_or_null = PyStackRef_FromPyObjectNew(((PyMethodObject *)callable_o)->im_self);
             callable = PyStackRef_FromPyObjectNew(((PyMethodObject *)callable_o)->im_func);
             assert(PyStackRef_FunctionCheck(callable));
-            PyStackRef_CLOSE(callable_s);
+            _PyStackRef_CLOSE(tstate, callable_s);
         }
 
         macro(CALL_KW_BOUND_METHOD) =

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -340,7 +340,7 @@ dummy_func(
             GETLOCAL(oparg1) = value1;
             DEAD(value1);
             value2 = PyStackRef_DUP(GETLOCAL(oparg2));
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
         }
 
         inst(STORE_FAST_STORE_FAST, (value2, value1 --)) {
@@ -349,15 +349,15 @@ dummy_func(
             _PyStackRef tmp = GETLOCAL(oparg1);
             GETLOCAL(oparg1) = value1;
             DEAD(value1);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             tmp = GETLOCAL(oparg2);
             GETLOCAL(oparg2) = value2;
             DEAD(value2);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
         }
 
         pure inst(POP_TOP, (value --)) {
-            PyStackRef_XCLOSE(value);
+            _PyStackRef_XCLOSE(tstate, value);
         }
 
         op(_POP_TOP_NOP, (value --)) {
@@ -396,14 +396,14 @@ dummy_func(
              * This has the benign side effect that if value is
              * finalized it will see the location as the FOR_ITER's.
              */
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
         }
 
 
         inst(POP_ITER, (iter, index_or_null -- )) {
             (void)index_or_null;
             DEAD(index_or_null);
-            PyStackRef_CLOSE(iter);
+            _PyStackRef_CLOSE(tstate, iter);
         }
 
         no_save_ip tier1 inst(INSTRUMENTED_END_FOR, (receiver, index_or_null, value -- receiver, index_or_null)) {
@@ -415,14 +415,14 @@ dummy_func(
                     ERROR_NO_POP();
                 }
             }
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
         }
 
         tier1 inst(INSTRUMENTED_POP_ITER, (iter, index_or_null -- )) {
             (void)index_or_null;
             DEAD(index_or_null);
             INSTRUMENTED_JUMP(prev_instr, this_instr+1, PY_MONITORING_EVENT_BRANCH_RIGHT);
-            PyStackRef_CLOSE(iter);
+            _PyStackRef_CLOSE(tstate, iter);
         }
 
         pure inst(END_SEND, (receiver, index_or_null, value -- val)) {
@@ -430,7 +430,7 @@ dummy_func(
             (void)index_or_null;
             DEAD(value);
             DEAD(index_or_null);
-            PyStackRef_CLOSE(receiver);
+            _PyStackRef_CLOSE(tstate, receiver);
         }
 
         tier1 inst(INSTRUMENTED_END_SEND, (receiver, index_or_null, value -- val)) {
@@ -445,7 +445,7 @@ dummy_func(
             (void)index_or_null;
             DEAD(index_or_null);
             DEAD(value);
-            PyStackRef_CLOSE(receiver);
+            _PyStackRef_CLOSE(tstate, receiver);
         }
 
         macro(UNARY_NEGATIVE) = _UNARY_NEGATIVE + POP_TOP;
@@ -504,7 +504,7 @@ dummy_func(
 
         op(_TO_BOOL, (value -- res)) {
             int err = PyObject_IsTrue(PyStackRef_AsPyObjectBorrow(value));
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             ERROR_IF(err < 0);
             res = err ? PyStackRef_True : PyStackRef_False;
         }
@@ -1097,7 +1097,7 @@ dummy_func(
                 }
                 else {
                     res_o = PyObject_GetItem(container_o, slice);
-                    Py_DECREF(slice);
+                    _Py_DECREF(tstate, slice);
                 }
             }
             DECREF_INPUTS();
@@ -1124,7 +1124,7 @@ dummy_func(
             }
             else {
                 err = PyObject_SetItem(PyStackRef_AsPyObjectBorrow(container), slice, PyStackRef_AsPyObjectBorrow(v));
-                Py_DECREF(slice);
+                _Py_DECREF(tstate, slice);
             }
             DECREF_INPUTS();
             ERROR_IF(err);
@@ -1441,7 +1441,7 @@ dummy_func(
             INPUTS_DEAD();
             ls = list_st;
             ss = sub_st;
-            Py_DECREF(old_value);
+            _Py_DECREF(tstate, old_value);
         }
 
         macro(STORE_SUBSCR_DICT) =
@@ -1456,7 +1456,7 @@ dummy_func(
                                             PyStackRef_AsPyObjectSteal(sub),
                                             PyStackRef_AsPyObjectSteal(value));
             if (err) {
-                PyStackRef_CLOSE(dict_st);
+                _PyStackRef_CLOSE(tstate, dict_st);
                 ERROR_IF(1);
             }
             DEAD(dict_st);
@@ -1473,7 +1473,7 @@ dummy_func(
                                                 (Py_hash_t)hash);
 
             if (err) {
-                PyStackRef_CLOSE(dict_st);
+                _PyStackRef_CLOSE(tstate, dict_st);
                 ERROR_IF(1);
             }
             DEAD(dict_st);
@@ -1549,7 +1549,7 @@ dummy_func(
             assert(tstate->current_executor == NULL);
             if (!PyStackRef_IsNull(executor)) {
                 tstate->current_executor = PyStackRef_AsPyObjectBorrow(executor);
-                PyStackRef_CLOSE(executor);
+                _PyStackRef_CLOSE(tstate, executor);
             }
 #endif
             LLTRACE_RESUME_FRAME();
@@ -1612,12 +1612,12 @@ dummy_func(
                               "'async for' requires an object with "
                               "__aiter__ method, got %.100s",
                               type->tp_name);
-                PyStackRef_CLOSE(obj);
+                _PyStackRef_CLOSE(tstate, obj);
                 ERROR_IF(true);
             }
 
             iter_o = (*getter)(obj_o);
-            PyStackRef_CLOSE(obj);
+            _PyStackRef_CLOSE(tstate, obj);
             ERROR_IF(iter_o == NULL);
 
             if (Py_TYPE(iter_o)->tp_as_async == NULL ||
@@ -1627,7 +1627,7 @@ dummy_func(
                               "'async for' received an object from __aiter__ "
                               "that does not implement __anext__: %.100s",
                               Py_TYPE(iter_o)->tp_name);
-                Py_DECREF(iter_o);
+                _Py_DECREF(tstate, iter_o);
                 ERROR_IF(true);
             }
             iter = PyStackRef_FromPyObjectSteal(iter_o);
@@ -1643,7 +1643,7 @@ dummy_func(
 
         inst(GET_AWAITABLE, (iterable -- iter)) {
             PyObject *iter_o = _PyEval_GetAwaitable(PyStackRef_AsPyObjectBorrow(iterable), oparg);
-            PyStackRef_CLOSE(iterable);
+            _PyStackRef_CLOSE(tstate, iterable);
             ERROR_IF(iter_o == NULL);
             iter = PyStackRef_FromPyObjectSteal(iter_o);
         }
@@ -1704,7 +1704,7 @@ dummy_func(
                 if (res.kind == PYGEN_ERROR) {
                     ERROR_NO_POP();
                 }
-                PyStackRef_CLOSE(v);
+                _PyStackRef_CLOSE(tstate, v);
                 retval = PyStackRef_FromPyObjectSteal(res.object);
                 if (res.kind == PYGEN_RETURN) {
                     JUMPBY(oparg);
@@ -1808,7 +1808,7 @@ dummy_func(
             if (what == PYGEN_ERROR) {
                 ERROR_NO_POP();
             }
-            PyStackRef_CLOSE(v);
+            _PyStackRef_CLOSE(tstate, v);
             asend = iter;
             DEAD(iter);
             null_out = null_in;
@@ -1834,7 +1834,7 @@ dummy_func(
             if (what == PYGEN_ERROR) {
                 ERROR_NO_POP();
             }
-            PyStackRef_CLOSE(v);
+            _PyStackRef_CLOSE(tstate, v);
             asend = iter;
             DEAD(iter);
             null_out = null_in;
@@ -1996,7 +1996,7 @@ dummy_func(
             if (ns == NULL) {
                 _PyErr_Format(tstate, PyExc_SystemError,
                               "no locals found when storing %R", name);
-                PyStackRef_CLOSE(v);
+                _PyStackRef_CLOSE(tstate, v);
                 ERROR_IF(true);
             }
             if (PyDict_CheckExact(ns)) {
@@ -2005,7 +2005,7 @@ dummy_func(
             else {
                 err = PyObject_SetItem(ns, name, PyStackRef_AsPyObjectBorrow(v));
             }
-            PyStackRef_CLOSE(v);
+            _PyStackRef_CLOSE(tstate, v);
             ERROR_IF(err);
         }
 
@@ -2051,7 +2051,7 @@ dummy_func(
         op(_UNPACK_SEQUENCE, (seq -- unused[oparg], top[0])) {
             PyObject *seq_o = PyStackRef_AsPyObjectSteal(seq);
             int res = _PyEval_UnpackIterableStackRef(tstate, seq_o, oparg, -1, top);
-            Py_DECREF(seq_o);
+            _Py_DECREF(tstate, seq_o);
             ERROR_IF(res == 0);
         }
 
@@ -2068,7 +2068,7 @@ dummy_func(
             STAT_INC(UNPACK_SEQUENCE, hit);
             val0 = PyStackRef_FromPyObjectNew(PyTuple_GET_ITEM(seq_o, 0));
             val1 = PyStackRef_FromPyObjectNew(PyTuple_GET_ITEM(seq_o, 1));
-            PyStackRef_CLOSE(seq);
+            _PyStackRef_CLOSE(tstate, seq);
         }
 
         op(_UNPACK_SEQUENCE_UNIQUE_TWO_TUPLE, (seq -- val1, val0)) {
@@ -2142,7 +2142,7 @@ dummy_func(
         inst(UNPACK_EX, (seq -- unused[oparg & 0xFF], unused, unused[oparg >> 8], top[0])) {
             PyObject *seq_o = PyStackRef_AsPyObjectSteal(seq);
             int res = _PyEval_UnpackIterableStackRef(tstate, seq_o, oparg & 0xFF, oparg >> 8, top);
-            Py_DECREF(seq_o);
+            _Py_DECREF(tstate, seq_o);
             ERROR_IF(res == 0);
         }
 
@@ -2178,14 +2178,14 @@ dummy_func(
         inst(DELETE_ATTR, (owner --)) {
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             int err = PyObject_DelAttr(PyStackRef_AsPyObjectBorrow(owner), name);
-            PyStackRef_CLOSE(owner);
+            _PyStackRef_CLOSE(tstate, owner);
             ERROR_IF(err);
         }
 
         inst(STORE_GLOBAL, (v --)) {
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             int err = PyDict_SetItem(GLOBALS(), name, PyStackRef_AsPyObjectBorrow(v));
-            PyStackRef_CLOSE(v);
+            _PyStackRef_CLOSE(tstate, v);
             ERROR_IF(err);
         }
 
@@ -2218,7 +2218,7 @@ dummy_func(
             int err;
             PyObject *v_o = _PyMapping_GetOptionalItem2(PyStackRef_AsPyObjectBorrow(mod_or_class_dict), name, &err);
 
-            PyStackRef_CLOSE(mod_or_class_dict);
+            _PyStackRef_CLOSE(tstate, mod_or_class_dict);
             ERROR_IF(err < 0);
             if (v_o == NULL) {
                 if (PyDict_CheckExact(GLOBALS())
@@ -2239,7 +2239,7 @@ dummy_func(
 
                     if (PyLazyImport_CheckExact(v_o)) {
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
-                        Py_SETREF(v_o, l_v);
+                        _Py_SETREF(tstate, v_o, l_v);
                         ERROR_IF(v_o == NULL);
                     }
                 }
@@ -2261,7 +2261,7 @@ dummy_func(
                     }
                     if (PyLazyImport_CheckExact(v_o)) {
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
-                        Py_SETREF(v_o, l_v);
+                        _Py_SETREF(tstate, v_o, l_v);
                         ERROR_IF(v_o == NULL);
                     }
                 }
@@ -2277,16 +2277,16 @@ dummy_func(
                 PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
                 // cannot early-decref v_o as it may cause a side-effect on l_v
                 if (l_v == NULL) {
-                    Py_DECREF(v_o);
+                    _Py_DECREF(tstate, v_o);
                     ERROR_IF(true);
                 }
                 int err = PyDict_SetItem(GLOBALS(), name, l_v);
                 if (err < 0) {
-                    Py_DECREF(v_o);
-                    Py_DECREF(l_v);
+                    _Py_DECREF(tstate, v_o);
+                    _Py_DECREF(tstate, l_v);
                     ERROR_IF(true);
                 }
-                Py_SETREF(v_o, l_v);
+                _Py_SETREF(tstate, v_o, l_v);
             }
 
             v = PyStackRef_FromPyObjectSteal(v_o);
@@ -2402,7 +2402,7 @@ dummy_func(
             }
             _PyStackRef tmp = GETLOCAL(oparg);
             GETLOCAL(oparg) = PyStackRef_NULL;
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
         }
 
         inst(MAKE_CELL, (--)) {
@@ -2415,7 +2415,7 @@ dummy_func(
             }
             _PyStackRef tmp = GETLOCAL(oparg);
             GETLOCAL(oparg) = PyStackRef_FromPyObjectSteal(cell);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
         }
 
         inst(DELETE_DEREF, (--)) {
@@ -2427,7 +2427,7 @@ dummy_func(
                 _PyEval_FormatExcUnbound(tstate, _PyFrame_GetCode(frame), oparg);
                 ERROR_NO_POP();
             }
-            Py_DECREF(oldobj);
+            _Py_DECREF(tstate, oldobj);
         }
 
         inst(LOAD_FROM_DICT_OR_DEREF, (class_dict_st -- value)) {
@@ -2450,7 +2450,7 @@ dummy_func(
                     ERROR_NO_POP();
                 }
             }
-            PyStackRef_CLOSE(class_dict_st);
+            _PyStackRef_CLOSE(tstate, class_dict_st);
             value = PyStackRef_FromPyObjectSteal(value_o);
         }
 
@@ -2502,13 +2502,13 @@ dummy_func(
             }
             PyObject *interpolation_o = _PyInterpolation_Build(value_o, str_o, conversion, format_o);
             if (oparg & 1) {
-                PyStackRef_CLOSE(format[0]);
+                _PyStackRef_CLOSE(tstate, format[0]);
             }
             else {
                 DEAD(format);
             }
-            PyStackRef_CLOSE(str);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, str);
+            _PyStackRef_CLOSE(tstate, value);
             ERROR_IF(interpolation_o == NULL);
             interpolation = PyStackRef_FromPyObjectSteal(interpolation_o);
         }
@@ -2517,8 +2517,8 @@ dummy_func(
             PyObject *strings_o = PyStackRef_AsPyObjectBorrow(strings);
             PyObject *interpolations_o = PyStackRef_AsPyObjectBorrow(interpolations);
             PyObject *template_o = _PyTemplate_Build(strings_o, interpolations_o);
-            PyStackRef_CLOSE(interpolations);
-            PyStackRef_CLOSE(strings);
+            _PyStackRef_CLOSE(tstate, interpolations);
+            _PyStackRef_CLOSE(tstate, strings);
             ERROR_IF(template_o == NULL);
             template = PyStackRef_FromPyObjectSteal(template_o);
         }
@@ -2592,12 +2592,12 @@ dummy_func(
                     err = _PySet_AddTakeRef((PySetObject *)set_o, PyStackRef_AsPyObjectSteal(value));
                 }
                 else {
-                    PyStackRef_CLOSE(value);
+                    _PyStackRef_CLOSE(tstate, value);
                 }
             }
             DEAD(values);
             if (err) {
-                Py_DECREF(set_o);
+                _Py_DECREF(tstate, set_o);
                 ERROR_IF(true);
             }
 
@@ -2628,11 +2628,11 @@ dummy_func(
                 ERROR_IF(ann_dict == NULL);
                 err = PyObject_SetItem(LOCALS(), &_Py_ID(__annotations__),
                                        ann_dict);
-                Py_DECREF(ann_dict);
+                _Py_DECREF(tstate, ann_dict);
                 ERROR_IF(err);
             }
             else {
-                Py_DECREF(ann_dict);
+                _Py_DECREF(tstate, ann_dict);
             }
         }
 
@@ -2654,7 +2654,7 @@ dummy_func(
                         _PyErr_Format(tstate, PyExc_TypeError,
                                         "'%T' object is not a mapping",
                                         update_o);
-                        Py_DECREF(exc);
+                        _Py_DECREF(tstate, exc);
                     }
                     else {
                         _PyErr_ChainExceptions1(exc);
@@ -2757,7 +2757,7 @@ dummy_func(
                         tstate, PY_MONITORING_EVENT_C_RETURN,
                         frame, this_instr, global_super, arg);
                     if (err < 0) {
-                        Py_CLEAR(super);
+                        _Py_CLEAR(tstate, super);
                     }
                 }
             }
@@ -2765,7 +2765,7 @@ dummy_func(
             ERROR_IF(super == NULL);
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg >> 2);
             PyObject *attr_o = PyObject_GetAttr(super, name);
-            Py_DECREF(super);
+            _Py_DECREF(tstate, super);
             ERROR_IF(attr_o == NULL);
             attr = PyStackRef_FromPyObjectSteal(attr_o);
         }
@@ -2834,7 +2834,7 @@ dummy_func(
                 self_or_null = self_st; // transfer ownership
                 DEAD(self_st);
             } else {
-                PyStackRef_CLOSE(self_st);
+                _PyStackRef_CLOSE(tstate, self_st);
                 self_or_null = PyStackRef_NULL;
             }
             DECREF_INPUTS();
@@ -2882,7 +2882,7 @@ dummy_func(
             else {
                 /* Classic, pushes one value. */
                 attr = _PyObject_GetAttrStackRef(tstate, PyStackRef_AsPyObjectBorrow(owner), name);
-                PyStackRef_CLOSE(owner);
+                _PyStackRef_CLOSE(tstate, owner);
                 ERROR_IF(PyStackRef_IsNull(attr));
             }
         }
@@ -3272,7 +3272,7 @@ dummy_func(
             ERROR_IF(res_o == NULL);
             if (oparg & 16) {
                 int res_bool = PyObject_IsTrue(res_o);
-                Py_DECREF(res_o);
+                _Py_DECREF(tstate, res_o);
                 ERROR_IF(res_bool < 0);
                 res = res_bool ? PyStackRef_True : PyStackRef_False;
             }
@@ -3482,7 +3482,7 @@ dummy_func(
             }
 
             int res = PyErr_GivenExceptionMatches(left_o, right_o);
-            PyStackRef_CLOSE(right);
+            _PyStackRef_CLOSE(tstate, right);
             b = res ? PyStackRef_True : PyStackRef_False;
         }
 
@@ -3808,7 +3808,7 @@ dummy_func(
 
         op(_GET_ITER_TRAD, (iterable -- iter, index_or_null)) {
             PyObject *iter_o = PyObject_GetIter(PyStackRef_AsPyObjectBorrow(iterable));
-            PyStackRef_CLOSE(iterable);
+            _PyStackRef_CLOSE(tstate, iterable);
             ERROR_IF(iter_o == NULL);
             iter = PyStackRef_FromPyObjectSteal(iter_o);
             index_or_null = PyStackRef_NULL;
@@ -4306,7 +4306,7 @@ dummy_func(
             assert((oparg & 1) == 0);
             STAT_INC(LOAD_ATTR, hit);
             assert(descr != NULL);
-            PyStackRef_CLOSE(owner);
+            _PyStackRef_CLOSE(tstate, owner);
             attr = PyStackRef_FromPyObjectNew(descr);
         }
 
@@ -4323,7 +4323,7 @@ dummy_func(
             assert(Py_TYPE(PyStackRef_AsPyObjectBorrow(owner))->tp_dictoffset == 0);
             STAT_INC(LOAD_ATTR, hit);
             assert(descr != NULL);
-            PyStackRef_CLOSE(owner);
+            _PyStackRef_CLOSE(tstate, owner);
             attr = PyStackRef_FromPyObjectNew(descr);
         }
 
@@ -4404,7 +4404,7 @@ dummy_func(
                 PyObject *method = ((PyMethodObject *)callable_o)->im_func;
                 _PyStackRef temp = callable;
                 callable = PyStackRef_FromPyObjectNew(method);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
             }
         }
 
@@ -4549,7 +4549,7 @@ dummy_func(
             _PyStackRef temp = callable;
             callable = PyStackRef_FromPyObjectNew(((PyMethodObject *)callable_o)->im_func);
             assert(PyStackRef_FunctionCheck(callable));
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
         }
 
         macro(CALL_BOUND_METHOD_GENERAL) =
@@ -4613,7 +4613,7 @@ dummy_func(
             self_or_null = PyStackRef_FromPyObjectNew(((PyMethodObject *)callable_o)->im_self);
             _PyStackRef temp = callable;
             callable = PyStackRef_FromPyObjectNew(((PyMethodObject *)callable_o)->im_func);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
         }
 
         op(_CHECK_PEP_523, (--)) {
@@ -4811,7 +4811,7 @@ dummy_func(
             self_or_null = PyStackRef_FromPyObjectSteal(self_o);
             _PyStackRef temp = callable;
             callable = PyStackRef_FromPyObjectNew(init_func);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
         }
 
         op(_CREATE_INIT_FRAME, (init, self, args[oparg] -- init_frame)) {
@@ -4883,7 +4883,7 @@ dummy_func(
             }
             _PyStackRef temp = callable;
             callable = PyStackRef_FromPyObjectSteal(res_o);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
         }
 
         macro(CALL_BUILTIN_CLASS) =
@@ -4965,7 +4965,7 @@ dummy_func(
             }
             _PyStackRef temp = callable;
             callable = PyStackRef_FromPyObjectSteal(res_o);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
         }
 
         macro(CALL_BUILTIN_FAST) =
@@ -4999,7 +4999,7 @@ dummy_func(
             }
             _PyStackRef temp = callable;
             callable = PyStackRef_FromPyObjectSteal(res_o);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
         }
 
         macro(CALL_BUILTIN_FAST_WITH_KEYWORDS) =
@@ -5062,10 +5062,10 @@ dummy_func(
                 ERROR_NO_POP();
             }
             (void)null; // Silence compiler warnings about unused variables
-            PyStackRef_CLOSE(cls);
-            PyStackRef_CLOSE(instance);
+            _PyStackRef_CLOSE(tstate, cls);
+            _PyStackRef_CLOSE(tstate, instance);
             DEAD(null);
-            PyStackRef_CLOSE(callable);
+            _PyStackRef_CLOSE(tstate, callable);
             res = retval ? PyStackRef_True : PyStackRef_False;
             assert((!PyStackRef_IsNull(res)) ^ (_PyErr_Occurred(tstate) != NULL));
         }
@@ -5228,7 +5228,7 @@ dummy_func(
             }
             _PyStackRef temp = callable;
             callable = PyStackRef_FromPyObjectSteal(res_o);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
         }
 
         tier2 op(_CALL_METHOD_DESCRIPTOR_FAST_WITH_KEYWORDS_INLINE, (callable, self_st, args[oparg], cfunc/4 -- callable, self_st, args[oparg])) {
@@ -5247,7 +5247,7 @@ dummy_func(
             }
             _PyStackRef temp = callable;
             callable = PyStackRef_FromPyObjectSteal(res_o);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
         }
 
         macro(CALL_METHOD_DESCRIPTOR_FAST_WITH_KEYWORDS) =
@@ -5370,7 +5370,7 @@ dummy_func(
             }
             _PyStackRef temp = callable;
             callable = PyStackRef_FromPyObjectSteal(res_o);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
         }
 
         tier2 op(_CALL_METHOD_DESCRIPTOR_FAST_INLINE, (callable, self_st, args[oparg], cfunc/4 -- callable, self_st, args[oparg])) {
@@ -5390,7 +5390,7 @@ dummy_func(
             }
             _PyStackRef temp = callable;
             callable = PyStackRef_FromPyObjectSteal(res_o);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
         }
 
         macro(CALL_METHOD_DESCRIPTOR_FAST) =
@@ -5436,7 +5436,7 @@ dummy_func(
                 PyObject *method = ((PyMethodObject *)callable_o)->im_func;
                 _PyStackRef temp = callable;
                 callable = PyStackRef_FromPyObjectNew(method);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
             }
         }
 
@@ -5655,7 +5655,7 @@ dummy_func(
                 }
                 _PyStackRef temp = callargs;
                 callargs = PyStackRef_FromPyObjectSteal(tuple_o);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
             }
         }
 
@@ -5694,7 +5694,7 @@ dummy_func(
                             tstate, PY_MONITORING_EVENT_C_RETURN,
                             frame, this_instr, func, arg);
                         if (err < 0) {
-                            Py_CLEAR(result_o);
+                            _Py_CLEAR(tstate, result_o);
                         }
                     }
                 }
@@ -5730,10 +5730,10 @@ dummy_func(
                 assert(kwargs == NULL || PyDict_CheckExact(kwargs));
                 result_o = _PyObject_Call(tstate, func, callargs, kwargs);
             }
-            PyStackRef_XCLOSE(kwargs_st);
-            PyStackRef_CLOSE(callargs_st);
+            _PyStackRef_XCLOSE(tstate, kwargs_st);
+            _PyStackRef_CLOSE(tstate, callargs_st);
             DEAD(null);
-            PyStackRef_CLOSE(func_st);
+            _PyStackRef_CLOSE(tstate, func_st);
             ERROR_IF(result_o == NULL);
             result = PyStackRef_FromPyObjectSteal(result_o);
         }
@@ -5808,10 +5808,10 @@ dummy_func(
             PyObject *kwargs = PyStackRef_AsPyObjectBorrow(kwargs_st);
             assert(kwargs == NULL || PyDict_CheckExact(kwargs));
             PyObject *result_o = _PyObject_Call(tstate, func, callargs, kwargs);
-            PyStackRef_XCLOSE(kwargs_st);
-            PyStackRef_CLOSE(callargs_st);
+            _PyStackRef_XCLOSE(tstate, kwargs_st);
+            _PyStackRef_CLOSE(tstate, callargs_st);
             DEAD(null);
-            PyStackRef_CLOSE(func_st);
+            _PyStackRef_CLOSE(tstate, func_st);
             ERROR_IF(result_o == NULL);
             result = PyStackRef_FromPyObjectSteal(result_o);
         }
@@ -5899,7 +5899,7 @@ dummy_func(
             assert(oparg >= FVC_STR && oparg <= FVC_ASCII);
             conv_fn = _PyEval_ConversionFuncs[oparg];
             PyObject *result_o = conv_fn(PyStackRef_AsPyObjectBorrow(value));
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             ERROR_IF(result_o == NULL);
             result = PyStackRef_FromPyObjectSteal(result_o);
         }
@@ -5910,7 +5910,7 @@ dummy_func(
              * of format(value) is value itself. */
             if (!PyUnicode_CheckExact(value_o)) {
                 PyObject *res_o = PyObject_Format(value_o, NULL);
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
                 ERROR_IF(res_o == NULL);
                 res = PyStackRef_FromPyObjectSteal(res_o);
             }
@@ -6059,7 +6059,7 @@ dummy_func(
                 INSTRUMENTED_JUMP(this_instr, next_instr + oparg, PY_MONITORING_EVENT_BRANCH_RIGHT);
             }
             else {
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
             }
         }
 
@@ -6067,7 +6067,7 @@ dummy_func(
             int jump = !PyStackRef_IsNone(value);
             RECORD_BRANCH_TAKEN(this_instr[1].cache, jump);
             if (jump) {
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
                 INSTRUMENTED_JUMP(this_instr, next_instr + oparg, PY_MONITORING_EVENT_BRANCH_RIGHT);
             }
             else {
@@ -6132,7 +6132,7 @@ dummy_func(
         op (_GUARD_IS_NONE_POP, (val -- )) {
             int is_none = PyStackRef_IsNone(val);
             if (!is_none) {
-                PyStackRef_CLOSE(val);
+                _PyStackRef_CLOSE(tstate, val);
                 AT_END_EXIT_IF(1);
             }
             DEAD(val);
@@ -6140,7 +6140,7 @@ dummy_func(
 
         op (_GUARD_IS_NOT_NONE_POP, (val -- )) {
             int is_none = PyStackRef_IsNone(val);
-            PyStackRef_CLOSE(val);
+            _PyStackRef_CLOSE(tstate, val);
             AT_END_EXIT_IF(is_none);
         }
 
@@ -6517,7 +6517,7 @@ dummy_func(
                 _PyStackRef *stackbase = _PyFrame_Stackbase(frame);
                 while (frame->stackpointer > stackbase) {
                     _PyStackRef ref = _PyFrame_StackPop(frame);
-                    PyStackRef_XCLOSE(ref);
+                    _PyStackRef_XCLOSE(tstate, ref);
                 }
                 monitor_unwind(tstate, frame, next_instr-1);
                 goto exit_unwind;
@@ -6527,7 +6527,7 @@ dummy_func(
             assert(frame->stackpointer >= new_top);
             while (frame->stackpointer > new_top) {
                 _PyStackRef ref = _PyFrame_StackPop(frame);
-                PyStackRef_XCLOSE(ref);
+                _PyStackRef_XCLOSE(tstate, ref);
             }
             if (lasti) {
                 int frame_lasti = _PyInterpreterFrame_LASTI(frame);
@@ -6586,7 +6586,7 @@ dummy_func(
                 assert(tstate->current_executor == NULL);
                 if (!PyStackRef_IsNull(executor)) {
                     tstate->current_executor = PyStackRef_AsPyObjectBorrow(executor);
-                    PyStackRef_CLOSE(executor);
+                    _PyStackRef_CLOSE(tstate, executor);
                 }
 #endif
                 return NULL;
@@ -6646,13 +6646,13 @@ dummy_func(
                 DISPATCH();
             }
             for (int i = 0; i < tracer->prev_state.recorded_count; i++) {
-                Py_CLEAR(tracer->prev_state.recorded_values[i]);
+                _Py_CLEAR(tstate, tracer->prev_state.recorded_values[i]);
             }
             tracer->prev_state.recorded_count = 0;
             tracer->prev_state.instr = next_instr;
             PyObject *prev_code = PyStackRef_AsPyObjectBorrow(frame->f_executable);
             if (tracer->prev_state.instr_code != (PyCodeObject *)prev_code) {
-                Py_SETREF(tracer->prev_state.instr_code, (PyCodeObject*)Py_NewRef((prev_code)));
+                _Py_SETREF(tstate, tracer->prev_state.instr_code, (PyCodeObject*)Py_NewRef((prev_code)));
             }
 
             tracer->prev_state.instr_frame = frame;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1648,7 +1648,7 @@ positional_only_passed_as_keyword(PyThreadState *tstate, PyCodeObject *co,
                 continue;
             }
 
-            int cmp = PyObject_RichCompareBool(posonly_name, kwname, Py_EQ);
+            int cmp = _PyObject_RichCompareBool(tstate, posonly_name, kwname, Py_EQ);
 
             if ( cmp > 0) {
                 if(PyList_Append(posonly_names, kwname) != 0) {
@@ -1783,7 +1783,7 @@ initialize_locals(PyThreadState *tstate, PyFunctionObject *func,
             /* Slow fallback, just in case */
             for (j = co->co_posonlyargcount; j < total_args; j++) {
                 PyObject *varname = co_varnames[j];
-                int cmp = PyObject_RichCompareBool( keyword, varname, Py_EQ);
+                int cmp = _PyObject_RichCompareBool(tstate, keyword, varname, Py_EQ);
                 if (cmp > 0) {
                     goto kw_found;
                 }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -474,8 +474,8 @@ _PyEval_MatchKeys(PyThreadState *tstate, PyObject *map, PyObject *keys)
         }
         if (value == dummy) {
             // key not in map!
-            Py_DECREF(value);
-            Py_DECREF(values);
+            _Py_DECREF(tstate, value);
+            _Py_DECREF(tstate, values);
             // Return None:
             values = Py_NewRef(Py_None);
             goto done;
@@ -486,15 +486,15 @@ _PyEval_MatchKeys(PyThreadState *tstate, PyObject *map, PyObject *keys)
 done:
     _PyThreadState_PopCStackRef(tstate, &method);
     _PyThreadState_PopCStackRef(tstate, &self);
-    Py_DECREF(seen);
-    Py_DECREF(dummy);
+    _Py_DECREF(tstate, seen);
+    _Py_DECREF(tstate, dummy);
     return values;
 fail:
     _PyThreadState_PopCStackRef(tstate, &method);
     _PyThreadState_PopCStackRef(tstate, &self);
-    Py_XDECREF(seen);
-    Py_XDECREF(dummy);
-    Py_XDECREF(values);
+    _Py_XDECREF(tstate, seen);
+    _Py_XDECREF(tstate, dummy);
+    _Py_XDECREF(tstate, values);
     return NULL;
 }
 
@@ -675,7 +675,7 @@ PyEval_EvalCode(PyObject *co, PyObject *globals, PyObject *locals)
     }
     EVAL_CALL_STAT_INC(EVAL_CALL_LEGACY);
     PyObject *res = _PyEval_Vector(tstate, func, locals, NULL, 0, NULL);
-    Py_DECREF(func);
+    _Py_DECREF(tstate, func);
     return res;
 }
 
@@ -729,15 +729,15 @@ _Py_VectorCall_StackRefSteal(
     STACKREFS_TO_PYOBJECTS_CLEANUP(args_o);
     assert((res != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
 cleanup:
-    PyStackRef_XCLOSE(kwnames);
+    _PyStackRef_XCLOSE(tstate, kwnames);
     // arguments is a pointer into the GC visible stack,
     // so we must NULL out values as we clear them.
     for (int i = total_args-1; i >= 0; i--) {
         _PyStackRef tmp = arguments[i];
         arguments[i] = PyStackRef_NULL;
-        PyStackRef_CLOSE(tmp);
+        _PyStackRef_CLOSE(tstate, tmp);
     }
-    PyStackRef_CLOSE(callable);
+    _PyStackRef_CLOSE(tstate, callable);
     return res;
 }
 
@@ -789,15 +789,15 @@ _Py_VectorCallInstrumentation_StackRefSteal(
     }
     assert((res != NULL) ^ (PyErr_Occurred() != NULL));
 cleanup:
-    PyStackRef_XCLOSE(kwnames);
+    _PyStackRef_XCLOSE(tstate, kwnames);
     // arguments is a pointer into the GC visible stack,
     // so we must NULL out values as we clear them.
     for (int i = total_args - 1; i >= 0; i--) {
         _PyStackRef tmp = arguments[i];
         arguments[i] = PyStackRef_NULL;
-        PyStackRef_CLOSE(tmp);
+        _PyStackRef_CLOSE(tstate, tmp);
     }
-    PyStackRef_CLOSE(callable);
+    _PyStackRef_CLOSE(tstate, callable);
     return res;
 }
 
@@ -1113,7 +1113,7 @@ stop_tracing_and_jit(PyThreadState *tstate, _PyInterpreterFrame *frame)
 
 
 _PyStackRef
-_PyEval_GetIter(_PyStackRef iterable, _PyStackRef *index_or_null, int yield_from)
+_PyEval_GetIter(PyThreadState *tstate, _PyStackRef iterable, _PyStackRef *index_or_null, int yield_from)
 {
     PyTypeObject *tp = PyStackRef_TYPE(iterable);
     if (tp->_tp_iteritem != NULL) {
@@ -1130,17 +1130,17 @@ _PyEval_GetIter(_PyStackRef iterable, _PyStackRef *index_or_null, int yield_from
         if (yield_from == GET_ITER_YIELD_FROM_CORO_CHECK) {
             /* `iterable` is a coroutine and it is used in a 'yield from'
             * expression of a regular generator. */
-            PyErr_SetString(PyExc_TypeError,
-                            "cannot 'yield from' a coroutine object "
-                            "in a non-coroutine generator");
-            PyStackRef_CLOSE(iterable);
+            _PyErr_SetString(tstate, PyExc_TypeError,
+                             "cannot 'yield from' a coroutine object "
+                             "in a non-coroutine generator");
+            _PyStackRef_CLOSE(tstate, iterable);
             return PyStackRef_ERROR;
         }
         return iterable;
     }
     /* Pop iterable, and push iterator then NULL */
     PyObject *iter_o = PyObject_GetIter(PyStackRef_AsPyObjectBorrow(iterable));
-    PyStackRef_CLOSE(iterable);
+    _PyStackRef_CLOSE(tstate, iterable);
     if (iter_o == NULL) {
         return PyStackRef_ERROR;
     }
@@ -1497,24 +1497,24 @@ format_missing(PyThreadState *tstate, const char *kind,
            fail, but we can't be too careful. */
         err = PyList_SetSlice(names, len - 2, len, NULL);
         if (err == -1) {
-            Py_DECREF(tail);
+            _Py_DECREF(tstate, tail);
             return;
         }
         /* Stitch everything up into a nice comma-separated list. */
         comma = PyUnicode_FromString(", ");
         if (comma == NULL) {
-            Py_DECREF(tail);
+            _Py_DECREF(tstate, tail);
             return;
         }
         tmp = PyUnicode_Join(comma, names);
-        Py_DECREF(comma);
+        _Py_DECREF(tstate, comma);
         if (tmp == NULL) {
-            Py_DECREF(tail);
+            _Py_DECREF(tstate, tail);
             return;
         }
         name_str = PyUnicode_Concat(tmp, tail);
-        Py_DECREF(tmp);
-        Py_DECREF(tail);
+        _Py_DECREF(tstate, tmp);
+        _Py_DECREF(tstate, tail);
         break;
     }
     if (name_str == NULL)
@@ -1526,7 +1526,7 @@ format_missing(PyThreadState *tstate, const char *kind,
                   kind,
                   len == 1 ? "" : "s",
                   name_str);
-    Py_DECREF(name_str);
+    _Py_DECREF(tstate, name_str);
 }
 
 static void
@@ -1557,7 +1557,7 @@ missing_arguments(PyThreadState *tstate, PyCodeObject *co,
             PyObject *raw = PyTuple_GET_ITEM(co->co_localsplusnames, i);
             PyObject *name = PyObject_Repr(raw);
             if (name == NULL) {
-                Py_DECREF(missing_names);
+                _Py_DECREF(tstate, missing_names);
                 return;
             }
             PyList_SET_ITEM(missing_names, j++, name);
@@ -1565,7 +1565,7 @@ missing_arguments(PyThreadState *tstate, PyCodeObject *co,
     }
     assert(j == missing);
     format_missing(tstate, kind, co, missing_names, qualname);
-    Py_DECREF(missing_names);
+    _Py_DECREF(tstate, missing_names);
 }
 
 static void
@@ -1605,7 +1605,7 @@ too_many_positional(PyThreadState *tstate, PyCodeObject *co,
                                           kwonly_given,
                                           kwonly_given != 1 ? "s" : "");
         if (kwonly_sig == NULL) {
-            Py_DECREF(sig);
+            _Py_DECREF(tstate, sig);
             return;
         }
     }
@@ -1622,8 +1622,8 @@ too_many_positional(PyThreadState *tstate, PyCodeObject *co,
                   given,
                   kwonly_sig,
                   given == 1 && !kwonly_given ? "was" : "were");
-    Py_DECREF(sig);
-    Py_DECREF(kwonly_sig);
+    _Py_DECREF(tstate, sig);
+    _Py_DECREF(tstate, kwonly_sig);
 }
 
 static int
@@ -1669,7 +1669,7 @@ positional_only_passed_as_keyword(PyThreadState *tstate, PyCodeObject *co,
             goto fail;
         }
         PyObject* error_names = PyUnicode_Join(comma, posonly_names);
-        Py_DECREF(comma);
+        _Py_DECREF(tstate, comma);
         if (error_names == NULL) {
             goto fail;
         }
@@ -1677,15 +1677,15 @@ positional_only_passed_as_keyword(PyThreadState *tstate, PyCodeObject *co,
                       "%U() got some positional-only arguments passed"
                       " as keyword arguments: '%U'",
                       qualname, error_names);
-        Py_DECREF(error_names);
+        _Py_DECREF(tstate, error_names);
         goto fail;
     }
 
-    Py_DECREF(posonly_names);
+    _Py_DECREF(tstate, posonly_names);
     return 0;
 
 fail:
-    Py_XDECREF(posonly_names);
+    _Py_XDECREF(tstate, posonly_names);
     return 1;
 
 }
@@ -1739,7 +1739,7 @@ initialize_locals(PyThreadState *tstate, PyFunctionObject *func,
             u = _PyTuple_FromStackRefStealOnSuccess(args + n, argcount - n);
             if (u == NULL) {
                 for (Py_ssize_t i = n; i < argcount; i++) {
-                    PyStackRef_CLOSE(args[i]);
+                    _PyStackRef_CLOSE(tstate, args[i]);
                 }
             }
         }
@@ -1752,7 +1752,7 @@ initialize_locals(PyThreadState *tstate, PyFunctionObject *func,
     else if (argcount > n) {
         /* Too many positional args. Error is reported later */
         for (j = n; j < argcount; j++) {
-            PyStackRef_CLOSE(args[j]);
+            _PyStackRef_CLOSE(tstate, args[j]);
         }
     }
 
@@ -1810,14 +1810,14 @@ initialize_locals(PyThreadState *tstate, PyFunctionObject *func,
                     PyObject* possible_keywords = PyList_New(total_args - co->co_posonlyargcount);
 
                     if (!possible_keywords) {
-                        PyErr_Clear();
+                        _PyErr_Clear(tstate);
                     } else {
                         for (Py_ssize_t k = co->co_posonlyargcount; k < total_args; k++) {
                             PyList_SET_ITEM(possible_keywords, k - co->co_posonlyargcount, co_varnames[k]);
                         }
 
                         suggestion_keyword = _Py_CalculateSuggestions(possible_keywords, keyword);
-                        Py_DECREF(possible_keywords);
+                        _Py_DECREF(tstate, possible_keywords);
                     }
                 }
 
@@ -1825,7 +1825,7 @@ initialize_locals(PyThreadState *tstate, PyFunctionObject *func,
                     _PyErr_Format(tstate, PyExc_TypeError,
                                 "%U() got an unexpected keyword argument '%S'. Did you mean '%S'?",
                                 func->func_qualname, keyword, suggestion_keyword);
-                    Py_DECREF(suggestion_keyword);
+                    _Py_DECREF(tstate, suggestion_keyword);
                 } else {
                     _PyErr_Format(tstate, PyExc_TypeError,
                                 "%U() got an unexpected keyword argument '%S'",
@@ -1838,12 +1838,12 @@ initialize_locals(PyThreadState *tstate, PyFunctionObject *func,
             if (PyDict_SetItem(kwdict, keyword, PyStackRef_AsPyObjectBorrow(value_stackref)) == -1) {
                 goto kw_fail;
             }
-            PyStackRef_CLOSE(value_stackref);
+            _PyStackRef_CLOSE(tstate, value_stackref);
             continue;
 
         kw_fail:
             for (;i < kwcount; i++) {
-                PyStackRef_CLOSE(args[i+argcount]);
+                _PyStackRef_CLOSE(tstate, args[i+argcount]);
             }
             goto fail_post_args;
 
@@ -1924,14 +1924,14 @@ initialize_locals(PyThreadState *tstate, PyFunctionObject *func,
 
 fail_pre_positional:
     for (j = 0; j < argcount; j++) {
-        PyStackRef_CLOSE(args[j]);
+        _PyStackRef_CLOSE(tstate, args[j]);
     }
     /* fall through */
 fail_post_positional:
     if (kwnames) {
         Py_ssize_t kwcount = PyTuple_GET_SIZE(kwnames);
         for (j = argcount; j < argcount+kwcount; j++) {
-            PyStackRef_CLOSE(args[j]);
+            _PyStackRef_CLOSE(tstate, args[j]);
         }
     }
     /* fall through */
@@ -2014,18 +2014,18 @@ _PyEvalFramePushAndInit(PyThreadState *tstate, _PyStackRef func,
     return frame;
 fail:
     /* Consume the references */
-    PyStackRef_CLOSE(func);
+    _PyStackRef_CLOSE(tstate, func);
     Py_XDECREF(locals);
     for (size_t i = 0; i < argcount; i++) {
-        PyStackRef_CLOSE(args[i]);
+        _PyStackRef_CLOSE(tstate, args[i]);
     }
     if (kwnames) {
         Py_ssize_t kwcount = PyTuple_GET_SIZE(kwnames);
         for (Py_ssize_t i = 0; i < kwcount; i++) {
-            PyStackRef_CLOSE(args[i+argcount]);
+            _PyStackRef_CLOSE(tsatte, args[i+argcount]);
         }
     }
-    PyErr_NoMemory();
+    _PyErr_NoMemory(tstate);
     return NULL;
 }
 
@@ -2044,7 +2044,7 @@ _PyEvalFramePushAndInit_Ex(PyThreadState *tstate, _PyStackRef func,
     if (has_dict) {
         object_array = _PyStack_UnpackDict(tstate, _PyTuple_ITEMS(callargs), nargs, kwargs, &kwnames);
         if (object_array == NULL) {
-            PyStackRef_CLOSE(func);
+            _PyStackRef_CLOSE(tstate, func);
             goto error;
         }
         size_t nkwargs = PyDict_GET_SIZE(kwargs);
@@ -2066,8 +2066,8 @@ _PyEvalFramePushAndInit_Ex(PyThreadState *tstate, _PyStackRef func,
         else {
             newargs = PyMem_Malloc(sizeof(_PyStackRef) *nargs);
             if (newargs == NULL) {
-                PyErr_NoMemory();
-                PyStackRef_CLOSE(func);
+                _PyErr_NoMemory(tstate);
+                _PyStackRef_CLOSE(tstate, func);
                 goto error;
             }
         }
@@ -2089,12 +2089,12 @@ _PyEvalFramePushAndInit_Ex(PyThreadState *tstate, _PyStackRef func,
     /* No need to decref func here because the reference has been stolen by
        _PyEvalFramePushAndInit.
     */
-    Py_DECREF(callargs);
-    Py_XDECREF(kwargs);
+    _Py_DECREF(tstate, callargs);
+    _Py_XDECREF(tstate, kwargs);
     return new_frame;
 error:
-    Py_DECREF(callargs);
-    Py_XDECREF(kwargs);
+    _Py_DECREF(tstate, callargs);
+    _Py_XDECREF(tstate, kwargs);
     return NULL;
 }
 
@@ -2116,7 +2116,7 @@ _PyEval_Vector(PyThreadState *tstate, PyFunctionObject *func,
     else {
         arguments = PyMem_Malloc(sizeof(_PyStackRef) * total_args);
         if (arguments == NULL) {
-            return PyErr_NoMemory();
+            return _PyErr_NoMemory(tstate);
         }
     }
     /* _PyEvalFramePushAndInit consumes the references
@@ -2210,11 +2210,11 @@ PyEval_EvalCodeEx(PyObject *_co, PyObject *globals, PyObject *locals,
                          allargs, argcount,
                          kwnames);
 fail:
-    Py_XDECREF(func);
-    Py_XDECREF(kwnames);
+    _Py_XDECREF(tstate, func);
+    _Py_XDECREF(tstate, kwnames);
     PyMem_Free(newargs);
     _Py_DECREF_BUILTINS(builtins);
-    Py_DECREF(defaults);
+    _Py_DECREF(tstate, defaults);
     return res;
 }
 
@@ -2368,10 +2368,10 @@ _PyEval_UnpackIterableStackRef(PyThreadState *tstate, PyObject *v,
         if (w == NULL) {
             if (_PyErr_Occurred(tstate))
                 goto Error;
-            Py_DECREF(it);
+            _Py_DECREF(tstate, it);
             return 1;
         }
-        Py_DECREF(w);
+        _Py_DECREF(tstate, w);
 
         if (PyList_CheckExact(v) || PyTuple_CheckExact(v)
               || PyDict_CheckExact(v)) {
@@ -2409,14 +2409,14 @@ _PyEval_UnpackIterableStackRef(PyThreadState *tstate, PyObject *v,
     }
     /* Resize the list. */
     Py_SET_SIZE(l, ll - argcntafter);
-    Py_DECREF(it);
+    _Py_DECREF(tstate, it);
     return 1;
 
 Error:
     for (; i > 0; i--, sp++) {
-        PyStackRef_CLOSE(*sp);
+        _PyStackRef_CLOSE(tstate, *sp);
     }
-    Py_XDECREF(it);
+    _Py_XDECREF(tstate, it);
     return 0;
 }
 
@@ -2640,7 +2640,7 @@ PyEval_GetLocals(void)
     if (PyFrameLocalsProxy_Check(locals)) {
         PyFrameObject *f = _PyFrame_GetFrameObject(current_frame);
         if (f == NULL) {
-            Py_DECREF(locals);
+            _Py_DECREF(tstate, locals);
             return NULL;
         }
 
@@ -2648,7 +2648,7 @@ PyEval_GetLocals(void)
         if (ret == NULL) {
             ret = PyDict_New();
             if (ret == NULL) {
-                Py_DECREF(locals);
+                _Py_DECREF(tstate, locals);
                 return NULL;
             }
             f->f_locals_cache = ret;
@@ -2658,13 +2658,13 @@ PyEval_GetLocals(void)
             // trying to clean it up or replace it will just cause other problems
             ret = NULL;
         }
-        Py_DECREF(locals);
+        _Py_DECREF(tstate, locals);
         return ret;
     }
 
     assert(PyMapping_Check(locals));
     assert(Py_REFCNT(locals) > 1);
-    Py_DECREF(locals);
+    _Py_DECREF(tstate, locals);
 
     return locals;
 }
@@ -2687,15 +2687,15 @@ _PyEval_GetFrameLocals(void)
     if (PyFrameLocalsProxy_Check(locals)) {
         PyObject* ret = PyDict_New();
         if (ret == NULL) {
-            Py_DECREF(locals);
+            _Py_DECREF(tstate, locals);
             return NULL;
         }
         if (PyDict_Update(ret, locals) < 0) {
-            Py_DECREF(ret);
-            Py_DECREF(locals);
+            _Py_DECREF(tstate, ret);
+            _Py_DECREF(tstate, locals);
             return NULL;
         }
-        Py_DECREF(locals);
+        _Py_DECREF(tstate, locals);
         return ret;
     }
 
@@ -2728,11 +2728,11 @@ _PyEval_GetGlobalsFromRunningMain(PyThreadState *tstate)
     }
     PyObject *mod = _Py_GetMainModule(tstate);
     if (_Py_CheckMainModule(mod) < 0) {
-        Py_XDECREF(mod);
+        _Py_XDECREF(tstate, mod);
         return NULL;
     }
     PyObject *globals = PyModule_GetDict(mod);  // borrowed
-    Py_DECREF(mod);
+    _Py_DECREF(tstate, mod);
     return globals;
 }
 
@@ -2791,7 +2791,7 @@ _PyEval_EnsureBuiltins(PyThreadState *tstate, PyObject *globals,
         }
         Py_INCREF(builtins);
         if (set_globals_builtins(globals, builtins) < 0) {
-            Py_DECREF(builtins);
+            _Py_DECREF(tstate, builtins);
             return -1;
         }
     }
@@ -2799,7 +2799,7 @@ _PyEval_EnsureBuiltins(PyThreadState *tstate, PyObject *globals,
         *p_builtins = builtins;
     }
     else {
-        Py_DECREF(builtins);
+        _Py_DECREF(tstate, builtins);
     }
     return 0;
 }
@@ -2818,7 +2818,7 @@ _PyEval_EnsureBuiltinsWithModule(PyThreadState *tstate, PyObject *globals,
             return -1;
         }
         if (set_globals_builtins(globals, builtins) < 0) {
-            Py_DECREF(builtins);
+            _Py_DECREF(tstate, builtins);
             return -1;
         }
     }
@@ -2826,7 +2826,7 @@ _PyEval_EnsureBuiltinsWithModule(PyThreadState *tstate, PyObject *globals,
         *p_builtins = builtins;
     }
     else {
-        Py_DECREF(builtins);
+        _Py_DECREF(tstate, builtins);
     }
     return 0;
 }
@@ -2977,7 +2977,7 @@ _PyEval_ImportName(PyThreadState *tstate, PyObject *builtins,
 
     PyObject *res = _PyEval_ImportNameWithImport(
         tstate, import_func, globals, locals, name, fromlist, level);
-    Py_DECREF(import_func);
+    _Py_DECREF(tstate, import_func);
     return res;
 }
 
@@ -3146,15 +3146,15 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
     }
     fullmodname = PyUnicode_FromFormat("%U.%U", mod_name, name);
     if (fullmodname == NULL) {
-        Py_DECREF(mod_name);
+        _Py_DECREF(tstate, mod_name);
         return NULL;
     }
     x = PyImport_GetModule(fullmodname);
-    Py_DECREF(fullmodname);
+    _Py_DECREF(tstate, fullmodname);
     if (x == NULL && !_PyErr_Occurred(tstate)) {
         goto error;
     }
-    Py_DECREF(mod_name);
+    _Py_DECREF(tstate, mod_name);
     return x;
 
  error:
@@ -3172,7 +3172,7 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
 
     origin = NULL;
     if (PyObject_GetOptionalAttr(v, &_Py_ID(__spec__), &spec) < 0) {
-        Py_DECREF(mod_name_or_unknown);
+        _Py_DECREF(tstate, mod_name_or_unknown);
         return NULL;
     }
     if (spec == NULL) {
@@ -3199,7 +3199,7 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
         if (stdlib_modules && PyAnySet_Check(stdlib_modules)) {
             is_possibly_shadowing_stdlib = PySet_Contains(stdlib_modules, mod_name_or_unknown);
             if (is_possibly_shadowing_stdlib < 0) {
-                Py_DECREF(stdlib_modules);
+                _Py_DECREF(tstate, stdlib_modules);
                 goto done;
             }
         }
@@ -3283,13 +3283,13 @@ done_with_errmsg:
     if (errmsg != NULL) {
         /* NULL checks for mod_name and origin done by _PyErr_SetImportErrorWithNameFrom */
         _PyErr_SetImportErrorWithNameFrom(errmsg, mod_name, origin, name);
-        Py_DECREF(errmsg);
+        _Py_DECREF(tstate, errmsg);
     }
 
 done:
-    Py_XDECREF(origin);
-    Py_XDECREF(spec);
-    Py_DECREF(mod_name_or_unknown);
+    _Py_XDECREF(tstate, origin);
+    _Py_XDECREF(tstate, spec);
+    _Py_DECREF(tstate, mod_name_or_unknown);
     return NULL;
 }
 
@@ -3309,16 +3309,16 @@ _PyEval_LazyImportFrom(PyThreadState *tstate, _PyInterpreterFrame *frame, PyObje
             PyObject *mod_dict = PyModule_GetDict(mod);
             if (mod_dict != NULL) {
                 if (PyDict_GetItemRef(mod_dict, name, &ret) < 0) {
-                    Py_DECREF(mod);
+                    _Py_DECREF(tstate, mod);
                     return NULL;
                 }
                 if (ret != NULL) {
-                    Py_DECREF(mod);
+                    _Py_DECREF(tstate, mod);
                     return ret;
                 }
             }
         }
-        Py_DECREF(mod);
+        _Py_DECREF(tstate, mod);
     }
 
     if (d->lz_attr != NULL) {
@@ -3329,7 +3329,7 @@ _PyEval_LazyImportFrom(PyThreadState *tstate, _PyInterpreterFrame *frame, PyObje
                 return NULL;
             }
             ret = _PyLazyImport_New(frame, d->lz_builtins, from, name);
-            Py_DECREF(from);
+            _Py_DECREF(tstate, from);
             return ret;
         }
     }
@@ -3343,7 +3343,7 @@ _PyEval_LazyImportFrom(PyThreadState *tstate, _PyInterpreterFrame *frame, PyObje
                 return NULL;
             }
             ret = _PyLazyImport_New(frame, d->lz_builtins, from, name);
-            Py_DECREF(from);
+            _Py_DECREF(tstate, from);
             return ret;
         }
     }
@@ -3457,7 +3457,7 @@ _PyEval_FormatKwargsError(PyThreadState *tstate, PyObject *func, PyObject *kwarg
                 tstate, PyExc_TypeError,
                 "Value after ** must be a mapping, not %T",
                 kwargs);
-            Py_DECREF(exc);
+            _Py_DECREF(tstate, exc);
         }
         else {
             _PyErr_ChainExceptions1Tstate(tstate, exc);
@@ -3609,7 +3609,7 @@ _PyEval_GetANext(PyObject *aiter)
             "from __anext__: %.100s",
             Py_TYPE(next_iter)->tp_name);
     }
-    Py_DECREF(next_iter);
+    _Py_DECREF(tstate, next_iter);
     return awaitable;
 }
 
@@ -3654,8 +3654,9 @@ _PyEval_LoadGlobalStackRef(PyObject *globals, PyObject *builtins, PyObject *name
 
     PyObject *res_o = PyStackRef_AsPyObjectBorrow(*writeto);
     if (res_o != NULL && PyLazyImport_CheckExact(res_o)) {
-        PyObject *l_v = _PyImport_LoadLazyImportTstate(PyThreadState_GET(), res_o);
-        PyStackRef_CLOSE(writeto[0]);
+        PyThreadState *tstate = PyThreadState_GET();
+        PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, res_o);
+        _PyStackRef_CLOSE(tstate, writeto[0]);
         if (l_v == NULL) {
             assert(PyErr_Occurred());
             *writeto = PyStackRef_NULL;
@@ -3663,7 +3664,7 @@ _PyEval_LoadGlobalStackRef(PyObject *globals, PyObject *builtins, PyObject *name
         }
         int err = PyDict_SetItem(globals, name, l_v);
         if (err < 0) {
-            Py_DECREF(l_v);
+            _Py_DECREF(tstate, l_v);
             *writeto = PyStackRef_NULL;
             return;
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -442,7 +442,7 @@ _PyEval_MatchKeys(PyThreadState *tstate, PyObject *map, PyObject *keys)
         goto fail;
     }
     // dummy = object()
-    dummy = _PyObject_CallNoArgs((PyObject *)&PyBaseObject_Type);
+    dummy = _PyObject_CallNoArgsTstate(tstate, (PyObject *)&PyBaseObject_Type);
     if (dummy == NULL) {
         goto fail;
     }
@@ -464,10 +464,10 @@ _PyEval_MatchKeys(PyThreadState *tstate, PyObject *map, PyObject *keys)
         PyObject *args[] = { self_obj, key, dummy };
         PyObject *value = NULL;
         if (!PyStackRef_IsNull(self.ref)) {
-            value = PyObject_Vectorcall(get, args, 3, NULL);
+            value = _PyObject_VectorcallTstate(tstate, get, args, 3, NULL);
         }
         else {
-            value = PyObject_Vectorcall(get, &args[1], 2, NULL);
+            value = _PyObject_VectorcallTstate(tstate, get, &args[1], 2, NULL);
         }
         if (value == NULL) {
             goto fail;
@@ -704,6 +704,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
 
 PyObject *
 _Py_VectorCall_StackRefSteal(
+    PyThreadState *tstate,
     _PyStackRef callable,
     _PyStackRef *arguments,
     int total_args,
@@ -721,12 +722,12 @@ _Py_VectorCall_StackRefSteal(
     if (kwnames_o != NULL) {
         positional_args -= (int)PyTuple_GET_SIZE(kwnames_o);
     }
-    res = PyObject_Vectorcall(
+    res = _PyObject_VectorcallTstate(tstate,
         callable_o, args_o,
         positional_args | PY_VECTORCALL_ARGUMENTS_OFFSET,
         kwnames_o);
     STACKREFS_TO_PYOBJECTS_CLEANUP(args_o);
-    assert((res != NULL) ^ (PyErr_Occurred() != NULL));
+    assert((res != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
 cleanup:
     PyStackRef_XCLOSE(kwnames);
     // arguments is a pointer into the GC visible stack,
@@ -763,7 +764,8 @@ _Py_VectorCallInstrumentation_StackRefSteal(
     if (kwnames_o != NULL) {
         positional_args -= (int)PyTuple_GET_SIZE(kwnames_o);
     }
-    res = PyObject_Vectorcall(
+    res = _PyObject_VectorcallTstate(
+        tstate,
         callable_o, args_o,
         positional_args | PY_VECTORCALL_ARGUMENTS_OFFSET,
         kwnames_o);
@@ -3003,7 +3005,7 @@ _PyEval_ImportNameWithImport(PyThreadState *tstate, PyObject *import_func,
     }
 
     PyObject *args[5] = {name, globals, locals, fromlist, level};
-    PyObject *res = PyObject_Vectorcall(import_func, args, 5, NULL);
+    PyObject *res = _PyObject_VectorcallTstate(tstate, import_func, args, 5, NULL);
     return res;
 }
 
@@ -3117,7 +3119,7 @@ _PyEval_LazyImportName(PyThreadState *tstate, PyObject *builtins,
     }
 
     PyObject *args[6] = {name, globals, locals, fromlist, level, builtins};
-    res = PyObject_Vectorcall(lazy_import_func, args, 6, NULL);
+    res = _PyObject_VectorcallTstate(tstate, lazy_import_func, args, 6, NULL);
 error:
     Py_XDECREF(lazy_import_func);
     return res;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1949,7 +1949,7 @@ clear_thread_frame(PyThreadState *tstate, _PyInterpreterFrame * frame)
         tstate->datastack_top);
     assert(frame->frame_obj == NULL || frame->frame_obj->f_frame == frame);
     _PyFrame_ClearExceptCode(frame);
-    PyStackRef_CLEAR(frame->f_executable);
+    _PyStackRef_CLEAR(tstate, frame->f_executable);
     _PyThreadState_PopFrame(tstate, frame);
 }
 
@@ -2015,14 +2015,14 @@ _PyEvalFramePushAndInit(PyThreadState *tstate, _PyStackRef func,
 fail:
     /* Consume the references */
     _PyStackRef_CLOSE(tstate, func);
-    Py_XDECREF(locals);
+    _Py_XDECREF(tstate, locals);
     for (size_t i = 0; i < argcount; i++) {
         _PyStackRef_CLOSE(tstate, args[i]);
     }
     if (kwnames) {
         Py_ssize_t kwcount = PyTuple_GET_SIZE(kwnames);
         for (Py_ssize_t i = 0; i < kwcount; i++) {
-            _PyStackRef_CLOSE(tsatte, args[i+argcount]);
+            _PyStackRef_CLOSE(tstate, args[i+argcount]);
         }
     }
     _PyErr_NoMemory(tstate);
@@ -3609,7 +3609,7 @@ _PyEval_GetANext(PyObject *aiter)
             "from __anext__: %.100s",
             Py_TYPE(next_iter)->tp_name);
     }
-    _Py_DECREF(tstate, next_iter);
+    Py_DECREF(next_iter);
     return awaitable;
 }
 

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -1779,7 +1779,11 @@ _PyErr_FormatUnraisable(PyThreadState *tstate, const char *format, ...)
 void
 PyErr_FormatUnraisable(const char *format, ...)
 {
-    _PyErr_FormatUnraisable(_PyThreadState_GET(), format);
+    PyThreadState *tstate = _PyThreadState_GET();
+    va_list va;
+    va_start(va, format);
+    format_unraisable_v(tstate, format, va, NULL);
+    va_end(va);
 }
 
 static void

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -29,25 +29,25 @@ _PyErr_SetRaisedException(PyThreadState *tstate, PyObject *exc)
 }
 
 static PyObject*
-_PyErr_CreateException(PyObject *exception_type, PyObject *value)
+_PyErr_CreateException(PyThreadState *tstate, PyObject *exception_type, PyObject *value)
 {
     PyObject *exc;
 
     if (value == NULL || value == Py_None) {
-        exc = _PyObject_CallNoArgs(exception_type);
+        exc = _PyObject_CallNoArgsTstate(tstate, exception_type);
     }
     else if (PyTuple_Check(value)) {
-        exc = PyObject_Call(exception_type, value, NULL);
+        exc = _PyObject_Call(tstate, exception_type, value, NULL);
     }
     else {
-        exc = PyObject_CallOneArg(exception_type, value);
+        exc = _PyObject_CallOneArgTstate(tstate, exception_type, value);
     }
 
     if (exc != NULL && !PyExceptionInstance_Check(exc)) {
-        PyErr_Format(PyExc_TypeError,
-                     "calling %R should have returned an instance of "
-                     "BaseException, not %s",
-                     exception_type, Py_TYPE(exc)->tp_name);
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "calling %R should have returned an instance of "
+                      "BaseException, not %s",
+                      exception_type, Py_TYPE(exc)->tp_name);
         Py_CLEAR(exc);
     }
 
@@ -74,7 +74,7 @@ _PyErr_Restore(PyThreadState *tstate, PyObject *type, PyObject *value,
 #endif
     }
     else {
-        PyObject *exc = _PyErr_CreateException(type, value);
+        PyObject *exc = _PyErr_CreateException(tstate, type, value);
         Py_XDECREF(value);
         if (exc == NULL) {
             Py_DECREF(type);
@@ -177,7 +177,7 @@ _PyErr_SetObject(PyThreadState *tstate, PyObject *exception, PyObject *value)
             exception set */
         _PyErr_Clear(tstate);
 
-        PyObject *fixed_value = _PyErr_CreateException(exception, value);
+        PyObject *fixed_value = _PyErr_CreateException(tstate, exception, value);
         if (fixed_value == NULL) {
             PyObject *exc = _PyErr_GetRaisedException(tstate);
             assert(PyExceptionInstance_Check(exc));
@@ -429,7 +429,7 @@ _PyErr_NormalizeException(PyThreadState *tstate, PyObject **exc,
            class.
         */
         if (!is_subclass) {
-            PyObject *fixed_value = _PyErr_CreateException(type, value);
+            PyObject *fixed_value = _PyErr_CreateException(tstate, type, value);
             if (fixed_value == NULL) {
                 goto error;
             }
@@ -1504,7 +1504,7 @@ write_unraisable_exc_file(PyThreadState *tstate, PyObject *exc_type,
                                                                    "_print_exception_bltin");
     if (print_exception_fn != NULL && PyCallable_Check(print_exception_fn)) {
         PyObject *args[2] = {exc_value, file};
-        PyObject *result = PyObject_Vectorcall(print_exception_fn, args, 2, NULL);
+        PyObject *result = _PyObject_VectorcallTstate(tstate, print_exception_fn, args, 2, NULL);
         int ok = (result != NULL);
         Py_DECREF(print_exception_fn);
         Py_XDECREF(result);
@@ -1659,11 +1659,9 @@ _PyErr_WriteUnraisableDefaultHook(PyObject *args)
    An exception must be set when calling this function. */
 
 static void
-format_unraisable_v(const char *format, va_list va, PyObject *obj)
+format_unraisable_v(PyThreadState *tstate, const char *format, va_list va, PyObject *obj)
 {
     const char *err_msg_str;
-    PyThreadState *tstate = _PyThreadState_GET();
-    _Py_EnsureTstateNotNULL(tstate);
 
     PyObject *err_msg = NULL;
     PyObject *hook = NULL;
@@ -1769,29 +1767,41 @@ done:
 }
 
 void
-PyErr_FormatUnraisable(const char *format, ...)
+_PyErr_FormatUnraisable(PyThreadState *tstate, const char *format, ...)
 {
     va_list va;
 
     va_start(va, format);
-    format_unraisable_v(format, va, NULL);
+    format_unraisable_v(tstate, format, va, NULL);
     va_end(va);
 }
 
+void
+PyErr_FormatUnraisable(const char *format, ...)
+{
+    _PyErr_FormatUnraisable(_PyThreadState_GET(), format);
+}
+
 static void
-format_unraisable(PyObject *obj, const char *format, ...)
+format_unraisable(PyThreadState *tstate, PyObject *obj, const char *format, ...)
 {
     va_list va;
 
     va_start(va, format);
-    format_unraisable_v(format, va, obj);
+    format_unraisable_v(tstate, format, va, obj);
     va_end(va);
+}
+
+void
+_PyErr_WriteUnraisable(PyThreadState *tstate, PyObject *obj)
+{
+    format_unraisable(tstate, obj, NULL);
 }
 
 void
 PyErr_WriteUnraisable(PyObject *obj)
 {
-    format_unraisable(obj, NULL);
+    _PyErr_WriteUnraisable(_PyThreadState_GET(), obj);
 }
 
 

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -11591,7 +11591,7 @@
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                attr = _PyObject_GetAttrStackRef(PyStackRef_AsPyObjectBorrow(owner), name);
+                attr = _PyObject_GetAttrStackRef(tstate, PyStackRef_AsPyObjectBorrow(owner), name);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer[-1] = attr;
                 stack_pointer += (oparg&1);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -16038,7 +16038,7 @@
                 stack_pointer += 3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                res_o = PyObject_Vectorcall(exit_func_o, stack + 2 - has_self,
+                res_o = _PyObject_VectorcallTstate(tstate, exit_func_o, stack + 2 - has_self,
                     (3 + has_self) | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
@@ -16886,6 +16886,7 @@
             }
             _PyFrame_SetStackPointer(frame, stack_pointer);
             PyObject *res_o = _Py_VectorCall_StackRefSteal(
+                tstate,
                 callable,
                 arguments,
                 total_args,
@@ -19794,6 +19795,7 @@
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             PyObject *res_o = _Py_VectorCall_StackRefSteal(
+                tstate,
                 callable,
                 arguments,
                 total_args,
@@ -20152,7 +20154,7 @@
             stack_pointer += 3;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyObject *result_o = PyObject_Call(func, callargs, kwargs);
+            PyObject *result_o = _PyObject_Call(tstate, func, callargs, kwargs);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -2251,7 +2251,7 @@
             _PyStackRef _stack_item_0 = _tos_cache0;
             value = _stack_item_0;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(value);
+            _PyStackRef_XCLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -2562,7 +2562,7 @@
             _PyStackRef _stack_item_0 = _tos_cache0;
             value = _stack_item_0;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -2583,7 +2583,7 @@
             iter = _stack_item_0;
             (void)index_or_null;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(iter);
+            _PyStackRef_CLOSE(tstate, iter);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -2612,7 +2612,7 @@
             stack_pointer += 1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(receiver);
+            _PyStackRef_CLOSE(tstate, receiver);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = val;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -2813,7 +2813,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err < 0) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -6753,7 +6753,7 @@
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
                     res_o = PyObject_GetItem(container_o, slice);
-                    Py_DECREF(slice);
+                    _Py_DECREF(tstate, slice);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     stack_pointer += -3;
                 }
@@ -6765,15 +6765,15 @@
             stack_pointer[-3] = container;
             stack_pointer[-2] = start;
             stack_pointer[-1] = stop;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = start;
             start = PyStackRef_NULL;
             stack_pointer[-2] = start;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = container;
             container = PyStackRef_NULL;
             stack_pointer[-3] = container;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -3;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -6823,7 +6823,7 @@
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 err = PyObject_SetItem(PyStackRef_AsPyObjectBorrow(container), slice, PyStackRef_AsPyObjectBorrow(v));
-                Py_DECREF(slice);
+                _Py_DECREF(tstate, slice);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += 2;
             }
@@ -6831,11 +6831,11 @@
             _PyStackRef tmp = container;
             container = PyStackRef_NULL;
             stack_pointer[-3] = container;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = v;
             v = PyStackRef_NULL;
             stack_pointer[-4] = v;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -4;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -8258,15 +8258,15 @@
             _PyStackRef tmp = sub;
             sub = PyStackRef_NULL;
             stack_pointer[-1] = sub;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = container;
             container = PyStackRef_NULL;
             stack_pointer[-2] = container;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = v;
             v = PyStackRef_NULL;
             stack_pointer[-3] = v;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -3;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -8337,7 +8337,7 @@
             stack_pointer += 2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            Py_DECREF(old_value);
+            _Py_DECREF(tstate, old_value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache1 = ss;
             _tos_cache0 = ls;
@@ -8379,7 +8379,7 @@
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(dict_st);
+                _PyStackRef_CLOSE(tstate, dict_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 SET_CURRENT_CACHED_VALUES(0);
                 JUMP_TO_ERROR();
@@ -8427,7 +8427,7 @@
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(dict_st);
+                _PyStackRef_CLOSE(tstate, dict_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 SET_CURRENT_CACHED_VALUES(0);
                 JUMP_TO_ERROR();
@@ -8462,11 +8462,11 @@
             _PyStackRef tmp = sub;
             sub = PyStackRef_NULL;
             stack_pointer[-1] = sub;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = container;
             container = PyStackRef_NULL;
             stack_pointer[-2] = container;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -8668,7 +8668,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(obj);
+                _PyStackRef_CLOSE(tstate, obj);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 SET_CURRENT_CACHED_VALUES(0);
                 JUMP_TO_ERROR();
@@ -8682,7 +8682,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(obj);
+            _PyStackRef_CLOSE(tstate, obj);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (iter_o == NULL) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -8695,7 +8695,7 @@
                               "'async for' received an object from __aiter__ "
                               "that does not implement __anext__: %.100s",
                               Py_TYPE(iter_o)->tp_name);
-                Py_DECREF(iter_o);
+                _Py_DECREF(tstate, iter_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 SET_CURRENT_CACHED_VALUES(0);
                 JUMP_TO_ERROR();
@@ -8754,7 +8754,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(iterable);
+            _PyStackRef_CLOSE(tstate, iterable);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (iter_o == NULL) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -9295,7 +9295,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(v);
+            _PyStackRef_CLOSE(tstate, v);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             asend = iter;
             null_out = null_in;
@@ -9485,7 +9485,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(v);
+                _PyStackRef_CLOSE(tstate, v);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 SET_CURRENT_CACHED_VALUES(0);
                 JUMP_TO_ERROR();
@@ -9509,7 +9509,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(v);
+            _PyStackRef_CLOSE(tstate, v);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -9570,7 +9570,7 @@
             PyObject *seq_o = PyStackRef_AsPyObjectSteal(seq);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             int res = _PyEval_UnpackIterableStackRef(tstate, seq_o, oparg, -1, top);
-            Py_DECREF(seq_o);
+            _Py_DECREF(tstate, seq_o);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (res == 0) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -9612,7 +9612,7 @@
             stack_pointer += 2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(seq);
+            _PyStackRef_CLOSE(tstate, seq);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache1 = val0;
             _tos_cache0 = val1;
@@ -9764,7 +9764,7 @@
             stack_pointer += oparg;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(seq);
+            _PyStackRef_CLOSE(tstate, seq);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -9836,7 +9836,7 @@
             stack_pointer += oparg;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(seq);
+            _PyStackRef_CLOSE(tstate, seq);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -9858,7 +9858,7 @@
             PyObject *seq_o = PyStackRef_AsPyObjectSteal(seq);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             int res = _PyEval_UnpackIterableStackRef(tstate, seq_o, oparg & 0xFF, oparg >> 8, top);
-            Py_DECREF(seq_o);
+            _Py_DECREF(tstate, seq_o);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (res == 0) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -9895,11 +9895,11 @@
             _PyStackRef tmp = owner;
             owner = PyStackRef_NULL;
             stack_pointer[-1] = owner;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = v;
             v = PyStackRef_NULL;
             stack_pointer[-2] = v;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -9932,7 +9932,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(owner);
+            _PyStackRef_CLOSE(tstate, owner);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -9963,7 +9963,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(v);
+            _PyStackRef_CLOSE(tstate, v);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -10099,7 +10099,7 @@
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (l_v == NULL) {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    Py_DECREF(v_o);
+                    _Py_DECREF(tstate, v_o);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     SET_CURRENT_CACHED_VALUES(0);
                     JUMP_TO_ERROR();
@@ -10109,8 +10109,8 @@
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err < 0) {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    Py_DECREF(v_o);
-                    Py_DECREF(l_v);
+                    _Py_DECREF(tstate, v_o);
+                    _Py_DECREF(tstate, l_v);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     SET_CURRENT_CACHED_VALUES(0);
                     JUMP_TO_ERROR();
@@ -10389,7 +10389,7 @@
             _PyStackRef tmp = GETLOCAL(oparg);
             GETLOCAL(oparg) = PyStackRef_NULL;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -10412,7 +10412,7 @@
             _PyStackRef tmp = GETLOCAL(oparg);
             GETLOCAL(oparg) = PyStackRef_FromPyObjectSteal(cell);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -10436,7 +10436,7 @@
                 JUMP_TO_ERROR();
             }
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            Py_DECREF(oldobj);
+            _Py_DECREF(tstate, oldobj);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -10484,7 +10484,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(class_dict_st);
+            _PyStackRef_CLOSE(tstate, class_dict_st);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             value = PyStackRef_FromPyObjectSteal(value_o);
             _tos_cache0 = value;
@@ -10689,7 +10689,7 @@
                 stack_pointer += -(oparg & 1);
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(format[0]);
+                _PyStackRef_CLOSE(tstate, format[0]);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             else {
@@ -10698,12 +10698,12 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(str);
+            _PyStackRef_CLOSE(tstate, str);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (interpolation_o == NULL) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -10740,12 +10740,12 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(interpolations);
+            _PyStackRef_CLOSE(tstate, interpolations);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(strings);
+            _PyStackRef_CLOSE(tstate, strings);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (template_o == NULL) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -10899,7 +10899,7 @@
                 for (int _i = oparg; --_i >= 0;) {
                     tmp = values[_i];
                     values[_i] = PyStackRef_NULL;
-                    PyStackRef_CLOSE(tmp);
+                    _PyStackRef_CLOSE(tstate, tmp);
                 }
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -oparg;
@@ -10918,7 +10918,7 @@
                 }
                 else {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(value);
+                    _PyStackRef_CLOSE(tstate, value);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -10926,7 +10926,7 @@
                 stack_pointer += -oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_DECREF(set_o);
+                _Py_DECREF(tstate, set_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 SET_CURRENT_CACHED_VALUES(0);
                 JUMP_TO_ERROR();
@@ -10999,7 +10999,7 @@
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 err = PyObject_SetItem(LOCALS(), &_Py_ID(__annotations__),
                                        ann_dict);
-                Py_DECREF(ann_dict);
+                _Py_DECREF(tstate, ann_dict);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err) {
                     SET_CURRENT_CACHED_VALUES(0);
@@ -11008,7 +11008,7 @@
             }
             else {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_DECREF(ann_dict);
+                _Py_DECREF(tstate, ann_dict);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             _tos_cache0 = PyStackRef_ZERO_BITS;
@@ -11049,7 +11049,7 @@
                         _PyErr_Format(tstate, PyExc_TypeError,
                                       "'%T' object is not a mapping",
                                       update_o);
-                        Py_DECREF(exc);
+                        _Py_DECREF(tstate, exc);
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                     }
                     else {
@@ -11200,15 +11200,15 @@
             _PyStackRef tmp = self_st;
             self_st = PyStackRef_NULL;
             stack_pointer[-1] = self_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = class_st;
             class_st = PyStackRef_NULL;
             stack_pointer[-2] = class_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = global_super_st;
             global_super_st = PyStackRef_NULL;
             stack_pointer[-3] = global_super_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -3;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -11532,7 +11532,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(self_st);
+                _PyStackRef_CLOSE(tstate, self_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 self_or_null = PyStackRef_NULL;
                 stack_pointer += 1;
@@ -11543,11 +11543,11 @@
             _PyStackRef tmp = global_super_st;
             global_super_st = self_or_null;
             stack_pointer[-2] = global_super_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = class_st;
             class_st = PyStackRef_NULL;
             stack_pointer[-1] = class_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -11597,7 +11597,7 @@
                 stack_pointer += (oparg&1);
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(owner);
+                _PyStackRef_CLOSE(tstate, owner);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (PyStackRef_IsNull(attr)) {
                     SET_CURRENT_CACHED_VALUES(0);
@@ -12524,7 +12524,7 @@
             _PyStackRef tmp = owner;
             owner = attr;
             stack_pointer[-1] = owner;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = attr;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -13119,11 +13119,11 @@
             _PyStackRef tmp = right;
             right = PyStackRef_NULL;
             stack_pointer[-1] = right;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = left;
             left = PyStackRef_NULL;
             stack_pointer[-2] = left;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -13134,7 +13134,7 @@
             if (oparg & 16) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 int res_bool = PyObject_IsTrue(res_o);
-                Py_DECREF(res_o);
+                _Py_DECREF(tstate, res_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (res_bool < 0) {
                     SET_CURRENT_CACHED_VALUES(0);
@@ -13787,11 +13787,11 @@
                 _PyStackRef tmp = match_type_st;
                 match_type_st = PyStackRef_NULL;
                 stack_pointer[-1] = match_type_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = exc_value_st;
                 exc_value_st = PyStackRef_NULL;
                 stack_pointer[-2] = exc_value_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -13806,11 +13806,11 @@
             _PyStackRef tmp = match_type_st;
             match_type_st = PyStackRef_NULL;
             stack_pointer[-1] = match_type_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = exc_value_st;
             exc_value_st = PyStackRef_NULL;
             stack_pointer[-2] = exc_value_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -13868,7 +13868,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(right);
+            _PyStackRef_CLOSE(tstate, right);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             b = res ? PyStackRef_True : PyStackRef_False;
             _tos_cache1 = b;
@@ -13923,11 +13923,11 @@
             _PyStackRef tmp = fromlist;
             fromlist = PyStackRef_NULL;
             stack_pointer[-1] = fromlist;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = level;
             level = PyStackRef_NULL;
             stack_pointer[-2] = level;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -14011,7 +14011,7 @@
                 _PyStackRef tmp = value;
                 value = b;
                 stack_pointer[-1] = value;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
             }
@@ -14513,7 +14513,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(iterable);
+            _PyStackRef_CLOSE(tstate, iterable);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (iter_o == NULL) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -16391,7 +16391,7 @@
             STAT_INC(LOAD_ATTR, hit);
             assert(descr != NULL);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(owner);
+            _PyStackRef_CLOSE(tstate, owner);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             attr = PyStackRef_FromPyObjectNew(descr);
             _tos_cache0 = attr;
@@ -16416,7 +16416,7 @@
             STAT_INC(LOAD_ATTR, hit);
             assert(descr != NULL);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(owner);
+            _PyStackRef_CLOSE(tstate, owner);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             attr = PyStackRef_FromPyObjectNew(descr);
             _tos_cache0 = attr;
@@ -16610,7 +16610,7 @@
                 stack_pointer[-2 - oparg] = callable;
                 stack_pointer[-1 - oparg] = self_or_null;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             _tos_cache0 = PyStackRef_ZERO_BITS;
@@ -16832,7 +16832,7 @@
             stack_pointer[-2 - oparg] = callable;
             stack_pointer[-1 - oparg] = self_or_null;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -16949,7 +16949,7 @@
             stack_pointer[-2 - oparg] = callable;
             stack_pointer[-1 - oparg] = self_or_null;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -18028,7 +18028,7 @@
             stack_pointer[-2 - oparg] = callable;
             stack_pointer[-1 - oparg] = self_or_null;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -18160,7 +18160,7 @@
             callable = PyStackRef_FromPyObjectSteal(res_o);
             stack_pointer[-2 - oparg] = callable;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -18299,7 +18299,7 @@
             callable = PyStackRef_FromPyObjectSteal(res_o);
             stack_pointer[-2 - oparg] = callable;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -18359,7 +18359,7 @@
             callable = PyStackRef_FromPyObjectSteal(res_o);
             stack_pointer[-2 - oparg] = callable;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -18645,17 +18645,17 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(cls);
+            _PyStackRef_CLOSE(tstate, cls);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(instance);
+            _PyStackRef_CLOSE(tstate, instance);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(callable);
+            _PyStackRef_CLOSE(tstate, callable);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             res = retval ? PyStackRef_True : PyStackRef_False;
             assert((!PyStackRef_IsNull(res)) ^ (_PyErr_Occurred(tstate) != NULL));
@@ -19230,7 +19230,7 @@
             callable = PyStackRef_FromPyObjectSteal(res_o);
             stack_pointer[-2 - oparg] = callable;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -19271,7 +19271,7 @@
             callable = PyStackRef_FromPyObjectSteal(res_o);
             stack_pointer[-2 - oparg] = callable;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -19490,7 +19490,7 @@
             callable = PyStackRef_FromPyObjectSteal(res_o);
             stack_pointer[-2 - oparg] = callable;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -19532,7 +19532,7 @@
             callable = PyStackRef_FromPyObjectSteal(res_o);
             stack_pointer[-2 - oparg] = callable;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(temp);
+            _PyStackRef_CLOSE(tstate, temp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = PyStackRef_ZERO_BITS;
             _tos_cache1 = PyStackRef_ZERO_BITS;
@@ -19566,7 +19566,7 @@
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
             }
@@ -19853,7 +19853,7 @@
                 callargs = PyStackRef_FromPyObjectSteal(tuple_o);
                 stack_pointer[-2] = callargs;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -3;
             }
@@ -20159,17 +20159,17 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(kwargs_st);
+            _PyStackRef_XCLOSE(tstate, kwargs_st);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(callargs_st);
+            _PyStackRef_CLOSE(tstate, callargs_st);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(func_st);
+            _PyStackRef_CLOSE(tstate, func_st);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (result_o == NULL) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -20378,7 +20378,7 @@
             for (int _i = oparg; --_i >= 0;) {
                 tmp = args[_i];
                 args[_i] = PyStackRef_NULL;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
             }
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -oparg;
@@ -20416,7 +20416,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (result_o == NULL) {
                 SET_CURRENT_CACHED_VALUES(0);
@@ -20449,7 +20449,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (res_o == NULL) {
                     SET_CURRENT_CACHED_VALUES(0);
@@ -20487,11 +20487,11 @@
             _PyStackRef tmp = fmt_spec;
             fmt_spec = PyStackRef_NULL;
             stack_pointer[-1] = fmt_spec;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = value;
             value = PyStackRef_NULL;
             stack_pointer[-2] = value;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -22177,7 +22177,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(val);
+                _PyStackRef_CLOSE(tstate, val);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (1) {
                     UOP_STAT_INC(uopcode, miss);
@@ -22201,7 +22201,7 @@
             int is_none = PyStackRef_IsNone(val);
             if (!is_none) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(val);
+                _PyStackRef_CLOSE(tstate, val);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (1) {
                     UOP_STAT_INC(uopcode, miss);
@@ -22227,7 +22227,7 @@
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(val);
+                _PyStackRef_CLOSE(tstate, val);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (1) {
                     UOP_STAT_INC(uopcode, miss);
@@ -22259,7 +22259,7 @@
                 stack_pointer += 2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(val);
+                _PyStackRef_CLOSE(tstate, val);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (1) {
                     UOP_STAT_INC(uopcode, miss);
@@ -22286,7 +22286,7 @@
             val = _stack_item_0;
             int is_none = PyStackRef_IsNone(val);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(val);
+            _PyStackRef_CLOSE(tstate, val);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (is_none) {
                 UOP_STAT_INC(uopcode, miss);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -10116,7 +10116,7 @@
                     JUMP_TO_ERROR();
                 }
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_SETREF(v_o, l_v);
+                _Py_SETREF(tstate, v_o, l_v);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             v = PyStackRef_FromPyObjectSteal(v_o);
@@ -14260,7 +14260,7 @@
             stack_pointer += 1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            _PyStackRef result = _PyEval_GetIter(iterable, &index_or_null, oparg);
+            _PyStackRef result = _PyEval_GetIter(tstate, iterable, &index_or_null, oparg);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (PyStackRef_IsError(result)) {
                 stack_pointer += -1;
@@ -19620,7 +19620,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(kwnames);
+            _PyStackRef_CLOSE(tstate, kwnames);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2 - oparg;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -19729,7 +19729,7 @@
             stack_pointer += 1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(callable_s);
+            _PyStackRef_CLOSE(tstate, callable_s);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             _tos_cache0 = _stack_item_0;
             _tos_cache1 = PyStackRef_ZERO_BITS;

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -4,7 +4,9 @@
 
 #include "Python.h"
 #include "pycore_ceval.h"         // _Py_set_eval_breaker_bit()
+#include "pycore_call.h"          // _PyObject_VectorcallTstate()
 #include "pycore_dict.h"          // _PyInlineValuesSize()
+#include "pycore_pyerrors.h"
 #include "pycore_initconfig.h"    // _PyStatus_OK()
 #include "pycore_context.h"
 #include "pycore_interp.h"        // PyInterpreterState.gc
@@ -1277,7 +1279,7 @@ invoke_gc_callback(PyThreadState *tstate, const char *phase,
             "candidates", stats->candidates,
             "duration", stats->duration);
         if (info == NULL) {
-            PyErr_FormatUnraisable("Exception ignored on invoking gc callbacks");
+            _PyErr_FormatUnraisable(tstate, "Exception ignored on invoking gc callbacks");
             return;
         }
     }
@@ -1285,7 +1287,7 @@ invoke_gc_callback(PyThreadState *tstate, const char *phase,
     PyObject *phase_obj = PyUnicode_FromString(phase);
     if (phase_obj == NULL) {
         Py_XDECREF(info);
-        PyErr_FormatUnraisable("Exception ignored on invoking gc callbacks");
+        _PyErr_FormatUnraisable(tstate, "Exception ignored on invoking gc callbacks");
         return;
     }
 
@@ -1293,10 +1295,10 @@ invoke_gc_callback(PyThreadState *tstate, const char *phase,
     for (Py_ssize_t i=0; i<PyList_GET_SIZE(gcstate->callbacks); i++) {
         PyObject *r, *cb = PyList_GET_ITEM(gcstate->callbacks, i);
         Py_INCREF(cb); /* make sure cb doesn't go away */
-        r = PyObject_Vectorcall(cb, stack, 2, NULL);
+        r = _PyObject_VectorcallTstate(tstate, cb, stack, 2, NULL);
         if (r == NULL) {
-            PyErr_FormatUnraisable("Exception ignored while "
-                                   "calling GC callback %R", cb);
+            _PyErr_FormatUnraisable(tstate, "Exception ignored while "
+                                    "calling GC callback %R", cb);
         }
         else {
             Py_DECREF(r);

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1971,13 +1971,13 @@ _Py_ScheduleGC(PyThreadState *tstate)
 }
 
 void
-_PyObject_GC_Link(PyObject *op)
+_PyObject_GC_Link(PyThreadState *tstate, PyObject *op)
 {
+    assert(tstate != NULL);
     PyGC_Head *gc = AS_GC(op);
     // gc must be correctly aligned
     _PyObject_ASSERT(op, ((uintptr_t)gc & (sizeof(uintptr_t)-1)) == 0);
 
-    PyThreadState *tstate = _PyThreadState_GET();
     GCState *gcstate = &tstate->interp->gc;
     gc->_gc_next = 0;
     gc->_gc_prev = 0;
@@ -2017,7 +2017,7 @@ gc_alloc(PyTypeObject *tp, size_t basicsize, size_t presize)
     ((PyObject **)mem)[0] = NULL;
     ((PyObject **)mem)[1] = NULL;
     PyObject *op = (PyObject *)(mem + presize);
-    _PyObject_GC_Link(op);
+    _PyObject_GC_Link(tstate, op);
     return op;
 }
 

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -2702,7 +2702,7 @@ _Py_ScheduleGC(PyThreadState *tstate)
 }
 
 void
-_PyObject_GC_Link(PyObject *op)
+_PyObject_GC_Link(PyThreadState *tstate, PyObject *op)
 {
     record_allocation(_PyThreadState_GET());
 }

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1949,8 +1949,8 @@ invoke_gc_callback(PyThreadState *tstate, const char *phase,
             "candidates", candidates,
             "duration", duration);
         if (info == NULL) {
-            PyErr_FormatUnraisable("Exception ignored while "
-                                   "invoking gc callbacks");
+            _PyErr_FormatUnraisable(tstate, "Exception ignored while "
+                                    "invoking gc callbacks");
             return;
         }
     }
@@ -1958,8 +1958,8 @@ invoke_gc_callback(PyThreadState *tstate, const char *phase,
     PyObject *phase_obj = PyUnicode_FromString(phase);
     if (phase_obj == NULL) {
         Py_XDECREF(info);
-        PyErr_FormatUnraisable("Exception ignored while "
-                               "invoking gc callbacks");
+        _PyErr_FormatUnraisable(tstate, "Exception ignored while "
+                                "invoking gc callbacks");
         return;
     }
 
@@ -1967,10 +1967,10 @@ invoke_gc_callback(PyThreadState *tstate, const char *phase,
     for (Py_ssize_t i=0; i<PyList_GET_SIZE(gcstate->callbacks); i++) {
         PyObject *r, *cb = PyList_GET_ITEM(gcstate->callbacks, i);
         Py_INCREF(cb); /* make sure cb doesn't go away */
-        r = PyObject_Vectorcall(cb, stack, 2, NULL);
+        r = _PyObject_VectorcallTstate(tstate, cb, stack, 2, NULL);
         if (r == NULL) {
-            PyErr_FormatUnraisable("Exception ignored while "
-                                   "calling GC callback %R", cb);
+            _PyErr_FormatUnraisable(tstate, "Exception ignored while "
+                                    "calling GC callback %R", cb);
         }
         else {
             Py_DECREF(r);

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1,6 +1,7 @@
 // Cyclic garbage collector implementation for free-threaded build.
 #include "Python.h"
 #include "pycore_brc.h"           // struct _brc_thread_state
+#include "pycore_call.h"          // _PyObject_VectorcallTstate()
 #include "pycore_ceval.h"         // _Py_set_eval_breaker_bit()
 #include "pycore_dict.h"          // _PyInlineValuesSize()
 #include "pycore_frame.h"         // FRAME_CLEARED

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -77,7 +77,7 @@
                 stack_pointer[-2] = res;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -86,7 +86,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -382,7 +382,7 @@
                 stack_pointer[-2] = res;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -391,7 +391,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -685,7 +685,7 @@
                 stack_pointer[-2] = res;
                 stack_pointer[-1] = ds;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -694,7 +694,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -873,7 +873,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -944,7 +944,7 @@
                 stack_pointer[-2] = res;
                 stack_pointer[-1] = ls;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -953,7 +953,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -1134,7 +1134,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -1427,7 +1427,7 @@
                     else {
                         _PyFrame_SetStackPointer(frame, stack_pointer);
                         res_o = PyObject_GetItem(container_o, slice);
-                        Py_DECREF(slice);
+                        _Py_DECREF(tstate, slice);
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                     }
                 }
@@ -1435,15 +1435,15 @@
                 _PyStackRef tmp = stop;
                 stop = PyStackRef_NULL;
                 stack_pointer[-1] = stop;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = start;
                 start = PyStackRef_NULL;
                 stack_pointer[-2] = start;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = container;
                 container = PyStackRef_NULL;
                 stack_pointer[-3] = container;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -1490,7 +1490,7 @@
                 stack_pointer += -(oparg & 1);
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(format[0]);
+                _PyStackRef_CLOSE(tstate, format[0]);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             else {
@@ -1499,12 +1499,12 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(str);
+            _PyStackRef_CLOSE(tstate, str);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (interpolation_o == NULL) {
                 JUMP_TO_LABEL(error);
@@ -1586,7 +1586,7 @@
                 for (int _i = oparg; --_i >= 0;) {
                     tmp = values[_i];
                     values[_i] = PyStackRef_NULL;
-                    PyStackRef_CLOSE(tmp);
+                    _PyStackRef_CLOSE(tstate, tmp);
                 }
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -oparg;
@@ -1604,7 +1604,7 @@
                 }
                 else {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(value);
+                    _PyStackRef_CLOSE(tstate, value);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -1612,7 +1612,7 @@
                 stack_pointer += -oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_DECREF(set_o);
+                _Py_DECREF(tstate, set_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 JUMP_TO_LABEL(error);
             }
@@ -1643,7 +1643,7 @@
             for (int _i = oparg; --_i >= 0;) {
                 tmp = args[_i];
                 args[_i] = PyStackRef_NULL;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
             }
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -oparg;
@@ -1705,12 +1705,12 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(interpolations);
+            _PyStackRef_CLOSE(tstate, interpolations);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(strings);
+            _PyStackRef_CLOSE(tstate, strings);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (template_o == NULL) {
                 JUMP_TO_LABEL(error);
@@ -1804,7 +1804,7 @@
                     stack_pointer[-2 - oparg] = callable;
                     stack_pointer[-1 - oparg] = self_or_null;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -1963,7 +1963,7 @@
                 stack_pointer[-2 - oparg] = callable;
                 stack_pointer[-1 - oparg] = self_or_null;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CREATE_INIT_FRAME
@@ -2064,7 +2064,7 @@
                 stack_pointer[-2 - oparg] = callable;
                 stack_pointer[-1 - oparg] = self_or_null;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // flush
@@ -2222,7 +2222,7 @@
                 stack_pointer[-2 - oparg] = callable;
                 stack_pointer[-1 - oparg] = self_or_null;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // flush
@@ -2342,7 +2342,7 @@
                 callable = PyStackRef_FromPyObjectSteal(res_o);
                 stack_pointer[-2 - oparg] = callable;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_OPARG
@@ -2358,7 +2358,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -2430,7 +2430,7 @@
                 callable = PyStackRef_FromPyObjectSteal(res_o);
                 stack_pointer[-2 - oparg] = callable;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_OPARG
@@ -2446,7 +2446,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -2514,7 +2514,7 @@
                 callable = PyStackRef_FromPyObjectSteal(res_o);
                 stack_pointer[-2 - oparg] = callable;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_OPARG
@@ -2530,7 +2530,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -2628,7 +2628,7 @@
                 stack_pointer += -oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -2637,7 +2637,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -2703,7 +2703,7 @@
                     callargs = PyStackRef_FromPyObjectSteal(tuple_o);
                     stack_pointer[-2] = callargs;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -2726,17 +2726,17 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(kwargs_st);
+                _PyStackRef_XCLOSE(tstate, kwargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(callargs_st);
+                _PyStackRef_CLOSE(tstate, callargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(func_st);
+                _PyStackRef_CLOSE(tstate, func_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (result_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -2807,7 +2807,7 @@
                     callargs = PyStackRef_FromPyObjectSteal(tuple_o);
                     stack_pointer[-2] = callargs;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -2938,7 +2938,7 @@
                     callargs = PyStackRef_FromPyObjectSteal(tuple_o);
                     stack_pointer[-2] = callargs;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -2988,7 +2988,7 @@
                             stack_pointer = _PyFrame_GetStackPointer(frame);
                             if (err < 0) {
                                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                                Py_CLEAR(result_o);
+                                _Py_CLEAR(tstate, result_o);
                                 stack_pointer = _PyFrame_GetStackPointer(frame);
                             }
                         }
@@ -3033,17 +3033,17 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(kwargs_st);
+                _PyStackRef_XCLOSE(tstate, kwargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(callargs_st);
+                _PyStackRef_CLOSE(tstate, callargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(func_st);
+                _PyStackRef_CLOSE(tstate, func_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (result_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -3094,7 +3094,7 @@
                 value = v;
                 stack_pointer[-1] = res;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -3137,7 +3137,7 @@
                 stack_pointer[-2] = res;
                 stack_pointer[-1] = vs1;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -3146,7 +3146,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -3207,17 +3207,17 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(cls);
+                _PyStackRef_CLOSE(tstate, cls);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(instance);
+                _PyStackRef_CLOSE(tstate, instance);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(callable);
+                _PyStackRef_CLOSE(tstate, callable);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 res = retval ? PyStackRef_True : PyStackRef_False;
                 assert((!PyStackRef_IsNull(res)) ^ (_PyErr_Occurred(tstate) != NULL));
@@ -3276,7 +3276,7 @@
                     stack_pointer[-3 - oparg] = callable;
                     stack_pointer[-2 - oparg] = self_or_null;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -3733,7 +3733,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -3742,7 +3742,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -3827,7 +3827,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -3836,7 +3836,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -3923,7 +3923,7 @@
                 callable = PyStackRef_FromPyObjectSteal(res_o);
                 stack_pointer[-2 - oparg] = callable;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_OPARG
@@ -3938,7 +3938,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4035,7 +4035,7 @@
                 callable = PyStackRef_FromPyObjectSteal(res_o);
                 stack_pointer[-2 - oparg] = callable;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(temp);
+                _PyStackRef_CLOSE(tstate, temp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_OPARG
@@ -4050,7 +4050,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4159,7 +4159,7 @@
                 stack_pointer += -oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -4168,7 +4168,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4280,7 +4280,7 @@
                 stack_pointer += 1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -4289,7 +4289,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -4298,7 +4298,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4664,7 +4664,7 @@
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4739,7 +4739,7 @@
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _CHECK_PERIODIC_AT_END
@@ -4808,7 +4808,7 @@
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -4838,11 +4838,11 @@
                 _PyStackRef tmp = match_type_st;
                 match_type_st = PyStackRef_NULL;
                 stack_pointer[-1] = match_type_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = exc_value_st;
                 exc_value_st = PyStackRef_NULL;
                 stack_pointer[-2] = exc_value_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -4856,11 +4856,11 @@
             _PyStackRef tmp = match_type_st;
             match_type_st = PyStackRef_NULL;
             stack_pointer[-1] = match_type_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = exc_value_st;
             exc_value_st = PyStackRef_NULL;
             stack_pointer[-2] = exc_value_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -4913,7 +4913,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(right);
+            _PyStackRef_CLOSE(tstate, right);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             b = res ? PyStackRef_True : PyStackRef_False;
             stack_pointer[0] = b;
@@ -4957,19 +4957,19 @@
                 _PyStackRef tmp = sub_iter;
                 sub_iter = value;
                 stack_pointer[-4] = sub_iter;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = exc_value_st;
                 exc_value_st = PyStackRef_NULL;
                 stack_pointer[-1] = exc_value_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = last_sent_val;
                 last_sent_val = PyStackRef_NULL;
                 stack_pointer[-2] = last_sent_val;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = null_in;
                 null_in = PyStackRef_NULL;
                 stack_pointer[-3] = null_in;
-                PyStackRef_XCLOSE(tmp);
+                _PyStackRef_XCLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -4;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -5032,11 +5032,11 @@
                 _PyStackRef tmp = right;
                 right = PyStackRef_NULL;
                 stack_pointer[-1] = right;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = left;
                 left = PyStackRef_NULL;
                 stack_pointer[-2] = left;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -5046,7 +5046,7 @@
                 if (oparg & 16) {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
                     int res_bool = PyObject_IsTrue(res_o);
-                    Py_DECREF(res_o);
+                    _Py_DECREF(tstate, res_o);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (res_bool < 0) {
                         JUMP_TO_LABEL(error);
@@ -5333,7 +5333,7 @@
                 stack_pointer[-2] = b;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -5342,7 +5342,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -5401,7 +5401,7 @@
                 stack_pointer[-2] = b;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -5410,7 +5410,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -5469,7 +5469,7 @@
                 stack_pointer[-2] = b;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -5478,7 +5478,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -5504,7 +5504,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (result_o == NULL) {
                 JUMP_TO_LABEL(error);
@@ -5572,7 +5572,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(owner);
+            _PyStackRef_CLOSE(tstate, owner);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {
                 JUMP_TO_LABEL(error);
@@ -5597,7 +5597,7 @@
                 JUMP_TO_LABEL(error);
             }
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            Py_DECREF(oldobj);
+            _Py_DECREF(tstate, oldobj);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -5623,7 +5623,7 @@
             _PyStackRef tmp = GETLOCAL(oparg);
             GETLOCAL(oparg) = PyStackRef_NULL;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -5703,11 +5703,11 @@
             _PyStackRef tmp = sub;
             sub = PyStackRef_NULL;
             stack_pointer[-1] = sub;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = container;
             container = PyStackRef_NULL;
             stack_pointer[-2] = container;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -5757,7 +5757,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -5796,7 +5796,7 @@
                             _PyErr_Format(tstate, PyExc_TypeError,
                                       "'%T' object is not a mapping",
                                       update_o);
-                            Py_DECREF(exc);
+                            _Py_DECREF(tstate, exc);
                             stack_pointer = _PyFrame_GetStackPointer(frame);
                         }
                         else {
@@ -5815,7 +5815,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -5847,11 +5847,11 @@
                 _PyStackRef tmp = exc_st;
                 exc_st = PyStackRef_NULL;
                 stack_pointer[-1] = exc_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = awaitable_st;
                 awaitable_st = PyStackRef_NULL;
                 stack_pointer[-2] = awaitable_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -5878,7 +5878,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -5904,7 +5904,7 @@
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(receiver);
+            _PyStackRef_CLOSE(tstate, receiver);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -6017,7 +6017,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (res_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -6052,11 +6052,11 @@
             _PyStackRef tmp = fmt_spec;
             fmt_spec = PyStackRef_NULL;
             stack_pointer[-1] = fmt_spec;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = value;
             value = PyStackRef_NULL;
             stack_pointer[-2] = value;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -6474,7 +6474,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(obj);
+                _PyStackRef_CLOSE(tstate, obj);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 JUMP_TO_LABEL(error);
             }
@@ -6484,7 +6484,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(obj);
+            _PyStackRef_CLOSE(tstate, obj);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (iter_o == NULL) {
                 JUMP_TO_LABEL(error);
@@ -6496,7 +6496,7 @@
                               "'async for' received an object from __aiter__ "
                               "that does not implement __anext__: %.100s",
                               Py_TYPE(iter_o)->tp_name);
-                Py_DECREF(iter_o);
+                _Py_DECREF(tstate, iter_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 JUMP_TO_LABEL(error);
             }
@@ -6548,7 +6548,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(iterable);
+            _PyStackRef_CLOSE(tstate, iterable);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (iter_o == NULL) {
                 JUMP_TO_LABEL(error);
@@ -6777,11 +6777,11 @@
             _PyStackRef tmp = fromlist;
             fromlist = PyStackRef_NULL;
             stack_pointer[-1] = fromlist;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = level;
             level = PyStackRef_NULL;
             stack_pointer[-2] = level;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -6827,7 +6827,7 @@
                     stack_pointer[-2 - oparg] = callable;
                     stack_pointer[-1 - oparg] = self_or_null;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -6966,7 +6966,7 @@
                     callargs = PyStackRef_FromPyObjectSteal(tuple_o);
                     stack_pointer[-2] = callargs;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -7016,7 +7016,7 @@
                             stack_pointer = _PyFrame_GetStackPointer(frame);
                             if (err < 0) {
                                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                                Py_CLEAR(result_o);
+                                _Py_CLEAR(tstate, result_o);
                                 stack_pointer = _PyFrame_GetStackPointer(frame);
                             }
                         }
@@ -7061,17 +7061,17 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(kwargs_st);
+                _PyStackRef_XCLOSE(tstate, kwargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(callargs_st);
+                _PyStackRef_CLOSE(tstate, callargs_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(func_st);
+                _PyStackRef_CLOSE(tstate, func_st);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (result_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -7125,7 +7125,7 @@
                     stack_pointer[-3 - oparg] = callable;
                     stack_pointer[-2 - oparg] = self_or_null;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(temp);
+                    _PyStackRef_CLOSE(tstate, temp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -7249,11 +7249,11 @@
                     _PyStackRef tmp = exc_st;
                     exc_st = PyStackRef_NULL;
                     stack_pointer[-1] = exc_st;
-                    PyStackRef_CLOSE(tmp);
+                    _PyStackRef_CLOSE(tstate, tmp);
                     tmp = awaitable_st;
                     awaitable_st = PyStackRef_NULL;
                     stack_pointer[-2] = awaitable_st;
-                    PyStackRef_CLOSE(tmp);
+                    _PyStackRef_CLOSE(tstate, tmp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     stack_pointer += -2;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -7293,7 +7293,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(value);
+            _PyStackRef_CLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -7330,7 +7330,7 @@
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(receiver);
+            _PyStackRef_CLOSE(tstate, receiver);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -7516,15 +7516,15 @@
                         _PyStackRef tmp = self_st;
                         self_st = PyStackRef_NULL;
                         stack_pointer[-1] = self_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         tmp = class_st;
                         class_st = PyStackRef_NULL;
                         stack_pointer[-2] = class_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         tmp = global_super_st;
                         global_super_st = PyStackRef_NULL;
                         stack_pointer[-3] = global_super_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         stack_pointer += -3;
                         ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -7555,7 +7555,7 @@
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         if (err < 0) {
                             _PyFrame_SetStackPointer(frame, stack_pointer);
-                            Py_CLEAR(super);
+                            _Py_CLEAR(tstate, super);
                             stack_pointer = _PyFrame_GetStackPointer(frame);
                         }
                     }
@@ -7564,15 +7564,15 @@
                 _PyStackRef tmp = self_st;
                 self_st = PyStackRef_NULL;
                 stack_pointer[-1] = self_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = class_st;
                 class_st = PyStackRef_NULL;
                 stack_pointer[-2] = class_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = global_super_st;
                 global_super_st = PyStackRef_NULL;
                 stack_pointer[-3] = global_super_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -7582,7 +7582,7 @@
                 PyObject *name = GETITEM(FRAME_CO_NAMES, oparg >> 2);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyObject *attr_o = PyObject_GetAttr(super, name);
-                Py_DECREF(super);
+                _Py_DECREF(tstate, super);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (attr_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -7638,7 +7638,7 @@
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(iter);
+            _PyStackRef_CLOSE(tstate, iter);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -7689,7 +7689,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += 1;
             }
@@ -7717,7 +7717,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 INSTRUMENTED_JUMP(this_instr, next_instr + oparg, PY_MONITORING_EVENT_BRANCH_RIGHT);
             }
@@ -7990,7 +7990,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(executor);
+                _PyStackRef_CLOSE(tstate, executor);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += 1;
             }
@@ -8028,7 +8028,7 @@
                 stack_pointer[-2] = b;
                 stack_pointer[-1] = l;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -8037,7 +8037,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -8258,7 +8258,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -8317,7 +8317,7 @@
                     stack_pointer += (oparg&1);
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(owner);
+                    _PyStackRef_CLOSE(tstate, owner);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (PyStackRef_IsNull(attr)) {
                         JUMP_TO_LABEL(error);
@@ -8374,7 +8374,7 @@
                 _PyStackRef tmp = owner;
                 owner = attr;
                 stack_pointer[-1] = owner;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _PUSH_NULL_CONDITIONAL
@@ -8442,7 +8442,7 @@
                 _PyStackRef tmp = owner;
                 owner = attr;
                 stack_pointer[-1] = owner;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _PUSH_NULL_CONDITIONAL
@@ -8618,7 +8618,7 @@
                 value = o;
                 stack_pointer[-1] = attr;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             /* Skip 5 cache entries */
@@ -8857,7 +8857,7 @@
                 value = o;
                 stack_pointer[-1] = attr;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             /* Skip 5 cache entries */
@@ -8910,7 +8910,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(owner);
+                _PyStackRef_CLOSE(tstate, owner);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 attr = PyStackRef_FromPyObjectNew(descr);
             }
@@ -8967,7 +8967,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(owner);
+                _PyStackRef_CLOSE(tstate, owner);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 attr = PyStackRef_FromPyObjectNew(descr);
             }
@@ -9120,7 +9120,7 @@
                 value = o;
                 stack_pointer[-1] = attr;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             /* Skip 5 cache entries */
@@ -9237,7 +9237,7 @@
                 value = o;
                 stack_pointer[-1] = attr;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             /* Skip 5 cache entries */
@@ -9500,7 +9500,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(class_dict_st);
+            _PyStackRef_CLOSE(tstate, class_dict_st);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             value = PyStackRef_FromPyObjectSteal(value_o);
             stack_pointer[0] = value;
@@ -9528,7 +9528,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(mod_or_class_dict);
+            _PyStackRef_CLOSE(tstate, mod_or_class_dict);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err < 0) {
                 JUMP_TO_LABEL(error);
@@ -9851,7 +9851,7 @@
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (l_v == NULL) {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    Py_DECREF(v_o);
+                    _Py_DECREF(tstate, v_o);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     JUMP_TO_LABEL(error);
                 }
@@ -9860,8 +9860,8 @@
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err < 0) {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    Py_DECREF(v_o);
-                    Py_DECREF(l_v);
+                    _Py_DECREF(tstate, v_o);
+                    _Py_DECREF(tstate, l_v);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     JUMP_TO_LABEL(error);
                 }
@@ -9994,15 +9994,15 @@
                         _PyStackRef tmp = self_st;
                         self_st = PyStackRef_NULL;
                         stack_pointer[-1] = self_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         tmp = class_st;
                         class_st = PyStackRef_NULL;
                         stack_pointer[-2] = class_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         tmp = global_super_st;
                         global_super_st = PyStackRef_NULL;
                         stack_pointer[-3] = global_super_st;
-                        PyStackRef_CLOSE(tmp);
+                        _PyStackRef_CLOSE(tstate, tmp);
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         stack_pointer += -3;
                         ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -10033,7 +10033,7 @@
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         if (err < 0) {
                             _PyFrame_SetStackPointer(frame, stack_pointer);
-                            Py_CLEAR(super);
+                            _Py_CLEAR(tstate, super);
                             stack_pointer = _PyFrame_GetStackPointer(frame);
                         }
                     }
@@ -10042,15 +10042,15 @@
                 _PyStackRef tmp = self_st;
                 self_st = PyStackRef_NULL;
                 stack_pointer[-1] = self_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = class_st;
                 class_st = PyStackRef_NULL;
                 stack_pointer[-2] = class_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = global_super_st;
                 global_super_st = PyStackRef_NULL;
                 stack_pointer[-3] = global_super_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -10060,7 +10060,7 @@
                 PyObject *name = GETITEM(FRAME_CO_NAMES, oparg >> 2);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyObject *attr_o = PyObject_GetAttr(super, name);
-                Py_DECREF(super);
+                _Py_DECREF(tstate, super);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (attr_o == NULL) {
                     JUMP_TO_LABEL(error);
@@ -10120,15 +10120,15 @@
             _PyStackRef tmp = self_st;
             self_st = PyStackRef_NULL;
             stack_pointer[-1] = self_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = class_st;
             class_st = PyStackRef_NULL;
             stack_pointer[-2] = class_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             tmp = global_super_st;
             global_super_st = PyStackRef_NULL;
             stack_pointer[-3] = global_super_st;
-            PyStackRef_CLOSE(tmp);
+            _PyStackRef_CLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             stack_pointer += -3;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -10203,7 +10203,7 @@
                     stack_pointer += -1;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(self_st);
+                    _PyStackRef_CLOSE(tstate, self_st);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     self_or_null = PyStackRef_NULL;
                     stack_pointer += 1;
@@ -10214,11 +10214,11 @@
                 _PyStackRef tmp = global_super_st;
                 global_super_st = self_or_null;
                 stack_pointer[-2] = global_super_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = class_st;
                 class_st = PyStackRef_NULL;
                 stack_pointer[-1] = class_st;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -10247,7 +10247,7 @@
             _PyStackRef tmp = GETLOCAL(oparg);
             GETLOCAL(oparg) = PyStackRef_FromPyObjectSteal(cell);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -10285,7 +10285,7 @@
                 value = co;
                 stack_pointer[-1] = func;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -10371,7 +10371,7 @@
                 stack_pointer[-2] = s;
                 stack_pointer[-1] = tp;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -10380,7 +10380,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP
@@ -10389,7 +10389,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -10519,7 +10519,7 @@
             stack_pointer += -2;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(iter);
+            _PyStackRef_CLOSE(tstate, iter);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -10572,7 +10572,7 @@
                     _PyStackRef tmp = value;
                     value = b;
                     stack_pointer[-1] = value;
-                    PyStackRef_CLOSE(tmp);
+                    _PyStackRef_CLOSE(tstate, tmp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -10615,7 +10615,7 @@
                     _PyStackRef tmp = value;
                     value = b;
                     stack_pointer[-1] = value;
-                    PyStackRef_CLOSE(tmp);
+                    _PyStackRef_CLOSE(tstate, tmp);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
@@ -10667,7 +10667,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(value);
+            _PyStackRef_XCLOSE(tstate, value);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -11132,7 +11132,7 @@
                     stack_pointer += -1;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(v);
+                    _PyStackRef_CLOSE(tstate, v);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     retval = PyStackRef_FromPyObjectSteal(res.object);
                     if (res.kind == PYGEN_RETURN) {
@@ -11191,7 +11191,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(v);
+                _PyStackRef_CLOSE(tstate, v);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 asend = iter;
                 null_out = null_in;
@@ -11373,7 +11373,7 @@
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 err = PyObject_SetItem(LOCALS(), &_Py_ID(__annotations__),
                                        ann_dict);
-                Py_DECREF(ann_dict);
+                _Py_DECREF(tstate, ann_dict);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err) {
                     JUMP_TO_LABEL(error);
@@ -11381,7 +11381,7 @@
             }
             else {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_DECREF(ann_dict);
+                _Py_DECREF(tstate, ann_dict);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11470,7 +11470,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11518,11 +11518,11 @@
                 _PyStackRef tmp = owner;
                 owner = PyStackRef_NULL;
                 stack_pointer[-1] = owner;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = v;
                 v = PyStackRef_NULL;
                 stack_pointer[-2] = v;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -11618,7 +11618,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11680,7 +11680,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11779,7 +11779,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11827,7 +11827,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -11851,7 +11851,7 @@
             value2 = PyStackRef_DUP(GETLOCAL(oparg2));
             stack_pointer[-1] = value2;
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -11875,14 +11875,14 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             tmp = GETLOCAL(oparg2);
             GETLOCAL(oparg2) = value2;
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_XCLOSE(tmp);
+            _PyStackRef_XCLOSE(tstate, tmp);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             DISPATCH();
         }
@@ -11904,7 +11904,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(v);
+            _PyStackRef_CLOSE(tstate, v);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {
                 JUMP_TO_LABEL(error);
@@ -11933,7 +11933,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(v);
+                _PyStackRef_CLOSE(tstate, v);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 JUMP_TO_LABEL(error);
             }
@@ -11950,7 +11950,7 @@
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(v);
+            _PyStackRef_CLOSE(tstate, v);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {
                 JUMP_TO_LABEL(error);
@@ -11996,7 +11996,7 @@
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
                     err = PyObject_SetItem(PyStackRef_AsPyObjectBorrow(container), slice, PyStackRef_AsPyObjectBorrow(v));
-                    Py_DECREF(slice);
+                    _Py_DECREF(tstate, slice);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     stack_pointer += 2;
                 }
@@ -12004,11 +12004,11 @@
                 _PyStackRef tmp = container;
                 container = PyStackRef_NULL;
                 stack_pointer[-3] = container;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = v;
                 v = PyStackRef_NULL;
                 stack_pointer[-4] = v;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -4;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -12059,15 +12059,15 @@
                 _PyStackRef tmp = sub;
                 sub = PyStackRef_NULL;
                 stack_pointer[-1] = sub;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = container;
                 container = PyStackRef_NULL;
                 stack_pointer[-2] = container;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 tmp = v;
                 v = PyStackRef_NULL;
                 stack_pointer[-3] = v;
-                PyStackRef_CLOSE(tmp);
+                _PyStackRef_CLOSE(tstate, tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -12127,7 +12127,7 @@
                     stack_pointer += -3;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(dict_st);
+                    _PyStackRef_CLOSE(tstate, dict_st);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     JUMP_TO_LABEL(error);
                 }
@@ -12139,7 +12139,7 @@
                 stack_pointer += -3;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12223,7 +12223,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_DECREF(old_value);
+                _Py_DECREF(tstate, old_value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // _POP_TOP_INT
@@ -12238,7 +12238,7 @@
                 stack_pointer += -2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12303,7 +12303,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(value);
+                _PyStackRef_CLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err < 0) {
                     JUMP_TO_LABEL(error);
@@ -12355,7 +12355,7 @@
                 value = v;
                 stack_pointer[-1] = res;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12469,7 +12469,7 @@
                 value = v;
                 stack_pointer[-1] = res;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12588,7 +12588,7 @@
             }
             for (int i = 0; i < tracer->prev_state.recorded_count; i++) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_CLEAR(tracer->prev_state.recorded_values[i]);
+                _Py_CLEAR(tstate, tracer->prev_state.recorded_values[i]);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             tracer->prev_state.recorded_count = 0;
@@ -12649,7 +12649,7 @@
                 value = v;
                 stack_pointer[-1] = res;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12683,7 +12683,7 @@
                 value = v;
                 stack_pointer[-1] = res;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_XCLOSE(value);
+                _PyStackRef_XCLOSE(tstate, value);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12724,7 +12724,7 @@
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             int res = _PyEval_UnpackIterableStackRef(tstate, seq_o, oparg & 0xFF, oparg >> 8, top);
-            Py_DECREF(seq_o);
+            _Py_DECREF(tstate, seq_o);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (res == 0) {
                 JUMP_TO_LABEL(error);
@@ -12774,7 +12774,7 @@
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 int res = _PyEval_UnpackIterableStackRef(tstate, seq_o, oparg, -1, top);
-                Py_DECREF(seq_o);
+                _Py_DECREF(tstate, seq_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (res == 0) {
                     JUMP_TO_LABEL(error);
@@ -12838,7 +12838,7 @@
                 stack_pointer += -1 + oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(seq);
+                _PyStackRef_CLOSE(tstate, seq);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12888,7 +12888,7 @@
                 stack_pointer += -1 + oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(seq);
+                _PyStackRef_CLOSE(tstate, seq);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -12939,7 +12939,7 @@
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(seq);
+                _PyStackRef_CLOSE(tstate, seq);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             DISPATCH();
@@ -13134,7 +13134,7 @@ JUMP_TO_LABEL(error);
                 _PyStackRef *stackbase = _PyFrame_Stackbase(frame);
                 while (frame->stackpointer > stackbase) {
                     _PyStackRef ref = _PyFrame_StackPop(frame);
-                    PyStackRef_XCLOSE(ref);
+                    _PyStackRef_XCLOSE(tstate, ref);
                 }
                 monitor_unwind(tstate, frame, next_instr-1);
                 JUMP_TO_LABEL(exit_unwind);
@@ -13144,7 +13144,7 @@ JUMP_TO_LABEL(error);
             assert(frame->stackpointer >= new_top);
             while (frame->stackpointer > new_top) {
                 _PyStackRef ref = _PyFrame_StackPop(frame);
-                PyStackRef_XCLOSE(ref);
+                _PyStackRef_XCLOSE(tstate, ref);
             }
             if (lasti) {
                 int frame_lasti = _PyInterpreterFrame_LASTI(frame);
@@ -13196,7 +13196,7 @@ JUMP_TO_LABEL(error);
                 assert(tstate->current_executor == NULL);
                 if (!PyStackRef_IsNull(executor)) {
                     tstate->current_executor = PyStackRef_AsPyObjectBorrow(executor);
-                    PyStackRef_CLOSE(executor);
+                    _PyStackRef_CLOSE(tstate, executor);
                 }
                 #endif
                 return NULL;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3310,7 +3310,7 @@
                     stack_pointer += -3 - oparg;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(kwnames);
+                    _PyStackRef_CLOSE(tstate, kwnames);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (new_frame == NULL) {
                         JUMP_TO_LABEL(error);
@@ -3412,7 +3412,7 @@
                 stack_pointer[-3 - oparg] = callable;
                 stack_pointer[-2 - oparg] = self_or_null;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(callable_s);
+                _PyStackRef_CLOSE(tstate, callable_s);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             // flush
@@ -3441,7 +3441,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(kwnames);
+                _PyStackRef_CLOSE(tstate, kwnames);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -3630,7 +3630,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyStackRef_CLOSE(kwnames);
+                _PyStackRef_CLOSE(tstate, kwnames);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -2 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -6594,7 +6594,7 @@
             // _GET_ITER
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                _PyStackRef result = _PyEval_GetIter(iterable, &index_or_null, oparg);
+                _PyStackRef result = _PyEval_GetIter(tstate, iterable, &index_or_null, oparg);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (PyStackRef_IsError(result)) {
                     JUMP_TO_LABEL(pop_1_error);
@@ -7183,7 +7183,7 @@
                     stack_pointer += -3 - oparg;
                     ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    PyStackRef_CLOSE(kwnames);
+                    _PyStackRef_CLOSE(tstate, kwnames);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (new_frame == NULL) {
                         JUMP_TO_LABEL(error);
@@ -9554,7 +9554,7 @@
                     if (PyLazyImport_CheckExact(v_o)) {
                         _PyFrame_SetStackPointer(frame, stack_pointer);
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
-                        Py_SETREF(v_o, l_v);
+                        _Py_SETREF(tstate, v_o, l_v);
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         if (v_o == NULL) {
                             JUMP_TO_LABEL(error);
@@ -9587,7 +9587,7 @@
                     if (PyLazyImport_CheckExact(v_o)) {
                         _PyFrame_SetStackPointer(frame, stack_pointer);
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
-                        Py_SETREF(v_o, l_v);
+                        _Py_SETREF(tstate, v_o, l_v);
                         stack_pointer = _PyFrame_GetStackPointer(frame);
                         if (v_o == NULL) {
                             JUMP_TO_LABEL(error);
@@ -9866,7 +9866,7 @@
                     JUMP_TO_LABEL(error);
                 }
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_SETREF(v_o, l_v);
+                _Py_SETREF(tstate, v_o, l_v);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             v = PyStackRef_FromPyObjectSteal(v_o);
@@ -12596,7 +12596,7 @@
             PyObject *prev_code = PyStackRef_AsPyObjectBorrow(frame->f_executable);
             if (tracer->prev_state.instr_code != (PyCodeObject *)prev_code) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_SETREF(tracer->prev_state.instr_code, (PyCodeObject*)Py_NewRef((prev_code)));
+                _Py_SETREF(tstate, tracer->prev_state.instr_code, (PyCodeObject*)Py_NewRef((prev_code)));
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             tracer->prev_state.instr_frame = frame;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -8309,7 +8309,7 @@
                 }
                 else {
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    attr = _PyObject_GetAttrStackRef(PyStackRef_AsPyObjectBorrow(owner), name);
+                    attr = _PyObject_GetAttrStackRef(tstate, PyStackRef_AsPyObjectBorrow(owner), name);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     stack_pointer[-1] = attr;
                     stack_pointer += (oparg&1);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2721,7 +2721,7 @@
                 assert(kwargs == NULL || PyDict_CheckExact(kwargs));
                 stack_pointer[-2] = callargs_st;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                PyObject *result_o = PyObject_Call(func, callargs, kwargs);
+                PyObject *result_o = _PyObject_Call(tstate, func, callargs, kwargs);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -2970,7 +2970,7 @@
                         JUMP_TO_LABEL(error);
                     }
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    result_o = PyObject_Call(func, callargs, kwargs);
+                    result_o = _PyObject_Call(tstate, func, callargs, kwargs);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (!PyFunction_Check(func) && !PyMethod_Check(func)) {
                         if (result_o == NULL) {
@@ -3027,7 +3027,7 @@
                     assert(kwargs == NULL || PyDict_CheckExact(kwargs));
                     stack_pointer[-2] = callargs_st;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    result_o = PyObject_Call(func, callargs, kwargs);
+                    result_o = _PyObject_Call(tstate, func, callargs, kwargs);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
                 stack_pointer += -1;
@@ -3526,6 +3526,7 @@
                 }
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyObject *res_o = _Py_VectorCall_StackRefSteal(
+                    tstate,
                     callable,
                     arguments,
                     total_args,
@@ -4360,6 +4361,7 @@
                 }
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyObject *res_o = _Py_VectorCall_StackRefSteal(
+                    tstate,
                     callable,
                     arguments,
                     total_args,
@@ -6996,7 +6998,7 @@
                         JUMP_TO_LABEL(error);
                     }
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    result_o = PyObject_Call(func, callargs, kwargs);
+                    result_o = _PyObject_Call(tstate, func, callargs, kwargs);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                     if (!PyFunction_Check(func) && !PyMethod_Check(func)) {
                         if (result_o == NULL) {
@@ -7053,7 +7055,7 @@
                     assert(kwargs == NULL || PyDict_CheckExact(kwargs));
                     stack_pointer[-2] = callargs_st;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    result_o = PyObject_Call(func, callargs, kwargs);
+                    result_o = _PyObject_Call(tstate, func, callargs, kwargs);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
                 stack_pointer += -1;
@@ -7533,7 +7535,7 @@
                 {
                     PyObject *stack[] = {class, self};
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    super = PyObject_Vectorcall(global_super, stack, oparg & 2, NULL);
+                    super = _PyObject_VectorcallTstate(tstate, global_super, stack, oparg & 2, NULL);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
                 if (opcode == INSTRUMENTED_LOAD_SUPER_ATTR) {
@@ -10011,7 +10013,7 @@
                 {
                     PyObject *stack[] = {class, self};
                     _PyFrame_SetStackPointer(frame, stack_pointer);
-                    super = PyObject_Vectorcall(global_super, stack, oparg & 2, NULL);
+                    super = _PyObject_VectorcallTstate(tstate, global_super, stack, oparg & 2, NULL);
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
                 if (opcode == INSTRUMENTED_LOAD_SUPER_ATTR) {
@@ -12976,7 +12978,7 @@
                 PyObject *stack[5] = {NULL, PyStackRef_AsPyObjectBorrow(exit_self), exc, val_o, tb};
                 int has_self = !PyStackRef_IsNull(exit_self);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                res_o = PyObject_Vectorcall(exit_func_o, stack + 2 - has_self,
+                res_o = _PyObject_VectorcallTstate(tstate, exit_func_o, stack + 2 - has_self,
                     (3 + has_self) | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }

--- a/Python/import.c
+++ b/Python/import.c
@@ -3764,12 +3764,12 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
         }
         else if (spec != NULL && spec != Py_None) {
             int equal;
-            PyObject *parent = PyObject_GetAttr(spec, &_Py_ID(parent));
+            PyObject *parent = _PyObject_GetAttr(tstate ,spec, &_Py_ID(parent));
             if (parent == NULL) {
                 goto error;
             }
 
-            equal = PyObject_RichCompareBool(package, parent, Py_EQ);
+            equal = _PyObject_RichCompareBool(tstate, package, parent, Py_EQ);
             Py_DECREF(parent);
             if (equal < 0) {
                 goto error;

--- a/Python/import.c
+++ b/Python/import.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "pycore_audit.h"         // _PySys_Audit()
+#include "pycore_call.h"          // _PyObject_VectorcallTstate()
 #include "pycore_ceval.h"
 #include "pycore_critical_section.h"  // Py_BEGIN_CRITICAL_SECTION()
 #include "pycore_dict.h"          // _PyDict_Contains_KnownHash()
@@ -4545,7 +4546,7 @@ _PyImport_LazyImportModuleLevelObject(PyThreadState *tstate,
             fromlist = Py_NewRef(Py_None);
         }
         PyObject *args[] = {modname, abs_name, fromlist};
-        PyObject *res = PyObject_Vectorcall(filter, args, 3, NULL);
+        PyObject *res = _PyObject_VectorcallTstate(tstate, filter, args, 3, NULL);
 
         Py_DECREF(modname);
         Py_DECREF(filter);

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -2982,6 +2982,7 @@ branch_handler_vectorcall(
     PyObject *op, PyObject *const *args,
     size_t nargsf, PyObject *kwnames
 ) {
+    PyThreadState *tstate = _PyThreadState_GET();
     _PyLegacyBranchEventHandler *self = _PyLegacyBranchEventHandler_CAST(op);
     // Find the other instrumented instruction and remove tool
     // The spec (PEP 669) allows spurious events after a DISABLE,
@@ -2997,7 +2998,7 @@ branch_handler_vectorcall(
         /* Already disabled */
         return &_PyInstrumentation_DISABLE;
     }
-    PyObject *res = PyObject_Vectorcall(self->handler, args, nargsf, kwnames);
+    PyObject *res = _PyObject_VectorcallTstate(tstate, self->handler, args, nargsf, kwnames);
     if (res == &_PyInstrumentation_DISABLE) {
         /* We need FOR_ITER and POP_JUMP_ to be the same size */
         assert(INLINE_CACHE_ENTRIES_FOR_ITER == 1);

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -2920,7 +2920,7 @@
                 }
                 if (oparg & 16) {
                     int res_bool = PyObject_IsTrue(res_o);
-                    Py_DECREF(res_o);
+                    _Py_DECREF(tstate, res_o);
                     if (res_bool < 0) {
                         goto error;
                     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -854,7 +854,7 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
      */
     // XXX Make sure we properly deal with problematic finalizers.
 
-    Py_CLEAR(interp->audit_hooks);
+    _Py_CLEAR(tstate, interp->audit_hooks);
 
     // gh-140257: Threads have already been cleared, but daemon threads may
     // still access eval_breaker atomically via take_gil() right before they
@@ -867,11 +867,11 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
     }
     for (int t = 0; t < PY_MONITORING_TOOL_IDS; t++) {
         for (int e = 0; e < _PY_MONITORING_EVENTS; e++) {
-            Py_CLEAR(interp->monitoring_callables[t][e]);
+            _Py_CLEAR(tstate, interp->monitoring_callables[t][e]);
         }
     }
     for (int t = 0; t < PY_MONITORING_TOOL_IDS; t++) {
-        Py_CLEAR(interp->monitoring_tool_names[t]);
+        _Py_CLEAR(tstate, interp->monitoring_tool_names[t]);
     }
     interp->_code_object_generation = 0;
 #ifdef Py_GIL_DISABLED
@@ -886,13 +886,13 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
     assert(interp->imports.importlib == NULL);
     assert(interp->imports.import_func == NULL);
 
-    Py_CLEAR(interp->sysdict_copy);
-    Py_CLEAR(interp->builtins_copy);
-    Py_CLEAR(interp->dict);
+    _Py_CLEAR(tstate, interp->sysdict_copy);
+    _Py_CLEAR(tstate, interp->builtins_copy);
+    _Py_CLEAR(tstate, interp->dict);
 #ifdef HAVE_FORK
-    Py_CLEAR(interp->before_forkers);
-    Py_CLEAR(interp->after_forkers_parent);
-    Py_CLEAR(interp->after_forkers_child);
+    _Py_CLEAR(tstate, interp->before_forkers);
+    _Py_CLEAR(tstate, interp->after_forkers_parent);
+    _Py_CLEAR(tstate, interp->after_forkers_child);
 #endif
 
 
@@ -933,8 +933,8 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
        which requires sysdict and builtins. */
     PyDict_Clear(interp->sysdict);
     PyDict_Clear(interp->builtins);
-    Py_CLEAR(interp->sysdict);
-    Py_CLEAR(interp->builtins);
+    _Py_CLEAR(tstate, interp->sysdict);
+    _Py_CLEAR(tstate, interp->builtins);
     common_constants_clear(interp);
 
 #if !defined(Py_GIL_DISABLED) && defined(Py_STACKREF_DEBUG)
@@ -1820,11 +1820,11 @@ PyThreadState_Clear(PyThreadState *tstate)
 
     /* Don't clear tstate->pyframe: it is a borrowed reference */
 
-    Py_CLEAR(tstate->threading_local_key);
-    Py_CLEAR(tstate->threading_local_sentinel);
+    _Py_CLEAR(tstate, tstate->threading_local_key);
+    _Py_CLEAR(tstate, tstate->threading_local_sentinel);
 
-    Py_CLEAR(((_PyThreadStateImpl *)tstate)->asyncio_running_loop);
-    Py_CLEAR(((_PyThreadStateImpl *)tstate)->asyncio_running_task);
+    _Py_CLEAR(tstate, ((_PyThreadStateImpl *)tstate)->asyncio_running_loop);
+    _Py_CLEAR(tstate, ((_PyThreadStateImpl *)tstate)->asyncio_running_task);
 
 
     PyMutex_Lock(&tstate->interp->asyncio_tasks_lock);
@@ -1834,12 +1834,12 @@ PyThreadState_Clear(PyThreadState *tstate)
                  &((_PyThreadStateImpl *)tstate)->asyncio_tasks_head);
     PyMutex_Unlock(&tstate->interp->asyncio_tasks_lock);
 
-    Py_CLEAR(tstate->dict);
-    Py_CLEAR(tstate->async_exc);
+    _Py_CLEAR(tstate, tstate->dict);
+    _Py_CLEAR(tstate, tstate->async_exc);
 
-    Py_CLEAR(tstate->current_exception);
+    _Py_CLEAR(tstate, tstate->current_exception);
 
-    Py_CLEAR(tstate->exc_state.exc_value);
+    _Py_CLEAR(tstate, tstate->exc_state.exc_value);
 
     /* The stack of exception states should contain just this thread. */
     if (verbose && tstate->exc_info != &tstate->exc_state) {
@@ -1856,13 +1856,13 @@ PyThreadState_Clear(PyThreadState *tstate)
         tstate->c_tracefunc = NULL;
     }
 
-    Py_CLEAR(tstate->c_profileobj);
-    Py_CLEAR(tstate->c_traceobj);
+    _Py_CLEAR(tstate, tstate->c_profileobj);
+    _Py_CLEAR(tstate, tstate->c_traceobj);
 
-    Py_CLEAR(tstate->async_gen_firstiter);
-    Py_CLEAR(tstate->async_gen_finalizer);
+    _Py_CLEAR(tstate, tstate->async_gen_firstiter);
+    _Py_CLEAR(tstate, tstate->async_gen_finalizer);
 
-    Py_CLEAR(tstate->context);
+    _Py_CLEAR(tstate, tstate->context);
 
 #ifdef Py_GIL_DISABLED
     // Each thread should clear own freelists in free-threading builds.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -13,6 +13,7 @@
 #include "pycore_ast.h"           // PyAST_mod2obj()
 #include "pycore_audit.h"         // _PySys_Audit()
 #include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
+#include "pycore_call.h"          // _PyObject_VectorcallTstate()
 #include "pycore_compile.h"       // _PyAST_Compile()
 #include "pycore_fileutils.h"     // _PyFile_Flush
 #include "pycore_import.h"        // _PyImport_GetImportlibExternalLoader()
@@ -730,7 +731,7 @@ _PyErr_PrintEx(PyThreadState *tstate, int set_sys_last_vars)
     }
     if (hook) {
         PyObject* args[3] = {typ, exc, tb};
-        PyObject *result = PyObject_Vectorcall(hook, args, 3, NULL);
+        PyObject *result = _PyObject_VectorcallTstate(tstate, hook, args, 3, NULL);
         if (result == NULL) {
             handle_system_exit();
 

--- a/Tools/cases_generator/analyzer.py
+++ b/Tools/cases_generator/analyzer.py
@@ -799,10 +799,11 @@ def escaping_call_in_simple_stmt(stmt: SimpleStmt, result: dict[SimpleStmt, Esca
                 continue
         elif tkn.kind != "RBRACKET":
             continue
-        if tkn.text in ("PyStackRef_CLOSE", "PyStackRef_XCLOSE"):
-            if len(tokens) <= idx+2:
+        if tkn.text.endswith(("PyStackRef_CLOSE", "PyStackRef_XCLOSE")):
+            amount = 4 if tkn.text.startswith("_") else 2
+            if len(tokens) <= idx+amount:
                 raise analysis_error("Unexpected end of file", next_tkn)
-            kills = tokens[idx+2]
+            kills = tokens[idx+amount]
             if kills.kind != "IDENTIFIER":
                 raise analysis_error(f"Expected identifier, got '{kills.text}'", kills)
         else:

--- a/Tools/cases_generator/stack.py
+++ b/Tools/cases_generator/stack.py
@@ -667,15 +667,15 @@ class Storage:
                 out.emit(f"tmp = {name};\n")
                 out.emit(f"{name} = {overwrite};\n")
                 self.stack.save_variables(out)
-                out.emit(f"{close}(tmp);\n")
+                out.emit(f"{close}(tstate, tmp);\n")
             else:
-                out.emit(f"{close}({name});\n")
+                out.emit(f"{close}(tstate, {name});\n")
 
         def close_variable(var: Local, overwrite: str) -> None:
             nonlocal tmp_defined
-            close = "PyStackRef_CLOSE"
+            close = "_PyStackRef_CLOSE"
             if "null" in var.name:
-                close = "PyStackRef_XCLOSE"
+                close = "_PyStackRef_XCLOSE"
             var.memory_offset = None
             self.save(out)
             out.start_line()

--- a/Tools/jit/template.c
+++ b/Tools/jit/template.c
@@ -38,6 +38,8 @@
 #include "pycore_tuple.h"
 #include "pycore_unicodeobject.h"
 
+#include <string.h>
+
 #include "ceval_macros.h"
 
 #include "jit.h"


### PR DESCRIPTION
This does a lot of refactoring to avoid repeated `_PyThreadState_GET` calls in hot code paths (primarily the eval loop + common object operations).

Most of the changes here are mechanical, but I did have to make some more convoluted changes to make this robust (such as the addition of `_Py_DECREF` and such).

<!-- gh-issue-number: gh-132312 -->
* Issue: gh-132312
<!-- /gh-issue-number -->
