### PR TITLE
gh-151456: Document the show_jit parameter in dis

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -139,7 +139,7 @@ code.
 
 .. class:: Bytecode(x, *, first_line=None, current_offset=None,\
                     show_caches=False, adaptive=False, show_offsets=False,\
-                    show_positions=False)
+                    show_positions=False, show_jit=False)
 
    Analyse the bytecode corresponding to a function, generator, asynchronous
    generator, coroutine, method, string of source code, or a code object (as
@@ -169,6 +169,9 @@ code.
 
    If *show_positions* is ``True``, :meth:`.dis` will include instruction
    source code positions in the output.
+
+   If *show_jit* is ``True``, :meth:`.dis` will show ``ENTER_EXECUTOR``
+   instructions, which mark JIT entry points and are hidden by default.
 
    .. classmethod:: from_traceback(tb, *, show_caches=False)
 
@@ -204,6 +207,9 @@ code.
 
    .. versionchanged:: 3.14
       Added the *show_positions* parameter.
+
+   .. versionchanged:: 3.16
+      Added the *show_jit* parameter.
 
 Example:
 
@@ -259,7 +265,8 @@ operation is being performed, so the intermediate analysis object isn't useful:
 
 
 .. function:: dis(x=None, *, file=None, depth=None, show_caches=False,\
-                  adaptive=False, show_offsets=False, show_positions=False)
+                  adaptive=False, show_offsets=False, show_positions=False,\
+                  show_jit=False)
 
    Disassemble the *x* object.  *x* can denote either a module, a class, a
    method, a function, a generator, an asynchronous generator, a coroutine,
@@ -286,6 +293,9 @@ operation is being performed, so the intermediate analysis object isn't useful:
    If *adaptive* is ``True``, this function will display specialized bytecode
    that may be different from the original bytecode.
 
+   If *show_jit* is ``True``, this function will show ``ENTER_EXECUTOR``
+   instructions, which mark JIT entry points and are hidden by default.
+
    .. versionchanged:: 3.4
       Added *file* parameter.
 
@@ -304,8 +314,11 @@ operation is being performed, so the intermediate analysis object isn't useful:
    .. versionchanged:: 3.14
       Added the *show_positions* parameter.
 
+   .. versionchanged:: 3.16
+      Added the *show_jit* parameter.
+
 .. function:: distb(tb=None, *, file=None, show_caches=False, adaptive=False,\
-                    show_offset=False, show_positions=False)
+                    show_offsets=False, show_positions=False, show_jit=False)
 
    Disassemble the top-of-stack function of a traceback, using the last
    traceback if none was passed.  The instruction causing the exception is
@@ -326,10 +339,14 @@ operation is being performed, so the intermediate analysis object isn't useful:
    .. versionchanged:: 3.14
       Added the *show_positions* parameter.
 
+   .. versionchanged:: 3.16
+      Added the *show_jit* parameter.
+
 .. function:: disassemble(code, lasti=-1, *, file=None, show_caches=False,\
-                          adaptive=False, show_offsets=False, show_positions=False)
+                          adaptive=False, show_offsets=False, show_positions=False,\
+                          show_jit=False)
               disco(code, lasti=-1, *, file=None, show_caches=False, adaptive=False,\
-                    show_offsets=False, show_positions=False)
+                    show_offsets=False, show_positions=False, show_jit=False)
 
    Disassemble a code object, indicating the last instruction if *lasti* was
    provided.  The output is divided in the following columns:
@@ -362,7 +379,10 @@ operation is being performed, so the intermediate analysis object isn't useful:
    .. versionchanged:: 3.14
       Added the *show_positions* parameter.
 
-.. function:: get_instructions(x, *, first_line=None, show_caches=False, adaptive=False)
+   .. versionchanged:: 3.16
+      Added the *show_jit* parameter.
+
+.. function:: get_instructions(x, *, first_line=None, show_caches=False, adaptive=False, show_jit=False)
 
    Return an iterator over the instructions in the supplied function, method,
    source code string or code object.
@@ -377,6 +397,8 @@ operation is being performed, so the intermediate analysis object isn't useful:
 
    The *adaptive* parameter works as it does in :func:`dis`.
 
+   The *show_jit* parameter works as it does in :func:`dis`.
+
    .. versionadded:: 3.4
 
    .. versionchanged:: 3.11
@@ -387,6 +409,9 @@ operation is being performed, so the intermediate analysis object isn't useful:
       generates the :class:`Instruction` instances with the *cache_info*
       field populated (regardless of the value of *show_caches*) and it no longer
       generates separate items for the cache entries.
+
+   .. versionchanged:: 3.16
+      Added the *show_jit* parameter.
 
 .. function:: findlinestarts(code)
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -208,7 +208,7 @@ code.
    .. versionchanged:: 3.14
       Added the *show_positions* parameter.
 
-   .. versionchanged:: 3.16
+   .. versionchanged:: next
       Added the *show_jit* parameter.
 
 Example:
@@ -314,7 +314,7 @@ operation is being performed, so the intermediate analysis object isn't useful:
    .. versionchanged:: 3.14
       Added the *show_positions* parameter.
 
-   .. versionchanged:: 3.16
+   .. versionchanged:: next
       Added the *show_jit* parameter.
 
 .. function:: distb(tb=None, *, file=None, show_caches=False, adaptive=False,\
@@ -339,7 +339,7 @@ operation is being performed, so the intermediate analysis object isn't useful:
    .. versionchanged:: 3.14
       Added the *show_positions* parameter.
 
-   .. versionchanged:: 3.16
+   .. versionchanged:: next
       Added the *show_jit* parameter.
 
 .. function:: disassemble(code, lasti=-1, *, file=None, show_caches=False,\
@@ -379,7 +379,7 @@ operation is being performed, so the intermediate analysis object isn't useful:
    .. versionchanged:: 3.14
       Added the *show_positions* parameter.
 
-   .. versionchanged:: 3.16
+   .. versionchanged:: next
       Added the *show_jit* parameter.
 
 .. function:: get_instructions(x, *, first_line=None, show_caches=False, adaptive=False, show_jit=False)
@@ -410,7 +410,7 @@ operation is being performed, so the intermediate analysis object isn't useful:
       field populated (regardless of the value of *show_caches*) and it no longer
       generates separate items for the cache entries.
 
-   .. versionchanged:: 3.16
+   .. versionchanged:: next
       Added the *show_jit* parameter.
 
 .. function:: findlinestarts(code)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -447,6 +447,7 @@ Erik Demaine
 Jeroen Demeyer
 Martin Dengler
 John Dennis
+Shardul Deshpande
 L. Peter Deutsch
 Roger Dev
 Philippe Devalkeneer

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -447,7 +447,6 @@ Erik Demaine
 Jeroen Demeyer
 Martin Dengler
 John Dennis
-Shardul Deshpande
 L. Peter Deutsch
 Roger Dev
 Philippe Devalkeneer


### PR DESCRIPTION
Documents the `show_jit` parameter (added in gh-150478; it shows `ENTER_EXECUTOR` instructions used as JIT entry points) across the five public `dis` APIs that accept it: `dis()`, `distb()`, `disassemble()`, `get_instructions()`, and the `Bytecode` class, with a `versionchanged:: 3.16` note on each.

Also fixes a pre-existing `show_offset` -> `show_offsets` typo in the documented `distb` signature.

Documentation-only change.

Issue: gh-151456