### PR TITLE
Skip test_highly_nested_objects_decoding during the PGO profile task.

### DIFF
--- a/Lib/test/test_json/test_recursion.py
+++ b/Lib/test/test_json/test_recursion.py
@@ -68,6 +68,7 @@ class TestRecursion:
             self.fail("didn't raise ValueError on default recursion")
 
 
+    @support.skip_if_pgo_task  # fails during PGO training w/ some stack sizes
     @support.skip_if_unlimited_stack_size
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()


### PR DESCRIPTION
One line change to disable test_json.test_highly_nested_objects_decoding during PGO training.

Since the recursion guard tracks real C-stack bounds (gh-91079), this test asserts that 500k nesting levels overflow the stack margin. On a 64 MiB stack (some Nix build envs use one that large), the optimized interpreter uses ~160 bytes/level (raises at ~420k levels) so the assertion holds with only ~16% margin; the PGO *instrumented* stage inlines less, its per-level scanner frames are smaller, and the 500k-deep decode completes -- "RecursionError not raised" fails the profile run and aborts `make profile-opt`. Upstream's skip_if_unlimited_stack_size (gh-143460) only covers RLIM_INFINITY, not large-finite stacks like ours.

We could also keep playing whack a mole and raise the 500k to a much larger number... but there's little value in PGO training on this test anyways.