### PR TITLE
gh-150732: Handle `SystemError` from compiler in the REPLs

### DIFF
--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -83,7 +83,7 @@ def _more_lines(console: code.InteractiveConsole, unicodetext: str) -> bool:
     src = _strip_final_indent(unicodetext)
     try:
         code = console.compile(src, "<stdin>", "single")
-    except (OverflowError, SyntaxError, ValueError):
+    except (OverflowError, SyntaxError, ValueError, SystemError):
         lines = src.splitlines(keepends=True)
         if len(lines) == 1:
             return False

--- a/Lib/code.py
+++ b/Lib/code.py
@@ -44,8 +44,8 @@ class InteractiveInterpreter:
         One of several things can happen:
 
         1) The input is incorrect; compile_command() raised an
-        exception (SyntaxError or OverflowError).  A syntax traceback
-        will be printed by calling the showsyntaxerror() method.
+        exception.  A syntax traceback will be printed by calling
+        the showsyntaxerror() method.
 
         2) The input is incomplete, and more input is required;
         compile_command() returned None.  Nothing happens.
@@ -62,7 +62,7 @@ class InteractiveInterpreter:
         """
         try:
             code = self.compile(source, filename, symbol)
-        except (OverflowError, SyntaxError, ValueError):
+        except (OverflowError, SyntaxError, ValueError, SystemError):
             # Case 1
             self.showsyntaxerror(filename, source=source)
             return False

--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -66,13 +66,11 @@ def _maybe_compile(compiler, source, filename, symbol, flags):
             try:
                 compiler(source + "\n", filename, symbol, flags=flags)
                 return None
-            except _IncompleteInputError:
+            except _IncompleteInputError, SystemError:
                 return None
             except SyntaxError:
                 pass
                 # fallthrough
-            except SystemError as exc:
-                raise exc from None
 
     return compiler(source, filename, symbol, incomplete_input=False)
 

--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -71,6 +71,8 @@ def _maybe_compile(compiler, source, filename, symbol, flags):
             except SyntaxError:
                 pass
                 # fallthrough
+            except SystemError as exc:
+                raise exc from None
 
     return compiler(source, filename, symbol, incomplete_input=False)
 
@@ -147,8 +149,8 @@ class CommandCompiler:
 
         - Return a code object if the command is complete and valid
         - Return None if the command is incomplete
-        - Raise SyntaxError, ValueError or OverflowError if the command is a
-          syntax error (OverflowError and ValueError can be produced by
-          malformed literals).
+        - Raise SyntaxError, ValueError, OverflowError or SystemError.
+          OverflowError and ValueError can be produced by malformed
+          literals, SystemError if source cannot be compiled.
         """
         return _maybe_compile(self.compiler, source, filename, symbol, flags=self.compiler.flags)

--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -324,6 +324,15 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         self.assertIsNotNone(self.sysmod.last_traceback)
         self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
 
+    def test_system_error(self):
+        # SystemError from the compiler should be reported (runsource returns
+        # False) rather than propagating to the caller.
+        from unittest import mock
+        err = SystemError("compiler internal error")
+        self.console.compile = mock.Mock(side_effect=err)
+        result = self.console.runsource("x = 1")
+        self.assertFalse(result)
+
 
 class TestInteractiveConsoleLocalExit(unittest.TestCase, MockSys):
 

--- a/Lib/test/test_codeop.py
+++ b/Lib/test/test_codeop.py
@@ -324,6 +324,18 @@ class CodeopTests(unittest.TestCase):
                    pass
             """), "duplicate parameter 'x' in function definition")
 
+    def test_system_error(self):
+        # SystemError from the compiler should propagate with context suppressed.
+        # The first call raises SyntaxError to enter the inner try block;
+        # the second (source + "\n") raises SystemError.
+        import unittest.mock as mock
+        err = SystemError("compiler internal error")
+        with mock.patch('codeop._compile', side_effect=[SyntaxError(), err]):
+            with self.assertRaises(SystemError) as cm:
+                compile_command("x = 1")
+        self.assertIs(cm.exception, err)
+        self.assertIsNone(err.__cause__)
+        self.assertTrue(err.__suppress_context__)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_codeop.py
+++ b/Lib/test/test_codeop.py
@@ -324,18 +324,6 @@ class CodeopTests(unittest.TestCase):
                    pass
             """), "duplicate parameter 'x' in function definition")
 
-    def test_system_error(self):
-        # SystemError from the compiler should propagate with context suppressed.
-        # The first call raises SyntaxError to enter the inner try block;
-        # the second (source + "\n") raises SystemError.
-        import unittest.mock as mock
-        err = SystemError("compiler internal error")
-        with mock.patch('codeop._compile', side_effect=[SyntaxError(), err]):
-            with self.assertRaises(SystemError) as cm:
-                compile_command("x = 1")
-        self.assertIs(cm.exception, err)
-        self.assertIsNone(err.__cause__)
-        self.assertTrue(err.__suppress_context__)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_pyrepl/support.py
+++ b/Lib/test/test_pyrepl/support.py
@@ -44,7 +44,7 @@ def more_lines(text: str, namespace: dict | None = None):
     console = InteractiveConsole(namespace, filename="<stdin>")
     try:
         code = console.compile(src, "<stdin>", "single")
-    except (OverflowError, SyntaxError, ValueError):
+    except (OverflowError, SyntaxError, ValueError, SystemError):
         return False
     else:
         return code is None

--- a/Lib/test/test_pyrepl/test_interact.py
+++ b/Lib/test/test_pyrepl/test_interact.py
@@ -275,6 +275,13 @@ class TestMoreLines(unittest.TestCase):
         console = InteractiveColoredConsole(namespace, filename="<stdin>")
         self.assertTrue(_more_lines(console, code))
 
+    def test_system_error_during_compilation(self):
+        namespace = {}
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        with patch.object(console, "compile", side_effect=SystemError("compiler bug")):
+            result = _more_lines(console, "some code")
+        self.assertFalse(result)
+
 
 class TestWarnings(unittest.TestCase):
     def test_pep_765_warning(self):

--- a/Misc/NEWS.d/next/Library/2026-06-01-21-31-06.gh-issue-150732.WqHBvP.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-01-21-31-06.gh-issue-150732.WqHBvP.rst
@@ -1,1 +1,1 @@
-Fix ``PyREPL`` and :mode:`code` REPL mishandling a :exc:`SystemError` from the compiler. Patch by Bartosz Sławecki.
+Handle :exc:`SystemError` from the compiler in ``PyREPL``, :mod:`code`, and :mod:`codeop`. Patch by Bartosz Sławecki.

--- a/Misc/NEWS.d/next/Library/2026-06-01-21-31-06.gh-issue-150732.WqHBvP.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-01-21-31-06.gh-issue-150732.WqHBvP.rst
@@ -1,0 +1,1 @@
+Fix ``PyREPL`` and :mode:`code` REPL mishandling a :exc:`SystemError` from the compiler. Patch by Bartosz Sławecki.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
**Try `>>> class C: [(lambda: __class__)() for () in ()]` at rev 580499177ca91477b53b4a40afcec7d3370265b0 or earlier as the prompt to reproduce organically at upstream.**

This covers cases in our REPLs when the compiler raises `SystemError`, e.g. because it has a bug.

<!-- gh-issue-number: gh-150732 -->
* Issue: gh-150732
<!-- /gh-issue-number -->
