### PR TITLE
Add `.toml` to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,11 @@
 root = true
 
-[*.{py,c,cpp,h,js,rst,md,yml,yaml,gram}]
+[*.{py,c,cpp,h,js,rst,md,yml,yaml,toml,gram}]
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 
-[*.{py,c,cpp,h,gram}]
+[*.{py,c,cpp,h,toml,gram}]
 indent_size = 4
 
 [*.rst]


### PR DESCRIPTION
There are lots of `.toml` files now in the repo, most of them use 4 spaces for indentation. All of the them use spaces, insert final newlines, trim trailing whitespaces.