### PR TITLE
fix(concurrent): resolve ThreadPoolExecutor shutdown deadlock in signal handlers

### DIFF
--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -192,7 +192,7 @@ class ThreadPoolExecutor(_base.Executor):
         self._threads = set()
         self._broken = False
         self._shutdown = False
-        self._shutdown_lock = threading.Lock()
+        self._shutdown_lock = threading.RLock()
         self._thread_name_prefix = (thread_name_prefix or
                                     ("ThreadPoolExecutor-%d" % self._counter()))
 
@@ -213,6 +213,10 @@ class ThreadPoolExecutor(_base.Executor):
 
             self._work_queue.put(w)
             self._adjust_thread_count()
+            if self._shutdown or _shutdown:
+                f.cancel()
+                w.task = None  # Clear reference to task arguments to avoid memory leak
+                raise RuntimeError('cannot schedule new futures after shutdown')
             return f
     submit.__doc__ = _base.Executor.submit.__doc__
 
@@ -252,6 +256,15 @@ class ThreadPoolExecutor(_base.Executor):
                     work_item.future.set_exception(self.BROKEN(self._broken))
 
     def shutdown(self, wait=True, *, cancel_futures=False):
+        # Detect if we are called reentrantly (e.g. from a signal handler on a thread
+        # already holding self._shutdown_lock). Fallback if RLock does not support _is_owned.
+        reentrant = False
+        if hasattr(self._shutdown_lock, '_is_owned'):
+            try:
+                reentrant = self._shutdown_lock._is_owned()
+            except Exception:
+                pass
+
         with self._shutdown_lock:
             self._shutdown = True
             if cancel_futures:
@@ -268,7 +281,10 @@ class ThreadPoolExecutor(_base.Executor):
             # Send a wake-up to prevent threads calling
             # _work_queue.get(block=True) from permanently blocking.
             self._work_queue.put(None)
-        if wait:
+        
+        # If we are reentrant, we cannot join threads synchronously because the current
+        # thread is interrupted and blocking it would cause a deadlock.
+        if wait and not reentrant:
             for t in self._threads:
                 t.join()
     shutdown.__doc__ = _base.Executor.shutdown.__doc__


### PR DESCRIPTION
### Description

This PR resolves a deadlock that occurs when attempting to shut down a `ThreadPoolExecutor` from within an OS signal handler (such as `SIGTERM` or `SIGINT`) if the main thread is interrupted while already executing `submit()` (which holds the executor's internal `_shutdown_lock`).

### Root Cause
Because `_shutdown_lock` is a standard, non-reentrant `threading.Lock()`, synchronous signal handlers executed on the main thread will deadlock if they attempt to acquire the lock a second time.

Simply changing the lock to an `RLock()` is insufficient because it introduces correctness and task leakage issues:
1. **Reentrant Join Deadlocks**: If the signal handler calls `shutdown(wait=True)` reentrantly, it blocks the main thread to join worker threads, which can deadlock if those worker threads are waiting for the GIL.
2. **Task/Memory Leakage**: If `shutdown()` executes and terminates the worker threads, when the signal handler exits, `submit()` resumes and places a task on the queue. This task will leak and hang indefinitely since all worker threads are already dead.

### Solution
This patch implements a safe, reentrancy-aware shutdown mechanism:
1. **Convert `_shutdown_lock` to `threading.RLock()`**: Prevents self-deadlocks on lock acquisition when executing inside signal handlers.
2. **Reentrancy Detection in `shutdown()`**: Uses `self._shutdown_lock._is_owned()` to check if the lock is already owned by the calling thread. If reentrant, it skips the synchronous `t.join()` loop to prevent blocking the interrupted thread. (Includes a safety fallback if the Python runtime does not implement `_is_owned()`).
3. **Queue Insertion Safeguards & Reference Clearing in `submit()`**: If `self._shutdown` is set to `True` reentrantly (detected at the end of the `submit()` critical section), we cancel the future, set `w.task = None` to clear references to user task positional/keyword arguments (avoiding memory leaks), and raise a `RuntimeError`.

### Verification
We verified the fix by simulating tight-loop signal delivery (`SIGINT`) during execution of a high-throughput `submit` loop. 
* On unmodified CPython, this consistently triggers a deadlock on `_shutdown_lock` and hangs the process.
* With this patch applied, the executor shuts down cleanly, cancels pending futures, clears references, raises the expected `RuntimeError`, and the process terminates successfully with exit code `0`.
