### PR TITLE
gh-151483: Make `PyCodeObject._co_unique_id` conditional on `Py_GIL_D…

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -34,9 +34,13 @@ typedef struct {
     char *entries[1];
 } _PyCodeArray;
 
+#define _PyCode_DEF_UNIQUE_ID() \
+    Py_ssize_t _co_unique_id;     /* ID used for per-thread refcounting */
+
 #define _PyCode_DEF_THREAD_LOCAL_BYTECODE() \
     _PyCodeArray *co_tlbc;
 #else
+#define _PyCode_DEF_UNIQUE_ID()
 #define _PyCode_DEF_THREAD_LOCAL_BYTECODE()
 #endif
 
@@ -101,7 +105,7 @@ typedef struct {
     _PyCoCached *_co_cached;      /* cached co_* attributes */                 \
     uintptr_t _co_instrumentation_version; /* current instrumentation version */ \
     struct _PyCoMonitoringData *_co_monitoring; /* Monitoring data */          \
-    Py_ssize_t _co_unique_id;     /* ID used for per-thread refcounting */   \
+    _PyCode_DEF_UNIQUE_ID()                                                    \
     int _co_firsttraceable;       /* index of first traceable instruction */   \
     /* Scratch space for extra data relating to the code object.               \
        Type is a void* to keep the format private in codeobject.c to force     \


### PR DESCRIPTION
`PyCodeObject._co_unique_id` is currently declared unconditionally, but its usage is entirely in free-threaded code paths. So maybe we can make `_co_unique_id` only present when `Py_GIL_DISABLED` is enabled.

I have run `./python -m test` and it seems fine.

<!-- gh-issue-number: gh-151483 -->
* Issue: gh-151483
<!-- /gh-issue-number -->
