### PR TITLE
gh-139227: Remove unused _PyRuntime.imports.pkgcontext

### DIFF
--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -308,8 +308,6 @@ struct _import_runtime_state {
            Modules are added there and looked up in _imp.find_extension(). */
         struct _Py_hashtable_t *hashtable;
     } extensions;
-    /* Package context -- the full module name for package imports */
-    const char * pkgcontext;
 };
 
 struct _import_state {

--- a/Python/import.c
+++ b/Python/import.c
@@ -81,8 +81,6 @@ static struct _inittab *inittab_copy = NULL;
 #define LAST_MODULE_INDEX _PyRuntime.imports.last_module_index
 #define EXTENSIONS _PyRuntime.imports.extensions
 
-#define PKGCONTEXT (_PyRuntime.imports.pkgcontext)
-
 
 /*******************************/
 /* interpreter import state */

--- a/Python/import.c
+++ b/Python/import.c
@@ -881,7 +881,6 @@ _PyImport_ClearModulesByIndex(PyInterpreterState *interp)
 */
 
 static _Py_thread_local const char *pkgcontext = NULL;
-# undef PKGCONTEXT
 # define PKGCONTEXT pkgcontext
 
 const char *


### PR DESCRIPTION
The global variable has been replaced by the thread local variable "pkgcontext" in Python/import.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139227 -->
* Issue: gh-139227
<!-- /gh-issue-number -->
