### PR TITLE
gh-151396: Document socket.AddressFamily and socket.SocketKind

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -364,10 +364,17 @@ Exceptions
 Constants
 ^^^^^^^^^
 
-The AF_* and SOCK_* constants are now :class:`AddressFamily` and
-:class:`SocketKind` :class:`.IntEnum` collections.
+.. class:: AddressFamily
 
-.. versionadded:: 3.4
+   :class:`enum.IntEnum` collection of AF_* constants.
+
+   .. versionadded:: 3.4
+
+.. class:: SocketKind
+
+   :class:`enum.IntEnum` collection of SOCK_* constants.
+
+   .. versionadded:: 3.4
 
 .. data:: AF_UNIX
           AF_INET


### PR DESCRIPTION
## Summary

Add explicit documentation entries for `socket.AddressFamily` and `socket.SocketKind`.

The `AF_*` and `SOCK_*` constants are already documented, but the enum classes themselves currently do not have Sphinx object entries. As a result, references to these exported classes cannot be resolved by Sphinx or intersphinx.

## Changes

* Add documentation entry for `socket.AddressFamily`
* Add documentation entry for `socket.SocketKind`

## Notes

Both classes are exported via `socket.__all__` and are already part of the public API.

This is a documentation-only change.

Fixes #151396.


<!-- gh-issue-number: gh-151396 -->
* Issue: gh-151396
<!-- /gh-issue-number -->
