### PR TITLE
gh-151496: Use process groups in test_dtrace

### DIFF
--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -59,13 +59,7 @@ def create_process_group(*args, **kwargs):
     return subprocess.Popen(*args, **kwargs)
 
 def kill_process_group(proc):
-    use_killpg = USE_PROCESS_GROUP
-    if use_killpg:
-        parent_sid = os.getsid(0)
-        sid = os.getsid(proc.pid)
-        use_killpg = (sid != parent_sid)
-
-    if use_killpg:
+    if USE_PROCESS_GROUP:
         os.killpg(proc.pid, signal.SIGKILL)
     else:
         proc.kill()

--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -60,9 +60,13 @@ def create_process_group(*args, **kwargs):
 
 def kill_process_group(proc):
     if USE_PROCESS_GROUP:
-        os.killpg(proc.pid, signal.SIGKILL)
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
     else:
         proc.kill()
+    proc.communicate()  # Clean up
 
 
 class TraceBackend:
@@ -267,7 +271,6 @@ gc__done:1""",
             stdout, stderr = proc.communicate(timeout=10)
         except subprocess.TimeoutExpired:
             kill_process_group(proc)
-            proc.communicate()  # Clean up
             raise unittest.SkipTest("bpftrace timed out during usability check")
         except OSError as e:
             raise unittest.SkipTest(f"bpftrace not available: {e}")

--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -1,6 +1,7 @@
 import dis
 import os.path
 import re
+import signal
 import subprocess
 import sys
 import sysconfig
@@ -48,6 +49,26 @@ def normalize_trace_output(output):
         raise AssertionError(
             "tracer produced unparsable output:\n{}".format(output)
         )
+
+
+USE_PROCESS_GROUP = (hasattr(os, "setsid") and hasattr(os, "killpg"))
+
+def create_process_group(*args, **kwargs):
+    if USE_PROCESS_GROUP:
+        kwargs['start_new_session'] = True
+    return subprocess.Popen(*args, **kwargs)
+
+def kill_process_group(proc):
+    use_killpg = USE_PROCESS_GROUP
+    if use_killpg:
+        parent_sid = os.getsid(0)
+        sid = os.getsid(proc.pid)
+        use_killpg = (sid != parent_sid)
+
+    if use_killpg:
+        os.killpg(proc.pid, signal.SIGKILL)
+    else:
+        proc.kill()
 
 
 class TraceBackend:
@@ -205,7 +226,7 @@ gc__done:1""",
         program = self.PROGRAMS[name].format(python=sys.executable)
 
         try:
-            proc = subprocess.Popen(
+            proc = create_process_group(
                 ["bpftrace", "-e", program, "-c", " ".join(subcommand)],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -213,7 +234,7 @@ gc__done:1""",
             )
             stdout, stderr = proc.communicate(timeout=60)
         except subprocess.TimeoutExpired:
-            proc.kill()
+            kill_process_group(proc)
             raise AssertionError("bpftrace timed out")
         except (FileNotFoundError, PermissionError) as e:
             raise unittest.SkipTest(f"bpftrace not available: {e}")
@@ -243,7 +264,7 @@ gc__done:1""",
         # Check if bpftrace is available and can attach to USDT probes
         program = f'usdt:{sys.executable}:python:function__entry {{ printf("probe: success\\n"); exit(); }}'
         try:
-            proc = subprocess.Popen(
+            proc = create_process_group(
                 ["bpftrace", "-e", program, "-c", f"{sys.executable} -c pass"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -251,7 +272,7 @@ gc__done:1""",
             )
             stdout, stderr = proc.communicate(timeout=10)
         except subprocess.TimeoutExpired:
-            proc.kill()
+            kill_process_group(proc)
             proc.communicate()  # Clean up
             raise unittest.SkipTest("bpftrace timed out during usability check")
         except OSError as e:


### PR DESCRIPTION
Create a new process group to run bpftrace commands, so it's possible to kill also child processes on timeout.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151496 -->
* Issue: gh-151496
<!-- /gh-issue-number -->
