### PR TITLE
gh-151519: Check effective gid in `_test_all_chown_common` group-0 guard

### DIFF
--- a/Lib/test/test_os/test_posix.py
+++ b/Lib/test/test_os/test_posix.py
@@ -901,7 +901,9 @@ class PosixTester(unittest.TestCase):
             self.assertRaises(OSError, chown_func, first_param, 0, -1)
             check_stat(uid, gid)
             if hasattr(os, 'getgroups'):
-                if 0 not in os.getgroups():
+                # Also check the effective gid, which the kernel
+                # accepts for chown even if not in getgroups().
+                if 0 not in os.getgroups() and os.getegid() != 0:
                     self.assertRaises(OSError, chown_func, first_param, -1, 0)
                     check_stat(uid, gid)
         # test illegal types


### PR DESCRIPTION
The guard that skips the "chown to gid 0 should fail" assertion used only `os.getgroups()` (supplementary groups). The kernel also accepts the effective/filesystem gid for chown, so when a process runs with egid 0 and a non-zero uid (common in containers and user namespaces), chown(-1, 0) succeeds and the assertion spuriously fails.

Add an `os.getegid() != 0` check alongside the existing `0 not in os.getgroups()` guard.

<!-- gh-issue-number: gh-151519 -->
* Issue: gh-151519
<!-- /gh-issue-number -->
