### PR TITLE
gh-151532: Validate xmlrpc.client.dumps() arguments under -O

### DIFF
--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -16,6 +16,7 @@ import io
 import contextlib
 from test import support
 from test.support import os_helper
+from test.support import script_helper
 from test.support import socket_helper
 from test.support import threading_helper
 from test.support import ALWAYS_EQ, LARGEST, SMALLEST
@@ -128,6 +129,56 @@ class XMLRPCTestCase(unittest.TestCase):
 
     def test_dump_bad_dict(self):
         self.assertRaises(TypeError, xmlrpclib.dumps, ({(1,2,3): 1},))
+
+    def test_dump_invalid_params(self):
+        for params in ([], ["x"], {"x": 1}, "abc", 1):
+            with self.subTest(params=params):
+                with self.assertRaisesRegex(
+                    TypeError,
+                    "^argument must be tuple or Fault instance$",
+                ):
+                    xmlrpclib.dumps(params)
+
+    def test_dump_invalid_methodresponse(self):
+        for params in ((), (1, 2)):
+            with self.subTest(params=params):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "^response tuple must be a singleton$",
+                ):
+                    xmlrpclib.dumps(params, methodresponse=True)
+
+    def test_dump_invalid_params_optimized(self):
+        code = r"""
+import xmlrpc.client as xmlrpclib
+
+if __debug__:
+    raise AssertionError("expected optimized mode")
+
+def check(exc_type, message, func):
+    try:
+        func()
+    except exc_type as exc:
+        if str(exc) != message:
+            raise AssertionError(str(exc))
+    else:
+        raise AssertionError(f"{exc_type.__name__} not raised")
+
+for params in [], ["x"], {"x": 1}, "abc", 1:
+    check(
+        TypeError,
+        "argument must be tuple or Fault instance",
+        lambda params=params: xmlrpclib.dumps(params),
+    )
+
+for params in (), (1, 2):
+    check(
+        ValueError,
+        "response tuple must be a singleton",
+        lambda params=params: xmlrpclib.dumps(params, methodresponse=True),
+    )
+"""
+        script_helper.assert_python_ok("-O", "-c", code)
 
     def test_dump_recursive_seq(self):
         l = [1,2,3]

--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -938,11 +938,12 @@ def dumps(params, methodname=None, methodresponse=None, encoding=None,
     where necessary.
     """
 
-    assert isinstance(params, (tuple, Fault)), "argument must be tuple or Fault instance"
+    if not isinstance(params, (tuple, Fault)):
+        raise TypeError("argument must be tuple or Fault instance")
     if isinstance(params, Fault):
         methodresponse = 1
-    elif methodresponse and isinstance(params, tuple):
-        assert len(params) == 1, "response tuple must be a singleton"
+    elif methodresponse and len(params) != 1:
+        raise ValueError("response tuple must be a singleton")
 
     if not encoding:
         encoding = "utf-8"

--- a/Misc/NEWS.d/next/Library/2026-06-16-05-55-00.gh-issue-151532.xmlrpc.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-16-05-55-00.gh-issue-151532.xmlrpc.rst
@@ -1,0 +1,3 @@
+Validate :func:`xmlrpc.client.dumps` arguments with explicit runtime checks
+so invalid arguments are rejected consistently when Python runs with
+optimization enabled.


### PR DESCRIPTION
## Summary

Fixes gh-151532.

`xmlrpc.client.dumps()` currently uses `assert` statements to validate public API arguments. When Python is executed with optimization enabled (`python -O`), those assertions are removed, causing invalid inputs to be accepted and serialized instead of being rejected.

This change replaces the assertion-based validation with explicit runtime checks so behavior remains consistent regardless of optimization mode.

## Reproduction

Before this change:

```python
import xmlrpc.client as xmlrpclib

xmlrpclib.dumps(["x"])
```

Normal execution:

```text
AssertionError: argument must be tuple or Fault instance
```

Optimized execution (`python -O`):

```text
No exception raised
```

Similarly:

```python
xmlrpclib.dumps((1, 2), methodresponse=True)
```

Normal execution:

```text
AssertionError: response tuple must be a singleton
```

Optimized execution (`python -O`):

```text
No exception raised
```

Because the validation relied on assertions, invalid inputs were silently accepted when optimization was enabled.

## Changes

* Replace the `assert` that validates `params` with an explicit `TypeError`.
* Replace the `assert` that validates `methodresponse=True` response tuples with an explicit `ValueError`.
* Preserve the existing validation messages.
* Add regression tests covering invalid argument types and invalid response tuple lengths.
* Add an optimized (`python -O`) subprocess test to verify validation remains enforced when assertions are disabled.
* Add a NEWS entry.

## Tests

Added regression coverage for:

* Invalid `params` values (`list`, `dict`, `str`, `int`)
* Invalid `methodresponse=True` tuple lengths
* Validation behavior under `python -O`

After this change, invalid inputs are rejected consistently in both normal and optimized execution modes.

Issue: gh-151532
