### PR TITLE
gh-151535: Bound _remote_debugging asyncio awaited_by graph recursion

### DIFF
--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -1191,6 +1191,11 @@ class TestGetStackTrace(RemoteInspectionTestBase):
                 async def leaf():
                     while not started.is_set():
                         await asyncio.sleep(0)
+                    # The whole awaited_by chain is built and this is now the
+                    # running task at the bottom of it. Signal here, then
+                    # busy-spin, so the observer inspects while the chain is
+                    # fully present and rooted at a running task.
+                    sock.sendall(b"ready")
                     end = time.time() + 10_000
                     while time.time() < end:
                         pass
@@ -1209,7 +1214,6 @@ class TestGetStackTrace(RemoteInspectionTestBase):
                 for _ in range(5):
                     await asyncio.sleep(0)
 
-                sock.sendall(b"ready")
                 started.set()
                 try:
                     await leaf_t

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -1169,6 +1169,85 @@ class TestGetStackTrace(RemoteInspectionTestBase):
         sys.platform == "linux" and not PROCESS_VM_READV_SUPPORTED,
         "Test only runs on Linux with process_vm_readv support",
     )
+    def test_async_deep_awaited_by_chain_is_bounded(self):
+        # A very deep awaited_by chain in the target (which a corrupted or
+        # concurrently-mutated remote process can also present as a cycle) must
+        # not drive unbounded C recursion in the debugger. get_async_stack_trace
+        # should raise instead of overflowing the stack.
+        depth = 2000
+        port = find_unused_port()
+        script = textwrap.dedent(
+            f"""\
+            import asyncio
+            import socket
+            import time
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect(('localhost', {port}))
+
+            async def main():
+                started = asyncio.Event()
+
+                async def leaf():
+                    while not started.is_set():
+                        await asyncio.sleep(0)
+                    end = time.time() + 10_000
+                    while time.time() < end:
+                        pass
+
+                leaf_t = asyncio.ensure_future(leaf())
+
+                async def waiter(child):
+                    await child
+
+                cur = leaf_t
+                tasks = [cur]
+                for _ in range({depth}):
+                    cur = asyncio.ensure_future(waiter(cur))
+                    tasks.append(cur)
+
+                for _ in range(5):
+                    await asyncio.sleep(0)
+
+                sock.sendall(b"ready")
+                started.set()
+                try:
+                    await leaf_t
+                finally:
+                    for t in tasks:
+                        t.cancel()
+
+            asyncio.run(main())
+            """
+        )
+
+        with os_helper.temp_dir() as work_dir:
+            script_dir = os.path.join(work_dir, "script_pkg")
+            os.mkdir(script_dir)
+
+            server_socket = _create_server_socket(port)
+            script_name = _make_test_script(script_dir, "script", script)
+            client_socket = None
+            try:
+                with _managed_subprocess([sys.executable, script_name]) as p:
+                    client_socket, _ = server_socket.accept()
+                    server_socket.close()
+                    server_socket = None
+
+                    _wait_for_signal(client_socket, b"ready")
+
+                    unwinder = RemoteUnwinder(p.pid)
+                    with self.assertRaises(RuntimeError) as cm:
+                        unwinder.get_async_stack_trace()
+                    self.assertIn("too deep or cyclic", str(cm.exception))
+            finally:
+                _cleanup_sockets(client_socket, server_socket)
+
+    @skip_if_not_supported
+    @unittest.skipIf(
+        sys.platform == "linux" and not PROCESS_VM_READV_SUPPORTED,
+        "Test only runs on Linux with process_vm_readv support",
+    )
     def test_async_global_awaited_by(self):
         # Reduced from 1000 to 100 to avoid file descriptor exhaustion
         # when running tests in parallel (e.g., -j 20)

--- a/Misc/NEWS.d/next/Library/2026-06-15-10-08-29.gh-issue-151535.CIumHj.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-15-10-08-29.gh-issue-151535.CIumHj.rst
@@ -1,0 +1,3 @@
+:meth:`!RemoteUnwinder.get_async_stack_trace` no longer crashes when the
+target process presents a deeply nested or concurrently-mutated ``awaited_by``
+graph; a :exc:`RuntimeError` is now raised instead.

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -147,7 +147,7 @@ typedef enum _WIN32_THREADSTATE {
 #define MAX_STACK_CHUNK_SIZE (16 * 1024 * 1024)  /* 16 MB max for stack chunks */
 #define MAX_LONG_DIGITS 64  /* Allows values up to ~2^1920 */
 #define MAX_SET_TABLE_SIZE (1 << 20)  /* 1 million entries max for set iteration */
-#define MAX_TASK_AWAITED_BY_DEPTH 1000  /* Bound recursion over the awaited_by graph */
+#define MAX_TASK_AWAITED_BY_DEPTH 1000  /* Bound the awaited_by graph walk so a cycle terminates */
 
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -147,6 +147,7 @@ typedef enum _WIN32_THREADSTATE {
 #define MAX_STACK_CHUNK_SIZE (16 * 1024 * 1024)  /* 16 MB max for stack chunks */
 #define MAX_LONG_DIGITS 64  /* Allows values up to ~2^1920 */
 #define MAX_SET_TABLE_SIZE (1 << 20)  /* 1 million entries max for set iteration */
+#define MAX_TASK_AWAITED_BY_DEPTH 1000  /* Bound recursion over the awaited_by graph */
 
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -516,6 +516,17 @@ error:
 // Forward declaration for mutual recursion
 static int process_waiter_task(RemoteUnwinderObject *unwinder, uintptr_t key_addr, void *context);
 
+// Carries the recursion depth so a cyclic or corrupted remote awaited_by graph
+// cannot drive unbounded C recursion and overflow the debugger's stack.
+typedef struct {
+    PyObject *result;
+    int depth;
+} waiter_context_t;
+
+static int process_task_and_waiters_impl(
+    RemoteUnwinderObject *unwinder, uintptr_t task_addr, PyObject *result,
+    int depth);
+
 // Processor function for parsing tasks in sets
 static int
 process_task_parser(
@@ -658,11 +669,12 @@ error:
     return -1;
 }
 
-int
-process_task_and_waiters(
+static int
+process_task_and_waiters_impl(
     RemoteUnwinderObject *unwinder,
     uintptr_t task_addr,
-    PyObject *result
+    PyObject *result,
+    int depth
 ) {
     // First, add this task to the result
     if (process_single_task_node(unwinder, task_addr, NULL, result) < 0) {
@@ -670,7 +682,17 @@ process_task_and_waiters(
     }
 
     // Now find all tasks that are waiting for this task and process them
-    return process_task_awaited_by(unwinder, task_addr, process_waiter_task, result);
+    waiter_context_t ctx = {result, depth};
+    return process_task_awaited_by(unwinder, task_addr, process_waiter_task, &ctx);
+}
+
+int
+process_task_and_waiters(
+    RemoteUnwinderObject *unwinder,
+    uintptr_t task_addr,
+    PyObject *result
+) {
+    return process_task_and_waiters_impl(unwinder, task_addr, result, 0);
 }
 
 // Processor function for task waiters
@@ -680,8 +702,17 @@ process_waiter_task(
     uintptr_t key_addr,
     void *context
 ) {
-    PyObject *result = (PyObject *)context;
-    return process_task_and_waiters(unwinder, key_addr, result);
+    waiter_context_t *ctx = (waiter_context_t *)context;
+    if (ctx->depth >= MAX_TASK_AWAITED_BY_DEPTH) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Task awaited_by chain is too deep or cyclic "
+                        "(corrupted remote memory)");
+        set_exception_cause(unwinder, PyExc_RuntimeError,
+                            "Task awaited_by recursion limit exceeded");
+        return -1;
+    }
+    return process_task_and_waiters_impl(unwinder, key_addr, ctx->result,
+                                         ctx->depth + 1);
 }
 
 /* ============================================================================
@@ -978,7 +1009,8 @@ process_running_task_chain(
     }
 
     // Now find all tasks that are waiting for this task and process them
-    if (process_task_awaited_by(unwinder, running_task_addr, process_waiter_task, result) < 0) {
+    waiter_context_t ctx = {result, 0};
+    if (process_task_awaited_by(unwinder, running_task_addr, process_waiter_task, &ctx) < 0) {
         return -1;
     }
 

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -513,19 +513,24 @@ error:
  * TASK AWAITED_BY PROCESSING
  * ============================================================================ */
 
-// Forward declaration for mutual recursion
-static int process_waiter_task(RemoteUnwinderObject *unwinder, uintptr_t key_addr, void *context);
-
-// Carries the recursion depth so a cyclic or corrupted remote awaited_by graph
-// cannot drive unbounded C recursion and overflow the debugger's stack.
+// The awaited_by graph is walked with an explicit, heap-allocated work-stack
+// rather than C recursion. A deeply nested -- or, in a corrupted or
+// concurrently-mutated remote process, cyclic -- chain would otherwise drive
+// unbounded recursion and overflow the debugger's own C stack: each level holds
+// a SIZEOF_TASK_OBJ buffer (see process_task_awaited_by), so even a few hundred
+// levels can exhaust a 1 MB stack. MAX_TASK_AWAITED_BY_DEPTH bounds the walk so
+// a cycle terminates.
 typedef struct {
-    PyObject *result;
+    uintptr_t addr;
     int depth;
-} waiter_context_t;
+} awaited_by_entry_t;
 
-static int process_task_and_waiters_impl(
-    RemoteUnwinderObject *unwinder, uintptr_t task_addr, PyObject *result,
-    int depth);
+typedef struct {
+    awaited_by_entry_t *items;
+    Py_ssize_t size;
+    Py_ssize_t capacity;
+    int current_depth;
+} awaited_by_stack_t;
 
 // Processor function for parsing tasks in sets
 static int
@@ -670,20 +675,73 @@ error:
 }
 
 static int
-process_task_and_waiters_impl(
+awaited_by_stack_push(
     RemoteUnwinderObject *unwinder,
-    uintptr_t task_addr,
-    PyObject *result,
+    awaited_by_stack_t *stack,
+    uintptr_t addr,
     int depth
 ) {
-    // First, add this task to the result
-    if (process_single_task_node(unwinder, task_addr, NULL, result) < 0) {
+    if (stack->size >= stack->capacity) {
+        Py_ssize_t new_capacity = stack->capacity ? stack->capacity * 2 : 16;
+        awaited_by_entry_t *new_items = PyMem_Realloc(
+            stack->items, (size_t)new_capacity * sizeof(awaited_by_entry_t));
+        if (new_items == NULL) {
+            PyErr_NoMemory();
+            set_exception_cause(unwinder, PyExc_MemoryError,
+                                "Failed to grow awaited_by work-stack");
+            return -1;
+        }
+        stack->items = new_items;
+        stack->capacity = new_capacity;
+    }
+    stack->items[stack->size].addr = addr;
+    stack->items[stack->size].depth = depth;
+    stack->size++;
+    return 0;
+}
+
+// set_entry_processor_func: enqueue a task waiting on the one currently being
+// expanded, one level deeper. The depth bound makes a cyclic or corrupted
+// awaited_by graph terminate instead of looping forever.
+static int
+push_awaited_by_waiter(
+    RemoteUnwinderObject *unwinder,
+    uintptr_t key_addr,
+    void *context
+) {
+    awaited_by_stack_t *stack = (awaited_by_stack_t *)context;
+    if (stack->current_depth >= MAX_TASK_AWAITED_BY_DEPTH) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Task awaited_by chain is too deep or cyclic "
+                        "(corrupted remote memory)");
+        set_exception_cause(unwinder, PyExc_RuntimeError,
+                            "Task awaited_by depth limit exceeded");
         return -1;
     }
+    return awaited_by_stack_push(unwinder, stack, key_addr,
+                                 stack->current_depth + 1);
+}
 
-    // Now find all tasks that are waiting for this task and process them
-    waiter_context_t ctx = {result, depth};
-    return process_task_awaited_by(unwinder, task_addr, process_waiter_task, &ctx);
+// Drain the work-stack: append each task node to result, then enqueue the
+// tasks waiting on it. Depth-first, with no C recursion over the graph.
+static int
+drain_awaited_by_stack(
+    RemoteUnwinderObject *unwinder,
+    PyObject *result,
+    awaited_by_stack_t *stack
+) {
+    while (stack->size > 0) {
+        awaited_by_entry_t entry = stack->items[--stack->size];
+        if (process_single_task_node(unwinder, entry.addr, NULL, result) < 0) {
+            return -1;
+        }
+        stack->current_depth = entry.depth;
+        if (process_task_awaited_by(unwinder, entry.addr,
+                                    push_awaited_by_waiter, stack) < 0) {
+            return -1;
+        }
+    }
+    return 0;
 }
 
 int
@@ -692,27 +750,13 @@ process_task_and_waiters(
     uintptr_t task_addr,
     PyObject *result
 ) {
-    return process_task_and_waiters_impl(unwinder, task_addr, result, 0);
-}
-
-// Processor function for task waiters
-static int
-process_waiter_task(
-    RemoteUnwinderObject *unwinder,
-    uintptr_t key_addr,
-    void *context
-) {
-    waiter_context_t *ctx = (waiter_context_t *)context;
-    if (ctx->depth >= MAX_TASK_AWAITED_BY_DEPTH) {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "Task awaited_by chain is too deep or cyclic "
-                        "(corrupted remote memory)");
-        set_exception_cause(unwinder, PyExc_RuntimeError,
-                            "Task awaited_by recursion limit exceeded");
-        return -1;
+    awaited_by_stack_t stack = {0};
+    int result_code = -1;
+    if (awaited_by_stack_push(unwinder, &stack, task_addr, 0) == 0) {
+        result_code = drain_awaited_by_stack(unwinder, result, &stack);
     }
-    return process_task_and_waiters_impl(unwinder, key_addr, ctx->result,
-                                         ctx->depth + 1);
+    PyMem_Free(stack.items);
+    return result_code;
 }
 
 /* ============================================================================
@@ -1008,9 +1052,17 @@ process_running_task_chain(
         return -1;
     }
 
-    // Now find all tasks that are waiting for this task and process them
-    waiter_context_t ctx = {result, 0};
-    if (process_task_awaited_by(unwinder, running_task_addr, process_waiter_task, &ctx) < 0) {
+    // Now find all tasks that are waiting for this task and process them with
+    // the same iterative, heap-stacked walk as process_task_and_waiters (the
+    // running task itself is already recorded via the frame chain above).
+    awaited_by_stack_t stack = {0};
+    int waiters_code = process_task_awaited_by(unwinder, running_task_addr,
+                                               push_awaited_by_waiter, &stack);
+    if (waiters_code == 0) {
+        waiters_code = drain_awaited_by_stack(unwinder, result, &stack);
+    }
+    PyMem_Free(stack.items);
+    if (waiters_code < 0) {
         return -1;
     }
 


### PR DESCRIPTION
`_remote_debugging.RemoteUnwinder.get_async_stack_trace()` walks the target
process's asyncio `awaited_by` graph with an unbounded three-function C recursion
(`process_task_and_waiters` → `process_task_awaited_by` → `process_waiter_task` →
`process_task_and_waiters`, in `Modules/_remote_debugging/asyncio.c`). Each level
also stack-allocates `char task_obj[SIZEOF_TASK_OBJ]` (4096 bytes), so a deep or
cyclic graph in the target overflows the **debugger's** C stack and crashes it with
SIGSEGV. This is asymmetric with the iterative sibling path
(`append_awaited_by_for_thread`), which already bounds its walk with
`MAX_ITERATIONS`.

This PR bounds the recursion with an explicit depth cap
(`MAX_TASK_AWAITED_BY_DEPTH`, defined next to the existing `MAX_ITERATIONS` /
`MAX_SET_TABLE_SIZE` / `MAX_*` constants in `_remote_debugging.h`). The depth is
threaded through the existing generic `processor`/`context` callback via a small
`waiter_context_t { result, depth }`, so the public `process_task_and_waiters`
signature is unchanged (it stays a `depth == 0` wrapper over the new
`process_task_and_waiters_impl`). On overflow the code raises a `RuntimeError`
through the module's existing `set_exception_cause` error path, matching how the
module reports every other "corrupted remote memory" condition. A depth counter
(rather than a visited-set) also covers a cyclic `awaited_by` graph from corrupted
remote memory, since each recursion still increments the depth.

The module already documents that the target's memory is untrusted input
(`debug_offsets_validation.h`), so a debugger reading an attacker-controlled or
merely deeply-nested target must not be crashable by the target's graph shape;
bounding this traversal is consistent with the module's existing invariants.

Adds `test_async_deep_awaited_by_chain_is_bounded` to
`Lib/test/test_external_inspection.py`: it spawns a target with a deep linear
`awaited_by` chain whose leaf is the running task and asserts that
`get_async_stack_trace()` raises `RuntimeError` ("too deep or cyclic") instead of
crashing.

Verified that the pre-fix interpreter segfaults (SIGSEGV) on a deep chain while the
patched interpreter raises a clean `RuntimeError`, and that a shallow chain still
returns a stack trace normally (negative control). The existing asyncio
stack-trace tests continue to pass.

Closes https://github.com/python/cpython/issues/151535

---

This change was prepared with AI assistance; I have reviewed and verified the code,
the reasoning, and the test myself.


<!-- gh-issue-number: gh-151535 -->
* Issue: gh-151535
<!-- /gh-issue-number -->
