### PR TITLE
 gh-151427: add  'not macOS' restriction on availabitity state of 7 functions in `os` module.

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -5107,7 +5107,7 @@ written in Python, such as a mail server's external command delivery program.
    Lock program segments into memory.  The value of *op* (defined in
    ``<sys/lock.h>``) determines which segments are locked.
 
-   .. availability:: Unix, not WASI, not iOS.
+   .. availability:: Unix, not WASI, not macOS, not iOS.
 
 
 .. function:: popen(cmd, mode='r', buffering=-1)

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1071,7 +1071,7 @@ as internal buffering of data.
    Force write of file with filedescriptor *fd* to disk. Does not force update of
    metadata.
 
-   .. availability:: Unix, not macOS.
+   .. availability:: Unix, not macOS, not iOS.
 
 
 .. function:: fpathconf(fd, name, /)

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -541,7 +541,7 @@ process and user.
    Return a tuple (ruid, euid, suid) denoting the current process's
    real, effective, and saved user ids.
 
-   .. availability:: Unix, not WASI, not macOS.
+   .. availability:: Unix, not WASI, not macOS, not iOS.
 
    .. versionadded:: 3.2
 
@@ -551,7 +551,7 @@ process and user.
    Return a tuple (rgid, egid, sgid) denoting the current process's
    real, effective, and saved group ids.
 
-   .. availability:: Unix, not WASI, not macOS.
+   .. availability:: Unix, not WASI, not macOS, not iOS.
 
    .. versionadded:: 3.2
 
@@ -725,7 +725,7 @@ process and user.
 
    Set the current process's real, effective, and saved group ids.
 
-   .. availability:: Unix, not WASI, not Android, not macOS.
+   .. availability:: Unix, not WASI, not Android, not macOS, not iOS.
 
    .. versionadded:: 3.2
 
@@ -734,7 +734,7 @@ process and user.
 
    Set the current process's real, effective, and saved user ids.
 
-   .. availability:: Unix, not WASI, not Android, not macOS.
+   .. availability:: Unix, not WASI, not Android, not macOS, not iOS.
 
    .. versionadded:: 3.2
 
@@ -1426,7 +1426,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    Return a pair of file descriptors ``(r, w)`` usable for reading and writing,
    respectively.
 
-   .. availability:: Unix, not WASI, not macOS.
+   .. availability:: Unix, not WASI, not macOS, not iOS.
 
    .. versionadded:: 3.3
 
@@ -1436,7 +1436,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    Ensures that enough disk space is allocated for the file specified by *fd*
    starting from *offset* and continuing for *len* bytes.
 
-   .. availability:: Unix, not macOS.
+   .. availability:: Unix, not macOS, not iOS.
 
    .. versionadded:: 3.3
 
@@ -1451,7 +1451,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    :data:`POSIX_FADV_RANDOM`, :data:`POSIX_FADV_NOREUSE`,
    :data:`POSIX_FADV_WILLNEED` or :data:`POSIX_FADV_DONTNEED`.
 
-   .. availability:: Unix, not macOS.
+   .. availability:: Unix, not macOS, not iOS.
 
    .. versionadded:: 3.3
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -541,7 +541,7 @@ process and user.
    Return a tuple (ruid, euid, suid) denoting the current process's
    real, effective, and saved user ids.
 
-   .. availability:: Unix, not WASI.
+   .. availability:: Unix, not WASI, not macOS.
 
    .. versionadded:: 3.2
 
@@ -551,7 +551,7 @@ process and user.
    Return a tuple (rgid, egid, sgid) denoting the current process's
    real, effective, and saved group ids.
 
-   .. availability:: Unix, not WASI.
+   .. availability:: Unix, not WASI, not macOS.
 
    .. versionadded:: 3.2
 
@@ -725,7 +725,7 @@ process and user.
 
    Set the current process's real, effective, and saved group ids.
 
-   .. availability:: Unix, not WASI, not Android.
+   .. availability:: Unix, not WASI, not Android, not macOS.
 
    .. versionadded:: 3.2
 
@@ -734,7 +734,7 @@ process and user.
 
    Set the current process's real, effective, and saved user ids.
 
-   .. availability:: Unix, not WASI, not Android.
+   .. availability:: Unix, not WASI, not Android, not macOS.
 
    .. versionadded:: 3.2
 
@@ -1426,7 +1426,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    Return a pair of file descriptors ``(r, w)`` usable for reading and writing,
    respectively.
 
-   .. availability:: Unix, not WASI.
+   .. availability:: Unix, not WASI, not macOS.
 
    .. versionadded:: 3.3
 
@@ -1436,7 +1436,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    Ensures that enough disk space is allocated for the file specified by *fd*
    starting from *offset* and continuing for *len* bytes.
 
-   .. availability:: Unix.
+   .. availability:: Unix, not macOS.
 
    .. versionadded:: 3.3
 
@@ -1451,7 +1451,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    :data:`POSIX_FADV_RANDOM`, :data:`POSIX_FADV_NOREUSE`,
    :data:`POSIX_FADV_WILLNEED` or :data:`POSIX_FADV_DONTNEED`.
 
-   .. availability:: Unix.
+   .. availability:: Unix, not macOS.
 
    .. versionadded:: 3.3
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1071,10 +1071,7 @@ as internal buffering of data.
    Force write of file with filedescriptor *fd* to disk. Does not force update of
    metadata.
 
-   .. availability:: Unix.
-
-   .. note::
-      This function is not available on MacOS.
+   .. availability:: Unix, not macOS.
 
 
 .. function:: fpathconf(fd, name, /)


### PR DESCRIPTION
These functions are not available on macOS.

+ `getresgid`, `setresgid`
+ `getresuid`, `setresuid`
+ `pipe2`
+ `posix_fallocate`
+ `posix_fadvise`

These updates should be backport to 3.13, 3.14 and 3.15 versions. The functions were added in  3.2 and 3.3 versions.

<!-- gh-issue-number: gh-151427 -->
* Issue: gh-151427
<!-- /gh-issue-number -->
