### PR TITLE
gh-151542: Use at least 2 MiB stack size, instead of 1 MiB

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-06-16-14-30-41.gh-issue-151542.QrLE0K.rst
+++ b/Misc/NEWS.d/next/Build/2026-06-16-14-30-41.gh-issue-151542.QrLE0K.rst
@@ -1,0 +1,3 @@
+Python now uses a stack size of at least 2 MiB, instead of 1 MiB. This is
+especially needed when Python is linked to musl (ex: Alpine Linux) which
+uses a default stack of 128 kiB. Patch by Victor Stinner.

--- a/configure
+++ b/configure
@@ -9901,7 +9901,7 @@ int main()
         return 2;
     }
 
-    if (size < 1024 * 1024) {
+    if (size < 2 * 1024 * 1024) {
         return 1;
     }
     return 0;
@@ -9913,7 +9913,7 @@ EOF
         ./conftest &>/dev/null
         exitcode=$?
         if test $exitcode -eq 1; then
-            ac_cv_thread_stack_size=1048576
+            ac_cv_thread_stack_size=2097152  # 2 MiB
         elif test $exitcode -eq 0; then
             ac_cv_thread_stack_size="default"
         fi

--- a/configure.ac
+++ b/configure.ac
@@ -2463,8 +2463,9 @@ AS_CASE([$ac_sys_system],
 )
 
 dnl On Linux, check the thread stack size. musl (ex: Alpine Linux) uses
-dnl a default thread stack size of 128 kB, whereas the glibc uses 8 MiB.
-dnl Python needs at least 1 MiB.
+dnl a default thread stack size of 128 kiB, whereas the glibc uses 8 MiB.
+dnl Python needs at least 2 MiB to run test_threading on Free Threading
+dnl (gh-151542).
 if test "$ac_sys_system" = "Linux" -a "$cross_compiling" = no; then
     AC_CACHE_CHECK([for thread stack size], [ac_cv_thread_stack_size], [
     cat > conftest.c <<EOF
@@ -2485,7 +2486,7 @@ int main()
         return 2;
     }
 
-    if (size < 1024 * 1024) {
+    if (size < 2 * 1024 * 1024) {
         return 1;
     }
     return 0;
@@ -2497,7 +2498,7 @@ EOF
         ./conftest &>/dev/null
         exitcode=$?
         if test $exitcode -eq 1; then
-            ac_cv_thread_stack_size=1048576
+            ac_cv_thread_stack_size=2097152  # 2 MiB
         elif test $exitcode -eq 0; then
             ac_cv_thread_stack_size="default"
         fi


### PR DESCRIPTION
Python needs at least 2 MiB stack to run test_threading on Free Threading.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151542 -->
* Issue: gh-151542
<!-- /gh-issue-number -->
