### PR TITLE
[wip] PyREPL: Add ctrl+up/down for multiline history

### DIFF
--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -371,6 +371,23 @@ class backward_word(MotionCommand):
         for i in range(r.get_arg()):
             r.pos = r.bow()
 
+class up_history(MotionCommand):
+    def do(self) -> None:
+        r = self.reader
+        if r.historyi > 0:
+            r.select_item(r.historyi - 1)
+        else:
+            r.error("start of history")
+            return
+
+class down_history(MotionCommand):
+    def do(self) -> None:
+        r = self.reader
+        if r.historyi < len(r.history):
+            r.select_item(r.historyi + 1)
+        else:
+            r.error("end of history")
+            return
 
 class self_insert(EditCommand):
     def do(self) -> None:

--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -377,8 +377,7 @@ class up_history(MotionCommand):
         if r.historyi > 0:
             r.select_item(r.historyi - 1)
         else:
-            r.error("start of history")
-            return
+            r.error("start of buffer")
 
 class down_history(MotionCommand):
     def do(self) -> None:
@@ -386,8 +385,7 @@ class down_history(MotionCommand):
         if r.historyi < len(r.history):
             r.select_item(r.historyi + 1)
         else:
-            r.error("end of history")
-            return
+            r.error("end of buffer")
 
 class self_insert(EditCommand):
     def do(self) -> None:

--- a/Lib/_pyrepl/keymap.py
+++ b/Lib/_pyrepl/keymap.py
@@ -183,7 +183,7 @@ def _parse_single_key_sequence(key: str, s: int) -> tuple[list[str], int]:
     if ctrl:
         if len(ret) == 1:
             ret = chr(ord(ret) & 0x1F)  # curses.ascii.ctrl()
-        elif ret in {"left", "right"}:
+        elif ret in {"left", "right", "up", "down"}:
             ret = f"ctrl {ret}"
         else:
             raise KeySpecError("\\C- followed by invalid key")

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -135,7 +135,9 @@ default_keymap: Keymap = tuple(
     + [(c, "self-insert") for c in map(chr, range(128, 256)) if c.isalpha()]
     + [
         (r"\<up>", "up"),
+        (r"\C-\<up>", "up_history"),
         (r"\<down>", "down"),
+        (r"\C-\<down>", "down_history"),
         (r"\<left>", "left"),
         (r"\C-\<left>", "backward-word"),
         (r"\<right>", "right"),

--- a/Lib/_pyrepl/unix_eventqueue.py
+++ b/Lib/_pyrepl/unix_eventqueue.py
@@ -49,9 +49,13 @@ CTRL_ARROW_KEYCODES= {
     # for xterm, gnome-terminal, xfce terminal, etc.
     b'\033[1;5D': 'ctrl left',
     b'\033[1;5C': 'ctrl right',
+    b'\033[1;5A': 'ctrl up',
+    b'\033[1;5B': 'ctrl down',
     # for rxvt
     b'\033Od': 'ctrl left',
     b'\033Oc': 'ctrl right',
+    b'\033Oa': 'ctrl up',
+    b'\033Ob': 'ctrl down',
 }
 
 def get_terminal_keycodes(ti: TermInfo) -> dict[bytes, str]:

--- a/Lib/_pyrepl/windows_eventqueue.py
+++ b/Lib/_pyrepl/windows_eventqueue.py
@@ -13,6 +13,8 @@ VT_MAP: dict[bytes, str] = {
     b'\x1b[D': 'left',
     b'\x1b[1;5D': 'ctrl left',
     b'\x1b[1;5C': 'ctrl right',
+    b'\x1b[1;5A': 'ctrl up',
+    b'\x1b[1;5B': 'ctrl down',
 
     b'\x1b[H': 'home',
     b'\x1b[F': 'end',

--- a/Lib/test/test_pyrepl/test_keymap.py
+++ b/Lib/test/test_pyrepl/test_keymap.py
@@ -48,6 +48,12 @@ class TestParseKeys(unittest.TestCase):
         self.assertEqual(parse_keys("\\C-a\\n\\<up>"), ["\x01", "\n", "up"])
         self.assertEqual(parse_keys("\\M-a\\t\\<down>"), ["\033", "a", "\t", "down"])
 
+    def test_control_arrow_keys(self):
+        self.assertEqual(parse_keys("\\C-\\<left>"), ["ctrl left"])
+        self.assertEqual(parse_keys("\\C-\\<right>"), ["ctrl right"])
+        self.assertEqual(parse_keys("\\C-\\<up>"), ["ctrl up"])
+        self.assertEqual(parse_keys("\\C-\\<down>"), ["ctrl down"])
+
     def test_keyspec_errors(self):
         cases = [
             ("\\Ca", "\\C must be followed by `-'"),

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -850,6 +850,79 @@ class TestPyReplOutput(ScreenEqualMixin, TestCase):
         self.assertEqual(output, "1+1")
         self.assert_screen_equal(reader, "1+1", clean=True)
 
+    def test_history_navigation_with_ctrl_up(self):
+        # Submit two multiline blocks, then use ctrl+up to jump directly
+        # to the previous history entry (unlike up which moves line-by-line)
+        code = "def foo():\nx = 1\n\ndef bar():\ny = 2\n\n"
+        events = itertools.chain(
+            code_to_events(code),
+            [
+                # Single ctrl+up should recall the entire previous entry
+                Event(evt="key", data="ctrl up", raw=bytearray(b"\x1b[1;5A")),
+                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+            ],
+        )
+
+        reader = self.prepare_reader(events)
+
+        output = multiline_input(reader)
+        self.assertEqual(output, "def foo():\n    x = 1\n    ")
+        output = multiline_input(reader)
+        self.assertEqual(output, "def bar():\n    y = 2\n    ")
+        # One ctrl+up jumps straight to previous history item
+        output = multiline_input(reader)
+        self.assertEqual(output, "def foo():\n    x = 1\n    ")
+
+    def test_history_navigation_with_ctrl_down(self):
+        # Submit two multiline entries, ctrl+up twice then ctrl+down once
+        # With multiline entries, regular down would only move one line,
+        # but ctrl+down jumps to the next history entry entirely.
+        code = "def foo():\nx = 1\n\ndef bar():\ny = 2\n\n"
+        events = itertools.chain(
+            code_to_events(code),
+            [
+                Event(evt="key", data="ctrl up", raw=bytearray(b"\x1b[1;5A")),
+                Event(evt="key", data="ctrl up", raw=bytearray(b"\x1b[1;5A")),
+                Event(evt="key", data="ctrl down", raw=bytearray(b"\x1b[1;5B")),
+                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+            ],
+        )
+
+        reader = self.prepare_reader(events)
+
+        output = multiline_input(reader)
+        self.assertEqual(output, "def foo():\n    x = 1\n    ")
+        output = multiline_input(reader)
+        self.assertEqual(output, "def bar():\n    y = 2\n    ")
+        # ctrl+up twice (to foo), ctrl+down once (back to bar)
+        output = multiline_input(reader)
+        self.assertEqual(output, "def bar():\n    y = 2\n    ")
+
+    def test_ctrl_up_at_start_of_history(self):
+        # Submit a multiline block, then try ctrl+up twice
+        # (second one should error since we're already at the oldest entry)
+        code = "def foo():\nx = 1\n\n"
+        events = itertools.chain(
+            code_to_events(code),
+            [
+                # Already at oldest item; second ctrl+up should error but not crash
+                Event(evt="key", data="ctrl up", raw=bytearray(b"\x1b[1;5A")),
+                Event(evt="key", data="ctrl up", raw=bytearray(b"\x1b[1;5A")),
+                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+            ],
+        )
+
+        reader = self.prepare_reader(events)
+
+        output = multiline_input(reader)
+        self.assertEqual(output, "def foo():\n    x = 1\n    ")
+        # Second ctrl+up at start of history stays on first item
+        output = multiline_input(reader)
+        self.assertEqual(output, "def foo():\n    x = 1\n    ")
+
     def test_history_search(self):
         events = itertools.chain(
             code_to_events("1+1\n2+2\n3+3\n"),


### PR DESCRIPTION
Currently, the up/down keys move the cursor in that direction inside the current code block until it reaches the beginning/end, then it goes to the previous/next. However, when traversing history with lots of multiline blocks, this can be a cumbersome process.

This PR introduces the ability to traverse history one block at a time using the CTRL+Up or CTRL+Down keys.

Originated from https://discuss.python.org/t/pyrepl-add-ctrl-up-down-for-multiline-history-retrieving/107779

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
