### PR TITLE
gh-150553: Document object.__weakref__

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2646,6 +2646,19 @@ Attribute lookup speed can be significantly improved as well.
    and *__weakref__* for each instance.
 
 
+.. attribute:: object.__weakref__
+
+   A descriptor added by the implementation to some classes whose instances
+   support weak references.
+
+   This attribute is either ``None`` or a weak reference or proxy object
+   associated with the instance. Use :func:`weakref.getweakrefs` to retrieve
+   all weak references and proxy objects that refer to an object.
+   .. impl-detail::
+
+      This attribute may not exist in all Python implementations.
+
+
 .. _datamodel-note-slots:
 
 Notes on using *__slots__*:


### PR DESCRIPTION
Document the public behavior of `object.__weakref__` in the data model reference.

The new entry explains that `__weakref__` is an implementation-provided descriptor for instances that support weak references, and that accessing it returns either `None` or a weak reference-related object associated with the instance.

The documentation also clarifies that `__weakref__` is not a complete list of all weak references and directs users to `weakref.getweakrefs()` when they need all weak references and proxies associated with an object.

No runtime behavior or C implementation is changed.


<!-- gh-issue-number: gh-150553 -->
* Issue: gh-150553
<!-- /gh-issue-number -->
