### PR TITLE
gh-151584: Remove `PyUnstable_Module_SetGIL` call in `_remote_debugging`

### DIFF
--- a/Modules/_remote_debugging/module.c
+++ b/Modules/_remote_debugging/module.c
@@ -1624,9 +1624,6 @@ _remote_debugging_exec(PyObject *m)
         return -1;
     }
 
-#ifdef Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
-#endif
     int rc = PyModule_AddIntConstant(m, "PROCESS_VM_READV_SUPPORTED", HAVE_PROCESS_VM_READV);
     if (rc < 0) {
         return -1;


### PR DESCRIPTION


<!-- gh-issue-number: gh-151584 -->
* Issue: gh-151584
<!-- /gh-issue-number -->
