### PR TITLE
gh-151126: Add missing `PyErr_NoMemory` in `_winapi.c`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-17-16-46-07.gh-issue-151126.vhTL0T.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-17-16-46-07.gh-issue-151126.vhTL0T.rst
@@ -1,0 +1,2 @@
+Avoid possible crash in ``_winapi.c`` where a device has no memory left. Now
+it properly raises a :exc:`MemoryError`. Patch by Ivy Xu.

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1684,6 +1684,10 @@ _winapi_GetShortPathName_impl(PyObject *module, LPCWSTR path)
             }
             PyMem_Free((void *)buffer);
         }
+        else {
+            PyErr_NoMemory();
+            return result;
+        }
     } else {
         PyErr_SetFromWindowsErr(0);
     }
@@ -2394,6 +2398,7 @@ _winapi_BatchedWaitForMultipleObjects_impl(PyObject *module,
     while (i < nhandles) {
         BatchedWaitData *data = (BatchedWaitData*)PyMem_Malloc(sizeof(BatchedWaitData));
         if (!data) {
+            PyErr_NoMemory();
             goto error;
         }
         thread_data[thread_count++] = data;

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1685,7 +1685,7 @@ _winapi_GetShortPathName_impl(PyObject *module, LPCWSTR path)
             PyMem_Free((void *)buffer);
         }
         else {
-            return PyErr_NoMemory();
+            PyErr_NoMemory();
         }
     } else {
         PyErr_SetFromWindowsErr(0);

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1685,8 +1685,7 @@ _winapi_GetShortPathName_impl(PyObject *module, LPCWSTR path)
             PyMem_Free((void *)buffer);
         }
         else {
-            PyErr_NoMemory();
-            return result;
+            return PyErr_NoMemory();
         }
     } else {
         PyErr_SetFromWindowsErr(0);


### PR DESCRIPTION
Follows-up to #151154

<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
