### PR TITLE
gh-151126: Fix missing `PyErr_NoMemory` in `getpath.c`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-17-16-26-45.gh-issue-151126.Yc_6wC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-17-16-26-45.gh-issue-151126.Yc_6wC.rst
@@ -1,0 +1,2 @@
+Avoid possible crash in ``getpath.c`` where a device has no memory left. Now
+it properly raises a :exc:`MemoryError`. Patch by Ivy Xu.

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -368,6 +368,7 @@ getpath_readlines(PyObject *Py_UNUSED(self), PyObject *args)
     if (!buffer) {
         Py_DECREF(r);
         fclose(fp);
+        PyErr_NoMemory();
         return NULL;
     }
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
