### PR TITLE
gh-151229: Finalize JIT tracer in test eval-frame stub

### DIFF
--- a/Modules/_testinternalcapi/interpreter.c
+++ b/Modules/_testinternalcapi/interpreter.c
@@ -18,8 +18,13 @@ int Test_EvalFrame_Resumes, Test_EvalFrame_Loads;
 static int
 stop_tracing_and_jit(PyThreadState *tstate, _PyInterpreterFrame *frame)
 {
-    (void)(tstate);
     (void)(frame);
+    // Don't actually JIT-compile in this test eval-frame, but we still must
+    // finalize the tracer so the thread-global is_tracing flag is reset.
+    // Otherwise a trace started inside this duplicated interpreter loop
+    // (reachable under low JIT thresholds, e.g. PYTHON_JIT_STRESS=1) would
+    // leave is_tracing stuck true and permanently disable the JIT.
+    _PyJit_FinalizeTracing(tstate, 0);
     return 0;
 }
 #endif


### PR DESCRIPTION
A test-only interpreter stubs out JIT compilation as a no-op, but the stub also forgot to reset the tracer's is_tracing flag. Under `PYTHON_JIT_STRESS=1`, a trace can start inside this stub and never finalize, leaving is_tracing stuck true, [so the recursive-trace guard rejects every future trace](https://github.com/python/cpython/blob/16185e9fe2037d2171626f79c3d099bd7772b53e/Python/optimizer.c#L1127-L1131), silently disabling the JIT for the rest of the process. 

<!-- gh-issue-number: gh-151229 -->
* Issue: gh-151229
<!-- /gh-issue-number -->
