### PR TITLE
docs: Fix indent misalignment in `library/logging.config.rst` (GH-151617)

### DIFF
--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -124,12 +124,12 @@ in :mod:`logging` itself) and defining handlers which are declared either in
         application (e.g. based on command-line parameters or other aspects
         of the runtime environment) before being passed to ``fileConfig``.
 
-    .. versionchanged:: 3.10
-       Added the *encoding* parameter.
+   .. versionchanged:: 3.10
+      Added the *encoding* parameter.
 
-    .. versionchanged:: 3.12
-       An exception will be thrown if the provided file
-       doesn't exist or is invalid or empty.
+   .. versionchanged:: 3.12
+      An exception will be thrown if the provided file
+      doesn't exist or is invalid or empty.
 
 .. function:: listen(port=DEFAULT_LOGGING_CONFIG_PORT, verify=None)
 


### PR DESCRIPTION
Fixed incorrect indentation that caused some sections to be rendered with the wrong document structure.

https://docs.python.org/3.16/library/logging.config.html#logging.config.fileConfig

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
