### PR TITLE
gh-142412: Document urlsplit netloc limitations for redirect validation

### DIFF
--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -476,6 +476,22 @@ code before trusting a returned component part.  Does that ``scheme`` make
 sense?  Is that a sensible ``path``?  Is there anything strange about that
 ``hostname``?  etc.
 
+When using :func:`urlsplit` or :func:`urlparse` to validate redirect
+targets, do not rely only on the ``netloc`` component. These functions
+only recognize a network location when the URL uses the ``//`` form.
+Some user agents may interpret other forms differently.
+
+For example::
+
+    >>> from urllib.parse import urlsplit
+    >>> urlsplit("////example.com")
+    SplitResult(scheme='', netloc='', path='//example.com', query='', fragment='')
+
+Some browsers may treat this URL as a redirect target for
+``example.com``, even though ``urlsplit`` reports an empty ``netloc``.
+Applications handling redirects should perform validation appropriate for their
+security requirements.
+
 What constitutes a URL is not universally well defined.  Different applications
 have different needs and desired constraints.  For instance the living `WHATWG
 spec`_ describes what user facing web clients such as a web browser require.


### PR DESCRIPTION
## Summary

Adds documentation clarifying that `urllib.parse.urlsplit()` and
`urllib.parse.urlparse()` should not be relied on solely for validating
redirect targets using the `netloc` component.

Certain URL forms may produce an empty `netloc` value while being interpreted
differently by user agents such as web browsers. This can lead to incorrect
assumptions when applications use `netloc` checks to prevent open redirects.

## Changes

- Added security documentation explaining the limitation of `netloc` checks.
- Included an example showing how `urlsplit()` handles URLs with multiple
  leading slashes.
- Clarified that applications handling redirects should perform validation
  appropriate for their security requirements.

## Issue

Fixes #142412

## Notes

This is a follow-up to #144448, incorporating the review feedback by placing
the guidance within the existing "URL parsing security" section rather than
adding a separate warning block.

## Testing

- Documentation change only.
- Verified the documentation formatting locally.

<!-- gh-issue-number: gh-142412 -->
* Issue: gh-142412
<!-- /gh-issue-number -->
