### PR TITLE
gh-151623: Improve curses documentation and docstrings

### DIFF
--- a/Doc/library/curses.ascii.rst
+++ b/Doc/library/curses.ascii.rst
@@ -114,7 +114,7 @@ C library:
 
 .. function:: isblank(c)
 
-   Checks for an ASCII whitespace character; space or horizontal tab.
+   Checks for an ASCII blank character; space or horizontal tab.
 
 
 .. function:: iscntrl(c)
@@ -168,7 +168,8 @@ C library:
 
 .. function:: isctrl(c)
 
-   Checks for an ASCII control character (ordinal values 0 to 31).
+   Checks for an ASCII control character (ordinal values 0 to 31).  Unlike
+   :func:`iscntrl`, this does not include the delete character (0x7f).
 
 
 .. function:: ismeta(c)

--- a/Doc/library/curses.panel.rst
+++ b/Doc/library/curses.panel.rst
@@ -26,7 +26,8 @@ The module :mod:`!curses.panel` defines the following functions:
 
 .. function:: new_panel(win)
 
-   Returns a panel object, associating it with the given window *win*. Be aware
+   Returns a panel object, associating it with the given window *win* and
+   placing the new panel on top of the panel stack.  Be aware
    that you need to keep the returned panel object referenced explicitly.  If you
    don't, the panel object is garbage collected and removed from the panel stack.
 
@@ -99,7 +100,8 @@ Panel objects have the following methods:
 
 .. method:: Panel.show()
 
-   Display the panel (which might have been hidden).
+   Display the panel (which might have been hidden), placing it on top of
+   the panel stack.
 
 
 .. method:: Panel.top()

--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -80,6 +80,8 @@ The module :mod:`!curses` defines the following functions:
 
    * Change the definition of the color-pair ``0`` to ``(fg, bg)``.
 
+   This is an ncurses extension.
+
    .. versionadded:: 3.14
 
 
@@ -116,7 +118,8 @@ The module :mod:`!curses` defines the following functions:
    Return the intensity of the red, green, and blue (RGB) components in the color
    *color_number*, which must be between ``0`` and ``COLORS - 1``.  Return a 3-tuple,
    containing the R,G,B values for the given color, which will be between
-   ``0`` (no component) and ``1000`` (maximum amount of component).
+   ``0`` (no component) and ``1000`` (maximum amount of component).  Raise an
+   exception if the color is not supported.
 
 
 .. function:: color_pair(pair_number)
@@ -162,7 +165,7 @@ The module :mod:`!curses` defines the following functions:
 
    Update the physical screen.  The curses library keeps two data structures, one
    representing the current physical screen contents and a virtual screen
-   representing the desired next state.  The :func:`doupdate` ground updates the
+   representing the desired next state.  The :func:`doupdate` function updates the
    physical screen to match the virtual screen.
 
    The virtual screen may be updated by a :meth:`~window.noutrefresh` call after write
@@ -194,7 +197,7 @@ The module :mod:`!curses` defines the following functions:
 .. function:: filter()
 
    The :func:`.filter` routine, if used, must be called before :func:`initscr` is
-   called.  The effect is that, during those calls, :envvar:`LINES` is set to ``1``; the
+   called.  The effect is that, during the initialization, :envvar:`LINES` is set to ``1``; the
    capabilities ``clear``, ``cup``, ``cud``, ``cud1``, ``cuu1``, ``cuu``, ``vpa`` are disabled; and the ``home``
    string is set to the value of ``cr``. The effect is that the cursor is confined to
    the current line, and so are screen updates.  This may be used for enabling
@@ -240,9 +243,10 @@ The module :mod:`!curses` defines the following functions:
 
 .. function:: getwin(file)
 
-   Read window related data stored in the file by an earlier :func:`window.putwin` call.
+   Read window related data stored in the file by an earlier :meth:`window.putwin` call.
    The routine then creates and initializes a new window using that data, returning
-   the new window object.
+   the new window object.  The *file* argument must be a file object opened for
+   reading in binary mode.
 
 
 .. function:: has_colors()
@@ -347,6 +351,8 @@ The module :mod:`!curses` defines the following functions:
    bytes object consisting of the prefix ``b'M-'`` followed by the name of the corresponding
    ASCII character.
 
+   Raise a :exc:`ValueError` if *k* is negative.
+
 
 .. function:: killchar()
 
@@ -372,7 +378,8 @@ The module :mod:`!curses` defines the following functions:
 
    Set the maximum time in milliseconds that can elapse between press and release
    events in order for them to be recognized as a click, and return the previous
-   interval value.  The default value is 200 milliseconds, or one fifth of a second.
+   interval value.  The default value is 166 milliseconds, or one sixth of a second.
+   Use a negative *interval* to obtain the interval value without changing it.
 
 
 .. function:: mousemask(mousemask)
@@ -380,7 +387,7 @@ The module :mod:`!curses` defines the following functions:
    Set the mouse events to be reported, and return a tuple ``(availmask,
    oldmask)``.   *availmask* indicates which of the specified mouse events can be
    reported; on complete failure it returns ``0``.  *oldmask* is the previous value of
-   the given window's mouse event mask.  If this function is never called, no mouse
+   the mouse event mask.  If this function is never called, no mouse
    events are ever reported.
 
 
@@ -417,11 +424,13 @@ The module :mod:`!curses` defines the following functions:
    right corner of the screen.
 
 
-.. function:: nl()
+.. function:: nl(flag=True)
 
    Enter newline mode.  This mode translates the return key into newline on input,
    and translates newline into return and line-feed on output. Newline mode is
    initially on.
+
+   If *flag* is ``False``, the effect is the same as calling :func:`nonl`.
 
 
 .. function:: nocbreak()
@@ -474,6 +483,8 @@ The module :mod:`!curses` defines the following functions:
    Equivalent to ``tputs(str, 1, putchar)``; emit the value of a specified
    terminfo capability for the current terminal.  Note that the output of :func:`putp`
    always goes to standard output.
+
+   :func:`setupterm` (or :func:`initscr`) must be called first.
 
 
 .. function:: qiflush([flag])
@@ -571,6 +582,10 @@ The module :mod:`!curses` defines the following functions:
    file descriptor to which any initialization sequences will be sent; if not
    supplied or ``-1``, the file descriptor for ``sys.stdout`` will be used.
 
+   Raise a :exc:`curses.error` if the terminal could not be found or its
+   terminfo database entry could not be read.  If the terminal has already
+   been initialized, this function has no effect.
+
 
 .. function:: start_color()
 
@@ -605,6 +620,8 @@ The module :mod:`!curses` defines the following functions:
    Boolean capability, or ``0`` if it is canceled or absent from the terminal
    description.
 
+   :func:`setupterm` (or :func:`initscr`) must be called first.
+
 
 .. function:: tigetnum(capname)
 
@@ -612,6 +629,8 @@ The module :mod:`!curses` defines the following functions:
    capability name *capname* as an integer.  Return the value ``-2`` if *capname* is not a
    numeric capability, or ``-1`` if it is canceled or absent from the terminal
    description.
+
+   :func:`setupterm` (or :func:`initscr`) must be called first.
 
 
 .. function:: tigetstr(capname)
@@ -621,13 +640,17 @@ The module :mod:`!curses` defines the following functions:
    is not a terminfo "string capability", or is canceled or absent from the
    terminal description.
 
+   :func:`setupterm` (or :func:`initscr`) must be called first.
+
 
 .. function:: tparm(str[, ...])
 
    Instantiate the bytes object *str* with the supplied parameters, where *str* should
    be a parameterized string obtained from the terminfo database.  E.g.
    ``tparm(tigetstr("cup"), 5, 3)`` could result in ``b'\033[6;4H'``, the exact
-   result depending on terminal type.
+   result depending on terminal type.  Up to nine integer parameters may be supplied.
+
+   :func:`setupterm` (or :func:`initscr`) must be called first.
 
 
 .. function:: typeahead(fd)
@@ -756,12 +779,11 @@ Window Objects
         Attempting to write to the lower right corner of a window, subwindow,
         or pad will cause an exception to be raised after the string is printed.
 
-      * A `bug in ncurses <https://bugs.python.org/issue35924>`_, the backend
-        for this Python module, can cause SegFaults when resizing windows. This
-        is fixed in ncurses-6.1-20190511.  If you are stuck with an earlier
-        ncurses, you can avoid triggering this if you do not call :func:`addstr`
-        with a *str* that has embedded newlines.  Instead, call :func:`addstr`
-        separately for each line.
+      * A bug in ncurses, the backend for this Python module, could cause
+        segfaults when resizing windows.  This was fixed in ncurses-6.1-20190511.
+        If you are stuck with an earlier ncurses, you can avoid triggering it by
+        not calling :meth:`!addstr` with a *str* that has embedded newlines;
+        instead, call :meth:`!addstr` separately for each line.
 
 
 .. method:: window.attroff(attr)
@@ -888,7 +910,8 @@ Window Objects
 
 .. method:: window.delch([y, x])
 
-   Delete any character at ``(y, x)``.
+   Delete the character under the cursor, or at ``(y, x)`` if specified.  All
+   characters to the right on the same line are shifted one position left.
 
 
 .. method:: window.deleteln()
@@ -990,6 +1013,7 @@ Window Objects
             window.getstr(y, x, n)
 
    Read a bytes object from the user, with primitive line editing capacity.
+   At most *n* characters are read (2047 by default).
    The maximum value for *n* is 2047.
 
    .. versionchanged:: 3.14
@@ -1002,11 +1026,12 @@ Window Objects
    upper-left corner.
 
 
-.. method:: window.hline(ch, n)
-            window.hline(y, x, ch, n)
+.. method:: window.hline(ch, n[, attr])
+            window.hline(y, x, ch, n[, attr])
 
    Display a horizontal line starting at ``(y, x)`` with length *n* consisting of
-   the character *ch*.
+   the character *ch* with attributes *attr*.  The line stops at the right edge
+   of the window if fewer than *n* cells are available.
 
 
 .. method:: window.idcok(flag)
@@ -1019,8 +1044,8 @@ Window Objects
 
 .. method:: window.idlok(flag)
 
-   If *flag* is ``True``, :mod:`!curses` will try and use hardware line
-   editing facilities. Otherwise, line insertion/deletion are disabled.
+   If *flag* is ``True``, :mod:`!curses` will try to use hardware line
+   editing facilities.  Otherwise, curses will not use them.
 
 
 .. method:: window.immedok(flag)
@@ -1040,8 +1065,10 @@ Window Objects
 .. method:: window.insch(ch[, attr])
             window.insch(y, x, ch[, attr])
 
-   Paint character *ch* at ``(y, x)`` with attributes *attr*, moving the line from
-   position *x* right by one character.
+   Insert character *ch* with attributes *attr* before the character under the
+   cursor, or at ``(y, x)`` if specified.  All characters to the right of the
+   cursor are shifted one position right, with the rightmost character on the
+   line being lost.  The cursor position does not change.
 
 
 .. method:: window.insdelln(nlines)
@@ -1082,7 +1109,8 @@ Window Objects
             window.instr(y, x[, n])
 
    Return a bytes object of characters, extracted from the window starting at the
-   current cursor position, or at *y*, *x* if specified. Attributes are stripped
+   current cursor position, or at *y*, *x* if specified, and stopping at the end
+   of the line. Attributes and color information are stripped
    from the characters.  If *n* is specified, :meth:`instr` returns a string
    at most *n* characters long (exclusive of the trailing NUL).
    The maximum value for *n* is 2047.
@@ -1114,8 +1142,7 @@ Window Objects
 .. method:: window.leaveok(flag)
 
    If *flag* is ``True``, cursor is left where it is on update, instead of being at "cursor
-   position."  This reduces cursor movement where possible. If possible the cursor
-   will be made invisible.
+   position."  This reduces cursor movement where possible.
 
    If *flag* is ``False``, cursor will always be at "cursor position" after an update.
 
@@ -1136,6 +1163,9 @@ Window Objects
 
    Move the window so its upper-left corner is at ``(new_y, new_x)``.
 
+   Moving the window so that any part of it would be off the screen is an error:
+   the window is not moved and :exc:`curses.error` is raised.
+
 
 .. method:: window.nodelay(flag)
 
@@ -1151,10 +1181,15 @@ Window Objects
 
 
 .. method:: window.noutrefresh()
+            window.noutrefresh(pminrow, pmincol, sminrow, smincol, smaxrow, smaxcol)
 
    Mark for refresh but wait.  This function updates the data structure
    representing the desired state of the window, but does not force an update of
    the physical screen.  To accomplish that, call  :func:`doupdate`.
+
+   The 6 arguments can only be specified, and are then required, when the window
+   is a pad created with :func:`newpad`; they have the same meaning as for
+   :meth:`refresh`.
 
 
 .. method:: window.overlay(destwin[, sminrow, smincol, dminrow, dmincol, dmaxrow, dmaxcol])
@@ -1206,8 +1241,8 @@ Window Objects
    Update the display immediately (sync actual screen with previous
    drawing/deleting methods).
 
-   The 6 optional arguments can only be specified when the window is a pad created
-   with :func:`newpad`.  The additional parameters are needed to indicate what part
+   The 6 arguments can only be specified, and are then required, when the window
+   is a pad created with :func:`newpad`.  The additional parameters are needed to indicate what part
    of the pad and screen are involved. *pminrow* and *pmincol* specify the upper
    left-hand corner of the rectangle to be displayed in the pad.  *sminrow*,
    *smincol*, *smaxrow*, and *smaxcol* specify the edges of the rectangle to be
@@ -1228,7 +1263,9 @@ Window Objects
 
 .. method:: window.scroll([lines=1])
 
-   Scroll the screen or scrolling region upward by *lines* lines.
+   Scroll the screen or scrolling region.  Scroll upward by *lines* lines if
+   *lines* is positive, or downward if it is negative.  Scrolling has no effect
+   unless it has been enabled for the window with :meth:`scrollok`.
 
 
 .. method:: window.scrollok(flag)
@@ -1261,15 +1298,17 @@ Window Objects
 .. method:: window.subpad(begin_y, begin_x)
             window.subpad(nlines, ncols, begin_y, begin_x)
 
-   Return a sub-window, whose upper-left corner is at ``(begin_y, begin_x)``, and
-   whose width/height is *ncols*/*nlines*.
+   Return a sub-pad, whose upper-left corner is at ``(begin_y, begin_x)``, and
+   whose width/height is *ncols*/*nlines*.  The coordinates are relative to the
+   parent pad (unlike :meth:`subwin`, which uses screen coordinates).  This
+   method is only available for pads created with :func:`newpad`.
 
 
 .. method:: window.subwin(begin_y, begin_x)
             window.subwin(nlines, ncols, begin_y, begin_x)
 
-   Return a sub-window, whose upper-left corner is at ``(begin_y, begin_x)``, and
-   whose width/height is *ncols*/*nlines*.
+   Return a sub-window, whose upper-left corner is at the screen-relative
+   coordinates ``(begin_y, begin_x)``, and whose width/height is *ncols*/*nlines*.
 
    By default, the sub-window will extend from the specified position to the lower
    right corner of the window.
@@ -1792,7 +1831,7 @@ The following table lists mouse button constants used by :meth:`getmouse`:
 +----------------------------------+---------------------------------------------+
 | .. data:: BUTTON_CTRL            | Control was down during button state change |
 +----------------------------------+---------------------------------------------+
-| .. data:: BUTTON_ALT             | Control was down during button state change |
+| .. data:: BUTTON_ALT             | Alt was down during button state change     |
 +----------------------------------+---------------------------------------------+
 
 .. versionchanged:: 3.10
@@ -1857,32 +1896,36 @@ Textbox objects
 You can instantiate a :class:`Textbox` object as follows:
 
 
-.. class:: Textbox(win)
+.. class:: Textbox(win, insert_mode=False)
 
    Return a textbox widget object.  The *win* argument should be a curses
    :ref:`window <curses-window-objects>` object in which the textbox is to
-   be contained. The edit cursor of the textbox is initially located at the
+   be contained.  If *insert_mode* is true, the textbox inserts typed
+   characters, shifting existing text to the right, rather than overwriting it.
+   The edit cursor of the textbox is initially located at the
    upper left hand corner of the containing window, with coordinates ``(0, 0)``.
    The instance's :attr:`stripspaces` flag is initially on.
 
    :class:`Textbox` objects have the following methods:
 
 
-   .. method:: edit([validator])
+   .. method:: edit(validate=None)
 
       This is the entry point you will normally use.  It accepts editing
       keystrokes until one of the termination keystrokes is entered.  If
-      *validator* is supplied, it must be a function.  It will be called for
+      *validate* is supplied, it must be a function.  It will be called for
       each keystroke entered with the keystroke as a parameter; command dispatch
-      is done on the result. This method returns the window contents as a
+      is done on the result.  If it returns a false value, the keystroke is
+      ignored.  This method returns the window contents as a
       string; whether blanks in the window are included is affected by the
       :attr:`stripspaces` attribute.
 
 
    .. method:: do_command(ch)
 
-      Process a single command keystroke.  Here are the supported special
-      keystrokes:
+      Process a single command keystroke.  Returns ``1`` to continue editing,
+      or ``0`` if a termination keystroke was processed.  Here are the supported
+      special keystrokes:
 
       +------------------+-------------------------------------------+
       | Keystroke        | Action                                    |
@@ -1905,7 +1948,8 @@ You can instantiate a :class:`Textbox` object as follows:
       | :kbd:`Control-H` | Delete character backward.                |
       +------------------+-------------------------------------------+
       | :kbd:`Control-J` | Terminate if the window is 1 line,        |
-      |                  | otherwise insert newline.                 |
+      |                  | otherwise move to the start of the next   |
+      |                  | line.                                     |
       +------------------+-------------------------------------------+
       | :kbd:`Control-K` | If line is blank, delete it, otherwise    |
       |                  | clear to end of line.                     |

--- a/Lib/curses/textpad.py
+++ b/Lib/curses/textpad.py
@@ -28,7 +28,8 @@ class Textbox:
     Ctrl-F      Cursor right, wrapping to next line when appropriate.
     Ctrl-G      Terminate, returning the window contents.
     Ctrl-H      Delete character backward.
-    Ctrl-J      Terminate if the window is 1 line, otherwise insert newline.
+    Ctrl-J      Terminate if the window is 1 line, otherwise move to start
+                of next line.
     Ctrl-K      If line is blank, delete it, otherwise clear to end of line.
     Ctrl-L      Refresh screen.
     Ctrl-N      Cursor down; move down one line.

--- a/Modules/_curses_panel.c
+++ b/Modules/_curses_panel.c
@@ -380,11 +380,13 @@ _curses_panel_panel_hide_impl(PyCursesPanelObject *self)
 _curses_panel.panel.show
 
 Display the panel (which might have been hidden).
+
+The panel is placed on top of the panel stack.
 [clinic start generated code]*/
 
 static PyObject *
 _curses_panel_panel_show_impl(PyCursesPanelObject *self)
-/*[clinic end generated code: output=6b4553ab45c97769 input=57b167bbefaa3755]*/
+/*[clinic end generated code: output=6b4553ab45c97769 input=9997cf364ca71422]*/
 {
     int rtn = show_panel(self->pan);
     return curses_panel_panel_check_err(self, rtn, "show_panel", "show");
@@ -724,11 +726,13 @@ _curses_panel.new_panel
     /
 
 Return a panel object, associating it with the given window win.
+
+The new panel is placed on top of the panel stack.
 [clinic start generated code]*/
 
 static PyObject *
 _curses_panel_new_panel_impl(PyObject *module, PyCursesWindowObject *win)
-/*[clinic end generated code: output=45e948e0176a9bd2 input=74d4754e0ebe4800]*/
+/*[clinic end generated code: output=45e948e0176a9bd2 input=3b6fea647b808fd7]*/
 {
     PANEL *pan = new_panel(win->win);
     if (pan == NULL) {

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1574,13 +1574,16 @@ _curses.window.delch
     ]
     /
 
-Delete any character at (y, x).
+Delete the character under the cursor, or at (y, x) if specified.
+
+All characters to the right on the same line are shifted one
+position left.
 [clinic start generated code]*/
 
 static PyObject *
 _curses_window_delch_impl(PyCursesWindowObject *self, int group_right_1,
                           int y, int x)
-/*[clinic end generated code: output=22e77bb9fa11b461 input=d2f79e630a4fc6d0]*/
+/*[clinic end generated code: output=22e77bb9fa11b461 input=61db3c7f4885e90c]*/
 {
     int rtn;
     const char *funcname;
@@ -2120,10 +2123,12 @@ PyDoc_STRVAR(_curses_window_instr__doc__,
 "  n\n"
 "    Maximal number of characters.\n"
 "\n"
-"Return a string of characters, extracted from the window starting at the\n"
-"current cursor position, or at y, x if specified.  Attributes are stripped\n"
-"from the characters.  If n is specified, instr() returns a string at most\n"
-"n characters long (exclusive of the trailing NUL).");
+"Return a string of characters, extracted from the window starting\n"
+"at the current cursor position, or at y, x if specified, and\n"
+"stopping at the end of the line.  Attributes and color\n"
+"information are stripped from the characters.  If n is specified,\n"
+"instr() returns a string at most n characters long (exclusive of\n"
+"the trailing NUL).");
 
 static PyObject *
 PyCursesWindow_instr(PyObject *op, PyObject *args)
@@ -4153,24 +4158,22 @@ _curses_mouseinterval_impl(PyObject *module, int interval)
 }
 
 /*[clinic input]
-@permit_long_summary
 _curses.mousemask
 
     newmask: unsigned_long(bitwise=True)
     /
 
-Set the mouse events to be reported, and return a tuple (availmask, oldmask).
+Set the mouse events to be reported, and return (availmask, oldmask).
 
 Return a tuple (availmask, oldmask).  availmask indicates which of the
 specified mouse events can be reported; on complete failure it returns
-0.  oldmask is the previous value of the given window's mouse event
-mask.  If this function is never called, no mouse events are ever
-reported.
+0.  oldmask is the previous value of the mouse event mask.  If this
+function is never called, no mouse events are ever reported.
 [clinic start generated code]*/
 
 static PyObject *
 _curses_mousemask_impl(PyObject *module, unsigned long newmask)
-/*[clinic end generated code: output=9406cf1b8a36e485 input=78990ec6c52aa888]*/
+/*[clinic end generated code: output=9406cf1b8a36e485 input=b8a9a4ccbce633f4]*/
 {
     mmask_t oldmask, availmask;
 

--- a/Modules/clinic/_curses_panel.c.h
+++ b/Modules/clinic/_curses_panel.c.h
@@ -47,7 +47,9 @@ PyDoc_STRVAR(_curses_panel_panel_show__doc__,
 "show($self, /)\n"
 "--\n"
 "\n"
-"Display the panel (which might have been hidden).");
+"Display the panel (which might have been hidden).\n"
+"\n"
+"The panel is placed on top of the panel stack.");
 
 #define _CURSES_PANEL_PANEL_SHOW_METHODDEF    \
     {"show", (PyCFunction)_curses_panel_panel_show, METH_NOARGS, _curses_panel_panel_show__doc__},
@@ -280,7 +282,9 @@ PyDoc_STRVAR(_curses_panel_new_panel__doc__,
 "new_panel($module, win, /)\n"
 "--\n"
 "\n"
-"Return a panel object, associating it with the given window win.");
+"Return a panel object, associating it with the given window win.\n"
+"\n"
+"The new panel is placed on top of the panel stack.");
 
 #define _CURSES_PANEL_NEW_PANEL_METHODDEF    \
     {"new_panel", (PyCFunction)_curses_panel_new_panel, METH_O, _curses_panel_new_panel__doc__},
@@ -343,4 +347,4 @@ _curses_panel_update_panels(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _curses_panel_update_panels_impl(module);
 }
-/*[clinic end generated code: output=62f20ef03eefdf44 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ec3fe619150e512e input=a9049054013a1b77]*/

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -540,12 +540,15 @@ exit:
 
 PyDoc_STRVAR(_curses_window_delch__doc__,
 "delch([y, x])\n"
-"Delete any character at (y, x).\n"
+"Delete the character under the cursor, or at (y, x) if specified.\n"
 "\n"
 "  y\n"
 "    Y-coordinate.\n"
 "  x\n"
-"    X-coordinate.");
+"    X-coordinate.\n"
+"\n"
+"All characters to the right on the same line are shifted one\n"
+"position left.");
 
 #define _CURSES_WINDOW_DELCH_METHODDEF    \
     {"delch", (PyCFunction)_curses_window_delch, METH_VARARGS, _curses_window_delch__doc__},
@@ -3147,13 +3150,12 @@ PyDoc_STRVAR(_curses_mousemask__doc__,
 "mousemask($module, newmask, /)\n"
 "--\n"
 "\n"
-"Set the mouse events to be reported, and return a tuple (availmask, oldmask).\n"
+"Set the mouse events to be reported, and return (availmask, oldmask).\n"
 "\n"
 "Return a tuple (availmask, oldmask).  availmask indicates which of the\n"
 "specified mouse events can be reported; on complete failure it returns\n"
-"0.  oldmask is the previous value of the given window\'s mouse event\n"
-"mask.  If this function is never called, no mouse events are ever\n"
-"reported.");
+"0.  oldmask is the previous value of the mouse event mask.  If this\n"
+"function is never called, no mouse events are ever reported.");
 
 #define _CURSES_MOUSEMASK_METHODDEF    \
     {"mousemask", (PyCFunction)_curses_mousemask, METH_O, _curses_mousemask__doc__},
@@ -4470,4 +4472,4 @@ _curses_has_extended_color_support(PyObject *module, PyObject *Py_UNUSED(ignored
 #ifndef _CURSES_ASSUME_DEFAULT_COLORS_METHODDEF
     #define _CURSES_ASSUME_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_ASSUME_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=e7c7932f4a4e9bce input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ab9b5057eeaf0f33 input=a9049054013a1b77]*/


### PR DESCRIPTION
Fix errors and clarify the curses, curses.panel and curses.ascii docs against X/Open Curses and ncurses, and sync the affected docstrings.


<!-- gh-issue-number: gh-151623 -->
* Issue: gh-151623
<!-- /gh-issue-number -->
