### PR TITLE
docs: Fix broken reference of parameter type in `library/logging.rst`

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -690,7 +690,7 @@ Formatter Objects
    :param defaults: A dictionary with default values to use in custom fields.
        For example,
        ``logging.Formatter('%(ip)s %(message)s', defaults={"ip": None})``
-   :type defaults: dict[str, Any]
+   :type defaults: dict[str, typing.Any]
 
    .. versionchanged:: 3.2
       Added the *style* parameter.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
