### PR TITLE
gh-86726: Fix "deprecated" directive for wm_attributes

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -2458,7 +2458,7 @@ Base and mixin classes
          ``-``, and attributes may be set using keyword arguments.
          The *return_python_dict* parameter was added.
 
-      .. deprecated:: next
+      .. deprecated:: 3.13
          Setting an attribute by passing the option name (with a leading
          ``-``) and its value as two positional arguments, as in
          ``w.attributes('-alpha', 0.5)``, is deprecated; use keyword arguments


### PR DESCRIPTION
I fixed this locally, but forgot to commit before pushing. :frowning: Fixed in the 3.14 backport, so only main and 3.15 should be fixed.

<!-- gh-issue-number: gh-86726 -->
* Issue: gh-86726
<!-- /gh-issue-number -->
