### PR TITLE
[3.14] gh-86726: Fix the documented return type of tkinter info_patchlevel() (GH-151655)

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -2307,7 +2307,13 @@ Base and mixin classes
 
    .. method:: info_patchlevel()
 
-      Return the Tcl/Tk patch level as a string, for example ``'8.6.15'``.
+      Return the Tcl/Tk patch level as a named tuple with the same five fields
+      as :data:`sys.version_info`: *major*, *minor*, *micro*, *releaselevel*
+      and *serial*.
+      *releaselevel* is ``'alpha'``, ``'beta'`` or ``'final'``.
+      Converting it to a string gives the version in the usual Tcl/Tk notation,
+      for example ``'9.0.3'`` for a final release or ``'9.1b2'`` for a
+      pre-release.
 
       .. versionadded:: 3.11
 


### PR DESCRIPTION
It returns a sys.version_info-like named tuple, not a string. (cherry picked from commit 3cd02a1c2da023974464fd1155982a16474f331b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-86726 -->
* Issue: gh-86726
<!-- /gh-issue-number -->
