### PR TITLE
gh-151666: Avoid LLVM libunwind bad-FDE warning for JIT frame registration.

### DIFF
--- a/Lib/test/test_c_stack_unwind.py
+++ b/Lib/test/test_c_stack_unwind.py
@@ -27,6 +27,9 @@ if not support.has_subprocess_support:
 
 
 STACK_DEPTH = 10
+BAD_DYNAMIC_FDE_WARNING = (
+    "libunwind: __unw_add_dynamic_fde: bad fde: FDE is really a CIE"
+)
 
 
 def _manual_unwind_expected(machine):
@@ -218,6 +221,8 @@ def _run_unwind_helper(helper_name, unwinder_name, **env):
     # Surface the output for debugging/visibility when running this test
     if proc.stdout:
         print(proc.stdout, end="")
+    if BAD_DYNAMIC_FDE_WARNING in proc.stderr:
+        raise RuntimeError(proc.stderr)
     if proc.returncode:
         raise RuntimeError(
             f"unwind helper failed (rc={proc.returncode}): {proc.stderr or proc.stdout}"

--- a/Python/jit_unwind.c
+++ b/Python/jit_unwind.c
@@ -31,6 +31,18 @@
  */
 void __register_frame(const void *);
 void __deregister_frame(const void *);
+
+#  if defined(__linux__) && defined(__clang__) && \
+        (__clang_major__ >= 22) && (__clang_major__ <= 23)
+#    define PY_JIT_GNU_BACKTRACE_REGISTER_FDE
+#  endif
+
+#  if defined(PY_JIT_GNU_BACKTRACE_REGISTER_FDE)
+typedef struct JitGnuBacktraceRegistration {
+    uint8_t *eh_frame;
+    const void *registered_frame;
+} JitGnuBacktraceRegistration;
+#  endif
 #endif
 #include <stdio.h>
 #include <string.h>
@@ -1008,6 +1020,50 @@ _PyJitUnwind_GdbUnregisterCode(void *handle)
 }
 
 #if defined(PY_HAVE_JIT_GNU_BACKTRACE_UNWIND)
+#if defined(PY_JIT_GNU_BACKTRACE_REGISTER_FDE)
+static const void *
+gnu_backtrace_registration_frame(const uint8_t *eh_frame, size_t eh_frame_size)
+{
+    /*
+     * LLVM libunwind 22 and 23 implement __register_frame as a single-FDE
+     * registration API. The compiler-version check above is intentionally a
+     * narrow toolchain guard requested for those releases; it is not a
+     * general runtime unwinder capability probe.
+     */
+    uint32_t cie_length;
+    if (eh_frame == NULL || eh_frame_size < 2 * sizeof(uint32_t)) {
+        return NULL;
+    }
+    memcpy(&cie_length, eh_frame, sizeof(cie_length));
+    if (cie_length == 0 || cie_length == UINT32_MAX) {
+        return NULL;
+    }
+
+    size_t fde_offset = sizeof(uint32_t) + (size_t)cie_length;
+    if (fde_offset > eh_frame_size - 2 * sizeof(uint32_t)) {
+        return NULL;
+    }
+
+    uint32_t fde_length;
+    memcpy(&fde_length, eh_frame + fde_offset, sizeof(fde_length));
+    if (fde_length == 0 || fde_length == UINT32_MAX) {
+        return NULL;
+    }
+    if ((size_t)fde_length > eh_frame_size - fde_offset - sizeof(uint32_t)) {
+        return NULL;
+    }
+
+    uint32_t cie_pointer;
+    memcpy(&cie_pointer, eh_frame + fde_offset + sizeof(fde_length),
+           sizeof(cie_pointer));
+    if (cie_pointer == 0) {
+        return NULL;
+    }
+
+    return eh_frame + fde_offset;
+}
+#endif
+
 void *
 _PyJitUnwind_GnuBacktraceRegisterCode(const void *code_addr, size_t code_size)
 {
@@ -1044,8 +1100,29 @@ _PyJitUnwind_GnuBacktraceRegisterCode(const void *code_addr, size_t code_size)
         return NULL;
     }
 
+#if defined(PY_JIT_GNU_BACKTRACE_REGISTER_FDE)
+    const void *registered_frame = gnu_backtrace_registration_frame(
+        eh_frame, eh_frame_size);
+    if (registered_frame == NULL) {
+        PyMem_RawFree(eh_frame);
+        return NULL;
+    }
+
+    JitGnuBacktraceRegistration *registration =
+        PyMem_RawMalloc(sizeof(*registration));
+    if (registration == NULL) {
+        PyMem_RawFree(eh_frame);
+        return NULL;
+    }
+    registration->eh_frame = eh_frame;
+    registration->registered_frame = registered_frame;
+
+    __register_frame(registered_frame);
+    return registration;
+#else
     __register_frame(eh_frame);
     return eh_frame;
+#endif
 }
 
 void
@@ -1054,8 +1131,16 @@ _PyJitUnwind_GnuBacktraceUnregisterCode(void *handle)
     if (handle == NULL) {
         return;
     }
+#if defined(PY_JIT_GNU_BACKTRACE_REGISTER_FDE)
+    JitGnuBacktraceRegistration *registration =
+        (JitGnuBacktraceRegistration *)handle;
+    __deregister_frame(registration->registered_frame);
+    PyMem_RawFree(registration->eh_frame);
+    PyMem_RawFree(registration);
+#else
     __deregister_frame(handle);
     PyMem_RawFree(handle);
+#endif
 }
 #endif  // defined(PY_HAVE_JIT_GNU_BACKTRACE_UNWIND)
 


### PR DESCRIPTION
This is a cautious reference patch for a warning I hit while experimenting with
CPython's JIT using newer LLVM/Clang toolchains.

CPython currently documents LLVM 21 as the officially supported LLVM version for
building the JIT. The issue described here was observed with LLVM 22.1.8 and
LLVM main `564e83191cc5686429cefe69aff81c2aeb268f5a` (`23.0.0git`), so I do not
want to present this as a request to expand the supported LLVM range. I am
opening this mainly to share the root cause and a possible small compatibility
patch, and I would appreciate maintainers taking a careful look at whether this
is appropriate for CPython.

When a JIT executor is published for GNU `backtrace()` unwinding, CPython builds
a small `.eh_frame` buffer containing a CIE, an FDE, and a zero-length
terminator. The current GNU backtrace registration path passes the start of that
buffer to `__register_frame()`. That matches GCC libgcc's behavior: libgcc walks
an `.eh_frame` section and skips from the CIE to the FDE.

LLVM libunwind 22 and 23 expose the same `__register_frame()` symbol, but their
implementation treats the argument as a single FDE address. If CPython passes the
start of the `.eh_frame` buffer, LLVM libunwind sees the CIE first and prints:

```text
libunwind: __unw_add_dynamic_fde: bad fde: FDE is really a CIE
```

I confirmed that passing the first FDE address avoids the warning with LLVM
libunwind 22 and 23. The same local check also showed that GCC libgcc continues
to accept the original `.eh_frame` section-start registration.

The patch takes a narrow approach:

- for Linux builds compiled with Clang major versions 22 or 23, register and
  deregister the first FDE instead of the `.eh_frame` section start;
- keep the allocated `.eh_frame` base pointer in a small registration handle so
  teardown still frees the correct allocation;
- leave all other compilers, platforms, and Clang versions on the existing code
  path;
- add a regression check that fails if the exact LLVM libunwind bad-FDE warning
  appears in the GNU backtrace unwind helper's stderr.

The version guard is intentionally conservative. It follows the toolchain range
where I reproduced and verified the warning, and it avoids changing behavior for
LLVM 21, which remains CPython's documented JIT dependency. That said, this is
only a compiler-version guard; it is not a runtime probe for the actual unwinder
implementation. If maintainers prefer a configure-time/runtime capability check,
or if this should be handled in a different layer, I am happy to rework the
patch.

Validation performed:

- main `bfecfcc2a860071c8e5022ac512bde94e0fb5f76` (`3.16.0a0`)
- Python `3.15.0b2`
- LLVM `22.1.8`
- LLVM main `564e83191cc5686429cefe69aff81c2aeb268f5a` (`23.0.0git`)

In those local builds, the warning disappeared with the patch applied.

<!-- gh-issue-number: gh-151666 -->
* Issue: gh-151666
<!-- /gh-issue-number -->
