### PR TITLE
gh-151674: Add tkinter Text.edit_canundo() and Text.edit_canredo()

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -5475,6 +5475,20 @@ Widget classes
       inserted or deleted.
       Otherwise set the flag to the boolean *arg*.
 
+   .. method:: edit_canundo()
+
+      Return ``True`` if there is an edit action on the undo stack that can be
+      undone, and ``False`` otherwise.
+
+      .. versionadded:: next
+
+   .. method:: edit_canredo()
+
+      Return ``True`` if there is an edit action on the redo stack that can be
+      reapplied, and ``False`` otherwise.
+
+      .. versionadded:: next
+
    .. method:: edit_undo()
 
       Undo the most recent edit action, that is, all the inserts and deletes

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -138,6 +138,14 @@ shlex
   a string, even if it is already safe for a shell without being quoted.
   (Contributed by Jay Berry in :gh:`148846`.)
 
+tkinter
+-------
+
+* Added new :class:`!tkinter.Text` methods :meth:`~tkinter.Text.edit_canundo`
+  and :meth:`~tkinter.Text.edit_canredo` which return whether an undo or redo
+  is possible.
+  (Contributed by Serhiy Storchaka in :gh:`151674`.)
+
 xml
 ---
 

--- a/Lib/test/test_tkinter/test_text.py
+++ b/Lib/test/test_tkinter/test_text.py
@@ -26,29 +26,6 @@ class TextTest(AbstractTkTest, unittest.TestCase):
             text.debug(olddebug)
             self.assertEqual(text.debug(), olddebug)
 
-    def test_edit_undo_redo(self):
-        text = self.text
-        text.configure(undo=True)
-
-        self.assertIs(text.edit_canundo(), False)
-        self.assertIs(text.edit_canredo(), False)
-
-        text.insert('1.0', 'spam')
-        self.assertIs(text.edit_canundo(), True)
-        self.assertIs(text.edit_canredo(), False)
-
-        text.edit_undo()
-        self.assertIs(text.edit_canundo(), False)
-        self.assertIs(text.edit_canredo(), True)
-
-        text.edit_redo()
-        self.assertIs(text.edit_canundo(), True)
-        self.assertIs(text.edit_canredo(), False)
-
-        text.edit_reset()
-        self.assertIs(text.edit_canundo(), False)
-        self.assertIs(text.edit_canredo(), False)
-
     def test_index(self):
         text = self.text
         text.insert('1.0', 'Lorem ipsum\ndolor sit amet')
@@ -328,6 +305,29 @@ class TextTest(AbstractTkTest, unittest.TestCase):
         # An empty undo stack raises.
         text.edit_reset()
         self.assertRaises(TclError, text.edit_undo)
+
+    def test_edit_canundo_canredo(self):
+        text = self.text
+        text.configure(undo=True)
+
+        self.assertIs(text.edit_canundo(), False)
+        self.assertIs(text.edit_canredo(), False)
+
+        text.insert('1.0', 'spam')
+        self.assertIs(text.edit_canundo(), True)
+        self.assertIs(text.edit_canredo(), False)
+
+        text.edit_undo()
+        self.assertIs(text.edit_canundo(), False)
+        self.assertIs(text.edit_canredo(), True)
+
+        text.edit_redo()
+        self.assertIs(text.edit_canundo(), True)
+        self.assertIs(text.edit_canredo(), False)
+
+        text.edit_reset()
+        self.assertIs(text.edit_canundo(), False)
+        self.assertIs(text.edit_canredo(), False)
 
     def test_dump(self):
         text = self.text

--- a/Lib/test/test_tkinter/test_text.py
+++ b/Lib/test/test_tkinter/test_text.py
@@ -25,6 +25,29 @@ class TextTest(AbstractTkTest, unittest.TestCase):
             text.debug(olddebug)
             self.assertEqual(text.debug(), olddebug)
 
+    def test_edit_undo_redo(self):
+        text = self.text
+        text.configure(undo=True)
+
+        self.assertIs(text.edit_canundo(), False)
+        self.assertIs(text.edit_canredo(), False)
+
+        text.insert('1.0', 'spam')
+        self.assertIs(text.edit_canundo(), True)
+        self.assertIs(text.edit_canredo(), False)
+
+        text.edit_undo()
+        self.assertIs(text.edit_canundo(), False)
+        self.assertIs(text.edit_canredo(), True)
+
+        text.edit_redo()
+        self.assertIs(text.edit_canundo(), True)
+        self.assertIs(text.edit_canredo(), False)
+
+        text.edit_reset()
+        self.assertIs(text.edit_canundo(), False)
+        self.assertIs(text.edit_canredo(), False)
+
     def test_search(self):
         text = self.text
 

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3970,6 +3970,22 @@ class Text(Widget, XView, YView):
         """
         return self.tk.call(self._w, 'edit', *args)
 
+    def edit_canredo(self):
+        """Return whether redo is possible.
+
+        Return True if redo is possible, i.e. when the redo stack is
+        not empty, and False otherwise.
+        """
+        return self.tk.getboolean(self.edit("canredo"))
+
+    def edit_canundo(self):
+        """Return whether undo is possible.
+
+        Return True if undo is possible, i.e. when the undo stack is
+        not empty, and False otherwise.
+        """
+        return self.tk.getboolean(self.edit("canundo"))
+
     def edit_modified(self, arg=None):
         """Get or Set the modified flag
 

--- a/Misc/NEWS.d/next/Library/2026-06-19-12-00-00.gh-issue-151674.FCYTvs.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-19-12-00-00.gh-issue-151674.FCYTvs.rst
@@ -1,0 +1,3 @@
+Add the :meth:`~tkinter.Text.edit_canundo` and :meth:`~tkinter.Text.edit_canredo`
+methods of :class:`!tkinter.Text`, wrapping the Tk ``edit canundo`` and
+``edit canredo`` subcommands.


### PR DESCRIPTION
Wrap the Tk text widget "edit canundo" and "edit canredo" subcommands, which report whether the undo and redo stacks are non-empty.


<!-- gh-issue-number: gh-151674 -->
* Issue: gh-151674
<!-- /gh-issue-number -->
