### PR TITLE
[3.14] gh-151544: Fixes CVE-2026-12003 by removing the fallback to %VPATH%/Modules/Setup.local for discovering sources in getpath.py (GH-151545)

### DIFF
--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
-      WASMTIME_VERSION: 22.0.0
+      WASMTIME_VERSION: 38.0.3
       WASI_SDK_VERSION: 24
       WASI_SDK_PATH: /opt/wasi-sdk
       CROSS_BUILD_PYTHON: cross-build/build

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1679,6 +1679,8 @@ Programs/_bootstrap_python.o: Programs/_bootstrap_python.c $(BOOTSTRAP_HEADERS) 
 _bootstrap_python: $(LIBRARY_OBJS_OMIT_FROZEN) Programs/_bootstrap_python.o Modules/getpath.o Modules/Setup.local
 	$(LINKCC) $(PY_LDFLAGS_NOLTO) -o $@ $(LIBRARY_OBJS_OMIT_FROZEN) \
 		Programs/_bootstrap_python.o Modules/getpath.o $(LIBS) $(MODLIBS) $(SYSLIBS)
+	# Dummy pybuilddir.txt  is needed for _bootstrap_python to be runnable
+	@echo "none" > ./pybuilddir.txt
 
 
 ############################################################################

--- a/Misc/NEWS.d/next/Security/2026-06-16-14-58-02.gh-issue-151544._bexVy.rst
+++ b/Misc/NEWS.d/next/Security/2026-06-16-14-58-02.gh-issue-151544._bexVy.rst
@@ -1,0 +1,4 @@
+:file:`Modules/Setup.local` is no longer used as a landmark to discover
+whether Python is running in a source tree, as it could potentially affect
+actual installs. The :file:`pybuilddir.txt` file is now the sole indicator
+of running in a source tree.

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -129,8 +129,7 @@
 # checked by looking for the BUILDDIR_TXT file, which contains the
 # relative path to the platlib dir. The executable_dir value is
 # derived from joining the VPATH preprocessor variable to the
-# directory containing pybuilddir.txt. If it is not found, the
-# BUILD_LANDMARK file is found, which is part of the source tree.
+# directory containing pybuilddir.txt.
 # prefix is then found by searching up for a file that should only
 # exist in the source tree, and the stdlib dir is set to prefix/Lib.
 
@@ -177,7 +176,6 @@ ABI_THREAD = ABI_THREAD or ''
 
 if os_name == 'posix' or os_name == 'darwin':
     BUILDDIR_TXT = 'pybuilddir.txt'
-    BUILD_LANDMARK = 'Modules/Setup.local'
     DEFAULT_PROGRAM_NAME = f'python{VERSION_MAJOR}'
     STDLIB_SUBDIR = f'{platlibdir}/python{VERSION_MAJOR}.{VERSION_MINOR}{ABI_THREAD}'
     STDLIB_LANDMARKS = [f'{STDLIB_SUBDIR}/os.py', f'{STDLIB_SUBDIR}/os.pyc']
@@ -190,7 +188,6 @@ if os_name == 'posix' or os_name == 'darwin':
 
 elif os_name == 'nt':
     BUILDDIR_TXT = 'pybuilddir.txt'
-    BUILD_LANDMARK = f'{VPATH}\\Modules\\Setup.local'
     DEFAULT_PROGRAM_NAME = f'python'
     STDLIB_SUBDIR = 'Lib'
     STDLIB_LANDMARKS = [f'{STDLIB_SUBDIR}\\os.py', f'{STDLIB_SUBDIR}\\os.pyc']
@@ -512,13 +509,9 @@ if ((not home_was_set and real_executable_dir and not py_setpath)
         platstdlib_dir = real_executable_dir
         build_prefix = joinpath(real_executable_dir, VPATH)
     except (FileNotFoundError, PermissionError):
-        if isfile(joinpath(real_executable_dir, BUILD_LANDMARK)):
-            build_prefix = joinpath(real_executable_dir, VPATH)
-            if os_name == 'nt':
-                # QUIRK: Windows builds need platstdlib_dir to be the executable
-                # dir. Normally the builddir marker handles this, but in this
-                # case we need to correct manually.
-                platstdlib_dir = real_executable_dir
+        # We used to check for an alternate landmark here, but now we require
+        # BUILDDIR_TXT to exist. (gh-151544; CVE-2026-12003)
+        pass
 
     if build_prefix:
         if os_name == 'nt':

--- a/Tools/wasm/wasi/__main__.py
+++ b/Tools/wasm/wasi/__main__.py
@@ -329,6 +329,7 @@ def configure_wasi_python(context, working_dir):
         "ENV_VAR_NAME": "PYTHONPATH",
         "ENV_VAR_VALUE": f"/{sysconfig_data_dir}",
         "PYTHON_WASM": working_dir / "python.wasm",
+        "ARGV0": wasi_build_dir / "python.wasm",
     }
     # Check dynamically for wasmtime in case it was specified manually via
     # `--host-runner`.
@@ -421,6 +422,8 @@ def main():
         "--wasm max-wasm-stack=16777216 "
         # Enable thread support; causes use of preview1.
         # "--wasm threads=y --wasi threads=y "
+        # Explicitly set the argv[0] value
+        "--argv0 {ARGV0} "
         # Map the checkout to / to load the stdlib from /Lib.
         "--dir {HOST_DIR}::{GUEST_DIR} "
         # Set PYTHONPATH to the sysconfig data.


### PR DESCRIPTION
Alternative backport to #151565 for validating different WASI fix.

<!-- gh-issue-number: gh-151544 -->
* Issue: gh-151544
<!-- /gh-issue-number -->
