### PR TITLE
gh-151627: protect OrderedDict iterator creation

### DIFF
--- a/Lib/test/test_free_threading/test_collections.py
+++ b/Lib/test/test_free_threading/test_collections.py
@@ -1,5 +1,5 @@
 import unittest
-from collections import deque
+from collections import OrderedDict, deque
 from copy import copy
 from test.support import threading_helper
 
@@ -46,6 +46,31 @@ class TestDeque(unittest.TestCase):
 
         threading_helper.run_concurrently(
             [index, *[mutate for _ in range(3)]],
+        )
+
+
+class TestOrderedDict(unittest.TestCase):
+    def test_iterator_update_clear_race(self):
+        # gh-151627: OrderedDict iterator construction must not race with
+        # concurrent clear()/update() operations that mutate the linked list.
+        od = OrderedDict((i, i) for i in range(100))
+
+        def mutate():
+            for i in range(5000):
+                od.clear()
+                od.update(((i, i), (i + 1, i + 1), (i + 2, i + 2)))
+
+        def iterate():
+            for _ in range(5000):
+                try:
+                    for _ in od:
+                        pass
+                    list(reversed(od))
+                except RuntimeError:
+                    pass
+
+        threading_helper.run_concurrently(
+            [mutate, *[iterate for _ in range(8)]],
         )
 
 

--- a/Misc/NEWS.d/next/Library/2026-06-19-08-30-00.gh-issue-151627.xY7kLm.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-19-08-30-00.gh-issue-151627.xY7kLm.rst
@@ -1,0 +1,2 @@
+Fix a crash in :class:`collections.OrderedDict` iterators in free-threaded
+builds when the dictionary is concurrently cleared or updated.

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1942,11 +1942,13 @@ odictiter_new(PyODictObject *od, int kind)
     }
 
     di->kind = kind;
+    Py_BEGIN_CRITICAL_SECTION(od);
     node = reversed ? _odict_LAST(od) : _odict_FIRST(od);
     di->di_current = node ? Py_NewRef(_odictnode_KEY(node)) : NULL;
     di->di_size = PyODict_SIZE(od);
     di->di_state = od->od_state;
     di->di_odict = (PyODictObject*)Py_NewRef(od);
+    Py_END_CRITICAL_SECTION();
 
     _PyObject_GC_TRACK(di);
     return (PyObject *)di;


### PR DESCRIPTION
Fixes gh-151627.

In free-threaded builds, `OrderedDict` iterator creation could read the ordered linked-list head/tail, the current node key, the size, and `od_state` without holding the `OrderedDict` critical section. A concurrent `clear()` or `update()` could mutate or free the linked-list nodes while `odictiter_new()` was taking that initial iterator snapshot, leading to a data race and a crash/use-after-free.

This change protects the initial iterator snapshot in `odictiter_new()` with the `OrderedDict` critical section. The mutation paths already update the linked-list state while holding the `OrderedDict` lock, so taking the iterator's initial current key, size, state, and object reference under the same critical section avoids racing with concurrent `clear()`/`update()`.

This is separate from gh-151633/gh-151634, which address `Counter.update()` in `_collectionsmodule.c`. This PR targets `OrderedDict` iterator construction in `Objects/odictobject.c`.

A free-threading regression test was added that repeatedly creates forward and reversed `OrderedDict` iterators while another thread concurrently clears and updates the same `OrderedDict`.

Tests run:

./python -m test test_free_threading.test_collections -v
./python -m test test_free_threading.test_collections -v -m test_iterator_update_clear_race
./python -m test test_ordered_dict -v
./python ../gh151627_reproducer.py
