### PR TITLE
[3.14] gh-151695: Fix use-after-free of the curses screen encoding (GH-151696)

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-19-07-26-20.gh-issue-151695.IBDlkN.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-19-07-26-20.gh-issue-151695.IBDlkN.rst
@@ -1,0 +1,4 @@
+Fix a use-after-free in the :mod:`curses` module.  The encoding of the initial
+screen, used by :func:`curses.unctrl` and :func:`curses.ungetch` to encode
+non-ASCII characters, is now kept as a private copy instead of a borrowed
+pointer to a window object that may be deallocated.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -209,7 +209,11 @@ static int curses_initscr_called = FALSE;
 /* Tells whether start_color() has been called to initialise color usage. */
 static int curses_start_color_called = FALSE;
 
-static const char *curses_screen_encoding = NULL;
+/* Encoding of the initial screen, used by module-level functions that have
+   no window object to take it from (e.g. unctrl(), ungetch()).  This is a
+   private copy: the window object that initscr() returns may be deallocated
+   while these functions are still in use. */
+static char *curses_screen_encoding = NULL;
 
 /* Utility Checking Procedures */
 
@@ -3518,6 +3522,21 @@ _curses_init_pair_impl(PyObject *module, int pair_number, int fg, int bg)
     Py_RETURN_NONE;
 }
 
+/* Refresh the private copy of the screen encoding from a freshly created
+   stdscr window object.  Returns 0 on success, -1 with an exception set. */
+static int
+curses_update_screen_encoding(PyObject *winobj)
+{
+    char *copy = _PyMem_Strdup(((PyCursesWindowObject *)winobj)->encoding);
+    if (copy == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    PyMem_Free(curses_screen_encoding);
+    curses_screen_encoding = copy;
+    return 0;
+}
+
 /*[clinic input]
 _curses.initscr
 
@@ -3535,7 +3554,15 @@ _curses_initscr_impl(PyObject *module)
     if (curses_initscr_called) {
         wrefresh(stdscr);
         cursesmodule_state *state = get_cursesmodule_state(module);
-        return PyCursesWindow_New(state, stdscr, NULL, NULL);
+        PyObject *winobj = PyCursesWindow_New(state, stdscr, NULL, NULL);
+        if (winobj == NULL) {
+            return NULL;
+        }
+        if (curses_update_screen_encoding(winobj) < 0) {
+            Py_DECREF(winobj);
+            return NULL;
+        }
+        return winobj;
     }
 
     win = initscr();
@@ -3643,7 +3670,10 @@ _curses_initscr_impl(PyObject *module)
     if (winobj == NULL) {
         return NULL;
     }
-    curses_screen_encoding = ((PyCursesWindowObject *)winobj)->encoding;
+    if (curses_update_screen_encoding(winobj) < 0) {
+        Py_DECREF(winobj);
+        return NULL;
+    }
     return winobj;
 }
 
@@ -5190,6 +5220,8 @@ static void
 cursesmodule_free(void *mod)
 {
     (void)cursesmodule_clear((PyObject *)mod);
+    PyMem_Free(curses_screen_encoding);
+    curses_screen_encoding = NULL;
     curses_module_loaded = 0;  // allow reloading once garbage-collected
 }
 


### PR DESCRIPTION
The module-global curses_screen_encoding stored a borrowed pointer to the encoding owned by the window returned by the first initscr() call.  That window can be deallocated while unctrl() and ungetch(), which have no window of their own, still use the pointer to encode non-ASCII characters.

Keep a private copy of the encoding instead.
(cherry picked from commit 551f8e16f8bb38a1e9c6df259a2a0969493de070)


<!-- gh-issue-number: gh-151695 -->
* Issue: gh-151695
<!-- /gh-issue-number -->
