### PR TITLE
gh-151693: Make the curses tests portable to other curses implementations

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -377,10 +377,12 @@ class TestCurses(unittest.TestCase):
         pad.addstr(0, 0, 'PADTEXT')
         self.assertEqual(pad.instr(0, 0, 7), b'PADTEXT')
 
-        # subpad() shares the parent pad's character cells.
+        # subpad() creates a pad within the parent pad.  Cell sharing with
+        # the parent is implementation-defined, so write to the subpad itself.
         sub = pad.subpad(3, 5, 0, 0)
         self.assertEqual(sub.getmaxyx(), (3, 5))
-        self.assertEqual(sub.instr(0, 0, 5), b'PADTE')
+        sub.addstr(1, 0, 'sub')
+        self.assertEqual(sub.instr(1, 0, 3), b'sub')
 
         # A pad is refreshed onto an explicit screen rectangle; the
         # 6-argument form is required (and rejected for ordinary windows).
@@ -414,7 +416,8 @@ class TestCurses(unittest.TestCase):
         self.assertRaises(curses.error, win.move, -1, -1)
         self.assertRaises(curses.error, win.addch, 100, 100, ord('x'))
         self.assertRaises(curses.error, win.inch, 100, 100)
-        self.assertRaises(curses.error, win.chgat, 100, 0, curses.A_BOLD)
+        if hasattr(win, 'chgat'):       # chgat() requires wchgat()
+            self.assertRaises(curses.error, win.chgat, 100, 0, curses.A_BOLD)
 
     def test_argument_errors(self):
         win = curses.newwin(5, 10, 0, 0)


### PR DESCRIPTION
Follow-up to GH-151694: make the new `test_curses` tests pass on curses implementations other than ncurses.

* `test_coordinate_errors` only calls `window.chgat()` when it is available — it requires a curses providing `wchgat()`.
* `test_pad` no longer assumes a subpad shares the parent pad's character cells; X/Open Curses leaves that implementation-defined, so the test now writes to and reads from the subpad itself.

<!-- gh-issue-number: gh-151693 -->
* Issue: gh-151693
<!-- /gh-issue-number -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
