### PR TITLE
[3.14] gh-151693: Make the curses tests portable to other curses implementations (GH-151729)

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -374,10 +374,12 @@ class TestCurses(unittest.TestCase):
         pad.addstr(0, 0, 'PADTEXT')
         self.assertEqual(pad.instr(0, 0, 7), b'PADTEXT')
 
-        # subpad() shares the parent pad's character cells.
+        # subpad() creates a pad within the parent pad.  Cell sharing with
+        # the parent is implementation-defined, so write to the subpad itself.
         sub = pad.subpad(3, 5, 0, 0)
         self.assertEqual(sub.getmaxyx(), (3, 5))
-        self.assertEqual(sub.instr(0, 0, 5), b'PADTE')
+        sub.addstr(1, 0, 'sub')
+        self.assertEqual(sub.instr(1, 0, 3), b'sub')
 
         # A pad is refreshed onto an explicit screen rectangle; the
         # 6-argument form is required (and rejected for ordinary windows).
@@ -410,7 +412,8 @@ class TestCurses(unittest.TestCase):
         self.assertRaises(curses.error, win.move, 100, 100)
         self.assertRaises(curses.error, win.move, -1, -1)
         self.assertRaises(curses.error, win.addch, 100, 100, ord('x'))
-        self.assertRaises(curses.error, win.chgat, 100, 0, curses.A_BOLD)
+        if hasattr(win, 'chgat'):       # chgat() requires wchgat()
+            self.assertRaises(curses.error, win.chgat, 100, 0, curses.A_BOLD)
 
     def test_argument_errors(self):
         win = curses.newwin(5, 10, 0, 0)


### PR DESCRIPTION

Make the curses tests portable to other curses implementations

Guard the chgat() check (chgat() needs wchgat()) and stop assuming a subpad shares the parent pad's cells (implementation-defined in X/Open). (cherry picked from commit 64fab74bd7288bfa67cd7727452febdaafed4270)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151693 -->
* Issue: gh-151693
<!-- /gh-issue-number -->
