### PR TITLE
gh-151749: Add 5f00::/16 (RFC 9602) and 100:0:0:1::/64 (RFC 9780) to ipaddress IPv6 private networks

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -2387,6 +2387,8 @@ class _IPv6Constants:
         IPv6Network('2002::/16'),
         # RFC 9637: https://www.rfc-editor.org/rfc/rfc9637.html#section-6-2.2
         IPv6Network('3fff::/20'),
+        IPv6Network('5f00::/16'),       # RFC 9602 Segment Routing (SRv6) SIDs
+        IPv6Network('100:0:0:1::/64'),  # RFC 9780 Dummy IPv6 Prefix
         IPv6Network('fc00::/7'),
         IPv6Network('fe80::/10'),
         ]

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -2387,8 +2387,10 @@ class _IPv6Constants:
         IPv6Network('2002::/16'),
         # RFC 9637: https://www.rfc-editor.org/rfc/rfc9637.html#section-6-2.2
         IPv6Network('3fff::/20'),
-        IPv6Network('5f00::/16'),       # RFC 9602 Segment Routing (SRv6) SIDs
-        IPv6Network('100:0:0:1::/64'),  # RFC 9780 Dummy IPv6 Prefix
+        # RFC 9602: https://www.rfc-editor.org/rfc/rfc9602.html
+        IPv6Network('5f00::/16'),
+        # RFC 9780: https://www.rfc-editor.org/rfc/rfc9780.html
+        IPv6Network('100:0:0:1::/64'),
         IPv6Network('fc00::/7'),
         IPv6Network('fe80::/10'),
         ]

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -2499,18 +2499,9 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertFalse(ipaddress.ip_address('2002::').is_global)
         # gh-124217: conform with RFC 9637
         self.assertFalse(ipaddress.ip_address('3fff::').is_global)
-        # gh-151749: 5f00::/16 (RFC 9602) and 100:0:0:1::/64 (RFC 9780)
-        # are not globally reachable per the IANA registry.
-        for addr in ('5f00::', '5f00::1',
-                     '5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
-                     '100:0:0:1::', '100:0:0:1:ffff:ffff:ffff:ffff'):
-            self.assertFalse(ipaddress.ip_address(addr).is_global)
-            self.assertTrue(ipaddress.ip_address(addr).is_private)
-        # Addresses adjacent to the new ranges are unaffected.
-        for addr in ('5eff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', '5f01::',
-                     '100:0:0:2::'):
-            self.assertTrue(ipaddress.ip_address(addr).is_global)
-            self.assertFalse(ipaddress.ip_address(addr).is_private)
+        # gh-151749: conform with RFC 9602 and RFC 9780
+        self.assertFalse(ipaddress.ip_address('5f00::').is_global)
+        self.assertFalse(ipaddress.ip_address('100:0:0:1::').is_global)
 
         # some generic IETF reserved addresses
         self.assertEqual(True, ipaddress.ip_address('100::').is_reserved)

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -2499,6 +2499,18 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertFalse(ipaddress.ip_address('2002::').is_global)
         # gh-124217: conform with RFC 9637
         self.assertFalse(ipaddress.ip_address('3fff::').is_global)
+        # gh-151749: 5f00::/16 (RFC 9602) and 100:0:0:1::/64 (RFC 9780)
+        # are not globally reachable per the IANA registry.
+        for addr in ('5f00::', '5f00::1',
+                     '5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+                     '100:0:0:1::', '100:0:0:1:ffff:ffff:ffff:ffff'):
+            self.assertFalse(ipaddress.ip_address(addr).is_global)
+            self.assertTrue(ipaddress.ip_address(addr).is_private)
+        # Addresses adjacent to the new ranges are unaffected.
+        for addr in ('5eff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', '5f01::',
+                     '100:0:0:2::'):
+            self.assertTrue(ipaddress.ip_address(addr).is_global)
+            self.assertFalse(ipaddress.ip_address(addr).is_private)
 
         # some generic IETF reserved addresses
         self.assertEqual(True, ipaddress.ip_address('100::').is_reserved)

--- a/Misc/NEWS.d/next/Library/2026-06-20-01-00-43.gh-issue-151749.5vLBmS.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-20-01-00-43.gh-issue-151749.5vLBmS.rst
@@ -1,0 +1,4 @@
+Fixed :attr:`ipaddress.IPv6Address.is_global` and
+:attr:`ipaddress.IPv6Address.is_private` for the ``5f00::/16`` (:rfc:`9602`)
+and ``100:0:0:1::/64`` (:rfc:`9780`) special-purpose ranges, which are not
+globally reachable per the IANA registry.


### PR DESCRIPTION
Add the `5f00::/16` (RFC 9602) and `100:0:0:1::/64` (RFC 9780) special-purpose IPv6 ranges to `ipaddress`'s `_private_networks` so `is_global`/`is_private` match the IANA registry.

Fixes #151749

## Problem

Both ranges are listed in the [IANA IPv6 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml) with **Globally Reachable = False**, but `ipaddress` currently reports them as globally reachable:

- `5f00::/16` — SRv6 SIDs, defined in [RFC 9602](https://www.rfc-editor.org/rfc/rfc9602.html) (Globally Reachable: False).
- `100:0:0:1::/64` — Dummy IPv6 Prefix, defined in [RFC 9780](https://www.rfc-editor.org/rfc/rfc9780.html) (Globally Reachable: False). Note this block is disjoint from the already-listed `100::/64` (RFC 6666 Discard-Only), so it is not currently covered.

Before this change `IPv6Address.is_global` returns `True` (and `is_private` returns `False`) for addresses in both blocks, which is incorrect.

## Fix

Adds the two networks to `_IPv6Constants._private_networks`, alongside the existing not-globally-reachable IPv6 entries. This follows the precedent set by CVE-2024-4032 / gh-113171 and gh-124217 (`3fff::/20`, RFC 9637), which added sibling ranges to these same tables.

**Scope:** This PR is intentionally limited to `_private_networks`. It does **not** touch `_private_networks_exceptions`; the related `2001:1::3/128` (RFC 9665) exception is handled separately in #151050 and is deliberately left unchanged here.

## Behaviour (stock vs. patched)

| Address | stock `is_global` | patched `is_global` | patched `is_private` |
| --- | --- | --- | --- |
| `5f00::` | True | **False** | **True** |
| `5f00::1` | True | **False** | **True** |
| `5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff` | True | **False** | **True** |
| `100:0:0:1::` | True | **False** | **True** |
| `100:0:0:1:ffff:ffff:ffff:ffff` | True | **False** | **True** |
| `5eff:ffff:ffff:ffff:ffff:ffff:ffff:ffff` (adjacent below) | True | True | False |
| `5f01::` (adjacent above) | True | True | False |
| `100:0:0:2::` (adjacent) | True | True | False |

Addresses immediately adjacent to each new block are unchanged. A regression test covering both the changed and adjacent addresses is added to `testReservedIpv6`, and a `Misc/NEWS.d` entry is included.


<!-- gh-issue-number: gh-151749 -->
* Issue: gh-151749
<!-- /gh-issue-number -->
