### PR TITLE
gh-151673: Fix crash in warnings.warn() under memory pressure

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -24,7 +24,6 @@ from test.test_warnings.data import stacklevel as warning_tests
 import warnings as original_warnings
 from warnings import deprecated
 
-
 py_warnings = import_helper.import_fresh_module('_py_warnings')
 py_warnings._set_module(py_warnings)
 
@@ -1236,6 +1235,25 @@ class _WarningsTests(BaseTest, unittest.TestCase):
             with support.swap_item(globals(), '__name__', b'foo'), \
                  support.swap_item(globals(), '__file__', None):
                 self.assertRaises(UserWarning, self.module.warn, 'bar')
+
+    @support.cpython_only
+    # Python built with Py_TRACE_REFS fail with a fatal error in
+    # _PyRefchain_Trace() on memory allocation error.
+    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
+    def test_issue151673(self):
+        # Skip this test if the _testcapi module isn't available.
+        _testcapi = import_helper.import_module('_testcapi')
+        # warn() shouldn't crash when the "<sys>" fallback filename
+        # can't be allocated under memory pressure.
+        code = """if 1:
+            import _testcapi, warnings
+            warnings.simplefilter("always")
+            _testcapi.set_nomemory(0)
+            warnings.warn("boom")
+        """
+        rc, out, err = assert_python_failure("-c", code)
+        self.assertIn(rc, (1, 120))
+        self.assertIn(b'MemoryError', err)
 
 
 class WarningsDisplayTests(BaseTest):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-19-21-58-01.gh-issue-151673.Kx9mPq.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-19-21-58-01.gh-issue-151673.Kx9mPq.rst
@@ -1,0 +1,3 @@
+Fix a crash in :func:`warnings.warn` when the ``"<sys>"`` fallback filename
+could not be allocated under memory pressure: :c:func:`!setup_context` left
+the filename ``NULL`` and it was later passed to :c:func:`Py_DECREF`.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1031,9 +1031,18 @@ setup_context(Py_ssize_t stack_level,
         }
     }
 
+    /* Initialize the output references so handle_error can Py_XDECREF them
+       even when we bail out before they are assigned. */
+    *filename = NULL;
+    *registry = NULL;
+    *module = NULL;
+
     if (f == NULL) {
         globals = interp->sysdict;
         *filename = PyUnicode_FromString("<sys>");
+        if (*filename == NULL) {
+            goto handle_error;
+        }
         *lineno = 0;
     }
     else {
@@ -1042,8 +1051,6 @@ setup_context(Py_ssize_t stack_level,
         *lineno = PyFrame_GetLineNumber(f);
         Py_DECREF(f);
     }
-
-    *module = NULL;
 
     /* Setup registry. */
     assert(globals != NULL);
@@ -1084,7 +1091,7 @@ setup_context(Py_ssize_t stack_level,
  handle_error:
     Py_XDECREF(*registry);
     Py_XDECREF(*module);
-    Py_DECREF(*filename);
+    Py_XDECREF(*filename);
     return 0;
 }
 


### PR DESCRIPTION
When `warnings.warn()` runs while every allocation is failing `setup_context()` took the `f == NULL` branch and called `PyUnicode_FromString("<sys>")` without checking the result. The resulting NULL filename was then passed to `Py_DECREF` either by `do_warn()` on the success path or by `setup_context()`'s own `handle_error:` label (which used `Py_DECREF`, not `Py_XDECREF`). This caused a segfault.

The fix initialize the output references up front then check the `"<sys>"` allocation and use `Py_XDECREF` in the error path.

Fixes #151673

<!-- gh-issue-number: gh-151673 -->
* Issue: gh-151673
<!-- /gh-issue-number -->
