### PR TITLE
gh-151770: Fix datetime.fromisoformat() assertion on an out-of-range month with a 24:00 time

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -1987,7 +1987,7 @@ class datetime(date):
                 if became_next_day:
                     year, month, day = date_components
                     # Only wrap day/month when it was previously valid
-                    if month <= 12 and day <= (days_in_month := _days_in_month(year, month)):
+                    if 1 <= month <= 12 and day <= (days_in_month := _days_in_month(year, month)):
                         # Calculate midnight of the next day
                         day += 1
                         if day > days_in_month:

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -55,7 +55,7 @@ def _days_before_year(year):
 
 def _days_in_month(year, month):
     "year, month -> number of days in that month in that year."
-    assert 1 <= month <= 12, month
+    assert 1 <= month <= 12, f"month must be in 1..12, not {month}"
     if month == 2 and _is_leap(year):
         return 29
     return _DAYS_IN_MONTH[month]

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3773,7 +3773,7 @@ class TestDateTime(TestDate):
             "2009-04-01T12:30:90",          # Second out of range
             "2009-04-01T12:90:45",          # Minute out of range
             "2009-04-01T25:30:45",          # Hour out of range
-            "2009-00-01T24:00:00",          # Month out of range (below)
+            "2009-00-01T24:00:00",          # Month below range
             "2009-13-01T24:00:00",          # Month out of range
             "9999-12-31T24:00:00",          # Year out of range
         ]

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3773,6 +3773,7 @@ class TestDateTime(TestDate):
             "2009-04-01T12:30:90",          # Second out of range
             "2009-04-01T12:90:45",          # Minute out of range
             "2009-04-01T25:30:45",          # Hour out of range
+            "2009-00-01T24:00:00",          # Month out of range (below)
             "2009-13-01T24:00:00",          # Month out of range
             "9999-12-31T24:00:00",          # Year out of range
         ]

--- a/Misc/NEWS.d/next/Library/2026-06-20-15-00-00.gh-issue-151770.dtiso0.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-20-15-00-00.gh-issue-151770.dtiso0.rst
@@ -1,3 +1,3 @@
-Fix :meth:`datetime.datetime.fromisoformat` raising an unexpected error on an
-out-of-range month combined with a ``24:00`` time, such as
-``"2009-00-01T24:00:00"``. It now consistently raises :exc:`ValueError`.
+Fix :meth:`datetime.datetime.fromisoformat` raising :exc:`AssertionError`
+instead of :exc:`ValueError` for an out-of-range month combined with a
+``24:00`` time.

--- a/Misc/NEWS.d/next/Library/2026-06-20-15-00-00.gh-issue-151770.dtiso0.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-20-15-00-00.gh-issue-151770.dtiso0.rst
@@ -1,0 +1,3 @@
+Fix :meth:`datetime.datetime.fromisoformat` raising an unexpected error on an
+out-of-range month combined with a ``24:00`` time, such as
+``"2009-00-01T24:00:00"``. It now consistently raises :exc:`ValueError`.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6144,7 +6144,7 @@ datetime_datetime_fromisoformat_impl(PyTypeObject *type, PyObject *string)
         goto error;
     }
 
-    if ((hour == 24) && (month >= 1) && (month <= 12))  {
+    if ((hour == 24) && (month >= 1 && month <= 12))  {
         int d_in_month = days_in_month(year, month);
         if (day <= d_in_month) {
             if (minute == 0 && second == 0 && microsecond == 0) {

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6144,7 +6144,7 @@ datetime_datetime_fromisoformat_impl(PyTypeObject *type, PyObject *string)
         goto error;
     }
 
-    if ((hour == 24) && (month <= 12))  {
+    if ((hour == 24) && (month >= 1) && (month <= 12))  {
         int d_in_month = days_in_month(year, month);
         if (day <= d_in_month) {
             if (minute == 0 && second == 0 && microsecond == 0) {


### PR DESCRIPTION
`datetime.fromisoformat()` reached `days_in_month()` with `month == 0` when the input combined an out-of-range (below 1) month with a `24:00` time, for example `"2009-00-01T24:00:00"`. On a `--with-pydebug` build this tripped `assert(month >= 1)` in `days_in_month` (`Modules/_datetimemodule.c`); the pure-Python implementation in `Lib/_pydatetime.py` raised `AssertionError` on the same input. On a release build both already raised `ValueError`.

The `24:00` midnight-rollover guard validated only the upper month bound (`month <= 12`) before the `days_in_month()` call, and the parser does not range-check the month before that point, so a month below 1 slipped through. The matching upper-bound input `"2009-13-01T24:00:00"` was already rejected by the `month <= 12` check.

This adds the missing `month >= 1` lower bound to the guard in both implementations (mirroring the existing `check_date_args` validation), so an out-of-range month consistently raises `ValueError`. A regression test is added next to the existing out-of-range-month case in `datetimetester.py`.

<!-- gh-issue-number: gh-151770 -->
* Issue: gh-151770
<!-- /gh-issue-number -->
