### PR TITLE
gh-151769: Make IPv6Address ordering scope_id-aware

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -2010,6 +2010,22 @@ class IPv6Address(_BaseV6, _BaseAddress):
             return False
         return self._scope_id == getattr(other, '_scope_id', None)
 
+    def __lt__(self, other):
+        if not isinstance(other, _BaseAddress):
+            return NotImplemented
+        if self.version != other.version:
+            raise TypeError('%s and %s are not of the same version' % (
+                             self, other))
+        if self._ip != other._ip:
+            return self._ip < other._ip
+        # Equal integer addresses are ordered by scope_id so that ordering
+        # stays consistent with __eq__/__hash__, which already fold it in.
+        # Unscoped sorts before scoped; scope ids compare lexicographically.
+        self_scope = self._scope_id
+        other_scope = getattr(other, '_scope_id', None)
+        return ((self_scope is not None, self_scope or '')
+                < (other_scope is not None, other_scope or ''))
+
     def __reduce__(self):
         return (self.__class__, (str(self),))
 

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -5,6 +5,7 @@
 
 
 import copy
+import itertools
 import unittest
 import re
 import contextlib
@@ -2028,6 +2029,43 @@ class IpaddrUnitTest(unittest.TestCase):
                         ipaddress.ip_address('::1%scope'))
         self.assertTrue(ipaddress.ip_address('::1%scope') <=
                         ipaddress.ip_address('::2%scope'))
+
+    def testScopedAddressComparison(self):
+        plain = ipaddress.ip_address('fe80::1')
+        eth0 = ipaddress.ip_address('fe80::1%eth0')
+        eth1 = ipaddress.ip_address('fe80::1%eth1')
+        scoped = [plain, eth0, eth1]
+        for a in scoped:
+            for b in scoped:
+                self.assertEqual((a < b) + (a == b) + (a > b), 1, msg=(a, b))
+                if a != b:
+                    self.assertNotEqual(a > b, b > a, msg=(a, b))
+        self.assertTrue(plain < eth0)
+        self.assertTrue(eth0 < eth1)
+        self.assertTrue(eth0 > plain)
+        self.assertFalse(plain > eth0)
+        self.assertTrue(plain <= eth0)
+        self.assertTrue(eth0 >= plain)
+        expected = [plain, eth0, eth1]
+        for perm in itertools.permutations(scoped):
+            self.assertEqual(sorted(perm), expected, msg=perm)
+            self.assertEqual(min(perm), plain, msg=perm)
+            self.assertEqual(max(perm), eth1, msg=perm)
+        v4 = [ipaddress.ip_address('10.0.0.1'),
+              ipaddress.ip_address('10.0.0.2'),
+              ipaddress.ip_address('10.0.0.3')]
+        for perm in itertools.permutations(v4):
+            self.assertEqual(sorted(perm), v4, msg=perm)
+        ifaces = [ipaddress.ip_interface('fe80::1/64'),
+                  ipaddress.ip_interface('fe80::1%eth0/64'),
+                  ipaddress.ip_interface('fe80::1%eth1/64')]
+        for perm in itertools.permutations(ifaces):
+            self.assertEqual(sorted(perm), ifaces, msg=perm)
+        nets = [ipaddress.ip_network('fe80::/64'),
+                ipaddress.ip_network('fe80::%eth0/64'),
+                ipaddress.ip_network('fe80::%eth1/64')]
+        for perm in itertools.permutations(nets):
+            self.assertEqual(sorted(perm), nets, msg=perm)
 
     def testInterfaceComparison(self):
         self.assertTrue(ipaddress.ip_interface('1.1.1.1/24') ==

--- a/Misc/NEWS.d/next/Library/2026-06-20-00-07-55.gh-issue-151769.7D4gBg.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-20-00-07-55.gh-issue-151769.7D4gBg.rst
@@ -1,0 +1,6 @@
+Fix ordering of scoped :class:`~ipaddress.IPv6Address` objects.  Comparison
+now takes the interface ``scope_id`` into account, consistent with equality
+and hashing, so that ``sorted()``, ``min()`` and ``max()`` are deterministic
+for addresses that differ only in scope.  Ordering of the corresponding
+scoped :class:`~ipaddress.IPv6Interface` and :class:`~ipaddress.IPv6Network`
+objects is fixed as well.  Patch by Olayinka Vaughan.


### PR DESCRIPTION
`IPv6Address.__eq__` and `__hash__` fold in the interface `scope_id`, but `IPv6Address` inherited the scope-blind `_BaseAddress.__lt__`. Under `@functools.total_ordering` — which derives `>` from `<` and `==` — that made ordering inconsistent for addresses differing only by scope: both `a > b` and `b > a` could be true, so antisymmetry broke and `sorted()`/`min()`/`max()` were non-deterministic for scoped addresses.

This adds a scope-aware `IPv6Address.__lt__` that tie-breaks on `scope_id` only when the integer address is equal (unscoped sorts before scoped; scope ids compare lexicographically). Because the derived operators dispatch through `type(self).__lt__`, overriding only `__lt__` routes all four comparisons through the scope-aware path — which also repairs scoped `IPv6Interface` and `IPv6Network` ordering, since they delegate to address comparison. `_BaseAddress.__lt__` is left untouched, so `IPv4Address` is unaffected.

Verified on a `3.16.0a0` build and on stock `3.14.6`: without the fix, antisymmetry fails and the three scoped permutations of one address yield 6 distinct sort orders; with it, ordering is total and deterministic. The new `testScopedAddressComparison` covers trichotomy, antisymmetry, and stable `sorted()`/`min()`/`max()` for scoped `IPv6Address`, `IPv6Interface`, and `IPv6Network`, with an IPv4 ordering guard.


<!-- gh-issue-number: gh-151769 -->
* Issue: gh-151769
<!-- /gh-issue-number -->
