### PR TITLE
gh-150948: Exclude macOS semaphore header from c-analyzer

### DIFF
--- a/Tools/c-analyzer/cpython/_parser.py
+++ b/Tools/c-analyzer/cpython/_parser.py
@@ -49,6 +49,7 @@ def format_tsv_lines(lines):
 EXCLUDED = format_conf_lines([
     # macOS
     'Modules/_scproxy.c',              # SystemConfiguration/SystemConfiguration.h
+    'Modules/_multiprocessing/semaphore_macosx.h',  # sys/sysctl.h
 
     # Windows
     'Modules/_winapi.c',               # windows.h


### PR DESCRIPTION
## Summary

Exclude `Modules/_multiprocessing/semaphore_macosx.h` from the c-analyzer parser configuration.

## Issue

`check-c-globals.py` scans files matched by `Modules/**/*.h`. The macOS-specific header `Modules/_multiprocessing/semaphore_macosx.h` includes:

```c
#include <sys/sysctl.h>
```

This header is not available on non-macOS CI environments, causing preprocessing to fail before the analyzer can inspect the file.

As a result, the "Check for unsupported C global variables" job can fail due to a platform-specific dependency rather than an actual c-analyzer issue.

## Fix

Add `Modules/_multiprocessing/semaphore_macosx.h` to the `EXCLUDED` list in `Tools/c-analyzer/cpython/_parser.py`.

This follows the existing pattern used for other platform-specific files that cannot be parsed reliably across all CI platforms, such as:

* `Modules/_scproxy.c`
* `Modules/_winapi.c`
* platform-specific dynload implementations

## Rationale

The current c-analyzer workflow already relies on explicit exclusions for files that depend on OS-specific headers unavailable on other platforms.

Since `semaphore_macosx.h` depends on the macOS-only `sys/sysctl.h` header, excluding it is consistent with the existing policy and avoids unrelated CI failures.


Fixes gh-150948.
