### PR TITLE
gh-151678: Add tests for the remaining tkinter Misc, Wm and Text methods

### DIFF
--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -490,9 +490,14 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
     def test_grab_set_global(self):
         # A successful global grab directs all events on the display to this
         # application, so only the error paths are tested here.
-        f = tkinter.Frame(self.root)  # not yet viewable
-        self.assertRaisesRegex(TclError, 'grab failed', f.grab_set_global)
         self.assertRaises(TypeError, self.root.grab_set_global, 'extra')
+        with self.subTest('non-viewable window'):
+            if self.root._windowingsystem != 'x11':
+                # Grabbing a non-viewable window fails only on X11; elsewhere
+                # it would actually grab the whole display.
+                self.skipTest('only X11 fails the grab')
+            f = tkinter.Frame(self.root)  # not yet viewable
+            self.assertRaisesRegex(TclError, 'grab failed', f.grab_set_global)
 
     def test_send(self):
         if self.root._windowingsystem != 'x11':

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -463,6 +463,43 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(root['background'], '#ffe4c4')
         self.assertRaises(TypeError, root.tk_bisque, 'x')
 
+    def test_wait_variable(self):
+        var = tkinter.StringVar(self.root)
+        self.assertEqual(self.root.waitvar, self.root.wait_variable)
+        self.root.after(1, var.set, 'done')
+        self.root.wait_variable(var)  # Returns once the variable is set.
+        self.assertEqual(var.get(), 'done')
+
+    def test_wait_window(self):
+        top = tkinter.Toplevel(self.root)
+        self.root.after(1, top.destroy)
+        self.root.wait_window(top)  # Returns once the window is destroyed.
+        self.assertFalse(top.winfo_exists())
+
+    def test_tk_focusFollowsMouse(self):
+        self.root.tk_focusFollowsMouse()  # No exception.
+
+    def test_selection_handle(self):
+        f = tkinter.Frame(self.root)
+        def handler(offset, length):
+            return 'PAYLOAD'[int(offset):int(offset) + int(length)]
+        f.selection_handle(handler)
+        f.selection_own()
+        self.assertEqual(f.selection_get(), 'PAYLOAD')
+
+    def test_grab_set_global(self):
+        # A successful global grab directs all events on the display to this
+        # application, so only the error paths are tested here.
+        f = tkinter.Frame(self.root)  # not yet viewable
+        self.assertRaisesRegex(TclError, 'grab failed', f.grab_set_global)
+        self.assertRaises(TypeError, self.root.grab_set_global, 'extra')
+
+    def test_send(self):
+        if self.root._windowingsystem != 'x11':
+            self.skipTest('send is only supported on X11')
+        self.assertRaisesRegex(TclError, 'no application named',
+                               self.root.send, 'no_such_interp_xyzzy', 'set x 1')
+
     def test_event_repr_defaults(self):
         e = tkinter.Event()
         e.serial = 12345
@@ -933,6 +970,35 @@ class WmTest(AbstractTkTest, unittest.TestCase):
         t = tkinter.Toplevel(self.root)
         t.iconname('Icon')
         self.assertIn(t.iconname(), ('Icon', ''))
+
+    def test_wm_iconposition(self):
+        t = tkinter.Toplevel(self.root)
+        t.wm_iconposition(3, 4)  # An X11 hint; may be a no-op elsewhere.
+        if t._windowingsystem == 'x11':
+            self.assertEqual(t.wm_iconposition(), (3, 4))
+
+    def test_wm_iconmask_iconwindow(self):
+        if self.root._windowingsystem != 'x11':
+            self.skipTest('iconmask and iconwindow are X11-specific')
+        t = tkinter.Toplevel(self.root)
+        t.wm_iconmask('gray50')  # No exception.
+        icon = tkinter.Toplevel(self.root)
+        t.wm_iconwindow(icon)
+        self.assertEqual(str(t.wm_iconwindow()), str(icon))
+
+    def test_wm_colormapwindows(self):
+        if self.root._windowingsystem != 'x11':
+            self.skipTest('colormapwindows is X11-specific')
+        t = tkinter.Toplevel(self.root)
+        self.assertEqual(t.wm_colormapwindows(), [])
+        f = tkinter.Frame(t)
+        t.wm_colormapwindows(f)
+        self.assertEqual([str(w) for w in t.wm_colormapwindows()], [str(f)])
+
+    def test_wm_manage_forget(self):
+        f = tkinter.Frame(self.root)
+        self.root.wm_manage(f)  # Make the frame a top-level window.
+        self.root.wm_forget(f)  # Revert it; no exception either way.
 
     def test_wm_client_command(self):
         t = tkinter.Toplevel(self.root)

--- a/Lib/test/test_tkinter/test_text.py
+++ b/Lib/test/test_tkinter/test_text.py
@@ -528,6 +528,7 @@ class TextTest(AbstractTkTest, unittest.TestCase):
         self.assertIsInstance(cnf, dict)
         self.assertIn('stretch', cnf)
         self.assertRaises(TclError, text.window_cget, '1.1', 'spam')
+        self.assertEqual(text.window_config, text.window_configure)
         button.destroy()
 
     def test_peer(self):
@@ -584,6 +585,11 @@ class TextTest(AbstractTkTest, unittest.TestCase):
         self.assertRaises(TclError, text.see, 'invalid')
         self.assertRaises(TypeError, text.see)
         self.assertRaises(TypeError, text.see, '1.0', '2.0')
+
+        # yview_pickplace is a deprecated way to make an index visible.
+        text.yview_pickplace('1.0')
+        text.update()
+        self.assertIsNotNone(text.bbox('1.0'))
 
     def test_search(self):
         text = self.text


### PR DESCRIPTION
Cover `Misc.wait_variable` and `wait_window`, `tk_focusFollowsMouse`, `selection_handle`, the error paths of `grab_set_global`, `send`, the X11-specific `Wm` methods `iconposition`, `iconmask`, `iconwindow`, `colormapwindows` and `manage`/`forget`, and the `Text.window_config` alias and deprecated `yview_pickplace`.

<!-- gh-issue-number: gh-151678 -->
* Issue: gh-151678
<!-- /gh-issue-number -->