### PR TITLE
`valgrind-python.supp`: Update suppression for readline leaks

### DIFF
--- a/Misc/valgrind-python.supp
+++ b/Misc/valgrind-python.supp
@@ -317,13 +317,10 @@
 {
    Avoid problems w/readline doing a putenv and leaking on exit
    Memcheck:Leak
-   fun:malloc
-   fun:xmalloc
-   fun:sh_set_lines_and_columns
-   fun:_rl_get_screen_size
-   fun:_rl_init_terminal_io
-   obj:/lib/libreadline.so.4.3
-   fun:rl_initialize
+   match-leak-kinds: definite,indirect
+   ...
+   fun:setup_readline
+   fun:PyInit_readline
 }
 
 # Valgrind emits "Conditional jump or move depends on uninitialised value(s)"

--- a/Misc/valgrind-python.supp
+++ b/Misc/valgrind-python.supp
@@ -317,10 +317,8 @@
 {
    Avoid problems w/readline doing a putenv and leaking on exit
    Memcheck:Leak
-   match-leak-kinds: definite,indirect
    ...
    fun:setup_readline
-   fun:PyInit_readline
 }
 
 # Valgrind emits "Conditional jump or move depends on uninitialised value(s)"


### PR DESCRIPTION
These have been causing the **[AMD64 Arch Linux Valgrind 3.x](https://buildbot.python.org/#/builders/1604)** Buildbot to fail, for example in [this build](https://buildbot.python.org/#/builders/1604/builds/697):

<details>

<summary>Long log</summary>

```
==3029599== 
==3029599== HEAP SUMMARY:
==3029599==     in use at exit: 281,121 bytes in 601 blocks
==3029599==   total heap usage: 11,617,887 allocs, 11,617,286 frees, 20,425,116,089 bytes allocated
==3029599== 
==3029599== 8 bytes in 1 blocks are definitely lost in loss record 2 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99A3ADD: ???
==3029599==    by 0x999D8B0: ???
==3029599==    by 0x999D987: ???
==3029599==    by 0x998A20D: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599==    by 0x3F3715: _imp_create_dynamic (import.c.h:489)
==3029599==    by 0x29BF9C: cfunction_vectorcall_FASTCALL (methodobject.c:449)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
   fun:_imp_create_dynamic
   fun:cfunction_vectorcall_FASTCALL
}
==3029599== 10 bytes in 1 blocks are definitely lost in loss record 3 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x4A0A2CF: strdup (strdup.c:42)
==3029599==    by 0x99F09E3: ???
==3029599==    by 0x99F3D16: ???
==3029599==    by 0x9A05FED: ???
==3029599==    by 0x99FDB04: ???
==3029599==    by 0x99FDC97: ???
==3029599==    by 0x99FE1D5: ???
==3029599==    by 0x999F2D9: ???
==3029599==    by 0x998A1E9: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   fun:strdup
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
}
==3029599== 13 bytes in 1 blocks are definitely lost in loss record 4 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99A3ADD: ???
==3029599==    by 0x9990AF8: ???
==3029599==    by 0x998A215: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599==    by 0x3F3715: _imp_create_dynamic (import.c.h:489)
==3029599==    by 0x29BF9C: cfunction_vectorcall_FASTCALL (methodobject.c:449)
==3029599==    by 0x243EA6: _PyVectorcall_Call (call.c:273)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
   fun:_imp_create_dynamic
   fun:cfunction_vectorcall_FASTCALL
   fun:_PyVectorcall_Call
}
==3029599== 16 bytes in 1 blocks are definitely lost in loss record 5 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x998A30B: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599==    by 0x3F3715: _imp_create_dynamic (import.c.h:489)
==3029599==    by 0x29BF9C: cfunction_vectorcall_FASTCALL (methodobject.c:449)
==3029599==    by 0x243EA6: _PyVectorcall_Call (call.c:273)
==3029599==    by 0x24411A: _PyObject_Call (call.c:348)
==3029599==    by 0x244152: PyObject_Call (call.c:373)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
   fun:_imp_create_dynamic
   fun:cfunction_vectorcall_FASTCALL
   fun:_PyVectorcall_Call
   fun:_PyObject_Call
   fun:PyObject_Call
}
==3029599== 20 bytes in 1 blocks are definitely lost in loss record 6 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99A3ADD: ???
==3029599==    by 0x998D954: ???
==3029599==    by 0x99906A0: ???
==3029599==    by 0x9990BA4: ???
==3029599==    by 0x998A215: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599==    by 0x3F3715: _imp_create_dynamic (import.c.h:489)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
   fun:_imp_create_dynamic
}
==3029599== 22 bytes in 1 blocks are definitely lost in loss record 7 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99F368A: ???
==3029599==    by 0x99F3D01: ???
==3029599==    by 0x9A05FED: ???
==3029599==    by 0x99FDB04: ???
==3029599==    by 0x99FDC97: ???
==3029599==    by 0x99FE1D5: ???
==3029599==    by 0x999F2D9: ???
==3029599==    by 0x998A1E9: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
}
==3029599== 101 (32 direct, 69 indirect) bytes in 1 blocks are definitely lost in loss record 26 of 88
==3029599==    at 0x484CC13: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99F38C4: ???
==3029599==    by 0x9A05FED: ???
==3029599==    by 0x99FDB04: ???
==3029599==    by 0x99FDC97: ???
==3029599==    by 0x99FE1D5: ???
==3029599==    by 0x999F2D9: ???
==3029599==    by 0x998A1E9: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:calloc
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
}
==3029599== 256 bytes in 1 blocks are definitely lost in loss record 30 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99A3ADD: ???
==3029599==    by 0x998A467: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599==    by 0x3F3715: _imp_create_dynamic (import.c.h:489)
==3029599==    by 0x29BF9C: cfunction_vectorcall_FASTCALL (methodobject.c:449)
==3029599==    by 0x243EA6: _PyVectorcall_Call (call.c:273)
==3029599==    by 0x24411A: _PyObject_Call (call.c:348)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
   fun:_imp_create_dynamic
   fun:cfunction_vectorcall_FASTCALL
   fun:_PyVectorcall_Call
   fun:_PyObject_Call
}
==3029599== 2,032 bytes in 1 blocks are definitely lost in loss record 56 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99A3ADD: ???
==3029599==    by 0x999F55A: ???
==3029599==    by 0x998A1E9: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599==    by 0x3F3715: _imp_create_dynamic (import.c.h:489)
==3029599==    by 0x29BF9C: cfunction_vectorcall_FASTCALL (methodobject.c:449)
==3029599==    by 0x243EA6: _PyVectorcall_Call (call.c:273)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
   fun:_imp_create_dynamic
   fun:cfunction_vectorcall_FASTCALL
   fun:_PyVectorcall_Call
}
==3029599== 3,808 (1,536 direct, 2,272 indirect) bytes in 1 blocks are definitely lost in loss record 64 of 88
==3029599==    at 0x484CE40: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99A46D2: ???
==3029599==    by 0x997F465: ???
==3029599==    by 0x997F4C0: ???
==3029599==    by 0x998A207: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599==    by 0x3F3715: _imp_create_dynamic (import.c.h:489)
==3029599==    by 0x29BF9C: cfunction_vectorcall_FASTCALL (methodobject.c:449)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:realloc
   obj:*
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
   fun:_imp_create_dynamic
   fun:cfunction_vectorcall_FASTCALL
}
==3029599== 4,016 bytes in 1 blocks are definitely lost in loss record 65 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99A3ADD: ???
==3029599==    by 0x999CB1A: ???
==3029599==    by 0x996012F: setup_readline (readline.c:1363)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599==    by 0x3F3715: _imp_create_dynamic (import.c.h:489)
==3029599==    by 0x29BF9C: cfunction_vectorcall_FASTCALL (methodobject.c:449)
==3029599==    by 0x243EA6: _PyVectorcall_Call (call.c:273)
==3029599==    by 0x24411A: _PyObject_Call (call.c:348)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
   fun:_imp_create_dynamic
   fun:cfunction_vectorcall_FASTCALL
   fun:_PyVectorcall_Call
   fun:_PyObject_Call
}
==3029599== 4,080 bytes in 1 blocks are definitely lost in loss record 66 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99A3ADD: ???
==3029599==    by 0x999F53A: ???
==3029599==    by 0x998A1E9: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599==    by 0x3F3715: _imp_create_dynamic (import.c.h:489)
==3029599==    by 0x29BF9C: cfunction_vectorcall_FASTCALL (methodobject.c:449)
==3029599==    by 0x243EA6: _PyVectorcall_Call (call.c:273)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
   fun:_imp_create_dynamic
   fun:cfunction_vectorcall_FASTCALL
   fun:_PyVectorcall_Call
}
==3029599== 7,777 (760 direct, 7,017 indirect) bytes in 1 blocks are definitely lost in loss record 75 of 88
==3029599==    at 0x484CC13: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99FDC40: ???
==3029599==    by 0x99FE1D5: ???
==3029599==    by 0x999F2D9: ???
==3029599==    by 0x998A1E9: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599==    by 0x3F3715: _imp_create_dynamic (import.c.h:489)
==3029599==    by 0x29BF9C: cfunction_vectorcall_FASTCALL (methodobject.c:449)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:calloc
   obj:*
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
   fun:_imp_create_dynamic
   fun:cfunction_vectorcall_FASTCALL
}
==3029599== 7,952 bytes in 1 blocks are definitely lost in loss record 76 of 88
==3029599==    at 0x484CC13: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99F0398: ???
==3029599==    by 0x99F234E: ???
==3029599==    by 0x99F5C52: ???
==3029599==    by 0x999F313: ???
==3029599==    by 0x998A1E9: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599==    by 0x3F3715: _imp_create_dynamic (import.c.h:489)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:calloc
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
   fun:_imp_create_dynamic
}
==3029599== 41,120 (4,112 direct, 37,008 indirect) bytes in 1 blocks are definitely lost in loss record 85 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99A3ADD: ???
==3029599==    by 0x997D8F2: ???
==3029599==    by 0x997E7F8: ???
==3029599==    by 0x9989F0E: ???
==3029599==    by 0x9989FF6: ???
==3029599==    by 0x998A271: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
}
==3029599== 53,456 (4,112 direct, 49,344 indirect) bytes in 1 blocks are definitely lost in loss record 87 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99A3ADD: ???
==3029599==    by 0x997D8F2: ???
==3029599==    by 0x997E7F8: ???
==3029599==    by 0x9989F0E: ???
==3029599==    by 0x9989FF6: ???
==3029599==    by 0x998A292: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
}
==3029599== 78,128 (12,336 direct, 65,792 indirect) bytes in 3 blocks are definitely lost in loss record 88 of 88
==3029599==    at 0x48457A8: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3029599==    by 0x99A3ADD: ???
==3029599==    by 0x997D8F2: ???
==3029599==    by 0x997E7F8: ???
==3029599==    by 0x9990917: ???
==3029599==    by 0x9990BA4: ???
==3029599==    by 0x998A215: ???
==3029599==    by 0x996032A: setup_readline (readline.c:1450)
==3029599==    by 0x9961872: PyInit_readline (readline.c:1689)
==3029599==    by 0x3F6F15: _PyImport_RunModInitFunc (importdl.c:436)
==3029599==    by 0x3F288F: import_run_extension (import.c:2170)
==3029599==    by 0x3F3683: _imp_create_dynamic_impl (import.c:5532)
==3029599== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   obj:*
   fun:setup_readline
   fun:PyInit_readline
   fun:_PyImport_RunModInitFunc
   fun:import_run_extension
   fun:_imp_create_dynamic_impl
}
==3029599== LEAK SUMMARY:
==3029599==    definitely lost: 41,313 bytes in 19 blocks
==3029599==    indirectly lost: 161,502 bytes in 189 blocks
==3029599==      possibly lost: 26,993 bytes in 276 blocks
==3029599==    still reachable: 29 bytes in 1 blocks
==3029599==         suppressed: 51,284 bytes in 116 blocks
==3029599== Reachable blocks (those to which a pointer was found) are not shown.
==3029599== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==3029599== 
==3029599== For lists of detected and suppressed errors, rerun with: -s
==3029599== ERROR SUMMARY: 54 errors from 54 contexts (suppressed: 0 from 0)
```

</details>

The current suppression doesn't match because it's pinned to `obj:/lib/libreadline.so.4.3`, I suggest making it more general.