### PR TITLE
gh-151763: Fix OOM-0034 tokenizer offset error handling

### DIFF
--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -11,7 +11,7 @@ from io import BytesIO, StringIO
 from textwrap import dedent
 from unittest import TestCase, mock
 from test import support
-from test.support import os_helper
+from test.support import import_helper, os_helper
 from test.support.script_helper import run_test_script, make_script, run_python_until_end
 from test.support.numbers import (
     VALID_UNDERSCORE_LITERALS,
@@ -2265,6 +2265,67 @@ class CTokenizeTest(TestCase):
                     encoding=encoding,
                 ))
                 self.assertEqual(tokens, expected)
+
+    @unittest.skipIf(support.Py_TRACE_REFS,
+                     '_testcapi.set_nomemory() is unreliable with Py_TRACE_REFS')
+    def test_col_offset_conversion_oom(self):
+        import_helper.import_module('_testcapi')
+        code = dedent(r"""
+            import _testcapi
+            import _tokenize
+
+            def check_indented_name(start):
+                source = "if True:\n  \u00e9 = 1\n"
+                it = _tokenize.TokenizerIter(
+                    iter(source.splitlines(True)).__next__,
+                    extra_tokens=False,
+                )
+                for _ in range(5):
+                    next(it)
+
+                _testcapi.set_nomemory(start, start + 1)
+                try:
+                    next(it)
+                except MemoryError:
+                    return True
+                finally:
+                    _testcapi.remove_mem_hooks()
+                return False
+
+            def check_multiline_string(start):
+                source = "x = '''abc\ndef'''\n"
+                it = _tokenize.TokenizerIter(
+                    iter(source.splitlines(True)).__next__,
+                    extra_tokens=False,
+                )
+                next(it)
+                next(it)
+
+                _testcapi.set_nomemory(start, start + 1)
+                try:
+                    next(it)
+                except MemoryError:
+                    return True
+                finally:
+                    _testcapi.remove_mem_hooks()
+                return False
+
+            def check_range(name, func):
+                seen_memory_error = False
+                for index in range(20):
+                    if func(index):
+                        seen_memory_error = True
+                if not seen_memory_error:
+                    raise AssertionError(f"{name}: MemoryError not raised")
+
+            check_range("line", check_indented_name)
+            check_range("raw", check_multiline_string)
+            print("MemoryError")
+        """)
+        with support.SuppressCrashReport():
+            res, _ = run_python_until_end("-c", code)
+        self.assertEqual(res.rc, 0, res.err.decode("ascii", "replace"))
+        self.assertIn(b"MemoryError", res.out)
 
     def test_int(self):
 

--- a/Misc/NEWS.d/next/Library/2026-06-20-18-21-28.gh-issue-151763.OOM0034.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-20-18-21-28.gh-issue-151763.OOM0034.rst
@@ -1,0 +1,4 @@
+Fix a possible crash in ``_tokenize.TokenizerIter`` when memory allocation
+fails while converting byte offsets to character offsets for non-ASCII source
+lines. The tokenizer now correctly propagates ``MemoryError`` instead of
+dereferencing a NULL pointer or returning a result with an exception set.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -27,6 +27,9 @@ Py_ssize_t
 _PyPegen_byte_offset_to_character_offset_line(PyObject *line, Py_ssize_t col_offset, Py_ssize_t end_col_offset)
 {
     const unsigned char *data = (const unsigned char*)PyUnicode_AsUTF8(line);
+    if (data == NULL) {
+        return -1;
+    }
 
     Py_ssize_t len = 0;
     while (col_offset < end_col_offset) {

--- a/Python/Python-tokenize.c
+++ b/Python/Python-tokenize.c
@@ -202,21 +202,27 @@ _get_current_line(tokenizeriterobject *it, const char *line_start, Py_ssize_t si
     return line;
 }
 
-static void
+static int
 _get_col_offsets(tokenizeriterobject *it, struct token token, const char *line_start,
                  PyObject *line, int line_changed, Py_ssize_t lineno, Py_ssize_t end_lineno,
                  Py_ssize_t *col_offset, Py_ssize_t *end_col_offset)
 {
     _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(it);
     Py_ssize_t byte_offset = -1;
+    Py_ssize_t byte_col_offset_diff = it->byte_col_offset_diff;
     if (token.start != NULL && token.start >= line_start) {
         byte_offset = token.start - line_start;
         if (line_changed) {
-            *col_offset = _PyPegen_byte_offset_to_character_offset_line(line, 0, byte_offset);
-            it->byte_col_offset_diff = byte_offset - *col_offset;
+            Py_ssize_t offset = _PyPegen_byte_offset_to_character_offset_line(
+                line, 0, byte_offset);
+            if (offset < 0) {
+                return -1;
+            }
+            *col_offset = offset;
+            byte_col_offset_diff = byte_offset - *col_offset;
         }
         else {
-            *col_offset = byte_offset - it->byte_col_offset_diff;
+            *col_offset = byte_offset - byte_col_offset_diff;
         }
     }
 
@@ -226,17 +232,28 @@ _get_col_offsets(tokenizeriterobject *it, struct token token, const char *line_s
             // If the whole token is at the same line, we can just use the token.start
             // buffer for figuring out the new column offset, since using line is not
             // performant for very long lines.
-            Py_ssize_t token_col_offset = _PyPegen_byte_offset_to_character_offset_line(line, byte_offset, end_byte_offset);
+            Py_ssize_t token_col_offset = _PyPegen_byte_offset_to_character_offset_line(
+                line, byte_offset, end_byte_offset);
+            if (token_col_offset < 0) {
+                return -1;
+            }
             *end_col_offset = *col_offset + token_col_offset;
-            it->byte_col_offset_diff += token.end - token.start - token_col_offset;
+            byte_col_offset_diff += token.end - token.start - token_col_offset;
         }
         else {
-            *end_col_offset = _PyPegen_byte_offset_to_character_offset_raw(it->tok->line_start, end_byte_offset);
-            it->byte_col_offset_diff += end_byte_offset - *end_col_offset;
+            Py_ssize_t offset = _PyPegen_byte_offset_to_character_offset_raw(
+                it->tok->line_start, end_byte_offset);
+            if (offset < 0) {
+                return -1;
+            }
+            *end_col_offset = offset;
+            byte_col_offset_diff += end_byte_offset - *end_col_offset;
         }
     }
+    it->byte_col_offset_diff = byte_col_offset_diff;
     it->last_lineno = lineno;
     it->last_end_lineno = end_lineno;
+    return 0;
 }
 
 static PyObject *
@@ -301,8 +318,11 @@ tokenizeriter_next(PyObject *op)
     Py_ssize_t end_lineno = it->tok->lineno;
     Py_ssize_t col_offset = -1;
     Py_ssize_t end_col_offset = -1;
-    _get_col_offsets(it, token, line_start, line, line_changed,
-                     lineno, end_lineno, &col_offset, &end_col_offset);
+    if (_get_col_offsets(it, token, line_start, line, line_changed,
+                         lineno, end_lineno, &col_offset, &end_col_offset) < 0) {
+        Py_DECREF(str);
+        goto exit;
+    }
 
     if (it->tok->tok_extra_tokens) {
         if (is_trailing_token) {


### PR DESCRIPTION
# Summary

This PR addresses **[OOM-0034](https://gist.github.com/devdanzin/9871a21facf4c9c6a415e220f9d10762)** from gh-151763.

It fixes an out-of-memory (OOM) failure path in the tokenizer offset conversion logic that could lead to:

* a NULL pointer dereference (access violation), or
* a tokenizer result being returned while a `MemoryError` was still pending.

# Issue

`_PyPegen_byte_offset_to_character_offset_line()` in `Parser/pegen.c` calls `PyUnicode_AsUTF8()` and immediately dereferences the returned pointer.

Under memory-allocation failure, `PyUnicode_AsUTF8()` can return `NULL` with a pending `MemoryError`. The existing code did not check for this condition before accessing the returned buffer.

Example crash path:

```text
tokenizeriter_next()
└── _get_col_offsets()
    └── _PyPegen_byte_offset_to_character_offset_line()
        └── PyUnicode_AsUTF8()
            └── returns NULL under OOM
                └── NULL dereference
```

The issue was reproducible with `_testcapi.set_nomemory()` using non-ASCII source lines that require byte-offset to character-offset conversion.

# Reproduction

Using a CPython debug build and OOM injection:

```python
import _testcapi
import _tokenize

source = "if True:\n  \u00e9 = 1\n"

it = _tokenize.TokenizerIter(
    iter(source.splitlines(True)).__next__,
    extra_tokens=False,
)

for _ in range(5):
    next(it)

_testcapi.set_nomemory(2, 3)
next(it)
```

Observed result before the fix:

```text
Windows fatal exception: access violation
RC 3221225477
```

Further investigation showed that a helper-only NULL check was not sufficient.

`_get_col_offsets()` ignored failure returns from offset-conversion helpers, allowing `tokenizeriter_next()` to continue execution with a pending `MemoryError`.

This could also result in:

```text
SystemError:
<built-in function next> returned a result with an exception set
```

# Root Cause

Two independent problems existed:

1. `_PyPegen_byte_offset_to_character_offset_line()` did not check whether `PyUnicode_AsUTF8()` failed.

2. `_get_col_offsets()` ignored failures from:

   * `_PyPegen_byte_offset_to_character_offset_line()`
   * `_PyPegen_byte_offset_to_character_offset_raw()`

   As a result, tokenizer execution could continue after offset conversion had already failed.

# Fix

This PR:

* Adds a NULL check after `PyUnicode_AsUTF8()`.
* Returns `-1` when UTF-8 conversion fails.
* Changes `_get_col_offsets()` from `void` to `int`.
* Propagates failures from both offset-conversion helpers.
* Stops token generation immediately when offset conversion fails.
* Preserves the pending `MemoryError`.
* Avoids modifying tokenizer state when offset computation fails.

# Regression Tests

Adds regression coverage in `Lib/test/test_tokenize.py`.

The test:

* Uses `_testcapi.set_nomemory()` in a subprocess.
* Exercises the non-ASCII tokenizer path.
* Exercises the raw offset-conversion path.
* Sweeps allocation-failure indexes rather than relying on a single build-specific allocation point.
* Verifies that OOM conditions produce `MemoryError` instead of crashes or invalid tokenizer results.

# Validation

Built and tested using a CPython debug build:

```text
PCbuild\build.bat -p x64 -c Debug
```

Executed:

```text
PCbuild/amd64/python_d.exe -m test test_tokenize
```

Result:

```text
131 tests passed
```

Also verified:

```text
git diff --check
```

No whitespace errors were reported.

# Impact

This change converts tokenizer OOM crash paths into correct exception propagation and ensures that allocation failures during column-offset conversion are handled safely and consistently.

Addresses OOM-0034 from gh-151763.
