### PR TITLE
gh-144133: Add a warning to `encodings.punycode` documentation

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1399,6 +1399,14 @@ encodings.
 | punycode           |         | Implement :rfc:`3492`.    |
 |                    |         | Stateful codecs are not   |
 |                    |         | supported.                |
+|                    |         |                           |
+|                    |         | .. warning::              |
+|                    |         |                           |
+|                    |         |    The decoding and       |
+|                    |         |    encoding algorithms    |
+|                    |         |    scale poorly, so       |
+|                    |         |    limit the length of    |
+|                    |         |    untrusted input.       |
 +--------------------+---------+---------------------------+
 | raw_unicode_escape |         | Latin-1 encoding with     |
 |                    |         | :samp:`\\u{XXXX}` and     |


### PR DESCRIPTION
The RFC's reference algorithms have quadratic complexity, as it was designed only designed to handle the intended (limited) input, as described in [Section 6.4](https://datatracker.ietf.org/doc/html/rfc3492#section-6.4). While some implementations have avoided this general complexity by introducing caps (e.g. [ICU](https://github.com/unicode-org/icu/blob/177fbc931d8f7d929c077c2b2254b79a741a4fae/icu4c/source/common/punycode.cpp#L175)), that's a little too drastic for us to do. Rewriting the algorithms is complicated, and people have tried before, however they capitulate as in practice, with appropriate limits (the DNS label length limit is 63), this should not cause issues.

CC @kjd @malemburg 

<!-- gh-issue-number: gh-144133 -->
* Issue: gh-144133
<!-- /gh-issue-number -->
