### PR TITLE
gh-148268: Fix debug assertion in unsafe_*_compare sort helpers

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-20-12-00-00.gh-issue-148268.SrtAsFx.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-20-12-00-00.gh-issue-148268.SrtAsFx.rst
@@ -1,0 +1,3 @@
+Fix debug assertion failure in ``unsafe_latin_compare``,
+``unsafe_long_compare``, and ``unsafe_float_compare`` when
+:c:func:`PyObject_RichCompareBool` returns ``-1`` on error.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2830,7 +2830,10 @@ unsafe_latin_compare(PyObject *v, PyObject *w, MergeState *ms)
            res < 0 :
            PyUnicode_GET_LENGTH(v) < PyUnicode_GET_LENGTH(w));
 
-    assert(res == PyObject_RichCompareBool(v, w, Py_LT));;
+#ifndef NDEBUG
+    int cmp = PyObject_RichCompareBool(v, w, Py_LT);
+    assert(cmp < 0 || res == cmp);
+#endif
     return res;
 }
 
@@ -2855,7 +2858,10 @@ unsafe_long_compare(PyObject *v, PyObject *w, MergeState *ms)
     w0 = _PyLong_CompactValue(wl);
 
     res = v0 < w0;
-    assert(res == PyObject_RichCompareBool(v, w, Py_LT));
+#ifndef NDEBUG
+    int cmp = PyObject_RichCompareBool(v, w, Py_LT);
+    assert(cmp < 0 || res == cmp);
+#endif
     return res;
 }
 
@@ -2870,7 +2876,10 @@ unsafe_float_compare(PyObject *v, PyObject *w, MergeState *ms)
     assert(Py_IS_TYPE(w, &PyFloat_Type));
 
     res = PyFloat_AS_DOUBLE(v) < PyFloat_AS_DOUBLE(w);
-    assert(res == PyObject_RichCompareBool(v, w, Py_LT));
+#ifndef NDEBUG
+    int cmp = PyObject_RichCompareBool(v, w, Py_LT);
+    assert(cmp < 0 || res == cmp);
+#endif
     return res;
 }
 


### PR DESCRIPTION
The `assert` in `unsafe_latin_compare`, `unsafe_long_compare`, and `unsafe_float_compare` assumed `PyObject_RichCompareBool` always succeeds. It can return `-1` on error (like recursion depth), causing a false assertion failure in debug builds.

Using the pattern [suggested by Tim Peters](https://github.com/python/cpython/issues/148268#issuecomment-4209729732) and [StanFromIreland](https://github.com/python/cpython/issues/148268#issuecomment-4209703021):

```c
#ifndef NDEBUG
    int cmp = PyObject_RichCompareBool(v, w, Py_LT);
    assert(cmp < 0 || res == cmp);
#endif
```

This preserves the debug check while allowing the error return.

<!-- gh-issue-number: gh-148268 -->
* Issue: gh-148268
<!-- /gh-issue-number -->