### PR TITLE
gh-151815: Fix segfault in template_iter on allocation failure

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-20-14-00-00.gh-issue-151815.TmplIt.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-20-14-00-00.gh-issue-151815.TmplIt.rst
@@ -1,0 +1,2 @@
+Fix segfault in t-string iterator deallocation when :c:func:`PyObject_GetIter`
+fails during construction, caused by ``Py_CLEAR`` on uninitialized pointers.

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -226,6 +226,8 @@ template_iter(PyObject *op)
     if (iter == NULL) {
         return NULL;
     }
+    iter->stringsiter = NULL;
+    iter->interpolationsiter = NULL;
 
     PyObject *stringsiter = PyObject_GetIter(self->strings);
     if (stringsiter == NULL) {

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -222,23 +222,22 @@ static PyObject *
 template_iter(PyObject *op)
 {
     templateobject *self = templateobject_CAST(op);
-    templateiterobject *iter = PyObject_GC_New(templateiterobject, &_PyTemplateIter_Type);
-    if (iter == NULL) {
-        return NULL;
-    }
-    iter->stringsiter = NULL;
-    iter->interpolationsiter = NULL;
 
     PyObject *stringsiter = PyObject_GetIter(self->strings);
     if (stringsiter == NULL) {
-        Py_DECREF(iter);
         return NULL;
     }
 
     PyObject *interpolationsiter = PyObject_GetIter(self->interpolations);
     if (interpolationsiter == NULL) {
-        Py_DECREF(iter);
         Py_DECREF(stringsiter);
+        return NULL;
+    }
+
+    templateiterobject *iter = PyObject_GC_New(templateiterobject, &_PyTemplateIter_Type);
+    if (iter == NULL) {
+        Py_DECREF(stringsiter);
+        Py_DECREF(interpolationsiter);
         return NULL;
     }
 


### PR DESCRIPTION
`template_iter()` allocates a `templateiterobject` with `PyObject_GC_New` (which does not zero memory), but only assigns `stringsiter` and `interpolationsiter` after both `PyObject_GetIter` calls succeed. If either call fails, `Py_DECREF(iter)` runs `templateiter_clear`, which calls `Py_CLEAR` on uninitialized pointers, causing a segfault.

Fix: initialize both fields to `NULL` immediately after allocation so `Py_CLEAR` is safe on the error paths.

<!-- gh-issue-number: gh-151815 -->
* Issue: gh-151815
<!-- /gh-issue-number -->