### PR TITLE
[3.14] gh-150484: Fix mock_open __exit__ with contextlib.ExitStack

### DIFF
--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -2108,6 +2108,15 @@ class MockTest(unittest.TestCase):
         self.assertEqual([], h.readlines())
         self.assertEqual([], h.readlines())
 
+    def test_mock_open_exit_with_contextlib_exit_stack(self):
+        # gh-150484: mock_open's __exit__ should work when called from
+        # contextlib.ExitStack, which passes (exctype, excinst, exctb).
+        from contextlib import ExitStack
+        with mock.patch('builtins.open', mock.mock_open()) as m:
+            with ExitStack() as exit_stack:
+                with exit_stack.enter_context(open('/tmp/test.txt', 'w')):
+                    pass
+
     def test_mock_parents(self):
         for Klass in Mock, MagicMock:
             m = Klass()

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -3010,7 +3010,7 @@ def mock_open(mock=None, read_data=''):
             return handle.readline.return_value
         return next(_state[0])
 
-    def _exit_side_effect(exctype, excinst, exctb):
+    def _exit_side_effect(*args):
         handle.close()
 
     global file_spec

--- a/Misc/NEWS.d/next/Library/2026-05-28-00-00-00.gh-issue-150484.XxYyZz.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-28-00-00-00.gh-issue-150484.XxYyZz.rst
@@ -1,0 +1,1 @@
+Fix :func:`unittest.mock.mock_open` ``__exit__`` raising ``TypeError`` when used with :class:`contextlib.ExitStack`.


### PR DESCRIPTION
Fixes #150484.

`mock_open()`'s `__exit__` raises `TypeError` when used with `contextlib.ExitStack` because `_exit_side_effect` had a fixed 3-arg signature `(exctype, excinst, exctb)`, but `ExitStack.__exit__` calls it with 4 args `(self, exctype, excinst, exctb)`. Since the function body only calls `handle.close()` and doesn't use the arguments, the fix changes the signature to `*args`.

This is the 3.14 backport of #150521 (opened per request).

<!-- gh-issue-number: gh-150484 -->
* Issue: gh-150484
<!-- /gh-issue-number -->
