### PR TITLE
gh-151830: Raise ValueError instead of SystemError for invalid code objects in marshal.loads()

### DIFF
--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -142,8 +142,8 @@ class CodeTestCase(unittest.TestCase):
         self.assertEqual(co2.co_filename, "f2")
 
     def test_inconsistent_code_object(self):
-        # len(localsplusnames) must equal len(localspluskinds); marshal data that
-        # breaks this must raise ValueError, not a leaked SystemError (gh-151830).
+        # localsplusnames and localspluskinds must have equal length; if
+        # not, marshal must raise ValueError, not SystemError (gh-151830).
         co = compile("def f(a, b):\n x = a\n", "<test>", "exec").co_consts[0]
         n = len(co.co_varnames) + len(co.co_cellvars) + len(co.co_freevars)
         blob = marshal.dumps(co)

--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -144,22 +144,24 @@ class CodeTestCase(unittest.TestCase):
     def test_inconsistent_code_object(self):
         # localsplusnames and localspluskinds must have equal length; if
         # not, marshal must raise ValueError, not SystemError (gh-151830).
-        co = compile("def f(a, b):\n x = a\n", "<test>", "exec").co_consts[0]
+        co = compile("def f():\n a=1;b=2;c=3", "<test>", "exec").co_consts[0]
         n = len(co.co_varnames) + len(co.co_cellvars) + len(co.co_freevars)
         blob = marshal.dumps(co)
         # Find the localspluskinds record: the TYPE_STRING ('s') whose payload
         # is exactly n bytes long (one kind byte per localsplus name).
+        kinds = None
         for off in range(len(blob) - 5):
             if blob[off] == ord('s'):
                 if struct.unpack_from('<i', blob, off + 1)[0] == n:
                     kinds = blob[off + 5:off + 5 + n]
                     break
-        else:
-            self.fail("could not locate localspluskinds in marshal data")
+        # f's locals (a, b, c) are all plain fast locals (CO_FAST_LOCAL).
+        self.assertEqual(kinds, bytes([0x20]) * n)
         # Rewrite it with one fewer kind byte than there are names.
         corrupt = (blob[:off] + b's' + struct.pack('<i', n - 1)
                    + kinds[:n - 1] + blob[off + 5 + n:])
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(
+                ValueError, r'bad marshal data \(invalid code object\)'):
             marshal.loads(corrupt)
 
     def test_no_allow_code(self):

--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -4,6 +4,7 @@ from test.support.script_helper import assert_python_ok
 import array
 import io
 import marshal
+import struct
 import sys
 import unittest
 import os
@@ -139,6 +140,27 @@ class CodeTestCase(unittest.TestCase):
         co1, co2 = marshal.loads(marshal.dumps((co1, co2)))
         self.assertEqual(co1.co_filename, "f1")
         self.assertEqual(co2.co_filename, "f2")
+
+    def test_inconsistent_code_object(self):
+        # len(localsplusnames) must equal len(localspluskinds); marshal data that
+        # breaks this must raise ValueError, not a leaked SystemError (gh-151830).
+        co = compile("def f(a, b):\n x = a\n", "<test>", "exec").co_consts[0]
+        n = len(co.co_varnames) + len(co.co_cellvars) + len(co.co_freevars)
+        blob = marshal.dumps(co)
+        # Find the localspluskinds record: the TYPE_STRING ('s') whose payload
+        # is exactly n bytes long (one kind byte per localsplus name).
+        for off in range(len(blob) - 5):
+            if blob[off] == ord('s'):
+                if struct.unpack_from('<i', blob, off + 1)[0] == n:
+                    kinds = blob[off + 5:off + 5 + n]
+                    break
+        else:
+            self.fail("could not locate localspluskinds in marshal data")
+        # Rewrite it with one fewer kind byte than there are names.
+        corrupt = (blob[:off] + b's' + struct.pack('<i', n - 1)
+                   + kinds[:n - 1] + blob[off + 5 + n:])
+        with self.assertRaises(ValueError):
+            marshal.loads(corrupt)
 
     def test_no_allow_code(self):
         data = {'a': [({0},)]}

--- a/Misc/NEWS.d/next/Library/2026-06-21-11-46-23.gh-issue-151830.qvOe1f.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-21-11-46-23.gh-issue-151830.qvOe1f.rst
@@ -1,0 +1,3 @@
+Fixed :func:`marshal.loads` raising :exc:`SystemError` instead of
+:exc:`ValueError` for serialized data containing a code object with
+inconsistent internal fields.

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1670,6 +1670,10 @@ r_object(RFILE *p)
             };
 
             if (_PyCode_Validate(&con) < 0) {
+                if (PyErr_ExceptionMatches(PyExc_SystemError)) {
+                    PyErr_SetString(PyExc_ValueError,
+                        "bad marshal data (invalid code object)");
+                }
                 goto code_error;
             }
 


### PR DESCRIPTION

`marshal.loads()` already raises `ValueError` with a `"bad marshal data
(...)"` message for malformed input, but a code object whose internal fields
are inconsistent (for example a `localsplusnames` tuple whose length differs
from the `localspluskinds` bytes) makes `_PyCode_Validate()` call
`PyErr_BadInternalCall()`, which surfaces as
`SystemError: bad argument to internal function`. This converts that one
case to `ValueError: bad marshal data (invalid code object)`, so the
code-object path is consistent with marshal's existing bad-marshal-data
errors. The change is narrowly scoped to the `SystemError` from
`PyErr_BadInternalCall()` and leaves the other `_PyCode_Validate()` failures
(which already raise `ValueError`/`OverflowError`) unchanged.

A regression test was added to `Lib/test/test_marshal.py` and a NEWS entry
was added under `Misc/NEWS.d/`.


<!-- gh-issue-number: gh-151830 -->
* Issue: gh-151830
<!-- /gh-issue-number -->
