### PR TITLE
gh-151833: List additional documentation make targets

### DIFF
--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -79,6 +79,8 @@ Available make targets are:
 
 * "text", which builds a plain text file for each source file.
 
+* "texinfo", which builds Texinfo source files.
+
 * "epub", which builds an EPUB document, suitable to be viewed on e-book
   readers.
 
@@ -96,6 +98,10 @@ Available make targets are:
 * "pydoc-topics", which builds a Python module containing a dictionary with
   plain text documentation for the labels defined in
   ``tools/pyspecific.py`` -- pydoc needs these to show topic and keyword help.
+
+* "doctest", which runs doctests in the documentation.
+
+* "gettext", which generates gettext message catalog templates.
 
 * "check", which checks for frequent markup errors.
 


### PR DESCRIPTION
Closes #151833.

Doc/README.rst lists the available documentation make targets, but it did not mention `texinfo`, `doctest`, or `gettext`.

These targets are defined in `Doc/Makefile` and are part of the documentation build tooling. This change updates the README target list so it is more complete for contributors reading the documentation build instructions.

Validation performed:

- `make check` from `Doc/`
- `git diff --check`

This is a documentation-only change.


<!-- gh-issue-number: gh-151833 -->
* Issue: gh-151833
<!-- /gh-issue-number -->
