### PR TITLE
gh-151773: NULL-check token_new() in PyContextVar_Set

### DIFF
--- a/Misc/NEWS.d/next/Core/2026-06-21-16-00-00.gh-issue-151773.mN4kRt.rst
+++ b/Misc/NEWS.d/next/Core/2026-06-21-16-00-00.gh-issue-151773.mN4kRt.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`contextvars.ContextVar.set` when
+:func:`!token_new` fails under memory pressure.

--- a/Misc/NEWS.d/next/Core/2026-06-21-16-00-00.gh-issue-151773.mN4kRt.rst
+++ b/Misc/NEWS.d/next/Core/2026-06-21-16-00-00.gh-issue-151773.mN4kRt.rst
@@ -1,2 +1,0 @@
-Fix a crash in :func:`contextvars.ContextVar.set` when
-:func:`!token_new` fails under memory pressure.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-21-16-00-00.gh-issue-151773.mN4kRt.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-21-16-00-00.gh-issue-151773.mN4kRt.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`contextvars.ContextVar.set` when memory allocation
+fails.

--- a/Python/context.c
+++ b/Python/context.c
@@ -362,6 +362,9 @@ PyContextVar_Set(PyObject *ovar, PyObject *val)
     Py_XINCREF(old_val);
     PyContextToken *tok = token_new(ctx, var, old_val);
     Py_XDECREF(old_val);
+    if (tok == NULL) {
+        return NULL;
+    }
 
     if (contextvar_set(var, val)) {
         Py_DECREF(tok);


### PR DESCRIPTION
Fixes #151773.

`token_new()` can return NULL on OOM, but `PyContextVar_Set` went straight into `contextvar_set()` and then `Py_DECREF(tok)` on the error path. Added an early return when `tok` is NULL.


<!-- gh-issue-number: gh-151773 -->
* Issue: gh-151773
<!-- /gh-issue-number -->