### PR TITLE
gh-151842: Make _PyXI_FreeExcInfo NULL-safe to fix crash on capture_exception() OOM (OOM-0031)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-30-13-00-00.gh-issue-151842.OOM31g.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-30-13-00-00.gh-issue-151842.OOM31g.rst
@@ -1,5 +1,0 @@
-Fix a segfault in ``_interpreters.capture_exception()`` under memory
-pressure. When ``_PyXI_NewExcInfo()`` failed to allocate, the cleanup path
-called ``_PyXI_FreeExcInfo(NULL)``, which then dereferenced offset 0 in
-``_excinfo_clear_type()``. ``_PyXI_FreeExcInfo()`` now accepts ``NULL`` like
-the surrounding ``PyMem_RawFree`` idiom. Patch by Amrutha Modela.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-30-13-00-00.gh-issue-151842.OOM31g.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-30-13-00-00.gh-issue-151842.OOM31g.rst
@@ -1,4 +1,4 @@
-Fix a segfault in :func:`_interpreters.capture_exception` under memory
+Fix a segfault in ``_interpreters.capture_exception()`` under memory
 pressure. When ``_PyXI_NewExcInfo()`` failed to allocate, the cleanup path
 called ``_PyXI_FreeExcInfo(NULL)``, which then dereferenced offset 0 in
 ``_excinfo_clear_type()``. ``_PyXI_FreeExcInfo()`` now accepts ``NULL`` like

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-30-13-00-00.gh-issue-151842.OOM31g.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-30-13-00-00.gh-issue-151842.OOM31g.rst
@@ -1,0 +1,5 @@
+Fix a segfault in :func:`_interpreters.capture_exception` under memory
+pressure. When ``_PyXI_NewExcInfo()`` failed to allocate, the cleanup path
+called ``_PyXI_FreeExcInfo(NULL)``, which then dereferenced offset 0 in
+``_excinfo_clear_type()``. ``_PyXI_FreeExcInfo()`` now accepts ``NULL`` like
+the surrounding ``PyMem_RawFree`` idiom. Patch by Amrutha Modela.

--- a/Misc/NEWS.d/next/Library/2026-06-30-13-00-00.gh-issue-151842.OOM31g.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-30-13-00-00.gh-issue-151842.OOM31g.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`!_interpreters.capture_exception` when
+:exc:`MemoryError` happens. Patch by Amrutha Modela.

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -1541,7 +1541,9 @@ _interpreters_capture_exception_impl(PyObject *module, PyObject *exc_arg)
     }
 
 finally:
-    _PyXI_FreeExcInfo(info);
+    if (info != NULL) {
+        _PyXI_FreeExcInfo(info);
+    }
     if (exc != exc_arg) {
         if (PyErr_Occurred()) {
             PyErr_SetRaisedException(exc);

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -1709,6 +1709,11 @@ _PyXI_NewExcInfo(PyObject *exc)
 void
 _PyXI_FreeExcInfo(_PyXI_excinfo *info)
 {
+    if (info == NULL) {
+        // Matches the PyMem_RawFree(NULL) idiom: callers may pass NULL when
+        // _PyXI_NewExcInfo() failed (e.g. under OOM) before any allocation.
+        return;
+    }
     _PyXI_excinfo_clear(info);
     PyMem_RawFree(info);
 }

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -1689,6 +1689,7 @@ _PyXI_NewExcInfo(PyObject *exc)
     }
     _PyXI_excinfo *info = PyMem_RawCalloc(1, sizeof(_PyXI_excinfo));
     if (info == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     const char *failure;
@@ -1709,11 +1710,7 @@ _PyXI_NewExcInfo(PyObject *exc)
 void
 _PyXI_FreeExcInfo(_PyXI_excinfo *info)
 {
-    if (info == NULL) {
-        // Matches the PyMem_RawFree(NULL) idiom: callers may pass NULL when
-        // _PyXI_NewExcInfo() failed (e.g. under OOM) before any allocation.
-        return;
-    }
+    assert(info != NULL);
     _PyXI_excinfo_clear(info);
     PyMem_RawFree(info);
 }


### PR DESCRIPTION
Closes #151842 

### Summary

`_interpreters.capture_exception()` builds a `_PyXI_excinfo` via `_PyXI_NewExcInfo()`. Under memory pressure that allocation can fail and return `NULL`. The cleanup path in `_interpreters_capture_exception_impl` (`Modules/_interpretersmodule.c:1544`) then unconditionally calls `_PyXI_FreeExcInfo(info)` with `info == NULL`. `_PyXI_FreeExcInfo` has no NULL guard, so `_PyXI_excinfo_clear` → `_excinfo_clear_type` dereferences `&NULL->type` (offset 0) at `Python/crossinterp.c:1319` → SIGSEGV. This reproduces on all build configurations (a NULL dereference, not a debug-only assert).

Part of #151763 (OOM umbrella, OOM-0031).

### Reproducer

```python
import faulthandler, _interpreters
faulthandler.enable()
from _testcapi import set_nomemory, remove_mem_hooks
for start in range(0, 40):
    try:
        set_nomemory(start, 0)
        try:
            _interpreters.capture_exception(Exception())
        finally:
            remove_mem_hooks()
    except BaseException:
        pass
    finally:
        try: remove_mem_hooks()
        except Exception: pass
```

### Backtrace

```
#0  _excinfo_clear_type                  Python/crossinterp.c:1319   # info == 0x0 -> offset-0 deref
#1  _PyXI_excinfo_clear                  Python/crossinterp.c:1374
#2  _PyXI_FreeExcInfo                    Python/crossinterp.c:1712   # called with info == NULL, no guard
#3  _interpreters_capture_exception_impl Modules/_interpretersmodule.c:1544
```

### Fix

Make `_PyXI_FreeExcInfo` NULL-safe, matching the surrounding `PyMem_RawFree(NULL)` idiom (and `Py_XDECREF`, `free()`, etc.). This is more defensive than guarding only the one call site, since `_PyXI_FreeExcInfo` is part of the cross-interpreter exception ABI and any future caller would otherwise have the same hazard.

```c
void
_PyXI_FreeExcInfo(_PyXI_excinfo *info)
{
    if (info == NULL) {
        return;
    }
    _PyXI_excinfo_clear(info);
    PyMem_RawFree(info);
}
```

### Verification

- `test_interpreters` passes on the rebuilt binary (no regression in the success path).
- Per the discussion in #151773 (same umbrella), no OOM-injection regression test is added — those tests rely on internal allocation counts that need re-tuning across implementation changes. The fix should be verified by running the reproducer on a debug+ASan build.



<!-- gh-issue-number: gh-151842 -->
* Issue: gh-151842
<!-- /gh-issue-number -->
