### PR TITLE
gh-151845: Fix formatfloat() return-value contract in unicode_format.c

### DIFF
--- a/Objects/unicode_format.c
+++ b/Objects/unicode_format.c
@@ -159,8 +159,13 @@ formatfloat(PyObject *v,
             return -1;
         }
     }
-    else
+    else {
         *p_output = _PyUnicode_FromASCII(p, len);
+        if (*p_output == NULL) {
+            PyMem_Free(p);
+            return -1;
+        }
+    }
     PyMem_Free(p);
     return 0;
 }


### PR DESCRIPTION
As mentioned in the issue, this don't affected to callers and users, so /skip-news and don't requires a test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151845 -->
* Issue: gh-151845
<!-- /gh-issue-number -->
