### PR TITLE
gh-151847: Avoid undefined behaviour negating PY_SSIZE_T_MIN width in str/bytes formatting

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -318,6 +318,8 @@ class FormatTest(unittest.TestCase):
                         "format argument 1: too big for width")
         test_exc_common('%*r', (-2**1000, 1), OverflowError,
                         "format argument 1: too big for width")
+        test_exc_common('%*r', (-maxsize - 1, 1), OverflowError,
+                        "format argument 1: too big for width")
         test_exc_common('%.*r', (2**1000, 1), OverflowError,
                         "format argument 1: too big for precision")
         test_exc_common('%.*r', (-2**1000, 1), OverflowError,

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-21-23-23-24.gh-issue-151847.5uNKTL.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-21-23-23-24.gh-issue-151847.5uNKTL.rst
@@ -1,3 +1,3 @@
 When formatting a ``str`` or ``bytes`` with ``%``, passing ``-sys.maxsize -
-1`` as the width previously negated it, this is undefined behaviour in C. it
+1`` as the width previously negated it, this is undefined behaviour in C. It
 now raises :exc:`OverflowError`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-21-23-23-24.gh-issue-151847.5uNKTL.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-21-23-23-24.gh-issue-151847.5uNKTL.rst
@@ -1,0 +1,3 @@
+When formatting a ``str`` or ``bytes`` with ``%``, passing ``-sys.maxsize -
+1`` as the width previously negated it, this is undefined behaviour in C. it
+now raises :exc:`OverflowError`.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -803,6 +803,11 @@ _PyBytes_FormatEx(const char *format, Py_ssize_t format_len,
                 }
                 if (width < 0) {
                     flags |= F_LJUST;
+                    if (width < -PY_SSIZE_T_MAX) {
+                        FORMAT_ERROR(PyExc_OverflowError,
+                                     "too big for width%s", "");
+                        goto error;
+                    }
                     width = -width;
                 }
                 if (--fmtcnt >= 0)

--- a/Objects/unicode_format.c
+++ b/Objects/unicode_format.c
@@ -560,6 +560,10 @@ unicode_format_arg_parse(struct unicode_formatter_t *ctx,
         }
         if (arg->width < 0) {
             arg->flags |= F_LJUST;
+            if (arg->width < -PY_SSIZE_T_MAX) {
+                FORMAT_ERROR(PyExc_OverflowError, "too big for width%s", "");
+                return -1;
+            }
             arg->width = -arg->width;
         }
         if (--ctx->fmtcnt >= 0) {


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151847 -->
* Issue: gh-151847
<!-- /gh-issue-number -->
