### PR TITLE
gh-151857: Fix IndexError in the email header parser on empty input

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -580,6 +580,8 @@ class DisplayName(Phrase):
             return res.value
         if res[0].token_type == 'cfws':
             res.pop(0)
+            if len(res) == 0:
+                return res.value
         else:
             if (isinstance(res[0], TokenList) and
                     res[0][0].token_type == 'cfws'):
@@ -2511,7 +2513,7 @@ def get_parameter(value):
             param.append(ValueTerminal('*', 'extended-parameter-marker'))
             value = value[1:]
             param.extended = True
-    if value[0] != '=':
+    if not value or value[0] != '=':
         raise errors.HeaderParseError("Parameter not followed by '='")
     param.append(ValueTerminal('=', 'parameter-separator'))
     value = value[1:]

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -1862,6 +1862,16 @@ class TestParser(TestParserMixin, TestEmailBase):
             ':Foo ', '', '', [errors.InvalidHeaderDefect], ':Foo ')
         self.assertEqual(display_name.value, '')
 
+    def test_get_display_name_comment_only(self):
+        # A display name consisting only of a comment (CFWS) used to raise an
+        # uncaught IndexError; it now degrades to an empty display name.
+        display_name = self._test_get_x(
+            parser.get_display_name,
+            '(c)', '(c)', ' "" ',
+            [errors.InvalidHeaderDefect, errors.ObsoleteHeaderDefect], '')
+        self.assertEqual(display_name.display_name, '')
+        self.assertEqual(display_name.value, ' "" ')
+
     # get_name_addr
 
     def test_get_name_addr_angle_addr_only(self):
@@ -3144,6 +3154,32 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
             'r*=\'a\'"',
             [('r', '"')],
             [errors.InvalidHeaderDefect]*2),
+
+        # gh-151857: A parameter name ending with the extended marker
+        # '*' but with no value used to raise an uncaught IndexError instead
+        # of degrading to a defect.  Each case below IndexErrors unpatched.
+        'extended_marker_no_value': (
+            'name*',
+            '',
+            'name*',
+            [],
+            [errors.InvalidHeaderDefect]),
+
+        # Sectioned form ('*0*') reaches the same marker-consuming branch.
+        'extended_marker_no_value_sectioned': (
+            'name*0*',
+            '',
+            'name*0*',
+            [],
+            [errors.InvalidHeaderDefect]),
+
+        # A trailing marker-only parameter after a valid one.
+        'extended_marker_no_value_after_param': (
+            'x=1; name*',
+            ' x="1"',
+            'x=1; name*',
+            [('x', '1')],
+            [errors.InvalidHeaderDefect]),
     }
 
 @parameterize

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -1863,8 +1863,7 @@ class TestParser(TestParserMixin, TestEmailBase):
         self.assertEqual(display_name.value, '')
 
     def test_get_display_name_comment_only(self):
-        # A display name consisting only of a comment (CFWS) used to raise an
-        # uncaught IndexError; it now degrades to an empty display name.
+        # gh-151857: a comment-only (CFWS) display name raised IndexError.
         display_name = self._test_get_x(
             parser.get_display_name,
             '(c)', '(c)', ' "" ',
@@ -3155,9 +3154,8 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
             [('r', '"')],
             [errors.InvalidHeaderDefect]*2),
 
-        # gh-151857: A parameter name ending with the extended marker
-        # '*' but with no value used to raise an uncaught IndexError instead
-        # of degrading to a defect.  Each case below IndexErrors unpatched.
+        # gh-151857: a parameter name ending in the extended marker '*' with
+        # no value used to raise an uncaught IndexError instead of a defect.
         'extended_marker_no_value': (
             'name*',
             '',
@@ -3165,7 +3163,6 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
             [],
             [errors.InvalidHeaderDefect]),
 
-        # Sectioned form ('*0*') reaches the same marker-consuming branch.
         'extended_marker_no_value_sectioned': (
             'name*0*',
             '',
@@ -3173,7 +3170,6 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
             [],
             [errors.InvalidHeaderDefect]),
 
-        # A trailing marker-only parameter after a valid one.
         'extended_marker_no_value_after_param': (
             'x=1; name*',
             ' x="1"',

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -1426,6 +1426,16 @@ class TestAddressHeader(TestHeaderBase):
         self.assertIsInstance(h.groups, tuple)
         self.assertIsInstance(h.groups[0], Group)
 
+    def test_comment_only_group_display_name(self):
+        # A group whose display name is only a comment used to raise an
+        # uncaught IndexError while parsing; it now degrades gracefully.
+        h = self.make_header('to', '(c):')
+        self.assertEqual(h.groups[0].display_name, '')
+        self.assertEqual(h.addresses, ())
+        h = self.make_header('cc', '(x): a@b.com;')
+        self.assertEqual(h.groups[0].display_name, '')
+        self.assertEqual(h.addresses[0].addr_spec, 'a@b.com')
+
     def test_set_from_Address(self):
         h = self.make_header('to', Address('me', 'foo', 'example.com'))
         self.assertEqual(h, 'me <foo@example.com>')

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -1427,8 +1427,7 @@ class TestAddressHeader(TestHeaderBase):
         self.assertIsInstance(h.groups[0], Group)
 
     def test_comment_only_group_display_name(self):
-        # A group whose display name is only a comment used to raise an
-        # uncaught IndexError while parsing; it now degrades gracefully.
+        # gh-151857: a comment-only group display name raised IndexError.
         h = self.make_header('to', '(c):')
         self.assertEqual(h.groups[0].display_name, '')
         self.assertEqual(h.addresses, ())

--- a/Misc/NEWS.d/next/Library/2026-06-22-10-00-00.gh-issue-151857.3j9GAn.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-22-10-00-00.gh-issue-151857.3j9GAn.rst
@@ -1,0 +1,4 @@
+Fixed two cases where the :mod:`email` header parser (under
+:class:`~email.policy.EmailPolicy`) raised an uncaught :exc:`IndexError` on
+malformed input: a MIME parameter name ending with ``*``, and an address
+header whose display name is only a comment. Both now degrade gracefully.


### PR DESCRIPTION
Fixes two instances of a single bug class in the email header parser: an empty token-list/string is indexed and escapes as a bare `IndexError` rather than being handled as a parse defect.

1. **`get_parameter`** — a parameter name ending in the extended-parameter marker `*` with no value leaves `value` empty before `value[0]`. Guard: `if not value or value[0] != '='`.
2. **`DisplayName.display_name`** — a display name consisting only of a comment empties `res` after `res.pop(0)`, then `res[-1]` raised. Guard: early-return `res.value` (`''`) when `res` is empty after the pop, mirroring the pre-existing `len(res) == 0` guard.

Both now degrade gracefully (a parse defect / an empty display name).

**Surveyed both instances and closed the class:** a focused fuzz of malformed address and parameter headers — 23.5k structured combinations plus 100k randomized `message_from_string` parses under `email.policy.default` — shows no other non-`HeaderParseError` exception escaping the parser. The empty-string `IndexError` still produced by directly calling the low-level `get_*` token parsers is their documented non-empty precondition and is unreachable from public header parsing (every caller checks non-empty first).

Tests: regression tests for both instances at the parser level (`test__header_value_parser.py`) and via the public header API (`test_headerregistry.py`). The previous `name*; charset=utf-8` case did not actually exercise the regression — it raises `HeaderParseError` on both patched and unpatched code — and has been replaced with cases that `IndexError` unpatched (`name*0*`, `x=1; name*`).


<!-- gh-issue-number: gh-151857 -->
* Issue: gh-151857
<!-- /gh-issue-number -->
