### PR TITLE
gh-151862: Fix NULL deref on non-str AttributeError when unpickling

### DIFF
--- a/Lib/test/test_interpreters/test_queues.py
+++ b/Lib/test/test_interpreters/test_queues.py
@@ -382,10 +382,8 @@ class TestQueueOps(TestBase):
                 self.assertIsNot(obj, obj2)
 
     def _check_unpickle_attributeerror_arg(self, arg):
-        # Put an object whose class is then removed so that get() must
-        # unpickle it via a module __getattr__ that raises AttributeError
-        # with the given arg, then confirm get() raises NotShareableError
-        # without crashing.
+        # Cross an object through a queue where get() must re-import its
+        # class via a module __getattr__ that raises AttributeError(arg).
         source = dedent("""
             _attrerr_arg = None
 
@@ -408,22 +406,15 @@ class TestQueueOps(TestBase):
                 queue.get()
 
     def test_get_unpickle_fails_with_bad_attributeerror_arg(self):
-        # gh-151862: getting an object that fails to unpickle with an
-        # AttributeError whose first argument cannot be encoded to UTF-8
-        # used to crash (NULL dereference in check_missing___main___attr()).
-        # Two distinct branches NULL the PyUnicode_AsUTF8() result: a
-        # non-str arg (fails the type check) and a surrogate str (is unicode
-        # but fails UTF-8 encoding).
+        # gh-151862: an AttributeError arg that can't be UTF-8 encoded used
+        # to crash (NULL deref); covers both non-str and surrogate-str args.
         for arg in [42, b'x', None, '\ud800']:
             with self.subTest(arg=arg):
                 self._check_unpickle_attributeerror_arg(arg)
 
     def test_get_unpickle_fails_with_str_attributeerror_arg(self):
-        # Positive control: a normal str arg (including the genuine missing
-        # __main__ attribute message shape) must not crash and is handled
-        # normally.  This locks in the non-NULL strncmp() path so a future
-        # "skip the guard when the arg is a str" change cannot silently
-        # reintroduce the NULL dereference.
+        # Positive control: a normal str arg (incl. the real missing-__main__
+        # message) must not crash, locking in the non-NULL strncmp() path.
         for arg in ['boom', "module '__main__' has no attribute 'Thing'"]:
             with self.subTest(arg=arg):
                 self._check_unpickle_attributeerror_arg(arg)

--- a/Lib/test/test_interpreters/test_queues.py
+++ b/Lib/test/test_interpreters/test_queues.py
@@ -381,6 +381,53 @@ class TestQueueOps(TestBase):
                 self.assertEqual(obj, obj2)
                 self.assertIsNot(obj, obj2)
 
+    def _check_unpickle_attributeerror_arg(self, arg):
+        # Put an object whose class is then removed so that get() must
+        # unpickle it via a module __getattr__ that raises AttributeError
+        # with the given arg, then confirm get() raises NotShareableError
+        # without crashing.
+        source = dedent("""
+            _attrerr_arg = None
+
+            class Thing:
+                pass
+
+            def break_module(mod, arg):
+                del mod.Thing
+                mod._attrerr_arg = arg
+                def __getattr__(name):
+                    raise AttributeError(mod._attrerr_arg)
+                mod.__getattr__ = __getattr__
+            """)
+        with import_helper.ready_to_import('_xi_attrerr', source) as (name, _):
+            mod = importlib.import_module(name)
+            queue = queues.create()
+            queue.put(mod.Thing())
+            mod.break_module(mod, arg)
+            with self.assertRaises(interpreters.NotShareableError):
+                queue.get()
+
+    def test_get_unpickle_fails_with_bad_attributeerror_arg(self):
+        # gh-151862: getting an object that fails to unpickle with an
+        # AttributeError whose first argument cannot be encoded to UTF-8
+        # used to crash (NULL dereference in check_missing___main___attr()).
+        # Two distinct branches NULL the PyUnicode_AsUTF8() result: a
+        # non-str arg (fails the type check) and a surrogate str (is unicode
+        # but fails UTF-8 encoding).
+        for arg in [42, b'x', None, '\ud800']:
+            with self.subTest(arg=arg):
+                self._check_unpickle_attributeerror_arg(arg)
+
+    def test_get_unpickle_fails_with_str_attributeerror_arg(self):
+        # Positive control: a normal str arg (including the genuine missing
+        # __main__ attribute message shape) must not crash and is handled
+        # normally.  This locks in the non-NULL strncmp() path so a future
+        # "skip the guard when the arg is a str" change cannot silently
+        # reintroduce the NULL dereference.
+        for arg in ['boom', "module '__main__' has no attribute 'Thing'"]:
+            with self.subTest(arg=arg):
+                self._check_unpickle_attributeerror_arg(arg)
+
     def test_put_get_same_interpreter(self):
         interp = interpreters.create()
         interp.exec(dedent("""

--- a/Lib/test/test_interpreters/test_queues.py
+++ b/Lib/test/test_interpreters/test_queues.py
@@ -1,6 +1,8 @@
 import importlib
 import pickle
+import sys
 import threading
+import types
 from textwrap import dedent
 import unittest
 
@@ -382,28 +384,25 @@ class TestQueueOps(TestBase):
                 self.assertIsNot(obj, obj2)
 
     def _check_unpickle_attributeerror_arg(self, arg):
-        # Cross an object through a queue where get() must re-import its
-        # class via a module __getattr__ that raises AttributeError(arg).
-        source = dedent("""
-            _attrerr_arg = None
-
-            class Thing:
-                pass
-
-            def break_module(mod, arg):
-                del mod.Thing
-                mod._attrerr_arg = arg
-                def __getattr__(name):
-                    raise AttributeError(mod._attrerr_arg)
-                mod.__getattr__ = __getattr__
-            """)
-        with import_helper.ready_to_import('_xi_attrerr', source) as (name, _):
-            mod = importlib.import_module(name)
-            queue = queues.create()
-            queue.put(mod.Thing())
-            mod.break_module(mod, arg)
-            with self.assertRaises(interpreters.NotShareableError):
-                queue.get()
+        # Put an object through a queue where get() must re-import its class
+        # via a module __getattr__ that raises AttributeError(arg).
+        modname = '_test_xi_attrerr'
+        mod = types.ModuleType(modname)
+        class Thing:
+            pass
+        Thing.__module__ = modname
+        Thing.__qualname__ = 'Thing'
+        mod.Thing = Thing
+        sys.modules[modname] = mod
+        self.addCleanup(sys.modules.pop, modname, None)
+        queue = queues.create()
+        queue.put(Thing())
+        del mod.Thing
+        def raise_attributeerror(name):
+            raise AttributeError(arg)
+        mod.__getattr__ = raise_attributeerror
+        with self.assertRaises(interpreters.NotShareableError):
+            queue.get()
 
     def test_get_unpickle_fails_with_bad_attributeerror_arg(self):
         # gh-151862: an AttributeError arg that can't be UTF-8 encoded used
@@ -413,11 +412,10 @@ class TestQueueOps(TestBase):
                 self._check_unpickle_attributeerror_arg(arg)
 
     def test_get_unpickle_fails_with_str_attributeerror_arg(self):
-        # Positive control: a normal str arg (incl. the real missing-__main__
-        # message) must not crash, locking in the non-NULL strncmp() path.
-        for arg in ['boom', "module '__main__' has no attribute 'Thing'"]:
-            with self.subTest(arg=arg):
-                self._check_unpickle_attributeerror_arg(arg)
+        # Positive control: a normal str arg must not crash, locking in the
+        # non-NULL strncmp() path.
+        with self.subTest(arg='boom'):
+            self._check_unpickle_attributeerror_arg('boom')
 
     def test_put_get_same_interpreter(self):
         interp = interpreters.create()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-21-12-00-00.gh-issue-151862.Xq7vTm.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-21-12-00-00.gh-issue-151862.Xq7vTm.rst
@@ -1,0 +1,3 @@
+Fixed a crash (``NULL`` dereference) when an object passed between
+interpreters via :mod:`concurrent.interpreters` fails to unpickle with an
+:exc:`AttributeError` whose first argument is not a string.

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -664,6 +664,11 @@ check_missing___main___attr(PyObject *exc)
         }
     }
     const char *err = PyUnicode_AsUTF8(msgobj);
+    if (err == NULL) {
+        PyErr_Clear();
+        Py_DECREF(msgobj);
+        return 0;
+    }
 
     // Check if it's a missing __main__ attr.
     int cmp = strncmp(err, "module '__main__' has no attribute '", 36);


### PR DESCRIPTION
`Python/crossinterp.c`'s `check_missing___main___attr()` passed the result of `PyUnicode_AsUTF8()` straight to `strncmp()` without a `NULL` check. `msgobj` is `args[0]` of an `AttributeError` raised on the receive side of the cross-interpreter pickle fallback (a `concurrent.interpreters` queue or channel). When `args[0]` is not a `str` (`AttributeError(42)`, `AttributeError(b'x')`, `AttributeError(None)`) or is a `str` with lone surrogates (`AttributeError('\ud800')`), `PyUnicode_AsUTF8()` returns `NULL` and `strncmp(NULL, ...)` crashes the interpreter.

This adds a `NULL` guard matching the checked sibling helper `_copy_string_obj_raw()`. Because `PyUnicode_AsUTF8` sets an exception on failure and the function asserts `!PyErr_Occurred()` on entry, the guard clears it, `Py_DECREF(msgobj)` (mirroring the success-path decref), and returns 0 (not a missing-`__main__` attribute), so the failure degrades to the normal `NotShareableError`.

A regression test is added in `Lib/test/test_interpreters/test_queues.py` covering all four `args[0]` shapes (`42`, `b'x'`, `None`, `'\ud800'` — the surrogate case is a distinct branch: `args[0]` is unicode but fails UTF-8 encoding), plus a positive control with normal `str` args (including the genuine missing-`__main__`-attribute message shape) to lock in the non-`NULL` `strncmp()` path. Without the fix the test crashes; with it the queue raises `NotShareableError`.

This fixes the `check_missing___main___attr()` crash reached through the queue/channel receive path. A separate crash on the `Interpreter.call()` result-preserve path is reported independently.


<!-- gh-issue-number: gh-151862 -->
* Issue: gh-151862
<!-- /gh-issue-number -->
