### PR TITLE
gh-151876: Add tkinter Canvas methods rotate and rchars

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -3648,6 +3648,15 @@ Widget classes
       *yOrigin* changes by a factor of *yScale* (a factor of ``1.0`` leaves the
       coordinate unchanged).
 
+   .. method:: rotate(tagOrId, xOrigin, yOrigin, angle, /)
+
+      Rotate the coordinates of all items given by *tagOrId* in canvas
+      coordinate space about the origin (*xOrigin*, *yOrigin*) by *angle*
+      degrees anticlockwise.
+      Negative values of *angle* rotate clockwise.
+
+      .. versionadded:: next
+
    .. method:: delete(*tagOrIds)
 
       Delete each of the items given by the *tagOrIds* arguments.
@@ -3666,6 +3675,17 @@ Widget classes
       character or coordinate whose index is *beforeThis*.
       For line and polygon items *string* must be a valid sequence of
       coordinates.
+
+   .. method:: rchars(tagOrId, first, last, string, /)
+
+      Replace the characters (for text items) or coordinates (for line and
+      polygon items) in the range from *first* to *last* inclusive of each of
+      the items given by *tagOrId* with *string*.
+      For line and polygon items *string* must be a valid sequence of
+      coordinates.
+      Items that do not support indexing ignore this operation.
+
+      .. versionadded:: next
 
    .. method:: itemcget(tagOrId, option)
 

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -157,6 +157,11 @@ tkinter
   synchronization of the displayed view with the underlying text.
   (Contributed by Serhiy Storchaka in :gh:`151675`.)
 
+* Added new :class:`!tkinter.Canvas` methods :meth:`~tkinter.Canvas.rchars`
+  which replaces the text or coordinates of canvas items, and
+  :meth:`~tkinter.Canvas.rotate` which rotates the coordinates of canvas items.
+  (Contributed by Serhiy Storchaka in :gh:`151876`.)
+
 xml
 ---
 

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -1390,6 +1390,34 @@ class CanvasTest(AbstractWidgetTest, unittest.TestCase):
         self.assertRaises(TclError, c.scale, rect, 0, 0, 'spam', 2)
         self.assertRaises(TclError, c.scale, rect, 0, 0)  # missing factors
 
+    @requires_tk(8, 6)
+    def test_rchars(self):
+        c = self.create()
+        # On a line item, rchars replaces a range of the coordinate list.
+        line = c.create_line(0, 0, 10, 10, 20, 0)
+        c.rchars(line, 2, 5, (30, 30, 40, 40))
+        self.assertEqual(c.coords(line), [0.0, 0.0, 30.0, 30.0, 40.0, 40.0])
+        # On a text item, rchars replaces a range of characters.
+        text = c.create_text(10, 10, text='hello')
+        c.rchars(text, 0, 2, 'HE')
+        self.assertEqual(c.itemcget(text, 'text'), 'HElo')
+        self.assertRaises(TclError, c.rchars)
+
+    @requires_tk(9, 0)
+    def test_rotate(self):
+        c = self.create()
+        line = c.create_line(10, 0, 20, 0)
+        # The canvas y-axis points down, so an anticlockwise rotation about
+        # the origin maps (x, y) to (y, -x).
+        c.rotate(line, 0, 0, 90)
+        for got, expected in zip(c.coords(line), [0, -10, 0, -20]):
+            self.assertAlmostEqual(got, expected, places=3)
+        # A negative angle rotates clockwise, restoring the original position.
+        c.rotate(line, 0, 0, -90)
+        for got, expected in zip(c.coords(line), [10, 0, 20, 0]):
+            self.assertAlmostEqual(got, expected, places=3)
+        self.assertRaises(TclError, c.rotate, line, 0, 0, 'spam')
+
     def test_delete(self):
         c = self.create()
         r1 = c.create_rectangle(10, 10, 30, 30)

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3226,6 +3226,22 @@ class Canvas(Widget, XView, YView):
 
     lift = tkraise = tag_raise
 
+    def rchars(self, *args):
+        """Replace the text or coordinates between indices FIRST and LAST of
+        the items identified by TAGORID with STRING.
+
+        Text items replace their text; line and polygon items replace their
+        coordinates, in which case STRING is a list of coordinates. Other
+        items ignore this operation."""
+        self.tk.call((self._w, 'rchars') + args)
+
+    def rotate(self, *args): # new in Tk 9.0
+        """Rotate the coordinates of the items identified by TAGORID about the
+        origin (XORIGIN, YORIGIN) by ANGLE degrees anticlockwise.
+
+        Negative values of ANGLE rotate clockwise."""
+        self.tk.call((self._w, 'rotate') + args)
+
     def scale(self, *args):
         """Scale item TAGORID with XORIGIN, YORIGIN, XSCALE, YSCALE."""
         self.tk.call((self._w, 'scale') + args)

--- a/Misc/NEWS.d/next/Library/2026-06-22-00-55-07.gh-issue-151876.sVe0xx.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-22-00-55-07.gh-issue-151876.sVe0xx.rst
@@ -1,0 +1,2 @@
+Add the :class:`tkinter.Canvas` methods :meth:`!rchars` and :meth:`!rotate`,
+wrapping the ``rchars`` and ``rotate`` Tk canvas commands.


### PR DESCRIPTION
Wrap two Tk canvas widget commands that previously had no tkinter wrapper and were reachable only through ``tk.call()``.

* ``Canvas.rchars()`` wraps ``rchars`` (since Tk 8.6): it replaces the characters (for text items) or coordinates (for line and polygon items) in a given index range with a new value, complementing the existing :meth:`!dchars` and :meth:`!insert` methods.
* ``Canvas.rotate()`` wraps ``rotate`` (new in Tk 9.0): it rotates the coordinates of items about an origin by a given angle (anticlockwise; negative values rotate clockwise), complementing the existing :meth:`!move` and :meth:`!scale` methods.

``rchars`` is tested on Tk 8.6 and newer; ``rotate`` is covered by a test gated on ``@requires_tk(9, 0)``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-151876 -->
* Issue: gh-151876
<!-- /gh-issue-number -->
