### PR TITLE
gh-151878: Add tkinter Entry and Spinbox validate methods

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -4141,6 +4141,14 @@ Widget classes
       Typically associated with mouse motion events, to produce the effect of
       dragging the entry at high speed through the window.
 
+   .. method:: validate()
+
+      Force an evaluation of the command given by the *validatecommand* option,
+      independently of the conditions specified by the *validate* option, and
+      return whether the value is considered valid.
+
+      .. versionadded:: next
+
 
 .. class:: Frame(master=None, cnf={}, **kw)
 
@@ -5068,6 +5076,14 @@ Widget classes
       the most recent anchor point.
 
       .. versionadded:: 3.8
+
+   .. method:: validate()
+
+      Force an evaluation of the command given by the *validatecommand* option,
+      independently of the conditions specified by the *validate* option, and
+      return whether the value is considered valid.
+
+      .. versionadded:: next
 
 
 

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -157,6 +157,11 @@ tkinter
   synchronization of the displayed view with the underlying text.
   (Contributed by Serhiy Storchaka in :gh:`151675`.)
 
+* Added a :meth:`!validate` method to the :class:`!tkinter.Entry` and
+  :class:`!tkinter.Spinbox` widgets, which forces an evaluation of the
+  validation command.
+  (Contributed by Serhiy Storchaka in :gh:`151878`.)
+
 xml
 ---
 

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -589,6 +589,25 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
         self.assertRaisesRegex(TclError, 'bad entry index "xyz"',
                                widget.select_range, 'xyz', 'end')
 
+    def test_validate(self):
+        calls = []
+        def validatecommand(value):
+            calls.append(value)
+            return value.isdigit()
+        # validate='none' means validation is never triggered automatically,
+        # so validate() exercises the forced evaluation.
+        widget = self.create(validate='none',
+                validatecommand=(self.root.register(validatecommand), '%P'))
+        widget.insert(0, '123')
+        result = widget.validate()
+        self.assertIs(result, True)
+        self.assertEqual(calls, ['123'])
+        widget.delete(0, 'end')
+        widget.insert(0, 'abc')
+        calls.clear()
+        self.assertIs(widget.validate(), False)
+        self.assertEqual(calls, ['abc'])
+
 
 @add_configure_tests(StandardOptionsTests)
 class SpinboxTest(EntryTest, unittest.TestCase):

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3401,6 +3401,14 @@ class Entry(Widget, XView):
 
     select_to = selection_to
 
+    def validate(self):
+        """Force an evaluation of the validation command.
+
+        This evaluates the command given by the validatecommand option,
+        independently of the conditions specified by the validate option.
+        Return whether the value is considered valid."""
+        return self.tk.getboolean(self.tk.call(self._w, 'validate'))
+
 
 class Frame(Widget):
     """Frame widget which may contain other widgets and can have a 3D border."""
@@ -4912,6 +4920,14 @@ class Spinbox(Widget, XView):
     def selection_to(self, index):
         """Set the variable end of a selection to INDEX."""
         self.selection('to', index)
+
+    def validate(self):
+        """Force an evaluation of the validation command.
+
+        This evaluates the command given by the validatecommand option,
+        independently of the conditions specified by the validate option.
+        Return whether the value is considered valid."""
+        return self.tk.getboolean(self.tk.call(self._w, 'validate'))
 
 ###########################################################################
 

--- a/Misc/NEWS.d/next/Library/2026-06-22-01-02-33.gh-issue-151878.IFIA5C.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-22-01-02-33.gh-issue-151878.IFIA5C.rst
@@ -1,0 +1,3 @@
+Add the :meth:`!validate` method to the :class:`tkinter.Entry` and
+:class:`tkinter.Spinbox` widgets, forcing an evaluation of the validation
+command.


### PR DESCRIPTION
Wrap the Tk ``validate`` widget command of the entry and spinbox widgets, which previously had no tkinter wrapper and was reachable only through ``tk.call()``.

``Entry.validate()`` and ``Spinbox.validate()`` force an evaluation of the command given by the ``validatecommand`` option, independently of the conditions specified by the ``validate`` option (by temporarily setting ``validate`` to ``all``), and return whether the value is considered valid.

The command is available since Tk 8.5, so no version guard is needed. The shared test in ``EntryTest`` is inherited by ``SpinboxTest``, covering both widgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-151878 -->
* Issue: gh-151878
<!-- /gh-issue-number -->
