### PR TITLE
gh-151888: Add tkinter PhotoImage.redither method

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -5860,6 +5860,14 @@ Image classes
       it is displayed as transparent and the background of whatever window it
       is displayed in shows through.
 
+   .. method:: redither()
+
+      Recalculate the dithered image in each window where it is displayed.
+      This is useful when the image data was supplied in pieces, in which case
+      the dithered image may not be exactly correct.
+
+      .. versionadded:: next
+
    .. method:: cget(option)
 
       Return the current value of the configuration option *option*.

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -157,6 +157,10 @@ tkinter
   synchronization of the displayed view with the underlying text.
   (Contributed by Serhiy Storchaka in :gh:`151675`.)
 
+* Added the :meth:`~tkinter.PhotoImage.redither` method which recalculates the
+  dithered image when its data was supplied in pieces.
+  (Contributed by Serhiy Storchaka in :gh:`151888`.)
+
 xml
 ---
 

--- a/Lib/test/test_tkinter/test_images.py
+++ b/Lib/test/test_tkinter/test_images.py
@@ -311,6 +311,12 @@ class PhotoImageTest(BaseImageTest, AbstractTkTest, unittest.TestCase):
         self.assertEqual(image.height(), 16)
         self.assertEqual(image.get(4, 6), self.colorlist(0, 0, 0))
 
+    def test_redither(self):
+        image = self.create()
+        pixel = image.get(4, 6)
+        image.redither()  # Recalculates the dithering; the data is unchanged.
+        self.assertEqual(image.get(4, 6), pixel)
+
     def test_copy(self):
         image = self.create()
         image2 = image.copy()

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -4469,6 +4469,13 @@ class PhotoImage(Image):
         """Display a transparent image."""
         self.tk.call(self.name, 'blank')
 
+    def redither(self):
+        """Recalculate the dithered image in each window where it is displayed.
+
+        Useful when the image data was supplied in pieces, in which case the
+        dithered image may not be exactly correct."""
+        self.tk.call(self.name, 'redither')
+
     def cget(self, option):
         """Return the value of OPTION."""
         return self.tk.call(self.name, 'cget', '-' + option)

--- a/Misc/NEWS.d/next/Library/2026-06-22-01-57-55.gh-issue-151888.hO7mxi.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-22-01-57-55.gh-issue-151888.hO7mxi.rst
@@ -1,0 +1,2 @@
+Add the :meth:`!tkinter.PhotoImage.redither` method, wrapping the photo image
+``redither`` Tk command.


### PR DESCRIPTION
Wrap the photo image ``redither`` Tk command (since Tk 8.5), which previously had no tkinter wrapper and was reachable only through ``tk.call()``.

``PhotoImage.redither()`` recalculates the dithered image in each window where it is displayed. This is useful when the image data was supplied in pieces, in which case the dithered image may not be exactly correct.

This completes the wrapping of the photo image subcommands. The command is available on the bundled Tk, so no version guard is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-151888 -->
* Issue: gh-151888
<!-- /gh-issue-number -->
