### PR TITLE
gh-130821: Add type info to error messages for __len__ and __sizeof__

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-22-10-39-56.gh-issue-130821.b5e011.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-22-10-39-56.gh-issue-130821.b5e011.rst
@@ -1,0 +1,2 @@
+Add type information to error messages for ``__len__()`` and ``__sizeof__()``.
+Patch by tangyuan0821.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -10625,8 +10625,8 @@ slot_sq_length(PyObject *self)
     assert(PyLong_Check(res));
     if (_PyLong_IsNegative((PyLongObject *)res)) {
         Py_DECREF(res);
-        PyErr_SetString(PyExc_ValueError,
-                        "__len__() should return >= 0");
+        PyErr_Format(PyExc_ValueError,
+                        "%T.__len__() must return >= 0", self);
         return -1;
     }
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1933,8 +1933,8 @@ _PySys_GetSizeOf(PyObject *o)
         return (size_t)-1;
 
     if (size < 0) {
-        _PyErr_SetString(tstate, PyExc_ValueError,
-                          "__sizeof__() should return >= 0");
+        _PyErr_Format(tstate, PyExc_ValueError,
+                          "%T.__sizeof__() must return >= 0", o);
         return (size_t)-1;
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Update two more ValueError messages to use the consistent format established in PR #130835 (commit 968f6e523a), which added %T type prefix and normalized should → must for invalid return type errors. These two locations were not covered by the original PR or the subsequent follow-ups #144827 and #144737.

Changes:

- Objects/typeobject.c — slot_sq_length: "__len__() should return >= 0" → "%T.__len__() must return >= 0"
- Python/sysmodule.c — __sizeof__ error: "__sizeof__() should return >= 0" → "%T.__sizeof__() must return >= 0"

<!-- gh-issue-number: gh-130821 -->
* Issue: gh-130821
<!-- /gh-issue-number -->
