### PR TITLE
gh-151895: Fix marshal.loads() crash on dict reference-tracking failure

### DIFF
--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -449,6 +449,34 @@ class BugsTestCase(unittest.TestCase):
             with self.subTest(data=data):
                 self.assertRaises(ValueError, marshal.loads, data)
 
+    @support.cpython_only
+    @unittest.skipUnless(_testcapi, 'requires _testcapi')
+    @unittest.skipIf(support.Py_TRACE_REFS,
+                     'Py_TRACE_REFS conflicts with _testcapi.set_nomemory')
+    def test_loads_dict_no_memory(self):
+        # gh-151895: loading a reference-tracked dict used to crash when the
+        # allocation that registers it in the reference list failed.
+        data = b'\xfbi\x01\x00\x00\x00i\x02\x00\x00\x000'  # {1: 2}, FLAG_REF
+        self.assertEqual(marshal.loads(data), {1: 2})
+        # The reference-list allocation fails early; 16 is ample headroom.
+        for index in range(16):
+            with self.subTest(index=index):
+                # Capture the outcome before touching memory again: any
+                # allocation made by an assertion would also fail while the
+                # nomemory hook is active.
+                result = error = None
+                _testcapi.set_nomemory(index, index + 1)
+                try:
+                    result = marshal.loads(data)
+                except MemoryError as exc:
+                    error = exc
+                finally:
+                    _testcapi.remove_mem_hooks()
+                if error is None:
+                    self.assertEqual(result, {1: 2})
+        # The interpreter must still be healthy after the sweep.
+        self.assertEqual(marshal.loads(data), {1: 2})
+
     def test_exact_type_match(self):
         # Former bug:
         #   >>> class Int(int): pass

--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -449,32 +449,6 @@ class BugsTestCase(unittest.TestCase):
             with self.subTest(data=data):
                 self.assertRaises(ValueError, marshal.loads, data)
 
-    @support.cpython_only
-    @unittest.skipUnless(_testcapi, 'requires _testcapi')
-    @unittest.skipIf(support.Py_TRACE_REFS,
-                     'Py_TRACE_REFS conflicts with _testcapi.set_nomemory')
-    def test_loads_dict_no_memory(self):
-        # gh-151895: loading a reference-tracked dict used to crash when the
-        # allocation that registers it in the reference list failed.
-        data = b'\xfbi\x01\x00\x00\x00i\x02\x00\x00\x000'  # {1: 2}, FLAG_REF
-        self.assertEqual(marshal.loads(data), {1: 2})
-        for index in range(16):
-            with self.subTest(index=index):
-                # Capture the outcome first: an assertion would itself
-                # allocate and fail while the nomemory hook is active.
-                result = error = None
-                _testcapi.set_nomemory(index, index + 1)
-                try:
-                    result = marshal.loads(data)
-                except MemoryError as exc:
-                    error = exc
-                finally:
-                    _testcapi.remove_mem_hooks()
-                if error is None:
-                    self.assertEqual(result, {1: 2})
-        # The interpreter must still be healthy after the sweep.
-        self.assertEqual(marshal.loads(data), {1: 2})
-
     def test_exact_type_match(self):
         # Former bug:
         #   >>> class Int(int): pass

--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -458,12 +458,10 @@ class BugsTestCase(unittest.TestCase):
         # allocation that registers it in the reference list failed.
         data = b'\xfbi\x01\x00\x00\x00i\x02\x00\x00\x000'  # {1: 2}, FLAG_REF
         self.assertEqual(marshal.loads(data), {1: 2})
-        # The reference-list allocation fails early; 16 is ample headroom.
         for index in range(16):
             with self.subTest(index=index):
-                # Capture the outcome before touching memory again: any
-                # allocation made by an assertion would also fail while the
-                # nomemory hook is active.
+                # Capture the outcome first: an assertion would itself
+                # allocate and fail while the nomemory hook is active.
                 result = error = None
                 _testcapi.set_nomemory(index, index + 1)
                 try:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-22-11-05-56.gh-issue-151895.QQsjUQ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-22-11-05-56.gh-issue-151895.QQsjUQ.rst
@@ -1,0 +1,2 @@
+Fixed a crash in :func:`marshal.loads` when an allocation failed while
+loading a reference-tracked dictionary; it now raises :exc:`MemoryError`.

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1471,6 +1471,9 @@ r_object(RFILE *p)
         }
         if (type == TYPE_DICT) {
             R_REF(v);
+            if (v == NULL) {
+                break;
+            }
         }
         else {
             idx = r_ref_reserve(flag, p);


### PR DESCRIPTION
`r_object()` in `Python/marshal.c` could dereference a `NULL` dictionary. When loading a back-referenced dict (`FLAG_REF`), the `TYPE_DICT` branch calls `R_REF(v)`, which expands to `v = r_ref(v, flag, p)` and can return `NULL` when `r_ref()`'s internal `PyList_Append()` fails under `MemoryError`. The branch then fell through to `PyDict_SetItem(v, ...)` with `v == NULL`, crashing the interpreter (SIGSEGV on a release build, an assertion abort on a debug build) instead of raising a clean `MemoryError`.

Every sibling container branch — `TYPE_TUPLE`, `TYPE_LIST`, `TYPE_FROZENDICT`, and the set/frozenset branches — already follows `R_REF(v)` with an `if (v == NULL) break;` (or `if (idx < 0)`) guard; `TYPE_DICT` was the only one missing it. This adds the guard. `r_ref()` has already decref'd the dict on its failure path, so the early `break` propagates the exception cleanly and `marshal.loads()` raises `MemoryError`.

A regression test is added in `Lib/test/test_marshal.py` that uses `_testcapi.set_nomemory()` to fail the reference-tracking allocation while loading a back-referenced dict: it crashes the interpreter without this change and raises `MemoryError` with it. `test_marshal` passes.

This is a regression introduced in 2e37d836411e (gh-148653), which refactored the `TYPE_DICT`/`TYPE_FROZENDICT` branches to share code and dropped the dict path's `if (v == NULL) break;`. It first shipped in v3.15.0b1, so only `main` and `3.15` are affected (3.13 and 3.14 still have the guard); no released version is exposed. Needs backport to 3.15.


<!-- gh-issue-number: gh-151895 -->
* Issue: gh-151895
<!-- /gh-issue-number -->
