### PR TITLE
gh-148314: Fix pydoc not recognising stdlib modules behind a symlink

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -544,7 +544,12 @@ class Doc:
             if srcdir:
                 basedir = os.path.join(srcdir, 'Lib')
 
-        basedir = os.path.normcase(basedir)
+        # Resolve symlinks so that the prefix comparison below is not defeated
+        # when ``basedir`` and ``file`` have symlinks resolved inconsistently,
+        # e.g. a source tree that is referenced through a symlink (gh-148314).
+        basedir = os.path.normcase(os.path.realpath(basedir))
+        if file != '(built-in)':
+            file = os.path.normcase(os.path.realpath(file))
         return (isinstance(object, type(os)) and
                 (object.__name__ in ('errno', 'exceptions', 'gc',
                                      'marshal', 'posix', 'signal', 'sys',

--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -2461,6 +2461,32 @@ class TestInternalUtilities(unittest.TestCase):
             self.assertEqual(version, "1.2.3")
             self.assertEqual(len(w), 1)
 
+    @os_helper.skip_unless_symlink
+    def test_is_stdlib_module_resolves_symlinks(self):
+        # gh-148314: _is_stdlib_module() must resolve symlinks so that a
+        # module whose file is reached through a symlink is still recognised
+        # as part of the standard library when basedir points at the real
+        # (symlink-resolved) location.
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        real = os.path.join(tmpdir.name, "real")
+        os.mkdir(real)
+        with open(os.path.join(real, "fakestdlibmod.py"), "w") as f:
+            f.write("x = 1\n")
+        link = os.path.join(tmpdir.name, "link")
+        os.symlink(real, link)
+
+        module = types.ModuleType("fakestdlibmod")
+        module.__file__ = os.path.join(link, "fakestdlibmod.py")
+
+        doc = pydoc.Doc()
+        # Force the explicit basedir to be honoured by bypassing the
+        # python-build branch that would override it with sysconfig's srcdir.
+        with unittest.mock.patch.object(
+            pydoc.sysconfig, "is_python_build", return_value=False
+        ):
+            self.assertTrue(doc._is_stdlib_module(module, basedir=real))
+
 
 def setUpModule():
     thread_info = threading_helper.threading_setup()

--- a/Misc/NEWS.d/next/Library/2026-06-22-12-00-00.gh-issue-148314.Qk3mZt.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-22-12-00-00.gh-issue-148314.Qk3mZt.rst
@@ -1,0 +1,4 @@
+Fix :mod:`pydoc` failing to recognise standard library modules (for example
+when deciding whether to link to the online documentation) when CPython's
+source tree is referenced through a symbolic link.  :mod:`pydoc` now resolves
+symbolic links before comparing module paths.


### PR DESCRIPTION
`pydoc.Doc._is_stdlib_module()` compares the module file against the standard
library base directory with `file.startswith(basedir)`. `file` comes from
`inspect.getabsfile()` (which uses `os.path.abspath`, so symlinks are not
resolved), while `basedir` is derived from `sysconfig.get_config_var('srcdir')`,
which on a source build can already have symlinks resolved. When the source tree
is referenced through a symlink the two paths have symlinks resolved
inconsistently, the prefix check fails, and standard-library modules are
classified as third-party (for example `pydoc` then omits the link to the online
documentation, and `test_pydoc` fails).

Resolve symlinks on both `basedir` and `file` before comparing. In the common,
non-symlinked case `realpath()` is a no-op.

A regression test is added that points a module's `__file__` through a symlink
and checks that `_is_stdlib_module()` still recognises it.


<!-- gh-issue-number: gh-148314 -->
* Issue: gh-148314
<!-- /gh-issue-number -->
