### PR TITLE
gh-82113: Fix ConfigParser.items() returning '' for value-less options

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -908,8 +908,10 @@ class RawConfigParser(MutableMapping):
         if vars:
             for key, value in vars.items():
                 d[self.optionxform(key)] = value
-        value_getter = lambda option: self._interpolation.before_get(self,
-            section, option, d[option], d)
+        value_getter = lambda option: (
+            d[option] if d[option] is None
+            else self._interpolation.before_get(self, section, option,
+                                                 d[option], d))
         if raw:
             value_getter = lambda option: d[option]
         return [(option, value_getter(option)) for option in orig_keys]

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -1327,6 +1327,17 @@ class ConfigParserTestCaseExtendedInterpolation(BasicTestCase, unittest.TestCase
 class ConfigParserTestCaseNoValue(ConfigParserTestCase):
     allow_no_value = True
 
+    def test_items_reports_none_for_no_value(self):
+        # gh-82113: items() must report None (not '') for value-less options,
+        # consistent with get(), mapping access and dict(section).
+        cf = self.fromstring("[s]\nno_value\nspam = ham\n")
+        self.assertIsNone(cf.get("s", "no_value"))
+        self.assertIsNone(cf["s"]["no_value"])
+        self.assertEqual(sorted(cf.items("s")),
+                         [("no_value", None), ("spam", "ham")])
+        self.assertEqual(sorted(cf.items("s", raw=True)),
+                         [("no_value", None), ("spam", "ham")])
+
 
 class NoValueAndExtendedInterpolation(CfgParserTestCaseClass):
     interpolation = configparser.ExtendedInterpolation()

--- a/Misc/NEWS.d/next/Library/2026-06-22-13-30-00.gh-issue-82113.Rb8xKt.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-22-13-30-00.gh-issue-82113.Rb8xKt.rst
@@ -1,0 +1,4 @@
+:meth:`configparser.ConfigParser.items` now reports ``None`` rather than an
+empty string for value-less options when ``allow_no_value`` is enabled, making
+it consistent with :meth:`~configparser.ConfigParser.get`, mapping access and
+``dict()`` conversion of a section.


### PR DESCRIPTION
With `allow_no_value=True`, a value-less option is stored as `None`.
`ConfigParser.get()` returns it directly (`if raw or value is None: return
value`), and mapping access and `dict(section)` also return `None`. But
`items(section)` always ran each value through
`self._interpolation.before_get()`, which turns `None` into an empty string, so
`items()` was inconsistent with every other accessor.

Make the non-raw value getter in `items()` mirror `get()`: return the stored
value directly when it is `None`, otherwise interpolate. Interpolation of real
values is unchanged.


<!-- gh-issue-number: gh-82113 -->
* Issue: gh-82113
<!-- /gh-issue-number -->
