### PR TITLE
gh-146643: Fix Protocol creation crashing on an __annotate__ member

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4254,6 +4254,19 @@ class ProtocolTests(BaseTestCase):
         self.assertEqual(frozenset(typing._get_protocol_attrs(PG)),
                          frozenset({'x', 'meth'}))
 
+    def test_protocol_with_annotate_method_does_not_crash(self):
+        # gh-146643: defining a Protocol whose member is named __annotate__
+        # (a reserved name whose value is not a usable annotate function)
+        # used to crash protocol attribute collection with a TypeError.
+        class CanAnnotate(Protocol):
+            def __annotate__(self, format, /): ...
+
+        self.assertIs(CanAnnotate._is_protocol, True)
+        # __annotate__ is an excluded special name, so it is not collected as
+        # a protocol member, but creating the class must not raise.
+        self.assertNotIn('__annotate__',
+                         typing._get_protocol_attrs(CanAnnotate))
+
     def test_no_runtime_deco_on_nominal(self):
         with self.assertRaises(TypeError):
             @runtime_checkable

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1874,9 +1874,16 @@ def _get_protocol_attrs(cls):
             annotations = base.__annotations__
         except Exception:
             # Only go through annotationlib to handle deferred annotations if we need to
-            annotations = annotationlib.get_annotations(
-                base, format=annotationlib.Format.FORWARDREF
-            )
+            try:
+                annotations = annotationlib.get_annotations(
+                    base, format=annotationlib.Format.FORWARDREF
+                )
+            except Exception:
+                # The annotations cannot be retrieved at all, e.g. the base
+                # defines an ``__annotate__`` member that is not a usable
+                # annotate function (gh-146643).  Treat it as un-annotated
+                # rather than letting the class definition fail.
+                annotations = {}
         for attr in (*base.__dict__, *annotations):
             if not attr.startswith('_abc_') and attr not in EXCLUDED_ATTRIBUTES:
                 attrs.add(attr)

--- a/Misc/NEWS.d/next/Library/2026-06-22-14-15-00.gh-issue-146643.Lm5wTq.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-22-14-15-00.gh-issue-146643.Lm5wTq.rst
@@ -1,0 +1,3 @@
+Fix a :exc:`TypeError` raised when defining a :class:`typing.Protocol` whose
+body (or one of its bases) declares a member named ``__annotate__`` that is not
+a usable annotate function.  Such a class can now be created without error.


### PR DESCRIPTION
`typing._get_protocol_attrs()` reads `base.__annotations__`, and on failure falls
back to `annotationlib.get_annotations(base, FORWARDREF)`. When a Protocol body
(or one of its bases) declares a member named `__annotate__` -- a reserved name --
whose value is an ordinary method rather than a valid annotate function, both
retrieval paths invoke it with the wrong arity and raise `TypeError`, so merely
defining the Protocol failed.

Wrap the `annotationlib.get_annotations()` fallback in `try/except`, treating a
base whose annotations cannot be retrieved as un-annotated instead of letting the
class definition fail. This mirrors the existing `try/except` around
`base.__annotations__`.

Note: because `__annotate__` is in `EXCLUDED_ATTRIBUTES`, such a Protocol still
collects no members; this only addresses the crash.


<!-- gh-issue-number: gh-146643 -->
* Issue: gh-146643
<!-- /gh-issue-number -->
