### PR TITLE
gh-151763: Fix OOM-0014 crash in _interpchannels._channel_id

### DIFF
--- a/Lib/test/test__interpchannels.py
+++ b/Lib/test/test__interpchannels.py
@@ -6,9 +6,7 @@ import threading
 import time
 import unittest
 
-from test import support
 from test.support import import_helper
-from test.support.script_helper import run_python_until_end
 
 _channels = import_helper.import_module('_interpchannels')
 from concurrent.interpreters import _crossinterp
@@ -309,33 +307,6 @@ class ChannelIDTests(TestBase):
     def test_bad_kwargs(self):
         with self.assertRaises(ValueError):
             _channels._channel_id(10, send=False, recv=False)
-
-    @unittest.skipIf(support.Py_TRACE_REFS,
-                     '_testcapi.set_nomemory() is unreliable with Py_TRACE_REFS')
-    def test_oom_in_module_lookup(self):
-        import_helper.import_module('_testcapi')
-        code = dedent("""
-            import _interpchannels
-            import _testcapi
-            from test.support import SuppressCrashReport
-
-            seen = False
-            with SuppressCrashReport():
-                _testcapi.set_nomemory(0, 1)
-                try:
-                    _interpchannels._channel_id(0)
-                except MemoryError:
-                    seen = True
-                finally:
-                    _testcapi.remove_mem_hooks()
-            if not seen:
-                raise AssertionError("MemoryError not raised")
-            print("MemoryError")
-        """)
-        with support.SuppressCrashReport():
-            res, _ = run_python_until_end("-c", code)
-        self.assertEqual(res.rc, 0, res.err.decode("ascii", "replace"))
-        self.assertIn(b"MemoryError", res.out)
 
     def test_does_not_exist(self):
         cid = _channels.create(REPLACE)

--- a/Lib/test/test__interpchannels.py
+++ b/Lib/test/test__interpchannels.py
@@ -6,7 +6,9 @@ import threading
 import time
 import unittest
 
+from test import support
 from test.support import import_helper
+from test.support.script_helper import run_python_until_end
 
 _channels = import_helper.import_module('_interpchannels')
 from concurrent.interpreters import _crossinterp
@@ -307,6 +309,33 @@ class ChannelIDTests(TestBase):
     def test_bad_kwargs(self):
         with self.assertRaises(ValueError):
             _channels._channel_id(10, send=False, recv=False)
+
+    @unittest.skipIf(support.Py_TRACE_REFS,
+                     '_testcapi.set_nomemory() is unreliable with Py_TRACE_REFS')
+    def test_oom_in_module_lookup(self):
+        import_helper.import_module('_testcapi')
+        code = dedent("""
+            import _interpchannels
+            import _testcapi
+            from test.support import SuppressCrashReport
+
+            seen = False
+            with SuppressCrashReport():
+                _testcapi.set_nomemory(0, 1)
+                try:
+                    _interpchannels._channel_id(0)
+                except MemoryError:
+                    seen = True
+                finally:
+                    _testcapi.remove_mem_hooks()
+            if not seen:
+                raise AssertionError("MemoryError not raised")
+            print("MemoryError")
+        """)
+        with support.SuppressCrashReport():
+            res, _ = run_python_until_end("-c", code)
+        self.assertEqual(res.rc, 0, res.err.decode("ascii", "replace"))
+        self.assertIn(b"MemoryError", res.out)
 
     def test_does_not_exist(self):
         cid = _channels.create(REPLACE)

--- a/Misc/NEWS.d/next/Library/2026-06-22-09-41-31.gh-issue-151763.OOM0014.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-22-09-41-31.gh-issue-151763.OOM0014.rst
@@ -1,0 +1,3 @@
+Fix a crash in ``_interpchannels._channel_id()`` when memory allocation
+fails while looking up module state. The function now correctly propagates
+``MemoryError``.

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -3484,6 +3484,9 @@ channelsmod__channel_id(PyObject *self, PyObject *args, PyObject *kwds)
     PyTypeObject *cls = state->ChannelIDType;
 
     PyObject *mod = get_module_from_owned_type(cls);
+    if (mod == NULL) {
+        return NULL;
+    }
     assert(mod == self);
     Py_DECREF(mod);
 


### PR DESCRIPTION
## Summary

This PR addresses **OOM-0014** from **gh-151763**.

It fixes a crash in `_interpchannels._channel_id()` when memory allocation fails while looking up module state.

## Issue

`channelsmod__channel_id()` obtains the owning module with:

```c
PyObject *mod = get_module_from_owned_type(cls);
assert(mod == self);
Py_DECREF(mod);
```

`get_module_from_owned_type()` eventually calls `_get_current_module()`, which allocates the module name using:

```c
PyUnicode_FromString(MODULE_NAME_STR)
```

Under out-of-memory conditions this allocation can fail and return `NULL` with a pending `MemoryError`.

Before this change, `channelsmod__channel_id()` assumed the helper could never fail.

As a result:

- **Debug builds** abort at:

```c
assert(mod == self);
```

because `mod == NULL`.

- **Release builds** compile out the assertion and continue to:

```c
Py_DECREF(mod);
```

which dereferences `NULL` and results in an access violation / segmentation fault.

## Root Cause

The helper `get_module_from_owned_type(cls)` returns a new reference on success but can legitimately return `NULL` when `_get_current_module()` fails during module-name allocation.

`channelsmod__channel_id()` did not check for that failure before using the returned object.

## Fix

Add an explicit NULL check immediately after obtaining the module:

```c
PyObject *mod = get_module_from_owned_type(cls);
if (mod == NULL) {
    return NULL;
}
assert(mod == self);
Py_DECREF(mod);
```

This preserves the existing invariant check while correctly propagating the pending `MemoryError` instead of aborting or crashing.

## Validation

I reproduced the issue locally on both debug and release builds.

### Before the fix

Debug build:

```text
Assertion failed: mod == self
Modules/_interpchannelsmodule.c
Fatal Python error: Aborted
```

Release build:

```text
Windows fatal exception: access violation
```

### After the fix

The same OOM path now returns a clean `MemoryError` and no longer aborts or crashes.

## Regression Test

Added a focused subprocess regression test in:

```
Lib/test/test__interpchannels.py
```

The test:

- uses `_testcapi.set_nomemory(0, 1)`
- exercises `_interpchannels._channel_id(0)`
- verifies that the subprocess exits normally
- verifies that `MemoryError` is propagated instead of aborting or crashing

The test is skipped under `Py_TRACE_REFS`, matching the existing limitations of `_testcapi.set_nomemory()`.

## Tests

Executed:

```text
PCbuild/amd64/python_d.exe -m test test__interpchannels
```

Result:

```text
== Tests result: SUCCESS ==

1 test OK.

Total tests: run=74 skipped=5
```

I also verified:

```text
git diff --check
```

which reports no patch formatting issues (only existing LF/CRLF working-copy warnings).

## NEWS

Added a NEWS fragment describing the crash fix and `MemoryError` propagation.

Addresses **OOM-0014** from **gh-151763**.