### PR TITLE
gh-151819: Clarify backtracking semantics of `(?(id/name)yes|no)` in `re` docs (gh-151819)

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -508,9 +508,17 @@ The special characters are:
    Will try to match with ``yes-pattern`` if the group with given *id* or
    *name* exists, and with ``no-pattern`` if it doesn't. ``no-pattern`` is
    optional and can be omitted. For example,
-   ``(<)?(\w+@\w+(?:\.\w+)+)(?(1)>|$)`` is a poor email matching pattern, which
-   will match with ``'<user@host.com>'`` as well as ``'user@host.com'``, but
-   not with ``'<user@host.com'`` nor ``'user@host.com>'``.
+   ``(<)?(\w+@\w+(?:\.\w+)+)(?(1)>|$)`` is a poor email matching pattern,
+   which will match with ``'<user@host.com>'`` as well as ``'user@host.com'``,
+   and will not match with ``'user@host.com>'``.
+
+   Note that when ``yes-pattern`` is not matched while the captured group
+   was set, backtracking clears the capture (the optional group falls
+   back to its no-match state). For example,
+   ``(<)?\w+(?(1)>)`` applied to ``'<3'`` matches only ``'3'`` at
+   position 1 with ``group(1) is None``: the engine first consumes the
+   leading ``<`` to satisfy group 1, fails to match ``>`` at position
+   2, then retries without consuming ``<``.
 
    .. versionchanged:: 3.12
       Group *id* can only contain ASCII digits.

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -706,6 +706,37 @@ class ReTests(unittest.TestCase):
         self.checkPatternError(r'()(?(2)a)',
                                "invalid group reference 2", 5)
 
+    def test_re_conditional_drops_capture_on_backtrack(self):
+        # Issue: a captured optional group is cleared when backtracking
+        # causes the ``yes-pattern`` of a (?(id/name)yes|no) construct
+        # to not match after the capture was set. See:
+        # https://github.com/python/cpython/issues/151819
+        # Minimal reproduction from the issue:
+        m = re.search(r'(<)?\w+(?(1)>)', '<3')
+        self.assertEqual(m.group(), '3')
+        self.assertEqual(m.span(), (1, 2))
+        self.assertEqual(m.group(1), None)
+
+        # The successful case keeps the capture intact:
+        m = re.search(r'(<)?\w+(?(1)>)', '<body>')
+        self.assertEqual(m.group(), '<body>')
+        self.assertEqual(m.span(), (0, 6))
+        self.assertEqual(m.group(1), '<')
+
+        # Same effect with ``\w`` style groups and a longer input:
+        m = re.search(r'(<)?[A-Za-z]+(?(1)>)', '<abcXYZ')
+        self.assertEqual(m.group(), 'abcXYZ')
+        self.assertEqual(m.span(), (1, 7))
+        self.assertEqual(m.group(1), None)
+
+        # The pattern documented in Re.rst: with yes-pattern failing
+        # the leading "<" is rerolled.
+        m = re.search(r'(<)?(\w+@\w+(?:\.\w+)+)(?(1)>|$)', '<user@host.com')
+        self.assertEqual(m.group(), 'user@host.com')
+        self.assertEqual(m.span(), (1, 14))
+        self.assertEqual(m.group(1), None)
+        self.assertEqual(m.group(2), 'user@host.com')
+
     def test_re_groupref_exists_validation_bug(self):
         for i in range(256):
             with self.subTest(code=i):

--- a/Misc/NEWS.d/next/Documentation/2026-06-22-00-00-00.gh-issue-151819.nULCij.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-06-22-00-00-00.gh-issue-151819.nULCij.rst
@@ -1,0 +1,4 @@
+Clarify the :ref:`re-syntax` for ``(?(id/name)yes-pattern|no-pattern)``:
+add a paragraph documenting that backtracking can clear an optional
+capture group whose ``yes-pattern`` fails to match. Also correct the
+embedded example pattern's expected matches.  Issue #151819.


### PR DESCRIPTION
Fixes #151819

## Summary

The :py:doc:`re-syntax` documentation for ``(?(id/name)yes-pattern|no-pattern)``
contains two issues:

1. The documented example pattern
   ``(<)?(\w+@\w+(?:\.\w+)+)(?(1)>|$)`` is claimed to "not match with
   ``'<user@host.com'``". That is not what the regex engine does. With
   that input the engine first consumes ``<`` to satisfy group 1,
   cannot match the closing ``>``, and backtracks. Backtracking drops
   the ``<`` capture and the engine then matches ``'user@host.com'``
   starting at position 1, with ``group(1) is None``.

2. The general interaction between the conditional construct and
   backtracking is undocumented. The simplest illustration is
   ``re.search('(<)?\\w+(?(1)>)', '<3')``: it returns ``match='3'`` at
   ``span=(1, 2)`` with ``group(1) is None``.

This PR corrects the email example wording and adds a paragraph that
documents the backtracking-clears-the-capture behavior, plus a
regression test that locks in the visible behavior across the
relevant cases.

## Test plan

- New ``ReTests.test_re_conditional_drops_capture_on_backtrack`` in
  ``Lib/test/test_re.py`` exercises the issue reproducer and several
  closely related inputs. All four assertions were verified locally
  against the regex engine; the test will be run as part of the CPython
  CI test suite for this PR.
- No C code or build-affecting change. Documentation-only and tests.

## AI assistance

This patch was drafted with the help of an AI coding assistant. The
diff was reviewed line by line before submission and the regex
behavior was verified independently against CPython's ``re`` engine.
Per the CPython AI policy this disclosure is offered; it is not
required.



<!-- gh-issue-number: gh-151819 -->
* Issue: gh-151819
<!-- /gh-issue-number -->
