### PR TITLE
gh-151920: Add the ttk.Style.theme_styles() method

### DIFF
--- a/Doc/library/tkinter.ttk.rst
+++ b/Doc/library/tkinter.ttk.rst
@@ -1598,6 +1598,16 @@ If you don't know the class name of a widget, use the method
       Returns a tuple of all known themes.
 
 
+   .. method:: theme_styles(themename=None)
+
+      Returns a tuple of all styles in *themename*.
+      If *themename* is not given, the current theme is used.
+
+      .. versionadded:: next
+
+      Availability: Tk 9.0.
+
+
    .. method:: theme_use(themename=None)
 
       If *themename* is not given, returns the theme in use.  Otherwise, sets

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -157,6 +157,11 @@ tkinter
   synchronization of the displayed view with the underlying text.
   (Contributed by Serhiy Storchaka in :gh:`151675`.)
 
+* Added the :meth:`ttk.Style.theme_styles
+  <tkinter.ttk.Style.theme_styles>` method which returns the list of styles
+  defined in a theme.
+  (Contributed by Serhiy Storchaka in :gh:`151920`.)
+
 xml
 ---
 

--- a/Lib/test/test_ttk/test_style.py
+++ b/Lib/test/test_ttk/test_style.py
@@ -6,7 +6,8 @@ from tkinter import TclError
 from test import support
 from test.support import requires
 from test.test_tkinter.support import setUpModule  # noqa: F401
-from test.test_tkinter.support import AbstractTkTest, get_tk_patchlevel
+from test.test_tkinter.support import (AbstractTkTest, get_tk_patchlevel,
+                                       requires_tk)
 
 requires('gui')
 
@@ -123,6 +124,25 @@ class StyleTest(AbstractTkTest, unittest.TestCase):
         self.assertFalse(new_theme != self.style.theme_use())
 
         self.style.theme_use(curr_theme)
+
+    @requires_tk(9, 0)
+    def test_theme_styles(self):
+        # The 'default' theme is always available and defines the base styles.
+        default_styles = self.style.theme_styles('default')
+        self.assertIsInstance(default_styles, tuple)
+        self.assertIn('.', default_styles)
+        self.assertIn('TButton', default_styles)
+
+        # Without an argument the current theme is used.
+        styles = self.style.theme_styles()
+        self.assertIsInstance(styles, tuple)
+        self.assertIn('.', styles)
+
+        for theme in self.style.theme_names():
+            self.assertIsInstance(self.style.theme_styles(theme), tuple)
+
+        self.assertRaises(tkinter.TclError,
+                          self.style.theme_styles, 'nonexistingname')
 
     def test_theme_settings(self):
         style = self.style

--- a/Lib/tkinter/ttk.py
+++ b/Lib/tkinter/ttk.py
@@ -492,6 +492,20 @@ class Style(object):
         return self.tk.splitlist(self.tk.call(self._name, "theme", "names"))
 
 
+    def theme_styles(self, themename=None):
+        """Returns a list of all styles in themename.
+
+        If themename is omitted, the current theme is used.
+
+        Availability: Tk 9.0.
+        """
+        if themename is None:
+            return self.tk.splitlist(
+                self.tk.call(self._name, "theme", "styles"))
+        return self.tk.splitlist(
+            self.tk.call(self._name, "theme", "styles", themename))
+
+
     def theme_use(self, themename=None):
         """If themename is None, returns the theme in use, otherwise, set
         the current theme to themename, refreshes all widgets and emits

--- a/Misc/NEWS.d/next/Library/2026-06-22-14-30-00.gh-issue-151920.Th3mSt.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-22-14-30-00.gh-issue-151920.Th3mSt.rst
@@ -1,0 +1,3 @@
+Add the :meth:`ttk.Style.theme_styles <tkinter.ttk.Style.theme_styles>`
+method, wrapping the Tk ``ttk::style theme styles`` subcommand, which
+returns the list of styles defined in a theme.


### PR DESCRIPTION
Wrap the Tk 9.0 `ttk::style theme styles ?themeName?` subcommand as `ttk.Style.theme_styles(themename=None)`, returning the list of styles defined in a theme (the current theme if `themename` is omitted). It is a clean introspection peer of the existing `ttk.Style.theme_names()`.

Tested locally against Tcl/Tk 9.0.4 and 9.1b0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-151920 -->
* Issue: gh-151920
<!-- /gh-issue-number -->
