### PR TITLE
Capitalize first word in `unittest.mock.{assert_any_call,assert_has_calls}` docs

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -345,7 +345,7 @@ the *new_callable* argument to :func:`patch`.
 
     .. method:: assert_any_call(*args, **kwargs)
 
-        assert the mock has been called with the specified arguments.
+        Assert the mock has been called with the specified arguments.
 
         The assert passes if the mock has *ever* been called, unlike
         :meth:`assert_called_with` and :meth:`assert_called_once_with` that
@@ -360,7 +360,7 @@ the *new_callable* argument to :func:`patch`.
 
     .. method:: assert_has_calls(calls, any_order=False)
 
-        assert the mock has been called with the specified calls.
+        Assert the mock has been called with the specified calls.
         The :attr:`mock_calls` list is checked for the calls.
 
         If *any_order* is false then the calls must be

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -935,7 +935,7 @@ class NonCallableMock(Base):
             return _call
 
     def assert_not_called(self):
-        """assert that the mock was never called.
+        """Assert that the mock was never called.
         """
         if self.call_count != 0:
             msg = ("Expected '%s' to not have been called. Called %s times.%s"
@@ -945,7 +945,7 @@ class NonCallableMock(Base):
             raise AssertionError(msg)
 
     def assert_called(self):
-        """assert that the mock was called at least once
+        """Assert that the mock was called at least once.
         """
         if self.call_count == 0:
             msg = ("Expected '%s' to have been called." %
@@ -953,7 +953,7 @@ class NonCallableMock(Base):
             raise AssertionError(msg)
 
     def assert_called_once(self):
-        """assert that the mock was called only once.
+        """Assert that the mock was called only once.
         """
         if not self.call_count == 1:
             msg = ("Expected '%s' to have been called once. Called %s times.%s"
@@ -963,7 +963,7 @@ class NonCallableMock(Base):
             raise AssertionError(msg)
 
     def assert_called_with(self, /, *args, **kwargs):
-        """assert that the last call was made with the specified arguments.
+        """Assert that the last call was made with the specified arguments.
 
         Raises an AssertionError if the args and keyword args passed in are
         different to the last call to the mock."""
@@ -985,7 +985,7 @@ class NonCallableMock(Base):
 
 
     def assert_called_once_with(self, /, *args, **kwargs):
-        """assert that the mock was called exactly once and that call was
+        """Assert that the mock was called exactly once and that call was
         with the specified arguments."""
         if not self.call_count == 1:
             msg = ("Expected '%s' to be called once. Called %s times.%s"
@@ -997,7 +997,7 @@ class NonCallableMock(Base):
 
 
     def assert_has_calls(self, calls, any_order=False):
-        """assert the mock has been called with the specified calls.
+        """Assert the mock has been called with the specified calls.
         The `mock_calls` list is checked for the calls.
 
         If `any_order` is False (the default) then the calls must be
@@ -1042,7 +1042,7 @@ class NonCallableMock(Base):
 
 
     def assert_any_call(self, /, *args, **kwargs):
-        """assert the mock has been called with the specified arguments.
+        """Assert the mock has been called with the specified arguments.
 
         The assert passes if the mock has *ever* been called, unlike
         `assert_called_with` and `assert_called_once_with` that only pass if


### PR DESCRIPTION
# Start sentences in `unittest.mock` with a capital letter

Change two occurrences of 'assert' to uppercase.