### PR TITLE
gh-151678: Add tests for ttk Menubutton and OptionMenu widget options

### DIFF
--- a/Lib/test/test_ttk/test_extensions.py
+++ b/Lib/test/test_ttk/test_extensions.py
@@ -4,9 +4,13 @@ import tkinter
 from tkinter import ttk
 from test.support import requires, gc_collect
 from test.test_tkinter.support import setUpModule  # noqa: F401
-from test.test_tkinter.support import AbstractTkTest, AbstractDefaultRootTest
+from test.test_tkinter.support import (AbstractTkTest, AbstractDefaultRootTest,
+                                       get_tk_patchlevel, widget_eq)
 
 requires('gui')
+
+from test.test_ttk import test_widgets
+
 
 class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
 
@@ -193,7 +197,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
         x.destroy()
 
 
-class OptionMenuTest(AbstractTkTest, unittest.TestCase):
+class OptionMenuTest(test_widgets.MenubuttonTest, unittest.TestCase):
 
     def setUp(self):
         super().setUp()
@@ -203,6 +207,47 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
         del self.textvar
         super().tearDown()
 
+    def create(self, default='b', values=('a', 'b', 'c'), **kwargs):
+        return ttk.OptionMenu(self.root, self.textvar, default, *values, **kwargs)
+
+    def test_bad_kwarg(self):
+        with self.assertRaisesRegex(tkinter.TclError, r"^unknown option -image$"):
+            ttk.OptionMenu(self.root, self.textvar, 'b', image='')
+
+    def test_configure_class(self):
+        # Unlike a plain Menubutton, OptionMenu does not accept a class at
+        # construction, so only the read-only nature of the option is tested.
+        widget = self.create()
+        self.assertEqual(widget['class'], '')
+        errmsg = 'attempt to change read-only option'
+        if get_tk_patchlevel(self.root) < (8, 6, 0, 'beta', 3):
+            errmsg = 'Attempt to change read-only option'
+        self.checkInvalidParam(widget, 'class', 'Foo', errmsg=errmsg)
+
+    def test_configure_style(self):
+        # Like Menubutton, but OptionMenu does not accept a class at
+        # construction, so the custom-class part of the standard test is omitted.
+        widget = self.create()
+        self.assertEqual(widget['style'], '')
+        self.checkInvalidParam(widget, 'style', 'Foo',
+                               errmsg='Layout Foo not found')
+        style = ttk.Style(self.root)
+        style.configure('Custom.TMenubutton')
+        self.checkParam(widget, 'style', 'Custom.TMenubutton')
+
+    def test_configure_menu(self):
+        # OptionMenu manages its own menu; ['menu'] returns that Menu widget.
+        widget = self.create()
+        self.assertIsInstance(widget['menu'], tkinter.Menu)
+        self.checkParam(widget, 'menu', widget['menu'], eq=widget_eq)
+
+    def test_configure_text(self):
+        # The displayed text is governed by the textvariable.
+        widget = self.create()
+        self.textvar.set('a')
+        self.assertEqual(widget['text'], 'a')
+        self.textvar.set('c')
+        self.assertEqual(widget['text'], 'c')
 
     def test_widget_destroy(self):
         var = tkinter.StringVar(self.root)

--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -789,6 +789,7 @@ class RadiobuttonTest(AbstractLabelTest, unittest.TestCase):
         self.assertEqual(str(cbtn['variable']), str(cbtn2['variable']))
 
 
+@add_configure_tests(StandardTtkOptionsTests)
 class MenubuttonTest(AbstractLabelTest, unittest.TestCase):
     OPTIONS = (
         'class', 'compound', 'cursor', 'direction',


### PR DESCRIPTION
Decorate ttk.MenubuttonTest with add_configure_tests() and make ttk.OptionMenuTest inherit it to cover the standard widget options.


<!-- gh-issue-number: gh-151678 -->
* Issue: gh-151678
<!-- /gh-issue-number -->
