### PR TITLE
gh-151763: Fix OOM-0013 crash when the parser or compiler fails to allocate

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-23-12-03-55.gh-issue-151763.K7QfWG.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-23-12-03-55.gh-issue-151763.K7QfWG.rst
@@ -1,0 +1,3 @@
+Fix a potential crash in :func:`compile`, :func:`exec`, :func:`eval` and
+:func:`ast.parse` when an allocation fails: the parser or compiler could
+return without setting an exception.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -940,6 +940,13 @@ _PyPegen_run_parser(Parser *p)
 {
     void *res = _PyPegen_parse(p);
     assert(p->level == 0);
+    if (res != NULL && PyErr_Occurred()) {
+        // The parser produced a result but left an exception pending, which
+        // happens when an allocation fails in a path the parser recovers from
+        // (for example while memoizing).  The result cannot be trusted, so
+        // discard it and let the pending exception (a MemoryError) propagate.
+        return NULL;
+    }
     if (res == NULL) {
         if ((p->flags & PyPARSE_ALLOW_INCOMPLETE_INPUT) &&  _is_end_of_source(p)) {
             PyErr_Clear();
@@ -995,7 +1002,10 @@ _PyPegen_run_parser_from_file_pointer(FILE *fp, int start_rule, PyObject *filena
     if (tok == NULL) {
         if (PyErr_Occurred()) {
             _PyTokenizer_raise_init_error(filename_ob);
-            return NULL;
+        }
+        else {
+            // The only silent tokenizer init failure is a failed allocation.
+            PyErr_NoMemory();
         }
         return NULL;
     }
@@ -1053,6 +1063,10 @@ _PyPegen_run_parser_from_string(const char *str, int start_rule, PyObject *filen
     if (tok == NULL) {
         if (PyErr_Occurred()) {
             _PyTokenizer_raise_init_error(filename_ob);
+        }
+        else {
+            // The only silent tokenizer init failure is a failed allocation.
+            PyErr_NoMemory();
         }
         return NULL;
     }

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -941,10 +941,8 @@ _PyPegen_run_parser(Parser *p)
     void *res = _PyPegen_parse(p);
     assert(p->level == 0);
     if (res != NULL && PyErr_Occurred()) {
-        // The parser produced a result but left an exception pending, which
-        // happens when an allocation fails in a path the parser recovers from
-        // (for example while memoizing).  The result cannot be trusted, so
-        // discard it and let the pending exception (a MemoryError) propagate.
+        // Discard a result returned with an exception still pending
+        // (e.g. a MemoryError from a recovered-from allocation failure).
         return NULL;
     }
     if (res == NULL) {

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -174,6 +174,7 @@ new_compiler(mod_ty mod, PyObject *filename, PyCompilerFlags *pflags,
 {
     compiler *c = PyMem_Calloc(1, sizeof(compiler));
     if (c == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     if (compiler_setup(c, mod, filename, pflags, optimize, arena, module) < 0) {


### PR DESCRIPTION
This fixes OOM-0013 from the gh-151763 umbrella.

`compile()`, `exec()`, `eval()` and `ast.parse()` can return NULL without
setting an exception when an allocation fails, breaking the result/error
contract every consumer relies on and crashing on the assertion that checks it
(for example the `(res != NULL) ^ (PyErr_Occurred())` check reached from the
evaluation loop, and `assert(!PyErr_Occurred())` at the top of
`_PyAST_Validate`).

Three points returned NULL silently under a failed allocation:

- `new_compiler()` returned NULL without calling `PyErr_NoMemory()` when its
  initial `PyMem_Calloc` failed -- the dominant `compile()`/`exec()`/`eval()`
  path.
- `_PyPegen_run_parser()` could return a valid result while leaving a stale
  exception pending.
- The tokenizer-init helpers could fail silently.

Setting the error indicator at each point makes a failed allocation surface as
`MemoryError` instead of a NULL-without-exception crash.

## Reproduction (debug build, `_testcapi.set_nomemory`)

- `ast.parse(...)` under `set_nomemory` aborted with "a function returned NULL
  without setting an exception"; a clean `MemoryError` is raised after the fix.
- `compile()` / `exec()` / `eval()` under `set_nomemory` aborted at the
  result/error contract assertion; clean after the fix.
- Reverting either guard reproduces the corresponding abort (negative control).

No test is added, following the convention for these OOM crash fixes.
