### PR TITLE
gh-101034: Clarify error for email domain ending with a dot

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1668,6 +1668,11 @@ def get_domain(value):
             domain[:] = domain[0]
         while value and value[0] == '.':
             domain.append(DOT)
+            # A trailing dot leaves get_atom an empty string, whose error
+            # ("expected atext but found ''") hides the real problem.
+            if len(value) == 1:
+                raise errors.HeaderParseError(
+                    "expected atom after '.' but found end of domain")
             token, value = get_atom(value[1:])
             domain.append(token)
     return domain, value

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -1501,6 +1501,13 @@ class TestParser(TestParserMixin, TestEmailBase):
         with self.assertRaises(errors.HeaderParseError):
             parser.get_domain("  (foo)\t, broken")
 
+    def test_get_domain_obsolete_trailing_dot_raises(self):
+        # gh-101034: a trailing dot must not surface get_atom's internal
+        # "expected atext but found ''" error.
+        with self.assertRaisesRegex(errors.HeaderParseError,
+                                    "expected atom after '.'"):
+            parser.get_domain("example.org.")
+
 
     # get_addr_spec
 

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -1596,6 +1596,13 @@ class TestAddressAndGroup(TestEmailBase):
         with self.assertRaises(ValueError):
             Address('foo', addr_spec="name@ex[]ample.com")
 
+    def test_trailing_dot_in_addr_spec_domain_raises(self):
+        # gh-101034: report a clear error instead of the internal
+        # "expected atext but found ''".
+        with self.assertRaisesRegex(errors.HeaderParseError,
+                                    "expected atom after '.'"):
+            Address('Jane Doe', addr_spec="jane_doe@example.org.")
+
     def test_empty_group(self):
         g = Group('foo')
         self.assertEqual(g.display_name, 'foo')

--- a/Misc/NEWS.d/next/Library/2026-06-23-08-06-58.gh-issue-101034.VYZ3dP.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-23-08-06-58.gh-issue-101034.VYZ3dP.rst
@@ -1,0 +1,4 @@
+Fix the misleading ``HeaderParseError`` raised for an email address whose
+domain ends with a dot (such as ``user@example.org.``) in
+:mod:`email.headerregistry`. It now reports a clear error instead of the
+internal ``expected atext but found ''``.


### PR DESCRIPTION
`email.headerregistry.Address(addr_spec="user@example.org.")` (a domain ending
in a dot) raises a cryptic `HeaderParseError: expected atext but found ''` that
gives no hint about the trailing dot.

Per RFC 5322 the rejection is correct -- `dot-atom` / `obs-domain` both require
an atom after every `.`, so a trailing-dot domain isn't a valid `addr-spec`
domain. The only defect is the message: in `_header_value_parser.get_domain`,
the obs-domain fallback reaches the final `.` and calls `get_atom('')`, which
surfaces that bare internal error.

This raises a clear `HeaderParseError("expected atom after '.' but found end of
domain")` instead. Behavior is unchanged (the trailing-dot domain is still
rejected); only the diagnostic improves -- the "more informative error"
requested in the issue.

If `email` should instead *accept* the FQDN-root trailing dot, that is a
behavior change that deserves its own issue and need not block this diagnostic
fix.

Issue: https://github.com/python/cpython/issues/101034


<!-- gh-issue-number: gh-101034 -->
* Issue: gh-101034
<!-- /gh-issue-number -->
