### PR TITLE
gh-126219: Fix crash in tkinter.Tk with non-BMP className on Tcl/Tk 8.x

### DIFF
--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -10,7 +10,8 @@ from test import support
 from test.support import os_helper
 from test.test_tkinter.support import setUpModule  # noqa: F401
 from test.test_tkinter.support import (AbstractTkTest, AbstractDefaultRootTest,
-                                       requires_tk, get_tk_patchlevel)
+                                       requires_tk, get_tk_patchlevel,
+                                       tcl_version)
 
 support.requires('gui')
 
@@ -708,6 +709,30 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
             iter(widget)
         with self.assertRaisesRegex(TypeError, 'is not a container or iterable'):
             widget in widget
+
+
+class TkTest(AbstractTkTest, unittest.TestCase):
+
+    def test_className(self):
+        # The className argument sets the class of the root window.  Tk
+        # title-cases it: the first letter is upper-cased, the rest lower-cased.
+        cases = [
+            ('fooBAR', 'Foobar'),
+            ('éÉ', 'Éé'),  # small and capital E WITH ACUTE
+        ]
+        if tcl_version >= (9, 0):
+            # small and capital DESERET LETTER LONG I (a non-BMP script)
+            cases.append(('\U00010428\U00010400', '\U00010400\U00010428'))
+        for className, klass in cases:
+            root = tkinter.Tk(className=className)
+            try:
+                self.assertEqual(root.winfo_class(), klass)
+            finally:
+                root.destroy()
+        if tcl_version < (9, 0):
+            # gh-126219: title-casing a non-BMP first letter crashed Tcl 8.x;
+            # such a class name is now rejected.
+            self.assertRaises(ValueError, tkinter.Tk, className='\U00010428')
 
 
 class WinfoTest(AbstractTkTest, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2026-06-23-13-27-14.gh-issue-126219.kOfv2g.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-23-13-27-14.gh-issue-126219.kOfv2g.rst
@@ -1,0 +1,3 @@
+Fixed a crash in :class:`tkinter.Tk` when *className* contains a non-BMP
+character and tkinter is built against Tcl/Tk 8.x.  Such a name is now
+rejected with a :exc:`ValueError`.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -3272,6 +3272,20 @@ _tkinter_create_impl(PyObject *module, const char *screenName,
     CHECK_STRING_LENGTH(className);
     CHECK_STRING_LENGTH(use);
 
+#if TCL_MAJOR_VERSION < 9
+    /* className is title-cased during Tk initialization.  Tcl 8.x does not
+     * support non-BMP characters (encoded as 4-byte UTF-8 sequences) there
+     * and crashes in Tcl_UtfToTitle (see gh-126219).  Reject them up front. */
+    for (const unsigned char *p = (const unsigned char *)className; *p; p++) {
+        if (*p >= 0xF0) {
+            PyErr_SetString(PyExc_ValueError,
+                            "className must not contain non-BMP characters "
+                            "with this version of Tcl/Tk");
+            return NULL;
+        }
+    }
+#endif
+
     return (PyObject *) Tkapp_New(screenName, className,
                                   interactive, wantobjects, wantTk,
                                   sync, use);


### PR DESCRIPTION
`tkinter.Tk(className='\U0010FFFF')` (and the underlying `_tkinter.create()`) crashes with a segfault when tkinter is built against Tcl/Tk 8.x.

The class name is title-cased during Tk initialization, and Tcl 8.x crashes in `Tcl_UtfToTitle()` on non-BMP characters (encoded as 4-byte UTF-8 sequences). Such a className is now rejected with a `ValueError` before Tk is initialized.

Tcl 9 supports non-BMP characters and is not affected; the check is compiled out there.

Among the other string arguments of `_tkinter.create()`, only `className` is affected — `screenName`, `baseName` and `use` fail gracefully.

(The same Tcl 8.x bug also affects `Tcl_UtfToUpper()`/`Tcl_UtfToLower()`, reachable via e.g. `tk.call('string', 'toupper', ...)`, but that is a general Tcl issue that cannot be guarded on the CPython side.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-126219 -->
* Issue: gh-126219
<!-- /gh-issue-number -->
