### PR TITLE
gh-119710: Let asyncio Process.wait() finish on only process exit.

### DIFF
--- a/Lib/asyncio/base_subprocess.py
+++ b/Lib/asyncio/base_subprocess.py
@@ -26,7 +26,6 @@ class BaseSubprocessTransport(transports.SubprocessTransport):
         self._pending_calls = collections.deque()
         self._pipes = {}
         self._finished = False
-        self._pipes_connected = False
 
         if stdin == subprocess.PIPE:
             self._pipes[0] = None
@@ -214,7 +213,6 @@ class BaseSubprocessTransport(transports.SubprocessTransport):
         else:
             if waiter is not None and not waiter.cancelled():
                 waiter.set_result(None)
-            self._pipes_connected = True
 
     def _call(self, cb, *data):
         if self._pending_calls is not None:
@@ -235,6 +233,16 @@ class BaseSubprocessTransport(transports.SubprocessTransport):
         if self._loop.get_debug():
             logger.info('%r exited with return code %r', self, returncode)
         self._returncode = returncode
+
+        # gh-119710: Wake up futures waiting for wait() as soon as the process
+        # exits. The pipe transports now check for the loop being closed before
+        # scheduling a callback preventing gh-114177. This is consistent with
+        # the behavior prior to 3.11 and the documented semantics in _wait().
+        for waiter in self._exit_waiters:
+            if not waiter.done():
+                waiter.set_result(returncode)
+        self._exit_waiters = None
+
         if self._proc.returncode is None:
             # asyncio uses a child watcher: copy the status into the Popen
             # object. On Python 3.6, it is required to avoid a ResourceWarning.
@@ -258,15 +266,7 @@ class BaseSubprocessTransport(transports.SubprocessTransport):
         assert not self._finished
         if self._returncode is None:
             return
-        if not self._pipes_connected:
-            # self._pipes_connected can be False if not all pipes were connected
-            # because either the process failed to start or the self._connect_pipes task
-            # got cancelled. In this broken state we consider all pipes disconnected and
-            # to avoid hanging forever in self._wait as otherwise _exit_waiters
-            # would never be woken up, we wake them up here.
-            for waiter in self._exit_waiters:
-                if not waiter.done():
-                    waiter.set_result(self._returncode)
+
         if all(p is not None and p.disconnected
                for p in self._pipes.values()):
             self._finished = True
@@ -276,11 +276,6 @@ class BaseSubprocessTransport(transports.SubprocessTransport):
         try:
             self._protocol.connection_lost(exc)
         finally:
-            # wake up futures waiting for wait()
-            for waiter in self._exit_waiters:
-                if not waiter.done():
-                    waiter.set_result(self._returncode)
-            self._exit_waiters = None
             self._loop = None
             self._proc = None
             self._protocol = None

--- a/Lib/asyncio/base_subprocess.py
+++ b/Lib/asyncio/base_subprocess.py
@@ -234,15 +234,6 @@ class BaseSubprocessTransport(transports.SubprocessTransport):
             logger.info('%r exited with return code %r', self, returncode)
         self._returncode = returncode
 
-        # gh-119710: Wake up futures waiting for wait() as soon as the process
-        # exits. The pipe transports now check for the loop being closed before
-        # scheduling a callback preventing gh-114177. This is consistent with
-        # the behavior prior to 3.11 and the documented semantics in _wait().
-        for waiter in self._exit_waiters:
-            if not waiter.done():
-                waiter.set_result(returncode)
-        self._exit_waiters = None
-
         if self._proc.returncode is None:
             # asyncio uses a child watcher: copy the status into the Popen
             # object. On Python 3.6, it is required to avoid a ResourceWarning.
@@ -250,6 +241,13 @@ class BaseSubprocessTransport(transports.SubprocessTransport):
         self._call(self._protocol.process_exited)
 
         self._try_finish()
+
+        # gh-119710: Wake up futures waiting for wait() as soon as the process
+        # exits.
+        for waiter in self._exit_waiters:
+            if not waiter.done():
+                waiter.set_result(returncode)
+        self._exit_waiters = None
 
     async def _wait(self):
         """Wait until the process exit and return the process return code.

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -128,9 +128,6 @@ class SubprocessTransportTests(test_utils.TestCase):
         exit_waiter = self.loop.create_future()
         transport._exit_waiters.append(exit_waiter)
 
-        # _connect_pipes hasn't completed, so _pipes_connected is False.
-        self.assertFalse(transport._pipes_connected)
-
         # Simulate process exit. _try_finish() will set the result on
         # exit_waiter because _pipes_connected is False, and then schedule
         # _call_connection_lost() because _pipes is empty (vacuously all
@@ -435,6 +432,47 @@ class SubprocessMixin:
         output, exitcode = self.loop.run_until_complete(len_message(b'abc'))
         self.assertEqual(output.rstrip(), b'3')
         self.assertEqual(exitcode, 0)
+
+    def test_wait_even_if_pipe_is_open(self):
+        # gh-119710: Process.wait() must return once the process exits even
+        # if its stdout pipe is inherited by a grandchild that keeps it open,
+        # so the pipe never reaches EOF. Otherwise wait() hangs forever
+        # despite the returncode being known.
+
+        async def run():
+            # Just setup a pipe to pass to the grandchild for reading to ensure it dies.
+            # Inheritable is to allow it to be passed on windows
+            r, w = os.pipe()
+            os.set_inheritable(r, True)
+
+            code = textwrap.dedent(f"""\
+                import subprocess, sys
+                subprocess.run([sys.executable, "-c", "import sys;sys.stdin.read()"])
+                """)
+
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable, "-c", code,
+                # This will be inherited by granchild and should not prevent
+                # *this* process from firing .wait().
+                stdout=subprocess.PIPE,
+                stdin=r,
+                pass_fds=(r,) if sys.platform != "win32" else (),
+                close_fds=False if sys.platform == "win32" else True,
+            )
+            os.close(r)
+
+            try:
+                # Ensure we start waiting before the process is killed.
+                wait_proc = asyncio.create_task(proc.wait())
+                await asyncio.sleep(0.1)
+                proc.kill()
+                await asyncio.wait_for(wait_proc, timeout=2.0)
+            finally:
+                os.close(w) # Allows the grandchild to exit
+                if proc.stdout is not None:
+                    await proc.stdout.read()
+
+        self.loop.run_until_complete(run())
 
     def test_empty_input(self):
 

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -466,7 +466,7 @@ class SubprocessMixin:
                 wait_proc = asyncio.create_task(proc.wait())
                 await asyncio.sleep(0)
                 proc.kill()
-                await asyncio.wait_for(wait_proc, timeout=2.0)
+                await asyncio.wait_for(wait_proc, timeout=support.SHORT_TIMEOUT)
             finally:
                 os.close(w) # Allows the grandchild to exit
                 if proc.stdout is not None:

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -412,37 +412,36 @@ class SubprocessMixin:
         # despite the returncode being known.
 
         async def run():
-            # Just setup a pipe to pass to the grandchild for reading to ensure it dies.
-            # Inheritable is to allow it to be passed on windows
-            r, w = os.pipe()
-            os.set_inheritable(r, True)
-
-            code = textwrap.dedent(f"""\
+            # The grandchild inherits the child's stdin and stdout pipes and
+            # keeps both open after the child is killed.  It writes "ready"
+            # so we know it has started, and exits once its stdin hits EOF.
+            code = textwrap.dedent("""\
                 import subprocess, sys
-                subprocess.run([sys.executable, "-c", "import sys;sys.stdin.read()"])
+                subprocess.run([sys.executable, "-c",
+                    "import sys; sys.stdout.write('ready');"
+                    " sys.stdout.flush(); sys.stdin.read()"])
                 """)
 
             proc = await asyncio.create_subprocess_exec(
                 sys.executable, "-c", code,
-                # This will be inherited by granchild and should not prevent
-                # *this* process from firing .wait().
+                stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stdin=r,
-                pass_fds=(r,) if sys.platform != "win32" else (),
-                close_fds=False if sys.platform == "win32" else True,
             )
-            os.close(r)
-
             try:
-                # Ensure we start waiting before the process is killed.
                 wait_proc = asyncio.create_task(proc.wait())
-                await asyncio.sleep(0)
+                # Wait until the grandchild holds the inherited pipes; this
+                # also lets the wait() task register its waiter.
+                await proc.stdout.readexactly(5)
                 proc.kill()
-                await asyncio.wait_for(wait_proc, timeout=support.SHORT_TIMEOUT)
+                returncode = await asyncio.wait_for(
+                    wait_proc, timeout=support.SHORT_TIMEOUT)
+                if sys.platform == 'win32':
+                    self.assertIsInstance(returncode, int)
+                else:
+                    self.assertEqual(-signal.SIGKILL, returncode)
             finally:
-                os.close(w) # Allows the grandchild to exit
-                if proc.stdout is not None:
-                    await proc.stdout.read()
+                proc.stdin.close()  # let the grandchild exit
+                await proc.stdout.read()
 
         self.loop.run_until_complete(run())
 

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -112,34 +112,6 @@ class SubprocessTransportTests(test_utils.TestCase):
         )
         transport.close()
 
-    def test_proc_exited_no_invalid_state_error_on_exit_waiters(self):
-        # gh-145541: when _connect_pipes hasn't completed (so
-        # _pipes_connected is False) and the process exits, _try_finish()
-        # sets the result on exit waiters. Then _call_connection_lost() must
-        # not call set_result() again on the same waiters.
-        self.loop.set_exception_handler(
-            lambda loop, context: self.fail(
-                f"unexpected exception: {context}")
-        )
-        waiter = self.loop.create_future()
-        transport, protocol = self.create_transport(waiter)
-
-        # Simulate a waiter registered via _wait() before the process exits.
-        exit_waiter = self.loop.create_future()
-        transport._exit_waiters.append(exit_waiter)
-
-        # Simulate process exit. _try_finish() will set the result on
-        # exit_waiter because _pipes_connected is False, and then schedule
-        # _call_connection_lost() because _pipes is empty (vacuously all
-        # disconnected). _call_connection_lost() must skip exit_waiter
-        # because it's already done.
-        transport._process_exited(6)
-        self.loop.run_until_complete(waiter)
-
-        self.assertEqual(exit_waiter.result(), 6)
-
-        transport.close()
-
 
 class SubprocessMixin:
 

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -464,7 +464,7 @@ class SubprocessMixin:
             try:
                 # Ensure we start waiting before the process is killed.
                 wait_proc = asyncio.create_task(proc.wait())
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(0)
                 proc.kill()
                 await asyncio.wait_for(wait_proc, timeout=2.0)
             finally:

--- a/Misc/NEWS.d/next/Library/2026-06-11-10-00-00.gh-issue-119710.Qz7Kp2.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-11-10-00-00.gh-issue-119710.Qz7Kp2.rst
@@ -1,0 +1,4 @@
+Fix :mod:`asyncio` subprocess :meth:`~asyncio.subprocess.Process.wait`
+hanging when the process has exited but one of its pipes is kept open by an
+inherited child process (so the pipe never reaches EOF). ``wait()`` now
+returns as soon as the process exits, regardless of the pipes' state.


### PR DESCRIPTION
# gh-119710: Let asyncio Process.wait() finish on only process exit

Letting Process.wait() only wait on actual process return is closer to how it's documented and consistent with Popen.wait(). This also reduces complexity for waking waiters which was inconsistend depending on ordering of wait/exit.