### PR TITLE
gh-84008: Document that the LC_NUMERIC locale affects tkinter numeric widgets

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -5042,6 +5042,9 @@ Widget classes
    dropped; *from* is spelled ``from_`` because :keyword:`from` is a Python
    keyword.
 
+   With a non-integer *resolution*, see :ref:`numeric values and the locale
+   <tkinter-numeric-locale>`.
+
    .. method:: get()
 
       Return the current value of the scale.
@@ -5139,6 +5142,9 @@ Widget classes
    are formatted; and the *validate* option enables validation of the entered
    text.
    Inherits from :class:`Widget` and :class:`XView`.
+
+   With a non-integer *increment*, see :ref:`numeric values and the locale
+   <tkinter-numeric-locale>`.
 
    Many of the methods take an *index* argument identifying a character in the
    spinbox's string.
@@ -6027,6 +6033,18 @@ Variable classes
    .. method:: get()
 
       Return the value of the variable as a :class:`float`.
+
+   .. _tkinter-numeric-locale:
+
+   .. note::
+
+      A floating-point value is always parsed with a period (``.``) as the
+      decimal separator, but :class:`Spinbox`, :class:`Scale` and
+      :class:`ttk.Spinbox <tkinter.ttk.Spinbox>` format it according to the
+      ``LC_NUMERIC`` locale.  Under a locale that uses a comma they produce a
+      value that :meth:`get` cannot read, raising :exc:`TclError`.  Set
+      ``LC_NUMERIC`` to a locale that uses a period (such as ``'C'``) to avoid
+      this.
 
 
 .. class:: BooleanVar(master=None, value=None, name=None)

--- a/Doc/library/tkinter.ttk.rst
+++ b/Doc/library/tkinter.ttk.rst
@@ -463,6 +463,9 @@ ttk.Spinbox
 
 .. class:: Spinbox
 
+   With a non-integer increment, see :ref:`numeric values and the locale
+   <tkinter-numeric-locale>`.
+
    .. versionadded:: 3.8
 
    .. method:: get()


### PR DESCRIPTION
`tkinter.Spinbox`, `tkinter.Scale` and `tkinter.ttk.Spinbox` format floating-point values according to the `LC_NUMERIC` locale (via Tcl's `format`, which uses the C library), but Tk always parses numbers with a period as the decimal separator.

Under a locale that uses a comma (for example `de_DE`), stepping such a widget writes a value like `"0,1"` into the linked variable, and `DoubleVar.get()` then fails with `TclError: expected floating-point number but got "0,1"`.

This is an inherent Tcl/Tk inconsistency (locale-dependent formatting vs locale-independent parsing) that cannot be fixed cleanly in tkinter; I confirmed it is still present on Tk 8.6.17, 9.0.4 and 9.1b0.  `ttk.Scale` is not affected, since it stores a raw double.

This documents the limitation: a note on `DoubleVar` describing it and the `LC_NUMERIC='C'` workaround, with cross-references from the affected widgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-84008 -->
* Issue: gh-84008
<!-- /gh-issue-number -->
