### PR TITLE
gh-151763: Fix `_interpreters.capture_exception` crash on memory errors

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-23-17-30-16.gh-issue-151763.-sTnNi.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-23-17-30-16.gh-issue-151763.-sTnNi.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`!_interpreters.capture_exception` when
+:exc:`MemoryError` happens.

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -1541,7 +1541,9 @@ _interpreters_capture_exception_impl(PyObject *module, PyObject *exc_arg)
     }
 
 finally:
-    _PyXI_FreeExcInfo(info);
+    if (info != NULL) {
+        _PyXI_FreeExcInfo(info);
+    }
     if (exc != exc_arg) {
         if (PyErr_Occurred()) {
             PyErr_SetRaisedException(exc);

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -1689,6 +1689,7 @@ _PyXI_NewExcInfo(PyObject *exc)
     }
     _PyXI_excinfo *info = PyMem_RawCalloc(1, sizeof(_PyXI_excinfo));
     if (info == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     const char *failure;


### PR DESCRIPTION
It actually had two possible crashes:
1. Rereferencing `NULL` in `_PyXI_FreeExcInfo(info);`
2. No setting memory exception on `PyMem_RawCalloc` failure

<!-- gh-issue-number: gh-151763 -->
* Issue: gh-151763
<!-- /gh-issue-number -->
