### PR TITLE
gh-152017: Fix `deque_clear` to no longer alters exceptions

### DIFF
--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -15,7 +15,6 @@ from test import support
 from test.support.import_helper import import_fresh_module
 import types
 import unittest
-import _testcapi
 
 from collections import namedtuple, Counter, OrderedDict, _count_elements
 from collections import UserDict, UserString, UserList
@@ -2476,22 +2475,6 @@ class TestCounter(unittest.TestCase):
             pp ^= qq
             self.assertEqual(pp, r)
 
-################################################################################
-### Deque
-################################################################################
-
-class TestDeque(unittest.TestCase):
-
-    def test_deque_oom(self):
-        for n in range(1, 80):
-            d = deque(range(200))
-            _testcapi.set_nomemory(n, 0)
-            try:
-                d.copy()
-                _testcapi.remove_mem_hooks()
-                break
-            except MemoryError:
-                _testcapi.remove_mem_hooks()
 
 def load_tests(loader, tests, pattern):
     tests.addTest(doctest.DocTestSuite(collections))

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -15,6 +15,7 @@ from test import support
 from test.support.import_helper import import_fresh_module
 import types
 import unittest
+import _testcapi
 
 from collections import namedtuple, Counter, OrderedDict, _count_elements
 from collections import UserDict, UserString, UserList
@@ -2475,6 +2476,22 @@ class TestCounter(unittest.TestCase):
             pp ^= qq
             self.assertEqual(pp, r)
 
+################################################################################
+### Deque
+################################################################################
+
+class TestDeque(unittest.TestCase):
+
+    def test_deque_oom(self):
+        for n in range(1, 80):
+            d = deque(range(200))
+            _testcapi.set_nomemory(n, 0)
+            try:
+                d.copy()
+                _testcapi.remove_mem_hooks()
+                break
+            except MemoryError:
+                _testcapi.remove_mem_hooks()
 
 def load_tests(loader, tests, pattern):
     tests.addTest(doctest.DocTestSuite(collections))

--- a/Misc/NEWS.d/next/Library/2026-06-23-15-02-27.gh-issue-152017.wH89hr.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-23-15-02-27.gh-issue-152017.wH89hr.rst
@@ -1,0 +1,1 @@
+:class:`collections.deque` no longer suppresses :exc:`MemoryError` in certain cases.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -746,9 +746,10 @@ deque_clear(PyObject *self)
        adversary could cause it to never terminate).
     */
 
+    PyObject *old_exc = PyErr_GetRaisedException();
     b = newblock(deque);
+    PyErr_SetRaisedException(old_exc);
     if (b == NULL) {
-        PyErr_Clear();
         goto alternate_method;
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152017 -->
* Issue: gh-152017
<!-- /gh-issue-number -->
