### PR TITLE
Re-raise unexpected exceptions instead of swallowing them in tests

### DIFF
--- a/Lib/test/test_fcntl.py
+++ b/Lib/test/test_fcntl.py
@@ -151,6 +151,7 @@ class TestFcntl(unittest.TestCase):
             except OSError as exc:
                 if exc.errno == errno.EINVAL:
                     self.skipTest("F_NOTIFY not available by this environment")
+                raise
             fcntl.fcntl(fd, cmd, flags)
         finally:
             os.close(fd)

--- a/Lib/test/test_launcher.py
+++ b/Lib/test/test_launcher.py
@@ -469,6 +469,7 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
         except subprocess.CalledProcessError:
             if not is_installed("2.7"):
                 raise unittest.SkipTest("requires at least one Python 2.x install")
+            raise
         self.assertEqual("PythonCore", data["env.company"])
         self.assertStartsWith(data["env.tag"], "2.")
 

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -2870,6 +2870,7 @@ class PathTest(PurePathTest):
             if (isinstance(e, PermissionError) or
                     "AF_UNIX path too long" in str(e)):
                 self.skipTest("cannot bind Unix socket: " + str(e))
+            raise
         self.assertTrue(P.is_socket())
         self.assertFalse(P.is_fifo())
         self.assertFalse(P.is_file())

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1427,6 +1427,7 @@ class GeneralModuleTests(unittest.TestCase):
             except OSError as e:
                 if e.winerror == 10022:
                     self.skipTest('IPv6 might not be supported')
+                raise
 
         f = lambda a: inet_pton(AF_INET6, a)
         assertInvalid = lambda a: self.assertRaises(
@@ -1517,6 +1518,7 @@ class GeneralModuleTests(unittest.TestCase):
             except OSError as e:
                 if e.winerror == 10022:
                     self.skipTest('IPv6 might not be supported')
+                raise
 
         f = lambda a: inet_ntop(AF_INET6, a)
         assertInvalid = lambda a: self.assertRaises(


### PR DESCRIPTION
When fixing https://github.com/python/cpython/pull/137420, I found that some existing test code swallows exceptions it doesn't care about.

I think these are simple, test only fixes, so the issue and the news entry aren't required.