### PR TITLE
gh-148529: Accept any contiguous bytes-like object for the struct 's' and 'p' formats

### DIFF
--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -357,8 +357,11 @@ Notes:
    are used.  Note that for :func:`unpack`, the ``'p'`` type code consumes
    ``count`` bytes, but that the :class:`!bytes` object returned can never contain more than 255
    bytes.
-   When packing, arguments of types :class:`bytes` and :class:`bytearray`
-   are accepted.
+   When packing, any contiguous :term:`bytes-like object` is accepted.
+
+   .. versionchanged:: next
+      Previously only :class:`bytes` and :class:`bytearray` objects were
+      accepted.
 
 (9)
    For the ``'s'`` type code, the count is interpreted as the length of the
@@ -373,8 +376,11 @@ Notes:
    unpacking, the resulting :class:`!bytes` object always has exactly the specified number
    of bytes.  As a special case, ``'0s'`` means a single, empty byte string (while
    ``'0c'`` means 0 characters).
-   When packing, arguments of types :class:`bytes` and :class:`bytearray`
-   are accepted.
+   When packing, any contiguous :term:`bytes-like object` is accepted.
+
+   .. versionchanged:: next
+      Previously only :class:`bytes` and :class:`bytearray` objects were
+      accepted.
 
 (10)
    For the ``'F'`` and ``'D'`` type codes, the packed representation uses

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -365,6 +365,37 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             (got,) = struct.unpack(code, got)
             self.assertEqual(got, expectedback)
 
+    def test_pack_s_p_bytes_like(self):
+        # gh-148529: the 's' and 'p' format codes accept any contiguous
+        # bytes-like object when packing, not only bytes and bytearray.
+        data = b'abcd'
+        providers = [
+            ('memoryview', memoryview(data)),
+            ('memoryview(bytearray)', memoryview(bytearray(data))),
+            ('array', array.array('b', data)),
+        ]
+        for code in ('4s', '10s', '0s', '4p', '10p', '1p'):
+            expected = struct.pack(code, data)
+            s = struct.Struct(code)
+            for name, value in providers:
+                with self.subTest(code=code, provider=name):
+                    self.assertEqual(struct.pack(code, value), expected)
+                    self.assertEqual(s.pack(value), expected)
+                    buf = bytearray(s.size)
+                    struct.pack_into(code, buf, 0, value)
+                    self.assertEqual(bytes(buf), expected)
+
+        # Non-contiguous buffers cannot be packed and raise struct.error.
+        noncontig = memoryview(bytearray(b'abcdefgh'))[::2]
+        self.assertRaises(struct.error, struct.pack, '4s', noncontig)
+        self.assertRaises(struct.error, struct.pack, '4p', noncontig)
+
+        # Objects that do not support the buffer protocol still raise
+        # struct.error for the 's' and 'p' codes.
+        for bad in (5, 'string', None, [1, 2, 3]):
+            self.assertRaises(struct.error, struct.pack, '4s', bad)
+            self.assertRaises(struct.error, struct.pack, '4p', bad)
+
     def test_705836(self):
         # SF bug 705836.  "<f" and ">f" had a severe rounding bug, where a carry
         # from the low-order discarded bits could propagate into the exponent

--- a/Misc/NEWS.d/next/Library/2026-06-24-12-00-00.gh-issue-148529.rwH6cW.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-24-12-00-00.gh-issue-148529.rwH6cW.rst
@@ -1,0 +1,4 @@
+:func:`struct.pack`, :func:`struct.pack_into` and :meth:`struct.Struct.pack`
+now accept any contiguous :term:`bytes-like object` (such as
+:class:`memoryview` or :class:`array.array`) for the ``'s'`` and ``'p'``
+format codes, instead of only :class:`bytes` and :class:`bytearray`.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2347,43 +2347,57 @@ s_pack_internal(PyStructObject *soself, PyObject *const *args,
             PyObject *v = args[i++];
             if (strcmp(e->format, "s") == 0) {
                 Py_ssize_t n;
-                int isstring;
                 const void *p;
-                isstring = PyBytes_Check(v);
-                if (!isstring && !PyByteArray_Check(v)) {
-                    PyErr_SetString(state->StructError,
-                                    "argument for 's' must be a bytes object");
-                    return -1;
-                }
-                if (isstring) {
+                Py_buffer view;
+                int gotview = 0;
+                if (PyBytes_Check(v)) {
                     n = PyBytes_GET_SIZE(v);
                     p = PyBytes_AS_STRING(v);
                 }
-                else {
+                else if (PyByteArray_Check(v)) {
                     n = PyByteArray_GET_SIZE(v);
                     p = PyByteArray_AS_STRING(v);
+                }
+                else if (PyObject_GetBuffer(v, &view, PyBUF_SIMPLE) == 0) {
+                    n = view.len;
+                    p = view.buf;
+                    gotview = 1;
+                }
+                else {
+                    PyErr_Format(state->StructError,
+                                 "argument for 's' must be a bytes-like object, "
+                                 "not %.200s", Py_TYPE(v)->tp_name);
+                    return -1;
                 }
                 if (n > code->size)
                     n = code->size;
                 if (n > 0)
                     memcpy(res, p, n);
+                if (gotview)
+                    PyBuffer_Release(&view);
             } else if (strcmp(e->format, "p") == 0) {
                 Py_ssize_t n;
-                int isstring;
                 const void *p;
-                isstring = PyBytes_Check(v);
-                if (!isstring && !PyByteArray_Check(v)) {
-                    PyErr_SetString(state->StructError,
-                                    "argument for 'p' must be a bytes object");
-                    return -1;
-                }
-                if (isstring) {
+                Py_buffer view;
+                int gotview = 0;
+                if (PyBytes_Check(v)) {
                     n = PyBytes_GET_SIZE(v);
                     p = PyBytes_AS_STRING(v);
                 }
-                else {
+                else if (PyByteArray_Check(v)) {
                     n = PyByteArray_GET_SIZE(v);
                     p = PyByteArray_AS_STRING(v);
+                }
+                else if (PyObject_GetBuffer(v, &view, PyBUF_SIMPLE) == 0) {
+                    n = view.len;
+                    p = view.buf;
+                    gotview = 1;
+                }
+                else {
+                    PyErr_Format(state->StructError,
+                                 "argument for 'p' must be a bytes-like object, "
+                                 "not %.200s", Py_TYPE(v)->tp_name);
+                    return -1;
                 }
                 if (code->size == 0) {
                     n = 0;
@@ -2396,6 +2410,8 @@ s_pack_internal(PyStructObject *soself, PyObject *const *args,
                 if (n > 255)
                     n = 255;
                 *res = Py_SAFE_DOWNCAST(n, Py_ssize_t, unsigned char);
+                if (gotview)
+                    PyBuffer_Release(&view);
             } else {
                 if (e->pack(state, res, v, e) < 0) {
                     if (PyLong_Check(v) && PyErr_ExceptionMatches(PyExc_OverflowError))


### PR DESCRIPTION
`struct.pack` (and `pack_into` / `Struct.pack`) only accepted `bytes` and `bytearray` for the `s` and `p` format codes. Passing any other buffer — `memoryview`, `array.array`, `mmap`, ... — failed with `struct.error`, even though it's a contiguous chunk of bytes that can be copied straight in:

```pycon
>>> struct.pack("4s", memoryview(b"abad"))
struct.error: argument for 's' must be a bytes object
```

Both codes now accept any contiguous bytes-like object. `bytes`/`bytearray` keep their existing fast path; anything else goes through the buffer protocol (`PyObject_GetBuffer` with `PyBUF_SIMPLE`), and the buffer is released on every exit path. Non-contiguous buffers and objects that don't expose a buffer still raise `struct.error` (with a slightly clearer message now).

serhiy-storchaka said as much on the issue — "there is no reason to limit it to bytes and bytearray, any object providing continuous buffer can be supported".

Added a regression test covering `memoryview` and `array.array` through `pack`, `pack_into` and `Struct.pack`, and updated the docs, which until now spelled out the bytes/bytearray-only restriction.


<!-- gh-issue-number: gh-148529 -->
* Issue: gh-148529
<!-- /gh-issue-number -->
