### PR TITLE
gh-152037: Raise ValueError for turtle.degrees(0) instead of ZeroDivisionError

### DIFF
--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -368,6 +368,11 @@ class TestTNavigator(VectorComparisonMixin, unittest.TestCase):
         self.nav.degrees()
         self.assertAlmostEqual(self.nav.heading(), 90)
 
+    def test_degrees_zero(self):
+        # degrees(0) used to raise ZeroDivisionError from 360/fullcircle.
+        with self.assertRaises(ValueError):
+            self.nav.degrees(0)
+
     def test_towards(self):
 
         coordinates = [

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -1615,6 +1615,8 @@ class TNavigator(object):
 
     def _setDegreesPerAU(self, fullcircle):
         """Helper function for degrees() and radians()"""
+        if fullcircle == 0:
+            raise ValueError("fullcircle must be a nonzero number")
         self._fullcircle = fullcircle
         self._degreesPerAU = 360/fullcircle
         if self._mode == "standard":

--- a/Misc/NEWS.d/next/Library/2026-06-23-19-41-01.gh-issue-152037.KjWrdg.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-23-19-41-01.gh-issue-152037.KjWrdg.rst
@@ -1,0 +1,2 @@
+Fix :exc:`ZeroDivisionError` in :func:`turtle.degrees` when *fullcircle* is
+``0``; it now raises :exc:`ValueError`.


### PR DESCRIPTION
`turtle.TNavigator.degrees(fullcircle)` — the public `Turtle.degrees` / `turtle.degrees` — computed
`360 / fullcircle` in `_setDegreesPerAU` with no check on *fullcircle*, so `degrees(0)` raised a cryptic
`ZeroDivisionError` straight through the public API:

```pycon
>>> import turtle
>>> turtle.TNavigator().degrees(0)
ZeroDivisionError: division by zero
```

`degrees` documents *fullcircle* only as "a number", and `0` reaches the division directly, so this
raises a clear `ValueError` instead. `radians()` passes `math.tau` and is unaffected.

Adds a regression test in `TestTNavigator` (which is Tk-free) and a `Misc/NEWS` entry.


<!-- gh-issue-number: gh-152037 -->
* Issue: gh-152037
<!-- /gh-issue-number -->
