### PR TITLE
gh-70398: Fix HTMLParser crash when reset()/feed() is called from a handler

### DIFF
--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -218,8 +218,7 @@ class HTMLParser(_markupbase.ParserBase):
         while i < n:
             if self.rawdata is not rawdata:
                 # A handler called reset() or feed() and replaced the buffer
-                # we are processing.  Stop and let the new data be handled by
-                # a subsequent call.
+                # we are processing; the rest is handled by a later call.
                 return
             if self.convert_charrefs and not self.cdata_elem:
                 j = rawdata.find('<', i)

--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -217,8 +217,7 @@ class HTMLParser(_markupbase.ParserBase):
         n = len(rawdata)
         while i < n:
             if self.rawdata is not rawdata:
-                # A handler called reset() or feed() and replaced the buffer
-                # we are processing; the rest is handled by a later call.
+                # A handler called reset()/feed() and replaced the buffer.
                 return
             if self.convert_charrefs and not self.cdata_elem:
                 j = rawdata.find('<', i)
@@ -248,8 +247,7 @@ class HTMLParser(_markupbase.ParserBase):
                 else:
                     self.handle_data(rawdata[i:j])
                 if self.rawdata is not rawdata:
-                    # handle_data() called reset() or feed() and replaced the
-                    # buffer; stop processing the now-stale data.
+                    # handle_data() called reset()/feed() and replaced it.
                     return
             i = self.updatepos(i, j)
             if i == n: break

--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -216,6 +216,11 @@ class HTMLParser(_markupbase.ParserBase):
         i = 0
         n = len(rawdata)
         while i < n:
+            if self.rawdata is not rawdata:
+                # A handler called reset() or feed() and replaced the buffer
+                # we are processing.  Stop and let the new data be handled by
+                # a subsequent call.
+                return
             if self.convert_charrefs and not self.cdata_elem:
                 j = rawdata.find('<', i)
                 if j < 0:
@@ -243,6 +248,10 @@ class HTMLParser(_markupbase.ParserBase):
                     self.handle_data(unescape(rawdata[i:j]))
                 else:
                     self.handle_data(rawdata[i:j])
+                if self.rawdata is not rawdata:
+                    # handle_data() called reset() or feed() and replaced the
+                    # buffer; stop processing the now-stale data.
+                    return
             i = self.updatepos(i, j)
             if i == n: break
             startswith = rawdata.startswith

--- a/Lib/test/test_htmlparser.py
+++ b/Lib/test/test_htmlparser.py
@@ -1011,7 +1011,27 @@ text
              ('endtag', 'a'), ('data', ' bar & baz')]
         )
 
-    def test_reset_in_handler(self):
+    @support.subTests('trigger,convert_charrefs,source,expected', [
+        # convert_charrefs=True takes the rawdata.find('<') branch.
+        ('data', True, 'abc<x>def', [('data', 'abc')]),
+        ('starttag', True, '<a>x<b>y', [('starttag', 'a')]),
+        ('endtag', True, '<a></a>tail<b>',
+         [('starttag', 'a'), ('endtag', 'a')]),
+        ('comment', True, '<!--c-->after<x>', [('comment', 'c')]),
+        # convert_charrefs=False takes the self.interesting.search branch
+        # and additionally reports charrefs/entityrefs.
+        ('data', False, 'abc<x>def', [('data', 'abc')]),
+        ('starttag', False, '<a>x<b>y', [('starttag', 'a')]),
+        ('endtag', False, '<a></a>tail<b>',
+         [('starttag', 'a'), ('endtag', 'a')]),
+        ('comment', False, '<!--c-->after<x>', [('comment', 'c')]),
+        ('charref', False, 'a&#97;b<x>',
+         [('data', 'a'), ('charref', '97')]),
+        ('entityref', False, 'a&amp;b<x>',
+         [('data', 'a'), ('entityref', 'amp')]),
+    ])
+    def test_reset_in_handler(self, trigger, convert_charrefs, source,
+                              expected):
         # gh-70398: calling reset() from within a handler used to leave
         # goahead() processing a stale buffer and crash with an
         # AssertionError.  It should instead stop parsing the current data.
@@ -1041,26 +1061,64 @@ text
                 self.events.append(('comment', data))
                 if self.trigger == 'comment':
                     self._reset_once()
+            def handle_charref(self, name):
+                self.events.append(('charref', name))
+                if self.trigger == 'charref':
+                    self._reset_once()
+            def handle_entityref(self, name):
+                self.events.append(('entityref', name))
+                if self.trigger == 'entityref':
+                    self._reset_once()
 
-        for trigger, source, expected in [
-            ('data', 'abc<x>def', [('data', 'abc')]),
-            ('starttag', '<a>x<b>y', [('starttag', 'a')]),
-            ('endtag', '<a></a>tail<b>', [('starttag', 'a'), ('endtag', 'a')]),
-            ('comment', '<!--c-->after<x>', [('comment', 'c')]),
-        ]:
-            with self.subTest(trigger=trigger):
-                parser = Resetter(trigger)
-                parser.feed(source)
-                # Only events up to the reset() call are reported; the rest
-                # of the now-discarded buffer is not processed.
-                self.assertEqual(parser.events, expected)
-                self.assertEqual(parser.rawdata, '')
-                # A fresh document still parses correctly after the reset.
-                parser.events.clear()
-                parser.feed('<keep>kept')
-                parser.close()
-                self.assertEqual(parser.events, [('starttag', 'keep'),
-                                                 ('data', 'kept')])
+        parser = Resetter(trigger, convert_charrefs=convert_charrefs)
+        parser.feed(source)
+        # Only events up to the reset() call are reported; the rest
+        # of the now-discarded buffer is not processed.
+        self.assertEqual(parser.events, expected)
+        self.assertEqual(parser.rawdata, '')
+        # A fresh document still parses correctly after the reset.
+        parser.events.clear()
+        parser.feed('<keep>kept')
+        parser.close()
+        self.assertEqual(parser.events,
+                         [('starttag', 'keep'), ('data', 'kept')])
+
+    @support.subTests('convert_charrefs', [True, False])
+    def test_feed_in_handler(self, convert_charrefs):
+        # gh-70398: a handler calling feed() (rather than reset()) also
+        # swaps self.rawdata mid-parse and used to crash goahead().  The
+        # already-consumed prefix is re-emitted (pre-existing behavior);
+        # what matters is that it does not crash and the parser stays
+        # usable for the newly fed data and for a later feed()/close().
+        class Feeder(html.parser.HTMLParser):
+            def __init__(self, extra, **kw):
+                super().__init__(**kw)
+                self.extra = extra
+                self.done = False
+                self.events = []
+            def handle_starttag(self, tag, attrs):
+                self.events.append(('starttag', tag))
+                if not self.done:
+                    self.done = True
+                    self.feed(self.extra)
+            def handle_endtag(self, tag):
+                self.events.append(('endtag', tag))
+            def handle_data(self, data):
+                self.events.append(('data', data))
+
+        parser = Feeder('<b>more', convert_charrefs=convert_charrefs)
+        parser.feed('<a>x</a>')
+        parser.close()
+        # The data fed from within the handler is parsed.
+        self.assertIn(('starttag', 'b'), parser.events)
+        self.assertIn(('data', 'more'), parser.events)
+        self.assertEqual(parser.rawdata, '')
+        # The parser remains usable afterwards.
+        parser.events.clear()
+        parser.feed('<keep>kept')
+        parser.close()
+        self.assertEqual(parser.events,
+                         [('starttag', 'keep'), ('data', 'kept')])
 
     @support.requires_resource('cpu')
     def test_eof_no_quadratic_complexity(self):

--- a/Lib/test/test_htmlparser.py
+++ b/Lib/test/test_htmlparser.py
@@ -1011,6 +1011,57 @@ text
              ('endtag', 'a'), ('data', ' bar & baz')]
         )
 
+    def test_reset_in_handler(self):
+        # gh-70398: calling reset() from within a handler used to leave
+        # goahead() processing a stale buffer and crash with an
+        # AssertionError.  It should instead stop parsing the current data.
+        class Resetter(html.parser.HTMLParser):
+            def __init__(self, trigger, **kw):
+                super().__init__(**kw)
+                self.trigger = trigger
+                self.done = False
+                self.events = []
+            def _reset_once(self):
+                if not self.done:
+                    self.done = True
+                    self.reset()
+            def handle_starttag(self, tag, attrs):
+                self.events.append(('starttag', tag))
+                if self.trigger == 'starttag':
+                    self._reset_once()
+            def handle_endtag(self, tag):
+                self.events.append(('endtag', tag))
+                if self.trigger == 'endtag':
+                    self._reset_once()
+            def handle_data(self, data):
+                self.events.append(('data', data))
+                if self.trigger == 'data':
+                    self._reset_once()
+            def handle_comment(self, data):
+                self.events.append(('comment', data))
+                if self.trigger == 'comment':
+                    self._reset_once()
+
+        for trigger, source, expected in [
+            ('data', 'abc<x>def', [('data', 'abc')]),
+            ('starttag', '<a>x<b>y', [('starttag', 'a')]),
+            ('endtag', '<a></a>tail<b>', [('starttag', 'a'), ('endtag', 'a')]),
+            ('comment', '<!--c-->after<x>', [('comment', 'c')]),
+        ]:
+            with self.subTest(trigger=trigger):
+                parser = Resetter(trigger)
+                parser.feed(source)
+                # Only events up to the reset() call are reported; the rest
+                # of the now-discarded buffer is not processed.
+                self.assertEqual(parser.events, expected)
+                self.assertEqual(parser.rawdata, '')
+                # A fresh document still parses correctly after the reset.
+                parser.events.clear()
+                parser.feed('<keep>kept')
+                parser.close()
+                self.assertEqual(parser.events, [('starttag', 'keep'),
+                                                 ('data', 'kept')])
+
     @support.requires_resource('cpu')
     def test_eof_no_quadratic_complexity(self):
         # Each of these examples used to take about an hour.

--- a/Misc/NEWS.d/next/Library/2026-06-24-01-35-49.gh-issue-70398.SgTcYz.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-24-01-35-49.gh-issue-70398.SgTcYz.rst
@@ -1,0 +1,4 @@
+Fix :class:`html.parser.HTMLParser` crashing with an :exc:`AssertionError`
+when :meth:`~html.parser.HTMLParser.reset` is called from within one of its
+handler methods.  Parsing of the current data now stops, and the parser can
+be reused for subsequent input.


### PR DESCRIPTION
A bare `assert` must never be reachable from ordinary user code. Today,
calling `reset()` (or `feed()`) from inside an `HTMLParser` handler trips
an internal assertion. The fix is not about supporting mid-handler
`reset()` as a feature; it is about leaving the parser in a clean,
reusable state after a handler swaps the buffer, instead of crashing
while slicing data that no longer exists.

## Root cause

`goahead()` caches the buffer it is parsing in a local variable:

```python
def goahead(self, end):
    rawdata = self.rawdata
    i = 0
    n = len(rawdata)
    while i < n:
        ...
```

It then loops, slicing `rawdata[i:j]` and calling handlers. The loop
assumes `self.rawdata` stays the same object for the whole call. A
handler breaks that assumption: `reset()` sets `self.rawdata = ''`, and a
re-entrant `feed()` rebuilds `self.rawdata`. After such a call, `goahead()`
keeps walking the now-stale local `rawdata` with indices that no longer
match `self.rawdata`. Downstream this produces a regex match against the
wrong string, the result is `None`, and `check_for_whole_start_tag()`
hits `assert match`.

```python
def check_for_whole_start_tag(self, i):
    rawdata = self.rawdata
    match = locatetagend.match(rawdata, i+1)
    assert match          # trips here
    j = match.end()
```

## Why the assert is load-bearing, not a debug-only invariant

Under `python -O` the `assert` is compiled out. The `None` then
propagates one line further to `j = match.end()`, raising an unrelated,
harder-to-diagnose error from a different call site:

```
  File ".../html/parser.py", line ..., in parse_starttag
    endpos = self.check_for_whole_start_tag(i)
  File ".../html/parser.py", line ..., in check_for_whole_start_tag
    j = match.end()
AttributeError: 'NoneType' object has no attribute 'end'
```

So the `assert` is acting as real control flow guarding a corrupt state,
not merely documenting an invariant. Honest caveat: in both modes the
failure is a raised exception at parse time (an `AssertionError`, or an
`AttributeError` under `-O`); it is not silent output corruption or an
infinite loop. But a parser should not raise an internal assertion in
response to a legitimate handler action, and `-O` turning one exception
type into a more confusing one confirms this code path needs an explicit
guard rather than an assertion.

## The fix

Detect that `self.rawdata` is no longer the object `goahead()` started
with, and stop. Two checks cover the two points at which a handler can
run during the loop: the top of the loop (covers handlers invoked by the
tag/ref parsing helpers on the previous iteration) and immediately after
`handle_data()`.

```python
while i < n:
    if self.rawdata is not rawdata:
        # A handler called reset() or feed() and replaced the buffer
        # we are processing; the rest is handled by a later call.
        return
    ...
        if i < j:
            ...
            self.handle_data(...)
            if self.rawdata is not rawdata:
                # handle_data() called reset() or feed() and replaced the
                # buffer; stop processing the now-stale data.
                return
```

After `reset()`, parsing of the current data stops and the parser is back
to a fresh state, ready to be reused. After a re-entrant `feed()`, the
newly fed data is handled by the in-progress call as usual; the parser is
left usable for later `feed()`/`close()` calls.

This answers the original 2016 report (Hibou57): "I expected `reset()` to
stop the parser." It now does, cleanly, instead of crashing.

Note: a handler that calls `feed()` mid-parse re-emits the prefix it has
already consumed. That is pre-existing behavior and is left unchanged; the
tests assert only what matters there (no crash, the newly fed data is
parsed, and the parser stays reusable), not the exact duplicated event
sequence.

## Compatibility

Normal parsing is unaffected: the new checks only fire when a handler
actually replaces `self.rawdata`. Output for inputs that do not call
`reset()`/`feed()` from a handler is byte-identical before and after,
including the default `convert_charrefs=True` path and chunked feeding.

## Tests

`test_reset_in_handler` is parameterized over both `convert_charrefs`
branches (the `rawdata.find('<')` path and the `self.interesting.search`
path) and over every handler entry point that can run mid-parse:
`handle_data`, `handle_starttag`, `handle_endtag`, `handle_comment`, plus
`handle_charref` and `handle_entityref` (which only fire under
`convert_charrefs=False`). A new `test_feed_in_handler` covers a handler
calling `feed()` instead of `reset()`. Each case asserts: no crash, the
expected events up to the swap, `rawdata == ''` afterward, and that the
parser still parses a fresh document. Every new case crashes on the
unpatched parser and passes on the fixed one.

Refs gh-70398.
