### PR TITLE
gh-152042: Preserve instance __dict__ when copying deque and array subclasses

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -305,6 +305,25 @@ class BaseTest:
         self.assertNotEqual(id(a), id(b))
         self.assertEqual(a, b)
 
+    def test_copy_subclass_preserves_type_and_dict(self):
+        # gh-152042: copy.copy() and copy.deepcopy() of an array subclass
+        # must preserve the subclass type and the instance __dict__
+        # (like pickle does).
+        import copy
+        a = ArraySubclass(self.typecode, self.example)
+        a.tag = "kept"
+        for b in (copy.copy(a), copy.deepcopy(a),
+                  pickle.loads(pickle.dumps(a))):
+            self.assertIs(type(b), ArraySubclass)
+            self.assertEqual(a, b)
+            self.assertEqual(b.tag, "kept")
+        # deepcopy must deep-copy the instance attributes.
+        a2 = ArraySubclass(self.typecode, self.example)
+        a2.payload = [1]
+        b2 = copy.deepcopy(a2)
+        a2.payload[0] = 99
+        self.assertEqual(b2.payload, [1])
+
     def test_reduce_ex(self):
         a = array.array(self.typecode, self.example)
         for protocol in range(3):

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -324,6 +324,20 @@ class BaseTest:
         a2.payload[0] = 99
         self.assertEqual(b2.payload, [1])
 
+    def test_deepcopy_subclass_self_reference(self):
+        # gh-152042: deepcopy() of a subclass instance whose __dict__ refers
+        # back to itself must terminate and rebind the reference to the copy,
+        # not recurse forever.  __deepcopy__ registers the new object in the
+        # memo before deep-copying the instance dict to make this work.
+        import copy
+        a = ArraySubclass(self.typecode, self.example)
+        a.self_ref = a
+        b = copy.deepcopy(a)
+        self.assertIs(type(b), ArraySubclass)
+        self.assertEqual(a, b)
+        self.assertIs(b.self_ref, b)
+        self.assertIsNot(b, a)
+
     def test_reduce_ex(self):
         a = array.array(self.typecode, self.example)
         for protocol in range(3):

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -810,6 +810,23 @@ class DequeWithBadIter(deque):
 
 class TestSubclass(unittest.TestCase):
 
+    def test_copy_preserves_dict(self):
+        # gh-152042: copy.copy(), copy.deepcopy() and .copy() of a deque
+        # subclass must preserve the instance __dict__ (like pickle does).
+        d = Deque([1, 2, 3])
+        d.label = "kept"
+        for e in (copy.copy(d), copy.deepcopy(d), d.copy(),
+                  pickle.loads(pickle.dumps(d))):
+            self.assertIs(type(e), Deque)
+            self.assertEqual(list(e), [1, 2, 3])
+            self.assertEqual(e.label, "kept")
+        # deepcopy must deep-copy the instance attributes.
+        d2 = Deque([1])
+        d2.payload = [10]
+        e2 = copy.deepcopy(d2)
+        d2.payload[0] = 11
+        self.assertEqual(e2.payload, [10])
+
     def test_basics(self):
         d = Deque(range(25))
         d.__init__(range(200))

--- a/Misc/NEWS.d/next/Library/2026-06-24-13-30-00.gh-issue-152042.s8BTeM.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-24-13-30-00.gh-issue-152042.s8BTeM.rst
@@ -1,0 +1,6 @@
+Copying an :class:`array.array` subclass with :func:`copy.copy` or
+:func:`copy.deepcopy` now returns an instance of the subclass and preserves its
+instance ``__dict__``, and copying a :class:`collections.deque` subclass now
+preserves its instance ``__dict__``.  Previously the attributes were dropped
+(and, for :class:`!array.array`, the result was a plain array), unlike
+:mod:`pickle`.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -658,6 +658,32 @@ deque_copy_impl(dequeobject *deque)
         Py_DECREF(result);
         return NULL;
     }
+    /* gh-152042: also copy the instance __dict__ onto the subclass copy so
+       that copy.copy() and deque.copy() preserve instance attributes
+       (matching pickle and copy.deepcopy()). */
+    if (result != NULL && _PyObject_GetDictPtr((PyObject *)deque) != NULL) {
+        PyObject *srcdict = PyObject_GenericGetDict((PyObject *)deque, NULL);
+        if (srcdict == NULL) {
+            Py_DECREF(result);
+            return NULL;
+        }
+        if (PyDict_GET_SIZE(srcdict) != 0) {
+            PyObject *newdict = PyDict_Copy(srcdict);
+            if (newdict == NULL) {
+                Py_DECREF(srcdict);
+                Py_DECREF(result);
+                return NULL;
+            }
+            int err = PyObject_GenericSetDict(result, newdict, NULL);
+            Py_DECREF(newdict);
+            if (err < 0) {
+                Py_DECREF(srcdict);
+                Py_DECREF(result);
+                return NULL;
+            }
+        }
+        Py_DECREF(srcdict);
+    }
     return result;
 }
 

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1105,35 +1105,34 @@ array_array___copy___impl(arrayobject *self)
 /*[clinic input]
 array.array.__deepcopy__
 
-    unused: object
+    memo: object(subclass_of="&PyDict_Type")
     /
 
 Return a copy of the array.
 [clinic start generated code]*/
 
 static PyObject *
-array_array___deepcopy___impl(arrayobject *self, PyObject *unused)
-/*[clinic end generated code: output=703b4c412feaaf31 input=2405ecb4933748c4]*/
+array_array___deepcopy___impl(arrayobject *self, PyObject *memo)
+/*[clinic end generated code: output=4f54235d9f41697e input=b38ca00fa84a5843]*/
 {
-    PyObject *memo = unused;     /* the copy.deepcopy() memo dict */
     PyObject *copy = array_copy_buffer(self);
     if (copy == NULL) {
         return NULL;
     }
     /* Register the copy in the memo before deep-copying the instance dict so
-       that self-referential attributes do not recurse forever. */
-    if (PyDict_Check(memo)) {
-        PyObject *key = PyLong_FromVoidPtr(self);
-        if (key == NULL) {
-            Py_DECREF(copy);
-            return NULL;
-        }
-        int err = PyDict_SetItem(memo, key, copy);
-        Py_DECREF(key);
-        if (err < 0) {
-            Py_DECREF(copy);
-            return NULL;
-        }
+       that a subclass instance whose attributes refer back to itself does not
+       recurse forever.  This mirrors _elementtree.Element.__deepcopy__() and
+       copy._reconstruct(), which likewise record id(self) in the memo. */
+    PyObject *key = PyLong_FromVoidPtr(self);
+    if (key == NULL) {
+        Py_DECREF(copy);
+        return NULL;
+    }
+    int err = PyDict_SetItem(memo, key, copy);
+    Py_DECREF(key);
+    if (err < 0) {
+        Py_DECREF(copy);
+        return NULL;
     }
     if (array_copy_dict((PyObject *)self, copy, memo) < 0) {
         Py_DECREF(copy);

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1016,6 +1016,71 @@ array_array_clear_impl(arrayobject *self)
     Py_RETURN_NONE;
 }
 
+/* gh-152042: produce a copy of the array as an instance of its actual
+   (sub)type, copying the raw item buffer.  The instance __dict__ is handled
+   separately by the callers. */
+static PyObject *
+array_copy_buffer(arrayobject *self)
+{
+    Py_ssize_t size = Py_SIZE(self);
+    arrayobject *np = (arrayobject *)newarrayobject(Py_TYPE(self), size,
+                                                    self->ob_descr);
+    if (np == NULL) {
+        return NULL;
+    }
+    if (size > 0) {
+        memcpy(np->ob_item, self->ob_item,
+               (size_t)size * self->ob_descr->itemsize);
+    }
+    return (PyObject *)np;
+}
+
+/* gh-152042: copy the instance __dict__ from src to dst.  When memo is NULL
+   the dict is shallow-copied (for __copy__); otherwise it is deep-copied via
+   copy.deepcopy(d, memo) (for __deepcopy__).  Returns 0 on success, including
+   when there is no instance dict. */
+static int
+array_copy_dict(PyObject *src, PyObject *dst, PyObject *memo)
+{
+    if (_PyObject_GetDictPtr(src) == NULL) {
+        return 0;               /* no instance dict (base array or __slots__) */
+    }
+    PyObject *srcdict = PyObject_GenericGetDict(src, NULL);
+    if (srcdict == NULL) {
+        return -1;
+    }
+    if (PyDict_GET_SIZE(srcdict) == 0) {
+        Py_DECREF(srcdict);
+        return 0;
+    }
+    PyObject *newdict;
+    if (memo == NULL) {
+        newdict = PyDict_Copy(srcdict);
+    }
+    else {
+        PyObject *copymod = PyImport_ImportModule("copy");
+        if (copymod == NULL) {
+            Py_DECREF(srcdict);
+            return -1;
+        }
+        PyObject *deepcopy = PyObject_GetAttrString(copymod, "deepcopy");
+        Py_DECREF(copymod);
+        if (deepcopy == NULL) {
+            Py_DECREF(srcdict);
+            return -1;
+        }
+        newdict = PyObject_CallFunctionObjArgs(deepcopy, srcdict, memo, NULL);
+        Py_DECREF(deepcopy);
+    }
+    Py_DECREF(srcdict);
+    if (newdict == NULL) {
+        return -1;
+    }
+    int err = PyObject_GenericSetDict(dst, newdict, NULL);
+    Py_DECREF(newdict);
+    return err;
+}
+
 /*[clinic input]
 array.array.__copy__
 
@@ -1026,7 +1091,15 @@ static PyObject *
 array_array___copy___impl(arrayobject *self)
 /*[clinic end generated code: output=dec7c3f925d9619e input=ad1ee5b086965f09]*/
 {
-    return array_slice(self, 0, Py_SIZE(self));
+    PyObject *copy = array_copy_buffer(self);
+    if (copy == NULL) {
+        return NULL;
+    }
+    if (array_copy_dict((PyObject *)self, copy, NULL) < 0) {
+        Py_DECREF(copy);
+        return NULL;
+    }
+    return copy;
 }
 
 /*[clinic input]
@@ -1042,7 +1115,31 @@ static PyObject *
 array_array___deepcopy___impl(arrayobject *self, PyObject *unused)
 /*[clinic end generated code: output=703b4c412feaaf31 input=2405ecb4933748c4]*/
 {
-    return array_array___copy___impl(self);
+    PyObject *memo = unused;     /* the copy.deepcopy() memo dict */
+    PyObject *copy = array_copy_buffer(self);
+    if (copy == NULL) {
+        return NULL;
+    }
+    /* Register the copy in the memo before deep-copying the instance dict so
+       that self-referential attributes do not recurse forever. */
+    if (PyDict_Check(memo)) {
+        PyObject *key = PyLong_FromVoidPtr(self);
+        if (key == NULL) {
+            Py_DECREF(copy);
+            return NULL;
+        }
+        int err = PyDict_SetItem(memo, key, copy);
+        Py_DECREF(key);
+        if (err < 0) {
+            Py_DECREF(copy);
+            return NULL;
+        }
+    }
+    if (array_copy_dict((PyObject *)self, copy, memo) < 0) {
+        Py_DECREF(copy);
+        return NULL;
+    }
+    return copy;
 }
 
 static PyObject *

--- a/Modules/clinic/arraymodule.c.h
+++ b/Modules/clinic/arraymodule.c.h
@@ -6,7 +6,7 @@ preserve
 #  include "pycore_runtime.h"     // _Py_SINGLETON()
 #endif
 #include "pycore_abstract.h"      // _PyNumber_Index()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(array_array_clear__doc__,
 "clear($self, /)\n"
@@ -45,7 +45,7 @@ array_array___copy__(PyObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 PyDoc_STRVAR(array_array___deepcopy____doc__,
-"__deepcopy__($self, unused, /)\n"
+"__deepcopy__($self, memo, /)\n"
 "--\n"
 "\n"
 "Return a copy of the array.");
@@ -54,15 +54,22 @@ PyDoc_STRVAR(array_array___deepcopy____doc__,
     {"__deepcopy__", (PyCFunction)array_array___deepcopy__, METH_O, array_array___deepcopy____doc__},
 
 static PyObject *
-array_array___deepcopy___impl(arrayobject *self, PyObject *unused);
+array_array___deepcopy___impl(arrayobject *self, PyObject *memo);
 
 static PyObject *
-array_array___deepcopy__(PyObject *self, PyObject *unused)
+array_array___deepcopy__(PyObject *self, PyObject *arg)
 {
     PyObject *return_value = NULL;
+    PyObject *memo;
 
-    return_value = array_array___deepcopy___impl((arrayobject *)self, unused);
+    if (!PyDict_Check(arg)) {
+        _PyArg_BadArgument("__deepcopy__", "argument", "dict", arg);
+        goto exit;
+    }
+    memo = arg;
+    return_value = array_array___deepcopy___impl((arrayobject *)self, memo);
 
+exit:
     return return_value;
 }
 
@@ -781,4 +788,4 @@ array_arrayiterator___setstate__(PyObject *self, PyObject *state)
 
     return return_value;
 }
-/*[clinic end generated code: output=32784678e77ac658 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=15f28826f243f877 input=a9049054013a1b77]*/


### PR DESCRIPTION
`copy.copy()` of a `collections.deque` subclass, and both `copy.copy()` and `copy.deepcopy()` of an `array.array` subclass, dropped the instance `__dict__`. For `array` the result was also a plain `array` rather than the subclass. `pickle` and the `list`/`dict`/`set` subclasses don't have this problem, so the behavior was inconsistent.

```pycon
>>> import copy
>>> from collections import deque
>>> class D(deque): pass
>>> d = D([1, 2, 3]); d.label = "kept"
>>> copy.copy(d).label          # was AttributeError
'kept'
>>> from array import array
>>> class A(array): pass
>>> a = A("i", [1, 2]); a.tag = "kept"
>>> copy.copy(a).tag, type(copy.copy(a)) is A   # was AttributeError, base array
('kept', True)
```

`deque.__copy__` (shared with `deque.copy()`) now copies the instance `__dict__` onto the new object. `array.__copy__`/`__deepcopy__` now build the actual subclass and copy the `__dict__` — shallow for `__copy__`, deep (via the memo) for `__deepcopy__`, registering the new object in the memo first so self-referential attributes don't recurse forever.

Both types' `__reduce_ex__` already carried this state, which is why `pickle` (and `deepcopy` of a deque, which has no `__deepcopy__`) were already correct.

Fixes #152042.


<!-- gh-issue-number: gh-152042 -->
* Issue: gh-152042
<!-- /gh-issue-number -->
