### PR TITLE
gh-152052: Fix misleading json error for \uXXXX escape at end of input

### DIFF
--- a/Lib/test/test_json/test_fail.py
+++ b/Lib/test/test_json/test_fail.py
@@ -144,9 +144,7 @@ class TestFail:
             ('"', 'Unterminated string starting at', 0),
             ('"spam', 'Unterminated string starting at', 0),
         ]
-        # A \uXXXX escape whose final hex digit is the last character of
-        # the input forms a complete, valid escape, so the string is
-        # unterminated rather than containing an invalid escape.
+        # A complete \uXXXX escape at end of input leaves it unterminated.
         test_cases += [
             (r'"\u0041', 'Unterminated string starting at', 0),
             (r'"\ud834', 'Unterminated string starting at', 0),

--- a/Lib/test/test_json/test_fail.py
+++ b/Lib/test/test_json/test_fail.py
@@ -144,6 +144,15 @@ class TestFail:
             ('"', 'Unterminated string starting at', 0),
             ('"spam', 'Unterminated string starting at', 0),
         ]
+        # A \uXXXX escape whose final hex digit is the last character of
+        # the input forms a complete, valid escape, so the string is
+        # unterminated rather than containing an invalid escape.
+        test_cases += [
+            (r'"\u0041', 'Unterminated string starting at', 0),
+            (r'"\ud834', 'Unterminated string starting at', 0),
+            (r'"\ud834\udd1e', 'Unterminated string starting at', 0),
+            (r'{"a": "\u0041', 'Unterminated string starting at', 6),
+        ]
         for data, msg, idx in test_cases:
             with self.assertRaises(self.JSONDecodeError) as cm:
                 self.loads(data)

--- a/Lib/test/test_json/test_scanstring.py
+++ b/Lib/test/test_json/test_scanstring.py
@@ -137,8 +137,7 @@ class TestScanstring:
             '"\\ud834\\u-123"',
             '"\\ud834\\u+123"',
             '"\\ud834\\u1_23"',
-            # A \uXXXX escape at the end of the input: too few hex digits
-            # before EOF, and the right number of non-hex characters.
+            # Truncated or non-hex \uXXXX escape at end of input.
             '"\\u004',
             '"\\uXYZW',
         ]

--- a/Lib/test/test_json/test_scanstring.py
+++ b/Lib/test/test_json/test_scanstring.py
@@ -137,6 +137,10 @@ class TestScanstring:
             '"\\ud834\\u-123"',
             '"\\ud834\\u+123"',
             '"\\ud834\\u1_23"',
+            # A \uXXXX escape at the end of the input: too few hex digits
+            # before EOF, and the right number of non-hex characters.
+            '"\\u004',
+            '"\\uXYZW',
         ]
         for s in bad_escapes:
             with self.assertRaises(self.JSONDecodeError, msg=s):

--- a/Misc/NEWS.d/next/Library/2026-06-24-12-00-00.gh-issue-152052.yBssDE.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-24-12-00-00.gh-issue-152052.yBssDE.rst
@@ -1,0 +1,3 @@
+The C accelerator of :mod:`json` now agrees with the pure-Python decoder and
+raises ``Unterminated string starting at`` instead of ``Invalid \uXXXX
+escape`` for a valid ``\uXXXX`` escape at the very end of the input.

--- a/Misc/NEWS.d/next/Library/2026-06-24-12-00-00.gh-issue-152052.yBssDE.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-24-12-00-00.gh-issue-152052.yBssDE.rst
@@ -1,3 +1,2 @@
-The C accelerator of :mod:`json` now agrees with the pure-Python decoder and
-raises ``Unterminated string starting at`` instead of ``Invalid \uXXXX
-escape`` for a valid ``\uXXXX`` escape at the very end of the input.
+The :mod:`json` C accelerator now correctly reports an unterminated string for a
+``\uXXXX`` escape at the end of the input.

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -576,7 +576,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             c = 0;
             next++;
             end = next + 4;
-            if (end >= len) {
+            if (end > len) {
                 raise_errmsg("Invalid \\uXXXX escape", pystr, next - 1);
                 goto bail;
             }


### PR DESCRIPTION
The C accelerator of `json` reported `Invalid \uXXXX escape` where the pure-Python decoder reported `Unterminated string starting at`, for a `\uXXXX` escape whose final hex digit is the last character of the input. The two decoders disagreed on the error class, and the C one pointed the user at a non-existent invalid escape rather than the missing closing quote.

Root cause in `Modules/_json.c` `scanstring_unicode()`: the bounds check used `>=` where `>` is correct. The four hex digits are read at indices `end-4 .. end-1`; when `end == len` those are all in bounds, so the escape is complete and valid and the string is merely unterminated. Changing `>=` to `>` lets control fall through to the existing `Unterminated string starting at` path, matching the pure-Python decoder (the two `json` error messages were synchronized in bpo-5067).

Tests cover both decoders: `test_fail.py::test_truncated_input` asserts the exact message/position under `TestCFail` and `TestPyFail` (including a high surrogate and a surrogate pair at EOF, and a nested non-zero offset), and `test_scanstring.py::test_bad_escapes` gains two no-regression cases (a genuinely truncated escape and four non-hex chars at EOF) confirming the change does not weaken rejection of real invalid escapes.

Fixes #152052


<!-- gh-issue-number: gh-152052 -->
* Issue: gh-152052
<!-- /gh-issue-number -->
