### PR TITLE
gh-152060: Fix datetime.fromisoformat() raising AssertionError in pure Python

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -358,7 +358,8 @@ def _find_isoformat_datetime_separator(dtstr):
 def _parse_isoformat_date(dtstr):
     # It is assumed that this is an ASCII-only string of lengths 7, 8 or 10,
     # see the comment on Modules/_datetimemodule.c:_find_isoformat_datetime_separator
-    assert len(dtstr) in (7, 8, 10)
+    if len(dtstr) not in (7, 8, 10):
+        raise ValueError(f"Invalid isoformat string: {dtstr!r}")
     year = int(dtstr[0:4])
     has_sep = dtstr[4] == '-'
 

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -359,7 +359,7 @@ def _parse_isoformat_date(dtstr):
     # It is assumed that this is an ASCII-only string of lengths 7, 8 or 10,
     # see the comment on Modules/_datetimemodule.c:_find_isoformat_datetime_separator
     if len(dtstr) not in (7, 8, 10):
-        raise ValueError(f"Invalid isoformat string: {dtstr!r}")
+        raise ValueError("Invalid isoformat string")
     year = int(dtstr[0:4])
     has_sep = dtstr[4] == '-'
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3757,6 +3757,8 @@ class TestDateTime(TestDate):
             '2009-04-19T12:30:45+00:00:90', # Time zone field out from range
             '2009-04-19T12:30:45-00:90:00', # Time zone field out from range
             '2009-04-19T12:30:45-00:00:90', # Time zone field out from range
+            '2020-2020',                    # Ambiguous 9-char date portion
+            '2020-1234',                    # Ambiguous 9-char date portion
         ]
 
         for bad_str in bad_strs:

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3758,7 +3758,6 @@ class TestDateTime(TestDate):
             '2009-04-19T12:30:45-00:90:00', # Time zone field out from range
             '2009-04-19T12:30:45-00:00:90', # Time zone field out from range
             '2020-2020',                    # Ambiguous 9-char date portion
-            '2020-1234',                    # Ambiguous 9-char date portion
         ]
 
         for bad_str in bad_strs:

--- a/Misc/NEWS.d/next/Library/2026-06-24-10-46-35.gh-issue-152060.f2asrt.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-24-10-46-35.gh-issue-152060.f2asrt.rst
@@ -1,0 +1,3 @@
+Fix :meth:`datetime.datetime.fromisoformat` raising :exc:`AssertionError`
+instead of :exc:`ValueError` for some malformed strings in the pure-Python
+implementation, matching the C implementation.


### PR DESCRIPTION
<!-- gh-issue-152060 -->

Fixes #152060.

`_pydatetime._parse_isoformat_date()` asserted that the date portion has length 7, 8 or
10. For some malformed inputs (e.g. `'2020-2020'`, `'2020-1234'`) the separator finder
yields a 9-character date portion, so the assert fires and a bare `AssertionError` escapes
`datetime.fromisoformat()`, which is documented to raise only `ValueError`. The C
accelerator already raises `ValueError`. Because the check is an `assert`, the input also
raises `ValueError` instead under `python -O`, so the behaviour differed by build flag.

This replaces the assert with an explicit `ValueError` whose message matches the C
implementation, so both implementations agree on every build. This is the sibling assert
site to the one fixed in #151771 (gh-151770).

`date.fromisoformat()` already validates the length before calling
`_parse_isoformat_date()`, so it is unaffected.

A regression test is added to `test_fromisoformat_fails_datetime`, which runs under both
the C (`_Fast`) and pure-Python (`_Pure`) test classes.

<!-- readability: keep the diff minimal -->


<!-- gh-issue-number: gh-152060 -->
* Issue: gh-152060
<!-- /gh-issue-number -->
