### PR TITLE
gh-152079: Fix C datetime.fromisoformat() dropping sub-second UTC offset

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3802,6 +3802,32 @@ class TestDateTime(TestDate):
 
         self.assertIs(dt.tzinfo, timezone.utc)
 
+    def test_fromisoformat_utc_subsecond_offset(self):
+        # A UTC offset whose whole-second part is zero but with a non-zero
+        # microsecond part must be preserved, not collapsed to UTC.
+        for us in (1, -1, 999999, -999999):
+            with self.subTest(microseconds=us):
+                tz = timezone(timedelta(microseconds=us))
+                dt = self.theclass(2020, 6, 15, 12, 34, 56, tzinfo=tz)
+                rt = self.theclass.fromisoformat(dt.isoformat())
+                self.assertEqual(rt.utcoffset(), timedelta(microseconds=us))
+                self.assertEqual(rt, dt)
+                self.assertIsNot(rt.tzinfo, timezone.utc)
+
+        tz = timezone(timedelta(hours=5, minutes=30, seconds=15,
+                                microseconds=123456))
+        dt = self.theclass(2020, 6, 15, 12, 34, 56, tzinfo=tz)
+        rt = self.theclass.fromisoformat(dt.isoformat())
+        self.assertEqual(rt.utcoffset(), tz.utcoffset(None))
+        self.assertEqual(rt, dt)
+
+        for tstr in ('2020-06-15T12:34:56+00:00',
+                     '2020-06-15T12:34:56+00:00:00.000000',
+                     '2020-06-15T12:34:56Z'):
+            with self.subTest(tstr=tstr):
+                self.assertIs(self.theclass.fromisoformat(tstr).tzinfo,
+                              timezone.utc)
+
     def test_fromisoformat_subclass(self):
         class DateTimeSubclass(self.theclass):
             pass

--- a/Misc/NEWS.d/next/Library/2026-06-24-12-00-00.gh-issue-152079.f1tzus.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-24-12-00-00.gh-issue-152079.f1tzus.rst
@@ -1,0 +1,3 @@
+Fix :meth:`datetime.datetime.fromisoformat` in the C implementation dropping
+the sub-second part of a UTC offset whose whole-second part is zero, matching
+the pure-Python implementation.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1668,7 +1668,7 @@ tzinfo_from_isoformat_results(int rv, int tzoffset, int tz_useconds)
 {
     PyObject *tzinfo;
     if (rv == 1) {
-        // Create a timezone from offset in seconds (0 returns UTC)
+        // Create a timezone from the offset (a zero offset returns UTC)
         if (tzoffset == 0 && tz_useconds == 0) {
             return Py_NewRef(CONST_UTC(NO_STATE));
         }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1669,7 +1669,7 @@ tzinfo_from_isoformat_results(int rv, int tzoffset, int tz_useconds)
     PyObject *tzinfo;
     if (rv == 1) {
         // Create a timezone from offset in seconds (0 returns UTC)
-        if (tzoffset == 0) {
+        if (tzoffset == 0 && tz_useconds == 0) {
             return Py_NewRef(CONST_UTC(NO_STATE));
         }
 


### PR DESCRIPTION
<!-- gh-issue-152079 -->

The C accelerator's `tzinfo_from_isoformat_results()` collapsed any UTC offset with a zero
whole-second part to `timezone.utc`, discarding the parsed sub-second microseconds. As a
result `'2020-06-15T12:34:56+00:00:00.000001'` round-tripped through `isoformat()` /
`fromisoformat()` lost its 1-microsecond offset, while the pure-Python implementation
preserved it.

This short-circuits to `timezone.utc` only when both the whole-second and sub-second parts
are zero. A plain `+00:00` offset still returns `timezone.utc`; the non-zero sub-second
case now falls through to the existing `new_timezone(new_delta(...))` path and is
preserved, matching pure Python.

I verified against a full C-vs-pure-Python differential corpus that the only inputs whose
behaviour changes are exactly these zero-whole-second sub-second offsets (75 previously
divergent cases now agree) and that no new divergence is introduced.

A round-trip regression test is added; it runs under both the C (`_Fast`) and pure-Python
(`_Pure`) test classes.

Fixes #152079. Sibling to #152060, a separate `fromisoformat()` defect in the pure-Python
implementation.


<!-- gh-issue-number: gh-152079 -->
* Issue: gh-152079
<!-- /gh-issue-number -->
