### PR TITLE
[WIP] gh-152090: Fix CALL_LIST_APPEND opcode error path

### DIFF
--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -3981,6 +3981,7 @@
                 int err = _PyList_AppendTakeRef((PyListObject *)self_o, PyStackRef_AsPyObjectSteal(arg));
                 UNLOCK_OBJECT(self_o);
                 if (err) {
+                    stack_pointer[-1] = PyStackRef_NULL;
                     JUMP_TO_LABEL(error);
                 }
                 c = callable;

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5108,6 +5108,7 @@ dummy_func(
             int err = _PyList_AppendTakeRef((PyListObject *)self_o, PyStackRef_AsPyObjectSteal(arg));
             UNLOCK_OBJECT(self_o);
             if (err) {
+                stack_pointer[-1] = PyStackRef_NULL;
                 ERROR_NO_POP();
             }
             c = callable;

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -19097,6 +19097,7 @@
             int err = _PyList_AppendTakeRef((PyListObject *)self_o, PyStackRef_AsPyObjectSteal(arg));
             UNLOCK_OBJECT(self_o);
             if (err) {
+                stack_pointer[-1] = PyStackRef_NULL;
                 SET_CURRENT_CACHED_VALUES(0);
                 JUMP_TO_ERROR();
             }
@@ -19139,6 +19140,7 @@
             int err = _PyList_AppendTakeRef((PyListObject *)self_o, PyStackRef_AsPyObjectSteal(arg));
             UNLOCK_OBJECT(self_o);
             if (err) {
+                stack_pointer[-1] = PyStackRef_NULL;
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 SET_CURRENT_CACHED_VALUES(0);
@@ -19185,6 +19187,7 @@
             int err = _PyList_AppendTakeRef((PyListObject *)self_o, PyStackRef_AsPyObjectSteal(arg));
             UNLOCK_OBJECT(self_o);
             if (err) {
+                stack_pointer[-1] = PyStackRef_NULL;
                 stack_pointer[0] = self;
                 stack_pointer += 2;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
@@ -19234,6 +19237,7 @@
             int err = _PyList_AppendTakeRef((PyListObject *)self_o, PyStackRef_AsPyObjectSteal(arg));
             UNLOCK_OBJECT(self_o);
             if (err) {
+                stack_pointer[-1] = PyStackRef_NULL;
                 stack_pointer[0] = callable;
                 stack_pointer[1] = self;
                 stack_pointer += 3;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3981,6 +3981,7 @@
                 int err = _PyList_AppendTakeRef((PyListObject *)self_o, PyStackRef_AsPyObjectSteal(arg));
                 UNLOCK_OBJECT(self_o);
                 if (err) {
+                    stack_pointer[-1] = PyStackRef_NULL;
                     JUMP_TO_LABEL(error);
                 }
                 c = callable;


### PR DESCRIPTION
Clear arg since PyStackRef_AsPyObjectSteal(arg) converted arg to a dangling stack reference.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152090 -->
* Issue: gh-152090
<!-- /gh-issue-number -->
