### PR TITLE
gh-152093: Fix test_tk_caret() on macOS

### DIFF
--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -485,7 +485,11 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
     def test_tk_caret(self):
         self.assertIsNone(self.root.tk_caret(x=5, y=10, height=20))
         caret = self.root.tk_caret()
-        self.assertEqual(caret, {'x': 5, 'y': 10, 'height': 20})
+        if self.root._windowingsystem == 'aqua':
+            # macOS records the caret only for the key window.
+            self.assertEqual(set(caret), {'x', 'y', 'height'})
+        else:
+            self.assertEqual(caret, {'x': 5, 'y': 10, 'height': 20})
 
     def test_tk_scaling(self):
         old = self.root.tk_scaling()


### PR DESCRIPTION
On macOS the caret position is recorded only while the window is the key (active) window: `Tk_SetCaretPos()` returns early without updating the display's caret when `![w isKeyWindow]` (`macosx/tkMacOSXKeyEvent.c`). On X11 it is always stored.

In the GHA macOS job the test's window is not the key window, so the set is a no-op and the query reads back the default zeroed position, failing the equality assertion. On Aqua the test now checks only that the query returns the expected keys; the exact round-trip is still verified on the other platforms.


<!-- gh-issue-number: gh-152093 -->
* Issue: gh-152093
<!-- /gh-issue-number -->
