### PR TITLE
gh-148731: Fix crash in Element.iter() on allocation failure

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-24-12-00-00.gh-issue-148731.ElItOm.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-24-12-00-00.gh-issue-148731.ElItOm.rst
@@ -1,0 +1,2 @@
+Fix crash in :meth:`xml.etree.ElementTree.Element.iter` when memory
+allocation fails during iterator construction.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -2368,6 +2368,9 @@ create_elementiter(elementtreestate *st, ElementObject *self, PyObject *tag,
     if (!it)
         return NULL;
 
+    it->parent_stack = NULL;
+    it->parent_stack_used = 0;
+
     it->sought_tag = Py_NewRef(tag);
     it->gettext = gettext;
     it->root_element = (ElementObject*)Py_NewRef(self);
@@ -2378,7 +2381,6 @@ create_elementiter(elementtreestate *st, ElementObject *self, PyObject *tag,
         PyErr_NoMemory();
         return NULL;
     }
-    it->parent_stack_used = 0;
     it->parent_stack_size = INIT_PARENT_STACK_SIZE;
 
     PyObject_GC_Track(it);


### PR DESCRIPTION
`create_elementiter` allocates an `ElementIterObject` via `PyObject_GC_New`, then attempts to allocate `parent_stack` via `PyMem_New`. If that second allocation fails, `Py_DECREF(it)` triggers `elementiter_dealloc`, which reads `parent_stack_used` (uninitialized garbage from `PyObject_GC_New`) and dereferences `parent_stack` (NULL), causing a segfault.

Fix by initializing `parent_stack` to `NULL` and `parent_stack_used` to `0` immediately after `PyObject_GC_New`, before any operations that can fail.

<!-- gh-issue-number: gh-148731 -->
* Issue: gh-148731
<!-- /gh-issue-number -->