### PR TITLE
gh-151475: Fix data race in faulthandler watchdog on free-threaded builds

### DIFF
--- a/Include/internal/pycore_faulthandler.h
+++ b/Include/internal/pycore_faulthandler.h
@@ -48,6 +48,8 @@ struct faulthandler_user_signal {
 
 
 struct _faulthandler_runtime_state {
+    PyMutex mutex;
+
     struct {
         int enabled;
         PyObject *file;

--- a/Misc/NEWS.d/next/Library/2026-06-24-14-00-00.gh-issue-151475.FhTrSf.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-24-14-00-00.gh-issue-151475.FhTrSf.rst
@@ -1,0 +1,4 @@
+Fix data race in :mod:`faulthandler` where concurrent calls to
+:func:`~faulthandler.dump_traceback_later` and
+:func:`~faulthandler.cancel_dump_traceback_later` could corrupt the
+watchdog lock handshake on free-threaded builds.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -56,6 +56,7 @@ typedef struct {
     int all_threads;
 } fault_handler_t;
 
+#define faulthandler_mutex _PyRuntime.faulthandler.mutex
 #define fatal_error _PyRuntime.faulthandler.fatal_error
 #define thread _PyRuntime.faulthandler.thread
 
@@ -836,17 +837,31 @@ faulthandler_dump_traceback_later_impl(PyObject *module,
         return NULL;
     }
 
+    /* format the timeout before acquiring the lock (no shared state) */
+    header = format_timeout(timeout_us);
+    if (header == NULL) {
+        Py_XDECREF(file);
+        return PyErr_NoMemory();
+    }
+    header_len = strlen(header);
+
+    PyMutex_Lock(&faulthandler_mutex);
+
     if (!thread.running) {
         thread.running = PyThread_allocate_lock();
         if (!thread.running) {
+            PyMutex_Unlock(&faulthandler_mutex);
             Py_XDECREF(file);
+            PyMem_Free(header);
             return PyErr_NoMemory();
         }
     }
     if (!thread.cancel_event) {
         thread.cancel_event = PyThread_allocate_lock();
         if (!thread.cancel_event || !thread.running) {
+            PyMutex_Unlock(&faulthandler_mutex);
             Py_XDECREF(file);
+            PyMem_Free(header);
             return PyErr_NoMemory();
         }
 
@@ -854,14 +869,6 @@ faulthandler_dump_traceback_later_impl(PyObject *module,
            the thread. */
         PyThread_acquire_lock(thread.cancel_event, 1);
     }
-
-    /* format the timeout */
-    header = format_timeout(timeout_us);
-    if (header == NULL) {
-        Py_XDECREF(file);
-        return PyErr_NoMemory();
-    }
-    header_len = strlen(header);
 
     /* Cancel previous thread, if running */
     cancel_dump_traceback_later();
@@ -885,11 +892,13 @@ faulthandler_dump_traceback_later_impl(PyObject *module,
         Py_CLEAR(thread.file);
         PyMem_Free(header);
         thread.header = NULL;
+        PyMutex_Unlock(&faulthandler_mutex);
         PyErr_SetString(PyExc_RuntimeError,
                         "unable to start watchdog thread");
         return NULL;
     }
 
+    PyMutex_Unlock(&faulthandler_mutex);
     Py_RETURN_NONE;
 }
 
@@ -904,7 +913,9 @@ static PyObject *
 faulthandler_cancel_dump_traceback_later_py_impl(PyObject *module)
 /*[clinic end generated code: output=2cf303015d39c926 input=51ad64b6ca8412a4]*/
 {
+    PyMutex_Lock(&faulthandler_mutex);
     cancel_dump_traceback_later();
+    PyMutex_Unlock(&faulthandler_mutex);
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
`dump_traceback_later()` and `cancel_dump_traceback_later()` mutate the watchdog state in `_PyRuntime.faulthandler.thread` without synchronization. On free-threaded builds, concurrent calls corrupt the `cancel_event`/`running` lock handshake, since two threads can both allocate `cancel_event` (leaking one lock), or release a lock they don't hold, causing a fatal abort.

Fix by adding a `PyMutex` to `_faulthandler_runtime_state` and acquiring it in both `dump_traceback_later` and `cancel_dump_traceback_later` entry points. The mutex is acquired after argument validation (which may call into Python) but before any shared state access.

These are not hot paths and none run in signal-handler context, so a simple mutex is sufficient.

<!-- gh-issue-number: gh-151475 -->
* Issue: gh-151475
<!-- /gh-issue-number -->