### PR TITLE
gh-151763: Fix crash in `_interpqueues.create` on `MemoryError`

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-25-01-00-43.gh-issue-151763.wWeHBe.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-01-00-43.gh-issue-151763.wWeHBe.rst
@@ -1,0 +1,2 @@
+Fix crash in :func:`!_interpqueues.create` on :exc:`MemoryError` when
+happens on queue creation.

--- a/Misc/NEWS.d/next/Library/2026-06-25-01-00-43.gh-issue-151763.wWeHBe.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-01-00-43.gh-issue-151763.wWeHBe.rst
@@ -1,2 +1,2 @@
-Fix crash in :func:`!_interpqueues.create` on :exc:`MemoryError` when
+Fix crash in :func:`!_interpqueues.create` whe :exc:`MemoryError`
 happens on queue creation.

--- a/Modules/_interpqueuesmodule.c
+++ b/Modules/_interpqueuesmodule.c
@@ -1101,6 +1101,7 @@ queue_create(_queues *queues, Py_ssize_t maxsize,
     }
     int64_t qid = _queues_add(queues, queue);
     if (qid < 0) {
+        queue->alive = 0;
         _queue_clear(queue);
         GLOBAL_FREE(queue);
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-151763 -->
* Issue: gh-151763
<!-- /gh-issue-number -->
