### PR TITLE
gh-51067: Remove trailing space in `_Repacker.repack()` error message

### DIFF
--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1514,7 +1514,7 @@ class _ZipRepacker:
                         zinfo.header_offset, entry_size, used_entry_size)
             if used_entry_size > entry_size:
                 raise BadZipFile(
-                    f"Overlapped entries: {zinfo.orig_filename!r} ")
+                    f"Overlapped entries: {zinfo.orig_filename!r}")
 
             if removed is not None and zinfo not in removed_zinfos:
                 used_entry_size = entry_size


### PR DESCRIPTION
Remove an accidental trailing space inside the `BadZipFile` exception string literal to ensure clean exception messages.


<!-- gh-issue-number: gh-51067 -->
* Issue: gh-51067
<!-- /gh-issue-number -->
