### PR TITLE
gh-152140: Rework and optimize `_Extra` class in `zipfile`

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4114,6 +4114,16 @@ class OtherTests(unittest.TestCase):
         with self.assertRaises(zipfile.BadZipfile):
             zipfile.ZipFile(TESTFN, "r").close()
 
+    def test_read_zipfile_with_corrupted_extra_field(self):
+        with zipfile.ZipFile(TESTFN, mode='w') as zf:
+            zinfo = zipfile.ZipInfo("file.txt")
+            zinfo.extra = struct.pack('<HH', 1, 1)
+            zf.writestr(zinfo, b'_')
+
+        with self.assertRaisesRegex(zipfile.BadZipFile, 'Corrupt extra field 0001'):
+            with zipfile.ZipFile(TESTFN) as zf:
+                pass
+
     def test_read_after_write_unicode_filenames(self):
         with zipfile.ZipFile(TESTFN2, 'w') as zipfp:
             zipfp.writestr('приклад', b'sample')
@@ -5840,20 +5850,21 @@ class StripExtraTests(unittest.TestCase):
 
     ZIP64_EXTRA = 1
 
+    strip_extra = staticmethod(zipfile._Extra.strip)
+
     def test_no_data(self):
         s = struct.Struct("<HH")
         a = s.pack(self.ZIP64_EXTRA, 0)
         b = s.pack(2, 0)
         c = s.pack(3, 0)
 
-        self.assertEqual(b'', zipfile._Extra.strip(a, (self.ZIP64_EXTRA,)))
-        self.assertEqual(b, zipfile._Extra.strip(b, (self.ZIP64_EXTRA,)))
-        self.assertEqual(
-            b+b"z", zipfile._Extra.strip(b+b"z", (self.ZIP64_EXTRA,)))
+        self.assertEqual(b'', self.strip_extra(a, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b, self.strip_extra(b, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b+b"z", self.strip_extra(b+b"z", (self.ZIP64_EXTRA,)))
 
-        self.assertEqual(b+c, zipfile._Extra.strip(a+b+c, (self.ZIP64_EXTRA,)))
-        self.assertEqual(b+c, zipfile._Extra.strip(b+a+c, (self.ZIP64_EXTRA,)))
-        self.assertEqual(b+c, zipfile._Extra.strip(b+c+a, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b+c, self.strip_extra(a+b+c, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b+c, self.strip_extra(b+a+c, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b+c, self.strip_extra(b+c+a, (self.ZIP64_EXTRA,)))
 
     def test_with_data(self):
         s = struct.Struct("<HH")
@@ -5861,38 +5872,47 @@ class StripExtraTests(unittest.TestCase):
         b = s.pack(2, 2) + b"bb"
         c = s.pack(3, 3) + b"ccc"
 
-        self.assertEqual(b"", zipfile._Extra.strip(a, (self.ZIP64_EXTRA,)))
-        self.assertEqual(b, zipfile._Extra.strip(b, (self.ZIP64_EXTRA,)))
-        self.assertEqual(
-            b+b"z", zipfile._Extra.strip(b+b"z", (self.ZIP64_EXTRA,)))
+        self.assertEqual(b"", self.strip_extra(a, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b, self.strip_extra(b, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b+b"z", self.strip_extra(b+b"z", (self.ZIP64_EXTRA,)))
 
-        self.assertEqual(b+c, zipfile._Extra.strip(a+b+c, (self.ZIP64_EXTRA,)))
-        self.assertEqual(b+c, zipfile._Extra.strip(b+a+c, (self.ZIP64_EXTRA,)))
-        self.assertEqual(b+c, zipfile._Extra.strip(b+c+a, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b+c, self.strip_extra(a+b+c, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b+c, self.strip_extra(b+a+c, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b+c, self.strip_extra(b+c+a, (self.ZIP64_EXTRA,)))
 
     def test_multiples(self):
         s = struct.Struct("<HH")
         a = s.pack(self.ZIP64_EXTRA, 1) + b"a"
         b = s.pack(2, 2) + b"bb"
 
-        self.assertEqual(b"", zipfile._Extra.strip(a+a, (self.ZIP64_EXTRA,)))
-        self.assertEqual(b"", zipfile._Extra.strip(a+a+a, (self.ZIP64_EXTRA,)))
-        self.assertEqual(
-            b"z", zipfile._Extra.strip(a+a+b"z", (self.ZIP64_EXTRA,)))
-        self.assertEqual(
-            b+b"z", zipfile._Extra.strip(a+a+b+b"z", (self.ZIP64_EXTRA,)))
+        self.assertEqual(b"", self.strip_extra(a+a, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b"", self.strip_extra(a+a+a, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b"z", self.strip_extra(a+a+b"z", (self.ZIP64_EXTRA,)))
+        self.assertEqual(b+b"z", self.strip_extra(a+a+b+b"z", (self.ZIP64_EXTRA,)))
 
-        self.assertEqual(b, zipfile._Extra.strip(a+a+b, (self.ZIP64_EXTRA,)))
-        self.assertEqual(b, zipfile._Extra.strip(a+b+a, (self.ZIP64_EXTRA,)))
-        self.assertEqual(b, zipfile._Extra.strip(b+a+a, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b, self.strip_extra(a+a+b, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b, self.strip_extra(a+b+a, (self.ZIP64_EXTRA,)))
+        self.assertEqual(b, self.strip_extra(b+a+a, (self.ZIP64_EXTRA,)))
+
+    def test_truncated_data_for_stripped_id(self):
+        s = struct.Struct("<HH")
+        a = s.pack(self.ZIP64_EXTRA, 3) + b"a"
+        b = s.pack(2, 2) + b"bb"
+
+        self.assertEqual(b, self.strip_extra(b+a, (self.ZIP64_EXTRA,)))
+
+    def test_truncated_data_for_nonstripped_id(self):
+        s = struct.Struct("<HH")
+        a = s.pack(self.ZIP64_EXTRA, 1) + b"a"
+        b = s.pack(2, 4) + b"bb"
+
+        self.assertEqual(b, self.strip_extra(a+b, (self.ZIP64_EXTRA,)))
 
     def test_too_short(self):
-        self.assertEqual(b"", zipfile._Extra.strip(b"", (self.ZIP64_EXTRA,)))
-        self.assertEqual(b"z", zipfile._Extra.strip(b"z", (self.ZIP64_EXTRA,)))
-        self.assertEqual(
-            b"zz", zipfile._Extra.strip(b"zz", (self.ZIP64_EXTRA,)))
-        self.assertEqual(
-            b"zzz", zipfile._Extra.strip(b"zzz", (self.ZIP64_EXTRA,)))
+        self.assertEqual(b"", self.strip_extra(b"", (self.ZIP64_EXTRA,)))
+        self.assertEqual(b"z", self.strip_extra(b"z", (self.ZIP64_EXTRA,)))
+        self.assertEqual(b"zz", self.strip_extra(b"zz", (self.ZIP64_EXTRA,)))
+        self.assertEqual(b"zzz", self.strip_extra(b"zzz", (self.ZIP64_EXTRA,)))
 
 
 class StatIO(_pyio.BytesIO):

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -207,10 +207,9 @@ class _Extra(bytes):
     @classmethod
     def read_one(cls, raw):
         try:
-            xid, xlen = cls.FIELD_STRUCT.unpack(raw[:4])
+            xid, xlen = cls.FIELD_STRUCT.unpack_from(raw)
         except struct.error:
-            xid = None
-            xlen = 0
+            xid, xlen = None, 0
         return cls(raw[:4+xlen], xid), raw[4+xlen:]
 
     @classmethod

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -205,19 +205,22 @@ class _Extra(bytes):
         self.id = id
 
     @classmethod
-    def read_one(cls, raw):
+    def read_one(cls, raw, validate=False):
         try:
             xid, xlen = cls.FIELD_STRUCT.unpack_from(raw)
         except struct.error:
             xid, xlen = None, 0
+        else:
+            if validate and xlen + 4 > len(raw):
+                raise BadZipFile("Corrupt extra field %04x (size=%d)" % (xid, xlen))
         return cls(raw[:4+xlen], xid), raw[4+xlen:]
 
     @classmethod
-    def split(cls, data):
+    def split(cls, data, validate=False):
         # use memoryview for zero-copy slices
         rest = memoryview(data)
         while rest:
-            extra, rest = cls.read_one(rest)
+            extra, rest = cls.read_one(rest, validate=validate)
             yield extra
 
     @classmethod
@@ -584,14 +587,11 @@ class ZipInfo:
 
     def _decodeExtra(self, filename_crc):
         # Try to decode the extra field.
-        extra = self.extra
         unpack = struct.unpack
-        while len(extra) >= 4:
-            tp, ln = unpack('<HH', extra[:4])
-            if ln+4 > len(extra):
-                raise BadZipFile("Corrupt extra field %04x (size=%d)" % (tp, ln))
+        for extra in _Extra.split(self.extra, True):
+            tp = extra.id
             if tp == 0x0001:
-                data = extra[4:ln+4]
+                data = extra[4:]
                 # ZIP64 extension (large files and/or large archives)
                 try:
                     if self.file_size in (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF):
@@ -609,7 +609,7 @@ class ZipInfo:
                     raise BadZipFile(f"Corrupt zip64 extra field. "
                                      f"{field} not found.") from None
             elif tp == 0x7075:
-                data = extra[4:ln+4]
+                data = extra[4:]
                 # Unicode Path Extra Field
                 try:
                     up_version, up_name_crc = unpack('<BL', data[:5])
@@ -624,8 +624,6 @@ class ZipInfo:
                     raise BadZipFile("Corrupt unicode path extra field (0x7075)") from e
                 except UnicodeDecodeError as e:
                     raise BadZipFile('Corrupt unicode path extra field (0x7075): invalid utf-8 bytes') from e
-
-            extra = extra[ln+4:]
 
     @classmethod
     def from_file(cls, filename, arcname=None, *, strict_timestamps=True):

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2665,7 +2665,7 @@ class ZipFile:
             extra_data = zinfo.extra
             min_version = 0
             if extra:
-                # Append a ZIP64 field to the extra's
+                # Prepend a ZIP64 field to the extra's
                 extra_data = _Extra.strip(extra_data, (1,))
                 extra_data = struct.pack(
                     '<HH' + 'Q'*len(extra),

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -195,53 +195,53 @@ _CD64_OFFSET_START_CENTDIR = 9
 _DD_SIGNATURE = 0x08074b50
 
 
-class _Extra(bytes):
+class _Extra:
     FIELD_STRUCT = struct.Struct('<HH')
 
-    def __new__(cls, val, id=None):
-        return super().__new__(cls, val)
-
-    def __init__(self, val, id=None):
-        self.id = id
-
     @classmethod
-    def read_one(cls, raw, validate=False):
-        try:
-            xid, xlen = cls.FIELD_STRUCT.unpack_from(raw)
-        except struct.error:
-            xid, xlen = None, 0
-        else:
-            if validate and xlen + 4 > len(raw):
-                raise BadZipFile("Corrupt extra field %04x (size=%d)" % (xid, xlen))
-        return cls(raw[:4+xlen], xid), raw[4+xlen:]
+    def iter(cls, data, validate=False):
+        """Iter through and yield each (field, id)."""
+        # early return for empty extra data
+        if not data:
+            return
 
-    @classmethod
-    def split(cls, data, validate=False):
-        # use memoryview for zero-copy slices
-        rest = memoryview(data)
-        while rest:
-            extra, rest = cls.read_one(rest, validate=validate)
-            yield extra
+        pos, data_len = 0, len(data)
+        while pos < data_len:
+            try:
+                xid, xlen = cls.FIELD_STRUCT.unpack_from(data, pos)
+            except struct.error:
+                xid, xlen = None, 0
+            else:
+                if validate and pos + 4 + xlen > data_len:
+                    raise BadZipFile(
+                        "Corrupt extra field %04x (size=%d)" % (xid, xlen))
+            yield data[pos:pos + 4 + xlen], xid
+            pos += 4 + xlen
 
     @classmethod
     def strip(cls, data, xids):
         """Remove Extra fields with specified IDs."""
         return b''.join(
             ex
-            for ex in cls.split(data)
-            if ex.id not in xids
+            for ex, xid in cls.iter(data)
+            if xid not in xids
         )
 
     @classmethod
     def update(cls, data, extra):
         """Insert fields from extra and strip duplicates."""
+        # early return for empty data
+        if not data:
+            return extra
+
         extras = {
-            ex.id: ex
-            for ex in cls.split(extra, True)
-            if ex.id is not None
+            xid: ex
+            for ex, xid in cls.iter(extra)
+            if xid is not None
         }
         # New fields first since data may have a corrupted tail that renders
-        # following fields inaccessible.
+        # following fields inaccessible.  (The caller is responsible for making
+        # sure that extra is valid.)
         return b''.join(extras.values()) + cls.strip(data, extras)
 
 
@@ -600,8 +600,7 @@ class ZipInfo:
     def _decodeExtra(self, filename_crc):
         # Try to decode the extra field.
         unpack = struct.unpack
-        for extra in _Extra.split(self.extra, True):
-            tp = extra.id
+        for extra, tp in _Extra.iter(self.extra, True):
             if tp == 0x0001:
                 data = extra[4:]
                 # ZIP64 extension (large files and/or large archives)

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -232,6 +232,18 @@ class _Extra(bytes):
             if ex.id not in xids
         )
 
+    @classmethod
+    def update(cls, data, extra):
+        """Insert fields from extra and strip duplicates."""
+        extras = {
+            ex.id: ex
+            for ex in cls.split(extra, True)
+            if ex.id is not None
+        }
+        # New fields first since data may have a corrupted tail that renders
+        # following fields inaccessible.
+        return b''.join(extras.values()) + cls.strip(data, extras)
+
 
 def _check_zipfile(fp):
     try:
@@ -2663,10 +2675,10 @@ class ZipFile:
             min_version = 0
             if extra:
                 # Prepend a ZIP64 field to the extra's
-                extra_data = _Extra.strip(extra_data, (1,))
-                extra_data = struct.pack(
+                extra_data = _Extra.update(extra_data, struct.pack(
                     '<HH' + 'Q'*len(extra),
-                    1, 8*len(extra), *extra) + extra_data
+                    1, 8*len(extra), *extra,
+                ))
 
                 min_version = ZIP64_VERSION
 

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -218,7 +218,7 @@ class _Extra(bytes):
         # use memoryview for zero-copy slices
         rest = memoryview(data)
         while rest:
-            extra, rest = _Extra.read_one(rest)
+            extra, rest = cls.read_one(rest)
             yield extra
 
     @classmethod

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -199,6 +199,10 @@ class _Extra:
     FIELD_STRUCT = struct.Struct('<HH')
 
     @classmethod
+    def _handle_bad_field(cls, xid, xlen):
+        raise BadZipFile("Corrupt extra field %04x (size=%d)" % (xid, xlen))
+
+    @classmethod
     def iter(cls, data, validate=False):
         """Iter through and yield each (field, id)."""
         # early return for empty extra data
@@ -213,8 +217,7 @@ class _Extra:
                 xid, xlen = None, 0
             else:
                 if validate and pos + 4 + xlen > data_len:
-                    raise BadZipFile(
-                        "Corrupt extra field %04x (size=%d)" % (xid, xlen))
+                    cls._handle_bad_field(xid, xlen)
             yield data[pos:pos + 4 + xlen], xid
             pos += 4 + xlen
 

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -599,33 +599,32 @@ class ZipInfo:
 
     def _decodeExtra(self, filename_crc):
         # Try to decode the extra field.
-        unpack = struct.unpack
+        unpack_from = struct.unpack_from
         for extra, tp in _Extra.iter(self.extra, True):
+            pos = 4
             if tp == 0x0001:
-                data = extra[4:]
                 # ZIP64 extension (large files and/or large archives)
                 try:
                     if self.file_size in (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF):
                         field = "File size"
-                        self.file_size, = unpack('<Q', data[:8])
-                        data = data[8:]
+                        self.file_size, = unpack_from('<Q', extra, pos)
+                        pos += 8
                     if self.compress_size == 0xFFFF_FFFF:
                         field = "Compress size"
-                        self.compress_size, = unpack('<Q', data[:8])
-                        data = data[8:]
+                        self.compress_size, = unpack_from('<Q', extra, pos)
+                        pos += 8
                     if self.header_offset == 0xFFFF_FFFF:
                         field = "Header offset"
-                        self.header_offset, = unpack('<Q', data[:8])
+                        self.header_offset, = unpack_from('<Q', extra, pos)
                 except struct.error:
                     raise BadZipFile(f"Corrupt zip64 extra field. "
                                      f"{field} not found.") from None
             elif tp == 0x7075:
-                data = extra[4:]
                 # Unicode Path Extra Field
                 try:
-                    up_version, up_name_crc = unpack('<BL', data[:5])
+                    up_version, up_name_crc = unpack_from('<BL', extra, pos)
                     if up_version == 1 and up_name_crc == filename_crc:
-                        up_unicode_name = data[5:].decode('utf-8')
+                        up_unicode_name = extra[pos+5:].decode('utf-8')
                         if up_unicode_name:
                             self.filename = _sanitize_filename(up_unicode_name)
                         else:

--- a/Misc/NEWS.d/next/Library/2026-06-25-00-41-52.gh-issue-152140.u0phBe.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-00-41-52.gh-issue-152140.u0phBe.rst
@@ -1,0 +1,2 @@
+Improve performance and internal pipelines of :mod:`zipfile` through
+reworking :class:`!_Extra`.


### PR DESCRIPTION
The `_Extra` class was over-engineered. Its only active usage was its `strip()` method, called by `ZipFile._write_end_record()` to provide the stripping logic for ZIP64 fields.  The context-dependent nature of extra fields also made it difficult to be reused by `_decodeExtra()` or other methods efficiently.  Additionally, its `split()` method called `_Extra` directly rather than utilizing `cls`, which was a suboptimal pattern that hindered extensibility.

Remove the `_Extra` class entirely and reimplement it as a private static method `_strip_extra_fields()` that processes a bytearray inside `ZipFile`, positioned directly beneath its caller.  This eliminates dead and suboptimal code, achieves clean encapsulation and code locality, and improves performance by avoiding temporary class allocations.

Additionally, bind this method as a class property in the tests to simplify the code.


<!-- gh-issue-number: gh-152140 -->
* Issue: gh-152140
<!-- /gh-issue-number -->
