### PR TITLE
Fix typo in Py_mod_state_traverse docs

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -488,7 +488,7 @@ defining the module state.
 
    .. versionadded:: 3.15
 
-      Use :c:member:`PyModuleDef.m_size` instead to support previous versions.
+      Use :c:member:`PyModuleDef.m_traverse` instead to support previous versions.
 
 .. c:macro:: Py_mod_state_clear
 


### PR DESCRIPTION
(Reopening #152144 this time linking to 3.15 branch instead of 3.16.)

I was reading the documentation here for `Py_mod_state_traverse`:

https://docs.python.org/3.15/c-api/module.html#c.Py_mod_state_traverse

It says at the bottom:

```Added in version 3.15: Use [PyModuleDef.m_size] instead to support previous versions.```

That confused me, since `Py_mod_state_clear` said to use `m_clear`, and `Py_mod_state_free` said to use `m_free`. I think the `m_size` for `Py_mod_state_traverse` is a copypaste error from the `Py_mod_state_size` docs (which also says to use `m_size`). 

That said, this API is still very new to me, so please double-check the docs yourselves. This change might also need to be ported to 3.16 docs.

Thanks.