### PR TITLE
gh-152148: Eliminate commented-out code referencing `callable_iterator` in `collections.abc` module source

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -67,7 +67,6 @@ __name__ = "collections.abc"
 # are not included on this list.
 bytes_iterator = type(iter(b''))
 bytearray_iterator = type(iter(bytearray()))
-#callable_iterator = ???
 dict_keyiterator = type(iter({}.keys()))
 dict_valueiterator = type(iter({}.values()))
 dict_itemiterator = type(iter({}.items()))
@@ -319,7 +318,6 @@ class Iterator(Iterable):
 
 Iterator.register(bytes_iterator)
 Iterator.register(bytearray_iterator)
-#Iterator.register(callable_iterator)
 Iterator.register(dict_keyiterator)
 Iterator.register(dict_valueiterator)
 Iterator.register(dict_itemiterator)


### PR DESCRIPTION


<!-- gh-issue-number: gh-152148 -->
* Issue: gh-152148
<!-- /gh-issue-number -->
