### PR TITLE
gh-152156: Fix a crash in `interpeters.create` under limited memory conditions

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-25-10-07-54.gh-issue-152156.gscPU9.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-10-07-54.gh-issue-152156.gscPU9.rst
@@ -1,0 +1,2 @@
+Fix a possible crash in :func:`concurrent.interpreters.create` under limited
+memory conditions.

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -2951,10 +2951,8 @@ channelsmod_create(PyObject *self, PyObject *args, PyObject *kwds)
                            &cidobj);
     if (handle_channel_error(err, self, cid)) {
         assert(cidobj == NULL);
-        err = channel_destroy(&_globals.channels, cid);
-        if (handle_channel_error(err, self, cid)) {
-            // XXX issue a warning?
-        }
+        assert(PyErr_Occurred());
+        (void)channel_destroy(&_globals.channels, cid);
         return NULL;
     }
     assert(cidobj != NULL);


### PR DESCRIPTION
In `handle_channel_error` we already set an error. When called the second time, we get end up with `err == 0` and run this code:

```python
if (err == 0) {
    assert(!PyErr_Occurred());
    return 0;
}
```

which will fail, because exception was already set by the first error. So, there's no need to call it twice.

<!-- gh-issue-number: gh-152156 -->
* Issue: gh-152156
<!-- /gh-issue-number -->
