### PR TITLE
gh-151763: Fix OOM cleanup of initial thread state

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-26-00-06-29.gh-issue-151763.pX4fYq.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-26-00-06-29.gh-issue-151763.pX4fYq.rst
@@ -1,0 +1,2 @@
+Fixed a possible crash in free-threaded builds when interpreter creation fails
+due to memory allocation failure.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1505,6 +1505,7 @@ alloc_threadstate(PyInterpreterState *interp)
         }
         reset_threadstate(tstate);
     }
+    tstate->base.interp = interp;
     return tstate;
 }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1505,7 +1505,6 @@ alloc_threadstate(PyInterpreterState *interp)
         }
         reset_threadstate(tstate);
     }
-    tstate->base.interp = interp;
     return tstate;
 }
 
@@ -1662,6 +1661,7 @@ new_threadstate(PyInterpreterState *interp, int whence)
     if (tstate == NULL) {
         return NULL;
     }
+    tstate->base.interp = interp;
 
 #ifdef Py_GIL_DISABLED
     Py_ssize_t qsbr_idx = _Py_qsbr_reserve(interp);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1661,6 +1661,8 @@ new_threadstate(PyInterpreterState *interp, int whence)
     if (tstate == NULL) {
         return NULL;
     }
+    // Set the back-pointer before init_threadstate() so early cleanup can
+    // recognize the preallocated initial thread state after allocation failures.
     tstate->base.interp = interp;
 
 #ifdef Py_GIL_DISABLED


### PR DESCRIPTION
## Summary

This PR addresses **OOM-0020** from gh-151763.

It fixes a free-threaded crash during interpreter creation when memory allocation fails after the preallocated initial thread state has been selected but before `init_threadstate()` initializes its interpreter back-pointer.

## Issue

In the free-threaded build, `_interpreters.create(reqrefs=True)` can fail during early thread-state allocation setup.

The affected path is:

```text
_interpreters.create(reqrefs=True)
-> _interpreters_create_impl()
-> _PyXI_NewInterpreter()
-> Py_NewInterpreterFromConfig()
-> new_interpreter()
-> _PyThreadState_New()
-> new_threadstate()
-> alloc_threadstate()
-> _Py_qsbr_reserve() / _Py_ReserveTLBCIndex()
-> free_threadstate()
```

For the initial thread state, `alloc_threadstate()` obtains memory embedded in `PyInterpreterState` rather than heap-allocated memory.

However, if a later free-threaded allocation fails before `init_threadstate()` runs, cleanup reaches `free_threadstate()` while `tstate->base.interp` is still unset.

As a result, `free_threadstate()` fails to recognize the preallocated initial thread state and may incorrectly call `PyMem_RawFree()` on embedded memory.

This can result in:

* `_PyMem_DebugRawFree: bad ID` in debug builds
* access violation in release builds

## Fix

Initialize the interpreter back-pointer earlier in `alloc_threadstate()`:

```c
tstate->base.interp = interp;
```

This ensures that cleanup paths can correctly identify the preallocated initial thread state even if a later allocation fails before `init_threadstate()` is reached.

The successful path remains unchanged because `init_threadstate()` already sets the same value later.

## Validation

Validated locally on Windows.

Builds completed successfully:

```text
PCbuild\build.bat -p x64 -c Debug --disable-gil
PCbuild\build.bat -p x64 -c Release --disable-gil
PCbuild\build.bat -p x64 -c Debug
```

Before the fix, the OOM-0020 reproducer crashed in the free-threaded build with:

```text
_PyMem_DebugRawFree: bad ID
```

After the fix, the same allocation-failure path reaches `MemoryError` instead of crashing.

Focused tests passed:

```text
PCbuild/amd64t/python_d.exe -m test test__interpreters
PCbuild/amd64/python_d.exe -m test test__interpreters
```

`git diff --check` also passes.

## Regression Test

No regression test is included.

The reproducer depends on `_testcapi.set_nomemory()` in a free-threaded build, and the exact allocation index is build-sensitive. This follows the recent maintainer direction for these OOM-path fixes, where a focused code fix is preferable to fragile allocation-index regression tests.

## Compatibility

This is a localized initialization-order fix for an OOM cleanup path.

Normal successful interpreter creation keeps the same final state, because `init_threadstate()` already assigns the same interpreter pointer later.

Addresses OOM-0020 from gh-151763.
