### PR TITLE
gh-152166: Fix array.array.fromlist() exposing uninitialized memory when an element's __index__ resizes the array

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -82,6 +82,28 @@ class MiscTest(unittest.TestCase):
                 with self.assertRaises(TypeError):
                     a.fromlist(lst)
 
+    def test_fromlist_reentrant_self_resize(self):
+        # gh-152166: if an element's __index__ resizes the array being
+        # filled, fromlist() must not skip the preallocated slots (which
+        # exposes uninitialized memory) or misplace items.  It raises
+        # RuntimeError and rolls back, mirroring the list-mutation guard.
+        for label, mutate in (("grow", lambda a: a.append(0)),
+                              ("shrink", lambda a: a.pop())):
+            for typecode in ('i', 'I', 'l', 'L', 'q', 'Q'):
+                with self.subTest(typecode=typecode, mutate=label):
+                    a = array.array(typecode, [1, 2, 3])
+                    before = a.tolist()
+
+                    class Evil:
+                        def __index__(self, _a=a, _m=mutate):
+                            _m(_a)
+                            return 0
+
+                    with self.assertRaises(RuntimeError):
+                        a.fromlist([Evil(), 4, 5])
+                    # The failed call must leave the array unchanged.
+                    self.assertEqual(a.tolist(), before)
+
     def test_typecodes(self):
         self.assertIsInstance(array.typecodes, tuple)
         for typecode in array.typecodes:

--- a/Misc/NEWS.d/next/Library/2026-06-25-14-03-16.gh-issue-152166.hH7w1v.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-14-03-16.gh-issue-152166.hH7w1v.rst
@@ -1,0 +1,4 @@
+Fix :meth:`array.array.fromlist` exposing uninitialized memory (and misplacing
+items) when an element's :meth:`~object.__index__` method resizes the array
+during the conversion.  The reserved slots are now filled at a fixed offset and
+the operation raises :exc:`RuntimeError` if the array is resized mid-iteration.

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1805,14 +1805,24 @@ array_array_fromlist_impl(arrayobject *self, PyObject *list)
             return NULL;
         for (i = 0; i < n; i++) {
             PyObject *v = PyList_GET_ITEM(list, i);
-            if ((*self->ob_descr->setitem)(self,
-                            Py_SIZE(self) - n + i, v) != 0) {
+            /* setitem may run arbitrary Python (e.g. __index__), which can
+               resize self.  Write to the fixed slot reserved above rather
+               than an offset recomputed from the live Py_SIZE, and bail out
+               if self was resized -- otherwise we would skip a preallocated
+               slot (exposing uninitialized memory) or misplace items. */
+            if ((*self->ob_descr->setitem)(self, old_size + i, v) != 0) {
                 array_resize(self, old_size);
                 return NULL;
             }
             if (n != PyList_GET_SIZE(list)) {
                 PyErr_SetString(PyExc_RuntimeError,
                                 "list changed size during iteration");
+                array_resize(self, old_size);
+                return NULL;
+            }
+            if (Py_SIZE(self) != old_size + n) {
+                PyErr_SetString(PyExc_RuntimeError,
+                                "array changed size during iteration");
                 array_resize(self, old_size);
                 return NULL;
             }


### PR DESCRIPTION
Fixes the uninitialized-memory exposure in `array.array.fromlist()` reported in #152166.

`fromlist()` preallocated `n` slots with `array_resize(self, old_size + n)` and then filled them at `Py_SIZE(self) - n + i`, recomputed from the **live** `Py_SIZE` each iteration, while only guarding against the source *list* changing size. When an element's `__index__` resized `self` as a side effect of the `setitem` callback, the write index slid forward, the reserved slots were left unwritten, and the array returned uninitialized heap memory (with the real items misplaced) on a successful return — `array_resize` uses `PyMem_RESIZE` with no zeroing.

This writes the reserved slot `old_size + i` directly and raises `RuntimeError("array changed size during iteration")` if `self` is resized mid-iteration, mirroring the adjacent list-mutation guard.

Distinct from #144128 / #144138, which fixed a use-after-free in the `II`/`LL`/`QQ`_setitem conversion helpers and did not touch `fromlist`'s index logic; this defect remained on `main`.

### Before
```python
import array
a = array.array('i')
class Evil:
    def __index__(self):
        a.extend([0]*5)
        return 111
a.fromlist([Evil(), 222, 333])
print(a.tolist())
# debug build: [111, -842150451, -842150451, 0, 0, 0, 222, 333]
#                    ^^^^^^^^^^^  ^^^^^^^^^^  0xCDCDCDCD = uninitialized
```

### After
```
RuntimeError: array changed size during iteration   # array left unchanged
```

Adds a regression test (`test_fromlist_reentrant_self_resize`) covering grow and shrink across the signed/unsigned integer typecodes.


<!-- gh-issue-number: gh-152166 -->
* Issue: gh-152166
<!-- /gh-issue-number -->
