### PR TITLE
[3.10] gh-149018: Use `XML_SetHashSalt16Bytes` in `pyexpat`/`_elementtree` when possible (GH-149023)

### DIFF
--- a/Include/pyexpat.h
+++ b/Include/pyexpat.h
@@ -57,6 +57,8 @@ struct PyExpat_CAPI
         XML_Parser parser, unsigned long long activationThresholdBytes);
     XML_Bool (*SetAllocTrackerMaximumAmplification)(
         XML_Parser parser, float maxAmplificationFactor);
+    /* might be NULL for expat < 2.8.0 */
+    XML_Bool (*SetHashSalt16Bytes)(
+        XML_Parser parser, const uint8_t entropy[16]);
     /* always add new stuff to the end! */
 };
-

--- a/Include/pyhash.h
+++ b/Include/pyhash.h
@@ -39,14 +39,14 @@ PyAPI_FUNC(Py_hash_t) _Py_HashBytes(const void*, Py_ssize_t);
  *   pppppppp ssssssss ........  fnv -- two Py_hash_t
  *   k0k0k0k0 k1k1k1k1 ........  siphash -- two uint64_t
  *   ........ ........ ssssssss  djbx33a -- 16 bytes padding + one Py_hash_t
- *   ........ ........ eeeeeeee  pyexpat XML hash salt
+ *   eeeeeeee eeeeeeee eeeeeeee  pyexpat XML hash salt
  *
  * memory layout on 32 bit systems
  *   cccccccc cccccccc cccccccc  uc
  *   ppppssss ........ ........  fnv -- two Py_hash_t
  *   k0k0k0k0 k1k1k1k1 ........  siphash -- two uint64_t (*)
  *   ........ ........ ssss....  djbx33a -- 16 bytes padding + one Py_hash_t
- *   ........ ........ eeee....  pyexpat XML hash salt
+ *   eeeeeeee eeeeeeee eeee....  pyexpat XML hash salt
  *
  * (*) The siphash member may not be available on 32 bit platforms without
  *     an unsigned int64 data type.
@@ -71,7 +71,9 @@ typedef union {
         Py_hash_t suffix;
     } djbx33a;
     struct {
-        unsigned char padding[16];
+        /* 16 bytes for XML_SetHashSalt16Bytes */
+        uint8_t hashsalt16[16];
+        /* 4/8 bytes for legacy XML_SetHashSalt */
         Py_hash_t hashsalt;
     } expat;
 } _Py_HashSecret_t;

--- a/Misc/NEWS.d/next/Security/2026-04-26-19-30-45.gh-issue-149018.a9SqWb.rst
+++ b/Misc/NEWS.d/next/Security/2026-04-26-19-30-45.gh-issue-149018.a9SqWb.rst
@@ -1,0 +1,3 @@
+Improved protection against XML hash-flooding attacks in
+:mod:`xml.parsers.expat` and :mod:`xml.etree.ElementTree` when Python is
+compiled with libExpat 2.8.0 or later.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3663,8 +3663,12 @@ _elementtree_XMLParser___init___impl(XMLParserObject *self, PyObject *target,
         PyErr_NoMemory();
         return -1;
     }
-    /* expat < 2.1.0 has no XML_SetHashSalt() */
-    if (EXPAT(SetHashSalt) != NULL) {
+    // Prefer 16-byte entropy, only expat >= 2.8.0. See gh-149018
+    if (EXPAT(SetHashSalt16Bytes) != NULL) {
+        EXPAT(SetHashSalt16Bytes)(self->parser,
+                                  _Py_HashSecret.expat.hashsalt16);
+    }
+    else if (EXPAT(SetHashSalt) != NULL) {
         EXPAT(SetHashSalt)(self->parser,
                            (unsigned long)_Py_HashSecret.expat.hashsalt);
     }

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1379,7 +1379,10 @@ newxmlparseobject(pyexpat_state *state, const char *encoding,
         Py_DECREF(self);
         return NULL;
     }
-#if XML_COMBINED_VERSION >= 20100
+#if XML_COMBINED_VERSION >= 20800
+    /* This feature was added upstream in libexpat 2.8.0. */
+    XML_SetHashSalt16Bytes(self->itself, _Py_HashSecret.expat.hashsalt16);
+#elif XML_COMBINED_VERSION >= 20100
     /* This feature was added upstream in libexpat 2.1.0. */
     XML_SetHashSalt(self->itself,
                     (unsigned long)_Py_HashSecret.expat.hashsalt);
@@ -2198,6 +2201,11 @@ pyexpat_exec(PyObject *mod)
 #else
     capi.SetAllocTrackerActivationThreshold = NULL;
     capi.SetAllocTrackerMaximumAmplification = NULL;
+#endif
+#if XML_COMBINED_VERSION >= 20800
+    capi.SetHashSalt16Bytes = XML_SetHashSalt16Bytes;
+#else
+    capi.SetHashSalt16Bytes = NULL;
 #endif
 
     /* export using capsule */


### PR DESCRIPTION
(cherry picked from commit 24b8f12544468e4cedf5bfbe25442fcd495391e4)

<!-- gh-issue-number: gh-149018 -->
* Issue: gh-149018
<!-- /gh-issue-number -->
