### PR TITLE
gh-152172: Fix itertools documentation method reference

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -200,7 +200,7 @@ loops that truncate the stream.
 
 .. classmethod:: chain.from_iterable(iterable)
 
-   Alternate constructor for :func:`chain`.  Gets chained inputs from a
+   Alternate constructor for :meth:`chain`.  Gets chained inputs from a
    single iterable argument that is evaluated lazily.  Roughly equivalent to::
 
       def from_iterable(iterables):


### PR DESCRIPTION
### Summary of changes
Corrected a documentation error in `Doc/library/itertools.rst`. 
Replaced the `:func:` directive with `:meth:` for `chain.from_iterable` to correctly identify it as a method of the `chain` class.

### Issue
gh-152172 # # #