### PR TITLE
gh-144361: Fix NameError when type parameter default refers to a forward name

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -823,6 +823,54 @@ class TypeParameterDefaultsTests(BaseTestCase):
                 self.assertEqual(z.__bound__, typevar.__bound__)
                 self.assertEqual(z.__default__, typevar.__default__)
 
+    def test_forward_reference_default_typevar(self):
+        ns = run_code(
+            """
+            class A[T, U = ForwardName]:
+                pass
+            """
+        )
+        U, A = ns["A"].__type_params__[1], ns["A"]
+        with self.assertRaises(NameError):
+            U.__default__
+        result = A[int]
+        self.assertIsInstance(result.__args__[0], type)
+        self.assertIs(int, result.__args__[0])
+        self.assertIsInstance(result.__args__[1], ForwardRef)
+        self.assertEqual(result.__args__[1].__forward_arg__, 'ForwardName')
+
+    def test_forward_reference_default_typevartuple(self):
+        ns = run_code(
+            """
+            class A[T, *Ts = ForwardName]:
+                pass
+            """
+        )
+        Ts, A = ns["A"].__type_params__[1], ns["A"]
+        with self.assertRaises(NameError):
+            Ts.__default__
+        result = A[int]
+        self.assertIsInstance(result.__args__[0], type)
+        self.assertIs(int, result.__args__[0])
+        self.assertIsInstance(result.__args__[1], ForwardRef)
+        self.assertEqual(result.__args__[1].__forward_arg__, 'ForwardName')
+
+    def test_forward_reference_default_paramspec(self):
+        ns = run_code(
+            """
+            class A[T, **P = ForwardName]:
+                pass
+            """
+        )
+        P, A = ns["A"].__type_params__[1], ns["A"]
+        with self.assertRaises(NameError):
+            P.__default__
+        result = A[int]
+        self.assertIsInstance(result.__args__[0], type)
+        self.assertIs(int, result.__args__[0])
+        self.assertIsInstance(result.__args__[1], ForwardRef)
+        self.assertEqual(result.__args__[1].__forward_arg__, 'ForwardName')
+
 
 def template_replace(templates: list[str], replacements: dict[str, list[str]]) -> list[tuple[str]]:
     """Renders templates with possible combinations of replacements.

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1099,7 +1099,12 @@ def _typevartuple_prepare_subst(self, alias, args):
         raise TypeError(f"Too few arguments for {alias};"
                         f" actual {alen}, expected at least {plen-1}")
     if left == alen - right and self.has_default():
-        replacement = _unpack_args(self.__default__)
+        try:
+            default = self.__default__
+        except NameError:
+            default = annotationlib.call_evaluate_function(
+                self.evaluate_default, annotationlib.Format.FORWARDREF)
+        replacement = _unpack_args(default)
     else:
         replacement = args[left: alen - right]
 
@@ -1125,7 +1130,12 @@ def _paramspec_prepare_subst(self, alias, args):
     params = alias.__parameters__
     i = params.index(self)
     if i == len(args) and self.has_default():
-        args = (*args, self.__default__)
+        try:
+            default = self.__default__
+        except NameError:
+            default = annotationlib.call_evaluate_function(
+                self.evaluate_default, annotationlib.Format.FORWARDREF)
+        args = (*args, default)
     if i >= len(args):
         raise TypeError(f"Too few arguments for {alias}")
     # Special case where Z[[int, str, bool]] == Z[int, str, bool] in PEP 612.
@@ -1185,7 +1195,12 @@ def _generic_class_getitem(cls, args):
         for param in parameters:
             prepare = getattr(param, '__typing_prepare_subst__', None)
             if prepare is not None:
-                args = prepare(cls, args)
+                try:
+                    args = prepare(cls, args)
+                except NameError:
+                    default = annotationlib.call_evaluate_function(
+                        param.evaluate_default, annotationlib.Format.FORWARDREF)
+                    args = (*args, default)
         _check_generic_specialization(cls, args)
 
         new_args = []

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1071,6 +1071,33 @@ def _typevar_subst(self, arg):
     return arg
 
 
+def _typeparam_default(tp):
+    """Return the default value of a type parameter.
+
+    If the default refers to a name that is not yet defined, return the
+    corresponding forward reference instead of raising NameError.
+    """
+    try:
+        return tp.__default__
+    except NameError:
+        return annotationlib.call_evaluate_function(
+            tp.evaluate_default, annotationlib.Format.FORWARDREF)
+
+
+def _typevar_prepare_subst(self, alias, args):
+    params = alias.__parameters__
+    i = params.index(self)
+    alen = len(args)
+    if i < alen:
+        # We already have a value for this TypeVar
+        return args
+    if i == alen and self.has_default():
+        # If the TypeVar has a default, use it.
+        return (*args, _typeparam_default(self))
+    raise TypeError(f"Too few arguments for {alias};"
+                    f" actual {alen}, expected at least {i + 1}")
+
+
 def _typevartuple_prepare_subst(self, alias, args):
     params = alias.__parameters__
     typevartuple_index = params.index(self)
@@ -1099,12 +1126,7 @@ def _typevartuple_prepare_subst(self, alias, args):
         raise TypeError(f"Too few arguments for {alias};"
                         f" actual {alen}, expected at least {plen-1}")
     if left == alen - right and self.has_default():
-        try:
-            default = self.__default__
-        except NameError:
-            default = annotationlib.call_evaluate_function(
-                self.evaluate_default, annotationlib.Format.FORWARDREF)
-        replacement = _unpack_args(default)
+        replacement = _unpack_args(_typeparam_default(self))
     else:
         replacement = args[left: alen - right]
 
@@ -1130,12 +1152,7 @@ def _paramspec_prepare_subst(self, alias, args):
     params = alias.__parameters__
     i = params.index(self)
     if i == len(args) and self.has_default():
-        try:
-            default = self.__default__
-        except NameError:
-            default = annotationlib.call_evaluate_function(
-                self.evaluate_default, annotationlib.Format.FORWARDREF)
-        args = (*args, default)
+        args = (*args, _typeparam_default(self))
     if i >= len(args):
         raise TypeError(f"Too few arguments for {alias}")
     # Special case where Z[[int, str, bool]] == Z[int, str, bool] in PEP 612.

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1195,12 +1195,7 @@ def _generic_class_getitem(cls, args):
         for param in parameters:
             prepare = getattr(param, '__typing_prepare_subst__', None)
             if prepare is not None:
-                try:
-                    args = prepare(cls, args)
-                except NameError:
-                    default = annotationlib.call_evaluate_function(
-                        param.evaluate_default, annotationlib.Format.FORWARDREF)
-                    args = (*args, default)
+                args = prepare(cls, args)
         _check_generic_specialization(cls, args)
 
         new_args = []

--- a/Misc/NEWS.d/next/Library/2026-06-25-22-30-00.gh-issue-144361.lL9mN2.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-22-30-00.gh-issue-144361.lL9mN2.rst
@@ -1,0 +1,4 @@
+Fix :exc:`NameError` when a type parameter default (PEP 696/PEP 749)
+refers to a name defined later in the module. Now three call sites in
+:mod:`typing` fall back to :func:`annotationlib.call_evaluate_function`
+with :data:`~annotationlib.Format.FORWARDREF` when eager evaluation fails.

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -351,24 +351,6 @@ call_typing_func_object(const char *name, PyObject **args, size_t nargs)
 }
 
 static PyObject *
-call_annotationlib_func_object(const char *name, PyObject **args, size_t nargs)
-{
-    PyObject *annotationlib = PyImport_ImportModule("annotationlib");
-    if (annotationlib == NULL) {
-        return NULL;
-    }
-    PyObject *func = PyObject_GetAttrString(annotationlib, name);
-    if (func == NULL) {
-        Py_DECREF(annotationlib);
-        return NULL;
-    }
-    PyObject *result = PyObject_Vectorcall(func, args, nargs, NULL);
-    Py_DECREF(func);
-    Py_DECREF(annotationlib);
-    return result;
-}
-
-static PyObject *
 type_check(PyObject *arg, const char *msg)
 {
     // Calling typing.py here leads to bootstrapping problems
@@ -798,71 +780,8 @@ typevar_typing_prepare_subst_impl(typevarobject *self, PyObject *alias,
                                   PyObject *args)
 /*[clinic end generated code: output=82c3f4691e0ded22 input=201a750415d14ffb]*/
 {
-    PyObject *params = PyObject_GetAttrString(alias, "__parameters__");
-    if (params == NULL) {
-        return NULL;
-    }
-    Py_ssize_t i = PySequence_Index(params, (PyObject *)self);
-    if (i == -1) {
-        Py_DECREF(params);
-        return NULL;
-    }
-    Py_ssize_t args_len = PySequence_Length(args);
-    if (args_len == -1) {
-        Py_DECREF(params);
-        return NULL;
-    }
-    if (i < args_len) {
-        // We already have a value for our TypeVar
-        Py_DECREF(params);
-        return Py_NewRef(args);
-    }
-    else if (i == args_len) {
-        // If the TypeVar has a default, use it.
-        PyObject *dflt = typevar_default((PyObject *)self, NULL);
-        if (dflt == NULL) {
-            if (!PyErr_ExceptionMatches(PyExc_NameError)) {
-                Py_DECREF(params);
-                return NULL;
-            }
-            PyErr_Clear();
-            if (self->evaluate_default == NULL) {
-                dflt = &_Py_NoDefaultStruct;
-            }
-            else {
-                PyObject *format = PyLong_FromLong(_Py_ANNOTATE_FORMAT_FORWARDREF);
-                if (format == NULL) {
-                    Py_DECREF(params);
-                    return NULL;
-                }
-                PyObject *call_args[2] = {self->evaluate_default, format};
-                dflt = call_annotationlib_func_object(
-                    "call_evaluate_function", call_args, 2);
-                Py_DECREF(format);
-                if (dflt == NULL) {
-                    Py_DECREF(params);
-                    return NULL;
-                }
-            }
-        }
-        if (dflt != &_Py_NoDefaultStruct) {
-            PyObject *new_args = PyTuple_Pack(1, dflt);
-            Py_DECREF(dflt);
-            if (new_args == NULL) {
-                Py_DECREF(params);
-                return NULL;
-            }
-            PyObject *result = PySequence_Concat(args, new_args);
-            Py_DECREF(params);
-            Py_DECREF(new_args);
-            return result;
-        }
-    }
-    Py_DECREF(params);
-    PyErr_Format(PyExc_TypeError,
-                 "Too few arguments for %S; actual %zd, expected at least %zd",
-                 alias, args_len, i + 1);
-    return NULL;
+    PyObject *args_array[3] = {(PyObject *)self, alias, args};
+    return call_typing_func_object("_typevar_prepare_subst", args_array, 3);
 }
 
 /*[clinic input]

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -351,6 +351,24 @@ call_typing_func_object(const char *name, PyObject **args, size_t nargs)
 }
 
 static PyObject *
+call_annotationlib_func_object(const char *name, PyObject **args, size_t nargs)
+{
+    PyObject *annotationlib = PyImport_ImportModule("annotationlib");
+    if (annotationlib == NULL) {
+        return NULL;
+    }
+    PyObject *func = PyObject_GetAttrString(annotationlib, name);
+    if (func == NULL) {
+        Py_DECREF(annotationlib);
+        return NULL;
+    }
+    PyObject *result = PyObject_Vectorcall(func, args, nargs, NULL);
+    Py_DECREF(func);
+    Py_DECREF(annotationlib);
+    return result;
+}
+
+static PyObject *
 type_check(PyObject *arg, const char *msg)
 {
     // Calling typing.py here leads to bootstrapping problems
@@ -803,8 +821,29 @@ typevar_typing_prepare_subst_impl(typevarobject *self, PyObject *alias,
         // If the TypeVar has a default, use it.
         PyObject *dflt = typevar_default((PyObject *)self, NULL);
         if (dflt == NULL) {
-            Py_DECREF(params);
-            return NULL;
+            if (!PyErr_ExceptionMatches(PyExc_NameError)) {
+                Py_DECREF(params);
+                return NULL;
+            }
+            PyErr_Clear();
+            if (self->evaluate_default == NULL) {
+                dflt = &_Py_NoDefaultStruct;
+            }
+            else {
+                PyObject *format = PyLong_FromLong(_Py_ANNOTATE_FORMAT_FORWARDREF);
+                if (format == NULL) {
+                    Py_DECREF(params);
+                    return NULL;
+                }
+                PyObject *call_args[2] = {self->evaluate_default, format};
+                dflt = call_annotationlib_func_object(
+                    "call_evaluate_function", call_args, 2);
+                Py_DECREF(format);
+                if (dflt == NULL) {
+                    Py_DECREF(params);
+                    return NULL;
+                }
+            }
         }
         if (dflt != &_Py_NoDefaultStruct) {
             PyObject *new_args = PyTuple_Pack(1, dflt);


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Fix #144361: PEP 696 + PEP 749 — delayed evaluation of type parameter defaults.

Three call sites in Lib/typing.py eagerly evaluate __default__ (Format.VALUE),
which fails when the default references a name defined later in the module.
Catch NameError and fall back to annotationlib.call_evaluate_function
with Format.FORWARDREF.

<!-- gh-issue-number: gh-144361 -->
* Issue: gh-144361
<!-- /gh-issue-number -->
