### PR TITLE
gh-152212: Reject a POSIX TZ footer with a missing std offset in pure-Python zoneinfo

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1142,6 +1142,11 @@ class TZStrTest(ZoneInfoTestBase):
     def test_invalid_tzstr(self):
         invalid_tzstrs = [
             "PST8PDT",  # DST but no transition specified
+            # gh-152212: the std offset is required (POSIX TZ grammar)
+            "AAA",
+            "A",
+            "AA",
+            "B",
             "+11",  # Unquoted alphanumeric
             "GMT,M3.2.0/2,M11.1.0/3",  # Transition rule but no DST
             "GMT0+11,M3.2.0/2,M11.1.0/3",  # Unquoted alphanumeric in DST

--- a/Lib/zoneinfo/_zoneinfo.py
+++ b/Lib/zoneinfo/_zoneinfo.py
@@ -672,6 +672,7 @@ def _parse_tz_str(tz_str):
         except ValueError as e:
             raise ValueError(f"Invalid STD offset in {tz_str}") from e
     else:
+        # The STD offset is required
         raise ValueError(f"Invalid STD offset in {tz_str}")
 
     if dst_abbr is not None:

--- a/Lib/zoneinfo/_zoneinfo.py
+++ b/Lib/zoneinfo/_zoneinfo.py
@@ -672,7 +672,7 @@ def _parse_tz_str(tz_str):
         except ValueError as e:
             raise ValueError(f"Invalid STD offset in {tz_str}") from e
     else:
-        std_offset = 0
+        raise ValueError(f"Invalid STD offset in {tz_str}")
 
     if dst_abbr is not None:
         if dst_offset := m.group("dstoff"):

--- a/Misc/NEWS.d/next/Library/2026-06-25-12-00-00.gh-issue-152212.Zk7Qm2.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-12-00-00.gh-issue-152212.Zk7Qm2.rst
@@ -1,6 +1,3 @@
-Fixed a parity bug in the pure-Python :mod:`zoneinfo` implementation, which
-accepted a POSIX TZ footer whose ``std`` field had no offset (for example
-``AAA``), silently building a fixed offset-0 zone. Such a string is invalid per
-POSIX (the offset following ``std`` is required), and the C accelerator already
-rejects it; the pure-Python parser now raises :exc:`ValueError` to match.
-Patch by tonghuaroot.
+Fix the pure-Python :mod:`zoneinfo` parser accepting a POSIX TZ string with a
+``std`` abbreviation but no offset. This is invalid per POSIX and now
+raises :exc:`ValueError`, matching the C accelerator. Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-06-25-12-00-00.gh-issue-152212.Zk7Qm2.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-12-00-00.gh-issue-152212.Zk7Qm2.rst
@@ -1,0 +1,6 @@
+Fixed a parity bug in the pure-Python :mod:`zoneinfo` implementation, which
+accepted a POSIX TZ footer whose ``std`` field had no offset (for example
+``AAA``), silently building a fixed offset-0 zone. Such a string is invalid per
+POSIX (the offset following ``std`` is required), and the C accelerator already
+rejects it; the pure-Python parser now raises :exc:`ValueError` to match.
+Patch by tonghuaroot.


### PR DESCRIPTION
The pure-Python `zoneinfo._parse_tz_str` defaults a missing std offset to `0` (`else: std_offset = 0`), so a POSIX TZ footer with a bare std abbreviation and no offset (`AAA`, `A`, `AA`, `B`) is silently accepted as a fixed offset-0 zone. POSIX requires the offset after `std` (Issue 8 §8.3), and the C accelerator already raises `ValueError: Invalid STD offset`, so this makes the pure-Python parser raise to match.

Adds `AAA`/`A`/`AA`/`B` to `test_invalid_tzstr`, which runs against both `TZStrTest` (pure) and `CTZStrTest` (C). Non-breaking: all 598 IANA zones still parse, and well-formed strings (`EST5`, `<ABC>5`, `AAA5`) are unaffected.

Fixes #152212.

<!-- gh-issue-number: gh-152212 -->
* Issue: gh-152212
<!-- /gh-issue-number -->
