### PR TITLE
gh-152099: Raise SendfileNotAvailableError for fallback-only transports

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1283,7 +1283,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                     raise
 
         if not fallback:
-            raise RuntimeError(
+            raise exceptions.SendfileNotAvailableError(
                 f"fallback is disabled and native sendfile is not "
                 f"supported for transport {transport!r}")
         return await self._sendfile_fallback(transport, file,

--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -580,7 +580,8 @@ class SendfileMixin(SendfileBase):
         transport = mock.Mock()
         transport.is_closing.side_effect = lambda: False
         transport._sendfile_compatible = constants._SendfileMode.FALLBACK
-        with self.assertRaisesRegex(RuntimeError, 'fallback is disabled'):
+        with self.assertRaisesRegex(asyncio.SendfileNotAvailableError,
+                                    'fallback is disabled'):
             self.loop.run_until_complete(
                 self.loop.sendfile(transport, None, fallback=False))
 

--- a/Misc/NEWS.d/next/Library/2026-06-25-22-19-04.gh-issue-152099.L7fKq9.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-22-19-04.gh-issue-152099.L7fKq9.rst
@@ -1,0 +1,4 @@
+``asyncio``'s ``loop.sendfile(..., fallback=False)`` now consistently raises
+:exc:`asyncio.SendfileNotAvailableError` for fallback-only transports, such as
+SSL/TLS transports, when native sendfile cannot be used. Previously, this case
+raised :exc:`RuntimeError`.


### PR DESCRIPTION
## Summary

This PR makes `BaseEventLoop.sendfile()` consistently raise `asyncio.SendfileNotAvailableError` when native sendfile cannot be used for fallback-capable transports (such as SSL/TLS) and `fallback=False`.

Currently, native sendfile failures on `_SendfileMode.TRY_NATIVE` transports already raise `SendfileNotAvailableError`, while `_SendfileMode.FALLBACK` transports raise a generic `RuntimeError`. This results in inconsistent exception behavior for the same practical condition: native sendfile is unavailable and fallback has been disabled.

The change updates only the fallback-only transport path. Unsupported transports and closing transports continue to raise `RuntimeError` unchanged.

### Changes

* Raise `SendfileNotAvailableError` instead of `RuntimeError` for `_SendfileMode.FALLBACK` when `fallback=False`.
* Update the corresponding asyncio sendfile test to expect the public exception type.
* Keep all other code paths unchanged.

### Validation

Executed:

```text
PCbuild\amd64\python_d.exe -m test test_asyncio -m test_sendfile_no_fallback_for_fallback_transport
PCbuild\amd64\python_d.exe -m test test_asyncio.test_sendfile
git diff --check
```

All focused tests passed.

### Compatibility

`SendfileNotAvailableError` subclasses `RuntimeError`, so existing code catching `RuntimeError` continues to work while allowing applications to reliably detect native sendfile unavailability.

Closes gh-152099.