### PR TITLE
[3.14] gh-151929: Add pythoninfo commands to Tools/wasm/wasi (#152136)

### DIFF
--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -51,7 +51,7 @@ jobs:
     - name: "Make build Python"
       run: python3 Tools/wasm/wasi make-build-python
     - name: "Display build info of the build Python"
-      run: python3 Platforms/WASI pythoninfo-build
+      run: python3 Tools/wasm/wasi pythoninfo-build
     - name: "Configure host/WASI Python"
       # `--with-pydebug` inferred from configure-build-python
       run: python3 Tools/wasm/wasi configure-host -- --config-cache

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -18,7 +18,6 @@ jobs:
       WASMTIME_VERSION: 38.0.3
       WASI_SDK_VERSION: 24
       WASI_SDK_PATH: /opt/wasi-sdk
-      CROSS_BUILD_PYTHON: cross-build/build
       CROSS_BUILD_WASI: cross-build/wasm32-wasip1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -51,12 +50,14 @@ jobs:
       run: python3 Tools/wasm/wasi configure-build-python -- --config-cache --with-pydebug
     - name: "Make build Python"
       run: python3 Tools/wasm/wasi make-build-python
-    - name: "Configure host"
+    - name: "Display build info of the build Python"
+      run: python3 Platforms/WASI pythoninfo-build
+    - name: "Configure host/WASI Python"
       # `--with-pydebug` inferred from configure-build-python
       run: python3 Tools/wasm/wasi configure-host -- --config-cache
-    - name: "Make host"
+    - name: "Make host/WASI Python"
       run: python3 Tools/wasm/wasi make-host
-    - name: "Display build info"
-      run: make --directory "${CROSS_BUILD_WASI}" pythoninfo
+    - name: "Display build info of the host/WASI Python"
+      run: python3 Tools/wasm/wasi pythoninfo-host
     - name: "Test"
       run: make --directory "${CROSS_BUILD_WASI}" test

--- a/Tools/wasm/wasi/__main__.py
+++ b/Tools/wasm/wasi/__main__.py
@@ -580,7 +580,7 @@ def main():
         "pythoninfo-host": pythoninfo_wasi_python,
         "build": build_steps(build_build_python, build_wasi_python),
         "clean": clean_contents,
-        None: lambda args: parser.print_help()
+        None: lambda args: parser.print_help(),
     }
     dispatch[context.subcommand](context)
 

--- a/Tools/wasm/wasi/__main__.py
+++ b/Tools/wasm/wasi/__main__.py
@@ -211,6 +211,12 @@ def make_build_python(context, working_dir):
     log("🎉", f"{binary} {version}")
 
 
+@subdir(BUILD_DIR)
+def pythoninfo_build_python(context, working_dir):
+    """Display build info of the build Python."""
+    call(["make", "pythoninfo"], context=context)
+
+
 def find_wasi_sdk():
     """Find the path to the WASI SDK."""
     wasi_sdk_path = None
@@ -390,6 +396,12 @@ def make_wasi_python(context, working_dir):
     )
 
 
+@subdir(lambda context: CROSS_BUILD_DIR / context.host_triple)
+def pythoninfo_wasi_python(context, working_dir):
+    """Display build info of the host/WASI Python."""
+    call(["make", "pythoninfo"], context=context)
+
+
 def clean_contents(context):
     """Delete all files created by this script."""
     if CROSS_BUILD_DIR.exists():
@@ -443,6 +455,9 @@ def main():
     build_python = subcommands.add_parser(
         "build-python", help="Build the build Python"
     )
+    pythoninfo_build = subcommands.add_parser(
+        "pythoninfo-build", help="Display build info of the build Python"
+    )
     configure_host = subcommands.add_parser(
         "configure-host",
         help="Run `configure` for the "
@@ -456,6 +471,9 @@ def main():
     build_host = subcommands.add_parser(
         "build-host", help="Build the host/WASI Python"
     )
+    pythoninfo_host = subcommands.add_parser(
+        "pythoninfo-host", help="Display build info of the host/WASI Python"
+    )
     subcommands.add_parser(
         "clean", help="Delete files and directories created by this script"
     )
@@ -464,8 +482,10 @@ def main():
         configure_build,
         make_build,
         build_python,
+        pythoninfo_build,
         configure_host,
         make_host,
+        pythoninfo_host,
         build_host,
     ):
         subcommand.add_argument(
@@ -520,7 +540,13 @@ def main():
             help="Command template for running the WASI host; defaults to "
             f"`{default_host_runner}`",
         )
-    for subcommand in build, configure_host, make_host, build_host:
+    for subcommand in (
+        build,
+        configure_host,
+        make_host,
+        build_host,
+        pythoninfo_host,
+    ):
         subcommand.add_argument(
             "--host-triple",
             action="store",
@@ -532,18 +558,29 @@ def main():
     context = parser.parse_args()
     context.init_dir = pathlib.Path().absolute()
 
-    build_build_python = build_steps(configure_build_python, make_build_python)
-    build_wasi_python = build_steps(configure_wasi_python, make_wasi_python)
+    build_build_python = build_steps(
+        configure_build_python,
+        make_build_python,
+        pythoninfo_build_python,
+    )
+    build_wasi_python = build_steps(
+        configure_wasi_python,
+        make_wasi_python,
+        pythoninfo_wasi_python,
+    )
 
     dispatch = {
         "configure-build-python": configure_build_python,
         "make-build-python": make_build_python,
         "build-python": build_build_python,
+        "pythoninfo-build": pythoninfo_build_python,
         "configure-host": configure_wasi_python,
         "make-host": make_wasi_python,
         "build-host": build_wasi_python,
+        "pythoninfo-host": pythoninfo_wasi_python,
         "build": build_steps(build_build_python, build_wasi_python),
         "clean": clean_contents,
+        None: lambda args: parser.print_help()
     }
     dispatch[context.subcommand](context)
 


### PR DESCRIPTION
The "build-python", "build-host" and "build" commands now also run "pythoninfo-build" and "pythoninfo-host" commands.

If no subcommand is provided, display the help.

GitHub Action "WASI":

* Add "pythoninfo-build" and "pythoninfo-host" commands.
* Remove unused and outdated CROSS_BUILD_PYTHON environment variable.

(cherry picked from commit 7c8163719cd23d41daeaed0b243be45de3e82e05)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151929 -->
* Issue: gh-151929
<!-- /gh-issue-number -->
