### PR TITLE
[3.13] gh-151929: Add pythoninfo commands to Tools/wasm/wasi.py (#152136) (#152224)

### DIFF
--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -18,7 +18,6 @@ jobs:
       WASMTIME_VERSION: 38.0.3
       WASI_SDK_VERSION: 24
       WASI_SDK_PATH: /opt/wasi-sdk
-      CROSS_BUILD_PYTHON: cross-build/build
       CROSS_BUILD_WASI: cross-build/wasm32-wasip1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -51,12 +50,14 @@ jobs:
       run: python3 Tools/wasm/wasi.py configure-build-python -- --config-cache --with-pydebug
     - name: "Make build Python"
       run: python3 Tools/wasm/wasi.py make-build-python
-    - name: "Configure host"
+    - name: "Display build info of the build Python"
+      run: python3 Tools/wasm/wasi.py pythoninfo-build
+    - name: "Configure host/WASI Python"
       # `--with-pydebug` inferred from configure-build-python
       run: python3 Tools/wasm/wasi.py configure-host -- --config-cache
-    - name: "Make host"
+    - name: "Make host/WASI Python"
       run: python3 Tools/wasm/wasi.py make-host
     - name: "Display build info"
-      run: make --directory "${CROSS_BUILD_WASI}" pythoninfo
+      run: python3 Tools/wasm/wasi.py pythoninfo-host
     - name: "Test"
       run: make --directory "${CROSS_BUILD_WASI}" test

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -57,7 +57,7 @@ jobs:
       run: python3 Tools/wasm/wasi.py configure-host -- --config-cache
     - name: "Make host/WASI Python"
       run: python3 Tools/wasm/wasi.py make-host
-    - name: "Display build info"
+    - name: "Display build info of the host/WASI Python"
       run: python3 Tools/wasm/wasi.py pythoninfo-host
     - name: "Test"
       run: make --directory "${CROSS_BUILD_WASI}" test

--- a/Tools/wasm/wasi.py
+++ b/Tools/wasm/wasi.py
@@ -171,6 +171,12 @@ def make_build_python(context, working_dir):
     print(f"🎉 {binary} {version}")
 
 
+@subdir(BUILD_DIR)
+def pythoninfo_build_python(context, working_dir):
+    """Display build info of the build Python."""
+    call(["make", "pythoninfo"], context=context)
+
+
 def find_wasi_sdk():
     """Find the path to wasi-sdk."""
     if wasi_sdk_path := os.environ.get("WASI_SDK_PATH"):
@@ -316,11 +322,19 @@ def build_all(context):
     steps = [
         configure_build_python,
         make_build_python,
+        pythoninfo_build_python,
         configure_wasi_python,
         make_wasi_python,
+        pythoninfo_wasi_python,
     ]
     for step in steps:
         step(context)
+
+
+@subdir(lambda context: CROSS_BUILD_DIR / context.host_triple)
+def pythoninfo_wasi_python(context, working_dir):
+    """Display build info of the host/WASI Python."""
+    call(["make", "pythoninfo"], context=context)
 
 
 def clean_contents(context):
@@ -364,6 +378,9 @@ def main():
     make_build = subcommands.add_parser(
         "make-build-python", help="Run `make` for the build Python"
     )
+    pythoninfo_build = subcommands.add_parser(
+        "pythoninfo-build", help="Display build info of the build Python"
+    )
     configure_host = subcommands.add_parser(
         "configure-host",
         help="Run `configure` for the "
@@ -374,6 +391,9 @@ def main():
     make_host = subcommands.add_parser(
         "make-host", help="Run `make` for the host/WASI"
     )
+    pythoninfo_host = subcommands.add_parser(
+        "pythoninfo-host", help="Display build info of the host/WASI Python"
+    )
     subcommands.add_parser(
         "clean", help="Delete files and directories created by this script"
     )
@@ -381,8 +401,10 @@ def main():
         build,
         configure_build,
         make_build,
+        pythoninfo_build,
         configure_host,
         make_host,
+        pythoninfo_host,
     ):
         subcommand.add_argument(
             "--quiet",
@@ -421,7 +443,12 @@ def main():
             "(default designed for wasmtime 14 or newer: "
             f"`{default_host_runner}`)",
         )
-    for subcommand in build, configure_host, make_host:
+    for subcommand in (
+        build,
+        configure_host,
+        make_host,
+        pythoninfo_host,
+    ):
         subcommand.add_argument(
             "--host-triple",
             action="store",
@@ -434,10 +461,13 @@ def main():
     dispatch = {
         "configure-build-python": configure_build_python,
         "make-build-python": make_build_python,
+        "pythoninfo-build": pythoninfo_build_python,
         "configure-host": configure_wasi_python,
         "make-host": make_wasi_python,
+        "pythoninfo-host": pythoninfo_wasi_python,
         "build": build_all,
         "clean": clean_contents,
+        None: lambda args: parser.print_help(),
     }
     dispatch[context.subcommand](context)
 

--- a/Tools/wasm/wasi.py
+++ b/Tools/wasm/wasi.py
@@ -174,7 +174,7 @@ def make_build_python(context, working_dir):
 @subdir(BUILD_DIR)
 def pythoninfo_build_python(context, working_dir):
     """Display build info of the build Python."""
-    call(["make", "pythoninfo"], context=context)
+    call(["make", "pythoninfo"], quiet=context.quiet)
 
 
 def find_wasi_sdk():
@@ -334,7 +334,7 @@ def build_all(context):
 @subdir(lambda context: CROSS_BUILD_DIR / context.host_triple)
 def pythoninfo_wasi_python(context, working_dir):
     """Display build info of the host/WASI Python."""
-    call(["make", "pythoninfo"], context=context)
+    call(["make", "pythoninfo"], quiet=context.quiet)
 
 
 def clean_contents(context):


### PR DESCRIPTION
The "build" command now also runs "pythoninfo-build" and "pythoninfo-host" commands.

If no subcommand is provided, display the help.

GitHub Action "WASI":

* Add "pythoninfo-build" and "pythoninfo-host" commands.
* Remove unused and outdated CROSS_BUILD_PYTHON environment variable.

(cherry picked from commit 7c8163719cd23d41daeaed0b243be45de3e82e05) (cherry picked from commit 6426887ba35ab618c2da413c2744eb7db4d82f53)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151929 -->
* Issue: gh-151929
<!-- /gh-issue-number -->
