### PR TITLE
Add statistics.median_absolute_deviation

### DIFF
--- a/Doc/library/statistics.rst
+++ b/Doc/library/statistics.rst
@@ -95,6 +95,7 @@ tends to deviate from the typical or average values.
 :func:`pvariance`        Population variance of data.
 :func:`stdev`            Sample standard deviation of data.
 :func:`variance`         Sample variance of data.
+:func:`median_absolute_deviation`  Median absolute deviation of data.
 =======================  =============================================
 
 Statistics for relations between two inputs
@@ -653,6 +654,52 @@ However, for reading convenience, most of the examples show sorted sequences.
       If you somehow know the actual population mean μ you should pass it to the
       :func:`pvariance` function as the *mu* parameter to get the variance of a
       sample.
+
+
+.. function:: median_absolute_deviation(data, *, scale=1.4826)
+
+   Return the median absolute deviation of *data*, a non-empty sequence or
+   iterable of real-valued numbers.  The median absolute deviation is a
+   measure of statistical dispersion: it is the median of the absolute
+   deviations from the median of *data*:
+
+   .. doctest::
+
+      >>> median_absolute_deviation([1, 1, 2, 2, 4, 6, 9])
+      1.4826
+
+   Unlike the standard deviation, the median absolute deviation is not
+   sensitive to outliers; a single extreme value does not move it.  This
+   makes it a robust measure of spread, particularly useful when *data*
+   contains outliers or comes from a heavy-tailed distribution.
+
+   The *scale* argument scales the result by a constant factor.  The
+   default ``scale=1.4826`` is the consistency constant for the normal
+   distribution: for normally distributed data, the result is a consistent
+   estimator of the population standard deviation.  Pass ``scale=1.0`` to
+   retrieve the raw median absolute deviation, or any other ``int`` or
+   ``float`` to scale the result to a custom unit.  Passing a
+   :class:`decimal.Decimal` or :class:`fractions.Fraction` *scale* raises
+   :exc:`TypeError`.
+
+   If *data* is empty, :exc:`StatisticsError` is raised.  If every value in
+   *data* is ``NaN``, :exc:`StatisticsError` is raised; otherwise ``NaN``
+   values propagate.
+
+   Decimals and Fractions are supported:
+
+   .. doctest::
+
+      >>> from decimal import Decimal as D
+      >>> median_absolute_deviation([D("1"), D("1"), D("2"), D("2"), D("4"), D("6"), D("9")])
+      Decimal('1.4826')
+
+      >>> from fractions import Fraction as F
+      >>> median_absolute_deviation([F(1), F(1), F(2), F(2), F(4), F(6), F(9)])
+      Fraction(7413, 5000)
+
+   .. versionadded:: 3.16
+
 
 .. function:: quantiles(data, *, n=4, method='exclusive')
 

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -210,7 +210,7 @@ statistics
   ``scale=1.4826`` (the consistency constant for the normal distribution) for
   an estimator of the population standard deviation that is consistent with
   :func:`statistics.stdev`.
-  (Contributed by [REPLACE WITH CONTRIBUTOR NAME] in :gh:`[REPLACE WITH PR NUMBER]`.)
+  (Contributed by Anand Sundar in :gh:`152227`.)
 
 
 tkinter

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -201,6 +201,18 @@ shlex
   (Contributed by Jay Berry in :gh:`148846`.)
 
 
+statistics
+----------
+
+* Added :func:`statistics.median_absolute_deviation` for robust measurement
+  of statistical dispersion: the median of the absolute deviations from the
+  median.  Pass ``scale=1`` for the raw value or accept the default
+  ``scale=1.4826`` (the consistency constant for the normal distribution) for
+  an estimator of the population standard deviation that is consistent with
+  :func:`statistics.stdev`.
+  (Contributed by [REPLACE WITH CONTRIBUTOR NAME] in :gh:`[REPLACE WITH PR NUMBER]`.)
+
+
 tkinter
 -------
 

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -7,21 +7,22 @@ averages, variance, and standard deviation.
 Calculating averages
 --------------------
 
-==================  ==================================================
-Function            Description
-==================  ==================================================
-mean                Arithmetic mean (average) of data.
-fmean               Fast, floating-point arithmetic mean.
-geometric_mean      Geometric mean of data.
-harmonic_mean       Harmonic mean of data.
-median              Median (middle value) of data.
-median_low          Low median of data.
-median_high         High median of data.
-median_grouped      Median, or 50th percentile, of grouped data.
-mode                Mode (most common value) of data.
-multimode           List of modes (most common values of data).
-quantiles           Divide data into intervals with equal probability.
-==================  ==================================================
+============================  ==================================================
+Function                      Description
+============================  ==================================================
+mean                          Arithmetic mean (average) of data.
+fmean                         Fast, floating-point arithmetic mean.
+geometric_mean                Geometric mean of data.
+harmonic_mean                 Harmonic mean of data.
+median                        Median (middle value) of data.
+median_low                    Low median of data.
+median_high                   High median of data.
+median_grouped                Median, or 50th percentile, of grouped data.
+mode                          Mode (most common value) of data.
+multimode                     List of modes (most common values of data).
+quantiles                     Divide data into intervals with equal probability.
+median_absolute_deviation     Median absolute deviation of data.
+============================  ==================================================
 
 Calculate the arithmetic mean ("the average") of data:
 
@@ -50,14 +51,15 @@ the class interval 3.5-4.5. The median of these data points is 2.8333...
 Calculating variability or spread
 ---------------------------------
 
-==================  =============================================
-Function            Description
-==================  =============================================
-pvariance           Population variance of data.
-variance            Sample variance of data.
-pstdev              Population standard deviation of data.
-stdev               Sample standard deviation of data.
-==================  =============================================
+============================  =============================================
+Function                      Description
+============================  =============================================
+pvariance                     Population variance of data.
+variance                      Sample variance of data.
+pstdev                        Population standard deviation of data.
+stdev                         Sample standard deviation of data.
+median_absolute_deviation     Median absolute deviation of data.
+============================  =============================================
 
 Calculate the standard deviation of sample data:
 
@@ -117,6 +119,7 @@ __all__ = [
     'linear_regression',
     'mean',
     'median',
+    'median_absolute_deviation',
     'median_grouped',
     'median_high',
     'median_low',
@@ -651,6 +654,93 @@ def pstdev(data, mu=None):
     if issubclass(T, Decimal):
         return _decimal_sqrt_of_frac(mss_numerator, mss_denominator)
     return _float_sqrt_of_frac(mss_numerator, mss_denominator)
+
+
+def median_absolute_deviation(data, *, scale=1.4826):
+    """Median absolute deviation of data.
+
+    The median absolute deviation (MAD) is a robust measure of the
+    variability of a univariate sample of quantitative data. It is the
+    median of the absolute deviations from the median:
+
+        MAD = median(|x_i - median(x)|)
+
+    For normally distributed data, multiplying MAD by the consistency
+    constant 1.4826 (the default *scale* parameter) produces an estimator
+    of the population standard deviation that is consistent with the
+    sample standard deviation. To get the raw MAD instead, pass
+    ``scale=1``.
+
+    *data* can be a sequence or iterable.  If *data* is empty,
+    :exc:`StatisticsError` will be raised.  *scale* must be an ``int``
+    or ``float``; passing a :class:`Decimal` or :class:`Fraction` raises
+    :exc:`TypeError`.  The result type follows *data*, not *scale*.
+
+    Some examples of use:
+
+    >>> median_absolute_deviation([1, 1, 2, 2, 4, 6, 9])
+    1.4826
+    >>> median_absolute_deviation([1, 1, 2, 2, 4, 6, 9], scale=1.0)
+    1.0
+
+    Decimals and Fractions are supported:
+
+    >>> from decimal import Decimal as D
+    >>> median_absolute_deviation([D("1"), D("1"), D("2"), D("2"), D("4"), D("6"), D("9")])
+    Decimal('1.4826')
+
+    >>> from fractions import Fraction as F
+    >>> median_absolute_deviation([F(1), F(1), F(2), F(2), F(4), F(6), F(9)])
+    Fraction(7413, 5000)
+
+    """
+    if not isinstance(scale, (int, float)):
+        raise TypeError(
+            'scale must be an int or float, not ' + type(scale).__name__
+        )
+
+    if iter(data) is data:
+        data = list(data)
+
+    n = len(data)
+    if n == 0:
+        raise StatisticsError(
+            'median_absolute_deviation requires at least one data point'
+        )
+
+    # All-NaN input raises StatisticsError; partial NaN propagates as NaN.
+    # statistics.median() leaves NaN where it sorts, which would give an
+    # implementation-defined center; we detect NaN explicitly so the
+    # behavior is well-defined regardless of where NaN ends up.
+    has_nan = False
+    all_nan = True
+    for x in data:
+        if isinstance(x, float) and math.isnan(x):
+            has_nan = True
+        else:
+            all_nan = False
+
+    if all_nan:
+        raise StatisticsError(
+            'median_absolute_deviation requires at least one data point'
+        )
+
+    if has_nan:
+        return float('nan')
+
+    center = median(data)
+    deviations = [abs(x - center) for x in data]
+    mad = median(deviations)
+
+    # Result type follows the input data, not the scale parameter.
+    # Decimal and Fraction inputs require explicit conversion so the
+    # returned value preserves precision; int and float inputs produce
+    # a float result via natural arithmetic (because the default scale
+    # is float).
+    T = type(data[0])
+    if T is Decimal or T is Fraction:
+        return T(Decimal(str(scale))) * mad
+    return scale * mad
 
 
 ## Statistics for relations between two inputs #############################

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -2233,6 +2233,169 @@ class TestStdev(VarianceStdevMixin, NumericTestCase):
         data = (1.0, 2.0)
         self.assertEqual(self.func(data, xbar=2.0), 1.0)
 
+
+class TestMedianAbsoluteDeviation(NumericTestCase):
+    """Tests for statistics.median_absolute_deviation."""
+    def setUp(self):
+        self.func = statistics.median_absolute_deviation
+
+    # --- Happy path: known answers ---
+
+    def test_ints_known_answer(self):
+        # Canonical example: median=2, deviations=[1,1,0,0,2,4,7], MAD=1.
+        self.assertEqual(self.func([1, 1, 2, 2, 4, 6, 9]), 1.4826)
+
+    def test_floats_known_answer(self):
+        # Same shape with floats: median=2.0, MAD=1.0.
+        self.assertEqual(
+            self.func([1.0, 1.0, 2.0, 2.0, 4.0, 6.0, 9.0]), 1.4826
+        )
+
+    def test_scale_default(self):
+        # Default scale is 1.4826 (the consistency constant).
+        self.assertEqual(self.func([1, 1, 2, 2, 4, 6, 9]), 1.4826)
+
+    def test_scale_one(self):
+        # scale=1.0 returns the raw MAD.
+        self.assertEqual(self.func([1, 1, 2, 2, 4, 6, 9], scale=1.0), 1.0)
+
+    def test_scale_custom(self):
+        # Any int or float scale is accepted.
+        self.assertEqual(self.func([1, 1, 2, 2, 4, 6, 9], scale=2.0), 2.0)
+        self.assertEqual(self.func([1, 1, 2, 2, 4, 6, 9], scale=3.0), 3.0)
+
+    def test_scale_negative(self):
+        # Negative scale is allowed (returns a negative value).
+        self.assertEqual(
+            self.func([1, 1, 2, 2, 4, 6, 9], scale=-1.4826), -1.4826
+        )
+
+    # --- Edge cases ---
+
+    def test_empty_raises(self):
+        # Empty input raises StatisticsError.
+        self.assertRaises(statistics.StatisticsError, self.func, [])
+
+    def test_single_value(self):
+        # A single data point has zero absolute deviation from itself.
+        self.assertEqual(self.func([5]), 0.0)
+        self.assertEqual(self.func([5], scale=2.5), 0.0)
+
+    def test_two_values_symmetric(self):
+        # Symmetric two-value input gives MAD == half the spread.
+        self.assertEqual(self.func([1, 3], scale=1.0), 1.0)
+
+    def test_all_same(self):
+        # All-same input has zero absolute deviation.
+        self.assertEqual(self.func([7, 7, 7, 7, 7]), 0.0)
+        self.assertEqual(self.func([3.14, 3.14, 3.14]), 0.0)
+
+    def test_even_count_averages(self):
+        # Even-length input: median of deviations is the average of the
+        # two middle sorted deviations.
+        # [1,2,3,4]: median=2.5, deviations=[1.5,0.5,0.5,1.5],
+        # sorted devs=[0.5,0.5,1.5,1.5], MAD=(0.5+1.5)/2=1.0.
+        self.assertEqual(self.func([1, 2, 3, 4]), 1.4826)
+        self.assertEqual(self.func([1, 2, 3, 4], scale=1.0), 1.0)
+
+    def test_iterator_input(self):
+        # Generators are accepted and consumed exactly once.
+        result = self.func(x * 2 for x in [1, 2, 3, 4])
+        self.assertEqual(result, 2.9652)
+
+    def test_tuple_input(self):
+        # Tuples (and any iterable) are accepted.
+        self.assertEqual(self.func((1, 1, 2, 2, 4, 6, 9)), 1.4826)
+
+    # --- Error and failure paths ---
+
+    def test_non_numeric_raises_type_error(self):
+        # Non-numeric data raises TypeError from arithmetic.
+        self.assertRaises(TypeError, self.func, ['a', 'b', 'c'])
+
+    def test_all_nan_raises(self):
+        # All-NaN input raises StatisticsError (consistent with median()).
+        self.assertRaises(
+            statistics.StatisticsError,
+            self.func,
+            [float('nan')] * 3,
+        )
+
+    def test_partial_nan_returns_nan(self):
+        # Partial NaN propagates as NaN when at least one real value is
+        # present.
+        result = self.func([1.0, 2.0, float('nan'), 4.0, 5.0])
+        self.assertTrue(math.isnan(result))
+
+    # --- Type acceptance ---
+
+    def test_decimal_input(self):
+        # Decimal input returns Decimal.
+        D = Decimal
+        data = [D('1'), D('1'), D('2'), D('2'), D('4'), D('6'), D('9')]
+        result = self.func(data)
+        self.assertIsInstance(result, Decimal)
+        self.assertEqual(result, D('1.4826'))
+
+    def test_fraction_input(self):
+        # Fraction input returns Fraction.
+        F = Fraction
+        data = [F(1), F(1), F(2), F(2), F(4), F(6), F(9)]
+        result = self.func(data)
+        self.assertIsInstance(result, Fraction)
+        # 1.4826 = 7413/5000 (exact decimal-to-fraction conversion).
+        self.assertEqual(result, F(7413, 5000))
+
+    def test_int_returns_float(self):
+        # Int input with default (float) scale yields a float result.
+        result = self.func([1, 1, 2, 2, 4, 6, 9])
+        self.assertIsInstance(result, float)
+
+    def test_decimal_input_preserves_precision(self):
+        # Decimal precision is preserved across the scale conversion.
+        D = Decimal
+        # mad is 1 (Decimal); default scale converts to Decimal('1.4826').
+        result = self.func([D('1'), D('2'), D('3')], scale=1)
+        self.assertEqual(result, D('1'))
+
+    def test_fraction_input_preserves_precision(self):
+        # Fraction precision is preserved.
+        F = Fraction
+        result = self.func([F(1), F(2), F(3)], scale=1)
+        self.assertEqual(result, F(1))
+
+    def test_mixed_int_float_returns_float(self):
+        # Mixed int+float input yields a float result (natural promotion).
+        self.assertIsInstance(self.func([1, 2.5, 3]), float)
+
+    # --- Scale type guard ---
+
+    def test_scale_decimal_raises(self):
+        self.assertRaises(
+            TypeError,
+            self.func,
+            [1, 2, 3],
+            scale=Decimal('1.4826'),
+        )
+
+    def test_scale_fraction_raises(self):
+        self.assertRaises(
+            TypeError,
+            self.func,
+            [1, 2, 3],
+            scale=Fraction(14826, 10000),
+        )
+
+    def test_scale_string_raises(self):
+        self.assertRaises(TypeError, self.func, [1, 2, 3], scale='1.0')
+
+    def test_scale_list_raises(self):
+        self.assertRaises(TypeError, self.func, [1, 2, 3], scale=[1.0])
+
+    def test_scale_none_raises(self):
+        self.assertRaises(TypeError, self.func, [1, 2, 3], scale=None)
+
+
 class TestGeometricMean(unittest.TestCase):
 
     def test_basics(self):


### PR DESCRIPTION
## Summary

Add `statistics.median_absolute_deviation(data, *, scale=1.4826)` to the CPython standard library. The median absolute deviation (MAD) is the textbook robust measure of statistical dispersion: the median of the absolute deviations from the median.

For normally distributed data, the default `scale=1.4826` (the consistency constant) produces an estimator of the population standard deviation that is consistent with `statistics.stdev`. Pass `scale=1.0` for the raw value.

## Why

The `statistics` module currently provides traditional spread measures (`variance`, `stdev`) but lacks a robust counterpart. Standard deviation is well known to be sensitive to outliers; MAD is the textbook alternative. It is the default "robust scale" in R (`mad()`) and NumPy (`median_abs_deviation`). For users who don't want a third-party dependency for a single stat — educators, stdlib-only scripts, Python-first learners — stdlib MAD closes an obvious gap.

## What changes

- **`Lib/statistics.py`** — new `median_absolute_deviation(data, *, scale=1.4826)` function. Result type follows input data (int/float → float; Decimal → Decimal; Fraction → Fraction). `scale` must be int or float (Decimal/Fraction raise `TypeError`). All-NaN input raises `StatisticsError`; partial NaN propagates. Top docstring autosummary table and "Measures of spread" table widened to fit the 25-character name. `__all__` updated.
- **`Lib/test/test_statistics.py`** — new `TestMedianAbsoluteDeviation` class with 28 test methods covering happy path, edge cases, error paths, type acceptance, and scale type guard. Follows `TestMedian`/`TestStdev` patterns.
- **`Doc/library/statistics.rst`** — autosummary table entry + full function directive with int/Decimal/Fraction doctest examples + `.. versionadded:: 3.16`.
- **`Doc/whatsnew/3.16.rst`** — new "statistics" section under "Improved modules".

## Out of scope (deliberately)

- **No `Lib/statistics.pyi`** — that file does not exist in CPython main. Type stubs for stdlib modules live in the separate [typeshed](https://github.com/python/typeshed) repo and will be filed there as a follow-up. (`grep -L '\.pyi' Lib/*.pyi` returns zero matches in `Lib/`.)
- **No C-level optimization** — pure Python, matching the surrounding spread-measure functions.
- **No `NormalDist` integration** — could be added as `NormalDist.from_mad()` in a follow-up PR if requested.

## TODO before merge

1. Replace `[REPLACE WITH CONTRIBUTOR NAME]` and `[REPLACE WITH PR NUMBER]` placeholders in the `Doc/whatsnew/3.16.rst` entry.
2. Update the `gh-XXXXXX` placeholders in the four commit messages with the actual issue/PR number (via `git rebase -i origin/main` and `reword`).
3. File the corresponding PR against [typeshed](https://github.com/python/typeshed) to add a type stub for `median_absolute_deviation`.