### PR TITLE
gh-98894: Skip dtrace tests when building without dtrace

### DIFF
--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -14,6 +14,10 @@ from test.support import findfile, MS_WINDOWS
 
 if not support.has_subprocess_support:
     raise unittest.SkipTest("test module requires subprocess")
+if not sysconfig.get_config_var('WITH_DTRACE'):
+    raise unittest.SkipTest(
+        "CPython must be configured with the --with-dtrace option."
+    )
 
 
 def abspath(filename):
@@ -397,12 +401,9 @@ class BPFTraceOptimizedTests(TraceTests, unittest.TestCase):
 class CheckDtraceProbes(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        if sysconfig.get_config_var('WITH_DTRACE'):
-            readelf_major_version, readelf_minor_version = cls.get_readelf_version()
-            if support.verbose:
-                print(f"readelf version: {readelf_major_version}.{readelf_minor_version}")
-        else:
-            raise unittest.SkipTest("CPython must be configured with the --with-dtrace option.")
+        readelf_major_version, readelf_minor_version = cls.get_readelf_version()
+        if support.verbose:
+            print(f"readelf version: {readelf_major_version}.{readelf_minor_version}")
 
 
     @staticmethod


### PR DESCRIPTION
Skip functional test_dtrace cases when CPython was not configured with --with-dtrace.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98894 -->
* Issue: gh-98894
<!-- /gh-issue-number -->
