### PR TITLE
gh-152240: Fix test_c_stack_unwind on Linux LoongArch builds

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-06-26-16-30-00.gh-issue-152240.loongarch.rst
+++ b/Misc/NEWS.d/next/Build/2026-06-26-16-30-00.gh-issue-152240.loongarch.rst
@@ -1,0 +1,2 @@
+Fix C stack unwinding tests on Linux LoongArch builds by teaching the manual
+frame pointer unwinder to recognize the LoongArch frame layout.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -98,6 +98,12 @@ static const uintptr_t min_frame_pointer_addr = 0x1000;
 // https://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi-1.9.html#STACK
 #  define FRAME_POINTER_NEXT_OFFSET 0
 #  define FRAME_POINTER_RETURN_OFFSET 2
+#elif defined(__loongarch__)
+// On LoongArch, the frame pointer is the caller's stack pointer.
+// The saved frame pointer is stored at fp[-2], and the return
+// address is stored at fp[-1].
+#  define FRAME_POINTER_NEXT_OFFSET -2
+#  define FRAME_POINTER_RETURN_OFFSET -1
 #else
 #  define FRAME_POINTER_NEXT_OFFSET 0
 #  define FRAME_POINTER_RETURN_OFFSET 1


### PR DESCRIPTION
Fix `test_c_stack_unwind` on Linux LoongArch builds.

This change teaches `_testinternalcapi`'s manual frame-pointer unwinder about
the LoongArch frame layout. On LoongArch, the frame pointer is the caller's
stack pointer; the previous frame pointer is at `fp[-2]`, and the return
address is at `fp[-1]`.

It also adds `-funwind-tables` for Linux LoongArch clang builds. clang/LoongArch
emits `.debug_frame` but not runtime `.eh_frame` unwind tables by default, so
glibc `backtrace()` cannot unwind through CPython frames unless unwind tables
are requested.

Validated on Linux LoongArch64:

GCC build:
```sh
../cpython/configure --with-pydebug CC=gcc
make -j8
PYTHON_JIT=0 ./python -m test -v test_c_stack_unwind
```

clang build with clang 20.1.8:
```sh
../cpython/configure --with-pydebug CC=clang
make -j8
PYTHON_JIT=0 ./python -m test -v test_c_stack_unwind
```

Also verified that `-funwind-tables` makes CPython C objects contain
`.eh_frame`, and the GNU backtrace test passes.


<!-- gh-issue-number: gh-152240 -->
* Issue: gh-152240
<!-- /gh-issue-number -->
