### PR TITLE
gh-151814: Add test for TextIOWrapper.write unbounded memory growth from repeated writes

### DIFF
--- a/Lib/test/test_io/test_textio.py
+++ b/Lib/test/test_io/test_textio.py
@@ -6,6 +6,7 @@ import pickle
 import sys
 import threading
 import time
+import tracemalloc
 import unittest
 import warnings
 import weakref
@@ -1521,6 +1522,21 @@ class CTextIOWrapperTest(TextIOWrapperTest, CTestCase):
         t.write("ghi")
         t.write("x"*chunk_size)
         self.assertEqual([b"abcdef", b"ghi", b"x"*chunk_size], buf._write_stack)
+
+    def test_write_empty_no_memory_growth(self):
+        # gh-151814: Writing empty string should have stable memory usage.
+        t = self.TextIOWrapper(self.BytesIO())
+        nwrites = 200_000
+        tracemalloc.start()
+        try:
+            for _ in range(nwrites):
+                t.write("")
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+        # No longer leaks several bytes per write.
+        self.assertLess(peak, nwrites)
 
     def test_issue119506(self):
         chunk_size = 8192


### PR DESCRIPTION
Use tracemalloc to measure memory usage.

Fails before GH-151817, passes after. Validated by changing condition between `> 0` and `>= 0` and rebuilding + running `make && ./python -m test test_io.test_textio -m "test_write_empty_no_memory_growth"`.

https://github.com/python/cpython/blob/908f438e198a753d40d1166b5f8725e650a9ed6e/Modules/_io/textio.c#L1823

Inspired by the report memory usage helper in GH-152203 (If it gets more use should probably move to `test.support`). 

cc: @StanFromIreland 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151814 -->
* Issue: gh-151814
<!-- /gh-issue-number -->
