### PR TITLE
gh-152248: Reject a POSIX TZ abbreviation with non-ASCII-letter characters in pure-Python zoneinfo

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1149,6 +1149,9 @@ class TZStrTest(ZoneInfoTestBase):
             "AB C3",
             " A B 3",
             "AAA4BB B,J60/2,J300/2",  # Embedded whitespace in DST
+            # Empty quoted abbreviation
+            "<>5",
+            "AAA4<>,M3.2.0/2,M11.1.0/3",
             "PST8PDT,M3.2.0/2",  # Only one transition rule
             # Invalid offset hours
             "AAA168",

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1145,6 +1145,12 @@ class TZStrTest(ZoneInfoTestBase):
             "+11",  # Unquoted alphanumeric
             "GMT,M3.2.0/2,M11.1.0/3",  # Transition rule but no DST
             "GMT0+11,M3.2.0/2,M11.1.0/3",  # Unquoted alphanumeric in DST
+            # Unquoted abbreviation with embedded or leading whitespace
+            # (accepted by the unmodified pure parser, rejected by the C
+            # implementation; both reject after the fix).
+            "AB C3",
+            " A B 3",
+            "AAA4BB B,J60/2,J300/2",  # Embedded whitespace in DST
             "PST8PDT,M3.2.0/2",  # Only one transition rule
             # Invalid offset hours
             "AAA168",
@@ -1221,6 +1227,35 @@ class TZStrTest(ZoneInfoTestBase):
                 tzstr_regex = re.escape(invalid_tzstr)
                 with self.assertRaisesRegex(ValueError, tzstr_regex):
                     self.zone_from_tzstr(invalid_tzstr)
+
+    def test_invalid_tzstr_non_ascii_abbr(self):
+        # A non-ASCII letter in an unquoted abbreviation is publicly reachable:
+        # from_file() UTF-8-decodes the footer, so b"AB\xc3\x80C3" decodes to
+        # "ABÀC3" and reaches the parser. The C implementation rejects it
+        # (Py_ISALPHA is ASCII-only); the unmodified pure parser accepted it.
+        #
+        # This case is kept out of the shared invalid_tzstrs list: the C error
+        # message embeds the bytes repr, which a re.escape() of the decoded
+        # string would not match, so each implementation is checked against
+        # its own message.
+        tzstr = "ABÀC3"
+        footer = tzstr.encode("utf-8")
+
+        def from_footer():
+            zonefile = io.BytesIO(self._tzif_header)
+            zonefile.seek(0, 2)
+            zonefile.write(b"\x0A")
+            zonefile.write(footer)
+            zonefile.write(b"\x0A")
+            zonefile.seek(0)
+            return self.klass.from_file(zonefile, key=tzstr)
+
+        if self.module is py_zoneinfo:
+            expected = re.escape(tzstr)
+        else:
+            expected = re.escape(repr(footer))
+        with self.assertRaisesRegex(ValueError, expected):
+            from_footer()
 
     @classmethod
     def _populate_test_cases(cls):

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1228,8 +1228,8 @@ class TZStrTest(ZoneInfoTestBase):
 
     def test_invalid_tzstr_non_ascii_abbr(self):
         # A non-ASCII letter reaches the parser via from_file()'s UTF-8 decode.
-        # It can't use the shared invalid_tzstrs list (encode("ascii") fails and
-        # the C message holds the bytes repr), so check each parser's message.
+        # It needs a separate test: it can't be ASCII-encoded for the shared
+        # invalid_tzstrs list, and the C error message holds the bytes repr.
         tzstr = "ABÀC3"
         footer = tzstr.encode("utf-8")
 

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1146,8 +1146,6 @@ class TZStrTest(ZoneInfoTestBase):
             "GMT,M3.2.0/2,M11.1.0/3",  # Transition rule but no DST
             "GMT0+11,M3.2.0/2,M11.1.0/3",  # Unquoted alphanumeric in DST
             # Unquoted abbreviation with embedded or leading whitespace
-            # (accepted by the unmodified pure parser, rejected by the C
-            # implementation; both reject after the fix).
             "AB C3",
             " A B 3",
             "AAA4BB B,J60/2,J300/2",  # Embedded whitespace in DST
@@ -1229,15 +1227,9 @@ class TZStrTest(ZoneInfoTestBase):
                     self.zone_from_tzstr(invalid_tzstr)
 
     def test_invalid_tzstr_non_ascii_abbr(self):
-        # A non-ASCII letter in an unquoted abbreviation is publicly reachable:
-        # from_file() UTF-8-decodes the footer, so b"AB\xc3\x80C3" decodes to
-        # "ABÀC3" and reaches the parser. The C implementation rejects it
-        # (Py_ISALPHA is ASCII-only); the unmodified pure parser accepted it.
-        #
-        # This case is kept out of the shared invalid_tzstrs list: the C error
-        # message embeds the bytes repr, which a re.escape() of the decoded
-        # string would not match, so each implementation is checked against
-        # its own message.
+        # A non-ASCII letter reaches the parser via from_file()'s UTF-8 decode.
+        # It can't use the shared invalid_tzstrs list (encode("ascii") fails and
+        # the C message holds the bytes repr), so check each parser's message.
         tzstr = "ABÀC3"
         footer = tzstr.encode("utf-8")
 

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1230,9 +1230,6 @@ class TZStrTest(ZoneInfoTestBase):
                     self.zone_from_tzstr(invalid_tzstr)
 
     def test_invalid_tzstr_non_ascii_abbr(self):
-        # A non-ASCII letter reaches the parser via from_file()'s UTF-8 decode.
-        # It needs a separate test: it can't be ASCII-encoded for the shared
-        # invalid_tzstrs list, and the C error message holds the bytes repr.
         tzstr = "ABÀC3"
         if self.module is py_zoneinfo:
             expected = re.escape(tzstr)

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1009,14 +1009,14 @@ class TZStrTest(ZoneInfoTestBase):
 
         cls._tzif_header = bytes(out)
 
-    def zone_from_tzstr(self, tzstr):
+    def zone_from_tzstr(self, tzstr, encoding="ascii"):
         """Creates a zoneinfo file following a POSIX rule."""
         zonefile = io.BytesIO(self._tzif_header)
         zonefile.seek(0, 2)
 
         # Write the footer
         zonefile.write(b"\x0A")
-        zonefile.write(tzstr.encode("ascii"))
+        zonefile.write(tzstr.encode(encoding))
         zonefile.write(b"\x0A")
 
         zonefile.seek(0)
@@ -1231,23 +1231,12 @@ class TZStrTest(ZoneInfoTestBase):
         # It needs a separate test: it can't be ASCII-encoded for the shared
         # invalid_tzstrs list, and the C error message holds the bytes repr.
         tzstr = "ABÀC3"
-        footer = tzstr.encode("utf-8")
-
-        def from_footer():
-            zonefile = io.BytesIO(self._tzif_header)
-            zonefile.seek(0, 2)
-            zonefile.write(b"\x0A")
-            zonefile.write(footer)
-            zonefile.write(b"\x0A")
-            zonefile.seek(0)
-            return self.klass.from_file(zonefile, key=tzstr)
-
         if self.module is py_zoneinfo:
             expected = re.escape(tzstr)
         else:
-            expected = re.escape(repr(footer))
+            expected = re.escape(repr(tzstr.encode("utf-8")))
         with self.assertRaisesRegex(ValueError, expected):
-            from_footer()
+            self.zone_from_tzstr(tzstr, encoding="utf-8")
 
     @classmethod
     def _populate_test_cases(cls):

--- a/Lib/zoneinfo/_zoneinfo.py
+++ b/Lib/zoneinfo/_zoneinfo.py
@@ -640,11 +640,11 @@ def _parse_tz_str(tz_str):
 
     parser_re = re.compile(
         r"""
-        (?P<std>[^<0-9:.+-]+|<[a-zA-Z0-9+-]+>)
+        (?P<std>[a-zA-Z]+|<[a-zA-Z0-9+-]+>)
         (?:
             (?P<stdoff>[+-]?\d{1,3}(?::\d{2}(?::\d{2})?)?)
             (?:
-                (?P<dst>[^0-9:.+-]+|<[a-zA-Z0-9+-]+>)
+                (?P<dst>[a-zA-Z]+|<[a-zA-Z0-9+-]+>)
                 (?P<dstoff>[+-]?\d{1,3}(?::\d{2}(?::\d{2})?)?)?
             )? # dst
         )? # stdoff

--- a/Misc/NEWS.d/next/Library/2026-06-26-13-39-11.gh-issue-152248.N2Rmaf.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-26-13-39-11.gh-issue-152248.N2Rmaf.rst
@@ -1,4 +1,3 @@
-Fix the pure-Python :mod:`zoneinfo` parser accepting an unquoted POSIX TZ
-abbreviation that contains characters other than ASCII letters (for example an
-embedded space), which the C implementation already rejects. Patch by
-tonghuaroot.
+Make the C and pure-Python :mod:`zoneinfo` parsers validate POSIX TZ
+abbreviations consistently, rejecting unquoted abbreviations with non-letter
+characters and empty quoted abbreviations (``<>``). Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-06-26-13-39-11.gh-issue-152248.N2Rmaf.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-26-13-39-11.gh-issue-152248.N2Rmaf.rst
@@ -1,0 +1,4 @@
+Fix the pure-Python :mod:`zoneinfo` parser accepting an unquoted POSIX TZ
+abbreviation that contains characters other than ASCII letters (for example an
+embedded space), which the C implementation already rejects. Patch by
+tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-06-26-13-39-11.gh-issue-152248.N2Rmaf.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-26-13-39-11.gh-issue-152248.N2Rmaf.rst
@@ -1,3 +1,3 @@
 Make the C and pure-Python :mod:`zoneinfo` parsers validate POSIX TZ
 abbreviations consistently, rejecting unquoted abbreviations with non-letter
-characters and empty quoted abbreviations (``<>``). Patch by tonghuaroot.
+characters and empty quoted abbreviations. Patch by tonghuaroot.

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -1762,6 +1762,9 @@ parse_abbr(const char **p, PyObject **abbr)
             ptr++;
         }
         str_end = ptr;
+        if (str_end == str_start) {
+            return -1;
+        }
         ptr++;
     }
     else {


### PR DESCRIPTION
The pure-Python `zoneinfo` parser accepts a POSIX TZ string whose unquoted std/dst abbreviation contains characters other than ASCII letters (for example an embedded space or a non-ASCII letter), while the C implementation rejects it. The unquoted alternative in the parser regex is a negated class (`[^<0-9:.+-]+`) that admits anything except a few delimiters, whereas the C `parse_abbr` walks the unquoted form with `Py_ISALPHA` (ASCII letters only), as POSIX (via RFC 8536) requires for the unquoted form.

This tightens the unquoted alternative to `[a-zA-Z]+`, matching the C accelerator and POSIX, and leaves the quoted `<...>` form untouched. Every well-formed TZ string and all bundled IANA zones still parse unchanged; only the previously-accepted strings now raise `ValueError`.

The non-ASCII case is reachable through the public `from_file` path, which UTF-8-decodes the footer, so it is covered by a dedicated regression test in addition to the whitespace cases added to the shared `invalid_tzstrs` list.


<!-- gh-issue-number: gh-152248 -->
* Issue: gh-152248
<!-- /gh-issue-number -->
