### PR TITLE
gh-71488: Support extension in BytesIO.truncate

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -785,6 +785,13 @@ than raw I/O does.
 
       .. versionadded:: 3.5
 
+   .. method:: truncate(size=None, /)
+
+      In :class:`BytesIO`, this is the same as :meth:`IOBase.truncate`.
+
+      .. versionchanged:: next
+         Now extends the underlying buffer as :meth:`IOBase.truncate` documents.
+
 .. class:: BufferedReader(raw, buffer_size=DEFAULT_BUFFER_SIZE)
 
    A buffered binary stream providing higher-level access to a readable, non

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1016,7 +1016,7 @@ class BytesIO(BufferedIOBase):
                     pos = pos_index()
                 if pos < 0:
                     raise ValueError("negative truncate position %r" % (pos,))
-            del self._buffer[pos:]
+            self._buffer.resize(pos)
         return pos
 
     def readable(self):

--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -558,6 +558,31 @@ class PyBytesIOTest(MemoryTestMixin, MemorySeekTestMixin, unittest.TestCase):
         memio.seek(1, 1)
         self.assertEqual(memio.read(), buf[1:])
 
+    def test_truncate_extend(self):
+        # gh-71448: Extending with truncate should allocate space.
+        buf = self.buftype("123")
+        memio = self.ioclass(buf)
+
+        self.assertEqual(memio.tell(), 0)
+        self.assertEqual(memio.truncate(4), 4)
+        self.assertEqual(len(memio.getbuffer()), 4)
+        self.assertEqual(memio.getvalue(), b"123\x00")
+        self.assertEqual(memio.tell(), 0)  # Truncate keeps pos.
+        # Truncate to position 0 should work.
+        self.assertEqual(memio.truncate(), 0)
+        self.assertEqual(memio.getvalue(), b"")
+
+        self.assertEqual(memio.seek(12), 12)
+        self.assertEqual(memio.truncate(1), 1)
+        self.assertEqual(len(memio.getbuffer()), 1)
+        self.assertEqual(memio.getvalue(), b"\x00")
+        self.assertEqual(memio.tell(), 12)
+
+        self.assertEqual(memio.truncate(), 12)
+        self.assertEqual(len(memio.getbuffer()), 12)
+        self.assertEqual(memio.getvalue(), b"\x00" * 12)
+        self.assertEqual(memio.tell(), 12)
+
     def test_issue141311(self):
         memio = self.ioclass()
         # Seek allows PY_SSIZE_T_MAX, read should handle that.

--- a/Misc/NEWS.d/next/Library/2026-06-25-22-43-34.gh-issue-71488.ajvMxg.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-22-43-34.gh-issue-71488.ajvMxg.rst
@@ -1,0 +1,2 @@
+Update :meth:`io.BytesIO.truncate` to match :meth:`io.IOBase.truncate`
+resize extension behavior. All resize behavior now matches.

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -667,10 +667,17 @@ _io_BytesIO_truncate_impl(bytesio *self, PyObject *size)
         }
     }
 
-    if (new_size < self->string_size) {
+    if (new_size != self->string_size) {
+        Py_ssize_t orig_size = self->string_size;
         self->string_size = new_size;
-        if (resize_buffer_lock_held(self, new_size) < 0)
+        if (resize_buffer_lock_held(self, new_size) < 0) {
             return NULL;
+        }
+        /* Fill new space with zeros */
+        if (new_size > orig_size) {
+            memset(PyBytes_AS_STRING(self->buf) + orig_size, '\0',
+                   (new_size - orig_size) * sizeof(char));
+        }
     }
 
     return PyLong_FromSsize_t(new_size);


### PR DESCRIPTION
Truncate beyond current size of I/O objects is documented to change the amount of allocated space. BytesIO supported truncate to shrink but not truncate to extend. Update BytesIO to support extension and fully implement the `IOBase.truncate()` API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-71488 -->
* Issue: gh-71488
<!-- /gh-issue-number -->
