### PR TITLE
gh-152236: Fix skips on `_testcapi.set_nomemory` tests

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1307,8 +1307,6 @@ def bigmemtest(size, memuse, dry_run=True):
 
 def nomemtest(f):
     """Check that we can use this test with `_testcapi.set_nomemory`."""
-    # Python built with Py_TRACE_REFS fail with a fatal error in
-    # _PyRefchain_Trace() on memory allocation error.
     from .import_helper import import_module
 
     @functools.wraps(f)
@@ -1317,6 +1315,8 @@ def nomemtest(f):
         return f(*args, **kwargs)
 
     return unittest.skipIf(
+        # Python built with Py_TRACE_REFS fail with a fatal error in
+        # _PyRefchain_Trace() on memory allocation error.
         Py_TRACE_REFS,
         'cannot test Py_TRACE_REFS build',
     )(cpython_only(internal))

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -35,7 +35,7 @@ __all__ = [
     "requires_gil_enabled", "requires_linux_version", "requires_mac_ver",
     "check_syntax_error",
     "requires_gzip", "requires_bz2", "requires_lzma", "requires_zstd",
-    "bigmemtest", "bigaddrspacetest", "cpython_only", "get_attribute",
+    "bigmemtest", "nomemtest", "bigaddrspacetest", "cpython_only", "get_attribute",
     "requires_IEEE_754", "requires_zlib",
     "has_fork_support", "requires_fork",
     "has_subprocess_support", "requires_subprocess",
@@ -1304,6 +1304,22 @@ def bigmemtest(size, memuse, dry_run=True):
         wrapper.memuse = memuse
         return wrapper
     return decorator
+
+def nomemtest(f):
+    """Check that we can use this test with `_testcapi.set_nomemory`."""
+    # Python built with Py_TRACE_REFS fail with a fatal error in
+    # _PyRefchain_Trace() on memory allocation error.
+    from .import_helper import import_module
+
+    @functools.wraps(f)
+    def internal(*args, **kwargs):
+        import_module('_testcapi')
+        return f(*args, **kwargs)
+
+    return unittest.skipIf(
+        Py_TRACE_REFS,
+        'cannot test Py_TRACE_REFS build',
+    )(cpython_only(internal))
 
 def bigaddrspacetest(f):
     """Decorator for tests that fill the address space."""

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -4,7 +4,7 @@ import subprocess
 import textwrap
 import unittest
 from test import support
-from test.support import SuppressCrashReport, script_helper
+from test.support import SuppressCrashReport, script_helper, import_helper
 from test.support import os_helper
 from test.support import threading_helper
 
@@ -194,9 +194,11 @@ class SubinterpreterTest(unittest.TestCase):
     # Python built with Py_TRACE_REFS fail with a fatal error in
     # _PyRefchain_Trace() on memory allocation error.
     @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
+    @support.cpython_only
     def test_atexit_with_low_memory(self):
         # gh-140080: Test that setting low memory after registering an atexit
         # callback doesn't cause an infinite loop during finalization.
+        import_helper.import_module('_testcapi')
         code = textwrap.dedent("""
             import atexit
             import _testcapi

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -4,7 +4,7 @@ import subprocess
 import textwrap
 import unittest
 from test import support
-from test.support import SuppressCrashReport, script_helper, import_helper
+from test.support import SuppressCrashReport, script_helper
 from test.support import os_helper
 from test.support import threading_helper
 
@@ -191,14 +191,10 @@ class SubinterpreterTest(unittest.TestCase):
         self.assertEqual(os.read(r, len(expected)), expected)
         os.close(r)
 
-    # Python built with Py_TRACE_REFS fail with a fatal error in
-    # _PyRefchain_Trace() on memory allocation error.
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
-    @support.cpython_only
+    @support.nomemtest
     def test_atexit_with_low_memory(self):
         # gh-140080: Test that setting low memory after registering an atexit
         # callback doesn't cause an infinite loop during finalization.
-        import_helper.import_module('_testcapi')
         code = textwrap.dedent("""
             import atexit
             import _testcapi

--- a/Lib/test/test_capi/test_mem.py
+++ b/Lib/test/test_capi/test_mem.py
@@ -117,10 +117,7 @@ class PyMemDebugTests(unittest.TestCase):
     def test_pyobject_freed_is_freed(self):
         self.check_pyobject_is_freed('check_pyobject_freed_is_freed')
 
-    # Python built with Py_TRACE_REFS fail with a fatal error in
-    # _PyRefchain_Trace() on memory allocation error.
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
-    @support.cpython_only
+    @support.nomemtest
     def test_set_nomemory(self):
         code = """if 1:
             import _testcapi

--- a/Lib/test/test_capi/test_mem.py
+++ b/Lib/test/test_capi/test_mem.py
@@ -120,6 +120,7 @@ class PyMemDebugTests(unittest.TestCase):
     # Python built with Py_TRACE_REFS fail with a fatal error in
     # _PyRefchain_Trace() on memory allocation error.
     @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
+    @support.cpython_only
     def test_set_nomemory(self):
         code = """if 1:
             import _testcapi

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -1014,6 +1014,7 @@ class TestInlineValues(unittest.TestCase):
         C.a = X()
 
     @cpython_only
+    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
     def test_detach_materialized_dict_no_memory(self):
         # Skip test if _testcapi is not available:
         import_helper.import_module('_testcapi')

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -449,7 +449,6 @@ class ClassTests(unittest.TestCase):
 
     def testHasAttrString(self):
         import sys
-        from test.support import import_helper
         _testlimitedcapi = import_helper.import_module('_testlimitedcapi')
 
         class A:

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -1013,12 +1013,8 @@ class TestInlineValues(unittest.TestCase):
         C.a = X()
         C.a = X()
 
-    @cpython_only
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
+    @support.nomemtest
     def test_detach_materialized_dict_no_memory(self):
-        # Skip test if _testcapi is not available:
-        import_helper.import_module('_testcapi')
-
         code = """if 1:
             import test.support
             import _testcapi

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1583,11 +1583,7 @@ class ExceptionTests(unittest.TestCase):
             sys.setrecursionlimit(recursionlimit)
 
 
-    @cpython_only
-    # Python built with Py_TRACE_REFS fail with a fatal error in
-    # _PyRefchain_Trace() on memory allocation error.
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
-    @unittest.skipIf(_testcapi is None, "requires _testcapi")
+    @support.nomemtest
     def test_recursion_normalizing_with_no_memory(self):
         # Issue #30697. Test that in the abort that occurs when there is no
         # memory left and the size of the Python frames stack is greater than
@@ -1774,11 +1770,7 @@ class ExceptionTests(unittest.TestCase):
                     self.assertIn("test message", report)
                 self.assertEndsWith(report, "\n")
 
-    @cpython_only
-    # Python built with Py_TRACE_REFS fail with a fatal error in
-    # _PyRefchain_Trace() on memory allocation error.
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
-    @unittest.skipIf(_testcapi is None, "requires _testcapi")
+    @support.nomemtest
     def test_memory_error_in_PyErr_PrintEx(self):
         code = """if 1:
             import _testcapi
@@ -1936,12 +1928,8 @@ class ExceptionTests(unittest.TestCase):
             exc2 = None
 
 
-    @cpython_only
-    # Python built with Py_TRACE_REFS fail with a fatal error in
-    # _PyRefchain_Trace() on memory allocation error.
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
+    @support.nomemtest
     def test_exec_set_nomemory_hang(self):
-        import_module("_testcapi")
         # gh-134163: A MemoryError inside code that was wrapped by a try/except
         # block would lead to an infinite loop.
 

--- a/Lib/test/test_interpreters/test_stress.py
+++ b/Lib/test/test_interpreters/test_stress.py
@@ -5,7 +5,7 @@ from test import support
 from test.support import import_helper
 from test.support import threading_helper
 # Raise SkipTest if subinterpreters not supported.
-import_helper.import_module('_interpreters')
+_interpreters = import_helper.import_module('_interpreters')
 from concurrent import interpreters
 from concurrent.interpreters import InterpreterError
 from .utils import TestBase
@@ -75,11 +75,9 @@ class StressTests(TestBase):
             start.set()
         support.gc_collect()
 
-    @support.cpython_only
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
+    @support.nomemtest
     def test_create_interpreter_no_memory(self):
-        import _interpreters
-        _testcapi = import_helper.import_module("_testcapi")
+        import _testcapi
 
         assertion = self.assertRaises(InterpreterError)
         _testcapi.set_nomemory(0, 1)

--- a/Lib/test/test_interpreters/test_stress.py
+++ b/Lib/test/test_interpreters/test_stress.py
@@ -75,12 +75,15 @@ class StressTests(TestBase):
             start.set()
         support.gc_collect()
 
+    @support.cpython_only
+    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
     def test_create_interpreter_no_memory(self):
         import _interpreters
         _testcapi = import_helper.import_module("_testcapi")
 
-        with self.assertRaises(InterpreterError):
-            _testcapi.set_nomemory(0, 1)
+        assertion = self.assertRaises(InterpreterError)
+        _testcapi.set_nomemory(0, 1)
+        with assertion:
             _interpreters.create()
 
 

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -3,7 +3,6 @@ import sys
 import textwrap
 from test import list_tests, support
 from test.support import cpython_only
-from test.support.import_helper import import_module
 from test.support.script_helper import assert_python_failure, assert_python_ok
 import pickle
 import unittest
@@ -326,11 +325,9 @@ class ListTest(list_tests.CommonTest):
             a.append(4)
             self.assertEqual(list(it), [])
 
-    @support.cpython_only
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
+    @support.nomemtest
     def test_no_memory(self):
         # gh-118331: Make sure we don't crash if list allocation fails
-        import_module("_testcapi")
         code = textwrap.dedent("""
         import _testcapi, sys
         # Prime the freelist

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -327,6 +327,7 @@ class ListTest(list_tests.CommonTest):
             self.assertEqual(list(it), [])
 
     @support.cpython_only
+    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
     def test_no_memory(self):
         # gh-118331: Make sure we don't crash if list allocation fails
         import_module("_testcapi")

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -17,7 +17,6 @@ from test.support import (
     SHORT_TIMEOUT,
 )
 from test.support.script_helper import kill_python
-from test.support.import_helper import import_module
 
 try:
     import pty
@@ -99,12 +98,8 @@ def run_on_interactive_mode(source):
 @support.force_not_colorized_test_class
 class TestInteractiveInterpreter(unittest.TestCase):
 
-    @cpython_only
-    # Python built with Py_TRACE_REFS fail with a fatal error in
-    # _PyRefchain_Trace() on memory allocation error.
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
+    @support.nomemtest
     def test_no_memory(self):
-        import_module("_testcapi")
         # Issue #30696: Fix the interactive interpreter looping endlessly when
         # no memory. Check also that the fix does not break the interactive
         # loop when an exception is raised.

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1024,12 +1024,10 @@ class ReferencesTestCase(TestBase):
         del x
         support.gc_collect()
 
-    @support.cpython_only
-    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
+    @support.nomemtest
     def test_no_memory_when_clearing(self):
         # gh-118331: Make sure we do not raise an exception from the destructor
         # when clearing weakrefs if allocating the intermediate tuple fails.
-        import_helper.import_module('_testcapi')
         code = textwrap.dedent("""
         import _testcapi
         import weakref

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1025,9 +1025,11 @@ class ReferencesTestCase(TestBase):
         support.gc_collect()
 
     @support.cpython_only
+    @unittest.skipIf(support.Py_TRACE_REFS, 'cannot test Py_TRACE_REFS build')
     def test_no_memory_when_clearing(self):
         # gh-118331: Make sure we do not raise an exception from the destructor
         # when clearing weakrefs if allocating the intermediate tuple fails.
+        import_helper.import_module('_testcapi')
         code = textwrap.dedent("""
         import _testcapi
         import weakref


### PR DESCRIPTION
Now all tests that use `_testcapi.set_nomemory` have all the right skips :)

<!-- gh-issue-number: gh-152236 -->
* Issue: gh-152236
<!-- /gh-issue-number -->
