### PR TITLE
gh-152254: Fix a crash in `PyObject_ClearManagedDict` under memory pressure

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-26-11-34-50.gh-issue-152254.yK6TGp.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-26-11-34-50.gh-issue-152254.yK6TGp.rst
@@ -1,0 +1,2 @@
+Fix a crash during the clean up of managed dict objects under a memory
+pressure in :c:func:`PyObject_ClearManagedDict`.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -7986,6 +7986,7 @@ PyObject_ClearManagedDict(PyObject *obj)
                 /* Clear the dict */
                 Py_BEGIN_CRITICAL_SECTION(dict);
                 PyDictKeysObject *oldkeys = dict->ma_keys;
+                ensure_shared_on_resize(dict);
                 set_keys(dict, Py_EMPTY_KEYS);
                 dict->ma_values = NULL;
                 dictkeys_decref(oldkeys, IS_DICT_SHARED(dict));


### PR DESCRIPTION


<!-- gh-issue-number: gh-152254 -->
* Issue: gh-152254
<!-- /gh-issue-number -->
