### PR TITLE
idle: fix dedent() usage in htest

### DIFF
--- a/Lib/idlelib/idle_test/htest.py
+++ b/Lib/idlelib/idle_test/htest.py
@@ -216,9 +216,9 @@ _module_browser_spec = {
     'file': 'browser',
     'kwds': {},
     'msg': textwrap.dedent("""
-        "Inspect names of module, class(with superclass if applicable),
-        "methods and functions.  Toggle nested items.  Double clicking
-        "on items prints a traceback for an exception that is ignored.""")
+        Inspect names of module, class(with superclass if applicable),
+        methods and functions.  Toggle nested items.  Double clicking
+        on items prints a traceback for an exception that is ignored.""")
     }
 
 _multistatus_bar_spec = {


### PR DESCRIPTION
In #112642, there was a mistake in the replacement of multiline string concat to textwrap.dedent(), and extra quote characters were mixed in.

This is a minor issue, so it is not necessary to backport.