### PR TITLE
gh-139145: Fix tkinter event loop in interactive mode

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-25-14-32-42.gh-issue-139145.kT9rmP.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-14-32-42.gh-issue-139145.kT9rmP.rst
@@ -1,0 +1,5 @@
+Fix a busy loop in :mod:`tkinter` on interactive Python.  When a Tcl command
+running its own event loop (such as ``vwait`` or :meth:`!wait_variable`) was
+active and input arrived on stdin, the event loop kept spinning at 100% CPU.
+The stdin file handler is now removed as soon as input is available.  Based on
+a patch by Michiel de Hoon.

--- a/Misc/NEWS.d/next/Library/2026-06-25-14-32-43.gh-issue-139816.Lq2vXa.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-25-14-32-43.gh-issue-139816.Lq2vXa.rst
@@ -1,0 +1,4 @@
+Fix a hang in :mod:`tkinter` on interactive Python built without
+:mod:`readline`.  An exception raised in a callback no longer causes the
+event loop to stop and wait for the user to press Enter; pending callbacks
+now keep running until input is actually available on stdin.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -3433,7 +3433,13 @@ static int stdin_ready = 0;
 static void
 MyFileProc(void *clientData, int mask)
 {
+    int tfile = (int)(Py_intptr_t)clientData;
     stdin_ready = 1;
+    /* Stop watching stdin now that input is available.  Doing it here rather
+       than after the loop below ensures that a nested event loop (e.g. the one
+       started by wait_variable) does not keep waking up on the same unread
+       input, spinning at 100% CPU. */
+    Tcl_DeleteFileHandler(tfile);
 }
 #endif
 
@@ -3450,9 +3456,10 @@ EventHook(void)
     errorInCmd = 0;
 #ifndef MS_WINDOWS
     tfile = fileno(stdin);
-    Tcl_CreateFileHandler(tfile, TCL_READABLE, MyFileProc, NULL);
+    Tcl_CreateFileHandler(tfile, TCL_READABLE, MyFileProc,
+                          (void *)(Py_intptr_t)tfile);
 #endif
-    while (!errorInCmd && !stdin_ready) {
+    while (!stdin_ready) {
         int result;
 #ifdef MS_WINDOWS
         if (_kbhit()) {
@@ -3472,18 +3479,23 @@ EventHook(void)
             Sleep(Tkinter_busywaitinterval);
         Py_END_ALLOW_THREADS
 
+        /* Report an exception raised in a callback, but keep pumping events
+           instead of returning to the prompt: without readline there is no
+           input waiting on stdin yet, so returning here would block in fgets
+           until the user hits enter, freezing later callbacks. */
+        if (errorInCmd) {
+            errorInCmd = 0;
+            PyErr_SetRaisedException(excInCmd);
+            excInCmd = NULL;
+            PyErr_Print();
+        }
         if (result < 0)
             break;
     }
 #ifndef MS_WINDOWS
-    Tcl_DeleteFileHandler(tfile);
+    if (!stdin_ready)
+        Tcl_DeleteFileHandler(tfile);
 #endif
-    if (errorInCmd) {
-        errorInCmd = 0;
-        PyErr_SetRaisedException(excInCmd);
-        excInCmd = NULL;
-        PyErr_Print();
-    }
     PyEval_SaveThread();
     return 0;
 }


### PR DESCRIPTION
This fixes two related bugs in the interactive-mode input hook (`EventHook` in `Modules/_tkinter.c`), with minimal changes and without requiring a thread-enabled Tcl, so it remains backportable.

gh-139145: when a Tcl command running its own event loop (such as `vwait` or `wait_variable`) is active and input arrives on stdin, the loop kept spinning at 100% CPU. The stdin file handler is now removed as soon as input becomes available, in `MyFileProc`, so a nested loop no longer keeps waking on the same unread input.

gh-139816: an exception raised in a callback made `EventHook` return to the prompt, where (on a build without readline) it blocks in `fgets` until the user presses Enter, starving later callbacks. The exception is now reported inline and the loop keeps pumping until stdin actually has input.

The handler is deleted on every loop-exit path, and the descriptor is passed by value through `clientData` rather than as a pointer to a stack variable, so no stack address can outlive `EventHook`.

This builds on @mdehoon's #139180 (gh-139145) and a suggestion there from @chrstphrchvz; both are credited as co-authors. It supersedes #139180 by also covering gh-139816 and closing the `result < 0` exit path.

No test is included: the spin and the without-readline hang both depend on the platform notifier and on timing/load, so a reliable, non-flaky regression test isn't practical across CI configurations.

<!-- gh-issue-number: gh-139145 -->
* Issue: gh-139145
<!-- /gh-issue-number -->

Also fixes gh-139816.
