### PR TITLE
[3.15] gh-121249: Soft deprecate F and D struct format types (#149346)

### DIFF
--- a/Doc/deprecations/soft-deprecations.rst
+++ b/Doc/deprecations/soft-deprecations.rst
@@ -19,3 +19,8 @@ There are no plans to remove :term:`soft deprecated` APIs.
 
   (Contributed by Gregory P. Smith in :gh:`86519` and
   Hugo van Kemenade in :gh:`148100`.)
+
+* Using ``'F'`` and ``'D'`` format type codes of the :mod:`struct` module
+  now are :term:`soft deprecated` in favor of two-letter forms ``'Zf'``
+  and ``'Zd'``.
+  (Contributed by Sergey B Kirpichev in :gh:`121249`.)

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -260,10 +260,6 @@ platform-dependent.
 +--------+--------------------------+--------------------+----------------+------------+
 | ``d``  | :c:expr:`double`         | float              | 8              | \(4)       |
 +--------+--------------------------+--------------------+----------------+------------+
-| ``F``  | :c:expr:`float complex`  | complex            | 8              | \(10)      |
-+--------+--------------------------+--------------------+----------------+------------+
-| ``D``  | :c:expr:`double complex` | complex            | 16             | \(10)      |
-+--------+--------------------------+--------------------+----------------+------------+
 | ``Zf`` | :c:expr:`float complex`  | complex            | 8              | \(10)      |
 +--------+--------------------------+--------------------+----------------+------------+
 | ``Zd`` | :c:expr:`double complex` | complex            | 16             | \(10)      |
@@ -286,6 +282,7 @@ platform-dependent.
 
 .. versionchanged:: 3.15
    Added support for the ``'Zf'`` and ``'Zd'`` formats.
+   ``'F'`` and ``'D'`` formats are :term:`soft deprecated`.
 
 .. seealso::
 
@@ -376,13 +373,15 @@ Notes:
    are accepted.
 
 (10)
-   For the ``'F'`` and ``'D'`` format characters, the packed representation uses
+   For the ``'Zf'`` and ``'Zd'`` type codes, the packed representation uses
    the IEEE 754 binary32 and binary64 format for components of the complex
    number, regardless of the floating-point format used by the platform.
-   Note that complex types (``F``/``Zf`` and ``D``/``Zd``) are available unconditionally,
+   Note that complex types are available unconditionally,
    despite complex types being an optional feature in C.
    As specified in the C11 standard, each complex type is represented by a
    two-element C array containing, respectively, the real and imaginary parts.
+   The ``'F'`` and ``'D'`` (for ``'Zf'`` and ``'Zd'``, respectively) format
+   characters are supported for compatibility.
 
 
 A format character may be preceded by an integral repeat count.  For example,

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -2280,6 +2280,11 @@ New deprecations
 
     (Contributed by Sergey B Kirpichev and Serhiy Storchaka in :gh:`143715`.)
 
+  * Using ``'F'`` and ``'D'`` type codes now are :term:`soft deprecated`
+    in favor of two-letter forms ``'Zf'`` and ``'Zd'``.
+    (Contributed by Sergey B Kirpichev in :gh:`121249`.)
+
+
 * :mod:`typing`:
 
   * The following statements now cause ``DeprecationWarning``\ s to be emitted


### PR DESCRIPTION
Remove F/D type codes from table in the struct module documentation.


(cherry picked from commit 5f17434a1ec9a121eb38f71dc3d5809020b5fbb4)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121249 -->
* Issue: gh-121249
<!-- /gh-issue-number -->
