### PR TITLE
gh-152276: Fix `assert(!_Py_IsImmortal(op))` failure when BRC merge queue races with `sys.intern`

### DIFF
--- a/Lib/test/test_free_threading/test_races.py
+++ b/Lib/test/test_free_threading/test_races.py
@@ -318,6 +318,33 @@ class TestWarningsRaces(TestBase):
 
         do_race(modify_filters, emit_warning)
 
+    def test_brc_queue_sys_intern_race(self):
+        # 1 million strings will take Thread A significant time to process in map()
+        # giving Thread B plenty of time to drop references to strings that Thread A
+        # hasn't interned yet!
+        strings = ["race_string_massive_" + str(j) for j in range(1000000)]
+        
+        # Give Thread B a copy of the list.
+        # Thread A still holds 'strings' so local refcount > 0.
+        shared = list(strings)
+        
+        def thread_b_func():
+            # Thread B simply clears its list, which decrements the shared refcount
+            # of every string. Since Thread B is not the owner, this calls _Py_DecRefShared.
+            # Since shared refcount drops to 0, they get queued to Thread A!
+            shared.clear()
+
+        tb = threading.Thread(target=thread_b_func)
+        tb.start()
+
+        # Thread A enters map() which runs entirely in C!
+        # While Thread A iterates over the 1,000,000 strings, Thread B is concurrently
+        # clearing its list and queueing them.
+        # Any string that Thread B queues BEFORE Thread A reaches it in map()
+        # will become queued, AND THEN made immortal by sys.intern!
+        list(map(sys.intern, strings))
+        tb.join()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_free_threading/test_races.py
+++ b/Lib/test/test_free_threading/test_races.py
@@ -323,23 +323,24 @@ class TestWarningsRaces(TestBase):
         # giving Thread B plenty of time to drop references to strings that Thread A
         # hasn't interned yet!
         strings = ["race_string_massive_" + str(j) for j in range(1000000)]
-        
+
         # Give Thread B a copy of the list.
         # Thread A still holds 'strings' so local refcount > 0.
         shared = list(strings)
-        
+
         def thread_b_func():
             # Thread B simply clears its list, which decrements the shared refcount
-            # of every string. Since Thread B is not the owner, this calls _Py_DecRefShared.
-            # Since shared refcount drops to 0, they get queued to Thread A!
+            # of every string. Since Thread B is not the owner, this calls
+            # _Py_DecRefShared. Since shared refcount drops to 0, they get queued
+            # to Thread A!
             shared.clear()
 
         tb = threading.Thread(target=thread_b_func)
         tb.start()
 
         # Thread A enters map() which runs entirely in C!
-        # While Thread A iterates over the 1,000,000 strings, Thread B is concurrently
-        # clearing its list and queueing them.
+        # While Thread A iterates over the 1,000,000 strings, Thread B is
+        # concurrently clearing its list and queueing them.
         # Any string that Thread B queues BEFORE Thread A reaches it in map()
         # will become queued, AND THEN made immortal by sys.intern!
         list(map(sys.intern, strings))

--- a/Misc/NEWS.d/next/Library/2026-06-26-13-25-59.gh-issue-152276.LGiipk.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-26-13-25-59.gh-issue-152276.LGiipk.rst
@@ -1,0 +1,1 @@
+Fix `assert(!_Py_IsImmortal(op))` failure when BRC merge queue races with objects that were recently made immortal.

--- a/Misc/NEWS.d/next/Library/2026-06-26-13-25-59.gh-issue-152276.LGiipk.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-26-13-25-59.gh-issue-152276.LGiipk.rst
@@ -1,1 +1,1 @@
-Fix `assert(!_Py_IsImmortal(op))` failure when BRC merge queue races with objects that were recently made immortal.
+Fix "assert(!_Py_IsImmortal(op))" failure when BRC merge queue races with objects that were recently made immortal.

--- a/Python/brc.c
+++ b/Python/brc.c
@@ -104,6 +104,9 @@ merge_queued_objects(_PyObjectStack *to_merge)
 {
     PyObject *ob;
     while ((ob = _PyObjectStack_Pop(to_merge)) != NULL) {
+        if (_Py_IsImmortal(ob)) {
+            continue;
+        }
         // Subtract one when merging because the queue had a reference.
         Py_ssize_t refcount = _Py_ExplicitMergeRefcount(ob, -1);
         if (refcount == 0) {


### PR DESCRIPTION
Fix `assert.h assertion failed at Objects/object.c:467 in Py_ssize_t _Py_ExplicitMergeRefcount(PyObject *, Py_ssize_t): !_Py_IsImmortal(op)`

Immortal objects don't use refcounts.
In the free-threaded build, when `_Py_DecRefShared` reduces an object's shared reference count to zero, it places the object into the interpreter's BRC merge queue. If another thread concurrently makes the object immortal (for example, via `sys.intern()`), `_Py_SetImmortalUntracked()` sets the object's reference fields to immortal constants. Later, when the original thread checks the eval breaker and attempts to merge the queued objects, it encounters the immortalized object and crashes on the assertion.

<!-- gh-issue-number: gh-152276 -->
* Issue: gh-152276
<!-- /gh-issue-number -->
