### PR TITLE
gh-76646: Fix proxy_bypass_registry trailing semicolon on Windows

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1528,7 +1528,6 @@ class HandlerTests(unittest.TestCase):
         self.assertEqual(req.host, "proxy.example.com:3128")
         self.assertEqual(req.get_header("Proxy-authorization"), "FooBar")
 
-    @unittest.skipUnless(os.name == "nt", "only relevant for Windows")
     def test_winreg_proxy_bypass(self):
         proxy_override = "www.example.com;*.example.net; 192.168.0.1"
         proxy_bypass = _proxy_bypass_winreg_override
@@ -1551,6 +1550,27 @@ class HandlerTests(unittest.TestCase):
             self.assertTrue(proxy_bypass(host, proxy_override),
                             "expect <local> to bypass intranet address '%s'"
                             % host)
+
+    def test_winreg_proxy_bypass_trailing_semicolon(self):
+        proxy_bypass = _proxy_bypass_winreg_override
+
+        proxy_override = "example.com;"
+        self.assertTrue(proxy_bypass("example.com", proxy_override))
+        self.assertFalse(proxy_bypass("notmatching.com", proxy_override))
+
+        proxy_override = ";example.com"
+        self.assertTrue(proxy_bypass("example.com", proxy_override))
+        self.assertFalse(proxy_bypass("notmatching.com", proxy_override))
+
+        proxy_override = "example.com;;*.example.net;"
+        self.assertTrue(proxy_bypass("example.com", proxy_override))
+        self.assertTrue(proxy_bypass("sub.example.net", proxy_override))
+        self.assertFalse(proxy_bypass("notmatching.com", proxy_override))
+
+        proxy_override = "example.com; <local>;"
+        self.assertTrue(proxy_bypass("example.com", proxy_override))
+        self.assertTrue(proxy_bypass("localhost", proxy_override))
+        self.assertFalse(proxy_bypass("notmatching.com", proxy_override))
 
     @unittest.skipUnless(sys.platform == 'darwin', "only relevant for OSX")
     def test_osx_proxy_bypass(self):

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -2024,6 +2024,8 @@ def _proxy_bypass_winreg_override(host, override):
     proxy_override = override.split(';')
     for test in proxy_override:
         test = test.strip()
+        if not test:
+            continue
         # "<local>" should bypass the proxy server for all intranet addresses
         if test == '<local>':
             if '.' not in host:

--- a/Misc/NEWS.d/next/Library/2026-06-26-13-00-00.gh-issue-76646.proxy_bypass.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-26-13-00-00.gh-issue-76646.proxy_bypass.rst
@@ -1,0 +1,2 @@
+Fix proxy bypass on Windows when the ``ProxyOverride`` registry value
+has a trailing semicolon, which previously could cause incorrect results.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
- Skip empty entries after splitting and stripping `ProxyOverride`
- Add unit tests for `_proxy_bypass_winreg_override` covering trailing,
  leading, and consecutive semicolons

<!-- gh-issue-number: gh-76646 -->
* Issue: gh-76646
<!-- /gh-issue-number -->
