### PR TITLE
gh-80937: Fix memory leak in tkinter createcommand

### DIFF
--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -3,6 +3,7 @@ import functools
 import platform
 import sys
 import unittest
+import weakref
 import tkinter
 from tkinter import TclError
 import enum
@@ -349,6 +350,17 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(result, [1])
         self.root.deletecommand(name)
         self.assertRaises(TclError, self.root.tk.call, name)
+
+    def test_createcommand_no_leak(self):
+        # gh-80937: dropping the interpreter must release a command's callback,
+        # even without an explicit deletecommand().
+        interp = tkinter.Tcl()
+        callback = lambda: ''
+        ref = weakref.ref(callback)
+        interp.tk.createcommand('cb', callback)
+        del callback, interp
+        support.gc_collect()
+        self.assertIsNone(ref())
 
     def test_option(self):
         self.addCleanup(self.root.option_clear)

--- a/Misc/NEWS.d/next/Library/2026-06-26-13-10-00.gh-issue-80937.Hq3mNp.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-26-13-10-00.gh-issue-80937.Hq3mNp.rst
@@ -1,0 +1,4 @@
+Fix a memory leak in :mod:`tkinter` when a Tcl command created with
+``createcommand`` was not explicitly removed before the interpreter was
+deleted.  The command no longer keeps the interpreter alive through a
+reference cycle.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -2464,7 +2464,7 @@ PythonCmdDelete(ClientData clientData)
     PythonCmd_ClientData *data = (PythonCmd_ClientData *)clientData;
 
     ENTER_PYTHON
-    Py_XDECREF(data->self);
+    /* data->self is borrowed. */
     Py_XDECREF(data->func);
     PyMem_Free(data);
     LEAVE_PYTHON
@@ -2533,7 +2533,9 @@ _tkinter_tkapp_createcommand_impl(TkappObject *self, const char *name,
     data = PyMem_NEW(PythonCmd_ClientData, 1);
     if (!data)
         return PyErr_NoMemory();
-    Py_INCREF(self);
+    /* Borrow the interpreter: a strong reference would form an uncollectable
+       cycle (interp -> command -> data->self -> interp) and leak the command
+       (gh-80937).  The command cannot outlive the interpreter. */
     data->self = self;
     data->func = Py_NewRef(func);
     if (self->threaded && self->thread_id != Tcl_GetCurrentThread()) {
@@ -2566,6 +2568,7 @@ _tkinter_tkapp_createcommand_impl(TkappObject *self, const char *name,
     }
     if (err) {
         PyErr_SetString(Tkinter_TclError, "can't create Tcl command");
+        Py_DECREF(data->func);
         PyMem_Free(data);
         return NULL;
     }


### PR DESCRIPTION
A command created with ``createcommand()`` held a strong reference to the interpreter in its client data, forming an uncollectable reference cycle (interpreter -> Tcl command -> client data -> interpreter).  The interpreter's refcount therefore never reached zero, so its commands were never deleted and their callbacks were never released, until the command was removed with ``deletecommand()`` or ``destroy()``.

The command now borrows the reference to the interpreter.  It cannot outlive the interpreter, which deletes all of its commands (running their delete callbacks) when it is finalized.

<!-- gh-issue-number: gh-80937 -->
* Issue: gh-80937
<!-- /gh-issue-number -->
