### PR TITLE
gh-151776: Fix test_state_getters on terminals without insert/delete capability

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1330,8 +1330,6 @@ class TestCurses(unittest.TestCase):
         # Each is_*() getter returns the value set by the matching setter.
         for setter, getter in [
             ('clearok', 'is_cleared'),
-            ('idcok', 'is_idcok'),
-            ('idlok', 'is_idlok'),
             ('keypad', 'is_keypad'),
             ('leaveok', 'is_leaveok'),
             ('nodelay', 'is_nodelay'),
@@ -1342,6 +1340,19 @@ class TestCurses(unittest.TestCase):
             self.assertIs(getattr(stdscr, getter)(), True)
             getattr(stdscr, setter)(False)
             self.assertIs(getattr(stdscr, getter)(), False)
+
+        # idcok()/idlok() only take effect if the terminal can insert/delete
+        # characters/lines, so the getter reflects that capability.
+        stdscr.idcok(True)
+        self.assertIs(stdscr.is_idcok(), curses.has_ic())
+        stdscr.idcok(False)
+        self.assertIs(stdscr.is_idcok(), False)
+
+        stdscr.idlok(True)
+        self.assertIs(stdscr.is_idlok(),
+                      curses.has_il() or curses.tigetstr('csr') is not None)
+        stdscr.idlok(False)
+        self.assertIs(stdscr.is_idlok(), False)
         if hasattr(stdscr, 'immedok'):
             stdscr.immedok(True)
             self.assertIs(stdscr.is_immedok(), True)


### PR DESCRIPTION
<!-- gh-issue-number: gh-151776 -->
* Issue: gh-151776
<!-- /gh-issue-number -->

`idcok()` and `idlok()` only take effect when the terminal can insert or delete characters or lines (ncurses sets the window flag to `flag && has_ic()` and `flag && (has_il() || change_scroll_region)` respectively).  On terminals without those capabilities, `is_idcok()`/`is_idlok()` return `False` even after setting the flag to `True`, so `test_state_getters` failed on many buildbots.

Drop these two from the unconditional round-trip loop and assert their getters against the terminal's actual capabilities instead.
