### PR TITLE
gh-152305: Fix pure-Python time.strftime AttributeError on %Y/%G/%C/%F

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -272,8 +272,8 @@ def _wrap_strftime(object, format, timetuple):
                     newformat.append(Zreplace)
                 # Note that datetime(1000, 1, 1).strftime('%G') == '1000' so
                 # year 1000 for %G can go on the fast path.
-                elif ((ch in 'YG' or ch in 'FC') and
-                        timetuple[0] < 1000 and _need_normalize_century()):
+                elif (ch in 'YGFC' and timetuple[0] < 1000 and
+                        _need_normalize_century()):
                     if ch == 'G':
                         year = int(_time.strftime("%G", timetuple))
                     else:

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -273,11 +273,11 @@ def _wrap_strftime(object, format, timetuple):
                 # Note that datetime(1000, 1, 1).strftime('%G') == '1000' so
                 # year 1000 for %G can go on the fast path.
                 elif ((ch in 'YG' or ch in 'FC') and
-                        object.year < 1000 and _need_normalize_century()):
+                        timetuple[0] < 1000 and _need_normalize_century()):
                     if ch == 'G':
                         year = int(_time.strftime("%G", timetuple))
                     else:
-                        year = object.year
+                        year = timetuple[0]
                     if ch == 'C':
                         push('{:02}'.format(year // 100))
                     else:

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -4084,13 +4084,6 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         # A naive object replaces %z, %:z and %Z with empty strings.
         self.assertEqual(t.strftime("'%z' '%:z' '%Z'"), "'' '' ''")
 
-        # gh-152305: the year directives must not raise on a time (1900-01-01).
-        t1230 = self.theclass(12, 30)
-        self.assertEqual(t1230.strftime('%Y'), '1900')
-        self.assertEqual(t1230.strftime('%G'), '1900')
-        self.assertEqual(t1230.strftime('%C'), '19')
-        self.assertEqual(t1230.strftime('%F'), '1900-01-01')
-
         # bpo-34482: Check that surrogates don't cause a crash.
         try:
             t.strftime('%H\ud800%M')
@@ -4126,6 +4119,11 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         self.assertEqual(t.strftime('\0'*1000), '\0'*1000)
         self.assertEqual(t.strftime('\0%I%p%Z\0%X'), f'\0{s1}\0{s2}')
         self.assertEqual(t.strftime('%I%p%Z\0%X\0'), f'{s1}\0{s2}\0')
+        # gh-152305: the year directives must not raise on a time.
+        for directive, expected in (('%Y', '1900'), ('%G', '1900'),
+                                    ('%C', '19'), ('%F', '1900-01-01')):
+            with self.subTest(directive=directive):
+                self.assertEqual(t.strftime(directive), expected)
 
     def test_format(self):
         t = self.theclass(1, 2, 3, 4)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -4084,6 +4084,13 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         # A naive object replaces %z, %:z and %Z with empty strings.
         self.assertEqual(t.strftime("'%z' '%:z' '%Z'"), "'' '' ''")
 
+        # gh-152305: the year directives must not raise on a time (1900-01-01).
+        t1230 = self.theclass(12, 30)
+        self.assertEqual(t1230.strftime('%Y'), '1900')
+        self.assertEqual(t1230.strftime('%G'), '1900')
+        self.assertEqual(t1230.strftime('%C'), '19')
+        self.assertEqual(t1230.strftime('%F'), '1900-01-01')
+
         # bpo-34482: Check that surrogates don't cause a crash.
         try:
             t.strftime('%H\ud800%M')

--- a/Misc/NEWS.d/next/Library/2026-06-26-15-41-34.gh-issue-152305.WnbbBc.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-26-15-41-34.gh-issue-152305.WnbbBc.rst
@@ -1,0 +1,3 @@
+Fix :meth:`datetime.time.strftime` raising :exc:`AttributeError` for the
+``%Y``, ``%G``, ``%C`` and ``%F`` directives in the pure-Python
+implementation. Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-06-26-15-41-34.gh-issue-152305.WnbbBc.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-26-15-41-34.gh-issue-152305.WnbbBc.rst
@@ -1,3 +1,2 @@
-Fix :meth:`datetime.time.strftime` raising :exc:`AttributeError` for the
-``%Y``, ``%G``, ``%C`` and ``%F`` directives in the pure-Python
-implementation. Patch by tonghuaroot.
+Fix the pure-Python :meth:`datetime.time.strftime` implementation raising :exc:`AttributeError` for the
+year directives. Patch by tonghuaroot.


### PR DESCRIPTION
`_wrap_strftime` in the pure-Python `datetime` implementation reads
`object.year` in its year-normalization branch. When `strftime` is called on a
`datetime.time` (which has no `.year`), this raises
`AttributeError: 'time' object has no attribute 'year'` for the `%Y`, `%G`, `%C`
and `%F` directives. The crash happens in the branch guard itself, before the
`_need_normalize_century()` platform check, so it occurs on every platform.

The C accelerator is correct: a `time` has no date, so `strftime` fills the
1900-01-01 placeholder and returns `'1900'`, `'19'`, `'1900-01-01'` and `'1900'`
respectively.

The year being formatted is `timetuple[0]`, which is `1900` for a `time` and
`object.year` for a `date`/`datetime`. This replaces `object.year` with
`timetuple[0]` at both occurrences, fixing `time` and leaving `date`/`datetime`
behaviour unchanged: the new pure-Python output equals the long-standing C
accelerator output.

Tests in `TestTime.test_strftime` assert the four directives, and run under both
the C and pure implementations via the `test_datetime` parametrization.


<!-- gh-issue-number: gh-152305 -->
* Issue: gh-152305
<!-- /gh-issue-number -->
