### PR TITLE
gh-152298: Fix LazyImportType.resolve reification

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -350,6 +350,16 @@ Standard names are defined for the following types:
    actually accessed. This type can be used to detect lazy imports
    programmatically.
 
+   .. method:: resolve()
+
+      Resolve the lazy import and return the imported object. Successful
+      resolutions are cached.
+
+      For a module-level lazy import, ``resolve()`` also updates the original
+      module global if that name still refers to this proxy. If the name was
+      deleted or rebound, it is left unchanged; later ``resolve()`` calls return
+      the cached object without updating that name.
+
    .. versionadded:: 3.15
 
    .. seealso:: :pep:`810`

--- a/Include/internal/pycore_lazyimportobject.h
+++ b/Include/internal/pycore_lazyimportobject.h
@@ -19,8 +19,16 @@ typedef struct {
     PyObject *lz_builtins;
     PyObject *lz_from;
     PyObject *lz_attr;
+    // Protected by the import lock. lz_owner_* records the first module
+    // global that resolve() may replace. Pending owners are being stored;
+    // finalized owners cannot be claimed again.
+    PyObject *lz_owner_globals;
+    PyObject *lz_owner_key;
+    PyObject *lz_resolved;
     // Frame information for the original import location.
     PyCodeObject *lz_code;     // Code object where the lazy import was created.
+    int lz_owner_pending;
+    int lz_owner_finalized;
     int lz_instr_offset;       // Instruction offset where the lazy import was created.
 } PyLazyImportObject;
 
@@ -28,6 +36,27 @@ typedef struct {
 PyAPI_FUNC(PyObject *) _PyLazyImport_GetName(PyObject *lazy_import);
 PyAPI_FUNC(PyObject *) _PyLazyImport_New(
     struct _PyInterpreterFrame *frame, PyObject *import_func, PyObject *from, PyObject *attr);
+PyAPI_FUNC(int) _PyLazyImport_BindGlobal(
+    PyThreadState *tstate,
+    PyObject *lazy_import,
+    PyObject *globals,
+    PyObject *name);
+PyAPI_FUNC(void) _PyLazyImport_FinishGlobalBinding(
+    PyThreadState *tstate,
+    PyObject *lazy_import,
+    PyObject *globals,
+    PyObject *name,
+    int stored);
+PyAPI_FUNC(int) _PyLazyImport_CommitIfCurrent(
+    PyThreadState *tstate,
+    PyObject *lazy_import,
+    PyObject *globals,
+    PyObject *name,
+    PyObject *resolved);
+PyAPI_FUNC(int) _PyLazyImport_CommitStoredIfCurrent(
+    PyThreadState *tstate,
+    PyObject *lazy_import,
+    PyObject *resolved);
 
 #ifdef __cplusplus
 }

--- a/Lib/test/test_lazy_import/__init__.py
+++ b/Lib/test/test_lazy_import/__init__.py
@@ -277,6 +277,538 @@ class LazyImportTypeTests(LazyImportTestCase):
         proc = assert_python_ok("-c", code)
         self.assertIn(b"<built-in method resolve of lazy_import object at", proc.out)
 
+    @support.requires_subprocess()
+    def test_resolve_replaces_original_global(self):
+        code = textwrap.dedent("""
+            import builtins
+            import types
+
+            real_import = builtins.__import__
+            calls = []
+
+            lazy import target_module as target
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    index = len(calls) + 1
+                    calls.append((index, name, globals.get("__name__"), fromlist))
+                    module = types.ModuleType(name)
+                    module.VALUE = f"value-{index}"
+                    return module
+                return real_import(name, globals, locals, fromlist, level)
+
+            builtins.__import__ = custom_import
+            try:
+                def resolve_from_dict():
+                    lazy_obj = globals()["target"]
+                    resolved = lazy_obj.resolve()
+                    assert resolved.VALUE == "value-1"
+                    assert globals()["target"] is resolved
+                    assert target.VALUE == "value-1"
+
+                resolve_from_dict()
+                assert len(calls) == 1, calls
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_resolve_is_cached_on_stale_proxy(self):
+        code = textwrap.dedent("""
+            import builtins
+            import types
+
+            real_import = builtins.__import__
+            calls = []
+
+            lazy import target_module as target
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    calls.append(name)
+                    module = types.ModuleType(name)
+                    module.VALUE = len(calls)
+                    return module
+                return real_import(name, globals, locals, fromlist, level)
+
+            builtins.__import__ = custom_import
+            try:
+                def resolve_twice():
+                    lazy_obj = globals()["target"]
+                    first = lazy_obj.resolve()
+                    second = lazy_obj.resolve()
+                    assert first is second
+                    assert globals()["target"] is first
+
+                resolve_twice()
+                assert len(calls) == 1, calls
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_resolve_after_automatic_reification_uses_cache(self):
+        code = textwrap.dedent("""
+            import builtins
+            import types
+
+            real_import = builtins.__import__
+            calls = []
+
+            lazy import target_module as target
+            holder = [globals()["target"]]
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    calls.append(name)
+                    module = types.ModuleType(name)
+                    module.VALUE = f"value-{len(calls)}"
+                    return module
+                return real_import(name, globals, locals, fromlist, level)
+
+            builtins.__import__ = custom_import
+            try:
+                first = target.VALUE
+                second = holder[0].resolve()
+                assert second.VALUE == first == "value-1"
+                assert globals()["target"] is second
+                assert len(calls) == 1, calls
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_resolve_uses_actual_alias_binding(self):
+        code = textwrap.dedent("""
+            import builtins
+            import types
+
+            real_import = builtins.__import__
+            calls = []
+
+            lazy import target_module as target
+            lazy from target_module import VALUE as alias
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    index = len(calls) + 1
+                    calls.append((name, fromlist))
+                    module = types.ModuleType(name)
+                    module.VALUE = f"value-{index}"
+                    return module
+                return real_import(name, globals, locals, fromlist, level)
+
+            builtins.__import__ = custom_import
+            try:
+                def resolve_aliases():
+                    target_lazy = globals()["target"]
+                    target_resolved = target_lazy.resolve()
+                    assert globals()["target"] is target_resolved
+                    assert globals().get("target_module") is not target_resolved
+
+                    alias_lazy = globals()["alias"]
+                    alias_resolved = alias_lazy.resolve()
+                    assert globals()["alias"] is alias_resolved
+                    assert alias_resolved == "value-2"
+
+                resolve_aliases()
+                assert len(calls) == 2, calls
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_resolve_does_not_clobber_rebound_or_deleted_global(self):
+        code = textwrap.dedent("""
+            import builtins
+            import types
+
+            real_import = builtins.__import__
+            calls = []
+
+            lazy import target_module as rebound
+            lazy import target_module as deleted
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    calls.append(name)
+                    module = types.ModuleType(name)
+                    module.VALUE = len(calls)
+                    return module
+                return real_import(name, globals, locals, fromlist, level)
+
+            builtins.__import__ = custom_import
+            try:
+                def resolve_after_changes():
+                    rebound_lazy = globals()["rebound"]
+                    deleted_lazy = globals()["deleted"]
+                    sentinel = object()
+                    globals()["rebound"] = sentinel
+                    del globals()["deleted"]
+
+                    rebound_resolved = rebound_lazy.resolve()
+                    deleted_resolved = deleted_lazy.resolve()
+
+                    assert globals()["rebound"] is sentinel
+                    assert "deleted" not in globals()
+                    assert rebound_resolved.VALUE == 1
+                    assert deleted_resolved.VALUE == 2
+
+                resolve_after_changes()
+                assert len(calls) == 2, calls
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_resolve_failure_preserves_lazy_global_for_retry(self):
+        code = textwrap.dedent("""
+            import builtins
+            import types
+
+            real_import = builtins.__import__
+            attempts = 0
+
+            lazy import target_module as target
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                global attempts
+                if name == "target_module":
+                    attempts += 1
+                    if attempts == 1:
+                        raise ImportError("not yet")
+                    module = types.ModuleType(name)
+                    module.VALUE = "ok"
+                    return module
+                return real_import(name, globals, locals, fromlist, level)
+
+            builtins.__import__ = custom_import
+            try:
+                def retry_resolve():
+                    lazy_obj = globals()["target"]
+                    try:
+                        lazy_obj.resolve()
+                    except ImportError:
+                        pass
+                    else:
+                        raise AssertionError("first resolve should fail")
+                    assert globals()["target"] is lazy_obj
+
+                    resolved = lazy_obj.resolve()
+                    assert globals()["target"] is resolved
+                    assert resolved.VALUE == "ok"
+
+                retry_resolve()
+                assert attempts == 2, attempts
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_automatic_reification_does_not_clobber_changed_global(self):
+        code = textwrap.dedent("""
+            import builtins
+            import types
+
+            real_import = builtins.__import__
+
+            lazy import target_module as target
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    globals["target"] = "user value"
+                    module = types.ModuleType(name)
+                    module.VALUE = "resolved"
+                    return module
+                return real_import(name, globals, locals, fromlist, level)
+
+            builtins.__import__ = custom_import
+            try:
+                assert target.VALUE == "resolved"
+                assert globals()["target"] == "user value"
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_module_attribute_reification_does_not_clobber_changed_global(self):
+        code = textwrap.dedent("""
+            import builtins
+            import sys
+            import types
+
+            real_import = builtins.__import__
+            module = sys.modules[__name__]
+
+            lazy import target_module as target
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    module.__dict__["target"] = "user value"
+                    resolved = types.ModuleType(name)
+                    resolved.VALUE = "resolved"
+                    return resolved
+                return real_import(name, globals, locals, fromlist, level)
+
+            builtins.__import__ = custom_import
+            try:
+                assert module.target.VALUE == "resolved"
+                assert module.__dict__["target"] == "user value"
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_module_attr_dynamic_equal_name_clears_owner(self):
+        code = textwrap.dedent("""
+            import builtins
+            import sys
+            import types
+
+            real_import = builtins.__import__
+            module = sys.modules[__name__]
+
+            lazy import target_module as target
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    resolved = types.ModuleType(name)
+                    resolved.VALUE = "resolved"
+                    return resolved
+                return real_import(name, globals, locals, fromlist, level)
+
+            def check():
+                proxy = globals()["target"]
+                stored_name = next(name for name in globals()
+                                   if name == "target")
+                dynamic_name = bytearray(b"target").decode()
+                assert dynamic_name == stored_name
+                assert dynamic_name is not stored_name
+
+                resolved = getattr(module, dynamic_name)
+                assert resolved.VALUE == "resolved"
+                assert module.__dict__["target"] is resolved
+
+                module.__dict__["target"] = proxy
+                again = proxy.resolve()
+                assert again is resolved
+                assert module.__dict__["target"] is proxy
+
+            builtins.__import__ = custom_import
+            try:
+                check()
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_rebound_back_to_same_proxy_after_stale_resolve_does_not_replace(self):
+        code = textwrap.dedent("""
+            import builtins
+            import types
+
+            real_import = builtins.__import__
+            calls = []
+
+            lazy import target_module as target
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    calls.append(name)
+                    resolved = types.ModuleType(name)
+                    resolved.VALUE = "resolved"
+                    return resolved
+                return real_import(name, globals, locals, fromlist, level)
+
+            def check():
+                proxy = globals()["target"]
+                sentinel = object()
+                globals()["target"] = sentinel
+                resolved = proxy.resolve()
+                assert globals()["target"] is sentinel
+
+                globals()["target"] = proxy
+                again = proxy.resolve()
+                assert again is resolved
+                assert globals()["target"] is proxy
+
+            builtins.__import__ = custom_import
+            try:
+                check()
+                assert len(calls) == 1, calls
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_resolve_replaces_unaliased_import_global(self):
+        code = textwrap.dedent("""
+            import builtins
+            import types
+
+            real_import = builtins.__import__
+
+            lazy import target_module
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    resolved = types.ModuleType(name)
+                    resolved.VALUE = "resolved"
+                    return resolved
+                return real_import(name, globals, locals, fromlist, level)
+
+            def check():
+                proxy = globals()["target_module"]
+                resolved = proxy.resolve()
+                assert resolved.VALUE == "resolved"
+                assert globals()["target_module"] is resolved
+
+            builtins.__import__ = custom_import
+            try:
+                check()
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_resolve_replaces_unaliased_dotted_import_binding(self):
+        code = textwrap.dedent("""
+            import types
+
+            lazy import test.test_lazy_import.data.pkg.bar
+
+            def check():
+                proxy = globals()["test"]
+                resolved = proxy.resolve()
+                assert isinstance(resolved, types.ModuleType)
+                assert resolved.__name__ == "test"
+                assert globals()["test"] is resolved
+                assert "test.test_lazy_import.data.pkg" not in globals()
+
+            check()
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_copying_lazy_proxy_to_second_global_keeps_first_owner(self):
+        code = textwrap.dedent("""
+            import builtins
+            import types
+
+            real_import = builtins.__import__
+            calls = []
+
+            lazy import target_module as primary
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    calls.append(name)
+                    resolved = types.ModuleType(name)
+                    resolved.VALUE = "resolved"
+                    return resolved
+                return real_import(name, globals, locals, fromlist, level)
+
+            def check():
+                exec('secondary = globals()["primary"]', globals())
+                proxy = globals()["secondary"]
+
+                resolved = proxy.resolve()
+                assert globals()["primary"] is resolved
+                assert globals()["secondary"] is proxy
+
+                again = globals()["secondary"].resolve()
+                assert again is resolved
+                assert globals()["secondary"] is proxy
+
+            builtins.__import__ = custom_import
+            try:
+                check()
+                assert len(calls) == 1, calls
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
+    @support.requires_subprocess()
+    def test_reentrant_store_resolution_waits_for_store_finish(self):
+        code = textwrap.dedent("""
+            import builtins
+            import types
+
+            real_import = builtins.__import__
+            calls = []
+            errors = []
+            proxies = []
+
+            def custom_import(name, globals=None, locals=None, fromlist=None,
+                              level=0):
+                if name == "target_module":
+                    calls.append(name)
+                    resolved = types.ModuleType(name)
+                    resolved.VALUE = "resolved"
+                    return resolved
+                return real_import(name, globals, locals, fromlist, level)
+
+            class Reenter:
+                def __del__(self):
+                    try:
+                        proxy = globals().copy()["target"]
+                        proxies.append(proxy)
+                        resolved = target
+                        assert resolved.VALUE == "resolved"
+                        assert globals()["target"] is proxy
+                    except BaseException as exc:
+                        errors.append((type(exc).__name__, str(exc)))
+
+            builtins.__import__ = custom_import
+            target = Reenter()
+            lazy import target_module as target
+
+            def check_after_store():
+                assert not errors, errors
+                assert len(proxies) == 1, proxies
+                proxy = proxies[0]
+                assert globals()["target"] is proxy
+
+                resolved = proxy.resolve()
+                assert resolved.VALUE == "resolved"
+                assert globals()["target"] is resolved
+
+                globals()["target"] = proxy
+                assert proxy.resolve() is resolved
+                assert globals()["target"] is proxy
+
+            try:
+                check_after_store()
+                assert len(calls) == 1, calls
+            finally:
+                builtins.__import__ = real_import
+        """)
+        assert_python_ok("-c", code)
+
 
 class SyntaxRestrictionTests(LazyImportTestCase):
     """Tests for syntax restrictions on lazy imports."""
@@ -658,14 +1190,15 @@ class ErrorHandlingTests(LazyImportTestCase):
     """
 
     def test_import_error_shows_chained_traceback(self):
-        """Accessing a nonexistent lazy submodule via parent attr raises AttributeError."""
+        """A failed dotted lazy import should preserve the import failure."""
         code = textwrap.dedent("""
             import sys
             lazy import test.test_lazy_import.data.nonexistent_module
 
             try:
                 x = test.test_lazy_import.data.nonexistent_module
-            except AttributeError as e:
+            except ModuleNotFoundError as e:
+                assert e.__cause__ is not None, "Expected chained exception"
                 print("OK")
         """)
         result = subprocess.run(
@@ -710,20 +1243,22 @@ class ErrorHandlingTests(LazyImportTestCase):
 
             lazy import test.test_lazy_import.data.broken_module
 
+            def lazy_proxy():
+                return globals()['test']
+
             # First access - should fail
             try:
                 x = test.test_lazy_import.data.broken_module
-            except AttributeError:
+            except ValueError:
                 pass
 
-            # The lazy object should still be a lazy proxy (not reified)
-            g = globals()
-            lazy_obj = g['test']
-            # The root 'test' binding should still allow retry
+            assert type(lazy_proxy()) is types.LazyImportType
+
             # Second access - should also fail (retry the import)
             try:
                 x = test.test_lazy_import.data.broken_module
-            except AttributeError:
+            except ValueError:
+                assert type(lazy_proxy()) is types.LazyImportType
                 print("OK - retry worked")
         """)
         result = subprocess.run(
@@ -743,7 +1278,8 @@ class ErrorHandlingTests(LazyImportTestCase):
             try:
                 _ = test.test_lazy_import.data.broken_module
                 print("FAIL - should have raised")
-            except AttributeError:
+            except ValueError as e:
+                assert str(e) == "This module always fails to import"
                 print("OK")
         """)
         result = subprocess.run(

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -5609,24 +5609,43 @@ class TestColorizedTraceback(unittest.TestCase):
 class TestLazyImportSuggestions(unittest.TestCase):
     """Test that lazy imports are not reified when computing AttributeError suggestions."""
 
+    @staticmethod
+    def _lazy_holder_script(body):
+        setup = textwrap.dedent("""
+            import atexit
+            import os
+            import shutil
+            import sys
+            import tempfile
+
+            tmpdir = tempfile.mkdtemp()
+            atexit.register(shutil.rmtree, tmpdir, ignore_errors=True)
+            with open(os.path.join(tmpdir, "lazy_traceback_bar.py"),
+                      "w", encoding="utf-8") as f:
+                f.write('print("BAR_MODULE_LOADED")\\n')
+            with open(os.path.join(tmpdir, "lazy_holder.py"),
+                      "w", encoding="utf-8") as f:
+                f.write("lazy import lazy_traceback_bar\\n")
+
+            sys.path.insert(0, tmpdir)
+            import lazy_holder
+        """)
+        return setup + textwrap.dedent(body)
+
     def test_attribute_error_does_not_reify_lazy_imports(self):
         """Printing an AttributeError should not trigger lazy import reification."""
-        # pkg.bar prints "BAR_MODULE_LOADED" when imported.
-        # If lazy import is reified during suggestion computation, we'll see it.
-        code = textwrap.dedent("""
-            lazy import test.test_lazy_import.data.pkg.bar
-            test.test_lazy_import.data.pkg.nonexistent
+        code = self._lazy_holder_script("""
+            lazy_holder.nonexistent
         """)
         rc, stdout, stderr = assert_python_failure('-c', code)
         self.assertNotIn(b"BAR_MODULE_LOADED", stdout)
 
     def test_traceback_formatting_does_not_reify_lazy_imports(self):
         """Formatting a traceback should not trigger lazy import reification."""
-        code = textwrap.dedent("""
+        code = self._lazy_holder_script("""
             import traceback
-            lazy import test.test_lazy_import.data.pkg.bar
             try:
-                test.test_lazy_import.data.pkg.nonexistent
+                lazy_holder.nonexistent
             except AttributeError:
                 traceback.format_exc()
             print("OK")
@@ -5637,10 +5656,8 @@ class TestLazyImportSuggestions(unittest.TestCase):
 
     def test_suggestion_still_works_for_non_lazy_attributes(self):
         """Suggestions should still work for non-lazy module attributes."""
-        code = textwrap.dedent("""
-            lazy import test.test_lazy_import.data.pkg.bar
-            # Typo for __name__
-            test.test_lazy_import.data.pkg.__nme__
+        code = self._lazy_holder_script("""
+            lazy_holder.__nme__
         """)
         rc, stdout, stderr = assert_python_failure('-c', code)
         self.assertIn(b"__name__", stderr)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-26-23-58-00.gh-issue-152298.5uT4tW.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-26-23-58-00.gh-issue-152298.5uT4tW.rst
@@ -1,0 +1,3 @@
+Make ``types.LazyImportType.resolve()`` cache successful resolutions and
+replace the original module global only when it still references the same lazy
+import proxy.

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -10023,10 +10023,12 @@
             mod_or_class_dict = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             int err;
+            PyObject *source = PyStackRef_AsPyObjectBorrow(mod_or_class_dict);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             _PyFrame_StackPointerValidate(frame);
-            PyObject *v_o = _PyMapping_GetOptionalItem2(PyStackRef_AsPyObjectBorrow(mod_or_class_dict), name, &err);
+            PyObject *v_o = _PyMapping_GetOptionalItem2(source, name, &err);
             _PyFrame_StackPointerInvalidate(frame);
+            int commit_source = (v_o != NULL && source == GLOBALS());
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
@@ -10061,13 +10063,33 @@
                         _PyFrame_StackPointerValidate(frame);
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
                         _PyFrame_StackPointerInvalidate(frame);
+                        if (l_v == NULL) {
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(v_o);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            JUMP_TO_LABEL(error);
+                        }
+                        assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                        _PyFrame_StackPointerValidate(frame);
+                        err = _PyLazyImport_CommitIfCurrent(
+                            tstate, v_o, GLOBALS(), name, l_v);
+                        _PyFrame_StackPointerInvalidate(frame);
+                        if (err < 0) {
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(v_o);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(l_v);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            JUMP_TO_LABEL(error);
+                        }
                         assert(stack_pointer == _PyFrame_GetStackPointer(frame));
                         _PyFrame_StackPointerValidate(frame);
                         Py_SETREF(v_o, l_v);
                         _PyFrame_StackPointerInvalidate(frame);
-                        if (v_o == NULL) {
-                            JUMP_TO_LABEL(error);
-                        }
                     }
                 }
                 else {
@@ -10101,15 +10123,68 @@
                         _PyFrame_StackPointerValidate(frame);
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
                         _PyFrame_StackPointerInvalidate(frame);
+                        if (l_v == NULL) {
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(v_o);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            JUMP_TO_LABEL(error);
+                        }
+                        assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                        _PyFrame_StackPointerValidate(frame);
+                        err = _PyLazyImport_CommitIfCurrent(
+                            tstate, v_o, GLOBALS(), name, l_v);
+                        _PyFrame_StackPointerInvalidate(frame);
+                        if (err < 0) {
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(v_o);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(l_v);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            JUMP_TO_LABEL(error);
+                        }
                         assert(stack_pointer == _PyFrame_GetStackPointer(frame));
                         _PyFrame_StackPointerValidate(frame);
                         Py_SETREF(v_o, l_v);
                         _PyFrame_StackPointerInvalidate(frame);
-                        if (v_o == NULL) {
-                            JUMP_TO_LABEL(error);
-                        }
                     }
                 }
+            }
+            else if (commit_source && PyLazyImport_CheckExact(v_o)) {
+                assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                _PyFrame_StackPointerValidate(frame);
+                PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
+                _PyFrame_StackPointerInvalidate(frame);
+                if (l_v == NULL) {
+                    assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                    _PyFrame_StackPointerValidate(frame);
+                    Py_DECREF(v_o);
+                    _PyFrame_StackPointerInvalidate(frame);
+                    JUMP_TO_LABEL(error);
+                }
+                assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                _PyFrame_StackPointerValidate(frame);
+                err = _PyLazyImport_CommitIfCurrent(
+                    tstate, v_o, source, name, l_v);
+                _PyFrame_StackPointerInvalidate(frame);
+                if (err < 0) {
+                    assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                    _PyFrame_StackPointerValidate(frame);
+                    Py_DECREF(v_o);
+                    _PyFrame_StackPointerInvalidate(frame);
+                    assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                    _PyFrame_StackPointerValidate(frame);
+                    Py_DECREF(l_v);
+                    _PyFrame_StackPointerInvalidate(frame);
+                    JUMP_TO_LABEL(error);
+                }
+                assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                _PyFrame_StackPointerValidate(frame);
+                Py_SETREF(v_o, l_v);
+                _PyFrame_StackPointerInvalidate(frame);
             }
             v = PyStackRef_FromPyObjectSteal(v_o);
             stack_pointer[0] = v;
@@ -10379,7 +10454,8 @@
                 }
                 assert(stack_pointer == _PyFrame_GetStackPointer(frame));
                 _PyFrame_StackPointerValidate(frame);
-                int err = PyDict_SetItem(GLOBALS(), name, l_v);
+                int err = _PyLazyImport_CommitIfCurrent(
+                    tstate, v_o, GLOBALS(), name, l_v);
                 _PyFrame_StackPointerInvalidate(frame);
                 if (err < 0) {
                     assert(stack_pointer == _PyFrame_GetStackPointer(frame));
@@ -12549,10 +12625,25 @@
             _PyStackRef v;
             v = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
+            PyObject *value = PyStackRef_AsPyObjectBorrow(v);
+            int bound = 0;
+            if (PyLazyImport_CheckExact(value)) {
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                _PyFrame_StackPointerValidate(frame);
+                bound = _PyLazyImport_BindGlobal(tstate, value, GLOBALS(), name);
+                _PyFrame_StackPointerInvalidate(frame);
+            }
             _PyFrame_SetStackPointer(frame, stack_pointer);
             _PyFrame_StackPointerValidate(frame);
-            int err = PyDict_SetItem(GLOBALS(), name, PyStackRef_AsPyObjectBorrow(v));
+            int err = PyDict_SetItem(GLOBALS(), name, value);
             _PyFrame_StackPointerInvalidate(frame);
+            if (bound) {
+                assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                _PyFrame_StackPointerValidate(frame);
+                _PyLazyImport_FinishGlobalBinding(
+                    tstate, value, GLOBALS(), name, err == 0);
+                _PyFrame_StackPointerInvalidate(frame);
+            }
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
@@ -12593,10 +12684,25 @@
                 JUMP_TO_LABEL(error);
             }
             if (PyDict_CheckExact(ns)) {
+                PyObject *value = PyStackRef_AsPyObjectBorrow(v);
+                int bound = 0;
+                if (ns == GLOBALS() && PyLazyImport_CheckExact(value)) {
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    _PyFrame_StackPointerValidate(frame);
+                    bound = _PyLazyImport_BindGlobal(tstate, value, ns, name);
+                    _PyFrame_StackPointerInvalidate(frame);
+                }
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 _PyFrame_StackPointerValidate(frame);
-                err = PyDict_SetItem(ns, name, PyStackRef_AsPyObjectBorrow(v));
+                err = PyDict_SetItem(ns, name, value);
                 _PyFrame_StackPointerInvalidate(frame);
+                if (bound) {
+                    assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                    _PyFrame_StackPointerValidate(frame);
+                    _PyLazyImport_FinishGlobalBinding(
+                        tstate, value, ns, name, err == 0);
+                    _PyFrame_StackPointerInvalidate(frame);
+                }
             }
             else {
                 _PyFrame_SetStackPointer(frame, stack_pointer);

--- a/Objects/lazyimportobject.c
+++ b/Objects/lazyimportobject.c
@@ -2,11 +2,14 @@
 
 #include "Python.h"
 #include "pycore_ceval.h"
+#include "pycore_critical_section.h"
+#include "pycore_dict.h"
 #include "pycore_frame.h"
 #include "pycore_import.h"
 #include "pycore_interpframe.h"
 #include "pycore_lazyimportobject.h"
 #include "pycore_modsupport.h"
+#include "pycore_unicodeobject.h"
 
 #define PyLazyImportObject_CAST(op) ((PyLazyImportObject *)(op))
 
@@ -33,6 +36,11 @@ _PyLazyImport_New(_PyInterpreterFrame *frame, PyObject *builtins, PyObject *name
     m->lz_builtins = Py_XNewRef(builtins);
     m->lz_from = Py_NewRef(name);
     m->lz_attr = Py_XNewRef(fromlist);
+    m->lz_owner_globals = NULL;
+    m->lz_owner_key = NULL;
+    m->lz_resolved = NULL;
+    m->lz_owner_pending = 0;
+    m->lz_owner_finalized = 0;
 
     // Capture frame information for the original import location.
     m->lz_code = NULL;
@@ -58,6 +66,9 @@ lazy_import_traverse(PyObject *op, visitproc visit, void *arg)
     Py_VISIT(m->lz_builtins);
     Py_VISIT(m->lz_from);
     Py_VISIT(m->lz_attr);
+    Py_VISIT(m->lz_owner_globals);
+    Py_VISIT(m->lz_owner_key);
+    Py_VISIT(m->lz_resolved);
     Py_VISIT(m->lz_code);
     return 0;
 }
@@ -69,6 +80,11 @@ lazy_import_clear(PyObject *op)
     Py_CLEAR(m->lz_builtins);
     Py_CLEAR(m->lz_from);
     Py_CLEAR(m->lz_attr);
+    Py_CLEAR(m->lz_owner_globals);
+    Py_CLEAR(m->lz_owner_key);
+    Py_CLEAR(m->lz_resolved);
+    m->lz_owner_pending = 0;
+    m->lz_owner_finalized = 0;
     Py_CLEAR(m->lz_code);
     return 0;
 }
@@ -116,16 +132,248 @@ _PyLazyImport_GetName(PyObject *op)
     return lazy_import_name(lazy_import);
 }
 
+int
+_PyLazyImport_BindGlobal(PyThreadState *tstate, PyObject *op,
+                         PyObject *globals, PyObject *name)
+{
+    if (!PyLazyImport_CheckExact(op) ||
+        !PyDict_CheckExact(globals) ||
+        !PyUnicode_CheckExact(name))
+    {
+        return 0;
+    }
+    PyLazyImportObject *m = PyLazyImportObject_CAST(op);
+    int bound = 0;
+    PyInterpreterState *interp = tstate->interp;
+    _PyImport_AcquireLock(interp);
+    // First owner wins: copies of the proxy do not change the original global
+    // binding that resolve() may replace.
+    if (m->lz_resolved == NULL &&
+        !m->lz_owner_pending &&
+        !m->lz_owner_finalized &&
+        m->lz_owner_globals == NULL &&
+        m->lz_owner_key == NULL)
+    {
+        m->lz_owner_globals = Py_NewRef(globals);
+        m->lz_owner_key = Py_NewRef(name);
+        m->lz_owner_pending = 1;
+        bound = 1;
+    }
+    _PyImport_ReleaseLock(interp);
+    return bound;
+}
+
+static int
+owner_matches(PyLazyImportObject *m, PyObject *globals, PyObject *name)
+{
+    return (m->lz_owner_globals == globals &&
+            m->lz_owner_key != NULL &&
+            _PyUnicode_Equal(m->lz_owner_key, name));
+}
+
+static void
+clear_owner_if_matches(PyThreadState *tstate, PyLazyImportObject *m,
+                       PyObject *globals, PyObject *name)
+{
+    PyInterpreterState *interp = tstate->interp;
+    _PyImport_AcquireLock(interp);
+    if (owner_matches(m, globals, name)) {
+        m->lz_owner_pending = 0;
+        // Keep lz_owner_finalized set: this owner has been committed or
+        // abandoned, so later stores of the same proxy are not canonical.
+        Py_CLEAR(m->lz_owner_globals);
+        Py_CLEAR(m->lz_owner_key);
+    }
+    _PyImport_ReleaseLock(interp);
+}
+
+void
+_PyLazyImport_FinishGlobalBinding(PyThreadState *tstate, PyObject *op,
+                                  PyObject *globals, PyObject *name,
+                                  int stored)
+{
+    if (!PyLazyImport_CheckExact(op) ||
+        !PyDict_CheckExact(globals) ||
+        !PyUnicode_CheckExact(name))
+    {
+        return;
+    }
+
+    PyLazyImportObject *m = PyLazyImportObject_CAST(op);
+    PyInterpreterState *interp = tstate->interp;
+    _PyImport_AcquireLock(interp);
+    if (m->lz_owner_pending && owner_matches(m, globals, name)) {
+        m->lz_owner_pending = 0;
+        if (!stored) {
+            Py_CLEAR(m->lz_owner_globals);
+            Py_CLEAR(m->lz_owner_key);
+        }
+    }
+    _PyImport_ReleaseLock(interp);
+}
+
+static int
+finalize_owner_if_matches(PyThreadState *tstate, PyLazyImportObject *m,
+                          PyObject *globals, PyObject *name)
+{
+    int finalized = 0;
+    PyInterpreterState *interp = tstate->interp;
+    _PyImport_AcquireLock(interp);
+    if (!m->lz_owner_pending &&
+        !m->lz_owner_finalized &&
+        owner_matches(m, globals, name))
+    {
+        m->lz_owner_finalized = 1;
+        finalized = 1;
+    }
+    _PyImport_ReleaseLock(interp);
+    return finalized;
+}
+
+static void
+restore_owner_if_matches(PyThreadState *tstate, PyLazyImportObject *m,
+                         PyObject *globals, PyObject *name)
+{
+    PyInterpreterState *interp = tstate->interp;
+    _PyImport_AcquireLock(interp);
+    if (m->lz_owner_finalized && owner_matches(m, globals, name)) {
+        m->lz_owner_finalized = 0;
+    }
+    _PyImport_ReleaseLock(interp);
+}
+
+static int
+owner_is_pending(PyThreadState *tstate, PyLazyImportObject *m,
+                 PyObject *globals, PyObject *name)
+{
+    int pending = 0;
+    PyInterpreterState *interp = tstate->interp;
+    _PyImport_AcquireLock(interp);
+    if (m->lz_owner_pending && owner_matches(m, globals, name)) {
+        pending = 1;
+    }
+    _PyImport_ReleaseLock(interp);
+    return pending;
+}
+
+static int
+claim_stored_owner(PyThreadState *tstate, PyLazyImportObject *m,
+                   PyObject **globals, PyObject **name)
+{
+    int claimed = 0;
+    PyInterpreterState *interp = tstate->interp;
+    _PyImport_AcquireLock(interp);
+    if (!m->lz_owner_pending &&
+        !m->lz_owner_finalized &&
+        m->lz_owner_globals != NULL &&
+        m->lz_owner_key != NULL)
+    {
+        m->lz_owner_finalized = 1;
+        *globals = Py_NewRef(m->lz_owner_globals);
+        *name = Py_NewRef(m->lz_owner_key);
+        claimed = 1;
+    }
+    _PyImport_ReleaseLock(interp);
+    return claimed;
+}
+
+static int
+commit_if_current(PyObject *op, PyObject *globals, PyObject *name,
+                  PyObject *value)
+{
+    PyObject *current = NULL;
+    int err = 0;
+    Py_BEGIN_CRITICAL_SECTION(globals);
+    int found = _PyDict_GetItemRef_Unicode_LockHeld(
+        (PyDictObject *)globals, name, &current);
+    if (found < 0) {
+        err = -1;
+    }
+    else if (found > 0 && current == op) {
+        err = _PyDict_SetItem_LockHeld((PyDictObject *)globals, name, value);
+    }
+    Py_END_CRITICAL_SECTION();
+    Py_XDECREF(current);
+    return err;
+}
+
+int
+_PyLazyImport_CommitIfCurrent(PyThreadState *tstate, PyObject *op,
+                              PyObject *globals, PyObject *name,
+                              PyObject *value)
+{
+    if (!PyLazyImport_CheckExact(op) ||
+        !PyDict_CheckExact(globals) ||
+        !PyUnicode_CheckExact(name))
+    {
+        return 0;
+    }
+
+    PyLazyImportObject *m = PyLazyImportObject_CAST(op);
+    if (owner_is_pending(tstate, m, globals, name)) {
+        return 0;
+    }
+
+    int finalized_owner = finalize_owner_if_matches(tstate, m, globals, name);
+    int err = commit_if_current(op, globals, name, value);
+    if (finalized_owner) {
+        if (err < 0) {
+            restore_owner_if_matches(tstate, m, globals, name);
+        }
+        else {
+            clear_owner_if_matches(tstate, m, globals, name);
+        }
+    }
+    return err;
+}
+
+int
+_PyLazyImport_CommitStoredIfCurrent(PyThreadState *tstate, PyObject *op,
+                                    PyObject *value)
+{
+    if (!PyLazyImport_CheckExact(op)) {
+        return 0;
+    }
+
+    PyLazyImportObject *m = PyLazyImportObject_CAST(op);
+    PyObject *globals = NULL;
+    PyObject *name = NULL;
+
+    if (!claim_stored_owner(tstate, m, &globals, &name)) {
+        return 0;
+    }
+
+    int err = commit_if_current(op, globals, name, value);
+    if (err < 0) {
+        restore_owner_if_matches(tstate, m, globals, name);
+    }
+    else {
+        clear_owner_if_matches(tstate, m, globals, name);
+    }
+    Py_DECREF(globals);
+    Py_DECREF(name);
+    return err;
+}
+
 static PyObject *
 lazy_import_resolve(PyObject *self, PyObject *args)
 {
-    return _PyImport_LoadLazyImportTstate(PyThreadState_GET(), self);
+    PyThreadState *tstate = PyThreadState_GET();
+    PyObject *resolved = _PyImport_LoadLazyImportTstate(tstate, self);
+    if (resolved == NULL) {
+        return NULL;
+    }
+    if (_PyLazyImport_CommitStoredIfCurrent(tstate, self, resolved) < 0) {
+        Py_DECREF(resolved);
+        return NULL;
+    }
+    return resolved;
 }
 
 static PyMethodDef lazy_import_methods[] = {
     {
         "resolve", lazy_import_resolve, METH_NOARGS,
-        PyDoc_STR("resolves the lazy import and returns the actual object")
+        PyDoc_STR("resolve the lazy import and return the actual object")
     },
     {NULL, NULL}
 };
@@ -137,9 +385,10 @@ PyDoc_STRVAR(lazy_import_doc,
 "\n"
 "Represents a lazy import that will be resolved on first use.\n"
 "\n"
-"Instances of this object accessed from the global scope will be\n"
-"automatically imported based upon their name and then replaced with\n"
-"the imported value.");
+"A successful resolution is cached. Instances of this object accessed\n"
+"from the global scope will be automatically imported based upon their\n"
+"name. The original global is replaced only if it still refers to this\n"
+"lazy import object.");
 
 PyTypeObject PyLazyImport_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -1353,8 +1353,9 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
                 }
                 PyErr_Clear();
             }
+            PyThreadState *tstate = PyThreadState_GET();
             PyObject *new_value = _PyImport_LoadLazyImportTstate(
-                PyThreadState_GET(), attr);
+                tstate, attr);
             if (new_value == NULL) {
                 if (suppress &&
                     PyErr_ExceptionMatches(PyExc_ImportCycleError)) {
@@ -1368,7 +1369,9 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
                 return NULL;
             }
 
-            if (PyDict_SetItem(m->md_dict, name, new_value) < 0) {
+            if (_PyLazyImport_CommitIfCurrent(
+                    tstate, attr, m->md_dict, name, new_value) < 0)
+            {
                 Py_CLEAR(new_value);
             }
             Py_DECREF(attr);

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2005,7 +2005,16 @@ dummy_func(
                 ERROR_IF(true);
             }
             if (PyDict_CheckExact(ns)) {
-                err = PyDict_SetItem(ns, name, PyStackRef_AsPyObjectBorrow(v));
+                PyObject *value = PyStackRef_AsPyObjectBorrow(v);
+                int bound = 0;
+                if (ns == GLOBALS() && PyLazyImport_CheckExact(value)) {
+                    bound = _PyLazyImport_BindGlobal(tstate, value, ns, name);
+                }
+                err = PyDict_SetItem(ns, name, value);
+                if (bound) {
+                    _PyLazyImport_FinishGlobalBinding(
+                        tstate, value, ns, name, err == 0);
+                }
             }
             else {
                 err = PyObject_SetItem(ns, name, PyStackRef_AsPyObjectBorrow(v));
@@ -2189,7 +2198,16 @@ dummy_func(
 
         inst(STORE_GLOBAL, (v --)) {
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
-            int err = PyDict_SetItem(GLOBALS(), name, PyStackRef_AsPyObjectBorrow(v));
+            PyObject *value = PyStackRef_AsPyObjectBorrow(v);
+            int bound = 0;
+            if (PyLazyImport_CheckExact(value)) {
+                bound = _PyLazyImport_BindGlobal(tstate, value, GLOBALS(), name);
+            }
+            int err = PyDict_SetItem(GLOBALS(), name, value);
+            if (bound) {
+                _PyLazyImport_FinishGlobalBinding(
+                    tstate, value, GLOBALS(), name, err == 0);
+            }
             PyStackRef_CLOSE(v);
             ERROR_IF(err);
         }
@@ -2221,7 +2239,9 @@ dummy_func(
         inst(LOAD_FROM_DICT_OR_GLOBALS, (mod_or_class_dict -- v)) {
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             int err;
-            PyObject *v_o = _PyMapping_GetOptionalItem2(PyStackRef_AsPyObjectBorrow(mod_or_class_dict), name, &err);
+            PyObject *source = PyStackRef_AsPyObjectBorrow(mod_or_class_dict);
+            PyObject *v_o = _PyMapping_GetOptionalItem2(source, name, &err);
+            int commit_source = (v_o != NULL && source == GLOBALS());
 
             PyStackRef_CLOSE(mod_or_class_dict);
             ERROR_IF(err < 0);
@@ -2244,8 +2264,18 @@ dummy_func(
 
                     if (PyLazyImport_CheckExact(v_o)) {
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
+                        if (l_v == NULL) {
+                            Py_DECREF(v_o);
+                            ERROR_IF(true);
+                        }
+                        err = _PyLazyImport_CommitIfCurrent(
+                            tstate, v_o, GLOBALS(), name, l_v);
+                        if (err < 0) {
+                            Py_DECREF(v_o);
+                            Py_DECREF(l_v);
+                            ERROR_IF(true);
+                        }
                         Py_SETREF(v_o, l_v);
-                        ERROR_IF(v_o == NULL);
                     }
                 }
                 else {
@@ -2266,10 +2296,35 @@ dummy_func(
                     }
                     if (PyLazyImport_CheckExact(v_o)) {
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
+                        if (l_v == NULL) {
+                            Py_DECREF(v_o);
+                            ERROR_IF(true);
+                        }
+                        err = _PyLazyImport_CommitIfCurrent(
+                            tstate, v_o, GLOBALS(), name, l_v);
+                        if (err < 0) {
+                            Py_DECREF(v_o);
+                            Py_DECREF(l_v);
+                            ERROR_IF(true);
+                        }
                         Py_SETREF(v_o, l_v);
-                        ERROR_IF(v_o == NULL);
                     }
                 }
+            }
+            else if (commit_source && PyLazyImport_CheckExact(v_o)) {
+                PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
+                if (l_v == NULL) {
+                    Py_DECREF(v_o);
+                    ERROR_IF(true);
+                }
+                err = _PyLazyImport_CommitIfCurrent(
+                    tstate, v_o, source, name, l_v);
+                if (err < 0) {
+                    Py_DECREF(v_o);
+                    Py_DECREF(l_v);
+                    ERROR_IF(true);
+                }
+                Py_SETREF(v_o, l_v);
             }
             v = PyStackRef_FromPyObjectSteal(v_o);
         }
@@ -2285,7 +2340,8 @@ dummy_func(
                     Py_DECREF(v_o);
                     ERROR_IF(true);
                 }
-                int err = PyDict_SetItem(GLOBALS(), name, l_v);
+                int err = _PyLazyImport_CommitIfCurrent(
+                    tstate, v_o, GLOBALS(), name, l_v);
                 if (err < 0) {
                     Py_DECREF(v_o);
                     Py_DECREF(l_v);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3651,14 +3651,17 @@ _PyEval_LoadGlobalStackRef(PyObject *globals, PyObject *builtins, PyObject *name
 
     PyObject *res_o = PyStackRef_AsPyObjectBorrow(*writeto);
     if (res_o != NULL && PyLazyImport_CheckExact(res_o)) {
-        PyObject *l_v = _PyImport_LoadLazyImportTstate(PyThreadState_GET(), res_o);
-        PyStackRef_CLOSE(writeto[0]);
+        PyThreadState *tstate = PyThreadState_GET();
+        PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, res_o);
         if (l_v == NULL) {
+            PyStackRef_CLOSE(writeto[0]);
             assert(PyErr_Occurred());
             *writeto = PyStackRef_NULL;
             return;
         }
-        int err = PyDict_SetItem(globals, name, l_v);
+        int err = _PyLazyImport_CommitIfCurrent(
+            tstate, res_o, globals, name, l_v);
+        PyStackRef_CLOSE(writeto[0]);
         if (err < 0) {
             Py_DECREF(l_v);
             *writeto = PyStackRef_NULL;

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -9587,13 +9587,32 @@
                 JUMP_TO_ERROR();
             }
             if (PyDict_CheckExact(ns)) {
+                PyObject *value = PyStackRef_AsPyObjectBorrow(v);
+                int bound = 0;
+                if (ns == GLOBALS() && PyLazyImport_CheckExact(value)) {
+                    stack_pointer[0] = v;
+                    stack_pointer += 1;
+                    ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    _PyFrame_StackPointerValidate(frame);
+                    bound = _PyLazyImport_BindGlobal(tstate, value, ns, name);
+                    _PyFrame_StackPointerInvalidate(frame);
+                    stack_pointer += -1;
+                }
                 stack_pointer[0] = v;
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 _PyFrame_StackPointerValidate(frame);
-                err = PyDict_SetItem(ns, name, PyStackRef_AsPyObjectBorrow(v));
+                err = PyDict_SetItem(ns, name, value);
                 _PyFrame_StackPointerInvalidate(frame);
+                if (bound) {
+                    assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                    _PyFrame_StackPointerValidate(frame);
+                    _PyLazyImport_FinishGlobalBinding(
+                        tstate, value, ns, name, err == 0);
+                    _PyFrame_StackPointerInvalidate(frame);
+                }
             }
             else {
                 stack_pointer[0] = v;
@@ -10076,13 +10095,32 @@
             oparg = CURRENT_OPARG();
             v = _stack_item_0;
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
+            PyObject *value = PyStackRef_AsPyObjectBorrow(v);
+            int bound = 0;
+            if (PyLazyImport_CheckExact(value)) {
+                stack_pointer[0] = v;
+                stack_pointer += 1;
+                ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                _PyFrame_StackPointerValidate(frame);
+                bound = _PyLazyImport_BindGlobal(tstate, value, GLOBALS(), name);
+                _PyFrame_StackPointerInvalidate(frame);
+                stack_pointer += -1;
+            }
             stack_pointer[0] = v;
             stack_pointer += 1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             _PyFrame_StackPointerValidate(frame);
-            int err = PyDict_SetItem(GLOBALS(), name, PyStackRef_AsPyObjectBorrow(v));
+            int err = PyDict_SetItem(GLOBALS(), name, value);
             _PyFrame_StackPointerInvalidate(frame);
+            if (bound) {
+                assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                _PyFrame_StackPointerValidate(frame);
+                _PyLazyImport_FinishGlobalBinding(
+                    tstate, value, GLOBALS(), name, err == 0);
+                _PyFrame_StackPointerInvalidate(frame);
+            }
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
@@ -10238,7 +10276,8 @@
                 }
                 assert(stack_pointer == _PyFrame_GetStackPointer(frame));
                 _PyFrame_StackPointerValidate(frame);
-                int err = PyDict_SetItem(GLOBALS(), name, l_v);
+                int err = _PyLazyImport_CommitIfCurrent(
+                    tstate, v_o, GLOBALS(), name, l_v);
                 _PyFrame_StackPointerInvalidate(frame);
                 if (err < 0) {
                     assert(stack_pointer == _PyFrame_GetStackPointer(frame));

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -10021,10 +10021,12 @@
             mod_or_class_dict = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             int err;
+            PyObject *source = PyStackRef_AsPyObjectBorrow(mod_or_class_dict);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             _PyFrame_StackPointerValidate(frame);
-            PyObject *v_o = _PyMapping_GetOptionalItem2(PyStackRef_AsPyObjectBorrow(mod_or_class_dict), name, &err);
+            PyObject *v_o = _PyMapping_GetOptionalItem2(source, name, &err);
             _PyFrame_StackPointerInvalidate(frame);
+            int commit_source = (v_o != NULL && source == GLOBALS());
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
@@ -10059,13 +10061,33 @@
                         _PyFrame_StackPointerValidate(frame);
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
                         _PyFrame_StackPointerInvalidate(frame);
+                        if (l_v == NULL) {
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(v_o);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            JUMP_TO_LABEL(error);
+                        }
+                        assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                        _PyFrame_StackPointerValidate(frame);
+                        err = _PyLazyImport_CommitIfCurrent(
+                            tstate, v_o, GLOBALS(), name, l_v);
+                        _PyFrame_StackPointerInvalidate(frame);
+                        if (err < 0) {
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(v_o);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(l_v);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            JUMP_TO_LABEL(error);
+                        }
                         assert(stack_pointer == _PyFrame_GetStackPointer(frame));
                         _PyFrame_StackPointerValidate(frame);
                         Py_SETREF(v_o, l_v);
                         _PyFrame_StackPointerInvalidate(frame);
-                        if (v_o == NULL) {
-                            JUMP_TO_LABEL(error);
-                        }
                     }
                 }
                 else {
@@ -10099,15 +10121,68 @@
                         _PyFrame_StackPointerValidate(frame);
                         PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
                         _PyFrame_StackPointerInvalidate(frame);
+                        if (l_v == NULL) {
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(v_o);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            JUMP_TO_LABEL(error);
+                        }
+                        assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                        _PyFrame_StackPointerValidate(frame);
+                        err = _PyLazyImport_CommitIfCurrent(
+                            tstate, v_o, GLOBALS(), name, l_v);
+                        _PyFrame_StackPointerInvalidate(frame);
+                        if (err < 0) {
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(v_o);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                            _PyFrame_StackPointerValidate(frame);
+                            Py_DECREF(l_v);
+                            _PyFrame_StackPointerInvalidate(frame);
+                            JUMP_TO_LABEL(error);
+                        }
                         assert(stack_pointer == _PyFrame_GetStackPointer(frame));
                         _PyFrame_StackPointerValidate(frame);
                         Py_SETREF(v_o, l_v);
                         _PyFrame_StackPointerInvalidate(frame);
-                        if (v_o == NULL) {
-                            JUMP_TO_LABEL(error);
-                        }
                     }
                 }
+            }
+            else if (commit_source && PyLazyImport_CheckExact(v_o)) {
+                assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                _PyFrame_StackPointerValidate(frame);
+                PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
+                _PyFrame_StackPointerInvalidate(frame);
+                if (l_v == NULL) {
+                    assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                    _PyFrame_StackPointerValidate(frame);
+                    Py_DECREF(v_o);
+                    _PyFrame_StackPointerInvalidate(frame);
+                    JUMP_TO_LABEL(error);
+                }
+                assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                _PyFrame_StackPointerValidate(frame);
+                err = _PyLazyImport_CommitIfCurrent(
+                    tstate, v_o, source, name, l_v);
+                _PyFrame_StackPointerInvalidate(frame);
+                if (err < 0) {
+                    assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                    _PyFrame_StackPointerValidate(frame);
+                    Py_DECREF(v_o);
+                    _PyFrame_StackPointerInvalidate(frame);
+                    assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                    _PyFrame_StackPointerValidate(frame);
+                    Py_DECREF(l_v);
+                    _PyFrame_StackPointerInvalidate(frame);
+                    JUMP_TO_LABEL(error);
+                }
+                assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                _PyFrame_StackPointerValidate(frame);
+                Py_SETREF(v_o, l_v);
+                _PyFrame_StackPointerInvalidate(frame);
             }
             v = PyStackRef_FromPyObjectSteal(v_o);
             stack_pointer[0] = v;
@@ -10377,7 +10452,8 @@
                 }
                 assert(stack_pointer == _PyFrame_GetStackPointer(frame));
                 _PyFrame_StackPointerValidate(frame);
-                int err = PyDict_SetItem(GLOBALS(), name, l_v);
+                int err = _PyLazyImport_CommitIfCurrent(
+                    tstate, v_o, GLOBALS(), name, l_v);
                 _PyFrame_StackPointerInvalidate(frame);
                 if (err < 0) {
                     assert(stack_pointer == _PyFrame_GetStackPointer(frame));
@@ -12546,10 +12622,25 @@
             _PyStackRef v;
             v = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
+            PyObject *value = PyStackRef_AsPyObjectBorrow(v);
+            int bound = 0;
+            if (PyLazyImport_CheckExact(value)) {
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                _PyFrame_StackPointerValidate(frame);
+                bound = _PyLazyImport_BindGlobal(tstate, value, GLOBALS(), name);
+                _PyFrame_StackPointerInvalidate(frame);
+            }
             _PyFrame_SetStackPointer(frame, stack_pointer);
             _PyFrame_StackPointerValidate(frame);
-            int err = PyDict_SetItem(GLOBALS(), name, PyStackRef_AsPyObjectBorrow(v));
+            int err = PyDict_SetItem(GLOBALS(), name, value);
             _PyFrame_StackPointerInvalidate(frame);
+            if (bound) {
+                assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                _PyFrame_StackPointerValidate(frame);
+                _PyLazyImport_FinishGlobalBinding(
+                    tstate, value, GLOBALS(), name, err == 0);
+                _PyFrame_StackPointerInvalidate(frame);
+            }
             stack_pointer += -1;
             ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
             _PyFrame_SetStackPointer(frame, stack_pointer);
@@ -12590,10 +12681,25 @@
                 JUMP_TO_LABEL(error);
             }
             if (PyDict_CheckExact(ns)) {
+                PyObject *value = PyStackRef_AsPyObjectBorrow(v);
+                int bound = 0;
+                if (ns == GLOBALS() && PyLazyImport_CheckExact(value)) {
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    _PyFrame_StackPointerValidate(frame);
+                    bound = _PyLazyImport_BindGlobal(tstate, value, ns, name);
+                    _PyFrame_StackPointerInvalidate(frame);
+                }
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 _PyFrame_StackPointerValidate(frame);
-                err = PyDict_SetItem(ns, name, PyStackRef_AsPyObjectBorrow(v));
+                err = PyDict_SetItem(ns, name, value);
                 _PyFrame_StackPointerInvalidate(frame);
+                if (bound) {
+                    assert(stack_pointer == _PyFrame_GetStackPointer(frame));
+                    _PyFrame_StackPointerValidate(frame);
+                    _PyLazyImport_FinishGlobalBinding(
+                        tstate, value, ns, name, err == 0);
+                    _PyFrame_StackPointerInvalidate(frame);
+                }
             }
             else {
                 _PyFrame_SetStackPointer(frame, stack_pointer);

--- a/Python/import.c
+++ b/Python/import.c
@@ -3897,6 +3897,12 @@ _PyImport_LoadLazyImportTstate(PyThreadState *tstate, PyObject *lazy_import)
     // Acquire the global import lock to serialize reification
     _PyImport_AcquireLock(interp);
 
+    if (lz->lz_resolved != NULL) {
+        obj = Py_NewRef(lz->lz_resolved);
+        _PyImport_ReleaseLock(interp);
+        return obj;
+    }
+
     // Check if we are already importing this module, if so, then we want to
     // return an error that indicates we've hit a cycle which will indicate
     // the value isn't yet available.
@@ -3940,19 +3946,6 @@ _PyImport_LoadLazyImportTstate(PyThreadState *tstate, PyObject *lazy_import)
         goto error;
     }
 
-    Py_ssize_t dot = -1;
-    int full = 0;
-    if (lz->lz_attr != NULL) {
-        full = 1;
-    }
-    if (!full) {
-        dot = PyUnicode_FindChar(lz->lz_from, '.', 0,
-                                 PyUnicode_GET_LENGTH(lz->lz_from), 1);
-    }
-    if (dot < 0) {
-        full = 1;
-    }
-
     if (lz->lz_attr != NULL) {
         if (PyUnicode_Check(lz->lz_attr)) {
             fromlist = PyTuple_New(1);
@@ -3978,23 +3971,10 @@ _PyImport_LoadLazyImportTstate(PyThreadState *tstate, PyObject *lazy_import)
         PyErr_SetString(PyExc_ImportError, "__import__ not found");
         goto error;
     }
-    if (full) {
-        obj = _PyEval_ImportNameWithImport(
-            tstate, import_func, globals, globals,
-            lz->lz_from, fromlist, _PyLong_GetZero()
-        );
-    }
-    else {
-        PyObject *name = PyUnicode_Substring(lz->lz_from, 0, dot);
-        if (name == NULL) {
-            goto error;
-        }
-        obj = _PyEval_ImportNameWithImport(
-            tstate, import_func, globals, globals,
-            name, fromlist, _PyLong_GetZero()
-        );
-        Py_DECREF(name);
-    }
+    obj = _PyEval_ImportNameWithImport(
+        tstate, import_func, globals, globals,
+        lz->lz_from, fromlist, _PyLong_GetZero()
+    );
     if (obj == NULL) {
         goto error;
     }
@@ -4092,6 +4072,9 @@ error:
 ok:
     if (PySet_Discard(importing, lazy_import) < 0) {
         Py_CLEAR(obj);
+    }
+    else if (obj != NULL) {
+        lz->lz_resolved = Py_NewRef(obj);
     }
 
     // Release the global import lock.


### PR DESCRIPTION
Make `types.LazyImportType.resolve()` cache successful reification and replace the original module global only when it still points at the same lazy proxy.

The tests cover cached resolves, stale/rebound/deleted globals, retry after failure, module attribute reification, copied proxies, and reentrant store handling.

Tests:
- `git diff --check`
- GitHub Actions required checks after squash

<!-- gh-issue-number: gh-152298 -->
* Issue: gh-152298
<!-- /gh-issue-number -->
