### PR TITLE
gh-111330: Fix GC of _pyio.BytesIO with exports

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -921,7 +921,7 @@ class BytesIO(BufferedIOBase):
 
     def close(self):
         if self._buffer is not None:
-            self._buffer.clear()
+            self._buffer = bytearray()
         super().close()
 
     def read(self, size=-1):

--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -457,7 +457,9 @@ class PyBytesIOTest(MemoryTestMixin, MemorySeekTestMixin, unittest.TestCase):
         # raises a BufferError.
         self.assertRaises(BufferError, memio.write, b'x' * 100)
         self.assertRaises(BufferError, memio.truncate)
-        self.assertRaises(BufferError, memio.close)
+        # gh-111049: _io.BytesIO detach on close would lead to corruption.
+        if self.ioclass is io.BytesIO:
+            self.assertRaises(BufferError, memio.close)
         self.assertFalse(memio.closed)
         # Mutating the buffer updates the BytesIO
         buf[3:6] = b"abc"
@@ -469,6 +471,23 @@ class PyBytesIOTest(MemoryTestMixin, MemorySeekTestMixin, unittest.TestCase):
         support.gc_collect()
         memio.truncate()
         memio.close()
+        self.assertRaises(ValueError, memio.getbuffer)
+
+    def test_getbuffer_delete(self):
+        # gh-111330: _pyio .close() works and the buffer stays working
+        if self.ioclass is io.BytesIO:
+            # gh-111049: _io.BytesIO detach on close would lead to corruption.
+            # gh-111331: It would be nice to support this.
+            self.skipTest("io.BytesIO does not support, gh-111049")
+
+        memio = self.ioclass(b"1234567890")
+        buf = memio.getbuffer()
+        self.assertEqual(bytes(buf), b"1234567890")
+        memio.close()
+        self.assertTrue(memio.closed)
+        self.assertEqual(bytes(buf), b"1234567890")
+        buf[3:6] = b"abc"
+        self.assertEqual(bytes(buf), b"123abc7890")
         self.assertRaises(ValueError, memio.getbuffer)
 
     def test_getbuffer_empty(self):

--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -493,9 +493,11 @@ class PyBytesIOTest(MemoryTestMixin, MemorySeekTestMixin, unittest.TestCase):
         # Create a reference loop.
         a = [buf]
         a.append(a)
-        # The Python implementation emits an unraisable exception.
-        with support.catch_unraisable_exception():
+
+        # gh-111330: _pyio GC with exports should pass.
+        with support.catch_unraisable_exception() as cm:
             del memio
+            self.assertIsNone(cm.unraisable)
         del buf
         del a
         # The C implementation emits an unraisable exception.

--- a/Misc/NEWS.d/next/Library/2026-06-26-13-00-46.gh-issue-111330.DBcCXA.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-26-13-00-46.gh-issue-111330.DBcCXA.rst
@@ -1,0 +1,2 @@
+Update pure-Python :class:`io.BytesIO` to close cleanly when the data has an
+export such as a :class:`memoryview`.


### PR DESCRIPTION
Swap out the buffer rather than using `.clear()` which will raise an exception if there are exports. Rely on `bytearray` (`self._buffer`) being the exported object to make sure it doesn't get garbage collected.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111330 -->
* Issue: gh-111330
<!-- /gh-issue-number -->
