### PR TITLE
gh-98894: Check readelf failures in test_dtrace

### DIFF
--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -423,7 +423,7 @@ class CheckDtraceProbes(unittest.TestCase):
                 version, stderr = proc.communicate()
 
             if proc.returncode:
-                raise Exception(
+                raise AssertionError(
                     f"Command {' '.join(cmd)!r} failed "
                     f"with exit code {proc.returncode}: "
                     f"stdout={version!r} stderr={stderr!r}"
@@ -464,13 +464,21 @@ class CheckDtraceProbes(unittest.TestCase):
         command = ["readelf", "-n", binary]
         # Force the C locale to disable localization.
         env = dict(os.environ, LC_ALL="C")
-        stdout, _ = subprocess.Popen(
+        proc = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
             env=env,
-        ).communicate()
+        )
+        with proc:
+            stdout, _ = proc.communicate()
+
+        if proc.returncode:
+            raise AssertionError(
+                f"Command {' '.join(command)!r} failed "
+                f"with exit code {proc.returncode}: stdout={stdout!r}"
+            )
         return stdout
 
     def test_check_probes(self):

--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -73,6 +73,33 @@ def kill_process_group(proc):
     proc.communicate()  # Clean up
 
 
+def run_readelf(cmd):
+    # Force the C locale to disable localization.
+    env = dict(os.environ, LC_ALL="C")
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+    except OSError:
+        raise unittest.SkipTest("Couldn't find readelf on the path")
+
+    with proc:
+        stdout, stderr = proc.communicate()
+
+    if proc.returncode:
+        raise AssertionError(
+            f"Command {' '.join(cmd)!r} failed "
+            f"with exit code {proc.returncode}: "
+            f"stdout={stdout!r} stderr={stderr!r}"
+        )
+
+    return stdout
+
+
 class TraceBackend:
     EXTENSION = None
     COMMAND = None
@@ -408,28 +435,7 @@ class CheckDtraceProbes(unittest.TestCase):
 
     @staticmethod
     def get_readelf_version():
-        try:
-            cmd = ["readelf", "--version"]
-            # Force the C locale to disable localization.
-            env = dict(os.environ, LC_ALL="C")
-            proc = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                universal_newlines=True,
-                env=env,
-            )
-            with proc:
-                version, stderr = proc.communicate()
-
-            if proc.returncode:
-                raise AssertionError(
-                    f"Command {' '.join(cmd)!r} failed "
-                    f"with exit code {proc.returncode}: "
-                    f"stdout={version!r} stderr={stderr!r}"
-                )
-        except OSError:
-            raise unittest.SkipTest("Couldn't find readelf on the path")
+        version = run_readelf(["readelf", "--version"])
 
         # Regex to parse:
         # 'GNU readelf (GNU Binutils) 2.40.0\n' -> 2.40
@@ -461,25 +467,7 @@ class CheckDtraceProbes(unittest.TestCase):
                         binary = libpython_path
                         break
 
-        command = ["readelf", "-n", binary]
-        # Force the C locale to disable localization.
-        env = dict(os.environ, LC_ALL="C")
-        proc = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            universal_newlines=True,
-            env=env,
-        )
-        with proc:
-            stdout, _ = proc.communicate()
-
-        if proc.returncode:
-            raise AssertionError(
-                f"Command {' '.join(command)!r} failed "
-                f"with exit code {proc.returncode}: stdout={stdout!r}"
-            )
-        return stdout
+        return run_readelf(["readelf", "-n", binary])
 
     def test_check_probes(self):
         readelf_output = self.get_readelf_output()


### PR DESCRIPTION
Report readelf command failures directly instead of later failing with missing-probe assertions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98894 -->
* Issue: gh-98894
<!-- /gh-issue-number -->
