### PR TITLE
Doc: fix typo "extenstion" -> "extension" in abi3t-migration.rst

### DIFF
--- a/Doc/howto/abi3t-migration.rst
+++ b/Doc/howto/abi3t-migration.rst
@@ -127,7 +127,7 @@ Prerequisites
 This guide assumes that you have an extension written directly in C (or C++),
 which you want to port to ``abi3t``.
 
-If your extenstion uses a code generator (like Cython) or language binding
+If your extension uses a code generator (like Cython) or language binding
 (like PyO3), it's best to wait until that tool has support for ``abi3t``.
 If you maintain such a tool, you might be able to adapt the instructions
 here for your tool.


### PR DESCRIPTION
### Summary

Fix a small typo in `Doc/howto/abi3t-migration.rst`: "extenstion" -> "extension".

### Files changed

- `Doc/howto/abi3t-migration.rst` (1 line)

This is a one-word spelling correction in prose; no behaviour change.

### AI assistance disclosure

This patch was prepared with assistance from an AI coding tool (Claude Code).
The human contributor reviewed and approved the change before submission.
