### PR TITLE
gh-152361: Add module docstring to dataclasses

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1,3 +1,10 @@
+"""Data classes and related helper functions.
+
+Data classes are user-defined classes whose fields are defined with type
+annotations. This module provides the @dataclass decorator to add generated
+special methods, and helper functions for working with dataclass objects.
+"""
+
 import sys
 import types
 import keyword


### PR DESCRIPTION
## Summary

Add a module-level docstring to `dataclasses` so that `help(dataclasses)` displays a useful module description instead of relying only on the automatically generated documentation.

## Changes

* Add a concise module docstring to `Lib/dataclasses.py`.
* No runtime behavior or public API changes.

## Validation

Executed:

```text
PCbuild\amd64\python_d.exe -c "import dataclasses; help(dataclasses)"
PCbuild\amd64\python_d.exe -m test test_dataclasses
git diff --check
```

All tests passed.

Closes gh-152361.
