### PR TITLE
gh-152373: Make pdb "until" step over a list comprehension with a breakpoint

### DIFF
--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -572,7 +572,8 @@ class Bdb:
         # the name "until" is borrowed from gdb
         if lineno is None:
             lineno = frame.f_lineno + 1
-        self._set_stopinfo(frame, frame, lineno)
+        self._set_stopinfo(frame, frame, lineno,
+                           cmdframe=frame, cmdlineno=frame.f_lineno)
 
     def set_step(self):
         """Stop after one line of code."""

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3264,6 +3264,35 @@ def test_pdb_issue_gh_136057():
     """
 
 
+def test_pdb_until_skip_comprehension():
+    """See GH-152373
+    "until" should get over a list comprehension with a breakpoint set on it
+    >>> def test_function():
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     lst = [i for i in range(10)]
+    ...     for i in lst: pass
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'break 3',
+    ...     'continue',
+    ...     'until',
+    ...     'continue',
+    ... ]):
+    ...     test_function()
+    > <doctest test.test_pdb.test_pdb_until_skip_comprehension[0]>(2)test_function()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) break 3
+    Breakpoint 1 at <doctest test.test_pdb.test_pdb_until_skip_comprehension[0]>:3
+    (Pdb) continue
+    > <doctest test.test_pdb.test_pdb_until_skip_comprehension[0]>(3)test_function()
+    -> lst = [i for i in range(10)]
+    (Pdb) until
+    > <doctest test.test_pdb.test_pdb_until_skip_comprehension[0]>(4)test_function()
+    -> for i in lst: pass
+    (Pdb) continue
+    """
+
+
 def test_pdb_issue_gh_80731():
     """See GH-80731
 

--- a/Misc/NEWS.d/next/Library/2026-06-27-08-31-30.gh-issue-152373.3cd0aa.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-27-08-31-30.gh-issue-152373.3cd0aa.rst
@@ -1,0 +1,2 @@
+Fix the :mod:`pdb` ``until`` command not stepping over a list comprehension
+when a breakpoint is set on it. Patch by tonghuaroot.


### PR DESCRIPTION
`until` re-stops on a list comprehension (or single-line loop) line when a
breakpoint is set on it, because `set_until` does not record the frame and
line where the command was issued. `next` and `step` already record this
(gh-136160), so the existing same-line guard in `dispatch_line` applies to
them. This records it for `set_until` too, so `until` steps past the line like
`next` and `step` do.

<!-- gh-issue-number: gh-152373 -->
