### PR TITLE
gh-82830: Improve tkinter messagebox docstrings and cursor documentation

### DIFF
--- a/Doc/library/tkinter.messagebox.rst
+++ b/Doc/library/tkinter.messagebox.rst
@@ -113,7 +113,7 @@ Common message box styles and layouts include but are not limited to:
 .. function:: askretrycancel(title=None, message=None, **options)
 
    Ask if operation should be retried. Shows buttons :data:`RETRY` and :data:`CANCEL`.
-   Return ``True`` if the answer is yes and ``False`` otherwise.
+   Return ``True`` if the answer is retry and ``False`` otherwise.
 
 .. function:: askyesno(title=None, message=None, **options)
 

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -770,6 +770,8 @@ cursor
    The standard X cursor names from :file:`cursorfont.h` can be used, without the
    ``XC_`` prefix.  For example to get a hand cursor (``XC_hand2``), use the
    string ``"hand2"``.  You can also specify a bitmap and mask file of your own.
+   On Windows a cursor file (:file:`.cur` or :file:`.ani`) may be used directly,
+   giving its path preceded with an ``@``, as in ``"@C:/cursors/bart.ani"``.
    See page 179 of Ousterhout's book.
 
 distance

--- a/Lib/tkinter/messagebox.py
+++ b/Lib/tkinter/messagebox.py
@@ -99,24 +99,24 @@ def showerror(title=None, message=None, **options):
 
 
 def askquestion(title=None, message=None, **options):
-    "Ask a question"
+    "Ask a question; return the symbolic name of the selected button"
     return _show(title, message, QUESTION, YESNO, **options)
 
 
 def askokcancel(title=None, message=None, **options):
-    "Ask if operation should proceed; return true if the answer is ok"
+    "Ask if operation should proceed; return True if the answer is ok"
     s = _show(title, message, QUESTION, OKCANCEL, **options)
     return s == OK
 
 
 def askyesno(title=None, message=None, **options):
-    "Ask a question; return true if the answer is yes"
+    "Ask a question; return True if the answer is yes"
     s = _show(title, message, QUESTION, YESNO, **options)
     return s == YES
 
 
 def askyesnocancel(title=None, message=None, **options):
-    "Ask a question; return true if the answer is yes, None if cancelled."
+    "Ask a question; return True if the answer is yes, None if cancelled"
     s = _show(title, message, QUESTION, YESNOCANCEL, **options)
     # s might be a Tcl index object, so convert it to a string
     s = str(s)
@@ -126,7 +126,7 @@ def askyesnocancel(title=None, message=None, **options):
 
 
 def askretrycancel(title=None, message=None, **options):
-    "Ask if operation should be retried; return true if the answer is yes"
+    "Ask if operation should be retried; return True if the answer is retry"
     s = _show(title, message, WARNING, RETRYCANCEL, **options)
     return s == RETRY
 


### PR DESCRIPTION
Fix the messagebox `ask*` docstrings to say they return `True` rather than "true", note that `askquestion` returns the symbolic button name, and correct `askretrycancel` to say "retry".

Also document that on Windows a cursor file (`.cur` or `.ani`) can be given directly as `"@C:/cursors/bart.ani"`.

<!-- gh-issue-number -->
* Issue: gh-82830
* Issue: gh-99089
<!-- /gh-issue-number -->