### PR TITLE
gh-152433: Windows: use GetFileSizeEx instead of GetFileSize

### DIFF
--- a/Misc/NEWS.d/next/Windows/2026-06-28-13-03-57.gh-issue-152433.jUXFwC.rst
+++ b/Misc/NEWS.d/next/Windows/2026-06-28-13-03-57.gh-issue-152433.jUXFwC.rst
@@ -1,0 +1,1 @@
+Use the Windows API ``GetFileSizeEx()`` for memory mapped files, rather than the older ``GetFileSize()``.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -806,20 +806,12 @@ mmap_mmap_size_impl(mmap_object *self)
 
 #ifdef MS_WINDOWS
     if (self->file_handle != INVALID_HANDLE_VALUE) {
-        DWORD low,high;
-        long long size;
-        low = GetFileSize(self->file_handle, &high);
-        if (low == INVALID_FILE_SIZE) {
-            /* It might be that the function appears to have failed,
-               when indeed its size equals INVALID_FILE_SIZE */
-            DWORD error = GetLastError();
-            if (error != NO_ERROR)
-                return PyErr_SetFromWindowsErr(error);
+        LARGE_INTEGER size;
+        if (!GetFileSizeEx(self->file_handle, &size)) {
+          DWORD error = GetLastError();
+          return PyErr_SetFromWindowsErr(error);
         }
-        if (!high && low < LONG_MAX)
-            return PyLong_FromLong((long)low);
-        size = (((long long)high)<<32) + low;
-        return PyLong_FromLongLong(size);
+        return PyLong_FromLongLong(size.QuadPart);
     }
 #endif /* MS_WINDOWS */
 
@@ -2127,18 +2119,14 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
             m_obj->file_handle = fh;
         }
         if (!map_size) {
-            DWORD low,high;
-            low = GetFileSize(fh, &high);
-            /* low might just happen to have the value INVALID_FILE_SIZE;
-               so we need to check the last error also. */
-            if (low == INVALID_FILE_SIZE &&
-                (dwErr = GetLastError()) != NO_ERROR)
+            LARGE_INTEGER li;
+            if (!GetFileSizeEx(fh, &li))
             {
+                dwErr = GetLastError();
                 Py_DECREF(m_obj);
                 return PyErr_SetFromWindowsErr(dwErr);
             }
-
-            size = (((long long) high) << 32) + low;
+            size = li.QuadPart;
             if (size == 0) {
                 PyErr_SetString(PyExc_ValueError,
                                 "cannot mmap an empty file");


### PR DESCRIPTION
GetFileSizeEx is available in all supported Windows versions and has the advantage is also present in UWP, then allows build also in UWP with the same common code.

It also simplifies error checking and makes handling files larger than 4GB easier.

The ultimate goal is to upstream some of Kodi patches required to build Python for Xbox... This is just the first step.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152433 -->
* Issue: gh-152433
<!-- /gh-issue-number -->
