### PR TITLE
gh-70273: Document default class bindings in tkinter

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -883,6 +883,20 @@ they are denoted in Tk, which can be useful when referring to the Tk man pages.
 | %d | detail              | %D | delta               |
 +----+---------------------+----+---------------------+
 
+The ``add`` parameter above only affects the bindings you make yourself.
+Every widget also inherits *class bindings*
+that implement its standard behavior --
+for example a :class:`Text` widget binds :kbd:`Control-t`
+to transpose two characters.
+These are described in the bindings section of the widget's Tk man page
+(such as :manpage:`text(3tk)` or :manpage:`entry(3tk)`).
+
+Class bindings are processed separately from your own,
+so binding an event yourself does not replace the default; both run.
+To suppress an unwanted default binding,
+bind the event on the widget
+and return the string ``"break"`` from your callback.
+
 
 The index parameter
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add a note to the "Bindings and events" section explaining that every widget inherits a set of Tk *class bindings* that implement its standard behavior (for example `Text` binds `Control-t` to transpose two characters), where those default bindings are documented (the widget's Tk man page), and how to suppress an unwanted one by returning `"break"` from a callback.

This complements the `add` parameter documented just above, which only affects the bindings created on the widget itself, not the inherited class bindings.

<!-- gh-issue-number -->
* Issue: gh-70273
<!-- /gh-issue-number -->
