### PR TITLE
gh-152260: Fix flaky curses test_scr_dump on macOS

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1120,9 +1120,10 @@ class TestCurses(unittest.TestCase):
     def test_scr_dump(self):
         # Test scr_dump(), scr_restore(), scr_init() and scr_set().
         # scr_dump() writes the virtual screen to a named file; the other three
-        # functions load it back.  The dumped image is internal curses state,
-        # not a window, so the round-trip is checked by comparing dump files
-        # rather than reading cells.
+        # load it back.  The dump is opaque internal curses state -- on some
+        # platforms (such as macOS) it embeds raw pointers that change whenever
+        # the screen is reallocated -- so the round-trip is exercised
+        # functionally rather than by comparing dump bytes.
         stdscr = self.stdscr
         stdscr.erase()
         stdscr.addstr(0, 0, 'screen dump test')
@@ -1131,27 +1132,14 @@ class TestCurses(unittest.TestCase):
             dump = os.path.join(d, 'dump')
             self.assertIsNone(curses.scr_dump(dump))
             with open(dump, 'rb') as f:
-                image = f.read()
-            self.assertTrue(image)
-            # The dump format embeds raw pointers on some platforms (such as
-            # macOS), so two dumps of the same screen are not always identical.
-            # Only compare dump files when the format proves deterministic.
-            dump2 = os.path.join(d, 'dump2')
-            curses.scr_dump(dump2)
-            with open(dump2, 'rb') as f:
-                deterministic = f.read() == image
-            # scr_restore() reloads that virtual screen, so dumping it again
-            # reproduces the original file even after the screen has changed.
+                self.assertTrue(f.read())
+            # scr_restore() reloads the saved virtual screen, even after the
+            # screen has changed.
             stdscr.erase()
             stdscr.addstr(0, 0, 'something else')
             stdscr.refresh()
             self.assertIsNone(curses.scr_restore(dump))
-            if deterministic:
-                restored = os.path.join(d, 'restored')
-                curses.scr_dump(restored)
-                with open(restored, 'rb') as f:
-                    self.assertEqual(f.read(), image)
-            # scr_init() and scr_set() accept a dump file and return None.
+            # scr_init() and scr_set() also accept a dump file and return None.
             self.assertIsNone(curses.scr_init(dump))
             self.assertIsNone(curses.scr_set(dump))
             # A bytes (path-like) filename is accepted too.


### PR DESCRIPTION
<!-- gh-issue-number: gh-152260 -->
* Issue: gh-152260
<!-- /gh-issue-number -->

The screen dump embeds raw pointers that change after `scr_restore()`
reallocates the virtual-screen structures, so comparing dump bytes is
unreliable on platforms such as macOS.

The previous attempt (gh-152260, PR #152340) tried to detect this by
comparing two consecutive dumps of the unchanged screen and only
byte-comparing when they matched.  That probe is a false predictor: two
back-to-back dumps share the same live-allocation pointers, but the
asserted comparison is against a dump taken *after* `scr_restore()`, whose
pointers differ.  So `test_scr_dump` stayed flaky-red on `macos-26-intel`.

Drop the byte comparison entirely and exercise the
`scr_dump`/`scr_restore`/`scr_init`/`scr_set` round-trip functionally.