### PR TITLE
Prefer memcpy and PyList_GetItemRef in core path code

### DIFF
--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -998,7 +998,7 @@ _PyModule_GetFilenameUTF8(PyObject *mod, char *buffer, Py_ssize_t maxlen)
             PyErr_SetString(PyExc_ValueError, "__file__ too long");
         }
         else {
-            (void)strcpy(buffer, filename);
+            memcpy(buffer, filename, (size_t)size + 1);
         }
     }
     Py_DECREF(filenameobj);

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -1099,7 +1099,7 @@ _copy_string_obj_raw(PyObject *strobj, Py_ssize_t *p_size)
         PyErr_NoMemory();
         return NULL;
     }
-    strcpy(copied, str);
+    memcpy(copied, str, (size_t)size + 1);
     if (p_size != NULL) {
         *p_size = size;
     }

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -419,14 +419,18 @@ _Py_FindSourceFile(PyObject *filename, char* namebuf, size_t namelen, PyObject *
         goto error;
     }
     for (i = 0; i < npath; i++) {
-        v = PyList_GetItem(syspath, i);
+        /* Strong ref: safer under free-threading if sys.path mutates. */
+        v = PyList_GetItemRef(syspath, i);
         if (v == NULL) {
             PyErr_Clear();
             break;
         }
-        if (!PyUnicode_Check(v))
+        if (!PyUnicode_Check(v)) {
+            Py_DECREF(v);
             continue;
+        }
         path = PyUnicode_EncodeFSDefault(v);
+        Py_DECREF(v);
         if (path == NULL) {
             PyErr_Clear();
             continue;
@@ -436,13 +440,17 @@ _Py_FindSourceFile(PyObject *filename, char* namebuf, size_t namelen, PyObject *
             Py_DECREF(path);
             continue; /* Too long */
         }
-        strcpy(namebuf, PyBytes_AS_STRING(path));
+        /* Length is known; use memcpy instead of strcpy. */
+        memcpy(namebuf, PyBytes_AS_STRING(path), (size_t)len);
+        namebuf[len] = '\0';
         Py_DECREF(path);
-        if (strlen(namebuf) != (size_t)len)
-            continue; /* v contains '\0' */
-        if (len > 0 && namebuf[len-1] != SEP)
+        if (memchr(namebuf, '\0', (size_t)len) != NULL) {
+            continue; /* v contains embedded '\0' */
+        }
+        if (len > 0 && namebuf[len-1] != SEP) {
             namebuf[len++] = SEP;
-        strcpy(namebuf+len, tail);
+        }
+        memcpy(namebuf + len, tail, taillen + 1);
 
         binary = _PyObject_CallMethodFormat(tstate, open, "ss", namebuf, "rb");
         if (binary != NULL) {


### PR DESCRIPTION
## Summary

- Replace `strcpy` with length-aware `memcpy` where the size is already known (traceback source-file search, cross-interpreter string copy, module `__file__` buffering). Avoids an extra `strlen` scan and matches modern C practice for bounded copies.
- In `_Py_FindSourceFile()`, use `PyList_GetItemRef()` for `sys.path` entries so each iteration holds a strong reference (safer if another thread mutates the list under free-threading).
- Embedded-NUL detection in the traceback path now uses `memchr` on the known-length prefix instead of a post-`strcpy` `strlen` compare.

## Motivation

Small, focused memory-safety / clarity wins in core runtime helpers that still used classic C string APIs after lengths were already measured. No behavior change intended for valid inputs.

## Test plan

- [x] Rebuilt `python.exe`
- [x] `./python.exe -m test test_traceback test_exceptions test_sys test_raise test_module -q`
- [x] Smoke checks for module `__file__` and implicit exception chaining

Left alone: remote_debug `sprintf` paths (separate concern), stable ABI, JIT.