### PR TITLE
gh-152409: Save the trace --file counts when --no-report is used

### DIFF
--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -1,5 +1,5 @@
 import os
-from pickle import dump
+from pickle import dump, load
 import sys
 from test.support import captured_stdout, requires_resource
 from test.support.os_helper import (TESTFN, rmtree, unlink)
@@ -560,6 +560,28 @@ class TestCommandLine(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertIn('lines   cov%   module   (path)', stdout)
         self.assertIn(f'6   100.0%   {modulename}   ({filename})', stdout)
+
+    def test_count_no_report_accumulates_counts(self):
+        # --no-report must still save the --file counts so they accumulate.
+        filename = f'{TESTFN}.py'
+        countsfile = f'{TESTFN}.counts'
+        with open(filename, 'w', encoding='utf-8') as fd:
+            self.addCleanup(unlink, filename)
+            self.addCleanup(unlink, countsfile)
+            fd.write('for i in range(3):\n    pass\n')
+        argv = ('-m', 'trace', '--count', '--no-report',
+                '--file', countsfile, filename)
+        assert_python_ok(*argv, PYTHONIOENCODING='utf-8')
+        self.assertTrue(os.path.exists(countsfile))
+        with open(countsfile, 'rb') as fd:
+            counts = load(fd)[0]
+        self.assertTrue(counts)
+        # A second run accumulates into the same file.
+        assert_python_ok(*argv, PYTHONIOENCODING='utf-8')
+        with open(countsfile, 'rb') as fd:
+            accumulated = load(fd)[0]
+        self.assertEqual(accumulated,
+                         {key: 2 * value for key, value in counts.items()})
 
     def test_run_as_module(self):
         assert_python_ok('-m', 'trace', '-l', '--module', 'timeit', '-n', '1')

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -287,8 +287,11 @@ class CoverageResults:
                 n_lines, n_hits, modulename, filename = sums[m]
                 print(f"{n_lines:5d}   {n_hits/n_lines:.1%}   {modulename}   ({filename})")
 
+        self.save_counts()
+
+    def save_counts(self):
+        """Save the accumulated counts to ``self.outfile`` if one was given."""
         if self.outfile:
-            # try and store counts and module info into self.outfile
             try:
                 with open(self.outfile, 'wb') as f:
                     pickle.dump((self.counts, self.calledfuncs, self.callers),
@@ -744,6 +747,8 @@ def main():
 
     if not opts.no_report:
         results.write_results(opts.missing, opts.summary, opts.coverdir)
+    else:
+        results.save_counts()
 
 if __name__=='__main__':
     main()

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -287,9 +287,9 @@ class CoverageResults:
                 n_lines, n_hits, modulename, filename = sums[m]
                 print(f"{n_lines:5d}   {n_hits/n_lines:.1%}   {modulename}   ({filename})")
 
-        self.save_counts()
+        self._save_counts()
 
-    def save_counts(self):
+    def _save_counts(self):
         """Save the accumulated counts to ``self.outfile`` if one was given."""
         if self.outfile:
             try:
@@ -748,7 +748,7 @@ def main():
     if not opts.no_report:
         results.write_results(opts.missing, opts.summary, opts.coverdir)
     else:
-        results.save_counts()
+        results._save_counts()
 
 if __name__=='__main__':
     main()

--- a/Misc/NEWS.d/next/Library/2026-06-27-10-30-00.gh-issue-152409.Tr8cE2.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-27-10-30-00.gh-issue-152409.Tr8cE2.rst
@@ -1,0 +1,3 @@
+Fix the :mod:`trace` command-line tool not saving the ``--file`` counts
+when ``--no-report`` is used, which prevented accumulating counts over
+several runs.  Patch by tonghuaroot.


### PR DESCRIPTION
`python -m trace --count --no-report --file FILE` now saves the counts to
`FILE`, so counts can be accumulated over several runs — which is what
`--file` and `--no-report` are documented to support.

The counts were pickled only at the end of
`CoverageResults.write_results()`, which `main()` skips when `--no-report`
is given, so `--no-report --file` silently discarded them. This extracts
that step into `CoverageResults.save_counts()` (still called from
`write_results()` exactly as before) and also calls it on the
`--no-report` branch.

`save_counts()` only writes when `--file` was given (it is a no-op
otherwise), and a `--file` run *without* `--no-report` already wrote the
file for every mode, so the two paths are now consistent.


<!-- gh-issue-number: gh-152409 -->
* Issue: gh-152409
<!-- /gh-issue-number -->
