### PR TITLE
gh-151126: Sets missing exceptions in `tkinter` and `socket` modules initializations

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-27-17-19-09.gh-issue-151126.huUyOM.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-27-17-19-09.gh-issue-151126.huUyOM.rst
@@ -1,0 +1,2 @@
+Fix two crashes in :mod:`tkinter` and :mod:`socket` modules initialization
+under a memory pressure. Sets missing :exc:`MemoryError`.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -3574,7 +3574,7 @@ PyInit__tkinter(void)
 
     tcl_lock = PyThread_allocate_lock();
     if (tcl_lock == NULL)
-        return NULL;
+        return PyErr_NoMemory();
 
     m = PyModule_Create(&_tkintermodule);
     if (m == NULL)

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -9296,6 +9296,7 @@ socket_exec(PyObject *m)
 #if defined(USE_GETHOSTBYNAME_LOCK)
     netdb_lock = PyThread_allocate_lock();
     if (netdb_lock == NULL) {
+        PyErr_NoMemory();
         goto error;
     }
 #endif


### PR DESCRIPTION
`PyThread_allocate_lock` does not set `MemoryError` exception, I added missing ones.

<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
