### PR TITLE
gh-90304: Fix IDLE startup failure with a broken font

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -329,7 +329,9 @@ class EditorWindow:
         # http://www.tcl.tk/man/tcl8.6/TkCmd/text.htm#M21
         zero_char_width = \
             Font(text, font=text.cget('font')).measure('0')
-        self.width = pixel_width // zero_char_width
+        # Some fonts report a zero width for '0' (gh-90304).
+        self.width = (pixel_width // zero_char_width if zero_char_width
+                      else text.tk.getint(text.cget('width')))
 
     def new_callback(self, event):
         dirname, basename = self.io.defaultfilename()

--- a/Lib/idlelib/idle_test/test_editor.py
+++ b/Lib/idlelib/idle_test/test_editor.py
@@ -3,6 +3,7 @@
 from idlelib import editor
 import unittest
 from collections import namedtuple
+from unittest import mock
 from test.support import requires
 from tkinter import Tk, Text
 
@@ -29,6 +30,18 @@ class EditorWindowTest(unittest.TestCase):
         e = Editor(root=self.root)
         self.assertEqual(e.root, self.root)
         e._close()
+
+    def test_set_width_zero_char_width(self):
+        # A zero-width '0' must not raise ZeroDivisionError (gh-90304).
+        e = Editor(root=self.root)
+        try:
+            with mock.patch.object(editor, 'Font') as MockFont:
+                MockFont.return_value.measure.return_value = 0
+                e.set_width()
+            self.assertEqual(e.width,
+                             e.text.tk.getint(e.text.cget('width')))
+        finally:
+            e._close()
 
 
 class GetLineIndentTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/IDLE/2026-06-27-17-27-21.gh-issue-90304.464d22.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-06-27-17-27-21.gh-issue-90304.464d22.rst
@@ -1,0 +1,4 @@
+Prevent IDLE from failing to start when a font reports a zero width for
+the ``'0'`` character.  Such a broken font caused a
+:exc:`ZeroDivisionError`; the editor now falls back to the configured
+width.


### PR DESCRIPTION
On some systems a font reports a zero width for the `'0'` character (seen with a broken font on openSUSE). `EditorWindow.set_width()` divides the Text widget's pixel width by that value, so the `ZeroDivisionError` prevented IDLE from starting at all.

`set_width()` now falls back to the configured width when the measured width is zero. `self.width` is consumed by the `=== RESTART ===` separator in the shell and by the squeezer's line wrapping.

<!-- gh-issue-number -->
* Issue: gh-90304
<!-- /gh-issue-number -->
