### PR TITLE
[3.13] Docs: Fix incomplete sentence in `tp_itemsize` documentation (GH-152381)

### DIFF
--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -494,7 +494,7 @@ The following functions and structs are used to create
       in the following situations:
 
       - The base is not variable-sized (its
-        :c:member:`~PyTypeObject.tp_itemsize`).
+        :c:member:`~PyTypeObject.tp_itemsize` is zero).
       - The requested :c:member:`PyType_Spec.basicsize` is positive,
         suggesting that the memory layout of the base class is known.
       - The requested :c:member:`PyType_Spec.basicsize` is zero,


### PR DESCRIPTION
(cherry picked from commit 0a21a248cc97eba3d75c7bd07c849ec645aea87b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
