### PR TITLE
gh-103878: Document that the cancelled file dialog value is only falsy

### DIFF
--- a/Doc/library/dialog.rst
+++ b/Doc/library/dialog.rst
@@ -159,7 +159,7 @@ listed below:
 The below functions when called create a modal, native look-and-feel dialog,
 wait for the user's selection, and return it.
 The exact return value depends on the function (see below); when the dialog is
-cancelled it is an empty string, an empty tuple, an empty list or ``None``.
+cancelled it is an empty string, an empty tuple or ``None``.
 The precise type of this empty value may vary between platforms and Tk
 versions, so test the result for truth rather than comparing it with a
 specific value.

--- a/Doc/library/dialog.rst
+++ b/Doc/library/dialog.rst
@@ -160,6 +160,9 @@ The below functions when called create a modal, native look-and-feel dialog,
 wait for the user's selection, and return it.
 The exact return value depends on the function (see below); when the dialog is
 cancelled it is an empty string, an empty tuple, an empty list or ``None``.
+The precise type of this empty value may vary between platforms and Tk
+versions, so test the result for truth rather than comparing it with a
+specific value.
 
 .. function:: askopenfile(mode="r", **options)
               askopenfiles(mode="r", **options)

--- a/Doc/library/dialog.rst
+++ b/Doc/library/dialog.rst
@@ -171,7 +171,7 @@ specific value.
    :func:`askopenfile` returns the opened file object, or ``None`` if the
    dialog is cancelled.
    :func:`askopenfiles` returns a list of the opened file objects, or an empty
-   list if cancelled.
+   tuple if cancelled.
    The files are opened in mode *mode* (read-only ``'r'`` by default).
 
 .. function:: asksaveasfile(mode="w", **options)


### PR DESCRIPTION
The static file dialog functions return a false value when the dialog is cancelled, but its exact type is not stable: `askdirectory()`, for example, yields `()` on some platforms and `""` on others (see the issue). Code that compares the result against a specific empty value is therefore fragile.

The blanket "or `None`" wording the issue reported was already corrected by the gh-86726 documentation overhaul. This adds a short note to the shared description advising callers to test the result for truth rather than comparing it with a specific value.

This is the documentation half of the issue; normalizing the return type itself is a separate, future-release change.

<!-- gh-issue-number -->
* Issue: gh-103878
<!-- /gh-issue-number -->
