### PR TITLE
Use Py_IsNone() for None identity checks in Objects/

### DIFF
--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -200,7 +200,7 @@ method_new_impl(PyTypeObject *type, PyObject *function, PyObject *instance)
                         "first argument must be callable");
         return NULL;
     }
-    if (instance == NULL || instance == Py_None) {
+    if (instance == NULL || Py_IsNone(instance)) {
         PyErr_SetString(PyExc_TypeError,
             "instance must not be None");
         return NULL;

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -2136,7 +2136,7 @@ code_returns_only_none(PyCodeObject *co)
     Py_ssize_t nconsts = PyTuple_Size(co->co_consts);
     int none_index = 0;
     for (; none_index < nconsts; none_index++) {
-        if (PyTuple_GET_ITEM(co->co_consts, none_index) == Py_None) {
+        if (Py_IsNone(PyTuple_GET_ITEM(co->co_consts, none_index))) {
             break;
         }
     }
@@ -2936,7 +2936,7 @@ _PyCode_ConstantKey(PyObject *op)
     PyObject *key;
 
     /* Py_None and Py_Ellipsis are singletons. */
-    if (op == Py_None || op == Py_Ellipsis
+    if (Py_IsNone(op) || op == Py_Ellipsis
        || PyLong_CheckExact(op)
        || PyUnicode_CheckExact(op)
           /* code_richcompare() uses _PyCode_ConstantKey() internally */

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -744,7 +744,7 @@ complex_pow(PyObject *v, PyObject *w, PyObject *z)
     TO_COMPLEX(v, a);
     TO_COMPLEX(w, b);
 
-    if (z != Py_None) {
+    if (!Py_IsNone(z)) {
         PyErr_SetString(PyExc_ValueError, "complex modulo");
         return NULL;
     }

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -368,7 +368,7 @@ reversed_new_impl(PyTypeObject *type, PyObject *seq)
     reversedobject *ro;
 
     reversed_meth = _PyObject_LookupSpecial(seq, &_Py_ID(__reversed__));
-    if (reversed_meth == Py_None) {
+    if (Py_IsNone(reversed_meth)) {
         Py_DECREF(reversed_meth);
         PyErr_Format(PyExc_TypeError,
                      "'%.200s' object is not reversible",

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -689,7 +689,7 @@ float_pow(PyObject *v, PyObject *w, PyObject *z)
     double iv, iw, ix;
     int negate_result = 0;
 
-    if ((PyObject *)z != Py_None) {
+    if ((PyObject *)!Py_IsNone(z)) {
         PyErr_SetString(PyExc_TypeError, "pow() 3rd argument not "
             "allowed unless all arguments are integers");
         return NULL;
@@ -1028,7 +1028,7 @@ float___round___impl(PyObject *self, PyObject *o_ndigits)
     Py_ssize_t ndigits;
 
     x = PyFloat_AsDouble(self);
-    if (o_ndigits == Py_None) {
+    if (Py_IsNone(o_ndigits)) {
         /* single-argument round or with None ndigits:
          * round to nearest integer */
         rounded = round(x);

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1828,9 +1828,9 @@ frame_lineno_set_impl(PyFrameObject *self, PyObject *value)
         if (top_of_stack(start_stack) == Except) {
             /* Pop exception stack as well as the evaluation stack */
             PyObject *exc = PyStackRef_AsPyObjectBorrow(popped);
-            assert(PyExceptionInstance_Check(exc) || exc == Py_None);
+            assert(PyExceptionInstance_Check(exc) || Py_IsNone(exc));
             PyThreadState *tstate = _PyThreadState_GET();
-            Py_XSETREF(tstate->exc_info->exc_value, exc == Py_None ? NULL : exc);
+            Py_XSETREF(tstate->exc_info->exc_value, Py_IsNone(exc) ? NULL : exc);
         }
         else {
             PyStackRef_XCLOSE(popped);
@@ -1874,7 +1874,7 @@ static int
 frame_trace_set_impl(PyFrameObject *self, PyObject *value)
 /*[clinic end generated code: output=d6fe08335cf76ae4 input=e57380734815dac5]*/
 {
-    if (value == Py_None) {
+    if (Py_IsNone(value)) {
         value = NULL;
     }
     if (value != self->f_trace) {

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -439,7 +439,7 @@ PyFunction_SetDefaults(PyObject *op, PyObject *defaults)
         PyErr_BadInternalCall();
         return -1;
     }
-    if (defaults == Py_None)
+    if (Py_IsNone(defaults))
         defaults = NULL;
     else if (defaults && PyTuple_Check(defaults)) {
         Py_INCREF(defaults);
@@ -480,7 +480,7 @@ PyFunction_SetKwDefaults(PyObject *op, PyObject *defaults)
         PyErr_BadInternalCall();
         return -1;
     }
-    if (defaults == Py_None)
+    if (Py_IsNone(defaults))
         defaults = NULL;
     else if (defaults && PyDict_Check(defaults)) {
         Py_INCREF(defaults);
@@ -514,7 +514,7 @@ PyFunction_SetClosure(PyObject *op, PyObject *closure)
         PyErr_BadInternalCall();
         return -1;
     }
-    if (closure == Py_None)
+    if (Py_IsNone(closure))
         closure = NULL;
     else if (PyTuple_Check(closure)) {
         Py_INCREF(closure);
@@ -594,7 +594,7 @@ PyFunction_SetAnnotations(PyObject *op, PyObject *annotations)
         PyErr_BadInternalCall();
         return -1;
     }
-    if (annotations == Py_None)
+    if (Py_IsNone(annotations))
         annotations = NULL;
     else if (annotations && PyDict_Check(annotations)) {
         Py_INCREF(annotations);
@@ -754,7 +754,7 @@ func_set_defaults(PyObject *self, PyObject *value, void *Py_UNUSED(ignored))
     /* Legal to del f.func_defaults.
      * Can only set func_defaults to NULL or a tuple. */
     PyFunctionObject *op = _PyFunction_CAST(self);
-    if (value == Py_None)
+    if (Py_IsNone(value))
         value = NULL;
     if (value != NULL && !PyTuple_Check(value)) {
         PyErr_SetString(PyExc_TypeError,
@@ -795,7 +795,7 @@ static int
 func_set_kwdefaults(PyObject *self, PyObject *value, void *Py_UNUSED(ignored))
 {
     PyFunctionObject *op = _PyFunction_CAST(self);
-    if (value == Py_None)
+    if (Py_IsNone(value))
         value = NULL;
     /* Legal to del f.func_kwdefaults.
      * Can only set func_kwdefaults to NULL or a dict. */
@@ -902,7 +902,7 @@ static int
 function___annotations___set_impl(PyFunctionObject *self, PyObject *value)
 /*[clinic end generated code: output=a61795d4a95eede4 input=5302641f686f0463]*/
 {
-    if (value == Py_None)
+    if (Py_IsNone(value))
         value = NULL;
     /* Legal to del f.func_annotations.
      * Can only set func_annotations to NULL (through C api)
@@ -1020,36 +1020,36 @@ func_new_impl(PyTypeObject *type, PyCodeObject *code, PyObject *globals,
     PyFunctionObject *newfunc;
     Py_ssize_t nclosure;
 
-    if (name != Py_None && !PyUnicode_Check(name)) {
+    if (!Py_IsNone(name) && !PyUnicode_Check(name)) {
         PyErr_SetString(PyExc_TypeError,
                         "arg 3 (name) must be None or string");
         return NULL;
     }
-    if (defaults != Py_None && !PyTuple_Check(defaults)) {
+    if (!Py_IsNone(defaults) && !PyTuple_Check(defaults)) {
         PyErr_SetString(PyExc_TypeError,
                         "arg 4 (defaults) must be None or tuple");
         return NULL;
     }
     if (!PyTuple_Check(closure)) {
-        if (code->co_nfreevars && closure == Py_None) {
+        if (code->co_nfreevars && Py_IsNone(closure)) {
             PyErr_SetString(PyExc_TypeError,
                             "arg 5 (closure) must be tuple");
             return NULL;
         }
-        else if (closure != Py_None) {
+        else if (!Py_IsNone(closure)) {
             PyErr_SetString(PyExc_TypeError,
                 "arg 5 (closure) must be None or tuple");
             return NULL;
         }
     }
-    if (kwdefaults != Py_None && !PyDict_Check(kwdefaults)) {
+    if (!Py_IsNone(kwdefaults) && !PyDict_Check(kwdefaults)) {
         PyErr_SetString(PyExc_TypeError,
                         "arg 6 (kwdefaults) must be None or dict");
         return NULL;
     }
 
     /* check that the closure is well-formed */
-    nclosure = closure == Py_None ? 0 : PyTuple_GET_SIZE(closure);
+    nclosure = Py_IsNone(closure) ? 0 : PyTuple_GET_SIZE(closure);
     if (code->co_nfreevars != nclosure)
         return PyErr_Format(PyExc_ValueError,
                             "%U requires closure of length %d, not %zd",
@@ -1074,16 +1074,16 @@ func_new_impl(PyTypeObject *type, PyCodeObject *code, PyObject *globals,
     if (newfunc == NULL) {
         return NULL;
     }
-    if (name != Py_None) {
+    if (!Py_IsNone(name)) {
         Py_SETREF(newfunc->func_name, Py_NewRef(name));
     }
-    if (defaults != Py_None) {
+    if (!Py_IsNone(defaults)) {
         newfunc->func_defaults = Py_NewRef(defaults);
     }
-    if (closure != Py_None) {
+    if (!Py_IsNone(closure)) {
         newfunc->func_closure = Py_NewRef(closure);
     }
-    if (kwdefaults != Py_None) {
+    if (!Py_IsNone(kwdefaults)) {
         newfunc->func_kwdefaults = Py_NewRef(kwdefaults);
     }
 
@@ -1176,7 +1176,7 @@ func_traverse(PyObject *self, visitproc visit, void *arg)
 static PyObject *
 func_descr_get(PyObject *func, PyObject *obj, PyObject *type)
 {
-    if (obj == Py_None || obj == NULL) {
+    if (Py_IsNone(obj) || obj == NULL) {
         return Py_NewRef(func);
     }
     return PyMethod_New(func, obj);

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -351,7 +351,7 @@ _unpacked_tuple_args(PyObject *arg)
     }
 
     if (PyObject_GetOptionalAttr(arg, &_Py_ID(__typing_unpacked_tuple_args__), &result) > 0) {
-        if (result == Py_None) {
+        if (Py_IsNone(result)) {
             Py_DECREF(result);
             return NULL;
         }
@@ -422,7 +422,7 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
             Py_DECREF(item);
             return NULL;
         }
-        if (prepare && prepare != Py_None) {
+        if (prepare && !Py_IsNone(prepare)) {
             if (PyTuple_Check(item)) {
                 tmp = PyObject_CallFunction(prepare, "OO", self, item);
             }

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -308,8 +308,8 @@ gen_send_ex2(PyGenObject *gen, PyObject *arg, PyObject **presult, int exc)
     /* If the generator just returned (as opposed to yielding), signal
      * that the generator is exhausted. */
     if (result) {
-        assert(result == Py_None || !PyAsyncGen_CheckExact(gen));
-        if (result == Py_None && !PyAsyncGen_CheckExact(gen) && !arg) {
+        assert(Py_IsNone(result) || !PyAsyncGen_CheckExact(gen));
+        if (Py_IsNone(result) && !PyAsyncGen_CheckExact(gen) && !arg) {
             /* Return NULL if called by gen_iternext() */
             Py_CLEAR(result);
         }
@@ -332,7 +332,7 @@ gen_send_ex(PyGenObject *gen, PyObject *arg, PyObject **presult)
     *presult = NULL;
     int8_t frame_state = FT_ATOMIC_LOAD_INT8_RELAXED(gen->gi_frame_state);
     do {
-        if (frame_state == FRAME_CREATED && arg && arg != Py_None) {
+        if (frame_state == FRAME_CREATED && arg && !Py_IsNone(arg)) {
             const char *msg = "can't send non-None value to a "
                                 "just-started generator";
             if (PyCoro_CheckExact(gen)) {
@@ -385,10 +385,10 @@ static PyObject *
 gen_set_stop_iteration(PyGenObject *gen, PyObject *result)
 {
     if (PyAsyncGen_CheckExact(gen)) {
-        assert(result == Py_None);
+        assert(Py_IsNone(result));
         PyErr_SetNone(PyExc_StopAsyncIteration);
     }
-    else if (result == Py_None) {
+    else if (Py_IsNone(result)) {
         PyErr_SetNone(PyExc_StopIteration);
     }
     else {
@@ -547,7 +547,7 @@ gen_set_exception(PyObject *typ, PyObject *val, PyObject *tb)
 {
     /* First, check the traceback argument, replacing None with
        NULL. */
-    if (tb == Py_None) {
+    if (Py_IsNone(tb)) {
         tb = NULL;
     }
     else if (tb != NULL && !PyTraceBack_Check(tb)) {
@@ -565,7 +565,7 @@ gen_set_exception(PyObject *typ, PyObject *val, PyObject *tb)
     }
     else if (PyExceptionInstance_Check(typ)) {
         /* Raising an instance.  The value should be a dummy. */
-        if (val && val != Py_None) {
+        if (val && !Py_IsNone(val)) {
             PyErr_SetString(PyExc_TypeError,
               "instance exception may not have a separate value");
             goto failed_throw;
@@ -765,7 +765,7 @@ gen_iternext(PyObject *self)
 
     PyObject *result;
     if (gen_send_ex(gen, NULL, &result) == PYGEN_RETURN) {
-        if (result != Py_None) {
+        if (!Py_IsNone(result)) {
             _PyGen_SetStopIterationValue(result);
         }
         Py_CLEAR(result);
@@ -1990,7 +1990,7 @@ async_gen_asend_send(PyObject *self, PyObject *arg)
             return NULL;
         }
 
-        if (arg == NULL || arg == Py_None) {
+        if (arg == NULL || Py_IsNone(arg)) {
             arg = o->ags_sendval;
         }
         o->ags_state = AWAITABLE_STATE_ITER;
@@ -2339,7 +2339,7 @@ async_gen_athrow_send(PyObject *self, PyObject *arg)
             return NULL;
         }
 
-        if (arg != Py_None) {
+        if (!Py_IsNone(arg)) {
             PyErr_SetString(PyExc_RuntimeError, NON_INIT_CORO_MSG);
             return NULL;
         }

--- a/Objects/interpolationobject.c
+++ b/Objects/interpolationobject.c
@@ -8,7 +8,7 @@
 static int
 _conversion_converter(PyObject *arg, PyObject **conversion)
 {
-    if (arg == Py_None) {
+    if (Py_IsNone(arg)) {
         return 1;
     }
 

--- a/Objects/lazyimportobject.c
+++ b/Objects/lazyimportobject.c
@@ -18,7 +18,7 @@ _PyLazyImport_New(_PyInterpreterFrame *frame, PyObject *builtins, PyObject *name
         PyErr_SetString(PyExc_TypeError, "expected str for name");
         return NULL;
     }
-    if (fromlist == Py_None || fromlist == NULL) {
+    if (Py_IsNone(fromlist) || fromlist == NULL) {
         fromlist = NULL;
     }
     else if (!PyUnicode_Check(fromlist) && !PyTuple_Check(fromlist)) {

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2957,7 +2957,7 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
 
     assert(self != NULL);
     assert(PyList_Check(self));
-    if (keyfunc == Py_None)
+    if (Py_IsNone(keyfunc))
         keyfunc = NULL;
 
     /* The list is temporarily made empty, so that mutations performed

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4992,7 +4992,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
     if (PyLong_Check(x)) {
         c = (PyLongObject *)Py_NewRef(x);
     }
-    else if (x == Py_None)
+    else if (Py_IsNone(x))
         c = NULL;
     else {
         Py_DECREF(a);
@@ -6216,7 +6216,7 @@ int___round___impl(PyObject *self, PyObject *o_ndigits)
      *
      *   m - divmod_near(m, 10**n)[1].
      */
-    if (o_ndigits == Py_None)
+    if (Py_IsNone(o_ndigits))
         return long_long(self);
 
     PyObject *ndigits = _PyNumber_Index(o_ndigits);

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -954,7 +954,7 @@ PyModule_GetFilenameObject(PyObject *mod)
     if (fileobj == NULL) {
         return NULL;
     }
-    if (fileobj == Py_None) {
+    if (Py_IsNone(fileobj)) {
         PyErr_SetString(PyExc_SystemError, "module filename missing");
         return NULL;
     }
@@ -985,7 +985,7 @@ _PyModule_GetFilenameUTF8(PyObject *mod, char *buffer, Py_ssize_t maxlen)
     if (filenameobj == NULL) {
         return -1;
     }
-    if (filenameobj == Py_None) {
+    if (Py_IsNone(filenameobj)) {
         // It is missing or invalid.
         buffer[0] = '\0';
         size = 0;
@@ -1060,7 +1060,7 @@ _PyModule_ClearDict(PyObject *d)
     /* First, clear only names starting with a single underscore */
     pos = 0;
     while (PyDict_Next(d, &pos, &key, &value)) {
-        if (value != Py_None && PyUnicode_Check(key)) {
+        if (!Py_IsNone(value) && PyUnicode_Check(key)) {
             if (PyUnicode_READ_CHAR(key, 0) == '_' &&
                 PyUnicode_READ_CHAR(key, 1) != '_') {
                 if (verbose > 1) {
@@ -1081,7 +1081,7 @@ _PyModule_ClearDict(PyObject *d)
     /* Next, clear all names except for __builtins__ */
     pos = 0;
     while (PyDict_Next(d, &pos, &key, &value)) {
-        if (value != Py_None && PyUnicode_Check(key)) {
+        if (!Py_IsNone(value) && PyUnicode_Check(key)) {
             if (PyUnicode_READ_CHAR(key, 0) != '_' ||
                 !_PyUnicode_EqualToASCIIString(key, "__builtins__"))
             {

--- a/Objects/sentinelobject.c
+++ b/Objects/sentinelobject.c
@@ -76,7 +76,7 @@ static PyObject *
 sentinel_new_impl(PyTypeObject *type, PyObject *name, PyObject *repr)
 /*[clinic end generated code: output=1eb7fab52e57d8c8 input=28cab6c468997b35]*/
 {
-    if (repr == Py_None) {
+    if (Py_IsNone(repr)) {
         repr = NULL;
     }
     else if (!PyUnicode_Check(repr)) {

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -181,20 +181,20 @@ PySlice_GetIndices(PyObject *_r, Py_ssize_t length,
 {
     PySliceObject *r = (PySliceObject*)_r;
     /* XXX support long ints */
-    if (r->step == Py_None) {
+    if (Py_IsNone(r->step)) {
         *step = 1;
     } else {
         if (!PyLong_Check(r->step)) return -1;
         *step = PyLong_AsSsize_t(r->step);
     }
-    if (r->start == Py_None) {
+    if (Py_IsNone(r->start)) {
         *start = *step < 0 ? length-1 : 0;
     } else {
         if (!PyLong_Check(r->start)) return -1;
         *start = PyLong_AsSsize_t(r->start);
         if (*start < 0) *start += length;
     }
-    if (r->stop == Py_None) {
+    if (Py_IsNone(r->stop)) {
         *stop = *step < 0 ? -1 : length;
     } else {
         if (!PyLong_Check(r->stop)) return -1;
@@ -217,7 +217,7 @@ PySlice_Unpack(PyObject *_r,
     static_assert(PY_SSIZE_T_MIN + 1 <= -PY_SSIZE_T_MAX,
                   "-PY_SSIZE_T_MAX < PY_SSIZE_T_MIN + 1");
 
-    if (r->step == Py_None) {
+    if (Py_IsNone(r->step)) {
         *step = 1;
     }
     else {
@@ -236,14 +236,14 @@ PySlice_Unpack(PyObject *_r,
             *step = -PY_SSIZE_T_MAX;
     }
 
-    if (r->start == Py_None) {
+    if (Py_IsNone(r->start)) {
         *start = *step < 0 ? PY_SSIZE_T_MAX : 0;
     }
     else {
         if (!_PyEval_SliceIndex(r->start, start)) return -1;
     }
 
-    if (r->stop == Py_None) {
+    if (Py_IsNone(r->stop)) {
         *stop = *step < 0 ? PY_SSIZE_T_MIN : PY_SSIZE_T_MAX;
     }
     else {
@@ -395,7 +395,7 @@ _PySlice_GetLongIndices(PySliceObject *self, PyObject *length,
     int step_is_negative, cmp_result;
 
     /* Convert step to an integer; raise for zero step. */
-    if (self->step == Py_None) {
+    if (Py_IsNone(self->step)) {
         step = _PyLong_GetOne();
         step_is_negative = 0;
     }
@@ -432,7 +432,7 @@ _PySlice_GetLongIndices(PySliceObject *self, PyObject *length,
     }
 
     /* Compute start. */
-    if (self->start == Py_None) {
+    if (Py_IsNone(self->start)) {
         start = Py_NewRef(step_is_negative ? upper : lower);
     }
     else {
@@ -465,7 +465,7 @@ _PySlice_GetLongIndices(PySliceObject *self, PyObject *length,
     }
 
     /* Compute stop. */
-    if (self->stop == Py_None) {
+    if (Py_IsNone(self->stop)) {
         stop = Py_NewRef(step_is_negative ? lower : upper);
     }
     else {

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -301,7 +301,7 @@ _Py_typing_type_repr(PyUnicodeWriter *writer, PyObject *p)
     if (PyObject_GetOptionalAttr(p, &_Py_ID(__module__), &module) < 0) {
         goto exit;
     }
-    if (module == NULL || module == Py_None) {
+    if (module == NULL || Py_IsNone(module)) {
         goto use_repr;
     }
 
@@ -2167,7 +2167,7 @@ typealias_new_impl(PyTypeObject *type, PyObject *name, PyObject *value,
         return NULL;
     }
 
-    if (qualname == NULL || qualname == Py_None) {
+    if (qualname == NULL || Py_IsNone(qualname)) {
         // If qualname was not set directly, we use name instead.
         qualname = name;
     } else {

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -243,7 +243,7 @@ unionbuilder_add_tuple(unionbuilder *ub, PyObject *tuple)
 static int
 is_unionable(PyObject *obj)
 {
-    if (obj == Py_None ||
+    if (Py_IsNone(obj) ||
         PyType_Check(obj) ||
         PySentinel_Check(obj) ||
         _PyGenericAlias_Check(obj) ||

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -78,7 +78,7 @@ init_weakref(PyWeakReference *self, PyObject *ob, PyObject *callback)
 static void
 clear_weakref_lock_held(PyWeakReference *self, PyObject **callback)
 {
-    if (self->wr_object != Py_None) {
+    if (!Py_IsNone(self->wr_object)) {
         PyWeakReference **list = GET_WEAKREFS_LISTPTR(self->wr_object);
         if (*list == self) {
             /* If 'self' is the end of the list (and thus self->wr_next ==
@@ -416,7 +416,7 @@ get_or_create_weakref(PyTypeObject *type, PyObject *obj, PyObject *callback)
                      Py_TYPE(obj)->tp_name);
         return NULL;
     }
-    if (callback == Py_None) {
+    if (Py_IsNone(callback)) {
         callback = NULL;
     }
     if (callback != NULL && !PyCallable_Check(callback)) {


### PR DESCRIPTION
## Summary

Prefer `Py_IsNone()` over direct `== Py_None` / `!= Py_None` comparisons in core object implementations (`Objects/*.c`). Matches modern CPython style (`Py_Is` / `Py_IsNone` / `Py_IsTrue`).

Touched areas: function objects, generators/coroutines/asyncgens, slices, modules, frames, code objects, and related types.

No behavior change intended.

## Test plan

- [x] Local build
- [x] `./python.exe -m test test_exceptions test_functools test_generators test_coroutines test_importlib test_traceback`

## Related cleanup PRs (parallel review)

This is one of several coherent themes from an interpreter cleanup sweep; see sibling branches on `vedikatai/cpython`:
- `cleanup/py-isnone-python`
- `cleanup/py-isnone-modules`
- `cleanup/errors-strong-refs`
- `cleanup/buffer-string-safety`
- `cleanup/import-list-getitemref`