### PR TITLE
Clarify strong-ref ownership on error-info and function setters

### DIFF
--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -439,10 +439,10 @@ PyFunction_SetDefaults(PyObject *op, PyObject *defaults)
         PyErr_BadInternalCall();
         return -1;
     }
-    if (defaults == Py_None)
+    if (Py_IsNone(defaults))
         defaults = NULL;
     else if (defaults && PyTuple_Check(defaults)) {
-        Py_INCREF(defaults);
+        defaults = Py_NewRef(defaults);
     }
     else {
         PyErr_SetString(PyExc_SystemError, "non-tuple default args");
@@ -480,10 +480,10 @@ PyFunction_SetKwDefaults(PyObject *op, PyObject *defaults)
         PyErr_BadInternalCall();
         return -1;
     }
-    if (defaults == Py_None)
+    if (Py_IsNone(defaults))
         defaults = NULL;
     else if (defaults && PyDict_Check(defaults)) {
-        Py_INCREF(defaults);
+        defaults = Py_NewRef(defaults);
     }
     else {
         PyErr_SetString(PyExc_SystemError,
@@ -514,10 +514,10 @@ PyFunction_SetClosure(PyObject *op, PyObject *closure)
         PyErr_BadInternalCall();
         return -1;
     }
-    if (closure == Py_None)
+    if (Py_IsNone(closure))
         closure = NULL;
     else if (PyTuple_Check(closure)) {
-        Py_INCREF(closure);
+        closure = Py_NewRef(closure);
     }
     else {
         PyErr_Format(PyExc_SystemError,
@@ -594,10 +594,10 @@ PyFunction_SetAnnotations(PyObject *op, PyObject *annotations)
         PyErr_BadInternalCall();
         return -1;
     }
-    if (annotations == Py_None)
+    if (Py_IsNone(annotations))
         annotations = NULL;
     else if (annotations && PyDict_Check(annotations)) {
-        Py_INCREF(annotations);
+        annotations = Py_NewRef(annotations);
     }
     else {
         PyErr_SetString(PyExc_SystemError,

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -551,8 +551,8 @@ PyErr_Clear(void)
 static PyObject*
 get_exc_type(PyObject *exc_value)  /* returns a strong ref */
 {
-    if (exc_value == NULL || exc_value == Py_None) {
-        return Py_None;
+    if (exc_value == NULL || Py_IsNone(exc_value)) {
+        return Py_NewRef(Py_None);
     }
     else {
         assert(PyExceptionInstance_Check(exc_value));
@@ -565,13 +565,13 @@ get_exc_type(PyObject *exc_value)  /* returns a strong ref */
 static PyObject*
 get_exc_traceback(PyObject *exc_value)  /* returns a strong ref */
 {
-    if (exc_value == NULL || exc_value == Py_None) {
-        return Py_None;
+    if (exc_value == NULL || Py_IsNone(exc_value)) {
+        return Py_NewRef(Py_None);
     }
     else {
         assert(PyExceptionInstance_Check(exc_value));
         PyObject *tb = PyException_GetTraceback(exc_value);
-        return tb ? tb : Py_None;
+        return tb ? tb : Py_NewRef(Py_None);
     }
 }
 


### PR DESCRIPTION
## Summary

### `Python/errors.c`
`get_exc_type` / `get_exc_traceback` are documented as returning strong references but returned a bare `Py_None` on the None/NULL path. Use `Py_NewRef(Py_None)` so ownership matches the documented contract. Immortal `None` makes this a no-op today; the API is consistent for reviewers and future-proof.

### `Objects/funcobject.c`
Use `Py_IsNone` and `Py_NewRef` in `PyFunction_SetDefaults` / `SetKwDefaults` / `SetClosure` / `SetAnnotations` instead of `Py_INCREF` on success paths.

## Test plan

- [x] Local rebuild
- [x] `test_exceptions`, `test_functools`, `test_generators`