### PR TITLE
Use Py_IsNone() in selected extension modules

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -504,7 +504,7 @@ future_init(FutureObj *fut, PyObject *loop)
     fut->fut_awaited_by_is_set = 0;
     fut->fut_is_task = 0;
 
-    if (loop == Py_None) {
+    if (Py_IsNone(loop)) {
         asyncio_state *state = get_asyncio_state_by_def((PyObject *)fut);
         loop = get_event_loop(state);
         if (loop == NULL) {
@@ -722,7 +722,7 @@ create_cancelled_error(asyncio_state *state, FutureObj *fut)
         return exc;
     }
     PyObject *msg = fut->fut_cancel_msg;
-    if (msg == NULL || msg == Py_None) {
+    if (msg == NULL || Py_IsNone(msg)) {
         exc = PyObject_CallNoArgs(state->asyncio_CancelledError);
     } else {
         exc = PyObject_CallOneArg(state->asyncio_CancelledError, msg);
@@ -1922,10 +1922,10 @@ FutureIter_throw(PyObject *op, PyObject *const *args, Py_ssize_t nargs)
         val = args[1];
     }
 
-    if (val == Py_None) {
+    if (Py_IsNone(val)) {
         val = NULL;
     }
-    if (tb == Py_None ) {
+    if (Py_IsNone(tb) ) {
         tb = NULL;
     } else if (tb != NULL && !PyTraceBack_Check(tb)) {
         PyErr_SetString(PyExc_TypeError, "throw() third argument must be a traceback");
@@ -2270,7 +2270,7 @@ swap_current_task(_PyThreadStateImpl *ts, PyObject *loop, PyObject *task)
 
     /* transfer ownership to avoid redundant ref counting */
     PyObject *prev_task = ts->asyncio_running_task;
-    if (task != Py_None) {
+    if (!Py_IsNone(task)) {
         ts->asyncio_running_task = Py_NewRef(task);
     } else {
         ts->asyncio_running_task = NULL;
@@ -2320,7 +2320,7 @@ _asyncio_Task___init___impl(TaskObj *self, PyObject *coro, PyObject *loop,
         return -1;
     }
 
-    if (context == Py_None) {
+    if (Py_IsNone(context)) {
         Py_XSETREF(self->task_context, PyContext_CopyCurrent());
         if (self->task_context == NULL) {
             return -1;
@@ -2338,7 +2338,7 @@ _asyncio_Task___init___impl(TaskObj *self, PyObject *coro, PyObject *loop,
     self->task_num_cancels_requested = 0;
     set_task_coro(self, coro);
 
-    if (name == Py_None) {
+    if (Py_IsNone(name)) {
         // optimization: defer task name formatting
         // store the task counter as PyLong in the name
         // for deferred formatting in get_name
@@ -3056,7 +3056,7 @@ task_step_impl(asyncio_state *state, TaskObj *task, PyObject *exc)
     }
 
     if (task->task_must_cancel) {
-        assert(exc != Py_None);
+        assert(!Py_IsNone(exc));
 
         if (!exc || !PyErr_GivenExceptionMatches(exc, state->asyncio_CancelledError)) {
             /* exc was not a CancelledError */
@@ -3144,7 +3144,7 @@ task_step_impl(asyncio_state *state, TaskObj *task, PyObject *exc)
             Py_DECREF(exc);
             goto fail;
         }
-        assert(o == Py_None);
+        assert(Py_IsNone(o));
         Py_DECREF(o);
 
         if (PyErr_GivenExceptionMatches(exc, PyExc_KeyboardInterrupt) ||
@@ -3254,7 +3254,7 @@ task_step_handle_result_impl(asyncio_state *state, TaskObj *task, PyObject *resu
     }
 
     /* Check if `result` is None */
-    if (result == Py_None) {
+    if (Py_IsNone(result)) {
         /* Bare yield relinquishes control for one event loop iteration. */
         if (task_call_step_soon(state, task, NULL)) {
             goto fail;
@@ -3266,7 +3266,7 @@ task_step_handle_result_impl(asyncio_state *state, TaskObj *task, PyObject *resu
     if (PyObject_GetOptionalAttr(result, &_Py_ID(_asyncio_future_blocking), &o) < 0) {
         goto fail;
     }
-    if (o != NULL && o != Py_None) {
+    if (o != NULL && !Py_IsNone(o)) {
         /* `result` is a Future-compatible object */
         PyObject *wrapper;
         PyObject *tmp;
@@ -3613,7 +3613,7 @@ _asyncio__set_running_loop(PyObject *module, PyObject *loop)
 /*[clinic end generated code: output=ae56bf7a28ca189a input=4c9720233d606604]*/
 {
     _PyThreadStateImpl *ts = (_PyThreadStateImpl *)_PyThreadState_GET();
-    if (loop == Py_None) {
+    if (Py_IsNone(loop)) {
         loop = NULL;
     }
     Py_XSETREF(ts->asyncio_running_loop, Py_XNewRef(loop));
@@ -3875,7 +3875,7 @@ static PyObject *
 _asyncio_current_task_impl(PyObject *module, PyObject *loop)
 /*[clinic end generated code: output=fe15ac331a7f981a input=58910f61a5627112]*/
 {
-    if (loop == Py_None) {
+    if (Py_IsNone(loop)) {
         loop = _asyncio_get_running_loop_impl(module);
         if (loop == NULL) {
             return NULL;
@@ -4025,7 +4025,7 @@ _asyncio_all_tasks_impl(PyObject *module, PyObject *loop)
 /*[clinic end generated code: output=0e107cbb7f72aa7b input=43a1b423c2d95bfa]*/
 {
     asyncio_state *state = get_asyncio_state(module);
-    if (loop == Py_None) {
+    if (Py_IsNone(loop)) {
         loop = _asyncio_get_running_loop_impl(module);
         if (loop == NULL) {
             return NULL;

--- a/Modules/_bisectmodule.c
+++ b/Modules/_bisectmodule.c
@@ -83,7 +83,7 @@ internal_bisect_right(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t 
         if (litem == NULL) {
             goto error;
         }
-        if (key != Py_None) {
+        if (!Py_IsNone(key)) {
             PyObject *newitem = PyObject_CallOneArg(key, litem);
             if (newitem == NULL) {
                 goto error;
@@ -202,7 +202,7 @@ _bisect_insort_right_impl(PyObject *module, PyObject *a, PyObject *x,
     PyObject *result, *key_x;
     Py_ssize_t index;
 
-    if (key == Py_None) {
+    if (Py_IsNone(key)) {
         index = internal_bisect_right(a, x, lo, hi, key);
     } else {
         key_x = PyObject_CallOneArg(key, x);
@@ -263,7 +263,7 @@ internal_bisect_left(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t h
         if (litem == NULL) {
             goto error;
         }
-        if (key != Py_None) {
+        if (!Py_IsNone(key)) {
             PyObject *newitem = PyObject_CallOneArg(key, litem);
             if (newitem == NULL) {
                 goto error;
@@ -384,7 +384,7 @@ _bisect_insort_left_impl(PyObject *module, PyObject *a, PyObject *x,
     PyObject *result, *key_x;
     Py_ssize_t index;
 
-    if (key == Py_None) {
+    if (Py_IsNone(key)) {
         index = internal_bisect_left(a, x, lo, hi, key);
     } else {
         key_x = PyObject_CallOneArg(key, x);

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1757,7 +1757,7 @@ deque_init_impl(dequeobject *deque, PyObject *iterable, PyObject *maxlenobj)
 /*[clinic end generated code: output=7084a39d71218dcd input=2b9e37af1fd73143]*/
 {
     Py_ssize_t maxlen = -1;
-    if (maxlenobj != NULL && maxlenobj != Py_None) {
+    if (maxlenobj != NULL && !Py_IsNone(maxlenobj)) {
         maxlen = PyLong_AsSsize_t(maxlenobj);
         if (maxlen == -1 && PyErr_Occurred())
             return -1;
@@ -2237,7 +2237,7 @@ defdict_missing(PyObject *op, PyObject *key)
     defdictobject *dd = defdictobject_CAST(op);
     PyObject *factory = dd->default_factory;
     PyObject *value;
-    if (factory == NULL || factory == Py_None) {
+    if (factory == NULL || Py_IsNone(factory)) {
         /* XXX Call dict.__missing__(key) */
         PyObject *tup;
         tup = PyTuple_Pack(1, key);
@@ -2307,7 +2307,7 @@ defdict_reduce(PyObject *op, PyObject *Py_UNUSED(dummy))
     PyObject *result;
     defdictobject *dd = defdictobject_CAST(op);
 
-    if (dd->default_factory == NULL || dd->default_factory == Py_None)
+    if (dd->default_factory == NULL || Py_IsNone(dd->default_factory))
         args = PyTuple_New(0);
     else
         args = PyTuple_Pack(1, dd->default_factory);
@@ -2475,7 +2475,7 @@ defdict_init(PyObject *self, PyObject *args, PyObject *kwds)
         Py_ssize_t n = PyTuple_GET_SIZE(args);
         if (n > 0) {
             newdefault = PyTuple_GET_ITEM(args, 0);
-            if (!PyCallable_Check(newdefault) && newdefault != Py_None) {
+            if (!PyCallable_Check(newdefault) && !Py_IsNone(newdefault)) {
                 PyErr_SetString(PyExc_TypeError,
                     "first argument must be callable or None");
                 return -1;
@@ -2700,7 +2700,7 @@ tuplegetter_descr_get(PyObject *self, PyObject *obj, PyObject *type)
         return Py_NewRef(self);
     }
     if (!PyTuple_Check(obj)) {
-        if (obj == Py_None) {
+        if (Py_IsNone(obj)) {
             return Py_NewRef(self);
         }
         PyErr_Format(PyExc_TypeError,

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -255,7 +255,7 @@ _set_char_or_none(const char *name, Py_UCS4 *target, PyObject *src, Py_UCS4 dflt
     if (src == NULL) {
         *target = dflt;
     }
-    else if (src == Py_None) {
+    else if (Py_IsNone(src)) {
         *target = NOT_SET;
     }
     else {
@@ -537,7 +537,7 @@ dialect_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     /* validate options */
     if (dialect_check_quoting(self->quoting))
         goto err;
-    if (quotechar == Py_None && quoting == NULL)
+    if (Py_IsNone(quotechar) && quoting == NULL)
         self->quoting = QUOTE_NONE;
     if (self->quoting != QUOTE_NONE && self->quotechar == NOT_SET) {
         PyErr_SetString(PyExc_TypeError,
@@ -1359,14 +1359,14 @@ csv_writerow_lock_held(PyObject *op, PyObject *seq)
             quoted = PyUnicode_Check(field);
             break;
         case QUOTE_NOTNULL:
-            quoted = field != Py_None;
+            quoted = !Py_IsNone(field);
             break;
         default:
             quoted = 0;
             break;
         }
 
-        null_field = (field == Py_None);
+        null_field = (Py_IsNone(field));
         if (PyUnicode_Check(field)) {
             append_ok = join_append(self, field, quoted);
             Py_DECREF(field);

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -926,7 +926,7 @@ deepcopy(elementtreestate *st, PyObject *object, PyObject *memo)
     /* do a deep copy of the given object */
 
     /* Fast paths */
-    if (object == Py_None || PyUnicode_CheckExact(object)) {
+    if (Py_IsNone(object) || PyUnicode_CheckExact(object)) {
         return Py_NewRef(object);
     }
 
@@ -1298,7 +1298,7 @@ _elementtree_Element_find_impl(ElementObject *self, PyTypeObject *cls,
 {
     elementtreestate *st = get_elementtree_state_by_cls(cls);
 
-    if (checkpath(path) || namespaces != Py_None) {
+    if (checkpath(path) || !Py_IsNone(namespaces)) {
         return PyObject_CallMethodObjArgs(
             st->elementpath_obj, st->str_find, self, path, namespaces, NULL
         );
@@ -1342,7 +1342,7 @@ _elementtree_Element_findtext_impl(ElementObject *self, PyTypeObject *cls,
 {
     elementtreestate *st = get_elementtree_state_by_cls(cls);
 
-    if (checkpath(path) || namespaces != Py_None)
+    if (checkpath(path) || !Py_IsNone(namespaces))
         return PyObject_CallMethodObjArgs(
             st->elementpath_obj, st->str_findtext,
             self, path, default_value, namespaces, NULL
@@ -1358,7 +1358,7 @@ _elementtree_Element_findtext_impl(ElementObject *self, PyTypeObject *cls,
         if (rc > 0) {
             PyObject *text = element_get_text((ElementObject *)item);
             Py_DECREF(item);
-            if (text == Py_None) {
+            if (Py_IsNone(text)) {
                 Py_DECREF(text);
                 return Py_GetConstant(Py_CONSTANT_EMPTY_STR);
             }
@@ -1390,7 +1390,7 @@ _elementtree_Element_findall_impl(ElementObject *self, PyTypeObject *cls,
 {
     elementtreestate *st = get_elementtree_state_by_cls(cls);
 
-    if (checkpath(path) || namespaces != Py_None) {
+    if (checkpath(path) || !Py_IsNone(namespaces)) {
         return PyObject_CallMethodObjArgs(
             st->elementpath_obj, st->str_findall, self, path, namespaces, NULL
         );
@@ -2297,7 +2297,7 @@ elementiter_next(PyObject *op)
             return NULL;
         }
         if (it->gettext) {
-            if (elem->tag != Py_None && !PyUnicode_Check(elem->tag)) {
+            if (!Py_IsNone(elem->tag) && !PyUnicode_Check(elem->tag)) {
                 Py_DECREF(elem);
                 continue;
             }
@@ -2305,7 +2305,7 @@ elementiter_next(PyObject *op)
             goto gettext;
         }
 
-        if (it->sought_tag == Py_None)
+        if (Py_IsNone(it->sought_tag))
             return (PyObject *)elem;
 
         rc = PyObject_RichCompareBool(elem->tag, it->sought_tag, Py_EQ);
@@ -2322,7 +2322,7 @@ gettext:
         if (!text) {
             return NULL;
         }
-        if (text == Py_None) {
+        if (Py_IsNone(text)) {
             Py_DECREF(text);
         }
         else {
@@ -2480,13 +2480,13 @@ _elementtree_TreeBuilder___init___impl(TreeBuilderObject *self,
                                        int insert_comments, int insert_pis)
 /*[clinic end generated code: output=8571d4dcadfdf952 input=ae98a94df20b5cc3]*/
 {
-    if (element_factory != Py_None) {
+    if (!Py_IsNone(element_factory)) {
         Py_XSETREF(self->element_factory, Py_NewRef(element_factory));
     } else {
         Py_CLEAR(self->element_factory);
     }
 
-    if (comment_factory == Py_None) {
+    if (Py_IsNone(comment_factory)) {
         elementtreestate *st = self->state;
         comment_factory = st->comment_factory;
     }
@@ -2498,7 +2498,7 @@ _elementtree_TreeBuilder___init___impl(TreeBuilderObject *self,
         self->insert_comments = 0;
     }
 
-    if (pi_factory == Py_None) {
+    if (Py_IsNone(pi_factory)) {
         elementtreestate *st = self->state;
         pi_factory = st->pi_factory;
     }
@@ -2594,12 +2594,12 @@ _elementtree__set_factories_impl(PyObject *module, PyObject *comment_factory,
     elementtreestate *st = get_elementtree_state(module);
     PyObject *old;
 
-    if (!PyCallable_Check(comment_factory) && comment_factory != Py_None) {
+    if (!PyCallable_Check(comment_factory) && !Py_IsNone(comment_factory)) {
         PyErr_Format(PyExc_TypeError, "Comment factory must be callable, not %.100s",
                      Py_TYPE(comment_factory)->tp_name);
         return NULL;
     }
-    if (!PyCallable_Check(pi_factory) && pi_factory != Py_None) {
+    if (!PyCallable_Check(pi_factory) && !Py_IsNone(pi_factory)) {
         PyErr_Format(PyExc_TypeError, "PI factory must be callable, not %.100s",
                      Py_TYPE(pi_factory)->tp_name);
         return NULL;
@@ -2609,12 +2609,12 @@ _elementtree__set_factories_impl(PyObject *module, PyObject *comment_factory,
         st->comment_factory ? st->comment_factory : Py_None,
         st->pi_factory ? st->pi_factory : Py_None);
 
-    if (comment_factory == Py_None) {
+    if (Py_IsNone(comment_factory)) {
         Py_CLEAR(st->comment_factory);
     } else {
         Py_XSETREF(st->comment_factory, Py_NewRef(comment_factory));
     }
-    if (pi_factory == Py_None) {
+    if (Py_IsNone(pi_factory)) {
         Py_CLEAR(st->pi_factory);
     } else {
         Py_XSETREF(st->pi_factory, Py_NewRef(pi_factory));
@@ -2631,7 +2631,7 @@ treebuilder_extend_element_text_or_tail(elementtreestate *st, PyObject *element,
     /* Fast paths for the "almost always" cases. */
     if (Element_CheckExact(st, element)) {
         PyObject *dest_obj = JOIN_OBJ(*dest);
-        if (dest_obj == Py_None) {
+        if (Py_IsNone(dest_obj)) {
             *dest = JOIN_SET(*data, PyList_CheckExact(*data));
             *data = NULL;
             Py_DECREF(dest_obj);
@@ -2658,7 +2658,7 @@ treebuilder_extend_element_text_or_tail(elementtreestate *st, PyObject *element,
             Py_DECREF(previous);
             return -1;
         }
-        if (previous != Py_None) {
+        if (!Py_IsNone(previous)) {
             PyObject *tmp = PyNumber_Add(previous, joined);
             Py_DECREF(joined);
             Py_DECREF(previous);
@@ -2772,7 +2772,7 @@ treebuilder_handle_start(TreeBuilderObject* self, PyObject* tag,
     this = self->this;
     Py_CLEAR(self->last_for_tail);
 
-    if (this != Py_None) {
+    if (!Py_IsNone(this)) {
         if (treebuilder_add_subelement(st, this, node) < 0) {
             goto error;
         }
@@ -2814,7 +2814,7 @@ LOCAL(PyObject*)
 treebuilder_handle_data(TreeBuilderObject* self, PyObject* data)
 {
     if (!self->data) {
-        if (self->last == Py_None) {
+        if (Py_IsNone(self->last)) {
             /* ignore calls to data before the first call to start */
             Py_RETURN_NONE;
         }
@@ -2897,7 +2897,7 @@ treebuilder_handle_comment(TreeBuilderObject* self, PyObject* text)
             return NULL;
 
         this = self->this;
-        if (self->insert_comments && this != Py_None) {
+        if (self->insert_comments && !Py_IsNone(this)) {
             if (treebuilder_add_subelement(self->state, this, comment) < 0) {
                 goto error;
             }
@@ -2937,7 +2937,7 @@ treebuilder_handle_pi(TreeBuilderObject* self, PyObject* target, PyObject* text)
         }
 
         this = self->this;
-        if (self->insert_pis && this != Py_None) {
+        if (self->insert_pis && !Py_IsNone(this)) {
             if (treebuilder_add_subelement(self->state, this, pi) < 0) {
                 goto error;
             }
@@ -3750,7 +3750,7 @@ _elementtree_XMLParser___init___impl(XMLParserObject *self, PyObject *target,
                            (unsigned long)_Py_HashSecret.expat.hashsalt);
     }
 
-    if (target != Py_None) {
+    if (!Py_IsNone(target)) {
         Py_INCREF(target);
     } else {
         target = treebuilder_new(st->TreeBuilder_Type, NULL, NULL);
@@ -4194,7 +4194,7 @@ _elementtree_XMLParser__setevents_impl(XMLParserObject *self,
     Py_CLEAR(target->comment_event_obj);
     Py_CLEAR(target->pi_event_obj);
 
-    if (events_to_report == Py_None) {
+    if (Py_IsNone(events_to_report)) {
         /* default is "end" only */
         target->end_event_obj = PyUnicode_FromString("end");
         Py_RETURN_NONE;

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -359,7 +359,7 @@ partial_dealloc(PyObject *self)
 static PyObject *
 partial_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 {
-    if (obj == Py_None || obj == NULL) {
+    if (Py_IsNone(obj) || obj == NULL) {
         return Py_NewRef(self);
     }
     return PyMethod_New(self, obj);
@@ -804,8 +804,8 @@ partial_setstate(PyObject *self, PyObject *state)
     if (!PyArg_ParseTuple(state, "OOOO", &fn, &fnargs, &kw, &dict) ||
         !PyCallable_Check(fn) ||
         !PyTuple_Check(fnargs) ||
-        (kw != Py_None && !PyDict_Check(kw)) ||
-        (dict != Py_None && !PyDict_Check(dict)))
+        (!Py_IsNone(kw) && !PyDict_Check(kw)) ||
+        (!Py_IsNone(dict) && !PyDict_Check(dict)))
     {
         PyErr_SetString(PyExc_TypeError, "invalid partial state");
         return NULL;
@@ -832,7 +832,7 @@ partial_setstate(PyObject *self, PyObject *state)
     if (fnargs == NULL)
         return NULL;
 
-    if (kw == Py_None)
+    if (Py_IsNone(kw))
         kw = PyDict_New();
     else if(!PyDict_CheckExact(kw))
         kw = PyDict_Copy(kw);
@@ -843,7 +843,7 @@ partial_setstate(PyObject *self, PyObject *state)
         return NULL;
     }
 
-    if (dict == Py_None)
+    if (Py_IsNone(dict))
         dict = NULL;
     else
         Py_INCREF(dict);
@@ -1640,7 +1640,7 @@ lru_cache_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     }
 
     /* select the caching function, and make/inc maxsize_O */
-    if (maxsize_O == Py_None) {
+    if (Py_IsNone(maxsize_O)) {
         wrapper = infinite_lru_cache_wrapper;
         /* use this only to initialize lru_cache_object attribute maxsize */
         maxsize = -1;
@@ -1747,7 +1747,7 @@ lru_cache_call(PyObject *op, PyObject *args, PyObject *kwds)
 static PyObject *
 lru_cache_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 {
-    if (obj == Py_None || obj == NULL) {
+    if (Py_IsNone(obj) || obj == NULL) {
         return Py_NewRef(self);
     }
     return PyMethod_New(self, obj);

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -756,7 +756,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *memo, PyObject *pystr, Py_ss
     Py_ssize_t end_idx;
     PyObject *rval = NULL;
     PyObject *key = NULL;
-    int has_pairs_hook = (s->object_pairs_hook != Py_None);
+    int has_pairs_hook = (!Py_IsNone(s->object_pairs_hook));
     Py_ssize_t next_idx;
     Py_ssize_t comma_idx;
 
@@ -861,7 +861,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *memo, PyObject *pystr, Py_ss
     }
 
     /* if object_hook is not None: rval = object_hook(rval) */
-    if (s->object_hook != Py_None) {
+    if (!Py_IsNone(s->object_hook)) {
         PyObject *res = PyObject_CallOneArg(s->object_hook, rval);
         Py_DECREF(rval);
         return res;
@@ -1322,7 +1322,7 @@ encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         &sort_keys, &skipkeys, &allow_nan))
         return NULL;
 
-    if (markers != Py_None && !PyDict_Check(markers)) {
+    if (!Py_IsNone(markers) && !PyDict_Check(markers)) {
         PyErr_Format(PyExc_TypeError,
                      "make_encoder() argument 1 must be dict or None, "
                      "not %.200s", Py_TYPE(markers)->tp_name);
@@ -1462,7 +1462,7 @@ encoder_call(PyObject *op, PyObject *args, PyObject *kwds)
     }
 
     PyObject *indent_cache = NULL;
-    if (self->indent != Py_None) {
+    if (!Py_IsNone(self->indent)) {
         indent_cache = create_indent_cache(self, indent_level);
         if (indent_cache == NULL) {
             PyUnicodeWriter_Discard(writer);
@@ -1490,7 +1490,7 @@ static PyObject *
 _encoded_const(PyObject *obj)
 {
     /* Return the JSON string representation of None, True, False */
-    if (obj == Py_None) {
+    if (Py_IsNone(obj)) {
         return &_Py_ID(null);
     }
     else if (obj == Py_True) {
@@ -1573,7 +1573,7 @@ encoder_listencode_obj(PyEncoderObject *s, PyUnicodeWriter *writer,
     PyObject *newobj;
     int rv;
 
-    if (obj == Py_None) {
+    if (Py_IsNone(obj)) {
       return PyUnicodeWriter_WriteASCII(writer, "null", 4);
     }
     else if (obj == Py_True) {
@@ -1617,7 +1617,7 @@ encoder_listencode_obj(PyEncoderObject *s, PyUnicodeWriter *writer,
     }
     else {
         PyObject *ident = NULL;
-        if (s->markers != Py_None) {
+        if (!Py_IsNone(s->markers)) {
             int has_key;
             ident = PyLong_FromVoidPtr(obj);
             if (ident == NULL)
@@ -1680,7 +1680,7 @@ encoder_encode_key_value(PyEncoderObject *s, PyUnicodeWriter *writer, bool *firs
     else if (PyFloat_Check(key)) {
         keystr = encoder_encode_float(s, key);
     }
-    else if (key == Py_True || key == Py_False || key == Py_None) {
+    else if (key == Py_True || key == Py_False || Py_IsNone(key)) {
                     /* This must come before the PyLong_Check because
                        True and False are also 1 and 0.*/
         keystr = _encoded_const(key);
@@ -1704,7 +1704,7 @@ encoder_encode_key_value(PyEncoderObject *s, PyUnicodeWriter *writer, bool *firs
 
     if (*first) {
         *first = false;
-        if (s->indent != Py_None) {
+        if (!Py_IsNone(s->indent)) {
             if (write_newline_indent(writer, indent_level, indent_cache) < 0) {
                 Py_DECREF(keystr);
                 return -1;
@@ -1807,7 +1807,7 @@ encoder_listencode_dict(PyEncoderObject *s, PyUnicodeWriter *writer,
         return PyUnicodeWriter_WriteASCII(writer, "{}", 2);
     }
 
-    if (s->markers != Py_None) {
+    if (!Py_IsNone(s->markers)) {
         int has_key;
         ident = PyLong_FromVoidPtr(dct);
         if (ident == NULL)
@@ -1828,7 +1828,7 @@ encoder_listencode_dict(PyEncoderObject *s, PyUnicodeWriter *writer,
     }
 
     PyObject *separator = s->item_separator; // borrowed reference
-    if (s->indent != Py_None) {
+    if (!Py_IsNone(s->indent)) {
         indent_level++;
         separator = get_item_separator(s, indent_level, indent_cache);
         if (separator == NULL)
@@ -1868,7 +1868,7 @@ encoder_listencode_dict(PyEncoderObject *s, PyUnicodeWriter *writer,
             goto bail;
         Py_CLEAR(ident);
     }
-    if (s->indent != Py_None && !first) {
+    if (!Py_IsNone(s->indent) && !first) {
         indent_level--;
         if (write_newline_indent(writer, indent_level, indent_cache) < 0) {
             goto bail;
@@ -1927,7 +1927,7 @@ encoder_listencode_list(PyEncoderObject *s, PyUnicodeWriter *writer,
         return PyUnicodeWriter_WriteASCII(writer, "[]", 2);
     }
 
-    if (s->markers != Py_None) {
+    if (!Py_IsNone(s->markers)) {
         int has_key;
         ident = PyLong_FromVoidPtr(seq);
         if (ident == NULL)
@@ -1948,7 +1948,7 @@ encoder_listencode_list(PyEncoderObject *s, PyUnicodeWriter *writer,
     }
 
     PyObject *separator = s->item_separator; // borrowed reference
-    if (s->indent != Py_None) {
+    if (!Py_IsNone(s->indent)) {
         indent_level++;
         separator = get_item_separator(s, indent_level, indent_cache);
         if (separator == NULL ||
@@ -1971,7 +1971,7 @@ encoder_listencode_list(PyEncoderObject *s, PyUnicodeWriter *writer,
         Py_CLEAR(ident);
     }
 
-    if (s->indent != Py_None) {
+    if (!Py_IsNone(s->indent)) {
         indent_level--;
         if (write_newline_indent(writer, indent_level, indent_cache) < 0) {
             goto bail;

--- a/Modules/_opcode.c
+++ b/Modules/_opcode.c
@@ -41,14 +41,14 @@ _opcode_stack_effect_impl(PyObject *module, int opcode, PyObject *oparg,
     int oparg_int = 0;
     int jump_int;
 
-    if (oparg != Py_None) {
+    if (!Py_IsNone(oparg)) {
         oparg_int = (int)PyLong_AsLong(oparg);
         if ((oparg_int == -1) && PyErr_Occurred()) {
             return -1;
         }
     }
 
-    if (jump == Py_None) {
+    if (Py_IsNone(jump)) {
         jump_int = -1;
     }
     else if (jump == Py_True) {

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1181,7 +1181,7 @@ _Pickler_SetProtocol(PicklerObject *self, PyObject *protocol, int fix_imports)
 {
     long proto;
 
-    if (protocol == Py_None) {
+    if (Py_IsNone(protocol)) {
         proto = DEFAULT_PROTOCOL;
     }
     else {
@@ -1224,7 +1224,7 @@ _Pickler_SetOutputStream(PicklerObject *self, PyObject *file)
 static int
 _Pickler_SetBufferCallback(PicklerObject *self, PyObject *buffer_callback)
 {
-    if (buffer_callback == Py_None) {
+    if (Py_IsNone(buffer_callback)) {
         buffer_callback = NULL;
     }
     if (buffer_callback != NULL && self->proto < 5) {
@@ -1811,7 +1811,7 @@ _Unpickler_SetInputEncoding(UnpicklerObject *self,
 static int
 _Unpickler_SetBuffers(UnpicklerObject *self, PyObject *buffers)
 {
-    if (buffers == NULL || buffers == Py_None) {
+    if (buffers == NULL || Py_IsNone(buffers)) {
         self->buffers = NULL;
     }
     else {
@@ -2008,7 +2008,7 @@ static int
 _checkmodule(PyObject *module_name, PyObject *module,
              PyObject *global, PyObject *dotted_path)
 {
-    if (module == Py_None) {
+    if (Py_IsNone(module)) {
         return -1;
     }
     if (PyUnicode_Check(module_name) &&
@@ -2046,7 +2046,7 @@ whichmodule(PickleState *st, PyObject *global, PyObject *global_name, PyObject *
     if (PyObject_GetOptionalAttr(global, &_Py_ID(__module__), &module_name) < 0) {
         return NULL;
     }
-    if (module_name == NULL || module_name == Py_None) {
+    if (module_name == NULL || Py_IsNone(module_name)) {
         /* In some rare cases (e.g., bound methods of extension types),
            __module__ can be None. If it is so, then search sys.modules for
            the module of global. */
@@ -4137,7 +4137,7 @@ save_pers(PickleState *state, PicklerObject *self, PyObject *obj)
     if (pid == NULL)
         return -1;
 
-    if (pid != Py_None) {
+    if (!Py_IsNone(pid)) {
         if (self->bin) {
             if (save(state, self, pid, 1) < 0 ||
                 _Pickler_Write(self, &binpersid_op, 1) < 0)
@@ -4239,10 +4239,10 @@ save_reduce(PickleState *st, PicklerObject *self, PyObject *args,
         return -1;
     }
 
-    if (state == Py_None)
+    if (Py_IsNone(state))
         state = NULL;
 
-    if (listitems == Py_None)
+    if (Py_IsNone(listitems))
         listitems = NULL;
     else if (!PyIter_Check(listitems)) {
         PyErr_Format(st->PicklingError,
@@ -4251,7 +4251,7 @@ save_reduce(PickleState *st, PicklerObject *self, PyObject *args,
         return -1;
     }
 
-    if (dictitems == Py_None)
+    if (Py_IsNone(dictitems))
         dictitems = NULL;
     else if (!PyIter_Check(dictitems)) {
         PyErr_Format(st->PicklingError,
@@ -4260,7 +4260,7 @@ save_reduce(PickleState *st, PicklerObject *self, PyObject *args,
         return -1;
     }
 
-    if (state_setter == Py_None)
+    if (Py_IsNone(state_setter))
         state_setter = NULL;
     else if (!PyCallable_Check(state_setter)) {
         PyErr_Format(st->PicklingError,
@@ -4580,7 +4580,7 @@ save(PickleState *st, PicklerObject *self, PyObject *obj, int pers_save)
 
     /* Atom types; these aren't memoized, so don't check the memo. */
 
-    if (obj == Py_None) {
+    if (Py_IsNone(obj)) {
         return save_none(self, obj);
     }
     else if (obj == Py_False || obj == Py_True) {
@@ -6937,7 +6937,7 @@ load_build(PickleState *st, UnpicklerObject *self)
         slotstate = NULL;
 
     /* Set inst.__dict__ from the state dict (if any). */
-    if (state != Py_None) {
+    if (!Py_IsNone(state)) {
         PyObject *dict;
         PyObject *d_key, *d_value;
         Py_ssize_t i;

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -695,7 +695,7 @@ PyThreadHandleObject_join(PyObject *op, PyObject *args)
     }
 
     PyTime_t timeout_ns = -1;
-    if (timeout_obj != NULL && timeout_obj != Py_None) {
+    if (timeout_obj != NULL && !Py_IsNone(timeout_obj)) {
         if (_PyTime_FromSecondsObject(&timeout_ns, timeout_obj,
                                       _PyTime_ROUND_TIMEOUT) < 0) {
             return NULL;
@@ -2015,7 +2015,7 @@ thread_PyThread_start_joinable_thread(PyObject *module, PyObject *fargs,
     if (hobj == NULL) {
         hobj = Py_None;
     }
-    else if (hobj != Py_None && !Py_IS_TYPE(hobj, state->thread_handle_type)) {
+    else if (!Py_IsNone(hobj) && !Py_IS_TYPE(hobj, state->thread_handle_type)) {
         PyErr_SetString(PyExc_TypeError, "'handle' must be a _ThreadHandle");
         return NULL;
     }
@@ -2025,7 +2025,7 @@ thread_PyThread_start_joinable_thread(PyObject *module, PyObject *fargs,
         return NULL;
     }
 
-    if (hobj == Py_None) {
+    if (Py_IsNone(hobj)) {
         hobj = (PyObject *)PyThreadHandleObject_new(state->thread_handle_type);
         if (hobj == NULL) {
             return NULL;
@@ -2255,7 +2255,7 @@ thread_excepthook_file(PyObject *file, PyObject *exc_type, PyObject *exc_value,
     }
 
     PyObject *name = NULL;
-    if (thread != Py_None) {
+    if (!Py_IsNone(thread)) {
         if (PyObject_GetOptionalAttr(thread, &_Py_ID(name), &name) < 0) {
             return -1;
         }
@@ -2351,9 +2351,9 @@ thread_excepthook(PyObject *module, PyObject *args)
     if (PySys_GetOptionalAttr( &_Py_ID(stderr), &file) < 0) {
         return NULL;
     }
-    if (file == NULL || file == Py_None) {
+    if (file == NULL || Py_IsNone(file)) {
         Py_XDECREF(file);
-        if (thread == Py_None) {
+        if (Py_IsNone(thread)) {
             /* do nothing if sys.stderr is None and thread is None */
             Py_RETURN_NONE;
         }
@@ -2362,7 +2362,7 @@ thread_excepthook(PyObject *module, PyObject *args)
         if (file == NULL) {
             return NULL;
         }
-        if (file == Py_None) {
+        if (Py_IsNone(file)) {
             Py_DECREF(file);
             /* do nothing if sys.stderr is None and sys.stderr was None
                when the thread was created */

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -234,7 +234,7 @@ zoneinfo_new_instance(zoneinfo_state *state, PyTypeObject *type, PyObject *key)
     if (file_path == NULL) {
         return NULL;
     }
-    else if (file_path == Py_None) {
+    else if (Py_IsNone(file_path)) {
         PyObject *meth = state->_common_mod;
         file_obj = PyObject_CallMethod(meth, "load_tzdata", "O", key);
         if (file_obj == NULL) {
@@ -331,7 +331,7 @@ zoneinfo_ZoneInfo_impl(PyTypeObject *type, PyObject *key)
         return NULL;
     }
 
-    if (instance == Py_None) {
+    if (Py_IsNone(instance)) {
         Py_DECREF(instance);
         PyObject *tmp = zoneinfo_new_instance(state, type, key);
         if (tmp == NULL) {
@@ -514,7 +514,7 @@ zoneinfo_ZoneInfo_clear_cache_impl(PyTypeObject *type, PyTypeObject *cls,
         return NULL;
     }
 
-    if (only_keys == NULL || only_keys == Py_None) {
+    if (only_keys == NULL || Py_IsNone(only_keys)) {
         PyObject *rv = PyObject_CallMethod(weak_cache, "clear", NULL);
         if (rv != NULL) {
             Py_DECREF(rv);
@@ -766,7 +766,7 @@ static PyObject *
 zoneinfo_repr(PyObject *op)
 {
     PyZoneInfo_ZoneInfo *self = PyZoneInfo_ZoneInfo_CAST(op);
-    if (self->key != Py_None) {
+    if (!Py_IsNone(self->key)) {
         return PyUnicode_FromFormat("%T(key=%R)", self, self->key);
     }
     assert(PyUnicode_Check(self->file_repr));
@@ -777,7 +777,7 @@ static PyObject *
 zoneinfo_str(PyObject *op)
 {
     PyZoneInfo_ZoneInfo *self = PyZoneInfo_ZoneInfo_CAST(op);
-    if (self->key != Py_None) {
+    if (!Py_IsNone(self->key)) {
         return Py_NewRef(self->key);
     }
     return zoneinfo_repr(op);
@@ -1181,7 +1181,7 @@ load_data(zoneinfo_state *state, PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
         self->ttinfo_before = &(self->_ttinfos[0]);
     }
 
-    if (tz_str != Py_None && PyObject_IsTrue(tz_str)) {
+    if (!Py_IsNone(tz_str) && PyObject_IsTrue(tz_str)) {
         if (parse_tz_str(state, tz_str, &(self->tzrule_after))) {
             goto error;
         }
@@ -1702,7 +1702,7 @@ complete:
     return 0;
 error:
     Py_XDECREF(std_abbr);
-    if (dst_abbr != NULL && dst_abbr != Py_None) {
+    if (dst_abbr != NULL && !Py_IsNone(dst_abbr)) {
         Py_DECREF(dst_abbr);
     }
 
@@ -2213,7 +2213,7 @@ find_ttinfo(zoneinfo_state *state, PyZoneInfo_ZoneInfo *self, PyObject *dt)
 {
     // datetime.time has a .tzinfo attribute that passes None as the dt
     // argument; it only really has meaning for fixed-offset zones.
-    if (dt == Py_None) {
+    if (Py_IsNone(dt)) {
         if (self->fixed_offset) {
             return &(self->tzrule_after.std);
         }

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -128,7 +128,7 @@ atexit_callfuncs(struct atexit_state *state)
 
         PyObject *res = PyObject_Call(func,
                                       args,
-                                      kwargs == Py_None ? NULL : kwargs);
+                                      Py_IsNone(kwargs) ? NULL : kwargs);
         if (res == NULL) {
             PyErr_FormatUnraisable(
                 "Exception ignored in atexit callback %R", func);

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -103,12 +103,12 @@ faulthandler_get_fileno(PyObject **file_ptr)
     PyObject *result;
     PyObject *file = *file_ptr;
 
-    if (file == NULL || file == Py_None) {
+    if (file == NULL || Py_IsNone(file)) {
         file = PySys_GetAttr(&_Py_ID(stderr));
         if (file == NULL) {
             return -1;
         }
-        if (file == Py_None) {
+        if (Py_IsNone(file)) {
             PyErr_SetString(PyExc_RuntimeError, "sys.stderr is None");
             Py_DECREF(file);
             return -1;

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -511,7 +511,7 @@ groupby_step(groupbyobject *gbo)
     if (newvalue == NULL)
         return -1;
 
-    if (gbo->keyfunc == Py_None) {
+    if (Py_IsNone(gbo->keyfunc)) {
         newkey = Py_NewRef(newvalue);
     } else {
         newkey = PyObject_CallOneArg(gbo->keyfunc, newvalue);
@@ -888,14 +888,14 @@ itertools_teedataobject_impl(PyTypeObject *type, PyObject *it,
     tdo->numread = Py_SAFE_DOWNCAST(len, Py_ssize_t, int);
 
     if (len == LINKCELLS) {
-        if (next != Py_None) {
+        if (!Py_IsNone(next)) {
             if (!Py_IS_TYPE(next, state->teedataobject_type))
                 goto err;
             assert(tdo->nextlink == NULL);
             tdo->nextlink = Py_NewRef(next);
         }
     } else {
-        if (next != Py_None)
+        if (!Py_IsNone(next))
             goto err; /* shouldn't have a next if we are not full */
     }
     return (PyObject*)tdo;
@@ -1538,7 +1538,7 @@ islice_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     numargs = PyTuple_Size(args);
     if (numargs == 2) {
-        if (a1 != Py_None) {
+        if (!Py_IsNone(a1)) {
             stop = PyNumber_AsSsize_t(a1, PyExc_OverflowError);
             if (stop == -1) {
                 if (PyErr_Occurred())
@@ -1550,11 +1550,11 @@ islice_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             }
         }
     } else {
-        if (a1 != Py_None)
+        if (!Py_IsNone(a1))
             start = PyNumber_AsSsize_t(a1, PyExc_OverflowError);
         if (start == -1 && PyErr_Occurred())
             PyErr_Clear();
-        if (a2 != Py_None) {
+        if (!Py_IsNone(a2)) {
             stop = PyNumber_AsSsize_t(a2, PyExc_OverflowError);
             if (stop == -1) {
                 if (PyErr_Occurred())
@@ -1574,7 +1574,7 @@ islice_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     }
 
     if (a3 != NULL) {
-        if (a3 != Py_None)
+        if (!Py_IsNone(a3))
             step = PyNumber_AsSsize_t(a3, PyExc_OverflowError);
         if (step == -1 && PyErr_Occurred())
             PyErr_Clear();
@@ -2791,7 +2791,7 @@ itertools_permutations_impl(PyTypeObject *type, PyObject *iterable,
     n = PyTuple_GET_SIZE(pool);
 
     r = n;
-    if (robj != Py_None) {
+    if (!Py_IsNone(robj)) {
         if (!PyLong_Check(robj)) {
             PyErr_SetString(PyExc_TypeError, "Expected int as r");
             goto error;
@@ -3045,7 +3045,7 @@ itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
         return NULL;
     }
 
-    if (binop != Py_None) {
+    if (!Py_IsNone(binop)) {
         lz->binop = Py_XNewRef(binop);
     }
     lz->total = NULL;
@@ -3087,7 +3087,7 @@ accumulate_next_lock_held(PyObject *op)
     accumulateobject *lz = accumulateobject_CAST(op);
     PyObject *val, *newtotal;
 
-    if (lz->initial != Py_None) {
+    if (!Py_IsNone(lz->initial)) {
         lz->total = lz->initial;
         lz->initial = Py_NewRef(Py_None);
         return Py_NewRef(lz->total);
@@ -3363,7 +3363,7 @@ filterfalse_next(PyObject *op)
         if (item == NULL)
             return NULL;
 
-        if (lz->func == Py_None || lz->func == (PyObject *)&PyBool_Type) {
+        if (Py_IsNone(lz->func) || lz->func == (PyObject *)&PyBool_Type) {
             ok = PyObject_IsTrue(item);
         } else {
             PyObject *good;

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -251,7 +251,7 @@ readline_read_init_file_impl(PyObject *module, PyObject *filename_obj)
 /*[clinic end generated code: output=8e059b676142831e input=62b767adfab6cc15]*/
 {
     PyObject *filename_bytes;
-    if (filename_obj != Py_None) {
+    if (!Py_IsNone(filename_obj)) {
         if (!PyUnicode_FSConverter(filename_obj, &filename_bytes))
             return NULL;
         if (PySys_Audit("open", "OCi", filename_obj, 'r', 0) < 0) {
@@ -295,7 +295,7 @@ readline_read_history_file_impl(PyObject *module, PyObject *filename_obj)
 /*[clinic end generated code: output=66a951836fb54fbb input=5d86fd7813172a67]*/
 {
     PyObject *filename_bytes;
-    if (filename_obj != Py_None) {
+    if (!Py_IsNone(filename_obj)) {
         if (!PyUnicode_FSConverter(filename_obj, &filename_bytes))
             return NULL;
         if (PySys_Audit("open", "OCi", filename_obj, 'r', 0) < 0) {
@@ -340,7 +340,7 @@ readline_write_history_file_impl(PyObject *module, PyObject *filename_obj)
     PyObject *filename_bytes;
     const char *filename;
     int err;
-    if (filename_obj != Py_None) {
+    if (!Py_IsNone(filename_obj)) {
         if (!PyUnicode_FSConverter(filename_obj, &filename_bytes))
             return NULL;
         filename = PyBytes_AS_STRING(filename_bytes);
@@ -398,7 +398,7 @@ readline_append_history_file_impl(PyObject *module, int nelements,
     PyObject *filename_bytes;
     const char *filename;
     int err;
-    if (filename_obj != Py_None) {
+    if (!Py_IsNone(filename_obj)) {
         if (!PyUnicode_FSConverter(filename_obj, &filename_bytes))
             return NULL;
         filename = PyBytes_AS_STRING(filename_bytes);
@@ -473,7 +473,7 @@ readline_get_history_length_impl(PyObject *module)
 static PyObject *
 set_hook(const char *funcname, PyObject **hook_var, PyObject *function)
 {
-    if (function == Py_None) {
+    if (Py_IsNone(function)) {
         Py_CLEAR(*hook_var);
     }
     else if (PyCallable_Check(function)) {
@@ -1116,7 +1116,7 @@ on_hook(PyObject *func)
         r = PyObject_CallNoArgs(func);
         if (r == NULL)
             goto error;
-        if (r == Py_None)
+        if (Py_IsNone(r))
             result = 0;
         else {
             result = PyLong_AsInt(r);
@@ -1206,7 +1206,7 @@ on_completion_display_matches_hook(char **matches,
     m=NULL;
 
     if (r == NULL ||
-        (r != Py_None && PyLong_AsLong(r) == -1 && PyErr_Occurred())) {
+        (!Py_IsNone(r) && PyLong_AsLong(r) == -1 && PyErr_Occurred())) {
         goto error;
     }
     Py_CLEAR(r);
@@ -1261,7 +1261,7 @@ on_completion(const char *text, int state)
         r = PyObject_CallFunction(module_state->completer, "Ni", t, state);
         if (r == NULL)
             goto error;
-        if (r == Py_None) {
+        if (Py_IsNone(r)) {
             result = NULL;
         }
         else {

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -300,7 +300,7 @@ select_select_impl(PyObject *module, PyObject *rlist, PyObject *wlist,
     int n;
     PyTime_t timeout, deadline = 0;
 
-    if (timeout_obj == Py_None)
+    if (Py_IsNone(timeout_obj))
         tvp = (struct timeval *)NULL;
     else {
         if (_PyTime_FromSecondsObject(&timeout, timeout_obj,
@@ -630,7 +630,7 @@ select_poll_poll_impl(pollObject *self, PyObject *timeout_obj)
     PyTime_t timeout = -1, deadline = 0;
     int async_err = 0;
 
-    if (timeout_obj != Py_None) {
+    if (!Py_IsNone(timeout_obj)) {
         if (_PyTime_FromMillisecondsObject(&timeout, timeout_obj,
                                            _PyTime_ROUND_TIMEOUT) < 0) {
             if (PyErr_ExceptionMatches(PyExc_TypeError)) {
@@ -645,7 +645,7 @@ select_poll_poll_impl(pollObject *self, PyObject *timeout_obj)
 #ifdef HAVE_PPOLL
     struct timespec ts, *ts_p = NULL;
 
-    if (timeout_obj != Py_None) {
+    if (!Py_IsNone(timeout_obj)) {
         if (_PyTime_AsTimespec(timeout, &ts) < 0) {
             return NULL;
         }
@@ -657,7 +657,7 @@ select_poll_poll_impl(pollObject *self, PyObject *timeout_obj)
 #else
     PyTime_t ms = -1;
 
-    if (timeout_obj != Py_None) {
+    if (!Py_IsNone(timeout_obj)) {
         ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_TIMEOUT);
         if (ms < INT_MIN || ms > INT_MAX) {
             PyErr_SetString(PyExc_OverflowError, "timeout is too large");
@@ -999,7 +999,7 @@ select_devpoll_poll_impl(devpollObject *self, PyObject *timeout_obj)
         return devpoll_err_closed();
 
     /* Check values for timeout */
-    if (timeout_obj == Py_None) {
+    if (Py_IsNone(timeout_obj)) {
         timeout = -1;
         ms = -1;
     }
@@ -1622,7 +1622,7 @@ select_epoll_poll_impl(pyEpoll_Object *self, PyObject *timeout_obj,
     if (self->epfd < 0)
         return pyepoll_err_closed();
 
-    if (timeout_obj != Py_None) {
+    if (!Py_IsNone(timeout_obj)) {
         /* epoll_wait() has a resolution of 1 millisecond, round towards
            infinity to wait at least timeout seconds. */
         if (_PyTime_FromSecondsObject(&timeout, timeout_obj,
@@ -2359,7 +2359,7 @@ select_kqueue_control_impl(kqueue_queue_Object *self, PyObject *changelist,
         return NULL;
     }
 
-    if (otimeout == Py_None) {
+    if (Py_IsNone(otimeout)) {
         ptimeoutspec = NULL;
     }
     else {
@@ -2382,7 +2382,7 @@ select_kqueue_control_impl(kqueue_queue_Object *self, PyObject *changelist,
         ptimeoutspec = &timeoutspec;
     }
 
-    if (changelist != Py_None) {
+    if (!Py_IsNone(changelist)) {
         seq = PySequence_Fast(changelist, "changelist is not iterable");
         if (seq == NULL) {
             return NULL;

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -1320,7 +1320,7 @@ signal_pidfd_send_signal_impl(PyObject *module, int pidfd, int signalnum,
 /*[clinic end generated code: output=2d59f04a75d9cbdf input=2a6543a1f4ac2000]*/
 
 {
-    if (siginfo != Py_None) {
+    if (!Py_IsNone(siginfo)) {
         PyErr_SetString(PyExc_TypeError, "siginfo must be None");
         return NULL;
     }
@@ -1738,7 +1738,7 @@ _PySignal_Fini(void)
         _Py_atomic_store_int_relaxed(&Handlers[signum].tripped, 0);
         set_handler(signum, NULL);
         if (func != NULL
-            && func != Py_None
+            && !Py_IsNone(func)
             && !compare_handler(func, state->default_handler)
             && !compare_handler(func, state->ignore_handler))
         {
@@ -1836,7 +1836,7 @@ _PyErr_CheckSignalsTstate(PyThreadState *tstate)
          * (see bpo-43406).
          */
         PyObject *func = get_handler(i);
-        if (func == NULL || func == Py_None ||
+        if (func == NULL || Py_IsNone(func) ||
             compare_handler(func, state->ignore_handler) ||
             compare_handler(func, state->default_handler)) {
             /* No Python signal handler due to aforementioned race condition.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3216,7 +3216,7 @@ socket_parse_timeout(PyTime_t *timeout, PyObject *timeout_obj)
 #endif
     int overflow = 0;
 
-    if (timeout_obj == Py_None) {
+    if (Py_IsNone(timeout_obj)) {
         *timeout = _PyTime_FromSeconds(-1);
         return 0;
     }
@@ -3363,12 +3363,12 @@ sock_setsockopt(PyObject *self, PyObject *args)
     }
 
     arglen = PyTuple_Size(args);
-    if (arglen == 3 && optval == Py_None) {
+    if (arglen == 3 && Py_IsNone(optval)) {
         PyErr_Format(PyExc_TypeError,
                      "setsockopt() requires 4 arguments when the third argument is None");
         return NULL;
     }
-    if (arglen == 4 && optval != Py_None) {
+    if (arglen == 4 && !Py_IsNone(optval)) {
         PyErr_Format(PyExc_TypeError,
                      "setsockopt() only takes 4 arguments when the third argument is None (got %T)",
                      optval);
@@ -3416,7 +3416,7 @@ sock_setsockopt(PyObject *self, PyObject *args)
     }
 
     /* setsockopt(level, opt, None, optlen) */
-    if (optval == Py_None) {
+    if (Py_IsNone(optval)) {
         assert(sizeof(socklen_t) >= sizeof(unsigned int));
         res = setsockopt(get_sock_fd(s), level, optname,
                          NULL, (socklen_t)optlen);
@@ -4966,7 +4966,7 @@ _socket_socket_sendmsg_impl(PySocketSockObject *s, PyObject *data_arg,
     memset(&msg, 0, sizeof(msg));
 
     /* Parse destination address. */
-    if (addr_arg != NULL && addr_arg != Py_None) {
+    if (addr_arg != NULL && !Py_IsNone(addr_arg)) {
         if (!getsockaddrarg(s, addr_arg, &addrbuf, &addrlen,
                             "sendmsg"))
         {
@@ -5654,7 +5654,7 @@ sock_initobj_impl(PySocketSockObject *self, int family, int type, int proto,
 
 #ifdef MS_WINDOWS
     /* In this case, we don't use the family, type and proto args */
-    if (fdobj == NULL || fdobj == Py_None)
+    if (fdobj == NULL || Py_IsNone(fdobj))
 #endif
     {
         if (PySys_Audit("socket.__new__", "Oiii",
@@ -5663,7 +5663,7 @@ sock_initobj_impl(PySocketSockObject *self, int family, int type, int proto,
         }
     }
 
-    if (fdobj != NULL && fdobj != Py_None) {
+    if (fdobj != NULL && !Py_IsNone(fdobj)) {
 #ifdef MS_WINDOWS
         /* recreate a socket that was duplicated */
         if (PyBytes_Check(fdobj)) {
@@ -6937,7 +6937,7 @@ socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
                           &protocol, &flags)) {
         return NULL;
     }
-    if (hobj == Py_None) {
+    if (Py_IsNone(hobj)) {
         hptr = NULL;
     } else if (PyUnicode_Check(hobj)) {
         idna = PyUnicode_AsEncodedString(hobj, "idna", NULL);
@@ -6970,7 +6970,7 @@ socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
             goto err;
     } else if (PyBytes_Check(pobj)) {
         pptr = PyBytes_AS_STRING(pobj);
-    } else if (pobj == Py_None) {
+    } else if (Py_IsNone(pobj)) {
         pptr = (char *)NULL;
     } else {
         PyErr_SetString(PyExc_OSError, "Int or String expected");


### PR DESCRIPTION
## Summary

Modernize None identity checks in high-traffic `Modules/` sources (`_asyncio`, `_pickle`, `_json`, `_elementtree`, `itertools`, `_thread`, `_functools`, `socket`, `select`, etc.) to use `Py_IsNone()` consistently with core interpreter style.

No behavior change intended.

## Test plan

- [x] Local build on sibling branches
- [ ] Broader module tests in CI