### PR TITLE
Use Py_IsNone() for None identity checks in Python/

### DIFF
--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -178,7 +178,7 @@ check_matched(PyInterpreterState *interp, PyObject *obj, PyObject *arg, PyObject
     int rc;
 
     /* A 'None' filter always matches */
-    if (obj == Py_None)
+    if (Py_IsNone(obj))
         return 1;
 
     /* An internal plain text default filter must match exactly */
@@ -298,7 +298,7 @@ get_warnings_context_filters(PyInterpreterState *interp)
     if (ctx == NULL) {
         return NULL;
     }
-    if (ctx == Py_None) {
+    if (Py_IsNone(ctx)) {
         Py_RETURN_NONE;
     }
     PyObject *context_filters = PyObject_GetAttr(ctx, &_Py_ID(_filters));
@@ -531,7 +531,7 @@ get_filter(PyInterpreterState *interp, PyObject *category,
         return NULL;
     }
     bool use_global_filters = false;
-    if (context_filters == Py_None) {
+    if (Py_IsNone(context_filters)) {
         use_global_filters = true;
     } else {
         PyObject *context_action = NULL;
@@ -785,10 +785,10 @@ warn_explicit(PyThreadState *tstate, PyObject *category, PyObject *message,
        In this case, the Python warnings module was probably unloaded, filters
        are no more available to choose as action. It is safer to ignore the
        warning and do nothing. */
-    if (module == Py_None)
+    if (Py_IsNone(module))
         Py_RETURN_NONE;
 
-    if (registry && !PyDict_Check(registry) && (registry != Py_None)) {
+    if (registry && !PyDict_Check(registry) && (!Py_IsNone(registry))) {
         PyErr_SetString(PyExc_TypeError, "'registry' must be a dict or None");
         return NULL;
     }
@@ -812,7 +812,7 @@ warn_explicit(PyThreadState *tstate, PyObject *category, PyObject *message,
     if (lineno_obj == NULL)
         goto cleanup;
 
-    if (source == Py_None) {
+    if (Py_IsNone(source)) {
         source = NULL;
     }
 
@@ -821,7 +821,7 @@ warn_explicit(PyThreadState *tstate, PyObject *category, PyObject *message,
     if (key == NULL)
         goto cleanup;
 
-    if ((registry != NULL) && (registry != Py_None)) {
+    if ((registry != NULL) && (!Py_IsNone(registry))) {
         rc = already_warned(interp, registry, key, 0);
         if (rc == -1)
             goto cleanup;
@@ -847,14 +847,14 @@ warn_explicit(PyThreadState *tstate, PyObject *category, PyObject *message,
        is "always" or "all". */
     rc = 0;
     if (!_PyUnicode_EqualToASCIIString(action, "always") && !_PyUnicode_EqualToASCIIString(action, "all")) {
-        if (registry != NULL && registry != Py_None &&
+        if (registry != NULL && !Py_IsNone(registry) &&
             PyDict_SetItem(registry, key, Py_True) < 0)
         {
             goto cleanup;
         }
 
         if (_PyUnicode_EqualToASCIIString(action, "once")) {
-            if (registry == NULL || registry == Py_None) {
+            if (registry == NULL || Py_IsNone(registry)) {
                 registry = get_once_registry(interp);
                 if (registry == NULL)
                     goto cleanup;
@@ -864,7 +864,7 @@ warn_explicit(PyThreadState *tstate, PyObject *category, PyObject *message,
         }
         else if (_PyUnicode_EqualToASCIIString(action, "module")) {
             /* registry[(text, category, 0)] = 1 */
-            if (registry != NULL && registry != Py_None)
+            if (registry != NULL && !Py_IsNone(registry))
                 rc = update_registry(interp, registry, text, category, 0);
         }
         else if (!_PyUnicode_EqualToASCIIString(action, "default")) {
@@ -1095,7 +1095,7 @@ get_category(PyObject *message, PyObject *category)
         /* Ignore the category argument. */
         return (PyObject*)Py_TYPE(message);
     }
-    if (category == NULL || category == Py_None) {
+    if (category == NULL || Py_IsNone(category)) {
         return PyExc_UserWarning;
     }
 
@@ -1221,7 +1221,7 @@ get_source_line(PyInterpreterState *interp, PyObject *module_globals, int lineno
     if (!source) {
         return NULL;
     }
-    if (source == Py_None) {
+    if (Py_IsNone(source)) {
         Py_DECREF(source);
         return NULL;
     }
@@ -1270,7 +1270,7 @@ warnings_warn_explicit_impl(PyObject *module, PyObject *message,
         return NULL;
     }
 
-    if (module_globals && module_globals != Py_None) {
+    if (module_globals && !Py_IsNone(module_globals)) {
         if (!PyAnyDict_Check(module_globals)) {
             PyErr_Format(PyExc_TypeError,
                          "module_globals must be a dict or a frozendict, "

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -157,7 +157,7 @@ static int
 validate_constant(PyObject *value)
 {
     assert(!PyErr_Occurred());
-    if (value == Py_None || value == Py_Ellipsis)
+    if (Py_IsNone(value) || value == Py_Ellipsis)
         return 1;
 
     if (PyLong_CheckExact(value)
@@ -560,7 +560,7 @@ validate_pattern(pattern_ty p, int star_ok)
             ret = validate_pattern_match_value(p->v.MatchValue.value);
             break;
         case MatchSingleton_kind:
-            ret = p->v.MatchSingleton.value == Py_None || PyBool_Check(p->v.MatchSingleton.value);
+            ret = Py_IsNone(p->v.MatchSingleton.value) || PyBool_Check(p->v.MatchSingleton.value);
             if (!ret) {
                 PyErr_SetString(PyExc_ValueError,
                                 "MatchSingleton can only contain True, False and None");
@@ -587,7 +587,7 @@ validate_pattern(pattern_ty p, int star_ok)
                 expr_ty key = asdl_seq_GET(keys, i);
                 if (key->kind == Constant_kind) {
                     PyObject *literal = key->v.Constant.value;
-                    if (literal == Py_None || PyBool_Check(literal)) {
+                    if (Py_IsNone(literal) || PyBool_Check(literal)) {
                         /* validate_pattern_match_value will ensure the key
                            doesn't contain True, False and None but it is
                            syntactically valid, so we will pass those on in

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -656,7 +656,7 @@ filter_next(PyObject *self)
     PyObject *it = lz->it;
     long ok;
     PyObject *(*iternext)(PyObject *);
-    int checktrue = lz->func == Py_None || lz->func == (PyObject *)&PyBool_Type;
+    int checktrue = Py_IsNone(lz->func) || lz->func == (PyObject *)&PyBool_Type;
 
     iternext = *Py_TYPE(it)->tp_iternext;
     for (;;) {
@@ -873,7 +873,7 @@ builtin_compile_impl(PyObject *module, PyObject *source, PyObject *filename,
                         "compile(): invalid optimize value");
         goto error;
     }
-    if (modname == Py_None) {
+    if (Py_IsNone(modname)) {
         modname = NULL;
     }
     else if (!PyUnicode_Check(modname)) {
@@ -1046,11 +1046,11 @@ builtin_eval_impl(PyObject *module, PyObject *source, PyObject *globals,
     PyObject *result = NULL, *source_copy;
     const char *str;
 
-    if (locals != Py_None && !PyMapping_Check(locals)) {
+    if (!Py_IsNone(locals) && !PyMapping_Check(locals)) {
         PyErr_SetString(PyExc_TypeError, "locals must be a mapping");
         return NULL;
     }
-    if (globals != Py_None && !PyAnyDict_Check(globals)) {
+    if (!Py_IsNone(globals) && !PyAnyDict_Check(globals)) {
         PyErr_SetString(PyExc_TypeError, PyMapping_Check(globals) ?
             "globals must be a real dict or a frozendict; "
             "try eval(expr, {}, mapping)"
@@ -1059,7 +1059,7 @@ builtin_eval_impl(PyObject *module, PyObject *source, PyObject *globals,
     }
 
     int fromframe = 0;
-    if (globals != Py_None) {
+    if (!Py_IsNone(globals)) {
         Py_INCREF(globals);
     }
     else if (_PyEval_GetFrame() != NULL) {
@@ -1081,7 +1081,7 @@ builtin_eval_impl(PyObject *module, PyObject *source, PyObject *globals,
         Py_INCREF(globals);
     }
 
-    if (locals != Py_None) {
+    if (!Py_IsNone(locals)) {
         Py_INCREF(locals);
     }
     else if (fromframe) {
@@ -1172,7 +1172,7 @@ builtin_exec_impl(PyObject *module, PyObject *source, PyObject *globals,
     PyObject *v;
 
     int fromframe = 0;
-    if (globals != Py_None) {
+    if (!Py_IsNone(globals)) {
         Py_INCREF(globals);
     }
     else if (_PyEval_GetFrame() != NULL) {
@@ -1193,7 +1193,7 @@ builtin_exec_impl(PyObject *module, PyObject *source, PyObject *globals,
         Py_INCREF(globals);
     }
 
-    if (locals != Py_None) {
+    if (!Py_IsNone(locals)) {
         Py_INCREF(locals);
     }
     else if (fromframe) {
@@ -1225,7 +1225,7 @@ builtin_exec_impl(PyObject *module, PyObject *source, PyObject *globals,
         goto error;
     }
 
-    if (closure == Py_None) {
+    if (Py_IsNone(closure)) {
         closure = NULL;
     }
 
@@ -2078,7 +2078,7 @@ min_max(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames, int op)
         }
     }
 
-    if (keyfunc == Py_None) {
+    if (Py_IsNone(keyfunc)) {
         keyfunc = NULL;
     }
 
@@ -2320,14 +2320,14 @@ builtin_print_impl(PyObject *module, PyObject * const *objects,
 {
     int i, err;
 
-    if (file == Py_None) {
+    if (Py_IsNone(file)) {
         file = PySys_GetAttr(&_Py_ID(stdout));
         if (file == NULL) {
             return NULL;
         }
 
         /* sys.stdout may be None when FILE* stdout isn't connected */
-        if (file == Py_None) {
+        if (Py_IsNone(file)) {
             Py_DECREF(file);
             Py_RETURN_NONE;
         }
@@ -2336,7 +2336,7 @@ builtin_print_impl(PyObject *module, PyObject * const *objects,
         Py_INCREF(file);
     }
 
-    if (sep == Py_None) {
+    if (Py_IsNone(sep)) {
         sep = NULL;
     }
     else if (sep && !PyUnicode_Check(sep)) {
@@ -2346,7 +2346,7 @@ builtin_print_impl(PyObject *module, PyObject * const *objects,
         Py_DECREF(file);
         return NULL;
     }
-    if (end == Py_None) {
+    if (Py_IsNone(end)) {
         end = NULL;
     }
     else if (end && !PyUnicode_Check(end)) {
@@ -2432,7 +2432,7 @@ builtin_input_impl(PyObject *module, PyObject *prompt)
     if (fin == NULL) {
         goto error;
     }
-    if (fin == Py_None) {
+    if (Py_IsNone(fin)) {
         PyErr_SetString(PyExc_RuntimeError, "lost sys.stdin");
         goto error;
     }
@@ -2440,7 +2440,7 @@ builtin_input_impl(PyObject *module, PyObject *prompt)
     if (fout == NULL) {
         goto error;
     }
-    if (fout == Py_None) {
+    if (Py_IsNone(fout)) {
         PyErr_SetString(PyExc_RuntimeError, "lost sys.stdout");
         goto error;
     }
@@ -2448,7 +2448,7 @@ builtin_input_impl(PyObject *module, PyObject *prompt)
     if (ferr == NULL) {
         goto error;
     }
-    if (ferr == Py_None) {
+    if (Py_IsNone(ferr)) {
         PyErr_SetString(PyExc_RuntimeError, "lost sys.stderr");
         goto error;
     }
@@ -2696,7 +2696,7 @@ builtin_round_impl(PyObject *module, PyObject *number, PyObject *ndigits)
 /*[clinic end generated code: output=ff0d9dd176c02ede input=bdcb7c67bf4a4320]*/
 {
     PyObject *result;
-    if (ndigits == Py_None) {
+    if (Py_IsNone(ndigits)) {
         result = _PyObject_MaybeCallSpecialNoArgs(number, &_Py_ID(__round__));
     }
     else {

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -187,7 +187,7 @@ PyObject *_PyCodec_Lookup(const char *encoding)
         Py_DECREF(func);
         if (result == NULL)
             goto onError;
-        if (result == Py_None) {
+        if (Py_IsNone(result)) {
             Py_CLEAR(result);
             continue;
         }

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -1867,7 +1867,7 @@ check_is_arg(expr_ty e)
         return true;
     }
     PyObject *value = e->v.Constant.value;
-    return (value == Py_None
+    return (Py_IsNone(value)
          || value == Py_False
          || value == Py_True
          || value == Py_Ellipsis);
@@ -3769,7 +3769,7 @@ check_subscripter(compiler *c, expr_ty e)
     switch (e->kind) {
     case Constant_kind:
         v = e->v.Constant.value;
-        if (!(v == Py_None || v == Py_Ellipsis ||
+        if (!(Py_IsNone(v) || v == Py_Ellipsis ||
               PyLong_Check(v) || PyFloat_Check(v) || PyComplex_Check(v) ||
               PyAnySet_Check(v)))
         {

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -340,7 +340,7 @@ const_cache_insert(PyObject *const_cache, PyObject *o, bool recursive)
     assert(PyDict_CheckExact(const_cache));
     // None and Ellipsis are immortal objects, and key is the singleton.
     // No need to merge object and key.
-    if (o == Py_None || o == Py_Ellipsis) {
+    if (Py_IsNone(o) || o == Py_Ellipsis) {
         return o;
     }
 

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -649,7 +649,7 @@ check_missing___main___attr(PyObject *exc)
 
     // Get the error message.
     PyObject *args = PyException_GetArgs(exc);
-    if (args == NULL || args == Py_None || PyObject_Size(args) < 1) {
+    if (args == NULL || Py_IsNone(args) || PyObject_Size(args) < 1) {
         Py_XDECREF(args);
         assert(!PyErr_Occurred());
         return 0;
@@ -1683,7 +1683,7 @@ _PyXI_excinfo *
 _PyXI_NewExcInfo(PyObject *exc)
 {
     assert(!PyErr_Occurred());
-    if (exc == NULL || exc == Py_None) {
+    if (exc == NULL || Py_IsNone(exc)) {
         PyErr_SetString(PyExc_ValueError, "missing exc");
         return NULL;
     }

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -33,7 +33,7 @@ _PyErr_CreateException(PyObject *exception_type, PyObject *value)
 {
     PyObject *exc;
 
-    if (value == NULL || value == Py_None) {
+    if (value == NULL || Py_IsNone(value)) {
         exc = _PyObject_CallNoArgs(exception_type);
     }
     else if (PyTuple_Check(value)) {
@@ -69,7 +69,7 @@ _PyErr_Restore(PyThreadState *tstate, PyObject *type, PyObject *value,
         /* Already normalized */
 #ifdef Py_DEBUG
         PyObject *tb = PyException_GetTraceback(value);
-        assert(tb != Py_None);
+        assert(!Py_IsNone(tb));
         Py_XDECREF(tb);
 #endif
     }
@@ -196,7 +196,7 @@ _PyErr_SetObject(PyThreadState *tstate, PyObject *exception, PyObject *value)
     }
 
     exc_value = _PyErr_GetTopmostException(tstate)->exc_value;
-    if (exc_value != NULL && exc_value != Py_None) {
+    if (exc_value != NULL && !Py_IsNone(exc_value)) {
         /* Implicit exception chaining */
         Py_INCREF(exc_value);
         /* Avoid creating new reference cycles through the
@@ -551,7 +551,7 @@ PyErr_Clear(void)
 static PyObject*
 get_exc_type(PyObject *exc_value)  /* returns a strong ref */
 {
-    if (exc_value == NULL || exc_value == Py_None) {
+    if (exc_value == NULL || Py_IsNone(exc_value)) {
         return Py_None;
     }
     else {
@@ -565,7 +565,7 @@ get_exc_type(PyObject *exc_value)  /* returns a strong ref */
 static PyObject*
 get_exc_traceback(PyObject *exc_value)  /* returns a strong ref */
 {
-    if (exc_value == NULL || exc_value == Py_None) {
+    if (exc_value == NULL || Py_IsNone(exc_value)) {
         return Py_None;
     }
     else {
@@ -591,7 +591,7 @@ _PyErr_GetHandledException(PyThreadState *tstate)
 {
     _PyErr_StackItem *exc_info = _PyErr_GetTopmostException(tstate);
     PyObject *exc = exc_info->exc_value;
-    if (exc == NULL || exc == Py_None) {
+    if (exc == NULL || Py_IsNone(exc)) {
         return NULL;
     }
     return Py_NewRef(exc);
@@ -607,7 +607,7 @@ PyErr_GetHandledException(void)
 void
 _PyErr_SetHandledException(PyThreadState *tstate, PyObject *exc)
 {
-    Py_XSETREF(tstate->exc_info->exc_value, Py_XNewRef(exc == Py_None ? NULL : exc));
+    Py_XSETREF(tstate->exc_info->exc_value, Py_XNewRef(Py_IsNone(exc) ? NULL : exc));
 }
 
 void
@@ -641,7 +641,7 @@ _PyErr_StackItemToExcInfoTuple(_PyErr_StackItem *err_info)
     PyObject *exc_value = err_info->exc_value;
 
     assert(exc_value == NULL ||
-           exc_value == Py_None ||
+           Py_IsNone(exc_value) ||
            PyExceptionInstance_Check(exc_value));
 
     PyObject *ret = PyTuple_New(3);
@@ -738,7 +738,7 @@ _PyErr_ChainStackItem(void)
     assert(_PyErr_Occurred(tstate));
 
     _PyErr_StackItem *exc_info = tstate->exc_info;
-    if (exc_info->exc_value == NULL || exc_info->exc_value == Py_None) {
+    if (exc_info->exc_value == NULL || Py_IsNone(exc_info->exc_value)) {
         return;
     }
 
@@ -1464,8 +1464,8 @@ write_unraisable_exc_file(PyThreadState *tstate, PyObject *exc_type,
     assert(file != NULL);
     assert(!Py_IsNone(file));
 
-    if (obj != NULL && obj != Py_None) {
-        if (err_msg != NULL && err_msg != Py_None) {
+    if (obj != NULL && !Py_IsNone(obj)) {
+        if (err_msg != NULL && !Py_IsNone(err_msg)) {
             if (PyFile_WriteObject(err_msg, file, Py_PRINT_RAW) < 0) {
                 return -1;
             }
@@ -1489,7 +1489,7 @@ write_unraisable_exc_file(PyThreadState *tstate, PyObject *exc_type,
             return -1;
         }
     }
-    else if (err_msg != NULL && err_msg != Py_None) {
+    else if (err_msg != NULL && !Py_IsNone(err_msg)) {
         if (PyFile_WriteObject(err_msg, file, Py_PRINT_RAW) < 0) {
             return -1;
         }
@@ -1519,14 +1519,14 @@ write_unraisable_exc_file(PyThreadState *tstate, PyObject *exc_type,
     // traceback module failed, fall back to pure C
     _PyErr_Clear(tstate);
 
-    if (exc_tb != NULL && exc_tb != Py_None) {
+    if (exc_tb != NULL && !Py_IsNone(exc_tb)) {
         if (PyTraceBack_Print(exc_tb, file) < 0) {
             /* continue even if writing the traceback failed */
             _PyErr_Clear(tstate);
         }
     }
 
-    if (exc_type == NULL || exc_type == Py_None) {
+    if (exc_type == NULL || Py_IsNone(exc_type)) {
         return -1;
     }
 
@@ -1573,7 +1573,7 @@ write_unraisable_exc_file(PyThreadState *tstate, PyObject *exc_type,
         Py_DECREF(qualname);
     }
 
-    if (exc_value && exc_value != Py_None) {
+    if (exc_value && !Py_IsNone(exc_value)) {
         if (PyFile_WriteString(": ", file) < 0) {
             return -1;
         }
@@ -1607,7 +1607,7 @@ write_unraisable_exc(PyThreadState *tstate, PyObject *exc_type,
     if (PySys_GetOptionalAttr(&_Py_ID(stderr), &file) < 0) {
         return -1;
     }
-    if (file == NULL || file == Py_None) {
+    if (file == NULL || Py_IsNone(file)) {
         Py_XDECREF(file);
         return 0;
     }
@@ -1690,7 +1690,7 @@ format_unraisable_v(const char *format, va_list va, PyObject *obj)
 
     _PyErr_NormalizeException(tstate, &exc_type, &exc_value, &exc_tb);
 
-    if (exc_tb != NULL && exc_tb != Py_None && PyTraceBack_Check(exc_tb)) {
+    if (exc_tb != NULL && !Py_IsNone(exc_tb) && PyTraceBack_Check(exc_tb)) {
         if (PyException_SetTraceback(exc_value, exc_tb) < 0) {
             _PyErr_Clear(tstate);
         }
@@ -1729,7 +1729,7 @@ format_unraisable_v(const char *format, va_list va, PyObject *obj)
         goto error;
     }
 
-    if (hook == Py_None) {
+    if (Py_IsNone(hook)) {
         Py_DECREF(hook_args);
         goto default_hook;
     }

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1456,7 +1456,7 @@ static int
 maybe_instr_make_load_common_const(cfg_instr *instr, PyObject *newconst)
 {
     int oparg;
-    if (newconst == Py_None) {
+    if (Py_IsNone(newconst)) {
         oparg = CONSTANT_NONE;
     }
     else if (newconst == Py_True) {

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -856,7 +856,7 @@ handle_weakref_callbacks(PyGC_Head *unreachable, PyGC_Head *old)
             // callback pointer intact.  Obscure: it also changes *wrlist.
             _PyObject_ASSERT((PyObject *)wr, wr->wr_object == op);
             _PyWeakref_ClearRef(wr);
-            _PyObject_ASSERT((PyObject *)wr, wr->wr_object == Py_None);
+            _PyObject_ASSERT((PyObject *)wr, Py_IsNone(wr->wr_object));
 
             /* Headache time.  `op` is going away, and is weakly referenced by
              * `wr`, which has a callback.  Should the callback be invoked?  If wr
@@ -996,7 +996,7 @@ clear_weakrefs(PyGC_Head *unreachable)
              */
             _PyObject_ASSERT((PyObject *)wr, wr->wr_object == op);
             _PyWeakref_ClearRef(wr);
-            _PyObject_ASSERT((PyObject *)wr, wr->wr_object == Py_None);
+            _PyObject_ASSERT((PyObject *)wr, Py_IsNone(wr->wr_object));
         }
     }
 }

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1571,7 +1571,7 @@ find_weakref_callbacks(struct collection_state *state)
                 // callback pointer intact.  Obscure: it also changes *wrlist.
                 _PyObject_ASSERT((PyObject *)wr, wr->wr_object == op);
                 _PyWeakref_ClearRef(wr);
-                _PyObject_ASSERT((PyObject *)wr, wr->wr_object == Py_None);
+                _PyObject_ASSERT((PyObject *)wr, Py_IsNone(wr->wr_object));
             }
 
             // We do not invoke callbacks for weakrefs that are themselves
@@ -1621,7 +1621,7 @@ clear_weakrefs(struct collection_state *state)
             // changes *wrlist.
             _PyObject_ASSERT((PyObject *)wr, wr->wr_object == op);
             _PyWeakref_ClearRef(wr);
-            _PyObject_ASSERT((PyObject *)wr, wr->wr_object == Py_None);
+            _PyObject_ASSERT((PyObject *)wr, Py_IsNone(wr->wr_object));
         }
     }
 }

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -566,7 +566,7 @@ converttuple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
         PyOS_snprintf(msgbuf, bufsize,
                       "must be %d-item tuple, not %.50s",
                   n,
-                  arg == Py_None ? "None" : Py_TYPE(arg)->tp_name);
+                  Py_IsNone(arg) ? "None" : Py_TYPE(arg)->tp_name);
         return msgbuf;
     }
     else {
@@ -666,7 +666,7 @@ _PyArg_BadArgument(const char *fname, const char *displayname,
     PyErr_Format(PyExc_TypeError,
                  "%.200s() %.200s must be %.50s, not %.50s",
                  fname, displayname, expected,
-                 arg == Py_None ? "None" : Py_TYPE(arg)->tp_name);
+                 Py_IsNone(arg) ? "None" : Py_TYPE(arg)->tp_name);
 }
 
 static const char *
@@ -681,7 +681,7 @@ converterr(const char *expected, PyObject *arg, char *msgbuf, size_t bufsize)
     else {
         PyOS_snprintf(msgbuf, bufsize,
                       "must be %.50s, not %.50s", expected,
-                      arg == Py_None ? "None" : Py_TYPE(arg)->tp_name);
+                      Py_IsNone(arg) ? "None" : Py_TYPE(arg)->tp_name);
     }
     return msgbuf;
 }
@@ -1046,7 +1046,7 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
             /* "s*" or "z*" */
             Py_buffer *p = (Py_buffer *)va_arg(*p_va, Py_buffer *);
 
-            if (c == 'z' && arg == Py_None)
+            if (c == 'z' && Py_IsNone(arg))
                 PyBuffer_FillInfo(p, NULL, NULL, 0, 1, 0);
             else if (PyUnicode_Check(arg)) {
                 Py_ssize_t len;
@@ -1072,7 +1072,7 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
             const void **p = (const void **)va_arg(*p_va, const char **);
             Py_ssize_t *psize = va_arg(*p_va, Py_ssize_t*);
 
-            if (c == 'z' && arg == Py_None) {
+            if (c == 'z' && Py_IsNone(arg)) {
                 *p = NULL;
                 *psize = 0;
             }
@@ -1100,7 +1100,7 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
             Py_ssize_t len;
             sarg = NULL;
 
-            if (c == 'z' && arg == Py_None)
+            if (c == 'z' && Py_IsNone(arg))
                 *p = NULL;
             else if (PyUnicode_Check(arg)) {
                 sarg = PyUnicode_AsUTF8AndSize(arg, &len);

--- a/Python/import.c
+++ b/Python/import.c
@@ -340,7 +340,7 @@ PyImport_GetModule(PyObject *name)
     PyObject *mod;
 
     mod = import_get_module(tstate, name);
-    if (mod != NULL && mod != Py_None) {
+    if (mod != NULL && !Py_IsNone(mod)) {
         if (import_ensure_initialized(tstate->interp, mod, name) < 0) {
             goto error;
         }
@@ -570,7 +570,7 @@ _modules_by_index_get(PyInterpreterState *interp, Py_ssize_t index)
         return NULL;
     }
     PyObject *res = PyList_GET_ITEM(MODULES_BY_INDEX(interp), index);
-    return res==Py_None ? NULL : res;
+    return Py_IsNone(res) ? NULL : res;
 }
 
 static int
@@ -3168,7 +3168,7 @@ find_frozen(PyObject *nameobj, struct frozen_info *info)
         memset(info, 0, sizeof(*info));
     }
 
-    if (nameobj == NULL || nameobj == Py_None) {
+    if (nameobj == NULL || Py_IsNone(nameobj)) {
         return FROZEN_BAD_NAME;
     }
     const char *name = _PyUnicode_AsUTF8NoNUL(nameobj);
@@ -3364,7 +3364,7 @@ bootstrap_imp(PyThreadState *tstate)
     if (mod == NULL) {
         goto error;
     }
-    assert(mod != Py_None);  // not found
+    assert(!Py_IsNone(mod));  // not found
 
     // Execute the _imp module: call imp_module_exec().
     if (exec_builtin_or_dynamic(mod) < 0) {
@@ -3745,7 +3745,7 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
     if (PyDict_GetItemRef(globals, &_Py_ID(__package__), &package) < 0) {
         goto error;
     }
-    if (package == Py_None) {
+    if (Py_IsNone(package)) {
         Py_DECREF(package);
         package = NULL;
     }
@@ -3759,7 +3759,7 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
                              "package must be a string");
             goto error;
         }
-        else if (spec != NULL && spec != Py_None) {
+        else if (spec != NULL && !Py_IsNone(spec)) {
             int equal;
             PyObject *parent = PyObject_GetAttr(spec, &_Py_ID(parent));
             if (parent == NULL) {
@@ -3779,7 +3779,7 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
             }
         }
     }
-    else if (spec != NULL && spec != Py_None) {
+    else if (spec != NULL && !Py_IsNone(spec)) {
         package = PyObject_GetAttr(spec, &_Py_ID(parent));
         if (package == NULL) {
             goto error;
@@ -4218,7 +4218,7 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
         goto error;
     }
 
-    if (mod != NULL && mod != Py_None) {
+    if (mod != NULL && !Py_IsNone(mod)) {
         if (import_ensure_initialized(tstate->interp, mod, abs_name) < 0) {
             goto error;
         }
@@ -4253,7 +4253,7 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
     }
 
     has_from = 0;
-    if (fromlist != NULL && fromlist != Py_None) {
+    if (fromlist != NULL && !Py_IsNone(fromlist)) {
         has_from = PyObject_IsTrue(fromlist);
         if (has_from < 0)
             goto error;
@@ -4956,7 +4956,7 @@ PyImport_ImportModuleAttrString(const char *modname, const char *attrname)
 int
 PyImport_SetLazyImportsFilter(PyObject *filter)
 {
-    if (filter == Py_None) {
+    if (Py_IsNone(filter)) {
         filter = NULL;
     }
     if (filter != NULL && !PyCallable_Check(filter)) {
@@ -5281,7 +5281,7 @@ _imp_get_frozen_object_impl(PyObject *module, PyObject *name,
         info.data = (const char *)buf.buf;
         info.size = buf.len;
     }
-    else if (dataobj != Py_None) {
+    else if (!Py_IsNone(dataobj)) {
         _PyArg_BadArgument("get_frozen_object", "argument 2", "bytes", dataobj);
         return NULL;
     }
@@ -5304,7 +5304,7 @@ _imp_get_frozen_object_impl(PyObject *module, PyObject *name,
 
     PyInterpreterState *interp = _PyInterpreterState_GET();
     PyObject *codeobj = unmarshal_frozen_code(interp, &info);
-    if (dataobj != Py_None) {
+    if (!Py_IsNone(dataobj)) {
         PyBuffer_Release(&buf);
     }
     return codeobj;

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -1498,7 +1498,7 @@ config_dict_get_wstr(PyObject *dict, const char *name, PyConfig *config,
     }
 
     PyStatus status;
-    if (item == Py_None) {
+    if (Py_IsNone(item)) {
         status = PyConfig_SetString(config, result, NULL);
     }
     else if (!PyUnicode_Check(item)) {
@@ -1547,7 +1547,7 @@ config_dict_get_wstrlist(PyObject *dict, const char *name, PyConfig *config,
     for (Py_ssize_t i=0; i < len; i++) {
         PyObject *item = is_list ? PyList_GET_ITEM(list, i) : PyTuple_GET_ITEM(list, i);
 
-        if (item == Py_None) {
+        if (Py_IsNone(item)) {
             config_dict_invalid_value(name);
             goto error;
         }
@@ -4941,7 +4941,7 @@ PyConfig_Set(const char *name, PyObject *value)
         break;
 
     case PyConfig_MEMBER_WSTR_OPT:
-        if (value != Py_None && !PyUnicode_CheckExact(value)) {
+        if (!Py_IsNone(value) && !PyUnicode_CheckExact(value)) {
             PyErr_Format(PyExc_TypeError, "expected str or None, got %T", value);
             return -1;
         }

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -2305,7 +2305,7 @@ monitoring_register_callback_impl(PyObject *module, int tool_id, int event,
     if (PySys_Audit("sys.monitoring.register_callback", "O", func) < 0) {
         return NULL;
     }
-    if (func == Py_None) {
+    if (Py_IsNone(func)) {
         func = NULL;
     }
     func = _PyMonitoring_RegisterCallback(tool_id, event_id, func);

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -474,7 +474,7 @@ w_object(PyObject *v, WFILE *p)
     else if (v == NULL) {
         w_byte(TYPE_NULL, p);
     }
-    else if (v == Py_None) {
+    else if (Py_IsNone(v)) {
         w_byte(TYPE_NONE, p);
     }
     else if (v == PyExc_StopIteration) {
@@ -1709,7 +1709,7 @@ r_object(RFILE *p)
             break;
         }
         v = PyList_GET_ITEM(p->refs, n);
-        if (v == Py_None) {
+        if (Py_IsNone(v)) {
             PyErr_SetString(PyExc_ValueError, "bad marshal data (invalid reference)");
             break;
         }

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -15,7 +15,7 @@ int
 _Py_convert_optional_to_ssize_t(PyObject *obj, void *result)
 {
     Py_ssize_t limit;
-    if (obj == Py_None) {
+    if (Py_IsNone(obj)) {
         return 1;
     }
     else if (_PyIndex_Check(obj)) {
@@ -40,7 +40,7 @@ _Py_convert_optional_to_non_negative_ssize_t(PyObject *obj, void *result)
     if (!_Py_convert_optional_to_ssize_t(obj, result)) {
         return 0;
     }
-    if (obj != Py_None && *((Py_ssize_t *)result) < 0) {
+    if (!Py_IsNone(obj) && *((Py_ssize_t *)result) < 0) {
         PyErr_SetString(PyExc_ValueError, "argument cannot be negative");
         return 0;
     }

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -882,7 +882,7 @@ _Py_uop_sym_truthiness(JitOptContext *ctx, JitOptRef ref)
     }
     PyObject *value = sym->value.value;
     /* Only handle a few known safe types */
-    if (value == Py_None) {
+    if (Py_IsNone(value)) {
         return 0;
     }
     PyTypeObject *tp = Py_TYPE(value);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2027,7 +2027,7 @@ flush_std_files(void)
     if (PySys_GetOptionalAttr(&_Py_ID(stdout), &file) < 0) {
         status = -1;
     }
-    else if (file != NULL && file != Py_None && !file_is_closed(file)) {
+    else if (file != NULL && !Py_IsNone(file) && !file_is_closed(file)) {
         if (_PyFile_Flush(file) < 0) {
             status = -1;
         }
@@ -2041,7 +2041,7 @@ flush_std_files(void)
         PyErr_Clear();
         status = -1;
     }
-    else if (file != NULL && file != Py_None && !file_is_closed(file)) {
+    else if (file != NULL && !Py_IsNone(file) && !file_is_closed(file)) {
         if (_PyFile_Flush(file) < 0) {
             PyErr_Clear();
             status = -1;
@@ -2947,7 +2947,7 @@ add_main_module(PyInterpreterState *interp)
     if (PyDict_GetItemStringRef(d, "__loader__", &loader) < 0) {
         return _PyStatus_ERR("Failed to test __main__.__loader__");
     }
-    int has_loader = !(loader == NULL || loader == Py_None);
+    int has_loader = !(loader == NULL || Py_IsNone(loader));
     Py_XDECREF(loader);
     if (!has_loader) {
         PyObject *loader = _PyImport_GetImportlibLoader(interp,
@@ -3416,7 +3416,7 @@ _Py_FatalError_PrintExc(PyThreadState *tstate)
     if (PySys_GetOptionalAttr(&_Py_ID(stderr), &ferr) < 0) {
         _PyErr_Clear(tstate);
     }
-    if (ferr == NULL || ferr == Py_None) {
+    if (ferr == NULL || Py_IsNone(ferr)) {
         /* sys.stderr is not set yet or set to None,
            no need to try to display the exception */
         Py_XDECREF(ferr);
@@ -3427,7 +3427,7 @@ _Py_FatalError_PrintExc(PyThreadState *tstate)
     PyErr_DisplayException(exc);
 
     PyObject *tb = PyException_GetTraceback(exc);
-    int has_tb = (tb != NULL) && (tb != Py_None);
+    int has_tb = (tb != NULL) && (!Py_IsNone(tb));
     Py_XDECREF(tb);
     Py_DECREF(exc);
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1231,7 +1231,7 @@ _Py_GetMainModule(PyThreadState *tstate)
 {
     // We return None to indicate "not found" or "bogus".
     PyObject *modules = _PyImport_GetModulesRef(tstate->interp);
-    if (modules == Py_None) {
+    if (Py_IsNone(modules)) {
         return modules;
     }
     PyObject *module = NULL;
@@ -1246,7 +1246,7 @@ _Py_GetMainModule(PyThreadState *tstate)
 int
 _Py_CheckMainModule(PyObject *module)
 {
-    if (module == NULL || module == Py_None) {
+    if (module == NULL || Py_IsNone(module)) {
         if (!PyErr_Occurred()) {
             (void)_PyErr_SetModuleNotFoundError(&_Py_ID(__main__));
         }
@@ -2812,7 +2812,7 @@ _PyThread_CurrentExceptions(void)
             }
             PyObject *exc = err_info->exc_value;
             assert(exc == NULL ||
-                   exc == Py_None ||
+                   Py_IsNone(exc) ||
                    PyExceptionInstance_Check(exc));
 
             int stat = PyDict_SetItem(result, id, exc == NULL ? Py_None : exc);

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -209,7 +209,7 @@ pyrun_one_parse_ast(FILE *fp, PyObject *filename,
         if (PySys_GetOptionalAttr(&_Py_ID(stdin), &attr) < 0) {
             PyErr_Clear();
         }
-        else if (attr != NULL && attr != Py_None) {
+        else if (attr != NULL && !Py_IsNone(attr)) {
             if (PyObject_GetOptionalAttr(attr, &_Py_ID(encoding), &encoding_obj) < 0) {
                 PyErr_Clear();
             }
@@ -606,7 +606,7 @@ parse_exit_code(PyObject *code, int *exitcode_p)
         *exitcode_p = exitcode;
         return 1;
     }
-    else if (code == Py_None) {
+    else if (Py_IsNone(code)) {
         *exitcode_p = 0;
         return 1;
     }
@@ -656,7 +656,7 @@ _Py_HandleSystemExitAndKeyboardInterrupt(int *exitcode_p)
     if (PySys_GetOptionalAttr(&_Py_ID(stderr), &sys_stderr) < 0) {
         PyErr_Clear();
     }
-    else if (sys_stderr != NULL && sys_stderr != Py_None) {
+    else if (sys_stderr != NULL && !Py_IsNone(sys_stderr)) {
         if (PyFile_WriteObject(exc, sys_stderr, Py_PRINT_RAW) < 0) {
             PyErr_Clear();
         }
@@ -810,7 +810,7 @@ print_exception_traceback(struct exception_print_context *ctx, PyObject *value)
     int err = 0;
 
     PyObject *tb = PyException_GetTraceback(value);
-    if (tb && tb != Py_None) {
+    if (tb && !Py_IsNone(tb)) {
         const char *header = EXCEPTION_TB_HEADER;
         err = _PyTraceBack_Print(tb, header, f);
     }
@@ -840,7 +840,7 @@ print_exception_file_and_line(struct exception_print_context *ctx,
     if (!v) {
         return -1;
     }
-    if (v == Py_None) {
+    if (Py_IsNone(v)) {
         Py_DECREF(v);
         _Py_DECLARE_STR(anon_string, "<string>");
         filename = Py_NewRef(&_Py_STR(anon_string));
@@ -1127,7 +1127,7 @@ void
 _PyErr_Display(PyObject *file, PyObject *unused, PyObject *value, PyObject *tb)
 {
     assert(value != NULL);
-    assert(file != NULL && file != Py_None);
+    assert(file != NULL && !Py_IsNone(file));
     if (PyExceptionInstance_Check(value)
         && tb != NULL && PyTraceBack_Check(tb)) {
         /* Put the traceback on the exception, otherwise it won't get
@@ -1206,7 +1206,7 @@ PyErr_Display(PyObject *unused, PyObject *value, PyObject *tb)
         fprintf(stderr, "lost sys.stderr\n");
         return;
     }
-    if (file == Py_None) {
+    if (Py_IsNone(file)) {
         Py_DECREF(file);
         return;
     }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -769,7 +769,7 @@ sys_displayhook(PyObject *module, PyObject *o)
     /* Print value except if None */
     /* After printing, also assign to '_' */
     /* Before, set '_' to None to avoid recursion */
-    if (o == Py_None) {
+    if (Py_IsNone(o)) {
         Py_RETURN_NONE;
     }
     if (PyObject_SetAttr(builtins, _Py_LATIN1_CHR('_'), Py_None) != 0)
@@ -778,7 +778,7 @@ sys_displayhook(PyObject *module, PyObject *o)
     if (outf == NULL) {
         return NULL;
     }
-    if (outf == Py_None) {
+    if (Py_IsNone(outf)) {
         _PyErr_SetString(tstate, PyExc_RuntimeError, "lost sys.stdout");
         Py_DECREF(outf);
         return NULL;
@@ -1121,7 +1121,7 @@ trace_trampoline(PyObject *self, PyFrameObject *frame,
         return -1;
     }
 
-    if (result != Py_None) {
+    if (!Py_IsNone(result)) {
         Py_XSETREF(frame->f_trace, result);
     }
     else {
@@ -1147,7 +1147,7 @@ sys_settrace(PyObject *module, PyObject *function)
 /*[clinic end generated code: output=999d12e9d6ec4678 input=8107feb01c5f1c4e]*/
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    if (function == Py_None) {
+    if (Py_IsNone(function)) {
         if (_PyEval_SetTrace(tstate, NULL, NULL) < 0) {
             return NULL;
         }
@@ -1180,7 +1180,7 @@ sys__settraceallthreads(PyObject *module, PyObject *arg)
     PyObject* argument = NULL;
     Py_tracefunc func = NULL;
 
-    if (arg != Py_None) {
+    if (!Py_IsNone(arg)) {
         func = trace_trampoline;
         argument = arg;
     }
@@ -1229,7 +1229,7 @@ sys_setprofile(PyObject *module, PyObject *function)
 /*[clinic end generated code: output=1c3503105939db9c input=055d0d7961413a62]*/
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    if (function == Py_None) {
+    if (Py_IsNone(function)) {
         if (_PyEval_SetProfile(tstate, NULL, NULL) < 0) {
             return NULL;
         }
@@ -1262,7 +1262,7 @@ sys__setprofileallthreads(PyObject *module, PyObject *arg)
     PyObject* argument = NULL;
     Py_tracefunc func = NULL;
 
-    if (arg != Py_None) {
+    if (!Py_IsNone(arg)) {
         func = profile_trampoline;
         argument = arg;
     }
@@ -1448,7 +1448,7 @@ sys_set_asyncgen_hooks(PyObject *self, PyObject *args, PyObject *kw)
         return NULL;
     }
 
-    if (finalizer && finalizer != Py_None) {
+    if (finalizer && !Py_IsNone(finalizer)) {
         if (!PyCallable_Check(finalizer)) {
             PyErr_Format(PyExc_TypeError,
                          "callable finalizer expected, got %.50s",
@@ -1457,7 +1457,7 @@ sys_set_asyncgen_hooks(PyObject *self, PyObject *args, PyObject *kw)
         }
     }
 
-    if (firstiter && firstiter != Py_None) {
+    if (firstiter && !Py_IsNone(firstiter)) {
         if (!PyCallable_Check(firstiter)) {
             PyErr_Format(PyExc_TypeError,
                          "callable firstiter expected, got %.50s",
@@ -1468,21 +1468,21 @@ sys_set_asyncgen_hooks(PyObject *self, PyObject *args, PyObject *kw)
 
     PyObject *cur_finalizer = _PyEval_GetAsyncGenFinalizer();
 
-    if (finalizer && finalizer != Py_None) {
+    if (finalizer && !Py_IsNone(finalizer)) {
         if (_PyEval_SetAsyncGenFinalizer(finalizer) < 0) {
             return NULL;
         }
     }
-    else if (finalizer == Py_None && _PyEval_SetAsyncGenFinalizer(NULL) < 0) {
+    else if (Py_IsNone(finalizer) && _PyEval_SetAsyncGenFinalizer(NULL) < 0) {
         return NULL;
     }
 
-    if (firstiter && firstiter != Py_None) {
+    if (firstiter && !Py_IsNone(firstiter)) {
         if (_PyEval_SetAsyncGenFirstiter(firstiter) < 0) {
             goto error;
         }
     }
-    else if (firstiter == Py_None && _PyEval_SetAsyncGenFirstiter(NULL) < 0) {
+    else if (Py_IsNone(firstiter) && _PyEval_SetAsyncGenFirstiter(NULL) < 0) {
         goto error;
     }
 

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -172,7 +172,7 @@ int
 PyThread_ParseTimeoutArg(PyObject *arg, int blocking, PY_TIMEOUT_T *timeout_p)
 {
     assert(_PyTime_FromSeconds(-1) == PyThread_UNSET_TIMEOUT);
-    if (arg == NULL || arg == Py_None) {
+    if (arg == NULL || Py_IsNone(arg)) {
         *timeout_p = blocking ? PyThread_UNSET_TIMEOUT : 0;
         return 0;
     }

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -114,7 +114,7 @@ tb_new_impl(PyTypeObject *type, PyObject *tb_next, PyFrameObject *tb_frame,
             int tb_lasti, int tb_lineno)
 /*[clinic end generated code: output=fa077debd72d861a input=b88143145454cb59]*/
 {
-    if (tb_next == Py_None) {
+    if (Py_IsNone(tb_next)) {
         tb_next = NULL;
     } else if (!PyTraceBack_Check(tb_next)) {
         return PyErr_Format(PyExc_TypeError,
@@ -190,7 +190,7 @@ traceback_tb_next_set_impl(PyTracebackObject *self, PyObject *value)
 
     /* We accept None or a traceback object, and map None -> NULL (inverse of
        tb_next_get) */
-    if (value == Py_None) {
+    if (Py_IsNone(value)) {
         value = NULL;
     } else if (!PyTraceBack_Check(value)) {
         PyErr_Format(PyExc_TypeError,


### PR DESCRIPTION
## Summary

Prefer `Py_IsNone()` over direct `== Py_None` / `!= Py_None` in core interpreter sources under `Python/` (errors, builtins, import, sys, warnings, lifecycle, etc.).

No behavior change intended.

## Test plan

- [x] Targeted tests: exceptions, importlib, traceback

Companion to Objects/ modernization PR.