### PR TITLE
Prefer memcpy over strcpy when string length is known

### DIFF
--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -1099,7 +1099,7 @@ _copy_string_obj_raw(PyObject *strobj, Py_ssize_t *p_size)
         PyErr_NoMemory();
         return NULL;
     }
-    strcpy(copied, str);
+    memcpy(copied, str, (size_t)size + 1);
     if (p_size != NULL) {
         *p_size = size;
     }

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -436,13 +436,14 @@ _Py_FindSourceFile(PyObject *filename, char* namebuf, size_t namelen, PyObject *
             Py_DECREF(path);
             continue; /* Too long */
         }
-        strcpy(namebuf, PyBytes_AS_STRING(path));
+        memcpy(namebuf, PyBytes_AS_STRING(path), (size_t)len);
+        namebuf[len] = '\0';
         Py_DECREF(path);
         if (strlen(namebuf) != (size_t)len)
             continue; /* v contains '\0' */
         if (len > 0 && namebuf[len-1] != SEP)
             namebuf[len++] = SEP;
-        strcpy(namebuf+len, tail);
+        memcpy(namebuf + len, tail, taillen + 1);
 
         binary = _PyObject_CallMethodFormat(tstate, open, "ss", namebuf, "rb");
         if (binary != NULL) {


### PR DESCRIPTION
## Summary

In traceback path search and cross-interpreter string copying we already know the source length. Use `memcpy` (including the NUL terminator) instead of `strcpy` so the copy is bounded by the measured size and avoids an extra scan of the source.

## Files

- `Python/traceback.c`
- `Python/crossinterp.c`

## Test plan

- [x] Local build
- [x] `test_traceback`

Note: overlaps with the import `PyList_GetItemRef` PR on `traceback.c` path-search; either can land first with a trivial conflict resolution.