### PR TITLE
Use PyList_GetItemRef in import hooks and traceback path search

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -3535,10 +3535,11 @@ get_path_importer(PyThreadState *tstate, PyObject *path_importer_cache,
         return NULL;
 
     for (j = 0; j < nhooks; j++) {
-        PyObject *hook = PyList_GetItem(path_hooks, j);
+        PyObject *hook = PyList_GetItemRef(path_hooks, j);
         if (hook == NULL)
             return NULL;
         importer = PyObject_CallOneArg(hook, p);
+        Py_DECREF(hook);
         if (importer != NULL)
             break;
 

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -419,14 +419,17 @@ _Py_FindSourceFile(PyObject *filename, char* namebuf, size_t namelen, PyObject *
         goto error;
     }
     for (i = 0; i < npath; i++) {
-        v = PyList_GetItem(syspath, i);
+        v = PyList_GetItemRef(syspath, i);
         if (v == NULL) {
             PyErr_Clear();
             break;
         }
-        if (!PyUnicode_Check(v))
+        if (!PyUnicode_Check(v)) {
+            Py_DECREF(v);
             continue;
+        }
         path = PyUnicode_EncodeFSDefault(v);
+        Py_DECREF(v);
         if (path == NULL) {
             PyErr_Clear();
             continue;
@@ -436,13 +439,14 @@ _Py_FindSourceFile(PyObject *filename, char* namebuf, size_t namelen, PyObject *
             Py_DECREF(path);
             continue; /* Too long */
         }
-        strcpy(namebuf, PyBytes_AS_STRING(path));
+        memcpy(namebuf, PyBytes_AS_STRING(path), (size_t)len);
+        namebuf[len] = '\0';
         Py_DECREF(path);
         if (strlen(namebuf) != (size_t)len)
             continue; /* v contains '\0' */
         if (len > 0 && namebuf[len-1] != SEP)
             namebuf[len++] = SEP;
-        strcpy(namebuf+len, tail);
+        memcpy(namebuf + len, tail, taillen + 1);
 
         binary = _PyObject_CallMethodFormat(tstate, open, "ss", namebuf, "rb");
         if (binary != NULL) {


### PR DESCRIPTION
## Summary

Borrowing list items while calling into Python (importer hooks, `open()`) is fragile under free-threading and list mutation. Hold a strong reference via `PyList_GetItemRef` for the duration of each iteration.

Also use `memcpy` with known lengths in the traceback path-search buffer fill.

## Files

- `Python/import.c` — `sys.path_hooks` iteration
- `Python/traceback.c` — `sys.path` iteration when locating source files

## Test plan

- [x] Local build
- [x] `test_importlib`, `test_traceback`