### PR TITLE
gh-152445: fix zipfile.writestr() ignoring strict_timestamps when SOURCE_DATE_EPOCH is set

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4019,7 +4019,7 @@ class OtherTests(unittest.TestCase):
             with zipfile.ZipFile(TESTFN, "r") as zf:
                 zip_info = zf.getinfo("test_no_source_date_epoch.txt")
                 self.assertTimestampAlmostEqual(time.localtime(), zip_info.date_time, tolerance=2)
-    
+
     def test_writestr_strict_timestamps_false_with_pre1980_source_date_epoch(self):
         # gh-152445: writestr() with strict_timestamps=False should clamp
         # SOURCE_DATE_EPOCH before 1980 to 1980-01-01, not raise.

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4019,6 +4019,37 @@ class OtherTests(unittest.TestCase):
             with zipfile.ZipFile(TESTFN, "r") as zf:
                 zip_info = zf.getinfo("test_no_source_date_epoch.txt")
                 self.assertTimestampAlmostEqual(time.localtime(), zip_info.date_time, tolerance=2)
+    
+    def test_writestr_strict_timestamps_false_with_pre1980_source_date_epoch(self):
+        # gh-152445: writestr() with strict_timestamps=False should clamp
+        # SOURCE_DATE_EPOCH before 1980 to 1980-01-01, not raise.
+        with os_helper.EnvironmentVarGuard() as env:
+            env['SOURCE_DATE_EPOCH'] = '0'  # 1970-01-01
+            with zipfile.ZipFile(TESTFN, 'w', strict_timestamps=False) as zf:
+                zf.writestr('test.txt', 'Hello World')
+            with zipfile.ZipFile(TESTFN, 'r') as zf:
+                info = zf.getinfo('test.txt')
+                self.assertEqual(info.date_time[:3], (1980, 1, 1))
+
+    def test_writestr_strict_timestamps_false_with_post2107_source_date_epoch(self):
+        # gh-152445: writestr() with strict_timestamps=False should clamp
+        # SOURCE_DATE_EPOCH after 2107 to 2107-12-31, not raise.
+        with os_helper.EnvironmentVarGuard() as env:
+            env['SOURCE_DATE_EPOCH'] = '4354819200'  # 2108-01-01
+            with zipfile.ZipFile(TESTFN, 'w', strict_timestamps=False) as zf:
+                zf.writestr('test.txt', 'Hello World')
+            with zipfile.ZipFile(TESTFN, 'r') as zf:
+                info = zf.getinfo('test.txt')
+                self.assertEqual(info.date_time[:3], (2107, 12, 31))
+
+    def test_writestr_strict_timestamps_true_raises_for_pre1980_source_date_epoch(self):
+        # gh-152445: writestr() with strict_timestamps=True (default) should
+        # still raise when SOURCE_DATE_EPOCH is before 1980.
+        with os_helper.EnvironmentVarGuard() as env:
+            env['SOURCE_DATE_EPOCH'] = '0'  # 1970-01-01
+            with zipfile.ZipFile(TESTFN, 'w') as zf:
+                with self.assertRaises((struct.error, ValueError)):
+                    zf.writestr('test.txt', 'Hello World')
 
     def assertTimestampAlmostEqual(self, time1, time2, tolerance):
         import datetime

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -683,6 +683,14 @@ class ZipInfo:
         else:
             self.date_time = time.localtime(time.time())[:6]
 
+        # gh-152445: Clamp date_time when strict_timestamps=False,
+        # mirroring the behaviour of ZipInfo.from_file().
+        if not archive._strict_timestamps:
+            if self.date_time[0] < 1980:
+                self.date_time = (1980, 1, 1, 0, 0, 0)
+            elif self.date_time[0] > 2107:
+                self.date_time = (2107, 12, 31, 23, 59, 59)
+
         self.compress_type = archive.compression
         self.compress_level = archive.compresslevel
         if self.filename.endswith('/'):  # pragma: no cover

--- a/Misc/NEWS.d/next/Library/2026-06-27-18-52-36.gh-issue-152445.jn6xhX.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-27-18-52-36.gh-issue-152445.jn6xhX.rst
@@ -1,0 +1,1 @@
+Fix :func:`zipfile.ZipFile.writestr` ignoring ``strict_timestamps=False`` when ``SOURCE_DATE_EPOCH`` is set to a date before 1980 or after 2107.


### PR DESCRIPTION
Fixes #152445.

`ZipInfo._for_archive()` (introduced in gh-91279) sets `date_time` from
`SOURCE_DATE_EPOCH` or the system clock, but did not apply the
`strict_timestamps=False` clamping that `ZipInfo.from_file()` performs.

This caused `writestr()` to raise `struct.error` when
`strict_timestamps=False` and `SOURCE_DATE_EPOCH` (or the system clock)
was set to a date before 1980, instead of silently clamping to 1980-01-01.

The fix mirrors the existing clamp logic in `from_file()`.

<!-- gh-issue-number: gh-152445 -->
* Issue: gh-152445
<!-- /gh-issue-number -->
