### PR TITLE
gh-152397: Add note to itertools.chain.from_iterable docs re PEP 798

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -208,6 +208,17 @@ loops that truncate the stream.
           for iterable in iterables:
               yield from iterable
 
+   .. note::
+      In Python 3.15+, the inline unpacking form ``(*it for it in iterables)``
+      (added by :pep:`798`) provides a more readable alternative for simple
+      flattening::
+
+          # equivalent to chain.from_iterable(iterables)
+          (*it for it in iterables)
+
+      ``chain.from_iterable`` remains useful as a first-class callable and
+      for compatibility with earlier Python versions.
+
 
 .. function:: combinations(iterable, r)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This PR adds a short note pointing readers to the inline unpacking-in-comprehension form added by PEP 798, as a more readable alternative for simple flattening on Python 3.15+.

Closes #152397


<!-- gh-issue-number: gh-152397 -->
* Issue: gh-152397
<!-- /gh-issue-number -->
