### PR TITLE
Docs: link to language reference instead of PEP

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -197,9 +197,9 @@ loops that truncate the stream.
           for iterable in iterables:
               yield from iterable
 
-   Note that :pep:`798` unpacking syntax provides similar functionality
-   so that ``list(chain(p, q))`` could be written as
-   ``[*s for s in (p, q)]``.
+   Note that :ref:`unpacking in comprehensions <unpacking-comprehensions>`
+   provides similar functionality so that ``list(chain(p, q))`` could be
+   written as ``[*s for s in (p, q)]``.
 
 
 .. classmethod:: chain.from_iterable(iterable)
@@ -212,9 +212,9 @@ loops that truncate the stream.
           for iterable in iterables:
               yield from iterable
 
-   Note that :pep:`798` unpacking syntax provides similar functionality
-   so that ``list(chain.from_iterable(iterables))`` could be written as
-   ``[*s for s in iterables]``.
+   Note that :ref:`unpacking in comprehensions <unpacking-comprehensions>`
+   provides similar functionality so that ``list(chain.from_iterable(iterables))``
+   could be written as ``[*s for s in iterables]``.
 
 
 .. function:: combinations(iterable, r)

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -848,6 +848,8 @@ appear directly in a class definition.
    ``yield`` and ``yield from`` prohibited in the implicitly nested scope.
 
 
+.. _unpacking-comprehensions:
+
 Unpacking in comprehensions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
The language reference is best at explaining what Python is. PEPs are good for explaining how Python came to be that way. We should prefer links within the docs over PEPs if we are explaining how Python is.