### PR TITLE
gh-151925: Clarify DictComp.value in ast docs

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -806,6 +806,8 @@ Comprehensions
    List and set comprehensions, generator expressions, and dictionary
    comprehensions. ``elt`` (or ``key`` and ``value``) is a single node
    representing the part that will be evaluated for each item.
+   For dictionary comprehensions using unpacking, ``value`` is ``None``; for example,
+   ``{**item for item in items}``
 
    ``generators`` is a list of :class:`comprehension` nodes.
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -806,8 +806,9 @@ Comprehensions
    List and set comprehensions, generator expressions, and dictionary
    comprehensions. ``elt`` (or ``key`` and ``value``) is a single node
    representing the part that will be evaluated for each item.
-   For dictionary comprehensions using unpacking, ``value`` is ``None``; for example,
-   ``{**item for item in items}``
+   For dictionary comprehensions using unpacking, for example
+   ``{**item for item in items}``, ``value`` is ``None``,
+   
 
    ``generators`` is a list of :class:`comprehension` nodes.
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -808,8 +808,6 @@ Comprehensions
    representing the part that will be evaluated for each item.
    For dictionary comprehensions using unpacking, for example
    ``{**item for item in items}``, ``value`` is ``None``,
-   
-
    ``generators`` is a list of :class:`comprehension` nodes.
 
    .. doctest::


### PR DESCRIPTION
Clarifies that DictComp.value is None for dictionary comprehensions using unpacking.

Testing:
- Not run; documentation-only change.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151925 -->
* Issue: gh-151925
<!-- /gh-issue-number -->
