### PR TITLE
Use tk_scaling() instead of a raw Tcl call in IDLE and tkinter tests

### DIFF
--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -392,7 +392,7 @@ def exit():
 def fix_scaling(root):
     """Scale fonts on HiDPI displays."""
     import tkinter.font
-    scaling = float(root.tk.call('tk', 'scaling'))
+    scaling = root.tk_scaling()
     if scaling > 1.4:
         for name in tkinter.font.names(root):
             font = tkinter.font.Font(root=root, name=name, exists=True)

--- a/Lib/test/test_tkinter/widget_tests.py
+++ b/Lib/test/test_tkinter/widget_tests.py
@@ -24,7 +24,7 @@ class AbstractWidgetTest(AbstractTkTest):
         try:
             return self._scaling
         except AttributeError:
-            self._scaling = float(self.root.call('tk', 'scaling'))
+            self._scaling = self.root.tk_scaling()
             return self._scaling
 
     def _str(self, value):


### PR DESCRIPTION
Replace explicit `tk.call()` invocations with `tk_scaling()`, which already returns a float. No behavior change.

* `idlelib.run.fix_scaling()`: `root.tk_scaling()` instead of `float(root.tk.call('tk', 'scaling'))`.
* tkinter widget tests: `root.tk_scaling()` instead of `float(root.call('tk', 'scaling'))`.

Split out from GH-152414 because `tk_scaling()` was only added in 3.16 (gh-151881), so this part is not backported.