### PR TITLE
gh-152356: Fix Windows blocking sampling after target process exit

### DIFF
--- a/Lib/test/test_profiling/test_sampling_profiler/test_blocking.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_blocking.py
@@ -1,6 +1,9 @@
 """Tests for blocking mode sampling profiler."""
 
 import io
+import os
+import subprocess
+import sys
 import textwrap
 import unittest
 from unittest import mock
@@ -15,7 +18,11 @@ except ImportError:
         "Test only runs when _remote_debugging is available"
     )
 
-from test.support import requires_remote_subprocess_debugging
+from test.support import (
+    SHORT_TIMEOUT,
+    os_helper,
+    requires_remote_subprocess_debugging,
+)
 
 from .helpers import test_subprocess
 
@@ -158,3 +165,51 @@ class TestBlockingModeStackAccuracy(unittest.TestCase):
             f"fibonacci_generator appears in the stack when consume_generator "
             f"is the leaf frame on an arithmetic line. This indicates "
             f"torn/inconsistent stack traces are being captured.")
+
+
+@requires_remote_subprocess_debugging()
+@unittest.skipUnless(sys.platform == "win32", "Windows only")
+class TestBlockingModeCLI(unittest.TestCase):
+    def test_run_blocking_exits_after_target_process_exits(self):
+        script = 'print("done")\n'
+
+        tmpdir = os.path.abspath(os_helper.TESTFN + "_profiling_blocking")
+        with os_helper.temp_dir(tmpdir) as tmpdir:
+            script_path = os.path.join(tmpdir, "tiny_target.py")
+            profile_path = os.path.join(tmpdir, "blocking.bin")
+            with open(script_path, "w", encoding="utf-8") as file:
+                file.write(script)
+
+            cmd = [
+                sys.executable, "-m", "profiling.sampling", "run",
+                "--binary", "-o", profile_path,
+                "--mode=cpu", "--blocking", "-r", "100",
+                script_path,
+            ]
+            result = subprocess.run(
+                cmd,
+                cwd=tmpdir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=SHORT_TIMEOUT,
+            )
+
+            self.assertEqual(
+                result.returncode, 0,
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+            self.assertGreater(os.path.getsize(profile_path), 0)
+
+            replay = subprocess.run(
+                [sys.executable, "-m", "profiling.sampling", "replay",
+                 profile_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=SHORT_TIMEOUT,
+            )
+            self.assertEqual(
+                replay.returncode, 0,
+                f"stdout:\n{replay.stdout}\nstderr:\n{replay.stderr}",
+            )

--- a/Misc/NEWS.d/next/Library/2026-06-28-12-45-09.gh-issue-152356.Dr4w2Q.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-28-12-45-09.gh-issue-152356.Dr4w2Q.rst
@@ -1,0 +1,3 @@
+Fix a hang in ``profiling.sampling run --blocking`` on Windows when the
+target process exits. The profiler now finalizes binary profiles instead of
+continuing to sample the exited process.

--- a/Modules/_remote_debugging/threads.c
+++ b/Modules/_remote_debugging/threads.c
@@ -862,6 +862,12 @@ _Py_RemoteDebug_StopAllThreads(RemoteUnwinderObject *unwinder, _Py_RemoteDebug_T
         return 0;
     }
 
+    if (!is_process_alive(unwinder->handle.hProcess)) {
+        PyErr_Format(PyExc_ProcessLookupError,
+            "Process %d has terminated", unwinder->handle.pid);
+        return -1;
+    }
+
     PyErr_Format(PyExc_RuntimeError, "NtSuspendProcess failed: 0x%lx", status);
     return -1;
 }


### PR DESCRIPTION
## Summary

Fixes gh-152356.

On Windows, `profiling.sampling run --blocking` could hang indefinitely after the target process had already exited, leaving an empty binary profile that could not be replayed.

The non-blocking sampling path already terminates correctly when the target exits, but the Windows blocking implementation classified the same process-exit condition differently.

## Root Cause

During blocking sampling, the profiler pauses the target through the Windows remote debugging layer.

If the target process has already exited, `NtSuspendProcess()` fails. The Windows implementation currently reports this as a `RuntimeError`.

The sampling loop treats `RuntimeError` as a recoverable sampling failure and continues retrying, so profiling never finishes and the binary profile writer is never finalized.

Other platforms already report terminated processes as `ProcessLookupError`, which the sampling loop correctly treats as a terminal condition.

## Changes

This patch updates the Windows implementation of `_Py_RemoteDebug_StopAllThreads()`.

When `NtSuspendProcess()` fails because the target process has already terminated, the remote debugging layer now raises `ProcessLookupError` instead of `RuntimeError`.

Existing `RuntimeError` behaviour is preserved for genuine `NtSuspendProcess()` failures while alive processes are unaffected.

No other profiling behaviour changes.

## Tests

Added a Windows-only regression test that:

* runs `profiling.sampling run --binary --mode=cpu --blocking` against a short-lived Python script,
* verifies the command exits successfully,
* verifies a non-empty binary profile is produced,
* verifies the generated profile can be replayed successfully.

## Validation

Validated with:

* `PCbuild\build.bat -p x64 -d`
* `PCbuild\amd64\python_d.exe -m unittest -v test.test_profiling.test_sampling_profiler.test_blocking.TestBlockingModeCLI`
* `PCbuild\amd64\python_d.exe -m test test_profiling`
* `PCbuild\amd64\python_d.exe -m test test_importlib test_subprocess`
* manual verification of `profiling.sampling run --blocking` and `profiling.sampling replay`
* `git diff --check`

After this change, Windows blocking sampling terminates correctly once the target process exits and produces a valid replayable binary profile.
