### PR TITLE
gh-73199: Fix incorrect zip64 threshold in doc

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -204,10 +204,12 @@ ZipFile objects
    (:mod:`zlib`, :mod:`bz2`, :mod:`lzma`, or :mod:`compression.zstd`) is not
    available, :exc:`RuntimeError` is raised. The default is :const:`ZIP_STORED`.
 
-   If *allowZip64* is ``True`` (the default) zipfile will create ZIP files that
-   use the ZIP64 extensions when the zipfile is larger than 4 GiB. If it is
-   ``false`` :mod:`!zipfile` will raise an exception when the ZIP file would
-   require ZIP64 extensions.
+   If *allowZip64* is ``True`` (the default), ZIP64 extensions will be used
+   on demand when the archive is written, such as when the total archive or a
+   member file is larger than 2 GiB (for compatibility with legacy tools even
+   though the official hard limit is 4 GiB), or when there are more than 65535
+   members in the archive.  If it is ``False``, an exception will be raised in
+   such cases.
 
    The *compresslevel* parameter controls the compression level to use when
    writing files to the archive.

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -205,11 +205,11 @@ ZipFile objects
    available, :exc:`RuntimeError` is raised. The default is :const:`ZIP_STORED`.
 
    If *allowZip64* is ``True`` (the default), ZIP64 extensions will be used
-   on demand when the archive is written, such as when the total archive or a
-   member file is larger than 2 GiB (for compatibility with legacy tools even
-   though the official hard limit is 4 GiB), or when there are more than 65535
-   members in the archive.  If it is ``False``, an exception will be raised in
-   such cases.
+   on demand when the archive is written, such as when the total archive or an
+   individual member is larger than 2 GiB (for compatibility with legacy tools
+   even though the official hard limit is 4 GiB), or when there are more than
+   65535 members in the archive.  If it is ``False``, an exception will be
+   raised instead.
 
    The *compresslevel* parameter controls the compression level to use when
    writing files to the archive.

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -15,7 +15,7 @@ defined in `PKZIP Application Note`_.
 
 This module does not handle multipart ZIP files.
 It can handle ZIP files that use the ZIP64 extensions
-(that is ZIP files that are more than 4 GiB in size).  It supports
+(mostly for ZIP files larger than 4 GiB).  It supports
 decryption of encrypted files in ZIP archives, but it cannot
 create an encrypted file.  Decryption is extremely slow as it is
 implemented in native Python rather than C.


### PR DESCRIPTION
Clarify the behavior of the `allowZip64` parameter, including the actual threshold for writing, and other cases like total file number and comment size.

<!-- gh-issue-number: gh-73199 -->
* Issue: gh-73199
<!-- /gh-issue-number -->
