### PR TITLE
gh-133138: Escape os.pathsep in BROWSER

### DIFF
--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -678,5 +678,19 @@ class CliTest(unittest.TestCase):
                 mock_open.assert_called_once_with(expected_url, expected_new_win)
 
 
+class SplitBrowserVarTest(unittest.TestCase):
+    def test_escaped_pathsep(self):
+        result = webbrowser._split_browser_var(
+            f'firefox ext+container\\{os.pathsep}name=ABC&url=%s'
+            f'{os.pathsep}chromium')
+        self.assertEqual(result,
+                         [f'firefox ext+container{os.pathsep}name=ABC&url=%s',
+                          'chromium'])
+
+    def test_backslash_not_before_pathsep(self):
+        result = webbrowser._split_browser_var('fire\\fox')
+        self.assertEqual(result, ['fire\\fox'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -112,6 +112,20 @@ def open_new_tab(url):
     return open(url, 2)
 
 
+def _split_browser_var(value):
+    # Split on os.pathsep, but allow backslash-escaping (e.g. \: on Unix)
+    # so protocol handlers like 'ext+container\:name=X&url=%s' work.
+    sep = os.pathsep
+    segments = value.split(sep)
+    entries = []
+    for segment in segments:
+        if entries and entries[-1].endswith('\\'):
+            entries[-1] = entries[-1][:-1] + sep + segment
+        else:
+            entries.append(segment)
+    return entries
+
+
 def _synthesize(browser, *, preferred=False):
     """Attempt to synthesize a controller based on existing controllers.
 
@@ -570,7 +584,7 @@ def register_standard_browsers():
     # OK, now that we know what the default preference orders for each
     # platform are, allow user to override them with the BROWSER variable.
     if "BROWSER" in os.environ:
-        userchoices = os.environ["BROWSER"].split(os.pathsep)
+        userchoices = _split_browser_var(os.environ["BROWSER"])
         userchoices.reverse()
 
         # Treat choices in same way as if passed into get() but do register

--- a/Misc/NEWS.d/next/Library/2026-06-28-10-19-32.gh-issue-133138.fc9738.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-28-10-19-32.gh-issue-133138.fc9738.rst
@@ -1,0 +1,2 @@
+Allow escaping :data:`os.pathsep` with backslash in the :envvar:`BROWSER`
+environment variable.


### PR DESCRIPTION


<!-- gh-issue-number: gh-133138 -->
* Issue: gh-133138
<!-- /gh-issue-number -->
