### PR TITLE
gh-85320: Use UTF-8 for IDLE configuration and breakpoint files

### DIFF
--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -6,6 +6,8 @@ Released on 2026-10-01
 
 gh-85320: IDLE now reads and writes its configuration files and the
 breakpoints file using UTF-8 instead of the locale encoding.
+Files with non-ASCII characters and non-UTF-8 encoding may need
+to be opened in an editor and resaved with UTF-8 encoding.
 
 gh-143774: Better explain the operation of Format / Format Paragraph.
 Patch by Terry J. Reedy.

--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -4,6 +4,9 @@ Released on 2026-10-01
 =========================
 
 
+gh-85320: IDLE now reads and writes its configuration files and the
+breakpoints file using UTF-8 instead of the locale encoding.
+
 gh-143774: Better explain the operation of Format / Format Paragraph.
 Patch by Terry J. Reedy.
 

--- a/Lib/idlelib/config.py
+++ b/Lib/idlelib/config.py
@@ -73,8 +73,9 @@ class IdleConfParser(ConfigParser):
 
     def Load(self):
         "Load the configuration file from disk."
-        if self.file:
-            self.read(self.file)
+        if self.file and os.path.exists(self.file):
+            with open(self.file, encoding='utf-8', errors='replace') as f:
+                self.read_file(f)
 
 class IdleUserConfParser(IdleConfParser):
     """
@@ -133,10 +134,10 @@ class IdleUserConfParser(IdleConfParser):
         if fname and fname[0] != '#':
             if not self.IsEmpty():
                 try:
-                    cfgFile = open(fname, 'w')
+                    cfgFile = open(fname, 'w', encoding='utf-8')
                 except OSError:
                     os.unlink(fname)
-                    cfgFile = open(fname, 'w')
+                    cfgFile = open(fname, 'w', encoding='utf-8')
                 with cfgFile:
                     self.write(cfgFile)
             elif os.path.exists(self.file):

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -242,12 +242,13 @@ class PyShellEditorWindow(EditorWindow):
         breaks = self.breakpoints
         filename = self.io.filename
         try:
-            with open(self.breakpointPath) as fp:
+            with open(self.breakpointPath,
+                      encoding='utf-8', errors='replace') as fp:
                 lines = fp.readlines()
         except OSError:
             lines = []
         try:
-            with open(self.breakpointPath, "w") as new_file:
+            with open(self.breakpointPath, "w", encoding='utf-8') as new_file:
                 for line in lines:
                     if not line.startswith(filename + '='):
                         new_file.write(line)
@@ -272,7 +273,8 @@ class PyShellEditorWindow(EditorWindow):
         if filename is None:
             return
         if os.path.isfile(self.breakpointPath):
-            with open(self.breakpointPath) as fp:
+            with open(self.breakpointPath,
+                      encoding='utf-8', errors='replace') as fp:
                 lines = fp.readlines()
             for line in lines:
                 if line.startswith(filename + '='):

--- a/Misc/NEWS.d/next/IDLE/2026-06-28-06-46-46.gh-issue-85320.Hq2vKn.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-06-28-06-46-46.gh-issue-85320.Hq2vKn.rst
@@ -1,0 +1,4 @@
+IDLE now reads and writes its configuration files and the breakpoints file
+using UTF-8 instead of the locale encoding.  This keeps non-ASCII data (such
+as non-ASCII paths) from being corrupted and makes the files portable between
+environments.


### PR DESCRIPTION
IDLE opened its configuration files (`.idlerc/config-*.cfg`) and the breakpoints file without an explicit encoding, so they used the locale encoding. Non-ASCII data — such as non-ASCII paths in the breakpoints file or help-source URLs in the config — could be corrupted, and the files were not portable between environments.

Read them as UTF-8 with `errors='replace'` and write them as UTF-8, matching the long-standing treatment of `recent-files.lst`.

Since UTF-8 mode is the default from 3.15 (PEP 686), this is mostly a no-op on current main except under `-X utf8=0`; the behavioral fix matters on the 3.13 and 3.14 backports, where the locale encoding is still used.

Reading with `errors='replace'` instead of the locale codec also means a config file written in a different encoding no longer raises `UnicodeDecodeError` and crashes IDLE on startup; it is decoded lossily instead.  This also fixes gh-84615.

<!-- gh-issue-number: gh-85320 -->
* Issue: gh-85320
<!-- /gh-issue-number -->