### PR TITLE
gh-151126: Fix a possible crash during the startup with no memory under `Py_STACKREF_DEBUG`

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-06-28-13-05-52.gh-issue-151126.KE2OvV.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-28-13-05-52.gh-issue-151126.KE2OvV.rst
@@ -1,0 +1,2 @@
+Fix a possible crash during the interpreter startup under a memory pressure
+with ``Py_STACKREF_DEBUG`` enabled.

--- a/Misc/NEWS.d/next/Library/2026-06-28-13-05-52.gh-issue-151126.KE2OvV.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-28-13-05-52.gh-issue-151126.KE2OvV.rst
@@ -1,2 +1,0 @@
-Fix a possible crash during the interpreter startup under a memory pressure
-with ``Py_STACKREF_DEBUG`` enabled.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -656,6 +656,9 @@ init_interpreter(PyInterpreterState *interp,
         NULL,
         &alloc
     );
+    if (interp->open_stackrefs_table == NULL) {
+        return _PyStatus_NO_MEMORY();
+    }
 #  ifdef Py_STACKREF_CLOSE_DEBUG
     interp->closed_stackrefs_table = _Py_hashtable_new_full(
         _Py_hashtable_hash_ptr,
@@ -664,6 +667,9 @@ init_interpreter(PyInterpreterState *interp,
         NULL,
         &alloc
     );
+    if (interp->closed_stackrefs_table == NULL) {
+        return _PyStatus_NO_MEMORY();
+    }
 #  endif
     _Py_stackref_associate(interp, Py_None, PyStackRef_None);
     _Py_stackref_associate(interp, Py_False, PyStackRef_False);


### PR DESCRIPTION
- `_Py_hashtable_new_full` can return `NULL` (when no memory is left) and does not set an exception
- `interp->open_stackrefs_table` and `interp->closed_stackrefs_table` are required to be non-NULL
- If they are, we can possibly get a NULL deref from using them

<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
