### PR TITLE
Remove now-wrapped functions from the curses unsupported list

### DIFF
--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -40,16 +40,10 @@
 
   Here's a list of currently unsupported functions:
 
-  addchnstr addchstr color_set define_key
-  del_curterm inchnstr inchstr innstr keyok
-  mcprint mvaddchnstr mvaddchstr mvcur mvinchnstr
-  mvinchstr mvinnstr mmvwaddchnstr mvwaddchstr
-  mvwinchnstr mvwinchstr mvwinnstr
-  restartterm ripoffline
-  scrl set_curterm setterm
-  tgetent tgetflag tgetnum tgetstr tgoto timeout tputs
-  vidattr vidputs waddchnstr waddchstr
-  wcolor_set winchnstr winchstr winnstr wmouse_trafo wscrl
+  del_curterm mcprint mvcur restartterm
+  ripoffline set_curterm setterm
+  tgetent tgetflag tgetnum tgetstr tgoto tputs
+  vidattr vidputs wmouse_trafo
 
   Low-priority:
   slk_attr slk_attr_off slk_attr_on slk_attr_set slk_attroff


### PR DESCRIPTION
The "currently unsupported functions" comment at the top of `Modules/_cursesmodule.c` had drifted out of date — it still listed a number of functions that have since been wrapped.

Removed the entries that are now exposed:

- the cell-array functions (`addchstr`/`addchnstr`/`inchstr`/`inchnstr` and their `mv`/`w` variants), now reachable through the complex-character API: `addstr(complexstr(...))` writes the cells via `waddchnstr`, and `in_wchstr()` reads them via `winchnstr`
- `innstr`/`winnstr` and variants — wrapped as `instr`
- `color_set`/`wcolor_set`, `define_key`, `keyok`
- `scrl`/`wscrl` — wrapped as `scroll`
- `timeout`

The genuinely unwrapped functions are kept, as are the soft-label-key, menu, and form sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
