### PR TITLE
gh-152486: Fix duplicated zip64 extra in local file entry

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -1189,6 +1189,34 @@ class StoredTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
                     self.assertEqual(zinfo.header_offset, expected_header_offset)
                     self.assertEqual(zf.read(zinfo), expected_content)
 
+    def test_generated_valid_zip64_extra_in_local_entry(self):
+        """Should not write duplicated zip64 fields to the local file entry."""
+        fh = io.BytesIO()
+        with zipfile.ZipFile(fh, 'w') as zh:
+            zinfo = zipfile.ZipInfo('strfile')
+            zinfo.extra = (
+                # zip64 (should be stripped)
+                b'\x01\x00\x10\x00'
+                b'\x00\x00\x00\x00\x00\x00\x00\x00'
+                b'\x00\x00\x00\x00\x00\x00\x00\x00'
+
+                # invalid tail
+                b'zzz'
+            )
+            zh.writestr(zinfo, self.data)
+
+        fh.seek(0)
+        fh.seek(zinfo.header_offset)
+        entry = fh.read(zh.start_dir - zinfo.header_offset - zinfo.compress_size)
+        header = struct.unpack_from(zipfile.structFileHeader, entry)
+        extra_bytes = entry[-header[zipfile._FH_EXTRA_FIELD_LENGTH]:]
+        self.assertEqual(extra_bytes, (
+            b'\x01\x00\x10\x00'
+            b'!e\x00\x00\x00\x00\x00\x00'
+            b'!e\x00\x00\x00\x00\x00\x00'
+            b'zzz'
+        ))
+
     def test_force_zip64(self):
         """Test that forcing zip64 extensions correctly notes this in the zip file"""
 

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -1217,6 +1217,28 @@ class StoredTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
             b'zzz'
         ))
 
+        # should strip zip64 field if zip64 not used
+        fh = io.BytesIO()
+        with zipfile.ZipFile(fh, 'w') as zh:
+            zinfo = zipfile.ZipInfo('strfile')
+            zinfo.extra = (
+                # zip64 (should be stripped)
+                b'\x01\x00\x10\x00'
+                b'\x00\x00\x00\x00\x00\x00\x00\x00'
+                b'\x00\x00\x00\x00\x00\x00\x00\x00'
+
+                # invalid tail
+                b'zzz'
+            )
+            zh.writestr(zinfo, 'foo')
+
+        fh.seek(0)
+        fh.seek(zinfo.header_offset)
+        entry = fh.read(zh.start_dir - zinfo.header_offset - zinfo.compress_size)
+        header = struct.unpack_from(zipfile.structFileHeader, entry)
+        extra_bytes = entry[-header[zipfile._FH_EXTRA_FIELD_LENGTH]:]
+        self.assertEqual(extra_bytes, b'zzz')
+
     def test_force_zip64(self):
         """Test that forcing zip64 extensions correctly notes this in the zip file"""
 

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -550,8 +550,13 @@ class ZipInfo:
             zip64 = file_size > ZIP64_LIMIT or compress_size > ZIP64_LIMIT
         if zip64:
             fmt = '<HHQQ'
-            extra = extra + struct.pack(fmt,
-                                        1, struct.calcsize(fmt)-4, file_size, compress_size)
+
+            # Prepend a ZIP64 field to extra data
+            extra = struct.pack(
+                fmt, 1, struct.calcsize(fmt)-4,
+                file_size, compress_size
+            ) + _Extra.strip(extra, (1,))
+
             file_size = 0xffffffff
             compress_size = 0xffffffff
             min_version = ZIP64_VERSION

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -541,7 +541,14 @@ class ZipInfo:
             compress_size = self.compress_size
             file_size = self.file_size
 
-        extra = self.extra
+        # Strip extra fields that should not exist in the local entry or should
+        # be determined later. (self.extra can be read from central directory
+        # when read in append mode)
+        extra = _Extra.strip(self.extra, (
+            0x0001,  # Zip64
+            0x0017,  # Strong Encryption Header
+            0x6375,  # Unicode Comment
+        ))
 
         min_version = 0
         if zip64 is None:
@@ -555,7 +562,7 @@ class ZipInfo:
             extra = struct.pack(
                 fmt, 1, struct.calcsize(fmt)-4,
                 file_size, compress_size
-            ) + _Extra.strip(extra, (1,))
+            ) + extra
 
             file_size = 0xffffffff
             compress_size = 0xffffffff

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -542,8 +542,7 @@ class ZipInfo:
             file_size = self.file_size
 
         # Strip extra fields that should not exist in the local entry or should
-        # be determined later. (self.extra can be read from central directory
-        # when read in append mode)
+        # be determined later.
         extra = _Extra.strip(self.extra, (
             0x0001,  # Zip64
             0x0017,  # Strong Encryption Header

--- a/Misc/NEWS.d/next/Library/2026-06-29-03-43-41.gh-issue-152486.kASYh8.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-29-03-43-41.gh-issue-152486.kASYh8.rst
@@ -1,0 +1,1 @@
+Fix an issue where duplicated Zip64 extra fields were written if :attr:`ZipInfo.extra <zipfile.ZipInfo.extra>` already contained a Zip64 field.

--- a/Misc/NEWS.d/next/Library/2026-06-29-03-43-41.gh-issue-152486.kASYh8.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-29-03-43-41.gh-issue-152486.kASYh8.rst
@@ -1,4 +1,4 @@
-Fix an issue where duplicated Zip64 extra fields or other invalid
-fields were written if :attr:`ZipInfo.extra <zipfile.ZipInfo.extra>`
-already contained them (which could be read from central directory in
-append mode).
+Fix an issue where duplicated Zip64 extra fields or other improper
+fields were written to the local file entry if
+:attr:`ZipInfo.extra <zipfile.ZipInfo.extra>` contained them.
+

--- a/Misc/NEWS.d/next/Library/2026-06-29-03-43-41.gh-issue-152486.kASYh8.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-29-03-43-41.gh-issue-152486.kASYh8.rst
@@ -1,1 +1,4 @@
-Fix an issue where duplicated Zip64 extra fields were written if :attr:`ZipInfo.extra <zipfile.ZipInfo.extra>` already contained a Zip64 field.
+Fix an issue where duplicated Zip64 extra fields or other invalid
+fields were written if :attr:`ZipInfo.extra <zipfile.ZipInfo.extra>`
+already contained them (which could be read from central directory in
+append mode).


### PR DESCRIPTION
Fix an issue where the local file entry may contain duplicated Zip64 extra fields if its `ZipInfo` already has one in the `extra` attribute.

<!-- gh-issue-number: gh-152486 -->
* Issue: gh-152486
<!-- /gh-issue-number -->
