### PR TITLE
gh-152405 Safer mapping proxy comparisons

### DIFF
--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1251,7 +1251,7 @@ mappingproxy_richcompare(PyObject *self, PyObject *w, int op)
             return PyObject_RichCompare(v->mapping, w, op);
         }
     }
-    Py_RETURN_NOTIMPLEMENTED;  // Defer to w's richcompare    
+    Py_RETURN_NOTIMPLEMENTED;  // Defer to w's richcompare 
 }
 
 static int

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1061,7 +1061,7 @@ static PyMappingMethods mappingproxy_as_mapping = {
     0,                                          /* mp_ass_subscript */
 };
 
-static int is_known_dict_subclass_or(PyObject *o) {
+static int mappingproxy_is_known_dict_subclass_or(PyObject *o) {
     return (PyAnyDict_CheckExact(o) || PyODict_CheckExact(o) ||
         (PyAnyDict_Check(o) && Py_TYPE(o)->tp_as_number->nb_or == PyDict_Type.tp_as_number->nb_or)) ||
         (PyODict_Check(o) && Py_TYPE(o)->tp_as_number->nb_or == PyODict_Type.tp_as_number->nb_or);
@@ -1075,13 +1075,13 @@ mappingproxy_or(PyObject *left, PyObject *right)
             right = ((mappingproxyobject*)right)->mapping; 
         }
         PyObject *left_mapping = ((mappingproxyobject*)left)->mapping;
-        if (is_known_dict_subclass_or(right) || PyFrozenDict_CheckExact(left_mapping)) {
+        if (mappingproxy_is_known_dict_subclass_or(right) || PyFrozenDict_CheckExact(left_mapping)) {
             return PyNumber_Or(left_mapping, right);
         }
     } else {
         assert(PyObject_TypeCheck(right, &PyDictProxy_Type));
         PyObject *right_mapping = ((mappingproxyobject*)right)->mapping;
-        if (is_known_dict_subclass_or(left) || PyFrozenDict_CheckExact(right_mapping)) {
+        if (mappingproxy_is_known_dict_subclass_or(left) || PyFrozenDict_CheckExact(right_mapping)) {
             return PyNumber_Or(left, right_mapping);
         }
     }
@@ -1246,6 +1246,13 @@ mappingproxy_traverse(PyObject *self, visitproc visit, void *arg)
     return 0;
 }
 
+static int
+mappingproxy_is_known_dict_subclass_richcompare(PyObject *o) {
+    return (PyAnyDict_CheckExact(o) || PyODict_CheckExact(o) ||
+        (PyAnyDict_Check(o) && Py_TYPE(o)->tp_richcompare == PyDict_Type.tp_richcompare) ||
+        (PyODict_Check(o) && Py_TYPE(o)->tp_richcompare == PyODict_Type.tp_richcompare));
+}
+
 static PyObject *
 mappingproxy_richcompare(PyObject *self, PyObject *w, int op)
 {
@@ -1254,17 +1261,7 @@ mappingproxy_richcompare(PyObject *self, PyObject *w, int op)
         if (PyObject_TypeCheck(w, &PyDictProxy_Type)) {
             w = ((mappingproxyobject *)w)->mapping;
         }
-
-        if (PyAnyDict_CheckExact(w) ||
-                (PyAnyDict_Check(w) && Py_TYPE(w)->tp_richcompare == PyDict_Type.tp_richcompare)) {
-            return PyObject_RichCompare(v->mapping, w, op);
-        }
-        if (PyODict_CheckExact(w) ||
-                (PyODict_Check(w) && Py_TYPE(w)->tp_richcompare == PyODict_Type.tp_richcompare)) {
-            return PyObject_RichCompare(v->mapping, w, op);
-        }
-        if (PyFrozenDict_CheckExact(v->mapping)) {
-            // immutable - safe to foward.
+        if (mappingproxy_is_known_dict_subclass_richcompare(w) || PyFrozenDict_CheckExact(v->mapping)) {
             return PyObject_RichCompare(v->mapping, w, op);
         }
     }

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1238,7 +1238,12 @@ mappingproxy_richcompare(PyObject *self, PyObject *w, int op)
             w = ((mappingproxyobject *)w)->mapping;
         }
 
-        if (PyAnyDict_CheckExact(w) || (PyAnyDict_Check(w) && Py_TYPE(w)->tp_richcompare == PyDict_Type.tp_richcompare)) {
+        if (PyAnyDict_CheckExact(w) ||
+                (PyAnyDict_Check(w) && Py_TYPE(w)->tp_richcompare == PyDict_Type.tp_richcompare)) {
+            return PyObject_RichCompare(v->mapping, w, op);
+        }
+        if (PyODict_CheckExact(w) ||
+                (PyODict_Check(w) && Py_TYPE(w)->tp_richcompare == PyODict_Type.tp_richcompare)) {
             return PyObject_RichCompare(v->mapping, w, op);
         }
         if (PyFrozenDict_CheckExact(v->mapping)) {

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1234,7 +1234,7 @@ mappingproxy_richcompare(PyObject *self, PyObject *w, int op)
 {
     if (op == Py_EQ || op == Py_NE) {
         mappingproxyobject *v = (mappingproxyobject *)self;
-        if (Py_TYPE(w) == Py_TYPE(self)) {
+        if (PyObject_TypeCheck(w, &PyDictProxy_Type)) {
             w = ((mappingproxyobject *)w)->mapping;
         }
 

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1232,11 +1232,21 @@ mappingproxy_traverse(PyObject *self, visitproc visit, void *arg)
 static PyObject *
 mappingproxy_richcompare(PyObject *self, PyObject *w, int op)
 {
-    mappingproxyobject *v = (mappingproxyobject *)self;
     if (op == Py_EQ || op == Py_NE) {
-        return PyObject_RichCompare(v->mapping, w, op);
+        mappingproxyobject *v = (mappingproxyobject *)self;
+        if (Py_TYPE(w) == Py_TYPE(self)) {
+            w = ((mappingproxyobject *)w)->mapping;
+        }
+
+        if (PyAnyDict_CheckExact(w) || (PyAnyDict_Check(w) && Py_TYPE(w)->tp_richcompare == PyDict_Type.tp_richcompare)) {
+            return PyObject_RichCompare(v->mapping, w, op);
+        }
+        if (PyFrozenDict_CheckExact(v->mapping)) {
+            // immutable - safe to foward.
+            return PyObject_RichCompare(v->mapping, w, op);
+        }
     }
-    Py_RETURN_NOTIMPLEMENTED;
+    Py_RETURN_NOTIMPLEMENTED;  // Defer to w's richcompare    
 }
 
 static int

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1251,7 +1251,7 @@ mappingproxy_richcompare(PyObject *self, PyObject *w, int op)
             return PyObject_RichCompare(v->mapping, w, op);
         }
     }
-    Py_RETURN_NOTIMPLEMENTED;  // Defer to w's richcompare 
+    Py_RETURN_NOTIMPLEMENTED;  // Defer to w's richcompare
 }
 
 static int

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1061,16 +1061,33 @@ static PyMappingMethods mappingproxy_as_mapping = {
     0,                                          /* mp_ass_subscript */
 };
 
+static int is_known_dict_subclass_or(PyObject *o) {
+    return (PyAnyDict_CheckExact(o) || PyODict_CheckExact(o) ||
+        (PyAnyDict_Check(o) && Py_TYPE(o)->tp_as_number->nb_or == PyDict_Type.tp_as_number->nb_or)) ||
+        (PyODict_Check(o) && Py_TYPE(o)->tp_as_number->nb_or == PyODict_Type.tp_as_number->nb_or);
+}
+
 static PyObject *
 mappingproxy_or(PyObject *left, PyObject *right)
 {
     if (PyObject_TypeCheck(left, &PyDictProxy_Type)) {
-        left = ((mappingproxyobject*)left)->mapping;
+        if (PyObject_TypeCheck(right, &PyDictProxy_Type)) {
+            right = ((mappingproxyobject*)right)->mapping; 
+        }
+        PyObject *left_mapping = ((mappingproxyobject*)left)->mapping;
+        if (is_known_dict_subclass_or(right) || PyFrozenDict_CheckExact(left_mapping)) {
+            return PyNumber_Or(left_mapping, right);
+        }
+    } else {
+        assert(PyObject_TypeCheck(right, &PyDictProxy_Type));
+        PyObject *right_mapping = ((mappingproxyobject*)right)->mapping;
+        if (is_known_dict_subclass_or(left) || PyFrozenDict_CheckExact(right_mapping)) {
+            return PyNumber_Or(left, right_mapping);
+        }
     }
-    if (PyObject_TypeCheck(right, &PyDictProxy_Type)) {
-        right = ((mappingproxyobject*)right)->mapping;
-    }
-    return PyNumber_Or(left, right);
+
+    // The non-mappingproxy "or" will have to deal with a mappingproxy.
+    Py_RETURN_NOTIMPLEMENTED;
 }
 
 static PyObject *


### PR DESCRIPTION
Essentially:
* if `w` is a mapping proxy then unwrap it.
* if `w` uses the dict comparison operator then use that.
* if `v->mapping` is a frozendict then forward that (because it's immutable so safe)
* otherwise return NOT_IMPLEMENTED (on the basis that it's likely that `w`'s rich comparison can do it through the standard mapping interface.

------------------------------

This is a draft (without tests) because two other people have already proposed possible solutions. I just wanted to propose my C code solution, but my assumption is that (if we want to use it) it'll be stolen and merged with someone else's proposed tests.

<!-- gh-issue-number: gh-152405 -->
* Issue: gh-152405
<!-- /gh-issue-number -->
