### PR TITLE
gh-110904: Recommend windows-curses in the curses HOWTO

### DIFF
--- a/Doc/howto/curses.rst
+++ b/Doc/howto/curses.rst
@@ -52,8 +52,8 @@ code, all the functions described here will probably be available.  The older
 versions of curses carried by some proprietary Unixes may not support
 everything, though.
 
-The Windows version of Python doesn't include the :mod:`curses`
-module.  A ported version called :pypi:`UniCurses` is available.
+The Windows version of Python doesn't include the :mod:`curses` module.
+The third-party :pypi:`windows-curses` package provides the same interface on Windows.
 
 
 The Python curses module


### PR DESCRIPTION
<!-- gh-issue-number: gh-110904 -->
* Issue: gh-110904
<!-- /gh-issue-number -->

The curses HOWTO recommended :pypi:`UniCurses`, which is unmaintained and exposes its own API rather than the standard :mod:`curses` interface.

Recommend :pypi:`windows-curses` instead: it provides the standard curses interface on Windows (so existing curses code runs unchanged) and is actively maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
