### PR TITLE
gh-152492 Allow OrderedDict.update to work with frozendict

### DIFF
--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -74,6 +74,9 @@ class OrderedDictTests:
         od.update(dict(pairs))
         self.assertEqual(sorted(od.items()), pairs)                                 # dict input
         od = OrderedDict()
+        od.update(frozendict(pairs))
+        self.assertEqual(sorted(od.items()), pairs)                                 # frozendict input
+        od = OrderedDict()
         od.update(**dict(pairs))
         self.assertEqual(sorted(od.items()), pairs)                                 # kwds input
         od = OrderedDict()
@@ -288,9 +291,11 @@ class OrderedDictTests:
         pairs = pairs[2:] + pairs[:2]
         od2 = OrderedDict(pairs)
         self.assertNotEqual(od1, od2)       # different order implies inequality
-        # comparison to regular dict is not order sensitive
+        # comparison to regular (frozen)dict is not order sensitive
         self.assertEqual(od1, dict(od2))
         self.assertEqual(dict(od2), od1)
+        self.assertEqual(od1, frozendict(od2))
+        self.assertEqual(frozendict(od1), od2)
         # different length implied inequality
         self.assertNotEqual(od1, OrderedDict(pairs[:-1]))
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-28-14-31-03.gh-issue-152492._09Zee.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-28-14-31-03.gh-issue-152492._09Zee.rst
@@ -1,0 +1,1 @@
+:func:`collections.OrderedDict.update` can now accept :type:`frozendict` as an argument.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-28-14-31-03.gh-issue-152492._09Zee.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-28-14-31-03.gh-issue-152492._09Zee.rst
@@ -1,1 +1,1 @@
-:func:`collections.OrderedDict.update` can now accept :type:`frozendict` as an argument.
+:type:`collections.OrderedDict` `update` method can now accept :type:`frozendict` as an argument.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-28-14-31-03.gh-issue-152492._09Zee.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-28-14-31-03.gh-issue-152492._09Zee.rst
@@ -1,1 +1,1 @@
-:type:`collections.OrderedDict` `update` method can now accept :type:`frozendict` as an argument.
+:type:`collections.OrderedDict` ``update`` method can now accept :type:`frozendict` as an argument.

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1487,7 +1487,7 @@ odict_tp_clear(PyObject *op)
 static PyObject *
 odict_richcompare_lock_held(PyObject *v, PyObject *w, int op)
 {
-    if (!PyODict_Check(v) || !PyDict_Check(w)) {
+    if (!PyODict_Check(v) || !PyAnyDict_Check(w)) {
         Py_RETURN_NOTIMPLEMENTED;
     }
 
@@ -2354,7 +2354,7 @@ mutablemapping_update(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     /* now handle kwargs */
-    assert(kwargs == NULL || PyDict_Check(kwargs));
+    assert(kwargs == NULL || PyAnyDict_Check(kwargs));
     if (kwargs != NULL && PyDict_GET_SIZE(kwargs)) {
         PyObject *items = PyDict_Items(kwargs);
         if (items == NULL)


### PR DESCRIPTION
Additionally, add tests for comparison with frozendict on the same basis as dict. This already worked but is good to confirm.

<!-- gh-issue-number: gh-152492 -->
* Issue: gh-152492
<!-- /gh-issue-number -->
