### PR TITLE
gh-152490: Fix TypeError when formatting SyntaxError with msg=NotImplemented in `traceback.py`

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -583,13 +583,15 @@ class TracebackCases(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, 'required positional argument'):
             traceback.format_exception(exc=e)
 
-    def test_format_syntax_error(self):
+    def test_format_exception_only_exc(self):
         output = traceback.format_exception_only(Exception("projector"))
         self.assertEqual(output, ["Exception: projector\n"])
 
+    def test_format_syntax_error_msg(self):
         exc = SyntaxError(NotImplemented)
         lines = traceback.format_exception_only(type(exc), exc)
-        self.assertIsInstance("".join(lines), str)
+        result = "".join(lines)
+        self.assertIn("NotImplemented", result)
 
         exc = SyntaxError("invalid syntax")
         lines = traceback.format_exception_only(type(exc), exc)

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -583,9 +583,19 @@ class TracebackCases(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, 'required positional argument'):
             traceback.format_exception(exc=e)
 
-    def test_format_exception_only_exc(self):
+    def test_format_syntax_error(self):
         output = traceback.format_exception_only(Exception("projector"))
         self.assertEqual(output, ["Exception: projector\n"])
+
+        exc = SyntaxError(NotImplemented)
+        lines = traceback.format_exception_only(type(exc), exc)
+        self.assertIsInstance("".join(lines), str)
+
+        exc = SyntaxError("invalid syntax")
+        lines = traceback.format_exception_only(type(exc), exc)
+        result = "".join(lines)
+        self.assertIn("SyntaxError", result)
+        self.assertIn("invalid syntax", result)
 
     def test_exception_is_None(self):
         NONE_EXC_STRING = 'NoneType: None\n'
@@ -624,11 +634,6 @@ class TracebackCases(unittest.TestCase):
         self.assertEqual(
             str(inspect.signature(traceback.format_exception_only)),
             '(exc, /, value=<implicit>, *, show_group=False, **kwargs)')
-
-    def test_syntax_error_with_not_implemented_msg(self):
-        exc = SyntaxError(NotImplemented)
-        lines = traceback.format_exception_only(type(exc), exc)
-        self.assertIsInstance("".join(lines), str)
 
 
 class PurePythonExceptionFormattingMixin:

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -625,6 +625,11 @@ class TracebackCases(unittest.TestCase):
             str(inspect.signature(traceback.format_exception_only)),
             '(exc, /, value=<implicit>, *, show_group=False, **kwargs)')
 
+    def test_syntax_error_with_not_implemented_msg(self):
+        exc = SyntaxError(NotImplemented)
+        lines = traceback.format_exception_only(type(exc), exc)
+        self.assertIsInstance("".join(lines), str)
+
 
 class PurePythonExceptionFormattingMixin:
     def get_exception(self, callable, slice_start=0, slice_end=-1):

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -589,7 +589,7 @@ class TracebackCases(unittest.TestCase):
 
     @support.subTests("arg", [NotImplemented, "invalid syntax"])
     def test_format_syntax_error_message(self, arg):
-        exc = SyntaxError(value)
+        exc = SyntaxError(arg)
         lines = traceback.format_exception_only(type(exc), exc)
         result = "".join(lines)
         self.assertIn(str(arg), result)

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -587,17 +587,12 @@ class TracebackCases(unittest.TestCase):
         output = traceback.format_exception_only(Exception("projector"))
         self.assertEqual(output, ["Exception: projector\n"])
 
-    def test_format_syntax_error_msg(self):
-        exc = SyntaxError(NotImplemented)
+    @support.subTests("arg", [NotImplemented, "invalid syntax"])
+    def test_format_syntax_error_message(self, arg):
+        exc = SyntaxError(value)
         lines = traceback.format_exception_only(type(exc), exc)
         result = "".join(lines)
-        self.assertIn("NotImplemented", result)
-
-        exc = SyntaxError("invalid syntax")
-        lines = traceback.format_exception_only(type(exc), exc)
-        result = "".join(lines)
-        self.assertIn("SyntaxError", result)
-        self.assertIn("invalid syntax", result)
+        self.assertIn(str(arg), result)
 
     def test_exception_is_None(self):
         NONE_EXC_STRING = 'NoneType: None\n'

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1611,7 +1611,7 @@ class TracebackException:
                     )
                 else:
                     yield '    {}\n'.format(ltext)
-        if self.msg is None:
+        if self.msg is None or self.msg == '':
             msg = "<no detail available>"
         else:
             msg = str(self.msg)

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1611,7 +1611,10 @@ class TracebackException:
                     )
                 else:
                     yield '    {}\n'.format(ltext)
-        msg = self.msg or "<no detail available>"
+        if self.msg is None:
+            msg = "<no detail available>"
+        else:
+            msg = str(self.msg)
         yield "{}{}{}: {}{}{}{}\n".format(
             theme.type,
             stype,

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1611,7 +1611,7 @@ class TracebackException:
                     )
                 else:
                     yield '    {}\n'.format(ltext)
-        if self.msg is None or self.msg == '':
+        if self.msg in (None, ''):
             msg = "<no detail available>"
         else:
             msg = str(self.msg)

--- a/Misc/NEWS.d/next/Library/2026-06-28-14-37-01.gh-issue-152490.A8qLbF.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-28-14-37-01.gh-issue-152490.A8qLbF.rst
@@ -1,2 +1,1 @@
-Fix :exc:`TypeError` when formatting a :exc:`SyntaxError` raised with :data:`NotImplemented` as its argument, which caused IDLE Shell to restart
-unexpectedly.
+Fix :exc:`TypeError` when formatting a :exc:`SyntaxError` raised with :data:`NotImplemented` as its argument, which caused IDLE Shell to restart unexpectedly.

--- a/Misc/NEWS.d/next/Library/2026-06-28-14-37-01.gh-issue-152490.A8qLbF.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-28-14-37-01.gh-issue-152490.A8qLbF.rst
@@ -1,1 +1,1 @@
-Fix :exc:`TypeError` when formatting a :exc:`SyntaxError` raised with :data:`NotImplemented` as its argument, which caused IDLE Shell to restart unexpectedly.
+Fix :exc:`TypeError` when formatting a :exc:`SyntaxError` raised with :data:`NotImplemented` as its argument, which caused unexpected REPL exit and IDLE Shell restart.

--- a/Misc/NEWS.d/next/Library/2026-06-28-14-37-01.gh-issue-152490.A8qLbF.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-28-14-37-01.gh-issue-152490.A8qLbF.rst
@@ -1,0 +1,2 @@
+Fix :exc:`TypeError` when formatting a :exc:`SyntaxError` raised with :data:`NotImplemented` as its argument, which caused IDLE Shell to restart
+unexpectedly.


### PR DESCRIPTION
Fixes #152490 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152490 -->
* Issue: gh-152490
<!-- /gh-issue-number -->
