### PR TITLE
gh-152434: Avoid Gecko export in async-aware test

### DIFF
--- a/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
@@ -711,7 +711,7 @@ class TestSampleProfilerComponents(unittest.TestCase):
             [MockAwaitedInfo(thread_id=100, awaited_by=[parent, child])],
             timestamps_us=[1000, 2000],
         )
-        profile_data = export_gecko_profile(self, collector)
+        profile_data = collector._build_profile()
 
         self.assertEqual(len(profile_data["threads"]), 1)
         thread_data = profile_data["threads"][0]


### PR DESCRIPTION
Fixes Emscripten CI.

<!-- gh-issue-number: gh-152434 -->
* Issue: gh-152434
<!-- /gh-issue-number -->
