### PR TITLE
gh-152431: Update StreamReader transport after asyncio TLS upgrade

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -218,7 +218,7 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
         self._over_ssl = transport.get_extra_info('sslcontext') is not None
         reader = self._stream_reader
         if reader is not None:
-            reader._transport = transport
+            reader.set_transport(transport)
 
     def connection_made(self, transport):
         if self._reject_connection:
@@ -475,7 +475,9 @@ class StreamReader:
                 waiter.set_result(None)
 
     def set_transport(self, transport):
-        assert self._transport is None, 'Transport already set'
+        assert self._transport is None or self._transport is transport, (
+            'Transport already set'
+        )
         self._transport = transport
 
     def _maybe_resume_transport(self):

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -216,6 +216,9 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
     def _replace_transport(self, transport):
         self._transport = transport
         self._over_ssl = transport.get_extra_info('sslcontext') is not None
+        reader = self._stream_reader
+        if reader is not None:
+            reader._transport = transport
 
     def connection_made(self, transport):
         if self._reject_connection:

--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -1737,6 +1737,36 @@ class TestSSL(test_utils.TestCase):
             loop.run_until_complete(client(srv.addr))
 
 
+    async def test_start_tls_updates_stream_reader_transport(self):
+        # gh-152431: after start_tls, the StreamReader must use the new
+        # transport, not the old one.
+        srv_ctx = test_utils.simple_server_sslcontext()
+        cli_ctx = test_utils.simple_client_sslcontext()
+
+        async def handler(reader, writer):
+            writer.close()
+
+        srv = await asyncio.start_server(handler, '127.0.0.1', 0)
+        addr = srv.sockets[0].getsockname()
+
+        reader, writer = await asyncio.open_connection(*addr)
+
+        old_transport = reader._transport
+        self.assertIsNotNone(old_transport)
+
+        new_transport = await self.loop.start_tls(
+            writer.transport, writer._protocol, srv_ctx,
+            server_side=False, ssl_handshake_timeout=self.TIMEOUT)
+
+        # The reader should now reference the TLS transport
+        self.assertIs(reader._transport, new_transport)
+        self.assertIsNot(reader._transport, old_transport)
+
+        writer.close()
+        srv.close()
+        await srv.wait_closed()
+
+
 ###############################################################################
 # Socket Testing Utilities
 ###############################################################################

--- a/Misc/NEWS.d/next/Library/2026-06-29-00-00-00.gh-issue-152431.XxYyZz.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-29-00-00-00.gh-issue-152431.XxYyZz.rst
@@ -1,0 +1,2 @@
+Fix :meth:`asyncio.StreamWriter.start_tls` to update the linked
+:class:`~asyncio.StreamReader` transport after the TLS handshake.


### PR DESCRIPTION
Fixes #152431

`StreamReaderProtocol._replace_transport` only updated its own
transport reference. After `start_tls`, the linked
`StreamReader` still held the old transport, causing reads to
use the wrong connection.

<!-- gh-issue-number: gh-152431 -->
* Issue: gh-152431
<!-- /gh-issue-number -->
