### PR TITLE
gh-152248: Fix zoneinfo TZ string regex to only accept ASCII letters

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1222,6 +1222,11 @@ class TZStrTest(ZoneInfoTestBase):
             "AAA4BBB,J60/2:00:100,J300/2",
             "AAA4BBB,J60/2,J300/2:00:0",
             "AAA4BBB,J60/2,J300/2:00:100",
+            # gh-152248: unquoted abbreviation must be ASCII letters only
+            "A A4BBB,J60/2,J300/2",        # space in std abbreviation
+            "AAA4B B,J60/2,J300/2",         # space in dst abbreviation
+            "ÄAA4BBB,J60/2,J300/2",        # non-ASCII letter in std
+            "AAA4ÄBB,J60/2,J300/2",         # non-ASCII letter in dst
         ]
 
         for invalid_tzstr in invalid_tzstrs:

--- a/Lib/zoneinfo/_zoneinfo.py
+++ b/Lib/zoneinfo/_zoneinfo.py
@@ -640,11 +640,11 @@ def _parse_tz_str(tz_str):
 
     parser_re = re.compile(
         r"""
-        (?P<std>[^<0-9:.+-]+|<[a-zA-Z0-9+-]+>)
+        (?P<std>[a-zA-Z]+|<[a-zA-Z0-9+-]+>)
         (?:
             (?P<stdoff>[+-]?\d{1,3}(?::\d{2}(?::\d{2})?)?)
             (?:
-                (?P<dst>[^0-9:.+-]+|<[a-zA-Z0-9+-]+>)
+                (?P<dst>[a-zA-Z]+|<[a-zA-Z0-9+-]+>)
                 (?P<dstoff>[+-]?\d{1,3}(?::\d{2}(?::\d{2})?)?)?
             )? # dst
         )? # stdoff

--- a/Misc/NEWS.d/next/Library/2026-06-29-00-00-01.gh-issue-152248.XxYyZz.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-29-00-00-01.gh-issue-152248.XxYyZz.rst
@@ -1,0 +1,3 @@
+Fix the pure-Python :func:`zoneinfo._parse_tz_str` to reject unquoted
+POSIX TZ string abbreviations containing non-ASCII characters or
+whitespace, matching the C implementation's behavior.


### PR DESCRIPTION
Fixes #152248

The pure-Python `_parse_tz_str` regex used `[^<0-9:.+-]+` for
unquoted abbreviations, which matched whitespace and non-ASCII
characters. The C implementation only accepts ASCII letters.

Tighten the regex to `[a-zA-Z]+` to match C behavior.

<!-- gh-issue-number: gh-152248 -->
* Issue: gh-152248
<!-- /gh-issue-number -->
