### PR TITLE
gh-79638: Restore "Treat an unreachable robots.txt as disallow all"

### DIFF
--- a/Lib/urllib/robotparser.py
+++ b/Lib/urllib/robotparser.py
@@ -65,9 +65,17 @@ class RobotFileParser:
             f = urllib.request.urlopen(self.url)
         except urllib.error.HTTPError as err:
             if err.code in (401, 403):
+                # If access to robot.txt has the status Unauthorized/Forbidden,
+                # then most likely this applies to the entire site.
                 self.disallow_all = True
-            elif err.code >= 400 and err.code < 500:
+            elif 400 <= err.code < 500:
+                # RFC 9309, Section 2.3.1.3: the crawler MAY access any
+                # resources on the server.
                 self.allow_all = True
+            elif 500 <= err.code < 600:
+                # RFC 9309, Section 2.3.1.4: the crawler MUST assume
+                # complete disallow.
+                self.disallow_all = True
             err.close()
         else:
             raw = f.read()

--- a/Misc/NEWS.d/next/Library/2025-09-05-20-50-35.gh-issue-79638.Y-JfaH.rst
+++ b/Misc/NEWS.d/next/Library/2025-09-05-20-50-35.gh-issue-79638.Y-JfaH.rst
@@ -1,0 +1,2 @@
+Disallow all access in :mod:`urllib.robotparser` if the ``robots.txt`` file
+is unreachable due to server or network errors.


### PR DESCRIPTION
The gh-79638 change ("Treat an unreachable robots.txt as 'disallow all'", GH-138555) was accidentally reverted by the gh-106693 / GH-149514 `ob_sval` revert, which removed the `read()` 5xx → `disallow_all` branch in `urllib.robotparser` and its NEWS entry along with the intended `bytesobject.h` revert.

This restores the `read()` behaviour and the NEWS entry. The tests were already restored separately by GH-149569.

<!-- gh-issue-number: gh-79638 -->
* Issue: gh-79638
<!-- /gh-issue-number -->
