### PR TITLE
gh-135523: Enforce RFC 3986 query chars in strict parse_qsl

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1541,6 +1541,18 @@ class UrlParseTestCase(unittest.TestCase):
         with self.assertRaises(UnicodeDecodeError):
             urllib.parse.parse_qsl('a=b', separator=b'\xa6')
 
+    def test_parse_qsl_strict_invalid_query_chars(self):
+        # gh-135523: RFC 3986 excludes '#', '[', ']', etc. from query
+        for qs in ['foo=#', 'foo=[bar]', 'a={b}', 'a=b c']:
+            with self.subTest(qs=qs):
+                self.assertRaises(ValueError, urllib.parse.parse_qsl,
+                                  qs, strict_parsing=True)
+        # bytes input
+        self.assertRaises(ValueError, urllib.parse.parse_qsl,
+                          b'foo=#', strict_parsing=True)
+        # valid query chars accepted
+        urllib.parse.parse_qsl('a=1&b=2%20x', strict_parsing=True)
+
     def test_urlencode_sequences(self):
         # Other tests incidentally urlencode things; test non-covered cases:
         # Sequence and object values.

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -856,6 +856,13 @@ def unquote(string, encoding='utf-8', errors='replace'):
     return ''.join(_generate_unquoted_parts(string, encoding, errors))
 
 
+# RFC 3986
+_VALID_QUERY_CHARS = frozenset(
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    "-._~!$&'()*+,;=:@/?%"
+)
+
+
 def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
              encoding='utf-8', errors='replace', max_num_fields=None, separator='&'):
     """Parse a query given as a string argument.
@@ -967,6 +974,19 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         num_fields = 1 + qs.count(separator)
         if max_num_fields < num_fields:
             raise ValueError('Max number of fields exceeded')
+
+    if strict_parsing:
+        if isinstance(qs, bytes):
+            qs_chars = {chr(b) for b in qs}
+            sep_chars = {chr(b) for b in separator}
+        else:
+            qs_chars = set(qs)
+            sep_chars = set(separator)
+        invalid = qs_chars - _VALID_QUERY_CHARS - sep_chars
+        if invalid:
+            raise ValueError(
+                "invalid query characters: %r" % ''.join(sorted(invalid))
+            )
 
     r = []
     for name_value in qs.split(separator):

--- a/Misc/NEWS.d/next/Library/2026-06-28-21-15-17.gh-issue-135523.eg32g4.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-28-21-15-17.gh-issue-135523.eg32g4.rst
@@ -1,0 +1,2 @@
+:func:`urllib.parse.parse_qsl` and :func:`urllib.parse.parse_qs` now reject
+characters not valid per :rfc:`3986` when *strict_parsing* is ``True``.


### PR DESCRIPTION
[RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.4) defines valid query characters as `pchar / "/" / "?"`. So, IMO with `strict_parsing` it makes sense to validate against this set and reject other characters like (`#`, `[`, `]`, etc)

<!-- gh-issue-number: gh-135523 -->
* Issue: gh-135523
<!-- /gh-issue-number -->
