### PR TITLE
gh-75952: Document negative offsets in tkinter geometry strings

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -2071,6 +2071,7 @@ Base and mixin classes
 
       Return the geometry of the widget, in the form ``widthxheight+x+y``.
       All dimensions are in pixels.
+      An offset can be negative; see :meth:`~Wm.geometry`.
 
    .. method:: winfo_height()
 
@@ -2541,6 +2542,8 @@ Base and mixin classes
       *width* and *height* are in pixels (or grid units for a gridded window);
       a position preceded by ``+`` is measured from the left or top edge of the
       screen and one preceded by ``-`` from the right or bottom edge.
+      An offset can be negative, as in ``'200x100+-9+-8'``, when the window
+      edge is positioned beyond the corresponding screen edge.
       An empty string cancels any user-specified geometry, letting the window
       revert to its natural size.
       With no argument, return the current geometry as a string of the form


### PR DESCRIPTION
Tk geometry strings can contain a negative offset, e.g. `geometry()` returns `'200x100+-9+-8'` when a window edge is positioned beyond the corresponding screen edge.  The documentation only described plain `+`/`-` offsets, so the `+-` form was unexpected.

Note the negative offset in the `geometry()` and `winfo_geometry()` documentation.

<!-- gh-issue-number: gh-75952 -->
* Issue: gh-75952
<!-- /gh-issue-number -->