### PR TITLE
gh-87577: Document that wm_manage does not accept ttk widgets

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -2699,7 +2699,8 @@ Base and mixin classes
       Make *widget* a stand-alone top-level window, decorated by the window
       manager with a title bar and so on.
       Only :class:`Frame`, :class:`LabelFrame` and :class:`Toplevel` widgets
-      may be used; passing any other widget type raises an error.
+      may be used (the :mod:`tkinter.ttk` versions are **not** accepted);
+      passing any other widget type raises an error.
       :meth:`wm_manage` is an alias of :meth:`!manage`.
 
       .. versionadded:: 3.3


### PR DESCRIPTION
Tk's `wm manage` accepts only the classic `frame`, `labelframe` and `toplevel` widget types, so `wm_manage()` fails with `tkinter.ttk.Frame` and `tkinter.ttk.LabelFrame`:

    _tkinter.TclError: window ".!frame" is not manageable: must be a frame, labelframe or toplevel

This is confusing for users who work mostly with ttk widgets.  Note in the `manage()` documentation that the `tkinter.ttk` versions are not accepted.

<!-- gh-issue-number: gh-87577 -->
* Issue: gh-87577
<!-- /gh-issue-number -->