### PR TITLE
Clarify when `typing.Unpack` added support for `typing.TypedDict`

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1714,6 +1714,8 @@ These can be used as types in annotations. They all support subscription using
       tup: tuple[*Ts]         # Syntax error on Python <= 3.10!
       tup: tuple[Unpack[Ts]]  # Semantically equivalent, and backwards-compatible
 
+   .. versionadded:: 3.11
+
    ``Unpack`` can also be used along with :class:`typing.TypedDict` for typing
    ``**kwargs`` in a function signature::
 
@@ -1729,7 +1731,7 @@ These can be used as types in annotations. They all support subscription using
 
    See :pep:`692` for more details on using ``Unpack`` for ``**kwargs`` typing.
 
-   .. versionadded:: 3.11
+   .. versionadded:: 3.12
 
 Building generic types and type aliases
 """""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
typing.Unpack was added in version 3.11, but the ability to use it with TypedDict for `**kwargs` was added in 3.12.

Currently, the positioning makes it look like using typing.Unpack with TypedDict was added in 3.11