### PR TITLE
gh-152563, test_math: Enable fma test on musl 1.2.6

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -2682,11 +2682,8 @@ class FMATests(unittest.TestCase):
     @unittest.skipIf(
         sys.platform.startswith(("freebsd", "wasi", "netbsd", "emscripten", "cygwin"))
         or (sys.platform == "android" and platform.machine() == "x86_64")
-        or support.linked_to_musl(),  # gh-131032
+        or (support.linked_to_musl() and support.linked_to_musl() < (1, 2, 6)),  # gh-131032
         f"this platform doesn't implement IEE 754-2008 properly")
-    # gh-131032: musl is fixed but the fix is not yet released; when the fixed
-    # version is known change this to:
-    #   or support.linked_to_musl() < (1, <m>, <p>)
     def test_fma_zero_result(self):
         nonnegative_finites = [0.0, 1e-300, 2.3, 1e300]
 


### PR DESCRIPTION
### Proposal:

#131313 fix many tests on Alpine Linux (musl C library). About `test_fma_zero_result`, it says 
```
    # gh-131032: musl is fixed but the fix is not yet released; when the fixed
    # version is known change this to:
    #   or support.linked_to_musl() < (1, <m>, <p>)
```
And now `musl 1.2.6` is available, and I have verified that the test can pass. So let's enable it.

- docker image: alpine:edge
- musl version: 1.2.6-r2
- test result: pass

I also test the older version
- docker image: alpine:3.21
- musl version: 1.2.5-r11
- test result: skipped


<!-- gh-issue-number: gh-152563 -->
* Issue: gh-152563
<!-- /gh-issue-number -->
