### PR TITLE
gh-71450: Document that Tcl sets the HOME variable on Windows

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -3394,6 +3394,14 @@ Toplevel widgets
    profile files is the :envvar:`HOME` environment variable or, if that
    isn't defined, then :data:`os.curdir`.
 
+   .. note::
+
+      On Windows, creating a Tcl interpreter (by instantiating :class:`Tk` or
+      calling :func:`Tcl`) sets the :envvar:`HOME` environment variable for
+      the process, if it is not already set, to ``%HOMEDRIVE%%HOMEPATH%`` (or
+      :envvar:`USERPROFILE`, or ``c:\``).  This is done by Tcl and can affect
+      other code that reads :envvar:`HOME`.
+
    .. attribute:: tk
 
       The Tk application object created by instantiating :class:`Tk`.  This

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -345,7 +345,7 @@ def _isreservedname(name):
 def expanduser(path):
     """Expand ~ and ~user constructs.
 
-    If user or $HOME is unknown, do nothing."""
+    If user or home directory is unknown, do nothing."""
     path = os.fspath(path)
     if isinstance(path, bytes):
         seps = b'\\/'


### PR DESCRIPTION
On Windows, Tcl sets the `HOME` environment variable when a Tcl interpreter is created (if it is not already set), to `%HOMEDRIVE%%HOMEPATH%`, `%USERPROFILE%`, or `c:\`.

Document this in the `tkinter` docs, since it can affect other code that reads `HOME`.

Also fix the `ntpath.expanduser()` docstring, which still mentioned `$HOME` even though it no longer uses it on Windows (since 3.8).

<!-- gh-issue-number: gh-71450 -->
* Issue: gh-71450
<!-- /gh-issue-number -->