### PR TITLE
gh-133031: Fix test_textbox_edit_wide on a narrow build

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -2366,15 +2366,19 @@ class TestCurses(unittest.TestCase):
             self.assertEqual(box.gather(), text + ' ')
 
     def test_textbox_edit_wide(self):
-        # edit() reads characters through get_wch().  Each is used only if
-        # encodable in the current locale.
+        # edit() reads characters through get_wch().  Each character is pushed
+        # with unget_wch(), which on a narrow build requires it to encode to a
+        # single byte, so a non-ASCII case needs a wide build or an 8-bit locale.
         for ch in ['A', 'é', '¤', '€', 'д']:
-            if self._encodable(ch):
-                with self.subTest(ch=ch):
-                    box, win = self._make_textbox(1, 10)
-                    for c in reversed(['a', ch, chr(curses.ascii.BEL)]):
-                        curses.unget_wch(c)
-                    self.assertEqual(box.edit(), 'a' + ch + ' ')
+            if not self._encodable(ch):
+                continue
+            if not WIDE_BUILD and len(ch.encode(self.stdscr.encoding)) != 1:
+                continue
+            with self.subTest(ch=ch):
+                box, win = self._make_textbox(1, 10)
+                for c in reversed(['a', ch, chr(curses.ascii.BEL)]):
+                    curses.unget_wch(c)
+                self.assertEqual(box.edit(), 'a' + ch + ' ')
 
     def test_textbox_movement(self):
         box, win = self._make_textbox(3, 10)


### PR DESCRIPTION
`test_textbox_edit_wide` is the only textbox test that feeds characters through `curses.unget_wch()`. On a narrow build (no wide-character support) `unget_wch()` can only push a character that encodes to a single byte, so under a UTF-8 locale a non-ASCII character such as `'é'` raises `OverflowError`. This was failing on the macOS buildbots, which link the system narrow curses.

Skip the multi-byte cases on a narrow build, the same way the existing 8-bit textbox tests do.

<!-- gh-issue-number: gh-133031 -->
* Issue: gh-133031
<!-- /gh-issue-number -->
