### PR TITLE
gh-152587: Stop documenting bogus default values in tkinter variable methods

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -1056,11 +1056,11 @@ Base and mixin classes
       :class:`int`.
       Raise :exc:`ValueError` if *s* is not a valid integer.
 
-   .. method:: getvar(name='PY_VAR')
+   .. method:: getvar(name)
 
       Return the value of the Tcl global variable named *name*.
 
-   .. method:: setvar(name='PY_VAR', value='1')
+   .. method:: setvar(name, value)
 
       Set the Tcl global variable named *name* to *value*.
 
@@ -1524,10 +1524,10 @@ Base and mixin classes
       This updates the display of windows, for example after geometry changes,
       but does not process events caused by the user.
 
-   .. method:: waitvar(name='PY_VAR')
+   .. method:: waitvar(name)
       :no-typesetting:
 
-   .. method:: wait_variable(name='PY_VAR')
+   .. method:: wait_variable(name)
 
       Wait until the Tcl variable *name* is modified, continuing to process
       events in the meantime so that the application stays responsive.


### PR DESCRIPTION
The *name* parameter of `Misc.wait_variable()`, `setvar()` and `getvar()` and the *value* parameter of `setvar()` should not be optional.
Their default values (`'PY_VAR'` and `'1'`) are not meaningful and should not be advertised, so stop documenting them.

This is the documentation-only part of the change (backportable).
A follow-up makes the parameters required in code on the main branch only.

<!-- gh-issue-number -->
* Issue: gh-152587
<!-- /gh-issue-number -->
