### PR TITLE
gh-152587: Make name and value required in tkinter variable methods

### DIFF
--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -559,6 +559,14 @@ Porting to Python 3.16
 This section lists previously described changes and other bugfixes
 that may require changes to your code.
 
+* In :mod:`tkinter`, the *name* parameter of the
+  :meth:`~tkinter.Misc.wait_variable`, :meth:`~tkinter.Misc.setvar` and
+  :meth:`~tkinter.Misc.getvar` methods and the *value* parameter of
+  :meth:`!setvar` are now required.  Calling these methods without
+  them, which formerly defaulted to ``'PY_VAR'`` and ``'1'``, now raises
+  :exc:`TypeError`.
+  (Contributed by Serhiy Storchaka in :gh:`152587`.)
+
 
 Build changes
 =============

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -367,6 +367,10 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
     def test_getvar(self):
         self.root.setvar('test_var', 'hello')
         self.assertEqual(self.root.getvar('test_var'), 'hello')
+        # The name and value are required (gh-152587).
+        self.assertRaises(TypeError, self.root.getvar)
+        self.assertRaises(TypeError, self.root.setvar)
+        self.assertRaises(TypeError, self.root.setvar, 'test_var')
 
     def test_register(self):
         result = []
@@ -598,6 +602,8 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         self.root.after(1, var.set, 'done')
         self.root.wait_variable(var)  # Returns once the variable is set.
         self.assertEqual(var.get(), 'done')
+        # The name is required (gh-152587).
+        self.assertRaises(TypeError, self.root.wait_variable)
 
     def test_wait_window(self):
         top = tkinter.Toplevel(self.root)

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -818,7 +818,7 @@ class Misc:
         else:
             return self.tk.getint(self.tk.call(args))
 
-    def wait_variable(self, name='PY_VAR'):
+    def wait_variable(self, name):
         """Wait until the variable is modified.
 
         A parameter of type IntVar, StringVar, DoubleVar or
@@ -843,11 +843,11 @@ class Misc:
             window = self
         self.tk.call('tkwait', 'visibility', window._w)
 
-    def setvar(self, name='PY_VAR', value='1'):
+    def setvar(self, name, value):
         """Set Tcl variable NAME to VALUE."""
         self.tk.setvar(name, value)
 
-    def getvar(self, name='PY_VAR'):
+    def getvar(self, name):
         """Return value of Tcl variable NAME."""
         return self.tk.getvar(name)
 

--- a/Misc/NEWS.d/next/Library/2026-06-29-12-50-28.gh-issue-152587.Lq8wVn.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-29-12-50-28.gh-issue-152587.Lq8wVn.rst
@@ -1,0 +1,5 @@
+In :mod:`tkinter`, the *name* parameter of the
+:meth:`~tkinter.Misc.wait_variable`, :meth:`~tkinter.Misc.setvar` and
+:meth:`~tkinter.Misc.getvar` methods and the *value* parameter of
+:meth:`!setvar` are now required.  Their former default values
+(``'PY_VAR'`` and ``'1'``) were not meaningful.


### PR DESCRIPTION
The *name* parameter of `Misc.wait_variable()`, `setvar()` and `getvar()` and the *value* parameter of `setvar()` no longer have default values.
The former defaults (`'PY_VAR'` and `'1'`) were not meaningful, and calling these methods without the arguments was almost always a bug.

The documentation was already updated separately (and backported); this is the code change, for the main branch only.

<!-- gh-issue-number -->
* Issue: gh-152587
<!-- /gh-issue-number -->
