### PR TITLE
gh-69134: Wait until mapped in keyboard virtual-event tests

### DIFF
--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -1994,7 +1994,7 @@ class ListboxTest(AbstractWidgetTest, unittest.TestCase):
         lb = self.create(selectmode='browse', exportselection=False)
         lb.insert(0, *('el%d' % i for i in range(5)))
         lb.pack()
-        lb.update()
+        self.require_mapped(lb)
         events = []
         lb.bind('<<ListboxSelect>>', lambda e: events.append(lb.curselection()))
         lb.focus_force()

--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -1977,7 +1977,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
         self.tv.insert(parent, 'end')
         item2 = self.tv.insert('', 'end')
         self.tv.pack()
-        self.tv.update()
+        self.require_mapped(self.tv)
         selects, opens, closes = [], [], []
         self.tv.bind('<<TreeviewSelect>>',
                      lambda e: selects.append(self.tv.selection()))


### PR DESCRIPTION
`TreeviewTest.test_virtual_events` and `ListboxTest.test_selection_event` (both added in gh-151678) drive keyboard navigation events with `event_generate('<Down>')` after `focus_force()`, but only called `update()` before generating them.
On Windows a synthetic key event is only delivered once the toplevel is actually mapped and holding the keyboard focus, so the events could be dropped and the selection never moved — `test_virtual_events` failed intermittently on the Windows buildbots.

This is the same window-manager map race that gh-69134 already hardened the other GUI tests against; these two keyboard tests were simply missed.
Wait until the widget is mapped (`require_mapped()`) before generating the events.

<!-- gh-issue-number -->
* Issue: gh-69134
<!-- /gh-issue-number -->
