### PR TITLE
gh-135669: Replace misleading root with base in _b_base_ docs

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -2531,8 +2531,8 @@ Data types
 
       Sometimes ctypes data instances do not own the memory block they contain,
       instead they share part of the memory block of a base object.  The
-      :attr:`_b_base_` read-only member is the root ctypes object that owns the
-      memory block.
+      :attr:`_b_base_` read-only member is the base ctypes object that shares
+      the memory block.
 
    .. attribute:: _b_needsfree_
 


### PR DESCRIPTION
The `_b_base_` docs described it as the root ctypes object, but looking at the code (comments and `PyCData_GetContainer()` walking the chain to find root), it clearly stores the immediate parent. So I changed wording to match.

<!-- gh-issue-number: gh-135669 -->
* Issue: gh-135669
<!-- /gh-issue-number -->
