### PR TITLE
gh-123193: Document tkinter Variable lifetime

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -656,6 +656,9 @@ method on it, and to change its value you call the :meth:`!set` method.
 If you follow this protocol, the widget will always track the value of the
 variable, with no further intervention on your part.
 
+Keep a reference to the variable for as long as a widget uses it, for example
+by storing it as an attribute (see :class:`Variable`).
+
 For example::
 
    import tkinter as tk
@@ -5915,6 +5918,14 @@ Variable classes
    In most cases you should use one of the typed subclasses below --
    :class:`StringVar`, :class:`IntVar`, :class:`DoubleVar` or
    :class:`BooleanVar` -- rather than :class:`!Variable` directly.
+
+   .. note::
+
+      When a :class:`!Variable` is garbage collected, its Tcl variable is unset.
+      Keep a reference to it for as long as a widget is linked to it, for example
+      by storing it as an attribute rather than in a local variable.
+      Otherwise Tk recreates the Tcl variable to keep the widget working, but it
+      is never unset again, leaking one Tcl variable per dropped wrapper.
 
    .. versionchanged:: 3.10
       Two variables now compare equal (``==``) only when they have the same


### PR DESCRIPTION
A Tk variable wrapper (`StringVar`, `IntVar`, ...) unsets its Tcl variable when the Python object is garbage collected.
If the wrapper is dropped while a widget still references it (through `variable`/`textvariable`), Tk recreates the Tcl variable to keep the widget working, but it is then no longer managed by Python and is never unset again — so it leaks.

This is the cause of gh-123193: dynamically creating widgets whose `Variable` objects are kept only in local variables (and thus collected while the widgets live on) steadily accumulates orphaned `PY_VAR*` Tcl globals.
It is the documented "keep a reference to your `Variable`" footgun rather than a fixable `_tkinter` bug, so this just documents the lifetime contract — on the `coupling-widget-variables` tutorial and on the `Variable` class.

<!-- gh-issue-number -->
* Issue: gh-123193
<!-- /gh-issue-number -->
