### PR TITLE
gh-50966: Fix unbounded recursion in turtle drag handlers

### DIFF
--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -577,6 +577,28 @@ class TestTurtleScreen(unittest.TestCase):
             s.update.assert_not_called()
         s.update.assert_called_once()
 
+    def test_update_is_not_reentrant(self):
+        # ondrag(goto) reenters _update() while cv.update() processes events;
+        # without a guard this recurses without bound (gh-50966).
+        s = turtle.TurtleScreen(cv=unittest.mock.MagicMock())
+        depth = max_depth = 0
+
+        def reenter():
+            nonlocal depth, max_depth
+            depth += 1
+            max_depth = max(max_depth, depth)
+            if depth < 50:
+                s._update()  # as an event handler would
+            depth -= 1
+
+        s.cv.update.reset_mock()  # ignore calls made during construction
+        s.cv.update.side_effect = reenter
+        s._update()
+        # cv.update() runs once; reentrant calls only flush idle tasks.
+        self.assertEqual(s.cv.update.call_count, 1)
+        self.assertEqual(max_depth, 1)
+        self.assertTrue(s.cv.update_idletasks.called)
+
 
 class TestTurtle(unittest.TestCase):
     def setUp(self):

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -486,6 +486,7 @@ class TurtleScreenBase(object):
         self.canvwidth = w
         self.canvheight = h
         self.xscale = self.yscale = 1.0
+        self._updating = False
 
     def _createpoly(self):
         """Create an invisible polygon item on canvas self.cv)
@@ -555,7 +556,16 @@ class TurtleScreenBase(object):
     def _update(self):
         """Redraw graphics items on canvas
         """
-        self.cv.update()
+        if self._updating:
+            # Reentrant call (e.g. a drag handler moving the turtle,
+            # gh-50966): flush drawing without reprocessing input.
+            self.cv.update_idletasks()
+            return
+        self._updating = True
+        try:
+            self.cv.update()
+        finally:
+            self._updating = False
 
     def _delay(self, delay):
         """Delay subsequent canvas actions for delay ms."""

--- a/Misc/NEWS.d/next/Library/2026-06-29-22-16-57.gh-issue-50966.Tq5mLp.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-29-22-16-57.gh-issue-50966.Tq5mLp.rst
@@ -1,0 +1,3 @@
+Fix unbounded recursion in :mod:`turtle` when a mouse event handler that moves
+the turtle is reentered while the screen is being redrawn, for example with
+``screen.ondrag(turtle.goto)``.  This could previously crash the interpreter.


### PR DESCRIPTION
`turtle.TurtleScreenBase._update()` redraws by calling `cv.update()`, which also reprocesses pending input events.
When a mouse handler moves the turtle — the canonical example being `screen.ondrag(turtle.goto)` — the move triggers another `_update()`, whose `cv.update()` dispatches the next queued motion event and reenters the handler.
With a continuous drag this recurses without bound (each level adds Python *and* Tcl C-stack frames), eventually crashing the interpreter (`Tcl_Panic` / segfault).

Guard `_update()` so that a reentrant call only flushes pending drawing with `update_idletasks()` instead of reprocessing input, turning the recursion into bounded iteration.
All drag callbacks still run (the turtle still follows the cursor); the non-reentrant path is unchanged.

Verified with a reproduction (reentrancy depth drops from dozens to 2 for a burst of queued drag events, all callbacks still processed) and a fast non-GUI regression test.

<!-- gh-issue-number -->
* Issue: gh-50966
<!-- /gh-issue-number -->
