### PR TITLE
gh-152633: Fix outdated default compresslevel in gzip docs

### DIFF
--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -112,7 +112,7 @@ The module defines the following items:
    The *compresslevel* argument is an integer from ``0`` to ``9`` controlling
    the level of compression; ``1`` is fastest and produces the least
    compression, and ``9`` is slowest and produces the most compression. ``0``
-   is no compression. The default is ``9``.
+   is no compression. The default is ``6``.
 
    The optional *mtime* argument is the timestamp requested by gzip. The time
    is in Unix format, i.e., seconds since 00:00:00 UTC, January 1, 1970. Set

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -39,7 +39,7 @@ def open(filename, mode="rb", compresslevel=_COMPRESS_LEVEL_TRADEOFF,
 
     The mode argument can be "r", "rb", "w", "wb", "x", "xb", "a" or "ab"
     for binary mode, or "rt", "wt", "xt" or "at" for text mode.  The default
-    mode is "rb", and the default compresslevel is 9.
+    mode is "rb", and the default compresslevel is 6.
 
     For binary mode, this function is equivalent to the GzipFile
     constructor: GzipFile(filename, mode, compresslevel).  In this case,
@@ -186,7 +186,7 @@ class GzipFile(_streams.BaseStream):
         The compresslevel argument is an integer from 0 to 9 controlling
         the level of compression; 1 is fastest and produces the least
         compression, and 9 is slowest and produces the most compression.
-        0 is no compression at all. The default is 9.
+        0 is no compression at all. The default is 6.
 
         The optional mtime argument is the timestamp requested by gzip.
         The time is in Unix format, i.e., seconds since 00:00:00 UTC,


### PR DESCRIPTION
The default compresslevel for gzip.open(), the GzipFile constructor, and gzip.compress() is COMPRESS_LEVEL_TRADEOFF (6). The signatures and the "Changed in version" notes in Doc/library/gzip.rst already reflect this (it says "the default compression level was reduced to 6, down from 9").
However, a few places still state the default is 9 and should be updated:-
1. the gzip.open() docstring in Lib/gzip.py
2. the GzipFile.init docstring in Lib/gzip.py
3. the GzipFile paragraph in Doc/library/gzip.rst

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152633 -->
* Issue: gh-152633
<!-- /gh-issue-number -->
