### PR TITLE
gh-152636: Add a note about `frozendict` to the `types.MappingProxyType`

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -390,12 +390,18 @@ Standard names are defined for the following types:
    signifying (respectively) the types of the underlying mapping's keys and
    values.
 
-   .. warning::
+   .. note::
 
-      ``MappingProxyType`` can expose its internal mapping
-      in some rare cases on some versions of Python.
-      Starting from Python 3.15 it is recommeneded
-      to use truly immutable :class:`frozendict` instead.
+      There are important differences between ``MappingProxyType``
+      and :class:`frozendict`.
+
+      ``MappingProxyType`` is a wrapper around a mapping that renders
+      the mapping immutable to the viewer of the proxy
+      without affecting the underlying container.
+      ``MappingProxyType`` can expose its internal mapping in some rare cases.
+
+      While ``frozendict`` is a concrete container type
+      that actually holds data that cannot be changed in any way.
 
    .. versionadded:: 3.3
 

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -390,6 +390,13 @@ Standard names are defined for the following types:
    signifying (respectively) the types of the underlying mapping's keys and
    values.
 
+   .. warning::
+
+      ``MappingProxyType`` can expose its internal mapping
+      in some rare cases on some versions of Python.
+      Starting from Python 3.15 it is recommeneded
+      to use truly immutable :class:`frozendict` instead.
+
    .. versionadded:: 3.3
 
    .. versionchanged:: 3.9

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -398,10 +398,9 @@ Standard names are defined for the following types:
       ``MappingProxyType`` is a wrapper around a mapping that renders
       the mapping immutable to the viewer of the proxy
       without affecting the underlying container.
-      ``MappingProxyType`` can expose its internal mapping in some rare cases.
+      ``MappingProxyType`` can expose its internal mutable mapping in some rare cases.
 
-      While ``frozendict`` is a concrete container type
-      that actually holds data that cannot be changed in any way.
+      On the other hand, ``frozendict`` is a concrete immutable mapping.
 
    .. versionadded:: 3.3
 


### PR DESCRIPTION
I didn't know provide links to the exact issue on github, but I can if others think that it is needed.

Refs https://github.com/python/cpython/issues/152405
Refs https://github.com/python/cpython/pull/152483

<!-- gh-issue-number: gh-152636 -->
* Issue: gh-152636
<!-- /gh-issue-number -->
