### PR TITLE
gh-152635: Raise MemoryError rather than fail assert() when the lock allocation fails in _interpchannels.create()

### DIFF
--- a/Lib/test/test_interpreters/test_channels.py
+++ b/Lib/test/test_interpreters/test_channels.py
@@ -9,9 +9,8 @@ from test.support import import_helper
 # Raise SkipTest if subinterpreters not supported.
 _channels = import_helper.import_module('_interpchannels')
 from concurrent import interpreters
-from test.support import channels
+from test.support import channels, nomemtest
 from .utils import _run_output, TestBase
-import _testcapi
 
 
 class LowLevelTests(TestBase):
@@ -31,16 +30,18 @@ class LowLevelTests(TestBase):
         # See gh-115490 (https://github.com/python/cpython/issues/115490).
         importlib.reload(channels)
 
+    @nomemtest
     def test_lock_allocation_failure(self):
         # see gh-152635 (https://github.com/python/cpython/issues/152635)
         # The first allocation to happen is the lock, which
         # historically triggered an assert if alloc failed.
+        import _testcapi
+
         cid = None
         _testcapi.set_nomemory(0, 1)
         try:
-            cid = _channels.create()
-        except MemoryError:
-            pass  # MemoryError is expected behavior
+            with self.assertRaises(MemoryError):
+                cid = _channels.create()
         finally:
             _testcapi.remove_mem_hooks()
             if cid is not None:

--- a/Lib/test/test_interpreters/test_channels.py
+++ b/Lib/test/test_interpreters/test_channels.py
@@ -38,9 +38,9 @@ class LowLevelTests(TestBase):
         import _testcapi
 
         cid = None
-        _testcapi.set_nomemory(0, 1)
         try:
             with self.assertRaises(MemoryError):
+                _testcapi.set_nomemory(0, 1)
                 cid = _channels.create()
         finally:
             _testcapi.remove_mem_hooks()

--- a/Lib/test/test_interpreters/test_channels.py
+++ b/Lib/test/test_interpreters/test_channels.py
@@ -9,7 +9,7 @@ from test.support import import_helper
 # Raise SkipTest if subinterpreters not supported.
 _channels = import_helper.import_module('_interpchannels')
 from concurrent import interpreters
-from test.support import channels, nomemtest
+from test.support import channels
 from .utils import _run_output, TestBase
 
 
@@ -29,24 +29,6 @@ class LowLevelTests(TestBase):
     def test_highlevel_reloaded(self):
         # See gh-115490 (https://github.com/python/cpython/issues/115490).
         importlib.reload(channels)
-
-    @nomemtest
-    def test_lock_allocation_failure(self):
-        # see gh-152635 (https://github.com/python/cpython/issues/152635)
-        # The first allocation to happen is the lock, which
-        # historically triggered an assert if alloc failed.
-        import _testcapi
-
-        cid = None
-        try:
-            with self.assertRaises(MemoryError):
-                _testcapi.set_nomemory(0, 1)
-                cid = _channels.create()
-        finally:
-            _testcapi.remove_mem_hooks()
-            if cid is not None:
-                _channels.close(cid, force=True)
-                _channels.destroy(cid)
 
 
 class TestChannels(TestBase):

--- a/Lib/test/test_interpreters/test_channels.py
+++ b/Lib/test/test_interpreters/test_channels.py
@@ -11,6 +11,7 @@ _channels = import_helper.import_module('_interpchannels')
 from concurrent import interpreters
 from test.support import channels
 from .utils import _run_output, TestBase
+import _testcapi
 
 
 class LowLevelTests(TestBase):
@@ -29,6 +30,22 @@ class LowLevelTests(TestBase):
     def test_highlevel_reloaded(self):
         # See gh-115490 (https://github.com/python/cpython/issues/115490).
         importlib.reload(channels)
+
+    def test_lock_allocation_failure(self):
+        # see gh-152635 (https://github.com/python/cpython/issues/152635)
+        # The first allocation to happen is the lock, which
+        # historically triggered an assert if alloc failed.
+        cid = None
+        _testcapi.set_nomemory(0, 1)
+        try:
+            cid = _channels.create()
+        except MemoryError:
+            pass  # MemoryError is expected behavior
+        finally:
+            _testcapi.remove_mem_hooks()
+            if cid is not None:
+                _channels.close(cid, force=True)
+                _channels.destroy(cid)
 
 
 class TestChannels(TestBase):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-29-23-29-14.gh-issue-152635.O21J0O.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-29-23-29-14.gh-issue-152635.O21J0O.rst
@@ -1,0 +1,2 @@
+Fix a crash caused when running out of memory creating a
+:mod:`!_interpchannels` channel. Now a :exc:`MemoryError` is correctly raised.

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -354,7 +354,7 @@ clear_module_state(module_state *state)
 #define ERR_CHANNEL_INTERP_CLOSED -4
 #define ERR_CHANNEL_EMPTY -5
 #define ERR_CHANNEL_NOT_EMPTY -6
-#define ERR_CHANNEL_MUTEX_INIT -7
+#define ERR_CHANNEL_MUTEX_ALLOC_FAIL -7
 #define ERR_CHANNELS_MUTEX_INIT -8
 #define ERR_NO_NEXT_CHANNEL_ID -9
 #define ERR_CHANNEL_CLOSED_WAITING -10
@@ -427,9 +427,8 @@ handle_channel_error(int err, PyObject *mod, int64_t cid)
                      "if not empty (try force=True)",
                      cid);
     }
-    else if (err == ERR_CHANNEL_MUTEX_INIT) {
-        PyErr_SetString(state->ChannelError,
-                        "can't initialize mutex for new channel");
+    else if (err == ERR_CHANNEL_MUTEX_ALLOC_FAIL) {
+        PyErr_NoMemory();
     }
     else if (err == ERR_CHANNELS_MUTEX_INIT) {
         PyErr_SetString(state->ChannelError,
@@ -1744,7 +1743,7 @@ channel_create(_channels *channels, struct _channeldefaults defaults)
 {
     PyThread_type_lock mutex = PyThread_allocate_lock();
     if (mutex == NULL) {
-        return ERR_CHANNEL_MUTEX_INIT;
+        return ERR_CHANNEL_MUTEX_ALLOC_FAIL;
     }
     _channel_state *chan = _channel_new(mutex, defaults);
     if (chan == NULL) {
@@ -2938,7 +2937,7 @@ channelsmod_create(PyObject *self, PyObject *args, PyObject *kwds)
 
     int64_t cid = channel_create(&_globals.channels, defaults);
     if (cid < 0) {
-        (void)handle_channel_error(-1, self, cid);
+        (void)handle_channel_error(cid, self, cid);
         return NULL;
     }
     module_state *state = get_module_state(self);

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -354,7 +354,7 @@ clear_module_state(module_state *state)
 #define ERR_CHANNEL_INTERP_CLOSED -4
 #define ERR_CHANNEL_EMPTY -5
 #define ERR_CHANNEL_NOT_EMPTY -6
-#define ERR_CHANNEL_MUTEX_ALLOC_FAIL -7
+#define ERR_CHANNEL_MUTEX_INIT -7  // currently unused
 #define ERR_CHANNELS_MUTEX_INIT -8
 #define ERR_NO_NEXT_CHANNEL_ID -9
 #define ERR_CHANNEL_CLOSED_WAITING -10
@@ -1743,7 +1743,8 @@ channel_create(_channels *channels, struct _channeldefaults defaults)
 {
     PyThread_type_lock mutex = PyThread_allocate_lock();
     if (mutex == NULL) {
-        return ERR_CHANNEL_MUTEX_ALLOC_FAIL;
+        PyErr_NoMemory();
+        return -1;
     }
     _channel_state *chan = _channel_new(mutex, defaults);
     if (chan == NULL) {

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -427,9 +427,6 @@ handle_channel_error(int err, PyObject *mod, int64_t cid)
                      "if not empty (try force=True)",
                      cid);
     }
-    else if (err == ERR_CHANNEL_MUTEX_ALLOC_FAIL) {
-        PyErr_NoMemory();
-    }
     else if (err == ERR_CHANNELS_MUTEX_INIT) {
         PyErr_SetString(state->ChannelError,
                         "can't initialize mutex for channel management");


### PR DESCRIPTION
Previously, an allocation failure when creating the lock for a channel in `_interpchannels` would trigger an assert. Caused by `handle_channel_error` being passed an error code of -1 which is only allowed if an exception has been set. (in this case, no exception was set)

`channelsmod_create` now forwards the error code from `channel_create` which `handle_channel_error` already handled.

Because the only way to get a -7 error code (was `ERR_CHANNEL_MUTEX_INIT`) is via an allocation failure in `PyThread_allocate_lock`, I made `handle_channel_error` raise a `MemoryError` for this case rather than a `ChannelError` which seems more consistent with general practice.

I also renamed the constant from `ERR_CHANNEL_MUTEX_INIT` to `ERR_CHANNEL_ALLOC_LOCK` to make this clearer for future changes.

There's a test to cover this, which does rely on `_interpchannels.create` code paths not changing too wildly (first allocation has to be the lock), but even if that changes, the test isn't invalid.

Full test suite passes, except `test_struct` which is known in gh-142414 on MacOS and Windows

<details>
<summary>Test summary</summary>

```
== Tests result: FAILURE ==

32 tests skipped:
    test.test_asyncio.test_windows_events
    test.test_asyncio.test_windows_utils test.test_gdb.test_backtrace
    test.test_gdb.test_cfunction test.test_gdb.test_cfunction_full
    test.test_gdb.test_jit test.test_gdb.test_misc
    test.test_gdb.test_pretty_print
    test.test_multiprocessing_fork.test_manager
    test.test_multiprocessing_fork.test_misc
    test.test_multiprocessing_fork.test_processes
    test.test_multiprocessing_fork.test_threads
    test.test_os.test_windows test_android test_dbm_gnu test_devpoll
    test_dtrace test_epoll test_free_threading test_idle test_launcher
    test_msvcrt test_startfile test_tcl test_tkinter test_ttk
    test_ttk_textonly test_turtle test_winapi test_winconsoleio
    test_winreg test_wmi

9 tests skipped (resource denied):
    test_curses test_peg_generator test_smtpnet test_socketserver
    test_urllib2net test_urllibnet test_winsound test_xpickle
    test_zipfile64

1 test altered the execution environment (env changed):
    test_httpservers

1 test failed:
    test_struct

462 tests OK.
```

</details>

<!-- gh-issue-number: gh-152635 -->
* Issue: gh-152635
<!-- /gh-issue-number -->
