### PR TITLE
gh-152325: Gate curses.has_mouse() on the ncurses patch level

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -465,6 +465,8 @@ Mouse
 
    Return ``True`` if the mouse driver has been successfully initialized.
 
+   Availability: ncurses 5.8 or later.
+
    .. versionadded:: next
 
 

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -7041,6 +7041,8 @@ _curses_meta_impl(PyObject *module, int yes)
 }
 
 #ifdef NCURSES_MOUSE_VERSION
+/* has_mouse() was added to ncurses after the 5.7 release. */
+#if defined(NCURSES_EXT_FUNCS) && NCURSES_EXT_FUNCS >= 20081122
 /*[clinic input]
 _curses.has_mouse
 
@@ -7055,6 +7057,7 @@ _curses_has_mouse_impl(PyObject *module)
 
     return PyBool_FromLong(has_mouse());
 }
+#endif /* NCURSES_EXT_FUNCS >= 20081122 */
 
 /*[clinic input]
 _curses.mouseinterval

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -4232,7 +4232,7 @@ exit:
     return return_value;
 }
 
-#if defined(NCURSES_MOUSE_VERSION)
+#if defined(NCURSES_MOUSE_VERSION) && (defined(NCURSES_EXT_FUNCS) && NCURSES_EXT_FUNCS >= 20081122)
 
 PyDoc_STRVAR(_curses_has_mouse__doc__,
 "has_mouse($module, /)\n"
@@ -4252,7 +4252,7 @@ _curses_has_mouse(PyObject *module, PyObject *Py_UNUSED(ignored))
     return _curses_has_mouse_impl(module);
 }
 
-#endif /* defined(NCURSES_MOUSE_VERSION) */
+#endif /* defined(NCURSES_MOUSE_VERSION) && (defined(NCURSES_EXT_FUNCS) && NCURSES_EXT_FUNCS >= 20081122) */
 
 #if defined(NCURSES_MOUSE_VERSION)
 
@@ -6174,4 +6174,4 @@ _curses_has_extended_color_support(PyObject *module, PyObject *Py_UNUSED(ignored
 #ifndef _CURSES_ASSUME_DEFAULT_COLORS_METHODDEF
     #define _CURSES_ASSUME_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_ASSUME_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=55829d2ef2b559a0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=809e4680d429b870 input=a9049054013a1b77]*/


### PR DESCRIPTION
Buildbot fix for [gh-152325](https://github.com/python/cpython/issues/152325).

has_mouse() was added to ncurses after the 5.7 release (2008-11-22), but the binding guarded it only with NCURSES_MOUSE_VERSION, which 5.7 already defines. On ncurses 5.7 — such as the system curses on macOS — has_mouse() is undeclared, and with clang treating implicit declarations as errors _cursesmodule.c failed to compile, breaking a number of buildbots.

Gate has_mouse() additionally on NCURSES_EXT_FUNCS, which holds the library's patch date when extended functions are enabled (the default), matching the existing is_cleared/is_cbreak guards.

wmouse_trafo()/mouse_trafo() need no guard — they are the same vintage as wenclose()/enclose(), which already compile on those buildbots.

<!-- gh-issue-number: gh-152325 -->
* Issue: gh-152325
<!-- /gh-issue-number -->