### PR TITLE
gh-151029: Fix `test_remote_exec_deleted_static_executable` on static installed builds

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -2282,8 +2282,8 @@ this is invalid python code
     def test_remote_exec_deleted_static_executable(self):
         """Test remote exec when the target static executable was deleted."""
         build_dir = sysconfig.get_config_var('abs_builddir')
-        srcdir = sysconfig.get_config_var('srcdir')
-        if not build_dir or not srcdir:
+        stdlib_dir = os.path.dirname(os.path.abspath(os.__file__))
+        if not build_dir or not os.path.isdir(stdlib_dir):
             self.skipTest('cannot determine build-tree locations')
 
         pybuilddir_txt = os.path.join(build_dir, 'pybuilddir.txt')
@@ -2300,8 +2300,7 @@ this is invalid python code
             copied_build_dir = os.path.join(copied_root, 'build')
             copied_pybuilddir = os.path.join(copied_build_dir, pybuilddir)
             os.makedirs(os.path.dirname(copied_pybuilddir))
-            os.symlink(os.path.join(srcdir, 'Lib'),
-                       os.path.join(copied_root, 'Lib'))
+            os.symlink(stdlib_dir, os.path.join(copied_root, 'Lib'))
             os.symlink(source_ext_dir, copied_pybuilddir)
             shutil.copy2(pybuilddir_txt,
                          os.path.join(copied_build_dir, 'pybuilddir.txt'))


### PR DESCRIPTION
`test_remote_exec_deleted_static_executable` (from gh-151029) rebuilds a fake build-tree and symlinks the stdlib via `srcdir/Lib`, but on an installed Python `sysconfig`'s `srcdir` points at the `config-*` directory (which has no `Lib/`). The copied interpreter then can't find the stdlib, so it dies at startup before connecting (`server_socket.accept()` hangs until it raises `TimeoutError`). [Failed run](https://buildbot.python.org/#/builders/14/builds/9058), for example.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
