### PR TITLE
gh-152674: Avoid quadratic behavior in xml.etree.ElementPath index predicates

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -3479,27 +3479,35 @@ class ElementFindTest(unittest.TestCase):
         self.assertRaisesRegex(SyntaxError, 'XPath', e.find, './tag[last()+1]')
 
     def test_find_xpath_index_no_quadratic_complexity(self):
-        root = ET.Element("root")
-        first_a = ET.SubElement(root, "a")
-        first_a.set("pos", "first")
-        n = 2 ** 15
-        for i in range(n):
-            ET.SubElement(root, "a")
-        last_a = ET.SubElement(root, "a")
-        last_a.set("pos", "last")
+        class CountingElement(ET.Element):
+            findall_calls = 0
+            def findall(self, *args, **kwargs):
+                type(self).findall_calls += 1
+                return super().findall(*args, **kwargs)
+
+        def work(n, pattern):
+            root = CountingElement("root")
+            for _ in range(n):
+                ET.SubElement(root, "a")
+            CountingElement.findall_calls = 0
+            root.findall(pattern)
+            return CountingElement.findall_calls
 
         for pattern in [".//a[1]", ".//a[last()]"]:
-            start = time.time()
-            result = root.findall(pattern)
-            end = time.time()
+            w1 = work(1024, pattern)
+            w2 = work(2048, pattern)
+            w3 = work(4096, pattern)
 
-            # Before the fix these took 30+ seconds.
-            self.assertLess(end - start, 1)
-
-        self.assertIs(root.find(".//a[1]"), first_a)
-        self.assertEqual(root.find(".//a[1]").get("pos"), "first")
-        self.assertIs(root.find(".//a[last()]"), last_a)
-        self.assertEqual(root.find(".//a[last()]").get("pos"), "last")
+            self.assertGreater(w1, 0)
+            r1 = w2 / w1
+            r2 = w3 / w2
+            # Doubling N must not ~double the parent.findall calls.
+            # Linear-in-N call counts indicate the cache is missing.
+            self.assertLess(
+                max(r1, r2), 1.5,
+                msg=f"Possible quadratic behavior on {pattern!r}: "
+                    f"calls={w1, w2, w3} ratios={r1, r2}",
+            )
 
     def test_findall(self):
         e = ET.XML(SAMPLE_XML)

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -16,7 +16,6 @@ import pickle
 import pyexpat
 import sys
 import textwrap
-import time
 import types
 import unittest
 import unittest.mock as mock

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -16,6 +16,7 @@ import pickle
 import pyexpat
 import sys
 import textwrap
+import time
 import types
 import unittest
 import unittest.mock as mock
@@ -3476,6 +3477,29 @@ class ElementFindTest(unittest.TestCase):
         self.assertRaisesRegex(SyntaxError, 'XPath', e.find, './tag[-1]')
         self.assertRaisesRegex(SyntaxError, 'XPath', e.find, './tag[last()-0]')
         self.assertRaisesRegex(SyntaxError, 'XPath', e.find, './tag[last()+1]')
+
+    def test_find_xpath_index_no_quadratic_complexity(self):
+        root = ET.Element("root")
+        first_a = ET.SubElement(root, "a")
+        first_a.set("pos", "first")
+        n = 2 ** 15
+        for i in range(n):
+            ET.SubElement(root, "a")
+        last_a = ET.SubElement(root, "a")
+        last_a.set("pos", "last")
+
+        for pattern in [".//a[1]", ".//a[last()]"]:
+            start = time.time()
+            result = root.findall(pattern)
+            end = time.time()
+
+            # Before the fix these took 30+ seconds.
+            self.assertLess(end - start, 1)
+
+        self.assertIs(root.find(".//a[1]"), first_a)
+        self.assertEqual(root.find(".//a[1]").get("pos"), "first")
+        self.assertIs(root.find(".//a[last()]"), last_a)
+        self.assertEqual(root.find(".//a[last()]").get("pos"), "last")
 
     def test_findall(self):
         e = ET.XML(SAMPLE_XML)

--- a/Lib/xml/etree/ElementPath.py
+++ b/Lib/xml/etree/ElementPath.py
@@ -324,19 +324,22 @@ def prepare_predicate(next, token):
                 index = -1
         def select(context, result):
             parent_map = get_parent_map(context)
-            sibling_cache = {}
+            cache = {}
             for elem in result:
                 try:
                     parent = parent_map[elem]
+                except KeyError:
+                    continue
+                key = (parent, elem.tag)
+                if key not in cache:
                     # FIXME: what if the selector is "*" ?
-                    cache_key = (parent, elem.tag)
-                    if cache_key not in sibling_cache:
-                        sibling_cache[cache_key] = list(parent.findall(elem.tag))
-                    elems = sibling_cache[cache_key]
-                    if elems[index] is elem:
-                        yield elem
-                except (IndexError, KeyError):
-                    pass
+                    elems = parent.findall(elem.tag)
+                    try:
+                        cache[key] = elems[index]
+                    except IndexError:
+                        cache[key] = None
+                if cache[key] is elem:
+                    yield elem
         return select
     raise SyntaxError("invalid predicate")
 

--- a/Lib/xml/etree/ElementPath.py
+++ b/Lib/xml/etree/ElementPath.py
@@ -324,11 +324,15 @@ def prepare_predicate(next, token):
                 index = -1
         def select(context, result):
             parent_map = get_parent_map(context)
+            sibling_cache = {}
             for elem in result:
                 try:
                     parent = parent_map[elem]
                     # FIXME: what if the selector is "*" ?
-                    elems = list(parent.findall(elem.tag))
+                    cache_key = (parent, elem.tag)
+                    if cache_key not in sibling_cache:
+                        sibling_cache[cache_key] = list(parent.findall(elem.tag))
+                    elems = sibling_cache[cache_key]
                     if elems[index] is elem:
                         yield elem
                 except (IndexError, KeyError):

--- a/Misc/NEWS.d/next/Security/2026-06-30-13-24-13.gh-issue-152674.-2QVoL.rst
+++ b/Misc/NEWS.d/next/Security/2026-06-30-13-24-13.gh-issue-152674.-2QVoL.rst
@@ -1,0 +1,6 @@
+The :class:`xml.etree.ElementTree.Element` methods
+:meth:`~xml.etree.ElementTree.Element.findall`,
+:meth:`~xml.etree.ElementTree.Element.iterfind` and
+:meth:`~xml.etree.ElementTree.Element.find` avoid quadratic behavior when
+using XPath index predicates (``[1]``, ``[last()]``, ``[last()-N]``) on XML
+documents with many same-tag siblings.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152674 -->
* Issue: gh-152674
<!-- /gh-issue-number -->
