### PR TITLE
gh-152614: Add raises to `QueueShutDown` in `asyncio.Queue.put_no_wait` and `asyncio.Queue.get_nowait` documentation methods

### DIFF
--- a/Doc/library/asyncio-queue.rst
+++ b/Doc/library/asyncio-queue.rst
@@ -71,6 +71,8 @@ Queue
       Return an item if one is immediately available, else raise
       :exc:`QueueEmpty`.
 
+      Raises :exc:`QueueShutDown` if the queue has been shut down and is empty.
+
    .. method:: join()
       :async:
 
@@ -95,6 +97,8 @@ Queue
       Put an item into the queue without blocking.
 
       If no free slot is immediately available, raise :exc:`QueueFull`.
+
+      Raises :exc:`QueueShutDown` if the queue has been shut down.
 
    .. method:: qsize()
 
@@ -188,8 +192,9 @@ Exceptions
 
 .. exception:: QueueShutDown
 
-   Exception raised when :meth:`~Queue.put` or :meth:`~Queue.get` is
-   called on a queue which has been shut down.
+   Exception raised when :meth:`~Queue.put`, :meth:`~Queue.put_nowait`,
+   :meth:`~Queue.get` or :meth:`~Queue.get_nowait` is called
+   on a queue which has been shut down.
 
    .. versionadded:: 3.13
 


### PR DESCRIPTION
Update 3 entries:

+ `asyncio.Queue.put_nowait` method, 
+ `asyncio.Queue.get_nowait` method, 
+ `asyncio.QueueShutDown` exception.

This PR should be backport to 3.13, 3.14 and 3.15 versions, `Shutdown` feature bwas added in 3.13 version.



<!-- gh-issue-number: gh-152614 -->
* Issue: gh-152614
<!-- /gh-issue-number -->
