### PR TITLE
gh-151881: Skip tk_inactive negativity check on Windows

### DIFF
--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -592,7 +592,10 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         ms = self.root.tk_inactive()
         self.assertIsInstance(ms, int)
         # A count of milliseconds, or -1 if the windowing system lacks support.
-        self.assertGreaterEqual(ms, -1)
+        if self.root._windowingsystem != 'win32':
+            # On Windows the value can overflow to a negative number
+            # (Tk ticket 3cb7c4ac72d4).
+            self.assertGreaterEqual(ms, -1)
         # Resetting the timer returns None and does not raise.
         self.assertIsNone(self.root.tk_inactive(reset=True))
 


### PR DESCRIPTION
On Windows `Tk_GetUserInactiveTime()` computes the inactivity interval as a C `long`, which is only 32-bit there. On a non-interactive session (such as a buildbot running as a service) the interval can exceed 2\*\*31 ms and overflow to a negative value, so `test_tk_inactive` fails the `assertGreaterEqual(ms, -1)` check on the AMD64 Windows11 buildbot.

Guard that lower-bound check on the win32 windowing system pending the Tk-side fix ([Tk ticket 3cb7c4ac72d4](https://core.tcl-lang.org/tk/tktview/3cb7c4ac72d4)).

<!-- gh-issue-number: gh-151881 -->
* Issue: gh-151881
<!-- /gh-issue-number -->
