### PR TITLE
gh-152682: Fix NULL dereference on OOM in symtable_visit_type_param_bound_or_default

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2861,6 +2861,7 @@ import textwrap
 import unittest
 
 from test import support
+from test.support.script_helper import assert_python_ok
 
 class SyntaxWarningTest(unittest.TestCase):
     def check_warning(self, code, errtext, filename="<testcase>", mode="exec"):
@@ -3200,6 +3201,22 @@ if x:
 class A:
     class B[{name}]: pass
                 """, "<testcase>", mode="exec")
+
+    @support.nomemtest
+    def test_disallowed_type_param_names_oom(self):
+        # gh-152682: Don't crash on OOM when formatting the SyntaxError message
+        # in symtable_visit_type_param_bound_or_default.
+        code = textwrap.dedent("""\
+            import _testcapi
+            _testcapi.set_nomemory(0)
+            try:
+                compile("class A[__classdict__]: pass", "<string>", "exec")
+            except MemoryError:
+                pass
+            else:
+                raise RuntimeError('MemoryError not raised')
+        """)
+        assert_python_ok("-c", code)
 
     @support.cpython_only
     def test_nested_named_except_blocks(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-30-14-00-00.gh-issue-152682.yId7e5.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-30-14-00-00.gh-issue-152682.yId7e5.rst
@@ -1,0 +1,3 @@
+Fix NULL pointer dereference in :func:`compile` when a reserved name (e.g.
+``__classdict__``) is used as a type parameter name and memory allocation
+fails while formatting the error message.

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -2678,6 +2678,9 @@ symtable_visit_type_param_bound_or_default(
 
         PyObject *error_msg = PyUnicode_FromFormat("reserved name '%U' cannot be "
                                                    "used for type parameter", name);
+        if (error_msg == NULL) {
+            return 0;
+        }
         PyErr_SetObject(PyExc_SyntaxError, error_msg);
         Py_DECREF(error_msg);
         SET_ERROR_LOCATION(st->st_filename, LOCATION(tp));


### PR DESCRIPTION
When a reserved name (e.g. `__classdict__`) is used as a type parameter,
`symtable_visit_type_param_bound_or_default()` calls `PyUnicode_FromFormat()`
to build the `SyntaxError` message. If the allocation fails and returns `NULL`,
the subsequent `PyErr_SetObject(PyExc_SyntaxError, NULL)` and `Py_DECREF(NULL)`
calls dereference the null pointer, causing a segfault.

Fix by returning `0` immediately when `PyUnicode_FromFormat()` returns `NULL`,
which propagates the `MemoryError` already set by `PyUnicode_FromFormat()`.

The bug was introduced in gh-128632 (commit 891c61c).

Found by static analyzer Svace (ISP RAS).

- [x] Add a NEWS entry in `Misc/NEWS.d/`
- [x] Add regression test (`test_disallowed_type_param_names_oom`)

<!-- gh-issue-number: gh-152682 -->
* Issue: gh-152682
<!-- /gh-issue-number -->
