### PR TITLE
gh-152692: Fix annotationlib.type_repr() for bound built-in methods

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -1090,7 +1090,8 @@ def type_repr(value):
 
     """
     if isinstance(value, (type, types.FunctionType, types.BuiltinFunctionType)):
-        if value.__module__ == "builtins":
+        # Built-in methods have __module__ set to None.
+        if value.__module__ is None or value.__module__ == "builtins":
             return value.__qualname__
         return f"{value.__module__}.{value.__qualname__}"
     elif isinstance(value, _Template):

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -1090,10 +1090,17 @@ def type_repr(value):
 
     """
     if isinstance(value, (type, types.FunctionType, types.BuiltinFunctionType)):
-        # Built-in methods have __module__ set to None.
-        if value.__module__ is None or value.__module__ == "builtins":
+        module = value.__module__
+        if module is None:
+            # Built-in methods have __module__ set to None; recover the module
+            # from the bound object (the class itself for class-bound methods).
+            obj = getattr(value, "__self__", None)
+            if obj is not None:
+                cls = obj if isinstance(obj, type) else type(obj)
+                module = cls.__module__
+        if module is None or module == "builtins":
             return value.__qualname__
-        return f"{value.__module__}.{value.__qualname__}"
+        return f"{module}.{value.__qualname__}"
     elif isinstance(value, _Template):
         tree = _template_to_ast(value)
         return ast.unparse(tree)

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1850,6 +1850,10 @@ class TestTypeRepr(unittest.TestCase):
             type_repr(nested), f"{__name__}.TestTypeRepr.test_type_repr.<locals>.nested"
         )
         self.assertEqual(type_repr(len), "len")
+        # gh-152692: built-in methods have __module__ set to None
+        self.assertEqual(type_repr([].append), "list.append")
+        self.assertEqual(type_repr((1).bit_length), "int.bit_length")
+        self.assertEqual(type_repr(dict.fromkeys), "dict.fromkeys")
         self.assertEqual(type_repr(type_repr), "annotationlib.type_repr")
         self.assertEqual(type_repr(times_three), f"{__name__}.times_three")
         self.assertEqual(type_repr(...), "...")

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1854,6 +1854,14 @@ class TestTypeRepr(unittest.TestCase):
         self.assertEqual(type_repr([].append), "list.append")
         self.assertEqual(type_repr((1).bit_length), "int.bit_length")
         self.assertEqual(type_repr(dict.fromkeys), "dict.fromkeys")
+        # Methods of extension types also have __module__ set to None, but
+        # are not in the builtins module.
+        import datetime
+        self.assertEqual(
+            type_repr(datetime.datetime(2000, 1, 1).isoformat),
+            "datetime.datetime.isoformat",
+        )
+        self.assertEqual(type_repr(datetime.date.today), "datetime.date.today")
         self.assertEqual(type_repr(type_repr), "annotationlib.type_repr")
         self.assertEqual(type_repr(times_three), f"{__name__}.times_three")
         self.assertEqual(type_repr(...), "...")

--- a/Misc/NEWS.d/next/Library/2026-06-30-15-00-00.gh-issue-152692.tr3pr0.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-30-15-00-00.gh-issue-152692.tr3pr0.rst
@@ -1,0 +1,4 @@
+Fix :func:`annotationlib.type_repr` returning a string such as
+``None.list.append`` for bound built-in methods, whose ``__module__`` is
+``None``.  It now returns the qualified name, as it already did for other
+builtins.


### PR DESCRIPTION
`type_repr()` returned a string naming a nonexistent module `None` -- e.g.
`type_repr([].append) == 'None.list.append'` -- for bound built-in methods,
whose `__module__` is `None`.

Return the qualified name when `__module__` is `None`, as already done for the
`"builtins"` module.  This also covers C-accelerator functions such as
`random.random`.  `annotations_to_string` and
`get_annotations(format=Format.STRING)` are fixed transitively when an
annotation value is such a method.


<!-- gh-issue-number: gh-152692 -->
* Issue: gh-152692
<!-- /gh-issue-number -->
