### PR TITLE
gh-152691: Document Windows ADS filename considerations for tarfile

### DIFF
--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -1195,6 +1195,8 @@ Here is an incomplete list of things to consider:
 * Check filenames against an allow-list of characters
   (to filter out control characters, confusables, foreign path separators,
   and so on).
+* Check for platform-specific filename semantics. For example, on Windows
+  some names can have reserved meanings.
 * Check that filenames have expected extensions (discouraging files that
   execute when you “click on them”, or extension-less files like Windows
   special device names).


### PR DESCRIPTION
## Summary

This documentation-only change updates the `tarfile` extraction guidance to mention platform-specific filename semantics.

It adds a note to the "Hints for further verification" section explaining that Windows pathnames may have reserved meanings, including NTFS Alternate Data Streams (ADS), and points users to `os.path.isreserved()` where appropriate.

No `tarfile` behavior, extraction filters, or runtime code are changed.

## Validation

- `git diff --check`

Closes gh-152691