### PR TITLE
gh-135894: Preserve _b_base_ in from_buffer for ctypes sources

### DIFF
--- a/Lib/test/test_ctypes/test_frombuffer.py
+++ b/Lib/test/test_ctypes/test_frombuffer.py
@@ -124,6 +124,25 @@ class Test(unittest.TestCase):
         with self.assertRaises(ValueError):
             (c_int * 1).from_buffer_copy(a, 16 * sizeof(c_int))
 
+    def test_from_buffer_b_base_with_ctypes_source(self):
+        class Inner(Structure):
+            _fields_ = [("x", c_int)]
+
+        class Outer(Structure):
+            _fields_ = [("inner", Inner), ("y", c_int)]
+
+        buf = bytearray(sizeof(Outer))
+        outer = Outer.from_buffer(buf)
+        inner = Inner.from_buffer(outer, 0)
+
+        self.assertIs(inner._b_base_, outer)
+
+    def test_from_buffer_b_base_with_non_ctypes_source(self):
+        buf = bytearray(sizeof(c_int))
+        x = c_int.from_buffer(buf)
+
+        self.assertIsNone(x._b_base_)
+
     def test_abstract(self):
         self.assertRaises(TypeError, Array.from_buffer, bytearray(10))
         self.assertRaises(TypeError, Structure.from_buffer, bytearray(10))

--- a/Misc/NEWS.d/next/Library/2026-06-30-21-16-45.gh-issue-135894.bBmV3U.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-30-21-16-45.gh-issue-135894.bBmV3U.rst
@@ -1,0 +1,2 @@
+:meth:`~ctypes._CData.from_buffer` now sets :attr:`~ctypes._CData._b_base_`
+when the source is a ctypes object.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -919,6 +919,10 @@ CDataType_from_buffer_impl(PyObject *type, PyTypeObject *cls, PyObject *obj,
         return NULL;
     }
 
+    if (CDataObject_Check(st, obj)) {
+        ((CDataObject *)result)->b_base = (CDataObject *)Py_NewRef(obj);
+    }
+
     return result;
 }
 


### PR DESCRIPTION
<!-- gh-issue-number: gh-135894 -->
* Issue: gh-135894
<!-- /gh-issue-number -->
