### PR TITLE
gh-152711: Add pythoninfo-build command to Platforms/Android

### DIFF
--- a/Platforms/Android/__main__.py
+++ b/Platforms/Android/__main__.py
@@ -313,6 +313,7 @@ def build_targets(context):
     if context.target in {"all", "build"}:
         configure_build_python(context)
         make_build_python(context)
+        pythoninfo_build_python(context)
 
     for host in HOSTS:
         if context.target in {"all", "hosts", host}:
@@ -824,6 +825,7 @@ def ci(context):
     for step in [
         configure_build_python,
         make_build_python,
+        pythoninfo_build_python,
         configure_host_python,
         make_host_python,
         package,

--- a/Platforms/Android/__main__.py
+++ b/Platforms/Android/__main__.py
@@ -207,6 +207,11 @@ def make_build_python(context):
     run(["make", "-j", str(os.cpu_count())])
 
 
+def pythoninfo_build_python(context):
+    os.chdir(subdir("build"))
+    run(["make", "pythoninfo"])
+
+
 # To create new builds of these dependencies, usually all that's necessary is to
 # push a tag to the cpython-android-source-deps repository, and GitHub Actions
 # will do the rest.
@@ -903,6 +908,8 @@ def parse_args():
         "configure-build", help="Run `configure` for the build Python")
     add_parser(
         "make-build", help="Run `make` for the build Python")
+    add_parser(
+        "pythoninfo-build", help="Display build info of the build Python")
     configure_host = add_parser(
         "configure-host", help="Run `configure` for Android")
     make_host = add_parser(
@@ -1019,6 +1026,7 @@ def main():
     dispatch = {
         "configure-build": configure_build_python,
         "make-build": make_build_python,
+        "pythoninfo-build": pythoninfo_build_python,
         "configure-host": configure_host_python,
         "make-host": make_host_python,
         "build": build_targets,


### PR DESCRIPTION
Add a pythoninfo-build command to Platforms/Android to display build info of the build Python. The command runs "make pythoninfo".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152711 -->
* Issue: gh-152711
<!-- /gh-issue-number -->
