### PR TITLE
gh-152709: Update ssl docs for OpenSSL 4

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -655,7 +655,7 @@ Constants
    Selects SSL version 3 as the channel encryption protocol.
 
    This protocol is not available if OpenSSL is compiled with the
-   ``no-ssl3`` option.
+   ``no-ssl3`` option, or with OpenSSL 4.0 or later.
 
    .. warning::
 
@@ -672,6 +672,7 @@ Constants
 .. data:: PROTOCOL_TLSv1
 
    Selects TLS version 1.0 as the channel encryption protocol.
+   This protocol is not available with OpenSSL 4.0 or later.
 
    .. deprecated:: 3.6
 
@@ -680,7 +681,7 @@ Constants
 .. data:: PROTOCOL_TLSv1_1
 
    Selects TLS version 1.1 as the channel encryption protocol.
-   Available only with openssl version 1.0.1+.
+   Available only with OpenSSL version 1.0.1 through 3.x.
 
    .. versionadded:: 3.4
 
@@ -691,7 +692,7 @@ Constants
 .. data:: PROTOCOL_TLSv1_2
 
    Selects TLS version 1.2 as the channel encryption protocol.
-   Available only with openssl version 1.0.1+.
+   Available only with OpenSSL version 1.0.1 through 3.x.
 
    .. versionadded:: 3.4
 
@@ -2037,7 +2038,7 @@ to speed up repeated connections from the same clients.
 
       import socket, ssl
 
-      context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+      context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
       context.verify_mode = ssl.CERT_REQUIRED
       context.check_hostname = True
       context.load_default_certs()

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -50,17 +50,14 @@ CERT_OPTIONAL - certificates are not required, but if provided will be
 CERT_REQUIRED - certificates are required, and will be validated, and
                 if validation fails, the connection will also fail
 
-The following constants identify various SSL protocol variants:
+The following constants identify various SSL protocol variants. Some legacy,
+version-specific protocol constants are only available when supported by the
+linked OpenSSL library:
 
-PROTOCOL_SSLv2
-PROTOCOL_SSLv3
 PROTOCOL_SSLv23
 PROTOCOL_TLS
 PROTOCOL_TLS_CLIENT
 PROTOCOL_TLS_SERVER
-PROTOCOL_TLSv1
-PROTOCOL_TLSv1_1
-PROTOCOL_TLSv1_2
 
 The following constants identify various SSL alert message descriptions as per
 http://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-6

--- a/Misc/NEWS.d/next/Documentation/2026-07-01-03-50-00.gh-issue-152709.ssl-openssl4-docs.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-07-01-03-50-00.gh-issue-152709.ssl-openssl4-docs.rst
@@ -1,0 +1,2 @@
+Update :mod:`ssl` documentation for legacy protocol constants unavailable
+with OpenSSL 4.0 and later.


### PR DESCRIPTION
gh-152709 updates the SSL module documentation for OpenSSL 4:

- avoids listing legacy version-specific protocol constants in the `ssl` module pydoc as generally available
- documents that `PROTOCOL_SSLv3`, `PROTOCOL_TLSv1`, `PROTOCOL_TLSv1_1`, and `PROTOCOL_TLSv1_2` are unavailable with OpenSSL 4.0 or later
- updates the hostname-checking example to use `PROTOCOL_TLS_CLIENT` instead of the version-specific `PROTOCOL_TLSv1_2`

Validation:

- `git diff --check`
- Attempted `make -C Doc venv`, but local validation could not complete because the macOS system Python failed while importing `site` during venv creation with a `UnicodeDecodeError` before Sphinx/blurb could be installed.
