### PR TITLE
gh-152715: Add pythoninfo-build command to Platforms/Apple

### DIFF
--- a/Platforms/Apple/__main__.py
+++ b/Platforms/Apple/__main__.py
@@ -272,6 +272,15 @@ def make_build_python(context: argparse.Namespace) -> None:
         run(["make", "-j", str(os.cpu_count())])
 
 
+def pythoninfo_build_python(context: argparse.Namespace) -> None:
+    """The implementation of the "pythoninfo-build" command."""
+    with (
+        group("Display build info of the build Python"),
+        cwd(subdir("build")),
+    ):
+        run(["make", "pythoninfo"])
+
+
 def apple_target(host: str) -> str:
     """Return the Apple platform identifier for a given host triple."""
     for _, platform_slices in HOSTS.items():
@@ -754,6 +763,7 @@ def build(context: argparse.Namespace, host: str | None = None) -> None:
         for step in [
             configure_build_python,
             make_build_python,
+            pythoninfo_build_python,
         ]:
             step(context)
 
@@ -909,6 +919,9 @@ def parse_args() -> argparse.Namespace:
     make_build = subcommands.add_parser(
         "make-build", help="Run `make` for the build Python"
     )
+    pythoninfo_build = subcommands.add_parser(
+        "pythoninfo-build", help="Display build info of the build Python"
+    )
     configure_host = subcommands.add_parser(
         "configure-host",
         help="Run `configure` for a specific platform and target",
@@ -967,6 +980,7 @@ def parse_args() -> argparse.Namespace:
         clean,
         configure_build,
         make_build,
+        pythoninfo_build,
         configure_host,
         make_host,
         build,
@@ -1078,6 +1092,7 @@ def main() -> None:
         "clean": clean,
         "configure-build": configure_build_python,
         "make-build": make_build_python,
+        "pythoninfo-build": pythoninfo_build_python,
         "configure-host": configure_host_python,
         "make-host": make_host_python,
         "package": package,


### PR DESCRIPTION
Add a pythoninfo-build command to Platforms/Apple to display build info of the build Python. The command runs "make pythoninfo".

The "ci" and "build" commands now also run "pythoninfo-build".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152715 -->
* Issue: gh-152715
<!-- /gh-issue-number -->
