### PR TITLE
gh-66331: Set correct WM_CLASS on X11 for IDLE windows

### DIFF
--- a/Lib/idlelib/idle_test/test_stackviewer.py
+++ b/Lib/idlelib/idle_test/test_stackviewer.py
@@ -35,6 +35,8 @@ class StackBrowserTest(unittest.TestCase):
         isi(stackviewer.sc, ScrolledCanvas)
         isi(stackviewer.item, stackviewer.StackTreeItem)
         isi(stackviewer.node, TreeNode)
+        top = stackviewer.sc.frame.winfo_toplevel()
+        self.assertEqual(top.winfo_class(), 'Idle')
 
 
 if __name__ == '__main__':

--- a/Lib/idlelib/idle_test/test_window.py
+++ b/Lib/idlelib/idle_test/test_window.py
@@ -39,6 +39,11 @@ class ListedToplevelTest(unittest.TestCase):
         win = window.ListedToplevel(self.root)
         self.assertIn(win, window.registry)
         self.assertEqual(win.focused_widget, win)
+        self.assertEqual(win.winfo_class(), 'Idle')
+
+    def test_init_class_override(self):
+        win = window.ListedToplevel(self.root, class_='Other')
+        self.assertEqual(win.winfo_class(), 'Other')
 
 
 if __name__ == '__main__':

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -643,7 +643,7 @@ class ModifiedInterpreter(InteractiveInterpreter):
             return
         item = debugobj_r.StubObjectTreeItem(self.rpcclt, oid)
         from idlelib.tree import ScrolledCanvas, TreeNode
-        top = Toplevel(self.tkconsole.root)
+        top = Toplevel(self.tkconsole.root, class_='Idle')
         theme = idleConf.CurrentTheme()
         background = idleConf.GetHighlight(theme, 'normal')['background']
         sc = ScrolledCanvas(top, bg=background, highlightthickness=0)

--- a/Lib/idlelib/stackviewer.py
+++ b/Lib/idlelib/stackviewer.py
@@ -11,7 +11,7 @@ from idlelib.tree import TreeNode, TreeItem, ScrolledCanvas
 def StackBrowser(root, exc, flist=None, top=None):
     global sc, item, node  # For testing.
     if top is None:
-        top = tk.Toplevel(root)
+        top = tk.Toplevel(root, class_='Idle')
     sc = ScrolledCanvas(top, bg="white", highlightthickness=0)
     sc.frame.pack(expand=1, fill="both")
     item = StackTreeItem(exc, flist)

--- a/Lib/idlelib/window.py
+++ b/Lib/idlelib/window.py
@@ -61,6 +61,10 @@ unregister_callback = registry.unregister_callback
 class ListedToplevel(Toplevel):
 
     def __init__(self, master, **kw):
+        # Set the WM_CLASS property so that X11 window managers group and
+        # label IDLE's windows under 'Idle' instead of the default
+        # 'Toplevel' (gh-66331).  It matches the class name passed to Tk().
+        kw.setdefault('class_', 'Idle')
         Toplevel.__init__(self, master, kw)
         registry.add(self)
         self.focused_widget = self

--- a/Misc/NEWS.d/next/IDLE/2026-07-01-00-00-00.gh-issue-66331.wMcLaS.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-07-01-00-00-00.gh-issue-66331.wMcLaS.rst
@@ -1,0 +1,3 @@
+Set the ``WM_CLASS`` window property of IDLE's windows to ``Idle`` on X11,
+so that window managers group and label them correctly instead of using the
+default ``Toplevel``.


### PR DESCRIPTION
The root window is created with `Tk(className="Idle")`, but IDLE's toplevel windows kept the default `Toplevel` WM_CLASS, so X11 window managers (GNOME Shell, KDE) group and label them incorrectly.

Set `class_='Idle'` on IDLE's long-lived, independently-listed windows so their WM_CLASS matches the root:

* window-list windows, via `ListedToplevel` (editor, shell, output, class/module/path browsers, debugger);
* the local and remote stack viewers.

Transient dialogs (Find/Replace, config, About, …) and override-redirect popups (autocomplete, calltip, tooltip) are left unchanged: the former are grouped with their parent via `WM_TRANSIENT_FOR`, the latter are not listed by the window manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-66331 -->
* Issue: gh-66331
<!-- /gh-issue-number -->
