### PR TITLE
gh-89360: Fix ValueError in IDLE MultiCall event_delete

### DIFF
--- a/Lib/idlelib/idle_test/test_multicall.py
+++ b/Lib/idlelib/idle_test/test_multicall.py
@@ -43,6 +43,22 @@ class MultiCallTest(unittest.TestCase):
         mctext = self.mc(self.root)
         self.assertIs(mctext.yview.__func__, Text.yview)
 
+    def test_event_delete_unbound_sequence(self):
+        # gh-89360: deleting a sequence that was not added to a virtual
+        # event is ignored instead of raising ValueError.
+        mctext = self.mc(self.root)
+        mctext.event_add('<<tester>>', '<Control-Key-a>')
+        info = mctext.event_info('<<tester>>')
+        self.assertEqual(len(info), 1)
+
+        # A different sequence, never added: a no-op, not an error.
+        mctext.event_delete('<<tester>>', '<Control-Key-b>')
+        self.assertEqual(mctext.event_info('<<tester>>'), info)
+
+        # The added sequence can still be deleted normally.
+        mctext.event_delete('<<tester>>', '<Control-Key-a>')
+        self.assertNotIn(info[0], mctext.event_info('<<tester>>'))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/Lib/idlelib/multicall.py
+++ b/Lib/idlelib/multicall.py
@@ -386,10 +386,11 @@ def MultiCallCreator(widget):
                 if triplet is None:
                     #print("Tkinter event_delete: %s" % seq, file=sys.__stderr__)
                     widget.event_delete(self, virtual, seq)
-                else:
+                elif triplet in triplets:
                     if func is not None:
                         self.__binders[triplet[1]].unbind(triplet, func)
                     triplets.remove(triplet)
+                # Else the sequence is not bound; ignore it (gh-89360).
 
         def event_info(self, virtual=None):
             if virtual is None or virtual not in self.__eventinfo:

--- a/Misc/NEWS.d/next/IDLE/2026-07-01-14-00-00.gh-issue-89360.mUlTiC.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-07-01-14-00-00.gh-issue-89360.mUlTiC.rst
@@ -1,0 +1,3 @@
+Fix a rare crash in the IDLE editor when the completion window is closed:
+deleting a key binding for a sequence that is not bound to the virtual
+event is now ignored instead of raising a ``ValueError``.


### PR DESCRIPTION
`MultiCall.event_delete()` called `triplets.remove(triplet)` unconditionally.  When the sequence was not actually bound to the virtual event — a rare discrepancy that could happen when the completion window was closed — this raised `ValueError: list.remove(x): x not in list`, crashing through the Tk callback (reported by @rhettinger).

The unbind and remove are now skipped when the sequence is not bound.  This is safer than catching only `triplets.remove()`, because the binder's `unbind()` also does `bindedfuncs.remove(func)`, which would raise `ValueError` as well.  `event_add()` pairs the bind and append, so the membership check keeps both structures consistent.

The added test reproduces the exact scenario (add one sequence, delete a different one); it raises the reported `ValueError` without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-89360 -->
* Issue: gh-89360
<!-- /gh-issue-number -->
