### PR TITLE
gh-134300: Remove idlelib from the path of the IDLE user process

### DIFF
--- a/Lib/idlelib/idle_test/test_pyshell.py
+++ b/Lib/idlelib/idle_test/test_pyshell.py
@@ -2,6 +2,7 @@
 # Plus coverage of test_warning.  Was 20% with test_openshell.
 
 from idlelib import pyshell
+import os
 import unittest
 from test.support import requires
 from tkinter import Tk
@@ -27,6 +28,14 @@ class FunctionTest(unittest.TestCase):
             with self.subTest(width=width):
                 self.assertEqual(pyshell.restart_line(width, ''), expect)
         self.assertEqual(pyshell.restart_line(taglen+2, ''), expect+' =')
+
+    def test_fix_user_path(self):
+        # gh-134300: the idlelib directory is removed, other entries kept.
+        eq = self.assertEqual
+        idlelib_dir = os.path.dirname(os.path.abspath(pyshell.__file__))
+        eq(pyshell.fix_user_path(['', '/a', idlelib_dir, '/b']), ['', '/a', '/b'])
+        eq(pyshell.fix_user_path(['/a', '/b']), ['/a', '/b'])
+        eq(pyshell.fix_user_path([idlelib_dir]), [])
 
 
 class PyShellFileListTest(unittest.TestCase):

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -407,6 +407,17 @@ def restart_line(width, filename):  # See bpo-38141.
         return tag[:-2]  # Remove ' ='.
 
 
+def fix_user_path(path):
+    """Return path without the idlelib directory (gh-134300).
+
+    That directory is on sys.path when idle.py is run as a script.
+    Otherwise user code could import idlelib submodules as top-level
+    modules, such as "import help".
+    """
+    idlelib_dir = os.path.dirname(os.path.abspath(__file__))
+    return [p for p in path if p != idlelib_dir]
+
+
 class ModifiedInterpreter(InteractiveInterpreter):
 
     def __init__(self, tkconsole):
@@ -567,6 +578,7 @@ class ModifiedInterpreter(InteractiveInterpreter):
             path.extend(sys.path)
         else:
             path = sys.path
+        path = fix_user_path(path)  # gh-134300
 
         self.runcommand("""if 1:
         import sys as _sys

--- a/Misc/NEWS.d/next/IDLE/2026-07-01-15-00-00.gh-issue-134300.iDlPaT.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-07-01-15-00-00.gh-issue-134300.iDlPaT.rst
@@ -1,0 +1,3 @@
+Do not add the ``idlelib`` directory to the path of the IDLE user process.
+User code run in IDLE can no longer import ``idlelib`` submodules as
+top-level modules, such as ``import help``.


### PR DESCRIPTION
When `idle.py` is run as a script, its directory (`.../idlelib`) is placed on `sys.path[0]`.  `ModifiedInterpreter.transfer_path()` then sends the whole GUI `sys.path` to the user subprocess (replacing its `sys.path`), so user code could import idlelib submodules as top-level modules, e.g. `import help` silently imports `idlelib.help`.  A subissue of #69674.

`transfer_path()` now removes the idlelib directory from the transferred path.  Only that entry is removed, so `import idlelib.run` and the other idlelib modules the subprocess needs still resolve via the `Lib` parent directory; as Terry noted in the issue, `idlelib.run` runs fine without idlelib on the path.

The removal is factored into a module-level `fix_user_path()` with a non-GUI unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-134300 -->
* Issue: gh-134300
<!-- /gh-issue-number -->
