### PR TITLE
gh-80504: Always show the full search path in IDLE Find in Files

### DIFF
--- a/Lib/idlelib/grep.py
+++ b/Lib/idlelib/grep.py
@@ -40,6 +40,20 @@ def grep(text, io=None, flist=None):
     dialog.open(text, searchphrase, io)
 
 
+def default_glob(path):
+    """Return the initial "In files:" pattern for a file path (gh-80504).
+
+    Always include a full directory so that grep output shows which
+    directory was searched.
+    """
+    dir, base = os.path.split(path)
+    dir = os.path.abspath(dir)  # An empty dir becomes the current directory.
+    head, tail = os.path.splitext(base)
+    if not tail:
+        tail = ".py"
+    return os.path.join(dir, "*" + tail)
+
+
 def walk_error(msg):
     "Handle os.walk error."
     print(msg)
@@ -103,11 +117,7 @@ class GrepDialog(SearchDialogBase):
             path = io.filename or ""
         else:
             path = ""
-        dir, base = os.path.split(path)
-        head, tail = os.path.splitext(base)
-        if not tail:
-            tail = ".py"
-        self.globvar.set(os.path.join(dir, "*" + tail))
+        self.globvar.set(default_glob(path))
 
     def create_entries(self):
         "Create base entry widgets and add widget for search path."

--- a/Lib/idlelib/idle_test/test_grep.py
+++ b/Lib/idlelib/idle_test/test_grep.py
@@ -37,6 +37,25 @@ class Dummy_grep:
 _grep = Dummy_grep()
 
 
+class DefaultGlobTest(unittest.TestCase):
+
+    def test_no_path(self):
+        # gh-80504: an unsaved editor or the Shell has no path, so the
+        # pattern uses the current directory, not just '*.py'.
+        self.assertEqual(grep.default_glob(''),
+                         os.path.join(os.getcwd(), '*.py'))
+
+    def test_full_path(self):
+        path = os.path.join(os.path.abspath(os.sep), 'ab', 'foo.py')
+        self.assertEqual(grep.default_glob(path),
+                         os.path.join(os.path.dirname(path), '*.py'))
+
+    def test_other_extension(self):
+        path = os.path.join(os.path.abspath(os.sep), 'ab', 'foo.txt')
+        self.assertEqual(grep.default_glob(path),
+                         os.path.join(os.path.dirname(path), '*.txt'))
+
+
 class FindfilesTest(unittest.TestCase):
 
     @classmethod

--- a/Misc/NEWS.d/next/IDLE/2026-07-01-16-00-00.gh-issue-80504.gReP.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-07-01-16-00-00.gh-issue-80504.gReP.rst
@@ -1,0 +1,3 @@
+The "In files:" field of IDLE's Find in Files dialog now always contains a
+full directory path, even for an unsaved editor or the Shell.  This shows
+in the grep output which directory was searched.


### PR DESCRIPTION
When Find in Files is opened from an unsaved editor, the Shell, or an Output window, `io.filename` is empty, so the "In files:" field started as a bare `*.py` (`os.path.join("", "*.py")`).  There was then no way to tell from the grep output which directory was actually searched.

The pattern computation is factored into a module-level `default_glob()` that makes the directory absolute (`os.path.abspath`, which maps `""` to the current directory and is idempotent on real paths), so the field always contains a full directory path.  This matches what saved editor files already showed.

Requested by Terry Reedy in the issue.  The added non-GUI test covers the no-path, full-path, and non-`.py` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-80504 -->
* Issue: gh-80504
<!-- /gh-issue-number -->
