### PR TITLE
gh-65339: Save IDLE Shell and Output windows as text by default

### DIFF
--- a/Lib/idlelib/idle_test/test_outwin.py
+++ b/Lib/idlelib/idle_test/test_outwin.py
@@ -41,6 +41,13 @@ class OutputWindowTest(unittest.TestCase):
         self.assertFalse(w.ispythonsource('test.txt'))
         self.assertFalse(w.ispythonsource(__file__))
 
+    def test_save_defaults_to_text(self):
+        # gh-65339: output is saved as text, not Python source.
+        io = self.window.io
+        self.assertEqual(io.defaultextension, '.txt')
+        # Text files are offered before Python files.
+        self.assertEqual(io.filetypes[0][0], 'Text files')
+
     def test_window_title(self):
         self.assertEqual(self.window.top.title(), 'Output' + ' (%s)' % platform.python_version())
 

--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -384,7 +384,16 @@ class IOBinding:
         ("All files", "*"),
         )
 
+    # Output windows (Shell, Output) are not Python source, so they list
+    # text files first and default to ".txt" (gh-65339).
+    text_filetypes = (
+        ("Text files", "*.txt", "TEXT"),
+        ("Python files", py_extensions, "TEXT"),
+        ("All files", "*"),
+        )
+
     defaultextension = '.py' if sys.platform == 'darwin' else ''
+    text_defaultextension = '.txt'
 
     def askopenfile(self):
         dir, base = self.defaultfilename("open")

--- a/Lib/idlelib/outwin.py
+++ b/Lib/idlelib/outwin.py
@@ -78,6 +78,10 @@ class OutputWindow(EditorWindow):
     def __init__(self, *args):
         EditorWindow.__init__(self, *args)
         self.text.bind("<<goto-file-line>>", self.goto_file_line)
+        # Output is not Python source, so save it as text by default
+        # (gh-65339).
+        self.io.filetypes = self.io.text_filetypes
+        self.io.defaultextension = self.io.text_defaultextension
 
     # Customize EditorWindow
     def ispythonsource(self, filename):

--- a/Misc/NEWS.d/next/IDLE/2026-07-01-17-00-00.gh-issue-65339.oUtTxt.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-07-01-17-00-00.gh-issue-65339.oUtTxt.rst
@@ -1,0 +1,3 @@
+Saving the IDLE Shell or an Output window now defaults to a ``.txt``
+extension and lists text files before Python files, since their content is
+not Python source.


### PR DESCRIPTION
The Shell and Output windows contain shell logs and Find in Files (grep) output, not Python source, so defaulting their Save As dialog to `.py` is misleading — beginners have saved a Shell session as `.py` and then hit a `SyntaxError` running it (see the issue).

`IOBinding` gains `text_filetypes` (text files listed first) and `text_defaultextension = '.txt'`.  `OutputWindow.__init__` switches its `io` to these, and the Shell (`PyShell(OutputWindow)`) inherits it.

`.py` is still selectable, just no longer the default.  Terry also considered removing `.py` as an option entirely for these windows; that stricter change is left out here.

The added test checks that an Output window's save defaults to text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-65339 -->
* Issue: gh-65339
<!-- /gh-issue-number -->
