### PR TITLE
gh-75595: Do not save a blank int entry in IDLE Settings

### DIFF
--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -2265,7 +2265,11 @@ class VarTrace:
         "Return default callback function to add values to changes instance."
         def default_callback(*params):
             "Add config values to changes instance."
-            changes.add_option(*config, var.get())
+            value = var.get()
+            # A blanked int entry is an empty string; do not save it as an
+            # invalid config value (gh-83653).
+            if value != '':
+                changes.add_option(*config, value)
         return default_callback
 
     def attach(self):

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -1544,6 +1544,17 @@ class VarTraceTest(unittest.TestCase):
         self.assertEqual(changes['main']['section']['option'], '42')
         changes.clear()
 
+        # gh-83653: a blank int entry is not saved as bad config data.
+        sv = StringVar(root)
+        cb = self.tracers.make_callback(sv, ('main', 'section', 'option'))
+        sv.set('')
+        cb()
+        self.assertNotIn('section', changes['main'])
+        sv.set('5')
+        cb()
+        self.assertEqual(changes['main']['section']['option'], '5')
+        changes.clear()
+
     def test_attach_detach(self):
         tr = self.tracers
         iv = tr.add(self.iv, self.var_changed_increment)

--- a/Misc/NEWS.d/next/IDLE/2026-07-01-18-00-00.gh-issue-83653.cFgInt.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-07-01-18-00-00.gh-issue-83653.cFgInt.rst
@@ -1,0 +1,3 @@
+Blanking an integer entry in IDLE's Settings dialog, such as "Auto squeeze
+min lines", no longer saves an empty string as an invalid configuration
+value.


### PR DESCRIPTION
Integer entry fields in the Settings dialog use a `StringVar` with a default per-keystroke callback that writes the raw value to `changes`.  Deleting all digits from a field (e.g. "Auto squeeze min lines") wrote an empty string to the config file, which then produced a `Warning: config.py - IdleConf.GetOption - invalid 'int' value` when the option was read back.

The default callback now skips empty values.  These entries are `digits_only`-validated, so blank is the only invalid value they can produce.  The check is `value != ''` rather than a truthiness test so that `IntVar` `0` and `BooleanVar` `False` are still saved.  Legitimate empty values (such as the second theme/key-set name) go through named callbacks, not this one.

Spinoff of gh-75595.  The added test covers a blanked entry being skipped and a valid entry being saved.
Also related to gh-83653.

Credit to Cheryl Sabella (@csabella), who reported this bug with a reproducer and wrote the original `VarTrace` int-entry handling (gh-75036) that this change completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-65339 -->
* Issue: gh-75595
<!-- /gh-issue-number -->