### PR TITLE
gh-82183: Do not restart the busy IDLE shell when running without restart

### DIFF
--- a/Lib/idlelib/idle_test/test_runscript.py
+++ b/Lib/idlelib/idle_test/test_runscript.py
@@ -2,6 +2,7 @@
 
 from idlelib import runscript
 import unittest
+from unittest import mock
 from test.support import requires
 from tkinter import Tk
 from idlelib.editor import EditorWindow
@@ -26,6 +27,26 @@ class ScriptBindingTest(unittest.TestCase):
     def test_init(self):
         ew = EditorWindow(root=self.root)
         sb = runscript.ScriptBinding(ew)
+        ew._close()
+
+    def test_run_module_event_shell_busy_no_restart(self):
+        # gh-82183: running without restarting the busy shell aborts.
+        ew = EditorWindow(root=self.root)
+        sb = runscript.ScriptBinding(ew)
+        sb.getfilename = mock.Mock(return_value='test.py')
+        sb.checksyntax = mock.Mock(return_value='code')
+        sb.tabnanny = mock.Mock(return_value=True)
+        sb.shell = shell = mock.Mock()
+        shell.executing = True
+        interp = shell.interp
+        with mock.patch.object(runscript, 'CustomRun') as customrun:
+            # Restart shell unchecked.
+            customrun.return_value.result = (['arg'], False)
+            result = sb.run_module_event(None, customize=True)
+        self.assertEqual(result, 'break')
+        interp.display_executing_dialog.assert_called_once()
+        interp.restart_subprocess.assert_not_called()
+        interp.runcode.assert_not_called()
         ew._close()
 
 

--- a/Lib/idlelib/runscript.py
+++ b/Lib/idlelib/runscript.py
@@ -139,6 +139,10 @@ class ScriptBinding:
                 return 'break'
         self.cli_args, restart = run_args if customize else ([], True)
         interp = self.shell.interp
+        if self.shell.executing and not restart:
+            # Cannot run without restarting the busy shell (gh-82183).
+            interp.display_executing_dialog()
+            return 'break'
         if pyshell.use_subprocess and restart:
             interp.restart_subprocess(
                     with_cwd=False, filename=filename)

--- a/Misc/NEWS.d/next/IDLE/2026-07-01-19-00-00.gh-issue-82183.rNsTrt.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-07-01-19-00-00.gh-issue-82183.rNsTrt.rst
@@ -1,0 +1,3 @@
+When the shell is busy running code, using "Run... Customized" with "Restart
+shell" unchecked now reports that the shell is executing instead of
+restarting it anyway.


### PR DESCRIPTION
The `AttributeError` in the original report (bpo-38002) was fixed by bpo-42508.  This addresses the remaining problem noted by @terryjreedy: with the Shell busy executing code (e.g. blocked on `input()`), using "Run... Customized" with "Restart shell" **unchecked** restarted the subprocess anyway.

`run_module_event` skips the explicit `restart_subprocess` when restart is unchecked, but `runcode` then restarts the busy shell on its own, overriding the user's choice and killing the pending input.

The new code cannot run in the busy shell's namespace without restarting it, so when restart is unchecked and the shell is executing it now reports "Already executing" and aborts, instead of restarting anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-82183 -->
* Issue: gh-82183
<!-- /gh-issue-number -->
