### PR TITLE
gh-83637: Make IDLE calltip tests pass without docstrings

### DIFF
--- a/Lib/idlelib/idle_test/test_calltip.py
+++ b/Lib/idlelib/idle_test/test_calltip.py
@@ -111,7 +111,6 @@ subclasses to override in order to tweak the default behaviour.
 If you want to completely replace the main wrapping algorithm,
 you\'ll probably have to override _wrap_chunks().''')
 
-    @requires_docstrings
     def test_properly_formatted(self):
 
         def foo(s='a'*100):
@@ -131,7 +130,9 @@ you\'ll probably have to override _wrap_chunks().''')
                "aaaaaaaaaa')"
         sbar = "(s='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" + indent + "aaaaaaaaa"\
-               "aaaaaaaaaa')\nHello Guido"
+               "aaaaaaaaaa')"
+        if bar.__doc__ is not None:
+            sbar += "\nHello Guido"
         sbaz = "(s='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" + indent + "aaaaaaaaa"\
                "aaaaaaaaaa', z='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"\
@@ -186,24 +187,32 @@ bytes() -> empty bytes object''')
             with self.subTest(func=func):
                 self.assertEqual(get_spec(func), func.tip + doc)
 
-    @requires_docstrings
     def test_methods(self):
-        doc = '\ndoc'
-        for meth in (TC.t1, TC.t2, TC.t3, TC.t4, TC.t5, TC.t6, TC.__call__):
+        doc = '\ndoc' if TC.__doc__ is not None else ''
+        for meth in (TC.t1, TC.t2, TC.t3, TC.t4, TC.t5, TC.t6):
             with self.subTest(meth=meth):
                 self.assertEqual(get_spec(meth), meth.tip + doc)
         self.assertEqual(get_spec(TC.cm), "(a)" + doc)
         self.assertEqual(get_spec(TC.sm), "(b)" + doc)
+        # __call__ inherits object.__call__'s docstring when its own is
+        # missing (build without docstrings or run with -OO).
+        call_doc = doc or ('\n' + object.__call__.__doc__
+                           if object.__call__.__doc__ else '')
+        self.assertEqual(get_spec(TC.__call__), TC.__call__.tip + call_doc)
 
-    @requires_docstrings
     def test_bound_methods(self):
         # test that first parameter is correctly removed from argspec
-        doc = '\ndoc'
+        doc = '\ndoc' if TC.__doc__ is not None else ''
         for meth, mtip  in ((tc.t1, "()"), (tc.t4, "(*args)"),
-                            (tc.t6, "(self)"), (tc.__call__, '(ci)'),
+                            (tc.t6, "(self)"),
                             (tc, '(ci)'), (TC.cm, "(a)"),):
             with self.subTest(meth=meth, mtip=mtip):
                 self.assertEqual(get_spec(meth), mtip + doc)
+        # __call__ inherits object.__call__'s docstring when its own is
+        # missing (build without docstrings or run with -OO).
+        call_doc = doc or ('\n' + object.__call__.__doc__
+                           if object.__call__.__doc__ else '')
+        self.assertEqual(get_spec(tc.__call__), '(ci)' + call_doc)
 
     def test_starred_parameter(self):
         # test that starred first parameter is *not* removed from argspec

--- a/Lib/idlelib/idle_test/test_calltip.py
+++ b/Lib/idlelib/idle_test/test_calltip.py
@@ -7,7 +7,7 @@ import textwrap
 import types
 import re
 from idlelib.idle_test.mock_tk import Text
-from test.support import MISSING_C_DOCSTRINGS
+from test.support import MISSING_C_DOCSTRINGS, requires_docstrings
 
 
 # Test Class TC is used in multiple get_argspec test methods
@@ -51,8 +51,7 @@ class Get_argspecTest(unittest.TestCase):
     # but a red buildbot is better than a user crash (as has happened).
     # For a simple mismatch, change the expected output to the actual.
 
-    @unittest.skipIf(MISSING_C_DOCSTRINGS,
-                     "Signature information for builtins requires docstrings")
+    @requires_docstrings
     def test_builtins(self):
 
         def tiptest(obj, out):
@@ -112,6 +111,7 @@ subclasses to override in order to tweak the default behaviour.
 If you want to completely replace the main wrapping algorithm,
 you\'ll probably have to override _wrap_chunks().''')
 
+    @requires_docstrings
     def test_properly_formatted(self):
 
         def foo(s='a'*100):
@@ -186,17 +186,19 @@ bytes() -> empty bytes object''')
             with self.subTest(func=func):
                 self.assertEqual(get_spec(func), func.tip + doc)
 
+    @requires_docstrings
     def test_methods(self):
-        doc = '\ndoc' if TC.__doc__ is not None else ''
+        doc = '\ndoc'
         for meth in (TC.t1, TC.t2, TC.t3, TC.t4, TC.t5, TC.t6, TC.__call__):
             with self.subTest(meth=meth):
                 self.assertEqual(get_spec(meth), meth.tip + doc)
         self.assertEqual(get_spec(TC.cm), "(a)" + doc)
         self.assertEqual(get_spec(TC.sm), "(b)" + doc)
 
+    @requires_docstrings
     def test_bound_methods(self):
         # test that first parameter is correctly removed from argspec
-        doc = '\ndoc' if TC.__doc__ is not None else ''
+        doc = '\ndoc'
         for meth, mtip  in ((tc.t1, "()"), (tc.t4, "(*args)"),
                             (tc.t6, "(self)"), (tc.__call__, '(ci)'),
                             (tc, '(ci)'), (TC.cm, "(a)"),):

--- a/Lib/idlelib/idle_test/test_pyparse.py
+++ b/Lib/idlelib/idle_test/test_pyparse.py
@@ -41,8 +41,9 @@ class PyParseTest(unittest.TestCase):
         setcode = p.set_code
 
         # Not empty and doesn't end with newline.
-        with self.assertRaises(AssertionError):
-            setcode('a')
+        if __debug__:  # Assertions are removed with -O.
+            with self.assertRaises(AssertionError):
+                setcode('a')
 
         tests = ('',
                  'a\n')
@@ -131,8 +132,9 @@ class PyParseTest(unittest.TestCase):
         p.set_code(code)
 
         # Previous character is not a newline.
-        with self.assertRaises(AssertionError):
-            p.set_lo(5)
+        if __debug__:  # Assertions are removed with -O.
+            with self.assertRaises(AssertionError):
+                p.set_lo(5)
 
         # A value of 0 doesn't change self.code.
         p.set_lo(0)
@@ -326,9 +328,10 @@ class PyParseTest(unittest.TestCase):
              )
 
         # Must be C_BRACKET continuation type.
-        setcode('def function1(self, a, b):\n')
-        with self.assertRaises(AssertionError):
-            indent()
+        if __debug__:  # Assertions are removed with -O.
+            setcode('def function1(self, a, b):\n')
+            with self.assertRaises(AssertionError):
+                indent()
 
         for test in tests:
             setcode(test.string)
@@ -345,11 +348,12 @@ class PyParseTest(unittest.TestCase):
                   ('    """ (\\\n'),                 # Docstring.
                   ('a = #\\\n'),                     # Inline comment.
                   )
-        for string in errors:
-            with self.subTest(string=string):
-                setcode(string)
-                with self.assertRaises(AssertionError):
-                    indent()
+        if __debug__:  # Assertions are removed with -O.
+            for string in errors:
+                with self.subTest(string=string):
+                    setcode(string)
+                    with self.assertRaises(AssertionError):
+                        indent()
 
         TestInfo = namedtuple('TestInfo', ('string', 'spaces'))
         tests = (TestInfo('a = (1 + 2) - 5 *\\\n', 4),

--- a/Lib/idlelib/idle_test/test_run.py
+++ b/Lib/idlelib/idle_test/test_run.py
@@ -454,7 +454,8 @@ class RecursionLimitTest(unittest.TestCase):
 
     def test_fixdoc(self):
         # Put here until better place for miscellaneous test.
-        def func(): "docstring"
+        def func(): pass
+        func.__doc__ = "docstring"
         run.fixdoc(func, "more")
         self.assertEqual(func.__doc__, "docstring\n\nmore")
         func.__doc__ = None

--- a/Misc/NEWS.d/next/IDLE/2026-07-01-20-00-00.gh-issue-83637.cTipOO.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-07-01-20-00-00.gh-issue-83637.cTipOO.rst
@@ -1,0 +1,2 @@
+Skip IDLE calltip tests that require docstrings when running with ``-OO`` or
+without docstrings.

--- a/Misc/NEWS.d/next/IDLE/2026-07-01-20-00-00.gh-issue-83637.cTipOO.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-07-01-20-00-00.gh-issue-83637.cTipOO.rst
@@ -1,2 +1,2 @@
-Skip IDLE calltip tests that require docstrings when running with ``-OO`` or
-without docstrings.
+Make IDLE tests pass when running with ``-O`` or ``-OO`` or without
+docstrings.


### PR DESCRIPTION
Four `Get_argspec` tests in `test_calltip` hard-code expected docstrings in their output, so they fail under `-OO` (and would under a build without docstrings): `test_builtins`, `test_methods`, `test_bound_methods`, and `test_properly_formatted`.

Skip them with `test.support.requires_docstrings`, as `test_inspect` and `test_pydoc` do.  This covers both `-OO` (Python docstrings stripped) and `MISSING_C_DOCSTRINGS` builds, so `test_builtins` moves from `@skipIf(MISSING_C_DOCSTRINGS)` to the stronger `@requires_docstrings`.  `test_multiline_docstring` keeps `@skipIf(MISSING_C_DOCSTRINGS)` since it only needs C docstrings and already passes under `-OO`.

Verified: normal run all pass; `-OO` run skips the four and reports no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-83637 -->
* Issue: gh-83637
<!-- /gh-issue-number -->
