### PR TITLE
Use `@force_not_colorized` in `test_syntactical_future_repl`

### DIFF
--- a/Lib/test/test_future_stmt/test_future.py
+++ b/Lib/test/test_future_stmt/test_future.py
@@ -3,7 +3,7 @@
 import __future__
 import ast
 import unittest
-from test.support import import_helper
+from test.support import force_not_colorized, import_helper
 from test.support.script_helper import spawn_python, kill_python
 from textwrap import dedent
 import os
@@ -176,6 +176,7 @@ class FutureTest(unittest.TestCase):
         exec("from __future__ import unicode_literals; x = ''", {}, scope)
         self.assertIsInstance(scope["x"], str)
 
+    @force_not_colorized
     def test_syntactical_future_repl(self):
         p = spawn_python('-i')
         p.stdin.write(b"from __future__ import barry_as_FLUFL\n")


### PR DESCRIPTION
Found while working on https://github.com/RustPython/RustPython/pull/8181

This is the only test that checks that the literal substring of `SyntaxError: ...` is not inside the output, but when coloring is enabled the output might contain a literal
```
[[1;35mSyntaxError[[0m: [[35minvalid syntax [[0m
```

making this test to always pass