### PR TITLE
gh-88574: Skip a spurious blank line after a literal in imaplib

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -1280,6 +1280,10 @@ class IMAP4:
 
                 dat = self._get_line()
 
+                # Skip a blank line that some servers send after a literal.
+                if dat == b'':
+                    dat = self._get_line()
+
             self._append_untagged(typ, dat)
 
         # Bracketed response information?

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -655,6 +655,23 @@ class NewIMAPTestsMixin:
         self.assertEqual(typ, 'OK')
         self.assertEqual(data[0], b'() "." directoryA')
 
+    def test_extra_blank_line_after_literal(self):
+        # Some buggy servers send an extra blank line after the counted
+        # literal data.  imaplib should skip it instead of failing.
+        class BlankLineHandler(SimpleIMAPHandler):
+            def cmd_FETCH(self, tag, args):
+                self._send(b'* 1 FETCH (BODY[HEADER] {13}\r\n')
+                self._send(b'Subject: test')       # 13-byte literal
+                self._send(b'\r\n)\r\n')            # stray blank line, then ')'
+                self._send_tagged(tag, 'OK', 'FETCH completed')
+        client, _ = self._setup(BlankLineHandler)
+        client.login('user', 'pass')
+        client.select()
+        typ, data = client.fetch('1', '(BODY[HEADER])')
+        self.assertEqual(typ, 'OK')
+        self.assertEqual(data, [(b'1 (BODY[HEADER] {13}', b'Subject: test'),
+                                b')'])
+
     def test_unselect(self):
         client, _ = self._setup(SimpleIMAPHandler)
         client.login('user', 'pass')

--- a/Misc/NEWS.d/next/Library/2026-07-01-10-00-00.gh-issue-88574.Kz3wQm.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-01-10-00-00.gh-issue-88574.Kz3wQm.rst
@@ -1,0 +1,2 @@
+:mod:`imaplib` no longer fails when a server sends a spurious blank line
+after the counted data of a literal.  Such a blank line is now skipped.


### PR DESCRIPTION
Some IMAP servers send an extra blank line after the counted data of a
literal.  `imaplib` mistook that blank line for the response trailer,
lost track of the real continuation, and aborted with an "unexpected
response" error on the next command.  Such a blank line is now skipped.

This revives the fix from the closed PR #26701, adding the regression
test it lacked.


<!-- gh-issue-number: gh-88574 -->
* Issue: gh-88574
<!-- /gh-issue-number -->
