### PR TITLE
gh-152741: Fix data race on `PyThreadState.thread_id` during thread bind

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-01-09-09-36.gh-issue-152741.Fq7wZk.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-01-09-09-36.gh-issue-152741.Fq7wZk.rst
@@ -1,0 +1,4 @@
+Fix a data race on a thread state's thread id in the free-threaded build.
+A starting thread now publishes its thread id with an atomic store so that
+stop-the-world readers such as ``sys._current_exceptions()`` and
+``sys._current_frames()`` no longer race with it.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -175,9 +175,13 @@ bind_tstate(PyThreadState *tstate)
     // Currently we don't necessarily store the thread state
     // in thread-local storage (e.g. per-interpreter).
 
-    tstate->thread_id = PyThread_get_thread_ident();
+    // Published while still attaching and already on the thread list, so a
+    // stop-the-world reader can load it concurrently; store atomically.
+    FT_ATOMIC_STORE_ULONG_RELAXED(tstate->thread_id,
+                                  PyThread_get_thread_ident());
 #ifdef PY_HAVE_THREAD_NATIVE_ID
-    tstate->native_thread_id = PyThread_get_thread_native_id();
+    FT_ATOMIC_STORE_ULONG_RELAXED(tstate->native_thread_id,
+                                  PyThread_get_thread_native_id());
 #endif
 
 #ifdef Py_GIL_DISABLED
@@ -2586,7 +2590,7 @@ PyThreadState_SetAsyncExc(unsigned long id, PyObject *exc)
      */
     PyThreadState *tstate = NULL;
     _Py_FOR_EACH_TSTATE_BEGIN(interp, t) {
-        if (t->thread_id == id) {
+        if (FT_ATOMIC_LOAD_ULONG_RELAXED(t->thread_id) == id) {
             tstate = t;
             break;
         }
@@ -2750,7 +2754,8 @@ _PyThread_CurrentFrames(void)
             if (frame == NULL) {
                 continue;
             }
-            PyObject *id = PyLong_FromUnsignedLong(t->thread_id);
+            PyObject *id = PyLong_FromUnsignedLong(
+                FT_ATOMIC_LOAD_ULONG_RELAXED(t->thread_id));
             if (id == NULL) {
                 goto fail;
             }
@@ -2814,7 +2819,8 @@ _PyThread_CurrentExceptions(void)
             if (err_info == NULL) {
                 continue;
             }
-            PyObject *id = PyLong_FromUnsignedLong(t->thread_id);
+            PyObject *id = PyLong_FromUnsignedLong(
+                FT_ATOMIC_LOAD_ULONG_RELAXED(t->thread_id));
             if (id == NULL) {
                 goto fail;
             }


### PR DESCRIPTION
`bind_tstate()` sets `tstate->thread_id` (and `native_thread_id`) without
synchronization while the thread state is already published to
`interp->threads.head` and the thread is not yet stop-the-world-stoppable. The
stop-the-world readers `_PyThread_CurrentExceptions` (`sys._current_exceptions()`)
and `_PyThread_CurrentFrames` (`sys._current_frames()`) read `t->thread_id`, so the
bind store races the reader (reproduced under a free-threaded ThreadSanitizer
build; see gh-152741).

Publish `thread_id`/`native_thread_id` with a relaxed atomic store in
`bind_tstate()` and read them with a relaxed atomic load in the readers that walk
the thread list — `_PyThread_CurrentExceptions`, `_PyThread_CurrentFrames`, and
`PyThreadState_SetAsyncExc` — matching the relaxed-atomic treatment already used
for `tstate->state`. `thread_id` is a standalone scalar written once during attach
(never reset on unbind) and read only as an identity value, so relaxed ordering is
sufficient. In the default (GIL) build the `FT_ATOMIC_*` wrappers expand to plain
loads/stores — no overhead.

Verified TSan-clean: 0 races across 32 short reproducer runs + 4 full 30s windows
(vs the race firing on every unpatched run); functional and `test_threading`
smokes pass under the FT+TSAN build.
