### PR TITLE
gh-140347: WIP spike: color IDLE with the _pyrepl tokenizer

### DIFF
--- a/Lib/idlelib/colorizer.py
+++ b/Lib/idlelib/colorizer.py
@@ -3,10 +3,24 @@ import keyword
 import re
 import time
 
+from _pyrepl.utils import gen_colors
+
 from idlelib.config import idleConf
 from idlelib.delegator import Delegator
 
 DEBUG = False
+
+# Map gen_colors' syntax categories to IDLE's tags (gh-140347).
+# "number" and "op" have no IDLE tag and stay uncolored.
+_category_to_tag = {
+    "keyword": "KEYWORD",
+    "keyword_constant": "KEYWORD",
+    "soft_keyword": "KEYWORD",
+    "builtin": "BUILTIN",
+    "definition": "DEFINITION",
+    "string": "STRING",
+    "comment": "COMMENT",
+}
 
 
 def any(name, alternates):
@@ -346,14 +360,18 @@ class ColorDelegator(Delegator):
 
             `head` is the index in the text widget where the text is found.
         """
+        # Colors come from the tokenizer, which handles grammar that regexps
+        # cannot, such as soft keywords and f-strings (gh-140347).  Span is
+        # inclusive, so the tag ends one past span.end.
+        for span, category in gen_colors(chars):
+            tag = _category_to_tag.get(category)
+            if tag:
+                self._add_tag(span.start, span.end + 1, head, tag)
+        # SYNC boundaries (newlines outside strings) still come from the regexp.
         for m in self.prog.finditer(chars):
-            for name, matched_text in matched_named_groups(m):
-                a, b = m.span(name)
-                self._add_tag(a, b, head, name)
-                if matched_text in ("def", "class"):
-                    if m1 := self.idprog.match(chars, b):
-                        a, b = m1.span(1)
-                        self._add_tag(a, b, head, "DEFINITION")
+            if m.group("SYNC"):
+                a, b = m.span("SYNC")
+                self._add_tag(a, b, head, "SYNC")
 
     def removecolors(self):
         "Remove all colorizing tags."


### PR DESCRIPTION
**Draft / proof-of-concept for gh-140347 — not for merge as-is.**

This is the Stage-1 spike from [my analysis on the issue](https://github.com/python/cpython/issues/140347#issuecomment-4852352713): it gives the discussion working code to react to.

## What it does

Replace the regexp in `ColorDelegator._add_tags_in_section` with `_pyrepl.utils.gen_colors` (the tokenizer-based colorizer that powers the PyREPL). IDLE's incremental engine is untouched — `notify_range` → `TODO` → `recolorize_main` walking `SYNC` boundaries still drives everything; only the per-section coloring changes. The regexp is kept solely to mark `SYNC` boundaries.

`gen_colors`' categories map cleanly onto IDLE's tags (pyrepl is a superset — it colors builtins too); only `number`/`op` are extra and left uncolored. On valid code this is strictly more correct: `match`/`case`/`type` soft keywords and f-strings the regexp can't handle.

## Why it's a draft

Three `test_colorizer` tests fail **by design**: `gen_colors` stops at the first `TokenError`, so one invalid token (e.g. an illegal string prefix) blanks the rest of a section, where the regexp used to continue. IDLE amplifies this because `recolorize_main` accumulates large `SYNC`-bounded sections.

The real fix is `TokenError` recovery in the shared `gen_colors` (restart tokenizing after a bad line), so PyREPL and IDLE both benefit rather than IDLE reintroducing regexp logic. That, plus the "un-tokenizable line" UX call, is the open question on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
