### PR TITLE
gh-89723: Set sys.last_* for SyntaxErrors in the IDLE Shell

### DIFF
--- a/Lib/idlelib/idle_test/test_run.py
+++ b/Lib/idlelib/idle_test/test_run.py
@@ -2,6 +2,7 @@
 
 from idlelib import run
 import io
+import pickle
 import sys
 from test.support import captured_output, captured_stderr
 import unittest
@@ -520,6 +521,32 @@ class ExecRuncodeTest(unittest.TestCase):
         t, e, tb = ex.user_exc_info
         self.assertIs(t, TypeError)
         self.assertTrue(isinstance(e.__context__, ZeroDivisionError))
+
+    def test_setup_last_exception(self):
+        # gh-89723: sys.last_* are set for a SyntaxError caught in the GUI.
+        attrs = 'last_type', 'last_value', 'last_traceback', 'last_exc'
+        saved = {a: getattr(sys, a) for a in attrs if hasattr(sys, a)}
+        def restore():
+            for a in attrs:
+                if a in saved:
+                    setattr(sys, a, saved[a])
+                elif hasattr(sys, a):
+                    delattr(sys, a)
+        self.addCleanup(restore)
+
+        try:
+            compile('1 +', '<pyshell#0>', 'exec')
+        except SyntaxError as e:
+            exc = e
+        # The exception reaches the user process pickled, without a traceback.
+        exc = pickle.loads(pickle.dumps(exc))
+        self.assertIsNone(exc.__traceback__)
+
+        self.ex.setup_last_exception(exc)
+        self.assertIs(sys.last_exc, exc)
+        self.assertIs(sys.last_value, exc)
+        self.assertIs(sys.last_type, SyntaxError)
+        self.assertIsNone(sys.last_traceback)
 
 
 if __name__ == '__main__':

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -732,6 +732,17 @@ class ModifiedInterpreter(InteractiveInterpreter):
         tkconsole.colorize_syntax_error(text, pos)
         tkconsole.resetoutput()
         self.write("SyntaxError: %s\n" % msg)
+        # The standard interpreter sets sys.last_* for an unhandled
+        # SyntaxError, but IDLE catches it here in the GUI process, so set
+        # them in the user process instead (gh-89723).
+        if self.rpcclt:
+            self.rpcclt.remotequeue("exec", "setup_last_exception",
+                                    (value,), {})
+        else:
+            value = value.with_traceback(None)
+            sys.last_exc = sys.last_value = value
+            sys.last_type = type
+            sys.last_traceback = None
         tkconsole.showprompt()
 
     def showtraceback(self):

--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -677,6 +677,12 @@ class Executive:
         else:
             flush_stdout()
 
+    def setup_last_exception(self, exc):
+        "Set sys.last_* for an exception caught in the GUI process (gh-89723)."
+        sys.last_exc = sys.last_value = exc
+        sys.last_type = type(exc)
+        sys.last_traceback = exc.__traceback__
+
     def interrupt_the_server(self):
         if interruptible:
             thread.interrupt_main()

--- a/Misc/NEWS.d/next/IDLE/2026-07-01-12-00-00.gh-issue-89723.Kd8xY2.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-07-01-12-00-00.gh-issue-89723.Kd8xY2.rst
@@ -1,0 +1,3 @@
+Set ``sys.last_exc`` and friends in the user process for a ``SyntaxError``
+entered in the Shell, as the standard interpreter does.  Previously they
+were left unset because IDLE catches the error in its GUI process.


### PR DESCRIPTION
The standard interpreter sets `sys.last_type`, `sys.last_value`, `sys.last_traceback`, and `sys.last_exc` for an unhandled `SyntaxError`, as `code.InteractiveInterpreter.showsyntaxerror` does. The IDLE Shell did not: it catches the error in its GUI process during the completeness-compile, so the user process — where user code queries `sys.last_*` — never sees it.

This adds `Executive.setup_last_exception` in the user process and calls it over RPC from `showsyntaxerror` (the exception pickles cleanly, dropping its GUI-side traceback in transit). In no-subprocess (`-n`) mode the attributes are set locally, clearing the traceback with `with_traceback(None)` to match the standard interpreter. `sys.last_traceback` is `None` because a `SyntaxError` has no user-code traceback.


<!-- gh-issue-number: gh-89723 -->
* Issue: gh-89723
<!-- /gh-issue-number -->
