### PR TITLE
gh-152682: Remove useless `test_syntax.test_disallowed_type_param_names_oom`

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2861,7 +2861,6 @@ import textwrap
 import unittest
 
 from test import support
-from test.support.script_helper import assert_python_ok
 
 class SyntaxWarningTest(unittest.TestCase):
     def check_warning(self, code, errtext, filename="<testcase>", mode="exec"):
@@ -3201,22 +3200,6 @@ if x:
 class A:
     class B[{name}]: pass
                 """, "<testcase>", mode="exec")
-
-    @support.nomemtest
-    def test_disallowed_type_param_names_oom(self):
-        # gh-152682: Don't crash on OOM when formatting the SyntaxError message
-        # in symtable_visit_type_param_bound_or_default.
-        code = textwrap.dedent("""\
-            import _testcapi
-            _testcapi.set_nomemory(0)
-            try:
-                compile("class A[__classdict__]: pass", "<string>", "exec")
-            except MemoryError:
-                pass
-            else:
-                raise RuntimeError('MemoryError not raised')
-        """)
-        assert_python_ok("-c", code)
 
     @support.cpython_only
     def test_nested_named_except_blocks(self):


### PR DESCRIPTION
The regression test has been removed because it was non-functional. The previous fix for this issue is covered by `test_disallowed_type_param_names()`. Tests are not required for fixes of this kind.

Since the main pull request has already been merged, I’ve opened a new one to remove the test.

Context: comment from @StanFromIreland
https://github.com/python/cpython/pull/152684#discussion_r3504849150

<!-- gh-issue-number: gh-152682 -->
* Issue: gh-152682
<!-- /gh-issue-number -->
