### PR TITLE
gh-49680: Add translate_line_endings parameter to imaplib.IMAP4.append

### DIFF
--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -195,7 +195,7 @@ upper bound (``'3:*'``).
 An :class:`IMAP4` instance has the following methods:
 
 
-.. method:: IMAP4.append(mailbox, flags, date_time, message)
+.. method:: IMAP4.append(mailbox, flags, date_time, message, *, translate_line_endings=True)
 
    Append *message* to named mailbox.
 
@@ -203,6 +203,14 @@ An :class:`IMAP4` instance has the following methods:
    flags are separated by spaces, for example ``r'\Seen \Answered'``.
    If *flags* is not already enclosed in parentheses, parentheses are
    added automatically.
+
+   If *translate_line_endings* is true (the default),
+   line endings in *message* are translated to CRLF.
+   Pass ``False`` to send the message literal exactly as given,
+   which is required to preserve messages that contain bare CR or LF.
+
+   .. versionchanged:: next
+      Added the *translate_line_endings* parameter.
 
 
 .. method:: IMAP4.authenticate(mechanism, authobject)

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -208,6 +208,9 @@ An :class:`IMAP4` instance has the following methods:
    line endings in *message* are translated to CRLF.
    Pass ``False`` to send the message literal exactly as given,
    which is required to preserve messages that contain bare CR or LF.
+   In that case *message* must already use CRLF line endings as required
+   by :rfc:`3501`; for example, serialize :mod:`email` messages using
+   :class:`email.policy.SMTP`.
 
    .. versionchanged:: next
       Added the *translate_line_endings* parameter.

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -483,12 +483,17 @@ class IMAP4:
     #       IMAP4 commands
 
 
-    def append(self, mailbox, flags, date_time, message):
+    def append(self, mailbox, flags, date_time, message, *,
+               translate_line_endings=True):
         """Append message to named mailbox.
 
         (typ, [data]) = <instance>.append(mailbox, flags, date_time, message)
 
                 All args except 'message' can be None.
+
+        If 'translate_line_endings' is true (the default), line endings in
+        'message' are translated to CRLF.  Pass false to send the message
+        literal exactly as given.
         """
         name = 'APPEND'
         if not mailbox:
@@ -502,8 +507,9 @@ class IMAP4:
             date_time = Time2Internaldate(date_time)
         else:
             date_time = None
-        literal = MapCRLF.sub(CRLF, message)
-        self.literal = literal
+        if translate_line_endings:
+            message = MapCRLF.sub(CRLF, message)
+        self.literal = message
         return self._simple_command(name, mailbox, flags, date_time)
 
 

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -634,6 +634,25 @@ class NewIMAPTestsMixin:
         self.assertEqual(data[0], b'LOGIN completed')
         self.assertEqual(client.state, 'AUTH')
 
+    def test_append_translate_line_endings(self):
+        # By default line endings in the message are normalized to CRLF;
+        # translate_line_endings=False sends the literal exactly (gh-49680).
+        class AppendHandler(SimpleIMAPHandler):
+            def cmd_APPEND(self, tag, args):
+                size = int(args[-1].strip('{}'))
+                self._send_textline('+')
+                self.server.response = self.rfile.read(size)
+                self.rfile.readline()  # trailing CRLF after the literal
+                self._send_tagged(tag, 'OK', 'APPEND completed')
+        message = b'a\rb\nc\r\nd'
+        client, server = self._setup(AppendHandler)
+        client.login('user', 'pass')
+        client.append('INBOX', None, None, message)
+        self.assertEqual(server.response, b'a\r\nb\r\nc\r\nd')
+        client.append('INBOX', None, None, message,
+                      translate_line_endings=False)
+        self.assertEqual(server.response, message)
+
     def test_logout(self):
         client, _ = self._setup(SimpleIMAPHandler)
         typ, data = client.login('user', 'pass')

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -2,6 +2,7 @@ from test import support
 from test.support import socket_helper
 
 from contextlib import contextmanager
+from email.message import EmailMessage
 import imaplib
 import os.path
 import socketserver
@@ -9,6 +10,7 @@ import time
 import calendar
 import threading
 import re
+import select
 import socket
 
 from test.support import verbose, run_with_tz, run_with_locale, cpython_only
@@ -25,6 +27,18 @@ support.requires_working_socket(module=True)
 
 CERTFILE = os.path.join(os.path.dirname(__file__) or os.curdir, "certdata", "keycert3.pem")
 CAFILE = os.path.join(os.path.dirname(__file__) or os.curdir, "certdata", "pycacert.pem")
+
+
+def _read_literal(handler, marker):
+    # Read one literal, a raw octet sequence, by its count from the marker
+    # ('{N}', or '(~{N}' in UTF8 mode).
+    size = int(re.search(r'\{(\d+)\}', marker).group(1))
+    # The client must wait for the continuation, so nothing should be readable.
+    if select.select([handler.connection], [], [], 0)[0]:
+        raise AssertionError('client sent the literal before the '
+                             'continuation request')
+    handler._send_textline('+')
+    return handler.rfile.read(size)
 
 
 class TestImaplib(unittest.TestCase):
@@ -371,10 +385,8 @@ class NewIMAPTestsMixin:
                 self.server.response = yield
                 self._send_tagged(tag, 'OK', 'FAKEAUTH successful')
             def cmd_APPEND(self, tag, args):
-                self._send_textline('+')
                 self.server.response = args
-                literal = yield
-                self.server.response.append(literal)
+                self.server.response.append(_read_literal(self, args[-1]))
                 literal = yield
                 self.server.response.append(literal)
                 self._send_tagged(tag, 'OK', 'okay')
@@ -635,20 +647,28 @@ class NewIMAPTestsMixin:
         self.assertEqual(client.state, 'AUTH')
 
     def test_append_translate_line_endings(self):
-        # By default line endings in the message are normalized to CRLF;
-        # translate_line_endings=False sends the literal exactly (gh-49680).
+        # By default line endings are normalized to CRLF; False sends the
+        # literal exactly (gh-49680).
         class AppendHandler(SimpleIMAPHandler):
             def cmd_APPEND(self, tag, args):
-                size = int(args[-1].strip('{}'))
-                self._send_textline('+')
-                self.server.response = self.rfile.read(size)
-                self.rfile.readline()  # trailing CRLF after the literal
+                self.server.response = _read_literal(self, args[-1])
+                yield  # read the trailer line
                 self._send_tagged(tag, 'OK', 'APPEND completed')
-        message = b'a\rb\nc\r\nd'
         client, server = self._setup(AppendHandler)
         client.login('user', 'pass')
+        message = b'a\rb\nc\r\nd'
         client.append('INBOX', None, None, message)
         self.assertEqual(server.response, b'a\r\nb\r\nc\r\nd')
+        client.append('INBOX', None, None, message,
+                      translate_line_endings=False)
+        self.assertEqual(server.response, message)
+
+        # An email message uses bare LF by default; False sends it verbatim.
+        message = EmailMessage()
+        message['Subject'] = 'line endings'
+        message.set_content('body line\n')
+        message = message.as_bytes()
+        self.assertNotIn(b'\r\n', message)
         client.append('INBOX', None, None, message,
                       translate_line_endings=False)
         self.assertEqual(server.response, message)
@@ -944,10 +964,8 @@ class ThreadedNetworkedTests(unittest.TestCase):
 
         class UTF8AppendServer(self.UTF8Server):
             def cmd_APPEND(self, tag, args):
-                self._send_textline('+')
                 self.server.response = args
-                literal = yield
-                self.server.response.append(literal)
+                self.server.response.append(_read_literal(self, args[-1]))
                 literal = yield
                 self.server.response.append(literal)
                 self._send_tagged(tag, 'OK', 'okay')

--- a/Misc/NEWS.d/next/Library/2026-07-01-14-00-00.gh-issue-49680.Lm5rQv.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-01-14-00-00.gh-issue-49680.Lm5rQv.rst
@@ -1,0 +1,4 @@
+Add the *translate_line_endings* parameter to :meth:`imaplib.IMAP4.append`.
+By default line endings in the message are translated to CRLF, as before;
+passing ``False`` sends the message literal exactly as given, preserving
+bare CR or LF octets.


### PR DESCRIPTION
`IMAP4.append()` rewrote every bare CR or LF in the message to CRLF
(`MapCRLF.sub(CRLF, message)`) before sending it as the APPEND literal.

But an IMAP literal is "a sequence of octets (including CR and LF)"
(:rfc:`3501`), and the protocol framing -- the octet count and the
trailing CRLF -- is handled separately by `_command()`, so rewriting the
payload silently corrupts the caller's message (for example, content with
intentional bare CR or LF, reported back in 2009).

This adds a keyword-only `translate_line_endings` parameter.  It defaults
to `True`, preserving the previous behavior; passing `False` sends the
message literal exactly as given.

`smtplib` is intentionally left unchanged: it transmits the message as
CRLF-terminated lines in the `DATA` command (:rfc:`5321`), where
normalization is required for correct framing -- unlike an octet-counted
IMAP literal.


<!-- gh-issue-number: gh-49680 -->
* Issue: gh-49680
<!-- /gh-issue-number -->
