### PR TITLE
gh-72507: Document that imaplib does not verify TLS certificates by default

### DIFF
--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -89,6 +89,13 @@ There's also a subclass for secure connections:
    (potentially long-lived) structure.  Please read :ref:`ssl-security` for
    best practices.
 
+   .. note::
+
+      With the default *ssl_context*, the connection is encrypted but the
+      server certificate and hostname are not verified.
+      To verify them, pass a context created by
+      :func:`ssl.create_default_context`.
+
    The optional *timeout* parameter specifies a timeout in seconds for the
    connection attempt. If timeout is not given or is ``None``, the global default
    socket timeout is used.
@@ -585,6 +592,13 @@ An :class:`IMAP4` instance has the following methods:
    and should be a :class:`ssl.SSLContext` object.  This will enable
    encryption on the IMAP connection.  Please read :ref:`ssl-security` for
    best practices.
+
+   .. note::
+
+      With the default *ssl_context*, the connection is encrypted but the
+      server certificate and hostname are not verified.
+      To verify them, pass a context created by
+      :func:`ssl.create_default_context`.
 
    .. versionadded:: 3.2
 


### PR DESCRIPTION
`IMAP4_SSL()` and `IMAP4.starttls()` fall back to
`ssl._create_stdlib_context()` when no *ssl_context* is given, and that
context has `check_hostname=False` and `verify_mode=CERT_NONE` -- so with
the default the connection is encrypted but the server certificate and
hostname are **not** verified.  The documentation implied otherwise ("the
class now supports hostname check").

This adds a note to both `IMAP4_SSL` and `IMAP4.starttls` stating that the
default does not verify, and pointing to `ssl.create_default_context()`.

Only the documentation is changed; the default behavior is left as-is
(that broader change is tracked in gh-91826).


<!-- gh-issue-number: gh-72507 -->
* Issue: gh-72507
<!-- /gh-issue-number -->
