### PR TITLE
gh-79964: Clarify the imaplib fetch example in the docs

### DIFF
--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -730,3 +730,10 @@ retrieves and prints all messages::
    M.close()
    M.logout()
 
+.. note::
+
+   A ``FETCH`` response may contain additional or unsolicited data
+   (see :rfc:`3501`, section 7.4.2),
+   so production code should inspect the whole response
+   rather than rely on ``data[0][1]``.
+


### PR DESCRIPTION
The "IMAP4 Example" prints the message body as `data[0][1]`, which is a
widely-copied pattern.  But a `FETCH` response may include additional or
unsolicited data (:rfc:`3501`, section 7.4.2), so `data[0][1]` is not
reliably the requested content.

This adds a note after the example clarifying that production code should
inspect the whole response.  The example itself is left minimal.


<!-- gh-issue-number: gh-79964 -->
* Issue: gh-79964
<!-- /gh-issue-number -->
