### PR TITLE
[3.14] gh-152060: Fix `_pydatetime.fromisoformat()` raising `AssertionError` on invalid lengths (GH-152061)

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -358,7 +358,8 @@ def _find_isoformat_datetime_separator(dtstr):
 def _parse_isoformat_date(dtstr):
     # It is assumed that this is an ASCII-only string of lengths 7, 8 or 10,
     # see the comment on Modules/_datetimemodule.c:_find_isoformat_datetime_separator
-    assert len(dtstr) in (7, 8, 10)
+    if len(dtstr) not in (7, 8, 10):
+        raise ValueError("Invalid isoformat string")
     year = int(dtstr[0:4])
     has_sep = dtstr[4] == '-'
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3581,7 +3581,7 @@ class TestDateTime(TestDate):
             '2009-04-19T12:30:45.400 +02:30',  # Space between ms and timezone (gh-130959)
             '2009-04-19T12:30:45.400 ',        # Trailing space (gh-130959)
             '2009-04-19T12:30:45. 400',        # Space before fraction (gh-130959)
-            '2020-2020',                      # Ambiguous 9-char date portion
+            '2020-2020',                       # Ambiguous 9-char date portion
         ]
 
         for bad_str in bad_strs:

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3581,6 +3581,7 @@ class TestDateTime(TestDate):
             '2009-04-19T12:30:45.400 +02:30',  # Space between ms and timezone (gh-130959)
             '2009-04-19T12:30:45.400 ',        # Trailing space (gh-130959)
             '2009-04-19T12:30:45. 400',        # Space before fraction (gh-130959)
+            '2020-2020',                    # Ambiguous 9-char date portion
         ]
 
         for bad_str in bad_strs:

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3581,7 +3581,7 @@ class TestDateTime(TestDate):
             '2009-04-19T12:30:45.400 +02:30',  # Space between ms and timezone (gh-130959)
             '2009-04-19T12:30:45.400 ',        # Trailing space (gh-130959)
             '2009-04-19T12:30:45. 400',        # Space before fraction (gh-130959)
-            '2020-2020',                    # Ambiguous 9-char date portion
+            '2020-2020',                      # Ambiguous 9-char date portion
         ]
 
         for bad_str in bad_strs:

--- a/Misc/NEWS.d/next/Library/2026-06-24-10-46-35.gh-issue-152060.f2asrt.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-24-10-46-35.gh-issue-152060.f2asrt.rst
@@ -1,0 +1,3 @@
+Fix :meth:`datetime.datetime.fromisoformat` raising :exc:`AssertionError`
+instead of :exc:`ValueError` for some malformed strings in the pure-Python
+implementation, matching the C implementation.


### PR DESCRIPTION
(cherry picked from commit ff781d52d451db56e154aac35ae7f2c41b1695a4)

Co-authored-by: tonghuaroot (童话) <tonghuaroot@gmail.com>

<!-- gh-issue-number: gh-152060 -->
* Issue: gh-152060
<!-- /gh-issue-number -->
