### PR TITLE
Use tk_scaling() instead of a raw Tcl call in IDLE and tkinter tests

### DIFF
--- a/Lib/idlelib/util.py
+++ b/Lib/idlelib/util.py
@@ -24,7 +24,7 @@ py_extensions = ('.py', '.pyw', '.pyi')
 def fix_scaling(root):  # Called in filelist _test, pyshell, and run.
     """Scale fonts on HiDPI displays, once per process."""
     import tkinter.font
-    scaling = float(root.tk.call('tk', 'scaling'))
+    scaling = root.tk_scaling()
     if scaling > 1.4:
         for name in tkinter.font.names(root):
             font = tkinter.font.Font(root=root, name=name, exists=True)

--- a/Lib/test/test_tkinter/widget_tests.py
+++ b/Lib/test/test_tkinter/widget_tests.py
@@ -34,7 +34,7 @@ class AbstractWidgetTest(AbstractTkTest):
         try:
             return self._scaling
         except AttributeError:
-            self._scaling = root.tk_scaling()
+            self._scaling = self.root.tk_scaling()
             return self._scaling
 
     def _str(self, value):

--- a/Lib/test/test_tkinter/widget_tests.py
+++ b/Lib/test/test_tkinter/widget_tests.py
@@ -34,7 +34,7 @@ class AbstractWidgetTest(AbstractTkTest):
         try:
             return self._scaling
         except AttributeError:
-            self._scaling = float(self.root.call('tk', 'scaling'))
+            self._scaling = root.tk_scaling()
             return self._scaling
 
     def _str(self, value):


### PR DESCRIPTION
Replace `tk.call('tk', 'scaling')` with `tk_scaling()`, which returns a float, in idlelib.util and test_tkinter.widget_tests.

Co-authored-by: Serhiy Storchaka [storchaka@gmail.com](mailto:storchaka@gmail.com)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
