### PR TITLE
gh-152813: Fix curses build warning on macOS

### DIFF
--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3137,7 +3137,8 @@ _curses_window_getbkgrnd_impl(PyCursesWindowObject *self)
     curses_cell_t wcval = {0};
     cursesmodule_state *state = get_cursesmodule_state_by_win(self);
 #ifdef HAVE_NCURSESW
-    if (wgetbkgrnd(self->win, &wcval) == ERR) {
+    int rtn = wgetbkgrnd(self->win, &wcval);  /* avoid -Wunreachable-code on macOS */
+    if (rtn == ERR) {
         curses_window_set_error(self, "wgetbkgrnd", "getbkgrnd");
         return NULL;
     }


### PR DESCRIPTION
Fixes #152813

Assigning the macro's result to a variable before comparing keeps clang from constant-folding the comparison and flagging the branch as dead code.

<!-- gh-issue-number: gh-152813 -->
* Issue: gh-152813
<!-- /gh-issue-number -->
