### PR TITLE
gh-151945: Fix reference warnings in http.cookiejar and http.server docs

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -98,7 +98,7 @@ The following classes are provided:
    1) are treated according to the RFC 2965 rules.  However, if RFC 2965 handling
    is turned off or :attr:`rfc2109_as_netscape` is ``True``, RFC 2109 cookies are
    'downgraded' by the :class:`CookieJar` instance to Netscape cookies, by
-   setting the :attr:`version` attribute of the :class:`Cookie` instance to 0.
+   setting the :attr:`~Cookie.version` attribute of the :class:`Cookie` instance to 0.
    :class:`DefaultCookiePolicy` also provides some parameters to allow some
    fine-tuning of policy.
 
@@ -107,7 +107,7 @@ The following classes are provided:
 
    This class represents Netscape, :rfc:`2109` and :rfc:`2965` cookies.  It is not
    expected that users of :mod:`!http.cookiejar` construct their own :class:`Cookie`
-   instances.  Instead, if necessary, call :meth:`make_cookies` on a
+   instances.  Instead, if necessary, call :meth:`~CookieJar.make_cookies` on a
    :class:`CookieJar` instance.
 
 
@@ -154,20 +154,27 @@ contained :class:`Cookie` objects.
 
    Add correct :mailheader:`Cookie` header to *request*.
 
-   If policy allows (ie. the :attr:`rfc2965` and :attr:`hide_cookie2` attributes of
+   If policy allows (ie. the :attr:`~CookiePolicy.rfc2965` and
+   :attr:`~CookiePolicy.hide_cookie2` attributes of
    the :class:`CookieJar`'s :class:`CookiePolicy` instance are true and false
    respectively), the :mailheader:`Cookie2` header is also added when appropriate.
 
    The *request* object (usually a :class:`urllib.request.Request` instance)
-   must support the methods :meth:`get_full_url`, :meth:`has_header`,
-   :meth:`get_header`, :meth:`header_items`, :meth:`add_unredirected_header`
-   and the attributes :attr:`host`, :attr:`!type`, :attr:`unverifiable`
-   and :attr:`origin_req_host` as documented by :mod:`urllib.request`.
+   must support the methods :meth:`~urllib.request.Request.get_full_url`,
+   :meth:`~urllib.request.Request.has_header`,
+   :meth:`~urllib.request.Request.get_header`,
+   :meth:`~urllib.request.Request.header_items`,
+   :meth:`~urllib.request.Request.add_unredirected_header`
+   and the attributes :attr:`~urllib.request.Request.host`, :attr:`!type`,
+   :attr:`~urllib.request.Request.unverifiable`
+   and :attr:`~urllib.request.Request.origin_req_host` as documented by
+   :mod:`urllib.request`.
 
    .. versionchanged:: 3.3
 
-    *request* object needs :attr:`origin_req_host` attribute. Dependency on a
-    deprecated method :meth:`get_origin_req_host` has been removed.
+    *request* object needs :attr:`~urllib.request.Request.origin_req_host`
+    attribute. Dependency on a deprecated method ``get_origin_req_host`` has
+    been removed.
 
 
 .. method:: CookieJar.extract_cookies(response, request)
@@ -180,20 +187,24 @@ contained :class:`Cookie` objects.
    as appropriate (subject to the :meth:`CookiePolicy.set_ok` method's approval).
 
    The *response* object (usually the result of a call to
-   :meth:`urllib.request.urlopen`, or similar) should support an :meth:`info`
-   method, which returns an :class:`email.message.Message` instance.
+   :meth:`urllib.request.urlopen`, or similar) should support an
+   :meth:`~urllib.response.addinfourl.info` method, which returns an
+   :class:`email.message.Message` instance.
 
    The *request* object (usually a :class:`urllib.request.Request` instance)
-   must support the method :meth:`get_full_url` and the attributes
-   :attr:`host`, :attr:`unverifiable` and :attr:`origin_req_host`,
+   must support the method :meth:`~urllib.request.Request.get_full_url` and
+   the attributes :attr:`~urllib.request.Request.host`,
+   :attr:`~urllib.request.Request.unverifiable`
+   and :attr:`~urllib.request.Request.origin_req_host`,
    as documented by :mod:`urllib.request`.  The request is used to set
    default values for cookie-attributes as well as for checking that the
    cookie is allowed to be set.
 
    .. versionchanged:: 3.3
 
-    *request* object needs :attr:`origin_req_host` attribute. Dependency on a
-    deprecated method :meth:`get_origin_req_host` has been removed.
+    *request* object needs :attr:`~urllib.request.Request.origin_req_host`
+    attribute. Dependency on a deprecated method ``get_origin_req_host`` has
+    been removed.
 
 .. method:: CookieJar.set_policy(policy)
 
@@ -236,13 +247,13 @@ contained :class:`Cookie` objects.
 
    Discard all session cookies.
 
-   Discards all contained cookies that have a true :attr:`discard` attribute
+   Discards all contained cookies that have a true :attr:`~Cookie.discard` attribute
    (usually because they had either no ``max-age`` or ``expires`` cookie-attribute,
    or an explicit ``discard`` cookie-attribute).  For interactive browsers, the end
    of a session usually corresponds to closing the browser window.
 
-   Note that the :meth:`save` method won't save session cookies anyway, unless you
-   ask otherwise by passing a true *ignore_discard* argument.
+   Note that the :meth:`~FileCookieJar.save` method won't save session cookies
+   anyway, unless you ask otherwise by passing a true *ignore_discard* argument.
 
 :class:`FileCookieJar` implements the following additional methods:
 
@@ -255,8 +266,9 @@ contained :class:`Cookie` objects.
    method unimplemented.
 
    *filename* is the name of file in which to save cookies.  If *filename* is not
-   specified, :attr:`self.filename` is used (whose default is the value passed to
-   the constructor, if any); if :attr:`self.filename` is :const:`None`,
+   specified, :attr:`~FileCookieJar.filename` is used (whose default is the
+   value passed to the constructor, if any); if
+   :attr:`~FileCookieJar.filename` is :const:`None`,
    :exc:`ValueError` is raised.
 
    *ignore_discard*: save even cookies set to be discarded. *ignore_expires*: save
@@ -463,9 +475,10 @@ blocking some benign cookies).
 A domain blocklist and allowlist is provided (both off by default). Only domains
 not in the blocklist and present in the allowlist (if the allowlist is active)
 participate in cookie setting and returning.  Use the *blocked_domains*
-constructor argument, and :meth:`blocked_domains` and
-:meth:`set_blocked_domains` methods (and the corresponding argument and methods
-for *allowed_domains*).  If you set an allowlist, you can turn it off again by
+constructor argument, and :meth:`~DefaultCookiePolicy.blocked_domains` and
+:meth:`~DefaultCookiePolicy.set_blocked_domains` methods (and the corresponding
+argument and methods for *allowed_domains*).  If you set an allowlist, you can
+turn it off again by
 setting it to :const:`None`.
 
 Domains in block or allow lists that do not start with a dot must equal the

--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -37,9 +37,9 @@ handler.  Code to create and run the server looks like this::
 .. class:: HTTPServer(server_address, RequestHandlerClass)
 
    This class builds on the :class:`~socketserver.TCPServer` class by storing
-   the server address as instance variables named :attr:`server_name` and
-   :attr:`server_port`. The server is accessible by the handler, typically
-   through the handler's :attr:`server` instance variable.
+   the server address as instance variables named ``server_name`` and
+   ``server_port``. The server is accessible by the handler, typically
+   through the handler's :attr:`~BaseHTTPRequestHandler.server` instance variable.
 
 .. class:: ThreadingHTTPServer(server_address, RequestHandlerClass)
 
@@ -437,7 +437,7 @@ instantiation, of which this module provides three different variants:
       If the request was mapped to a directory, the directory is checked for a
       file named ``index.html`` or ``index.htm`` (in that order). If found, the
       file's contents are returned; otherwise a directory listing is generated
-      by calling the :meth:`list_directory` method. This method uses
+      by calling the ``list_directory`` method. This method uses
       :func:`os.listdir` to scan the directory, and returns a ``404`` error
       response if the :func:`~os.listdir` fails.
 
@@ -446,7 +446,7 @@ instantiation, of which this module provides three different variants:
       ``'File not found'`` error. If there was an ``'If-Modified-Since'``
       header in the request, and the file was not modified after this time,
       a ``304``, ``'Not Modified'`` response is sent. Otherwise, the content
-      type is guessed by calling the :meth:`guess_type` method, which in turn
+      type is guessed by calling the ``guess_type`` method, which in turn
       uses the *extensions_map* variable, and the file contents are returned.
 
       A ``'Content-type:'`` header with the guessed content type is output,
@@ -483,7 +483,7 @@ the current directory::
 
 :class:`SimpleHTTPRequestHandler` can also be subclassed to enhance behavior,
 such as using different index file names by overriding the class attribute
-:attr:`index_pages`.
+``index_pages``.
 
 
 .. _http-server-cli:

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -9,8 +9,6 @@ Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
 Doc/library/email.charset.rst
 Doc/library/email.parser.rst
-Doc/library/http.cookiejar.rst
-Doc/library/http.server.rst
 Doc/library/importlib.rst
 Doc/library/logging.config.rst
 Doc/library/logging.handlers.rst


### PR DESCRIPTION
Fixes the Sphinx nit-picky reference warnings for
`Doc/library/http.cookiejar.rst` and `Doc/library/http.server.rst`, and
removes both files from `Doc/tools/.nitignore` so future regressions are
caught by CI.

Approach:

- Documented targets are qualified with their owning class, e.g.
  `Cookie.version`, `CookiePolicy.rfc2965`/`hide_cookie2`, the
  `urllib.request.Request` methods and attributes, and
  `urllib.response.addinfourl.info`.
- References with no documented target become inline literals: the removed
  `get_origin_req_host` method, and the undocumented `http.server` members
  `server_name`, `server_port`, `list_directory`, `guess_type` and
  `index_pages`. I'm happy to document any of these instead if a reviewer
  prefers.

Verified with a full nit-picky docs build: both files now emit zero
warnings, and `Doc/tools/check-warnings.py --fail-if-regression
--fail-if-improved` passes.

Documentation-only reference fix, so no `Misc/NEWS.d` entry (skip news).

Disclosure: I used AI assistance on this change; I've reviewed it and can
explain it.

<!-- gh-issue-number: gh-151945 -->
* Issue: gh-151945
<!-- /gh-issue-number -->
