### PR TITLE
gh-151945: Fix reference warnings in http.cookiejar docs

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -98,7 +98,7 @@ The following classes are provided:
    1) are treated according to the RFC 2965 rules.  However, if RFC 2965 handling
    is turned off or :attr:`rfc2109_as_netscape` is ``True``, RFC 2109 cookies are
    'downgraded' by the :class:`CookieJar` instance to Netscape cookies, by
-   setting the :attr:`version` attribute of the :class:`Cookie` instance to 0.
+   setting the :attr:`~Cookie.version` attribute of the :class:`Cookie` instance to 0.
    :class:`DefaultCookiePolicy` also provides some parameters to allow some
    fine-tuning of policy.
 
@@ -107,7 +107,7 @@ The following classes are provided:
 
    This class represents Netscape, :rfc:`2109` and :rfc:`2965` cookies.  It is not
    expected that users of :mod:`!http.cookiejar` construct their own :class:`Cookie`
-   instances.  Instead, if necessary, call :meth:`make_cookies` on a
+   instances.  Instead, if necessary, call :meth:`~CookieJar.make_cookies` on a
    :class:`CookieJar` instance.
 
 
@@ -154,20 +154,27 @@ contained :class:`Cookie` objects.
 
    Add correct :mailheader:`Cookie` header to *request*.
 
-   If policy allows (ie. the :attr:`rfc2965` and :attr:`hide_cookie2` attributes of
+   If policy allows (ie. the :attr:`~CookiePolicy.rfc2965` and
+   :attr:`~CookiePolicy.hide_cookie2` attributes of
    the :class:`CookieJar`'s :class:`CookiePolicy` instance are true and false
    respectively), the :mailheader:`Cookie2` header is also added when appropriate.
 
    The *request* object (usually a :class:`urllib.request.Request` instance)
-   must support the methods :meth:`get_full_url`, :meth:`has_header`,
-   :meth:`get_header`, :meth:`header_items`, :meth:`add_unredirected_header`
-   and the attributes :attr:`host`, :attr:`!type`, :attr:`unverifiable`
-   and :attr:`origin_req_host` as documented by :mod:`urllib.request`.
+   must support the methods :meth:`~urllib.request.Request.get_full_url`,
+   :meth:`~urllib.request.Request.has_header`,
+   :meth:`~urllib.request.Request.get_header`,
+   :meth:`~urllib.request.Request.header_items`,
+   :meth:`~urllib.request.Request.add_unredirected_header`
+   and the attributes :attr:`~urllib.request.Request.host`, :attr:`!type`,
+   :attr:`~urllib.request.Request.unverifiable`
+   and :attr:`~urllib.request.Request.origin_req_host` as documented by
+   :mod:`urllib.request`.
 
    .. versionchanged:: 3.3
 
-    *request* object needs :attr:`origin_req_host` attribute. Dependency on a
-    deprecated method :meth:`get_origin_req_host` has been removed.
+    *request* object needs :attr:`~urllib.request.Request.origin_req_host`
+    attribute. Dependency on a deprecated method ``get_origin_req_host`` has
+    been removed.
 
 
 .. method:: CookieJar.extract_cookies(response, request)
@@ -180,20 +187,24 @@ contained :class:`Cookie` objects.
    as appropriate (subject to the :meth:`CookiePolicy.set_ok` method's approval).
 
    The *response* object (usually the result of a call to
-   :meth:`urllib.request.urlopen`, or similar) should support an :meth:`info`
-   method, which returns an :class:`email.message.Message` instance.
+   :meth:`urllib.request.urlopen`, or similar) should support an
+   :meth:`~urllib.response.addinfourl.info` method, which returns an
+   :class:`email.message.Message` instance.
 
    The *request* object (usually a :class:`urllib.request.Request` instance)
-   must support the method :meth:`get_full_url` and the attributes
-   :attr:`host`, :attr:`unverifiable` and :attr:`origin_req_host`,
+   must support the method :meth:`~urllib.request.Request.get_full_url` and
+   the attributes :attr:`~urllib.request.Request.host`,
+   :attr:`~urllib.request.Request.unverifiable`
+   and :attr:`~urllib.request.Request.origin_req_host`,
    as documented by :mod:`urllib.request`.  The request is used to set
    default values for cookie-attributes as well as for checking that the
    cookie is allowed to be set.
 
    .. versionchanged:: 3.3
 
-    *request* object needs :attr:`origin_req_host` attribute. Dependency on a
-    deprecated method :meth:`get_origin_req_host` has been removed.
+    *request* object needs :attr:`~urllib.request.Request.origin_req_host`
+    attribute. Dependency on a deprecated method ``get_origin_req_host`` has
+    been removed.
 
 .. method:: CookieJar.set_policy(policy)
 
@@ -236,13 +247,13 @@ contained :class:`Cookie` objects.
 
    Discard all session cookies.
 
-   Discards all contained cookies that have a true :attr:`discard` attribute
+   Discards all contained cookies that have a true :attr:`~Cookie.discard` attribute
    (usually because they had either no ``max-age`` or ``expires`` cookie-attribute,
    or an explicit ``discard`` cookie-attribute).  For interactive browsers, the end
    of a session usually corresponds to closing the browser window.
 
-   Note that the :meth:`save` method won't save session cookies anyway, unless you
-   ask otherwise by passing a true *ignore_discard* argument.
+   Note that the :meth:`~FileCookieJar.save` method won't save session cookies
+   anyway, unless you ask otherwise by passing a true *ignore_discard* argument.
 
 :class:`FileCookieJar` implements the following additional methods:
 
@@ -255,8 +266,9 @@ contained :class:`Cookie` objects.
    method unimplemented.
 
    *filename* is the name of file in which to save cookies.  If *filename* is not
-   specified, :attr:`self.filename` is used (whose default is the value passed to
-   the constructor, if any); if :attr:`self.filename` is :const:`None`,
+   specified, :attr:`~FileCookieJar.filename` is used (whose default is the
+   value passed to the constructor, if any); if
+   :attr:`~FileCookieJar.filename` is :const:`None`,
    :exc:`ValueError` is raised.
 
    *ignore_discard*: save even cookies set to be discarded. *ignore_expires*: save
@@ -463,9 +475,10 @@ blocking some benign cookies).
 A domain blocklist and allowlist is provided (both off by default). Only domains
 not in the blocklist and present in the allowlist (if the allowlist is active)
 participate in cookie setting and returning.  Use the *blocked_domains*
-constructor argument, and :meth:`blocked_domains` and
-:meth:`set_blocked_domains` methods (and the corresponding argument and methods
-for *allowed_domains*).  If you set an allowlist, you can turn it off again by
+constructor argument, and :meth:`~DefaultCookiePolicy.blocked_domains` and
+:meth:`~DefaultCookiePolicy.set_blocked_domains` methods (and the corresponding
+argument and methods for *allowed_domains*).  If you set an allowlist, you can
+turn it off again by
 setting it to :const:`None`.
 
 Domains in block or allow lists that do not start with a dot must equal the

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -165,8 +165,8 @@ contained :class:`Cookie` objects.
    :meth:`~urllib.request.Request.get_header`,
    :meth:`~urllib.request.Request.header_items`,
    :meth:`~urllib.request.Request.add_unredirected_header`
-   and the attributes :attr:`~urllib.request.Request.host`, :attr:`!type`,
-   :attr:`~urllib.request.Request.unverifiable`
+   and the attributes :attr:`~urllib.request.Request.host`,
+   :attr:`~urllib.request.Request.type`, :attr:`~urllib.request.Request.unverifiable`
    and :attr:`~urllib.request.Request.origin_req_host` as documented by
    :mod:`urllib.request`.
 

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -266,9 +266,9 @@ contained :class:`Cookie` objects.
    method unimplemented.
 
    *filename* is the name of file in which to save cookies.  If *filename* is not
-   specified, :attr:`!self.filename` is used (whose default is the
-   value passed to the constructor, if any); if
-   :attr:`!self.filename` is ``None``,
+   specified, :attr:`self.filename <FileCookieJar.filename>` is used (whose
+   default is the value passed to the constructor, if any); if
+   :attr:`self.filename <FileCookieJar.filename>` is ``None``,
    :exc:`ValueError` is raised.
 
    *ignore_discard*: save even cookies set to be discarded. *ignore_expires*: save

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -26,7 +26,7 @@ introduced with RFC 2965.
 .. note::
 
    The various named parameters found in :mailheader:`Set-Cookie` and
-   :mailheader:`Set-Cookie2` headers (eg. ``domain`` and ``expires``) are
+   :mailheader:`Set-Cookie2` headers (for example, ``domain`` and ``expires``) are
    conventionally referred to as :dfn:`attributes`.  To distinguish them from
    Python attributes, the documentation for this module uses the term
    :dfn:`cookie-attribute` instead.
@@ -85,7 +85,7 @@ The following classes are provided:
 
    Constructor arguments should be passed as keyword arguments only.
    *blocked_domains* is a sequence of domain names that we never accept cookies
-   from, nor return cookies to. *allowed_domains* if not :const:`None`, this is a
+   from, nor return cookies to. *allowed_domains* if not ``None``, this is a
    sequence of the only domains for which we accept and return cookies.
    *secure_protocols* is a sequence of protocols for which secure cookies can be
    added to. By default *https* and *wss* (secure websocket) are considered
@@ -93,7 +93,7 @@ The following classes are provided:
    :class:`CookiePolicy` and :class:`DefaultCookiePolicy` objects.
 
    :class:`DefaultCookiePolicy` implements the standard accept / reject rules for
-   Netscape and :rfc:`2965` cookies.  By default, :rfc:`2109` cookies (ie. cookies
+   Netscape and :rfc:`2965` cookies.  By default, :rfc:`2109` cookies (that is, cookies
    received in a :mailheader:`Set-Cookie` header with a version cookie-attribute of
    1) are treated according to the RFC 2965 rules.  However, if RFC 2965 handling
    is turned off or :attr:`rfc2109_as_netscape` is ``True``, RFC 2109 cookies are
@@ -141,7 +141,7 @@ The following classes are provided:
 
 .. _cookie-jar-objects:
 
-CookieJar and FileCookieJar Objects
+CookieJar and FileCookieJar objects
 -----------------------------------
 
 :class:`CookieJar` objects support the :term:`iterator` protocol for iterating over
@@ -154,7 +154,7 @@ contained :class:`Cookie` objects.
 
    Add correct :mailheader:`Cookie` header to *request*.
 
-   If policy allows (ie. the :attr:`~CookiePolicy.rfc2965` and
+   If policy allows (that is, the :attr:`~CookiePolicy.rfc2965` and
    :attr:`~CookiePolicy.hide_cookie2` attributes of
    the :class:`CookieJar`'s :class:`CookiePolicy` instance are true and false
    respectively), the :mailheader:`Cookie2` header is also added when appropriate.
@@ -173,8 +173,8 @@ contained :class:`Cookie` objects.
    .. versionchanged:: 3.3
 
     *request* object needs :attr:`~urllib.request.Request.origin_req_host`
-    attribute. Dependency on a deprecated method ``get_origin_req_host`` has
-    been removed.
+    attribute. Dependency on a deprecated method
+    :meth:`!get_origin_req_host` has been removed.
 
 
 .. method:: CookieJar.extract_cookies(response, request)
@@ -203,8 +203,8 @@ contained :class:`Cookie` objects.
    .. versionchanged:: 3.3
 
     *request* object needs :attr:`~urllib.request.Request.origin_req_host`
-    attribute. Dependency on a deprecated method ``get_origin_req_host`` has
-    been removed.
+    attribute. Dependency on a deprecated method
+    :meth:`!get_origin_req_host` has been removed.
 
 .. method:: CookieJar.set_policy(policy)
 
@@ -268,7 +268,7 @@ contained :class:`Cookie` objects.
    *filename* is the name of file in which to save cookies.  If *filename* is not
    specified, :attr:`~FileCookieJar.filename` is used (whose default is the
    value passed to the constructor, if any); if
-   :attr:`~FileCookieJar.filename` is :const:`None`,
+   :attr:`~FileCookieJar.filename` is ``None``,
    :exc:`ValueError` is raised.
 
    *ignore_discard*: save even cookies set to be discarded. *ignore_expires*: save
@@ -361,7 +361,7 @@ writing.
 
 .. _cookie-policy-objects:
 
-CookiePolicy Objects
+CookiePolicy objects
 --------------------
 
 Objects implementing the :class:`CookiePolicy` interface have the following
@@ -445,7 +445,7 @@ setting and receiving any and all cookies (this is unlikely to be useful).
 
 .. _default-cookie-policy-objects:
 
-DefaultCookiePolicy Objects
+DefaultCookiePolicy objects
 ---------------------------
 
 Implements the standard rules for accepting and returning cookies.
@@ -478,8 +478,7 @@ participate in cookie setting and returning.  Use the *blocked_domains*
 constructor argument, and :meth:`~DefaultCookiePolicy.blocked_domains` and
 :meth:`~DefaultCookiePolicy.set_blocked_domains` methods (and the corresponding
 argument and methods for *allowed_domains*).  If you set an allowlist, you can
-turn it off again by
-setting it to :const:`None`.
+turn it off again by setting it to ``None``.
 
 Domains in block or allow lists that do not start with a dot must equal the
 cookie domain to be matched.  For example, ``"example.com"`` matches a blocklist
@@ -511,12 +510,12 @@ and ``".168.1.2"``, 192.168.1.2 is blocked, but 193.168.1.2 is not.
 
 .. method:: DefaultCookiePolicy.allowed_domains()
 
-   Return :const:`None`, or the sequence of allowed domains (as a tuple).
+   Return ``None``, or the sequence of allowed domains (as a tuple).
 
 
 .. method:: DefaultCookiePolicy.set_allowed_domains(allowed_domains)
 
-   Set the sequence of allowed domains, or :const:`None`.
+   Set the sequence of allowed domains, or ``None``.
 
 
 .. method:: DefaultCookiePolicy.is_not_allowed(domain)
@@ -532,9 +531,9 @@ all be assigned to.
 .. attribute:: DefaultCookiePolicy.rfc2109_as_netscape
 
    If true, request that the :class:`CookieJar` instance downgrade :rfc:`2109` cookies
-   (ie. cookies received in a :mailheader:`Set-Cookie` header with a version
+   (that is, cookies received in a :mailheader:`Set-Cookie` header with a version
    cookie-attribute of 1) to Netscape cookies by setting the version attribute of
-   the :class:`Cookie` instance to 0.  The default value is :const:`None`, in which
+   the :class:`Cookie` instance to 0.  The default value is ``None``, in which
    case RFC 2109 cookies are downgraded if and only if :rfc:`2965` handling is turned
    off.  Therefore, RFC 2109 cookies are downgraded by default.
 
@@ -587,7 +586,7 @@ both flags are set).
 
 .. attribute:: DefaultCookiePolicy.DomainStrictNoDots
 
-   When setting cookies, the 'host prefix' must not contain a dot (eg.
+   When setting cookies, the 'host prefix' must not contain a dot (for example,
    ``www.foo.bar.com`` can't set a cookie for ``.bar.com``, because ``www.foo``
    contains a dot).
 
@@ -595,7 +594,7 @@ both flags are set).
 .. attribute:: DefaultCookiePolicy.DomainStrictNonDomain
 
    Cookies that did not explicitly specify a ``domain`` cookie-attribute can only
-   be returned to a domain equal to the domain that set the cookie (eg.
+   be returned to a domain equal to the domain that set the cookie (for example,
    ``spam.example.com`` won't be returned cookies from ``example.com`` that had no
    ``domain`` cookie-attribute).
 
@@ -610,7 +609,7 @@ combinations of the above flags:
 
 .. attribute:: DefaultCookiePolicy.DomainLiberal
 
-   Equivalent to 0 (ie. all of the above Netscape domain strictness flags switched
+   Equivalent to 0 (that is, all of the above Netscape domain strictness flags switched
    off).
 
 
@@ -619,7 +618,7 @@ combinations of the above flags:
    Equivalent to ``DomainStrictNoDots|DomainStrictNonDomain``.
 
 
-Cookie Objects
+Cookie objects
 --------------
 
 :class:`Cookie` instances have Python attributes roughly corresponding to the
@@ -637,7 +636,7 @@ internal consistency, so you should know what you're doing if you do that.
 
 .. attribute:: Cookie.version
 
-   Integer or :const:`None`.  Netscape cookies have :attr:`version` 0. :rfc:`2965` and
+   Integer or ``None``.  Netscape cookies have :attr:`version` 0. :rfc:`2965` and
    :rfc:`2109` cookies have a ``version`` cookie-attribute of 1.  However, note that
    :mod:`!http.cookiejar` may 'downgrade' RFC 2109 cookies to Netscape cookies, in which
    case :attr:`version` is 0.
@@ -650,13 +649,13 @@ internal consistency, so you should know what you're doing if you do that.
 
 .. attribute:: Cookie.value
 
-   Cookie value (a string), or :const:`None`.
+   Cookie value (a string), or ``None``.
 
 
 .. attribute:: Cookie.port
 
-   String representing a port or a set of ports (eg. '80', or '80,8080'), or
-   :const:`None`.
+   String representing a port or a set of ports (for example, '80', or '80,8080'), or
+   ``None``.
 
 
 .. attribute:: Cookie.domain
@@ -666,7 +665,7 @@ internal consistency, so you should know what you're doing if you do that.
 
 .. attribute:: Cookie.path
 
-   Cookie path (a string, eg. ``'/acme/rocket_launchers'``).
+   Cookie path (a string, for example, ``'/acme/rocket_launchers'``).
 
 
 .. attribute:: Cookie.secure
@@ -676,7 +675,7 @@ internal consistency, so you should know what you're doing if you do that.
 
 .. attribute:: Cookie.expires
 
-   Integer expiry date in seconds since epoch, or :const:`None`.  See also the
+   Integer expiry date in seconds since epoch, or ``None``.  See also the
    :meth:`is_expired` method.
 
 
@@ -688,18 +687,18 @@ internal consistency, so you should know what you're doing if you do that.
 .. attribute:: Cookie.comment
 
    String comment from the server explaining the function of this cookie, or
-   :const:`None`.
+   ``None``.
 
 
 .. attribute:: Cookie.comment_url
 
    URL linking to a comment from the server explaining the function of this cookie,
-   or :const:`None`.
+   or ``None``.
 
 
 .. attribute:: Cookie.rfc2109
 
-   ``True`` if this cookie was received as an :rfc:`2109` cookie (ie. the cookie
+   ``True`` if this cookie was received as an :rfc:`2109` cookie (that is, the cookie
    arrived in a :mailheader:`Set-Cookie` header, and the value of the Version
    cookie-attribute in that header was 1).  This attribute is provided because
    :mod:`!http.cookiejar` may 'downgrade' RFC 2109 cookies to Netscape cookies, in

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -188,7 +188,7 @@ contained :class:`Cookie` objects.
 
    The *response* object (usually the result of a call to
    :meth:`urllib.request.urlopen`, or similar) should support an
-   :meth:`~urllib.response.addinfourl.info` method, which returns an
+   :meth:`~http.client.HTTPResponse.info` method, which returns an
    :class:`email.message.Message` instance.
 
    The *request* object (usually a :class:`urllib.request.Request` instance)
@@ -266,9 +266,9 @@ contained :class:`Cookie` objects.
    method unimplemented.
 
    *filename* is the name of file in which to save cookies.  If *filename* is not
-   specified, :attr:`~FileCookieJar.filename` is used (whose default is the
+   specified, :attr:`!self.filename` is used (whose default is the
    value passed to the constructor, if any); if
-   :attr:`~FileCookieJar.filename` is ``None``,
+   :attr:`!self.filename` is ``None``,
    :exc:`ValueError` is raised.
 
    *ignore_discard*: save even cookies set to be discarded. *ignore_expires*: save

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -9,7 +9,6 @@ Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
 Doc/library/email.charset.rst
 Doc/library/email.parser.rst
-Doc/library/http.cookiejar.rst
 Doc/library/http.server.rst
 Doc/library/importlib.rst
 Doc/library/logging.config.rst


### PR DESCRIPTION
Per @picnixz's suggestion in gh-151945, this covers the `http.cookiejar`
half of the issue; @picnixz is taking `http.server`.

Fixes the Sphinx nit-picky reference warnings for
`Doc/library/http.cookiejar.rst` and removes the file from
`Doc/tools/.nitignore` so future regressions are caught by CI.

- Documented targets are qualified with their owning class, e.g.
  `Cookie.version`, `CookiePolicy.rfc2965`/`hide_cookie2`, the
  `urllib.request.Request` methods and attributes, and
  `urllib.response.addinfourl.info`.
- The removed `get_origin_req_host` method, which has no documented
  target, becomes an inline literal.

Verified with a full nit-picky build: the file emits no warnings and
`Doc/tools/check-warnings.py --fail-if-regression --fail-if-improved`
passes. Documentation-only reference fix, so no NEWS entry (skip news).

Disclosure: I used AI assistance on this change; I've reviewed it and can
explain it.

<!-- gh-issue-number: gh-151945 -->
* Issue: gh-151945
<!-- /gh-issue-number -->
