### PR TITLE
gh-152680: Use the _wmi module in test.pythoninfo

### DIFF
--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -1162,30 +1162,38 @@ def detect_virt_windows(info_add):
     # On Windows, use WMI to detect the virtualization.
     #
     # Microsoft Hyper-V:
-    # - Win32_Bios.Version = "VRTUAL - 1"
-    # - Win32_ComputerSystem.Model = "Virtual Machine"
-    # - Win32_ComputerSystem.Manufacturer = "Microsoft Corporation"
+    # - Win32_Bios.Version = 'VRTUAL - 12001807'
+    # - Win32_Bios.Manufacturer = 'American Megatrends Inc.'
+    # - Win32_ComputerSystem.Model = 'Virtual Machine'
+    # - Win32_ComputerSystem.Manufacturer = 'Microsoft Corporation'
     #
     # VMware:
-    # - Win32_ComputerSystem.Model = "VMware"
-    # - Win32_ComputerSystem.Manufacturer = "VMware"
-    # - Win32_Bios.SerialNumber starts with "VMware-"
+    # - Win32_ComputerSystem.Model = 'VMware'
+    # - Win32_ComputerSystem.Manufacturer = 'VMWare' (uppercase W in Ware)
+    # - Win32_Bios.SerialNumber starts with 'VMware-'
     #
     # QEMU:
-    # - Win32_ComputerSystem.Manufacturer = "QEMU"
-    # - Win32_ComputerSystem.Model = "Standard PC (Q35 + ICH9, 2009)"
-    # - Win32_Bios.Version = "BOCHS  - 1"
-    # - Win32_Bios.Manufacturer = "EDK II"
+    # - Win32_ComputerSystem.Manufacturer = 'QEMU'
+    # - Win32_ComputerSystem.Model = 'Standard PC (Q35 + ICH9, 2009)'
+    # - Win32_Bios.Version = 'BOCHS  - 1'
+    # - Win32_Bios.Manufacturer = 'EDK II'
     #
     # Parallels:
-    # - Win32_Bios.Version = "PARALLELS"
+    # - Win32_Bios.Version = 'PARALLELS'
     #
     # VirtualBox:
-    # - Win32_Bios.Version = "VBOX"
-    # - Win32_ComputerSystem.Model = "VirtualBox"
-    # - Win32_ComputerSystem.Manufacturer = "innotek GmbH"
+    # - Win32_Bios.Version = 'VBOX'
+    # - Win32_ComputerSystem.Model = 'VirtualBox'
+    # - Win32_ComputerSystem.Manufacturer = 'innotek GmbH'
+    #
+    # Amazon EC2:
+    # - Win32_Bios.Version = 'AMAZON - 1'
+    # - Win32_Bios.Manufacturer = 'Amazon EC2'
+    # - Win32_ComputerSystem.Model = 'm7i.4xlarge'
+    # - Win32_ComputerSystem.Manufacturer = 'Amazon EC2'
 
     KNOWN_VIRT = (
+        'Amazon EC2',
         'QEMU',
         'VMware',
         'VirtualBox',
@@ -1193,24 +1201,30 @@ def detect_virt_windows(info_add):
         'oVirt',
     )
     KNOWN_BIOS_VERSIONS = {
-        "VRTUAL - 1": "Microsoft Hyper-V",
-        "PARALLELS": "Parallels",
-        "VBOX": "VirtualBox",
+        'PARALLELS': 'Parallels',
+        'VBOX': 'VirtualBox',
     }
 
-    computer = wmi_query("SELECT Model, Manufacturer FROM Win32_ComputerSystem")
+    computer = wmi_query('SELECT Model, Manufacturer FROM Win32_ComputerSystem')
     computer_model = computer.get('Model', '')
+    computer_manufacturer = computer.get('Manufacturer', '')
+    if computer_manufacturer == 'Amazon EC2':
+        # Log the VM model (ex: 'm7i.4xlarge')
+        info_add('system.computer.model', computer_model)
+        return computer_manufacturer
     if computer_model in KNOWN_VIRT:
         return computer_model
-    computer_manufacturer = computer.get('Manufacturer', '')
     if computer_manufacturer in KNOWN_VIRT:
         return computer_manufacturer
 
-    bios = wmi_query("SELECT Version, Manufacturer FROM Win32_Bios")
+    bios = wmi_query('SELECT Version, Manufacturer FROM Win32_Bios')
 
     bios_version = bios.get('Version', '')
     if bios_version in KNOWN_VIRT:
         return bios_version
+    if (bios_version.startswith('VRTUAL - ')
+        and computer_manufacturer == 'Microsoft Corporation'):
+        return 'Microsoft Hyper-V'
     try:
         return KNOWN_BIOS_VERSIONS[bios_version]
     except KeyError:

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -1158,7 +1158,35 @@ def get_machine_id():
     return None
 
 
-def detect_virt():
+def detect_virt(info_add):
+    # On Windows, use WMI to get the computer manufacturer and the BIOS version
+    if MS_WINDOWS:
+        data = wmi_query("SELECT Manufacturer FROM Win32_ComputerSystem")
+        manufacturer = data.get('Manufacturer', '')
+        patterns = (
+            'QEMU',
+            'VMWare',
+            'Virtual',
+        )
+        if any(pattern in manufacturer for pattern in patterns):
+            return manufacturer
+        elif manufacturer:
+            # Log the value to update patterns on new VM
+            info_add('system.manufacturer', manufacturer)
+
+        data = wmi_query("SELECT Version FROM Win32_Bios")
+        bios_version = data.get('Version', '')
+        patterns = (
+            'VIRTUAL',
+            'VMware',
+            'Xen',
+        )
+        if any(pattern in bios_version for pattern in patterns):
+            return bios_version
+        elif bios_version:
+            # Log the value to update patterns on new VM
+            info_add('system.bios_version', bios_version)
+
     # Run systemd-detect-virt command
     virt = run_command(["systemd-detect-virt"], check=False)
     if virt and virt != "none":
@@ -1216,16 +1244,7 @@ def collect_system(info_add):
             uptime = f'{uptime} sec'
         info_add('system.uptime', uptime)
 
-    virt = None
-    if MS_WINDOWS:
-        data = wmi_query("SELECT Manufacturer FROM Win32_ComputerSystem")
-        manufacturer = data.get('Manufacturer', '')
-        if manufacturer == 'QEMU':
-            virt = manufacturer
-        elif manufacturer:
-            info_add('system.manufacturer', manufacturer)
-    if not virt:
-        virt = detect_virt()
+    virt = detect_virt()
     if virt:
         info_add('system.virt', virt)
 

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -969,17 +969,16 @@ def winreg_query(path):
         return None
 
 
-def wmi_get_os():
+def wmi_query(query):
     try:
         import _wmi
     except ImportError:
-        return
+        return {}
 
-    query = "SELECT Caption, Version FROM Win32_OperatingSystem"
     try:
         data = _wmi.exec_query(query)
     except OSError:
-        return
+        return {}
 
     dict_data = {}
     for item in data.split("\0"):
@@ -1035,14 +1034,13 @@ def collect_windows(info_add):
         call_func(info_add, 'windows.oem_code_page', _winapi, 'GetOEMCP')
 
     # Get operating system caption and version using WMI
-    data = wmi_get_os()
-    if data:
-        caption = data.get('Caption', '')
-        if caption:
-            info_add('windows.version_caption', caption)
-        version = data.get('Version', '')
-        if version:
-            info_add('windows.version', version)
+    data = wmi_query("SELECT Caption, Version FROM Win32_OperatingSystem")
+    caption = data.get('Caption', '')
+    if caption:
+        info_add('windows.version_caption', caption)
+    version = data.get('Version', '')
+    if version:
+        info_add('windows.version', version)
 
     # windows.ver: "ver" command
     output = run_command(["ver"], shell=True)
@@ -1218,7 +1216,16 @@ def collect_system(info_add):
             uptime = f'{uptime} sec'
         info_add('system.uptime', uptime)
 
-    virt = detect_virt()
+    virt = None
+    if MS_WINDOWS:
+        data = wmi_query("SELECT Manufacturer FROM Win32_ComputerSystem")
+        manufacturer = data.get('Manufacturer', '')
+        if manufacturer == 'QEMU':
+            virt = manufacturer
+        elif manufacturer:
+            info_add('system.manufacturer', manufacturer)
+    if not virt:
+        virt = detect_virt()
     if virt:
         info_add('system.virt', virt)
 

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -1158,47 +1158,65 @@ def get_machine_id():
     return None
 
 
-def detect_virt(info_add):
+def detect_virt_windows(info_add):
     # On Windows, use WMI to get the computer manufacturer and the BIOS version
-    if MS_WINDOWS:
-        data = wmi_query("SELECT Manufacturer, Model FROM Win32_ComputerSystem")
-        manufacturer = data.get('Manufacturer', '')
-        model = data.get('Model', '')
-        patterns = (
-            'QEMU',
-            'KVM',
-            'VMWare',
-            'Virtual',
-        )
-        if any(pattern in manufacturer for pattern in patterns):
-            return manufacturer
-        elif any(pattern in model for pattern in patterns):
-            return model
-        else:
-            # Log the values to update patterns on new VM
-            if manufacturer and manufacturer != "Microsoft Corporation":
-                info_add('system.manufacturer', manufacturer)
-            if model:
-                info_add('system.model', model)
+    #
+    # VMware:
+    # - Win32_Bios.SerialNumber starts with "VMware-"
+    # - Win32_ComputerSystem.Model = "VMware"
+    # - Win32_ComputerSystem.Manufacturer = "VMware"
+    #
+    # QEMU:
+    # - Win32_ComputerSystem.Manufacturer = "QEMU"
+    #
+    # Parallels:
+    # - Win32_Bios.Version = "PARALLELS"
+    #
+    # VirtualBox:
+    # - Win32_Bios.Version = "VBOX"
+    # - Win32_ComputerSystem.Model = "VirtualBox"
+    # - Win32_ComputerSystem.Manufacturer = "innotek GmbH"
 
-        data = wmi_query("SELECT SerialNumber, Version FROM Win32_Bios")
-        bios_serial_number = data.get('SerialNumber', '')
-        bios_version = data.get('Version', '')
-        patterns = (
-            'VIRTUAL',
-            'VMware',
-            'Xen',
-        )
-        if any(pattern in bios_serial_number for pattern in patterns):
-            return bios_serial_number
-        elif any(pattern in bios_version for pattern in patterns):
-            return bios_version
-        else:
-            # Log the values to update patterns on new VM
-            if bios_version:
-                info_add('system.bios_version', bios_version)
-            if bios_serial_number:
-                info_add('system.bios_serial_number', bios_serial_number)
+    data = wmi_query("SELECT Model, Manufacturer FROM Win32_ComputerSystem")
+    known_virt = (
+        'QEMU',
+        'VMware',
+        'VirtualBox',
+    )
+    model = data.get('Model', '')
+    if model in known_virt:
+        return model
+    manufacturer = data.get('Manufacturer', '')
+    if manufacturer in known_virt:
+        return manufacturer
+
+    data = wmi_query("SELECT Version FROM Win32_Bios")
+    bios_version = data.get('Version', '')
+    if bios_version in known_virt:
+        return bios_version
+    known_bios_versions = {
+        "PARALLELS": "Parallels",
+        "VBOX": "VirtualBox",
+    }
+    try:
+        return known_bios_versions[bios_version]
+    except KeyError:
+        pass
+
+    # Log the values to update patterns on new VM
+    if model:
+        info_add('system.model', model)
+    if manufacturer:
+        info_add('system.manufacturer', manufacturer)
+    if bios_version:
+        info_add('system.bios_version', bios_version)
+
+
+def detect_virt(info_add):
+    if MS_WINDOWS:
+        virt = detect_virt_windows(info_add)
+        if virt:
+            return virt
 
     # Run systemd-detect-virt command
     virt = run_command(["systemd-detect-virt"], check=False)

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -1159,15 +1159,23 @@ def get_machine_id():
 
 
 def detect_virt_windows(info_add):
-    # On Windows, use WMI to get the computer manufacturer and the BIOS version
+    # On Windows, use WMI to detect the virtualization.
+    #
+    # Microsoft Hyper-V:
+    # - Win32_Bios.Version = "VRTUAL - 1"
+    # - Win32_ComputerSystem.Model = "Virtual Machine"
+    # - Win32_ComputerSystem.Manufacturer = "Microsoft Corporation"
     #
     # VMware:
-    # - Win32_Bios.SerialNumber starts with "VMware-"
     # - Win32_ComputerSystem.Model = "VMware"
     # - Win32_ComputerSystem.Manufacturer = "VMware"
+    # - Win32_Bios.SerialNumber starts with "VMware-"
     #
     # QEMU:
     # - Win32_ComputerSystem.Manufacturer = "QEMU"
+    # - Win32_ComputerSystem.Model = "Standard PC (Q35 + ICH9, 2009)"
+    # - Win32_Bios.Version = "BOCHS  - 1"
+    # - Win32_Bios.Manufacturer = "EDK II"
     #
     # Parallels:
     # - Win32_Bios.Version = "PARALLELS"
@@ -1177,46 +1185,55 @@ def detect_virt_windows(info_add):
     # - Win32_ComputerSystem.Model = "VirtualBox"
     # - Win32_ComputerSystem.Manufacturer = "innotek GmbH"
 
-    data = wmi_query("SELECT Model, Manufacturer FROM Win32_ComputerSystem")
-    known_virt = (
+    KNOWN_VIRT = (
         'QEMU',
         'VMware',
         'VirtualBox',
+        'Xen',
+        'oVirt',
     )
-    model = data.get('Model', '')
-    if model in known_virt:
-        return model
-    manufacturer = data.get('Manufacturer', '')
-    if manufacturer in known_virt:
-        return manufacturer
-
-    data = wmi_query("SELECT Version FROM Win32_Bios")
-    bios_version = data.get('Version', '')
-    if bios_version in known_virt:
-        return bios_version
-    known_bios_versions = {
+    KNOWN_BIOS_VERSIONS = {
+        "VRTUAL - 1": "Microsoft Hyper-V",
         "PARALLELS": "Parallels",
         "VBOX": "VirtualBox",
     }
+
+    computer = wmi_query("SELECT Model, Manufacturer FROM Win32_ComputerSystem")
+    computer_model = computer.get('Model', '')
+    if computer_model in KNOWN_VIRT:
+        return computer_model
+    computer_manufacturer = computer.get('Manufacturer', '')
+    if computer_manufacturer in KNOWN_VIRT:
+        return computer_manufacturer
+
+    bios = wmi_query("SELECT Version, Manufacturer FROM Win32_Bios")
+
+    bios_version = bios.get('Version', '')
+    if bios_version in KNOWN_VIRT:
+        return bios_version
     try:
-        return known_bios_versions[bios_version]
+        return KNOWN_BIOS_VERSIONS[bios_version]
     except KeyError:
         pass
 
-    # Log the values to update patterns on new VM
-    if model:
-        info_add('system.model', model)
-    if manufacturer:
-        info_add('system.manufacturer', manufacturer)
+    bios_manufacturer = bios.get('Manufacturer', '')
+    if bios_manufacturer in KNOWN_VIRT:
+        return bios_manufacturer
+
+    # Log the values to update the code if a new VM is discovered
+    if computer_model:
+        info_add('system.computer.model', computer_model)
+    if computer_manufacturer:
+        info_add('system.computer.manufacturer', computer_manufacturer)
     if bios_version:
-        info_add('system.bios_version', bios_version)
+        info_add('system.bios.version', bios_version)
+    if bios_manufacturer:
+        info_add('system.bios.manufacturer', bios_manufacturer)
 
 
 def detect_virt(info_add):
     if MS_WINDOWS:
-        virt = detect_virt_windows(info_add)
-        if virt:
-            return virt
+        return detect_virt_windows(info_add)
 
     # Run systemd-detect-virt command
     virt = run_command(["systemd-detect-virt"], check=False)

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -1174,18 +1174,24 @@ def detect_virt(info_add):
             # Log the value to update patterns on new VM
             info_add('system.manufacturer', manufacturer)
 
-        data = wmi_query("SELECT Version FROM Win32_Bios")
+        data = wmi_query("SELECT SerialNumber,Version FROM Win32_Bios")
+        bios_serial_number = data.get('SerialNumber', '')
         bios_version = data.get('Version', '')
         patterns = (
             'VIRTUAL',
             'VMware',
             'Xen',
         )
-        if any(pattern in bios_version for pattern in patterns):
+        if any(pattern in bios_serial_number for pattern in patterns):
+            return bios_serial_number
+        elif any(pattern in bios_version for pattern in patterns):
             return bios_version
-        elif bios_version:
-            # Log the value to update patterns on new VM
-            info_add('system.bios_version', bios_version)
+        else:
+            # Log the values to update patterns on new VM
+            if bios_version:
+                info_add('system.bios_version', bios_version)
+            if bios_serial_number:
+                info_add('system.bios_serial_number', bios_serial_number)
 
     # Run systemd-detect-virt command
     virt = run_command(["systemd-detect-virt"], check=False)

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -1250,7 +1250,7 @@ def collect_system(info_add):
             uptime = f'{uptime} sec'
         info_add('system.uptime', uptime)
 
-    virt = detect_virt()
+    virt = detect_virt(info_add)
     if virt:
         info_add('system.virt', virt)
 

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -452,6 +452,12 @@ def collect_readline(info_add):
 
 def run_command(cmd, check=True, **kwargs):
     import subprocess
+    from test.support import has_subprocess_support
+
+    if not has_subprocess_support:
+        # subprocess is not supported by the current platform
+        return ''
+
     timeout = COMMAND_TIMEOUT
 
     cmd_str = ' '.join(cmd)
@@ -963,6 +969,25 @@ def winreg_query(path):
         return None
 
 
+def wmi_get_os():
+    try:
+        import _wmi
+    except ImportError:
+        return
+
+    query = "SELECT Caption, Version FROM Win32_OperatingSystem"
+    try:
+        data = _wmi.exec_query(query)
+    except OSError:
+        return
+
+    dict_data = {}
+    for item in data.split("\0"):
+        key, _, value = item.partition("=")
+        dict_data[key] = value
+    return dict_data
+
+
 def collect_windows(info_add):
     if not MS_WINDOWS:
         # Code specific to Windows
@@ -1009,22 +1034,15 @@ def collect_windows(info_add):
         call_func(info_add, 'windows.ansi_code_page', _winapi, 'GetACP')
         call_func(info_add, 'windows.oem_code_page', _winapi, 'GetOEMCP')
 
-    # windows.version_caption: "wmic os get Caption,Version /value" command
-    output = run_command(["wmic", "os", "get", "Caption,Version", "/value"],
-                         # When wmic.exe output is redirected to a pipe,
-                         # it uses the OEM code page
-                         encoding="oem")
-    if output:
-        for line in output.splitlines():
-            line = line.strip()
-            if line.startswith('Caption='):
-                line = line.removeprefix('Caption=').strip()
-                if line:
-                    info_add('windows.version_caption', line)
-            elif line.startswith('Version='):
-                line = line.removeprefix('Version=').strip()
-                if line:
-                    info_add('windows.version', line)
+    # Get operating system caption and version using WMI
+    data = wmi_get_os()
+    if data:
+        caption = data.get('Caption', '')
+        if caption:
+            info_add('windows.version_caption', caption)
+        version = data.get('Version', '')
+        if version:
+            info_add('windows.version', version)
 
     # windows.ver: "ver" command
     output = run_command(["ver"], shell=True)

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -1161,20 +1161,27 @@ def get_machine_id():
 def detect_virt(info_add):
     # On Windows, use WMI to get the computer manufacturer and the BIOS version
     if MS_WINDOWS:
-        data = wmi_query("SELECT Manufacturer FROM Win32_ComputerSystem")
+        data = wmi_query("SELECT Manufacturer, Model FROM Win32_ComputerSystem")
         manufacturer = data.get('Manufacturer', '')
+        model = data.get('Model', '')
         patterns = (
             'QEMU',
+            'KVM',
             'VMWare',
             'Virtual',
         )
         if any(pattern in manufacturer for pattern in patterns):
             return manufacturer
-        elif manufacturer:
-            # Log the value to update patterns on new VM
-            info_add('system.manufacturer', manufacturer)
+        elif any(pattern in model for pattern in patterns):
+            return model
+        else:
+            # Log the values to update patterns on new VM
+            if manufacturer and manufacturer != "Microsoft Corporation":
+                info_add('system.manufacturer', manufacturer)
+            if model:
+                info_add('system.model', model)
 
-        data = wmi_query("SELECT SerialNumber,Version FROM Win32_Bios")
+        data = wmi_query("SELECT SerialNumber, Version FROM Win32_Bios")
         bios_serial_number = data.get('SerialNumber', '')
         bios_version = data.get('Version', '')
         patterns = (


### PR DESCRIPTION
On Windows, replace wmic command with _wmi module to get the operating system caption and version.

The wmic tool is deprecated since January 2024:
https://techcommunity.microsoft.com/blog/windows-itpro-blog/wmi-command-line-wmic-utility-deprecation-next-steps/4039242

For example, it's no longer installed in Windows images on GitHub Action.

Fix also run_command(): no longer try to spawn a subprocess if the platform doesn't support subprocess. It avoids logging run_command() errors.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152680 -->
* Issue: gh-152680
<!-- /gh-issue-number -->
