### PR TITLE
gh-152902: Add Intel `icx` compiler to `configure.ac`

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-07-19-12-06-45.gh-issue-152902.0BXdab.rst
+++ b/Misc/NEWS.d/next/Build/2026-07-19-12-06-45.gh-issue-152902.0BXdab.rst
@@ -1,0 +1,2 @@
+Added Intel ``icx`` compiler support to ``configure.ac``. Contributed by
+High Performance Kernels LLC.

--- a/configure
+++ b/configure
@@ -6390,8 +6390,8 @@ else case e in #(
 cat > conftest.c <<EOF
 #if defined(__EMSCRIPTEN__)
   emcc
-#elif defined(__INTEL_COMPILER) || defined(__ICC)
-  icc
+#elif defined(__INTEL_CLANG_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+  icx
 #elif defined(__ibmxl__) || defined(__xlc__) || defined(__xlC__)
   xlc
 #elif defined(_MSC_VER)
@@ -6859,7 +6859,7 @@ else
   CXX="$ac_cv_path_CXX"
 fi
  ;;
-        clang)             if test -n "$ac_tool_prefix"; then
+        clang)  if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}clang++", so it can be a program name with args.
 set dummy ${ac_tool_prefix}clang++; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -6969,9 +6969,9 @@ else
   CXX="$ac_cv_path_CXX"
 fi
  ;;
-        icc)               if test -n "$ac_tool_prefix"; then
-  # Extract the first word of "${ac_tool_prefix}icpc", so it can be a program name with args.
-set dummy ${ac_tool_prefix}icpc; ac_word=$2
+        icx)    if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}icpx", so it can be a program name with args.
+set dummy ${ac_tool_prefix}icpx; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 printf %s "checking for $ac_word... " >&6; }
 if test ${ac_cv_path_CXX+y}
@@ -7019,8 +7019,8 @@ fi
 fi
 if test -z "$ac_cv_path_CXX"; then
   ac_pt_CXX=$CXX
-  # Extract the first word of "icpc", so it can be a program name with args.
-set dummy icpc; ac_word=$2
+  # Extract the first word of "icpx", so it can be a program name with args.
+set dummy icpx; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 printf %s "checking for $ac_word... " >&6; }
 if test ${ac_cv_path_ac_pt_CXX+y}
@@ -9117,7 +9117,7 @@ fi
 LLVM_PROF_ERR=no
 
 case "$ac_cv_cc_name" in
-  clang)
+  clang|icx)
     # Any changes made here should be reflected in the GCC+Darwin case below
     PGO_PROF_GEN_FLAG="-fprofile-instr-generate"
     PGO_PROF_USE_FLAG="-fprofile-instr-use=\"\$(shell pwd)/code.profclangd\""
@@ -9228,12 +9228,6 @@ fi
 fi
 
     PGO_PROF_USE_FLAG="-fprofile-use -fprofile-correction"
-    LLVM_PROF_MERGER="true"
-    LLVM_PROF_FILE=""
-    ;;
-  icc)
-    PGO_PROF_GEN_FLAG="-prof-gen"
-    PGO_PROF_USE_FLAG="-prof-use"
     LLVM_PROF_MERGER="true"
     LLVM_PROF_FILE=""
     ;;
@@ -10699,11 +10693,6 @@ then :
   BASECFLAGS="$BASECFLAGS -fno-strict-aliasing"
 fi
 
-    # ICC doesn't recognize the option, but only emits a warning
-    ## XXX does it emit an unused result warning and can it be disabled?
-    case "$ac_cv_cc_name" in #(
-  icc) :
-    ac_cv_disable_unused_result_warning=no
 
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC unused-result warning" >&5
@@ -10741,10 +10730,7 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_result_warning" >&5
 printf "%s\n" "$ac_cv_disable_unused_result_warning" >&6; }
 
- ;; #(
-  *) :
-     ;;
-esac
+
     if test "x$ac_cv_disable_unused_result_warning" = xyes
 then :
   BASECFLAGS="$BASECFLAGS -Wno-unused-result"
@@ -11405,9 +11391,9 @@ case "$ac_cv_cc_name" in
 mpicc)
     CFLAGS_NODIST="$CFLAGS_NODIST"
     ;;
-icc)
-    # ICC needs -fp-model strict or floats behave badly
-    CFLAGS_NODIST="$CFLAGS_NODIST -fp-model strict"
+icx)
+    # ICX needs fp-model=precise (the default in clang) or floats behave badly
+    CFLAGS_NODIST="$CFLAGS_NODIST -ffp-model=precise"
     ;;
 xlc)
     CFLAGS_NODIST="$CFLAGS_NODIST -qalias=noansi -qmaxmem=-1"
@@ -26841,7 +26827,7 @@ esac
 # rounding precision of 64 bits.  For gcc/x86, we can fix this by
 # using inline assembler to get and set the x87 FPU control word.
 
-# This inline assembler syntax may also work for suncc and icc,
+# This inline assembler syntax may also work for suncc and icx,
 # so we try it on all platforms.
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we can use gcc inline assembler to get and set x87 control word" >&5

--- a/configure
+++ b/configure
@@ -6392,6 +6392,8 @@ cat > conftest.c <<EOF
   emcc
 #elif defined(__INTEL_CLANG_COMPILER) || defined(__INTEL_LLVM_COMPILER)
   icx
+#elif defined(__INTEL_COMPILER) || defined(__ICC)
+  icc
 #elif defined(__ibmxl__) || defined(__xlc__) || defined(__xlC__)
   xlc
 #elif defined(_MSC_VER)
@@ -7021,6 +7023,116 @@ if test -z "$ac_cv_path_CXX"; then
   ac_pt_CXX=$CXX
   # Extract the first word of "icpx", so it can be a program name with args.
 set dummy icpx; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_path_ac_pt_CXX+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) case $ac_pt_CXX in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_ac_pt_CXX="$ac_pt_CXX" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_path_ac_pt_CXX="$as_dir$ac_word$ac_exec_ext"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac ;;
+esac
+fi
+ac_pt_CXX=$ac_cv_path_ac_pt_CXX
+if test -n "$ac_pt_CXX"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_pt_CXX" >&5
+printf "%s\n" "$ac_pt_CXX" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+  if test "x$ac_pt_CXX" = x; then
+    CXX="notfound"
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    CXX=$ac_pt_CXX
+  fi
+else
+  CXX="$ac_cv_path_CXX"
+fi
+ ;;
+        icc)    if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}icpc", so it can be a program name with args.
+set dummy ${ac_tool_prefix}icpc; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_path_CXX+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) case $CXX in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_CXX="$CXX" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_path_CXX="$as_dir$ac_word$ac_exec_ext"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac ;;
+esac
+fi
+CXX=$ac_cv_path_CXX
+if test -n "$CXX"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CXX" >&5
+printf "%s\n" "$CXX" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+fi
+if test -z "$ac_cv_path_CXX"; then
+  ac_pt_CXX=$CXX
+  # Extract the first word of "icpc", so it can be a program name with args.
+set dummy icpc; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 printf %s "checking for $ac_word... " >&6; }
 if test ${ac_cv_path_ac_pt_CXX+y}
@@ -9231,6 +9343,12 @@ fi
     LLVM_PROF_MERGER="true"
     LLVM_PROF_FILE=""
     ;;
+  icc)
+    PGO_PROF_GEN_FLAG="-prof-gen"
+    PGO_PROF_USE_FLAG="-prof-use"
+    LLVM_PROF_MERGER="true"
+    LLVM_PROF_FILE=""
+    ;;
 esac
 
 # BOLT optimization. Always configured after PGO since it always runs after PGO.
@@ -10693,6 +10811,11 @@ then :
   BASECFLAGS="$BASECFLAGS -fno-strict-aliasing"
 fi
 
+    # ICC doesn't recognize the option, but only emits a warning
+    ## XXX does it emit an unused result warning and can it be disabled?
+    case "$ac_cv_cc_name" in #(
+  icc) :
+    ac_cv_disable_unused_result_warning=no
 
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can disable $CC unused-result warning" >&5
@@ -10730,7 +10853,10 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_result_warning" >&5
 printf "%s\n" "$ac_cv_disable_unused_result_warning" >&6; }
 
-
+ ;; #(
+  *) :
+     ;;
+esac
     if test "x$ac_cv_disable_unused_result_warning" = xyes
 then :
   BASECFLAGS="$BASECFLAGS -Wno-unused-result"
@@ -11394,6 +11520,10 @@ mpicc)
 icx)
     # ICX needs fp-model=precise (the default in clang) or floats behave badly
     CFLAGS_NODIST="$CFLAGS_NODIST -ffp-model=precise"
+    ;;
+icc)
+    # ICC needs -fp-model strict or floats behave badly
+    CFLAGS_NODIST="$CFLAGS_NODIST -fp-model strict"
     ;;
 xlc)
     CFLAGS_NODIST="$CFLAGS_NODIST -qalias=noansi -qmaxmem=-1"
@@ -26827,8 +26957,8 @@ esac
 # rounding precision of 64 bits.  For gcc/x86, we can fix this by
 # using inline assembler to get and set the x87 FPU control word.
 
-# This inline assembler syntax may also work for suncc and icx,
-# so we try it on all platforms.
+# This inline assembler syntax works for icx and may also work for
+# suncc and icc, so we try it on all platforms.
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we can use gcc inline assembler to get and set x87 control word" >&5
 printf %s "checking whether we can use gcc inline assembler to get and set x87 control word... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -1090,8 +1090,8 @@ AC_CACHE_CHECK([for CC compiler name], [ac_cv_cc_name], [
 cat > conftest.c <<EOF
 #if defined(__EMSCRIPTEN__)
   emcc
-#elif defined(__INTEL_COMPILER) || defined(__ICC)
-  icc
+#elif defined(__INTEL_CLANG_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+  icx
 #elif defined(__ibmxl__) || defined(__xlc__) || defined(__xlC__)
   xlc
 #elif defined(_MSC_VER)
@@ -1139,8 +1139,8 @@ then
         case "$ac_cv_cc_name" in
         gcc)    AC_PATH_TOOL([CXX], [g++], [notfound]) ;;
         cc)     AC_PATH_TOOL([CXX], [c++], [notfound]) ;;
-        clang)             AC_PATH_TOOL([CXX], [clang++], [notfound]) ;;
-        icc)               AC_PATH_TOOL([CXX], [icpc], [notfound]) ;;
+        clang)  AC_PATH_TOOL([CXX], [clang++], [notfound]) ;;
+        icx)    AC_PATH_TOOL([CXX], [icpx], [notfound]) ;;
         esac
 	if test "$CXX" = "notfound"
 	then
@@ -2085,7 +2085,7 @@ fi
 LLVM_PROF_ERR=no
 
 case "$ac_cv_cc_name" in
-  clang)
+  clang|icx)
     # Any changes made here should be reflected in the GCC+Darwin case below
     PGO_PROF_GEN_FLAG="-fprofile-instr-generate"
     PGO_PROF_USE_FLAG="-fprofile-instr-use=\"\$(shell pwd)/code.profclangd\""
@@ -2132,12 +2132,6 @@ case "$ac_cv_cc_name" in
     ])
 
     PGO_PROF_USE_FLAG="-fprofile-use -fprofile-correction"
-    LLVM_PROF_MERGER="true"
-    LLVM_PROF_FILE=""
-    ;;
-  icc)
-    PGO_PROF_GEN_FLAG="-prof-gen"
-    PGO_PROF_USE_FLAG="-prof-use"
     LLVM_PROF_MERGER="true"
     LLVM_PROF_FILE=""
     ;;
@@ -2667,11 +2661,7 @@ AS_VAR_IF([ac_cv_gcc_compat], [yes], [
     AS_VAR_IF([ac_cv_no_strict_aliasing], [yes],
               [BASECFLAGS="$BASECFLAGS -fno-strict-aliasing"])
 
-    # ICC doesn't recognize the option, but only emits a warning
-    ## XXX does it emit an unused result warning and can it be disabled?
-    AS_CASE(["$ac_cv_cc_name"],
-            [icc], [ac_cv_disable_unused_result_warning=no]
-            [PY_CHECK_CC_WARNING([disable], [unused-result])])
+    PY_CHECK_CC_WARNING([disable], [unused-result])
     AS_VAR_IF([ac_cv_disable_unused_result_warning], [yes],
               [BASECFLAGS="$BASECFLAGS -Wno-unused-result"
                CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"])
@@ -2967,9 +2957,9 @@ case "$ac_cv_cc_name" in
 mpicc)
     CFLAGS_NODIST="$CFLAGS_NODIST"
     ;;
-icc)
-    # ICC needs -fp-model strict or floats behave badly
-    CFLAGS_NODIST="$CFLAGS_NODIST -fp-model strict"
+icx)
+    # ICX needs fp-model=precise (the default in clang) or floats behave badly
+    CFLAGS_NODIST="$CFLAGS_NODIST -ffp-model=precise"
     ;;
 xlc)
     CFLAGS_NODIST="$CFLAGS_NODIST -qalias=noansi -qmaxmem=-1"
@@ -6296,7 +6286,7 @@ AX_C_FLOAT_WORDS_BIGENDIAN(
 # rounding precision of 64 bits.  For gcc/x86, we can fix this by
 # using inline assembler to get and set the x87 FPU control word.
 
-# This inline assembler syntax may also work for suncc and icc,
+# This inline assembler syntax may also work for suncc and icx,
 # so we try it on all platforms.
 
 AC_CACHE_CHECK([whether we can use gcc inline assembler to get and set x87 control word], [ac_cv_gcc_asm_for_x87], [

--- a/configure.ac
+++ b/configure.ac
@@ -1092,6 +1092,8 @@ cat > conftest.c <<EOF
   emcc
 #elif defined(__INTEL_CLANG_COMPILER) || defined(__INTEL_LLVM_COMPILER)
   icx
+#elif defined(__INTEL_COMPILER) || defined(__ICC)
+  icc
 #elif defined(__ibmxl__) || defined(__xlc__) || defined(__xlC__)
   xlc
 #elif defined(_MSC_VER)
@@ -1141,6 +1143,7 @@ then
         cc)     AC_PATH_TOOL([CXX], [c++], [notfound]) ;;
         clang)  AC_PATH_TOOL([CXX], [clang++], [notfound]) ;;
         icx)    AC_PATH_TOOL([CXX], [icpx], [notfound]) ;;
+        icc)    AC_PATH_TOOL([CXX], [icpc], [notfound]) ;;
         esac
 	if test "$CXX" = "notfound"
 	then
@@ -2135,6 +2138,12 @@ case "$ac_cv_cc_name" in
     LLVM_PROF_MERGER="true"
     LLVM_PROF_FILE=""
     ;;
+  icc)
+    PGO_PROF_GEN_FLAG="-prof-gen"
+    PGO_PROF_USE_FLAG="-prof-use"
+    LLVM_PROF_MERGER="true"
+    LLVM_PROF_FILE=""
+    ;;
 esac
 
 # BOLT optimization. Always configured after PGO since it always runs after PGO.
@@ -2661,7 +2670,11 @@ AS_VAR_IF([ac_cv_gcc_compat], [yes], [
     AS_VAR_IF([ac_cv_no_strict_aliasing], [yes],
               [BASECFLAGS="$BASECFLAGS -fno-strict-aliasing"])
 
-    PY_CHECK_CC_WARNING([disable], [unused-result])
+    # ICC doesn't recognize the option, but only emits a warning
+    ## XXX does it emit an unused result warning and can it be disabled?
+    AS_CASE(["$ac_cv_cc_name"],
+            [icc], [ac_cv_disable_unused_result_warning=no]
+            [PY_CHECK_CC_WARNING([disable], [unused-result])])
     AS_VAR_IF([ac_cv_disable_unused_result_warning], [yes],
               [BASECFLAGS="$BASECFLAGS -Wno-unused-result"
                CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"])
@@ -2960,6 +2973,10 @@ mpicc)
 icx)
     # ICX needs fp-model=precise (the default in clang) or floats behave badly
     CFLAGS_NODIST="$CFLAGS_NODIST -ffp-model=precise"
+    ;;
+icc)
+    # ICC needs -fp-model strict or floats behave badly
+    CFLAGS_NODIST="$CFLAGS_NODIST -fp-model strict"
     ;;
 xlc)
     CFLAGS_NODIST="$CFLAGS_NODIST -qalias=noansi -qmaxmem=-1"
@@ -6286,8 +6303,8 @@ AX_C_FLOAT_WORDS_BIGENDIAN(
 # rounding precision of 64 bits.  For gcc/x86, we can fix this by
 # using inline assembler to get and set the x87 FPU control word.
 
-# This inline assembler syntax may also work for suncc and icx,
-# so we try it on all platforms.
+# This inline assembler syntax works for icx and may also work for
+# suncc and icc, so we try it on all platforms.
 
 AC_CACHE_CHECK([whether we can use gcc inline assembler to get and set x87 control word], [ac_cv_gcc_asm_for_x87], [
 AC_LINK_IFELSE(   [AC_LANG_PROGRAM([[]], [[


### PR DESCRIPTION
The Intel(R) oneAPI DPC++/C++ Compiler 2026.0.0 is not officially supported by CPython, and I am not suggesting to change that.
However, I see that there is code in `configure.ac` that applies to the Intel classic compiler (`icc` for C and `icpc` for C++).  The last version of the classic compiler was 2021.10 and it stopped shipping in 2023.

I would like to suggest updating `icc` to `icx` in `configure.ac`.

Note that not all tests pass.  In particular:
```
  File "/tmp/Lib/test/test_cmath.py", line 412, in test_phase
    self.assertAlmostEqual(phase(0), 0.)
                           ~~~~~^^^
ValueError: math domain error
```
and
```
  File "/tmp/Lib/test/test_math.py", line 304, in testAtan2
    self.ftest('atan2(0., -0.)', math.atan2(0., -0.), math.pi)
                                 ~~~~~~~~~~^^^^^^^^^
ValueError: math domain error
```

I do not think the Intel math library is wrong here; it's OK to set `errno` to `EDOM` for `atan2(0.0, 0.0)`.  GCC using glibc does not, and that's OK too.  Both libraries return `0.0` for `atan2(0.0, 0.0)` and `math.pi` for `atan2(0.0, -0.0)`.

If I comment out those tests, I can compile locally with PGO.  Also, `icx` does support `-Wno-unused-result`, and `-ffp-model=precise` is needed or else other floating-point tests will fail.  (As noted in the comment, clang uses `precise` by default.  The Intel compiler is based on clang, but it has changed the default to `fast`.)

<!-- gh-issue-number: gh-152902 -->
* Issue: gh-152902
<!-- /gh-issue-number -->
