### PR TITLE
gh-151518: Avoid STW starvation of attaching threads

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -118,8 +118,7 @@ struct _ts {
 
     int _whence;
 
-    /* Thread state (_Py_THREAD_ATTACHED, _Py_THREAD_DETACHED, _Py_THREAD_SUSPENDED).
-       See Include/internal/pycore_pystate.h for more details. */
+    /* Thread state. See Include/internal/pycore_pystate.h for details. */
     int state;
 
     int py_recursion_remaining;

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -21,13 +21,13 @@ extern "C" {
 // interpreter at the same time. Only the "bound" thread may perform the
 // transitions between "attached" and "detached" on its own PyThreadState.
 //
-// The "suspended" state is used to implement stop-the-world pauses, such as
-// for cyclic garbage collection. It is only used in `--disable-gil` builds.
-// The "suspended" state is similar to the "detached" state in that in both
-// states the thread is not allowed to call most Python APIs. However, unlike
-// the "detached" state, a thread may not transition itself out from the
-// "suspended" state. Only the thread performing a stop-the-world pause may
-// transition a thread from the "suspended" state back to the "detached" state.
+// The "suspended" states are used to implement stop-the-world pauses, such as
+// for cyclic garbage collection. They are only used in `--disable-gil` builds.
+// They are similar to the "detached" state in that the thread is not allowed
+// to call most Python APIs. However, unlike the "detached" state, a thread may
+// not transition itself out from a "suspended" state. Only the thread
+// performing a stop-the-world pause may transition a thread from a "suspended"
+// state back to the "detached" state.
 //
 // The "shutting down" state is used when the interpreter is being finalized.
 // Threads in this state can't do anything other than block the OS thread.
@@ -36,9 +36,9 @@ extern "C" {
 // State transition diagram:
 //
 //            (bound thread)        (stop-the-world thread)
-// [attached]       <->       [detached]       <->       [suspended]
+// [attached]       <->       [detached]       <->       [suspended-detached]
 //   |                                                        ^
-//   +---------------------------->---------------------------+
+//   +----------------------> [suspended] ---------------------+
 //                          (bound thread)
 //
 // The (bound thread) and (stop-the-world thread) labels indicate which thread
@@ -46,7 +46,8 @@ extern "C" {
 #define _Py_THREAD_DETACHED         0
 #define _Py_THREAD_ATTACHED         1
 #define _Py_THREAD_SUSPENDED        2
-#define _Py_THREAD_SHUTTING_DOWN    3
+#define _Py_THREAD_SUSPENDED_DETACHED  3
+#define _Py_THREAD_SHUTTING_DOWN    4
 
 
 /* Check if the current thread is the main thread.

--- a/Include/internal/pycore_tstate.h
+++ b/Include/internal/pycore_tstate.h
@@ -105,8 +105,16 @@ typedef struct _PyThreadStateImpl {
 
 #ifdef Py_GIL_DISABLED
     // gh-144438: Add padding to ensure that the fields above don't share a
-    // cache line with other allocations.
-    char __padding[64];
+    // cache line with other allocations. Reuse the first bytes of the padding
+    // for a cold stop-the-world flag without growing the thread state.
+    union {
+        struct {
+            // Set while the thread is waiting to attach after a
+            // stop-the-world pause suspended it while detached.
+            int stw_attach_waiting;
+        };
+        char __padding[64];
+    };
 #endif
 } _PyThreadStateImpl;
 

--- a/Lib/test/test_free_threading/test_gc.py
+++ b/Lib/test/test_free_threading/test_gc.py
@@ -1,10 +1,14 @@
 import unittest
 
+import subprocess
+import sys
+import textwrap
 import threading
 from threading import Thread
 from unittest import TestCase
 import gc
 
+from test import support
 from test.support import threading_helper
 
 
@@ -152,6 +156,50 @@ class TestGC(TestCase):
 
         with threading_helper.start_threads(threads):
             pass
+
+    @support.requires_subprocess()
+    def test_tight_gc_loop_does_not_starve_attach(self):
+        script = textwrap.dedent("""
+            import gc
+            import importlib
+            import threading
+            import time
+
+            modules = (
+                "abc", "argparse", "collections", "contextlib",
+                "decimal", "enum", "functools", "heapq",
+                "importlib", "inspect", "itertools", "json",
+                "math", "operator", "random", "re",
+            )
+            for name in modules:
+                importlib.import_module(name)
+
+            stop = threading.Event()
+
+            def collect():
+                while not stop.is_set():
+                    gc.collect()
+
+            thread = threading.Thread(target=collect, daemon=True)
+            thread.start()
+            time.sleep(1.0)
+            stop.set()
+            thread.join(5.0)
+            if thread.is_alive():
+                raise SystemExit("GC thread did not stop")
+        """)
+        proc = subprocess.run(
+            [sys.executable, "-I", "-X", "faulthandler", "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=support.SHORT_TIMEOUT,
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+        )
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-16-19-20-00.gh-issue-151518.e6v0Js.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-16-19-20-00.gh-issue-151518.e6v0Js.rst
@@ -1,0 +1,2 @@
+Fix a free-threaded stop-the-world race that could starve a thread reattaching
+after being suspended while detached.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1938,7 +1938,9 @@ tstate_delete_common(PyThreadState *tstate, int release_gil)
     if (tstate->next) {
         tstate->next->prev = tstate->prev;
     }
-    if (tstate->state != _Py_THREAD_SUSPENDED) {
+    if (tstate->state != _Py_THREAD_SUSPENDED &&
+        tstate->state != _Py_THREAD_SUSPENDED_DETACHED)
+    {
         // Any ongoing stop-the-world request should not wait for us because
         // our thread is getting deleted.
         if (interp->stoptheworld.requested) {
@@ -2236,9 +2238,22 @@ tstate_set_detached(PyThreadState *tstate, int detached_state)
 static void
 tstate_wait_attach(PyThreadState *tstate)
 {
+#ifdef Py_GIL_DISABLED
+    _PyThreadStateImpl *tstate_impl = (_PyThreadStateImpl *)tstate;
+    int stw_attach_waiting = 0;
+#endif
     do {
         int state = _Py_atomic_load_int_relaxed(&tstate->state);
-        if (state == _Py_THREAD_SUSPENDED) {
+        if (state == _Py_THREAD_SUSPENDED ||
+            state == _Py_THREAD_SUSPENDED_DETACHED)
+        {
+#ifdef Py_GIL_DISABLED
+            if (state == _Py_THREAD_SUSPENDED_DETACHED) {
+                stw_attach_waiting = 1;
+                _Py_atomic_store_int_relaxed(
+                    &tstate_impl->stw_attach_waiting, 1);
+            }
+#endif
             // Wait until we're switched out of SUSPENDED to DETACHED.
             _PyParkingLot_Park(&tstate->state, &state, sizeof(tstate->state),
                                /*timeout=*/-1, NULL, /*detach=*/0);
@@ -2252,6 +2267,11 @@ tstate_wait_attach(PyThreadState *tstate)
         }
         // Once we're back in DETACHED we can re-attach
     } while (!tstate_try_attach(tstate));
+#ifdef Py_GIL_DISABLED
+    if (stw_attach_waiting) {
+        _Py_atomic_store_int_relaxed(&tstate_impl->stw_attach_waiting, 0);
+    }
+#endif
 }
 
 void
@@ -2421,9 +2441,16 @@ park_detached_threads(struct _stoptheworld_state *stw)
         _Py_FOR_EACH_TSTATE_UNLOCKED(i, t) {
             int state = _Py_atomic_load_int_relaxed(&t->state);
             if (state == _Py_THREAD_DETACHED) {
+                _PyThreadStateImpl *tstate_impl = (_PyThreadStateImpl *)t;
+                if (_Py_atomic_load_int_relaxed(
+                        &tstate_impl->stw_attach_waiting))
+                {
+                    continue;
+                }
                 // Atomically transition to "suspended" if in "detached" state.
                 if (_Py_atomic_compare_exchange_int(
-                                &t->state, &state, _Py_THREAD_SUSPENDED)) {
+                                &t->state, &state,
+                                _Py_THREAD_SUSPENDED_DETACHED)) {
                     num_parked++;
                 }
             }
@@ -2508,8 +2535,11 @@ start_the_world(struct _stoptheworld_state *stw)
     _Py_FOR_EACH_STW_INTERP(stw, i) {
         _Py_FOR_EACH_TSTATE_UNLOCKED(i, t) {
             if (t != stw->requester) {
-                assert(_Py_atomic_load_int_relaxed(&t->state) ==
-                       _Py_THREAD_SUSPENDED);
+#ifndef NDEBUG
+                int state = _Py_atomic_load_int_relaxed(&t->state);
+                assert(state == _Py_THREAD_SUSPENDED ||
+                       state == _Py_THREAD_SUSPENDED_DETACHED);
+#endif
                 _Py_atomic_store_int(&t->state, _Py_THREAD_DETACHED);
                 _PyParkingLot_UnparkAll(&t->state);
             }


### PR DESCRIPTION
Fixes #151518.

Repeated stop-the-world requests can starve a thread returning from a detached operation. After `start_the_world()` restores its state to `DETACHED`, the next requester can suspend it again before its OS thread completes `_PyThreadState_Attach()`.

This change distinguishes thread states suspended while detached from those suspended while attached. An active attach waiter records that it encountered the detached-origin suspension; subsequent stop-the-world scans let that waiter attach before suspending it again. The waiter remains in the stop-the-world countdown until it actually stops. Threads detached for sleep or I/O without an active attach attempt remain immediately parkable, and the uncontended attach path remains a single CAS.

The waiting flag reuses trailing `_PyThreadStateImpl` padding. Existing state numbers are preserved, and both suspended states resume directly to `DETACHED`.

The subprocess regression explicitly uses `-X gil=0`, waits for the collector to start, and repeatedly returns from sleep while another thread calls `gc.collect()` in a tight loop. It performs 50 reattachments with one second of total intentional sleep and relies on the test framework's outer timeout for stalled progress or shutdown.

Validation on Linux x86-64 after rebasing onto `89c67a98aee`:

- Debug free-threaded build (`--with-pydebug --enable-safety --enable-slower-safety --disable-gil`): `test_free_threading test_gc test_threading test_capi test_embed` passed, 2,211 tests run. `test_interpreters` is unsupported in this build and skipped.
- Release free-threaded build: `test_free_threading test_gc test_threading test_embed` passed, 647 tests run.
- Debug free-threaded binary with `-X gil=1`: GC, threading, embedding, and free-threaded GC tests passed, 403 tests run. The final regression also passed separately with this parent setting.
- Normal GIL build, using a separate bytecode cache: `test_gc test_threading test_capi test_embed test_interpreters` passed, 2,132 tests run. `test_free_threading` skipped as expected.
- Final regression passed `-R 3:3` reference-leak checking. Seven additional stress trials passed with mixed global/local pauses, repeated detach/reattach, and workers blocked waiting for collector completion.
- Compiled layout comparison matched all 64 common measurements: `_PyThreadStateImpl` remains 18,200 bytes, and the new flag overlays padding at offset 18,136. `make patchcheck` and `git diff --check` passed.


<!-- gh-issue-number: gh-151518 -->
* Issue: gh-151518
<!-- /gh-issue-number -->
