### PR TITLE
[3.13] gh-151763: Fix OOM-0013 crash when the parser or compiler fails to allocate (GH-151968)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-23-12-03-55.gh-issue-151763.K7QfWG.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-23-12-03-55.gh-issue-151763.K7QfWG.rst
@@ -1,0 +1,3 @@
+Fix a potential crash in :func:`compile`, :func:`exec`, :func:`eval` and
+:func:`ast.parse` when an allocation fails: the parser or compiler could
+return without setting an exception.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -894,6 +894,11 @@ _PyPegen_run_parser(Parser *p)
 {
     void *res = _PyPegen_parse(p);
     assert(p->level == 0);
+    if (res != NULL && PyErr_Occurred()) {
+        // Discard a result returned with an exception still pending
+        // (e.g. a MemoryError from a recovered-from allocation failure).
+        return NULL;
+    }
     if (res == NULL) {
         if ((p->flags & PyPARSE_ALLOW_INCOMPLETE_INPUT) &&  _is_end_of_source(p)) {
             PyErr_Clear();
@@ -944,7 +949,10 @@ _PyPegen_run_parser_from_file_pointer(FILE *fp, int start_rule, PyObject *filena
     if (tok == NULL) {
         if (PyErr_Occurred()) {
             _PyPegen_raise_tokenizer_init_error(filename_ob);
-            return NULL;
+        }
+        else {
+            // The only silent tokenizer init failure is a failed allocation.
+            PyErr_NoMemory();
         }
         return NULL;
     }
@@ -997,6 +1005,10 @@ _PyPegen_run_parser_from_string(const char *str, int start_rule, PyObject *filen
     if (tok == NULL) {
         if (PyErr_Occurred()) {
             _PyPegen_raise_tokenizer_init_error(filename_ob);
+        }
+        else {
+            // The only silent tokenizer init failure is a failed allocation.
+            PyErr_NoMemory();
         }
         return NULL;
     }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -430,6 +430,7 @@ new_compiler(mod_ty mod, PyObject *filename, PyCompilerFlags *pflags,
 {
     struct compiler *c = PyMem_Calloc(1, sizeof(struct compiler));
     if (c == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     if (compiler_setup(c, mod, filename, pflags, optimize, arena) < 0) {


### PR DESCRIPTION
(cherry picked from commit 669299b62f6c2176d4bedcf550fb9baaabd6a9d6)

Co-authored-by: tonghuaroot (童话) <tonghuaroot@gmail.com>

<!-- gh-issue-number: gh-151763 -->
* Issue: gh-151763
<!-- /gh-issue-number -->
