### PR TITLE
gh-152847: Reject POSIX TZ rule with non-digit day-of-year in `_zoneinfo.py`

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1111,6 +1111,9 @@ class TZStrTest(ZoneInfoTestBase):
             "AAA4BBB,J1/2,J1/14",
             "AAA4BBB,J20/2,J365/2",
             "AAA4BBB,J365/2,J365/14",
+            # Leading-zero day-of-year
+            "AAA4BBB,J001/2,J065/2",
+            "AAA4BBB,001/2,065/2",
             # Extreme transition hour
             "AAA4BBB,J60/167,J300/2",
             "AAA4BBB,J60/+167,J300/2",
@@ -1209,6 +1212,15 @@ class TZStrTest(ZoneInfoTestBase):
             # Invalid julian offset
             "AAA4BBB,J0/2,J20/2",
             "AAA4BBB,J20/2,J366/2",
+            # gh-152847: non-digit day-of-year (e.g. J1_0)
+            "AAA4BBB,J1_0,J300/2",
+            "AAA4BBB,J60/2,J30_0/2",
+            "AAA4BBB,1_0,J300/2",
+            "AAA4BBB,J+1,J300/2",
+            "AAA4BBB,J 1,J300/2",
+            "AAA4BBB, 1,J300/2",
+            "AAA4BBB,J0001,J300/2",
+            "AAA4BBB,0001,J300/2",
             # Invalid transition time
             "AAA4BBB,J60/2/3,J300/2",
             "AAA4BBB,J60/2,J300/2/3",
@@ -1241,6 +1253,15 @@ class TZStrTest(ZoneInfoTestBase):
 
     def test_invalid_tzstr_non_ascii_abbr(self):
         tzstr = "ABÀC3"
+        if self.module is py_zoneinfo:
+            expected = re.escape(tzstr)
+        else:
+            expected = re.escape(repr(tzstr.encode("utf-8")))
+        with self.assertRaisesRegex(ValueError, expected):
+            self.zone_from_tzstr(tzstr, encoding="utf-8")
+
+    def test_invalid_tzstr_non_ascii_dst_date(self):
+        tzstr = "AAA4BBB,J١,J300/2"
         if self.module is py_zoneinfo:
             expected = re.escape(tzstr)
         else:

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1212,7 +1212,7 @@ class TZStrTest(ZoneInfoTestBase):
             # Invalid julian offset
             "AAA4BBB,J0/2,J20/2",
             "AAA4BBB,J20/2,J366/2",
-            # gh-152847: non-digit day-of-year (e.g. J1_0)
+            # gh-152847: non-digit day-of-year
             "AAA4BBB,J1_0,J300/2",
             "AAA4BBB,J60/2,J30_0/2",
             "AAA4BBB,1_0,J300/2",

--- a/Lib/zoneinfo/_zoneinfo.py
+++ b/Lib/zoneinfo/_zoneinfo.py
@@ -720,6 +720,8 @@ def _parse_dst_start_end(dststr):
         else:
             n_is_julian = False
 
+        if re.fullmatch(r"\d{1,3}", date, re.ASCII) is None:
+            raise ValueError(f"Invalid dst start/end date: {dststr}")
         doy = int(date)
         offset = _DayOffset(doy, n_is_julian)
 

--- a/Misc/NEWS.d/next/Library/2026-07-02-12-00-00.gh-issue-152847.PitKqc.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-02-12-00-00.gh-issue-152847.PitKqc.rst
@@ -1,0 +1,3 @@
+Fix the pure-Python :mod:`zoneinfo` parser accepting non-digit characters in
+the day-of-year field of a POSIX TZ transition rule (such as ``J1_0``), which
+the C implementation rejects. Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-07-02-12-00-00.gh-issue-152847.PitKqc.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-02-12-00-00.gh-issue-152847.PitKqc.rst
@@ -1,3 +1,3 @@
-Fix the pure-Python :mod:`zoneinfo` parser accepting non-digit characters in
-the day-of-year field of a POSIX TZ transition rule (such as ``J1_0``), which
-the C implementation rejects. Patch by tonghuaroot.
+Reject a POSIX TZ transition rule with non-digit characters in the
+day-of-year field in the pure-Python :mod:`zoneinfo` parser. Patch by
+tonghuaroot.


### PR DESCRIPTION
The pure-Python `zoneinfo` parser validated the `Mm.w.d` transition rule
strictly, but the `Jn` (Julian) and `n` (0-based) day-of-year branches of
`_parse_dst_start_end()` fell through to a bare `int(date)` with no format
check. `int()` accepts input the C accelerator rejects, so the two
implementations disagreed on the same POSIX TZ string.

The C accelerator reads the day-of-year field with
`parse_digits(&ptr, 1, 3, &day)` in `Modules/_zoneinfo.c`, consuming 1 to 3
ASCII digits (`Py_ISDIGIT`) and nothing else. This PR adds the matching guard

```python
if re.fullmatch(r"\d{1,3}", date, re.ASCII) is None:
    raise ValueError(f"Invalid dst start/end date: {dststr}")
```

before `int()`, so the pure parser now matches the C accelerator exactly for
this field — not stricter, not looser.

The most notable case is a silent miscompile rather than a crash: `int('1_0')`
is `10`, so `AAA4BBB,J1_0,J300/2` previously built a valid *but different* zone
(DST on day 10) in pure Python while the C accelerator raised `ValueError`.
The fix also aligns the `J+1`, leading-space, 4+-digit-width (`J0001`), and
non-ASCII-digit cases. The `1`-to-`3`-digit bound is deliberate: the C parser
consumes at most three digits, so `\d+` would make the pure parser accept
`J0001`, which C rejects. Leading zeros within three digits (`J01`, `J001`)
are still accepted by both. The existing `_DayOffset` range check
(`[julian, 365]`) is untouched, so no numeric-range behaviour changes.

Verified with a C-vs-pure differential (10 divergent inputs before, 0 after),
a zero-regression pass over all 499 bundled IANA zones (byte-identical through
both implementations), and the full `test_zoneinfo` suite. Added invalid-TZ
cases (`J1_0`, `1_0`, `J+1`, `J 1`, ` 1`, `J0001`, `0001`) and leading-zero
valid controls (`J001`, `001`); these run against both `TZStrTest` and
`CTZStrTest`.

This covers a distinct field in the same POSIX TZ parity audit as gh-152212
(std offset), gh-152246 (`Mm.w.d` separator), and gh-152248 (abbreviation
regex).


<!-- gh-issue-number: gh-152847 -->
* Issue: gh-152847
<!-- /gh-issue-number -->
