### PR TITLE
gh-149123: Avoid InvalidStateError in Windows Proactor polling

### DIFF
--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -804,11 +804,13 @@ class IocpProactor:
                 try:
                     value = callback(transferred, key, ov)
                 except OSError as e:
-                    f.set_exception(e)
-                    self._results.append(f)
+                    if not f.done():
+                        f.set_exception(e)
+                        self._results.append(f)
                 else:
-                    f.set_result(value)
-                    self._results.append(f)
+                    if not f.done():
+                        f.set_result(value)
+                        self._results.append(f)
                 finally:
                     f = None
 

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -220,6 +220,38 @@ class ProactorTests(WindowsEventsTestCase):
         fut.cancel()
         fut.cancel()
 
+    def _poll_with_future_done_during_callback(self, callback_exception=None):
+        proactor = self.loop._proactor
+        ov = _overlapped.Overlapped(_winapi.NULL)
+        fut = windows_events._OverlappedFuture(ov, loop=self.loop)
+
+        class Obj:
+            pass
+
+        def callback(transferred, key, ov):
+            self.assertFalse(fut.done())
+            fut.cancel()
+            if callback_exception is not None:
+                raise callback_exception
+            return object()
+
+        proactor._cache[ov.address] = (fut, ov, Obj(), callback)
+        _overlapped.PostQueuedCompletionStatus(proactor._iocp, 0, 0,
+                                               ov.address)
+
+        proactor._poll(0)
+
+        self.assertTrue(fut.cancelled())
+        self.assertEqual(proactor._results, [])
+
+    def test_poll_skips_exception_if_future_done_during_callback(self):
+        exc = ConnectionResetError(_overlapped.ERROR_OPERATION_ABORTED,
+                                   "operation aborted")
+        self._poll_with_future_done_during_callback(exc)
+
+    def test_poll_skips_result_if_future_done_during_callback(self):
+        self._poll_with_future_done_during_callback()
+
     def test_read_self_pipe_restart(self):
         # Regression test for https://bugs.python.org/issue39010
         # Previously, restarting a proactor event loop in certain states

--- a/Misc/NEWS.d/next/Library/2026-07-02-01-55-00.gh-issue-149123.GN8o4M.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-02-01-55-00.gh-issue-149123.GN8o4M.rst
@@ -1,0 +1,2 @@
+Avoid raising :exc:`asyncio.InvalidStateError` from the Windows proactor event
+loop when an overlapped future becomes done while handling an I/O completion.


### PR DESCRIPTION
## Summary

This PR addresses the race condition described in gh-149123.

`IocpProactor._poll()` checks whether an `_OverlappedFuture` is pending before invoking its completion callback. However, the callback may eventually call `Overlapped.getresult()`, which releases the GIL while waiting for the underlying Windows I/O completion.

During that window, another thread may complete or cancel the same future. When `_poll()` resumes, the subsequent call to `Future.set_exception()` or `Future.set_result()` can therefore raise `asyncio.InvalidStateError`, even though the future was pending before the callback started.

This change re-checks the future state immediately before setting the result or exception. If the future became done while the callback was executing, `_poll()` simply skips result delivery, matching the existing behavior for futures that are already done before callback execution.

No public API or observable behavior is otherwise changed.

## Tests

Adds deterministic regression tests covering both execution paths:

- Future becomes done during the callback before `set_exception()`
- Future becomes done during the callback before `set_result()`

Both tests verify that `_poll()` no longer raises `asyncio.InvalidStateError` when the future transitions to a completed state during callback execution.

## Validation

Validated using a Windows debug build of current `main`.

Targeted regression tests:

```text
PCbuild\amd64\python_d.exe -m unittest -v \
test.test_asyncio.test_windows_events.ProactorTests.test_poll_skips_exception_if_future_done_during_callback \
test.test_asyncio.test_windows_events.ProactorTests.test_poll_skips_result_if_future_done_during_callback
```

Both regression tests pass.

Additional validation:

```text
git diff --check
```

passed successfully.

A broader local `test_asyncio` run encountered unrelated Windows environment permission failures involving named pipes and temporary-directory cleanup, but the new regression tests completed successfully.

## Changes

- Re-check `Future.done()` after the completion callback returns or raises.
- Skip calling `set_exception()` or `set_result()` if the future became done during callback execution.
- Add deterministic regression tests covering both exception and success paths.
- Add a NEWS entry.

Fixes gh-149123.