### PR TITLE
gh-152870: Fix compile error with decimal when EXTRA_FUNCTIONALITY enabled

### DIFF
--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -4968,6 +4968,14 @@ class CFunctionality(unittest.TestCase):
         self.assertEqual(c._traps, C.DecRounded)
 
     @requires_extra_functionality
+    def test_c_context_apply(self):
+        c = C.Context(prec=3)
+        self.assertEqual(c.apply(C.Decimal('1.23456')), C.Decimal('1.23'))
+        # A higher precision won't see them as equal.
+        c = C.Context(prec=5)
+        self.assertNotEqual(c.apply(C.Decimal('1.23456')), C.Decimal('1.23'))
+
+    @requires_extra_functionality
     def test_constants(self):
         # Condition flags
         cond = (

--- a/Misc/NEWS.d/next/Build/2026-07-02-16-25-13.gh-issue-152870.oh9eD1.rst
+++ b/Misc/NEWS.d/next/Build/2026-07-02-16-25-13.gh-issue-152870.oh9eD1.rst
@@ -1,0 +1,4 @@
+Fix a compilation error in the :mod:`decimal` C extension (``_decimal``) when
+it is built with ``EXTRA_FUNCTIONALITY``. ``Context.apply()`` called the
+internal ``_apply`` helper using its pre-Argument-Clinic signature; the call is
+now made through the generated ``_impl`` function.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -6993,7 +6993,7 @@ _decimal_Context_apply_impl(PyObject *context, PyTypeObject *cls,
                             PyObject *x)
 /*[clinic end generated code: output=f8a7142d47ad4ff3 input=388e66ca82733516]*/
 {
-    return _decimal_Context__apply(context, x);
+    return _decimal_Context__apply_impl(context, cls, x);
 }
 #endif
 


### PR DESCRIPTION
As mentioned in #152870, there is compilation error about `EXTRA_FUNCTIONALITY`
## Root cause
The `Context.apply()` wrapper (guarded by `#ifdef EXTRA_FUNCTIONALITY`) still calls `_decimal_Context__apply()` using its pre-Argument-Clinic signature. But since #73487 , the generated `_decimal_Context__apply()` is now a `METH_FASTCALL` wrapper with the signature `(context, cls, args, nargs, kwnames)`, so the old call no longer compiles. 

PR #142441 previously touched this line, but it fixed a typo, rather than the signature mismatch issue.

## Test
After the fix, it builds correctly and the full `test_decimal` suite (including the C-only tests) passes.

<!-- gh-issue-number: gh-152870 -->
* Issue: gh-152870
<!-- /gh-issue-number -->
