### PR TITLE
gh-66335: Test uppercase IMAP4 command names

### DIFF
--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -1415,6 +1415,16 @@ class NewIMAPTestsMixin:
         self.assertEqual(data, [b'MYCOMMAND completed'])
         self.assertEqual(server.args, ['arg1', 'arg2'])
 
+    def test_uppercase_command_names(self):
+        client, server = self._setup(SimpleIMAPHandler)
+        client.login('user', 'pass')
+        self.assertEqual(client.CAPABILITY, client.capability)
+        self.assertEqual(client.SELECT, client.select)
+        typ, data = client.CAPABILITY()
+        self.assertEqual(typ, 'OK')
+        with self.assertRaises(AttributeError):
+            client.NONEXISTENT
+
     def test_control_characters(self):
         client, _ = self._setup(SimpleIMAPHandler)
         for c0 in support.control_characters_c0():


### PR DESCRIPTION
Follow-up to #152872 (gh-66335).

``imaplib.IMAP4.__getattr__`` lets a command be called under its uppercase name (``client.CAPABILITY()`` in addition to ``client.capability()``), as documented, and raises ``AttributeError`` for an unknown name. This adds a test for that behavior, which the coverage PR left out.

Co-authored with the author of the original bpo-22137 patch, which included this test.