### PR TITLE
[3.13] gh-49680: Test imaplib.IMAP4.append line-ending normalization

### DIFF
--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -9,6 +9,7 @@ import time
 import calendar
 import threading
 import re
+import select
 import socket
 
 from test.support import verbose, run_with_tz, run_with_locale, cpython_only, requires_resource
@@ -88,6 +89,18 @@ def make_simple_handler(command, untagged_response=(),
     Handler.__qualname__ = Handler.__name__
     cmd.__qualname__ = Handler.__qualname__ + '.' + cmd.__name__
     return Handler
+
+
+def _read_literal(handler, marker):
+    # Read one literal, a raw octet sequence, by its count from the marker
+    # ('{N}', or '(~{N}' in UTF8 mode).
+    size = int(re.search(r'\{(\d+)\}', marker).group(1))
+    # The client must wait for the continuation, so nothing should be readable.
+    if select.select([handler.connection], [], [], 0)[0]:
+        raise AssertionError('client sent the literal before the '
+                             'continuation request')
+    handler._send_textline('+')
+    return handler.rfile.read(size)
 
 
 class TestImaplib(unittest.TestCase):
@@ -425,10 +438,8 @@ class NewIMAPTestsMixin:
                 self.server.response = yield
                 self._send_tagged(tag, 'OK', 'FAKEAUTH successful')
             def cmd_APPEND(self, tag, args):
-                self._send_textline('+')
                 self.server.response = args
-                literal = yield
-                self.server.response.append(literal)
+                self.server.response.append(_read_literal(self, args[-1]))
                 literal = yield
                 self.server.response.append(literal)
                 self._send_tagged(tag, 'OK', 'okay')
@@ -625,6 +636,19 @@ class NewIMAPTestsMixin:
         self.assertEqual(typ, 'OK')
         self.assertEqual(data[0], b'LOGIN completed')
         self.assertEqual(client.state, 'AUTH')
+
+    def test_append_line_endings(self):
+        # append() normalizes bare CR and LF in the message to CRLF.
+        class AppendHandler(SimpleIMAPHandler):
+            def cmd_APPEND(self, tag, args):
+                self.server.response = _read_literal(self, args[-1])
+                yield  # read the trailer line
+                self._send_tagged(tag, 'OK', 'APPEND completed')
+        client, server = self._setup(AppendHandler)
+        client.login('user', 'pass')
+        message = b'a\rb\nc\r\nd'
+        client.append('INBOX', None, None, message)
+        self.assertEqual(server.response, b'a\r\nb\r\nc\r\nd')
 
     def test_logout(self):
         client, _ = self._setup(SimpleIMAPHandler)
@@ -1461,10 +1485,8 @@ class ThreadedNetworkedTests(unittest.TestCase):
 
         class UTF8AppendServer(self.UTF8Server):
             def cmd_APPEND(self, tag, args):
-                self._send_textline('+')
                 self.server.response = args
-                literal = yield
-                self.server.response.append(literal)
+                self.server.response.append(_read_literal(self, args[-1]))
                 literal = yield
                 self.server.response.append(literal)
                 self._send_tagged(tag, 'OK', 'okay')


### PR DESCRIPTION
Backport of the APPEND line-ending test to 3.13 (gh-49680).

``append()``'s default CR/LF normalization is existing behavior on 3.13; the ``translate_line_endings`` parameter is main-only, so only the test (plus the ``_read_literal`` helper and the UTF8-append test refactor) is backported.

(cherry picked from commit 6759fd82117a50c40a0911189eda1c8dfa93ad03)