### PR TITLE
gh-98894: Check tracer exit status in test_dtrace

### DIFF
--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -125,7 +125,8 @@ class TraceBackend:
             command += ["-c", subcommand]
         return command
 
-    def trace(self, script_file, subcommand=None, *, timeout=None):
+    def trace(self, script_file, subcommand=None, *, timeout=None,
+              check_returncode=False):
         command = self.generate_trace_command(script_file, subcommand)
         proc = create_process_group(command,
                                     stdout=subprocess.PIPE,
@@ -136,6 +137,11 @@ class TraceBackend:
         except subprocess.TimeoutExpired:
             kill_process_group(proc)
             raise
+        if check_returncode and proc.returncode:
+            raise AssertionError(
+                f"Command {' '.join(command)!r} failed "
+                f"with exit code {proc.returncode}: output={stdout!r}"
+            )
         return stdout
 
     def trace_python(self, script_file, python_file, optimize_python=None):
@@ -143,7 +149,8 @@ class TraceBackend:
         if optimize_python:
             python_flags.extend(["-O"] * optimize_python)
         subcommand = " ".join([sys.executable] + python_flags + [python_file])
-        return self.trace(script_file, subcommand, timeout=60)
+        return self.trace(script_file, subcommand, timeout=60,
+                          check_returncode=True)
 
     def assert_usable(self):
         try:


### PR DESCRIPTION
Fail functional dtrace and SystemTap cases directly when the tracer exits non-zero.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98894 -->
* Issue: gh-98894
<!-- /gh-issue-number -->
