### PR TITLE
[3.15] gh-144067: Document terminal leak when initscr() follows setupterm() (GH-152624)

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -324,6 +324,8 @@ The module :mod:`!curses` defines the following functions:
    Initialize the library. Return a :ref:`window <curses-window-objects>` object
    which represents the whole screen.
 
+   See :func:`setupterm` for a caveat about calling it before this function.
+
    .. note::
 
       If there is an error opening the terminal, the underlying curses library may
@@ -592,6 +594,13 @@ The module :mod:`!curses` defines the following functions:
    Raise a :exc:`curses.error` if the terminal could not be found or its
    terminfo database entry could not be read.  If the terminal has already
    been initialized, this function has no effect.
+
+   .. note::
+
+      Calling :func:`initscr` after :func:`setupterm`
+      leaks the terminal that :func:`setupterm` allocated:
+      the curses library keeps only a single current terminal
+      and does not free the previously allocated one.
 
 
 .. function:: start_color()


### PR DESCRIPTION
Manual backport of #152624 (the auto-backport failed to apply).

`curses.newterm()` was added in 3.16, so it does not exist in 3.15: the `newterm()` cross-reference hunk is dropped and the note on `setupterm()` mentions only `initscr()`.

(cherry picked from commit e471712958515b65b737ac742b294acf7de9220c)

<!-- gh-issue-number: gh-144067 -->
* Issue: gh-144067
<!-- /gh-issue-number -->
