### PR TITLE
[3.14] gh-152785: Upgrade Java from 17 to 21 in GHA Android (GH-152783)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,7 +378,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build and test
-        run: ./Android/android.py ci --fast-ci ${{ matrix.arch }}-linux-android
+        run: JAVA_HOME="${JAVA_HOME_21_X64:-$JAVA_HOME_21_arm64}" ./Android/android.py ci --fast-ci ${{ matrix.arch }}-linux-android
 
   build-ios:
     name: iOS

--- a/Android/README.md
+++ b/Android/README.md
@@ -31,7 +31,8 @@ any packages it needs.
 The script also requires the following commands to be on the `PATH`:
 
 * `curl`
-* `java` (or set the `JAVA_HOME` environment variable)
+* `java` (or set the `JAVA_HOME` environment variable).
+  Java versions 17 and 21 are supported.
 
 
 ## Building


### PR DESCRIPTION
Upgrade Java from 17 to 21 in GHA Android, and document the Java version requirement.
(cherry picked from commit 0a13efc3fb0bf0896612ed20decce3ce4eb5e05b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152785 -->
* Issue: gh-152785
<!-- /gh-issue-number -->
