### PR TITLE
gh-152762: Fix zipfile.Path.is_symlink() raising KeyError for missing entries

### DIFF
--- a/Lib/test/test_zipfile/_path/test_path.py
+++ b/Lib/test/test_zipfile/_path/test_path.py
@@ -552,6 +552,18 @@ class TestPath(unittest.TestCase):
         assert root.joinpath('n.txt').is_symlink()
 
     @pass_alpharep
+    def test_is_symlink_missing(self, alpharep):
+        """
+        is_symlink returns False for entries missing from the archive
+        (including the root and implied directories) rather than
+        raising KeyError.
+        """
+        root = zipfile.Path(alpharep)
+        assert not root.is_symlink()
+        assert not root.joinpath('b').is_symlink()
+        assert not root.joinpath('missing.txt').is_symlink()
+
+    @pass_alpharep
     def test_relative_to(self, alpharep):
         root = zipfile.Path(alpharep)
         relative = root.joinpath("b", "c.txt").relative_to(root / "b")

--- a/Lib/zipfile/_path/__init__.py
+++ b/Lib/zipfile/_path/__init__.py
@@ -414,7 +414,10 @@ class Path:
         """
         Return whether this path is a symlink.
         """
-        info = self.root.getinfo(self.at)
+        try:
+            info = self.root.getinfo(self.at)
+        except KeyError:
+            return False
         mode = info.external_attr >> 16
         return stat.S_ISLNK(mode)
 

--- a/Misc/NEWS.d/next/Library/2026-07-02-11-24-08.gh-issue-152762.qL7vXe.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-02-11-24-08.gh-issue-152762.qL7vXe.rst
@@ -1,0 +1,3 @@
+Fix :meth:`zipfile.Path.is_symlink` raising :exc:`KeyError` for paths not
+present in the archive.  It now returns ``False``, consistent with the other
+:class:`zipfile.Path` predicates and with :meth:`pathlib.Path.is_symlink`.


### PR DESCRIPTION
`zipfile.Path.is_symlink()` called `ZipFile.getinfo()` unguarded, so it raised `KeyError` for any path not present in the archive:

```python
import io, zipfile

buf = io.BytesIO()
with zipfile.ZipFile(buf, "w") as zf:
    zf.writestr("present.txt", b"x")

buf.seek(0)
with zipfile.ZipFile(buf) as zf:
    p = zipfile.Path(zf) / "missing.txt"
    p.exists()      # False
    p.is_file()     # False
    p.is_dir()      # False
    p.is_symlink()  # KeyError: "There is no item named 'missing.txt' in the archive"
```

The same `KeyError` was raised for the archive root (`zipfile.Path(zf)`) and for implied directories, since neither has a `ZipInfo` entry backing it.

This change catches the `KeyError` from `getinfo()` and returns `False`, so `is_symlink()` behaves like the neighboring predicates (`exists()`, `is_file()`, `is_dir()`) and like `pathlib.Path.is_symlink()` on a missing filesystem path. Existing symlink entries are unaffected.

Added a test covering the missing-entry, root, and implied-directory cases (all raise `KeyError` without the fix), and a NEWS entry.


<!-- gh-issue-number: gh-152762 -->
* Issue: gh-152762
<!-- /gh-issue-number -->
