### PR TITLE
gh-142049: Clarify escaped quotes in tutorial

### DIFF
--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -168,6 +168,8 @@ Alternatively, we can use the other type of quotation marks::
    '"Yes," they said.'
    >>> '"Isn\'t," they said.'
    '"Isn\'t," they said.'
+   >>> print('"Isn\'t," they said.')
+   "Isn't," they said.
 
 In the Python shell, the string definition and output string can look
 different.  The :func:`print` function produces a more readable output, by


### PR DESCRIPTION
## Summary
- add a `print()` example after the escaped quote tutorial example
- clarify that the backslash is part of the interactive representation, not the string output

## Issue
- gh-142049

## Validation
- `Doc\make.bat check`
- `Doc\make.bat html tutorial\introduction.rst`