### PR TITLE
gh-151221: Raise ValueError for invalid <date> in plistlib

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -139,16 +139,22 @@ _dateParser = re.compile(r"(?P<year>\d\d\d\d)(?:-(?P<month>\d\d)(?:-(?P<day>\d\d
 
 def _date_from_string(s, aware_datetime):
     order = ('year', 'month', 'day', 'hour', 'minute', 'second')
-    gd = _dateParser.match(s).groupdict()
+    m = _dateParser.match(s)
+    if m is None:
+        raise ValueError(f"invalid date string: {s!r}")
+    gd = m.groupdict()
     lst = []
     for key in order:
         val = gd[key]
         if val is None:
             break
         lst.append(int(val))
-    if aware_datetime:
-        return datetime.datetime(*lst, tzinfo=datetime.UTC)
-    return datetime.datetime(*lst)
+    try:
+        if aware_datetime:
+            return datetime.datetime(*lst, tzinfo=datetime.UTC)
+        return datetime.datetime(*lst)
+    except (TypeError, ValueError):
+        raise ValueError(f"invalid date string: {s!r}") from None
 
 
 def _date_to_string(d, aware_datetime):

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -876,6 +876,13 @@ class TestPlistlib(unittest.TestCase):
         self.assertRaises(ValueError, plistlib.loads,
                           b"<plist><integer>not real</integer></plist>")
 
+    def test_invaliddate(self):
+        for xml in (b"<plist><date>not a date</date></plist>",
+                    b"<plist><date></date></plist>",
+                    b"<plist><date>2004Z</date></plist>",
+                    b"<plist><date>2004-11Z</date></plist>"):
+            self.assertRaises(ValueError, plistlib.loads, xml)
+
     def test_integer_notations(self):
         pl = b"<plist><integer>456</integer></plist>"
         value = plistlib.loads(pl)

--- a/Misc/NEWS.d/next/Library/2026-07-03-12-29-41.gh-issue-152957.Cat86k.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-03-12-29-41.gh-issue-152957.Cat86k.rst
@@ -1,0 +1,2 @@
+:mod:`plistlib` now raises :exc:`ValueError` for an invalid ``<date>`` in an
+XML plist. Patch by tonghuaroot.


### PR DESCRIPTION
`_date_from_string` in `Lib/plistlib.py` did `_dateParser.match(s).groupdict()`.
On a non-matching `<date>` value `match()` returns `None`, so `.groupdict()`
fails with `AttributeError`; on a partial match (the regex allows year-only and
year-month) too few fields reach `datetime.datetime(*lst)`, which fails with
`TypeError`. Both now raise `ValueError`, matching the sibling `<integer>` and
`<real>` elements. The binary plist format decodes dates with `struct.unpack`
and is unaffected.

* Issue: gh-152957


<!-- gh-issue-number: gh-151221 -->
* Issue: gh-151221
<!-- /gh-issue-number -->
