### PR TITLE
gh-152959: Raise ValueError for a <key> outside a <dict> in plistlib

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -243,7 +243,8 @@ class _PlistParser:
         self.stack.pop()
 
     def end_key(self):
-        if self.current_key or not isinstance(self.stack[-1], dict):
+        if (self.current_key or not self.stack
+                or not isinstance(self.stack[-1], dict)):
             raise ValueError("unexpected key at line %d" %
                              self.parser.CurrentLineNumber)
         self.current_key = self.get_data()

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -857,6 +857,12 @@ class TestPlistlib(unittest.TestCase):
             self.assertRaises(ValueError, plistlib.loads,
                               ("<plist><array>%s</array></plist>"%i).encode())
 
+    def test_invalidkey(self):
+        for xml in (b"<plist><key>x</key></plist>",
+                    b'<?xml version="1.0"?><key>x</key>',
+                    b"<plist><array><key>x</key></array></plist>"):
+            self.assertRaises(ValueError, plistlib.loads, xml)
+
     def test_invaliddict(self):
         for i in ["<key><true/>k</key><string>compound key</string>",
                   "<key>single key</key>",
@@ -875,12 +881,6 @@ class TestPlistlib(unittest.TestCase):
     def test_invalidreal(self):
         self.assertRaises(ValueError, plistlib.loads,
                           b"<plist><integer>not real</integer></plist>")
-
-    def test_invalidkey(self):
-        for xml in (b"<plist><key>x</key></plist>",
-                    b'<?xml version="1.0"?><key>x</key>',
-                    b"<plist><array><key>x</key></array></plist>"):
-            self.assertRaises(ValueError, plistlib.loads, xml)
 
     def test_integer_notations(self):
         pl = b"<plist><integer>456</integer></plist>"

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -876,6 +876,12 @@ class TestPlistlib(unittest.TestCase):
         self.assertRaises(ValueError, plistlib.loads,
                           b"<plist><integer>not real</integer></plist>")
 
+    def test_invalidkey(self):
+        for xml in (b"<plist><key>x</key></plist>",
+                    b'<?xml version="1.0"?><key>x</key>',
+                    b"<plist><array><key>x</key></array></plist>"):
+            self.assertRaises(ValueError, plistlib.loads, xml)
+
     def test_integer_notations(self):
         pl = b"<plist><integer>456</integer></plist>"
         value = plistlib.loads(pl)

--- a/Misc/NEWS.d/next/Library/2026-07-03-15-30-00.gh-issue-152959.Kx7Qm2.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-03-15-30-00.gh-issue-152959.Kx7Qm2.rst
@@ -1,0 +1,2 @@
+:mod:`plistlib` now raises :exc:`ValueError` for a ``<key>`` outside a
+``<dict>`` in an XML plist. Patch by tonghuaroot.


### PR DESCRIPTION
`_PlistParser.end_key` in `Lib/plistlib.py` evaluated `self.stack[-1]` before
checking whether the stack was empty, so a `<key>` element outside a `<dict>`
(for example at the document root) leaked an `IndexError` from
`plistlib.loads` instead of a `ValueError`. The guard now short-circuits on an
empty stack, raising `ValueError` consistently with the sibling `<integer>`
and `<real>` elements (which go through `add_object`, already guarded). The
binary plist format decodes with `struct.unpack` and is unaffected.

* Issue: gh-152959
