### PR TITLE
gh-152951 - Fix double DECREF when `newblock` fails during deque.extend calls

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-03-14-54-33.gh-issue-152951.u8tPCI.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-03-14-54-33.gh-issue-152951.u8tPCI.rst
@@ -1,0 +1,2 @@
+:class:`collections.deque` prevent rare crash when calling ``extend`` under
+high memory pressure conditions.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -512,7 +512,6 @@ deque_extend_impl(dequeobject *deque, PyObject *iterable)
     iternext = *Py_TYPE(it)->tp_iternext;
     while ((item = iternext(it)) != NULL) {
         if (deque_append_lock_held(deque, item, maxlen) == -1) {
-            Py_DECREF(item);
             Py_DECREF(it);
             return NULL;
         }


### PR DESCRIPTION
When deque.extend is called, items from the passed-in sequence are appended using `deque_append_lock_held`.
`deque_append_lock_held` steals the reference to `item`, and (if needed) allocates a new block to store the item.

If the `netblock` call fails, then `deque_append_lock_held` DECREFs the item and returns -1

BUT: if `deque_extend_impl` sees the -1 return from `deque_append_lock_held`, it also DECREF's `item` again, despite not owning it any more.  This can cause negative refcounts and crashes.

This fix removes the output DECREF, as it's handled by the inner func already.

There's no tests for this, as triggering an allocation failure within `newblock` is a bit tricky to do reliably. 

<!-- gh-issue-number: gh-152951 -->
* Issue: gh-152951
<!-- /gh-issue-number -->
