### PR TITLE
gh-83386: Enable test_hang_gh83386 for ProcessPoolExecutor

### DIFF
--- a/Lib/test/test_concurrent_futures/test_shutdown.py
+++ b/Lib/test/test_concurrent_futures/test_shutdown.py
@@ -115,20 +115,21 @@ class ExecutorShutdownTest:
 
         See https://github.com/python/cpython/issues/83386.
         """
-        if self.executor_type == futures.ProcessPoolExecutor:
-            raise unittest.SkipTest(
-                "Hangs, see https://github.com/python/cpython/issues/83386")
-
         rc, out, err = assert_python_ok('-c', """if True:
             from concurrent.futures import {executor_type}
             from test.test_concurrent_futures.test_shutdown import sleep_and_print
             if __name__ == "__main__":
-                if {context!r}: multiprocessing.set_start_method({context!r})
-                t = {executor_type}(max_workers=3)
+                context = '{context}'
+                if context == "":
+                    t = {executor_type}(max_workers=3)
+                else:
+                    from multiprocessing import get_context
+                    t = {executor_type}(max_workers=3,
+                                        mp_context=get_context(context))
                 t.submit(sleep_and_print, 1.0, "apple")
                 t.shutdown(wait=False)
             """.format(executor_type=self.executor_type.__name__,
-                       context=getattr(self, 'ctx', None)))
+                       context=getattr(self, 'ctx', '')))
         self.assertFalse(err)
         self.assertEqual(out.strip(), b"apple")
 
@@ -243,8 +244,6 @@ class ThreadPoolShutdownTest(ThreadPoolMixin, ExecutorShutdownTest, BaseTestCase
             t.join()
 
     def test_cancel_futures_wait_false(self):
-        # Can only be reliably tested for TPE, since PPE often hangs with
-        # `wait=False` (even without *cancel_futures*).
         rc, out, err = assert_python_ok('-c', """if True:
             from concurrent.futures import ThreadPoolExecutor
             from test.test_concurrent_futures.test_shutdown import sleep_and_print


### PR DESCRIPTION
The hang this test guards against (interpreter exit after shutdown(wait=False) with running futures) was fixed for ProcessPoolExecutor by the executor management rewrite in ~3.9 years ago _(probably #17670 fixing bpo-39104 but i didn't confirm exactly)_, but the test stayed skipped.

The skip meaning the code was never maintained also hid a latent NameError in the subprocess template, which only selects a start method in the process pool variants; rewrite it to use the same mp_context=get_context() shape as the other templates.

Also remove a stale comment claiming ProcessPoolExecutor often hangs with wait=False.

Closes: #83386

<!-- gh-issue-number: gh-83386 -->
* Issue: gh-83386
<!-- /gh-issue-number -->
