### PR TITLE
gh-54930: Send a status line in error responses to malformed request lines

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -334,10 +334,13 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
                     raise ValueError("unreasonable length http version")
                 version_number = int(version_number[0]), int(version_number[1])
             except (ValueError, IndexError):
+                # Send the error response with a status line and headers.
+                self.request_version = ''
                 self.send_error(
                     HTTPStatus.BAD_REQUEST,
                     "Bad request version (%r)" % version)
                 return False
+            self.request_version = version
             if version_number >= (1, 1) and self.protocol_version >= "HTTP/1.1":
                 self.close_connection = False
             if version_number >= (2, 0):
@@ -345,9 +348,9 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
                     HTTPStatus.HTTP_VERSION_NOT_SUPPORTED,
                     "Invalid HTTP version (%s)" % base_version_number)
                 return False
-            self.request_version = version
 
         if not 2 <= len(words) <= 3:
+            self.request_version = ''
             self.send_error(
                 HTTPStatus.BAD_REQUEST,
                 "Bad request syntax (%r)" % requestline)
@@ -356,6 +359,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
         if len(words) == 2:
             self.close_connection = True
             if command != 'GET':
+                self.request_version = ''
                 self.send_error(
                     HTTPStatus.BAD_REQUEST,
                     "Bad HTTP/0.9 request type (%r)" % command)

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -386,6 +386,8 @@ class HTTP09ServerTestCase(BaseTestCase):
     def test_invalid_request(self):
         self.sock.send(b'POST /index.html\r\n')
         res = self.sock.recv(1024)
+        # The error response is not sent in the bare HTTP/0.9 style.
+        self.assertStartsWith(res, b'HTTP/1.0 400 ')
         self.assertIn(b"Bad HTTP/0.9 request type ('POST')", res)
 
     def test_single_request(self):
@@ -1101,6 +1103,19 @@ class BaseHTTPRequestHandlerTestCase(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], b'<html><body>Data</body></html>\r\n')
         self.verify_get_called()
+
+    @support.subTests('request,code', [
+        (b'GET / FUBAR\r\n\r\n', 400),     # bad version
+        (b'GET / HTTP/2.0\r\n\r\n', 505),  # unsupported version
+        (b'GET\r\n', 400),                 # bad syntax
+        (b'POST /\r\n', 400),              # bad HTTP/0.9 request type
+    ])
+    def test_request_line_error_has_status_line(self, request, code):
+        self.handler = SocketlessRequestHandler()
+        result = self.send_typical_request(request)
+        self.assertStartsWith(result[0], b'HTTP/1.1 %d ' % code)
+        self.verify_expected_headers(result[1:result.index(b'\r\n')])
+        self.assertFalse(self.handler.get_called)
 
     def test_extra_space(self):
         result = self.send_typical_request(

--- a/Misc/NEWS.d/next/Library/2026-07-03-21-10-00.gh-issue-54930.hq09Er.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-03-21-10-00.gh-issue-54930.hq09Er.rst
@@ -1,0 +1,5 @@
+Error responses of :class:`http.server.BaseHTTPRequestHandler` to malformed
+request lines now include a status line and headers instead of being sent in
+the bare HTTP/0.9 style.
+Only a valid HTTP/0.9 request (a two-word ``GET`` request line) now receives
+an HTTP/0.9 style response.


### PR DESCRIPTION
Previously, if the request line could not be parsed (malformed or unsupported version, bad syntax, or a non-GET two-word request), the error response was sent in the bare HTTP/0.9 style, without a status line and headers, because the request version defaulted to `"HTTP/0.9"`. The client received raw HTML and could not see the 400 or 505 status.

Now only a valid HTTP/0.9 request (a two-word GET request line) receives an HTTP/0.9 style response.

The other defect discussed in the issue (deadlock on a one-line HTTP/0.9 request) was fixed in gh-70765. The test suite previously worked around the present defect by setting `default_request_version = 'HTTP/1.1'` in its test handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-54930 -->
* Issue: gh-54930
<!-- /gh-issue-number -->
