### PR TITLE
[3.14] Backport idlelib changes in PR 142294

### DIFF
--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -512,7 +512,6 @@ class ModifiedInterpreter(InteractiveInterpreter):
         self.rpcclt.close()
         self.terminate_subprocess()
         console = self.tkconsole
-        was_executing = console.executing
         console.executing = False
         self.spawn_subprocess()
         try:

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -129,8 +129,8 @@ class ViewWindow(Toplevel):
         self.title(title)
         self.viewframe = ViewFrame(self, contents, wrap=wrap)
         self.protocol("WM_DELETE_WINDOW", self.ok)
-        self.button_ok = button_ok = Button(self, text='Close',
-                                            command=self.ok, takefocus=False)
+        self.button_ok = Button(self, text='Close',
+                                command=self.ok, takefocus=False)
         self.viewframe.pack(side='top', expand=True, fill='both')
 
         self.is_modal = modal


### PR DESCRIPTION
PR-#142294 (3.15) deleted 'button_ok in textview and was_executing in pyshell.  Backport to 3.14 and 3.13.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
