### PR TITLE
gh-152767: Fix a data race in `multibytecodec`

### DIFF
--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -191,8 +191,10 @@ codecctx_errors_set(PyObject *op, PyObject *value, void *Py_UNUSED(closure))
     if (cb == NULL)
         return -1;
 
+    Py_BEGIN_CRITICAL_SECTION(self);
     ERROR_DECREF(self->errors);
     self->errors = cb;
+    Py_END_CRITICAL_SECTION();
     return 0;
 }
 


### PR DESCRIPTION
Since it's a rare data race and a minor fix, I think a news entry is not needed.

<!-- gh-issue-number: gh-152767 -->
* Issue: gh-152767
<!-- /gh-issue-number -->
