### PR TITLE
gh-153005: Fix timeout handling in concurrent.interpreters.Queue

### DIFF
--- a/Lib/concurrent/interpreters/_queues.py
+++ b/Lib/concurrent/interpreters/_queues.py
@@ -217,15 +217,15 @@ class Queue:
         else:
             unboundop, = _serialize_unbound(unbounditems)
         if timeout is not None:
-            timeout = int(timeout)
-            if timeout < 0:
-                raise ValueError(f'timeout value must be non-negative')
-            end = time.time() + timeout
+            timeout = float(timeout)
+            if not timeout >= 0:  # also rejects NaN
+                raise ValueError('timeout value must be non-negative')
+            end = time.monotonic() + timeout
         while True:
             try:
                 _queues.put(self._id, obj, unboundop)
             except QueueFull:
-                if timeout is not None and time.time() >= end:
+                if timeout is not None and time.monotonic() >= end:
                     raise  # re-raise
                 time.sleep(_delay)
             else:
@@ -252,15 +252,15 @@ class Queue:
         if not block:
             return self.get_nowait()
         if timeout is not None:
-            timeout = int(timeout)
-            if timeout < 0:
-                raise ValueError(f'timeout value must be non-negative')
-            end = time.time() + timeout
+            timeout = float(timeout)
+            if not timeout >= 0:  # also rejects NaN
+                raise ValueError('timeout value must be non-negative')
+            end = time.monotonic() + timeout
         while True:
             try:
                 obj, unboundop = _queues.get(self._id)
             except QueueEmpty:
-                if timeout is not None and time.time() >= end:
+                if timeout is not None and time.monotonic() >= end:
                     raise  # re-raise
                 time.sleep(_delay)
             else:

--- a/Lib/test/test_interpreters/test_queues.py
+++ b/Lib/test/test_interpreters/test_queues.py
@@ -1,6 +1,7 @@
 import importlib
 import pickle
 import threading
+import time
 from textwrap import dedent
 import unittest
 
@@ -353,6 +354,42 @@ class TestQueueOps(TestBase):
             queue.get(timeout=0.1)
         with self.assertRaises(queues.QueueEmpty):
             queue.get(HUGE_TIMEOUT, 0.1)
+
+    def test_put_timeout_fractional(self):
+        # A fractional timeout must not be truncated to whole seconds.
+        queue = queues.create(1)
+        queue.put(None)
+        start = time.monotonic()
+        with self.assertRaises(queues.QueueFull):
+            queue.put(None, timeout=0.1)
+        self.assertGreaterEqual(time.monotonic() - start, 0.05)
+
+    def test_get_timeout_fractional(self):
+        # A fractional timeout must not be truncated to whole seconds.
+        queue = queues.create()
+        start = time.monotonic()
+        with self.assertRaises(queues.QueueEmpty):
+            queue.get(timeout=0.1)
+        self.assertGreaterEqual(time.monotonic() - start, 0.05)
+
+    def test_timeout_zero_does_not_block(self):
+        queue = queues.create(1)
+        queue.put(None)
+        start = time.monotonic()
+        with self.assertRaises(queues.QueueFull):
+            queue.put(None, timeout=0)
+        self.assertLess(time.monotonic() - start, 1.0)
+        empty = queues.create()
+        with self.assertRaises(queues.QueueEmpty):
+            empty.get(timeout=0)
+
+    def test_timeout_invalid(self):
+        queue = queues.create()
+        for bad in (-0.5, float('nan')):
+            with self.assertRaisesRegex(ValueError, 'non-negative'):
+                queue.get(timeout=bad)
+            with self.assertRaisesRegex(ValueError, 'non-negative'):
+                queue.put(None, timeout=bad)
 
     def test_get_nowait(self):
         queue = queues.create()

--- a/Misc/NEWS.d/next/Library/2026-07-04-16-44-43.gh-issue-153005.lWdjWt.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-04-16-44-43.gh-issue-153005.lWdjWt.rst
@@ -1,0 +1,3 @@
+Fix :meth:`concurrent.interpreters.Queue.get` and
+:meth:`concurrent.interpreters.Queue.put` truncating a floating-point *timeout*
+to whole seconds.  A negative or NaN timeout now raises :exc:`ValueError`.


### PR DESCRIPTION
Fixes #153005.

`Queue.get()` and `Queue.put()` converted the `timeout` argument with `int()`.
This changes the timeout handling to match `queue.Queue`:

- A floating-point timeout is used as given instead of being truncated to
  whole seconds, so a sub-second timeout actually blocks.
- A negative or NaN timeout now raises `ValueError`. Previously a small
  negative float was truncated to `0` and silently ignored, and a NaN would
  have made the wait loop run forever.
- The deadline is computed with `time.monotonic()` instead of `time.time()`,
  so it is unaffected by system clock adjustments.

The wait is still a poll loop with a 10 ms delay, so the timeout resolution is
bounded by that interval; this PR does not change the polling design.


<!-- gh-issue-number: gh-153005 -->
* Issue: gh-153005
<!-- /gh-issue-number -->
