### PR TITLE
gh-135661: Fix abrupt closing of empty comment in HTMLParser

### DIFF
--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -387,9 +387,11 @@ class HTMLParser(_markupbase.ParserBase):
     def parse_comment(self, i, report=True):
         rawdata = self.rawdata
         assert rawdata.startswith('<!--', i), 'unexpected call to parse_comment()'
-        match = commentclose.search(rawdata, i+4)
+        # An empty comment is abruptly closed by the first ">" or "->",
+        # taking priority over a later "-->" or "--!>" close.
+        match = commentabruptclose.match(rawdata, i+4)
         if not match:
-            match = commentabruptclose.match(rawdata, i+4)
+            match = commentclose.search(rawdata, i+4)
             if not match:
                 return -1
         if report:

--- a/Lib/test/test_htmlparser.py
+++ b/Lib/test/test_htmlparser.py
@@ -116,6 +116,11 @@ class TestCaseBase(unittest.TestCase):
                    *, collector=None, convert_charrefs=False):
         if collector is None:
             collector = self.get_collector(convert_charrefs=convert_charrefs)
+            if isinstance(source, str):
+                # Also feed the whole string at once, not just character by
+                # character (below), to exercise different input buffering.
+                self._run_check([source], expected_events,
+                                convert_charrefs=convert_charrefs)
         parser = collector
         for s in source:
             parser.feed(s)
@@ -593,6 +598,9 @@ text
                 '<!-- <!-- nested --> -->'
                 '<!--<!-->'
                 '<!--<!--!>'
+                # abruptly closed empty comment must not swallow later text
+                '<!-->x-->'
+                '<!--->y-->'
         )
         expected = [('comment', " I'm a valid comment "),
                     ('comment', 'me too!'),
@@ -613,6 +621,8 @@ text
                     ('comment', ' <!-- nested '), ('data', ' -->'),
                     ('comment', '<!'),
                     ('comment', '<!'),
+                    ('comment', ''), ('data', 'x-->'),
+                    ('comment', ''), ('data', 'y-->'),
         ]
         self._run_check(html, expected)
 

--- a/Misc/NEWS.d/next/Library/2026-07-04-13-00-00.gh-issue-135661.CIkADG.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-04-13-00-00.gh-issue-135661.CIkADG.rst
@@ -1,0 +1,3 @@
+Fix :class:`html.parser.HTMLParser`: an abruptly closed empty comment
+(``<!-->`` or ``<!--->``) no longer extends up to a later ``-->`` in the same
+:meth:`~html.parser.HTMLParser.feed` call.


### PR DESCRIPTION
An abruptly closed empty comment (`<!-->` or `<!--->`) no longer extends up to a later `-->` in the same `feed()` call.

`commentabruptclose` is now matched before searching for the normal `-->`/`--!>` close, so the empty comment does not swallow the following markup.
This only showed up when the whole construct arrived in a single `feed()` call, so `test_htmlparser` now also feeds each string source as a single chunk, in addition to one character at a time.

<!-- gh-issue-number: gh-135661 -->
* Issue: gh-135661
<!-- /gh-issue-number -->