### PR TITLE
[3.14] gh-150641: Fix evaluating forward references in STRING format can 'leak' internal names (GH-150648)

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7446,6 +7446,18 @@ class EvaluateForwardRefTests(BaseTestCase):
         typing.evaluate_forward_ref(
             fwdref_module.fw,)
 
+    def test_evaluate_forward_ref_string_format(self):
+        # Test evaluating forward references in STRING format
+        # does not 'leak' internal names
+        # See https://github.com/python/cpython/issues/150641
+
+        def f(arg: unknown | str | int | list[str] | tuple[int, ...]): ...
+
+        ref = annotationlib.get_annotations(f, format=annotationlib.Format.FORWARDREF)['arg']
+        self.assertEqual(
+            typing.evaluate_forward_ref(ref, format=annotationlib.Format.STRING),
+            "unknown | str | int | list[str] | tuple[int, ...]",
+        )
 
 class CollectionsAbcTests(BaseTestCase):
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -991,7 +991,7 @@ def evaluate_forward_ref(
 
     """
     if format == _lazy_annotationlib.Format.STRING:
-        return forward_ref.__forward_arg__
+        return forward_ref.__resolved_str__
     if forward_ref.__forward_arg__ in _recursive_guard:
         return forward_ref
 

--- a/Misc/NEWS.d/next/Library/2026-05-31-14-39-25.gh-issue-150641.LLIhd1.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-31-14-39-25.gh-issue-150641.LLIhd1.rst
@@ -1,0 +1,2 @@
+Fix bug where :func:`typing.evaluate_forward_ref` with the ``STRING`` format
+could leak internal names used by the annotation machinery.


### PR DESCRIPTION
(cherry picked from commit f75028f7ceebee4cbeb46bf040834e2005d57436)

Co-authored-by: Ivy Xu [fakeshadow1337@gmail.com](mailto:fakeshadow1337@gmail.com)
Co-authored-by: Jelle Zijlstra [jelle.zijlstra@gmail.com](mailto:jelle.zijlstra@gmail.com)

<!-- gh-issue-number: gh-150641 -->
* Issue: gh-150641
<!-- /gh-issue-number -->
