### PR TITLE
gh-59598: Strip leading whitespace in JSONDecoder.raw_decode

### DIFF
--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -370,6 +370,8 @@ class JSONDecoder(object):
         have extraneous data at the end.
 
         """
+        s = s.lstrip()
+
         try:
             obj, end = self.scan_once(s, idx)
         except StopIteration as err:


### PR DESCRIPTION
## Summary

Fixes #59598

`JSONDecoder.raw_decode()` raises `JSONDecodeError` on strings with leading whitespace (e.g., `'  {"key": "value"}'`), while `JSONDecoder.decode()` handles it fine. This is inconsistent behavior.

## Changes

Add `s = s.lstrip()` at the start of `raw_decode()` to strip leading whitespace before decoding, matching the behavior of `decode()`.

## Test

```python
import json
decoder = json.JSONDecoder()
# Should work with leading whitespace
result = decoder.raw_decode('  {"key": "value"}')
assert result == ({"key": "value"}, 18)
```

This matches the behavior of `decoder.decode('  {"key": "value"}')` which already works correctly.

<!-- gh-issue-number: gh-59598 -->
* Issue: gh-59598
<!-- /gh-issue-number -->
