### PR TITLE
gh-152433: Windows: use ``CreateFile2`` on Windows UWP build

### DIFF
--- a/Include/internal/pycore_fileutils_windows.h
+++ b/Include/internal/pycore_fileutils_windows.h
@@ -93,6 +93,58 @@ static inline BOOL _Py_GetFileInformationByName_ErrorIsTrustworthy(int error)
     return FALSE;
 }
 
+// Convert absolute paths to relative paths for paths within the installation path
+static const wchar_t* _Py_AbsolutePath_To_RelativePath(const wchar_t* abs_path)
+{
+    const wchar_t* rel_path = NULL;
+    wchar_t process_path[512] = { 0 };
+    if (GetModuleFileNameW(NULL, process_path, 512))
+    {
+        wchar_t* path = wcsrchr(process_path, L'\\');
+        path[1] = L'\0'; // strip process name
+        if (wcsstr(abs_path, process_path))
+            rel_path = &abs_path[wcslen(process_path)];
+    }
+    return rel_path;
+}
+
+static inline HANDLE _Py_WinCreateFile(
+    _In_ LPCWSTR lpFileName,
+    _In_ DWORD dwDesiredAccess,
+    _In_ DWORD dwShareMode,
+    _In_opt_ LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+    _In_ DWORD dwCreationDisposition,
+    _In_ DWORD dwFlagsAndAttributes,
+    _In_opt_ HANDLE hTemplateFile
+)
+{
+#ifndef MS_WINDOWS_DESKTOP
+    if (dwShareMode == 0)
+        dwShareMode = FILE_SHARE_READ;
+
+    CREATEFILE2_EXTENDED_PARAMETERS ext;
+    ZeroMemory(&ext, sizeof(CREATEFILE2_EXTENDED_PARAMETERS));
+    ext.dwSize = sizeof(CREATEFILE2_EXTENDED_PARAMETERS);
+    ext.dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
+    ext.dwFileFlags = dwFlagsAndAttributes & 0xFFFF0000;
+
+    // UWP does not allow absolute paths due security restrictions and only has access to 'AppData'
+    // folder outside of the install path.
+    // If path is contained inside install path (sub folder), use the relative path instead.
+    if (wcschr(lpFileName, L':')) {
+        const wchar_t* rel_path = _Py_AbsolutePath_To_RelativePath(lpFileName);
+        if (rel_path) {
+            return CreateFile2(rel_path, dwDesiredAccess, dwShareMode, dwCreationDisposition, &ext);
+        }
+    }
+
+    return CreateFile2(lpFileName, dwDesiredAccess, dwShareMode, dwCreationDisposition, &ext);
+#else
+    return CreateFileW(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes,
+                       dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+#endif
+}
+
 #endif
 
 #endif

--- a/Misc/NEWS.d/next/Windows/2026-07-04-13-33-04.gh-issue-152433.0EUfvN.rst
+++ b/Misc/NEWS.d/next/Windows/2026-07-04-13-33-04.gh-issue-152433.0EUfvN.rst
@@ -1,0 +1,1 @@
+Use ``CreateFile2`` on Windows UWP build.

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 
 #include "_iomodule.h"
+#include "internal/pycore_fileutils_windows.h"
 
 /* BUFSIZ determines how many characters can be typed at the console
    before it starts blocking. */
@@ -435,10 +436,10 @@ _io__WindowsConsoleIO___init___impl(winconsoleio *self, PyObject *nameobj,
            on the specific access. This is required for modern names
            CONIN$ and CONOUT$, which allow reading/writing state as
            well as reading/writing content. */
-        handle = CreateFileW(name, GENERIC_READ | GENERIC_WRITE,
+        handle = _Py_WinCreateFile(name, GENERIC_READ | GENERIC_WRITE,
             FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
         if (handle == INVALID_HANDLE_VALUE)
-            handle = CreateFileW(name, access,
+            handle = _Py_WinCreateFile(name, access,
                 FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
         Py_END_ALLOW_THREADS
 

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -48,6 +48,7 @@
 #include <winioctl.h>
 #include <crtdbg.h>
 #include "winreparse.h"
+#include "internal/pycore_fileutils_windows.h"
 
 // PSAPI_VERSION=2 redirects GetProcessMemoryInfo() to
 // K32GetProcessMemoryInfo() in kernel32.dll, so we don't need to link
@@ -546,7 +547,7 @@ _winapi_CreateFile_impl(PyObject *module, LPCWSTR file_name,
     }
 
     Py_BEGIN_ALLOW_THREADS
-    handle = CreateFileW(file_name, desired_access,
+    handle = _Py_WinCreateFile(file_name, desired_access,
                          share_mode, security_attributes,
                          creation_disposition,
                          flags_and_attributes, template_file);
@@ -721,7 +722,7 @@ _winapi_CreateJunction_impl(PyObject *module, LPCWSTR src_path,
     if (!CreateDirectoryW(dst_path, NULL))
         goto cleanup;
 
-    junction = CreateFileW(dst_path, GENERIC_READ | GENERIC_WRITE, 0, NULL,
+    junction = _Py_WinCreateFile(dst_path, GENERIC_READ | GENERIC_WRITE, 0, NULL,
         OPEN_EXISTING,
         FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
     if (junction == INVALID_HANDLE_VALUE)

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -14,6 +14,7 @@
 #ifdef MS_WINDOWS
 #  include <windows.h>            // GetFullPathNameW(), MAX_PATH
 #  include <pathcch.h>
+#  include "internal/pycore_fileutils_windows.h"
 #endif
 
 #ifdef __APPLE__
@@ -527,7 +528,7 @@ done:
     }
 
     Py_BEGIN_ALLOW_THREADS
-    hFile = CreateFileW(path, 0, 0, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    hFile = _Py_WinCreateFile(path, 0, 0, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
     if (hFile != INVALID_HANDLE_VALUE) {
         len = GetFinalPathNameByHandleW(hFile, resolved, MAXPATHLEN, VOLUME_NAME_DOS);
         err = len ? 0 : GetLastError();

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -14,7 +14,11 @@
 #include "Python.h"
 #include "pycore_tuple.h"           // _PyTuple_FromPairSteal
 
-#define WINDOWS_LEAN_AND_MEAN
+#ifdef MS_WINDOWS
+#  define WINDOWS_LEAN_AND_MEAN
+#  include "internal/pycore_fileutils_windows.h"
+#endif
+
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <mswsock.h>
@@ -1635,7 +1639,7 @@ _overlapped_Overlapped_ConnectPipe_impl(OverlappedObject *self,
     HANDLE PipeHandle;
 
     Py_BEGIN_ALLOW_THREADS
-    PipeHandle = CreateFileW(Address,
+    PipeHandle = _Py_WinCreateFile(Address,
                              GENERIC_READ | GENERIC_WRITE,
                              0, NULL, OPEN_EXISTING,
                              FILE_FLAG_OVERLAPPED, NULL);

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2124,7 +2124,7 @@ win32_xstat_slow_impl(const wchar_t *path, struct _Py_stat_struct *result,
         flags |= FILE_FLAG_OPEN_REPARSE_POINT;
     }
 
-    hFile = CreateFileW(path, access, 0, NULL, OPEN_EXISTING, flags, NULL);
+    hFile = _Py_WinCreateFile(path, access, 0, NULL, OPEN_EXISTING, flags, NULL);
     if (hFile == INVALID_HANDLE_VALUE) {
         /* Either the path doesn't exist, or the caller lacks access. */
         error = GetLastError();
@@ -2159,7 +2159,7 @@ win32_xstat_slow_impl(const wchar_t *path, struct _Py_stat_struct *result,
 
         case ERROR_INVALID_PARAMETER:
             /* \\.\con requires read or write access. */
-            hFile = CreateFileW(path, access | GENERIC_READ,
+            hFile = _Py_WinCreateFile(path, access | GENERIC_READ,
                         FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
                         OPEN_EXISTING, flags, NULL);
             if (hFile == INVALID_HANDLE_VALUE) {
@@ -2173,7 +2173,7 @@ win32_xstat_slow_impl(const wchar_t *path, struct _Py_stat_struct *result,
             if (traverse) {
                 traverse = FALSE;
                 isUnhandledTag = TRUE;
-                hFile = CreateFileW(path, access, 0, NULL, OPEN_EXISTING,
+                hFile = _Py_WinCreateFile(path, access, 0, NULL, OPEN_EXISTING,
                             flags | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
             }
             if (hFile == INVALID_HANDLE_VALUE) {
@@ -4107,7 +4107,7 @@ os_chmod_impl(PyObject *module, path_t *path, int mode, int dir_fd,
         result = win32_fchmod(path->fd, mode);
     }
     else if (follow_symlinks) {
-        HANDLE hfile = CreateFileW(path->wide,
+        HANDLE hfile = _Py_WinCreateFile(path->wide,
                                    FILE_READ_ATTRIBUTES|FILE_WRITE_ATTRIBUTES,
                                    0, NULL,
                                    OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
@@ -5384,7 +5384,7 @@ os__path_isdevdrive_impl(PyObject *module, path_t *path)
         /* only care about local dev drives */
         r = Py_False;
     } else {
-        HANDLE hVolume = CreateFileW(
+        HANDLE hVolume = _Py_WinCreateFile(
             volume,
             FILE_READ_ATTRIBUTES,
             FILE_SHARE_READ | FILE_SHARE_WRITE,
@@ -5532,7 +5532,7 @@ os__getfinalpathname_impl(PyObject *module, path_t *path)
     PyObject *result;
 
     Py_BEGIN_ALLOW_THREADS
-    hFile = CreateFileW(
+    hFile = _Py_WinCreateFile(
         path->wide,
         0, /* desired access */
         0, /* share mode */
@@ -5807,7 +5807,7 @@ _testFileTypeByName(LPCWSTR path, int testedType)
     if (testedType != PY_IFREG && testedType != PY_IFDIR) {
         flags |= FILE_FLAG_OPEN_REPARSE_POINT;
     }
-    HANDLE hfile = CreateFileW(path, FILE_READ_ATTRIBUTES, 0, NULL,
+    HANDLE hfile = _Py_WinCreateFile(path, FILE_READ_ATTRIBUTES, 0, NULL,
                                OPEN_EXISTING, flags, NULL);
     if (hfile != INVALID_HANDLE_VALUE) {
         BOOL result = _testFileTypeByHandle(hfile, testedType, FALSE);
@@ -5863,7 +5863,7 @@ _testFileExistsByName(LPCWSTR path, BOOL followLinks)
     if (!followLinks) {
         flags |= FILE_FLAG_OPEN_REPARSE_POINT;
     }
-    HANDLE hfile = CreateFileW(path, FILE_READ_ATTRIBUTES, 0, NULL,
+    HANDLE hfile = _Py_WinCreateFile(path, FILE_READ_ATTRIBUTES, 0, NULL,
                                OPEN_EXISTING, flags, NULL);
     if (hfile != INVALID_HANDLE_VALUE) {
         if (followLinks) {
@@ -5876,7 +5876,7 @@ _testFileExistsByName(LPCWSTR path, BOOL followLinks)
         if (!result) {
             return TRUE;
         }
-        hfile = CreateFileW(path, FILE_READ_ATTRIBUTES, 0, NULL, OPEN_EXISTING,
+        hfile = _Py_WinCreateFile(path, FILE_READ_ATTRIBUTES, 0, NULL, OPEN_EXISTING,
                             FILE_FLAG_BACKUP_SEMANTICS, NULL);
         if (hfile != INVALID_HANDLE_VALUE) {
             CloseHandle(hfile);
@@ -7172,7 +7172,7 @@ os_utime_impl(PyObject *module, path_t *path, PyObject *times, PyObject *ns,
 
 #ifdef MS_WINDOWS
     Py_BEGIN_ALLOW_THREADS
-    hFile = CreateFileW(path->wide, FILE_WRITE_ATTRIBUTES, 0,
+    hFile = _Py_WinCreateFile(path->wide, FILE_WRITE_ATTRIBUTES, 0,
                         NULL, OPEN_EXISTING,
                         FILE_FLAG_BACKUP_SEMANTICS, NULL);
     Py_END_ALLOW_THREADS
@@ -10954,7 +10954,7 @@ os_readlink_impl(PyObject *module, path_t *path, int dir_fd)
 
     /* First get a handle to the reparse point */
     Py_BEGIN_ALLOW_THREADS
-    reparse_point_handle = CreateFileW(
+    reparse_point_handle = _Py_WinCreateFile(
         path->wide,
         0,
         0,


### PR DESCRIPTION
Windows: use ``CreateFile2`` on Windows UWP build.

UWP does not support ``CreateFileW`` because it is only compatible with the Win32 desktop API.

`CreateFile2` is available in all supported Windows versions (it could be used for everything) but for now created a wrapper to use only in UWP and avoid side effects or unexpected behavior changes on regular Windows builds. 

UWP also needs convert absolute paths to relative paths due the security restrictions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152433 -->
* Issue: gh-152433
<!-- /gh-issue-number -->
