### PR TITLE
gh-153027: Make CDATA section parsing in HTMLParser context-dependent

### DIFF
--- a/Doc/library/html.parser.rst
+++ b/Doc/library/html.parser.rst
@@ -15,7 +15,8 @@
 This module defines a class :class:`HTMLParser` which serves as the basis for
 parsing text files formatted in HTML (HyperText Mark-up Language) and XHTML.
 
-.. class:: HTMLParser(*, convert_charrefs=True, scripting=False)
+.. class:: HTMLParser(*, convert_charrefs=True, scripting=False, \
+                      support_cdata=None)
 
    Create a parser instance able to parse invalid markup.
 
@@ -26,6 +27,21 @@ parsing text files formatted in HTML (HyperText Mark-up Language) and XHTML.
    If *scripting* is false (the default), the content of the ``noscript``
    element is parsed normally; if it's true, it's returned as is without
    being parsed.
+
+   If *support_cdata* is ``None`` (the default),
+   a CDATA section ``<![CDATA[...]]>`` is only recognized in foreign content
+   (the content of ``svg`` and ``math`` elements,
+   which the parser detects by following start and end tags);
+   in HTML content it is parsed as a bogus comment
+   which ends at the first ``>``.
+   RAWTEXT and RCDATA elements
+   (such as ``script``, ``style``, ``title`` or ``textarea``)
+   are only special in HTML content;
+   in foreign content they are parsed as normal elements.
+   If *support_cdata* is true, a CDATA section is recognized in any context
+   (the previous default behavior);
+   if it's false -- in no context.
+   In both cases foreign content is not detected.
 
    An :class:`.HTMLParser` instance is fed HTML data and calls handler methods
    when start tags, end tags, text, comments, and other markup elements are
@@ -43,6 +59,13 @@ parsing text files formatted in HTML (HyperText Mark-up Language) and XHTML.
 
    .. versionchanged:: 3.14.1
       Added the *scripting* parameter.
+
+   .. versionchanged:: next
+      Added the *support_cdata* parameter.
+      By default, CDATA sections are now only recognized in foreign content,
+      and RAWTEXT and RCDATA elements in foreign content
+      are parsed as normal elements.
+      Pass ``support_cdata=True`` to restore the previous behavior.
 
 
 Example HTML Parser Application
@@ -226,11 +249,17 @@ implementations do nothing (except for :meth:`~HTMLParser.handle_startendtag`):
 
 .. method:: HTMLParser.unknown_decl(data)
 
-   This method is called when an unrecognized declaration is read by the parser.
+   This method is called when an unrecognized declaration is read by the
+   parser, and for a CDATA section ``<![CDATA[...]]>`` in foreign content
+   (the *data* parameter will be ``'CDATA[...'`` in this case).
 
    The *data* parameter will be the entire contents of the declaration inside
    the ``<![...]>`` markup.  It is sometimes useful to be overridden by a
    derived class.  The base class implementation does nothing.
+
+   .. versionchanged:: next
+      This method is no longer called for a CDATA section in HTML content;
+      :meth:`~HTMLParser.handle_comment` is called for it instead.
 
 
 .. _htmlparser-examples:

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -578,6 +578,21 @@ Porting to Python 3.16
 This section lists previously described changes and other bugfixes
 that may require changes to your code.
 
+* :class:`html.parser.HTMLParser` now handles CDATA sections and RAWTEXT
+  and RCDATA elements depending on the foreign content context by
+  default, in accordance with the HTML5 standard.
+  In HTML content, ``<![CDATA[...]]>`` is now parsed as a bogus comment
+  which ends at the first ``>`` and is passed to
+  :meth:`~html.parser.HTMLParser.handle_comment` instead of
+  :meth:`~html.parser.HTMLParser.unknown_decl`.
+  In the content of ``svg`` and ``math`` elements, RAWTEXT and RCDATA
+  elements (such as ``script``, ``style``, ``title`` or ``textarea``)
+  are now parsed as normal elements.
+  Pass ``support_cdata=True`` to the constructor to restore the previous
+  behavior for XML-like input (CDATA sections recognized in any context),
+  or ``support_cdata=False`` to never recognize CDATA sections.
+  (Contributed by Serhiy Storchaka in :gh:`135661`.)
+
 * In :mod:`tkinter`, the *name* parameter of the
   :meth:`~tkinter.Misc.wait_variable`, :meth:`~tkinter.Misc.setvar` and
   :meth:`~tkinter.Misc.getvar` methods and the *value* parameter of

--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -88,6 +88,51 @@ locatestarttagend_tolerant = re.compile(r"""
 endendtag = re.compile('>')
 endtagfind = re.compile(r'</\s*([a-zA-Z][-.a-zA-Z0-9:_]*)\s*>')
 
+# The following tables are used for tracking foreign content (the content
+# of "svg" and "math" elements).
+# See the HTML5 specs section "13.2.6.5 The rules for parsing tokens in
+# foreign content".
+# https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign
+
+# Start tags (and end tags "br" and "p") which break out of foreign content.
+_BREAKOUT_ELEMENTS = frozenset({
+    'b', 'big', 'blockquote', 'body', 'br', 'center', 'code', 'dd', 'div',
+    'dl', 'dt', 'em', 'embed', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head',
+    'hr', 'i', 'img', 'li', 'listing', 'menu', 'meta', 'nobr', 'ol', 'p',
+    'pre', 'ruby', 's', 'small', 'span', 'strong', 'strike', 'sub', 'sup',
+    'table', 'tt', 'u', 'ul', 'var'})
+# HTML elements which are immediately popped from the stack of open elements.
+_VOID_ELEMENTS = frozenset({
+    'area', 'base', 'basefont', 'bgsound', 'br', 'col', 'embed', 'frame',
+    'hr', 'img', 'input', 'keygen', 'link', 'meta', 'param', 'source',
+    'track', 'wbr'})
+# Elements in the "special" category, which stop the search for a matching
+# end tag in HTML content.
+# https://html.spec.whatwg.org/multipage/parsing.html#special
+_SPECIAL_ELEMENTS = {
+    'html': frozenset({
+        'address', 'applet', 'area', 'article', 'aside', 'base', 'basefont',
+        'bgsound', 'blockquote', 'body', 'br', 'button', 'caption', 'center',
+        'col', 'colgroup', 'dd', 'details', 'dir', 'div', 'dl', 'dt',
+        'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form',
+        'frame', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head',
+        'header', 'hgroup', 'hr', 'html', 'iframe', 'img', 'input', 'keygen',
+        'li', 'link', 'listing', 'main', 'marquee', 'menu', 'meta', 'nav',
+        'noembed', 'noframes', 'noscript', 'object', 'ol', 'p', 'param',
+        'plaintext', 'pre', 'script', 'search', 'section', 'select',
+        'source', 'style', 'summary', 'table', 'tbody', 'td', 'template',
+        'textarea', 'tfoot', 'th', 'thead', 'title', 'tr', 'track', 'ul',
+        'wbr', 'xmp'}),
+    'math': frozenset({'mi', 'mo', 'mn', 'ms', 'mtext', 'annotation-xml'}),
+    'svg': frozenset({'foreignobject', 'desc', 'title'}),
+}
+# https://html.spec.whatwg.org/multipage/parsing.html#mathml-text-integration-point
+_MATHML_TEXT_INTEGRATION_POINTS = frozenset({'mi', 'mo', 'mn', 'ms', 'mtext'})
+# SVG elements which are HTML integration points.  A MathML annotation-xml
+# element is an HTML integration point depending on its "encoding" attribute.
+# https://html.spec.whatwg.org/multipage/parsing.html#html-integration-point
+_SVG_HTML_INTEGRATION_POINTS = frozenset({'foreignobject', 'desc', 'title'})
+
 # Character reference processing logic specific to attribute values
 # See: https://html.spec.whatwg.org/multipage/parsing.html#named-character-reference-state
 def _replace_attr_charref(match):
@@ -134,7 +179,8 @@ class HTMLParser(_markupbase.ParserBase):
     CDATA_CONTENT_ELEMENTS = ("script", "style", "xmp", "iframe", "noembed", "noframes")
     RCDATA_CONTENT_ELEMENTS = ("textarea", "title")
 
-    def __init__(self, *, convert_charrefs=True, scripting=False):
+    def __init__(self, *, convert_charrefs=True, scripting=False,
+                 support_cdata=None):
         """Initialize and reset this instance.
 
         If convert_charrefs is true (the default), all character references
@@ -143,10 +189,19 @@ class HTMLParser(_markupbase.ParserBase):
         If *scripting* is false (the default), the content of the
         ``noscript`` element is parsed normally; if it's true,
         it's returned as is without being parsed.
+
+        If *support_cdata* is None (the default), a CDATA section
+        "<![CDATA[...]]>" is only recognized in foreign content (the
+        content of "svg" and "math" elements), where RAWTEXT and RCDATA
+        elements (such as "script" or "title") are also parsed as normal
+        elements.  If *support_cdata* is true, a CDATA section is
+        recognized in any context; if it's false -- in no context.  In
+        both cases foreign content is not detected.
         """
         super().__init__()
         self.convert_charrefs = convert_charrefs
         self.scripting = scripting
+        self.support_cdata = support_cdata
         self.reset()
 
     def reset(self):
@@ -155,7 +210,8 @@ class HTMLParser(_markupbase.ParserBase):
         self.lasttag = '???'
         self.interesting = interesting_normal
         self.cdata_elem = None
-        self._support_cdata = True
+        self._open_elements = []
+        self._support_cdata = bool(self.support_cdata)
         self._escapable = True
         super().reset()
 
@@ -197,16 +253,129 @@ class HTMLParser(_markupbase.ParserBase):
 
     def _set_support_cdata(self, flag=True):
         """Enable or disable support of the CDATA sections.
-        If enabled, "<[CDATA[" starts a CDATA section which ends with "]]>".
-        If disabled, "<[CDATA[" starts a bogus comments which ends with ">".
+        If enabled, "<![CDATA[" starts a CDATA section which ends with "]]>".
+        If disabled, "<![CDATA[" starts a bogus comment which ends with ">".
 
-        This method is not called by default. Its purpose is to be called
-        in custom handle_starttag() and handle_endtag() methods, with
-        value that depends on the adjusted current node.
+        Calling this method disables automatic detection of foreign
+        content, as if the parser was created with support_cdata=flag.
+        It can be called in custom handle_starttag() and handle_endtag()
+        methods, with value that depends on the adjusted current node.
         See https://html.spec.whatwg.org/multipage/parsing.html#markup-declaration-open-state
         for details.
         """
-        self._support_cdata = flag
+        self.support_cdata = bool(flag)
+        self._open_elements = []
+        self._support_cdata = bool(flag)
+
+    # Internal -- update the stack of open elements for a start tag and
+    # return whether it was processed by the rules for HTML content.
+    # The stack contains (namespace, name, html_integration_point) triples
+    # and only tracks foreign elements and their descendants.
+    # This approximates the tree construction dispatcher and the rules for
+    # parsing tokens in foreign content.
+    # https://html.spec.whatwg.org/multipage/parsing.html#tree-construction-dispatcher
+    # https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign
+    def _handle_starttag_context(self, tag, attrs, selfclosing):
+        stack = self._open_elements
+        if self._dispatch_html(tag):
+            if tag in ('svg', 'math'):
+                if not selfclosing:
+                    stack.append((tag, tag, False))
+            elif stack and not selfclosing and tag not in _VOID_ELEMENTS:
+                stack.append(('html', tag, False))
+            html = True
+        elif (tag in _BREAKOUT_ELEMENTS or
+              (tag == 'font' and
+               any(name in ('color', 'face', 'size') for name, _ in attrs))):
+            self._exit_foreign_content()
+            # Reprocess following the rules for HTML content.
+            if stack and not selfclosing and tag not in _VOID_ELEMENTS:
+                stack.append(('html', tag, False))
+            html = True
+        else:
+            ns = stack[-1][0]
+            if not selfclosing:
+                if ns == 'svg':
+                    html_ip = tag in _SVG_HTML_INTEGRATION_POINTS
+                    if tag == 'foreignobject':
+                        # The adjusted element name does not match
+                        # the lowercased end tag name in HTML content.
+                        tag = 'foreignObject'
+                else:
+                    html_ip = (tag == 'annotation-xml' and
+                               self._get_attr(attrs, 'encoding', '').lower()
+                               in ('text/html', 'application/xhtml+xml'))
+                stack.append((ns, tag, html_ip))
+            html = False
+        self._support_cdata = bool(stack) and stack[-1][0] != 'html'
+        return html
+
+    # Internal -- return whether a start tag is processed by the rules
+    # for HTML content.
+    def _dispatch_html(self, tag):
+        stack = self._open_elements
+        if not stack:
+            return True
+        ns, name, html_ip = stack[-1]
+        return (ns == 'html' or
+                html_ip or
+                (ns == 'math' and name in _MATHML_TEXT_INTEGRATION_POINTS and
+                 tag not in ('mglyph', 'malignmark')) or
+                (ns == 'math' and name == 'annotation-xml' and tag == 'svg'))
+
+    @staticmethod
+    def _get_attr(attrs, name, default=None):
+        for attrname, attrvalue in attrs:
+            if attrname == name:
+                return attrvalue if attrvalue is not None else default
+        return default
+
+    # Internal -- pop foreign elements from the stack of open elements
+    # until the current node is a MathML text integration point, an HTML
+    # integration point, or an element in HTML content.
+    def _exit_foreign_content(self):
+        stack = self._open_elements
+        while stack:
+            ns, name, html_ip = stack[-1]
+            if (ns == 'html' or html_ip or
+                (ns == 'math' and name in _MATHML_TEXT_INTEGRATION_POINTS)):
+                break
+            stack.pop()
+
+    # Internal -- update the stack of open elements for an end tag.
+    def _handle_endtag_context(self, tag):
+        stack = self._open_elements
+        if stack:
+            if stack[-1][0] == 'html':
+                self._pop_matching_element(tag)
+            elif tag in ('br', 'p'):
+                # An end tag "br" or "p" breaks out of foreign content.
+                self._exit_foreign_content()
+            else:
+                # The rules for parsing an end tag in foreign content.
+                for i in reversed(range(len(stack))):
+                    ns, name, html_ip = stack[i]
+                    if ns == 'html':
+                        self._pop_matching_element(tag)
+                        break
+                    if name is not None and name.lower() == tag:
+                        del stack[i:]
+                        break
+        self._support_cdata = bool(stack) and stack[-1][0] != 'html'
+
+    # Internal -- pop the matching element and all elements above it from
+    # the stack of open elements.  The search stops at a "special" element.
+    # This approximates "any other end tag" in the "in body" insertion mode.
+    # https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody
+    def _pop_matching_element(self, tag):
+        stack = self._open_elements
+        for i in reversed(range(len(stack))):
+            ns, name, html_ip = stack[i]
+            if name == tag:
+                del stack[i:]
+                break
+            if name is not None and name.lower() in _SPECIAL_ELEMENTS[ns]:
+                break
 
     # Internal -- handle data as far as reasonable.  May leave state
     # and data to be processed by a subsequent call.  If 'end' is
@@ -460,17 +629,24 @@ class HTMLParser(_markupbase.ParserBase):
         if end not in (">", "/>"):
             self.handle_data(rawdata[i:endpos])
             return endpos
+        if (self.support_cdata is None and
+                (self._open_elements or tag in ('svg', 'math'))):
+            html = self._handle_starttag_context(tag, attrs, end == "/>")
+        else:
+            html = True
         if end.endswith('/>'):
             # XHTML-style empty tag: <span attr="value" />
             self.handle_startendtag(tag, attrs)
         else:
             self.handle_starttag(tag, attrs)
-            if (tag in self.CDATA_CONTENT_ELEMENTS or
-                (self.scripting and tag == "noscript") or
-                tag == "plaintext"):
-                self.set_cdata_mode(tag, escapable=False)
-            elif tag in self.RCDATA_CONTENT_ELEMENTS:
-                self.set_cdata_mode(tag, escapable=True)
+            # In foreign content these elements are not special.
+            if html:
+                if (tag in self.CDATA_CONTENT_ELEMENTS or
+                    (self.scripting and tag == "noscript") or
+                    tag == "plaintext"):
+                    self.set_cdata_mode(tag, escapable=False)
+                elif tag in self.RCDATA_CONTENT_ELEMENTS:
+                    self.set_cdata_mode(tag, escapable=True)
         return endpos
 
     # Internal -- check to see if we have a complete starttag; return end
@@ -510,6 +686,8 @@ class HTMLParser(_markupbase.ParserBase):
         match = tagfind_tolerant.match(rawdata, i+2)
         assert match
         tag = match.group(1).lower()
+        if self.support_cdata is None and self._open_elements:
+            self._handle_endtag_context(tag)
         self.handle_endtag(tag)
         self.clear_cdata_mode()
         return j

--- a/Lib/test/test_htmlparser.py
+++ b/Lib/test/test_htmlparser.py
@@ -22,13 +22,10 @@ SAMPLE_RAWTEXT = SAMPLE_RCDATA + '&amp;&#9786;'
 
 class EventCollector(html.parser.HTMLParser):
 
-    def __init__(self, *args, autocdata=False, **kw):
-        self.autocdata = autocdata
+    def __init__(self, *args, **kw):
         self.events = []
         self.append = self.events.append
         html.parser.HTMLParser.__init__(self, *args, **kw)
-        if autocdata:
-            self._set_support_cdata(False)
 
     def get_events(self):
         # Normalize the list of events so that buffer artefacts don't
@@ -49,16 +46,12 @@ class EventCollector(html.parser.HTMLParser):
 
     def handle_starttag(self, tag, attrs):
         self.append(("starttag", tag, attrs))
-        if self.autocdata and tag == 'svg':
-            self._set_support_cdata(True)
 
     def handle_startendtag(self, tag, attrs):
         self.append(("startendtag", tag, attrs))
 
     def handle_endtag(self, tag):
         self.append(("endtag", tag))
-        if self.autocdata and tag == 'svg':
-            self._set_support_cdata(False)
 
     # all other markup
 
@@ -441,7 +434,7 @@ text
             ('starttag', 'noscript', []),
             ('comment', ' not a comment '),
             ('starttag', 'not', [('a', 'start tag')]),
-            ('unknown decl', 'CDATA[not a cdata'),
+            ('comment', '[CDATA[not a cdata]]'),
             ('comment', 'not a bogus comment'),
             ('endtag', 'not'),
             ('data', '☃'),
@@ -890,10 +883,10 @@ text
     @support.subTests('content', ['', 'x', 'x]', 'x]]'])
     def test_eof_in_cdata(self, content):
         self._run_check('<![CDATA[' + content,
-                        [('unknown decl', 'CDATA[' + content)])
+                        [('comment', '[CDATA[' + content)])
         self._run_check('<![CDATA[' + content,
-                        [('comment', '[CDATA[' + content)],
-                        collector=EventCollector(autocdata=True))
+                        [('unknown decl', 'CDATA[' + content)],
+                        collector=EventCollector(support_cdata=True))
         self._run_check('<svg><text y="100"><![CDATA[' + content,
                         [('starttag', 'svg', []),
                          ('starttag', 'text', [('y', '100')]),
@@ -989,7 +982,6 @@ text
             ('endtag', 'svg'),
         ]
         self._run_check(html, expected)
-        self._run_check(html, expected, collector=EventCollector(autocdata=True))
 
     def test_cdata_section(self):
         # See "13.2.5.42 Markup declaration open state".
@@ -1007,7 +999,317 @@ text
             ('comment', '[CDATA[foo<br'),
             ('data', 'bar]]>'),
         ]
-        self._run_check(html, expected, collector=EventCollector(autocdata=True))
+        self._run_check(html, expected)
+
+    def test_cdata_in_foreign_content(self):
+        # A CDATA section is only recognized if the adjusted current node
+        # is not an element in the HTML namespace.
+        # See "13.2.5.42 Markup declaration open state".
+        for html, expected in [
+            ('<svg><![CDATA[x]]></svg>',
+             [('starttag', 'svg', []),
+              ('unknown decl', 'CDATA[x'),
+              ('endtag', 'svg')]),
+            ('<math><![CDATA[x]]></math>',
+             [('starttag', 'math', []),
+              ('unknown decl', 'CDATA[x'),
+              ('endtag', 'math')]),
+            # nested foreign elements
+            ('<svg><g><circle><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'g', []),
+              ('starttag', 'circle', []),
+              ('unknown decl', 'CDATA[x')]),
+            # after the foreign element is closed
+            ('<svg></svg><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('endtag', 'svg'),
+              ('comment', '[CDATA[x]]')]),
+            # a self-closing foreign element is immediately popped
+            ('<svg/><![CDATA[x]]>',
+             [('startendtag', 'svg', []),
+              ('comment', '[CDATA[x]]')]),
+            ('<svg><circle/><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('startendtag', 'circle', []),
+              ('unknown decl', 'CDATA[x')]),
+        ]:
+            with self.subTest(html=html):
+                self._run_check(html, expected)
+
+    def test_cdata_at_integration_points(self):
+        # HTML integration points and MathML text integration points are
+        # themselves foreign elements, but HTML elements nested in them
+        # switch back to HTML content.
+        for html, expected in [
+            ('<svg><foreignObject><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'foreignobject', []),
+              ('unknown decl', 'CDATA[x')]),
+            ('<svg><foreignObject><div><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'foreignobject', []),
+              ('starttag', 'div', []),
+              ('comment', '[CDATA[x]]')]),
+            ('<svg><foreignObject><div></div><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'foreignobject', []),
+              ('starttag', 'div', []),
+              ('endtag', 'div'),
+              ('unknown decl', 'CDATA[x')]),
+            ('<svg><foreignObject><div><svg><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'foreignobject', []),
+              ('starttag', 'div', []),
+              ('starttag', 'svg', []),
+              ('unknown decl', 'CDATA[x')]),
+            ('<math><mi><![CDATA[x]]>',
+             [('starttag', 'math', []),
+              ('starttag', 'mi', []),
+              ('unknown decl', 'CDATA[x')]),
+            ('<math><mi><span><![CDATA[x]]>',
+             [('starttag', 'math', []),
+              ('starttag', 'mi', []),
+              ('starttag', 'span', []),
+              ('comment', '[CDATA[x]]')]),
+            # "mglyph" and "malignmark" stay foreign at a MathML text
+            # integration point
+            ('<math><mi><mglyph><![CDATA[x]]>',
+             [('starttag', 'math', []),
+              ('starttag', 'mi', []),
+              ('starttag', 'mglyph', []),
+              ('unknown decl', 'CDATA[x')]),
+            # "annotation-xml" is an HTML integration point only with an
+            # HTML "encoding" attribute
+            ('<math><annotation-xml encoding=text/HTML><mrow><![CDATA[x]]>',
+             [('starttag', 'math', []),
+              ('starttag', 'annotation-xml', [('encoding', 'text/HTML')]),
+              ('starttag', 'mrow', []),
+              ('comment', '[CDATA[x]]')]),
+            ('<math><annotation-xml><mrow><![CDATA[x]]>',
+             [('starttag', 'math', []),
+              ('starttag', 'annotation-xml', []),
+              ('starttag', 'mrow', []),
+              ('unknown decl', 'CDATA[x')]),
+            ('<math><annotation-xml><svg><![CDATA[x]]>',
+             [('starttag', 'math', []),
+              ('starttag', 'annotation-xml', []),
+              ('starttag', 'svg', []),
+              ('unknown decl', 'CDATA[x')]),
+        ]:
+            with self.subTest(html=html):
+                self._run_check(html, expected)
+
+    def test_foreign_content_breakout(self):
+        # Most HTML elements break out of foreign content, up to an
+        # integration point.
+        for html, expected in [
+            ('<svg><div><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'div', []),
+              ('comment', '[CDATA[x]]')]),
+            ('<svg><font color=red><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'font', [('color', 'red')]),
+              ('comment', '[CDATA[x]]')]),
+            # "font" without a "color", "face" or "size" attribute is a
+            # foreign element
+            ('<svg><font><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'font', []),
+              ('unknown decl', 'CDATA[x')]),
+            # end tags "br" and "p" break out too
+            ('<svg><g></p><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'g', []),
+              ('endtag', 'p'),
+              ('comment', '[CDATA[x]]')]),
+            ('<svg><foreignObject><svg><div><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'foreignobject', []),
+              ('starttag', 'svg', []),
+              ('starttag', 'div', []),
+              ('comment', '[CDATA[x]]')]),
+        ]:
+            with self.subTest(html=html):
+                self._run_check(html, expected)
+
+    def test_foreign_content_end_tags(self):
+        for html, expected in [
+            # an end tag pops all elements up to the matching one
+            ('<svg><g><circle></svg><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'g', []),
+              ('starttag', 'circle', []),
+              ('endtag', 'svg'),
+              ('comment', '[CDATA[x]]')]),
+            # an unmatched end tag is ignored
+            ('<svg><g></nosuch><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'g', []),
+              ('endtag', 'nosuch'),
+              ('unknown decl', 'CDATA[x')]),
+            # an end tag does not match across an integration point
+            ('<svg><foreignObject><div></svg><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'foreignobject', []),
+              ('starttag', 'div', []),
+              ('endtag', 'svg'),
+              ('comment', '[CDATA[x]]')]),
+            # the element name is adjusted to "foreignObject", so it does
+            # not match an end tag in HTML content
+            ('<svg><foreignObject><div></foreignobject><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'foreignobject', []),
+              ('starttag', 'div', []),
+              ('endtag', 'foreignobject'),
+              ('comment', '[CDATA[x]]')]),
+            # but it does match an end tag in foreign content, where tag
+            # names are compared after conversion to lowercase
+            ('<svg><foreignObject></foreignobject><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'foreignobject', []),
+              ('endtag', 'foreignobject'),
+              ('unknown decl', 'CDATA[x')]),
+        ]:
+            with self.subTest(html=html):
+                self._run_check(html, expected)
+
+    def test_rawtext_in_foreign_content(self):
+        # RAWTEXT and RCDATA elements are only special in HTML content.
+        for html, expected in [
+            ('<svg><title>a<b>c</b></title></svg>',
+             [('starttag', 'svg', []),
+              ('starttag', 'title', []),
+              ('data', 'a'),
+              ('starttag', 'b', []),
+              ('data', 'c'),
+              ('endtag', 'b'),
+              ('endtag', 'title'),
+              ('endtag', 'svg')]),
+            ('<svg><script>a<b>c</b></script></svg>',
+             [('starttag', 'svg', []),
+              ('starttag', 'script', []),
+              ('data', 'a'),
+              ('starttag', 'b', []),
+              ('data', 'c'),
+              ('endtag', 'b'),
+              ('endtag', 'script'),
+              ('endtag', 'svg')]),
+            ('<svg><style>a<b></style>',
+             [('starttag', 'svg', []),
+              ('starttag', 'style', []),
+              ('data', 'a'),
+              ('starttag', 'b', []),
+              ('endtag', 'style')]),
+            # at an HTML integration point they are special again
+            ('<svg><foreignObject><title>a<b>c</b></title>',
+             [('starttag', 'svg', []),
+              ('starttag', 'foreignobject', []),
+              ('starttag', 'title', []),
+              ('data', 'a<b>c</b>'),
+              ('endtag', 'title')]),
+            ('<svg></svg><script>a<b></script>',
+             [('starttag', 'svg', []),
+              ('endtag', 'svg'),
+              ('starttag', 'script', []),
+              ('data', 'a<b>'),
+              ('endtag', 'script')]),
+        ]:
+            with self.subTest(html=html):
+                self._run_check(html, expected)
+
+    def test_support_cdata_true(self):
+        # CDATA sections are recognized in any context and foreign
+        # content is not detected (the previous default behavior).
+        for html, expected in [
+            ('<![CDATA[x]]>', [('unknown decl', 'CDATA[x')]),
+            ('<svg><![CDATA[x]]></svg>',
+             [('starttag', 'svg', []),
+              ('unknown decl', 'CDATA[x'),
+              ('endtag', 'svg')]),
+            ('<svg><foreignObject><div><![CDATA[x]]>',
+             [('starttag', 'svg', []),
+              ('starttag', 'foreignobject', []),
+              ('starttag', 'div', []),
+              ('unknown decl', 'CDATA[x')]),
+            # RAWTEXT and RCDATA elements are special even in foreign
+            # content
+            ('<svg><title>a<b>c</b></title>',
+             [('starttag', 'svg', []),
+              ('starttag', 'title', []),
+              ('data', 'a<b>c</b>'),
+              ('endtag', 'title')]),
+        ]:
+            with self.subTest(html=html):
+                self._run_check(html, expected,
+                                collector=EventCollector(support_cdata=True))
+
+    def test_support_cdata_false(self):
+        # CDATA sections are parsed as bogus comments in any context and
+        # foreign content is not detected.
+        for html, expected in [
+            ('<![CDATA[x]]>', [('comment', '[CDATA[x]]')]),
+            ('<svg><![CDATA[x]]></svg>',
+             [('starttag', 'svg', []),
+              ('comment', '[CDATA[x]]'),
+              ('endtag', 'svg')]),
+            ('<svg><title>a<b>c</b></title>',
+             [('starttag', 'svg', []),
+              ('starttag', 'title', []),
+              ('data', 'a<b>c</b>'),
+              ('endtag', 'title')]),
+        ]:
+            with self.subTest(html=html):
+                self._run_check(html, expected,
+                                collector=EventCollector(support_cdata=False))
+
+    def test_set_support_cdata(self):
+        # Manual control of CDATA support from the start and end tag
+        # handlers (supported for backward compatibility).  The user's
+        # stack machinery can be simpler than the automatic detection of
+        # foreign content (here it only follows the "svg" tags), but it
+        # takes full control after the first _set_support_cdata() call,
+        # so such code works as before.
+        class Collector(EventCollector):
+            def __init__(self, **kw):
+                super().__init__(**kw)
+                self._set_support_cdata(False)
+            def handle_starttag(self, tag, attrs):
+                super().handle_starttag(tag, attrs)
+                if tag == 'svg':
+                    self._set_support_cdata(True)
+            def handle_endtag(self, tag):
+                super().handle_endtag(tag)
+                if tag == 'svg':
+                    self._set_support_cdata(False)
+        html = ('<![CDATA[a]]>'
+                '<svg>'
+                # the simple machinery does not detect the switch to HTML
+                # content, unlike the automatic detection
+                '<foreignObject><div><![CDATA[b]]></div></foreignObject>'
+                # RAWTEXT and RCDATA elements are special in manual mode
+                '<title>x<b>y</title>'
+                '<![CDATA[c]]>'
+                '</svg>'
+                '<![CDATA[d]]>')
+        expected = [
+            ('comment', '[CDATA[a]]'),
+            ('starttag', 'svg', []),
+            ('starttag', 'foreignobject', []),
+            ('starttag', 'div', []),
+            ('unknown decl', 'CDATA[b'),
+            ('endtag', 'div'),
+            ('endtag', 'foreignobject'),
+            ('starttag', 'title', []),
+            ('data', 'x<b>y'),
+            ('endtag', 'title'),
+            ('unknown decl', 'CDATA[c'),
+            ('endtag', 'svg'),
+            ('comment', '[CDATA[d]]'),
+        ]
+        self._run_check(html, expected, collector=Collector())
+        self._run_check([html], expected, collector=Collector())
 
     def test_convert_charrefs_dropped_text(self):
         # #23144: make sure that all the events are triggered when

--- a/Misc/NEWS.d/next/Library/2026-07-04-15-00-00.gh-issue-153027.fXcCwd.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-04-15-00-00.gh-issue-153027.fXcCwd.rst
@@ -1,0 +1,12 @@
+:class:`html.parser.HTMLParser` now handles CDATA sections and RAWTEXT and
+RCDATA elements depending on the foreign content context by default, in
+accordance with the HTML5 standard.
+The parser follows start and end tags to detect foreign content
+(the content of ``svg`` and ``math`` elements).
+In HTML content, ``<![CDATA[...]]>`` is now parsed as a bogus comment which
+ends at the first ``>``.
+In foreign content, RAWTEXT and RCDATA elements (such as ``script``,
+``style``, ``title`` or ``textarea``) are now parsed as normal elements.
+Use the new *support_cdata* parameter of the constructor to force
+recognizing CDATA sections in any context (the previous behavior) or in no
+context.


### PR DESCRIPTION
HTMLParser now follows start and end tags to detect foreign content (the content of `svg` and `math` elements), approximating the tree construction dispatcher and the rules for parsing tokens in foreign content of the HTML5 standard: integration points, breakout tags, self-closing foreign elements.

In HTML content, `<![CDATA[...]]>` is now parsed as a bogus comment which ends at the first `>`. In foreign content, RAWTEXT and RCDATA elements (such as `script`, `style`, `title` or `textarea`) are now parsed as normal elements.

The new *support_cdata* parameter of the constructor allows forcing recognition of CDATA sections in any context (the previous default behavior) or in no context. Calling the private method `_set_support_cdata()` disables the automatic detection, so existing code which maintains its own tracking machinery in `handle_starttag()` and `handle_endtag()` works as before.

There is no performance impact for parsing HTML content without foreign elements: the stack of open elements is only maintained inside foreign content.

<!-- gh-issue-number: gh-153027 -->
* Issue: gh-153027
<!-- /gh-issue-number -->