### PR TITLE
gh-153037: Fix `AttributeError` when iterating over a non-readable `ZstdFile`

### DIFF
--- a/Lib/compression/zstd/_zstdfile.py
+++ b/Lib/compression/zstd/_zstdfile.py
@@ -246,6 +246,7 @@ class ZstdFile(_streams.BaseStream):
         return self._buffer.peek(size)
 
     def __next__(self):
+        self._check_can_read()
         if ret := self._buffer.readline():
             return ret
         raise StopIteration

--- a/Lib/test/test_zstd.py
+++ b/Lib/test/test_zstd.py
@@ -2373,6 +2373,8 @@ class FileTestCase(unittest.TestCase):
                 f.read(100)
             with self.assertRaises(io.UnsupportedOperation):
                 f.seek(100)
+            with self.assertRaises(io.UnsupportedOperation):
+                next(iter(f))
         self.assertEqual(f.closed, True)
         with self.assertRaises(ValueError):
             f.readable()

--- a/Misc/NEWS.d/next/Library/2026-07-04-20-28-51.gh-issue-153037.XUSp_g.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-04-20-28-51.gh-issue-153037.XUSp_g.rst
@@ -1,0 +1,3 @@
+Fix :class:`~compression.zstd.ZstdFile` raising :exc:`AttributeError`
+instead of :exc:`io.UnsupportedOperation` when iterating over a file that
+is not open for reading.


### PR DESCRIPTION
Make `ZstdFile.__next__` raise `io.UnsupportedOperation` on non-readable files.

This makes it consistent with other read methods and compression modules, like `LZMAFile`, `BZ2File`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-153037 -->
* Issue: gh-153037
<!-- /gh-issue-number -->
