### PR TITLE
gh-56229: Document flush expectation for stdout and stderr replacements

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -2180,6 +2180,10 @@ always available. Unless explicitly noted otherwise, all variables are read-only
       may be replaced with file-like objects like :class:`io.StringIO` which
       do not support the :attr:`!buffer` attribute.
 
+      At interpreter shutdown, the ``stdout`` and ``stderr`` streams are
+      flushed, so objects used to replace them should provide a ``flush()``
+      method.
+
 
 .. data:: __stdin__
           __stdout__


### PR DESCRIPTION
## Summary

Document that replacement `sys.stdout` and `sys.stderr` objects should provide `flush()` because these streams are flushed during interpreter shutdown.

## What changed

- Added one focused sentence to `Doc/library/sys.rst`.
- No behavior changes.
- No new dependencies.

## Tests

- `git diff --check`
- `Doc\make.bat check`
- Full Sphinx HTML build with `--fail-on-warning`

Closes #56229

<!-- gh-issue-number: gh-56229 -->
* Issue: gh-56229
<!-- /gh-issue-number -->
