### PR TITLE
Fix gh-152835: make inspect.signature robust to TYPE_CHECKING-only annotations

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2347,8 +2347,15 @@ def _signature_from_function(cls, func, skip_bound_arg=True,
     positional = arg_names[:pos_count]
     keyword_only_count = func_code.co_kwonlyargcount
     keyword_only = arg_names[pos_count:pos_count + keyword_only_count]
-    annotations = get_annotations(func, globals=globals, locals=locals, eval_str=eval_str,
-                                  format=annotation_format)
+    try:
+        annotations = get_annotations(func, globals=globals, locals=locals, eval_str=eval_str,
+                                      format=annotation_format)
+    except (NameError, AttributeError, ImportError):
+        if annotation_format == Format.VALUE:
+            annotations = get_annotations(func, globals=globals, locals=locals, eval_str=False,
+                                          format=Format.FORWARDREF)
+        else:
+            raise
     defaults = func.__defaults__
     kwdefaults = func.__kwdefaults__
 

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -1392,12 +1392,12 @@ class TestClassesAndFunctions(unittest.TestCase):
                                      kwonlyargs_e=['e', 'f'],
                                      kwonlydefaults_e={'e': 4, 'f': 5})
 
-    def get_getfullargspec_with_undefined_names_in_annotations(self):
+    def test_getfullargspec_with_undefined_names_in_annotations(self):
         def my_func(a: undefined_name):
             pass
 
-        with self.assertRaises(NameError):
-            inspect.getfullargspec(my_func)
+        arg_spec = inspect.getfullargspec(my_func)
+        self.assertIsInstance(arg_spec.annotations['a'], ForwardRef)
 
         self.assertFullArgSpecEquals(my_func, ['a'], ann_e={'a': 'undefined_name'},
                                      annotation_format=Format.STRING)
@@ -3106,6 +3106,18 @@ class TestSignatureObject(unittest.TestCase):
                                     for param in sig.parameters.values()),
                 (... if sig.return_annotation is sig.empty
                                             else sig.return_annotation))
+
+    def test_signature_on_type_checking_only_annotations(self):
+        # Issue #152835: inspect.signature should fall back to FORWARDREF format
+        # when annotations fail to evaluate due to NameError/AttributeError/ImportError.
+        def f(arg: UndefinedName, arg2: sys.NonExistentAttribute):
+            pass
+
+        sig = inspect.signature(f)
+        self.assertIsInstance(sig.parameters['arg'].annotation, ForwardRef)
+        self.assertEqual(sig.parameters['arg'].annotation.__forward_arg__, 'UndefinedName')
+        self.assertIsInstance(sig.parameters['arg2'].annotation, ForwardRef)
+        self.assertEqual(sig.parameters['arg2'].annotation.__forward_arg__, 'sys.NonExistentAttribute')
 
     def test_signature_object(self):
         S = inspect.Signature
@@ -5389,10 +5401,14 @@ class TestSignatureObject(unittest.TestCase):
                     signature_func(ida.f, annotation_format=Format.FORWARDREF),
                     sig([par("x", PORK, annotation=EqualToForwardRef("undefined", owner=ida.f))])
                 )
-                with self.assertRaisesRegex(NameError, "undefined"):
-                    signature_func(ida.f, annotation_format=Format.VALUE)
-                with self.assertRaisesRegex(NameError, "undefined"):
-                    signature_func(ida.f)
+                self.assertEqual(
+                    signature_func(ida.f, annotation_format=Format.VALUE),
+                    sig([par("x", PORK, annotation=EqualToForwardRef("undefined", owner=ida.f))])
+                )
+                self.assertEqual(
+                    signature_func(ida.f),
+                    sig([par("x", PORK, annotation=EqualToForwardRef("undefined", owner=ida.f))])
+                )
 
     def test_signature_deferred_annotations(self):
         def f(x: undef):


### PR DESCRIPTION
Fixes #152835

This PR introduces a robust fallback mechanism in inspect.signature() to handle annotation evaluation failures (such as NameError, AttributeError, or ImportError).

When an exception is raised while evaluating parameter annotations under the default Format.VALUE format (common for annotations only imported in if TYPE_CHECKING: blocks), the logic now falls back to Format.FORWARDREF with eval_str=False, converting the failed references to ForwardRef objects instead of crashing. This prevents regressions for libraries and frameworks (like FastAPI, Pydantic, Click) that inspect signatures.

<!-- gh-issue-number: gh-152835 -->
* Issue: gh-152835
<!-- /gh-issue-number -->
