### PR TITLE
gh-151819: Clarify the conditional-pattern email example in re docs

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -531,8 +531,9 @@ The special characters are:
    *name* exists, and with ``no-pattern`` if it doesn't. ``no-pattern`` is
    optional and can be omitted. For example,
    ``(<)?(\w+@\w+(?:\.\w+)+)(?(1)>|$)`` is a poor email matching pattern, which
-   will match with ``'<user@host.com>'`` as well as ``'user@host.com'``, but
-   not with ``'<user@host.com'`` nor ``'user@host.com>'``.
+   matches ``'<user@host.com>'`` as well as ``'user@host.com'``, but does not
+   match ``'<user@host.com'`` nor ``'user@host.com>'`` in their entirety
+   (:func:`re.search` finds only ``'user@host.com'`` in the former).
 
    .. versionchanged:: 3.12
       Group *id* can only contain ASCII digits.


### PR DESCRIPTION
The `(?(id/name)yes-pattern|no-pattern)` example claimed the pattern does "not match" `'<user@host.com'`, but `re.search` matches `'user@host.com'` in it; only the whole string fails. Reword to say so.

See gh-151819.
