### PR TITLE
[3.14] gh-66335: Test uppercase IMAP4 command names (GH-152876)

### DIFF
--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -1731,6 +1731,16 @@ class NewIMAPTestsMixin:
         self.assertEqual(data, [b'MYCOMMAND completed'])
         self.assertEqual(server.args, ['arg1', 'arg2'])
 
+    def test_uppercase_command_names(self):
+        client, server = self._setup(SimpleIMAPHandler)
+        client.login('user', 'pass')
+        self.assertEqual(client.CAPABILITY, client.capability)
+        self.assertEqual(client.SELECT, client.select)
+        typ, data = client.CAPABILITY()
+        self.assertEqual(typ, 'OK')
+        with self.assertRaises(AttributeError):
+            client.NONEXISTENT
+
     # property tests
 
     def test_file_property_should_not_be_accessed(self):


### PR DESCRIPTION
``imaplib.IMAP4.__getattr__`` lets a command be called under its uppercase name (``client.CAPABILITY()`` in addition to ``client.capability()``), as documented, and raises ``AttributeError`` for an unknown name. This adds a test for that behavior, which the coverage PR left out.

Co-authored with the author of the original bpo-22137 patch, which included this test.
(cherry picked from commit 3cd6b7406442ad976c6651b9fba6f078971cdf10)

<!-- gh-issue-number: gh-66335 -->
* Issue: gh-66335
<!-- /gh-issue-number -->
