### PR TITLE
[3.15] gh-69134: Wait until mapped in SimpleDialog keyboard tests (GH-152690)

### DIFF
--- a/Lib/test/test_tkinter/test_simpledialog.py
+++ b/Lib/test/test_tkinter/test_simpledialog.py
@@ -49,6 +49,7 @@ class SimpleDialogTest(AbstractTkTest, unittest.TestCase):
     def test_return_activates_default(self):
         # <Return> invokes the default button.
         d = self.create()  # default 0
+        self.require_mapped(d.root)
         d.root.focus_force()
         d.root.update()
         d.root.event_generate('<Return>')
@@ -59,6 +60,7 @@ class SimpleDialogTest(AbstractTkTest, unittest.TestCase):
         # With no default button, <Return> rings the bell and leaves the dialog
         # open instead of activating a button.
         d = self.create(default=None)
+        self.require_mapped(d.root)
         d.root.focus_force()
         d.root.update()
         bells = []


### PR DESCRIPTION
Manual backport of #152690 (miss-islington could not backport it automatically).

The SimpleDialog ttk modernization is not on 3.15, so only two of the keyboard tests it touched exist here — `test_return_activates_default` and `test_return_no_default` (the buildbot flake). This adds the mapped-wait to those two.

<!-- gh-issue-number: gh-69134 -->