### PR TITLE
Seed pip caches for docs on `main`/`3.x` branches

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -3,6 +3,17 @@ name: Reusable Docs
 on:
   workflow_call:
   workflow_dispatch:
+  # Pushes to CPython branches seed the pip caches under the exact keys every
+  # docs PR restores from. Without a branch-scoped copy, each PR saves a
+  # duplicate into its own refs/pull/N/merge scope that nothing else can read.
+  push:
+    branches:
+      - main
+      - '3.*'
+    paths:
+      - 'Doc/pylock.toml'
+      - 'Doc/requirements.txt'
+      - '.github/workflows/reusable-docs.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Our GitHub Actions cache is always full:

> Approaching total cache storage limit (10.65 GB of 10 GB Used)
> 
> Least recently used caches will be automatically evicted to limit the total cache storage to 10 GB. Learn more about cache usage.

https://github.com/python/cpython/actions/caches

Right now, PR caches use up 3.54 GB across 52 PRs:

* 32 PRs are closed and using 1.81 GB
* 20 are open with 1.73 GB

They tend to get evicted after about a day due to the storage limit, and don't last the full 7-day limit.

---

But why are there so many caches for PRs?

Nearly all of this is pip caches from docs builds, and they're virtually identical.

There's also about Hypothesis cache of about 6 MB for the `main` branch. For Hypothesis, PRs usually use the `main` cache and don't need to write their own cache.

However, the docs workflow only runs for PRs, so `main`/`3.*` branches never get to save a cache. If they had, the vast majority would just use a cache from `main` and carry on. No need to save their own PR cache.

We can do this by letting this workflow run on `main` and `3.*`, and also limit to only run if one of these files change:

- `Doc/pylock.toml`
- `Doc/requirements.txt`
- `.github/workflows/reusable-docs.yml`

