### PR TITLE
gh-153141: Fix mutable default argument in _SharedMemoryTracker.__init__

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -1294,9 +1294,9 @@ if HAS_SHMEM:
     class _SharedMemoryTracker:
         "Manages one or more shared memory segments."
 
-        def __init__(self, name, segment_names=[]):
+        def __init__(self, name, segment_names=None):
             self.shared_memory_context_name = name
-            self.segment_names = segment_names
+            self.segment_names = [] if segment_names is None else segment_names
 
         def register_segment(self, segment_name):
             "Adds the supplied shared memory block name to tracker."


### PR DESCRIPTION
## Summary

Replace the mutable default argument (`segment_names=[]`) in `_SharedMemoryTracker.__init__` with `None` to avoid unintended shared state between instances.

Fixes: #153141 

<!-- gh-issue-number: gh-153141 -->
* Issue: gh-153141
<!-- /gh-issue-number -->
