### PR TITLE
gh-150626: Update Format String Syntax documentation

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -219,10 +219,11 @@ The grammar for a replacement field is as follows:
 .. productionlist:: format-string
    replacement_field: "{" [`field_name`] ["!" `conversion`] [":" `format_spec`] "}"
    field_name: `arg_name` ("." `attribute_name` | "[" `element_index` "]")*
-   arg_name: [`~python-grammar:identifier` | `~python-grammar:digit`+]
-   attribute_name: `~python-grammar:identifier`
-   element_index: `~python-grammar:digit`+ | `index_string`
+   arg_name: [`decimal_number` | `attribute_name`]
+   attribute_name: <any source character except "{", "}", "[", ".", "!", or ":"> +
+   element_index: `decimal_number` | `index_string`
    index_string: <any source character except "]"> +
+   decimal_number: <any Unicode decimal digit character> +
    conversion: "r" | "s" | "a"
    format_spec: `format-spec:format_spec`
 


### PR DESCRIPTION
This PR is a replacement for the original PR https://github.com/python/cpython/pull/132736 that I have accidentally ruined. :grimacing:

Related Issue: https://github.com/python/cpython/issues/150626

Original PR description.

----

Hello, let me try to help a bit with docs.

Here is an string formatting example:
```
In [29]: "{a-b} {-}".format(**{"-": "_-_", "a-b": "ABC"})
Out[29]: 'ABC _-_'
```

This behaviour differs from [Format String Syntax](https://docs.python.org/3.14/library/string.html#format-string-syntax):
```
arg_name: [identifier | digit+]
attribute_name: identifier
```

So I updated `arg_name` and `attribute_name` syntax in that section to follow the actual behaviour:
- replaced `identifier` with `attribute_name` in `arg_name`
- set syntax for `attribute_name` as `anything that doesn’t contain "." or "]"`

You can find original discussion thread [here](https://discuss.python.org/t/format-string-syntax-specification-differs-from-actual-behaviour/46716/2)


<!-- gh-issue-number: gh-150626 -->
* Issue: gh-150626
<!-- /gh-issue-number -->
