### PR TITLE
[3.14] gh-151640: Track sharing of `BytesIO` buffer in free-threaded builds (GH-151651)

### DIFF
--- a/Lib/test/test_free_threading/test_io.py
+++ b/Lib/test/test_free_threading/test_io.py
@@ -113,6 +113,35 @@ class TestBytesIO(TestCase):
 
         # no tests for seek or tell because they don't break anything
 
+    @threading_helper.requires_working_threading()
+    @threading_helper.reap_threads
+    def test_concurrent_whole_buffer_read_and_resize(self):
+        shared = self.ioclass(b"x" * 64)
+        writers = 2
+        readers = 8
+        loops = 2000
+        barrier = threading.Barrier(writers + readers)
+
+        def writer():
+            barrier.wait()
+            for i in range(loops):
+                shared.seek(0)
+                shared.write(b"a" * (64 + (i & 63)))
+
+        def reader():
+            barrier.wait()
+            for _ in range(loops):
+                shared.seek(0)
+                shared.read()
+                shared.seek(0)
+                shared.peek()
+                shared.getvalue()
+
+        threads = [threading.Thread(target=writer) for _ in range(writers)]
+        threads += [threading.Thread(target=reader) for _ in range(readers)]
+        with threading_helper.start_threads(threads):
+            pass
+
 
 class IncrementalNewlineDecoderTest(TestCase):
     def make_decoder(self):

--- a/Lib/test/test_free_threading/test_io.py
+++ b/Lib/test/test_free_threading/test_io.py
@@ -116,7 +116,7 @@ class TestBytesIO(TestCase):
     @threading_helper.requires_working_threading()
     @threading_helper.reap_threads
     def test_concurrent_whole_buffer_read_and_resize(self):
-        shared = self.ioclass(b"x" * 64)
+        shared = BytesIO(b"x" * 64)
         writers = 2
         readers = 8
         loops = 2000
@@ -134,7 +134,6 @@ class TestBytesIO(TestCase):
                 shared.seek(0)
                 shared.read()
                 shared.seek(0)
-                shared.peek()
                 shared.getvalue()
 
         threads = [threading.Thread(target=writer) for _ in range(writers)]

--- a/Lib/test/test_memoryio.py
+++ b/Lib/test/test_memoryio.py
@@ -868,7 +868,10 @@ class CBytesIOTest(PyBytesIOTest):
 
     @support.cpython_only
     def test_sizeof(self):
-        basesize = support.calcobjsize('P2n2Pn')
+        if support.Py_GIL_DISABLED:
+            basesize = support.calcobjsize('P2n2Pni')
+        else:
+            basesize = support.calcobjsize('P2n2Pn')
         check = self.check_sizeof
         self.assertEqual(object.__sizeof__(io.BytesIO()), basesize)
         check(io.BytesIO(), basesize )

--- a/Misc/NEWS.d/next/Library/2026-06-18-12-48-03.gh-issue-151640.R4c3Fx.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-18-12-48-03.gh-issue-151640.R4c3Fx.rst
@@ -1,0 +1,3 @@
+Fix a data race in :class:`io.BytesIO` in free-threaded builds when
+whole-buffer reads or peeks, or :meth:`~io.BytesIO.getvalue`, share the
+internal buffer with concurrent writes.

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -22,6 +22,9 @@ typedef struct {
     PyObject *dict;
     PyObject *weakreflist;
     Py_ssize_t exports;
+#ifdef Py_GIL_DISABLED
+    int buf_shared;
+#endif
 } bytesio;
 
 #define bytesio_CAST(op)    ((bytesio *)(op))
@@ -71,7 +74,45 @@ check_exports(bytesio *self)
         return NULL; \
     }
 
+#ifdef Py_GIL_DISABLED
+#define SHARED_BUF(self) ((self)->buf_shared || !_PyObject_IsUniquelyReferenced((self)->buf))
+#else
 #define SHARED_BUF(self) (!_PyObject_IsUniquelyReferenced((self)->buf))
+#endif
+
+static inline void
+set_shared_buf(bytesio *self)
+{
+#ifdef Py_GIL_DISABLED
+    self->buf_shared = 1;
+#endif
+}
+
+static inline void
+clear_shared_buf(bytesio *self)
+{
+#ifdef Py_GIL_DISABLED
+    self->buf_shared = 0;
+#endif
+}
+
+static int
+resize_unshared_buffer_lock_held(bytesio *self, Py_ssize_t size)
+{
+    _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(self);
+
+#ifdef Py_GIL_DISABLED
+    /* If the internal bytes object escaped via a zero-copy getvalue(), read(),
+       or peek(), resizing it would mutate an object visible to Python code.
+       Callers must detach first. */
+    assert(!self->buf_shared);
+#endif
+    int ret = _PyBytes_Resize(&self->buf, size);
+    if (ret == 0) {
+        clear_shared_buf(self);
+    }
+    return ret;
+}
 
 
 /* Internal routine to get a line from the buffer of a BytesIO
@@ -128,6 +169,7 @@ unshare_buffer_lock_held(bytesio *self, size_t size)
     memcpy(PyBytes_AS_STRING(new_buf), PyBytes_AS_STRING(self->buf),
            self->string_size);
     Py_SETREF(self->buf, new_buf);
+    clear_shared_buf(self);
     return 0;
 }
 
@@ -173,7 +215,7 @@ resize_buffer_lock_held(bytesio *self, size_t size)
             return -1;
     }
     else {
-        if (_PyBytes_Resize(&self->buf, alloc) < 0)
+        if (resize_unshared_buffer_lock_held(self, alloc) < 0)
             return -1;
     }
 
@@ -381,10 +423,11 @@ _io_BytesIO_getvalue_impl(bytesio *self)
                 return NULL;
         }
         else {
-            if (_PyBytes_Resize(&self->buf, self->string_size) < 0)
+            if (resize_unshared_buffer_lock_held(self, self->string_size) < 0)
                 return NULL;
         }
     }
+    set_shared_buf(self);
     return Py_NewRef(self->buf);
 }
 
@@ -433,6 +476,7 @@ read_bytes_lock_held(bytesio *self, Py_ssize_t size)
         self->pos == 0 && size == PyBytes_GET_SIZE(self->buf) &&
         FT_ATOMIC_LOAD_SSIZE_RELAXED(self->exports) == 0) {
         self->pos += size;
+        set_shared_buf(self);
         return Py_NewRef(self->buf);
     }
 
@@ -1046,6 +1090,7 @@ _io_BytesIO___init___impl(bytesio *self, PyObject *initvalue)
     if (initvalue && initvalue != Py_None) {
         if (PyBytes_CheckExact(initvalue)) {
             Py_XSETREF(self->buf, Py_NewRef(initvalue));
+            clear_shared_buf(self);
             self->string_size = PyBytes_GET_SIZE(initvalue);
         }
         else {


### PR DESCRIPTION
(cherry picked from commit 881a13a97c7a29b9de57913c773cd5f195270fbd)

<!-- gh-issue-number: gh-151640 -->
* Issue: gh-151640
<!-- /gh-issue-number -->
