### PR TITLE
gh-89774: Fix pprint ignoring the depth limit at small width

### DIFF
--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -195,7 +195,10 @@ class PrettyPrinter:
             return
         rep = self._repr(object, context, level)
         max_width = self._width - indent - allowance
-        if len(rep) > max_width:
+        # Past the depth limit _safe_repr already folded this to '...'; do not
+        # re-expand it just because it does not fit the width.
+        if len(rep) > max_width and not (
+                self._depth is not None and level >= self._depth):
             p = self._dispatch.get(type(object).__repr__, None)
             # Lazy import to improve module import time
             from dataclasses import is_dataclass

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -1039,6 +1039,24 @@ frozenset2({0,
         self.assertEqual(pprint.pformat(nested_dict, depth=1), lv1_dict)
         self.assertEqual(pprint.pformat(nested_list, depth=1), lv1_list)
 
+    def test_depth_with_narrow_width(self):
+        # gh-89774: a narrow width must not override the depth limit.
+        nested_dict = {1: {2: {3: 3}}}
+        nested_list = [1, [2, [3, [4]]]]
+        nested_tuple = (1, (2, (3,)))
+        self.assertEqual(pprint.pformat(nested_dict, depth=1, width=5),
+                         '{1: {...}}')
+        self.assertEqual(pprint.pformat(nested_dict, depth=2, width=5),
+                         '{1: {2: {...}}}')
+        self.assertEqual(pprint.pformat(nested_list, depth=1, width=6),
+                         '[1,\n [...]]')
+        self.assertEqual(pprint.pformat(nested_tuple, depth=1, width=6),
+                         '(1,\n (...))')
+        # Depth folding is independent of width: a narrow width folds at the
+        # same level as the default wide width.
+        self.assertEqual(pprint.pformat(nested_dict, depth=1, width=5),
+                         pprint.pformat(nested_dict, depth=1))
+
     def test_sort_unorderable_values(self):
         # Issue 3976:  sorted pprints fail for unorderable values.
         n = 20

--- a/Misc/NEWS.d/next/Library/2026-07-06-10-00-00.gh-issue-89774.d3Pth1.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-06-10-00-00.gh-issue-89774.d3Pth1.rst
@@ -1,0 +1,2 @@
+Fix :mod:`pprint` ignoring the *depth* limit when a small *width* forces
+nested structures onto multiple lines.


### PR DESCRIPTION
`PrettyPrinter._format` re-dispatches to the per-type formatter (`_pprint_dict`, `_pprint_list`, ...) whenever a node's repr exceeds the available line width. Those formatters re-expand children that `_safe_repr` had already folded to `...` at the depth limit, so a small `width` silently defeats `depth`.

```python
>>> import pprint
>>> pprint.pformat({1: {2: {3: 3}}}, depth=1, width=80)
'{1: {...}}'
>>> pprint.pformat({1: {2: {3: 3}}}, depth=1, width=5)
'{1: {2: {3: 3}}}'   # depth ignored
```

The fix skips the re-dispatch once the depth limit is reached, using the same boundary `_safe_repr` uses (`level >= self._depth`). Depth truncation is now independent of width, which also restores the narrow-width example documented in `Doc/library/pprint.rst`.

The regression test covers the dict, list, and tuple formatter branches and asserts that a narrow width folds at the same level as the default width. `depth` is always positive (`__init__` rejects `depth <= 0`), so the `is not None` guard and `_safe_repr`'s truthiness check are equivalent here.

I have left the backport labels for a maintainer to assign.

<!-- gh-issue-number: gh-89774 -->
* Issue: gh-89774
<!-- /gh-issue-number -->
