### PR TITLE
[3.11] RTD Previews: Get correct base branch for backports (GH-150690)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,8 +11,50 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3"
+  apt_packages:
+    - jq
 
-  commands:
-    - make -C Doc venv html
-    - mkdir _readthedocs
-    - mv Doc/build/html _readthedocs/html
+  jobs:
+    post_system_dependencies:
+      # https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html#skip-builds-based-on-conditions
+      #
+      # Cancel building pull requests when there are no changes in the Doc
+      # directory or RTD configuration, or if we can't cleanly merge the base
+      # branch.
+      - |
+        set -eEux;
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ];
+        then
+          base_branch=$(wget -qO- "https://api.github.com/repos/python/cpython/pulls/$READTHEDOCS_VERSION" | jq -er ".base.ref");
+          git fetch --depth=50 origin $base_branch:origin-$base_branch;
+          for attempt in $(seq 10);
+          do
+            if ! git merge-base HEAD origin-$base_branch;
+            then
+              git fetch --deepen=50 origin $base_branch;
+            else
+              break;
+            fi;
+          done;
+          if ! git -c "user.name=rtd" -c "user.email=no-reply@readthedocs.org" merge --no-stat --no-edit origin-$base_branch;
+          then
+            echo "Unsuccessful merge with '$base_branch' branch, skipping the build";
+            exit 183;
+          fi;
+          if git diff --exit-code --stat origin-$base_branch -- Doc/ .readthedocs.yml;
+          then
+            echo "No changes to Doc/ - skipping the build.";
+            exit 183;
+          fi;
+        fi;
+    create_environment:
+      - echo "Skipping default environment creation"
+    install:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    build:
+      html:
+        - make -C Doc venv html
+        - mkdir -p "$READTHEDOCS_OUTPUT"
+        - mv Doc/build/html "$READTHEDOCS_OUTPUT/"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ sphinx:
    configuration: Doc/conf.py
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3"
   apt_packages:


### PR DESCRIPTION
(cherry picked from commit 082ac30eaf51b9b9c218b81b4db71628a487d6c8)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Also bumping the OS to `ubuntu-24.04` to match newer branches.

22.04 is still supported, RTD have only just removed `ubuntu-20.04`.

Separately, at some point we can switch to `ubuntu-26.04` across the board, or `ubuntu-lts-latest`.

* https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/
* https://about.readthedocs.com/blog/2026/05/ubuntu-26-04/