### PR TITLE
[3.10] RTD Previews: Get correct base branch for backports (GH-150690)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
 build:
   os: ubuntu-24.04
   tools:
-    python: "3"
+    python: "3.10"
   apt_packages:
     - jq
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,14 +1,60 @@
-# This is a dummy config file so that readthedocs.org doesn't fail on security branches.
-# Note that this won't result in docs actually getting built;
-# clicking on the docs preview link on a PR will result in a 404.
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Project page: https://readthedocs.org/projects/cpython-previews/
+
 version: 2
-formats: []
+
 sphinx:
-  configuration: Doc/conf.py
+   configuration: Doc/conf.py
+
 build:
-  os: "ubuntu-22.04"
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3"
+  apt_packages:
+    - jq
+
   jobs:
-    post_checkout:
-    - exit 183
+    post_system_dependencies:
+      # https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html#skip-builds-based-on-conditions
+      #
+      # Cancel building pull requests when there are no changes in the Doc
+      # directory or RTD configuration, or if we can't cleanly merge the base
+      # branch.
+      - |
+        set -eEux;
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ];
+        then
+          base_branch=$(wget -qO- "https://api.github.com/repos/python/cpython/pulls/$READTHEDOCS_VERSION" | jq -er ".base.ref");
+          git fetch --depth=50 origin $base_branch:origin-$base_branch;
+          for attempt in $(seq 10);
+          do
+            if ! git merge-base HEAD origin-$base_branch;
+            then
+              git fetch --deepen=50 origin $base_branch;
+            else
+              break;
+            fi;
+          done;
+          if ! git -c "user.name=rtd" -c "user.email=no-reply@readthedocs.org" merge --no-stat --no-edit origin-$base_branch;
+          then
+            echo "Unsuccessful merge with '$base_branch' branch, skipping the build";
+            exit 183;
+          fi;
+          if git diff --exit-code --stat origin-$base_branch -- Doc/ .readthedocs.yml;
+          then
+            echo "No changes to Doc/ - skipping the build.";
+            exit 183;
+          fi;
+        fi;
+    create_environment:
+      - echo "Skipping default environment creation"
+    install:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    build:
+      html:
+        - make -C Doc venv html
+        - mkdir -p "$READTHEDOCS_OUTPUT"
+        - mv Doc/build/html "$READTHEDOCS_OUTPUT/"


### PR DESCRIPTION
(cherry picked from commit 082ac30eaf51b9b9c218b81b4db71628a487d6c8)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Also bumping the OS to ubuntu-24.04 to match newer branches, like in https://github.com/python/cpython/pull/153166.

---

Hmm, 3.10 currently has a dummy RTD config file that always cancels the build. It was added in https://github.com/python/cpython/pull/108908 and also to 3.9 and 3.8, the security branches at the time.

We've not kept that up for the current newer security branches (3.12 and 3.11).

We don't often have PRs to them, but I think it might be useful to build previews for security branches too. 

Otherwise, we should forward port the current 3.10 skip to 3.12 and 3.11.