### PR TITLE
gh-153182: Explicitly return NULL when `new_keys_object` call fails in `_PyDict_NewKeysForClass`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-06-11-22-58.gh-issue-153182.pHqb1F.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-06-11-22-58.gh-issue-153182.pHqb1F.rst
@@ -1,0 +1,1 @@
+Fix a crash when defining a class in low memory conditions.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -7219,13 +7219,12 @@ _PyDict_NewKeysForClass(PyHeapTypeObject *cls)
     PyDictKeysObject *keys = new_keys_object(NEXT_LOG2_SHARED_KEYS_MAX_SIZE, 1);
     if (keys == NULL) {
         PyErr_Clear();
+        return NULL;
     }
-    else {
-        assert(keys->dk_nentries == 0);
-        /* Set to max size+1 as it will shrink by one before each new object */
-        keys->dk_usable = SHARED_KEYS_MAX_SIZE;
-        keys->dk_kind = DICT_KEYS_SPLIT;
-    }
+    assert(keys->dk_nentries == 0);
+    /* Set to max size+1 as it will shrink by one before each new object */
+    keys->dk_usable = SHARED_KEYS_MAX_SIZE;
+    keys->dk_kind = DICT_KEYS_SPLIT;
     if (cls->ht_type.tp_dict) {
         PyObject *attrs = PyDict_GetItem(cls->ht_type.tp_dict, &_Py_ID(__static_attributes__));
         if (attrs != NULL && PyTuple_Check(attrs)) {


### PR DESCRIPTION
This prevents a segfault when code further down the function tries to populate `keys` with the contents of `__static_attributes__`

<!-- gh-issue-number: gh-153182 -->
* Issue: gh-153182
<!-- /gh-issue-number -->
