### PR TITLE
gh-148286: Remove invalid test in `test_decodeescape`

### DIFF
--- a/Lib/test/test_capi/test_bytes.py
+++ b/Lib/test/test_capi/test_bytes.py
@@ -226,6 +226,7 @@ class CAPITest(unittest.TestCase):
         self.assertRaises(OverflowError, decodeescape, b'abc', NULL, PY_SSIZE_T_MAX)
         self.assertRaises(OverflowError, decodeescape, NULL, NULL, PY_SSIZE_T_MAX)
 
+        # INVALID decodeescape(NULL)
         # CRASHES decodeescape(b'abc', NULL, -1)
         # CRASHES decodeescape(NULL, NULL, 1)
 

--- a/Lib/test/test_capi/test_bytes.py
+++ b/Lib/test/test_capi/test_bytes.py
@@ -222,7 +222,6 @@ class CAPITest(unittest.TestCase):
         self.assertEqual(decodeescape(br'x\xa\xy', 'replace'), b'x??y')
         self.assertEqual(decodeescape(br'x\xa\xy', 'ignore'), b'xy')
         self.assertRaises(ValueError, decodeescape, b'\\', 'spam')
-        self.assertEqual(decodeescape(NULL), b'')
         self.assertRaises(OverflowError, decodeescape, b'abc', NULL, PY_SSIZE_T_MAX)
         self.assertRaises(OverflowError, decodeescape, NULL, NULL, PY_SSIZE_T_MAX)
 

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1188,6 +1188,9 @@ PyObject *_PyBytes_DecodeEscape2(const char *s,
     *first_invalid_escape_char = -1;
     *first_invalid_escape_ptr = NULL;
 
+    if (len == 0) {
+        return PyBytesWriter_FinishWithPointer(writer, p);
+    }
     const char *end = s + len;
     while (s < end) {
         if (*s != '\\') {

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1188,9 +1188,6 @@ PyObject *_PyBytes_DecodeEscape2(const char *s,
     *first_invalid_escape_char = -1;
     *first_invalid_escape_ptr = NULL;
 
-    if (len == 0) {
-        return PyBytesWriter_FinishWithPointer(writer, p);
-    }
     const char *end = s + len;
     while (s < end) {
         if (*s != '\\') {

--- a/Tools/ubsan/suppressions.txt
+++ b/Tools/ubsan/suppressions.txt
@@ -20,6 +20,3 @@ pointer-overflow:Modules/_zstd/decompressor.c
 
 # Modules/_io/stringio.c:350:24: runtime error: addition of unsigned offset to 0x7fd01ec25850 overflowed to 0x7fd01ec2584c
 pointer-overflow:Modules/_io/stringio.c
-
-# Objects/bytesobject.c:1190:25: runtime error: applying zero offset to null pointer
-pointer-overflow:Objects/bytesobject.c

--- a/Tools/ubsan/suppressions.txt
+++ b/Tools/ubsan/suppressions.txt
@@ -20,3 +20,6 @@ pointer-overflow:Modules/_zstd/decompressor.c
 
 # Modules/_io/stringio.c:350:24: runtime error: addition of unsigned offset to 0x7fd01ec25850 overflowed to 0x7fd01ec2584c
 pointer-overflow:Modules/_io/stringio.c
+
+# Objects/bytesobject.c:1190:25: runtime error: applying zero offset to null pointer
+pointer-overflow:Objects/bytesobject.c


### PR DESCRIPTION
This is technically disallowed by the documentation of [`PyBytes_DecodeEscape`](https://docs.python.org/3/c-api/bytes.html#c.PyBytes_DecodeEscape) (added in https://github.com/python/cpython/commit/37e2762ee12c2d7fc465938d7161a9a0640bd71f), which says:

> _s_ must not be `NULL`

However, this was triggered by our test suite, which explicitly tests this case:

https://github.com/python/cpython/blob/9c29e17d1cd32537d7e5aad27722d9a5edea0128/Lib/test/test_capi/test_bytes.py#L225

Should we also update the documentation? CC @ZeroIntensity (added docs) and @serhiy-storchaka (added test)
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148286 -->
* Issue: gh-148286
<!-- /gh-issue-number -->
