### PR TITLE
Add tests for syntax error messages that had no test coverage

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1706,6 +1706,9 @@ except Exception:
         with self.assertRaisesRegex(SyntaxError,
                                     "f-string: expecting '=', or '!', or ':', or '}'"):
             compile("f'{a $ b}'", "?", "exec")
+        with self.assertRaisesRegex(SyntaxError,
+                                    "f-string: expecting '!', or ':', or '}'"):
+            compile("f'{a=b}'", "?", "exec")
 
     def test_with_two_commas_in_format_specifier(self):
         error_msg = re.escape("Cannot specify ',' with ','.")

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2238,6 +2238,16 @@ SyntaxError: only single target (not tuple) can be annotated
 Traceback (most recent call last):
 SyntaxError: only single target (not list) can be annotated
 
+>>> 1: int
+Traceback (most recent call last):
+SyntaxError: illegal target for annotation
+>>> -x: int = 1
+Traceback (most recent call last):
+SyntaxError: illegal target for annotation
+>>> (x for x in y): int
+Traceback (most recent call last):
+SyntaxError: illegal target for annotation
+
 # 'not' after operators:
 
 >>> 3 + not 3

--- a/Lib/test/test_unpack_ex.py
+++ b/Lib/test/test_unpack_ex.py
@@ -355,6 +355,20 @@ Error messages for specific failure modes of unpacking
         ^^^
     SyntaxError: cannot use dict unpacking in a dictionary value
 
+    >>> (**a)
+    Traceback (most recent call last):
+    ...
+    (**a)
+     ^^
+    SyntaxError: cannot use dict unpacking here
+
+    >>> {**a for a in {1: 2}.items(): b}
+    Traceback (most recent call last):
+    ...
+    {**a for a in {1: 2}.items(): b}
+     ^^
+    SyntaxError: cannot use dict unpacking here
+
 
 # Generator expression in function arguments
 


### PR DESCRIPTION
Add tests for three specialized syntax error messages which a coverage audit of the error rules in `Grammar/python.gram` found untested:

* `illegal target for annotation` (e.g. `1: int`) had no tests at all;
* `cannot use dict unpacking here` (e.g. `(**a)`) had no tests at all;
* `f-string: expecting '!', or ':', or '}'` (e.g. `f'{a=b}'`) was only tested for its t-string variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
