### PR TITLE
gh-153171: Produce specialized syntax errors in more cases

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -783,6 +783,7 @@ inversion[expr_ty] (memo):
 # --------------------
 
 comparison[expr_ty]:
+    | invalid_comparison
     | a=bitwise_or b=compare_op_bitwise_or_pair+ {
         _PyAST_Compare(
             a,
@@ -825,6 +826,7 @@ bitwise_or[expr_ty]:
 
 bitwise_xor[expr_ty]:
     | a=bitwise_xor '^' b=bitwise_and { _PyAST_BinOp(a, BitXor, b, EXTRA) }
+    | invalid_bitwise_xor
     | bitwise_and
 
 bitwise_and[expr_ty]:
@@ -835,6 +837,7 @@ bitwise_and[expr_ty]:
 shift_expr[expr_ty]:
     | a=shift_expr '<<' b=sum { _PyAST_BinOp(a, LShift, b, EXTRA) }
     | a=shift_expr '>>' b=sum { _PyAST_BinOp(a, RShift, b, EXTRA) }
+    | invalid_shift_expr
     | sum
 
 # Arithmetic operators
@@ -863,6 +866,7 @@ factor[expr_ty] (memo):
 
 power[expr_ty]:
     | a=await_primary '**' b=factor { _PyAST_BinOp(a, Pow, b, EXTRA) }
+    | invalid_power
     | await_primary
 
 # Primary elements
@@ -1373,7 +1377,7 @@ invalid_parameters:
     | param_maybe_default+ '/' a='*' {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "expected comma between / and *") }
 invalid_default:
-    | a='=' &(')'|',') { RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "expected default value expression") }
+    | a='=' &(')'|','|':') { RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "expected default value expression") }
 invalid_star_etc:
     | a='*' (')' | ',' (')' | '**')) { RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "named parameters must follow bare *") }
     | '*' ',' TYPE_COMMENT { RAISE_SYNTAX_ERROR("bare * has associated type comment") }
@@ -1640,14 +1644,25 @@ invalid_arithmetic:
     | sum ('+'|'-'|'*'|'/'|'%'|'//'|'@') a='not' b=inversion { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
 invalid_factor:
     | ('+' | '-' | '~') a='not' b=factor { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
+invalid_comparison:
+    | bitwise_or ('=='|'!='|'<='|'<'|'>='|'>') a='not' b=inversion { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
+invalid_bitwise_xor:
+    | bitwise_xor '^' a='not' b=inversion { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
+invalid_shift_expr:
+    | shift_expr ('<<'|'>>') a='not' b=inversion { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
+invalid_power:
+    | await_primary '**' a='not' b=inversion { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
 
 invalid_type_params:
+    | '[' ','.type_param+ a='=' &(']' | ',') {
+        RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "expected default value expression") }
     | '[' token=']' {
         RAISE_SYNTAX_ERROR_STARTING_FROM(
             token,
             "Type parameter list cannot be empty")}
 
 invalid_bitwise_and:
+    | bitwise_and '&' a='not' b=inversion { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
     | a=bitwise_and b='&' c='&' {
         _PyPegen_tokens_are_adjacent(b, c)
         ? RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'and' or '&' instead of '&&'?")
@@ -1655,6 +1670,7 @@ invalid_bitwise_and:
     }
 
 invalid_bitwise_or:
+    | bitwise_or '|' a='not' b=inversion { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
     | a=bitwise_or b='|' c='|' {
         _PyPegen_tokens_are_adjacent(b, c)
         ? RAISE_SYNTAX_ERROR_KNOWN_RANGE(b, c, "invalid syntax.  Maybe you meant 'or' or '|' instead of '||'?")

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -657,6 +657,10 @@ SyntaxError: expected default value expression
 Traceback (most recent call last):
 SyntaxError: expected default value expression
 
+>>> lambda a,d=: None
+Traceback (most recent call last):
+SyntaxError: expected default value expression
+
 >>> lambda a,d=3,c: None
 Traceback (most recent call last):
 SyntaxError: parameter without a default follows parameter with a default
@@ -2284,6 +2288,38 @@ SyntaxError: 'not' after an operator must be parenthesized
 Traceback (most recent call last):
 SyntaxError: 'not' after an operator must be parenthesized
 
+>>> 1 << not 2
+Traceback (most recent call last):
+SyntaxError: 'not' after an operator must be parenthesized
+
+>>> 1 >> not 2
+Traceback (most recent call last):
+SyntaxError: 'not' after an operator must be parenthesized
+
+>>> 1 & not 2
+Traceback (most recent call last):
+SyntaxError: 'not' after an operator must be parenthesized
+
+>>> 1 ^ not 2
+Traceback (most recent call last):
+SyntaxError: 'not' after an operator must be parenthesized
+
+>>> 1 | not 2
+Traceback (most recent call last):
+SyntaxError: 'not' after an operator must be parenthesized
+
+>>> 1 < not 2
+Traceback (most recent call last):
+SyntaxError: 'not' after an operator must be parenthesized
+
+>>> 1 == not 2
+Traceback (most recent call last):
+SyntaxError: 'not' after an operator must be parenthesized
+
+>>> 2 ** not 2
+Traceback (most recent call last):
+SyntaxError: 'not' after an operator must be parenthesized
+
 # Check that we don't introduce misleading errors
 >>> not 1 */ 2
 Traceback (most recent call last):
@@ -2587,6 +2623,26 @@ Invalid expressions in type scopes:
    Traceback (most recent call last):
    ...
    SyntaxError: Type parameter list cannot be empty
+
+   >>> type A[T=] = int
+   Traceback (most recent call last):
+   ...
+   SyntaxError: expected default value expression
+
+   >>> def f[T: int =](): ...
+   Traceback (most recent call last):
+   ...
+   SyntaxError: expected default value expression
+
+   >>> class A[*T=]: ...
+   Traceback (most recent call last):
+   ...
+   SyntaxError: expected default value expression
+
+   >>> class A[**T=, U]: ...
+   Traceback (most recent call last):
+   ...
+   SyntaxError: expected default value expression
 
    >>> class A[]: ...
    Traceback (most recent call last):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-06-21-00-00.gh-issue-153171.errloc2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-06-21-00-00.gh-issue-153171.errloc2.rst
@@ -1,0 +1,8 @@
+Produce specialized syntax error messages in more cases
+where a generic or unrelated error was previously reported:
+for ``not`` after shift, bitwise, comparison and power operators
+(such as ``1 << not x``),
+for a missing parameter default value in lambda expressions
+(such as ``lambda x=: 0``),
+and for a missing type parameter default value
+(such as ``def f[T=](): pass``).

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -35,7 +35,7 @@ static KeywordToken *reserved_keywords[] = {
         {"for", 712},
         {"try", 674},
         {"and", 590},
-        {"not", 721},
+        {"not", 727},
         {NULL, -1},
     },
     (KeywordToken[]) {
@@ -362,189 +362,196 @@ static char *soft_keywords[] = {
 #define invalid_string_tstring_concat_type 1273
 #define invalid_arithmetic_type 1274  // Left-recursive
 #define invalid_factor_type 1275
-#define invalid_type_params_type 1276
-#define invalid_bitwise_and_type 1277  // Left-recursive
-#define invalid_bitwise_or_type 1278  // Left-recursive
-#define _loop0_1_type 1279
-#define _loop1_2_type 1280
-#define _loop0_3_type 1281
-#define _gather_4_type 1282
-#define _tmp_5_type 1283
-#define _tmp_6_type 1284
-#define _tmp_7_type 1285
-#define _tmp_8_type 1286
-#define _tmp_9_type 1287
-#define _tmp_10_type 1288
-#define _tmp_11_type 1289
-#define _loop1_12_type 1290
-#define _loop0_13_type 1291
-#define _gather_14_type 1292
-#define _tmp_15_type 1293
-#define _tmp_16_type 1294
-#define _loop0_17_type 1295
-#define _loop1_18_type 1296
-#define _loop0_19_type 1297
-#define _gather_20_type 1298
-#define _tmp_21_type 1299
-#define _loop0_22_type 1300
-#define _gather_23_type 1301
-#define _loop1_24_type 1302
-#define _tmp_25_type 1303
-#define _tmp_26_type 1304
-#define _loop0_27_type 1305
-#define _loop0_28_type 1306
-#define _loop1_29_type 1307
-#define _loop1_30_type 1308
-#define _loop0_31_type 1309
-#define _loop1_32_type 1310
-#define _loop0_33_type 1311
-#define _gather_34_type 1312
-#define _tmp_35_type 1313
-#define _loop1_36_type 1314
-#define _loop1_37_type 1315
-#define _loop1_38_type 1316
-#define _loop0_39_type 1317
-#define _gather_40_type 1318
-#define _tmp_41_type 1319
-#define _tmp_42_type 1320
-#define _tmp_43_type 1321
-#define _loop0_44_type 1322
-#define _gather_45_type 1323
-#define _loop0_46_type 1324
-#define _gather_47_type 1325
-#define _tmp_48_type 1326
-#define _loop0_49_type 1327
-#define _gather_50_type 1328
-#define _loop0_51_type 1329
-#define _gather_52_type 1330
-#define _loop0_53_type 1331
-#define _gather_54_type 1332
-#define _loop1_55_type 1333
-#define _loop1_56_type 1334
-#define _loop0_57_type 1335
-#define _gather_58_type 1336
-#define _loop0_59_type 1337
-#define _gather_60_type 1338
-#define _loop1_61_type 1339
-#define _loop1_62_type 1340
-#define _loop1_63_type 1341
-#define _tmp_64_type 1342
-#define _loop0_65_type 1343
-#define _gather_66_type 1344
-#define _tmp_67_type 1345
-#define _tmp_68_type 1346
-#define _tmp_69_type 1347
-#define _tmp_70_type 1348
-#define _tmp_71_type 1349
-#define _loop0_72_type 1350
-#define _loop0_73_type 1351
-#define _loop1_74_type 1352
-#define _loop1_75_type 1353
-#define _loop0_76_type 1354
-#define _loop1_77_type 1355
-#define _loop0_78_type 1356
-#define _loop0_79_type 1357
-#define _loop0_80_type 1358
-#define _loop0_81_type 1359
-#define _loop1_82_type 1360
-#define _loop1_83_type 1361
-#define _tmp_84_type 1362
-#define _loop0_85_type 1363
-#define _gather_86_type 1364
-#define _loop1_87_type 1365
-#define _loop0_88_type 1366
-#define _tmp_89_type 1367
-#define _loop0_90_type 1368
-#define _gather_91_type 1369
-#define _tmp_92_type 1370
-#define _loop0_93_type 1371
-#define _gather_94_type 1372
-#define _loop0_95_type 1373
-#define _gather_96_type 1374
-#define _loop0_97_type 1375
-#define _loop0_98_type 1376
-#define _gather_99_type 1377
-#define _loop1_100_type 1378
-#define _tmp_101_type 1379
-#define _loop0_102_type 1380
-#define _gather_103_type 1381
-#define _loop0_104_type 1382
-#define _gather_105_type 1383
-#define _tmp_106_type 1384
-#define _tmp_107_type 1385
-#define _loop0_108_type 1386
-#define _gather_109_type 1387
-#define _tmp_110_type 1388
-#define _tmp_111_type 1389
-#define _tmp_112_type 1390
-#define _tmp_113_type 1391
-#define _tmp_114_type 1392
-#define _loop1_115_type 1393
-#define _tmp_116_type 1394
-#define _tmp_117_type 1395
-#define _tmp_118_type 1396
-#define _tmp_119_type 1397
-#define _tmp_120_type 1398
-#define _loop0_121_type 1399
-#define _loop0_122_type 1400
-#define _tmp_123_type 1401
-#define _tmp_124_type 1402
-#define _tmp_125_type 1403
-#define _tmp_126_type 1404
-#define _tmp_127_type 1405
-#define _tmp_128_type 1406
-#define _tmp_129_type 1407
-#define _tmp_130_type 1408
-#define _loop0_131_type 1409
-#define _gather_132_type 1410
-#define _tmp_133_type 1411
-#define _tmp_134_type 1412
-#define _tmp_135_type 1413
-#define _tmp_136_type 1414
-#define _loop0_137_type 1415
-#define _gather_138_type 1416
-#define _tmp_139_type 1417
-#define _loop0_140_type 1418
-#define _gather_141_type 1419
-#define _loop0_142_type 1420
-#define _gather_143_type 1421
-#define _tmp_144_type 1422
-#define _loop0_145_type 1423
-#define _tmp_146_type 1424
-#define _tmp_147_type 1425
-#define _tmp_148_type 1426
-#define _tmp_149_type 1427
-#define _tmp_150_type 1428
-#define _tmp_151_type 1429
-#define _tmp_152_type 1430
-#define _tmp_153_type 1431
-#define _tmp_154_type 1432
-#define _tmp_155_type 1433
-#define _tmp_156_type 1434
-#define _tmp_157_type 1435
-#define _tmp_158_type 1436
-#define _tmp_159_type 1437
-#define _tmp_160_type 1438
-#define _tmp_161_type 1439
-#define _tmp_162_type 1440
-#define _tmp_163_type 1441
-#define _tmp_164_type 1442
-#define _tmp_165_type 1443
-#define _tmp_166_type 1444
-#define _tmp_167_type 1445
-#define _tmp_168_type 1446
-#define _tmp_169_type 1447
-#define _tmp_170_type 1448
-#define _tmp_171_type 1449
-#define _tmp_172_type 1450
-#define _tmp_173_type 1451
-#define _loop0_174_type 1452
-#define _tmp_175_type 1453
-#define _tmp_176_type 1454
-#define _tmp_177_type 1455
-#define _tmp_178_type 1456
-#define _tmp_179_type 1457
-#define _tmp_180_type 1458
+#define invalid_comparison_type 1276
+#define invalid_bitwise_xor_type 1277  // Left-recursive
+#define invalid_shift_expr_type 1278  // Left-recursive
+#define invalid_power_type 1279
+#define invalid_type_params_type 1280
+#define invalid_bitwise_and_type 1281  // Left-recursive
+#define invalid_bitwise_or_type 1282  // Left-recursive
+#define _loop0_1_type 1283
+#define _loop1_2_type 1284
+#define _loop0_3_type 1285
+#define _gather_4_type 1286
+#define _tmp_5_type 1287
+#define _tmp_6_type 1288
+#define _tmp_7_type 1289
+#define _tmp_8_type 1290
+#define _tmp_9_type 1291
+#define _tmp_10_type 1292
+#define _tmp_11_type 1293
+#define _loop1_12_type 1294
+#define _loop0_13_type 1295
+#define _gather_14_type 1296
+#define _tmp_15_type 1297
+#define _tmp_16_type 1298
+#define _loop0_17_type 1299
+#define _loop1_18_type 1300
+#define _loop0_19_type 1301
+#define _gather_20_type 1302
+#define _tmp_21_type 1303
+#define _loop0_22_type 1304
+#define _gather_23_type 1305
+#define _loop1_24_type 1306
+#define _tmp_25_type 1307
+#define _tmp_26_type 1308
+#define _loop0_27_type 1309
+#define _loop0_28_type 1310
+#define _loop1_29_type 1311
+#define _loop1_30_type 1312
+#define _loop0_31_type 1313
+#define _loop1_32_type 1314
+#define _loop0_33_type 1315
+#define _gather_34_type 1316
+#define _tmp_35_type 1317
+#define _loop1_36_type 1318
+#define _loop1_37_type 1319
+#define _loop1_38_type 1320
+#define _loop0_39_type 1321
+#define _gather_40_type 1322
+#define _tmp_41_type 1323
+#define _tmp_42_type 1324
+#define _tmp_43_type 1325
+#define _loop0_44_type 1326
+#define _gather_45_type 1327
+#define _loop0_46_type 1328
+#define _gather_47_type 1329
+#define _tmp_48_type 1330
+#define _loop0_49_type 1331
+#define _gather_50_type 1332
+#define _loop0_51_type 1333
+#define _gather_52_type 1334
+#define _loop0_53_type 1335
+#define _gather_54_type 1336
+#define _loop1_55_type 1337
+#define _loop1_56_type 1338
+#define _loop0_57_type 1339
+#define _gather_58_type 1340
+#define _loop0_59_type 1341
+#define _gather_60_type 1342
+#define _loop1_61_type 1343
+#define _loop1_62_type 1344
+#define _loop1_63_type 1345
+#define _tmp_64_type 1346
+#define _loop0_65_type 1347
+#define _gather_66_type 1348
+#define _tmp_67_type 1349
+#define _tmp_68_type 1350
+#define _tmp_69_type 1351
+#define _tmp_70_type 1352
+#define _tmp_71_type 1353
+#define _loop0_72_type 1354
+#define _loop0_73_type 1355
+#define _loop1_74_type 1356
+#define _loop1_75_type 1357
+#define _loop0_76_type 1358
+#define _loop1_77_type 1359
+#define _loop0_78_type 1360
+#define _loop0_79_type 1361
+#define _loop0_80_type 1362
+#define _loop0_81_type 1363
+#define _loop1_82_type 1364
+#define _loop1_83_type 1365
+#define _tmp_84_type 1366
+#define _loop0_85_type 1367
+#define _gather_86_type 1368
+#define _loop1_87_type 1369
+#define _loop0_88_type 1370
+#define _tmp_89_type 1371
+#define _loop0_90_type 1372
+#define _gather_91_type 1373
+#define _tmp_92_type 1374
+#define _loop0_93_type 1375
+#define _gather_94_type 1376
+#define _loop0_95_type 1377
+#define _gather_96_type 1378
+#define _loop0_97_type 1379
+#define _loop0_98_type 1380
+#define _gather_99_type 1381
+#define _loop1_100_type 1382
+#define _tmp_101_type 1383
+#define _loop0_102_type 1384
+#define _gather_103_type 1385
+#define _loop0_104_type 1386
+#define _gather_105_type 1387
+#define _tmp_106_type 1388
+#define _tmp_107_type 1389
+#define _loop0_108_type 1390
+#define _gather_109_type 1391
+#define _tmp_110_type 1392
+#define _tmp_111_type 1393
+#define _tmp_112_type 1394
+#define _tmp_113_type 1395
+#define _tmp_114_type 1396
+#define _loop1_115_type 1397
+#define _tmp_116_type 1398
+#define _tmp_117_type 1399
+#define _tmp_118_type 1400
+#define _tmp_119_type 1401
+#define _tmp_120_type 1402
+#define _loop0_121_type 1403
+#define _loop0_122_type 1404
+#define _tmp_123_type 1405
+#define _tmp_124_type 1406
+#define _tmp_125_type 1407
+#define _tmp_126_type 1408
+#define _tmp_127_type 1409
+#define _tmp_128_type 1410
+#define _tmp_129_type 1411
+#define _tmp_130_type 1412
+#define _loop0_131_type 1413
+#define _gather_132_type 1414
+#define _tmp_133_type 1415
+#define _tmp_134_type 1416
+#define _tmp_135_type 1417
+#define _tmp_136_type 1418
+#define _loop0_137_type 1419
+#define _gather_138_type 1420
+#define _tmp_139_type 1421
+#define _loop0_140_type 1422
+#define _gather_141_type 1423
+#define _loop0_142_type 1424
+#define _gather_143_type 1425
+#define _tmp_144_type 1426
+#define _loop0_145_type 1427
+#define _tmp_146_type 1428
+#define _tmp_147_type 1429
+#define _tmp_148_type 1430
+#define _tmp_149_type 1431
+#define _tmp_150_type 1432
+#define _tmp_151_type 1433
+#define _tmp_152_type 1434
+#define _tmp_153_type 1435
+#define _tmp_154_type 1436
+#define _tmp_155_type 1437
+#define _tmp_156_type 1438
+#define _tmp_157_type 1439
+#define _tmp_158_type 1440
+#define _tmp_159_type 1441
+#define _tmp_160_type 1442
+#define _tmp_161_type 1443
+#define _tmp_162_type 1444
+#define _tmp_163_type 1445
+#define _tmp_164_type 1446
+#define _tmp_165_type 1447
+#define _tmp_166_type 1448
+#define _tmp_167_type 1449
+#define _tmp_168_type 1450
+#define _tmp_169_type 1451
+#define _tmp_170_type 1452
+#define _tmp_171_type 1453
+#define _tmp_172_type 1454
+#define _tmp_173_type 1455
+#define _tmp_174_type 1456
+#define _tmp_175_type 1457
+#define _tmp_176_type 1458
+#define _loop0_177_type 1459
+#define _tmp_178_type 1460
+#define _tmp_179_type 1461
+#define _tmp_180_type 1462
+#define _tmp_181_type 1463
+#define _tmp_182_type 1464
+#define _tmp_183_type 1465
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -822,6 +829,10 @@ static void *invalid_tstring_conversion_character_rule(Parser *p);
 static void *invalid_string_tstring_concat_rule(Parser *p);
 static void *invalid_arithmetic_rule(Parser *p);
 static void *invalid_factor_rule(Parser *p);
+static void *invalid_comparison_rule(Parser *p);
+static void *invalid_bitwise_xor_rule(Parser *p);
+static void *invalid_shift_expr_rule(Parser *p);
+static void *invalid_power_rule(Parser *p);
 static void *invalid_type_params_rule(Parser *p);
 static void *invalid_bitwise_and_rule(Parser *p);
 static void *invalid_bitwise_or_rule(Parser *p);
@@ -998,13 +1009,16 @@ static void *_tmp_170_rule(Parser *p);
 static void *_tmp_171_rule(Parser *p);
 static void *_tmp_172_rule(Parser *p);
 static void *_tmp_173_rule(Parser *p);
-static asdl_seq *_loop0_174_rule(Parser *p);
+static void *_tmp_174_rule(Parser *p);
 static void *_tmp_175_rule(Parser *p);
 static void *_tmp_176_rule(Parser *p);
-static void *_tmp_177_rule(Parser *p);
+static asdl_seq *_loop0_177_rule(Parser *p);
 static void *_tmp_178_rule(Parser *p);
 static void *_tmp_179_rule(Parser *p);
 static void *_tmp_180_rule(Parser *p);
+static void *_tmp_181_rule(Parser *p);
+static void *_tmp_182_rule(Parser *p);
+static void *_tmp_183_rule(Parser *p);
 
 
 // file: statements? $
@@ -12707,7 +12721,7 @@ inversion_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 721))  // token='not'
+            (_keyword = _PyPegen_expect_token(p, 727))  // token='not'
             &&
             (a = inversion_rule(p))  // inversion
         )
@@ -12760,7 +12774,7 @@ inversion_rule(Parser *p)
     return _res;
 }
 
-// comparison: bitwise_or compare_op_bitwise_or_pair+ | bitwise_or
+// comparison: invalid_comparison | bitwise_or compare_op_bitwise_or_pair+ | bitwise_or
 static expr_ty
 comparison_rule(Parser *p)
 {
@@ -12782,6 +12796,25 @@ comparison_rule(Parser *p)
     UNUSED(_start_lineno); // Only used by EXTRA macro
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
+    if (p->call_invalid_rules) { // invalid_comparison
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> comparison[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_comparison"));
+        void *invalid_comparison_var;
+        if (
+            (invalid_comparison_var = invalid_comparison_rule(p))  // invalid_comparison
+        )
+        {
+            D(fprintf(stderr, "%*c+ comparison[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "invalid_comparison"));
+            _res = invalid_comparison_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s comparison[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_comparison"));
+    }
     { // bitwise_or compare_op_bitwise_or_pair+
         if (p->error_indicator) {
             p->level--;
@@ -13361,7 +13394,7 @@ notin_bitwise_or_rule(Parser *p)
         Token * _keyword_1;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 721))  // token='not'
+            (_keyword = _PyPegen_expect_token(p, 727))  // token='not'
             &&
             (_keyword_1 = _PyPegen_expect_token(p, 713))  // token='in'
             &&
@@ -13458,7 +13491,7 @@ isnot_bitwise_or_rule(Parser *p)
         if (
             (_keyword = _PyPegen_expect_token(p, 597))  // token='is'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 721))  // token='not'
+            (_keyword_1 = _PyPegen_expect_token(p, 727))  // token='not'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -13670,7 +13703,7 @@ bitwise_or_raw(Parser *p)
 }
 
 // Left-recursive
-// bitwise_xor: bitwise_xor '^' bitwise_and | bitwise_and
+// bitwise_xor: bitwise_xor '^' bitwise_and | invalid_bitwise_xor | bitwise_and
 static expr_ty bitwise_xor_raw(Parser *);
 static expr_ty
 bitwise_xor_rule(Parser *p)
@@ -13765,6 +13798,25 @@ bitwise_xor_raw(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s bitwise_xor[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "bitwise_xor '^' bitwise_and"));
+    }
+    if (p->call_invalid_rules) { // invalid_bitwise_xor
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> bitwise_xor[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_bitwise_xor"));
+        void *invalid_bitwise_xor_var;
+        if (
+            (invalid_bitwise_xor_var = invalid_bitwise_xor_rule(p))  // invalid_bitwise_xor
+        )
+        {
+            D(fprintf(stderr, "%*c+ bitwise_xor[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "invalid_bitwise_xor"));
+            _res = invalid_bitwise_xor_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s bitwise_xor[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_bitwise_xor"));
     }
     { // bitwise_and
         if (p->error_indicator) {
@@ -13933,7 +13985,7 @@ bitwise_and_raw(Parser *p)
 }
 
 // Left-recursive
-// shift_expr: shift_expr '<<' sum | shift_expr '>>' sum | sum
+// shift_expr: shift_expr '<<' sum | shift_expr '>>' sum | invalid_shift_expr | sum
 static expr_ty shift_expr_raw(Parser *);
 static expr_ty
 shift_expr_rule(Parser *p)
@@ -14067,6 +14119,25 @@ shift_expr_raw(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s shift_expr[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "shift_expr '>>' sum"));
+    }
+    if (p->call_invalid_rules) { // invalid_shift_expr
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> shift_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_shift_expr"));
+        void *invalid_shift_expr_var;
+        if (
+            (invalid_shift_expr_var = invalid_shift_expr_rule(p))  // invalid_shift_expr
+        )
+        {
+            D(fprintf(stderr, "%*c+ shift_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "invalid_shift_expr"));
+            _res = invalid_shift_expr_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s shift_expr[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_shift_expr"));
     }
     { // sum
         if (p->error_indicator) {
@@ -14736,7 +14807,7 @@ factor_rule(Parser *p)
     return _res;
 }
 
-// power: await_primary '**' factor | await_primary
+// power: await_primary '**' factor | invalid_power | await_primary
 static expr_ty
 power_rule(Parser *p)
 {
@@ -14796,6 +14867,25 @@ power_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s power[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "await_primary '**' factor"));
+    }
+    if (p->call_invalid_rules) { // invalid_power
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> power[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_power"));
+        void *invalid_power_var;
+        if (
+            (invalid_power_var = invalid_power_rule(p))  // invalid_power
+        )
+        {
+            D(fprintf(stderr, "%*c+ power[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "invalid_power"));
+            _res = invalid_power_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s power[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_power"));
     }
     { // await_primary
         if (p->error_indicator) {
@@ -23226,7 +23316,7 @@ invalid_parameters_rule(Parser *p)
     return _res;
 }
 
-// invalid_default: '=' &(')' | ',')
+// invalid_default: '=' &(')' | ',' | ':')
 static void *
 invalid_default_rule(Parser *p)
 {
@@ -23239,12 +23329,12 @@ invalid_default_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
-    { // '=' &(')' | ',')
+    { // '=' &(')' | ',' | ':')
         if (p->error_indicator) {
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> invalid_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'=' &(')' | ',')"));
+        D(fprintf(stderr, "%*c> invalid_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'=' &(')' | ',' | ':')"));
         Token * a;
         if (
             (a = _PyPegen_expect_token(p, 22))  // token='='
@@ -23252,7 +23342,7 @@ invalid_default_rule(Parser *p)
             _PyPegen_lookahead(1, _tmp_126_rule, p)
         )
         {
-            D(fprintf(stderr, "%*c+ invalid_default[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'=' &(')' | ',')"));
+            D(fprintf(stderr, "%*c+ invalid_default[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'=' &(')' | ',' | ':')"));
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "expected default value expression" );
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -23263,7 +23353,7 @@ invalid_default_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s invalid_default[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'=' &(')' | ',')"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'=' &(')' | ',' | ':')"));
     }
     _res = NULL;
   done:
@@ -28438,7 +28528,7 @@ invalid_arithmetic_rule(Parser *p)
             &&
             (_tmp_157_var = _tmp_157_rule(p))  // '+' | '-' | '*' | '/' | '%' | '//' | '@'
             &&
-            (a = _PyPegen_expect_token(p, 721))  // token='not'
+            (a = _PyPegen_expect_token(p, 727))  // token='not'
             &&
             (b = inversion_rule(p))  // inversion
         )
@@ -28487,7 +28577,7 @@ invalid_factor_rule(Parser *p)
         if (
             (_tmp_158_var = _tmp_158_rule(p))  // '+' | '-' | '~'
             &&
-            (a = _PyPegen_expect_token(p, 721))  // token='not'
+            (a = _PyPegen_expect_token(p, 727))  // token='not'
             &&
             (b = factor_rule(p))  // factor
         )
@@ -28511,7 +28601,217 @@ invalid_factor_rule(Parser *p)
     return _res;
 }
 
-// invalid_type_params: '[' ']'
+// invalid_comparison: bitwise_or ('==' | '!=' | '<=' | '<' | '>=' | '>') 'not' inversion
+static void *
+invalid_comparison_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // bitwise_or ('==' | '!=' | '<=' | '<' | '>=' | '>') 'not' inversion
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_comparison[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_or ('==' | '!=' | '<=' | '<' | '>=' | '>') 'not' inversion"));
+        void *_tmp_159_var;
+        Token * a;
+        expr_ty b;
+        expr_ty bitwise_or_var;
+        if (
+            (bitwise_or_var = bitwise_or_rule(p))  // bitwise_or
+            &&
+            (_tmp_159_var = _tmp_159_rule(p))  // '==' | '!=' | '<=' | '<' | '>=' | '>'
+            &&
+            (a = _PyPegen_expect_token(p, 727))  // token='not'
+            &&
+            (b = inversion_rule(p))  // inversion
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_comparison[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_or ('==' | '!=' | '<=' | '<' | '>=' | '>') 'not' inversion"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "'not' after an operator must be parenthesized" );
+            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_comparison[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "bitwise_or ('==' | '!=' | '<=' | '<' | '>=' | '>') 'not' inversion"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
+// Left-recursive
+// invalid_bitwise_xor: bitwise_xor '^' 'not' inversion
+static void *
+invalid_bitwise_xor_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // bitwise_xor '^' 'not' inversion
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_bitwise_xor[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_xor '^' 'not' inversion"));
+        Token * _literal;
+        Token * a;
+        expr_ty b;
+        expr_ty bitwise_xor_var;
+        if (
+            (bitwise_xor_var = bitwise_xor_rule(p))  // bitwise_xor
+            &&
+            (_literal = _PyPegen_expect_token(p, 32))  // token='^'
+            &&
+            (a = _PyPegen_expect_token(p, 727))  // token='not'
+            &&
+            (b = inversion_rule(p))  // inversion
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_bitwise_xor[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_xor '^' 'not' inversion"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "'not' after an operator must be parenthesized" );
+            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_bitwise_xor[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "bitwise_xor '^' 'not' inversion"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
+// Left-recursive
+// invalid_shift_expr: shift_expr ('<<' | '>>') 'not' inversion
+static void *
+invalid_shift_expr_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // shift_expr ('<<' | '>>') 'not' inversion
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_shift_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "shift_expr ('<<' | '>>') 'not' inversion"));
+        void *_tmp_160_var;
+        Token * a;
+        expr_ty b;
+        expr_ty shift_expr_var;
+        if (
+            (shift_expr_var = shift_expr_rule(p))  // shift_expr
+            &&
+            (_tmp_160_var = _tmp_160_rule(p))  // '<<' | '>>'
+            &&
+            (a = _PyPegen_expect_token(p, 727))  // token='not'
+            &&
+            (b = inversion_rule(p))  // inversion
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_shift_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "shift_expr ('<<' | '>>') 'not' inversion"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "'not' after an operator must be parenthesized" );
+            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_shift_expr[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "shift_expr ('<<' | '>>') 'not' inversion"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
+// invalid_power: await_primary '**' 'not' inversion
+static void *
+invalid_power_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // await_primary '**' 'not' inversion
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_power[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "await_primary '**' 'not' inversion"));
+        Token * _literal;
+        Token * a;
+        expr_ty await_primary_var;
+        expr_ty b;
+        if (
+            (await_primary_var = await_primary_rule(p))  // await_primary
+            &&
+            (_literal = _PyPegen_expect_token(p, 35))  // token='**'
+            &&
+            (a = _PyPegen_expect_token(p, 727))  // token='not'
+            &&
+            (b = inversion_rule(p))  // inversion
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_power[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "await_primary '**' 'not' inversion"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "'not' after an operator must be parenthesized" );
+            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_power[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "await_primary '**' 'not' inversion"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
+// invalid_type_params: '[' ','.type_param+ '=' &(']' | ',') | '[' ']'
 static void *
 invalid_type_params_rule(Parser *p)
 {
@@ -28524,6 +28824,38 @@ invalid_type_params_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
+    { // '[' ','.type_param+ '=' &(']' | ',')
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_type_params[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'[' ','.type_param+ '=' &(']' | ',')"));
+        asdl_seq * _gather_54_var;
+        Token * _literal;
+        Token * a;
+        if (
+            (_literal = _PyPegen_expect_token(p, 9))  // token='['
+            &&
+            (_gather_54_var = _gather_54_rule(p))  // ','.type_param+
+            &&
+            (a = _PyPegen_expect_token(p, 22))  // token='='
+            &&
+            _PyPegen_lookahead(1, _tmp_161_rule, p)
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_type_params[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'[' ','.type_param+ '=' &(']' | ',')"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "expected default value expression" );
+            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_type_params[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'[' ','.type_param+ '=' &(']' | ',')"));
+    }
     { // '[' ']'
         if (p->error_indicator) {
             p->level--;
@@ -28558,7 +28890,7 @@ invalid_type_params_rule(Parser *p)
 }
 
 // Left-recursive
-// invalid_bitwise_and: bitwise_and '&' '&'
+// invalid_bitwise_and: bitwise_and '&' 'not' inversion | bitwise_and '&' '&'
 static void *
 invalid_bitwise_and_rule(Parser *p)
 {
@@ -28571,6 +28903,39 @@ invalid_bitwise_and_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
+    { // bitwise_and '&' 'not' inversion
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_bitwise_and[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_and '&' 'not' inversion"));
+        Token * _literal;
+        Token * a;
+        expr_ty b;
+        expr_ty bitwise_and_var;
+        if (
+            (bitwise_and_var = bitwise_and_rule(p))  // bitwise_and
+            &&
+            (_literal = _PyPegen_expect_token(p, 19))  // token='&'
+            &&
+            (a = _PyPegen_expect_token(p, 727))  // token='not'
+            &&
+            (b = inversion_rule(p))  // inversion
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_bitwise_and[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_and '&' 'not' inversion"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "'not' after an operator must be parenthesized" );
+            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_bitwise_and[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "bitwise_and '&' 'not' inversion"));
+    }
     { // bitwise_and '&' '&'
         if (p->error_indicator) {
             p->level--;
@@ -28608,7 +28973,7 @@ invalid_bitwise_and_rule(Parser *p)
 }
 
 // Left-recursive
-// invalid_bitwise_or: bitwise_or '|' '|'
+// invalid_bitwise_or: bitwise_or '|' 'not' inversion | bitwise_or '|' '|'
 static void *
 invalid_bitwise_or_rule(Parser *p)
 {
@@ -28621,6 +28986,39 @@ invalid_bitwise_or_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
+    { // bitwise_or '|' 'not' inversion
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_bitwise_or[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_or '|' 'not' inversion"));
+        Token * _literal;
+        Token * a;
+        expr_ty b;
+        expr_ty bitwise_or_var;
+        if (
+            (bitwise_or_var = bitwise_or_rule(p))  // bitwise_or
+            &&
+            (_literal = _PyPegen_expect_token(p, 18))  // token='|'
+            &&
+            (a = _PyPegen_expect_token(p, 727))  // token='not'
+            &&
+            (b = inversion_rule(p))  // inversion
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_bitwise_or[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_or '|' 'not' inversion"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "'not' after an operator must be parenthesized" );
+            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_bitwise_or[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "bitwise_or '|' 'not' inversion"));
+    }
     { // bitwise_or '|' '|'
         if (p->error_indicator) {
             p->level--;
@@ -29378,12 +29776,12 @@ _loop1_12_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_12[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(star_targets '=')"));
-        void *_tmp_159_var;
+        void *_tmp_162_var;
         while (
-            (_tmp_159_var = _tmp_159_rule(p))  // star_targets '='
+            (_tmp_162_var = _tmp_162_rule(p))  // star_targets '='
         )
         {
-            _res = _tmp_159_var;
+            _res = _tmp_162_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -29670,12 +30068,12 @@ _loop0_17_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_17[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('.' | '...')"));
-        void *_tmp_160_var;
+        void *_tmp_163_var;
         while (
-            (_tmp_160_var = _tmp_160_rule(p))  // '.' | '...'
+            (_tmp_163_var = _tmp_163_rule(p))  // '.' | '...'
         )
         {
-            _res = _tmp_160_var;
+            _res = _tmp_163_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -29737,12 +30135,12 @@ _loop1_18_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_18[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('.' | '...')"));
-        void *_tmp_160_var;
+        void *_tmp_163_var;
         while (
-            (_tmp_160_var = _tmp_160_rule(p))  // '.' | '...'
+            (_tmp_163_var = _tmp_163_rule(p))  // '.' | '...'
         )
         {
-            _res = _tmp_160_var;
+            _res = _tmp_163_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -30089,12 +30487,12 @@ _loop1_24_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_24[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('@' named_expression NEWLINE)"));
-        void *_tmp_161_var;
+        void *_tmp_164_var;
         while (
-            (_tmp_161_var = _tmp_161_rule(p))  // '@' named_expression NEWLINE
+            (_tmp_164_var = _tmp_164_rule(p))  // '@' named_expression NEWLINE
         )
         {
-            _res = _tmp_161_var;
+            _res = _tmp_164_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -32122,12 +32520,12 @@ _loop1_56_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_56[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(',' star_expression)"));
-        void *_tmp_162_var;
+        void *_tmp_165_var;
         while (
-            (_tmp_162_var = _tmp_162_rule(p))  // ',' star_expression
+            (_tmp_165_var = _tmp_165_rule(p))  // ',' star_expression
         )
         {
-            _res = _tmp_162_var;
+            _res = _tmp_165_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -32428,12 +32826,12 @@ _loop1_61_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_61[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('or' conjunction)"));
-        void *_tmp_163_var;
+        void *_tmp_166_var;
         while (
-            (_tmp_163_var = _tmp_163_rule(p))  // 'or' conjunction
+            (_tmp_166_var = _tmp_166_rule(p))  // 'or' conjunction
         )
         {
-            _res = _tmp_163_var;
+            _res = _tmp_166_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -32500,12 +32898,12 @@ _loop1_62_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_62[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('and' inversion)"));
-        void *_tmp_164_var;
+        void *_tmp_167_var;
         while (
-            (_tmp_164_var = _tmp_164_rule(p))  // 'and' inversion
+            (_tmp_167_var = _tmp_167_rule(p))  // 'and' inversion
         )
         {
-            _res = _tmp_164_var;
+            _res = _tmp_167_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -32692,7 +33090,7 @@ _loop0_65_rule(Parser *p)
         while (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = _tmp_165_rule(p))  // slice | starred_expression
+            (elem = _tmp_168_rule(p))  // slice | starred_expression
         )
         {
             _res = elem;
@@ -32757,7 +33155,7 @@ _gather_66_rule(Parser *p)
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_165_rule(p))  // slice | starred_expression
+            (elem = _tmp_168_rule(p))  // slice | starred_expression
             &&
             (seq = _loop0_65_rule(p))  // _loop0_65
         )
@@ -34202,12 +34600,12 @@ _loop0_88_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_88[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('if' disjunction)"));
-        void *_tmp_166_var;
+        void *_tmp_169_var;
         while (
-            (_tmp_166_var = _tmp_166_rule(p))  // 'if' disjunction
+            (_tmp_169_var = _tmp_169_rule(p))  // 'if' disjunction
         )
         {
-            _res = _tmp_166_var;
+            _res = _tmp_169_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -34352,7 +34750,7 @@ _loop0_90_rule(Parser *p)
         while (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = _tmp_167_rule(p))  // starred_expression | (assignment_expression | expression !':=') !'='
+            (elem = _tmp_170_rule(p))  // starred_expression | (assignment_expression | expression !':=') !'='
         )
         {
             _res = elem;
@@ -34418,7 +34816,7 @@ _gather_91_rule(Parser *p)
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_167_rule(p))  // starred_expression | (assignment_expression | expression !':=') !'='
+            (elem = _tmp_170_rule(p))  // starred_expression | (assignment_expression | expression !':=') !'='
             &&
             (seq = _loop0_90_rule(p))  // _loop0_90
         )
@@ -34745,12 +35143,12 @@ _loop0_97_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_97[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(',' star_target)"));
-        void *_tmp_168_var;
+        void *_tmp_171_var;
         while (
-            (_tmp_168_var = _tmp_168_rule(p))  // ',' star_target
+            (_tmp_171_var = _tmp_171_rule(p))  // ',' star_target
         )
         {
-            _res = _tmp_168_var;
+            _res = _tmp_171_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -34929,12 +35327,12 @@ _loop1_100_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_100[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(',' star_target)"));
-        void *_tmp_168_var;
+        void *_tmp_171_var;
         while (
-            (_tmp_168_var = _tmp_168_rule(p))  // ',' star_target
+            (_tmp_171_var = _tmp_171_rule(p))  // ',' star_target
         )
         {
-            _res = _tmp_168_var;
+            _res = _tmp_171_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -35309,13 +35707,13 @@ _tmp_107_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_107[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(','.(starred_expression | (assignment_expression | expression !':=') !'=')+ ',' kwargs)"));
-        void *_tmp_169_var;
+        void *_tmp_172_var;
         if (
-            (_tmp_169_var = _tmp_169_rule(p))  // ','.(starred_expression | (assignment_expression | expression !':=') !'=')+ ',' kwargs
+            (_tmp_172_var = _tmp_172_rule(p))  // ','.(starred_expression | (assignment_expression | expression !':=') !'=')+ ',' kwargs
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_107[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "(','.(starred_expression | (assignment_expression | expression !':=') !'=')+ ',' kwargs)"));
-            _res = _tmp_169_var;
+            _res = _tmp_172_var;
             goto done;
         }
         p->mark = _mark;
@@ -35380,7 +35778,7 @@ _loop0_108_rule(Parser *p)
         while (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = _tmp_170_rule(p))  // starred_expression !'='
+            (elem = _tmp_173_rule(p))  // starred_expression !'='
         )
         {
             _res = elem;
@@ -35445,7 +35843,7 @@ _gather_109_rule(Parser *p)
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_170_rule(p))  // starred_expression !'='
+            (elem = _tmp_173_rule(p))  // starred_expression !'='
             &&
             (seq = _loop0_108_rule(p))  // _loop0_108
         )
@@ -35767,12 +36165,12 @@ _loop1_115_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_115[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(!STRING expression_without_invalid)"));
-        void *_tmp_171_var;
+        void *_tmp_174_var;
         while (
-            (_tmp_171_var = _tmp_171_rule(p))  // !STRING expression_without_invalid
+            (_tmp_174_var = _tmp_174_rule(p))  // !STRING expression_without_invalid
         )
         {
-            _res = _tmp_171_var;
+            _res = _tmp_174_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -36289,12 +36687,12 @@ _loop0_122_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_122[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(star_targets '=')"));
-        void *_tmp_159_var;
+        void *_tmp_162_var;
         while (
-            (_tmp_159_var = _tmp_159_rule(p))  // star_targets '='
+            (_tmp_162_var = _tmp_162_rule(p))  // star_targets '='
         )
         {
-            _res = _tmp_159_var;
+            _res = _tmp_162_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -36499,7 +36897,7 @@ _tmp_125_rule(Parser *p)
     return _res;
 }
 
-// _tmp_126: ')' | ','
+// _tmp_126: ')' | ',' | ':'
 static void *
 _tmp_126_rule(Parser *p)
 {
@@ -36550,6 +36948,25 @@ _tmp_126_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _tmp_126[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "','"));
     }
+    { // ':'
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_126[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':'"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 11))  // token=':'
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_126[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "':'"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_126[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "':'"));
+    }
     _res = NULL;
   done:
     p->level--;
@@ -36595,15 +37012,15 @@ _tmp_127_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> _tmp_127[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' (')' | '**')"));
         Token * _literal;
-        void *_tmp_172_var;
+        void *_tmp_175_var;
         if (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (_tmp_172_var = _tmp_172_rule(p))  // ')' | '**'
+            (_tmp_175_var = _tmp_175_rule(p))  // ')' | '**'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_127[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "',' (')' | '**')"));
-            _res = _PyPegen_dummy_name(p, _literal, _tmp_172_var);
+            _res = _PyPegen_dummy_name(p, _literal, _tmp_175_var);
             goto done;
         }
         p->mark = _mark;
@@ -37019,15 +37436,15 @@ _tmp_134_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> _tmp_134[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' (':' | '**')"));
         Token * _literal;
-        void *_tmp_173_var;
+        void *_tmp_176_var;
         if (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (_tmp_173_var = _tmp_173_rule(p))  // ':' | '**'
+            (_tmp_176_var = _tmp_176_rule(p))  // ':' | '**'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_134[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "',' (':' | '**')"));
-            _res = _PyPegen_dummy_name(p, _literal, _tmp_173_var);
+            _res = _PyPegen_dummy_name(p, _literal, _tmp_176_var);
             goto done;
         }
         p->mark = _mark;
@@ -37116,20 +37533,20 @@ _tmp_136_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_136[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "bitwise_or ((',' bitwise_or))* ','?"));
-        asdl_seq * _loop0_174_var;
+        asdl_seq * _loop0_177_var;
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty bitwise_or_var;
         if (
             (bitwise_or_var = bitwise_or_rule(p))  // bitwise_or
             &&
-            (_loop0_174_var = _loop0_174_rule(p))  // ((',' bitwise_or))*
+            (_loop0_177_var = _loop0_177_rule(p))  // ((',' bitwise_or))*
             &&
             (_opt_var = _PyPegen_expect_token(p, 12), !p->error_indicator)  // ','?
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_136[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "bitwise_or ((',' bitwise_or))* ','?"));
-            _res = _PyPegen_dummy_name(p, bitwise_or_var, _loop0_174_var, _opt_var);
+            _res = _PyPegen_dummy_name(p, bitwise_or_var, _loop0_177_var, _opt_var);
             goto done;
         }
         p->mark = _mark;
@@ -37278,16 +37695,16 @@ _tmp_139_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _tmp_139[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME (',' | ')' | ';' | NEWLINE)"));
-        void *_tmp_175_var;
+        void *_tmp_178_var;
         expr_ty name_var;
         if (
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
-            (_tmp_175_var = _tmp_175_rule(p))  // ',' | ')' | ';' | NEWLINE
+            (_tmp_178_var = _tmp_178_rule(p))  // ',' | ')' | ';' | NEWLINE
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_139[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME (',' | ')' | ';' | NEWLINE)"));
-            _res = _PyPegen_dummy_name(p, name_var, _tmp_175_var);
+            _res = _PyPegen_dummy_name(p, name_var, _tmp_178_var);
             goto done;
         }
         p->mark = _mark;
@@ -37333,7 +37750,7 @@ _loop0_140_rule(Parser *p)
         while (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = _tmp_176_rule(p))  // expression ['as' star_target]
+            (elem = _tmp_179_rule(p))  // expression ['as' star_target]
         )
         {
             _res = elem;
@@ -37398,7 +37815,7 @@ _gather_141_rule(Parser *p)
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_176_rule(p))  // expression ['as' star_target]
+            (elem = _tmp_179_rule(p))  // expression ['as' star_target]
             &&
             (seq = _loop0_140_rule(p))  // _loop0_140
         )
@@ -37450,7 +37867,7 @@ _loop0_142_rule(Parser *p)
         while (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = _tmp_177_rule(p))  // expressions ['as' star_target]
+            (elem = _tmp_180_rule(p))  // expressions ['as' star_target]
         )
         {
             _res = elem;
@@ -37515,7 +37932,7 @@ _gather_143_rule(Parser *p)
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_177_rule(p))  // expressions ['as' star_target]
+            (elem = _tmp_180_rule(p))  // expressions ['as' star_target]
             &&
             (seq = _loop0_142_rule(p))  // _loop0_142
         )
@@ -38507,9 +38924,256 @@ _tmp_158_rule(Parser *p)
     return _res;
 }
 
-// _tmp_159: star_targets '='
+// _tmp_159: '==' | '!=' | '<=' | '<' | '>=' | '>'
 static void *
 _tmp_159_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // '=='
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_159[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'=='"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 27))  // token='=='
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_159[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'=='"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_159[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'=='"));
+    }
+    { // '!='
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_159[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'!='"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 28))  // token='!='
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_159[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'!='"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_159[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'!='"));
+    }
+    { // '<='
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_159[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'<='"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 29))  // token='<='
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_159[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'<='"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_159[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'<='"));
+    }
+    { // '<'
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_159[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'<'"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 20))  // token='<'
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_159[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'<'"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_159[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'<'"));
+    }
+    { // '>='
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_159[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'>='"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 30))  // token='>='
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_159[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'>='"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_159[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'>='"));
+    }
+    { // '>'
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_159[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'>'"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 21))  // token='>'
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_159[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'>'"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_159[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'>'"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
+// _tmp_160: '<<' | '>>'
+static void *
+_tmp_160_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // '<<'
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_160[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'<<'"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 33))  // token='<<'
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_160[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'<<'"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_160[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'<<'"));
+    }
+    { // '>>'
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_160[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'>>'"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 34))  // token='>>'
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_160[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'>>'"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_160[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'>>'"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
+// _tmp_161: ']' | ','
+static void *
+_tmp_161_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // ']'
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_161[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "']'"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 10))  // token=']'
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_161[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "']'"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_161[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "']'"));
+    }
+    { // ','
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_161[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 12))  // token=','
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_161[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_161[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "','"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
+// _tmp_162: star_targets '='
+static void *
+_tmp_162_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -38525,7 +39189,7 @@ _tmp_159_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_159[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_targets '='"));
+        D(fprintf(stderr, "%*c> _tmp_162[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_targets '='"));
         Token * _literal;
         expr_ty z;
         if (
@@ -38534,7 +39198,7 @@ _tmp_159_rule(Parser *p)
             (_literal = _PyPegen_expect_token(p, 22))  // token='='
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_159[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "star_targets '='"));
+            D(fprintf(stderr, "%*c+ _tmp_162[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "star_targets '='"));
             _res = z;
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -38544,7 +39208,7 @@ _tmp_159_rule(Parser *p)
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_159[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_162[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "star_targets '='"));
     }
     _res = NULL;
@@ -38553,9 +39217,9 @@ _tmp_159_rule(Parser *p)
     return _res;
 }
 
-// _tmp_160: '.' | '...'
+// _tmp_163: '.' | '...'
 static void *
-_tmp_160_rule(Parser *p)
+_tmp_163_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -38571,18 +39235,18 @@ _tmp_160_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_160[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'.'"));
+        D(fprintf(stderr, "%*c> _tmp_163[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'.'"));
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 23))  // token='.'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_160[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'.'"));
+            D(fprintf(stderr, "%*c+ _tmp_163[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'.'"));
             _res = _literal;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_160[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_163[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'.'"));
     }
     { // '...'
@@ -38590,18 +39254,18 @@ _tmp_160_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_160[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'...'"));
+        D(fprintf(stderr, "%*c> _tmp_163[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'...'"));
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 52))  // token='...'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_160[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'...'"));
+            D(fprintf(stderr, "%*c+ _tmp_163[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'...'"));
             _res = _literal;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_160[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_163[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'...'"));
     }
     _res = NULL;
@@ -38610,9 +39274,9 @@ _tmp_160_rule(Parser *p)
     return _res;
 }
 
-// _tmp_161: '@' named_expression NEWLINE
+// _tmp_164: '@' named_expression NEWLINE
 static void *
-_tmp_161_rule(Parser *p)
+_tmp_164_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -38628,7 +39292,7 @@ _tmp_161_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_161[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'@' named_expression NEWLINE"));
+        D(fprintf(stderr, "%*c> _tmp_164[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'@' named_expression NEWLINE"));
         Token * _literal;
         expr_ty f;
         Token * newline_var;
@@ -38640,7 +39304,7 @@ _tmp_161_rule(Parser *p)
             (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_161[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'@' named_expression NEWLINE"));
+            D(fprintf(stderr, "%*c+ _tmp_164[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'@' named_expression NEWLINE"));
             _res = f;
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -38650,7 +39314,7 @@ _tmp_161_rule(Parser *p)
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_161[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_164[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'@' named_expression NEWLINE"));
     }
     _res = NULL;
@@ -38659,9 +39323,9 @@ _tmp_161_rule(Parser *p)
     return _res;
 }
 
-// _tmp_162: ',' star_expression
+// _tmp_165: ',' star_expression
 static void *
-_tmp_162_rule(Parser *p)
+_tmp_165_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -38677,7 +39341,7 @@ _tmp_162_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_162[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' star_expression"));
+        D(fprintf(stderr, "%*c> _tmp_165[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' star_expression"));
         Token * _literal;
         expr_ty c;
         if (
@@ -38686,7 +39350,7 @@ _tmp_162_rule(Parser *p)
             (c = star_expression_rule(p))  // star_expression
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_162[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "',' star_expression"));
+            D(fprintf(stderr, "%*c+ _tmp_165[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "',' star_expression"));
             _res = c;
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -38696,7 +39360,7 @@ _tmp_162_rule(Parser *p)
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_162[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_165[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' star_expression"));
     }
     _res = NULL;
@@ -38705,9 +39369,9 @@ _tmp_162_rule(Parser *p)
     return _res;
 }
 
-// _tmp_163: 'or' conjunction
+// _tmp_166: 'or' conjunction
 static void *
-_tmp_163_rule(Parser *p)
+_tmp_166_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -38723,7 +39387,7 @@ _tmp_163_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_163[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'or' conjunction"));
+        D(fprintf(stderr, "%*c> _tmp_166[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'or' conjunction"));
         Token * _keyword;
         expr_ty c;
         if (
@@ -38732,7 +39396,7 @@ _tmp_163_rule(Parser *p)
             (c = conjunction_rule(p))  // conjunction
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_163[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'or' conjunction"));
+            D(fprintf(stderr, "%*c+ _tmp_166[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'or' conjunction"));
             _res = c;
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -38742,7 +39406,7 @@ _tmp_163_rule(Parser *p)
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_163[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_166[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'or' conjunction"));
     }
     _res = NULL;
@@ -38751,9 +39415,9 @@ _tmp_163_rule(Parser *p)
     return _res;
 }
 
-// _tmp_164: 'and' inversion
+// _tmp_167: 'and' inversion
 static void *
-_tmp_164_rule(Parser *p)
+_tmp_167_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -38769,7 +39433,7 @@ _tmp_164_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_164[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'and' inversion"));
+        D(fprintf(stderr, "%*c> _tmp_167[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'and' inversion"));
         Token * _keyword;
         expr_ty c;
         if (
@@ -38778,7 +39442,7 @@ _tmp_164_rule(Parser *p)
             (c = inversion_rule(p))  // inversion
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_164[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'and' inversion"));
+            D(fprintf(stderr, "%*c+ _tmp_167[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'and' inversion"));
             _res = c;
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -38788,7 +39452,7 @@ _tmp_164_rule(Parser *p)
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_164[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_167[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'and' inversion"));
     }
     _res = NULL;
@@ -38797,9 +39461,9 @@ _tmp_164_rule(Parser *p)
     return _res;
 }
 
-// _tmp_165: slice | starred_expression
+// _tmp_168: slice | starred_expression
 static void *
-_tmp_165_rule(Parser *p)
+_tmp_168_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -38815,18 +39479,18 @@ _tmp_165_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_165[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "slice"));
+        D(fprintf(stderr, "%*c> _tmp_168[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "slice"));
         expr_ty slice_var;
         if (
             (slice_var = slice_rule(p))  // slice
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_165[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "slice"));
+            D(fprintf(stderr, "%*c+ _tmp_168[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "slice"));
             _res = slice_var;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_165[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_168[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "slice"));
     }
     { // starred_expression
@@ -38834,18 +39498,18 @@ _tmp_165_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_165[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "starred_expression"));
+        D(fprintf(stderr, "%*c> _tmp_168[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "starred_expression"));
         expr_ty starred_expression_var;
         if (
             (starred_expression_var = starred_expression_rule(p))  // starred_expression
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_165[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "starred_expression"));
+            D(fprintf(stderr, "%*c+ _tmp_168[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "starred_expression"));
             _res = starred_expression_var;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_165[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_168[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "starred_expression"));
     }
     _res = NULL;
@@ -38854,9 +39518,9 @@ _tmp_165_rule(Parser *p)
     return _res;
 }
 
-// _tmp_166: 'if' disjunction
+// _tmp_169: 'if' disjunction
 static void *
-_tmp_166_rule(Parser *p)
+_tmp_169_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -38872,7 +39536,7 @@ _tmp_166_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_166[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'if' disjunction"));
+        D(fprintf(stderr, "%*c> _tmp_169[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'if' disjunction"));
         Token * _keyword;
         expr_ty z;
         if (
@@ -38881,7 +39545,7 @@ _tmp_166_rule(Parser *p)
             (z = disjunction_rule(p))  // disjunction
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_166[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'if' disjunction"));
+            D(fprintf(stderr, "%*c+ _tmp_169[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'if' disjunction"));
             _res = z;
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -38891,7 +39555,7 @@ _tmp_166_rule(Parser *p)
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_166[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_169[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'if' disjunction"));
     }
     _res = NULL;
@@ -38900,9 +39564,9 @@ _tmp_166_rule(Parser *p)
     return _res;
 }
 
-// _tmp_167: starred_expression | (assignment_expression | expression !':=') !'='
+// _tmp_170: starred_expression | (assignment_expression | expression !':=') !'='
 static void *
-_tmp_167_rule(Parser *p)
+_tmp_170_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -38918,18 +39582,18 @@ _tmp_167_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_167[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "starred_expression"));
+        D(fprintf(stderr, "%*c> _tmp_170[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "starred_expression"));
         expr_ty starred_expression_var;
         if (
             (starred_expression_var = starred_expression_rule(p))  // starred_expression
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_167[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "starred_expression"));
+            D(fprintf(stderr, "%*c+ _tmp_170[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "starred_expression"));
             _res = starred_expression_var;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_167[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_170[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "starred_expression"));
     }
     { // (assignment_expression | expression !':=') !'='
@@ -38937,20 +39601,20 @@ _tmp_167_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_167[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(assignment_expression | expression !':=') !'='"));
-        void *_tmp_178_var;
+        D(fprintf(stderr, "%*c> _tmp_170[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(assignment_expression | expression !':=') !'='"));
+        void *_tmp_181_var;
         if (
-            (_tmp_178_var = _tmp_178_rule(p))  // assignment_expression | expression !':='
+            (_tmp_181_var = _tmp_181_rule(p))  // assignment_expression | expression !':='
             &&
             _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 22)  // token='='
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_167[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "(assignment_expression | expression !':=') !'='"));
-            _res = _tmp_178_var;
+            D(fprintf(stderr, "%*c+ _tmp_170[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "(assignment_expression | expression !':=') !'='"));
+            _res = _tmp_181_var;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_167[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_170[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(assignment_expression | expression !':=') !'='"));
     }
     _res = NULL;
@@ -38959,9 +39623,9 @@ _tmp_167_rule(Parser *p)
     return _res;
 }
 
-// _tmp_168: ',' star_target
+// _tmp_171: ',' star_target
 static void *
-_tmp_168_rule(Parser *p)
+_tmp_171_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -38977,7 +39641,7 @@ _tmp_168_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_168[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' star_target"));
+        D(fprintf(stderr, "%*c> _tmp_171[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' star_target"));
         Token * _literal;
         expr_ty c;
         if (
@@ -38986,7 +39650,7 @@ _tmp_168_rule(Parser *p)
             (c = star_target_rule(p))  // star_target
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_168[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "',' star_target"));
+            D(fprintf(stderr, "%*c+ _tmp_171[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "',' star_target"));
             _res = c;
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -38996,7 +39660,7 @@ _tmp_168_rule(Parser *p)
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_168[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_171[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' star_target"));
     }
     _res = NULL;
@@ -39005,10 +39669,10 @@ _tmp_168_rule(Parser *p)
     return _res;
 }
 
-// _tmp_169:
+// _tmp_172:
 //     | ','.(starred_expression | (assignment_expression | expression !':=') !'=')+ ',' kwargs
 static void *
-_tmp_169_rule(Parser *p)
+_tmp_172_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39024,7 +39688,7 @@ _tmp_169_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_169[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.(starred_expression | (assignment_expression | expression !':=') !'=')+ ',' kwargs"));
+        D(fprintf(stderr, "%*c> _tmp_172[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.(starred_expression | (assignment_expression | expression !':=') !'=')+ ',' kwargs"));
         asdl_seq * _gather_91_var;
         Token * _literal;
         asdl_seq* kwargs_var;
@@ -39036,12 +39700,12 @@ _tmp_169_rule(Parser *p)
             (kwargs_var = kwargs_rule(p))  // kwargs
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_169[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.(starred_expression | (assignment_expression | expression !':=') !'=')+ ',' kwargs"));
+            D(fprintf(stderr, "%*c+ _tmp_172[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.(starred_expression | (assignment_expression | expression !':=') !'=')+ ',' kwargs"));
             _res = _PyPegen_dummy_name(p, _gather_91_var, _literal, kwargs_var);
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_169[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_172[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "','.(starred_expression | (assignment_expression | expression !':=') !'=')+ ',' kwargs"));
     }
     _res = NULL;
@@ -39050,9 +39714,9 @@ _tmp_169_rule(Parser *p)
     return _res;
 }
 
-// _tmp_170: starred_expression !'='
+// _tmp_173: starred_expression !'='
 static void *
-_tmp_170_rule(Parser *p)
+_tmp_173_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39068,7 +39732,7 @@ _tmp_170_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_170[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "starred_expression !'='"));
+        D(fprintf(stderr, "%*c> _tmp_173[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "starred_expression !'='"));
         expr_ty starred_expression_var;
         if (
             (starred_expression_var = starred_expression_rule(p))  // starred_expression
@@ -39076,12 +39740,12 @@ _tmp_170_rule(Parser *p)
             _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 22)  // token='='
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_170[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "starred_expression !'='"));
+            D(fprintf(stderr, "%*c+ _tmp_173[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "starred_expression !'='"));
             _res = starred_expression_var;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_170[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_173[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "starred_expression !'='"));
     }
     _res = NULL;
@@ -39090,9 +39754,9 @@ _tmp_170_rule(Parser *p)
     return _res;
 }
 
-// _tmp_171: !STRING expression_without_invalid
+// _tmp_174: !STRING expression_without_invalid
 static void *
-_tmp_171_rule(Parser *p)
+_tmp_174_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39108,7 +39772,7 @@ _tmp_171_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_171[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "!STRING expression_without_invalid"));
+        D(fprintf(stderr, "%*c> _tmp_174[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "!STRING expression_without_invalid"));
         expr_ty expression_without_invalid_var;
         if (
             _PyPegen_lookahead(0, _PyPegen_string_token, p)
@@ -39116,12 +39780,12 @@ _tmp_171_rule(Parser *p)
             (expression_without_invalid_var = expression_without_invalid_rule(p))  // expression_without_invalid
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_171[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "!STRING expression_without_invalid"));
+            D(fprintf(stderr, "%*c+ _tmp_174[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "!STRING expression_without_invalid"));
             _res = expression_without_invalid_var;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_171[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_174[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "!STRING expression_without_invalid"));
     }
     _res = NULL;
@@ -39130,9 +39794,9 @@ _tmp_171_rule(Parser *p)
     return _res;
 }
 
-// _tmp_172: ')' | '**'
+// _tmp_175: ')' | '**'
 static void *
-_tmp_172_rule(Parser *p)
+_tmp_175_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39148,18 +39812,18 @@ _tmp_172_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_172[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "')'"));
+        D(fprintf(stderr, "%*c> _tmp_175[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "')'"));
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_172[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "')'"));
+            D(fprintf(stderr, "%*c+ _tmp_175[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "')'"));
             _res = _literal;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_172[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_175[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "')'"));
     }
     { // '**'
@@ -39167,18 +39831,18 @@ _tmp_172_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_172[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**'"));
+        D(fprintf(stderr, "%*c> _tmp_175[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**'"));
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 35))  // token='**'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_172[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'**'"));
+            D(fprintf(stderr, "%*c+ _tmp_175[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'**'"));
             _res = _literal;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_172[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_175[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'**'"));
     }
     _res = NULL;
@@ -39187,9 +39851,9 @@ _tmp_172_rule(Parser *p)
     return _res;
 }
 
-// _tmp_173: ':' | '**'
+// _tmp_176: ':' | '**'
 static void *
-_tmp_173_rule(Parser *p)
+_tmp_176_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39205,18 +39869,18 @@ _tmp_173_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_173[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':'"));
+        D(fprintf(stderr, "%*c> _tmp_176[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':'"));
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_173[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "':'"));
+            D(fprintf(stderr, "%*c+ _tmp_176[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "':'"));
             _res = _literal;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_173[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_176[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "':'"));
     }
     { // '**'
@@ -39224,18 +39888,18 @@ _tmp_173_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_173[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**'"));
+        D(fprintf(stderr, "%*c> _tmp_176[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**'"));
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 35))  // token='**'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_173[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'**'"));
+            D(fprintf(stderr, "%*c+ _tmp_176[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'**'"));
             _res = _literal;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_173[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_176[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'**'"));
     }
     _res = NULL;
@@ -39244,9 +39908,9 @@ _tmp_173_rule(Parser *p)
     return _res;
 }
 
-// _loop0_174: (',' bitwise_or)
+// _loop0_177: (',' bitwise_or)
 static asdl_seq *
-_loop0_174_rule(Parser *p)
+_loop0_177_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39271,13 +39935,13 @@ _loop0_174_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _loop0_174[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(',' bitwise_or)"));
-        void *_tmp_179_var;
+        D(fprintf(stderr, "%*c> _loop0_177[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(',' bitwise_or)"));
+        void *_tmp_182_var;
         while (
-            (_tmp_179_var = _tmp_179_rule(p))  // ',' bitwise_or
+            (_tmp_182_var = _tmp_182_rule(p))  // ',' bitwise_or
         )
         {
-            _res = _tmp_179_var;
+            _res = _tmp_182_var;
             if (_n == _children_capacity) {
                 _children_capacity *= 2;
                 void **_new_children = PyMem_Realloc(_children, _children_capacity*sizeof(void *));
@@ -39294,7 +39958,7 @@ _loop0_174_rule(Parser *p)
             _mark = p->mark;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _loop0_174[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _loop0_177[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(',' bitwise_or)"));
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -39311,9 +39975,9 @@ _loop0_174_rule(Parser *p)
     return _seq;
 }
 
-// _tmp_175: ',' | ')' | ';' | NEWLINE
+// _tmp_178: ',' | ')' | ';' | NEWLINE
 static void *
-_tmp_175_rule(Parser *p)
+_tmp_178_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39329,18 +39993,18 @@ _tmp_175_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_175[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','"));
+        D(fprintf(stderr, "%*c> _tmp_178[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','"));
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_175[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','"));
+            D(fprintf(stderr, "%*c+ _tmp_178[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','"));
             _res = _literal;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_175[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_178[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "','"));
     }
     { // ')'
@@ -39348,18 +40012,18 @@ _tmp_175_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_175[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "')'"));
+        D(fprintf(stderr, "%*c> _tmp_178[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "')'"));
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_175[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "')'"));
+            D(fprintf(stderr, "%*c+ _tmp_178[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "')'"));
             _res = _literal;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_175[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_178[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "')'"));
     }
     { // ';'
@@ -39367,18 +40031,18 @@ _tmp_175_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_175[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "';'"));
+        D(fprintf(stderr, "%*c> _tmp_178[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "';'"));
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 13))  // token=';'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_175[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "';'"));
+            D(fprintf(stderr, "%*c+ _tmp_178[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "';'"));
             _res = _literal;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_175[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_178[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "';'"));
     }
     { // NEWLINE
@@ -39386,18 +40050,18 @@ _tmp_175_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_175[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE"));
+        D(fprintf(stderr, "%*c> _tmp_178[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE"));
         Token * newline_var;
         if (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_175[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NEWLINE"));
+            D(fprintf(stderr, "%*c+ _tmp_178[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NEWLINE"));
             _res = newline_var;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_175[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_178[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NEWLINE"));
     }
     _res = NULL;
@@ -39406,9 +40070,9 @@ _tmp_175_rule(Parser *p)
     return _res;
 }
 
-// _tmp_176: expression ['as' star_target]
+// _tmp_179: expression ['as' star_target]
 static void *
-_tmp_176_rule(Parser *p)
+_tmp_179_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39424,22 +40088,22 @@ _tmp_176_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_176[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ['as' star_target]"));
+        D(fprintf(stderr, "%*c> _tmp_179[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression ['as' star_target]"));
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty expression_var;
         if (
             (expression_var = expression_rule(p))  // expression
             &&
-            (_opt_var = _tmp_180_rule(p), !p->error_indicator)  // ['as' star_target]
+            (_opt_var = _tmp_183_rule(p), !p->error_indicator)  // ['as' star_target]
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_176[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expression ['as' star_target]"));
+            D(fprintf(stderr, "%*c+ _tmp_179[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expression ['as' star_target]"));
             _res = _PyPegen_dummy_name(p, expression_var, _opt_var);
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_176[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_179[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "expression ['as' star_target]"));
     }
     _res = NULL;
@@ -39448,9 +40112,9 @@ _tmp_176_rule(Parser *p)
     return _res;
 }
 
-// _tmp_177: expressions ['as' star_target]
+// _tmp_180: expressions ['as' star_target]
 static void *
-_tmp_177_rule(Parser *p)
+_tmp_180_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39466,22 +40130,22 @@ _tmp_177_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_177[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expressions ['as' star_target]"));
+        D(fprintf(stderr, "%*c> _tmp_180[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expressions ['as' star_target]"));
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty expressions_var;
         if (
             (expressions_var = expressions_rule(p))  // expressions
             &&
-            (_opt_var = _tmp_180_rule(p), !p->error_indicator)  // ['as' star_target]
+            (_opt_var = _tmp_183_rule(p), !p->error_indicator)  // ['as' star_target]
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_177[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expressions ['as' star_target]"));
+            D(fprintf(stderr, "%*c+ _tmp_180[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expressions ['as' star_target]"));
             _res = _PyPegen_dummy_name(p, expressions_var, _opt_var);
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_177[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_180[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "expressions ['as' star_target]"));
     }
     _res = NULL;
@@ -39490,9 +40154,9 @@ _tmp_177_rule(Parser *p)
     return _res;
 }
 
-// _tmp_178: assignment_expression | expression !':='
+// _tmp_181: assignment_expression | expression !':='
 static void *
-_tmp_178_rule(Parser *p)
+_tmp_181_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39508,18 +40172,18 @@ _tmp_178_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_178[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
+        D(fprintf(stderr, "%*c> _tmp_181[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
         expr_ty assignment_expression_var;
         if (
             (assignment_expression_var = assignment_expression_rule(p))  // assignment_expression
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_178[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
+            D(fprintf(stderr, "%*c+ _tmp_181[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "assignment_expression"));
             _res = assignment_expression_var;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_178[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_181[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "assignment_expression"));
     }
     { // expression !':='
@@ -39527,7 +40191,7 @@ _tmp_178_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_178[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression !':='"));
+        D(fprintf(stderr, "%*c> _tmp_181[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression !':='"));
         expr_ty expression_var;
         if (
             (expression_var = expression_rule(p))  // expression
@@ -39535,12 +40199,12 @@ _tmp_178_rule(Parser *p)
             _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 53)  // token=':='
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_178[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expression !':='"));
+            D(fprintf(stderr, "%*c+ _tmp_181[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expression !':='"));
             _res = expression_var;
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_178[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_181[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "expression !':='"));
     }
     _res = NULL;
@@ -39549,9 +40213,9 @@ _tmp_178_rule(Parser *p)
     return _res;
 }
 
-// _tmp_179: ',' bitwise_or
+// _tmp_182: ',' bitwise_or
 static void *
-_tmp_179_rule(Parser *p)
+_tmp_182_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39567,7 +40231,7 @@ _tmp_179_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_179[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' bitwise_or"));
+        D(fprintf(stderr, "%*c> _tmp_182[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' bitwise_or"));
         Token * _literal;
         expr_ty bitwise_or_var;
         if (
@@ -39576,12 +40240,12 @@ _tmp_179_rule(Parser *p)
             (bitwise_or_var = bitwise_or_rule(p))  // bitwise_or
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_179[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "',' bitwise_or"));
+            D(fprintf(stderr, "%*c+ _tmp_182[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "',' bitwise_or"));
             _res = _PyPegen_dummy_name(p, _literal, bitwise_or_var);
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_179[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_182[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' bitwise_or"));
     }
     _res = NULL;
@@ -39590,9 +40254,9 @@ _tmp_179_rule(Parser *p)
     return _res;
 }
 
-// _tmp_180: 'as' star_target
+// _tmp_183: 'as' star_target
 static void *
-_tmp_180_rule(Parser *p)
+_tmp_183_rule(Parser *p)
 {
     if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
         _Pypegen_stack_overflow(p);
@@ -39608,7 +40272,7 @@ _tmp_180_rule(Parser *p)
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_180[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' star_target"));
+        D(fprintf(stderr, "%*c> _tmp_183[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'as' star_target"));
         Token * _keyword;
         expr_ty star_target_var;
         if (
@@ -39617,12 +40281,12 @@ _tmp_180_rule(Parser *p)
             (star_target_var = star_target_rule(p))  // star_target
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_180[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'as' star_target"));
+            D(fprintf(stderr, "%*c+ _tmp_183[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'as' star_target"));
             _res = _PyPegen_dummy_name(p, _keyword, star_target_var);
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_180[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _tmp_183[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'as' star_target"));
     }
     _res = NULL;


### PR DESCRIPTION
Continuation of gh-153171: a coverage audit of the error rules found more cases where a specialized error message is not produced in all positions where the invalid construct can occur.

* `'not' after an operator must be parenthesized` was only reported after arithmetic and unary operators. Now it is also reported after shift, bitwise, comparison and power operators (`1 << not x`, `1 & not x`, `1 < not x`, `2 ** not x`). Each operator tier gets its own error rule requiring the actual preceding operator -- a single rule matching bare `not` at the operand position would misfire when a valid leading `not` expression is followed by garbage (the "no misleading errors" cases in test_syntax guard exactly this).
* `expected default value expression` was not reported for a missing parameter default before `:` in lambda expressions (`lambda x=: 0` reported generic "invalid syntax").
* A missing type parameter default value (`def f[T=](): pass`, `type X[T=] = int`) reported a misleading `expected '('`. It could not be handled in `invalid_type_param` because the base rule succeeds without consuming `=` (the default is optional), so it is handled at the type parameter list level.

The remaining known gap (no specialized error for a starred expression at an operand position, e.g. `x = 1 + *y`) is left out: an error alternative at the operand rule preempts better specialized errors in the second pass (e.g. `X[**A: str]` is explored as a subscript with a slice, and `del (*x,)` loses "cannot delete starred"), so it needs a different approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
