### PR TITLE
gh-151126: Set MemoryError in test C API allocation failures

### DIFF
--- a/Modules/_testcapi/monitoring.c
+++ b/Modules/_testcapi/monitoring.c
@@ -24,6 +24,7 @@ CodeLike_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyMonitoringState *states = (PyMonitoringState *)PyMem_Calloc(
             num_events, sizeof(PyMonitoringState));
     if (states == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     PyCodeLikeObject *self = (PyCodeLikeObject *) type->tp_alloc(type, 0);

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -2033,6 +2033,7 @@ check_pyobject_uninitialized_is_freed(PyObject *self,
 {
     PyObject *op = (PyObject *)PyObject_Malloc(sizeof(PyObject));
     if (op == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     /* Initialize reference count to avoid early crash in ceval or GC */
@@ -2049,6 +2050,7 @@ check_pyobject_forbidden_bytes_is_freed(PyObject *self,
     /* Allocate an incomplete PyObject structure: truncate 'ob_type' field */
     PyObject *op = (PyObject *)PyObject_Malloc(offsetof(PyObject, ob_type));
     if (op == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     /* Initialize reference count to avoid early crash in ceval or GC */


### PR DESCRIPTION
Found these while working on https://github.com/python/cpython/pull/153206. But I think these fixes can be backport to 3.13 while https://github.com/python/cpython/pull/153206 can't, so creating a new PR should be a good choice.

I think the fixes are simple and trivial, so a news entry <del>and an issue</del> can be skipped.

<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
