### PR TITLE
gh-150880: Clarify DirEntry.path construction semantics

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3037,10 +3037,16 @@ features:
 
    .. attribute:: path
 
-      The entry's full path name: equivalent to ``os.path.join(scandir_path,
-      entry.name)`` where *scandir_path* is the :func:`scandir` *path*
-      argument.  The path is only absolute if the :func:`scandir` *path*
-      argument was absolute.  If the :func:`scandir` *path*
+      The entry's path name: equivalent to ``os.path.join(scandir_path,
+      entry.name)`` where *scandir_path* is the original :func:`scandir`
+      *path* argument.  Apart from the filename, the path preserves the
+      original :func:`scandir` argument.  If the :func:`scandir` *path*
+      argument was relative, the :attr:`path` attribute is also relative.
+      Changing the current working directory after creating the
+      :func:`scandir` iterator may cause later uses of :attr:`path` to resolve
+      differently.  On some platforms, the constructed path may not be valid
+      if the original :func:`scandir` argument was usable for enumeration but
+      not for joining with the entry name.  If the :func:`scandir` *path*
       argument was a :ref:`file descriptor <path_fd>`, the :attr:`path`
       attribute is the same as the :attr:`name` attribute.
 


### PR DESCRIPTION
## Summary

This is a documentation-only follow-up to GH-152906.

After the Windows wildcard normalization fix was merged, follow-up discussion highlighted that `os.DirEntry.path` intentionally preserves the original `os.scandir()` argument rather than a normalized path.

This PR clarifies the documented semantics of `DirEntry.path`, including:

- `DirEntry.path` is constructed from the original `os.scandir()` argument and `entry.name`.
- Relative `scandir()` arguments produce relative `DirEntry.path` values.
- Changing the current working directory after creating the iterator can affect how relative `DirEntry.path` values resolve.
- On some platforms, a path accepted for enumeration may not necessarily produce a valid path when later joined with the filename.

This PR is documentation only and does not change runtime behavior.


<!-- gh-issue-number: gh-150880 -->
* Issue: gh-150880
<!-- /gh-issue-number -->
