### PR TITLE
gh-145177: Update Emscripten to 6.0.2

### DIFF
--- a/Platforms/emscripten/config.toml
+++ b/Platforms/emscripten/config.toml
@@ -1,7 +1,7 @@
 # Any data that can vary between Python versions is to be kept in this file.
 # This allows for blanket copying of the Emscripten build code between supported
 # Python versions.
-emscripten-version = "6.0.0"
+emscripten-version = "6.0.2"
 node-version = "24"
 test-args = [
     "-m", "test",

--- a/Python/emscripten_syscalls.c
+++ b/Python/emscripten_syscalls.c
@@ -293,26 +293,6 @@ int __syscall_poll(intptr_t fds, int nfds, int timeout) {
     return __block_for_int(p);
 }
 
-
-// Workaround for an Emscripten bug: getentropy(buffer, 1) returns the single
-// byte of entropy as the return code. Fixed upstream by
-// emscripten-core/emscripten#27122
-int __real_getentropy(void*, size_t);
-
-int __wrap_getentropy(void *buffer, size_t len) {
-    if (len != 1) {
-        return __real_getentropy(buffer, len);
-    }
-    // Length is 1. Workaround is to get two bytes of entropy and write the
-    // first one into the original target buffer.
-    uint8_t tmp[2];
-    int ret = __real_getentropy(tmp, 2);
-    if (ret == 0) {
-        *(uint8_t *)buffer = tmp[0];
-    }
-    return ret;
-}
-
 #include <sys/ioctl.h>
 
 int syscall_ioctl_orig(int fd, int request, void* varargs)

--- a/configure
+++ b/configure
@@ -9803,8 +9803,6 @@ fi
     as_fn_append LINKFORSHARED " -sSTACK_SIZE=5MB"
         as_fn_append LINKFORSHARED " -sTEXTDECODER=2"
 
-            as_fn_append LDFLAGS_NODIST " -Wl,--wrap=getentropy"
-
     if test "x$enable_wasm_dynamic_linking" = xyes
 then :
 

--- a/configure.ac
+++ b/configure.ac
@@ -2411,10 +2411,6 @@ AS_CASE([$ac_sys_system],
     dnl Avoid bugs in JS fallback string decoding path
     AS_VAR_APPEND([LINKFORSHARED], [" -sTEXTDECODER=2"])
 
-    dnl Workaround for a bug in Emscipten libc's getentropy. See
-    dnl __wrap_getentropy in Python/emscripten_syscalls.c.
-    AS_VAR_APPEND([LDFLAGS_NODIST], [" -Wl,--wrap=getentropy"])
-
     AS_VAR_IF([enable_wasm_dynamic_linking], [yes], [
       AS_VAR_APPEND([LINKFORSHARED], [" -sMAIN_MODULE"])
     ])


### PR DESCRIPTION
Since it includes my fix to `getentropy()` we can drop our workaround.


<!-- gh-issue-number: gh-145177 -->
* Issue: gh-145177
<!-- /gh-issue-number -->
