### PR TITLE
gh-153210: Fix `array` module import crash under a memory pressure

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -5,7 +5,7 @@
 import collections.abc
 import unittest
 from test import support
-from test.support import import_helper
+from test.support import import_helper, script_helper
 from test.support import os_helper
 from test.support import _2G
 from test.support import subTests
@@ -41,6 +41,23 @@ class MiscTest(unittest.TestCase):
         self.assertRaises(ValueError, array.array, 'xx')
         self.assertRaises(ValueError, array.array, 'x')
         self.assertRaises(ValueError, array.array, 'Z')
+
+    @support.cpython_only
+    def test_does_not_crash_on_broken_imports(self):
+        # gh-153210
+        code = """if 1:
+            import collections.abc
+
+            del collections.abc.MutableSequence
+
+            try:
+                import array  # it used to crash before
+            except AttributeError:
+                pass
+            else:
+                raise AssertionError('AttributeError was not raised')
+        """
+        script_helper.assert_python_ok('-c', code)
 
     @support.cpython_only
     def test_disallow_instantiation(self):

--- a/Misc/NEWS.d/next/Library/2026-07-07-02-26-43.gh-issue-153210.LUXIcm.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-07-02-26-43.gh-issue-153210.LUXIcm.rst
@@ -1,0 +1,1 @@
+Fix crash on :mod:`array` import under a memory pressure.

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3401,22 +3401,15 @@ array_modexec(PyObject *m)
     CREATE_TYPE(m, state->ArrayIterType, &arrayiter_spec);
     Py_SET_TYPE(state->ArrayIterType, &PyType_Type);
 
-    if (PyModule_AddObjectRef(m, "ArrayType",
-                              (PyObject *)state->ArrayType) < 0) {
-        return -1;
-    }
-
     PyObject *mutablesequence = PyImport_ImportModuleAttrString(
             "collections.abc", "MutableSequence");
     if (!mutablesequence) {
-        Py_DECREF((PyObject *)state->ArrayType);
         return -1;
     }
     PyObject *res = PyObject_CallMethod(mutablesequence, "register", "O",
                                         (PyObject *)state->ArrayType);
     Py_DECREF(mutablesequence);
     if (!res) {
-        Py_DECREF((PyObject *)state->ArrayType);
         return -1;
     }
     Py_DECREF(res);


### PR DESCRIPTION
Note that `PyModule_AddObjectRef` was not required, because `if (PyModule_AddType(m, state->ArrayType) < 0)` is used right after that overriding the module registation. Now it is only registered once.

<!-- gh-issue-number: gh-153210 -->
* Issue: gh-153210
<!-- /gh-issue-number -->
