### PR TITLE
gh-153210: Do not DECREF ArrayType in array_modexc when errors occur

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -9,11 +9,13 @@ from test.support import import_helper
 from test.support import os_helper
 from test.support import _2G
 from test.support import subTests
+from test.support.script_helper import assert_python_ok
 import weakref
 import pickle
 import operator
 import struct
 import sys
+import textwrap
 
 import array
 from array import _array_reconstructor as array_reconstructor
@@ -34,6 +36,23 @@ class MiscTest(unittest.TestCase):
     def test_array_is_sequence(self):
         self.assertIsInstance(array.array("B"), collections.abc.MutableSequence)
         self.assertIsInstance(array.array("B"), collections.abc.Reversible)
+
+    @support.cpython_only
+    def test_module_init_mutablesequence_register_failure(self):
+        # gh-153210: Check that when collections.abc.MutableSequence is unavailable
+        # The refcount of ArrayType is decremented correctly.
+        # This test only catches the issue in a debug build.
+        script = textwrap.dedent("""
+            import collections.abc
+            del collections.abc.MutableSequence
+            try:
+                import array
+            except AttributeError:
+                pass
+            else:
+                raise SystemExit("import array should have failed")
+        """)
+        assert_python_ok("-c", script)
 
     def test_bad_constructor(self):
         self.assertRaises(TypeError, array.array)

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -49,8 +49,6 @@ class MiscTest(unittest.TestCase):
                 import array
             except AttributeError:
                 pass
-            else:
-                raise SystemExit("import array should have failed")
         """)
         assert_python_ok("-c", script)
 

--- a/Misc/NEWS.d/next/Library/2026-07-07-00-26-06.gh-issue-153210.HRwj-j.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-07-00-26-06.gh-issue-153210.HRwj-j.rst
@@ -1,0 +1,2 @@
+:mod:`array`: Fix incorrect handling of reference counts when errors occur
+during module import

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3409,14 +3409,12 @@ array_modexec(PyObject *m)
     PyObject *mutablesequence = PyImport_ImportModuleAttrString(
             "collections.abc", "MutableSequence");
     if (!mutablesequence) {
-        Py_DECREF((PyObject *)state->ArrayType);
         return -1;
     }
     PyObject *res = PyObject_CallMethod(mutablesequence, "register", "O",
                                         (PyObject *)state->ArrayType);
     Py_DECREF(mutablesequence);
     if (!res) {
-        Py_DECREF((PyObject *)state->ArrayType);
         return -1;
     }
     Py_DECREF(res);


### PR DESCRIPTION
`ArrayType` is initialized directly on the `array` module state struct.  

This means that the reference ownership of `ArrayType` belongs to the state, NOT the local function.

In two error cases, `ArrayType` was being DECREF'd by the function.  Both of these DECREFS unbalanced the refcount because the ArrayType pointer is left populated on the module state.  When the module is eventually cleaned up (probably by GC), then `ArrayType` is DECREF'd again.

This change just removes the DECREF's and relies on the module tp_clear to walk the deps and clean up the state for us.

Note, the test only catches this issue in a debug build.  I don't know enough to know if there's a better way to write this test, but because `ArrayType` is a `Type`, reasoning about specific refcount numbers is hard, this approach should be robust.

<!-- gh-issue-number: gh-153210 -->
* Issue: gh-153210
<!-- /gh-issue-number -->
