### PR TITLE
gh-151221: Raise ValueError for invalid <date> in plistlib

### DIFF
--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -81,6 +81,11 @@ This module defines the following functions:
    .. versionchanged:: 3.13
       The keyword-only parameter *aware_datetime* has been added.
 
+   .. versionchanged:: next
+      A :exc:`ValueError` is now raised for an invalid ``<date>`` value in an
+      XML plist (for example ``2024-06Z``).  Previously such values raised an
+      unspecified :exc:`TypeError`.
+
 
 .. function:: loads(data, *, fmt=None, dict_type=dict, aware_datetime=False)
 

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -139,16 +139,22 @@ _dateParser = re.compile(r"(?P<year>\d\d\d\d)(?:-(?P<month>\d\d)(?:-(?P<day>\d\d
 
 def _date_from_string(s, aware_datetime):
     order = ('year', 'month', 'day', 'hour', 'minute', 'second')
-    gd = _dateParser.match(s).groupdict()
+    m = _dateParser.match(s)
+    if m is None:
+        raise ValueError(f"invalid date string: {s!r}")
+    gd = m.groupdict()
     lst = []
     for key in order:
         val = gd[key]
         if val is None:
             break
         lst.append(int(val))
-    if aware_datetime:
-        return datetime.datetime(*lst, tzinfo=datetime.UTC)
-    return datetime.datetime(*lst)
+    try:
+        if aware_datetime:
+            return datetime.datetime(*lst, tzinfo=datetime.UTC)
+        return datetime.datetime(*lst)
+    except (TypeError, ValueError):
+        raise ValueError(f"invalid date string: {s!r}") from None
 
 
 def _date_to_string(d, aware_datetime):

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -876,6 +876,17 @@ class TestPlistlib(unittest.TestCase):
         self.assertRaises(ValueError, plistlib.loads,
                           b"<plist><integer>not real</integer></plist>")
 
+    def test_invaliddate(self):
+        for xml in (b"<plist><date>not a date</date></plist>",
+                    b"<plist><date></date></plist>",
+                    b"<plist><date>2024Z</date></plist>",
+                    b"<plist><date>2024-06Z</date></plist>",
+                    b"<plist><date>2024-13-01T00:00:00Z</date></plist>"):
+            with self.subTest(xml=xml):
+                self.assertRaises(ValueError, plistlib.loads, xml)
+                self.assertRaises(ValueError, plistlib.loads, xml,
+                                  aware_datetime=True)
+
     def test_integer_notations(self):
         pl = b"<plist><integer>456</integer></plist>"
         value = plistlib.loads(pl)

--- a/Misc/NEWS.d/next/Library/2026-07-06-11-05-00.gh-issue-151221.Kp7Qm2.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-06-11-05-00.gh-issue-151221.Kp7Qm2.rst
@@ -1,0 +1,3 @@
+:mod:`plistlib` now raises :exc:`ValueError` instead of an obscure
+:exc:`TypeError` when loading an invalid ``<date>`` value (for example
+``2024-06Z``) from an XML plist.


### PR DESCRIPTION
`plistlib._date_from_string()` raised a confusing TypeError an AttributeError when an XML <date> element held an invalid or partial ISO 8601 value such as "2024-06Z" or "2024Z". It now raises ValueError, consistent with the sibling <integer> and <real> elements.

<!-- gh-issue-number: gh-151221 -->
* Issue: gh-151221
<!-- /gh-issue-number -->
