### PR TITLE
gh-153210: Restore accidental `array.ArrayType` removal

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -31,6 +31,11 @@ typecodes = array.typecodes
 
 class MiscTest(unittest.TestCase):
 
+    def test_array_type_importable(self):
+        from array import ArrayType
+
+        self.assertIs(array.array, ArrayType)
+
     def test_array_is_sequence(self):
         self.assertIsInstance(array.array("B"), collections.abc.MutableSequence)
         self.assertIsInstance(array.array("B"), collections.abc.Reversible)

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3401,6 +3401,12 @@ array_modexec(PyObject *m)
     CREATE_TYPE(m, state->ArrayIterType, &arrayiter_spec);
     Py_SET_TYPE(state->ArrayIterType, &PyType_Type);
 
+    // Older undocumented alias:
+    if (PyModule_AddObjectRef(m, "ArrayType",
+                              (PyObject *)state->ArrayType) < 0) {
+        return -1;
+    }
+
     PyObject *mutablesequence = PyImport_ImportModuleAttrString(
             "collections.abc", "MutableSequence");
     if (!mutablesequence) {


### PR DESCRIPTION
Ok, here's what happened:
1. I got confused that `array.ArrayType` and `array.array` is the same thing, it is exported under two different names
2. There was no test to catch this :(

I added a test case and a comment.
Refs https://github.com/python/cpython/pull/153238

Backporting to all the same versions as #153238

<!-- gh-issue-number: gh-153210 -->
* Issue: gh-153210
<!-- /gh-issue-number -->
