### PR TITLE
gh-152798: update sys.thread_info.lock documentation t match implemen…

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -2240,9 +2240,8 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
       The name of the lock implementation:
 
-      * ``"semaphore"``: a lock uses a semaphore
-      * ``"mutex+cond"``: a lock uses a mutex and a condition variable
-      * ``None`` if this information is unknown
+      * ``"pymutex"``: a lock uses the PyMutex implementation
+      * ``None`` if the lock implementation is not exposed (e.g. : on Windows and WASI)
 
    .. attribute:: thread_info.version
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -2240,8 +2240,10 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
       The name of the lock implementation:
 
-      * ``"pymutex"``: a lock uses the PyMutex implementation
-      * ``None`` if the lock implementation is not exposed (e.g. : on Windows and WASI)
+      * ``"semaphore"``: a lock uses a semaphore (Python 3.14 and older)
+      * ``"mutex+cond"``: a lock uses a mutex and a condition variable (Python 3.14 and older)
+      * ``"pymutex"``: a lock uses the PyMutex implementation (Python 3.15 and newer)
+      * ``None`` if this information is unknown
 
    .. attribute:: thread_info.version
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -2242,7 +2242,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
       * ``"semaphore"``: a lock uses a semaphore (Python 3.14 and older)
       * ``"mutex+cond"``: a lock uses a mutex and a condition variable (Python 3.14 and older)
-      * ``"pymutex"``: a lock uses the PyMutex implementation (Python 3.15 and newer)
+      * ``"pymutex"``: a lock uses the :c:type:`PyMutex` implementation (Python 3.15 and newer)
       * ``None`` if this information is unknown
 
    .. attribute:: thread_info.version


### PR DESCRIPTION
this PR updates the documentation for “sys.thread_info.lock” to reflect what the code actually returns today

the code currently returns "pymutex" on POSIX platforms ( except Windows and WASI, where it returns  None ), but the docs still described the old  "semaphore" and "mutex+cond" values

as discussed in the issue the consensus is that it's too late to change the code behavior, but the documentation should be corrected to avoid confusion

(no code changes are made here and only docs)

Closes gh-152798.