### PR TITLE
gh-65557: Clarify 'only evaluated once' in augmented assignment docs

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -286,11 +286,15 @@ symbols.)
 An augmented assignment evaluates the target (which, unlike normal assignment
 statements, cannot be an unpacking) and the expression list, performs the binary
 operation specific to the type of assignment on the two operands, and assigns
-the result to the original target.  The target is only evaluated once.
+the result to the original target.  Subexpressions of the target are only
+evaluated once.
 
 An augmented assignment statement like ``x += 1`` can be rewritten as ``x = x +
 1`` to achieve a similar, but not exactly equal effect. In the augmented
-version, ``x`` is only evaluated once. Also, when possible, the actual operation
+version, subexpressions of ``x`` are only evaluated once: for a target of the
+form ``y[k]``, ``y`` and ``k`` are each evaluated only once, but the
+subscription may be performed twice, once to fetch the old value and once to
+store the result. Also, when possible, the actual operation
 is performed *in-place*, meaning that rather than creating a new object and
 assigning that to the target, the old object is modified instead.
 


### PR DESCRIPTION
The reference manual currently says that the target of an augmented
assignment "is only evaluated once".  As discussed in the issue, this is
imprecise: for a target like `y[k]`, the subexpressions `y` and `k`
are evaluated only once, but the subscription itself may be performed
twice — once to fetch the old value and once to store the result.

This can be observed directly:

```pycon
>>> def ob():  print('ob evaluated');  return d
>>> def key(): print('key evaluated'); return 0
>>> d = [[]]
>>> ob()[key()] += [1]   # ob and key run once, but d[0] is read and then written
ob evaluated
key evaluated
```

This PR rewords both sentences to say that the *subexpressions* of the
target are only evaluated once, and adds the `y[k]` example, following
the wording suggested by @terryjreedy in the issue.

Fixes gh-65557