### PR TITLE
gh-143990: Preserve the size when creating a Font from a named font

### DIFF
--- a/Lib/test/test_tkinter/test_font.py
+++ b/Lib/test/test_tkinter/test_font.py
@@ -73,6 +73,44 @@ class FontTest(AbstractTkTest, unittest.TestCase):
         self.assertRaises(tkinter.TclError, font.Font, root=self.root,
                           name='testfont', font=('Times', 10))
 
+    def test_create_from_named_font(self):
+        # gh-143990: a font created from a named font copies its configured
+        # options, preserving a size specified in pixels (a negative size).
+        sizetype = int if self.wantobjects else str
+        named = font.Font(root=self.root, name='my named font',  # name with spaces
+                          family='Times', size=-20, weight='bold')
+        # The source is the name of a named font or a Font representing one.
+        for source in ['my named font', named]:
+            with self.subTest(source=source):
+                f = font.Font(root=self.root, font=source)
+                self.assertEqual(f.cget('size'), sizetype(-20))
+                self.assertEqual(f.actual('family'), named.actual('family'))
+                self.assertEqual(f.actual('weight'), 'bold')
+        # Explicit options still override the copied settings.
+        f = font.Font(root=self.root, font=named, size=30)
+        self.assertEqual(f.cget('size'), sizetype(30))
+
+    def test_create_from_description(self):
+        # gh-143990: a font created from a font description is resolved via
+        # "font actual", so a size in pixels (negative) becomes a size in points.
+        descriptions = [
+            ('Times', -20),                     # tuple
+            ('Times', -20, 'bold'),             # tuple with a style
+            'Times -20',                        # string
+            'Times -20 bold',                   # string with a style
+            '{Times New Roman} -20',            # string, family with spaces
+            # a Font wrapping a description, as a tuple and as a string
+            font.Font(root=self.root, font=('Times', -20), exists=True),
+            font.Font(root=self.root, font='Times -20', exists=True),
+        ]
+        for desc in descriptions:
+            with self.subTest(font=desc):
+                f = font.Font(root=self.root, font=desc)
+                # resolved as if the description were wrapped by exists=True
+                wrapped = font.Font(root=self.root, font=desc, exists=True)
+                self.assertEqual(f.actual(), wrapped.actual())
+                self.assertGreater(int(f.cget('size')), 0)  # pixels -> points
+
     def test_existing(self):
         sizetype = int if self.wantobjects else str
 
@@ -109,16 +147,19 @@ class FontTest(AbstractTkTest, unittest.TestCase):
         self.assertRaises(TypeError, font.Font, root=self.root, exists=True)
 
     def test_copy(self):
-        f = font.Font(root=self.root, family='Times', size=10, weight='bold')
+        # size=-20 (pixels): copy() copies the configured options, so the
+        # size is preserved rather than resolved (gh-143990).
+        f = font.Font(root=self.root, family='Times', size=-20, weight='bold')
         copied = f.copy()
         self.assertIsInstance(copied, font.Font)
         self.assertIsNot(copied, f)
         self.assertNotEqual(copied.name, f.name)
         self.assertEqual(copied.actual(), f.actual())
-        # The copy is independent of the original.
         sizetype = int if self.wantobjects else str
+        self.assertEqual(copied.cget('size'), sizetype(-20))
+        # The copy is independent of the original.
         copied.configure(size=20)
-        self.assertEqual(f.cget('size'), sizetype(10))
+        self.assertEqual(f.cget('size'), sizetype(-20))
         self.assertEqual(copied.cget('size'), sizetype(20))
         self.assertRaises(TypeError, f.copy, 'x')
 

--- a/Lib/tkinter/font.py
+++ b/Lib/tkinter/font.py
@@ -83,8 +83,15 @@ class Font:
             self.name = font
         else:
             if font:
-                # start from the actual settings of the given font
-                font = tk.splitlist(tk.call("font", "actual", font))
+                # start from the settings of the given font
+                try:
+                    # a named font: copy its options, preserving the size,
+                    # which can be negative (specified in pixels)
+                    font = tk.splitlist(tk.call("font", "configure", font))
+                except tkinter.TclError:
+                    # a font description: resolve it ("font configure" only
+                    # accepts a font name); this loses a size in pixels
+                    font = tk.splitlist(tk.call("font", "actual", font))
                 if options:
                     # explicit options override the corresponding settings
                     settings = self._mkdict(font)
@@ -146,7 +153,7 @@ class Font:
 
     def copy(self):
         "Return a distinct copy of the current font"
-        return Font(self._tk, **self.actual())
+        return Font(self._tk, self.name)
 
     def actual(self, option=None, displayof=None):
         "Return actual font attributes"

--- a/Misc/NEWS.d/next/Library/2026-07-07-17-50-54.gh-issue-143990.FoNtCf.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-07-17-50-54.gh-issue-143990.FoNtCf.rst
@@ -1,0 +1,4 @@
+A :class:`tkinter.font.Font` created from a named font,
+including by :meth:`~tkinter.font.Font.copy`,
+now copies its configured options rather than the options resolved by Tcl's ``font actual``,
+preserving a size specified in pixels (a negative size).


### PR DESCRIPTION
When a `tkinter.font.Font` is created from another font, `Font.__init__` expanded it into concrete options with Tcl's `font actual`.  For a named font this resolves the configured size, so a size specified in pixels (a negative size) was silently converted to a size in points (gh-143990).

`font configure` returns the *configured* options and preserves such a size, but it only accepts a font name, not a font description.  So the font is now expanded with `font configure` when it is a named font, falling back to `font actual` when it is a font description:

```python
try:
    font = tk.splitlist(tk.call("font", "configure", font))
except tkinter.TclError:
    font = tk.splitlist(tk.call("font", "actual", font))
```

Trying `font configure` first delegates the "is this a named font?" decision to Tcl, which is robust even for font names containing spaces.

A font description (a tuple or a string) is still resolved via `font actual`, since there is no way to parse it into options otherwise; wrapping it with `exists=True` (gh-143990, #152025) remains the way to use it without loss of precision.

`Font.copy()` has always been equivalent to constructing a `Font` from the original font (both went through `font actual`), so it is updated to match and now preserves the size too.

This is the general form of #143992, which restored the size only for a size given in a tuple.

<!-- gh-issue-number: gh-143990 -->
* Issue: gh-143990
<!-- /gh-issue-number -->
