### PR TITLE
gh-153279: Don't unlink another process's shared memory block on failed attach

### DIFF
--- a/Lib/multiprocessing/shared_memory.py
+++ b/Lib/multiprocessing/shared_memory.py
@@ -116,7 +116,14 @@ class SharedMemory:
                 size = stats.st_size
                 self._mmap = mmap.mmap(self._fd, size)
             except OSError:
-                self.unlink()
+                self.close()
+                # Only destroy the shared memory block if we created it in
+                # this call.  When attaching to a block created by another
+                # process we must not unlink another owner's memory.  The
+                # block has not been registered with the resource tracker
+                # yet, so unlink it directly to avoid a spurious UNREGISTER.
+                if create:
+                    _posixshmem.shm_unlink(self._name)
                 raise
             if self._track:
                 resource_tracker.register(self._name, "shared_memory")

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4615,6 +4615,44 @@ class _TestSharedMemory(BaseTestCase):
 
         sms.close()
 
+    @unittest.skipUnless(shared_memory._USE_POSIX,
+                         "POSIX shared memory required")
+    def test_shared_memory_attach_failure_preserves_block(self):
+        # A failure to mmap while *attaching* to an existing shared memory
+        # block (create=False) must not unlink (destroy) the block, which
+        # is owned by another party.
+        name = self._new_shm_name('test_attach_fail')
+        owner = shared_memory.SharedMemory(name, create=True, size=1024)
+        self.addCleanup(owner.unlink)
+        self.addCleanup(owner.close)
+
+        with unittest.mock.patch(
+                'multiprocessing.shared_memory.mmap.mmap',
+                side_effect=OSError("simulated mmap failure")):
+            with self.assertRaises(OSError):
+                shared_memory.SharedMemory(name)  # attach must not unlink
+
+        # The owner's block must still be attachable.
+        attached = shared_memory.SharedMemory(name)
+        self.addCleanup(attached.close)
+        self.assertGreaterEqual(attached.size, 1024)
+
+    @unittest.skipUnless(shared_memory._USE_POSIX,
+                         "POSIX shared memory required")
+    def test_shared_memory_create_failure_cleans_up(self):
+        # A failure to mmap while *creating* a block must destroy the
+        # just-created block so that it is not leaked.
+        name = self._new_shm_name('test_create_fail')
+        with unittest.mock.patch(
+                'multiprocessing.shared_memory.mmap.mmap',
+                side_effect=OSError("simulated mmap failure")):
+            with self.assertRaises(OSError):
+                shared_memory.SharedMemory(name, create=True, size=1024)
+
+        # The half-created block must not survive.
+        with self.assertRaises(FileNotFoundError):
+            shared_memory.SharedMemory(name)
+
     def test_shared_memory_recreate(self):
         # Test if shared memory segment is created properly,
         # when _make_filename returns an existing shared memory segment name

--- a/Misc/NEWS.d/next/Library/2026-07-07-19-30-33.gh-issue-153279.xxY4MA.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-07-19-30-33.gh-issue-153279.xxY4MA.rst
@@ -1,0 +1,6 @@
+Fix :class:`multiprocessing.shared_memory.SharedMemory` destroying another
+process's shared memory block when attaching to it fails.  A failure to
+:func:`~mmap.mmap` while attaching (``create=False``) no longer unlinks the
+block, which is owned by another process; the file descriptor is simply
+closed.  The block is now unlinked only when it was created in the failing
+call.


### PR DESCRIPTION
`SharedMemory.__init__` called `self.unlink()` from its `OSError` cleanup
handler unconditionally:

```python
except OSError:
    self.unlink()
    raise
```

On the attach path (`create=False`) this permanently destroyed a block owned
by another process when `mmap()` failed (e.g. `ENOMEM` under memory pressure),
since `unlink()` calls `shm_unlink()`.

The cleanup now only closes the file descriptor, and unlinks the block only
when it was created in the failing call. Because the block has not been
registered with the resource tracker at that point (`register()` runs after the
`try`/`except`), it is unlinked directly rather than through `unlink()`, which
avoids a spurious `UNREGISTER` that raised `KeyError` in the resource tracker
on the `create=True` path.

Added regression tests for both the attach and create failure paths; the attach
test fails without the fix.

<!-- gh-issue-number: gh-153279 -->
