### PR TITLE
gh-151396: Document socket.AddressFamily and socket.SocketKind

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -369,6 +369,18 @@ The AF_* and SOCK_* constants are now :class:`AddressFamily` and
 
 .. versionadded:: 3.4
 
+.. class:: AddressFamily
+
+   An :class:`.IntEnum` collection whose members are the ``AF_*`` address
+   family constants.  This class can be used in type annotations and
+   documentation cross-references.
+
+.. class:: SocketKind
+
+   An :class:`.IntEnum` collection whose members are the ``SOCK_*`` socket
+   type constants.  This class can be used in type annotations and
+   documentation cross-references.
+
 .. data:: AF_UNIX
           AF_INET
           AF_INET6


### PR DESCRIPTION
## Summary

Add explicit documentation entries for `socket.AddressFamily` and `socket.SocketKind`.

These enum classes are exported through `socket.__all__` and collect the `AF_*` and `SOCK_*` constants respectively. The new entries are intentionally brief and avoid duplicating the existing constant documentation.

This allows Sphinx/intersphinx references to resolve these enum classes directly.

Docs-only change. No runtime behavior changes.

Close: gh-151396