### PR TITLE
gh-86017: Document displayof for Font.actual() and clarify Font.copy()

### DIFF
--- a/Doc/library/tkinter.font.rst
+++ b/Doc/library/tkinter.font.rst
@@ -74,6 +74,8 @@ The different font weights and slants are:
       requested ones because of platform limitations.
       With no *option*, return a dictionary of all the attributes; if *option*
       is given, return the value of that single attribute.
+      The attributes are resolved on the display of the *displayof* widget,
+      or the main application window if it is not specified.
 
    .. method:: cget(option)
 
@@ -97,7 +99,11 @@ The different font weights and slants are:
 
    .. method:: copy()
 
-      Return new instance of the current font.
+      Return a distinct copy of the current font:
+      a new named font with the same attributes but a different name,
+      which can be reconfigured independently of the original.
+      If the current font wraps a font description,
+      the copy is instead a named font with its resolved attributes.
 
    .. method:: measure(text, displayof=None)
 


### PR DESCRIPTION
Two small additions to the `tkinter.font.Font` documentation:

* Document the `displayof` argument of `Font.actual()` (it was undocumented, unlike `Font.measure()`).
* Clarify what `Font.copy()` returns — a distinct, independently reconfigurable named font — and note that copying a font that wraps a font description resolves it into a named font.

<!-- gh-issue-number: gh-86017 -->
* Issue: gh-86017
<!-- /gh-issue-number -->
