### PR TITLE
[3.13] gh-153210: Restore accidental `array.ArrayType` removal (GH-153261)

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -35,6 +35,11 @@ typecodes = 'uwbBhHiIlLfdqQ'
 
 class MiscTest(unittest.TestCase):
 
+    def test_array_type_importable(self):
+        from array import ArrayType
+
+        self.assertIs(array.array, ArrayType)
+
     def test_array_is_sequence(self):
         self.assertIsInstance(array.array("B"), collections.abc.MutableSequence)
         self.assertIsInstance(array.array("B"), collections.abc.Reversible)

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3262,7 +3262,13 @@ array_modexec(PyObject *m)
     CREATE_TYPE(m, state->ArrayIterType, &arrayiter_spec);
     Py_SET_TYPE(state->ArrayIterType, &PyType_Type);
 
-    PyObject *mutablesequence = _PyImport_GetModuleAttrString(
+    // Older undocumented alias:
+    if (PyModule_AddObjectRef(m, "ArrayType",
+                              (PyObject *)state->ArrayType) < 0) {
+        return -1;
+    }
+
+    PyObject *mutablesequence = _PyImport_ImportModuleAttrString(
             "collections.abc", "MutableSequence");
     if (!mutablesequence) {
         return -1;

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3268,7 +3268,7 @@ array_modexec(PyObject *m)
         return -1;
     }
 
-    PyObject *mutablesequence = _PyImport_ImportModuleAttrString(
+    PyObject *mutablesequence = _PyImport_GetModuleAttrString(
             "collections.abc", "MutableSequence");
     if (!mutablesequence) {
         return -1;


### PR DESCRIPTION
(cherry picked from commit ac2e14b4e29b2d11a14d289969cfffc298ea75d9)


<!-- gh-issue-number: gh-153210 -->
* Issue: gh-153210
<!-- /gh-issue-number -->
