### PR TITLE
gh-153293: Clear opcode statistics in the live profiler's reset_stats()

### DIFF
--- a/Lib/profiling/sampling/live_collector/collector.py
+++ b/Lib/profiling/sampling/live_collector/collector.py
@@ -702,6 +702,7 @@ class LiveStatsCollector(Collector):
     def reset_stats(self):
         """Reset all collected statistics."""
         self.result.clear()
+        self.opcode_stats.clear()
         self.per_thread_data.clear()
         self.thread_ids.clear()
         self.view_mode = "ALL"

--- a/Lib/test/test_profiling/test_sampling_profiler/test_live_collector_interaction.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_live_collector_interaction.py
@@ -99,6 +99,7 @@ class TestLiveCollectorInteractiveControls(unittest.TestCase):
             "cumulative_calls": 75,
             "total_rec_calls": 0,
         }
+        self.collector.opcode_stats[("test.py", 1, "func")][100] = 5
 
         # Reset
         self.collector.reset_stats()
@@ -107,6 +108,7 @@ class TestLiveCollectorInteractiveControls(unittest.TestCase):
         self.assertEqual(self.collector.successful_samples, 0)
         self.assertEqual(self.collector.failed_samples, 0)
         self.assertEqual(len(self.collector.result), 0)
+        self.assertEqual(len(self.collector.opcode_stats), 0)
 
     def test_increase_refresh_rate(self):
         """Test increasing refresh rate (faster updates)."""

--- a/Misc/NEWS.d/next/Library/2026-07-07-22-06-52.gh-issue-153293.0DvYdc.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-07-22-06-52.gh-issue-153293.0DvYdc.rst
@@ -1,0 +1,2 @@
+Fix the live sampling profiler TUI keeping stale aggregated opcode
+statistics after a stats reset.


### PR DESCRIPTION
`LiveStatsCollector.reset_stats()` cleared everything except the aggregated `opcode_stats`. 
So after pressing `r` in `--opcodes` live mode the opcode panel kept counting instead of resetting.

Clear the opcodes counter correctly and extend the tests.

If this is merged, then 3.15 backport is needed.

<!-- gh-issue-number: gh-153293 -->
* Issue: gh-153293
<!-- /gh-issue-number -->
