### PR TITLE
gh-153292: Fix data race in `threading.RLock.__repr__` in FT builds

### DIFF
--- a/Lib/test/test_free_threading/test_threading.py
+++ b/Lib/test/test_free_threading/test_threading.py
@@ -1,0 +1,29 @@
+import unittest
+from test.support import threading_helper
+
+threading_helper.requires_working_threading(module=True)
+
+
+class TestRlock(unittest.TestCase):
+    def test_repr_race(self):
+        # gh-153292
+        import _thread
+        r = _thread.RLock()
+
+        def repr_thread():
+            for _ in range(2000):
+                try:
+                    repr(r)
+                except Exception:
+                    pass
+
+        def mutate_thread():
+            for _ in range(2000):
+                r.acquire()
+                r.release()
+
+        threading_helper.run_concurrently([repr_thread, mutate_thread])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_free_threading/test_threading.py
+++ b/Lib/test/test_free_threading/test_threading.py
@@ -12,10 +12,7 @@ class TestRlock(unittest.TestCase):
 
         def repr_thread():
             for _ in range(2000):
-                try:
-                    repr(r)
-                except Exception:
-                    pass
+                repr(r)
 
         def mutate_thread():
             for _ in range(2000):

--- a/Misc/NEWS.d/next/Library/2026-07-08-01-03-17.gh-issue-153292.oHDt3l.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-08-01-03-17.gh-issue-153292.oHDt3l.rst
@@ -1,0 +1,1 @@
+Fix data race in repr of :class:`threading.RLock` in free-threading build.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1288,7 +1288,7 @@ static PyObject *
 rlock_repr(PyObject *op)
 {
     rlockobject *self = rlockobject_CAST(op);
-    PyThread_ident_t owner = self->lock.thread;
+    PyThread_ident_t owner = FT_ATOMIC_LOAD_ULLONG_RELAXED(self->lock.thread);
     int locked = rlock_locked_impl(self);
     size_t count;
     if (locked) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-153292 -->
* Issue: gh-153292
<!-- /gh-issue-number -->
