### PR TITLE
gh-153305: Fix dbm.whichdb docstring return-value example

### DIFF
--- a/Lib/dbm/__init__.py
+++ b/Lib/dbm/__init__.py
@@ -102,8 +102,8 @@ def whichdb(filename):
 
     - None if the database file can't be read;
     - empty string if the file can be read but can't be recognized
-    - the name of the dbm submodule (e.g. "dbm.ndbm" or "dbm.gnu") if
-      recognized.
+    - the name of the dbm submodule (for example "dbm.ndbm" or "dbm.gnu")
+      if recognized.
 
     Importing the given module may still fail, and opening the
     database using that module may still fail.

--- a/Lib/dbm/__init__.py
+++ b/Lib/dbm/__init__.py
@@ -102,7 +102,8 @@ def whichdb(filename):
 
     - None if the database file can't be read;
     - empty string if the file can be read but can't be recognized
-    - the name of the dbm submodule (e.g. "ndbm" or "gnu") if recognized.
+    - the name of the dbm submodule (e.g. "dbm.ndbm" or "dbm.gnu") if
+      recognized.
 
     Importing the given module may still fail, and opening the
     database using that module may still fail.


### PR DESCRIPTION
`dbm.whichdb()` returns the dotted submodule name (`"dbm.ndbm"`, `"dbm.gnu"`,
`"dbm.sqlite3"`, `"dbm.dumb"`), matching the keys of the internal dispatch
table and the values already documented in `Doc/library/dbm.rst`. The
docstring example still used the pre-package `"ndbm"` / `"gnu"` form. This
corrects the example only.

Documentation-only change; no behavior change and no test needed.


<!-- gh-issue-number: gh-153305 -->
* Issue: gh-153305
<!-- /gh-issue-number -->
