### PR TITLE
gh-148488: Clarify py -V documentation examples

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -165,7 +165,8 @@ Runtimes from other distributors may require the *company* to be included as
 well. This should be separated from the tag by a slash, and may be a prefix.
 Specifying the company is optional when it is ``PythonCore``, and specifying the
 tag is optional (but not the slash) when you want the latest release from a
-specific company.
+specific company. The following examples are illustrative and may use either
+``/`` or ``\``.
 
 .. code::
 


### PR DESCRIPTION
## Summary

Clarify that the `py -V` examples in the Windows documentation are illustrative.

This small documentation change helps reduce ambiguity around the examples while keeping the section tutorial-oriented, without describing the underlying parsing behavior or implementation details.

No runtime behavior is changed.

Close: gh-148488