### PR TITLE
gh-88574: Do not swallow the line after a terminating literal in imaplib

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -138,6 +138,12 @@ _non_list_char = re.compile(br'[(){ \x00-\x1f\x7f-\xff\\"]')
 _quoted = re.compile(br'"(?:[^"\\]|\\.)*+"')
 
 
+def _paren_depth(data, depth=0):
+    # Net parenthesis nesting of data, ignoring parentheses in quoted strings.
+    data = _quoted.sub(b'', data)
+    return depth + data.count(b'(') - data.count(b')')
+
+
 class IMAP4:
 
     r"""IMAP4 client class.
@@ -1345,6 +1351,11 @@ class IMAP4:
         else:
             resp = self._get_line()
 
+        # Skip spurious blank lines between responses (some servers send one
+        # after a literal that ends a response).
+        while resp == b'':
+            resp = self._get_line()
+
         # Command completion response?
 
         if self._match(self.tagre, resp):
@@ -1382,6 +1393,7 @@ class IMAP4:
 
             # Is there a literal to come?
 
+            depth = 0                   # open parenthesis nesting so far
             while self._match(self.Literal, dat):
 
                 # Read literal direct from connection.
@@ -1395,13 +1407,15 @@ class IMAP4:
                 # Store response with literal as tuple
 
                 self._append_untagged(typ, (dat, data))
+                depth = _paren_depth(dat, depth)
 
                 # Read trailer - possibly containing another literal
 
                 dat = self._get_line()
 
-                # Skip a blank line that some servers send after a literal.
-                if dat == b'':
+                # Skip spurious blank lines after a literal, but only inside an
+                # unclosed parenthesis (at top level they end the response).
+                while dat == b'' and depth > 0:
                     dat = self._get_line()
 
             self._append_untagged(typ, dat)

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -1041,6 +1041,51 @@ class NewIMAPTestsMixin:
         self.assertEqual(data, [(b'1 (BODY[HEADER] {13}', b'Subject: test'),
                                 b')'])
 
+    def test_literal_terminating_response(self):
+        # A literal ending a response (a LIST mailbox name sent as a literal)
+        # has an empty trailer that must not be swallowed.  Conforming case:
+        # no spurious blank lines.
+        names = [b'My (box)"', b'Another', b'Third']
+        class Handler(SimpleIMAPHandler):
+            def cmd_LIST(self, tag, args):
+                for name in names:
+                    self._send(b'* LIST (\\HasNoChildren) "/" {%d}\r\n'
+                               % len(name))
+                    self._send(name)
+                    self._send(b'\r\n')             # ends the response, no blank
+                self._send_tagged(tag, 'OK', 'LIST completed')
+        client, _ = self._setup(Handler)
+        client.login('user', 'pass')
+        typ, data = client.list()
+        self.assertEqual(typ, 'OK')
+        self.assertEqual(data, [
+            (b'(\\HasNoChildren) "/" {9}', b'My (box)"'), b'',
+            (b'(\\HasNoChildren) "/" {7}', b'Another'), b'',
+            (b'(\\HasNoChildren) "/" {5}', b'Third'), b'',
+        ])
+
+    def test_spurious_blank_lines_between_responses(self):
+        # A spurious blank line after each terminating literal falls between the
+        # untagged responses and must be skipped, even several in a row.
+        names = [b'My (box)"', b'Another', b'Third']
+        class Handler(SimpleIMAPHandler):
+            def cmd_LIST(self, tag, args):
+                for name in names:
+                    self._send(b'* LIST (\\HasNoChildren) "/" {%d}\r\n'
+                               % len(name))
+                    self._send(name)
+                    self._send(b'\r\n\r\n')     # ends the response, then a blank
+                self._send_tagged(tag, 'OK', 'LIST completed')
+        client, _ = self._setup(Handler)
+        client.login('user', 'pass')
+        typ, data = client.list()
+        self.assertEqual(typ, 'OK')
+        self.assertEqual(data, [
+            (b'(\\HasNoChildren) "/" {9}', b'My (box)"'), b'',
+            (b'(\\HasNoChildren) "/" {7}', b'Another'), b'',
+            (b'(\\HasNoChildren) "/" {5}', b'Third'), b'',
+        ])
+
     def test_unselect(self):
         client, server = self._setup(SimpleIMAPHandler)
         client.login('user', 'pass')

--- a/Misc/NEWS.d/next/Library/2026-07-01-10-00-00.gh-issue-88574.Kz3wQm.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-01-10-00-00.gh-issue-88574.Kz3wQm.rst
@@ -1,2 +1,4 @@
 :mod:`imaplib` no longer fails when a server sends a spurious blank line
-after the counted data of a literal.  Such a blank line is now skipped.
+after the counted data of a literal, including after a literal that
+terminates a response (such as a mailbox name returned by ``LIST``).
+Such blank lines are now skipped without swallowing the following line.


### PR DESCRIPTION
[GH-152751](https://github.com/python/cpython/pull/152751) made `imaplib` skip a spurious blank line that some servers send after a literal, but it did so unconditionally. That corrupted a response ending with a literal (such as a mailbox name returned by `LIST`/`LSUB` as a literal): the literal's legitimately empty trailer was mistaken for the spurious blank, so the following line was swallowed and the framing was lost.

Spurious blank lines are now handled in both positions a literal can occupy:

* **Inside a response** (e.g. before the closing `)` of a `FETCH`) the blank is skipped only while the response line is still open, i.e. inside an unclosed parenthesis. A literal that terminates the response is at depth 0, so its empty trailer is preserved.
* **Between responses**, after a literal that ends a response, the blank arrives as an empty line before the next response and is skipped there. This covers a `LIST`/`LSUB` reply that returns a literal mailbox name in every response.


<!-- gh-issue-number: gh-88574 -->
* Issue: gh-88574
<!-- /gh-issue-number -->

