### PR TITLE
gh-150191: temporarily skip two openssl tests which have internal data races under TSAN

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1604,6 +1604,9 @@ class ContextTests(unittest.TestCase):
         gc.collect()
         self.assertIs(wr(), None)
 
+    @support.skip_if_sanitizer("gh-150191: OpenSSL has an internal data race "
+                               "when the SNI callback is replaced during a "
+                               "handshake", thread=True)
     @threading_helper.requires_working_threading()
     def test_sni_callback_race(self):
         # Replacing sni_callback while a handshake is in-flight must not
@@ -5045,6 +5048,9 @@ class ThreadedTests(unittest.TestCase):
             with client_context.wrap_socket(socket.socket()) as s:
                 s.connect((HOST, server.port))
 
+    @support.skip_if_sanitizer("gh-137583: OpenSSL races on SSL->rwstate and "
+                               "the socket BIO flags with concurrent read "
+                               "and write", thread=True)
     def test_thread_recv_while_main_thread_sends(self):
         # GH-137583: Locking was added to calls to send() and recv() on SSL
         # socket objects. This seemed fine at the surface level because those

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5048,7 +5048,7 @@ class ThreadedTests(unittest.TestCase):
             with client_context.wrap_socket(socket.socket()) as s:
                 s.connect((HOST, server.port))
 
-    @support.skip_if_sanitizer("gh-137583: OpenSSL races on SSL->rwstate and "
+    @support.skip_if_sanitizer("gh-150191: OpenSSL races on SSL->rwstate and "
                                "the socket BIO flags with concurrent read "
                                "and write", thread=True)
     def test_thread_recv_while_main_thread_sends(self):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

See https://github.com/python/cpython/issues/150191


## `ContextTests.test_sni_callback_race` — 2 reports

**Default build** — setter write vs `final_server_name` read:

```
WARNING: ThreadSanitizer: data race (pid=36258)
  Write of size 8 at 0x726c00056c30 by thread T15:          # toggler thread
    #0 ssl3_ctx_callback_ctrl        ssl/s3_lib.c:4200      # ctx->ext.servername_cb = fp
    #1 SSL_CTX_callback_ctrl         ssl/ssl_lib.c:3251
    #2 _ssl__SSLContext_sni_callback_set_impl  Modules/_ssl.c:5319
    #4 getset_set → PyObject_SetAttr                        # server_ctx.sni_callback = ...

  Previous read of size 8 at 0x726c00056c30 by thread T12:  # handshake worker
    #0 final_server_name             ssl/statem/extensions.c:1004   # reads servername_cb
    #1 tls_parse_all_extensions      ssl/statem/extensions.c:816
    #2 tls_early_post_process_client_hello  ssl/statem/statem_srvr.c:1965
    #7 ossl_statem_accept → #8 SSL_do_handshake
    #9 _ssl__SSLSocket_do_handshake_impl  Modules/_ssl.c:1099       # server.do_handshake()

  Location: heap block of size 1768 (SSL_CTX, allocated in SSL_CTX_new
            from _ssl__SSLContext_impl, Modules/_ssl.c:3509)
```

**Free-threading build** — same write, different read site:

```
WARNING: ThreadSanitizer: data race (pid=36449)
  Read of size 8 at 0x726c00002c30 by thread T12:           # handshake worker
    #0 is_tls13_capable              ssl/statem/statem_lib.c:1932
       # if (sctx->ext.servername_cb != NULL || s->session_ctx->ext.servername_cb != NULL)
    #1 ssl_version_supported         ssl/statem/statem_lib.c:2011
    #2 ssl_choose_server_version     ssl/statem/statem_lib.c:2240
    #9 SSL_do_handshake → _ssl__SSLSocket_do_handshake_impl  Modules/_ssl.c:1099

  Previous write of size 8 by thread T15:                   # toggler thread
    #0 ssl3_ctx_callback_ctrl        ssl/s3_lib.c:4200
    #2 _ssl__SSLContext_sni_callback_set_impl  Modules/_ssl.c:5319

SUMMARY: data race statem_lib.c:1932 in is_tls13_capable
```

## `ThreadedTests.test_thread_recv_while_main_thread_sends` — 3 reports

**`s->rwstate` (both builds, identical stacks):**

```
WARNING: ThreadSanitizer: data race
  Write of size 4 by main thread:                           # sock.sendall(data)
    #0 ssl3_write_bytes              ssl/record/rec_layer_s3.c:285   # s->rwstate = SSL_NOTHING
    #3 SSL_write_ex2 → #4 SSL_write_ex
    #5 _ssl__SSLSocket_write_impl    Modules/_ssl.c:2832

  Previous write of size 4 by thread T272:                  # background sock.recv()
    #0 ssl3_read_bytes               ssl/record/rec_layer_s3.c:681   # s->rwstate = SSL_NOTHING
    #4 SSL_read_ex
    #5 _ssl__SSLSocket_read_impl     Modules/_ssl.c:2989

  Location: heap block of size 5560 (the SSL object, allocated in SSL_new
            from newPySSLSocket, Modules/_ssl.c:959, via context.wrap_socket)

SUMMARY: data race rec_layer_s3.c:285 in ssl3_write_bytes
```

**Socket BIO `flags` (free-threading build only):**

```
WARNING: ThreadSanitizer: data race (pid=36449)
  Write of size 4 at 0x72200001d530 by thread T507:         # background sock.recv()
    #0 BIO_clear_flags               crypto/bio/bio_lib.c:201        # bio->flags &= ~...
    #1 sock_read                     crypto/bio/bss_sock.c:128
    #4 BIO_read → tls_default_read_n → tls_get_more_records → tls_read_record
    #8 ssl3_read_bytes               ssl/record/rec_layer_s3.c:696
    #12 SSL_read_ex → _ssl__SSLSocket_read_impl  Modules/_ssl.c:2989

  Previous write of size 4 by main thread:                  # sock.sendall(data)
    #0 BIO_clear_flags               crypto/bio/bio_lib.c:201
    #1 sock_write                    crypto/bio/bss_sock.c:168
    #5 tls_retry_write_records → SSL_write_ex → _ssl__SSLSocket_write_impl

  Location: heap block of size 128 (the socket BIO, allocated via SSL_set_fd,
            ssl/ssl_lib.c:1728, from newPySSLSocket)
```


<!-- gh-issue-number: gh-150191 -->
* Issue: gh-150191
<!-- /gh-issue-number -->
