### PR TITLE
gh-153354: Fix bool conversion in generated __annotate__

### DIFF
--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1714,7 +1714,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
                 annotationlib.call_annotate_function(annotate, format=fmt)
 
     def test_generated_annotate_non_bool_compare_result(self):
-        class NonBool:
+        class NonBool(int):
             def __gt__(self, other):
                 return None
 
@@ -1723,7 +1723,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
             pass
 
         self.assertEqual(
-            func.__annotate__(NonBool()),
+            func.__annotate__(NonBool(1)),
             {"x": int},
         )
 
@@ -1732,7 +1732,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
             y: int
 
         self.assertEqual(
-            C.__annotate__(NonBool()),
+            C.__annotate__(NonBool(1)),
             {"y": int},
         )
 
@@ -1741,7 +1741,7 @@ class TestCallAnnotateFunction(unittest.TestCase):
         exec("z: int", ns)
 
         self.assertEqual(
-            ns["__annotate__"](NonBool()),
+            ns["__annotate__"](NonBool(1)),
             {"z": int},
         )
 

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1713,6 +1713,37 @@ class TestCallAnnotateFunction(unittest.TestCase):
             with self.assertRaises(DemoException):
                 annotationlib.call_annotate_function(annotate, format=fmt)
 
+    def test_generated_annotate_non_bool_compare_result(self):
+        class NonBool:
+            def __gt__(self, other):
+                return None
+
+        # Function __annotate__
+        def func(x: int):
+            pass
+
+        self.assertEqual(
+            func.__annotate__(NonBool()),
+            {"x": int},
+        )
+
+        # Class __annotate__
+        class C:
+            y: int
+
+        self.assertEqual(
+            C.__annotate__(NonBool()),
+            {"y": int},
+        )
+
+        # Module __annotate__
+        ns = {}
+        exec("z: int", ns)
+
+        self.assertEqual(
+            ns["__annotate__"](NonBool()),
+            {"z": int},
+        )
 
 class MetaclassTests(unittest.TestCase):
     def test_annotated_meta(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-09-13-28-27.gh-issue-153354.It4Jj_.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-09-13-28-27.gh-issue-153354.It4Jj_.rst
@@ -1,0 +1,2 @@
+Fix a crash in compiler-generated ``__annotate__`` functions when the
+annotation format comparison returned a non-boolean result.

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -724,6 +724,7 @@ codegen_setup_annotations_scope(compiler *c, location loc,
     ADDOP_I(c, loc, LOAD_FAST, 0);
     ADDOP_LOAD_CONST_NEW(c, loc, value_with_fake_globals);
     ADDOP_I(c, loc, COMPARE_OP, (Py_GT << 5) | compare_masks[Py_GT]);
+    ADDOP(c, loc, TO_BOOL);
     NEW_JUMP_TARGET_LABEL(c, body);
     ADDOP_JUMP(c, loc, POP_JUMP_IF_FALSE, body);
     ADDOP_I(c, loc, LOAD_COMMON_CONSTANT, CONSTANT_NOTIMPLEMENTEDERROR);


### PR DESCRIPTION
## Summary

Fix the compiler-generated `__annotate__` guard by emitting `TO_BOOL` after `COMPARE_OP`, allowing the optimizer to generate the bool-converting `COMPARE_OP` before `POP_JUMP_IF_FALSE`.

Previously, the generated bytecode omitted the bool conversion required before `POP_JUMP_IF_FALSE`, allowing a non-boolean result from `__gt__` to reach the jump. On debug builds this triggered an assertion failure, while release builds could exhibit incorrect behavior.

## Changes

- Emit `TO_BOOL` after the generated `COMPARE_OP` in `codegen_setup_annotations_scope()`, allowing the optimizer to fold it into a bool-converting `COMPARE_OP`.
- Expand the regression test to cover compiler-generated `__annotate__` functions for functions, classes, and modules.

## Issue

Fixes gh-153354.

## Testing

- Built CPython (Debug, x64).
- Verified that the original reproducer no longer crashes.
- Verified that the generated bytecode now emits `COMPARE_OP (bool(>))`, matching normal conditional comparison code generation after optimization.
- Ran the following test suites successfully:

```text
PCbuild\amd64\python_d.exe -m test test_annotationlib
PCbuild\amd64\python_d.exe -m test test_compile
```