### PR TITLE
gh-153364: Make frame, coroutine, and task-waiter chain walks iterative and bounded

### DIFF
--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -423,7 +423,6 @@ sock.connect(('localhost', {port}))
     def _get_awaited_by_relationships(self, stack_trace):
         """Extract task name to awaited_by set mapping."""
         id_to_task = self._get_task_id_map(stack_trace)
-
         return {
             task.task_name: set(
                 id_to_task[awaited.task_name].task_name

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -3809,6 +3809,7 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
     """Frame chain walks abort instead of looping/overflowing on deep chains."""
 
     CHAIN_DEPTH = 1024 + 512 + 1
+    TASK_WAITER_CHAIN_DEPTH = 512 + 1
 
     def _assert_unwinder_limit_error(self, unwind, expected_substring):
         """Call unwind() until it raises the frame chain limit error.
@@ -3883,7 +3884,7 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
                 task = asyncio.create_task(chain(n - 1))
                 await task
 
-            asyncio.run(chain({self.CHAIN_DEPTH}))
+            asyncio.run(chain({self.TASK_WAITER_CHAIN_DEPTH}))
             """
         with self._target_process(script_body) as (p, client_socket, _):
             _wait_for_signal(client_socket, b"ready")

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -3809,7 +3809,8 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
     """Frame chain walks abort instead of looping/overflowing on deep chains."""
 
     CHAIN_DEPTH = 1024 + 512 + 1
-    TASK_WAITER_CHAIN_DEPTH = 512 + 1
+
+    TASK_WAITER_CHAIN_DEPTH = 256 + 1
 
     def _assert_unwinder_limit_error(self, unwind, expected_substring):
         """Call unwind() until it raises the frame chain limit error.

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -424,15 +424,10 @@ sock.connect(('localhost', {port}))
         """Extract task name to awaited_by set mapping."""
         id_to_task = self._get_task_id_map(stack_trace)
 
-        def task_name(task_id):
-            task = id_to_task.get(task_id)
-            if task is None:
-                return f"<unknown object at {task_id:#x}>"
-            return task.task_name
-
         return {
             task.task_name: set(
-                task_name(awaited.task_name) for awaited in task.awaited_by
+                id_to_task[awaited.task_name].task_name
+                for awaited in task.awaited_by
             )
             for task in stack_trace[0].awaited_by
         }

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -1480,27 +1480,29 @@ class TestGetStackTrace(RemoteInspectionTestBase):
         script_body = """\
             import asyncio
 
-            class RemovedTask(asyncio.Task):
-                def __hash__(self):
-                    return 0
+            class HashedTask(asyncio.Task):
+                def __init__(self, coro, task_hash, **kwargs):
+                    self.task_hash = task_hash
+                    super().__init__(coro, **kwargs)
 
-            class RemainingTask(asyncio.Task):
                 def __hash__(self):
-                    return 1
-
-            async def wait_forever():
-                await asyncio.Event().wait()
+                    return self.task_hash
 
             async def main():
-                victim = asyncio.create_task(wait_forever(), name="victim")
-                removed = RemovedTask(wait_forever(), name="removed")
-                remaining = RemainingTask(wait_forever(), name="remaining")
+                victim = asyncio.create_task(
+                    asyncio.sleep(10_000), name="victim"
+                )
+                removed = HashedTask(
+                    asyncio.sleep(10_000), 0, name="removed"
+                )
+                remaining = HashedTask(
+                    asyncio.sleep(10_000), 1, name="remaining"
+                )
 
                 asyncio.future_add_to_awaited_by(victim, removed)
                 asyncio.future_add_to_awaited_by(victim, remaining)
 
-                # Put a dummy in slot 0 before the only active entry in
-                # slot 1. It must not count toward the set's used entries.
+                # Removing hash 0 leaves a dummy before the live hash-1 entry.
                 asyncio.future_discard_from_awaited_by(victim, removed)
 
                 sock.sendall(b"ready")

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -1476,6 +1476,60 @@ class TestGetStackTrace(RemoteInspectionTestBase):
         sys.platform == "linux" and not PROCESS_VM_READV_SUPPORTED,
         "Test only runs on Linux with process_vm_readv support",
     )
+    def test_async_global_awaited_by_skips_set_tombstones(self):
+        script_body = """\
+            import asyncio
+
+            class RemovedTask(asyncio.Task):
+                def __hash__(self):
+                    return 0
+
+            class RemainingTask(asyncio.Task):
+                def __hash__(self):
+                    return 1
+
+            async def wait_forever():
+                await asyncio.Event().wait()
+
+            async def main():
+                victim = asyncio.create_task(wait_forever(), name="victim")
+                removed = RemovedTask(wait_forever(), name="removed")
+                remaining = RemainingTask(wait_forever(), name="remaining")
+
+                asyncio.future_add_to_awaited_by(victim, removed)
+                asyncio.future_add_to_awaited_by(victim, remaining)
+
+                # Put a dummy in slot 0 before the only active entry in
+                # slot 1. It must not count toward the set's used entries.
+                asyncio.future_discard_from_awaited_by(victim, removed)
+
+                sock.sendall(b"ready")
+                sock.recv(16)
+
+            asyncio.run(main())
+            """
+
+        with self._target_process(script_body) as (p, client_socket, _):
+            _wait_for_signal(client_socket, b"ready")
+
+            all_awaited_by = get_all_awaited_by(p.pid)
+            tasks_by_name = {
+                task.task_name: task
+                for task in self._get_task_id_map(all_awaited_by).values()
+            }
+            victim = tasks_by_name["victim"]
+            remaining = tasks_by_name["remaining"]
+            self.assertEqual(
+                [waiter.task_name for waiter in victim.awaited_by],
+                [remaining.task_id],
+            )
+            client_socket.sendall(b"done")
+
+    @skip_if_not_supported
+    @unittest.skipIf(
+        sys.platform == "linux" and not PROCESS_VM_READV_SUPPORTED,
+        "Test only runs on Linux with process_vm_readv support",
+    )
     def test_async_global_awaited_by_from_non_main_thread(self):
         port = find_unused_port()
         script = textwrap.dedent(

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -3809,9 +3809,9 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
     """Frame chain walks abort instead of looping/overflowing on deep chains."""
 
     # Limits plus one, to exceed them (must match MAX_FRAME_CHAIN_DEPTH /
-    # MAX_TASK_WAITER_CHAIN_DEPTH from _remote_debugging.h)
+    # MAX_TASK_WAITER_WALK_TASKS from _remote_debugging.h)
     FRAME_CHAIN_DEPTH = 1024 + 512 + 1
-    TASK_WAITER_CHAIN_DEPTH = 256 + 1
+    TASK_WAITER_WALK_TASKS = 2**16 + 1
 
     def _assert_unwinder_limit_error(self, unwind, expected_substring):
         """Call unwind() until it raises the frame chain limit error.
@@ -3886,7 +3886,7 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
                 task = asyncio.create_task(chain(n - 1))
                 await task
 
-            asyncio.run(chain({self.TASK_WAITER_CHAIN_DEPTH}))
+            asyncio.run(chain({self.TASK_WAITER_WALK_TASKS}))
             """
         with self._target_process(script_body) as (p, client_socket, _):
             _wait_for_signal(client_socket, b"ready")

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -3811,7 +3811,7 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
     # Limits plus one, to exceed them (must match MAX_FRAME_CHAIN_DEPTH /
     # MAX_TASK_WAITER_WALK_TASKS from _remote_debugging.h)
     FRAME_CHAIN_DEPTH = 1024 + 512 + 1
-    TASK_WAITER_WALK_TASKS = 2**16 + 1
+    TASK_WAITER_WALK_TASKS = 2**14 + 1
 
     def _assert_unwinder_limit_error(self, unwind, expected_substring):
         """Call unwind() until it raises the frame chain limit error.

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -3808,6 +3808,8 @@ recurse({depth})
 class TestFrameChainLimits(RemoteInspectionTestBase):
     """Frame chain walks abort instead of looping/overflowing on deep chains."""
 
+    # Limits plus one, to exceed them (must match MAX_FRAME_CHAIN_DEPTH /
+    # MAX_TASK_WAITER_CHAIN_DEPTH from _remote_debugging.h)
     CHAIN_DEPTH = 1024 + 512 + 1
 
     TASK_WAITER_CHAIN_DEPTH = 256 + 1

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -423,10 +423,16 @@ sock.connect(('localhost', {port}))
     def _get_awaited_by_relationships(self, stack_trace):
         """Extract task name to awaited_by set mapping."""
         id_to_task = self._get_task_id_map(stack_trace)
+
+        def task_name(task_id):
+            task = id_to_task.get(task_id)
+            if task is None:
+                return f"<unknown object at {task_id:#x}>"
+            return task.task_name
+
         return {
             task.task_name: set(
-                id_to_task[awaited.task_name].task_name
-                for awaited in task.awaited_by
+                task_name(awaited.task_name) for awaited in task.awaited_by
             )
             for task in stack_trace[0].awaited_by
         }
@@ -1476,33 +1482,34 @@ class TestGetStackTrace(RemoteInspectionTestBase):
         sys.platform == "linux" and not PROCESS_VM_READV_SUPPORTED,
         "Test only runs on Linux with process_vm_readv support",
     )
-    def test_async_global_awaited_by_skips_set_tombstones(self):
+    def test_async_awaited_by_skips_set_tombstones(self):
         script_body = """\
             import asyncio
 
-            class HashedTask(asyncio.Task):
-                def __init__(self, coro, task_hash, **kwargs):
-                    self.task_hash = task_hash
-                    super().__init__(coro, **kwargs)
-
+            class RemovedTask(asyncio.Task):
                 def __hash__(self):
-                    return self.task_hash
+                    return 0
+
+            class RemainingTask(asyncio.Task):
+                def __hash__(self):
+                    return 1
 
             async def main():
-                victim = asyncio.create_task(
-                    asyncio.sleep(10_000), name="victim"
+                victim = asyncio.current_task()
+                victim.set_name("victim")
+                removed = RemovedTask(
+                    asyncio.sleep(10_000), name="removed"
                 )
-                removed = HashedTask(
-                    asyncio.sleep(10_000), 0, name="removed"
-                )
-                remaining = HashedTask(
-                    asyncio.sleep(10_000), 1, name="remaining"
+                remaining = RemainingTask(
+                    asyncio.sleep(10_000), name="remaining"
                 )
 
                 asyncio.future_add_to_awaited_by(victim, removed)
                 asyncio.future_add_to_awaited_by(victim, remaining)
 
-                # Removing hash 0 leaves a dummy before the live hash-1 entry.
+                # Removing hash 0 leaves a dummy in slot 0 before the only
+                # active entry in slot 1. It must not count toward the set's
+                # used entries.
                 asyncio.future_discard_from_awaited_by(victim, removed)
 
                 sock.sendall(b"ready")
@@ -1511,20 +1518,28 @@ class TestGetStackTrace(RemoteInspectionTestBase):
             asyncio.run(main())
             """
 
-        with self._target_process(script_body) as (p, client_socket, _):
+        with self._target_process(script_body) as (
+            _,
+            client_socket,
+            make_unwinder,
+        ):
             _wait_for_signal(client_socket, b"ready")
 
-            all_awaited_by = get_all_awaited_by(p.pid)
-            tasks_by_name = {
-                task.task_name: task
-                for task in self._get_task_id_map(all_awaited_by).values()
-            }
-            victim = tasks_by_name["victim"]
-            remaining = tasks_by_name["remaining"]
-            self.assertEqual(
-                [waiter.task_name for waiter in victim.awaited_by],
-                [remaining.task_id],
-            )
+            for method_name in (
+                "get_async_stack_trace",
+                "get_all_awaited_by",
+            ):
+                with self.subTest(method=method_name):
+                    unwinder = make_unwinder(cache_frames=False)
+                    stack_trace = getattr(unwinder, method_name)()
+                    relationships = self._get_awaited_by_relationships(
+                        stack_trace
+                    )
+                    self.assertEqual(
+                        relationships["victim"],
+                        {"remaining"},
+                    )
+
             client_socket.sendall(b"done")
 
     @skip_if_not_supported

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -3810,8 +3810,7 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
 
     # Limits plus one, to exceed them (must match MAX_FRAME_CHAIN_DEPTH /
     # MAX_TASK_WAITER_CHAIN_DEPTH from _remote_debugging.h)
-    CHAIN_DEPTH = 1024 + 512 + 1
-
+    FRAME_CHAIN_DEPTH = 1024 + 512 + 1
     TASK_WAITER_CHAIN_DEPTH = 256 + 1
 
     def _assert_unwinder_limit_error(self, unwind, expected_substring):
@@ -3848,7 +3847,7 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
         synchronous stack walk instead of walking it indefinitely."""
         script_body = f"""\
             import sys
-            sys.setrecursionlimit({self.CHAIN_DEPTH * 2})
+            sys.setrecursionlimit({self.FRAME_CHAIN_DEPTH * 2})
 
             def recurse(n):
                 if n <= 0:
@@ -3857,7 +3856,7 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
                     return
                 recurse(n - 1)
 
-            recurse({self.CHAIN_DEPTH})
+            recurse({self.FRAME_CHAIN_DEPTH})
             """
         with self._target_process(script_body) as (p, client_socket, _):
             _wait_for_signal(client_socket, b"ready")
@@ -3907,7 +3906,7 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
         stack walk instead of walking it indefinitely."""
         script_body = f"""\
             import sys, asyncio
-            sys.setrecursionlimit({self.CHAIN_DEPTH * 2})
+            sys.setrecursionlimit({self.FRAME_CHAIN_DEPTH * 2})
 
             def recurse(n):
                 if n <= 0:
@@ -3917,7 +3916,7 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
                 recurse(n - 1)
 
             async def deep():
-                recurse({self.CHAIN_DEPTH})
+                recurse({self.FRAME_CHAIN_DEPTH})
 
             asyncio.run(deep())
             """
@@ -3939,7 +3938,7 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
         the walk instead of overflowing the C stack."""
         script_body = f"""\
             import sys, asyncio
-            sys.setrecursionlimit({self.CHAIN_DEPTH * 2})
+            sys.setrecursionlimit({self.FRAME_CHAIN_DEPTH * 2})
 
             async def chain(n):
                 if n <= 0:
@@ -3948,7 +3947,7 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
                 await chain(n - 1)
 
             async def main():
-                task = asyncio.create_task(chain({self.CHAIN_DEPTH}))
+                task = asyncio.create_task(chain({self.FRAME_CHAIN_DEPTH}))
                 await asyncio.sleep(0)
                 sock.sendall(b"ready")
                 await task

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -3909,12 +3909,17 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
 
             async def chain(n):
                 if n <= 0:
-                    sock.sendall(b"ready")
                     await asyncio.sleep(10_000)
                     return
                 await chain(n - 1)
 
-            asyncio.run(chain({self.CHAIN_DEPTH}))
+            async def main():
+                task = asyncio.create_task(chain({self.CHAIN_DEPTH}))
+                await asyncio.sleep(0)
+                sock.sendall(b"ready")
+                await task
+
+            asyncio.run(main())
             """
         with self._target_process(script_body) as (p, client_socket, _):
             _wait_for_signal(client_socket, b"ready")

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -3868,6 +3868,36 @@ class TestFrameChainLimits(RemoteInspectionTestBase):
         sys.platform == "linux" and not PROCESS_VM_READV_SUPPORTED,
         "Test only runs on Linux with process_vm_readv support",
     )
+    def test_get_async_stack_trace_deep_task_waiter_chain_aborts(self):
+        """Test that a task waiter chain deeper than the limit aborts
+        the walk instead of overflowing the C stack."""
+        script_body = f"""\
+            import asyncio
+
+            async def chain(n):
+                if n <= 0:
+                    sock.sendall(b"ready")
+                    sock.recv(16)
+                    return
+
+                task = asyncio.create_task(chain(n - 1))
+                await task
+
+            asyncio.run(chain({self.CHAIN_DEPTH}))
+            """
+        with self._target_process(script_body) as (p, client_socket, _):
+            _wait_for_signal(client_socket, b"ready")
+            self._assert_unwinder_limit_error(
+                lambda: RemoteUnwinder(p.pid).get_async_stack_trace(),
+                "Too many task waiters",
+            )
+            client_socket.sendall(b"done")
+
+    @skip_if_not_supported
+    @unittest.skipIf(
+        sys.platform == "linux" and not PROCESS_VM_READV_SUPPORTED,
+        "Test only runs on Linux with process_vm_readv support",
+    )
     def test_get_async_stack_trace_deep_frame_chain_aborts(self):
         """Test that a frame chain deeper than the limit aborts the async
         stack walk instead of walking it indefinitely."""

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -339,6 +339,40 @@ class RemoteInspectionTestBase(unittest.TestCase):
             finally:
                 _cleanup_sockets(client_socket, server_socket)
 
+    @contextmanager
+    def _target_process(self, script_body):
+        """Context manager for running a target process with socket sync."""
+        port = find_unused_port()
+        script = f"""\
+import socket
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.connect(('localhost', {port}))
+{textwrap.dedent(script_body)}
+"""
+
+        with os_helper.temp_dir() as work_dir:
+            script_dir = os.path.join(work_dir, "script_pkg")
+            os.mkdir(script_dir)
+
+            server_socket = _create_server_socket(port)
+            script_name = _make_test_script(script_dir, "script", script)
+            client_socket = None
+
+            try:
+                with _managed_subprocess([sys.executable, script_name]) as p:
+                    client_socket, _ = server_socket.accept()
+                    server_socket.close()
+                    server_socket = None
+
+                    def make_unwinder(cache_frames=True):
+                        return RemoteUnwinder(
+                            p.pid, all_threads=True, cache_frames=cache_frames
+                        )
+
+                    yield p, client_socket, make_unwinder
+            finally:
+                _cleanup_sockets(client_socket, server_socket)
+
     def _find_frame_in_trace(self, stack_trace, predicate):
         """
         Find a frame matching predicate in stack trace.
@@ -2927,40 +2961,6 @@ class TestFrameCaching(RemoteInspectionTestBase):
     All tests verify cache reuse via object identity checks (assertIs).
     """
 
-    @contextmanager
-    def _target_process(self, script_body):
-        """Context manager for running a target process with socket sync."""
-        port = find_unused_port()
-        script = f"""\
-import socket
-sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-sock.connect(('localhost', {port}))
-{textwrap.dedent(script_body)}
-"""
-
-        with os_helper.temp_dir() as work_dir:
-            script_dir = os.path.join(work_dir, "script_pkg")
-            os.mkdir(script_dir)
-
-            server_socket = _create_server_socket(port)
-            script_name = _make_test_script(script_dir, "script", script)
-            client_socket = None
-
-            try:
-                with _managed_subprocess([sys.executable, script_name]) as p:
-                    client_socket, _ = server_socket.accept()
-                    server_socket.close()
-                    server_socket = None
-
-                    def make_unwinder(cache_frames=True):
-                        return RemoteUnwinder(
-                            p.pid, all_threads=True, cache_frames=cache_frames
-                        )
-
-                    yield p, client_socket, make_unwinder
-            finally:
-                _cleanup_sockets(client_socket, server_socket)
-
     def _get_frames_with_retry(self, unwinder, required_funcs):
         """Get frames containing required_funcs, with retry for transient errors."""
         for _ in range(MAX_TRIES):
@@ -3802,6 +3802,126 @@ recurse({depth})
                 unwinder.get_stats()
 
             client_socket.sendall(b"done")
+
+
+@requires_remote_subprocess_debugging()
+class TestFrameChainLimits(RemoteInspectionTestBase):
+    """Frame chain walks abort instead of looping/overflowing on deep chains."""
+
+    CHAIN_DEPTH = 1024 + 512 + 1
+
+    def _assert_unwinder_limit_error(self, unwind, expected_substring):
+        """Call unwind() until it raises the frame chain limit error.
+
+        unwind must construct the RemoteUnwinder and call it, so that
+        transient RuntimeErrors from either step are retried; a successful
+        call means the limit never triggered and fails immediately.
+        """
+        last_error = None
+        for _ in busy_retry(SHORT_TIMEOUT, error=False):
+            try:
+                unwind()
+            except TRANSIENT_ERRORS as e:
+                if expected_substring in str(e):
+                    return
+                last_error = e
+                continue
+            self.fail(
+                "frame chain limit did not trigger; call returned a result"
+            )
+        self.fail(
+            f"frame chain limit never raised; last transient error: "
+            f"{last_error!r}"
+        )
+
+    @skip_if_not_supported
+    @unittest.skipIf(
+        sys.platform == "linux" and not PROCESS_VM_READV_SUPPORTED,
+        "Test only runs on Linux with process_vm_readv support",
+    )
+    def test_get_stack_trace_deep_frame_chain_aborts(self):
+        """Test that a frame chain deeper than the limit aborts the
+        synchronous stack walk instead of walking it indefinitely."""
+        script_body = f"""\
+            import sys
+            sys.setrecursionlimit({self.CHAIN_DEPTH * 2})
+
+            def recurse(n):
+                if n <= 0:
+                    sock.sendall(b"ready")
+                    sock.recv(16)
+                    return
+                recurse(n - 1)
+
+            recurse({self.CHAIN_DEPTH})
+            """
+        with self._target_process(script_body) as (p, client_socket, _):
+            _wait_for_signal(client_socket, b"ready")
+            self._assert_unwinder_limit_error(
+                lambda: RemoteUnwinder(p.pid).get_stack_trace(),
+                "Too many stack frames",
+            )
+            client_socket.sendall(b"done")
+
+    @skip_if_not_supported
+    @unittest.skipIf(
+        sys.platform == "linux" and not PROCESS_VM_READV_SUPPORTED,
+        "Test only runs on Linux with process_vm_readv support",
+    )
+    def test_get_async_stack_trace_deep_frame_chain_aborts(self):
+        """Test that a frame chain deeper than the limit aborts the async
+        stack walk instead of walking it indefinitely."""
+        script_body = f"""\
+            import sys, asyncio
+            sys.setrecursionlimit({self.CHAIN_DEPTH * 2})
+
+            def recurse(n):
+                if n <= 0:
+                    sock.sendall(b"ready")
+                    sock.recv(16)
+                    return
+                recurse(n - 1)
+
+            async def deep():
+                recurse({self.CHAIN_DEPTH})
+
+            asyncio.run(deep())
+            """
+        with self._target_process(script_body) as (p, client_socket, _):
+            _wait_for_signal(client_socket, b"ready")
+            self._assert_unwinder_limit_error(
+                lambda: RemoteUnwinder(p.pid).get_async_stack_trace(),
+                "Too many async stack frames",
+            )
+            client_socket.sendall(b"done")
+
+    @skip_if_not_supported
+    @unittest.skipIf(
+        sys.platform == "linux" and not PROCESS_VM_READV_SUPPORTED,
+        "Test only runs on Linux with process_vm_readv support",
+    )
+    def test_get_all_awaited_by_deep_coro_chain_aborts(self):
+        """Test that a coroutine await chain deeper than the limit aborts
+        the walk instead of overflowing the C stack."""
+        script_body = f"""\
+            import sys, asyncio
+            sys.setrecursionlimit({self.CHAIN_DEPTH * 2})
+
+            async def chain(n):
+                if n <= 0:
+                    sock.sendall(b"ready")
+                    await asyncio.sleep(10_000)
+                    return
+                await chain(n - 1)
+
+            asyncio.run(chain({self.CHAIN_DEPTH}))
+            """
+        with self._target_process(script_body) as (p, client_socket, _):
+            _wait_for_signal(client_socket, b"ready")
+            self._assert_unwinder_limit_error(
+                lambda: RemoteUnwinder(p.pid).get_all_awaited_by(),
+                "Too many coroutine frames",
+            )
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2026-07-08-22-18-04.gh-issue-153364.JBFHEg.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-08-22-18-04.gh-issue-153364.JBFHEg.rst
@@ -1,3 +1,2 @@
-Add limits to frame, coroutine and task-waiter walks in the Tachyon sampling
-profiler. This avoids potential hangs and stack overflows.  Patch by Maurycy
-Pawłowski-Wieroński.
+Make frame, coroutine and task-waiter walks iterative and bounded, avoiding
+potential hangs and stack overflows. Patch by Maurycy Pawłowski-Wieroński.

--- a/Misc/NEWS.d/next/Library/2026-07-08-22-18-04.gh-issue-153364.JBFHEg.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-08-22-18-04.gh-issue-153364.JBFHEg.rst
@@ -1,2 +1,3 @@
 Make frame, coroutine and task-waiter walks iterative and bounded, avoiding
-potential hangs and stack overflows. Patch by Maurycy Pawłowski-Wieroński.
+potential hangs and stack overflows. Fix asyncio task inspection when
+awaited-by sets contain removed entries. Patch by Maurycy Pawłowski-Wieroński.

--- a/Misc/NEWS.d/next/Library/2026-07-08-22-18-04.gh-issue-153364.JBFHEg.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-08-22-18-04.gh-issue-153364.JBFHEg.rst
@@ -1,0 +1,2 @@
+Add limits to frame and coroutine-chain walks in the Tachyon sampling
+profiler. This avoids potential hangs. Patch by Maurycy Pawłowski-Wieroński.

--- a/Misc/NEWS.d/next/Library/2026-07-08-22-18-04.gh-issue-153364.JBFHEg.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-08-22-18-04.gh-issue-153364.JBFHEg.rst
@@ -1,2 +1,3 @@
-Add limits to frame and coroutine-chain walks in the Tachyon sampling
-profiler. This avoids potential hangs. Patch by Maurycy Pawłowski-Wieroński.
+Add limits to frame, coroutine and task-waiter walks in the Tachyon sampling
+profiler. This avoids potential hangs and stack overflows.  Patch by Maurycy
+Pawłowski-Wieroński.

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -733,7 +733,8 @@ extern int parse_task(
 extern int parse_coro_chain(
     RemoteUnwinderObject *unwinder,
     uintptr_t coro_address,
-    PyObject *render_to
+    PyObject *render_to,
+    size_t depth
 );
 
 extern int parse_async_frame_chain(

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -482,7 +482,8 @@ typedef int (*thread_processor_func)(
 typedef int (*set_entry_processor_func)(
     RemoteUnwinderObject *unwinder,
     uintptr_t key_addr,
-    void *context
+    void *context,
+    size_t depth
 );
 
 typedef int (*interpreter_processor_func)(
@@ -749,7 +750,8 @@ extern int iterate_set_entries(
     RemoteUnwinderObject *unwinder,
     uintptr_t set_addr,
     set_entry_processor_func processor,
-    void *context
+    void *context,
+    size_t depth
 );
 
 /* Task awaited_by processing */
@@ -757,7 +759,8 @@ extern int process_task_awaited_by(
     RemoteUnwinderObject *unwinder,
     uintptr_t task_address,
     set_entry_processor_func processor,
-    void *context
+    void *context,
+    size_t depth
 );
 
 extern int process_single_task_node(
@@ -770,7 +773,8 @@ extern int process_single_task_node(
 extern int process_task_and_waiters(
     RemoteUnwinderObject *unwinder,
     uintptr_t task_addr,
-    PyObject *result
+    PyObject *result,
+    size_t depth
 );
 
 extern int find_running_task_in_thread(

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -725,13 +725,6 @@ extern int parse_task(
     PyObject *render_to
 );
 
-extern int parse_coro_chain(
-    RemoteUnwinderObject *unwinder,
-    uintptr_t coro_address,
-    PyObject *render_to,
-    size_t depth
-);
-
 extern int parse_async_frame_chain(
     RemoteUnwinderObject *unwinder,
     PyObject *calls,

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -148,7 +148,7 @@ typedef enum _WIN32_THREADSTATE {
 #define MAX_LONG_DIGITS 64  /* Allows values up to ~2^1920 */
 #define MAX_SET_TABLE_SIZE (1 << 20)  /* 1 million entries max for set iteration */
 #define MAX_FRAME_CHAIN_DEPTH (1024 + 512)  /* Iteration bound for frame chain walks */
-#define MAX_TASK_WAITER_CHAIN_DEPTH 256
+#define MAX_TASK_WAITER_CHAIN_DEPTH 256  /* Task waiter walk recursion cap: 256 * SIZEOF_TASK_OBJ ~= 1 MiB */
 
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -148,7 +148,7 @@ typedef enum _WIN32_THREADSTATE {
 #define MAX_LONG_DIGITS 64  /* Allows values up to ~2^1920 */
 #define MAX_SET_TABLE_SIZE (1 << 20)  /* 1 million entries max for set iteration */
 #define MAX_FRAME_CHAIN_DEPTH (1024 + 512)  /* Iteration bound for frame chain walks */
-#define MAX_TASK_WAITER_WALK_TASKS (1 << 16)  /* Total-task bound for waiter walks */
+#define MAX_TASK_WAITER_WALK_TASKS (1 << 14)  /* Total-task bound for waiter walks */
 
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -148,6 +148,7 @@ typedef enum _WIN32_THREADSTATE {
 #define MAX_LONG_DIGITS 64  /* Allows values up to ~2^1920 */
 #define MAX_SET_TABLE_SIZE (1 << 20)  /* 1 million entries max for set iteration */
 #define MAX_FRAME_CHAIN_DEPTH (1024 + 512)  /* Iteration bound for frame chain walks */
+#define MAX_TASK_WAITER_CHAIN_DEPTH 512
 
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -148,7 +148,7 @@ typedef enum _WIN32_THREADSTATE {
 #define MAX_LONG_DIGITS 64  /* Allows values up to ~2^1920 */
 #define MAX_SET_TABLE_SIZE (1 << 20)  /* 1 million entries max for set iteration */
 #define MAX_FRAME_CHAIN_DEPTH (1024 + 512)  /* Iteration bound for frame chain walks */
-#define MAX_TASK_WAITER_CHAIN_DEPTH 512
+#define MAX_TASK_WAITER_CHAIN_DEPTH 256
 
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -147,6 +147,7 @@ typedef enum _WIN32_THREADSTATE {
 #define MAX_STACK_CHUNK_SIZE (16 * 1024 * 1024)  /* 16 MB max for stack chunks */
 #define MAX_LONG_DIGITS 64  /* Allows values up to ~2^1920 */
 #define MAX_SET_TABLE_SIZE (1 << 20)  /* 1 million entries max for set iteration */
+#define MAX_FRAME_CHAIN_DEPTH (1024 + 512)  /* Iteration bound for frame chain walks */
 
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -148,7 +148,7 @@ typedef enum _WIN32_THREADSTATE {
 #define MAX_LONG_DIGITS 64  /* Allows values up to ~2^1920 */
 #define MAX_SET_TABLE_SIZE (1 << 20)  /* 1 million entries max for set iteration */
 #define MAX_FRAME_CHAIN_DEPTH (1024 + 512)  /* Iteration bound for frame chain walks */
-#define MAX_TASK_WAITER_CHAIN_DEPTH 256  /* Task waiter walk recursion cap: 256 * SIZEOF_TASK_OBJ ~= 1 MiB */
+#define MAX_TASK_WAITER_WALK_TASKS (1 << 16)  /* Total-task bound for waiter walks */
 
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
@@ -480,13 +480,6 @@ typedef int (*thread_processor_func)(
     void *context
 );
 
-typedef int (*set_entry_processor_func)(
-    RemoteUnwinderObject *unwinder,
-    uintptr_t key_addr,
-    void *context,
-    size_t depth
-);
-
 typedef int (*interpreter_processor_func)(
     RuntimeOffsets *offsets,
     uintptr_t interpreter_state_addr,
@@ -746,36 +739,11 @@ extern int parse_async_frame_chain(
     uintptr_t running_task_code_obj
 );
 
-/* Set iteration */
-extern int iterate_set_entries(
-    RemoteUnwinderObject *unwinder,
-    uintptr_t set_addr,
-    set_entry_processor_func processor,
-    void *context,
-    size_t depth
-);
-
-/* Task awaited_by processing */
-extern int process_task_awaited_by(
-    RemoteUnwinderObject *unwinder,
-    uintptr_t task_address,
-    set_entry_processor_func processor,
-    void *context,
-    size_t depth
-);
-
 extern int process_single_task_node(
     RemoteUnwinderObject *unwinder,
     uintptr_t task_addr,
     PyObject **task_info,
     PyObject *result
-);
-
-extern int process_task_and_waiters(
-    RemoteUnwinderObject *unwinder,
-    uintptr_t task_addr,
-    PyObject *result,
-    size_t depth
 );
 
 extern int find_running_task_in_thread(

--- a/Modules/_remote_debugging/_remote_debugging.h
+++ b/Modules/_remote_debugging/_remote_debugging.h
@@ -524,7 +524,6 @@ extern int validate_debug_offsets(struct _Py_DebugOffsets *debug_offsets);
  * ============================================================================ */
 
 extern int read_ptr(RemoteUnwinderObject *unwinder, uintptr_t address, uintptr_t *result);
-extern int read_Py_ssize_t(RemoteUnwinderObject *unwinder, uintptr_t address, Py_ssize_t *result);
 extern int read_char(RemoteUnwinderObject *unwinder, uintptr_t address, char *result);
 extern int read_py_ptr(RemoteUnwinderObject *unwinder, uintptr_t address, uintptr_t *ptr_addr);
 

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -252,7 +252,8 @@ handle_yield_from_frame(
     RemoteUnwinderObject *unwinder,
     uintptr_t gi_iframe_addr,
     uintptr_t gen_type_addr,
-    PyObject *render_to
+    PyObject *render_to,
+    size_t depth
 ) {
     // Read the entire interpreter frame at once
     char iframe[SIZEOF_INTERP_FRAME];
@@ -309,7 +310,8 @@ handle_yield_from_frame(
                    doesn't match the type of whatever it points to
                    in its cr_await.
                 */
-                err = parse_coro_chain(unwinder, gi_await_addr, render_to);
+                err = parse_coro_chain(unwinder, gi_await_addr, render_to,
+                                       depth + 1);
                 if (err) {
                     set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to parse coroutine chain in yield_from");
                     return -1;
@@ -325,9 +327,18 @@ int
 parse_coro_chain(
     RemoteUnwinderObject *unwinder,
     uintptr_t coro_address,
-    PyObject *render_to
+    PyObject *render_to,
+    size_t depth
 ) {
     assert((void*)coro_address != NULL);
+
+    if (depth >= MAX_FRAME_CHAIN_DEPTH) {
+        PyErr_SetString(PyExc_RuntimeError,
+            "Too many coroutine frames (possible infinite loop)");
+        set_exception_cause(unwinder, PyExc_RuntimeError,
+            "Coroutine chain depth limit exceeded");
+        return -1;
+    }
 
     // Read the entire generator object at once
     char gen_object[SIZEOF_GEN_OBJ];
@@ -371,7 +382,8 @@ parse_coro_chain(
     Py_DECREF(name);
 
     if (frame_state == FRAME_SUSPENDED_YIELD_FROM) {
-        return handle_yield_from_frame(unwinder, gi_iframe_addr, gen_type_addr, render_to);
+        return handle_yield_from_frame(unwinder, gi_iframe_addr, gen_type_addr,
+                                       render_to, depth);
     }
 
     return 0;
@@ -417,7 +429,7 @@ create_task_result(
     coro_addr = GET_MEMBER_NO_TAG(uintptr_t, task_obj, unwinder->async_debug_offsets.asyncio_task_object.task_coro);
 
     if ((void*)coro_addr != NULL) {
-        if (parse_coro_chain(unwinder, coro_addr, call_stack) < 0) {
+        if (parse_coro_chain(unwinder, coro_addr, call_stack, 0) < 0) {
             set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to parse coroutine chain");
             goto error;
         }

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -145,19 +145,22 @@ iterate_set_entries(
     Py_ssize_t i = 0;
     Py_ssize_t els = 0;
     while (i < set_len && els < num_els) {
-        uintptr_t key_addr;
-        if (read_py_ptr(unwinder, table_ptr, &key_addr) < 0) {
+        setentry entry;
+        if (_Py_RemoteDebug_PagedReadRemoteMemory(
+                &unwinder->handle, table_ptr, sizeof(entry), &entry) < 0)
+        {
             set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to read set entry key");
             return -1;
         }
 
-        if ((void*)key_addr != NULL) {
+        uintptr_t key_addr = (uintptr_t)entry.key;
+        if (key_addr != 0 && entry.hash != -1) {
             if (parse_task(unwinder, key_addr, awaited_by) < 0) {
                 return -1;
             }
             els++;
         }
-        table_ptr += sizeof(void*) * 2;
+        table_ptr += sizeof(entry);
         i++;
     }
 

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -688,7 +688,7 @@ process_task_and_waiters(
     PyObject *result,
     size_t depth
 ) {
-    if (depth >= MAX_FRAME_CHAIN_DEPTH) {
+    if (depth >= MAX_TASK_WAITER_CHAIN_DEPTH) {
         PyErr_SetString(PyExc_RuntimeError,
             "Too many task waiters (possible infinite loop)");
         set_exception_cause(unwinder, PyExc_RuntimeError,

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -654,6 +654,7 @@ process_task_waiters(
                 return -1;
             }
             PyObject *waiter = PyList_GET_ITEM(waiters, j);
+            // CoroInfo item 1 holds the waiter task address stored by parse_task().
             PyObject *task_id = PyStructSequence_GET_ITEM(waiter, 1);
             void *task_ptr = PyLong_AsVoidPtr(task_id);
             if (task_ptr == NULL && PyErr_Occurred()) {

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -121,7 +121,8 @@ iterate_set_entries(
     RemoteUnwinderObject *unwinder,
     uintptr_t set_addr,
     set_entry_processor_func processor,
-    void *context
+    void *context,
+    size_t depth
 ) {
     char set_object[SIZEOF_SET_OBJ];
     if (_Py_RemoteDebug_PagedReadRemoteMemory(&unwinder->handle, set_addr,
@@ -161,7 +162,7 @@ iterate_set_entries(
 
             if (ref_cnt) {
                 // Process this valid set entry
-                if (processor(unwinder, key_addr, context) < 0) {
+                if (processor(unwinder, key_addr, context, depth) < 0) {
                     return -1;
                 }
                 els++;
@@ -526,15 +527,22 @@ error:
  * ============================================================================ */
 
 // Forward declaration for mutual recursion
-static int process_waiter_task(RemoteUnwinderObject *unwinder, uintptr_t key_addr, void *context);
+static int process_waiter_task(
+    RemoteUnwinderObject *unwinder,
+    uintptr_t key_addr,
+    void *context,
+    size_t depth
+);
 
 // Processor function for parsing tasks in sets
 static int
 process_task_parser(
     RemoteUnwinderObject *unwinder,
     uintptr_t key_addr,
-    void *context
+    void *context,
+    size_t depth
 ) {
+    (void)depth;
     PyObject *awaited_by = (PyObject *)context;
     return parse_task(unwinder, key_addr, awaited_by);
 }
@@ -545,7 +553,8 @@ parse_task_awaited_by(
     uintptr_t task_address,
     PyObject *awaited_by
 ) {
-    return process_task_awaited_by(unwinder, task_address, process_task_parser, awaited_by);
+    return process_task_awaited_by(
+        unwinder, task_address, process_task_parser, awaited_by, 0);
 }
 
 int
@@ -553,7 +562,8 @@ process_task_awaited_by(
     RemoteUnwinderObject *unwinder,
     uintptr_t task_address,
     set_entry_processor_func processor,
-    void *context
+    void *context,
+    size_t depth
 ) {
     // Read the entire TaskObj at once
     char task_obj[SIZEOF_TASK_OBJ];
@@ -572,10 +582,11 @@ process_task_awaited_by(
     char awaited_by_is_a_set = GET_MEMBER(char, task_obj, unwinder->async_debug_offsets.asyncio_task_object.task_awaited_by_is_set);
 
     if (awaited_by_is_a_set) {
-        return iterate_set_entries(unwinder, task_ab_addr, processor, context);
+        return iterate_set_entries(
+            unwinder, task_ab_addr, processor, context, depth);
     } else {
         // Single task waiting
-        return processor(unwinder, task_ab_addr, context);
+        return processor(unwinder, task_ab_addr, context, depth);
     }
 }
 
@@ -674,15 +685,25 @@ int
 process_task_and_waiters(
     RemoteUnwinderObject *unwinder,
     uintptr_t task_addr,
-    PyObject *result
+    PyObject *result,
+    size_t depth
 ) {
+    if (depth >= MAX_FRAME_CHAIN_DEPTH) {
+        PyErr_SetString(PyExc_RuntimeError,
+            "Too many task waiters (possible infinite loop)");
+        set_exception_cause(unwinder, PyExc_RuntimeError,
+            "Task waiter chain depth limit exceeded");
+        return -1;
+    }
+
     // First, add this task to the result
     if (process_single_task_node(unwinder, task_addr, NULL, result) < 0) {
         return -1;
     }
 
     // Now find all tasks that are waiting for this task and process them
-    return process_task_awaited_by(unwinder, task_addr, process_waiter_task, result);
+    return process_task_awaited_by(
+        unwinder, task_addr, process_waiter_task, result, depth + 1);
 }
 
 // Processor function for task waiters
@@ -690,10 +711,10 @@ static int
 process_waiter_task(
     RemoteUnwinderObject *unwinder,
     uintptr_t key_addr,
-    void *context
+    void *context,
+    size_t depth
 ) {
-    PyObject *result = (PyObject *)context;
-    return process_task_and_waiters(unwinder, key_addr, result);
+    return process_task_and_waiters(unwinder, key_addr, (PyObject *)context, depth);
 }
 
 /* ============================================================================
@@ -996,7 +1017,9 @@ process_running_task_chain(
     }
 
     // Now find all tasks that are waiting for this task and process them
-    if (process_task_awaited_by(unwinder, running_task_addr, process_waiter_task, result) < 0) {
+    if (process_task_awaited_by(
+            unwinder, running_task_addr, process_waiter_task, result, 1) < 0)
+    {
         return -1;
     }
 

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -791,7 +791,7 @@ parse_async_frame_chain(
     size_t frame_count = 0;
     while ((void*)address_of_current_frame != NULL) {
         if (++frame_count > MAX_FRAME_CHAIN_DEPTH) {
-            PyErr_SetString(PyExc_RuntimeError, "Too many stack frames (possible infinite loop)");
+            PyErr_SetString(PyExc_RuntimeError, "Too many async stack frames (possible infinite loop)");
             set_exception_cause(unwinder, PyExc_RuntimeError, "Async frame chain iteration limit exceeded");
             return -1;
         }

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -776,7 +776,13 @@ parse_async_frame_chain(
         return -1;
     }
 
+    size_t frame_count = 0;
     while ((void*)address_of_current_frame != NULL) {
+        if (++frame_count > MAX_FRAME_CHAIN_DEPTH) {
+            PyErr_SetString(PyExc_RuntimeError, "Too many stack frames (possible infinite loop)");
+            set_exception_cause(unwinder, PyExc_RuntimeError, "Async frame chain iteration limit exceeded");
+            return -1;
+        }
         PyObject* frame_info = NULL;
         uintptr_t address_of_code_object;
         int res = parse_frame_object(

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -149,7 +149,7 @@ iterate_set_entries(
         if (_Py_RemoteDebug_PagedReadRemoteMemory(
                 &unwinder->handle, table_ptr, sizeof(entry), &entry) < 0)
         {
-            set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to read set entry key");
+            set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to read set entry");
             return -1;
         }
 

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -238,13 +238,14 @@ parse_task_name(
  * ============================================================================ */
 
 static int
-handle_yield_from_frame(
+get_awaited_coro_address(
     RemoteUnwinderObject *unwinder,
     uintptr_t gi_iframe_addr,
     uintptr_t gen_type_addr,
-    PyObject *render_to,
-    size_t depth
+    uintptr_t *next_coro
 ) {
+    *next_coro = 0;
+
     // Read the entire interpreter frame at once
     char iframe[SIZEOF_INTERP_FRAME];
     int err = _Py_RemoteDebug_PagedReadRemoteMemory(
@@ -300,12 +301,7 @@ handle_yield_from_frame(
                    doesn't match the type of whatever it points to
                    in its cr_await.
                 */
-                err = parse_coro_chain(unwinder, gi_await_addr, render_to,
-                                       depth + 1);
-                if (err) {
-                    set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to parse coroutine chain in yield_from");
-                    return -1;
-                }
+                *next_coro = gi_await_addr;
             }
         }
     }
@@ -313,67 +309,72 @@ handle_yield_from_frame(
     return 0;
 }
 
-int
+static int
 parse_coro_chain(
     RemoteUnwinderObject *unwinder,
     uintptr_t coro_address,
-    PyObject *render_to,
-    size_t depth
+    PyObject *render_to
 ) {
     assert((void*)coro_address != NULL);
 
-    if (depth >= MAX_FRAME_CHAIN_DEPTH) {
-        PyErr_SetString(PyExc_RuntimeError,
-            "Too many coroutine frames (possible infinite loop)");
-        set_exception_cause(unwinder, PyExc_RuntimeError,
-            "Coroutine chain depth limit exceeded");
-        return -1;
-    }
+    for (size_t depth = 0; (void*)coro_address != NULL; depth++) {
+        if (depth >= MAX_FRAME_CHAIN_DEPTH) {
+            PyErr_SetString(PyExc_RuntimeError,
+                "Too many coroutine frames (possible infinite loop)");
+            set_exception_cause(unwinder, PyExc_RuntimeError,
+                "Coroutine chain depth limit exceeded");
+            return -1;
+        }
 
-    // Read the entire generator object at once
-    char gen_object[SIZEOF_GEN_OBJ];
-    int err = _Py_RemoteDebug_PagedReadRemoteMemory(
-        &unwinder->handle,
-        coro_address,
-        SIZEOF_GEN_OBJ,
-        gen_object);
-    if (err < 0) {
-        set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to read generator object in coro chain");
-        return -1;
-    }
+        // Read the entire generator object at once
+        char gen_object[SIZEOF_GEN_OBJ];
+        int err = _Py_RemoteDebug_PagedReadRemoteMemory(
+            &unwinder->handle,
+            coro_address,
+            SIZEOF_GEN_OBJ,
+            gen_object);
+        if (err < 0) {
+            set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to read generator object in coro chain");
+            return -1;
+        }
 
-    int8_t frame_state = GET_MEMBER(int8_t, gen_object, unwinder->debug_offsets.gen_object.gi_frame_state);
-    if (frame_state == FRAME_CLEARED) {
-        return 0;
-    }
+        int8_t frame_state = GET_MEMBER(int8_t, gen_object, unwinder->debug_offsets.gen_object.gi_frame_state);
+        if (frame_state == FRAME_CLEARED) {
+            return 0;
+        }
 
-    uintptr_t gen_type_addr = GET_MEMBER(uintptr_t, gen_object, unwinder->debug_offsets.pyobject.ob_type);
+        uintptr_t gen_type_addr = GET_MEMBER(uintptr_t, gen_object, unwinder->debug_offsets.pyobject.ob_type);
 
-    PyObject* name = NULL;
+        PyObject* name = NULL;
 
-    // Parse the previous frame using the gi_iframe from local copy
-    uintptr_t prev_frame;
-    uintptr_t gi_iframe_addr = coro_address + (uintptr_t)unwinder->debug_offsets.gen_object.gi_iframe;
-    uintptr_t address_of_code_object = 0;
-    if (parse_frame_object(unwinder, &name, gi_iframe_addr, &address_of_code_object, &prev_frame) < 0) {
-        set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to parse frame object in coro chain");
-        return -1;
-    }
+        // Parse the previous frame using the gi_iframe from local copy
+        uintptr_t prev_frame;
+        uintptr_t gi_iframe_addr = coro_address + (uintptr_t)unwinder->debug_offsets.gen_object.gi_iframe;
+        uintptr_t address_of_code_object = 0;
+        if (parse_frame_object(unwinder, &name, gi_iframe_addr, &address_of_code_object, &prev_frame) < 0) {
+            set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to parse frame object in coro chain");
+            return -1;
+        }
 
-    if (!name) {
-        return 0;
-    }
+        if (!name) {
+            return 0;
+        }
 
-    if (PyList_Append(render_to, name)) {
+        if (PyList_Append(render_to, name)) {
+            Py_DECREF(name);
+            set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to append frame to coro chain");
+            return -1;
+        }
         Py_DECREF(name);
-        set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to append frame to coro chain");
-        return -1;
-    }
-    Py_DECREF(name);
 
-    if (frame_state == FRAME_SUSPENDED_YIELD_FROM) {
-        return handle_yield_from_frame(unwinder, gi_iframe_addr, gen_type_addr,
-                                       render_to, depth);
+        if (frame_state != FRAME_SUSPENDED_YIELD_FROM) {
+            return 0;
+        }
+
+        if (get_awaited_coro_address(unwinder, gi_iframe_addr, gen_type_addr,
+                                     &coro_address) < 0) {
+            return -1;
+        }
     }
 
     return 0;
@@ -419,7 +420,7 @@ create_task_result(
     coro_addr = GET_MEMBER_NO_TAG(uintptr_t, task_obj, unwinder->async_debug_offsets.asyncio_task_object.task_coro);
 
     if ((void*)coro_addr != NULL) {
-        if (parse_coro_chain(unwinder, coro_addr, call_stack, 0) < 0) {
+        if (parse_coro_chain(unwinder, coro_addr, call_stack) < 0) {
             set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to parse coroutine chain");
             goto error;
         }

--- a/Modules/_remote_debugging/asyncio.c
+++ b/Modules/_remote_debugging/asyncio.c
@@ -116,13 +116,11 @@ ensure_async_debug_offsets(RemoteUnwinderObject *unwinder)
  * SET ITERATION FUNCTIONS
  * ============================================================================ */
 
-int
+static int
 iterate_set_entries(
     RemoteUnwinderObject *unwinder,
     uintptr_t set_addr,
-    set_entry_processor_func processor,
-    void *context,
-    size_t depth
+    PyObject *awaited_by
 ) {
     char set_object[SIZEOF_SET_OBJ];
     if (_Py_RemoteDebug_PagedReadRemoteMemory(&unwinder->handle, set_addr,
@@ -154,19 +152,10 @@ iterate_set_entries(
         }
 
         if ((void*)key_addr != NULL) {
-            Py_ssize_t ref_cnt;
-            if (read_Py_ssize_t(unwinder, table_ptr, &ref_cnt) < 0) {
-                set_exception_cause(unwinder, PyExc_RuntimeError, "Failed to read set entry ref count");
+            if (parse_task(unwinder, key_addr, awaited_by) < 0) {
                 return -1;
             }
-
-            if (ref_cnt) {
-                // Process this valid set entry
-                if (processor(unwinder, key_addr, context, depth) < 0) {
-                    return -1;
-                }
-                els++;
-            }
+            els++;
         }
         table_ptr += sizeof(void*) * 2;
         i++;
@@ -526,44 +515,11 @@ error:
  * TASK AWAITED_BY PROCESSING
  * ============================================================================ */
 
-// Forward declaration for mutual recursion
-static int process_waiter_task(
-    RemoteUnwinderObject *unwinder,
-    uintptr_t key_addr,
-    void *context,
-    size_t depth
-);
-
-// Processor function for parsing tasks in sets
-static int
-process_task_parser(
-    RemoteUnwinderObject *unwinder,
-    uintptr_t key_addr,
-    void *context,
-    size_t depth
-) {
-    (void)depth;
-    PyObject *awaited_by = (PyObject *)context;
-    return parse_task(unwinder, key_addr, awaited_by);
-}
-
 static int
 parse_task_awaited_by(
     RemoteUnwinderObject *unwinder,
     uintptr_t task_address,
     PyObject *awaited_by
-) {
-    return process_task_awaited_by(
-        unwinder, task_address, process_task_parser, awaited_by, 0);
-}
-
-int
-process_task_awaited_by(
-    RemoteUnwinderObject *unwinder,
-    uintptr_t task_address,
-    set_entry_processor_func processor,
-    void *context,
-    size_t depth
 ) {
     // Read the entire TaskObj at once
     char task_obj[SIZEOF_TASK_OBJ];
@@ -582,11 +538,10 @@ process_task_awaited_by(
     char awaited_by_is_a_set = GET_MEMBER(char, task_obj, unwinder->async_debug_offsets.asyncio_task_object.task_awaited_by_is_set);
 
     if (awaited_by_is_a_set) {
-        return iterate_set_entries(
-            unwinder, task_ab_addr, processor, context, depth);
+        return iterate_set_entries(unwinder, task_ab_addr, awaited_by);
     } else {
         // Single task waiting
-        return processor(unwinder, task_ab_addr, context, depth);
+        return parse_task(unwinder, task_ab_addr, awaited_by);
     }
 }
 
@@ -681,40 +636,39 @@ error:
     return -1;
 }
 
-int
-process_task_and_waiters(
-    RemoteUnwinderObject *unwinder,
-    uintptr_t task_addr,
-    PyObject *result,
-    size_t depth
-) {
-    if (depth >= MAX_TASK_WAITER_CHAIN_DEPTH) {
-        PyErr_SetString(PyExc_RuntimeError,
-            "Too many task waiters (possible infinite loop)");
-        set_exception_cause(unwinder, PyExc_RuntimeError,
-            "Task waiter chain depth limit exceeded");
-        return -1;
-    }
-
-    // First, add this task to the result
-    if (process_single_task_node(unwinder, task_addr, NULL, result) < 0) {
-        return -1;
-    }
-
-    // Now find all tasks that are waiting for this task and process them
-    return process_task_awaited_by(
-        unwinder, task_addr, process_waiter_task, result, depth + 1);
-}
-
-// Processor function for task waiters
 static int
-process_waiter_task(
+process_task_waiters(
     RemoteUnwinderObject *unwinder,
-    uintptr_t key_addr,
-    void *context,
-    size_t depth
+    PyObject *result
 ) {
-    return process_task_and_waiters(unwinder, key_addr, (PyObject *)context, depth);
+    for (Py_ssize_t i = 0; i < PyList_GET_SIZE(result); i++) {
+        PyObject *task_info = PyList_GET_ITEM(result, i);
+        PyObject *waiters = PyStructSequence_GET_ITEM(task_info, 3);
+        for (Py_ssize_t j = 0; j < PyList_GET_SIZE(waiters); j++) {
+            if (PyList_GET_SIZE(result) >= MAX_TASK_WAITER_WALK_TASKS) {
+                PyErr_SetString(PyExc_RuntimeError,
+                    "Too many task waiters (possible infinite loop)");
+                set_exception_cause(unwinder, PyExc_RuntimeError,
+                    "Task waiter walk size limit exceeded");
+                return -1;
+            }
+            PyObject *waiter = PyList_GET_ITEM(waiters, j);
+            PyObject *task_id = PyStructSequence_GET_ITEM(waiter, 1);
+            void *task_ptr = PyLong_AsVoidPtr(task_id);
+            if (task_ptr == NULL && PyErr_Occurred()) {
+                set_exception_cause(unwinder, PyExc_RuntimeError,
+                                    "Failed to parse waiter task ID");
+                return -1;
+            }
+            if (process_single_task_node(
+                    unwinder, (uintptr_t)task_ptr, NULL, result) < 0)
+            {
+                return -1;
+            }
+        }
+    }
+
+    return 0;
 }
 
 /* ============================================================================
@@ -1017,9 +971,7 @@ process_running_task_chain(
     }
 
     // Now find all tasks that are waiting for this task and process them
-    if (process_task_awaited_by(
-            unwinder, running_task_addr, process_waiter_task, result, 1) < 0)
-    {
+    if (process_task_waiters(unwinder, result) < 0) {
         return -1;
     }
 

--- a/Modules/_remote_debugging/frames.c
+++ b/Modules/_remote_debugging/frames.c
@@ -305,9 +305,7 @@ process_frame_chain(
     uintptr_t frame_addr = ctx->frame_addr;
     uintptr_t prev_frame_addr = 0;
     uintptr_t last_frame_addr = 0;
-    const size_t MAX_FRAMES = 1024 + 512;
     size_t frame_count = 0;
-    assert(MAX_FRAMES > 0 && MAX_FRAMES < 10000);
 
     ctx->stopped_at_cached_frame = 0;
     ctx->last_frame_visited = 0;
@@ -318,12 +316,12 @@ process_frame_chain(
         uintptr_t stackpointer = 0;
         last_frame_addr = frame_addr;
 
-        if (++frame_count > MAX_FRAMES) {
+        if (++frame_count > MAX_FRAME_CHAIN_DEPTH) {
             PyErr_SetString(PyExc_RuntimeError, "Too many stack frames (possible infinite loop)");
             set_exception_cause(unwinder, PyExc_RuntimeError, "Frame chain iteration limit exceeded");
             return -1;
         }
-        assert(frame_count <= MAX_FRAMES);
+        assert(frame_count <= MAX_FRAME_CHAIN_DEPTH);
 
         if (ctx->chunks && ctx->chunks->count > 0) {
             if (parse_frame_from_chunks(unwinder, &frame, frame_addr, &next_frame_addr, &stackpointer, ctx->chunks) == 0) {

--- a/Modules/_remote_debugging/object_reading.c
+++ b/Modules/_remote_debugging/object_reading.c
@@ -25,7 +25,6 @@ read_##type_name(RemoteUnwinderObject *unwinder, uintptr_t address, c_type *resu
 }
 
 DEFINE_MEMORY_READER(ptr, uintptr_t, "Failed to read pointer from remote memory")
-DEFINE_MEMORY_READER(Py_ssize_t, Py_ssize_t, "Failed to read Py_ssize_t from remote memory")
 DEFINE_MEMORY_READER(char, char, "Failed to read char from remote memory")
 
 int


### PR DESCRIPTION
The PR hardens and cleans up frame, coro and task-waiter walks a bit, by making them iterative and bounded.

I'm addressing two issues here:

1. No walk limits.  The walks use pointers read from the target without any guarantees, so a torn read could stitch a cycle. Not to mention adversial targets. `process_frame_chain()` already had `1024 + 512` limit, but the PR extracts it as `MAX_FRAME_CHAIN_DEPTH` and applies in the `parse_coro_chain()`, used by both sync and async paths, and `parse_async_frame_chain()`. The task-waiter walk in `get_async_stack_trace()` gets a separate limit (`MAX_TASK_WAITER_WALK_TASKS`), on the total number of tasks visited (including duplicates), since its' a graph, not a chain.
2. Stack overflows. Both coro and task-waiter walks were recursive. With 4KB (`SIZEOF_TASK_OBJ`) 256 was enough to overflow a 1MiB stack.

The obvious context here is avoiding infinite loops. Truth be told, I think that in some places torn reads were also responsible for avoiding them and early exits. :-)

<!-- gh-issue-number: gh-153364 -->
* Issue: gh-153364
<!-- /gh-issue-number -->
