### PR TITLE
gh-151540: Use a selector event loop in the happy-eyeballs tests

### DIFF
--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1092,7 +1092,11 @@ class BaseEventLoopTests(test_utils.TestCase):
                 await asyncio.sleep(1)
             sock.connect(address)
 
-        loop = asyncio.new_event_loop()
+        # gh-151540: use a selector event loop instead of the platform
+        # default; the Windows proactor loop would register the mocked
+        # socket with a real IOCP handle instead of the mocked
+        # _add_reader/_add_writer below.
+        loop = asyncio.SelectorEventLoop()
         loop._add_writer = mock.Mock()
         loop._add_writer = mock.Mock()
         loop._add_reader = mock.Mock()
@@ -1124,7 +1128,8 @@ class BaseEventLoopTests(test_utils.TestCase):
                 await asyncio.sleep(1)
             sock.connect(address)
 
-        loop = asyncio.new_event_loop()
+        # gh-151540: see test_create_connection_happy_eyeballs above.
+        loop = asyncio.SelectorEventLoop()
         loop._add_writer = mock.Mock()
         loop._add_writer = mock.Mock()
         loop._add_reader = mock.Mock()

--- a/Misc/NEWS.d/next/Tests/2026-07-08-21-45-00.gh-issue-151540.pQx3Wm.rst
+++ b/Misc/NEWS.d/next/Tests/2026-07-08-21-45-00.gh-issue-151540.pQx3Wm.rst
@@ -1,0 +1,5 @@
+Fix the happy-eyeballs tests in ``test.test_asyncio.test_base_events``
+raising ``TypeError`` in a callback on Windows. The tests now use a
+selector event loop explicitly instead of the platform default, as the
+Windows proactor event loop registers the mocked test socket with a real
+I/O completion port.

--- a/Misc/NEWS.d/next/Tests/2026-07-08-21-45-00.gh-issue-151540.pQx3Wm.rst
+++ b/Misc/NEWS.d/next/Tests/2026-07-08-21-45-00.gh-issue-151540.pQx3Wm.rst
@@ -1,5 +1,0 @@
-Fix the happy-eyeballs tests in ``test.test_asyncio.test_base_events``
-raising ``TypeError`` in a callback on Windows. The tests now use a
-selector event loop explicitly instead of the platform default, as the
-Windows proactor event loop registers the mocked test socket with a real
-I/O completion port.


### PR DESCRIPTION
`test_create_connection_happy_eyeballs` and `test_create_connection_happy_eyeballs_ipv4_only` in `test.test_asyncio.test_base_events` create their event loop with `asyncio.new_event_loop()`, which defaults to `ProactorEventLoop` on Windows. Creating the socket transport on that loop immediately registers the socket with a real I/O completion port via `_overlapped.CreateIoCompletionPort(obj.fileno(), ...)`. The tests use a `MagicMock` socket (from `test_utils.mock_nonblocking_socket()`), so `fileno()` returns a `MagicMock` and the callback fails with `TypeError: an integer is required`. The proactor path never consults the `_add_reader`/`_add_writer` mocks the tests set up.

These tests exercise the platform-independent happy-eyeballs address selection in `BaseEventLoop.create_connection()`, not proactor behavior, so create the loop with `asyncio.SelectorEventLoop()` explicitly. This matches the code path the tests already exercise on non-Windows platforms, and follows the existing pattern in this file (`BaseEventLoopWithSelectorTests`) and elsewhere in `test_asyncio`.

Verified on Windows 11 against `main`: reproduced the `TypeError` before the change; after it, `test_asyncio.test_base_events` (118 tests) and the full `test_asyncio` suite (2547 tests) pass with no exceptions logged.

<!-- gh-issue-number: gh-151540 -->
* Issue: gh-151540
<!-- /gh-issue-number -->