### PR TITLE
gh-153290: Fix data race in BytesIO.__setstate__ installing __dict__

### DIFF
--- a/Lib/test/test_free_threading/test_io.py
+++ b/Lib/test/test_free_threading/test_io.py
@@ -124,6 +124,34 @@ class CBytesIOTest(ThreadSafetyMixin, TestCase):
 
     @threading_helper.requires_working_threading()
     @threading_helper.reap_threads
+    def test_concurrent_setstate_and_method_call(self):
+        # gh-153290: __setstate__() installed the instance __dict__ with a
+        # plain store, racing the lock-free LOAD_ATTR method fast path that
+        # reads the dict slot with an atomic acquire load.
+        states = [(b"A" * 64, 0, {}), (b"B" * 128, 32, {}), (b"C" * 256, 0, {})]
+        nreaders = 4
+        for _ in range(25):
+            shared = self.ioclass(b"initial payload")
+            barrier = threading.Barrier(1 + nreaders)
+
+            def setter():
+                barrier.wait()
+                for state in states:
+                    shared.__setstate__(state)
+
+            def reader():
+                barrier.wait()
+                for _ in range(100):
+                    shared.read(8)
+
+            threads = [threading.Thread(target=setter)]
+            threads += [threading.Thread(target=reader)
+                        for _ in range(nreaders)]
+            with threading_helper.start_threads(threads):
+                pass
+
+    @threading_helper.requires_working_threading()
+    @threading_helper.reap_threads
     def test_concurrent_whole_buffer_read_and_resize(self):
         shared = self.ioclass(b"x" * 64)
         writers = 2

--- a/Misc/NEWS.d/next/Library/2026-07-09-08-40-00.gh-issue-153290.GTzSEa.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-09-08-40-00.gh-issue-153290.GTzSEa.rst
@@ -1,0 +1,3 @@
+Fix a data race on the free-threaded build when :meth:`!io.BytesIO.__setstate__`
+installs the instance dictionary while another thread concurrently calls a
+method on the same object.

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -1054,7 +1054,9 @@ bytesio_setstate_lock_held(PyObject *op, PyObject *state)
                 return NULL;
         }
         else {
-            self->dict = Py_NewRef(dict);
+            /* The LOAD_ATTR specializations read the dict slot lock-free
+               with an acquire load, so pair it with a release store. */
+            FT_ATOMIC_STORE_PTR_RELEASE(self->dict, Py_NewRef(dict));
         }
     }
 


### PR DESCRIPTION
Fixes #153290

On the free-threaded build, `BytesIO.__setstate__()` installed the instance
`__dict__` with a plain pointer store, while the lock-free LOAD_ATTR method
fast path (`_CHECK_ATTR_METHOD_LAZY_DICT`) reads the same dict slot with an
atomic acquire load. ThreadSanitizer reports a data race between the two, and
an unordered store could publish the dict pointer before its contents are
visible to the reading thread.

Use `FT_ATOMIC_STORE_PTR_RELEASE` for the store, pairing it with the acquire
load, the same way `ensure_nonmanaged_dict()` in `Objects/dictobject.c`
handles non-managed dict slots. This is a no-op on the default build.

Verified with TSAN on a `--disable-gil --with-pydebug` build: the issue's
reproducer reports the race before the change and is clean after. Added a
regression test in `test_free_threading/test_io.py`.


<!-- gh-issue-number: gh-153290 -->
* Issue: gh-153290
<!-- /gh-issue-number -->