### PR TITLE
gh-118860: docs: clarify custom build output directory in PCbuild/readme.txt

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-07-09-10-37-00.gh-issue-118860.abc123.rst
+++ b/Misc/NEWS.d/next/Build/2026-07-09-10-37-00.gh-issue-118860.abc123.rst
@@ -1,1 +1,0 @@
-Clarify the use of ``Py_OutDir`` and ``PC/layout`` for customizing the build output directory in ``PCbuild/readme.txt``.

--- a/Misc/NEWS.d/next/Build/2026-07-09-10-37-00.gh-issue-118860.abc123.rst
+++ b/Misc/NEWS.d/next/Build/2026-07-09-10-37-00.gh-issue-118860.abc123.rst
@@ -1,0 +1,1 @@
+Clarify the use of ``Py_OutDir`` and ``PC/layout`` for customizing the build output directory in ``PCbuild/readme.txt``.

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -108,12 +108,21 @@ this behavior, try `build.bat -h` to learn more.
 Custom Output Directory
 -----------------------
 
-If you want to move the build outputs to a different directory, do not use the standard MSBuild `/p:OutDir=` property, as CPython has many assumptions about where the source repository is relative to the built files. 
-Instead, you can override the output directory by setting `Py_OutDir` (for example, `build.bat "/p:Py_OutDir=C:\MyOutput"`). 
+If you want to move the build outputs to a different directory, do not use the
+standard MSBuild `/p:OutDir=` property, as CPython has many assumptions about
+where the source repository is relative to the built files. Instead, you can
+override the output directory by setting `Py_OutDir` as an environment
+variable or by passing it to build.bat (for example,
+`build.bat "/p:Py_OutDir=C:\MyOutput"`).
 
-However, be aware that the compiled binaries probably won't run directly from that location. If you want to make an install-shaped layout without creating the installer, build CPython normally first, and then use the `PC/layout` script with the runtime you just built:
+However, be aware that the compiled binaries probably won't run directly from
+that location. If you want to make an install-shaped layout without creating the
+installer, build CPython normally first, and then use the `PC/layout` script
+with the runtime you just built, or using the `--build` and `--source` options
+to specify the directories:
     python.bat PC/layout --<options>
-Use `-h` with that command to see all available options for customizing the layout.
+Use `-h` with that command to see all available options for customizing the
+layout.
 
 
 C Runtime

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -108,12 +108,11 @@ this behavior, try `build.bat -h` to learn more.
 Custom Output Directory
 -----------------------
 
-If you want to move the build outputs to a different directory, do not use the
-standard MSBuild `/p:OutDir=` property, as CPython has many assumptions about
-where the source repository is relative to the built files. Instead, you can
-override the output directory by setting `Py_OutDir` as an environment
-variable or by passing it to build.bat (for example,
-`build.bat "/p:Py_OutDir=C:\MyOutput"`).
+If you want to move the build outputs to a different directory, use the
+`Py_OutDir` property either as a standard MSBuild `/p:Py_OutDir=` argument
+(for example, `build.bat "/p:Py_OutDir=C:\MyOutput"`) or an environment
+variable. Using the standard MSBuild `/p:OutDir=` property will more
+directly override the output location, which may result in a broken build.
 
 However, be aware that the compiled binaries probably won't run directly from
 that location. If you want to make an install-shaped layout without creating the

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -105,6 +105,17 @@ the 32-bit Win32 platform.  It accepts several arguments to change
 this behavior, try `build.bat -h` to learn more.
 
 
+Custom Output Directory
+-----------------------
+
+If you want to move the build outputs to a different directory, do not use the standard MSBuild `/p:OutDir=` property, as CPython has many assumptions about where the source repository is relative to the built files. 
+Instead, you can override the output directory by setting `Py_OutDir` (for example, `build.bat "/p:Py_OutDir=C:\MyOutput"`). 
+
+However, be aware that the compiled binaries probably won't run directly from that location. If you want to make an install-shaped layout without creating the installer, build CPython normally first, and then use the `PC/layout` script with the runtime you just built:
+    python.bat PC/layout --<options>
+Use `-h` with that command to see all available options for customizing the layout.
+
+
 C Runtime
 ---------
 


### PR DESCRIPTION
Fixes #118860. This PR adds a small section to `PCbuild/readme.txt` clarifying the use of `Py_OutDir` for custom output directories and `PC/layout` for creating install-shaped layouts, as suggested by the maintainers in the issue thread.

<!-- gh-issue-number: gh-118860 -->
* Issue: gh-118860
<!-- /gh-issue-number -->
